### PR TITLE
Moving css declaration out of the extrahead section

### DIFF
--- a/Code/Mantid/docs/source/_templates/layout.html
+++ b/Code/Mantid/docs/source/_templates/layout.html
@@ -1,9 +1,6 @@
 {% extends "!layout.html" %}
 
 {% block extrahead %}
-{# Custom CSS overrides #}
-{% set bootswatch_css_custom = ['_static/custom.css'] %}
-
 {% if builder == "html" %}
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -16,5 +13,7 @@
 
 </script>
 {% endif %}
-
 {% endblock %}
+
+{# Custom CSS overrides #}
+{% set bootswatch_css_custom = ['_static/custom.css'] %}


### PR DESCRIPTION
This is a fix for the issue reported in #160.

To test: build the online help and look for `custom.css` to appear in the head of the html files.
