### PR TITLE
Fix crash on Linux when opening VSI

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -252,16 +252,18 @@ void MdViewerWidget::createAppCoreForPlugin()
   if (!pqApplicationCore::instance())
   {
     // Provide ParaView's application core with a path to ParaView
-    int argc = 1;
-
     std::string paraviewPath = Mantid::Kernel::ConfigService::Instance().getParaViewPath();
+    if(paraviewPath.empty())
+    {
+      // ParaView crashes with an empty string but on Linux/OSX we dont set this property
+      paraviewPath = "/tmp/MantidPlot";
+    }
     std::vector<char> argvConversion(paraviewPath.begin(), paraviewPath.end());
     argvConversion.push_back('\0');
 
+    int argc = 1;
     char *argv[] = {&argvConversion[0]};
-
     g_log.debug() << "Intialize pqApplicationCore with " << argv << "\n";
-
     new pqPVApplicationCore(argc, argv);
   }
   else

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ThreesliceView.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ThreesliceView.cpp
@@ -43,13 +43,17 @@ ThreeSliceView::ThreeSliceView(QWidget *parent) : ViewBase(parent)
 {
   this->ui.setupUi(this);
 
-  // We need to load the QuadView.dll plugin. The Windows system requires the full
+  // We need to load the QuadView plugin
+  QString quadViewLibrary;
+#ifdef Q_OS_WIN32
+  // Windows requires the full
   // path information. The DLL is located in the apropriate executeable path of paraview.
   const Poco::Path paraviewPath(Mantid::Kernel::ConfigService::Instance().getParaViewPath());
-
   Poco::Path quadViewFullPath(paraviewPath, QUADVIEW_LIBRARY.toStdString());
-
-  QString quadViewLibrary(quadViewFullPath.toString().c_str());
+  quadViewLibrary = quadViewFullPath.toString().c_str();
+#else
+  quadViewLibrary = QUADVIEW_LIBRARY;
+#endif
 
   // Need to load plugin
   pqPluginManager* pm = pqApplicationCore::instance()->getPluginManager();
@@ -57,7 +61,7 @@ ThreeSliceView::ThreeSliceView(QWidget *parent) : ViewBase(parent)
   pm->loadExtension(pqActiveObjects::instance().activeServer(),
                     quadViewLibrary, &error, false);
 
-  g_log.debug() << "Loading QuadView.dll from " << quadViewLibrary.toStdString() << "\n";
+  g_log.debug() << "Loading QuadView library from " << quadViewLibrary.toStdString() << "\n";
 
   this->mainView = this->createRenderView(this->ui.mainRenderFrame,
                                           QString("pqQuadView"));


### PR DESCRIPTION
Fixes trac issue [#10740](http://trac.mantidproject.org/mantid/ticket/10740)

The issue came in with ticket [#10533](http://trac.mantidproject.org/mantid/ticket/10533). The code now does what it did before 10533 for Linux/Mac but uses the absolute paths for Windows.

This should be tested on both Linux and Windows. It will require a build with ParaView. The following script can be used to create a test MD workspace

``` python
CreateSimulationWorkspace(Instrument='MARI', BinParams='-11,0.1,11', OutputWorkspace='mari')
AddSampleLog(Workspace='mari', LogName='ei', LogText='12.5', LogType='Number')
ConvertToMD(InputWorkspace='mari', QDimensions='Q3D', OutputWorkspace='mdws')
```

If Mantid is linked to ParaView then right click on the MD workspace & show the VSI. You should see the image in the default view. Now try and choose the quad view and it should load successfully.
