### PR TITLE
Refs #10710 Fix uninitialized scalar variable

### DIFF
--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -11375,7 +11375,7 @@ void ApplicationWindow::openSurfacePlot(const std::string& lines, const int file
         }
       } //select line "title"
 
-      int style;
+      int style = Qwt3D::WIREFRAME;
       if(tsv.selectLine("Style"))
         tsv >> style;
 


### PR DESCRIPTION
It's an uninitialized scalar variable in code I wrote. It's an easy fix, and Coverity's flagged its impact as high, so it may as well be taken care of. 

http://trac.mantidproject.org/mantid/ticket/10710

**Testing**
This is a trivial change. Code inspection + verifying build has not been broken ought to be sufficient.
