### PR TITLE
Fix drag-n-drop plotting to respect distribution flag.

### DIFF
--- a/Code/Mantid/MantidPlot/src/MultiLayer.cpp
+++ b/Code/Mantid/MantidPlot/src/MultiLayer.cpp
@@ -1395,7 +1395,9 @@ void MultiLayer::dropOntoMatrixCurve(Graph *g, MantidMatrixCurve* originalCurve,
     for( ; setIt != it.value().end(); ++setIt)
     {
       try {
-        new MantidMatrixCurve(it.key(),g,(*setIt),MantidMatrixCurve::Spectrum, errorBars); // The graph takes ownership
+        // If the current curve is plotted as a distribution then do so also here
+        new MantidMatrixCurve(it.key(),g,(*setIt),MantidMatrixCurve::Spectrum, errorBars,
+                              originalCurve->isDistribution()); // The graph takes ownership
       } catch (Mantid::Kernel::Exception::NotFoundError &) {
         // Get here if workspace name is invalid - shouldn't be possible, but just in case
       } catch (std::invalid_argument&) {


### PR DESCRIPTION
Fixes trac issue [#10743](http://trac.mantidproject.org/mantid/ticket/10743)

Tester: The following script (reproduced from the ticket)

``` python
w=Load('CNCS_7860')
w=SumSpectra(w)
w=Rebin(w,10)
```

produces a workspace. Plot a spectrum from the workspace and then once the plot is open drag the same workspace on to the plot. The curves should now match.
