### PR TITLE
Re #10805 Modify solid angle correction for tubes

### DIFF
--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
@@ -139,15 +139,17 @@ void SANSSolidAngleCorrection::exec()
 
     // Compute solid angle correction factor
     const bool is_tube = getProperty("DetectorTubes");
-    double tanTheta;
+    const double tanTheta = tan( inputWS->detectorTwoTheta(det) );
+    const double theta_term = sqrt(tanTheta*tanTheta + 1.0);
+    double corr;
     if (is_tube)
     {
-    	tanTheta = tan( getYTubeAngle(det, inputWS) );
+        const double tanAlpha = tan( getYTubeAngle(det, inputWS) );
+        const double alpha_term = sqrt(tanAlpha*tanAlpha + 1.0);
+        corr = alpha_term*theta_term*theta_term;
     } else {
-        tanTheta = tan( inputWS->detectorTwoTheta(det) );
+        corr = theta_term*theta_term*theta_term;
     }
-    const double term = sqrt(tanTheta*tanTheta + 1.0);
-    const double corr = term*term*term;
 
     // Correct data for all X bins
     for (int j = 0; j < xLength; j++)
@@ -211,9 +213,18 @@ void SANSSolidAngleCorrection::execEvent()
     if ( det->isMonitor() || det->isMasked() ) continue;
 
     // Compute solid angle correction factor
+    const bool is_tube = getProperty("DetectorTubes");
     const double tanTheta = tan( inputEventWS->detectorTwoTheta(det) );
-    const double term = sqrt(tanTheta*tanTheta + 1.0);
-    const double corr = term*term*term;
+    const double theta_term = sqrt(tanTheta*tanTheta + 1.0);
+    double corr;
+    if (is_tube)
+    {
+        const double tanAlpha = tan( getYTubeAngle(det, inputWS) );
+        const double alpha_term = sqrt(tanAlpha*tanAlpha + 1.0);
+        corr = alpha_term*theta_term*theta_term;
+    } else {
+        corr = theta_term*theta_term*theta_term;
+    }
     EventList& el = outputEventWS->getEventList(i);
     el*=corr;
     progress.report("Solid Angle Correction");


### PR DESCRIPTION
The instrument scientists asked to modify the solid angle correction for tubes.
The code they sent was the following:

```
if (is_tube)
{
    tanAlpha = tan( getYTubeAngle(det, inputWS) );
    tanTheta = tan( inputWS->detectorTwoTheta(det) );       
    const double term1 = sqrt(tanAlpha*tanAlpha + 1.0);
    const double term2 = sqrt(tanTheta*tanTheta + 1.0);
    const double corr = term1*term2*term2;
} else {
    tanTheta = tan( inputWS->detectorTwoTheta(det) );
    const double term3 = sqrt(tanTheta*tanTheta + 1.0);
    const double corr = term3*term3*term3;
}
```

Please double check the implementation. The system tests should all pass and there should be no change in functionality.

The ticket is here: http://trac.mantidproject.org/mantid/ticket/10805
