### PR TITLE
Allow MWRunFiles to take a default instrument and fix Indirect UIs

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmission.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmission.h
@@ -55,6 +55,7 @@ namespace CustomInterfaces
     void dataLoaded();
     void previewPlot();
     void transAlgDone(bool error);
+    void instrumentSet();
 
   private:
     Ui::IndirectTransmission m_uiForm;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCalibration.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCalibration.cpp
@@ -320,6 +320,9 @@ namespace CustomInterfaces
     // Get spectra, peak and background details
     std::map<QString, QString> instDetails = getInstrumentDetails();
 
+    // Set the search instrument for runs
+    m_uiForm.leRunNo->setInstrumentOverride(instDetails["instrument"]);
+
     // Set spectra range
     m_dblManager->setValue(m_properties["ResSpecMin"], instDetails["spectra-min"].toDouble());
     m_dblManager->setValue(m_properties["ResSpecMax"], instDetails["spectra-max"].toDouble());

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectConvertToEnergy.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectConvertToEnergy.cpp
@@ -223,6 +223,9 @@ namespace CustomInterfaces
   {
     std::map<QString, QString> instDetails = getInstrumentDetails();
 
+    // Set the search instrument for runs
+    m_uiForm.dsRunFiles->setInstrumentOverride(instDetails["instrument"]);
+
     if(instDetails["spectra-min"].isEmpty() || instDetails["spectra-max"].isEmpty())
     {
       emit showMessageBox("Could not gather necessary data from parameter file.");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiagnostics.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiagnostics.cpp
@@ -223,6 +223,9 @@ namespace CustomInterfaces
     //Get spectra, peak and background details
     std::map<QString, QString> instDetails = getInstrumentDetails();
 
+    // Set the search instrument for runs
+    m_uiForm.dsInputFiles->setInstrumentOverride(instDetails["instrument"]);
+
     //Set spectra range
     m_dblManager->setValue(m_properties["SpecMin"], instDetails["spectra-min"].toDouble());
     m_dblManager->setValue(m_properties["SpecMax"], instDetails["spectra-max"].toDouble());

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTransmission.cpp
@@ -17,6 +17,8 @@ namespace CustomInterfaces
   {
     m_uiForm.setupUi(parent);
 
+    connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(instrumentSet()));
+
     // Preview plot
     m_plots["PreviewPlot"] = new QwtPlot(m_parentWidget);
     m_plots["PreviewPlot"]->setAxisFont(QwtPlot::xBottom, parent->font());
@@ -135,6 +137,15 @@ namespace CustomInterfaces
     // Set X range to data range
     setXAxisToCurve("PreviewPlot", "TransCurve");
     m_plots["PreviewPlot"]->replot();
+  }
+
+  void IndirectTransmission::instrumentSet()
+  {
+    std::map<QString, QString> instDetails = getInstrumentDetails();
+
+    // Set the search instrument for runs
+    m_uiForm.dsSampleInput->setInstrumentOverride(instDetails["instrument"]);
+    m_uiForm.dsCanInput->setInstrumentOverride(instDetails["instrument"]);
   }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataSelector.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/DataSelector.h
@@ -51,6 +51,7 @@ namespace MantidQt
       Q_PROPERTY(QStringList workspaceSuffixes READ getWSSuffixes WRITE setWSSuffixes)
       Q_PROPERTY(QStringList fileBrowserSuffixes READ getFBSuffixes WRITE setFBSuffixes)
       Q_PROPERTY(bool showLoad READ willShowLoad WRITE setShowLoad)
+      Q_PROPERTY(QString instrumentOverride READ getInstrumentOverride WRITE setInstrumentOverride)
 
     public:
       DataSelector(QWidget *parent = 0);
@@ -92,6 +93,10 @@ namespace MantidQt
       bool willShowLoad();
       /// Set if the load button should be shown
       void setShowLoad(bool load);
+      /// Gets the instrument currently fixed to
+      QString getInstrumentOverride();
+      /// Overrides the value of default instrument
+      void setInstrumentOverride(const QString & instName);
 
     signals:
       /// Signal emitted when files were found but widget isn't autoloading

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
@@ -29,7 +29,7 @@ namespace MantidQt
       /// Constructor.
       FindFilesThread(QObject *parent = NULL);
       /// Set the various file-finding values / options.
-      void set(QString text, bool isForRunFiles, bool isOptional, const QString & algorithmProperty = "");
+      void set(QString text, bool isForRunFiles, bool isOptional, const QString & defaultInstrumentName = "", const QString & algorithmProperty = "");
 
       /// Returns the error string.  Empty if no error was caught.
       std::string error() const { return m_error; }
@@ -60,6 +60,7 @@ namespace MantidQt
       QString m_property;
       bool m_isForRunFiles;
       bool m_isOptional;
+      QString m_defaultInstrumentName;
     };
 
     /** 
@@ -104,9 +105,12 @@ namespace MantidQt
       Q_PROPERTY(QStringList fileExtensions READ getFileExtensions WRITE setFileExtensions)
       Q_PROPERTY(bool extsAsSingleOption READ extsAsSingleOption WRITE extsAsSingleOption)
       Q_PROPERTY(LiveButtonOpts liveButton READ liveButtonState WRITE liveButtonState)
+      Q_PROPERTY(QString instrumentOverride READ getInstrumentOverride WRITE setInstrumentOverride)
       Q_ENUMS(ButtonOpts)
       Q_ENUMS(LiveButtonOpts)
+
       friend class DataSelector;
+
     public:
       /// options for bringing up the load file dialog
       enum ButtonOpts
@@ -189,6 +193,10 @@ namespace MantidQt
       void setNumberOfEntries(int number);
       /// Inform the widget of a running instance of MonitorLiveData to be used in stopLiveListener()
       void setLiveAlgorithm(const boost::shared_ptr<Mantid::API::IAlgorithm>& monitorLiveData);
+      /// Gets the instrument currently fixed to
+      QString getInstrumentOverride();
+      /// Overrides the value of default instrument
+      void setInstrumentOverride(const QString & instName);
 
     signals:
       /// Emitted when the file text changes
@@ -281,6 +289,8 @@ namespace MantidQt
       QString m_fileFilter;
       /// Thread to allow asynchronous finding of files.
       FindFilesThread * m_thread;
+
+      QString m_defaultInstrumentName;
     };
   }
 }

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
@@ -29,7 +29,7 @@ namespace MantidQt
       /// Constructor.
       FindFilesThread(QObject *parent = NULL);
       /// Set the various file-finding values / options.
-      void set(QString text, bool isForRunFiles, bool isOptional, const QString & defaultInstrumentName = "", const QString & algorithmProperty = "");
+      void set(QString text, bool isForRunFiles, bool isOptional, const QString & algorithmProperty = "");
 
       /// Returns the error string.  Empty if no error was caught.
       std::string error() const { return m_error; }
@@ -60,7 +60,6 @@ namespace MantidQt
       QString m_property;
       bool m_isForRunFiles;
       bool m_isOptional;
-      QString m_defaultInstrumentName;
     };
 
     /** 

--- a/Code/Mantid/MantidQt/MantidWidgets/src/DataSelector.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/DataSelector.cpp
@@ -416,6 +416,33 @@ namespace MantidQt
     }
 
     /**
+     * Gets the instrument currently set by the override property.
+     *
+     * If no override is set then the instrument set by default instrument configurtion
+     * option will be used and this function returns an empty string.
+     *
+     * @return Name of instrument, empty if not set
+     */
+    QString DataSelector::getInstrumentOverride()
+    {
+      return m_uiForm.rfFileInput->getInstrumentOverride();
+    }
+
+    /**
+     * Sets an instrument to fix the widget to.
+     *
+     * If an instrument name is geven then the widget will only look for files for that
+     * instrument, providing na empty string will remove this restriction and will search
+     * using the default instrument.
+     *
+     * @param instName Name of instrument, empty to disable override
+     */
+    void DataSelector::setInstrumentOverride(const QString & instName)
+    {
+      m_uiForm.rfFileInput->setInstrumentOverride(instName);
+    }
+
+    /**
      * Called when an item is dropped
      * @param de :: the drop event data package
      */


### PR DESCRIPTION
Fixes [#11048](http://trac.mantidproject.org/mantid/ticket/11048).

To reproduce old issue:
- Set default instrument to TOSCA
- Set log level to Debug
- Open Indirect > Data Reduction > Energy Transfer
- Ensure IRIS is the selected instrument
- Enter `26176` in run files
- Notice in log that it is looking for a TOSCA (TSC) data file (it should also fail to find a file here, run button disabled)

To test:
- Repeat this with the fix applied and the correct file will be found, confirm by running energy transfer (will fail if the file if from a different instrument).
- Also check that multiple files work (e.g. `26173, 26176, 26174` and `26173-6`)
- Check Transmission tab also loads correct files (sample: `26176`, background: `26173`)
