### PR TITLE
InstrumentSelector should not change the default instrument

### DIFF
--- a/Code/Mantid/MantidPlot/src/ConfigDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/ConfigDialog.cpp
@@ -662,13 +662,12 @@ void ConfigDialog::initMantidPage()
   grid->addWidget(new QLabel("Facility"), 0, 0);
   grid->addWidget(facility, 0, 1);
 
-
   defInstr = new MantidQt::MantidWidgets::InstrumentSelector();
+  // Here we only want the default instrument updated if the user clicks Ok/Apply
+  defInstr->updateInstrumentOnSelection(false);
   grid->addWidget(new QLabel("Default Instrument"), 2, 0);
   grid->addWidget(defInstr, 2, 1);
   grid->setRowStretch(3,1);
-  //Here we only want the default instrument updated if the user clicks Ok/Apply
-  disconnect(defInstr, SIGNAL(currentIndexChanged(const QString&)), defInstr, SLOT(updateDefaultInstrument(const QString &)));
 
   //Ignore paraview.
   ckIgnoreParaView = new QCheckBox("Ignore ParaView");

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
@@ -170,11 +170,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::InstrumentSelector</class>
-   <extends>QComboBox</extends>
-   <header>MantidQtMantidWidgets/InstrumentSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::MantidWidgets::IndirectInstrumentConfig</class>
    <extends>QComboBox</extends>
    <header>MantidQtMantidWidgets/IndirectInstrumentConfig.h</header>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/DirectConvertToEnergy.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/DirectConvertToEnergy.cpp
@@ -233,6 +233,14 @@ void DirectConvertToEnergy::instrumentLoadingDone(bool error)
  */
 void DirectConvertToEnergy::userSelectInstrument(const QString& prefix) 
 {
+  // Search for files for the current selected instrument
+  m_uiForm.runFiles->setInstrumentOverride(prefix);
+  m_uiForm.mapFile->setInstrumentOverride(prefix);
+  m_uiForm.whiteBeamFile->setInstrumentOverride(prefix);
+  m_uiForm.absRunFiles->setInstrumentOverride(prefix);
+  m_uiForm.absMapFile->setInstrumentOverride(prefix);
+  m_uiForm.absWhiteFile->setInstrumentOverride(prefix);
+
   if ( prefix != m_curInterfaceSetup )
   {
     // Remove the old empty instrument workspace if it is there

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -703,6 +703,9 @@ MatrixWorkspace_sptr MuonAnalysis::getPeriodWorkspace(PeriodType periodType, Wor
 */
 void MuonAnalysis::userSelectInstrument(const QString& prefix)
 {
+  // Set file browsing to current instrument
+  m_uiForm.mwRunFiles->setInstrumentOverride(prefix);
+
   if ( prefix != m_curInterfaceSetup )
   {
     runClearGroupingButton();

--- a/Code/Mantid/MantidQt/MantidWidgets/src/InstrumentSelector.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/InstrumentSelector.cpp
@@ -37,7 +37,7 @@ namespace MantidWidgets
   */
   InstrumentSelector::InstrumentSelector(QWidget *parent, bool init)
     : QComboBox(parent), m_changeObserver(*this, &InstrumentSelector::handleConfigChange),
-      m_techniques(), m_currentFacility(NULL), m_init(init), m_storeChanges(true),
+      m_techniques(), m_currentFacility(NULL), m_init(init), m_storeChanges(false),
       m_updateOnFacilityChange(true), m_selectedInstrument()
   {
     setEditable(false);


### PR DESCRIPTION
Ticket [#11049](http://trac.mantidproject.org/mantid/ticket/11049).

To test:
- Verify that changes to the default instrument on configuration UI and first time setup are persisted as expected.
- Verify that the MWRunFile widgets on Direct Convert to Energy and Muon Analysis attempt to load the correct file for the available instruments on the instrument selector (should be prefixed with instrument selected in UI, can be seen with log level set to debug)
