### PR TITLE
Fix creation of symbolic links in rpm scripts.

### DIFF
--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
@@ -6,17 +6,20 @@
 #
 ENVVARS_ON_INSTALL=@ENVVARS_ON_INSTALL_INT@
 
-if [ ! -e $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidplot ]; then
-  ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidplot
-fi
-
+# Create symbolic links
 if [ -f $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot ]; then
-  mv $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot_exe
-  ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot
+    mv $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot_exe
+    if [ ! -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot ]; then
+        ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot
+    fi
+    if [ ! -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidplot ]; then
+        ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidplot
+    fi
 fi
 
+# Environment updates if required
 if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
-  # Link profiles to /etc/profile.d
-  ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.sh /etc/profile.d/mantid.sh
-  ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.csh /etc/profile.d/mantid.csh
+    # Link profiles to /etc/profile.d
+    ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.sh /etc/profile.d/mantid.sh
+    ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.csh /etc/profile.d/mantid.csh
 fi

--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_install.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_install.sh.in
@@ -6,8 +6,16 @@
 #
 ENVVARS_ON_INSTALL=@ENVVARS_ON_INSTALL_INT@
 
+# Remove stale links if left around
 if [  -h $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidplot ]; then
   rm $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidplot
+fi
+if [  -h $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot ]; then
+    rm $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot
+fi
+# Stale _exe
+if [  -f @CMAKE_INSTALL_PREFIX@/@BIN_DIR@/MantidPlot_exe ]; then
+    rm $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot_exe
 fi
 
 if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then


### PR DESCRIPTION
Fixes trac issue [#10784](http://trac.mantidproject.org/mantid/ticket/10784)

Tester: The best check here is to look at the contents of the bin directory of the installed package. Both `MantidPlot` and `mantidplot` should be symbolic links to the `launch_mantidplot.sh` script. This script then deals with the TCMALLOC wrapper around the actually executable `MantidPlot_exe` 
