### PR TITLE
Move cross-hair cursor using arrow keys

### DIFF
--- a/Code/Mantid/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/SVConnections.h
+++ b/Code/Mantid/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/SVConnections.h
@@ -81,9 +81,9 @@ public slots:
   void v_scroll_bar_moved();
   void h_scroll_bar_moved();
   void imageSplitter_moved();
-  void imagePicker_moved();
-  void h_graphPicker_moved();
-  void v_graphPicker_moved();
+  void imagePicker_moved(const QPoint &point);
+  void h_graphPicker_moved(const QPoint &point);
+  void v_graphPicker_moved(const QPoint & point);
   void intensity_slider_moved();
   void heat_color_scale();
   void gray_color_scale();
@@ -109,6 +109,10 @@ private:
   TrackingPicker*  h_graph_picker;
   TrackingPicker*  v_graph_picker;
   QActionGroup*    color_group;
+  /// Last known cursor position in the data (x-direction).
+  int m_picker_x;
+  /// Last known cursor position in the data (y-direction).
+  int m_picker_y;
 
 };
 

--- a/Code/Mantid/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/TrackingPicker.h
+++ b/Code/Mantid/MantidQt/SpectrumViewer/inc/MantidQtSpectrumViewer/TrackingPicker.h
@@ -56,7 +56,7 @@ public:
 
 signals:
   /// This signal will be emitted for each mouse moved event
-  void mouseMoved() const;
+  void mouseMoved(const QPoint & point) const;
 
 protected:
 

--- a/Code/Mantid/MantidQt/SpectrumViewer/src/SVConnections.cpp
+++ b/Code/Mantid/MantidQt/SpectrumViewer/src/SVConnections.cpp
@@ -35,7 +35,8 @@ SVConnections::SVConnections( Ui_SpectrumViewer* ui,
                               SpectrumView*      spectrum_view,
                               SpectrumDisplay*   spectrum_display,
                               GraphDisplay*   h_graph_display,
-                              GraphDisplay*   v_graph_display )
+                              GraphDisplay*   v_graph_display ) :
+  m_picker_x(-1), m_picker_y(-1)
 {
   sv_ui = ui;
                               // first disable a few un-implemented controls
@@ -146,8 +147,8 @@ SVConnections::SVConnections( Ui_SpectrumViewer* ui,
   image_picker->setSelectionFlags(QwtPicker::PointSelection | 
                                   QwtPicker::ClickSelection  );
 */
-  QObject::connect( image_picker, SIGNAL(mouseMoved()),
-                    this, SLOT(imagePicker_moved()) );
+  QObject::connect( image_picker, SIGNAL(mouseMoved(const QPoint &)),
+                    this, SLOT(imagePicker_moved(const QPoint &)) );
 
   QObject::connect(sv_ui->imageSplitter, SIGNAL(splitterMoved(int,int)),
                    this, SLOT(imageSplitter_moved()) );
@@ -249,8 +250,8 @@ SVConnections::SVConnections( Ui_SpectrumViewer* ui,
   h_graph_picker->setRubberBand(QwtPicker::CrossRubberBand);
   h_graph_picker->setSelectionFlags(QwtPicker::PointSelection |
                                   QwtPicker::DragSelection  );
-  QObject::connect( h_graph_picker, SIGNAL(mouseMoved()),
-                    this, SLOT(h_graphPicker_moved()) );
+  QObject::connect( h_graph_picker, SIGNAL(mouseMoved(const QPoint &)),
+                    this, SLOT(h_graphPicker_moved(const QPoint &)) );
 
   // NOTE: This initialization could be a (static?) method in TrackingPicker
   v_graph_picker = new TrackingPicker( sv_ui->v_graphPlot->canvas() );
@@ -260,8 +261,8 @@ SVConnections::SVConnections( Ui_SpectrumViewer* ui,
   v_graph_picker->setRubberBand(QwtPicker::CrossRubberBand);
   v_graph_picker->setSelectionFlags(QwtPicker::PointSelection |
                                     QwtPicker::DragSelection  );
-  QObject::connect( v_graph_picker, SIGNAL(mouseMoved()),
-                    this, SLOT(v_graphPicker_moved()) );
+  QObject::connect( v_graph_picker, SIGNAL(mouseMoved(const QPoint &)),
+                    this, SLOT(v_graphPicker_moved(const QPoint &)) );
 
   QObject::connect( sv_ui->actionOnline_Help_Page, SIGNAL(triggered()),
                     this, SLOT(online_help_slot()) );
@@ -300,6 +301,37 @@ bool SVConnections::eventFilter(QObject *object, QEvent *event)
         return sv_ui->imageHorizontalScrollBar->event(wheelEvent);
       }
     }
+  }
+  else if (event->type() == QEvent::KeyPress)
+  {
+    QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>(event);
+    int key = keyEvent->key();
+    switch (key)
+    {
+    case Qt::Key_Up:
+      m_picker_y += -1;
+      break;
+    case Qt::Key_Down:
+      m_picker_y += 1;
+      break;
+    case Qt::Key_Left:
+      m_picker_x += -1;
+      break;
+    case Qt::Key_Right:
+      m_picker_x += 1;
+      break;
+    default:
+      // this is not the event we were looking for
+      return false;
+    }
+    // determine where the canvas is in global coords
+    QPoint canvasPos = sv_ui->spectrumPlot->canvas()->mapToGlobal(QPoint(0,0));
+    // move the cursor to the correct position
+    sv_ui->spectrumPlot->canvas()->cursor().setPos(QPoint(canvasPos.x()+m_picker_x, canvasPos.y()+m_picker_y));
+    // update the pointed at position
+    spectrum_display->SetPointedAtPoint( QPoint(m_picker_x, m_picker_y) );
+    // consume the event
+    return true;
   }
   return false;
 }
