### PR TITLE
Fix Python tests in debug mode under Windows & ctest.

### DIFF
--- a/Code/Mantid/Build/CMake/FindPyUnitTest.cmake
+++ b/Code/Mantid/Build/CMake/FindPyUnitTest.cmake
@@ -30,8 +30,8 @@ macro ( PYUNITTEST_ADD_TEST _test_src_dir _testname_prefix )
                  COMMAND ${PYTHON_EXECUTABLE_DEBUG} -B ${_test_src_dir}/${_filename} )
       # Set the PYTHONPATH so that the built modules can be found
       set_tests_properties ( ${_pyunit_separate_name}_Debug PROPERTIES
-                             ENVIRONMENT "PYTHONPATH=${_module_dir}"
-                             WORKING_DIRECTORY ${_working_dir}
+                             ENVIRONMENT "PYTHONPATH=${_module_dir_debug}"
+                             WORKING_DIRECTORY ${_working_dir_debug}
                              TIMEOUT ${TESTING_TIMEOUT} )
       # Release
       add_test ( NAME ${_pyunit_separate_name} CONFIGURATIONS Release


### PR DESCRIPTION
Fixes trac issue [#10745](http://trac.mantidproject.org/mantid/ticket/10745)

It should be enough to verify that the Windows debug build passes: http://builds.mantidproject.org/view/Develop%20Builds/job/develop_clean_win7_debug/
