### PR TITLE
Refs #10990 Use consistent title levels

### DIFF
--- a/Code/Mantid/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst
+++ b/Code/Mantid/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst
@@ -147,7 +147,7 @@ Refinement Algorithm
 Two refinement algorithms, DirectFit and MonteCarlo, are provided.
 
 DirectFit
-#########
+^^^^^^^^^
 
 This is a simple one step fitting. If there is one parameter to fit,
 Levenberg Marquart minimizer is chosen. As its coefficients are strongly
@@ -155,7 +155,7 @@ correlated to each other, Simplex minimizer is used if there are more
 than 1 parameter to fit.
 
 MonteCarlo
-##########
+^^^^^^^^^^
 
 This adopts the concept of Monte Carlo random walk in the parameter
 space. In each MC step, one parameter will be chosen, and a new value is
@@ -166,7 +166,7 @@ Simulated annealing will be tried as soon as it is implemented in
 Mantid.
 
 Constraint
-##########
+^^^^^^^^^^
 In future, constaint will be considered.
 
 


### PR DESCRIPTION
Trac: [#10990](http://trac.mantidproject.org/mantid/ticket/10990)

When compiling documentation these warnings are emitted. This pull-request resolves the warnings.

```
/home/harry/MantidProject/testing/repo/Code/Mantid/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst:149: SEVERE: Title level inconsistent:

DirectFit
#########
/home/harry/MantidProject/testing/repo/Code/Mantid/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst:157: SEVERE: Title level inconsistent:

MonteCarlo
##########
/home/harry/MantidProject/testing/repo/Code/Mantid/docs/source/algorithms/RefinePowderInstrumentParameters-v3.rst:168: SEVERE: Title level inconsistent:

Constraint
##########
```

**Testing**
- Build `docs-qthelp`, the warning should no longer occur.
