### PR TITLE
Fix rpms for Fedora >= 18 and RHEL >= 7

### DIFF
--- a/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
+++ b/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
@@ -22,6 +22,10 @@ endif()
 
 set ( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR};${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR} )
 
+# Tell rpm that this package does not own /opt /usr/share/{applications,pixmaps}
+# Required for Fedora >= 18 and RHEL >= 7
+set ( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /opt /usr/share/applications /usr/share/pixmaps )
+
 ###########################################################################
 # LD_PRELOAD libraries
 ###########################################################################


### PR DESCRIPTION
This fixes trac issue [#10911](http://trac.mantidproject.org/mantid/ticket/10911)

To test, try out the rpm on a Fedora 20 system.
