### PR TITLE
11039 fix failing poldi doctest

### DIFF
--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
@@ -61,6 +61,9 @@ public:
   void setParameter(const std::string &name, const double &value, bool explicitlySet = true);
   void setParameter(size_t i, const double &value, bool explicitlySet = true);
 
+  double getParameter(const std::string &name) const;
+  double getParameter(size_t i) const;
+
 protected:
   void init();
 

--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
@@ -58,7 +58,8 @@ public:
                                const API::FunctionDomain1D &domain,
                                API::FunctionValues &values) const;
 
-  void setParameter(const std::string &name, const double &value, bool explicitlySet = true);
+  void setParameter(const std::string &name, const double &value,
+                    bool explicitlySet = true);
   void setParameter(size_t i, const double &value, bool explicitlySet = true);
 
   double getParameter(const std::string &name) const;

--- a/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp
@@ -80,6 +80,20 @@ void PoldiSpectrumConstantBackground::setParameter(size_t i,
   }
 }
 
+double PoldiSpectrumConstantBackground::getParameter(const std::string &name) const
+{
+    return ParamFunction::getParameter(name);
+}
+
+double PoldiSpectrumConstantBackground::getParameter(size_t i) const
+{
+    if(m_flatBackground) {
+        return m_flatBackground->getParameter(i);
+    }
+
+    return 0;
+}
+
 void PoldiSpectrumConstantBackground::init() {
   m_flatBackground = boost::dynamic_pointer_cast<IFunction1D>(
       FunctionFactory::Instance().createFunction("FlatBackground"));

--- a/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiSpectrumConstantBackground.cpp
@@ -80,18 +80,17 @@ void PoldiSpectrumConstantBackground::setParameter(size_t i,
   }
 }
 
-double PoldiSpectrumConstantBackground::getParameter(const std::string &name) const
-{
-    return ParamFunction::getParameter(name);
+double
+PoldiSpectrumConstantBackground::getParameter(const std::string &name) const {
+  return ParamFunction::getParameter(name);
 }
 
-double PoldiSpectrumConstantBackground::getParameter(size_t i) const
-{
-    if(m_flatBackground) {
-        return m_flatBackground->getParameter(i);
-    }
+double PoldiSpectrumConstantBackground::getParameter(size_t i) const {
+  if (m_flatBackground) {
+    return m_flatBackground->getParameter(i);
+  }
 
-    return 0;
+  return 0;
 }
 
 void PoldiSpectrumConstantBackground::init() {


### PR DESCRIPTION
Fixes trac issue [#11039](http://trac.mantidproject.org/mantid/ticket/11039)

In ticket #11035 PoldiSpectrumConstantBackground was modified to wrap FlatBackground instead of inheriting from it. The getParameter method was not implemented, which leads to a failing doctest.
