### PR TITLE
Ignore deprecation warnings about numpy.oldnumeric

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/__init__.py
+++ b/Code/Mantid/Framework/PythonInterface/mantid/__init__.py
@@ -44,7 +44,12 @@ except ImportError:
 # Set deprecation warnings back to default (they are ignored in 2.7)
 ###############################################################################
 import warnings as _warnings
+# Default we see everything
 _warnings.filterwarnings("default",category=DeprecationWarning)
+# We can't do anything about numpy.oldnumeric being deprecated but
+# still used in other libraries, e.g scipy, so just ignore those
+_warnings.filterwarnings("ignore",category=DeprecationWarning,
+                         module="numpy.oldnumeric")
 
 ###############################################################################
 # Try to be smarter when finding Mantid framework libraries


### PR DESCRIPTION
Fixes trac issue [#10734](http://trac.mantidproject.org/mantid/ticket/10734)

Tester: This should be tested on a system with `numpy v1.8` & `scipy v0.13`. Build the code and run `python -c "import mantid"`, you should see no warnings.

To check that all deprecation warnings have not been squashed you can use this script

``` python
from mantid.simpleapi import CreateSampleWorkspace

ws = CreateSampleWorkspace()
ws.getNumberBins()
```

It should produce a warning about `getNumberBins` being deprecated
