### PR TITLE
Refs #10387. OPENSSL_ROOT_DIR now points to homebrew opt directory

### DIFF
--- a/Code/Mantid/Build/CMake/DarwinSetup.cmake
+++ b/Code/Mantid/Build/CMake/DarwinSetup.cmake
@@ -128,9 +128,7 @@ else()
  set ( PYQT4_PYTHONPATH /usr/local/lib/python${PY_VER}/site-packages/PyQt4 )
  set ( SITEPACKAGES /usr/local/lib/python${PY_VER}/site-packages )
  # use homebrew OpenSSL package
- EXEC_PROGRAM( brew ARGS info openssl | grep openssl: | cut -c 17-22 OUTPUT_VARIABLE _openssl_version )
- MESSAGE(STATUS "OpenSSL version: ${_openssl_version}")
- set ( OPENSSL_ROOT_DIR /usr/local/Cellar/openssl/${_openssl_version}/ )
+ set ( OPENSSL_ROOT_DIR /usr/local/opt/openssl )
 endif()
 
 # Python packages


### PR DESCRIPTION
OPENSSL_ROOT_DIR should point to /usr/local/opt/openssl rather than to a specific version in the cellar. This way the build will continue to function after homebrew updates openssl and deletes the older version. 

testing: code review and make sure it still builds on OS X Mavericks + clang

http://trac.mantidproject.org/mantid/ticket/10387
