### PR TITLE
Refs #10439 Update FindPyQt.py and FindPyQt4.cmake from kdelibs.

### DIFF
--- a/Code/Mantid/Build/CMake/FindPyQt.py
+++ b/Code/Mantid/Build/CMake/FindPyQt.py
@@ -1,25 +1,48 @@
 # Copyright (c) 2007, Simon Edwards <simon@simonzone.com>
+# Copyright (c) 2014, Raphael Kubo da Costa <rakuco@FreeBSD.org>
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
-import PyQt4.pyqtconfig
+import PyQt4.QtCore
+import os
+import sys
 
-pyqtcfg = PyQt4.pyqtconfig.Configuration()
-print("pyqt_version:%06.0x" % pyqtcfg.pyqt_version)
-print("pyqt_version_str:%s" % pyqtcfg.pyqt_version_str)
-
-pyqt_version_tag = ""
-in_t = False
-for item in pyqtcfg.pyqt_sip_flags.split(' '):
-    if item=="-t":
-        in_t = True
-    elif in_t:
-        if item.startswith("Qt_4"):
-            pyqt_version_tag = item
+def get_default_sip_dir():
+    # This is based on QScintilla's configure.py, and only works for the
+    # default case where installation paths have not been changed in PyQt's
+    # configuration process.
+    if sys.platform == 'win32':
+        pyqt_sip_dir = os.path.join(sys.platform, 'sip', 'PyQt4')
     else:
-        in_t = False
-print("pyqt_version_tag:%s" % pyqt_version_tag)
+        pyqt_sip_dir = os.path.join(sys.platform, 'share', 'sip', 'PyQt4')
+    return pyqt_sip_dir
 
-print("pyqt_sip_dir:%s" % pyqtcfg.pyqt_sip_dir)
-print("pyqt_sip_flags:%s" % pyqtcfg.pyqt_sip_flags)
+def get_qt4_tag(sip_flags):
+    in_t = False
+    for item in sip_flags.split(' '):
+        if item == '-t':
+            in_t = True
+        elif in_t:
+            if item.startswith('Qt_4'):
+                return item
+        else:
+            in_t = False
+    raise ValueError('Cannot find Qt\'s tag in PyQt4\'s SIP flags.')
 
+if __name__ == '__main__':
+    try:
+        import PyQt4.pyqtconfig
+        pyqtcfg = PyQt4.pyqtconfig.Configuration()
+        sip_dir = pyqtcfg.pyqt_sip_dir
+        sip_flags = pyqtcfg.pyqt_sip_flags
+    except ImportError:
+        # PyQt4 >= 4.10.0 was built with configure-ng.py instead of
+        # configure.py, so pyqtconfig.py is not installed.
+        sip_dir = get_default_sip_dir()
+        sip_flags = PyQt4.QtCore.PYQT_CONFIGURATION['sip_flags']
+
+    print('pyqt_version:%06.x' % PyQt4.QtCore.PYQT_VERSION)
+    print('pyqt_version_str:%s' % PyQt4.QtCore.PYQT_VERSION_STR)
+    print('pyqt_version_tag:%s' % get_qt4_tag(sip_flags))
+    print('pyqt_sip_dir:%s' % sip_dir)
+    print('pyqt_sip_flags:%s' % sip_flags)

--- a/Code/Mantid/Build/CMake/FindPyQt4.cmake
+++ b/Code/Mantid/Build/CMake/FindPyQt4.cmake
@@ -9,16 +9,20 @@
 # Find the installed version of PyQt4. FindPyQt4 should only be called after
 # Python has been found.
 #
-# This file defines the following variables:
+# This file defines the following variables, which can also be overriden by
+# users:
 #
 # PYQT4_VERSION - The version of PyQt4 found expressed as a 6 digit hex number
-#     suitable for comparision as a string
+#     suitable for comparison as a string
 #
 # PYQT4_VERSION_STR - The version of PyQt4 as a human readable string.
 #
-# PYQT4_VERSION_TAG - The PyQt version tag using by PyQt's sip files.
+# PYQT4_VERSION_TAG - The Qt4 version tag used by PyQt's sip files.
 #
-# PYQT4_SIP_DIR - The directory holding the PyQt4 .sip files.
+# PYQT4_SIP_DIR - The directory holding the PyQt4 .sip files. This can be unset
+# if PyQt4 was built using its new build system and pyqtconfig.py is not
+# present on the system, as in this case its value cannot be determined
+# automatically.
 #
 # PYQT4_SIP_FLAGS - The SIP flags used to build PyQt.
 
