### PR TITLE
Fix crash when clicking on deleted windows in the project explorer

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3131,7 +3131,6 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString,int>& toPlot, bool spectrum
   }
   bool isGraphNew = false;
   MultiLayer* ml = appWindow()->prepareMultiLayer(isGraphNew, plotWindow, plotTitle, clearWindow);
-  ml->setName(appWindow()->generateUniqueName(plotTitle + "-"));
   m_lastShown1DPlotWin = ml;
 
   // Do we plot try to plot as distribution. If request and it is not already one!


### PR DESCRIPTION
Fixes trac issue [#10887](http://trac.mantidproject.org/mantid/ticket/10887)

**Tester**
 The steps to reproduce the problem are in issue description in the link above. It is worth checking that you can reproduce the problem before merging the fix locally to make sure you understand what is happening and can be confident that the fix is correct.
