### PR TITLE
Add jsconcpp as a required dependency for Kernel.

### DIFF
--- a/Code/Mantid/Build/CMake/CommonSetup.cmake
+++ b/Code/Mantid/Build/CMake/CommonSetup.cmake
@@ -55,6 +55,8 @@ include_directories ( SYSTEM ${NEXUS_INCLUDE_DIR} )
 
 find_package ( MuParser REQUIRED )
 
+find_package ( JsonCPP REQUIRED )
+
 find_package ( Doxygen ) # optional
 
 # Need to change search path to find zlib include on Windows.

--- a/Code/Mantid/Build/CMake/FindJsonCPP.cmake
+++ b/Code/Mantid/Build/CMake/FindJsonCPP.cmake
@@ -1,0 +1,33 @@
+# - Find jsoncpp include dirs and libraries
+# Use this module by invoking find_package with the form:
+#  find_package(JsonCPP [required] [quiet] )
+#
+# The module sets the following variables 
+#  JSONCPP_FOUND          - True if headers and libraries were found
+#  JSONCPP_INCLUDE_DIR    - jsoncpp include directories
+#  JSONCPP_LIBRARY        - library files for linking (optimised version)
+#  JSONCPP_LIBRARY_DEBUG  - library files for linking (debug version)
+#  JSONCPP_LIBRARIES      - All required libraries, including the configuration type
+
+# Headers
+find_path ( JSONCPP_INCLUDE_DIR jsoncpp/json/json.h )
+
+# Libraries
+find_library ( JSONCPP_LIBRARY NAMES jsoncpp ) # optimized
+find_library ( JSONCPP_LIBRARY_DEBUG NAMES jsoncpp_d ) # debug
+
+if ( JSONCPP_LIBRARY AND JSONCPP_LIBRARY_DEBUG )
+  set ( JSONCPP_LIBRARIES optimized ${JSONCPP_LIBRARY} debug ${JSONCPP_LIBRARY_DEBUG} )
+else()
+  set ( JSONCPP_LIBRARIES ${JSONCPP_LIBRARY} )
+endif()
+
+# Handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE if 
+# all listed variables are TRUE
+include ( FindPackageHandleStandardArgs )
+find_package_handle_standard_args( JsonCPP DEFAULT_MSG JSONCPP_INCLUDE_DIR JSONCPP_LIBRARIES )
+
+# Advanced variables
+mark_as_advanced ( JSONCPP_INCLUDE_DIR JSONCPP_LIBRARIES )
+
+

--- a/Code/Mantid/Build/CMake/WindowsSetup.cmake
+++ b/Code/Mantid/Build/CMake/WindowsSetup.cmake
@@ -82,7 +82,7 @@ set ( PYTHONW_EXECUTABLE "${CMAKE_LIBRARY_PATH}/Python27/pythonw.exe" CACHE FILE
 ###########################################################################
 add_definitions ( -DWIN32 -D_WINDOWS -DMS_VISUAL_STUDIO )
 add_definitions ( -D_USE_MATH_DEFINES -DNOMINMAX )
-add_definitions ( -DGSL_DLL )
+add_definitions ( -DGSL_DLL -DJSON_DLL )
 add_definitions ( -DPOCO_NO_UNWINDOWS )
 add_definitions ( -D_SCL_SECURE_NO_WARNINGS )
 add_definitions ( -D_CRT_SECURE_NO_WARNINGS )

--- a/Code/Mantid/Framework/Kernel/CMakeLists.txt
+++ b/Code/Mantid/Framework/Kernel/CMakeLists.txt
@@ -376,7 +376,8 @@ set_target_properties ( Kernel PROPERTIES OUTPUT_NAME MantidKernel
 # Add to the 'Framework' group in VS
 set_property ( TARGET Kernel PROPERTY FOLDER "MantidFramework" )
 
-target_link_libraries ( Kernel ${MANTIDLIBS} ${GSL_LIBRARIES} ${NEXUS_LIBRARIES} ${NETWORK_LIBRARIES} )
+target_link_libraries ( Kernel ${MANTIDLIBS} ${GSL_LIBRARIES} ${NEXUS_LIBRARIES}
+                        ${NETWORK_LIBRARIES} ${JSONCPP_LIBRARIES} )
 if ( WIN32 )
   target_link_libraries ( Kernel Psapi.lib ) # For memory usage queries
 endif()


### PR DESCRIPTION
Fixes trac issue [#10573](http://trac.mantidproject.org/mantid/ticket/10573)

No tests really just check all the builds work and that you agree with the code changes.