@@ -30,19 +34,38 @@ ELSE(EXISTS PYQT4_VERSION)
   FIND_FILE(_find_pyqt_py FindPyQt.py PATHS ${CMAKE_MODULE_PATH})
 
   EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} ${_find_pyqt_py} OUTPUT_VARIABLE pyqt_config)
-  IF( NOT ${pyqt_config} MATCHES "Traceback" )
-    STRING(REGEX REPLACE "^pyqt_version:([^\n]+).*$" "\\1" PYQT4_VERSION ${pyqt_config})
-    STRING(REGEX REPLACE ".*\npyqt_version_str:([^\n]+).*$" "\\1" PYQT4_VERSION_STR ${pyqt_config})
-    STRING(REGEX REPLACE ".*\npyqt_version_tag:([^\n]+).*$" "\\1" PYQT4_VERSION_TAG ${pyqt_config})
-    STRING(REGEX REPLACE ".*\npyqt_sip_dir:([^\n]+).*$" "\\1" PYQT4_SIP_DIR ${pyqt_config})
-    STRING(REGEX REPLACE ".*\npyqt_sip_flags:([^\n]+).*$" "\\1" PYQT4_SIP_FLAGS ${pyqt_config})
+  IF(pyqt_config)
+    STRING(REGEX MATCH "^pyqt_version:([^\n]+).*$" _dummy ${pyqt_config})
+    SET(PYQT4_VERSION "${CMAKE_MATCH_1}" CACHE STRING "PyQt4's version as a 6-digit hexadecimal number")
 
-    SET(PYQT4_FOUND TRUE)
-  ENDIF()
+    STRING(REGEX MATCH ".*\npyqt_version_str:([^\n]+).*$" _dummy ${pyqt_config})
+    SET(PYQT4_VERSION_STR "${CMAKE_MATCH_1}" CACHE STRING "PyQt4's version as a human-readable string")
 
-  include ( FindPackageHandleStandardArgs )
-  find_package_handle_standard_args ( PyQt4 DEFAULT_MSG PYQT4_VERSION )
+    STRING(REGEX MATCH ".*\npyqt_version_tag:([^\n]+).*$" _dummy ${pyqt_config})
+    SET(PYQT4_VERSION_TAG "${CMAKE_MATCH_1}" CACHE STRING "The Qt4 version tag used by PyQt4's .sip files")
 
-  mark_as_advanced ( _find_pyqt_py )
+    STRING(REGEX MATCH ".*\npyqt_sip_dir:([^\n]+).*$" _dummy ${pyqt_config})
+    SET(PYQT4_SIP_DIR "${CMAKE_MATCH_1}" CACHE FILEPATH "The base directory where PyQt4's .sip files are installed")
+
+    STRING(REGEX MATCH ".*\npyqt_sip_flags:([^\n]+).*$" _dummy ${pyqt_config})
+    SET(PYQT4_SIP_FLAGS "${CMAKE_MATCH_1}" CACHE STRING "The SIP flags used to build PyQt4")
+
+    IF(NOT IS_DIRECTORY "${PYQT4_SIP_DIR}")
+      MESSAGE(WARNING "The base directory where PyQt4's SIP files are installed could not be determined. This usually means PyQt4 was built with its new build system and pyqtconfig.py is not present.\n"
+                      "Please set the PYQT4_SIP_DIR variable manually.")
+    ELSE(NOT IS_DIRECTORY "${PYQT4_SIP_DIR}")
+      SET(PYQT4_FOUND TRUE)
+    ENDIF(NOT IS_DIRECTORY "${PYQT4_SIP_DIR}")
+  ENDIF(pyqt_config)
+
+  IF(PYQT4_FOUND)
+    IF(NOT PYQT4_FIND_QUIETLY)
+      MESSAGE(STATUS "Found PyQt4 version: ${PYQT4_VERSION_STR}")
+    ENDIF(NOT PYQT4_FIND_QUIETLY)
+  ELSE(PYQT4_FOUND)
+    IF(PYQT4_FIND_REQUIRED)
+      MESSAGE(FATAL_ERROR "Could not find Python")
+    ENDIF(PYQT4_FIND_REQUIRED)
+  ENDIF(PYQT4_FOUND)
 
 ENDIF(EXISTS PYQT4_VERSION)


### PR DESCRIPTION
Trac ticket [#10439](http://trac.mantidproject.org/mantid/ticket/10439).

FindPyQt.py should optionally use PyQt4.QtCore.PYQT_CONFIGURATION in order to determine version and pyqt_sip_flags.

This change is just taken from https://projects.kde.org/projects/kde/kdelibs/repository/revisions/a7e47438d4e3469dc9df70d613826cb360fc8d19

**To Test**: Does cmake still find PyQt4? Good.
