### PR TITLE
Use RelWithDbgInfo as default build type for build servers

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -61,6 +61,7 @@ if [[ ${JOB_NAME} == *clean* ]]; then
     # Mac packaging
     PACKAGINGVARS="-DPACKAGE_DOCS=ON"
   fi
+
 fi
 
 ###############################################################################
@@ -81,13 +82,14 @@ cd $WORKSPACE/build
 
 ###############################################################################
 ## Check the required build configuration
+## Use RelWithDbgInfo unless requested by the job name
 ###############################################################################
 if [[ ${JOB_NAME} == *debug* ]]; then
   BUILD_CONFIG="Debug"
-elif [[ ${JOB_NAME} == *relwithdbg* ]]; then
-  BUILD_CONFIG="RelWithDbg"
-else
+elif [[ ${JOB_NAME} == *release* ]]; then
   BUILD_CONFIG="Release"
+else
+  BUILD_CONFIG="RelWithDebInfo"
 fi
 
 ###############################################################################

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -7,20 +7,21 @@
 :: BUILD_THREADS & PARAVIEW_DIR should be set in the configuration of each slave.
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --version 
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --version
 echo %sha1%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Check the required build configuration
+:: Use RelWithDbgInfo unless specified by job name
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 set BUILD_CONFIG=
 if not "%JOB_NAME%"=="%JOB_NAME:debug=%" (
     set BUILD_CONFIG=Debug
 ) else (
-if not "%JOB_NAME%"=="%JOB_NAME:relwithdbg=%" (
-    set BUILD_CONFIG=RelWithDbg
-) else (
+if not "%JOB_NAME%"=="%JOB_NAME:release=%" (
     set BUILD_CONFIG=Release
+) else (
+    set BUILD_CONFIG=RelWithDebInfo
     ))
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
Fixes trac issue [#10690](http://trac.mantidproject.org/mantid/ticket/10690)

Code review should be sufficient here.
