### PR TITLE
refs #10934. Fix 4d problem.

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CutMD.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/CutMD.py
@@ -252,13 +252,13 @@ class CutMD(DataProcessorAlgorithm):
                     max = p4_bins[1]
                     nbins = 1
                 elif n_args == 3:
-                    min = p4_bins[i][0]
-                    max = p4_bins[i][2]
+                    min = p4_bins[0]
+                    max = p4_bins[2]
                     step_size = p4_bins[1]
                     dim_range = max - min
                     if step_size > dim_range:
                         step_size = dim_range
-                    n_bins = int( dim_range / step_size)
+                    nbins = int( dim_range / step_size)
                 
                 extents.append(min)
                 extents.append(max)
@@ -303,7 +303,7 @@ class CutMD(DataProcessorAlgorithm):
                 label = orthogonal_dimension.getName() 
                 unit = orthogonal_dimension.getUnits()
                 vec = [0] * ndims
-                vec[i] = i
+                vec[i] = 1
             
             value = "%s, %s, %s" % ( label, unit, ",".join(map(str, vec))) 
             cut_alg.setPropertyValue("BasisVector{0}".format(i) , value)    

--- a/Code/Mantid/Framework/PythonInterface/test/python/mantid/api/CutMDTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/mantid/api/CutMDTest.py
@@ -221,7 +221,13 @@ class CutMDTest(unittest.TestCase):
         
         self.assertTrue(isinstance(out_md, IMDHistoWorkspace), "Expect that the output was an IMDHistoWorkspace given the NoPix flag.")
                 
-                    
+        '''
+        Process the 4D workspace again, this time with different binning
+        '''
+        out_md = CutMD(to_cut, P1Bin=[-0.5,0.5], P2Bin=[-0.1,0.1], P3Bin=[-0.3,0.3], P4Bin=[-8,1,8],  NoPix=True) 
+        self.assertEqual(16, out_md.getDimension(3).getNBins())
+        self.assertTrue(isinstance(out_md, IMDHistoWorkspace), "Expect that the output was an IMDHistoWorkspace given the NoPix flag.")
+                
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
CutMD not working with step size specified in 4 dimensions. 

Test example in trac ticket.

[#10934](http://trac.mantidproject.org/mantid/ticket/10934)
