### PR TITLE
remove implicit conversion from NULL to false

### DIFF
--- a/Code/Mantid/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
@@ -72,7 +72,7 @@ namespace CustomDialogs
 ///Constructor
 StartLiveDataDialog::StartLiveDataDialog(QWidget *parent) :
   AlgorithmDialog(parent),
-  m_useProcessAlgo(false), m_useProcessScript(NULL),
+  m_useProcessAlgo(false), m_useProcessScript(false),
   m_usePostProcessAlgo(false), m_usePostProcessScript(false)
 {
   // Create the input history. This loads it too.


### PR DESCRIPTION
Remove an implicit conversion generating a warning with osx+clang.

http://trac.mantidproject.org/mantid/ticket/10635
