### PR TITLE
Paraview 4.3 fixes

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/LibHelper.h.in
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/LibHelper.h.in
@@ -10,8 +10,6 @@ namespace Vates
 namespace SimpleGui
 {
 
-const QString QUADVIEW_LIBRARY("@CMAKE_SHARED_LIBRARY_PREFIX@QuadView@CMAKE_SHARED_LIBRARY_SUFFIX@");
-
 } // namespace SimpleGui
 } // namespace Vates
 } // namespace Mantid

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.ui
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.ui
@@ -343,7 +343,7 @@
   <customwidget>
    <class>pqProxiesWidget</class>
    <extends>QWidget</extends>
-   <header>pqproxieswidget.h</header>
+   <header>pqProxiesWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ThreesliceView.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ThreesliceView.cpp
@@ -43,29 +43,8 @@ namespace
 ThreeSliceView::ThreeSliceView(QWidget *parent) : ViewBase(parent)
 {
   this->ui.setupUi(this);
-
-  // We need to load the QuadView plugin
-  QString quadViewLibrary;
-#ifdef Q_OS_WIN32
-  // Windows requires the full
-  // path information. The DLL is located in the apropriate executeable path of paraview.
-  const Poco::Path paraviewPath(Mantid::Kernel::ConfigService::Instance().getParaViewPath());
-  Poco::Path quadViewFullPath(paraviewPath, QUADVIEW_LIBRARY.toStdString());
-  quadViewLibrary = quadViewFullPath.toString().c_str();
-#else
-  quadViewLibrary = QUADVIEW_LIBRARY;
-#endif
-
-  // Need to load plugin
-  pqPluginManager* pm = pqApplicationCore::instance()->getPluginManager();
-  QString error;
-  pm->loadExtension(pqActiveObjects::instance().activeServer(),
-                    quadViewLibrary, &error, false);
-
-  g_log.debug() << "Loading QuadView library from " << quadViewLibrary.toStdString() << "\n";
-
   this->mainView = this->createRenderView(this->ui.mainRenderFrame,
-                                          QString("QuadView"));
+                                          QString("OrthographicSliceView"));
   pqActiveObjects::instance().setActiveView(this->mainView);
 }
 


### PR DESCRIPTION
First batch of changes to get Mantid building with ParaView pre-4.3 (specifically, v4.2.0-339-g3d6f539). 

This replaces the QuadView with the new OrthographicSliceView.
