### PR TITLE
Failure in PoldiPeakSearchTest under Windows debug

### DIFF
--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiPeakSearch.h
@@ -94,10 +94,12 @@ protected:
   double
   minimumPeakHeightFromBackground(UncertainValue backgroundWithSigma) const;
   std::vector<PoldiPeak_sptr>
-  getPeaks(MantidVec::const_iterator baseListStart,
+  getPeaks(const MantidVec::const_iterator &baseListStart,
+           const MantidVec::const_iterator &baseListEnd,
            std::list<MantidVec::const_iterator> peakPositions,
            const MantidVec &xData) const;
-  double getFWHMEstimate(MantidVec::const_iterator baseListStart,
+  double getFWHMEstimate(const MantidVec::const_iterator &baseListStart,
+                         const MantidVec::const_iterator &baseListEnd,
                          MantidVec::const_iterator peakPosition,
                          const MantidVec &xData) const;
 

--- a/Code/Mantid/Framework/SINQ/test/PoldiPeakSearchTest.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiPeakSearchTest.h
@@ -133,7 +133,7 @@ public:
 
         maxima.sort();
 
-        std::vector<PoldiPeak_sptr> peaks = poldiPeakSearch.getPeaks(baseData.begin(), maxima, testXData);
+        std::vector<PoldiPeak_sptr> peaks = poldiPeakSearch.getPeaks(baseData.begin(), baseData.end(), maxima, testXData);
 
         TS_ASSERT_EQUALS(peaks.size(), 4);
 


### PR DESCRIPTION
Fixes trac issue [#11065](http://trac.mantidproject.org/mantid/ticket/11065)

The MSVC debugger is giving an out of bounds error for the PoldiPeakSearch::getFWHMEstimate.  The debugger says that during the testGetPeakCoordinates method the nextIntensity iterator goes past the end of the vector.
