### PR TITLE
fix performance of geometry test

### DIFF
--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -10,7 +10,7 @@
 #include "MantidGeometry/Objects/BoundingBox.h"
 #include "MantidKernel/Cache.h"
 
-#include <boost/unordered_map.hpp>
+#include <map>
 #include <vector>
 #include <typeinfo>
 
@@ -54,19 +54,19 @@ namespace Geometry
     File change history is stored at: <https://github.com/mantidproject/mantid>.
     Code Documentation is available at: <http://doxygen.mantidproject.org>
   */
-   /// Parameter map iterator typedef
-   typedef boost::unordered_multimap<const ComponentID,boost::shared_ptr<Parameter> >::iterator component_map_it;
-   typedef boost::unordered_multimap<const ComponentID,boost::shared_ptr<Parameter> >::const_iterator component_map_cit;
+  /// Parameter map iterator typedef
+  typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::iterator component_map_it;
+  typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::const_iterator component_map_cit;
 
   class MANTID_GEOMETRY_DLL ParameterMap
   {
   public:
     /// Parameter map typedef
-    typedef boost::unordered_multimap<const ComponentID,boost::shared_ptr<Parameter> > pmap;
+      typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> > pmap;
     /// Parameter map iterator typedef
-    typedef boost::unordered_multimap<const ComponentID,boost::shared_ptr<Parameter> >::iterator pmap_it;
+      typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::iterator pmap_it;
     /// Parameter map iterator typedef
-    typedef boost::unordered_multimap<const ComponentID,boost::shared_ptr<Parameter> >::const_iterator pmap_cit;
+      typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::const_iterator pmap_cit;
     /// Default constructor
     ParameterMap();
     /// Returns true if the map is empty, false otherwise

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Instrument/ParameterMap.h
@@ -62,11 +62,11 @@ namespace Geometry
   {
   public:
     /// Parameter map typedef
-      typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> > pmap;
+    typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> > pmap;
     /// Parameter map iterator typedef
-      typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::iterator pmap_it;
+    typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::iterator pmap_it;
     /// Parameter map iterator typedef
-      typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::const_iterator pmap_cit;
+    typedef std::multimap<const ComponentID,boost::shared_ptr<Parameter> >::const_iterator pmap_cit;
     /// Default constructor
     ParameterMap();
     /// Returns true if the map is empty, false otherwise

--- a/Code/Mantid/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -616,8 +616,8 @@ namespace Mantid
       pmap_cit it_found = m_map.find(id);
       if(it_found != m_map.end())
       {
-        pmap_cit itr, itr_end;
-        std::tie(itr,itr_end) = m_map.equal_range(id);
+        pmap_cit itr = m_map.lower_bound(id);
+        pmap_cit itr_end = m_map.upper_bound(id);
         for(; itr != itr_end; ++itr)
         {
           const Parameter_sptr & param = itr->second;
@@ -680,8 +680,8 @@ namespace Mantid
           pmap_it it_found = m_map.find(id);
           if (it_found != m_map.end())
           {
-            pmap_it itr, itr_end;
-            std::tie(itr,itr_end) = m_map.equal_range(id);
+            pmap_it itr = m_map.lower_bound(id);
+            pmap_it itr_end = m_map.upper_bound(id);
             for( ; itr != itr_end; ++itr )
             {
               Parameter_sptr param = itr->second;
@@ -713,8 +713,8 @@ namespace Mantid
           pmap_cit it_found = m_map.find(id);
           if (it_found != m_map.end())
           {
-            pmap_cit itr, itr_end;
-            std::tie(itr,itr_end) = m_map.equal_range(id);
+            pmap_cit itr = m_map.lower_bound(id);
+            pmap_cit itr_end = m_map.upper_bound(id);
             for( ; itr != itr_end; ++itr )
             {
               Parameter_sptr param = itr->second;
@@ -749,8 +749,8 @@ namespace Mantid
           {
              if (it_found->first)
              {
-                pmap_cit itr, itr_end;
-                std::tie(itr,itr_end) = m_map.equal_range(id);
+                pmap_cit itr = m_map.lower_bound(id);
+                pmap_cit itr_end = m_map.upper_bound(id);
                 for( ; itr != itr_end; ++itr )
                 {
                     Parameter_sptr param = itr->second;
@@ -864,8 +864,8 @@ namespace Mantid
         return paramNames;
       }
 
-      pmap_cit itr, itr_end;
-      std::tie(itr,itr_end) = m_map.equal_range(id);
+      pmap_cit itr = m_map.lower_bound(id);
+      pmap_cit itr_end = m_map.upper_bound(id);
       for(pmap_cit it = itr; it != itr_end; ++it)
       {
         paramNames.insert(it->second->name());

--- a/Code/Mantid/Framework/Geometry/src/Instrument/ParameterMap.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument/ParameterMap.cpp
@@ -617,7 +617,7 @@ namespace Mantid
       if(it_found != m_map.end())
       {
         pmap_cit itr, itr_end;
-        boost::tie(itr,itr_end) = m_map.equal_range(id);
+        std::tie(itr,itr_end) = m_map.equal_range(id);
         for(; itr != itr_end; ++itr)
         {
           const Parameter_sptr & param = itr->second;
@@ -681,7 +681,7 @@ namespace Mantid
           if (it_found != m_map.end())
           {
             pmap_it itr, itr_end;
-            boost::tie(itr,itr_end) = m_map.equal_range(id);
+            std::tie(itr,itr_end) = m_map.equal_range(id);
             for( ; itr != itr_end; ++itr )
             {
               Parameter_sptr param = itr->second;
@@ -714,7 +714,7 @@ namespace Mantid
           if (it_found != m_map.end())
           {
             pmap_cit itr, itr_end;
-            boost::tie(itr,itr_end) = m_map.equal_range(id);
+            std::tie(itr,itr_end) = m_map.equal_range(id);
             for( ; itr != itr_end; ++itr )
             {
               Parameter_sptr param = itr->second;
@@ -750,7 +750,7 @@ namespace Mantid
              if (it_found->first)
              {
                 pmap_cit itr, itr_end;
-                boost::tie(itr,itr_end) = m_map.equal_range(id);
+                std::tie(itr,itr_end) = m_map.equal_range(id);
                 for( ; itr != itr_end; ++itr )
                 {
                     Parameter_sptr param = itr->second;
@@ -865,7 +865,7 @@ namespace Mantid
       }
 
       pmap_cit itr, itr_end;
-      boost::tie(itr,itr_end) = m_map.equal_range(id);
+      std::tie(itr,itr_end) = m_map.equal_range(id);
       for(pmap_cit it = itr; it != itr_end; ++it)
       {
         paramNames.insert(it->second->name());


### PR DESCRIPTION
This [ticket](http://trac.mantidproject.org/mantid/ticket/10487) investigated a performance regression introduced in [performance build 527](https://github.com/mantidproject/mantid/commit/f94f814ce5e1d89785aece20fa280c2963b94b40). I changed back from boost::unordered_multimap to std::multimap and performance appears to have improved slightly. 

For testing, I think a code review is sufficient. 
