### PR TITLE
fix -Wall warnings on OS X with AppleClang

### DIFF
--- a/Code/Mantid/Build/CMake/DarwinSetup.cmake
+++ b/Code/Mantid/Build/CMake/DarwinSetup.cmake
@@ -79,14 +79,16 @@ endif ()
 ###########################################################################
 # Force 64-bit compiler as that's all we support
 ###########################################################################
-set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64" )
+
+set ( CLANG_WARNINGS "-Wall -Wno-deprecated-register")
+
+set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 ${CLANG_WARNINGS}" )
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=c++0x" )
 set ( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++0x" )
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++" )
-  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register" )
-  set ( CMAKE_XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS "-Wno-deprecated-register")
+  set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CLANG_WARNINGS} -stdlib=libc++" )
+  set ( CMAKE_XCODE_ATTRIBUTE_OTHER_CPLUSPLUSFLAGS "${CLANG_WARNINGS}")
   set ( CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++" )
 endif()
 

--- a/Code/Mantid/Framework/API/test/CostFunctionFactoryTest.h
+++ b/Code/Mantid/Framework/API/test/CostFunctionFactoryTest.h
@@ -16,7 +16,6 @@ using namespace Mantid::API;
 
 class CostFunctionFactoryTest_A: public ICostFunction
 {
-  int m_attr;
 public:
   CostFunctionFactoryTest_A() {}
 

--- a/Code/Mantid/Framework/API/test/FuncMinimizerFactoryTest.h
+++ b/Code/Mantid/Framework/API/test/FuncMinimizerFactoryTest.h
@@ -16,7 +16,6 @@ using namespace Mantid::API;
 
 class FuncMinimizerFactoryTest_A: public IFuncMinimizer
 {
-  int m_attr;
 public:
   FuncMinimizerFactoryTest_A() 
   {

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PhaseQuadMuon.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PhaseQuadMuon.h
@@ -85,20 +85,12 @@ namespace Mantid
       int m_nHist;
       /// Number of datapoints per histogram
       int m_nData;
-      /// TODO: remove if not necessary
-      double m_res;
       /// Mean of time-shifts TODO: remove if not necessary
       double m_meanLag;
       /// Good muons from here on (bin no) TODO: remove if not necessary
       size_t m_tValid;
       /// Pulse definitely finished by here (bin no) TODO: remove if not necessary
       size_t m_tNoPulse;
-      /// Double-pulse flag TODO: remove if not necessary
-      bool m_isDouble;
-      /// Muon decay curve TODO: remove if not necessary
-      double m_tau;
-      /// Freq (of silver run) TODO: remove if not necessary
-      double m_w;
       /// Muon lifetime
       double m_muLife;
       /// Poisson limit TODO: remove if not necessary

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/DownloadInstrument.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/DownloadInstrument.h
@@ -64,7 +64,6 @@ namespace DataHandling
                                   const std::set<std::string>& filenamesToKeep) const;
 
     Kernel::ProxyInfo m_proxyInfo;
-    bool m_isProxySet;
   };
 
 

--- a/Code/Mantid/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -44,7 +44,7 @@ namespace Mantid
     //----------------------------------------------------------------------------------------------
     /** Constructor
     */
-    DownloadInstrument::DownloadInstrument() : m_proxyInfo(), m_isProxySet(false)
+    DownloadInstrument::DownloadInstrument() : m_proxyInfo()
     {
     }
 

--- a/Code/Mantid/Framework/DataHandling/test/MoveInstrumentComponentTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/MoveInstrumentComponentTest.h
@@ -141,7 +141,7 @@ public:
 
 private:
     std::string wsName;
-    Detector *det1,*det2,*det3;
+    Detector *det1;
     boost::shared_ptr<Instrument> instrument;
     MatrixWorkspace_sptr WS;
 

--- a/Code/Mantid/Framework/DataHandling/test/SaveNexusTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/SaveNexusTest.h
@@ -111,7 +111,6 @@ private:
   SaveNexus algToBeTested;
   std::string outputFile;
   std::string title;
-  int entryNumber;
-  
+ 
 };
 #endif /*SAVENEXUSTEST_H_*/

--- a/Code/Mantid/Framework/DataHandling/test/SaveToSNSHistogramNexusTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/SaveToSNSHistogramNexusTest.h
@@ -53,7 +53,6 @@ private:
   SaveToSNSHistogramNexus algToBeTested;
   std::string outputFile;
   std::string title;
-  int entryNumber;
   
 };
 #endif /*SaveToSNSHistogramNexusTEST_H_*/

