### PR TITLE
Check location of TestingTools in build scripts.

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -84,6 +84,14 @@ if [[ ${JOB_NAME} == *clean* ]]; then
   fi
 fi
 
+if [[ -e $WORKSPACE/build/CMakeCache.txt ]]; then
+  # Temporary while the builds flick between old & new TestingTools locations
+  TESTINGTOOLS_DIR=$(grep 'Code/Mantid/TestingTools/cxxtest' $WORKSPACE/build/CMakeCache.txt || true)
+  if [ ! -z "$TESTINGTOOLS_DIR"  ]; then
+    rm -fr $WORKSPACE/build
+  fi
+fi
+
 ###############################################################################
 # RHEL6 setup steps - nodes must have a "rhel6" label set (in lowercase)
 ###############################################################################

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -54,6 +54,13 @@ if "%JOB_NAME%"=="%JOB_NAME:clean=%" (
     rmdir /S /Q build
 )
 
+if EXIST %WORKSPACE%\build\CMakeCache.txt (
+  TYPE %WORKSPACE%\build\CMakeCache.txt | FINDSTR "Code/Mantid/TestingTools/cxxtest"
+  if %ERRORLEVEL% EQU 0 (
+    rmdir /S /Q %WORKSPACE%\build
+  )
+)
+
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Create the build directory if it doesn't exist
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
It has been moved on a separate branch & as a result builds need to check if a clean cmake run is required.

**Tester**
Check the changes and make sure the builds are passing.
