### PR TITLE
Refs #10838. Suppress new clang warnings. Fix remaining warning.

### DIFF
--- a/Code/Mantid/Build/CMake/CommonSetup.cmake
+++ b/Code/Mantid/Build/CMake/CommonSetup.cmake
@@ -242,7 +242,10 @@ endif ()
 if ( CMAKE_COMPILER_IS_GNUCXX )
   include ( GNUSetup )
 elseif ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
-  include ( GNUSetup )
+  # Remove once clang warnings have been fixed. 
+  if ( NOT APPLE)
+    include ( GNUSetup )
+  endif ()
 endif ()
 
 ###########################################################################

--- a/Code/Mantid/QtPropertyBrowser/src/qtvariantproperty.cpp
+++ b/Code/Mantid/QtPropertyBrowser/src/qtvariantproperty.cpp
@@ -192,7 +192,6 @@ static QtProperty *wrappedProperty(QtProperty *property)
 
 class QtVariantPropertyPrivate
 {
-    QtVariantProperty *q_ptr;
 public:
     QtVariantPropertyPrivate(QtVariantPropertyManager *m) : manager(m) {}
 


### PR DESCRIPTION
Additional warning options were added to the osx+clang build in ticket #10685. This is to temporarily suppress these warnings on OSX. I also removed an unused private field that was still generating a warning.

testing: given the minimal changes, code review plus checking the build results should be sufficient.

http://trac.mantidproject.org/mantid/ticket/10838
