### PR TITLE
update build script for develop_incremental-clang

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -15,28 +15,30 @@
 cmake --version
 echo "SHA1=${sha1}"
 
+if [[ ${JOB_NAME} == *clang* ]]; then
+  # Assuming we are using the clang compiler
+  echo "Using clang/llvm compiler."
+  clang --version
+  export CC=clang
+  export CXX=clang++
+fi
+
 ###############################################################################
-# OS X setup steps
+# OS X 10.8 setup steps
 ###############################################################################
-if [[ $(uname) == 'Darwin' ]]; then
-  if [[ ${JOB_NAME} == *clang* ]]; then
-    # Assuming we are using the clang compiler
-    echo "Using clang/llvm compiler."
-    clang --version
-  else
-    # Assuming we are using the Intel compiler
-    cd $WORKSPACE/Code
-    ./fetch_Third_Party.sh
-    cd $WORKSPACE
-    # Setup environment variables
-    source /opt/intel/bin/iccvars.sh intel64
-    export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$WORKSPACE/Code/Third_Party/lib/mac64:/Library/Frameworks
-    # Make sure we pick up the Intel compiler
-    export CC=icc
-    export CXX=icpc
-    echo "Using Intel compiler."
-    icpc --version
-  fi
+if [[ $(uname) == 'Darwin' ]] && [[ ${JOB_NAME} != *clang* ]]; then
+  # Assuming we are using the Intel compiler
+  cd $WORKSPACE/Code
+  ./fetch_Third_Party.sh
+  cd $WORKSPACE
+  # Setup environment variables
+  source /opt/intel/bin/iccvars.sh intel64
+  export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$WORKSPACE/Code/Third_Party/lib/mac64:/Library/Frameworks
+  # Make sure we pick up the Intel compiler
+  export CC=icc
+  export CXX=icpc
+  echo "Using Intel compiler."
+  icpc --version
 fi
 
 ###############################################################################

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -21,8 +21,8 @@ if [[ ${JOB_NAME} == *clang* ]]; then
   clang --version
   export CC=clang
   export CXX=clang++
-  GCCVERSION=`grep 'GCC_COMPILER_VERSION' $WORKSPACE/build/CMakeCache.txt` 
-  if [[ $GCCVERSION != "" ]]; then 
+  COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt` 
+  if [[ $COMPILERFILEPATH != *clang++* ]]; then 
     # Removing the build directory entirely guarantees clang is used.
     rm -rf $WORKSPACE/build
   fi 

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -21,6 +21,11 @@ if [[ ${JOB_NAME} == *clang* ]]; then
   clang --version
   export CC=clang
   export CXX=clang++
+  GCCVERSION=`grep 'GCC_COMPILER_VERSION' $WORKSPACE/build/CMakeCache.txt` 
+  if [[ ${GCCVERSION} != "" ]]; then 
+    # Removing the build directory entirely guarantees clang is used.
+    rm -rf $WORKSPACE/build
+  fi 
 fi
 
 ###############################################################################

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -22,7 +22,7 @@ if [[ ${JOB_NAME} == *clang* ]]; then
   export CC=clang
   export CXX=clang++
   GCCVERSION=`grep 'GCC_COMPILER_VERSION' $WORKSPACE/build/CMakeCache.txt` 
-  if [[ ${GCCVERSION} != "" ]]; then 
+  if [[ $GCCVERSION != "" ]]; then 
     # Removing the build directory entirely guarantees clang is used.
     rm -rf $WORKSPACE/build
   fi 


### PR DESCRIPTION
This updates the build script so that linux builds with clang in the title use clang and not gcc. If gcc was used previously, It also deletes the build directory.

testing: In the jenkins job develop_incremental-clang, verify that fedora20-build is using clang and clang++ instead of gcc and g++.

http://trac.mantidproject.org/mantid/ticket/10950
