### PR TITLE
PeaksViewer crash

### DIFF
--- a/Code/Mantid/MantidPlot/test/MantidPlotSliceViewerTest.py
+++ b/Code/Mantid/MantidPlot/test/MantidPlotSliceViewerTest.py
@@ -161,9 +161,6 @@ class MantidPlotSliceViewerTest(unittest.TestCase):
 
         # Set the Foreground Colour
         peaksPresenter.setForegroundColor(QtGui.QColor(255, 0, 0, 255))
-        
-        # Check that it responds to changed workspaces
-        RenameWorkspace('pw',OutputWorkspace='pw_renamed')
 
         # Zoom in on peak.
         peaksPresenter.zoomToPeak(0)

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeaksViewer.h
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/PeaksViewer.h
@@ -36,9 +36,11 @@ public:
       boost::shared_ptr<const Mantid::API::IPeaksWorkspace> toWorkspace);
   bool removePeaksWorkspace(
       boost::shared_ptr<const Mantid::API::IPeaksWorkspace> toRemove);
+  bool removePeaksWorkspace(const std::string &toRemove);
   void hide();
   ~PeaksViewer();
   bool hasThingsToShow() const;
+
 public slots:
   void onPeakColourChanged(Mantid::API::IPeaksWorkspace_const_sptr, QColor);
   void onBackgroundColourChanged(Mantid::API::IPeaksWorkspace_const_sptr,

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewerWindow.h
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewerWindow.h
@@ -65,6 +65,9 @@ protected:
                           const boost::shared_ptr<Mantid::API::Workspace> ws);
   void resizeEvent(QResizeEvent *event);
 
+  void renameHandle(const std::string& oldName,
+          const std::string& newName);
+
   /// The SliceViewer
   MantidQt::SliceViewer::SliceViewer *m_slicer;
 

--- a/Code/Mantid/MantidQt/SliceViewer/src/PeaksViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/PeaksViewer.cpp
@@ -297,6 +297,35 @@ bool PeaksViewer::removePeaksWorkspace(
   return somethingToRemove;
 }
 
+bool PeaksViewer::removePeaksWorkspace(const
+    std::string& toRemove) {
+  bool somethingToRemove = false;
+
+  if (m_presenter) {
+
+    QList<PeaksWorkspaceWidget *> children =
+        qFindChildren<PeaksWorkspaceWidget *>(this);
+
+    for (int i = 0; i < children.size(); ++i) {
+      PeaksWorkspaceWidget *candidateWidget = children.at(i);
+      const std::string candidateWorkspaceName =
+          candidateWidget->getWSName();
+      somethingToRemove = (candidateWorkspaceName == toRemove);
+      if (somethingToRemove) {
+        // We have the right widget to update. Workspace is the same, just
+        // redraw
+        // the table.
+        candidateWidget->hide();
+        children.removeAt(i);
+        m_presenter->remove(candidateWidget->getPeaksWorkspace());
+        break;
+      }
+    }
+
+  }
+  return somethingToRemove;
+}
+
 /**
  * Slot called when the user wants to see the dialog for selecting
  * what columns are visible in the tables of peaks.


### PR DESCRIPTION
[10952](http://trac.mantidproject.org/mantid/ticket/10952) SliceViewer crash reported by @mantid-roman when a PeaksWorkspace is renamed in place while it is being used in the PeaksViewer mode of the SliceViewer. The original trac ticket contains instructions to reproduce this.
