### PR TITLE
Fix rpm dependencies on RHEL6

### DIFF
--- a/Code/Mantid/Build/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/Code/Mantid/Build/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,5 +1,5 @@
 Name:           mantid-developer
-Version:        1.5
+Version:        1.6
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -47,8 +47,12 @@ Requires: sip-devel
 Requires: git
 Requires: openssl-devel
 Requires: texlive-latex
+%if 0%{?el6}
+# do nothing
+%else
 Requires: texlive-latex-bin
 Requires: texlive-was
+%endif
 Requires: tex-preview
 Requires: dvipng
 %if 0%{?el6}


### PR DESCRIPTION
This was originally [trac #10608](http://trac.mantidproject.org/mantid/ticket/10608).

**To test:** Look at the difference and see that the new version is install-able. [Link to copr](https://copr.fedoraproject.org/coprs/mantid/mantid/monitor/) 
