### PR TITLE
Added if section for google analytics in online help.

### DIFF
--- a/Code/Mantid/docs/source/_templates/layout.html
+++ b/Code/Mantid/docs/source/_templates/layout.html
@@ -1,4 +1,20 @@
 {% extends "!layout.html" %}
 
+{% block extrahead %}
 {# Custom CSS overrides #}
 {% set bootswatch_css_custom = ['_static/custom.css'] %}
+
+{% if builder == "html" %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-59110517-1', 'auto');
+  ga('send', 'pageview');
+
+</script>
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
This was originally [#10992](http://trac.mantidproject.org/mantid/ticket/10992)

To test:
1. Build `docs-html` and `docs-qthelp`. 
2. Look at any html file in the results and see that the online help has the javascript and that the offline doesn't.
