### PR TITLE
Fix error caused by PoldiSpectrumConstantBackground with some compilers

### DIFF
--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiUtilities/PoldiSpectrumConstantBackground.h
@@ -38,8 +38,8 @@ namespace Poldi {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
   */
 class MANTID_SINQ_DLL PoldiSpectrumConstantBackground
-    : public API::ParamFunction,
-      public API::IFunction1D,
+    : virtual public API::ParamFunction,
+      virtual public API::IFunction1D,
       public IPoldiFunction1D {
 public:
   PoldiSpectrumConstantBackground();


### PR DESCRIPTION
When compiling Mantid with gcc 4.9.1 (for example in Ubuntu 14.10), the compiler gives an error message when processing PoldiSpectrumConstantBackground.
