### PR TITLE
Make ctest run MantidPlot tests serially.

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -101,7 +101,7 @@ $SCL_ON_RHEL6 "cmake -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE
 # Build step
 ###############################################################################
 $SCL_ON_RHEL6 "cmake --build . -- -j$BUILD_THREADS"
-$SCL_ON_RHEL6 "cmake --build . --target=AllTests -- -j$BUILD_THREADS"
+$SCL_ON_RHEL6 "cmake --build . --target AllTests -- -j$BUILD_THREADS"
 
 ###############################################################################
 # Run the tests
@@ -120,7 +120,7 @@ if [[ "$CLEANBUILD" == true ]]; then
   if [[ $(uname) == 'Darwin' ]]; then
     export MANTIDPATH=$PWD/bin
   fi
-  $SCL_ON_RHEL6 "cmake --build . --target=docs-qthelp"
+  $SCL_ON_RHEL6 "cmake --build . --target docs-qthelp"
 fi
 
 ###############################################################################
@@ -143,7 +143,7 @@ if [[ "$CLEANBUILD" == true ]]; then
   # and labelled by the commit id it was built with. This assumes the Jenkins git plugin
   # has set the GIT_COMMIT environment variable
   if [[ "$ON_RHEL6" == true ]]; then
-    $SCL_ON_RHEL6 "cmake --build --target=docs-html"
+    $SCL_ON_RHEL6 "cmake --build --target docs-html"
     tar -cjf mantiddocs-g${GIT_COMMIT:0:7}.tar.bz2 --exclude='*.buildinfo' --exclude="MantidProject.q*" docs/html
     # The ..._PREFIX argument avoids opt/Mantid directories at the top of the tree
     $SCL_ON_RHEL6 "cpack --config CPackSourceConfig.cmake -D CPACK_PACKAGING_INSTALL_PREFIX="

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -143,7 +143,7 @@ if [[ "$CLEANBUILD" == true ]]; then
   # and labelled by the commit id it was built with. This assumes the Jenkins git plugin
   # has set the GIT_COMMIT environment variable
   if [[ "$ON_RHEL6" == true ]]; then
-    $SCL_ON_RHEL6 "cmake --build --target docs-html"
+    $SCL_ON_RHEL6 "cmake --build . --target docs-html"
     tar -cjf mantiddocs-g${GIT_COMMIT:0:7}.tar.bz2 --exclude='*.buildinfo' --exclude="MantidProject.q*" docs/html
     # The ..._PREFIX argument avoids opt/Mantid directories at the top of the tree
     $SCL_ON_RHEL6 "cpack --config CPackSourceConfig.cmake -D CPACK_PACKAGING_INSTALL_PREFIX="

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -100,17 +100,15 @@ $SCL_ON_RHEL6 "cmake -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE
 ###############################################################################
 # Build step
 ###############################################################################
-$SCL_ON_RHEL6 "make -j$BUILD_THREADS"
-$SCL_ON_RHEL6 "make -j$BUILD_THREADS AllTests"
+$SCL_ON_RHEL6 "cmake --build . -- -j$BUILD_THREADS"
+$SCL_ON_RHEL6 "cmake --build . --target=AllTests -- -j$BUILD_THREADS"
 
 ###############################################################################
 # Run the tests
 ###############################################################################
 # Remove any Mantid.user.properties file
 rm -f ~/.mantid/Mantid.user.properties
-$SCL_ON_RHEL6 "ctest -j$BUILD_THREADS --schedule-random --output-on-failure -E MantidPlot"
-# Run GUI tests serially
-$SCL_ON_RHEL6 "ctest --output-on-failure -R MantidPlot"
+$SCL_ON_RHEL6 "ctest -j$BUILD_THREADS --schedule-random --output-on-failure"
 
 ###############################################################################
 # Documentation
@@ -122,7 +120,7 @@ if [[ "$CLEANBUILD" == true ]]; then
   if [[ $(uname) == 'Darwin' ]]; then
     export MANTIDPATH=$PWD/bin
   fi
-  $SCL_ON_RHEL6 "make docs-qthelp"
+  $SCL_ON_RHEL6 "cmake --build . --target=docs-qthelp"
 fi
 
 ###############################################################################
@@ -145,7 +143,7 @@ if [[ "$CLEANBUILD" == true ]]; then
   # and labelled by the commit id it was built with. This assumes the Jenkins git plugin
   # has set the GIT_COMMIT environment variable
   if [[ "$ON_RHEL6" == true ]]; then
