### PR TITLE
Fix instrument selection issues in indirect

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -91,9 +91,6 @@ void IndirectDiffractionReduction::initLayout()
   // Update the list of plot options when individual grouping is toggled
   connect(m_uiForm.ckIndividualGrouping, SIGNAL(stateChanged(int)), this, SLOT(individualGroupingToggled(int)));
 
-  // Set initial layout based on instrument
-  m_uiForm.iicInstrumentConfiguration->newInstrumentConfiguration();
-
   loadSettings();
 
   // Update invalid rebinning markers

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/IndirectInstrumentConfig.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/IndirectInstrumentConfig.h
@@ -56,7 +56,7 @@ namespace MantidQt
       Q_PROPERTY(bool showInstrumentLabel READ isInstrumentLabelShown WRITE setShowInstrumentLabel)
 
     public:
-      IndirectInstrumentConfig(QWidget *parent = 0, bool init = true);
+      IndirectInstrumentConfig(QWidget *parent = 0);
       virtual ~IndirectInstrumentConfig();
 
       /* Getters and setters for Qt properties */

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentSelector.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/InstrumentSelector.h
@@ -86,10 +86,12 @@ namespace MantidQt
       /// Indicate that the instrument selection has changed. The parameter will contain the new name
       void instrumentSelectionChanged(const QString &);
       void configValueChanged(const QString&, const QString&, const QString&);
+      /// Signals that the list of instruments has been updated
+      void instrumentListUpdated();
 
     private slots:
-      /// Update Mantid's default instrument
-      void updateDefaultInstrument(const QString & name) const;
+      /// Handle an instrument seelction
+      void updateInstrument(const QString & name);
 
     private:
       void handleConfigChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
@@ -109,6 +111,9 @@ namespace MantidQt
       bool m_storeChanges;
       /// If the instrument list should be reloaded when the facility changes
       bool m_updateOnFacilityChange;
+      /// The last selected instrument
+      QString m_selectedInstrument;
+
     };
 
   }

--- a/Code/Mantid/MantidQt/MantidWidgets/src/IndirectInstrumentConfig.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/IndirectInstrumentConfig.cpp
@@ -22,18 +22,18 @@ namespace MantidQt
   namespace MantidWidgets
   {
 
-    IndirectInstrumentConfig::IndirectInstrumentConfig(QWidget *parent, bool init): API::MantidWidget(parent),
+    IndirectInstrumentConfig::IndirectInstrumentConfig(QWidget *parent): API::MantidWidget(parent),
       m_algRunner(),
       m_disabledInstruments()
     {
       m_uiForm.setupUi(this);
 
-      m_instrumentSelector = new InstrumentSelector(0, init);
+      m_instrumentSelector = new InstrumentSelector(0, false);
       m_instrumentSelector->updateInstrumentOnSelection(false);
 			m_uiForm.loInstrument->addWidget(m_instrumentSelector);
 
       // Use this signal to filter the instrument list for disabled instruments
-      connect(m_instrumentSelector, SIGNAL(currentIndexChanged(int)),
+      connect(m_instrumentSelector, SIGNAL(instrumentListUpdated()),
               this, SLOT(filterDisabledInstruments()));
 
       connect(m_instrumentSelector, SIGNAL(instrumentSelectionChanged(const QString)),
@@ -42,6 +42,8 @@ namespace MantidQt
               this, SLOT(updateReflectionsList(int)));
       connect(m_uiForm.cbReflection, SIGNAL(currentIndexChanged(int)),
               this, SLOT(newInstrumentConfiguration()));
+
+      m_instrumentSelector->fillWithInstrumentsFromFacility();
     }
 
 
@@ -142,6 +144,7 @@ namespace MantidQt
         forceDiffraction(false);
 
       m_removeDiffraction = !enabled;
+      updateInstrumentConfigurations(getInstrumentName());
     }
 
 
@@ -167,6 +170,7 @@ namespace MantidQt
         enableDiffraction(true);
 
       m_forceDiffraction = forced;
+      updateInstrumentConfigurations(getInstrumentName());
     }
 
 
@@ -422,6 +426,8 @@ namespace MantidQt
           ++i;
         }
       }
+
+      updateInstrumentConfigurations(getInstrumentName());
     }
 
   } /* namespace MantidWidgets */


### PR DESCRIPTION
Ticket [#11047](http://trac.mantidproject.org/mantid/ticket/11047)

To test, do the following with a combination of facilities and default instruments:
- Open Indirect Data reduction, an ISIS instrument should be shown with a valid configuration, diffraction should not be an option for analyser.
- Open Indirect Diffraction, an ISIS instrument should be shown, diffraction should be the only option for analyser.
- Open Indirect Tools > Transmission, an indirect spectrometer from the current facility should be shown, diffraction should not be an option.
- Open Indirect Tools > LoadILL, when facility is set to ILL the ILL spectrometers will be shown with valid configurations.
