### PR TITLE
fix master_clean-clang build

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -21,7 +21,9 @@ if [[ ${JOB_NAME} == *clang* ]]; then
   clang --version
   export CC=clang
   export CXX=clang++
-  if [[ -e $WORKSPACE/build/CMakeCache.txt ]]; then
+  #check if CMakeCache.txt exists and if so that the cxx compiler is clang++
+  #only needed with incremental builds. Clean builds delete this directory in a later step. 
+  if [[ -e $WORKSPACE/build/CMakeCache.txt ]] && [[ ${JOB_NAME} != *clean* ]]; then
     COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt` 
     if [[ $COMPILERFILEPATH != *clang++* ]]; then 
       # Removing the build directory entirely guarantees clang is used.

--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -21,10 +21,12 @@ if [[ ${JOB_NAME} == *clang* ]]; then
   clang --version
   export CC=clang
   export CXX=clang++
-  COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt 2>/dev/null` 
-  if [[ $COMPILERFILEPATH != *clang++* ]]; then 
-    # Removing the build directory entirely guarantees clang is used.
-    rm -rf $WORKSPACE/build
+  if [[ -e $WORKSPACE/build/CMakeCache.txt ]]; then
+    COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt` 
+    if [[ $COMPILERFILEPATH != *clang++* ]]; then 
+      # Removing the build directory entirely guarantees clang is used.
+      rm -rf $WORKSPACE/build
+    fi
   fi 
 fi
 


### PR DESCRIPTION
When CMakeCache.txt isn't present, the jenkins build ends in a failure. We need to suppress this error so that the buildscript will continue. Only the *-clang builds are affected.

testing: Check that develop_clean-clang builds correctly. 

http://trac.mantidproject.org/mantid/ticket/10972