-    $SCL_ON_RHEL6 "make docs-html"
+    $SCL_ON_RHEL6 "cmake --build --target=docs-html"
     tar -cjf mantiddocs-g${GIT_COMMIT:0:7}.tar.bz2 --exclude='*.buildinfo' --exclude="MantidProject.q*" docs/html
     # The ..._PREFIX argument avoids opt/Mantid directories at the top of the tree
     $SCL_ON_RHEL6 "cpack --config CPackSourceConfig.cmake -D CPACK_PACKAGING_INSTALL_PREFIX="

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -61,7 +61,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :: Build step
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-msbuild /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% Mantid.sln
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% Mantid.sln
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -75,7 +75,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if "%CLEANBUILD%" EQU "yes" (
     :: Build offline documentation
-    msbuild /nologo /nr:false /p:Configuration=%BUILD_CONFIG% docs/docs-qthelp.vcxproj
+    C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /nr:false /p:Configuration=%BUILD_CONFIG% docs/docs-qthelp.vcxproj
 
     :: ignore errors as the exit code of the build isn't correct
     ::if ERRORLEVEL 1 exit /B %ERRORLEVEL%

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -61,10 +61,8 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :: Build step
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" .
 "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --target AllTests .
 "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . --target AllTests -- /nologo /m:%BUILD_THREADS% /nr:false
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
@@ -79,7 +77,6 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if "%CLEANBUILD%" EQU "yes" (
     :: Build offline documentation
-    "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" . --target docs-qthelp
     "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . --target docs-qthelp -- /nologo /m:%BUILD_THREADS% /nr:false
 
     :: ignore errors as the exit code of the build isn't correct

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -61,9 +61,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :: Build step
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false
-if ERRORLEVEL 1 exit /B %ERRORLEVEL%
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . --target AllTests -- /nologo /m:%BUILD_THREADS% /nr:false
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% Mantid.sln
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -77,7 +75,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if "%CLEANBUILD%" EQU "yes" (
     :: Build offline documentation
-    "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . --target docs-qthelp -- /nologo /m:%BUILD_THREADS% /nr:false
+    "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% docs/docs-qthelp.vcxproj
 
     :: ignore errors as the exit code of the build isn't correct
     ::if ERRORLEVEL 1 exit /B %ERRORLEVEL%

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -67,10 +67,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Run the tests
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-"C:\Program Files (x86)\CMake 2.8\bin\ctest.exe" -C %BUILD_CONFIG% -j%BUILD_THREADS% --schedule-random --output-on-failure -E MantidPlot
-if ERRORLEVEL 1 exit /B %ERRORLEVEL%
-:: Run GUI tests serially
-ctest -C %BUILD_CONFIG% --output-on-failure -R MantidPlot
+"C:\Program Files (x86)\CMake 2.8\bin\ctest.exe" -C %BUILD_CONFIG% -j%BUILD_THREADS% --schedule-random --output-on-failure
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -60,8 +60,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Build step
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% Mantid.sln
+msbuild /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% Mantid.sln
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -75,7 +74,7 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if "%CLEANBUILD%" EQU "yes" (
     :: Build offline documentation
-    "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% docs/docs-qthelp.vcxproj
+    msbuild /nologo /nr:false /p:Configuration=%BUILD_CONFIG% docs/docs-qthelp.vcxproj
 
     :: ignore errors as the exit code of the build isn't correct
     ::if ERRORLEVEL 1 exit /B %ERRORLEVEL%

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -61,7 +61,11 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :: Build step
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false /p:Configuration=%BUILD_CONFIG% Mantid.sln
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" .
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /m:%BUILD_THREADS% /nr:false
+if ERRORLEVEL 1 exit /B %ERRORLEVEL%
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --target AllTests .
+"C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . --target AllTests -- /nologo /m:%BUILD_THREADS% /nr:false
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -75,7 +79,8 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if "%CLEANBUILD%" EQU "yes" (
     :: Build offline documentation
-    C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . -- /nologo /nr:false /p:Configuration=%BUILD_CONFIG% docs/docs-qthelp.vcxproj
+    "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" . --target docs-qthelp
+    "C:\Program Files (x86)\CMake 2.8\bin\cmake.exe" --build . --target docs-qthelp -- /nologo /m:%BUILD_THREADS% /nr:false
 
     :: ignore errors as the exit code of the build isn't correct
     ::if ERRORLEVEL 1 exit /B %ERRORLEVEL%

--- a/Code/Mantid/MantidPlot/CMakeLists.txt
+++ b/Code/Mantid/MantidPlot/CMakeLists.txt
@@ -993,7 +993,7 @@ else ()
 	 	# Add the test. Name of test = name of the file
 		ADD_TEST( ${PYFILE} ${MANTIDPLOT_PATH} -xq ${CMAKE_CURRENT_SOURCE_DIR}/test/${PYFILE} )
 		# Set the previously-built environment
-		set_tests_properties( ${PYFILE} PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
+		set_tests_properties( ${PYFILE} PROPERTIES RUN_SERIAL 1 ENVIRONMENT "${TEST_ENVIRONMENT}")
 	endforeach ()
 
     add_dependencies( GUITests MantidPlot )


### PR DESCRIPTION
adding the property "RUN_SERIAL 1" will run the MantidPlot unit tests serially and lets us avoid excluding these tests and running the separately.

Linux and OSX now use cmake --build . instead of make. I still need to do this for windows.  

http://trac.mantidproject.org/mantid/ticket/10694
