### PR TITLE
Workspace2D::blocksize should call const version of dataY to avoid copies

### DIFF
--- a/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
@@ -90,7 +90,7 @@ size_t Workspace2D::size() const { return data.size() * blocksize(); }
 
 /// get the size of each vector
 size_t Workspace2D::blocksize() const {
-  return (data.size() > 0) ? data[0]->dataY().size() : 0;
+  return (data.size() > 0) ? static_cast<ISpectrum const *>(data[0])->dataY().size() : 0;
 }
 
 /**


### PR DESCRIPTION
This fixes trac issue [#11033](http://trac.mantidproject.org/mantid/ticket/11033)

Tester:
A code review should be sufficient here, assuming the tests pass.
