### PR TITLE
Feature/10507 fix clang warnings

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/IPowderDiffPeakFunction.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IPowderDiffPeakFunction.h
@@ -151,11 +151,6 @@ protected:
 
   size_t LATTICEINDEX;
   size_t HEIGHTINDEX;
-
-private:
-  /// Peak intensity
-  double m_intensity;
-
 };
 
 typedef boost::shared_ptr<IPowderDiffPeakFunction> IPowderDiffPeakFunction_sptr;

--- a/Code/Mantid/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Code/Mantid/Framework/API/test/WorkspaceFactoryTest.h
@@ -61,8 +61,15 @@ public:
     MatrixWorkspace_sptr space;
     TS_ASSERT_THROWS_NOTHING( space = WorkspaceFactory::Instance().create("work",1,1,1) );
     // AppleClang gives warning if the result is unused.
-    WorkspaceTester* useMe;
-    TS_ASSERT_THROWS_NOTHING( useMe = dynamic_cast<WorkspaceTester*>(space.get()) );
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+      TS_ASSERT_THROWS_NOTHING(dynamic_cast<WorkspaceTester*>(space.get()) );
+#if __clang__
+#pragma clang diagnostic pop
+#endif
+  
   }
 
   /** Make a parent, have the child be created with the same sizes */

--- a/Code/Mantid/Framework/API/test/WorkspaceFactoryTest.h
+++ b/Code/Mantid/Framework/API/test/WorkspaceFactoryTest.h
@@ -60,7 +60,9 @@ public:
     WorkspaceFactory::Instance().subscribe<WorkspaceTester>("work");
     MatrixWorkspace_sptr space;
     TS_ASSERT_THROWS_NOTHING( space = WorkspaceFactory::Instance().create("work",1,1,1) );
-    TS_ASSERT_THROWS_NOTHING( dynamic_cast<WorkspaceTester*>(space.get()) );
+    // AppleClang gives warning if the result is unused.
+    WorkspaceTester* useMe;
+    TS_ASSERT_THROWS_NOTHING( useMe = dynamic_cast<WorkspaceTester*>(space.get()) );
   }
 
   /** Make a parent, have the child be created with the same sizes */

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/CreateCalFileByNames.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/CreateCalFileByNames.h
@@ -91,8 +91,6 @@ private:
   std::string groups;
   /// Calibration map used if the *.cal file exist. All entries in the *.cal file are registered with the udet number as the key and the <Number,Offset,Select,Group> as the tuple value.
   instrcalmap instrcalib;
-  /// Number of groups
-  int group_no;
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/CreateDummyCalFile.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/CreateDummyCalFile.h
@@ -87,8 +87,6 @@ private:
   std::string groups;
   /// Calibration map used if the *.cal file exist. All entries in the *.cal file are registered with the udet number as the key and the <Number,Offset,Select,Group> as the tuple value.
   instrcalmap instrcalib;
-  /// Number of groups
-  int group_no;
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ExtractMaskToTable.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ExtractMaskToTable.h
@@ -87,13 +87,6 @@ namespace Algorithms
 
     /// Input workspace type
     bool m_inputIsMask;
-
-    /// Minimum X range
-    double m_XMin;
-
-    /// Maximum X range
-    double m_XMax;
-    
   };
 
 

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/NormaliseByCurrent.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/NormaliseByCurrent.h
@@ -71,9 +71,6 @@ private:
   void exec();
   // Extract the charge value from the logs.
   double extractCharge(boost::shared_ptr<Mantid::API::MatrixWorkspace> inputWs) const;
-  /// Progress reporting
-  API::Progress* m_progress;
-  
 };
 
 } // namespace Algorithm

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SmoothNeighbours.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SmoothNeighbours.h
@@ -128,12 +128,6 @@ private:
   static const std::string RECTANGULAR_GROUP;
   /// Input workspace name
   static const std::string INPUT_WORKSPACE;
-
-  /// Pixels in the detector
-  int XPixels;
-  /// Pixels in the detector
-  int YPixels;
-
   /// Number to sum
   int AdjX;
   /// Number to sum

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SumNeighbours.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SumNeighbours.h
@@ -62,12 +62,6 @@ private:
   // Overridden Algorithm methods
   void init();
   void exec();
-
-  /// Pixels in the detector
-  int XPixels;
-  /// Pixels in the detector
-  int YPixels;
-
   /// Number to sum
   int SumX;
   /// Number to sum

