### PR TITLE
ISIS specific indirect tests should work with any facility set

### DIFF
--- a/Code/Mantid/scripts/test/IndirectApplyCorrectionsTest.py
+++ b/Code/Mantid/scripts/test/IndirectApplyCorrectionsTest.py
@@ -30,6 +30,9 @@ def setup_can_test(test_case):
 class ApplyCorrectionsTests(unittest.TestCase):
 
     def setUp(self):
+        self._config_defaults = config
+        config['default.facility'] = 'ISIS'
+
         self._sample_workspace = self.make_sample_workspace()
         self._can_workspace = ''
         self._corrections_workspace = ''
@@ -48,6 +51,8 @@ class ApplyCorrectionsTests(unittest.TestCase):
     def tearDown(self):
         mtd.clear()
         self.clean_up_saved_workspaces()
+
+        config = self._config_defaults
 
     @setup_can_test
     def test_with_can_workspace(self):

--- a/Code/Mantid/scripts/test/IndirectCommonTests.py
+++ b/Code/Mantid/scripts/test/IndirectCommonTests.py
@@ -16,6 +16,7 @@ class IndirectCommonTests(unittest.TestCase):
 
     def setUp(self):
         self._config_defaults = config
+        config['default.facility'] = 'ISIS'
 
     def tearDown(self):
         config = self._config_defaults


### PR DESCRIPTION
Ticket [#11118](http://trac.mantidproject.org/mantid/ticket/11118).

To test, set facility to SNS (or anything other than ISIS), run at least `PythonScriptsTest_IndirectApplyCorrectionsTest` and `PythonScriptsTest_IndirectCommonTest` and see that they pass.
