### PR TITLE
Add DynamicKuboToyabe fitting function

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/CMakeLists.txt
+++ b/Code/Mantid/Framework/CurveFitting/CMakeLists.txt
@@ -239,7 +239,6 @@ set ( TEST_FILES
 	DeltaFunctionTest.h
 	DiffRotDiscreteCircleTest.h
 	DiffSphereTest.h
-	DynamicKuboToyabeTest.h
 	EndErfcTest.h
 	ExpDecayMuonTest.h
 	ExpDecayOscTest.h

--- a/Code/Mantid/Framework/CurveFitting/CMakeLists.txt
+++ b/Code/Mantid/Framework/CurveFitting/CMakeLists.txt
@@ -239,6 +239,7 @@ set ( TEST_FILES
 	DeltaFunctionTest.h
 	DiffRotDiscreteCircleTest.h
 	DiffSphereTest.h
+	DynamicKuboToyabeTest.h
 	EndErfcTest.h
 	ExpDecayMuonTest.h
 	ExpDecayOscTest.h

--- a/Code/Mantid/Framework/CurveFitting/CMakeLists.txt
+++ b/Code/Mantid/Framework/CurveFitting/CMakeLists.txt
@@ -29,6 +29,7 @@ set ( SRC_FILES
 	src/DerivMinimizer.cpp
 	src/DiffRotDiscreteCircle.cpp
 	src/DiffSphere.cpp
+	src/DynamicKuboToyabe.cpp
 	src/EndErfc.cpp
 	src/ExpDecay.cpp
 	src/ExpDecayMuon.cpp
@@ -135,6 +136,7 @@ set ( INC_FILES
 	inc/MantidCurveFitting/DiffRotDiscreteCircle.h
 	inc/MantidCurveFitting/DiffSphere.h
 	inc/MantidCurveFitting/DllConfig.h
+	inc/MantidCurveFitting/DynamicKuboToyabe.h
 	inc/MantidCurveFitting/EndErfc.h
 	inc/MantidCurveFitting/ExpDecay.h
 	inc/MantidCurveFitting/ExpDecayMuon.h

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
@@ -9,21 +9,15 @@
 #include "MantidAPI/IFunctionWithLocation.h"
 #include <cmath>
 
-//#include "MantidAPI/ParamFunction.h"
-//#include "MantidAPI/IPeakFunction.h"
-
-//#include "MantidAPI/IFunctionMW.h"
-//#include "MantidAPI/IFunction1D.h"
-
 namespace Mantid
 {
   namespace CurveFitting
   {
     /** 
-     Provide Dynamic Kubo Toyabe function interface to IPeakFunction for muon scientists.
+     Provide Dynamic Kubo Toyabe function interface to IFunction1D for muon scientists.
    
-     @author Karl Palmen, ISIS, RAL 
-     @date 21/03/2012 
+     @author Raquel Alvarez, ISIS, RAL 
+     @date 18/02/2015 
   
      Copyright &copy; 2007-2012 ISIS Rutherford Appleton Laboratory & NScD Oak Ridge National Laboratory 
   

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
@@ -1,0 +1,72 @@
+#ifndef MANTID_CURVEFITTING_DYNAMICKUBOTOYABE_H_
+#define MANTID_CURVEFITTING_DYNAMICKUBOTOYABE_H_
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/IFunctionMW.h"
+#include "MantidAPI/IFunctionWithLocation.h"
+#include <cmath>
+
+//#include "MantidAPI/ParamFunction.h"
+//#include "MantidAPI/IPeakFunction.h"
+
+//#include "MantidAPI/IFunctionMW.h"
+//#include "MantidAPI/IFunction1D.h"
+
+namespace Mantid
+{
+  namespace CurveFitting
+  {
+    /** 
+     Provide Dynamic Kubo Toyabe function interface to IPeakFunction for muon scientists.
+   
+     @author Karl Palmen, ISIS, RAL 
+     @date 21/03/2012 
+  
+     Copyright &copy; 2007-2012 ISIS Rutherford Appleton Laboratory & NScD Oak Ridge National Laboratory 
+  
+     This file is part of Mantid. 
+  
+     Mantid is free software; you can redistribute it and/or modify 
+     it under the terms of the GNU General Public License as published by 
+     the Free Software Foundation; either version 3 of the License, or 
+     (at your option) any later version. 
+  
+     Mantid is distributed in the hope that it will be useful, 
+     but WITHOUT ANY WARRANTY; without even the implied warranty of 
+     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+     GNU General Public License for more details. 
+  
+     You should have received a copy of the GNU General Public License 
+     along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+  
+     File change history is stored at: <https://github.com/mantidproject/mantid> 
+     Code Documentation is available at: <http://doxygen.mantidproject.org> 
+     */ 
+
+    class DLLExport DynamicKuboToyabe :  public API::ParamFunction, public API::IFunction1D
+    {
+    public:
+
+      /// Destructor
+      virtual ~DynamicKuboToyabe() {}
+
+      /// overwrite base class methods
+      std::string name()const{return "DynamicKuboToyabe";}
+      virtual const std::string category() const { return "Muon";}
+
+    protected:
+      virtual void function1D(double* out, const double* xValues, const size_t nData)const;
+      virtual void functionDeriv1D(API::Jacobian* out, const double* xValues, const size_t nData);
+      virtual void functionDeriv(const API::FunctionDomain& domain, API::Jacobian& jacobian);
+      virtual void init();
+      virtual void setActiveParameter(size_t i, double value);
+
+    };
+
+  } // namespace CurveFitting
+} // namespace Mantid
+
+#endif /*MANTID_CURVEFITTING_DYNAMICKUBOTOYABE_H_*/

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -6,13 +6,6 @@
 #include "MantidAPI/FunctionFactory.h"
 #include <vector>
 
-#define EPS 1e-6
-#define JMAX 14
-#define JMAXP (JMAX+1)
-#define K 5
-#define NR_END 1
-#define FREE_ARG char*
-
 namespace Mantid
 {
 namespace CurveFitting

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -48,10 +48,11 @@ double midpnt(double func(const double, const double, const double),
 	const double a, const double b, const int n, const double g, const double w0) {
 // quote & modified from numerical recipe 2nd edtion (page147)	
 	
+  static double s;
 
 	if (n==1) {
-    double s1 = (b-a)*func(0.5*(a+b),g,w0);
-    return (s1);
+    s = (b-a)*func(0.5*(a+b),g,w0);
+    return (s);
 	} else {
 		double x, tnm, sum, del, ddel;
 		int it, j;
@@ -67,7 +68,6 @@ double midpnt(double func(const double, const double, const double),
 			sum += func(x,g,w0);
 			x += del;
 		}
-    static double s;
 		s=(s+(b-a)*sum/tnm)/3.0;
 		return s;
 	}
@@ -114,8 +114,8 @@ double integrate (double func(const double, const double, const double),
 	int j;
 	double ss,dss;
 	double h[JMAXP+1], s[JMAXP];
-	
-	h[0] = 1.0;
+
+	h[1] = 1.0;
 	for (j=1; j<= JMAX; j++) {
 		s[j]=midpnt(func,a,b,j,g,w0);
 		if (j >= K) {

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -4,9 +4,7 @@
 #include "MantidCurveFitting/DynamicKuboToyabe.h"
 #include "MantidAPI/Jacobian.h"
 #include "MantidAPI/FunctionFactory.h"
-#include <cmath>
 #include <vector>
-//#include <boost/math/special_functions/fpclassify.hpp> // TODO Remove
 
 #define EPS 1e-6
 #define JMAX 14
@@ -22,7 +20,6 @@ namespace CurveFitting
 
 using namespace Kernel;
 using namespace API;
-using namespace boost::math;
 
 DECLARE_FUNCTION(DynamicKuboToyabe)
 

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -48,7 +48,6 @@ double midpnt(double func(const double, const double, const double),
 	const double a, const double b, const int n, const double g, const double w0) {
 // quote & modified from numerical recipe 2nd edtion (page147)	
 	
-	static double s;
 
 	if (n==1) {
     double s1 = (b-a)*func(0.5*(a+b),g,w0);
@@ -68,6 +67,7 @@ double midpnt(double func(const double, const double, const double),
 			sum += func(x,g,w0);
 			x += del;
 		}
+    static double s;
 		s=(s+(b-a)*sum/tnm)/3.0;
 		return s;
 	}
@@ -75,12 +75,13 @@ double midpnt(double func(const double, const double, const double),
 
 void polint (double xa[], double ya[], int n, double x, double& y, double& dy) {
 	int i, m, ns = 1;
-  double den, dif, dift, ho, hp, w;
+  double dif;
 
   dif = fabs(x-xa[1]);
   std::vector<double> c(n+1);
   std::vector<double> d(n+1);
 	for (i=1;i<=n;i++){
+    double dift;
 		if((dift=fabs(x-xa[i]))<dif) {
 			ns=i;
 			dif=dift;
@@ -91,6 +92,7 @@ void polint (double xa[], double ya[], int n, double x, double& y, double& dy) {
 	y=ya[ns--];
 	for (m=1;m<n;m++) {
 		for (i=1;i<=n-m;i++) {
+      double den, ho, hp, w;
 			ho=xa[i]-x;
 			hp=xa[i+m]-x;
 			w=c[i+1]-d[i];

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -16,15 +16,6 @@ using namespace API;
 
 DECLARE_FUNCTION(DynamicKuboToyabe)
 
-// ** MODIFY THIS **
-// Here specify/declare the parameters of your Fit Function
-// 
-// declareParameter takes three arguments:
-//
-//   1st: The name of the parameter
-//   2nd: The default (initial) value of the parameter
-//   3rd: A description of the parameter (optional)
-//
 void DynamicKuboToyabe::init()
 {
   declareParameter("Asym",  0.2, "Amplitude at time 0");
@@ -40,25 +31,18 @@ double ZFKT (const double x, const double G){
   return (0.3333333333 + 0.6666666667*exp(-0.5*q)*(1-q));
 }
 
-// Static Non-Zero field Kubo Toyabe relaxation function
-//double HKT (const double x, const double G, const double F) 
-//{
-//  throw std::runtime_error("HKT not implemented yet");
-//}
-
 // Dynamic Kubo-Toyabe
 double getDKT (double t, double G, double v){
 
   const int tsmax = 656; // Length of the time axis, 32 us of valid data
   const double eps = 0.05; // Bin width for calculations
-  //  const int stk = 25; // Not used for the moment
 
   static double oldG=-1., oldV=-1.;
   static std::vector<double> gStat(tsmax), gDyn(tsmax);
 
 
   if ( (G != oldG) || (v != oldV) ){
-   
+
     // If G or v have changed with respect to the 
     // previous call, we need to re-do the computations
 
@@ -110,8 +94,8 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
   const double& v = fabs(getParameter("Nu"));
 
 
-    // Zero hopping rate
-	if (v == 0.0) {
+  // Zero hopping rate
+  if (v == 0.0) {
 
     // Zero external field
     if ( F == 0.0 ){
@@ -126,10 +110,10 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
       //}
       throw std::runtime_error("HKT() not implemented yet");
     }
-	} 
+  } 
 
   // Non-zero hopping rate
-	else {
+  else {
 
     if ( F==0.0 ) {
 
@@ -137,13 +121,13 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
         out[i] = A*getDKT(xValues[i],G,v);
       }
 
-	  } else {
+    } else {
 
-	    // Non-zero field
+      // Non-zero field
       throw std::runtime_error("HKT() not implemented yet");
     }
 
-	} // else hopping rate != 0
+  } // else hopping rate != 0
 
 
 }

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -36,10 +36,10 @@ DECLARE_FUNCTION(DynamicKuboToyabe)
 //
 void DynamicKuboToyabe::init()
 {
-  declareParameter("Asym", 0.2);
-  declareParameter("Delta", 0.2);
-  declareParameter("Field",0.0);
-  declareParameter("Nu",0.0);
+  declareParameter("Asym",  0.2, "Amplitude at time 0");
+  declareParameter("Delta", 0.2, "Local field");
+  declareParameter("Field", 0.0, "External field");
+  declareParameter("Nu",    0.0, "Hopping rate");
   //declareParameter("EndX",15);
 }
 
@@ -197,13 +197,11 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 
   // Non-zero hopping rate
 	else {
-
     const int n = 1000;
     const double stepsize = fabs(xValues[nData-1]/n);
     // do{stepsizeTemp=stepsizeTemp/10;nTemp=nTemp*10; }while (xValues[0]<stepsizeTemp);
     //make sure stepsize is smaller than spacing between xValues.
     std::vector<double> funcG(n);
-
     for (int i = 0; i < n; i++) {
 
       double Integral=0.0;
@@ -216,7 +214,8 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 
 		for (size_t i = 0; i < nData; i++) {
 			double a =xValues[i]/stepsize;
-			out[i] = A*(funcG.at(int(a)-1));
+      a = a<nData ? a : a-1;
+      out[i] = A*(funcG.at(int(a)));
 		}
 
    } // else hopping rate != 0

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -5,7 +5,8 @@
 #include "MantidAPI/Jacobian.h"
 #include "MantidAPI/FunctionFactory.h"
 #include <cmath>
-#include <boost/math/special_functions/fpclassify.hpp> // TODO Remove
+#include <vector>
+//#include <boost/math/special_functions/fpclassify.hpp> // TODO Remove
 
 #define EPS 1e-6
 #define JMAX 14
@@ -40,35 +41,21 @@ void DynamicKuboToyabe::init()
   declareParameter("Delta", 0.2, "Local field");
   declareParameter("Field", 0.0, "External field");
   declareParameter("Nu",    0.0, "Hopping rate");
-  //declareParameter("EndX",15);
 }
 
 
 //------------------------------------------------------------------------------------------------
-double *vector(long nl, long nh)
-/* allocate a double vector with subscript range v[nl..nh] */
-{
-	double *v;
+// Routines from Numerical Recipes
 
-	v=(double *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(double)));
-  if (!v) throw std::runtime_error("allocation failure in dvector()");
-	return v-nl+NR_END;
-}
-void free_vector(double *v, long nl, long nh)
-/* free a double vector allocated with dvector() */
-{
-	free((FREE_ARG) (v+nl-NR_END));
-}
 double midpnt(double func(const double, const double, const double),
 	const double a, const double b, const int n, const double g, const double w0) {
 // quote & modified from numerical recipe 2nd edtion (page147)	
 	
 	static double s;
 
-	if (n==1) { 
-    double s1 = 0.5*(b-a)*func(a,g,w0)+func(b,g,w0);
-    double s2 = (b-a)*func(0.5*(a+b),g,w0);
-    return (s2);
+	if (n==1) {
+    double s1 = (b-a)*func(0.5*(a+b),g,w0);
+    return (s1);
 	} else {
 		double x, tnm, sum, del, ddel;
 		int it, j;
@@ -93,11 +80,9 @@ void polint (double xa[], double ya[], int n, double x, double& y, double& dy) {
 	int i, m, ns = 1;
   double den, dif, dift, ho, hp, w;
 
-  double *c,*d;
-
   dif = fabs(x-xa[1]);
-  c = vector(1,n);
-  d = vector(1,n);
+  std::vector<double> c(n+1);
+  std::vector<double> d(n+1);
 	for (i=1;i<=n;i++){
 		if((dift=fabs(x-xa[i]))<dif) {
 			ns=i;
@@ -122,8 +107,6 @@ void polint (double xa[], double ya[], int n, double x, double& y, double& dy) {
 
 	}
 
-  free_vector(d,1,n);
-  free_vector(c,1,n);
 }
 
 
@@ -150,26 +133,34 @@ double integrate (double func(const double, const double, const double),
 
 
 double f1(const double x, const double G, const double w0) {
+
   return( exp(-G*G*x*x/2)*sin(w0*x));
 }
 
+// Zero Field Kubo Toyabe relaxation function
 double ZFKT (double q){
-  // In zero field: 
-  // g(t) = 1/3 + 2/3 exp( -q/2 ) ( 1 - q )
-  // q = t *sigma
+
   return (0.3333333333 + 0.6666666667*exp(-0.5*q)*(1-q));
 }
+
+// Relaxation function
 double gz (const double x, const double G, const double F) 
 {
 	double w0 = 2.0*3.1415926536*0.01355342*F;
 	const double q = G*G*x*x;
 	
 	if (w0 == 0.0) {
+    // Zero field
 		return (ZFKT(q)); 
 	}
 	else {
-		
-		if (F>2.0*G) { w0 = 2*3.1415926*0.01355342*F ;} else { w0 =2*3.1415926*0.01355342*2.0*G; }
+    // Non-zero field
+
+    if (F>2.0*G) { 
+      w0 = 2*3.1415926*0.01355342*F ;
+    } else { 
+      w0 =2*3.1415926*0.01355342*2.0*G; 
+    }
 			
 		double p = G*G/(w0*w0);
 		double HKT = 1.0-2.0*p*(1-exp(-q/2.0)*cos(w0*x))+2.0*p*p*w0*integrate(f1,0.0,x,G,w0);
@@ -179,7 +170,7 @@ double gz (const double x, const double G, const double F)
    }
 }
 
-// Original function by mark telling
+// Dynamic Kubo Toyabe function
 void DynamicKuboToyabe::function1D(double* out, const double* xValues, const size_t nData)const
 {
   const double& A = getParameter("Asym");
@@ -197,20 +188,41 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 
   // Non-zero hopping rate
 	else {
-    const int n = 1000;
+
+    // Make sure stepsize is smaller than spacing between xValues
+    int n = 1000;
+    //while (n<nData) {
+    //   n=n*2; 
+    //}
     const double stepsize = fabs(xValues[nData-1]/n);
-    // do{stepsizeTemp=stepsizeTemp/10;nTemp=nTemp*10; }while (xValues[0]<stepsizeTemp);
-    //make sure stepsize is smaller than spacing between xValues.
+
     std::vector<double> funcG(n);
+
+    // Mark's implementation
     for (int i = 0; i < n; i++) {
 
-      double Integral=0.0;
-      for (int c = 1; c <= i; c++) {
-        Integral= gz(c*stepsize,G,F)*exp(-v*c*stepsize)*funcG[i-c]*(stepsize) + Integral; 
+      double efac1=exp(-v*stepsize); // survival prob for step
+      double efac2=(1.0-efac1);      // hop prob ~ hoprate*step
+
+      funcG[0]=gz(0,G,F);
+      funcG[1]=gz(stepsize,G,F);
+
+      for(i=1; i<n; i++) {
+        double gdi=gz(i*stepsize,G,F);
+        for(int j=1; j<i; j++) {
+          gdi= gdi*efac1 + funcG[j]*gz((i-j)*stepsize,G,F)*efac2;
+        }
+        funcG[i]=gdi;
       }
-      funcG[i] = (gz(i*stepsize,G,F)*exp(-v*i*stepsize) + v*Integral);
     }
 
+    //for (int i = 0; i < n; i++) {
+    //  double Integral=0.0;
+    //  for (int c = 1; c <= i; c++) {
+    //    Integral= gz(c*stepsize,G,F)*exp(-v*c*stepsize)*funcG[i-c]*(stepsize) + Integral; 
+    //  }
+    //  funcG[i] = (gz(i*stepsize,G,F)*exp(-v*i*stepsize) + v*Integral);
+    //}
 
 		for (size_t i = 0; i < nData; i++) {
 			double a =xValues[i]/stepsize;
@@ -237,12 +249,6 @@ void DynamicKuboToyabe::functionDeriv1D(API::Jacobian* , const double* , const s
 void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
 
   setParameter( i, fabs(value), false);
-
-  if (parameterName(i)=="Nu"){
-    if (value<1e-10){
-      setParameter(i,0,false);
-    }
-  }
 
 }
 

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -41,10 +41,10 @@ double ZFKT (const double x, const double G){
 }
 
 // Static Non-Zero field Kubo Toyabe relaxation function
-double HKT (const double x, const double G, const double F) 
-{
-  throw std::runtime_error("HKT not implemented yet");
-}
+//double HKT (const double x, const double G, const double F) 
+//{
+//  throw std::runtime_error("HKT not implemented yet");
+//}
 
 // Dynamic Kubo-Toyabe
 double getDKT (double t, double G, double v){
@@ -121,9 +121,10 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
     }
     // Non-zero external field
     else{
-      for (size_t i = 0; i < nData; i++) {
-        out[i] = A*HKT(xValues[i],G,F);
-      }
+      //for (size_t i = 0; i < nData; i++) {
+      //  out[i] = A*HKT(xValues[i],G,F);
+      //}
+      throw std::runtime_error("HKT() not implemented yet");
     }
 	} 
 
@@ -139,7 +140,7 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 	  } else {
 
 	    // Non-zero field
-      throw std::runtime_error("Not implemented yet");
+      throw std::runtime_error("HKT() not implemented yet");
     }
 
 	} // else hopping rate != 0

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -238,6 +238,12 @@ void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
 
   setParameter( i, fabs(value), false);
 
+  if (parameterName(i)=="Nu"){
+    if (value<1e-10){
+      setParameter(i,0,false);
+    }
+  }
+
 }
 
 } // namespace CurveFitting

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -1,0 +1,245 @@
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidCurveFitting/DynamicKuboToyabe.h"
+#include "MantidAPI/Jacobian.h"
+#include "MantidAPI/FunctionFactory.h"
+#include <cmath>
+#include <boost/math/special_functions/fpclassify.hpp> // TODO Remove
+
+#define EPS 1e-6
+#define JMAX 14
+#define JMAXP (JMAX+1)
+#define K 5
+#define NR_END 1
+#define FREE_ARG char*
+
+namespace Mantid
+{
+namespace CurveFitting
+{
+
+using namespace Kernel;
+using namespace API;
+using namespace boost::math;
+
+DECLARE_FUNCTION(DynamicKuboToyabe)
+
+// ** MODIFY THIS **
+// Here specify/declare the parameters of your Fit Function
+// 
+// declareParameter takes three arguments:
+//
+//   1st: The name of the parameter
+//   2nd: The default (initial) value of the parameter
+//   3rd: A description of the parameter (optional)
+//
+void DynamicKuboToyabe::init()
+{
+  declareParameter("Asym", 0.2);
+  declareParameter("Delta", 0.2);
+  declareParameter("Field",0.0);
+  declareParameter("Nu",0.0);
+  //declareParameter("EndX",15);
+}
+
+
+//------------------------------------------------------------------------------------------------
+double *vector(long nl, long nh)
+/* allocate a double vector with subscript range v[nl..nh] */
+{
+	double *v;
+
+	v=(double *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(double)));
+  if (!v) throw std::runtime_error("allocation failure in dvector()");
+	return v-nl+NR_END;
+}
+void free_vector(double *v, long nl, long nh)
+/* free a double vector allocated with dvector() */
+{
+	free((FREE_ARG) (v+nl-NR_END));
+}
+double midpnt(double func(const double, const double, const double),
+	const double a, const double b, const int n, const double g, const double w0) {
+// quote & modified from numerical recipe 2nd edtion (page147)	
+	
+	static double s;
+
+	if (n==1) { 
+    double s1 = 0.5*(b-a)*func(a,g,w0)+func(b,g,w0);
+    double s2 = (b-a)*func(0.5*(a+b),g,w0);
+    return (s2);
+	} else {
+		double x, tnm, sum, del, ddel;
+		int it, j;
+		for (it=1,j=1;j<n-1;j++) it *= 3;
+		tnm = it;
+		del = (b-a)/(3*tnm);
+		ddel=del+del;
+		x = a+0.5*del;
+		sum =0.0;
+		for (j=1;j<=it;j++) {
+			sum += func(x,g,w0);
+			x += ddel;
+			sum += func(x,g,w0);
+			x += del;
+		}
+		s=(s+(b-a)*sum/tnm)/3.0;
+		return s;
+	}
+}
+
+void polint (double xa[], double ya[], int n, double x, double& y, double& dy) {
+	int i, m, ns = 1;
+  double den, dif, dift, ho, hp, w;
+
+  double *c,*d;
+
+  dif = fabs(x-xa[1]);
+  c = vector(1,n);
+  d = vector(1,n);
+	for (i=1;i<=n;i++){
+		if((dift=fabs(x-xa[i]))<dif) {
+			ns=i;
+			dif=dift;
+		}
+    c[i]=ya[i];
+		d[i]=ya[i];
+	}
+	y=ya[ns--];
+	for (m=1;m<n;m++) {
+		for (i=1;i<=n-m;i++) {
+			ho=xa[i]-x;
+			hp=xa[i+m]-x;
+			w=c[i+1]-d[i];
+			if((den=ho-hp)==0.0) //error message!!!
+        throw std::runtime_error("Error in routine polint\n");
+			den=w/den;
+			d[i]=hp*den;
+			c[i]=ho*den;
+		}
+		y += (dy=(2*(ns)<(n-m) ? c[ns+1] : d[ns--]));
+
+	}
+
+  free_vector(d,1,n);
+  free_vector(c,1,n);
+}
+
+
+double integrate (double func(const double, const double, const double),
+				const double a, const double b, const double g, const double w0) {
+	int j;
+	double ss,dss;
+	double h[JMAXP+1], s[JMAXP];
+	
+	h[0] = 1.0;
+	for (j=1; j<= JMAX; j++) {
+		s[j]=midpnt(func,a,b,j,g,w0);
+		if (j >= K) {
+			polint(&h[j-K],&s[j-K],K,0.0,ss,dss);
+			if (fabs(dss) <= fabs(ss)) return ss;
+		}
+		h[j+1]=h[j]/9.0;
+	}
+  throw std::runtime_error("integrate(): Too many steps in routine integrate\n");
+	return 0.0;
+}
+
+//--------------------------------------------------------------------------------------------------------------------------------------
+
+
+double f1(const double x, const double G, const double w0) {
+  return( exp(-G*G*x*x/2)*sin(w0*x));
+}
+
+double ZFKT (double q){
+  // In zero field: 
+  // g(t) = 1/3 + 2/3 exp( -q/2 ) ( 1 - q )
+  // q = t *sigma
+  return (0.3333333333 + 0.6666666667*exp(-0.5*q)*(1-q));
+}
+double gz (const double x, const double G, const double F) 
+{
+	double w0 = 2.0*3.1415926536*0.01355342*F;
+	const double q = G*G*x*x;
+	
+	if (w0 == 0.0) {
+		return (ZFKT(q)); 
+	}
+	else {
+		
+		if (F>2.0*G) { w0 = 2*3.1415926*0.01355342*F ;} else { w0 =2*3.1415926*0.01355342*2.0*G; }
+			
+		double p = G*G/(w0*w0);
+		double HKT = 1.0-2.0*p*(1-exp(-q/2.0)*cos(w0*x))+2.0*p*p*w0*integrate(f1,0.0,x,G,w0);
+		if (F>2.0*G) {return (HKT);} 
+		else {return (ZFKT(q)+ (F/2.0/G)*(HKT-ZFKT(q)));}	 
+		
+   }
+}
+
+// Original function by mark telling
+void DynamicKuboToyabe::function1D(double* out, const double* xValues, const size_t nData)const
+{
+  const double& A = getParameter("Asym");
+  const double& G = fabs(getParameter("Delta"));
+  const double& F = fabs(getParameter("Field"));
+  const double& v = fabs(getParameter("Nu"));
+
+
+  // Zero hopping rate
+	if (v == 0.0) {
+		for (size_t i = 0; i < nData; i++) {
+			out[i] = A*gz(xValues[i],G,F);
+		}
+	} 
+
+  // Non-zero hopping rate
+	else {
+
+    const int n = 1000;
+    const double stepsize = fabs(xValues[nData-1]/n);
+    // do{stepsizeTemp=stepsizeTemp/10;nTemp=nTemp*10; }while (xValues[0]<stepsizeTemp);
+    //make sure stepsize is smaller than spacing between xValues.
+    std::vector<double> funcG(n);
+
+    for (int i = 0; i < n; i++) {
+
+      double Integral=0.0;
+      for (int c = 1; c <= i; c++) {
+        Integral= gz(c*stepsize,G,F)*exp(-v*c*stepsize)*funcG[i-c]*(stepsize) + Integral; 
+      }
+      funcG[i] = (gz(i*stepsize,G,F)*exp(-v*i*stepsize) + v*Integral);
+    }
+
+
+		for (size_t i = 0; i < nData; i++) {
+			double a =xValues[i]/stepsize;
+			out[i] = A*(funcG.at(int(a)-1));
+		}
+
+   } // else hopping rate != 0
+
+}
+
+
+
+void DynamicKuboToyabe::functionDeriv(const API::FunctionDomain& domain, API::Jacobian& jacobian)
+{
+  calNumericalDeriv(domain, jacobian);
+}
+
+void DynamicKuboToyabe::functionDeriv1D(API::Jacobian* , const double* , const size_t )
+{
+  throw Mantid::Kernel::Exception::NotImplementedError("functionDerivLocal is not implemented for DynamicKuboToyabe.");
+}
+
+void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
+
+  setParameter( i, fabs(value), false);
+
+}
+
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -105,9 +105,6 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
     }
     // Non-zero external field
     else{
-      //for (size_t i = 0; i < nData; i++) {
-      //  out[i] = A*HKT(xValues[i],G,F);
-      //}
       throw std::runtime_error("HKT() not implemented yet");
     }
   } 

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -69,7 +69,7 @@ double getDKT (double t, double G, double v){
       // re-compute gStat if G has changed
 
       // Generate static Kubo-Toyabe
-      for (size_t k=0; k<tsmax; k++){
+      for (int k=0; k<tsmax; k++){
         gStat[k]= ZFKT(k*eps,G);
       }
       // Store new G value

--- a/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
@@ -72,12 +72,11 @@ public:
     Mantid::API::FunctionValues y(x);
 
     TS_ASSERT_THROWS_NOTHING(dkt.function(x,y));
-
-    TS_ASSERT_DELTA( y[0], 1.0000, 0.0001);
-    TS_ASSERT_DELTA( y[1], 0.8501, 0.0001);
-    TS_ASSERT_DELTA( y[2], 0.6252, 0.0001);
-    TS_ASSERT_DELTA( y[3], 0.4490, 0.0001);
-    TS_ASSERT_DELTA( y[4], 0.3233, 0.0001);
+    TS_ASSERT_DELTA( y[0], 1.000000, 0.000001);
+    TS_ASSERT_DELTA( y[1], 0.850107, 0.000001);
+    TS_ASSERT_DELTA( y[2], 0.625283, 0.000001);
+    TS_ASSERT_DELTA( y[3], 0.449064, 0.000001);
+    TS_ASSERT_DELTA( y[4], 0.323394, 0.000001);
   }
 
   void xtestZNDKTFunction()

--- a/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
@@ -73,14 +73,14 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(dkt.function(x,y));
 
-    TS_ASSERT_DELTA( y[0], 1.000000, 0.000001);
-    TS_ASSERT_DELTA( y[1], 0.849898, 0.000001);
-    TS_ASSERT_DELTA( y[2], 0.621963, 0.000001);
-    TS_ASSERT_DELTA( y[3], 0.443612, 0.000001);
-    TS_ASSERT_DELTA( y[4], 0.317374, 0.000001);
+    TS_ASSERT_DELTA( y[0], 1.0000, 0.0001);
+    TS_ASSERT_DELTA( y[1], 0.8501, 0.0001);
+    TS_ASSERT_DELTA( y[2], 0.6252, 0.0001);
+    TS_ASSERT_DELTA( y[3], 0.4490, 0.0001);
+    TS_ASSERT_DELTA( y[4], 0.3233, 0.0001);
   }
 
-  void testZNDKTFunction()
+  void xtestZNDKTFunction()
   {
     // Test Dynamic Kubo Toyabe (DKT) for non-zero Field and Zero Nu (ZN)
     const double asym = 1.0;
@@ -108,7 +108,7 @@ public:
     TS_ASSERT_DELTA( y[4], 0.055052, 0.000001);
   }
 
-  void testDKTFunction()
+  void xtestDKTFunction()
   {
     // Test Dynamic Kubo Toyabe (DKT) (non-zero Field, non-zero Nu)
     const double asym = 1.0;

--- a/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
@@ -80,7 +80,35 @@ public:
     TS_ASSERT_DELTA( y[4], 0.317374, 0.000001);
   }
 
-  void xtestDKTFunction()
+  void testZNDKTFunction()
+  {
+    // Test Dynamic Kubo Toyabe (DKT) for non-zero Field and Zero Nu (ZN)
+    const double asym = 1.0;
+    const double delta = 0.39;
+    const double field = 0.1;
+    const double nu = 0.0;
+
+    DynamicKuboToyabe dkt; 
+    dkt.initialize();
+    dkt.setParameter("Asym", asym);
+    dkt.setParameter("Delta",delta );
+    dkt.setParameter("Field",field);
+    dkt.setParameter("Nu",   nu);
+
+    // define 1d domain of 5 points in interval [0,5]
+    Mantid::API::FunctionDomain1DVector x(0,5,5);
+    Mantid::API::FunctionValues y(x);
+
+    TS_ASSERT_THROWS_NOTHING(dkt.function(x,y));
+
+    TS_ASSERT_DELTA( y[0], 1.000000, 0.000001);
+    TS_ASSERT_DELTA( y[1], 0.784636, 0.000001);
+    TS_ASSERT_DELTA( y[2], 0.353978, 0.000001);
+    TS_ASSERT_DELTA( y[3], 0.073286, 0.000001);
+    TS_ASSERT_DELTA( y[4], 0.055052, 0.000001);
+  }
+
+  void testDKTFunction()
   {
     // Test Dynamic Kubo Toyabe (DKT) (non-zero Field, non-zero Nu)
     const double asym = 1.0;
@@ -102,10 +130,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(dkt.function(x,y));
 
     TS_ASSERT_DELTA( y[0], 1.000000, 0.000001);
-    TS_ASSERT_DELTA( y[1], 0.816422, 0.000001);
-    TS_ASSERT_DELTA( y[2], 0.503185, 0.000001);
-    TS_ASSERT_DELTA( y[3], 0.274738, 0.000001);
-    TS_ASSERT_DELTA( y[4], 0.152792, 0.000001);
+    TS_ASSERT_DELTA( y[1], 0.822498, 0.000001);
+    TS_ASSERT_DELTA( y[2], 0.518536, 0.000001);
+    TS_ASSERT_DELTA( y[3], 0.295988, 0.000001);
+    TS_ASSERT_DELTA( y[4], 0.175489, 0.000001);
   }
 
 

--- a/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
@@ -1,0 +1,108 @@
+#ifndef DYNAMICKUBOTOYABETEST_H_
+#define DYNAMICKUBOTOYABETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidCurveFitting/DynamicKuboToyabe.h"
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidCurveFitting/LinearBackground.h"
+#include "MantidCurveFitting/BoundaryConstraint.h"
+#include "MantidCurveFitting/Fit.h"
+#include "MantidKernel/UnitFactory.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/Algorithm.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/Exception.h"
+#include "MantidAPI/FunctionFactory.h"
+
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+using namespace Mantid::CurveFitting;
+using namespace Mantid::DataObjects;
+
+
+class DynamicKuboToyabeTest : public CxxTest::TestSuite
+{
+public:
+
+  void getMockData(Mantid::MantidVec& y, Mantid::MantidVec& e)
+  {
+    // Calculated with A = 0.24 and Delta = 0.16 on an Excel spreadsheet
+    y[0] = 0.24;
+    y[1] = 0.233921146;
+    y[2] = 0.216447929;
+    y[3] = 0.189737312;
+    y[4] = 0.156970237;
+    y[5] = 0.121826185;
+    y[6] = 0.08791249;
+    y[7] = 0.058260598;
+    y[8] = 0.034976545;
+    y[9] = 0.019090369;
+
+    for (int i = 0; i <10; i++)
+    {
+      e[i] = 0.01;
+    }
+
+  }
+
+  void testAgainstMockData()
+  {
+    Fit alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    TS_ASSERT( alg2.isInitialized() );
+
+    // create mock data to test against
+    std::string wsName = "DynamicKuboToyabeData";
+    int histogramNumber = 1;
+    int timechannels = 10;
+    Workspace_sptr ws = WorkspaceFactory::Instance().create("Workspace2D",histogramNumber,timechannels,timechannels);
+    Workspace2D_sptr ws2D = boost::dynamic_pointer_cast<Workspace2D>(ws);
+    for (int i = 0; i < 10; i++) ws2D->dataX(0)[i] = i;
+    Mantid::MantidVec& y = ws2D->dataY(0); // y-values (counts)
+    Mantid::MantidVec& e = ws2D->dataE(0); // error values of counts
+    getMockData(y, e);
+
+    //put this workspace in the data service
+    TS_ASSERT_THROWS_NOTHING(AnalysisDataService::Instance().addOrReplace(wsName, ws2D));
+
+    // set up fitting function
+//    DynamicKuboToyabe fn;
+    std::string fnString = "name=DynamicKuboToyabe,ties=(Field=0,Nu=0);";
+    IFunction_sptr fn = FunctionFactory::Instance().createInitialized(fnString);
+
+    //alg2.setFunction(fn);
+    TS_ASSERT_THROWS_NOTHING(alg2.setProperty("Function",fnString));
+
+    // Set which spectrum to fit against and initial starting values
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("InputWorkspace", wsName));
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("WorkspaceIndex","0"));
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("StartX","0"));
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("EndX","17"));
+
+    fn->applyTies();
+    // execute fit
+   TS_ASSERT_THROWS_NOTHING(
+      TS_ASSERT( alg2.execute() )
+    )
+
+    TS_ASSERT( alg2.isExecuted() );
+
+    auto out = FunctionFactory::Instance().createInitialized(alg2.getPropertyValue("Function"));
+    TS_ASSERT_DELTA( out->getParameter("Asym"),  0.238 ,0.001);
+    TS_ASSERT_DELTA( out->getParameter("Delta"), 0.157 ,0.001);
+
+    // check its categories
+    const std::vector<std::string> categories = out->categories();
+    TS_ASSERT( categories.size() == 1 );
+    TS_ASSERT( categories[0] == "Muon" );
+
+    AnalysisDataService::Instance().remove(wsName);
+
+  }
+
+
+};
+
+#endif /*DYNAMICKUBOTOYABETEST_H_*/

--- a/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
@@ -43,8 +43,8 @@ public:
     Mantid::API::FunctionValues y1(x);
     Mantid::API::FunctionValues y2(x);
 
-    dkt.function(x,y1);
-    skt.function(x,y2);
+    TS_ASSERT_THROWS_NOTHING(dkt.function(x,y1));
+    TS_ASSERT_THROWS_NOTHING(skt.function(x,y2));
 
     for(size_t i = 0; i < x.size(); ++i)
     {
@@ -71,7 +71,7 @@ public:
     Mantid::API::FunctionDomain1DVector x(0,5,5);
     Mantid::API::FunctionValues y(x);
 
-    dkt.function(x,y);
+    TS_ASSERT_THROWS_NOTHING(dkt.function(x,y));
 
     TS_ASSERT_DELTA( y[0], 1.000000, 0.000001);
     TS_ASSERT_DELTA( y[1], 0.849898, 0.000001);
@@ -80,7 +80,7 @@ public:
     TS_ASSERT_DELTA( y[4], 0.317374, 0.000001);
   }
 
-  void testDKTFunction()
+  void xtestDKTFunction()
   {
     // Test Dynamic Kubo Toyabe (DKT) (non-zero Field, non-zero Nu)
     const double asym = 1.0;
@@ -99,7 +99,7 @@ public:
     Mantid::API::FunctionDomain1DVector x(0,5,5);
     Mantid::API::FunctionValues y(x);
 
-    dkt.function(x,y);
+    TS_ASSERT_THROWS_NOTHING(dkt.function(x,y));
 
     TS_ASSERT_DELTA( y[0], 1.000000, 0.000001);
     TS_ASSERT_DELTA( y[1], 0.816422, 0.000001);

--- a/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/DynamicKuboToyabeTest.h
@@ -7,22 +7,10 @@
 #include "MantidCurveFitting/StaticKuboToyabe.h"
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/FunctionValues.h"
-//#include "MantidAPI/CompositeFunction.h"
-//#include "MantidCurveFitting/LinearBackground.h"
-//#include "MantidCurveFitting/BoundaryConstraint.h"
-//#include "MantidCurveFitting/Fit.h"
-//#include "MantidKernel/UnitFactory.h"
-//#include "MantidAPI/AnalysisDataService.h"
-//#include "MantidAPI/WorkspaceFactory.h"
-//#include "MantidAPI/Algorithm.h"
-//#include "MantidDataObjects/Workspace2D.h"
-//#include "MantidKernel/Exception.h"
-//#include "MantidAPI/FunctionFactory.h"
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::CurveFitting;
-//using namespace Mantid::DataObjects;
 
 
 class DynamicKuboToyabeTest : public CxxTest::TestSuite

--- a/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -14,15 +14,17 @@ by
 
 .. math:: G_z \left(t\right) = g_z\left(t\right) e^{-\nu t} + \nu \int_0^t g_z\left(\tau\right) e^{-\nu\tau} G_z\left(t-\tau\right) d\tau
 
-where :math:`g_z\left(t\right)` is the static KT function.
+where :math:`g_z\left(t\right)` is the static KT function, and :math:`\nu` the muon hopping rate.
 
 | In zero field, :math:`B_0=0`: 
 
 .. math:: g_z\left(t\right) = \mbox{A} \Bigg[ \frac{1}{3} + \frac{2}{3} \left( 1 - {\Delta}^2 {t}^2 \right) e^{-\frac{1}{2}\Delta^2 t^2} \Bigg]
 
-| In the presence of a longitudinal field, :math:`B_0=\omega_0 /\gamma_{\mu}>0`: 
+| In the presence of a longitudinal field, :math:`B_0=\omega_0 /\left(2\pi \gamma_{\mu}\right)>0`: 
 
 .. math:: g_z\left(t\right) = \mbox{A} \Bigg[ 1 - 2\frac{\Delta^2}{\omega_0^2}\Big(1-cos(\omega_0 t)e^{-\frac{1}{2}\Delta^2 t^2}\Big) + 2\frac{\Delta^4}{\omega_0^4}\omega_0\int_0^\tau \sin(\omega_0\tau)e^{-\frac{1}{2}\Delta^2\tau^2}d\tau \Bigg]
+
+Note: The static function in longitudinal field will be implemented soon. In the meantime, please fix the external field :math:`B_0` (F parameter) to 0.
 
 .. attributes::
 

--- a/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -1,8 +1,8 @@
 .. _func-DynamicKuboToyabe:
 
-================
+=================
 DynamicKuboToyabe
-================
+=================
 
 .. index:: DynamicKuboToyabe
 

--- a/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -1,0 +1,31 @@
+.. _func-DynamicKuboToyabe:
+
+================
+DynamicKuboToyabe
+================
+
+.. index:: DynamicKuboToyabe
+
+Description
+-----------
+
+Dynamic Kubo Toyabe fitting function for use by Muon scientists defined
+by
+
+.. math:: G_z \left(t\right) = g_z\left(t\right) e^{-\nu t} + \nu \int_0^t g_z\left(\tau\right) e^{-\nu\tau} G_z\left(t-\tau\right) d\tau
+
+where :math:`g_z\left(t\right)` is the static KT function.
+
+| In zero field, :math:`B_0=0`: 
+
+.. math:: g_z\left(t\right) = \mbox{A} \Bigg[ \frac{1}{3} + \frac{2}{3} \left( 1 - {\Delta}^2 {t}^2 \right) e^{-\frac{1}{2}\Delta^2 t^2} \Bigg]
+
+| In the presence of a longitudinal field, :math:`B_0=\omega_0 /\gamma_{\mu}>0`: 
+
+.. math:: g_z\left(t\right) = \mbox{A} \Bigg[ 1 - 2\frac{\Delta^2}{\omega_0^2}\Big(1-cos(\omega_0 t)e^{-\frac{1}{2}\Delta^2 t^2}\Big) + 2\frac{\Delta^4}{\omega_0^4}\omega_0\int_0^\tau \sin(\omega_0\tau)e^{-\frac{1}{2}\Delta^2\tau^2}d\tau \Bigg]
+
+.. attributes::
+
+.. properties::
+
+.. categories::


### PR DESCRIPTION
Fixes trac issue #9556

For tester: Open the muon analysis interface and load one of the muon datasets attached in the trac ticket. Set Alpha=0.96 in the first row in "Pair Table", in "Grouping Options" tab, and hit "Plot". Go to "Data Analysis" and add "DynamicKuboToyabe" fitting function. You should be able to obtain a good fit if you fix the Field parameter to 0 (otherwise an exception will be raised, as the DKT function for non-zero magnetic field will be implemented in ticket #11086). Play with different fitting ranges and the other dataset attached.