--- a/Code/Mantid/Framework/Kernel/test/DiskBufferTest.h
+++ b/Code/Mantid/Framework/Kernel/test/DiskBufferTest.h
@@ -29,7 +29,7 @@ using Mantid::Kernel::CPUTimer;
 class SaveableTesterWithFile : public ISaveable
 {
 public:
-  SaveableTesterWithFile(size_t id, uint64_t pos, uint64_t size, char ch,bool wasSaved=true) : ISaveable(),
+  SaveableTesterWithFile(uint64_t pos, uint64_t size, char ch,bool wasSaved=true) : ISaveable(),
     m_memory(size),m_ch(ch)
   {
     // the object knows its place on file
@@ -141,7 +141,7 @@ public:
     SaveableTesterWithFile::fakeFile = "";
     data.clear();
     for (size_t i=0; i<num; i++)
-      data.push_back( new SaveableTesterWithFile(i,uint64_t(2*i),2,char(i+0x41)) );  
+      data.push_back( new SaveableTesterWithFile(uint64_t(2*i),2,char(i+0x41)) );
   }
 
   void tearDown()
@@ -299,7 +299,7 @@ public:
     std::vector<ISaveable *> bigData;
     bigData.reserve(bigNum);
     for (size_t i=0; i<bigNum; i++)
-      bigData.push_back( new SaveableTesterWithFile(i,2*i,2,char(i+0x41)) );  
+      bigData.push_back( new SaveableTesterWithFile(2*i,2,char(i+0x41)) );
 
 
     PARALLEL_FOR_NO_WSP_CHECK()
@@ -574,9 +574,9 @@ public:
   void test_allocate_with_file_manually()
   {
     // Start by faking a file
-    SaveableTesterWithFile * blockA = new SaveableTesterWithFile(0, 0, 2, 'A');
-    SaveableTesterWithFile * blockB = new SaveableTesterWithFile(1, 2, 3, 'B');
-    SaveableTesterWithFile * blockC = new SaveableTesterWithFile(2, 5, 5, 'C');
+    SaveableTesterWithFile * blockA = new SaveableTesterWithFile(0, 2, 'A');
+    SaveableTesterWithFile * blockB = new SaveableTesterWithFile(2, 3, 'B');
+    SaveableTesterWithFile * blockC = new SaveableTesterWithFile(5, 5, 'C');
     blockA->save();
     blockB->save();
     blockC->save();
@@ -608,7 +608,7 @@ public:
     // Now let's allocate a new block
     newPos = dbuf.allocate(2);
     TS_ASSERT_EQUALS( newPos, 2 );
-    SaveableTesterWithFile * blockD = new SaveableTesterWithFile(3, newPos, 2, 'D');
+    SaveableTesterWithFile * blockD = new SaveableTesterWithFile(newPos, 2, 'D');
     blockD->save();
     TS_ASSERT_EQUALS( SaveableTesterWithFile::fakeFile, "AADDBCCCCCBBBBBBB");
     TSM_ASSERT_EQUALS( "Still one freed block", map.size(), 1);
@@ -641,9 +641,9 @@ public:
     // filePosition has to be identified by the fileBuffer
     uint64_t filePos = std::numeric_limits<uint64_t>::max();
     // Start by faking a file
-    SaveableTesterWithFile * blockA = new SaveableTesterWithFile(0, filePos, 2, 'A',false);
-    SaveableTesterWithFile * blockB = new SaveableTesterWithFile(1, filePos, 3, 'B',false);
-    SaveableTesterWithFile * blockC = new SaveableTesterWithFile(2, filePos, 5, 'C',false);
+    SaveableTesterWithFile * blockA = new SaveableTesterWithFile(filePos, 2, 'A',false);
+    SaveableTesterWithFile * blockB = new SaveableTesterWithFile(filePos, 3, 'B',false);
+    SaveableTesterWithFile * blockC = new SaveableTesterWithFile(filePos, 5, 'C',false);
     
     DiskBuffer dbuf(3);
     dbuf.toWrite(blockB);
@@ -667,7 +667,7 @@ public:
     TS_ASSERT(!blockB->isDataChanged())
 
     //// Now let's allocate a new block
-    SaveableTesterWithFile * blockD = new SaveableTesterWithFile(3, filePos, 2, 'D',false);
+    SaveableTesterWithFile * blockD = new SaveableTesterWithFile(filePos, 2, 'D',false);
     dbuf.toWrite(blockD);
     // small block, nothing still sitting in the buffer
     TS_ASSERT_EQUALS( SaveableTesterWithFile::fakeFile, "AABBBCCCCCBBBBBBB");

--- a/Code/Mantid/Framework/Kernel/test/DiskBufferTest.h
+++ b/Code/Mantid/Framework/Kernel/test/DiskBufferTest.h
@@ -28,10 +28,9 @@ using Mantid::Kernel::CPUTimer;
 /** An ISaveable that fakes writing to a fixed-size file */
 class SaveableTesterWithFile : public ISaveable
 {
-    size_t ID;
 public:
   SaveableTesterWithFile(size_t id, uint64_t pos, uint64_t size, char ch,bool wasSaved=true) : ISaveable(),
-    ID(id),m_memory(size),m_ch(ch)
+    m_memory(size),m_ch(ch)
   {
     // the object knows its place on file
     this->setFilePosition(pos,size,wasSaved);
@@ -716,11 +715,9 @@ public:
 /** An Saveable that will fake seeking to disk */
 class SaveableTesterWithSeek : public ISaveable
 {  
-    size_t ID;
     size_t m_memory;
 public:
-  SaveableTesterWithSeek(size_t id) : ISaveable(),
-      ID(id)
+  SaveableTesterWithSeek(size_t id) : ISaveable()
   {
     m_memory=1;
     this->setFilePosition(10+id,this->m_memory,true);

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormSXD.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormSXD.h
@@ -69,8 +69,6 @@ namespace DataObjects
                        double &theta, double &phi);
       std::vector<Kernel::VMD> calculateIntersections(const double theta, const double phi);
 
-      /// number of MD dimensions
-      size_t m_nDims;
       /// Normalization workspace
       MDEvents::MDHistoWorkspace_sptr m_normWS;
       /// Input workspace

--- a/Code/Mantid/Framework/MDAlgorithms/src/MDNormSXD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/MDNormSXD.cpp
@@ -35,7 +35,7 @@ namespace Mantid
      * Constructor
      */
     MDNormSXD::MDNormSXD() :
-      m_nDims(0), m_normWS(), m_inputWS(), m_hmin(0.0f), m_hmax(0.0f),
+      m_normWS(), m_inputWS(), m_hmin(0.0f), m_hmax(0.0f),
       m_kmin(0.0f), m_kmax(0.0f), m_lmin(0.0f), m_lmax(0.0f), m_hIntegrated(true),
       m_kIntegrated(true), m_lIntegrated(true), m_rubw(3,3),
       m_kiMin(0.0), m_kiMax(EMPTY_DBL()), m_hIdx(-1), m_kIdx(-1), m_lIdx(-1),

--- a/Code/Mantid/Framework/MDEvents/test/MDEventWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDEvents/test/MDEventWorkspaceTest.h
@@ -630,7 +630,7 @@ public:
 
 private:
   MDEventWorkspace3Lean::sptr m_ws;
-  size_t nEvents,nBoxes;
+  size_t nBoxes;
 public: 
     void setUp()
     {

--- a/Code/Mantid/MantidPlot/src/TiledWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/TiledWindow.cpp
@@ -22,7 +22,6 @@ const int minimumTileHeight = 100;
 const QColor normalColor("black");
 const QColor selectedColor("green");
 const QColor acceptDropColor("red");
-const int normalWidth(0);
 const int selectedWidth(5);
 const int acceptDropWidth(5);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSPlotSpecial.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSPlotSpecial.h
@@ -55,7 +55,6 @@ public:
     TransformType m_type;
     QList<QWidget*> m_xWidgets;
     QList<QWidget*> m_yWidgets;
-    QWidget* m_parent;
     QString m_gDeriv;
     QString m_iDeriv;
   };

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSPlotSpecial.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSPlotSpecial.cpp
@@ -844,7 +844,7 @@ QPair<QStringList, QMap<QString, double> > SANSPlotSpecial::getProperties(const 
 //------- Utility "Transform" Class ----------------------------------
 //--------------------------------------------------------------------
 SANSPlotSpecial::Transform::Transform(Transform::TransformType type) : m_type(type), 
-  m_xWidgets(QList<QWidget*>()), m_yWidgets(QList<QWidget*>()), m_parent(NULL), m_gDeriv(""), m_iDeriv("")
+  m_xWidgets(QList<QWidget*>()), m_yWidgets(QList<QWidget*>()), m_gDeriv(""), m_iDeriv("")
 {
   init();
 }

--- a/Code/Mantid/Vates/VatesAPI/test/vtkMDHistoLineFactoryTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/vtkMDHistoLineFactoryTest.h
@@ -1,5 +1,5 @@
 #ifndef VTK_MD_HISTO_LINE_FACTORY_TEST_H_
-#define VTK_MD_HISOT_LINE_FACTORY_TEST_H_
+#define VTK_MD_HISTO_LINE_FACTORY_TEST_H_
 
 #include "MantidAPI/IMDIterator.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"


### PR DESCRIPTION
I turned on -Wall when compiling with AppleClang on os x and discovered a few warnings. I was able to successfully fix all warnings. 

At the moment, I'm just checking this didn't break any tests on other platforms. I'll add another comment when this is ready for testings.

http://trac.mantidproject.org/mantid/ticket/10686
