### PR TITLE
Refs #10363. silence warnings from glu* and openssl

### DIFF
--- a/Code/Mantid/Build/CMake/DarwinSetup.cmake
+++ b/Code/Mantid/Build/CMake/DarwinSetup.cmake
@@ -84,6 +84,7 @@ set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=c++0x" )
 set ( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++0x" )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++" )
   set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register" )
   set ( CMAKE_XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS "-Wno-deprecated-register")
   set ( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
@@ -120,8 +121,16 @@ if (OSX_VERSION VERSION_LESS 10.9)
  set ( SITEPACKAGES /Library/Python/${PY_VER}/site-packages )
 else()
  # Assume we are using homebrew for now
+ # set Deployment target to 10.8
+ set ( CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk )
+ set ( CMAKE_OSX_ARCHITECTURES x86_64 )
+ set ( CMAKE_OSX_DEPLOYMENT_TARGET 10.8 )
  set ( PYQT4_PYTHONPATH /usr/local/lib/python${PY_VER}/site-packages/PyQt4 )
  set ( SITEPACKAGES /usr/local/lib/python${PY_VER}/site-packages )
+ # use homebrew OpenSSL package
+ EXEC_PROGRAM( brew ARGS info openssl | grep openssl: | cut -c 17-22 OUTPUT_VARIABLE _openssl_version )
+ MESSAGE(STATUS "OpenSSL version: ${_openssl_version}")
+ set ( OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/${_openssl_version}/ )
 endif()
 
 # Python packages

--- a/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -1,4 +1,4 @@
-#ifndef @MULTIPLYDIVIDETEST_CLASS@_H
+#ifndef @MULTIPLYDIVIDETEST_CLASS@_H_
 #define @MULTIPLYDIVIDETEST_CLASS@_H_
 
 #include <cxxtest/TestSuite.h>
@@ -980,4 +980,4 @@ public:
 };
 
 
-#endif /*MULTIPLYTEST_H_ or DIVIDETEST_H*/
+#endif /*MULTIPLYTEST_H_ or DIVIDETEST_H_*/


### PR DESCRIPTION
Currently building mantid on OS X 10.9 with clang generates two deprecation warnings (-Wdeprecated-declarations).

1) "glu\* is deprecated. First deprecated in OS X 10.9." I silenced this warning by making the build target 10.8.

2) Apple's OpenSSL library is deprecated since OS X 10.7. I fixed this by linking against Homebrew's OpenSSL library.

For testing, I would suggest building mantid and verifying that 1)  it is linking against Homebrew's openssl library and 2) you aren't seeing -Wdeprecated-declarations warnings from either glut and openssl.  

http://trac.mantidproject.org/mantid/ticket/10363
