### PR TITLE
Refs #11022. Fixing PoldiAnalyseResiduals doctest

### DIFF
--- a/Code/Mantid/docs/source/algorithms/PoldiAnalyseResiduals-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiAnalyseResiduals-v1.rst
@@ -40,7 +40,10 @@ The following example shows how to calculate the residuals following a fit perfo
                                     Version=1)
 
     # Fit peaks to original 2D data
-    fit_result_Si_2D = PoldiFitPeaks2D(data_Si, PoldiPeakWorkspace="peaks_Si_1D", MaximumIterations=100, RefinedPoldiPeakWorkspace="peaks_Si_2D")
+    fit_result_Si_2D = PoldiFitPeaks2D(data_Si,
+				    PoldiPeakWorkspace="peaks_Si_1D", MaximumIterations=100,
+				    RefinedPoldiPeakWorkspace="peaks_Si_2D",
+				    Calculated1DSpectrum="fit_result_Si_1D")
 
     # Calculate residuals
     residuals_Si = PoldiAnalyseResiduals(MeasuredCountData=data_Si, FittedCountData="fit_result_Si_2D", MaxIterations=5)


### PR DESCRIPTION
In tickets #10263 and #10774 some POLDI algorithms changed and somehow the changes in the documentation overlapped and after merging into master, the doctest for PoldiAnalyseResiduals failed because of a missing output parameter. I'm going to add the parameter.
