### PR TITLE
Fix coverity builds

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -104,7 +104,11 @@ if [[ ${JOB_NAME} == *coverity_build_and_submit* ]]; then
   status=$(curl --form token=$COVERITY_TOKEN --form email=mantidproject@gmail.com \
        --form file=@mantid.tgz --form version=$GIT_COMMIT \
        https://scan.coverity.com/builds?project=mantidproject%2Fmantid)
-  return $status
+  if [[ ${status} ]]; then
+    return ${status}
+  else
+    return 0
+  fi
 fi
 
 ###############################################################################

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -104,10 +104,12 @@ if [[ ${JOB_NAME} == *coverity_build_and_submit* ]]; then
   status=$(curl --form token=$COVERITY_TOKEN --form email=mantidproject@gmail.com \
        --form file=@mantid.tgz --form version=$GIT_COMMIT \
        https://scan.coverity.com/builds?project=mantidproject%2Fmantid)
-  if [[ ${status} ]]; then
-    exit 1
-  else
+  status=$(echo ${status} | sed -e 's/^ *//' -e 's/ *$//')
+  if [[ -z $status ]]; then
     exit 0
+  else
+    echo "$status"
+    exit 1
   fi
 fi
 

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -96,6 +96,18 @@ fi
 $SCL_ON_RHEL6 "cmake -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DDOCS_HTML=ON ${PACKAGINGVARS} ../Code/Mantid"
 
 ###############################################################################
+# Coverity build should exit early
+###############################################################################
+if [[ ${JOB_NAME} == *coverity_build_and_submit* ]]; then
+  ${COVERITY_DIR}/cov-build --dir cov-int scl enable mantidlibs "make -j${BUILD_THREADS}"
+  tar czvf mantid.tgz cov-int
+  status=$(curl --form token=$COVERITY_TOKEN --form email=mantidproject@gmail.com \
+       --form file=@mantid.tgz --form version=$GIT_COMMIT \
+       https://scan.coverity.com/builds?project=mantidproject%2Fmantid)
+  return $status
+fi
+
+###############################################################################
 # Build step
 ###############################################################################
 $SCL_ON_RHEL6 "make -j$BUILD_THREADS"

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -105,9 +105,9 @@ if [[ ${JOB_NAME} == *coverity_build_and_submit* ]]; then
        --form file=@mantid.tgz --form version=$GIT_COMMIT \
        https://scan.coverity.com/builds?project=mantidproject%2Fmantid)
   if [[ ${status} ]]; then
-    return ${status}
+    exit 1
   else
-    return 0
+    exit 0
   fi
 fi
 


### PR DESCRIPTION
This was originally [trac #10636](http://trac.mantidproject.org/mantid/ticket/10636).

**To test:** see that the [build](http://builds.mantidproject.org/view/Static%20Analysis/job/coverity_build_and_submit/) is actually getting the results to [coverity](https://scan.coverity.com/) again.
