### PR TITLE
Add a ctest TIMEOUT property to all tests.

### DIFF
--- a/Code/Mantid/Build/CMake/CommonSetup.cmake
+++ b/Code/Mantid/Build/CMake/CommonSetup.cmake
@@ -36,6 +36,10 @@ if ( stdint )
   add_definitions ( -DHAVE_STDINT_H )
 endif ( stdint )
 
+# Configure a variable to hold the required test timeout value for all tests
+set ( TESTING_TIMEOUT 300 CACHE INTEGER
+      "Timeout in seconds for each test (default 300=5minutes)")
+
 ###########################################################################
 # Look for dependencies - bail out if any not found
 ###########################################################################

--- a/Code/Mantid/Build/CMake/FindCxxTest.cmake
+++ b/Code/Mantid/Build/CMake/FindCxxTest.cmake
@@ -160,6 +160,8 @@ macro(CXXTEST_ADD_TEST _cxxtest_testname)
         add_test ( NAME ${_cxxtest_separate_name}
                   COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_BINARY_DIR}/bin/Testing" 
 		          $<TARGET_FILE:${_cxxtest_testname}> ${_suitename} )
+        set_tests_properties ( ${_cxxtest_separate_name} PROPERTIES
+                               TIMEOUT ${TESTING_TIMEOUT} )
 
 		if (CXXTEST_ADD_PERFORMANCE)
 			# ------ Performance test version -------
@@ -175,6 +177,8 @@ macro(CXXTEST_ADD_TEST _cxxtest_testname)
 				add_test ( NAME ${_cxxtest_separate_name}
 				          COMMAND ${CMAKE_COMMAND} -E chdir "${CMAKE_BINARY_DIR}/bin/Testing" 
 						  $<TARGET_FILE:${_cxxtest_testname}> ${_performance_suite_name} )
+        set_tests_properties ( ${_cxxtest_separate_name} PROPERTIES
+                               TIMEOUT ${TESTING_TIMEOUT} )
 			endif ()
 		endif ()
       endforeach ( part ${ARGN} )

--- a/Code/Mantid/Build/CMake/FindPyUnitTest.cmake
+++ b/Code/Mantid/Build/CMake/FindPyUnitTest.cmake
@@ -29,27 +29,26 @@ macro ( PYUNITTEST_ADD_TEST _test_src_dir _testname_prefix )
       add_test ( NAME ${_pyunit_separate_name}_Debug CONFIGURATIONS Debug
                  COMMAND ${PYTHON_EXECUTABLE_DEBUG} -B ${_test_src_dir}/${_filename} )
       # Set the PYTHONPATH so that the built modules can be found
-      set_property ( TEST ${_pyunit_separate_name}_Debug 
-        PROPERTY ENVIRONMENT "PYTHONPATH=${_module_dir_debug}" )
-      set_property ( TEST ${_pyunit_separate_name}_Debug 
-        PROPERTY WORKING_DIRECTORY ${_working_dir_debug} )
-
+      set_tests_properties ( ${_pyunit_separate_name}_Debug PROPERTIES
+                             ENVIRONMENT "PYTHONPATH=${_module_dir}"
+                             WORKING_DIRECTORY ${_working_dir}
+                             TIMEOUT ${TESTING_TIMEOUT} )
       # Release
       add_test ( NAME ${_pyunit_separate_name} CONFIGURATIONS Release
                  COMMAND ${PYTHON_EXECUTABLE} -B ${_test_src_dir}/${_filename} )
       # Set the PYTHONPATH so that the built modules can be found
-      set_property ( TEST ${_pyunit_separate_name}
-        PROPERTY ENVIRONMENT "PYTHONPATH=${_module_dir}" )
-      set_property ( TEST ${_pyunit_separate_name} 
-        PROPERTY WORKING_DIRECTORY ${_working_dir} )
+      set_tests_properties ( ${_pyunit_separate_name} PROPERTIES
+                             ENVIRONMENT "PYTHONPATH=${_module_dir}"
+                             WORKING_DIRECTORY ${_working_dir}
+                             TIMEOUT ${TESTING_TIMEOUT} )
     else()
       add_test ( NAME ${_pyunit_separate_name}
                  COMMAND ${PYTHON_EXECUTABLE} -B ${_test_src_dir}/${_filename} )
       # Set the PYTHONPATH so that the built modules can be found
-      set_property ( TEST ${_pyunit_separate_name} 
-        PROPERTY ENVIRONMENT "PYTHONPATH=${_module_dir}" )
-      set_property ( TEST ${_pyunit_separate_name} 
-        PROPERTY WORKING_DIRECTORY ${_working_dir} )
+      set_tests_properties ( ${_pyunit_separate_name} PROPERTIES
+                             ENVIRONMENT "PYTHONPATH=${_module_dir}"
+                             WORKING_DIRECTORY ${_working_dir}
+                             TIMEOUT ${TESTING_TIMEOUT} )
     endif()
   endforeach ( part ${ARGN} )
 endmacro ( PYUNITTEST_ADD_TEST )

--- a/Code/Mantid/MantidPlot/CMakeLists.txt
+++ b/Code/Mantid/MantidPlot/CMakeLists.txt
@@ -1001,9 +1001,12 @@ else ()
 	# Make a ctest target for each file
 	foreach  ( PYFILE ${MANTIDPLOT_TEST_PY_FILES} )
 	 	# Add the test. Name of test = name of the file
-		ADD_TEST( ${PYFILE} ${MANTIDPLOT_PATH} -xq ${CMAKE_CURRENT_SOURCE_DIR}/test/${PYFILE} )
+		add_test ( ${PYFILE} ${MANTIDPLOT_PATH} -xq ${CMAKE_CURRENT_SOURCE_DIR}/test/${PYFILE} )
 		# Set the previously-built environment
-		set_tests_properties( ${PYFILE} PROPERTIES RUN_SERIAL 1 ENVIRONMENT "${TEST_ENVIRONMENT}")
+		set_tests_properties ( ${PYFILE} PROPERTIES
+                           RUN_SERIAL 1
+                           ENVIRONMENT "${TEST_ENVIRONMENT}"
+                           TIMEOUT ${TESTING_TIMEOUT} )
 	endforeach ()
 
     add_dependencies( GUITests MantidPlot )


### PR DESCRIPTION
Fixes trac issue [#10721](http://trac.mantidproject.org/mantid/ticket/10721).

Tester: The test timeout defaults to 300 seconds but is configurable using the TESTING_TIMEOUT cmake property. You can verify that this works by setting it to 1 second and observing that a lot of tests fail. 