@@ -373,37 +405,36 @@ void SVConnections::imageSplitter_moved()
   spectrum_display->UpdateImage();
 }
 
-
-void SVConnections::imagePicker_moved()
+/**
+ * Update the pointed at position for the image_picker.
+ *
+ * @param point The position moved to.
+ */
+void SVConnections::imagePicker_moved(const QPoint & point)
 {
-  QwtPolygon selected_points = image_picker->selection();
-  if ( selected_points.size() >= 1 )
-  {
-    int index = selected_points.size() - 1;
-    spectrum_display->SetPointedAtPoint( selected_points[index] );
-  }
+  m_picker_x = point.x();
+  m_picker_y = point.y();
+  spectrum_display->SetPointedAtPoint( point );
 }
 
-
-void SVConnections::h_graphPicker_moved()
+/**
+ * Update the pointed at position for the h_graph_display.
+ *
+ * @param point The position moved to.
+ */
+void SVConnections::h_graphPicker_moved(const QPoint & point)
 {
-  QwtPolygon selected_points = h_graph_picker->selection();
-  if ( selected_points.size() >= 1 )
-  {
-    int index = selected_points.size() - 1;
-    h_graph_display->SetPointedAtPoint( selected_points[index] );
-  }
+  h_graph_display->SetPointedAtPoint(point);
 }
 
-
-void SVConnections::v_graphPicker_moved()
+/**
+ * Update the pointed at position for the v_graph_display.
+ *
+ * @param point The position moved to.
+ */
+void SVConnections::v_graphPicker_moved(const QPoint & point)
 {
-  QwtPolygon selected_points = v_graph_picker->selection();
-  if ( selected_points.size() >= 1 )
-  {
-    int index = selected_points.size() - 1;
-    v_graph_display->SetPointedAtPoint( selected_points[index] );
-  }
+  v_graph_display->SetPointedAtPoint(point);
 }
 
 void SVConnections::intensity_slider_moved()

--- a/Code/Mantid/MantidQt/SpectrumViewer/src/SVConnections.cpp
+++ b/Code/Mantid/MantidQt/SpectrumViewer/src/SVConnections.cpp
@@ -304,26 +304,46 @@ bool SVConnections::eventFilter(QObject *object, QEvent *event)
   }
   else if (event->type() == QEvent::KeyPress)
   {
+    // don't bother if the values aren't set
+    if (m_picker_x < 0) return false;
+    if (m_picker_y < 0) return false;
+
+    // temporary variables so we can step back to previous state
+    int newX = m_picker_x;
+    int newY = m_picker_y;
+
     QKeyEvent *keyEvent = dynamic_cast<QKeyEvent *>(event);
     int key = keyEvent->key();
     switch (key)
     {
     case Qt::Key_Up:
-      m_picker_y += -1;
+      newY += -1;
       break;
     case Qt::Key_Down:
-      m_picker_y += 1;
+      newY += 1;
       break;
     case Qt::Key_Left:
-      m_picker_x += -1;
+      newX += -1;
       break;
     case Qt::Key_Right:
-      m_picker_x += 1;
+      newX += 1;
       break;
     default:
       // this is not the event we were looking for
       return false;
     }
+
+    // see if we should react
+    if (newX < 0) return false;
+    if (newY < 0) return false;
+    const QSize canvasSize = sv_ui->spectrumPlot->canvas()->size();
+    if (newX > canvasSize.width()) return false;
+    if (newY > canvasSize.height()) return false;
+
+    // make the changes real
+    m_picker_x = newX;
+    m_picker_y = newY;
+
     // determine where the canvas is in global coords
     QPoint canvasPos = sv_ui->spectrumPlot->canvas()->mapToGlobal(QPoint(0,0));
     // move the cursor to the correct position
@@ -333,6 +353,8 @@ bool SVConnections::eventFilter(QObject *object, QEvent *event)
     // consume the event
     return true;
   }
+
+  // don't filter the event
   return false;
 }
 

--- a/Code/Mantid/MantidQt/SpectrumViewer/src/TrackingPicker.cpp
+++ b/Code/Mantid/MantidQt/SpectrumViewer/src/TrackingPicker.cpp
@@ -40,7 +40,7 @@ void TrackingPicker::HideReadout( bool hide )
  */
 QwtText TrackingPicker::trackerText( const QPoint & point ) const
 {
-  emit mouseMoved();
+  emit mouseMoved(point);
   if ( hide_readout )
   {
     return QwtText();
@@ -60,7 +60,7 @@ QwtText TrackingPicker::trackerText( const QPoint & point ) const
  */
 QwtText TrackingPicker::trackerText( const QwtDoublePoint & pos ) const
 {
-  emit mouseMoved();
+  emit mouseMoved(pos.toPoint());
   if ( hide_readout )
   {
     return QwtText();


### PR DESCRIPTION
This is a pull request for [trac #7896](http://trac.mantidproject.org/mantid/ticket/7896).

**To test:**
- Load data
- View in spectrum viewer
- Use the arrow keys to update the pointed at position in the data. You will have to click somewhere on the main image to start things off.
