### PR TITLE
Fix broken link in SaveAscii documentation

### DIFF
--- a/Code/Mantid/docs/source/algorithms/SaveAscii-v2.rst
+++ b/Code/Mantid/docs/source/algorithms/SaveAscii-v2.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-The workspace data are stored in the file in columns: the first column contains the X-values, followed by pairs of Y and E values. Columns are separated by commas. The resulting file can normally be loaded into a workspace by the `LoadAscii2 <http://www.mantidproject.org/LoadAscii2>`_ algorithm.
+The workspace data are stored in the file in columns: the first column contains the X-values, followed by pairs of Y and E values. Columns are separated by commas. The resulting file can normally be loaded into a workspace by the :ref:`algm-LoadAscii` algorithm.
 
 Limitations
 ###########


### PR DESCRIPTION
The link to LoadAscii v2 in the SaveAscii documentation is broken. This pull request fixes it.
