### PR TITLE
Fix newer REF_L IDF attribute names to follow schema

### DIFF
--- a/Code/Mantid/instrument/REF_L_Definition_after_10102014.xml
+++ b/Code/Mantid/instrument/REF_L_Definition_after_10102014.xml
@@ -8,7 +8,7 @@
     <reference-frame>
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
-      <handedness axis="right"/>
+      <handedness val="right"/>
     </reference-frame>
   </defaults>
   <!--SOURCE AND SAMPLE POSITION-->
@@ -25,7 +25,7 @@
     <location/>
   </component>
   <type name="monitors">
-    <component mark-as="monitor" type="monitor">
+    <component type="monitor">
       <location name="monitor1" z="-0.23368"/>
     </component>
   </type>
@@ -3938,12 +3938,12 @@
     </component>
   </type>
   <!--FIXME: Do something real here.-->
-  <type is="detector" name="monitor">
+  <type is="monitor" name="monitor">
     <cylinder id="cyl-approx">
       <centre-of-bottom-base x="0.0" y="0.0" z="0.0"/>
       <axis x="0.0" y="0.0" z="1.0"/>
-      <radius radius="0.01"/>
-      <height height="0.03"/>
+      <radius val="0.01"/>
+      <height val="0.03"/>
     </cylinder>
     <algebra val="cyl-approx"/>
   </type>


### PR DESCRIPTION
Fixes trac issue [#11076](http://trac.mantidproject.org/mantid/ticket/11076)

**Tester**
You should be able to load the `REF_L_Definition_after_10102014.xml` file using LoadEmptyInstrument without any warnings.
