### PR TITLE
Add a define for the OF macro

### DIFF
--- a/Code/Mantid/MantidPlot/src/zlib123/minigzip.c
+++ b/Code/Mantid/MantidPlot/src/zlib123/minigzip.c
@@ -50,6 +50,10 @@
 #  include <unix.h> /* for fileno */
 #endif
 
+#ifndef OF
+#define OF(args) args
+#define
+
 #ifndef WIN32 /* unlink already in stdio.h for WIN32 */
   extern int unlink OF((const char *));
 #else

--- a/Code/Mantid/MantidPlot/src/zlib123/minigzip.c
+++ b/Code/Mantid/MantidPlot/src/zlib123/minigzip.c
@@ -50,9 +50,14 @@
 #  include <unix.h> /* for fileno */
 #endif
 
+/* New versions of zlib use _Z_OF rather than OF */
 #ifndef OF
-#define OF(args) args
-#define
+#  ifdef _Z_OF
+#    define OF _Z_OF
+#  else
+#    define OF(args) args
+#  endif
+#endif
 
 #ifndef WIN32 /* unlink already in stdio.h for WIN32 */
   extern int unlink OF((const char *));


### PR DESCRIPTION
This macro is not defined on my system, giving compile errors

I added a #define defining it as nothing -- is that correct? I'm not sure what it was supposed to do.
