### PR TITLE
Fix documentation warning

### DIFF
--- a/Code/Mantid/docs/source/concepts/Using_XML_Schema.rst
+++ b/Code/Mantid/docs/source/concepts/Using_XML_Schema.rst
@@ -1,7 +1,7 @@
 .. _Using_XML_Schema:
 
 Using XML Schemas
-=============
+=================
 
 This page gives instructions on how to configure various editing programs for 
 writing XML with schema validation. This helps by finding errors in 


### PR DESCRIPTION
Fixes a warning caused by a title underline being too short.

To test: build documentation see that there are no warnings.
