### PR TITLE
Fix valgrind warning in PeakShapeSpherical test

### DIFF
--- a/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalTest.h
@@ -96,6 +96,8 @@ public:
     TS_ASSERT_EQUALS(a.algorithmName(), clone->algorithmName());
     TS_ASSERT_EQUALS(a.algorithmVersion(), clone->algorithmVersion());
     TS_ASSERT_DIFFERS(clone, &a);
+    
+    delete clone;
   }
 
   void test_toJSON() {


### PR DESCRIPTION
A valgrind warning has appeared in [PeakShapeSphericalTest](http://builds.mantidproject.org/view/Valgrind/job/valgrind_develop_core_packages/314/valgrindResult/pid=17859,0x321/). This fixes the warning by deleting the cloned object.
