### PR TITLE
CheckWorkspacesMatch returns 'did not match' when comparing a workspace to itself

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
@@ -842,10 +842,10 @@ bool CheckWorkspacesMatch::checkRunProperties(const API::Run& run1, const API::R
     PARALLEL_START_INTERUPT_REGION
     if (matched)
     {
-      if ( *(ws1logs[i]) != *(ws1logs[i]))
+      if ( *(ws1logs[i]) != *(ws2logs[i]))
       {
         matched = false;
-        result = "Log value mismatch";
+        result = "Log mismatch";
       }
     }
     PARALLEL_END_INTERUPT_REGION

--- a/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
@@ -836,8 +836,9 @@ bool CheckWorkspacesMatch::checkRunProperties(const API::Run& run1, const API::R
   
   // Now loop over the individual logs
   bool matched(true);
+  int64_t length(static_cast<int64_t>(ws1logs.size()));
   PARALLEL_FOR_IF(true)
-  for ( size_t i = 0; i < ws1logs.size(); ++i )
+  for ( int64_t i = 0; i < length; ++i )
   {
     PARALLEL_START_INTERUPT_REGION
     if (matched)

--- a/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
@@ -488,7 +488,6 @@ bool CheckWorkspacesMatch::compareEventWorkspaces(DataObjects::EventWorkspace_co
   }
   else
   {
-    result = "Success!";
     wsmatch = true;
   }
 
@@ -836,27 +835,23 @@ bool CheckWorkspacesMatch::checkRunProperties(const API::Run& run1, const API::R
   }
   
   // Now loop over the individual logs
+  bool matched(true);
+  PARALLEL_FOR_IF(true)
   for ( size_t i = 0; i < ws1logs.size(); ++i )
   {
-    // Check the log name
-    if ( ws1logs[i]->name() != ws2logs[i]->name() )
+    PARALLEL_START_INTERUPT_REGION
+    if (matched)
     {
-      g_log.debug() << "WS1 log " << i << " name: " << ws1logs[i]->name() << "\n";
-      g_log.debug() << "WS2 log " << i << " name: " << ws2logs[i]->name() << "\n";
-      result = "Log name mismatch";
-      return false;
+      if ( *(ws1logs[i]) != *(ws1logs[i]))
+      {
+        matched = false;
+        result = "Log value mismatch";
+      }
     }
-    
-    // Now check the log entry itself, using the method that gives it back as a string
-    if ( ws1logs[i]->value() != ws2logs[i]->value() )
-    {
-      g_log.debug() << "WS1 log " << ws1logs[i]->name() << ": " << ws1logs[i]->value() << "\n";
-      g_log.debug() << "WS2 log " << ws2logs[i]->name() << ": " << ws2logs[i]->value() << "\n";
-      result = "Log value mismatch";
-      return false;
-    }
+    PARALLEL_END_INTERUPT_REGION
   }
-  return true;
+  PARALLEL_CHECK_INTERUPT_REGION
+  return matched;
 }
 
 //------------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/Algorithms/test/CheckWorkspacesMatchTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/CheckWorkspacesMatchTest.h
@@ -688,7 +688,7 @@ public:
     TS_ASSERT_THROWS_NOTHING( checker.setProperty("Workspace2",ws3) );
     
     TS_ASSERT( checker.execute() );
-    TS_ASSERT_EQUALS( checker.getPropertyValue("Result"), "Log name mismatch" );
+    TS_ASSERT_EQUALS( checker.getPropertyValue("Result"), "Log mismatch" );
     
     Mantid::API::MatrixWorkspace_sptr ws4 = WorkspaceCreationHelper::Create2DWorkspace123(2,2);
     ws4->mutableRun().addLogData(new Mantid::Kernel::PropertyWithValue<int>("Prop1",100));
@@ -697,7 +697,7 @@ public:
     TS_ASSERT_THROWS_NOTHING( checker.setProperty("Workspace2",ws4) );
     
     TS_ASSERT( checker.execute() );
-    TS_ASSERT_EQUALS( checker.getPropertyValue("Result"), "Log value mismatch" );
+    TS_ASSERT_EQUALS( checker.getPropertyValue("Result"), "Log mismatch" );
   }
 
   void test_Input_With_Two_Groups_That_Are_The_Same_Matches()

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/Property.h
@@ -217,8 +217,13 @@ private:
   bool m_remember;
 };
 
-  /// Return the name corresponding to the mangled string given by typeid
-  MANTID_KERNEL_DLL std::string getUnmangledTypeName(const std::type_info& type);
+/// Compares this to another property for equality
+MANTID_KERNEL_DLL bool operator==( const Mantid::Kernel::Property & lhs, const Mantid::Kernel::Property & rhs );
+/// Compares this to another property for inequality
+MANTID_KERNEL_DLL bool operator!=( const Mantid::Kernel::Property & lhs, const Mantid::Kernel::Property & rhs );
+
+/// Return the name corresponding to the mangled string given by typeid
+MANTID_KERNEL_DLL std::string getUnmangledTypeName(const std::type_info& type);
 
 } // namespace Kernel
 } // namespace Mantid

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -331,6 +331,28 @@ public:
     return toString(m_value);
   }
 
