### PR TITLE
Fix PlotAsymmetryByLogValue when dead times are loaded from file

### DIFF
--- a/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
@@ -215,5 +215,5 @@ void PlotAsymmetryByLogValueDialog::fillLogBox(const QString&)
 void PlotAsymmetryByLogValueDialog::showHideDeadTimeFileWidget(int deadTimeTypeIndex)
 {
   // Show only if "Using specified file" selected
-  m_uiForm.dtcFileContainer->setVisible(deadTimeTypeIndex == 1);
+  m_uiForm.dtcFileContainer->setVisible(deadTimeTypeIndex == 2);
 }


### PR DESCRIPTION
Fixes trac issue [#10886](http://trac.mantidproject.org/mantid/ticket/10886).

For tester: in PlotAsymmetryByLog value algorithm, check that options "FromRunData" and "FromSpecifiedFile" work as expected. See trac for more information.
