### PR TITLE
Refs #10972. pipe error output to /dev/null

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -21,7 +21,7 @@ if [[ ${JOB_NAME} == *clang* ]]; then
   clang --version
   export CC=clang
   export CXX=clang++
-  COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt` 
+  COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt 2>/dev/null` 
   if [[ $COMPILERFILEPATH != *clang++* ]]; then 
     # Removing the build directory entirely guarantees clang is used.
     rm -rf $WORKSPACE/build


### PR DESCRIPTION
When CMakeCache.txt isn't present, grep outputs an error. We need to suppress this error so that the buildscript will continue. Only the *-clang builds are affected. 

testing: Given the size of the change, a code review is sufficient.

http://trac.mantidproject.org/mantid/ticket/10972
