### PR TITLE
Refs #11016 Throw error on invalid screenshot

### DIFF
--- a/Code/Mantid/docs/sphinxext/mantiddoc/directives/interface.py
+++ b/Code/Mantid/docs/sphinxext/mantiddoc/directives/interface.py
@@ -59,14 +59,7 @@ class InterfaceDirective(BaseDirective):
         if not os.path.exists(screenshots_dir):
             os.makedirs(screenshots_dir)
 
-        try:
-            picture = custominterface_screenshot(self.interface_name(), screenshots_dir, widget_name = widget_name)
-        except RuntimeError, exc:
-            env = self.state.document.settings.env
-            env.warn(env.docname, "Unable to generate screenshot for '%s' - %s" % (self.interface_name(), str(exc)))
-            picture = None
-
-        return picture
+        return custominterface_screenshot(self.interface_name(), screenshots_dir, widget_name = widget_name)
 
     def _insert_screenshot_link(self, picture, align=None, width=None):
         """

--- a/Code/Mantid/docs/sphinxext/mantiddoc/tools/screenshot.py
+++ b/Code/Mantid/docs/sphinxext/mantiddoc/tools/screenshot.py
@@ -85,8 +85,13 @@ def custominterface_screenshot(name, directory, ext = ".png", widget_name = None
     # threadsafe_call required for MantidPlot
     dlg = threadsafe_call(iface_mgr.createSubWindow, name, None)
 
+    if dlg is None:
+      raise RuntimeError("Interface '%s' could not be created" % name)
+
     if widget_name:
       widget = dlg.findChild(QWidget, widget_name)
+      if widget is None:
+        raise RuntimeError("Widget '%s' does not exist in interface '%s'" % (widget_name, name))
       picture = Screenshot(widget, name.replace(' ','_') + "_" + widget_name + "_widget" + ext, directory)
     else:
       picture = Screenshot(dlg, name.replace(' ','_') + "_interface" + ext, directory)


### PR DESCRIPTION
This is for trac ticket: http://trac.mantidproject.org/mantid/ticket/11016

When an error occurs taking a screenshot of the interface we should fail noisily, rather than silently ignoring it.
