### PR TITLE
Add sstream header to NetworkProxyWin

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/NetworkProxyWin.cpp
+++ b/Code/Mantid/Framework/Kernel/src/NetworkProxyWin.cpp
@@ -2,6 +2,9 @@
 #if defined(_WIN32) || defined(_WIN64)
 
 #include "MantidKernel/NetworkProxy.h"
+// std
+#include <sstream>
+// windows
 #include <windows.h>
 #include <Winhttp.h>
 


### PR DESCRIPTION
Fixes issue [#10494](http://trac.mantidproject.org/mantid/ticket/10494)

Tester: Check http://builds.mantidproject.org/view/Develop%20Builds/job/develop_clean_win7_debug/. It now builds but one of the tests is failing. However, the failing test is related to [#10494](http://trac.mantidproject.org/mantid/ticket/10482) and will be fixed there.