--- a/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CheckWorkspacesMatch.cpp
@@ -390,11 +390,9 @@ bool CheckWorkspacesMatch::compareEventWorkspaces(DataObjects::EventWorkspace_co
   size_t numUnequalBothEvents = 0;
 
   std::vector<int> vec_mismatchedwsindex;
-  bool condition = m_ParallelComparison && ews1->threadSafe()  &&  ews2->threadSafe() ;
-  PARALLEL_FOR_IF(condition)
+  PARALLEL_FOR_IF(m_ParallelComparison && ews1->threadSafe()  &&  ews2->threadSafe())
   for (int i=0; i<static_cast<int>(ews1->getNumberHistograms()); ++i)
-  for (int i=0; i<static_cast<int>(ews1->getNumberHistograms()); i++)
-  {   
+  {
     PARALLEL_START_INTERUPT_REGION
     prog->report("EventLists");
     if (!mismatchedEvent || checkallspectra) // This guard will avoid checking unnecessarily
@@ -527,8 +525,7 @@ bool CheckWorkspacesMatch::checkData(API::MatrixWorkspace_const_sptr ws1, API::M
   bool resultBool = true;
 
   // Now check the data itself
-  bool condition = m_ParallelComparison && ws1->threadSafe()  &&  ws2->threadSafe() ;
-  PARALLEL_FOR_IF(condition)
+  PARALLEL_FOR_IF(m_ParallelComparison && ws1->threadSafe()  &&  ws2->threadSafe())
   for ( long i = 0; i < static_cast<long>(numHists); ++i )
   {
     PARALLEL_START_INTERUPT_REGION

--- a/Code/Mantid/Framework/Algorithms/src/CreateCalFileByNames.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateCalFileByNames.cpp
@@ -32,7 +32,7 @@ namespace Mantid
     using API::FileProperty;
     using Geometry::Instrument_const_sptr;
 
-    CreateCalFileByNames::CreateCalFileByNames():API::Algorithm(),group_no(0)
+    CreateCalFileByNames::CreateCalFileByNames():API::Algorithm()
     {
     }
 

--- a/Code/Mantid/Framework/Algorithms/src/CreateDummyCalFile.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateDummyCalFile.cpp
@@ -45,7 +45,7 @@ namespace Mantid
     using namespace Geometry;
     using namespace DataObjects;
 
-    CreateDummyCalFile::CreateDummyCalFile():API::Algorithm(),group_no(0)
+    CreateDummyCalFile::CreateDummyCalFile():API::Algorithm()
     {
     }
 

--- a/Code/Mantid/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -28,47 +28,6 @@ namespace Mantid
 {
 namespace Algorithms
 {
-  namespace
-  { // anonymous name space
-    /**
-   * Determine if the table contains raw parameters.
-   */
-    bool isRawTable(const std::vector<std::string> & colNames)
-    {
-      if (colNames.size() != 6)
-        return true;
-      if (colNames[0].compare("centre") != 0)
-        return true;
-      if (colNames[1].compare("width") != 0)
-        return true;
-      if (colNames[2].compare("height") != 0)
-        return true;
-      if (colNames[3].compare("backgroundintercept") != 0)
-        return true;
-      if (colNames[4].compare("backgroundslope") != 0)
-        return true;
-      if (colNames[5].compare("A2") != 0)
-        return true;
-      return false;
-    }
-
-    /**
-    * Determine how many parameters are in the peak function.
-   */
-    std::size_t getBkgOffset(const std::vector<std::string> & colNames, const bool isRaw)
-    {
-      if (!isRaw)
-        return 3;
-
-      for (std::size_t i = 0; i < colNames.size(); i++)
-      {
-        if (colNames[i].substr(0,3).compare("f1.") == 0)
-          return i;
-      }
-      return colNames.size(); // shouldn't get here
-    }
-  }
-
   DECLARE_ALGORITHM(GeneratePeaks)
 
   //----------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Code/Mantid/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -1678,8 +1678,7 @@ namespace Mantid
            workspaceIndex= wi_to_detid_map.find(DetID)->second;
         else
         {
-         g_log.error("No workspaceIndex for detID="+DetID);
-         throw  std::runtime_error("No workspaceIndex for detID="+DetID);
+          throw std::runtime_error("No workspaceIndex for detID="+boost::lexical_cast<std::string>(DetID));
         }
 
 

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/CalculateMSVesuvio.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/CalculateMSVesuvio.h
@@ -127,7 +127,6 @@ namespace Mantid
       Kernel::V3D m_beamDir; // Directional vector for beam
       double m_srcR2; // beam penumbra radius (m)
       double m_halfSampleHeight, m_halfSampleWidth, m_halfSampleThick; // (m)
-      double m_maxWidthSampleFrame; // Maximum width in sample frame (m)
       Geometry::Object const *m_sampleShape; // sample shape
       SampleComptonProperties *m_sampleProps; // description of sample properties
       double m_detHeight, m_detWidth, m_detThick; // (m)

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DampingMinimizer.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DampingMinimizer.h
@@ -58,8 +58,6 @@ public:
 private:
   /// Pointer to the cost function. Must be the least squares.
   boost::shared_ptr<CostFuncLeastSquares> m_leastSquares;
-  /// Relative tolerance.
-  double m_relTol;
   /// The damping mu parameter in the Levenberg-Marquardt method.
   //double m_damping;
 };

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DampingMinimizer.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DampingMinimizer.h
@@ -44,7 +44,7 @@ class DLLExport DampingMinimizer : public API::IFuncMinimizer
 {
 public:
   /// Constructor
-  DampingMinimizer();
+  DampingMinimizer(double relTol = 0.0001);
   /// Name of the minimizer.
   std::string name() const {return "DampingMinimizer";}
 
@@ -58,6 +58,8 @@ public:
 private:
   /// Pointer to the cost function. Must be the least squares.
   boost::shared_ptr<CostFuncLeastSquares> m_leastSquares;
+  /// Relative tolerance.
+  double m_relTol;
   /// The damping mu parameter in the Levenberg-Marquardt method.
   //double m_damping;
 };

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/FullprofPolynomial.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/FullprofPolynomial.h
@@ -70,12 +70,6 @@ namespace CurveFitting
 
     /// Background origin position
     double m_bkpos;
-
-    /// Lower x boundary.
-    double m_StartX;
-
-    /// Upper x boundary
-    double m_EndX;
   };
 
   typedef boost::shared_ptr<FullprofPolynomial> FullprofPolynomial_sptr;

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/Polynomial.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/Polynomial.h
@@ -69,12 +69,6 @@ namespace CurveFitting
 
     /// Polynomial order
     int m_n;
-
-    /// Lower x boundary.
-    double m_StartX;
-
-    /// Upper x boundary
-    double m_EndX;
   };
 
   typedef boost::shared_ptr<Polynomial> Polynomial_sptr;

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/UserFunction1D.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/UserFunction1D.h
@@ -67,7 +67,7 @@ namespace Mantid
       {
       public:
           /// Constructor
-          UserFunction1D():m_x_set(false),m_parameters(new double[100]),m_buffSize(100),m_nPars(0) {};
+          UserFunction1D():m_x_set(false),m_parameters(new double[100]),m_nPars(0) {};
           /// Destructor
           virtual ~UserFunction1D() {};
           /// Algorithm's name for identification overriding a virtual method
@@ -99,8 +99,6 @@ namespace Mantid
           bool m_x_set;
           /// Pointer to muParser variables' buffer
           boost::shared_array<double> m_parameters;
-          /// Size of the variables' buffer
-          const int m_buffSize;
           /// Number of actual parameters
           int m_nPars;
           /// Temporary data storage

--- a/Code/Mantid/Framework/CurveFitting/src/CalculateMSVesuvio.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/CalculateMSVesuvio.cpp
@@ -51,7 +51,7 @@ namespace Mantid
       m_randgen(NULL),
       m_acrossIdx(0), m_upIdx(1), m_beamIdx(3), m_beamDir(), m_srcR2(0.0),
       m_halfSampleHeight(0.0), m_halfSampleWidth(0.0), m_halfSampleThick(0.0),
-      m_maxWidthSampleFrame(0.0), m_sampleShape(NULL), m_sampleProps(NULL),
+      m_sampleShape(NULL), m_sampleProps(NULL),
       m_detHeight(-1.0), m_detWidth(-1.0), m_detThick(-1.0),
       m_tmin(-1.0), m_tmax(-1.0), m_delt(-1.0), m_foilRes(-1.0),
       m_nscatters(0), m_nruns(0), m_nevents(0),

--- a/Code/Mantid/Framework/CurveFitting/src/DampingMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DampingMinimizer.cpp
@@ -30,8 +30,7 @@ DECLARE_FUNCMINIMIZER(DampingMinimizer,Damping)
 
 /// Constructor
 DampingMinimizer::DampingMinimizer():
-IFuncMinimizer(),
-m_relTol(1e-6)
+IFuncMinimizer()
 {
   declareProperty("Damping",0.0,"The damping parameter.");
 }

--- a/Code/Mantid/Framework/CurveFitting/src/DampingMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DampingMinimizer.cpp
@@ -29,8 +29,8 @@ DECLARE_FUNCMINIMIZER(DampingMinimizer,Damping)
 
 
 /// Constructor
-DampingMinimizer::DampingMinimizer():
-IFuncMinimizer()
+DampingMinimizer::DampingMinimizer(double relTol):
+IFuncMinimizer(), m_relTol(relTol)
 {
   declareProperty("Damping",0.0,"The damping parameter.");
 }
@@ -113,8 +113,7 @@ bool DampingMinimizer::iterate(size_t)
   GSLVector p(n);
   m_leastSquares->getParameters(p);
   double dx_norm = gsl_blas_dnrm2(dx.gsl());
-  //double p_norm = gsl_blas_dnrm2(p.gsl());
-  if (dx_norm < 0.0001)
+  if (dx_norm < m_relTol)
   {
     return false;
   }

--- a/Code/Mantid/Framework/CurveFitting/src/Fit.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/Fit.cpp
@@ -45,12 +45,7 @@ namespace CurveFitting
   // Register the class into the algorithm factory
   DECLARE_ALGORITHM(Fit)
 
-    using API::IDomainCreator;
-
-  namespace
-  {
-    bool isStringEmpty(const std::string& str){return str.empty();}
-  }
+  using API::IDomainCreator;
   
   /**
    * Examine "Function" and "InputWorkspace" properties to decide which domain creator to use.

--- a/Code/Mantid/Framework/CurveFitting/src/FitMW.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/FitMW.cpp
@@ -35,7 +35,7 @@ namespace
   {
   public:
     /// Constructor
-    SimpleJacobian(size_t nData,size_t nParams):m_nData(nData),m_nParams(nParams),m_data(nData*nParams){}
+    SimpleJacobian(size_t nData,size_t nParams):m_nParams(nParams),m_data(nData*nParams){}
     /// Setter
     virtual void set(size_t iY, size_t iP, double value)
     {
@@ -47,7 +47,6 @@ namespace
       return m_data[iY * m_nParams + iP];
     }
   private:
-    size_t m_nData; ///< size of the data / first dimension
     size_t m_nParams; ///< number of parameters / second dimension
     std::vector<double> m_data; ///< data storage
   };

--- a/Code/Mantid/Framework/CurveFitting/src/LeBailFit.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/LeBailFit.cpp
@@ -26,12 +26,10 @@ const int CALDATAINDEX(1);
 const int DATADIFFINDEX(2);
 const int CALPUREPEAKINDEX(3);
 const int CALBKGDINDEX(4); // Output workspace background at ws index 4
-const int INPUTCALDATAINDEX(5);
 const int INPUTBKGDINDEX(6);  // Input background
 const int INPUTPUREPEAKINDEX(7);  // Output workspace:  pure peak (data with background removed)
 const int SMOOTHEDBKGDINDEX(8); //  Smoothed background
 
-const double NEG_DBL_MAX(-1.*DBL_MAX);
 const double NOBOUNDARYLIMIT(1.0E10);
 const double EPSILON(1.0E-10);
 

--- a/Code/Mantid/Framework/CurveFitting/src/LeBailFunction.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/LeBailFunction.cpp
@@ -22,7 +22,6 @@ namespace CurveFitting
 {
   namespace
   {
-    const int PEAKRADIUS = 8;
     const double PEAKRANGECONSTANT = 5.0;
 
     const string CHEBYSHEV_BACKGROUND("Chebyshev");

--- a/Code/Mantid/Framework/CurveFitting/src/SimplexMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/SimplexMinimizer.cpp
@@ -99,7 +99,7 @@ bool SimplexMinimizer::iterate(size_t)
     return false;
   }
   double size = gsl_multimin_fminimizer_size(m_gslSolver);
-  status = gsl_multimin_test_size(size, 1e-6);
+  status = gsl_multimin_test_size(size,m_epsabs);
   if (status != GSL_CONTINUE)
   {
     m_errorString = gsl_strerror(status);

--- a/Code/Mantid/Framework/CurveFitting/test/UserFunctionTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/UserFunctionTest.h
@@ -16,11 +16,11 @@ public:
 
   class UserTestJacobian: public Jacobian
   {
-    int m_nData,m_nParams;
+    int m_nParams;
     std::vector<double> m_buffer;
   public:
     UserTestJacobian(int nData,int nParams)
-      :m_nData(nData),m_nParams(nParams)
+      : m_nParams(nParams)
     {
       m_buffer.resize(nData*nParams);
     }

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadRaw3.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadRaw3.h
@@ -121,8 +121,6 @@ namespace Mantid
 
       /// Read in the time bin boundaries
       int64_t m_lengthIn;
-      /// boolean for list spectra options
-      bool m_bmspeclist;
       /// time channels vector
       std::vector<boost::shared_ptr<MantidVec> > m_timeChannelsVec;
       /// total number of specs

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadRawBin0.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadRawBin0.h
@@ -108,8 +108,6 @@ namespace Mantid
 
       /// Read in the time bin boundaries
       int64_t m_lengthIn;
-      /// boolean for list spectra options
-      bool m_bmspeclist;
       /// TimeSeriesProperty<int> containing data periods.
       boost::shared_ptr<Kernel::Property> m_perioids;
 

--- a/Code/Mantid/Framework/DataHandling/src/Load.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/Load.cpp
@@ -43,29 +43,6 @@ namespace
   }
 
   /**
-   * Helper function that takes a vector of runs, and generates a suggested workspace name.
-   * This will likely need to be improved and may have to include instrument name, etc.
-   *
-   * @param runs :: a vector of run numbers.
-   *
-   * @returns a string containing a suggested ws name based on the given run numbers.
-   */
-  std::string generateWsNameFromRuns(std::vector<unsigned int> runs)
-  {
-    std::string wsName("");
-
-    for(size_t i = 0; i < runs.size(); ++i)
-    {
-      if(!wsName.empty())
-        wsName += "_";
-
-      wsName += boost::lexical_cast<std::string>(runs[i]);
-    }
-
-    return wsName;
-  }
-
-  /**
    * Helper function that takes a vector of filenames, and generates a suggested workspace name.
    *
    * @param filenames :: a vector of filenames.

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -115,7 +115,6 @@ namespace Mantid
       * @param alg :: LoadEventNexus
       * @param entry_name :: name of the bank
       * @param prog :: Progress reporter
-      * @param scheduler :: ThreadScheduler running this task
       * @param event_id :: array with event IDs
       * @param event_time_of_flight :: array with event TOFS
       * @param numEvents :: how many events in the arrays

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -139,7 +139,7 @@ namespace Mantid
         detid_t min_event_id, detid_t max_event_id)
         : Task(), alg(alg), entry_name(entry_name), pixelID_to_wi_vector(alg->pixelID_to_wi_vector),
         pixelID_to_wi_offset(alg->pixelID_to_wi_offset),
-        prog(prog), scheduler(scheduler),
+        prog(prog),
         event_id(event_id), event_time_of_flight(event_time_of_flight), numEvents(numEvents), startAt(startAt),
         event_index(event_index),
         thisBankPulseTimes(thisBankPulseTimes), have_weight(have_weight),
@@ -391,8 +391,6 @@ namespace Mantid
       detid_t pixelID_to_wi_offset;
       /// Progress reporting
       Progress * prog;
-      /// ThreadScheduler running this task
-      ThreadScheduler * scheduler;
       /// event pixel ID array
       boost::shared_array<uint32_t> event_id;
       /// event TOF array
@@ -444,7 +442,6 @@ namespace Mantid
         Progress * prog, boost::shared_ptr<Mutex> ioMutex, ThreadScheduler * scheduler)
         : Task(),
         alg(alg), entry_name(entry_name), entry_type(entry_type),
-        pixelID_to_wi_vector(alg->pixelID_to_wi_vector), pixelID_to_wi_offset(alg->pixelID_to_wi_offset),
         // prog(prog), scheduler(scheduler), thisBankPulseTimes(NULL), m_loadError(false),
         prog(prog), scheduler(scheduler), m_loadError(false),
         m_oldNexusFileNames(oldNeXusFileNames), m_loadStart(), m_loadSize(), m_event_id(NULL),
@@ -919,10 +916,6 @@ namespace Mantid
       std::string entry_name;
       /// NXS type
       std::string entry_type;
-      /// Vector where (index = pixel ID+pixelID_to_wi_offset), value = workspace index)
-      const std::vector<size_t> & pixelID_to_wi_vector;
-      /// Offset in the pixelID_to_wi_vector to use.
-      detid_t pixelID_to_wi_offset;
       /// Progress reporting
       Progress * prog;
       /// ThreadScheduler running this task

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -129,7 +129,7 @@ namespace Mantid
       * @return
       */
       ProcessBankData(LoadEventNexus * alg, std::string entry_name,
-        Progress * prog, ThreadScheduler * scheduler,
+        Progress * prog,
         boost::shared_array<uint32_t> event_id,
         boost::shared_array<float> event_time_of_flight,
         size_t numEvents, size_t startAt,
@@ -878,14 +878,14 @@ namespace Mantid
         if (alg->splitProcessing)
           mid_id = (m_max_id + m_min_id) / 2;
 
-        ProcessBankData * newTask1 = new ProcessBankData(alg, entry_name, prog,scheduler,
+        ProcessBankData * newTask1 = new ProcessBankData(alg, entry_name, prog,
           event_id_shrd, event_time_of_flight_shrd, numEvents, startAt, event_index_shrd,
           thisBankPulseTimes, m_have_weight, event_weight_shrd,
           m_min_id, mid_id);
         scheduler->push(newTask1);
         if (alg->splitProcessing)
         {
-          ProcessBankData * newTask2 = new ProcessBankData(alg, entry_name, prog,scheduler,
+          ProcessBankData * newTask2 = new ProcessBankData(alg, entry_name, prog,
             event_id_shrd, event_time_of_flight_shrd, numEvents, startAt, event_index_shrd,
             thisBankPulseTimes, m_have_weight, event_weight_shrd,
             (mid_id+1), m_max_id);

--- a/Code/Mantid/Framework/DataHandling/src/LoadRaw/isisraw.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRaw/isisraw.cpp
@@ -8,7 +8,7 @@
 #define FAILURE 1
 
 /// stuff
-ISISRAW::ISISRAW() : m_crpt(0), m_ntc1(0), m_nsp1(0), m_nper(0),dat1(0)
+ISISRAW::ISISRAW() : m_crpt(0),dat1(0)
 {
 	int i, j;
 	// section 1
@@ -139,7 +139,7 @@ int ISISRAW::addItems()
 
 // create one bound to a CRPT
 /// stuff
-ISISRAW::ISISRAW(ISISCRPT_STRUCT* crpt) : m_crpt(crpt),m_ntc1(0),m_nsp1(0), m_nper(0),
+ISISRAW::ISISRAW(ISISCRPT_STRUCT* crpt) : m_crpt(crpt),
     frmt_ver_no(0),data_format(0),ver2(0),r_number(0),ver3(0),
     i_det(0),i_mon(0),i_use(0),mdet(0),monp(0),spec(0),delt(0),len2(0),code(0),tthe(0),ut(0),
     ver4(0),ver5(0),crat(0),modn(0),mpos(0),timr(0),udet(0),ver6(0),t_ntrg(0),t_nfpp(0),t_nper(0),
@@ -164,7 +164,7 @@ ISISRAW::ISISRAW(ISISCRPT_STRUCT* crpt) : m_crpt(crpt),m_ntc1(0),m_nsp1(0), m_np
 
 // create one bound to a CRPT
 /// stuff
-ISISRAW::ISISRAW(ISISCRPT_STRUCT* crpt, bool doUpdateFromCRPT) : m_crpt(crpt),m_ntc1(0),m_nsp1(0), m_nper(0),
+ISISRAW::ISISRAW(ISISCRPT_STRUCT* crpt, bool doUpdateFromCRPT) : m_crpt(crpt),
     frmt_ver_no(0),data_format(0),ver2(0),r_number(0),ver3(0),
     i_det(0),i_mon(0),i_use(0),mdet(0),monp(0),spec(0),delt(0),len2(0),code(0),tthe(0),ut(0),
     ver4(0),ver5(0),crat(0),modn(0),mpos(0),timr(0),udet(0),ver6(0),t_ntrg(0),t_nfpp(0),t_nper(0),

--- a/Code/Mantid/Framework/DataHandling/src/LoadRaw/isisraw.h
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRaw/isisraw.h
@@ -275,11 +275,6 @@ class ISISRAW
 {
 private:
 	ISISCRPT_STRUCT* m_crpt; ///< CRPT from ICP
-// these are used for caching on updates
-	int m_ntc1;	///< dunno
-	int m_nsp1;	///< dunno
-	int m_nper;	///< dunno
-
 	item_struct<char> m_char_items;	///< dunno
 	item_struct<float> m_real_items;	///< dunno
 	item_struct<int> m_int_items;	///< dunno

--- a/Code/Mantid/Framework/DataHandling/src/LoadRawBin0.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRawBin0.cpp
@@ -33,7 +33,7 @@ using namespace API;
 /// Constructor
 LoadRawBin0::LoadRawBin0() :
    m_filename(), m_numberOfSpectra(0),
-   m_specTimeRegimes(), m_prog(0.0), m_bmspeclist(false)
+   m_specTimeRegimes(), m_prog(0.0)
 {
 }
 

--- a/Code/Mantid/Framework/DataHandling/src/SaveAscii.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveAscii.cpp
@@ -122,13 +122,13 @@ namespace Mantid
         bool ice = getProperty("ICEFormat");
         if (ice)
         {
-        	// overwrite properties so file can be read by ICE
-        	errstr = "Y";
-        	errstr2 = "_error";
-        	comstr = ", ";
-        	writeHeader = true;
-        	write_dx = false;
-        	comment = "#features:";
+          // overwrite properties so file can be read by ICE
+          errstr = "Y";
+          errstr2 = "_error";
+          comstr = ", ";
+          writeHeader = true;
+          write_dx = false;
+          comment = "#features:";
         }
 
         // Create an spectra index list for output
@@ -137,22 +137,22 @@ namespace Mantid
         // Add spectra interval into the index list
         if (spec_max != EMPTY_INT() && spec_min != EMPTY_INT())
         {
-            if (spec_min >= nSpectra || spec_max >= nSpectra || spec_min > spec_max)
-                throw std::invalid_argument("Inconsistent spectra interval");
-            for(int spec=spec_min;spec<=spec_max;spec++)
-                    idx.insert(spec);
+          if (spec_min >= nSpectra || spec_max >= nSpectra || spec_min > spec_max)
+            throw std::invalid_argument("Inconsistent spectra interval");
+          for(int spec=spec_min;spec<=spec_max;spec++)
+            idx.insert(spec);
         }
 
         // Add spectra list into the index list
         if (!spec_list.empty())
         {
-            for(size_t i=0;i<spec_list.size();i++)
-            {
-                if (spec_list[i] >= nSpectra)
-                  throw std::invalid_argument("Inconsistent spectra list");
-                else
-                  idx.insert(spec_list[i]);
-            }
+          for(size_t i=0;i<spec_list.size();i++)
+          {
+            if (spec_list[i] >= nSpectra)
+              throw std::invalid_argument("Inconsistent spectra list");
+            else
+              idx.insert(spec_list[i]);
+          }
         }
         if (!idx.empty()) nSpectra = static_cast<int>(idx.size());
 

--- a/Code/Mantid/Framework/DataHandling/src/SaveAscii.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveAscii.cpp
@@ -145,11 +145,15 @@ namespace Mantid
 
         // Add spectra list into the index list
         if (!spec_list.empty())
+        {
             for(size_t i=0;i<spec_list.size();i++)
-                if (spec_list[i] >= nSpectra) throw std::invalid_argument("Inconsistent spectra list");
+            {
+                if (spec_list[i] >= nSpectra)
+                  throw std::invalid_argument("Inconsistent spectra list");
                 else
-                    idx.insert(spec_list[i]);
-
+                  idx.insert(spec_list[i]);
+            }
+        }
         if (!idx.empty()) nSpectra = static_cast<int>(idx.size());
 
         if (nBins == 0 || nSpectra == 0) throw std::runtime_error("Trying to save an empty workspace");

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryRenderer.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Rendering/GluGeometryRenderer.h
@@ -42,8 +42,6 @@ namespace Mantid
     */
     class MANTID_GEOMETRY_DLL GluGeometryRenderer
     {
-    private:
-      int                                                  mErrorCode; ///< The lastest error code
     public:
       GluGeometryRenderer();       ///< Constructor
       ~GluGeometryRenderer();      ///< Destructor

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Rendering/OCGeometryGenerator.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Rendering/OCGeometryGenerator.h
@@ -57,7 +57,6 @@ namespace Mantid
     private:                    
       const Object *Obj; ///< Input Object
       TopoDS_Shape* ObjSurface; ///< Storage for the output surface
-      int   iGridSize; ///< Grid size for sampling the object
       ///Analyze the object
       void AnalyzeObject();
       ///Analyze a geometry rule for n object rule

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Rendering/vtkGeometryCacheReader.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Rendering/vtkGeometryCacheReader.h
@@ -50,7 +50,6 @@ namespace Mantid
     private:
 
       Poco::XML::Document* mDoc;         ///< The XML document
-      Poco::XML::Element*  mRoot;        ///< The root XML element
       Poco::XML::DOMParser*  pParser;    ///< The XML parser
       std::string          mFileName;    ///< The file name
       //Private Methods

--- a/Code/Mantid/Framework/Geometry/src/Crystal/NiggliCell.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/NiggliCell.cpp
@@ -16,8 +16,6 @@ namespace Geometry
   using Mantid::Kernel::Matrix;
 
   namespace {
-  const double TWO_PI = 2.*M_PI;
-  const double DEG_TO_RAD = M_PI / 180.;
   const double RAD_TO_DEG = 180. / M_PI;
   }
   /**

--- a/Code/Mantid/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Math/Acomp.cpp
@@ -152,11 +152,8 @@ namespace Mantid
         return true;
 
       // Assume that comp Units are sorted.
-      std::vector<Acomp>::const_iterator acv,xcv;
-      acv=A.Comp.begin();
-      for(xcv=Comp.begin();xcv!=Comp.end() &&
-        *xcv==*acv ;++xcv,++acv);
-        return (xcv==Comp.end()) ? true : false;
+      return A.Comp==Comp;
+        
     }
 
     bool
@@ -1090,7 +1087,8 @@ namespace Mantid
         if (*dx>=0 && DNFscore[*dx]==1)        // EPI (definately)
         {
           for(px=PIactive.begin();
-            px!=PIactive.end() && !Grid[*px][*dx];++px);
+            px!=PIactive.end() && !Grid[*px][*dx];++px)
+              ;
 
             EPI.push_back(PIform[*px]);
           // remove all minterm that the EPI covered
@@ -1154,10 +1152,10 @@ namespace Mantid
 
           for(di=0;di<Dsize;di++)   //check each orignal position
           {
-            for(vecI=0;vecI<Icount &&
-              !Cmat[Index[vecI]][di];vecI++);
-              if (vecI==Icount)
-                break;
+            for(vecI=0;vecI<Icount &&!Cmat[Index[vecI]][di];vecI++)
+                ;
+            if (vecI==Icount)
+              break;
           }
           if (di==Dsize)          // SUCCESS!!!!!
           {

--- a/Code/Mantid/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Math/Acomp.cpp
@@ -1086,9 +1086,11 @@ namespace Mantid
       {
         if (*dx>=0 && DNFscore[*dx]==1)        // EPI (definately)
         {
-          for(px=PIactive.begin();
-            px!=PIactive.end() && !Grid[*px][*dx];++px)
-              ;
+          for(px=PIactive.begin();px!=PIactive.end();++px)
+          {
+           if(Grid[*px][*dx])
+              break;
+          }
 
             EPI.push_back(PIform[*px]);
           // remove all minterm that the EPI covered
@@ -1152,8 +1154,11 @@ namespace Mantid
 
           for(di=0;di<Dsize;di++)   //check each orignal position
           {
-            for(vecI=0;vecI<Icount &&!Cmat[Index[vecI]][di];vecI++)
-                ;
+            for(vecI=0;vecI<Icount;vecI++)
+            {
+              if(Cmat[Index[vecI]][di])
+                  break;
+            }
             if (vecI==Icount)
               break;
           }

--- a/Code/Mantid/Framework/Geometry/src/Surfaces/General.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Surfaces/General.cpp
@@ -8,8 +8,6 @@ namespace Mantid
 namespace Geometry
 {
 
-const double GTolerance(1e-6);  ///< Tolerance
-
 General::General() : Quadratic()
   /**
     Standard Constructor

--- a/Code/Mantid/Framework/Geometry/src/Surfaces/Sphere.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Surfaces/Sphere.cpp
@@ -101,10 +101,10 @@ namespace Mantid
       else if (item.length()==1)
       {
         int index;
-        for(index=0;index<3 && Mantid::Kernel::Strings::section(Line,cent[index]);
-          index++);
-          if (index!=3)
-            return -5;
+        for(index=0;index<3 && Mantid::Kernel::Strings::section(Line,cent[index]);index++)
+          ;
+        if (index!=3)
+          return -5;
       }
       else
         return -6;

--- a/Code/Mantid/Framework/Geometry/test/GroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/GroupTest.h
@@ -177,10 +177,13 @@ public:
 
         // Make sure that null-pointer do not work
         Group_const_sptr null;
+        
+        //AppleClang gives a warning if we don't use the result;
+        bool useResult;
 
         TS_ASSERT_THROWS(null * null, std::invalid_argument);
-        TS_ASSERT_THROWS(null == null, std::invalid_argument);
-        TS_ASSERT_THROWS(null != null, std::invalid_argument);
+        TS_ASSERT_THROWS(useResult = (null == null), std::invalid_argument);
+        TS_ASSERT_THROWS(useResult = (null != null), std::invalid_argument);
         TS_ASSERT_THROWS(three * null, std::invalid_argument);
         TS_ASSERT_THROWS(null * three, std::invalid_argument);
 

--- a/Code/Mantid/Framework/Geometry/test/GroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/GroupTest.h
@@ -177,13 +177,18 @@ public:
 
         // Make sure that null-pointer do not work
         Group_const_sptr null;
-        
-        //AppleClang gives a warning if we don't use the result;
-        bool useResult;
 
         TS_ASSERT_THROWS(null * null, std::invalid_argument);
-        TS_ASSERT_THROWS(useResult = (null == null), std::invalid_argument);
-        TS_ASSERT_THROWS(useResult = (null != null), std::invalid_argument);
+        //AppleClang gives a warning if we don't use the result
+#if __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-comparison"
+#endif
+        TS_ASSERT_THROWS(null == null, std::invalid_argument);
+        TS_ASSERT_THROWS(null != null, std::invalid_argument);
+#if __clang__
+#pragma clang diagnostic pop
+#endif
         TS_ASSERT_THROWS(three * null, std::invalid_argument);
         TS_ASSERT_THROWS(null * three, std::invalid_argument);
 

--- a/Code/Mantid/Framework/ISISLiveData/inc/MantidISISLiveData/TCPEventStreamDefs.h
+++ b/Code/Mantid/Framework/ISISLiveData/inc/MantidISISLiveData/TCPEventStreamDefs.h
@@ -43,10 +43,14 @@ struct TCPStreamEventHeader
 	static const uint32_t marker = 0xffffffff;  ///< magic value for marker1, marker2
 	TCPStreamEventHeader() : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(InvalidStream) { }
 	TCPStreamEventHeader(uint32_t type_) : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(type_) { }
+#if __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
 	bool isValid() const { return marker1 == marker && marker2 == marker && length >= sizeof(TCPStreamEventHeader) && majorVersion() == TCPStreamEventHeader::major_version && minorVersion() >= TCPStreamEventHeader::minor_version && type != InvalidStream; }
-#pragma clang diagnostic pop    
+#if __clang__
+#pragma clang diagnostic pop  
+#endif
 	static const uint32_t major_version = 1; ///< starts at 1, then incremented whenever layout of this or further packets changes in a non backward compatible way
 	static const uint32_t minor_version = 0; ///< reset to 0 in major version change, then incremented whenever layout of this or further packets changes in a backward compatible way
 	static const uint32_t current_version = (major_version << 16) | minor_version; ///< starts at 1, then incremented whenever layout of this or further packets changes

--- a/Code/Mantid/Framework/ISISLiveData/inc/MantidISISLiveData/TCPEventStreamDefs.h
+++ b/Code/Mantid/Framework/ISISLiveData/inc/MantidISISLiveData/TCPEventStreamDefs.h
@@ -43,7 +43,10 @@ struct TCPStreamEventHeader
 	static const uint32_t marker = 0xffffffff;  ///< magic value for marker1, marker2
 	TCPStreamEventHeader() : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(InvalidStream) { }
 	TCPStreamEventHeader(uint32_t type_) : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(type_) { }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
 	bool isValid() const { return marker1 == marker && marker2 == marker && length >= sizeof(TCPStreamEventHeader) && majorVersion() == TCPStreamEventHeader::major_version && minorVersion() >= TCPStreamEventHeader::minor_version && type != InvalidStream; }
+#pragma clang diagnostic pop    
 	static const uint32_t major_version = 1; ///< starts at 1, then incremented whenever layout of this or further packets changes in a non backward compatible way
 	static const uint32_t minor_version = 0; ///< reset to 0 in major version change, then incremented whenever layout of this or further packets changes in a backward compatible way
 	static const uint32_t current_version = (major_version << 16) | minor_version; ///< starts at 1, then incremented whenever layout of this or further packets changes

--- a/Code/Mantid/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -2717,67 +2717,6 @@ namespace
       return ret_val;
   } /* ddot_sl__ */
 
-  double dnrm1_(int *, double *x, int *i__, int *j)
-  {
-      /* Initialized data */
-
-      static double zero = 0.;
-      static double one = 1.;
-
-      /* System generated locals */
-      int i__1;
-      double ret_val, d__1, d__2, d__3;
-
-      /* Local variables */
-      static int k;
-      static double sum, temp, scale, snormx;
-
-      /* Parameter adjustments */
-      --x;
-
-      /* Function Body */
-  /*      DNRM1 - COMPUTES THE I-NORM OF A VECTOR */
-  /*              BETWEEN THE ITH AND THE JTH ELEMENTS */
-  /*      INPUT - */
-  /*      N       LENGTH OF VECTOR */
-  /*      X       VECTOR OF LENGTH N */
-  /*      I       INITIAL ELEMENT OF VECTOR TO BE USED */
-  /*      J       FINAL ELEMENT TO USE */
-  /*      OUTPUT - */
-  /*      DNRM1   NORM */
-      snormx = zero;
-      i__1 = *j;
-      for (k = *i__; k <= i__1; ++k) {
-  /* L10: */
-  /* Computing MAX */
-    d__2 = snormx, d__3 = (d__1 = x[k], std::abs(d__1));
-    snormx = std::max(d__2,d__3);
-      }
-      ret_val = snormx;
-      if (snormx == zero) {
-    return ret_val;
-      }
-      scale = snormx;
-      if (snormx >= one) {
-    scale = sqrt(snormx);
-      }
-      sum = zero;
-      i__1 = *j;
-      for (k = *i__; k <= i__1; ++k) {
-    temp = zero;
-    if ((d__1 = x[k], std::abs(d__1)) + scale != scale) {
-        temp = x[k] / snormx;
-    }
-    if (one + temp != one) {
-        sum += temp * temp;
-    }
-  /* L20: */
-      }
-      sum = sqrt(sum);
-      ret_val = snormx * sum;
-      return ret_val;
-  } /* dnrm1_ */
-
   double dnrm2___(int *n, double *dx, int *incx)
   {
       /* Initialized data */

--- a/Code/Mantid/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1388,8 +1388,8 @@ namespace Mantid
         else
         {
           // 3. Regular
-          DateAndTime startT = m_values[n].time();
-          DateAndTime endT = m_values[n+1].time();
+            DateAndTime startT = m_values[static_cast<std::size_t>(n)].time();
+            DateAndTime endT = m_values[static_cast<std::size_t>(n)+1].time();
           TimeInterval dt(startT, endT);
           deltaT = dt;
         }
@@ -1408,8 +1408,8 @@ namespace Mantid
         else if (static_cast<size_t>(n) == m_filterQuickRef.back().second+1)
         {
           // 2. n = size of the allowed region, duplicate the last one
-          size_t ind_t1 = m_filterQuickRef.back().first;
-          size_t ind_t2 = ind_t1-1;
+          long ind_t1 = static_cast<long>(m_filterQuickRef.back().first);
+          long ind_t2 = ind_t1-1;
           Kernel::DateAndTime t1 = (m_values.begin()+ind_t1)->time();
           Kernel::DateAndTime t2 = (m_values.begin()+ind_t2)->time();
           time_duration d = t1-t2;
@@ -1505,12 +1505,12 @@ namespace Mantid
         // 3. Situation 1:  No filter
         if (static_cast<size_t>(n) < m_values.size())
         {
-          TimeValueUnit<TYPE> entry = m_values[n];
+          TimeValueUnit<TYPE> entry = m_values[static_cast<std::size_t>(n)];
           value = entry.value();
         }
         else
         {
-          TimeValueUnit<TYPE> entry = m_values[m_size-1];
+          TimeValueUnit<TYPE> entry = m_values[static_cast<std::size_t>(m_size)-1];
           value = entry.value();
         }
       }
@@ -1536,7 +1536,7 @@ namespace Mantid
           {
             throw std::logic_error("Not consider out of boundary case here. ");
           }
-          size_t ilog = m_filterQuickRef[refindex+1].first + (n-m_filterQuickRef[refindex].second);
+          size_t ilog = m_filterQuickRef[refindex+1].first + (static_cast<std::size_t>(n)-m_filterQuickRef[refindex].second);
           value = m_values[ilog].value();
         } // END-IF-ELSE Cases
       }
@@ -1564,7 +1564,7 @@ namespace Mantid
       if (n < 0 || n >= static_cast<int>(m_values.size()))
         n = static_cast<int>(m_values.size())-1;
 
-      return m_values[n].time();
+      return m_values[static_cast<size_t>(n)].time();
     }
 
     /* Divide the property into  allowed and disallowed time intervals according to \a filter.
@@ -2015,7 +2015,7 @@ namespace Mantid
             {
               numintervals = m_filterQuickRef.back().second;
             }
-            if (m_filter[ift].first < m_values[icurlog].time())
+            if (m_filter[ift].first < m_values[static_cast<std::size_t>(icurlog)].time())
             {
               if (icurlog == 0)
               {

--- a/Code/Mantid/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
+++ b/Code/Mantid/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
@@ -43,7 +43,10 @@ struct TCPStreamEventHeader
 	static const uint32_t marker = 0xffffffff;  ///< magic value for marker1, marker2
 	TCPStreamEventHeader() : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(InvalidStream) { }
 	TCPStreamEventHeader(uint32_t type_) : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(type_) { }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wtautological-compare"
 	bool isValid() const { return marker1 == marker && marker2 == marker && length >= sizeof(TCPStreamEventHeader) && majorVersion() == TCPStreamEventHeader::major_version && minorVersion() >= TCPStreamEventHeader::minor_version && type != InvalidStream; }
+#pragma clang diagnostic pop
 	static const uint32_t major_version = 1; ///< starts at 1, then incremented whenever layout of this or further packets changes in a non backward compatible way
 	static const uint32_t minor_version = 0; ///< reset to 0 in major version change, then incremented whenever layout of this or further packets changes in a backward compatible way
 	static const uint32_t current_version = (major_version << 16) | minor_version; ///< starts at 1, then incremented whenever layout of this or further packets changes

--- a/Code/Mantid/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
+++ b/Code/Mantid/Framework/LiveData/inc/MantidLiveData/ISIS/TCPEventStreamDefs.h
@@ -43,10 +43,14 @@ struct TCPStreamEventHeader
 	static const uint32_t marker = 0xffffffff;  ///< magic value for marker1, marker2
 	TCPStreamEventHeader() : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(InvalidStream) { }
 	TCPStreamEventHeader(uint32_t type_) : marker1(marker), marker2(marker), version(current_version), length(sizeof(TCPStreamEventHeader)), type(type_) { }
+#if __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
+#endif
 	bool isValid() const { return marker1 == marker && marker2 == marker && length >= sizeof(TCPStreamEventHeader) && majorVersion() == TCPStreamEventHeader::major_version && minorVersion() >= TCPStreamEventHeader::minor_version && type != InvalidStream; }
+#if __clang__
 #pragma clang diagnostic pop
+#endif    
 	static const uint32_t major_version = 1; ///< starts at 1, then incremented whenever layout of this or further packets changes in a non backward compatible way
 	static const uint32_t minor_version = 0; ///< reset to 0 in major version change, then incremented whenever layout of this or further packets changes in a backward compatible way
 	static const uint32_t current_version = (major_version << 16) | minor_version; ///< starts at 1, then incremented whenever layout of this or further packets changes

--- a/Code/Mantid/Framework/MDAlgorithms/src/Quantification/Models/MullerAnsatz.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/Quantification/Models/MullerAnsatz.cpp
@@ -33,18 +33,18 @@ namespace Mantid
 
 
       /// Parameter names, same order as above
-      static char * PAR_NAMES[NPARAMS];
+      static const char * PAR_NAMES[NPARAMS];
       /// N attrs
       enum {NATTS = 3};
       /// Attribute names
-      static char * ATTR_NAMES[NATTS];
+      static const char * ATTR_NAMES[NATTS];
 
     };
     MullerAnsatz::MullerAnsatz():
       m_ChainDirection(Along_c),m_FFDirection(Isotropic)
     {}
-    char* AnsatzParameters::PAR_NAMES[AnsatzParameters::NPARAMS] = {"Amplitude","J_coupling"};
-    char* AnsatzParameters::ATTR_NAMES[AnsatzParameters::NATTS] = {"IonName","ChainDirection","MagneticFFDirection"};
+    const char* AnsatzParameters::PAR_NAMES[AnsatzParameters::NPARAMS] = {"Amplitude","J_coupling"};
+    const char* AnsatzParameters::ATTR_NAMES[AnsatzParameters::NATTS] = {"IonName","ChainDirection","MagneticFFDirection"};
     //static 
     /**
     * Initialize the model

--- a/Code/Mantid/Framework/MDAlgorithms/src/Quantification/Models/Strontium122.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/Quantification/Models/Strontium122.cpp
@@ -25,9 +25,6 @@ namespace Mantid
       const unsigned int NATTS = 2;
       /// Attribute names
       const char * ATTR_NAMES[NATTS] = { "MultEps", "TwinType" };
-
-      /// 2 \pi
-      const double TWO_PI = 2.*M_PI;
     }
     Strontium122::Strontium122():
       m_twinType(1),m_multEps(true)

--- a/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/MDHistoWorkspace.h
+++ b/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/MDHistoWorkspace.h
@@ -443,8 +443,6 @@ namespace MDEvents
     coord_t * m_origin;
     /// the number of events, contributed into the workspace;
     mutable uint64_t m_nEventsContributed;
-    /// The special coordinate system of the workspace.
-    Mantid::API::SpecialCoordinateSystem m_coordinateSystem;
   protected:
   
     /// Linear array of masks for each bin

--- a/Code/Mantid/Framework/Nexus/src/NexusClasses.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusClasses.cpp
@@ -169,7 +169,7 @@ void NXClass::readAllInfo()
 {
     clear();
     NXClassInfo info;
-    while(info = getNextEntry())
+    while((info = getNextEntry()))
     {
         if (info.nxclass == "SDS")
         {

--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/LoadFlexiNexus.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/LoadFlexiNexus.h
@@ -95,7 +95,6 @@ private:
   int safeOpenpath(NeXus::File *fin, std::string path);
   int calculateCAddress(int *pos, int* dim, int rank);
   int calculateF77Address(int *pos, int rank);
-  size_t *indexMaker;
 };
 
 #endif /*FLEXINEXUSLOADER_H_*/

--- a/Code/Mantid/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Code/Mantid/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -264,7 +264,7 @@ double LoadFlexiNexus::dblSqrt(double in)
 
 MDHistoDimension_sptr LoadFlexiNexus::makeDimension(NeXus::File *fin, int index, int length)
 {
-  static char *axisNames[] = {"x","y","z"};
+  static const char *axisNames[] = {"x","y","z"};
   std::map<std::string,std::string>::const_iterator it;
 
   // get a name

--- a/Code/Mantid/Framework/SINQ/src/SINQHMListener.cpp
+++ b/Code/Mantid/Framework/SINQ/src/SINQHMListener.cpp
@@ -104,7 +104,7 @@ ILiveListener::RunStatus SINQHMListener::runStatus()
 
 boost::shared_ptr<Workspace> SINQHMListener::extractData()
 {
-	static char *dimNames[] = {"x","y","z","t"};
+	static const char *dimNames[] = {"x","y","z","t"};
 
 	if(dimDirty){
 		runStatus(); //make sure that hmhost is initialized

--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/EQSANSDarkCurrentSubtraction.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/EQSANSDarkCurrentSubtraction.cpp
@@ -121,7 +121,7 @@ void EQSANSDarkCurrentSubtraction::exec()
     }
 
     std::string darkWSOutputName = getPropertyValue("OutputDarkCurrentWorkspace");
-    if (!darkWSOutputName.size()==0)
+    if (!(darkWSOutputName.size()==0))
       setProperty("OutputDarkCurrentWorkspace", darkWS);
     AnalysisDataService::Instance().addOrReplace(darkWSName, darkWS);
     reductionManager->declareProperty(new WorkspaceProperty<>(entryName,"",Direction::Output));

--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -9720,7 +9720,7 @@ void ApplicationWindow::closeEvent( QCloseEvent* ce )
 {
   if(scriptingWindow && scriptingWindow->isExecuting())
   {
-    if( ! QMessageBox::question(this, tr("MantidPlot"), "A script is still running, abort and quit application?", tr("Yes"), tr("No")) == 0 )
+    if( ! (QMessageBox::question(this, tr("MantidPlot"), "A script is still running, abort and quit application?", tr("Yes"), tr("No")) == 0) )
     {
       ce->ignore();
       return;

--- a/Code/Mantid/MantidPlot/src/Matrix.cpp
+++ b/Code/Mantid/MantidPlot/src/Matrix.cpp
@@ -946,7 +946,8 @@ void Matrix::print(const QString& fileName)
   // print header
   p.setFont(QFont());
   QString header_label = d_matrix_model->headerData(0, Qt::Horizontal).toString();
-  QRect br = p.boundingRect(br, Qt::AlignCenter, header_label);
+  QRect br;
+  br = p.boundingRect(br, Qt::AlignCenter, header_label);
   p.drawLine(right, height, right, height+br.height());
   QRect tr(br);
 

--- a/Code/Mantid/MantidPlot/src/PythonScript.cpp
+++ b/Code/Mantid/MantidPlot/src/PythonScript.cpp
@@ -59,7 +59,9 @@ namespace
     Q_UNUSED(arg);
     int retcode(0);
     if(event != PyTrace_LINE) return retcode;
-    PyObject_CallMethod(scriptObj, "lineNumberChanged", "O i", frame->f_code->co_filename, frame->f_lineno);
+      std::string str1 = "lineNumberChanged";
+      std::string str2 = "O i";
+    PyObject_CallMethod(scriptObj,&str1[0],&str2[0], frame->f_code->co_filename, frame->f_lineno);
     return retcode;
   }
 

--- a/Code/Mantid/MantidPlot/src/Table.cpp
+++ b/Code/Mantid/MantidPlot/src/Table.cpp
@@ -230,7 +230,8 @@ void Table::print(const QString& fileName)
 
   // print header
   p.setFont(hHeader->font());
-  QRect br=p.boundingRect(br,Qt::AlignCenter,	hHeader->label(0));
+  QRect br;
+  br=p.boundingRect(br,Qt::AlignCenter,	hHeader->label(0));
   p.drawLine(right,height,right,height+br.height());
   QRect tr(br);
 

--- a/Code/Mantid/MantidPlot/src/origin/OPJFile.cpp
+++ b/Code/Mantid/MantidPlot/src/origin/OPJFile.cpp
@@ -2346,7 +2346,7 @@ void OPJFile::readGraphInfo(FILE *f, FILE *debug)
 
           fseek(f,LAYER+0x19,SEEK_SET);
           fread(&h,1,1,f);
-          if(h >= 0x64 && h < 0x1F4)
+          if(h >= 0x64)
           {
             col=findDataByIndex(nColY - 1 + h - 0x64);
             if(col.size()>0)

--- a/Code/Mantid/MantidPlot/src/pixmaps.cpp
+++ b/Code/Mantid/MantidPlot/src/pixmaps.cpp
@@ -12786,7 +12786,7 @@ static const char * managefolders_xpm[] = {
 
 
 /* TiledWindow icon */
-static char * tiledwindow_xpm[] = {
+static const char * tiledwindow_xpm[] = {
 "15 16 5 1",
 " 	c None",
 ".	c #000000",

--- a/Code/Mantid/MantidQt/API/src/FilePropertyWidget.cpp
+++ b/Code/Mantid/MantidQt/API/src/FilePropertyWidget.cpp
@@ -119,7 +119,7 @@ namespace API
           filter.append(QString::fromStdString(*itr) + " (*" + QString::fromStdString(*itr) + ");;");
         }
       }
-      filter.trimmed();
+      filter = filter.trimmed();
     }
     filter.append("All Files (*.*)");
     return filter;

--- a/Code/Mantid/MantidQt/API/src/UserSubWindow.cpp
+++ b/Code/Mantid/MantidQt/API/src/UserSubWindow.cpp
@@ -133,7 +133,7 @@ QString UserSubWindow::openFileDialog(const bool save, const QStringList &exts)
     {
       filter.append("*." + exts[i] + " ");
     }
-    filter.trimmed();
+    filter = filter.trimmed();
   }
   filter.append(";;All Files (*.*)");
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/IndirectDataReduction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/IndirectDataReduction.ui
@@ -1785,7 +1785,7 @@ Later steps in the process (saving, renaming) will not be done.</string>
       <attribute name="title">
        <string>Symmetrise</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_15">
+      <layout class="QVBoxLayout" name="verticalLayout_151">
        <item>
         <widget class="QGroupBox" name="gbSymmInput">
          <property name="title">
@@ -1876,7 +1876,7 @@ Later steps in the process (saving, renaming) will not be done.</string>
          <property name="title">
           <string>Output</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
+         <layout class="QHBoxLayout" name="horizontalLayout1">
           <property name="margin">
            <number>6</number>
           </property>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflWindow.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflWindow.ui
@@ -362,8 +362,6 @@
     </item>
    </layout>
    <zorder>splitterTables</zorder>
-   <zorder></zorder>
-   <zorder></zorder>
   </widget>
   <widget class="QMenuBar" name="menuBar">
    <property name="geometry">

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/CreateMDWorkspace.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/CreateMDWorkspace.cpp
@@ -208,7 +208,7 @@ void CreateMDWorkspace::findUBMatrixClicked()
 
     command = command.arg(args);
     // Run peak indexing
-    runPythonCode(command).trimmed();
+    runPythonCode(command);
   }
   catch(std::invalid_argument& ex)
   {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Homer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Homer.cpp
@@ -393,7 +393,7 @@ QString Homer::openFileDia(const bool save, const QStringList &exts)
     {
       filter.append("*." + exts[i] + " ");
     }
-    filter.trimmed();
+    filter = filter.trimmed();
   }
   filter.append(";;All Files (*.*)");
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/IndirectSqw.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/IndirectSqw.cpp
@@ -264,7 +264,7 @@ namespace CustomInterfaces
         "plotSpectrum(sqw_ws, range(0, n_spec))\n";
     }
 
-    m_pythonRunner.runPythonCode(pyInput).trimmed();
+    m_pythonRunner.runPythonCode(pyInput);
   }
 
   /**
@@ -318,7 +318,7 @@ namespace CustomInterfaces
       convertSpecAlg->execute();
 
       QString pyInput = "plot2D('" + convertedWsName + "')\n";
-      m_pythonRunner.runPythonCode(pyInput).trimmed();
+      m_pythonRunner.runPythonCode(pyInput);
     }
     else
     {

--- a/Code/Mantid/MantidQt/MantidWidgets/src/MWDiag.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/MWDiag.cpp
@@ -490,7 +490,7 @@ QString MWDiag::openFileDialog(const bool save, const QStringList &exts)
     {
       filter.append("*." + exts[i] + " ");
     }
-    filter.trimmed();
+    filter = filter.trimmed();
   }
   filter.append(";;All Files (*.*)");
 

--- a/Code/Mantid/MantidQt/SpectrumViewer/src/EModeHandler.cpp
+++ b/Code/Mantid/MantidQt/SpectrumViewer/src/EModeHandler.cpp
@@ -54,7 +54,6 @@ void EModeHandler::setEMode( const int mode )
     g_log.error() << "Mode number invalid: " << QString::number(mode).toStdString() << std::endl;
 }
 
-
 /**
  *  Return the user specified EFixed value, OR 0, if no valid
  *  EFixed value was set.


### PR DESCRIPTION
I fixed or suppressed many compiler warnings from AppleClang on OSX. 

for testing: code review, verify that targets "all" and "AllTests" now build cleanly with AppleClang on OSX and this doesn't create new errors or warnings on the build servers.

This is a continuation of pull request #63 
http://trac.mantidproject.org/mantid/ticket/10507
