### PR TITLE
Feature/10228 rhel7 rpm depends

### DIFF
--- a/Code/Mantid/Build/CMake/LinuxSetup.cmake
+++ b/Code/Mantid/Build/CMake/LinuxSetup.cmake
@@ -97,9 +97,15 @@ if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" )
 							             "  ln -s $RPM_INSTALL_PREFIX0/${BIN_DIR}/launch_mantidplot.sh $RPM_INSTALL_PREFIX0/${BIN_DIR}/MantidPlot\n"
                                                                      "fi\n"
 	)
-	file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh "#!/bin/sh\n"
-								      "scl enable mantidlibs \"${CMAKE_INSTALL_PREFIX}/${BIN_DIR}/MantidPlot_exe $*\" \n"
+        if ( "${UNIX_CODENAME}" MATCHES "Santiago" ) # el6
+            file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh "#!/bin/sh\n"
+	           "scl enable mantidlibs \"${CMAKE_INSTALL_PREFIX}/${BIN_DIR}/MantidPlot_exe $*\" \n"
 	)
+        else ()
+            file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh "#!/bin/sh\n"
+	           "LD_LIBRARY_PATH=/usr/lib64/paraview:${LD_LIBRARY_PATH} ${CMAKE_INSTALL_PREFIX}/${BIN_DIR}/MantidPlot_exe $* \n"
+	)
+	endif()
 
     install ( FILES  ${CMAKE_CURRENT_BINARY_DIR}/launch_mantidplot.sh
           DESTINATION ${BIN_DIR}

--- a/Code/Mantid/CMakeLists.txt
+++ b/Code/Mantid/CMakeLists.txt
@@ -184,13 +184,20 @@ if ( ENABLE_CPACK )
       message ( STATUS " CPACK_PACKAGE_FILE_NAME = ${CPACK_PACKAGE_FILE_NAME}" )
 
       # rhel requirements
-      set ( CPACK_RPM_PACKAGE_REQUIRES "boost >= 1.34.1,qt4 >= 4.2,nexus,nexus-python,qwt,gsl,glibc,qwtplot3d-qt4,muParser,numpy" )
-      # OpenCASCADE changed names when packaged for Fedora 20
-      if( "${UNIX_CODENAME}" MATCHES "Heisenbug" )
+      set ( CPACK_RPM_PACKAGE_REQUIRES "boost >= 1.34.1,qt4 >= 4.2,nexus,nexus-python,gsl,glibc,qwtplot3d-qt4,muParser,numpy" )
+      # OpenCASCADE changed names when packaged for Fedora 20 and RHEL7
+      if( "${UNIX_CODENAME}" MATCHES "Heisenbug" OR "${UNIX_CODENAME}" MATCHES "Maipo" )
         set( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},OCE-devel" )
       else()
         set( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},OpenCASCADE-libs-modelling >= 6.3.0,OpenCASCADE-libs-foundation >= 6.3.0,OpenCASCADE-libs-visualization >= 6.3.0,OpenCASCADE-libs-ocaf >= 6.3.0,OpenCASCADE-libs-ocaf-lite >= 6.3.0" )
       endif()
+      # Qwt is qwt5-qt4 in RHEL7
+      if( "${UNIX_CODENAME}" MATCHES "Maipo" )
+        set( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},qwt5-qt4" )
+      else()
+        set( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},qwt" )
+      endif()
+
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},poco-crypto,poco-data,poco-mysql,poco-sqlite,poco-odbc,poco-util,poco-xml,poco-zip,poco-net,poco-netssl,poco-foundation,PyQt4,sip" )
       set ( CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES},python-ipython >= 1.1.0" )
       # scipy & matplotlib


### PR DESCRIPTION
This was originally [trac #10228](http://trac.mantidproject.org/mantid/ticket/10228)

Tester: ISIS required a test version of Mantid for RHEL7 in short order. To facilitate this a mantidlibs-paraview rpm has been created and placed [here](http://files.mantidproject.org/kits/el7/beta/). A repo for el7 is still in the process of being created. The installation will also require the current testing mantid [copr repo](https://copr.fedoraproject.org/coprs/sic/mantid/repo/epel-7/sic-mantid-epel-7.repo).
