### PR TITLE
Revise FindQwt.cmake.

### DIFF
--- a/Code/Mantid/Build/CMake/FindQwt.cmake
+++ b/Code/Mantid/Build/CMake/FindQwt.cmake
@@ -1,43 +1,36 @@
 ###############################################################################
-# - Attempt to find Qwt libraries and include files. 
-# QWT_INCLUDE_DIR where to find qwt_plot.h, etc.
-# QWT_LIBRARIES libraries to link against
-# QWT_FOUND If false, do not try to use Qwt
-# QWT_VERSION Sets a string containing the version number parsed from 
-#             qwt_global.h
+# Attempt to find Qwt libraries and include files.
+# Set
+#   QWT_INCLUDE_DIR: where to find qwt_plot.h, etc.
+#   QWT_LIBRARIES:   libraries to link against
+#   QWT_VERSION:     a string containing the version number
 ###############################################################################
 
 find_path ( QWT_INCLUDE_DIR qwt.h 
-            /usr/include/qwt-qt4 /usr/include/qwt /usr/include/qwt5 /usr/include/qwt5-qt4
-	    ${CMAKE_INCLUDE_PATH}/qwt 
-)
-find_library ( QWT_LIBRARY NAMES qwt-qt4 qwt qwt5-qt4 )
+            PATHS /opt/include /usr/local/include /usr/include ${CMAKE_INCLUDE_PATH}
+            PATH_SUFFIXES qwt5 qwt5-qt4 qwt-qt4 qwt )
+find_library ( QWT_LIBRARY NAMES qwt5-qt4 qwt-qt4 qwt )
 find_library ( QWT_LIBRARY_DEBUG qwtd )
 
-# handle the QUIETLY and REQUIRED arguments and set QWT_FOUND to TRUE if 
-# all listed variables are TRUE
+# in REQUIRED mode: terminate if one of the above find commands failed
 include ( FindPackageHandleStandardArgs )
 find_package_handle_standard_args( Qwt DEFAULT_MSG QWT_LIBRARY QWT_INCLUDE_DIR )
 
-if ( QWT_INCLUDE_DIR )
-  # Look for line in qwt_global.h containing version string
-  file ( STRINGS ${QWT_INCLUDE_DIR}/qwt_global.h QWT_VERSION 
-         REGEX "^#define[ \t]+QWT_VERSION_STR[ \t]+\"[0-9]+.[0-9]+.[0-9]+\"$" )
-  if ( NOT QWT_VERSION )
-    message ( WARNING "Unrecognized Qwt version, cannot find QWT_VERSION_STR in qwt_global.h" )
-    set ( QWT_VERSION "0.0.0" )
-  else()
-    # Hack off the portion up to and including the first double quote 
-    string( REGEX REPLACE "^#define[ \t]+QWT_VERSION_STR[ \t]+\"" "" QWT_VERSION ${QWT_VERSION} )
-    # Hack off the portion from the second double quote to the end of the line
-    string( REGEX REPLACE "\"$" "" QWT_VERSION ${QWT_VERSION} )
-  endif()
-
-  if ( QWT_LIBRARY_DEBUG )
-    set( QWT_LIBRARIES optimized ${QWT_LIBRARY} debug ${QWT_LIBRARY_DEBUG} )
-  else ()
-    set( QWT_LIBRARIES ${QWT_LIBRARY} )
-  endif ()
+# Parse version string from qwt_global.h
+file ( STRINGS ${QWT_INCLUDE_DIR}/qwt_global.h QWT_VERSION 
+       REGEX "^#define[ \t]+QWT_VERSION_STR[ \t]+\"[0-9]+.[0-9]+.[0-9]+\"$" )
+if ( NOT QWT_VERSION )
+    message ( FATAL_ERROR "Unrecognized Qwt version (cannot find QWT_VERSION_STR in qwt_global.h)" )
 endif()
+#   hack off the portion up to and including the first double quote 
+string( REGEX REPLACE "^#define[ \t]+QWT_VERSION_STR[ \t]+\"" "" QWT_VERSION ${QWT_VERSION} )
+#   hack off the portion from the second double quote to the end of the line
+string( REGEX REPLACE "\"$" "" QWT_VERSION ${QWT_VERSION} )
+
+if ( QWT_LIBRARY_DEBUG )
+  set( QWT_LIBRARIES optimized ${QWT_LIBRARY} debug ${QWT_LIBRARY_DEBUG} )
+else ()
+  set( QWT_LIBRARIES ${QWT_LIBRARY} )
+endif ()
 
 mark_as_advanced ( QWT_INCLUDE_DIR QWT_LIBRARY QWT_LIBRARY_DEBUG )


### PR DESCRIPTION
Revise FindQwt.cmake to fix the following:
- in case of error, don't set version="0.0.0" to provoke upstream
  fatal error, but exit immediately with clear error message;
- search qwt.h in all possible combinations of include paths
  and qwt subdirectory names, using CMake's PATH_SUFFIXES parameter;
- try versioned directory and library names first.

refs #9619