+  /**
+   * Deep comparison.
+   * @param right The other property to compare to.
+   * @return true if the are equal.
+   */
+  virtual bool operator==(const PropertyWithValue<TYPE> & rhs) const
+  {
+    if (this->name() != rhs.name())
+      return false;
+    return (m_value == rhs.m_value);
+  }
+
+  /**
+   * Deep comparison (not equal).
+   * @param right The other property to compare to.
+   * @return true if the are not equal.
+   */
+  virtual bool operator!=(const PropertyWithValue<TYPE> & rhs) const
+  {
+    return !(*this == rhs);
+  }
+
   /** Get the size of the property.
   */
   virtual int size() const

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -158,6 +158,10 @@ namespace Mantid
       virtual bool operator==( const TimeSeriesProperty<TYPE> & right ) const;
       ///Deep comparison (not equal).
       virtual bool operator!=(const TimeSeriesProperty<TYPE> & right ) const;
+      /// Deep comparison
+      virtual bool operator==( const Property & right ) const;
+      ///Deep comparison (not equal).
+      virtual bool operator!=(const Property & right ) const;
 
       /// Set name of property
       void setName(const std::string name);

--- a/Code/Mantid/Framework/Kernel/src/Property.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Property.cpp
@@ -4,6 +4,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/IPropertySettings.h"
 #include "MantidKernel/PropertyHistory.h"
+#include "MantidKernel/TimeSeriesProperty.h"
 
 #include <map>
 #include <sstream>
@@ -312,6 +313,50 @@ namespace DataObjects
 
 namespace Kernel
 {
+
+/**
+ * @param lhs Thing on the left
+ * @param rhs Thing on the right
+ * @return true if they are equal
+ */
+bool operator==( const Property & lhs, const Property & rhs )
+{
+  if (lhs.name() != rhs.name())
+    return false;
+  if (lhs.type() != rhs.type())
+    return false;
+
+  // check for TimeSeriesProperty specializations
+  auto lhs_tsp_float = dynamic_cast<const TimeSeriesProperty<float> *>(&lhs);
+  if (lhs_tsp_float)
+    return lhs_tsp_float->operator==(rhs);
+
+  auto lhs_tsp_double = dynamic_cast<const TimeSeriesProperty<double> *>(&lhs);
+  if (lhs_tsp_double)
+    return lhs_tsp_double->operator==(rhs);
+
+  auto lhs_tsp_string = dynamic_cast<const TimeSeriesProperty<std::string> *>(&lhs);
+  if (lhs_tsp_string)
+    return lhs_tsp_string->operator==(rhs);
+
+  auto lhs_tsp_bool = dynamic_cast<const TimeSeriesProperty<bool> *>(&lhs);
+  if (lhs_tsp_bool)
+    return lhs_tsp_bool->operator==(rhs);
+
+  // use fallthrough behavior
+  return (lhs.value() == rhs.value());
+}
+
+/**
+ * @param lhs Thing on the left
+ * @param rhs Thing on the right
+ * @return true if they are not equal
+ */
+bool operator!=( const Property & lhs, const Property & rhs )
+{
+  return (!(lhs == rhs));
+}
+
 /**
  * Get the unmangled name of the given typestring for some common types that we use. Note that
  * this is just a lookup and NOT an unmangling algorithm

--- a/Code/Mantid/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -146,6 +146,20 @@ namespace Mantid
     }
 
     /**
+     * Deep comparison.
+     * @param right The other property to compare to.
+     * @return true if the are equal.
+     */
+    template<typename TYPE>
+    bool TimeSeriesProperty<TYPE>::operator==( const Property & right ) const
+    {
+      auto rhs_tsp = dynamic_cast<const TimeSeriesProperty<TYPE> *>(&right);
+      if (!rhs_tsp)
+        return false;
+      return this->operator==(*rhs_tsp);
+    }
+
+    /**
      * Deep comparison (not equal).
      * @param right The other property to compare to.
      * @return true if the are not equal.
@@ -156,7 +170,18 @@ namespace Mantid
       return !(*this == right);
     }
 
-    /*
+    /**
+     * Deep comparison (not equal).
+     * @param right The other property to compare to.
+     * @return true if the are not equal.
+     */
+    template<typename TYPE>
+    bool TimeSeriesProperty<TYPE>::operator!=( const Property & right ) const
+    {
+      return !(*this == right);
+    }
+
+    /**
      * Set name of the property
      */
     template <typename TYPE>


### PR DESCRIPTION
This is closing [trac #10311](http://trac.mantidproject.org/mantid/ticket/10311).

**To test:** Try loading a file twice (two different workspace names) and compare them. The result should be that they are the same.
