### PR TITLE
Remove setting/unsetting facility unnecessarily in indirect scripts

### DIFF
--- a/Code/Mantid/scripts/Inelastic/inelastic_indirect_reduction_steps.py
+++ b/Code/Mantid/scripts/Inelastic/inelastic_indirect_reduction_steps.py
@@ -986,14 +986,11 @@ class Naming(ReductionStep):
         try:
             short_name = config.getFacility().instrument(inst).shortName().lower()
         except RuntimeError:
-            original_facility = config['default.facility']
             for facility in config.getFacilities():
-                config['default.facility'] = facility.name()
                 try:
-                    short_name = config.getFacility().instrument(inst).shortName().lower()
+                    short_name = facility.instrument(inst).shortName().lower()
                 except RuntimeError:
                     pass
-            config['default.facility'] = original_facility
 
         if short_name == '':
             raise RuntimeError('Cannot find instrument "%s" in any facility' % str(inst))


### PR DESCRIPTION
This fixes trac issue [#11038](http://trac.mantidproject.org/mantid/ticket/11038)

Tester:
Check the changes to be sure you agree with what I have removed. I've checked with the system tests by merging with `develop` while we still have it. The documentation tests seem more stable, i.e. they don't segfault but there are two _real_ failures now.
