### PR TITLE
Coverity issues in framework: algorithms and nexus load*

### DIFF
--- a/Code/Mantid/Framework/API/src/Algorithm.cpp
+++ b/Code/Mantid/Framework/API/src/Algorithm.cpp
@@ -1164,7 +1164,7 @@ bool Algorithm::checkGroups() {
     // Workspace groups are NOT returned by IWP->getWorkspace() most of the time
     // because WorkspaceProperty is templated by <MatrixWorkspace>
     // and WorkspaceGroup does not subclass <MatrixWorkspace>
-    if (!wsGroup && !prop->value().empty()) {
+    if (!wsGroup && prop && !prop->value().empty()) {
       // So try to use the name in the AnalysisDataService
       try {
         wsGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(

--- a/Code/Mantid/Framework/API/src/PropertyNexus.cpp
+++ b/Code/Mantid/Framework/API/src/PropertyNexus.cpp
@@ -193,7 +193,9 @@ Property *loadProperty(::NeXus::File *file, const std::string &group) {
   file->closeData();
   file->closeGroup();
   // add units
-  retVal->setUnits(unitsStr);
+  if (retVal)
+    retVal->setUnits(unitsStr);
+
   return retVal;
 }
 

--- a/Code/Mantid/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -86,12 +86,23 @@ void CreateWorkspace::exec() {
   const Property *const dataXprop = getProperty("DataX");
   const Property *const dataYprop = getProperty("DataY");
   const Property *const dataEprop = getProperty("DataE");
-  const std::vector<double> &dataX =
-      *dynamic_cast<const ArrayProperty<double> *>(dataXprop);
-  const std::vector<double> &dataY =
-      *dynamic_cast<const ArrayProperty<double> *>(dataYprop);
-  const std::vector<double> &dataE =
-      *dynamic_cast<const ArrayProperty<double> *>(dataEprop);
+
+  const ArrayProperty<double> *pCheck = NULL;
+
+  pCheck = dynamic_cast<const ArrayProperty<double> *>(dataXprop);
+  if (!pCheck)
+    throw std::invalid_argument("DataX cannot be casted to a double vector");
+  const std::vector<double> &dataX = *pCheck;
+
+  pCheck = dynamic_cast<const ArrayProperty<double> *>(dataYprop);
+  if (!pCheck)
+    throw std::invalid_argument("DataY cannot be casted to a double vector");
+  const std::vector<double> &dataY = *pCheck;
+
+  pCheck = dynamic_cast<const ArrayProperty<double> *>(dataEprop);
+  if (!pCheck)
+    throw std::invalid_argument("DataE cannot be casted to a double vector");
+  const std::vector<double> &dataE = *pCheck;
 
   const int nSpec = getProperty("NSpec");
   const std::string xUnit = getProperty("UnitX");

--- a/Code/Mantid/Framework/Algorithms/src/Integration.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Integration.cpp
@@ -121,11 +121,13 @@ void Integration::exec() {
     if (axisIsText) {
       Mantid::API::TextAxis *newAxis =
           dynamic_cast<Mantid::API::TextAxis *>(outputWorkspace->getAxis(1));
-      newAxis->setLabel(outWI, localworkspace->getAxis(1)->label(i));
+      if (newAxis)
+        newAxis->setLabel(outWI, localworkspace->getAxis(1)->label(i));
     } else if (axisIsNumeric) {
       Mantid::API::NumericAxis *newAxis =
           dynamic_cast<Mantid::API::NumericAxis *>(outputWorkspace->getAxis(1));
-      newAxis->setValue(outWI, (*(localworkspace->getAxis(1)))(i));
+      if (newAxis)
+        newAxis->setValue(outWI, (*(localworkspace->getAxis(1)))(i));
     }
 
     // This is the output

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -2153,7 +2153,8 @@ void LoadEventNexus::deleteBanks(API::MatrixWorkspace_sptr workspace,
         for (int row = 0; row < static_cast<int>(grandchildren.size()); row++) {
           Detector *d = dynamic_cast<Detector *>(
               const_cast<IComponent *>(grandchildren[row].get()));
-          inst->removeDetector(d);
+          if (d)
+            inst->removeDetector(d);
         }
       }
       IComponent *comp = dynamic_cast<IComponent *>(detList[i].get());
@@ -2823,7 +2824,9 @@ LoadEventNexus::runLoadNexusLogs(const std::string &nexusfilename,
     Kernel::TimeSeriesProperty<double> *log =
         dynamic_cast<Kernel::TimeSeriesProperty<double> *>(
             localWorkspace->mutableRun().getProperty("proton_charge"));
-    const std::vector<Kernel::DateAndTime> temp = log->timesAsVector();
+    std::vector<Kernel::DateAndTime> temp;
+    if (log)
+      temp = log->timesAsVector();
     // if (returnpulsetimes) out = new BankPulseTimes(temp);
     if (returnpulsetimes)
       out = boost::make_shared<BankPulseTimes>(temp);

--- a/Code/Mantid/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadInstrument.cpp
@@ -122,9 +122,14 @@ void LoadInstrument::exec() {
 
     // Initialize the parser. Avoid copying the xmltext out of the property
     // here.
-    parser.initialize(
-        m_filename, m_instName,
-        *dynamic_cast<const PropertyWithValue<std::string> *>(InstrumentXML));
+    const PropertyWithValue<std::string> *xml =
+      dynamic_cast<const PropertyWithValue<std::string> *>(InstrumentXML);
+    if (xml) {
+      parser.initialize(m_filename, m_instName, *xml);
+    } else {
+      throw std::invalid_argument("The instrument XML passed cannot be "
+                                  "casted to a standard string.");
+    }
   }
   // otherwise we need either Filename or InstrumentName to be set
   else {

--- a/Code/Mantid/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -133,9 +133,6 @@ void LoadNexusLogs::exec() {
   // the code below will allow current SANS2D files to load
   if (workspace->mutableRun().hasProperty("proton_log")) {
     std::vector<int> event_frame_number;
-    Kernel::TimeSeriesProperty<double> *plog =
-        dynamic_cast<Kernel::TimeSeriesProperty<double> *>(
-            workspace->mutableRun().getProperty("proton_log"));
     this->getLogger().notice()
         << "Using old ISIS proton_log and event_frame_number indirection..."
         << std::endl;
@@ -167,15 +164,19 @@ void LoadNexusLogs::exec() {
     file.openPath("/" + entry_name);
     if (!event_frame_number.empty()) // ISIS indirection - see above comments
     {
+      Kernel::TimeSeriesProperty<double> *plog =
+          dynamic_cast<Kernel::TimeSeriesProperty<double> *>(
+              workspace->mutableRun().getProperty("proton_log"));
+      if (!plog)
+        throw std::runtime_error("Could not cast (interpret) proton_log as a time "
+                                 "series property. Cannot continue.");
       Kernel::TimeSeriesProperty<double> *pcharge =
           new Kernel::TimeSeriesProperty<double>("proton_charge");
       std::vector<double> pval;
       std::vector<Mantid::Kernel::DateAndTime> ptime;
       pval.reserve(event_frame_number.size());
       ptime.reserve(event_frame_number.size());
-      std::vector<Mantid::Kernel::DateAndTime> plogt;
-      if (plog)
-        plogt = plog->timesAsVector();
+      std::vector<Mantid::Kernel::DateAndTime> plogt = plog->timesAsVector();
       std::vector<double> plogv = plog->valuesAsVector();
       for (size_t i = 0; i < event_frame_number.size(); ++i) {
         ptime.push_back(plogt[event_frame_number[i]]);

--- a/Code/Mantid/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -173,7 +173,9 @@ void LoadNexusLogs::exec() {
       std::vector<Mantid::Kernel::DateAndTime> ptime;
       pval.reserve(event_frame_number.size());
       ptime.reserve(event_frame_number.size());
-      std::vector<Mantid::Kernel::DateAndTime> plogt = plog->timesAsVector();
+      std::vector<Mantid::Kernel::DateAndTime> plogt;
+      if (plog)
+        plogt = plog->timesAsVector();
       std::vector<double> plogv = plog->valuesAsVector();
       for (size_t i = 0; i < event_frame_number.size(); ++i) {
         ptime.push_back(plogt[event_frame_number[i]]);

--- a/Code/Mantid/Framework/DataHandling/src/ProcessDasNexusLog.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/ProcessDasNexusLog.cpp
@@ -388,9 +388,10 @@ void ProcessDasNexusLog::convertToAbsoluteTime(
   Kernel::Property *log = ws->run().getProperty(logname);
   Kernel::TimeSeriesProperty<double> *tslog =
       dynamic_cast<Kernel::TimeSeriesProperty<double> *>(log);
-  std::vector<Kernel::DateAndTime> times;
-  if (tslog)
-    times = tslog->timesAsVector();
+  if (!tslog)
+    throw std::runtime_error("Invalid time series log: it could not be cast "
+                             "(interpreted) as a time series property");
+  std::vector<Kernel::DateAndTime> times = tslog->timesAsVector();
   std::vector<double> values = tslog->valuesAsVector();
 
   // 2. Get converted
@@ -447,9 +448,10 @@ void ProcessDasNexusLog::writeLogtoFile(API::MatrixWorkspace_sptr ws,
   Kernel::Property *log = ws->run().getProperty(logname);
   Kernel::TimeSeriesProperty<double> *tslog =
       dynamic_cast<Kernel::TimeSeriesProperty<double> *>(log);
-  std::vector<Kernel::DateAndTime> times;
-  if (tslog)
-    tslog->timesAsVector();
+  if (!tslog)
+    throw std::runtime_error("Invalid time series log: it could not be cast "
+                             "(interpreted) as a time series property");
+  std::vector<Kernel::DateAndTime> times = tslog->timesAsVector();
   std::vector<double> values = tslog->valuesAsVector();
 
   // 2. Write out

--- a/Code/Mantid/Framework/DataHandling/src/ProcessDasNexusLog.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/ProcessDasNexusLog.cpp
@@ -388,7 +388,9 @@ void ProcessDasNexusLog::convertToAbsoluteTime(
   Kernel::Property *log = ws->run().getProperty(logname);
   Kernel::TimeSeriesProperty<double> *tslog =
       dynamic_cast<Kernel::TimeSeriesProperty<double> *>(log);
-  std::vector<Kernel::DateAndTime> times = tslog->timesAsVector();
+  std::vector<Kernel::DateAndTime> times;
+  if (tslog)
+    times = tslog->timesAsVector();
   std::vector<double> values = tslog->valuesAsVector();
 
   // 2. Get converted
@@ -445,7 +447,9 @@ void ProcessDasNexusLog::writeLogtoFile(API::MatrixWorkspace_sptr ws,
   Kernel::Property *log = ws->run().getProperty(logname);
   Kernel::TimeSeriesProperty<double> *tslog =
       dynamic_cast<Kernel::TimeSeriesProperty<double> *>(log);
-  std::vector<Kernel::DateAndTime> times = tslog->timesAsVector();
+  std::vector<Kernel::DateAndTime> times;
+  if (tslog)
+    tslog->timesAsVector();
   std::vector<double> values = tslog->valuesAsVector();
 
   // 2. Write out

--- a/Code/Mantid/Framework/Geometry/src/Instrument/Detector.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument/Detector.cpp
@@ -45,10 +45,14 @@ Detector::~Detector() {}
  *  @returns the detector id
  */
 detid_t Detector::getID() const {
-  if (m_map)
-    return dynamic_cast<const Detector *>(m_base)->getID();
-  else
-    return m_id;
+  if (m_map) {
+    const Detector *d = dynamic_cast<const Detector *>(m_base);
+    if (d) {
+      return d->getID();
+    }
+  }
+
+  return m_id;
 }
 
 /// Get the distance between the detector and another component
@@ -137,10 +141,14 @@ bool Detector::isMasked() const {
 /// Is the detector a monitor?
 ///@return true if it is a monitor
 bool Detector::isMonitor() const {
-  if (m_map)
-    return dynamic_cast<const Detector *>(m_base)->isMonitor();
-  else
-    return m_isMonitor;
+  if (m_map) {
+    const Detector *d = dynamic_cast<const Detector *>(m_base);
+    if (d) {
+      return d->isMonitor();
+    }
+  }
+
+  return m_isMonitor;
 }
 
 /** Sets the flag for whether this detector object is a monitor


### PR DESCRIPTION
Fixes trac issue [#11062](http://trac.mantidproject.org/mantid/ticket/11062).

**To test**

This fixes 14 null dereference issues detected by coverity (see list in ticket description). The issues are in Framework, with a bit of focus on Load***Nexus and related classes.
- Review code
- Check that unit and system tests pass as they seem to do locally.
