### PR TITLE
Fix compiler error and warning on AppleClang

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
@@ -134,7 +134,7 @@ int InternetHelper::sendRequestAndProcess(HTTPClientSession &session,
                                           std::ostream &responseStream) {
   // create a request
   this->createRequest(uri);
-  session.sendRequest(*m_request) << m_body;
+  session.sendRequest(*m_request) << m_body.rdbuf();
 
   HTTPResponse res;
   std::istream &rs = session.receiveResponse(res);

--- a/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
@@ -134,7 +134,7 @@ int InternetHelper::sendRequestAndProcess(HTTPClientSession &session,
                                           std::ostream &responseStream) {
   // create a request
   this->createRequest(uri);
-  session.sendRequest(*m_request) << m_body.rdbuf();
+  session.sendRequest(*m_request) << m_body.str();
 
   HTTPResponse res;
   std::istream &rs = session.receiveResponse(res);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectSymmetrise.cpp
@@ -275,7 +275,7 @@ namespace CustomInterfaces
     }
 
     // If we get this far then properties are valid so update mini plots
-    if((prop == m_properties["PreviewSpec"]))
+    if(prop == m_properties["PreviewSpec"])
       updateMiniPlots();
   }
 


### PR DESCRIPTION
this fixes issue [#11110](http://trac.mantidproject.org/mantid/ticket/11110)

This fixes a compiler error that was recently introduced on master.  I also fixed a compiler warning introduced the day before. 

testing: Review changes and verify they don't affect the supported platforms. We can use the master_clean-clang job to verify that this fixes the osx+clang build.
