### PR TITLE
Remove always on top hint from splashscreen

### DIFF
--- a/Code/Mantid/MantidPlot/src/main.cpp
+++ b/Code/Mantid/MantidPlot/src/main.cpp
@@ -187,7 +187,7 @@ int main( int argc, char ** argv )
     // Splash
     QPixmap pixmap;
     if (!pixmap.load(":/MantidSplashScreen.png")) std::cerr << "Couldn't load splashscreen\n";
-    QSplashScreen splash(pixmap, Qt::WindowStaysOnTopHint);
+    QSplashScreen splash(pixmap);
     const QString releaseDateTime(Mantid::Kernel::MantidVersion::releaseDate());
     const QString versionInfo(Mantid::Kernel::MantidVersion::version());
     splash.showMessage("Release: " + releaseDateTime + " (Version " + versionInfo + ")", Qt::AlignLeft | Qt::AlignBottom);


### PR DESCRIPTION
ticket http://trac.mantidproject.org/mantid/ticket/11114
# to test
1. Needs to be tested on Windows, Linux and Mac
2. Startup mantidplot - the splash screen should show on top, but then clicking on other windows should make it drop behind.
