### PR TITLE
Add fields to SendUsage

### DIFF
--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/SendUsage.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/SendUsage.cpp
@@ -87,7 +87,8 @@ const std::string SendUsage::summary() const {
 /** Initialize the algorithm's properties.
  */
 void SendUsage::init() {
-  // declareProperty("UsageString", "", Direction::Input);
+  declareProperty("Application", "mantidplot", "how mantid was invoked");
+  declareProperty("Component", "", "leave blank for now");
   declareProperty("Json", "", Direction::Output);
   declareProperty("HtmlCode", -1, Direction::Output);
 }
@@ -127,7 +128,23 @@ void SendUsage::sendReport(const std::string &json) {
 std::string SendUsage::generateJson() {
   // later in life the additional parameters can be done after
   // the current date and time
-  return std::string(g_header + currentDateAndTime() + "}");
+  std::stringstream buffer;
+  buffer << g_header << currentDateAndTime();
+
+  // get the properties that were set
+  std::string application = this->getPropertyValue("Application");
+  if (!application.empty()) {
+    buffer << ",\"application\":\"" << application << "\"";
+  }
+  std::string component = this->getPropertyValue("Component");
+  if (!component.empty()) {
+    buffer << ",\"component\":\"" << component << "\"";
+  }
+
+  // close the document
+  buffer << "}";
+
+  return buffer.str();
 }
 
 /**

--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/SendUsage.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/SendUsage.cpp
@@ -160,7 +160,9 @@ void SendUsage::generateHeader() {
          << "\"osArch\":\"" << ConfigService::Instance().getOSArchitecture()
          << "\","
          << "\"osVersion\":\"" << ConfigService::Instance().getOSVersion()
-         << "\",";
+         << "\","
+         << "\"osReadable\":\""
+         << ConfigService::Instance().getOSVersionReadable() << "\",";
 
   // paraview version or zero
   buffer << "\"ParaView\":\"";


### PR DESCRIPTION
This was originally [trac #10810](http://trac.mantidproject.org/mantid/ticket/10810).

**To test:** Enable actually sending with `usagereports.enabled=1` and see that things appear in http://reports.mantidproject.org/api/usage (the last page will have your call).
