### PR TITLE
Use unix-style line endings in script editor on OSX.

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/ScriptEditor.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/ScriptEditor.cpp
@@ -146,6 +146,14 @@ ScriptEditor::ScriptEditor(QWidget *parent, QsciLexer *codelexer, const QString 
   m_currentExecLine(0), m_completer(NULL),m_previousKey(0),
   m_findDialog(new FindReplaceDialog(this)), m_settingsGroup(settingsGroup)
 {
+  // Older versions of QScintilla still use just CR as the line ending, which is pre-OSX.
+  // New versions just use unix-style for everything but Windows.
+#if defined(Q_OS_WIN)
+  setEolMode(EolWindows);
+#else
+  setEolMode(EolUnix);
+#endif
+
   //Syntax highlighting and code completion
   setLexer(codelexer);
   readSettings();


### PR DESCRIPTION
Fixes issue [#10654](http://trac.mantidproject.org/mantid/ticket/10654)

Tester: This needs to be verified on OSX. To reproduce the problem before merging:
1. Start MantidPlot
2. Open the script window
3. Type a few separate lines of text and save the file.
4. Close the file in the window and then reopen it again. The line endings will have disppeared!

Merge the fix and try the steps above. It should give you back the file as before.
