### PR TITLE
refs #10998. Delete pointer.

### DIFF
--- a/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalFactoryTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalFactoryTest.h
@@ -91,6 +91,7 @@ public:
     TS_ASSERT(sphericalShapeProduct);
 
     TS_ASSERT_EQUALS(sourceShape, *sphericalShapeProduct);
+    delete productShape;
   }
 };
 


### PR DESCRIPTION
Fix valgrind error with PeakShapeSphericalTest.
​http://builds.mantidproject.org/job/valgrind_develop_core_packages/308/valgrindResult/pid=17860/

[#10998](http://trac.mantidproject.org/mantid/ticket/10998)
