### PR TITLE
Fix clean MPI-enabled build

### DIFF
--- a/Code/Mantid/Framework/CMakeLists.txt
+++ b/Code/Mantid/Framework/CMakeLists.txt
@@ -40,6 +40,16 @@ if ( boost_stdint )
 endif ()
 
 ###########################################################################
+# Globally-linked libraries variable
+###########################################################################
+
+# Might just as well link everything to Boost & Poco (found in CommonSetup)
+# Boost_LIBRARIES variable is redefined by MPISetup so capture the value here
+# and just add MPI stuff if required
+# TCMalloc & MPI_CXX variables will be empty if not using
+set ( MANTIDLIBS  ${Boost_LIBRARIES} ${POCO_LIBRARIES} ${TCMALLOC_LIBRARY} )
+
+###########################################################################
 # MPI-enable build setup
 ###########################################################################
 
@@ -48,16 +58,9 @@ if ( ${CMAKE_PROJECT_NAME} MATCHES "MantidFramework" AND ${CMAKE_SYSTEM_NAME} MA
   set ( MPI_BUILD OFF CACHE BOOL "Enable MPI options" )
   if ( MPI_BUILD )
 	include ( MPISetup )
+        set ( MANTIDLIBS  ${MANTIDLIBS} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES} )
   endif ( MPI_BUILD )
 endif ()
-
-###########################################################################
-# Globally-linked libraries variable
-###########################################################################
-
-# Might just as well link everything to Boost & Poco (found in CommonSetup)
-# TCMalloc & MPI_CXX variables will be empty if not using
-set ( MANTIDLIBS  ${Boost_LIBRARIES} ${POCO_LIBRARIES} ${TCMALLOC_LIBRARY} ${MPI_CXX_LIBRARIES} )
 
 ###########################################################################
 # Now add the packages one-by-one, building up the dependencies as we go


### PR DESCRIPTION
Fixes trac issue [#10632](http://trac.mantidproject.org/mantid/ticket/10632)

A clean build with MPI enabled now completes sucessfully on Ubuntu. On RHEL, however, there seems to be a problem with boost that produces a linker error

```
/tmp/ccQU3mJK.o: In function `main':
start_env.cpp:(.text+0x15): undefined reference to `boost::mpi::environment::environment(bool)'
collect2: ld returned 1 exit status
```

but this is, as far as I can tell, not something we can fix in our code base. I have filed a bug with redhat: https://bugzilla.redhat.com/show_bug.cgi?id=1169501
