### PR TITLE
Fix qthelp docs build with later versions of Sphinx

### DIFF
--- a/Code/Mantid/MantidPlot/ipython_widget/mantid_ipython_widget.py
+++ b/Code/Mantid/MantidPlot/ipython_widget/mantid_ipython_widget.py
@@ -3,6 +3,13 @@ import types
 
 from PyQt4 import QtGui
 
+# IPython monkey patches the  pygments.lexer.RegexLexer.get_tokens_unprocessed method
+# and breaks Sphinx when running within MantidPlot.
+# We store the original method definition here on the pygments module before importing IPython
+from pygments.lexer import RegexLexer
+# Monkeypatch!
+RegexLexer.get_tokens_unprocessed_unpatched = RegexLexer.get_tokens_unprocessed
+
 from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
 from IPython.qt.inprocess import QtInProcessKernelManager
 

--- a/Code/Mantid/docs/runsphinx.py.in
+++ b/Code/Mantid/docs/runsphinx.py.in
@@ -64,7 +64,18 @@ def main(sysarg):
 
     # Run
     import sphinx
-    sys.exit(sphinx.main(argv))
+    # IPython monkey patches the RegexLexer.get_tokens_unprocessed method and
+    # causes Sphinx to fall over. We need to put it back while processing
+    # the documentation
+    from pygments.lexer import RegexLexer
+    # Reverse monkeypatch using unpatched function stored in mantid_ipython_widget!
+    RegexLexer.get_tokens_unprocessed = RegexLexer.get_tokens_unprocessed_unpatched
+    try:
+        return_value = sphinx.main(argv)
+    finally:
+        from IPython.qt.console import pygments_highlighter
+        RegexLexer.get_tokens_unprocessed = pygments_highlighter.get_tokens_unprocessed
+    sys.exit(return_value)
 
 #-----------------------------------------------------------------------------------------------
 

--- a/Code/Mantid/docs/sphinxext/mantiddoc/directives/base.py
+++ b/Code/Mantid/docs/sphinxext/mantiddoc/directives/base.py
@@ -153,7 +153,7 @@ class AlgorithmBaseDirective(BaseDirective):
         # warn the user
         if len(msg) > 0:
             env = self.state.document.settings.env
-            env.app.verbose(env.docname, msg)
+            env.app.verbose(msg)
         return msg
 
     def algorithm_name(self):


### PR DESCRIPTION
Newer versions of Sphinx (I tried 1.3 which one of the build servers has) don't play well with IPython's messing around with pygments.lexer. Our build falls over in a strange fashion so we have to undo IPython's monkeypatch before running our Sphinx build.

There is also a minor fix to a logger call that I spotted.
