### PR TITLE
11023 fix inequality operator of matrix

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/Matrix.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Matrix.cpp
@@ -435,7 +435,7 @@ Element by Element comparison
 @return false :: failure
 */
 {
-  return (this->operator==(A));
+  return !(this->operator==(A));
 }
 
 template <typename T>

--- a/Code/Mantid/Framework/Kernel/test/MatrixTest.h
+++ b/Code/Mantid/Framework/Kernel/test/MatrixTest.h
@@ -86,6 +86,17 @@ public:
     TS_ASSERT( A.equals(B, 0.15) );
   }
 
+  void test_not_equal()
+  {
+      Matrix<double> A(3, 3, true);
+      Matrix<double> B(3, 3, true);
+
+      A[0][0] = -1.0;
+
+      TS_ASSERT(A != B);
+      TS_ASSERT(!(A == B));
+  }
+
   /**
   Check that we can swap rows and columns
   */


### PR DESCRIPTION
While working on #10305 I discovered that Kernel::Matrix::operator!=() does exactly the opposite of what it's supposed to do. It returns the result of Kernel::Matrix::equal(), while it should return the negative of that.
