### PR TITLE
 Fix linking issues and failed unit test with Boost 1.56 and newer

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/test/CalculateMSVesuvioTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/CalculateMSVesuvioTest.h
@@ -3,6 +3,8 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "boost/version.hpp"
+
 #include "MantidCurveFitting/CalculateMSVesuvio.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
@@ -36,8 +38,12 @@ public:
     auto alg = createTestAlgorithm(createFlatPlateSampleWS());
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     TS_ASSERT(alg->isExecuted());
-    
+// seed has different effect in boost version 1.56 and newer
+#if (BOOST_VERSION / 100000) == 1 && (BOOST_VERSION / 100 % 1000) >= 56
+    checkOutputValuesAsExpected(alg, 0.0111204555, 0.0019484356);
+#else
     checkOutputValuesAsExpected(alg, 0.0099824991, 0.0020558473);
+#endif
   }
 
   // ------------------------ Failure Cases -----------------------------------------
@@ -205,6 +211,7 @@ private:
     TS_ASSERT_DELTA(expectedMS, msY[checkIdx], tolerance);
     const auto & msX = multScatter->readX(0);
     TS_ASSERT_DELTA(150.0, msX[checkIdx], tolerance); // based on workspace setup
+
   }
 };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -13,6 +13,16 @@
 using namespace MantidQt::CustomInterfaces;
 using namespace testing;
 
+namespace boost{
+  template<class CharType, class CharTrait>
+  std::basic_ostream<CharType, CharTrait>& operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<std::pair<double,double> > const& maybe)
+  {
+    if (maybe)
+        out << maybe->first << ", " << maybe->second;
+    return out;
+  }
+}
+
 class MockALCDataLoadingView : public IALCDataLoadingView
 {
   // XXX: A workaround, needed because of the way the comma is treated in a macro

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -17,6 +17,17 @@ using namespace Mantid;
 using namespace MantidQt::CustomInterfaces;
 using namespace testing;
 
+namespace boost
+{
+  template<class CharType, class CharTrait>
+  std::basic_ostream<CharType, CharTrait>& operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<QString> const& maybe)
+  {
+    if (maybe)
+      out << maybe->toStdString();
+    return out;
+  }
+}
+
 class MockALCPeakFittingView : public IALCPeakFittingView
 {
 public:


### PR DESCRIPTION
Boost 1.56 introduces a linking error in CustomInterfacesTest. The unit test CalculateMSVesuvioTest also fails. 

The linking issue was fixed by providing a '<<' operator for optionals.
​https://github.com/jthornber/thin-provisioning-tools/commit/41354f10f5940c72917eb4205ce5adad26f7a369

It looks like the same seed produces different results in boost version 1.56 and newer. Results are very close, but checking the boost version is probably better than reducing the tolerance.
​http://stackoverflow.com/questions/26506550/consistent-random-number-generation-accross-platforms-with-boostrandom 
​https://groups.google.com/forum/#!msg/bob-devel/EzZwQvxxxYc/GPFZjISsX2oJ 

TESTING: code review and verify that Mantid builds and passes all unit tests with boost >= 1.56

Refs #10329. http://trac.mantidproject.org/mantid/ticket/10329
