### PR TITLE
Coverity issues (resource leaks) in Framework/MDEvents

### DIFF
--- a/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/AffineMatrixParameter.h
+++ b/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/AffineMatrixParameter.h
@@ -42,11 +42,13 @@ public:
 private:
   void copyRawMatrix();
 
-  /// Raw matrix used for speed.
-  coord_t **rawMatrix;
+  /// Raw matrix used for speed (array of pointers to columns).
+  coord_t **m_rawMatrix;
+  /// pointer to large memory block (matrix)
+  coord_t *m_rawMem;
 
   /// Affine matrix.
-  AffineMatrixType affineMatrix;
+  AffineMatrixType m_affineMatrix;
 };
 }
 }

--- a/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/CoordTransformAffine.h
+++ b/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/CoordTransformAffine.h
@@ -55,12 +55,12 @@ protected:
    * can be
    * combined by simply multiplying the matrices.
    */
-  Mantid::Kernel::Matrix<coord_t> affineMatrix;
+  Mantid::Kernel::Matrix<coord_t> m_affineMatrix;
 
   /// Raw pointer to the same underlying matrix as affineMatrix.
-  coord_t **rawMatrix;
+  coord_t **m_rawMatrix;
   /// raw pointer to the memory block, referred by the raw Matrix;
-  coord_t *rawMemory;
+  coord_t *m_rawMemory;
 
   void copyRawMatrix();
 };

--- a/Code/Mantid/Framework/MDEvents/src/AffineMatrixParameter.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/AffineMatrixParameter.cpp
@@ -10,15 +10,17 @@ namespace MDEvents {
 * @param inD the nubmer of input dimensions
 */
 AffineMatrixParameter::AffineMatrixParameter(size_t outD, size_t inD)
-    : affineMatrix(outD + 1, inD + 1) {
+    : m_affineMatrix(outD + 1, inD + 1) {
   m_isValid = false;
-  affineMatrix.identityMatrix();
-  size_t nx = affineMatrix.numRows();
-  size_t ny = affineMatrix.numCols();
-  coord_t *tmpX = new coord_t[nx * ny];
-  rawMatrix = new coord_t *[nx];
+  m_affineMatrix.identityMatrix();
+  size_t nx = m_affineMatrix.numRows();
+  size_t ny = m_affineMatrix.numCols();
+  // big chunk of memory holding the whole matrix
+  m_rawMem = new coord_t[nx * ny];
+  // array of pointers (one per column)
+  m_rawMatrix = new coord_t *[nx];
   for (size_t i = 0; i < nx; i++)
-    rawMatrix[i] = tmpX + (i * ny);
+    m_rawMatrix[i] = m_rawMem + (i * ny);
   // Copy into the raw matrix (for speed)
   copyRawMatrix();
 }
@@ -26,19 +28,20 @@ AffineMatrixParameter::AffineMatrixParameter(size_t outD, size_t inD)
 //----------------------------------------------------------------------------------------------
 /// Destructor
 AffineMatrixParameter::~AffineMatrixParameter() {
-  if (rawMatrix) {
-    delete[] * rawMatrix;
-    delete[] rawMatrix;
+  if (m_rawMatrix) {
+    delete[] * m_rawMatrix;
+    delete[] m_rawMatrix;
   }
-  rawMatrix = NULL;
+  m_rawMatrix = NULL;
+  m_rawMem = NULL;
 }
 
 //----------------------------------------------------------------------------------------------
 /// Copy elements from affinematrix into raw array.
 void AffineMatrixParameter::copyRawMatrix() {
-  for (size_t x = 0; x < affineMatrix.numRows(); ++x)
-    for (size_t y = 0; y < affineMatrix.numCols(); ++y)
-      rawMatrix[x][y] = affineMatrix[x][y];
+  for (size_t x = 0; x < m_affineMatrix.numRows(); ++x)
+    for (size_t y = 0; y < m_affineMatrix.numCols(); ++y)
+      m_rawMatrix[x][y] = m_affineMatrix[x][y];
 }
 
 //----------------------------------------------------------------------------------------------
@@ -47,7 +50,7 @@ void AffineMatrixParameter::copyRawMatrix() {
 * @return A copy of the underlying affine matrix.
 */
 AffineMatrixType AffineMatrixParameter::getAffineMatrix() const {
-  return affineMatrix;
+  return m_affineMatrix;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -55,7 +58,7 @@ AffineMatrixType AffineMatrixParameter::getAffineMatrix() const {
 *
 * @return the matrix as an array.
 */
-coord_t **AffineMatrixParameter::getRawMatrix() { return rawMatrix; }
+coord_t **AffineMatrixParameter::getRawMatrix() { return m_rawMatrix; }
 
 //----------------------------------------------------------------------------------------------
 /** Get the name of the parameter
@@ -72,7 +75,7 @@ std::string AffineMatrixParameter::getName() const {
 * @return the object as serialized. Xml in a std::string.
 */
 std::string AffineMatrixParameter::toXMLString() const {
-  std::vector<coord_t> elements = this->affineMatrix.getVector();
+  std::vector<coord_t> elements = this->m_affineMatrix.getVector();
   const size_t size = elements.size();
   std::string parameterValue;
 
@@ -81,7 +84,7 @@ std::string AffineMatrixParameter::toXMLString() const {
     sstream << elements[i - 1];
     parameterValue.append(sstream.str());
     sstream.clear();
-    if (i % affineMatrix.numCols() == 0) {
+    if (i % m_affineMatrix.numCols() == 0) {
       if (i != size) {
         parameterValue.append(";");
       }
@@ -99,8 +102,8 @@ std::string AffineMatrixParameter::toXMLString() const {
 * @return Cloned parameter.
 */
 AffineMatrixParameter *AffineMatrixParameter::clone() const {
-  return new AffineMatrixParameter(affineMatrix.numRows() - 1,
-                                   affineMatrix.numCols() - 1);
+  return new AffineMatrixParameter(m_affineMatrix.numRows() - 1,
+                                   m_affineMatrix.numCols() - 1);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -117,14 +120,14 @@ bool AffineMatrixParameter::isValid() const { return m_isValid; }
 */
 AffineMatrixParameter &AffineMatrixParameter::
 operator=(const AffineMatrixParameter &other) {
-  if ((other.affineMatrix.numCols() != this->affineMatrix.numCols()) ||
-      (other.affineMatrix.numRows() != this->affineMatrix.numRows())) {
+  if ((other.m_affineMatrix.numCols() != this->m_affineMatrix.numCols()) ||
+      (other.m_affineMatrix.numRows() != this->m_affineMatrix.numRows())) {
     throw std::runtime_error("Cannot make assignemnts between "
                              "AffineMatrixParameter when the matrixes are of "
                              "different sizes.");
   }
   if (this != &other) {
-    this->affineMatrix = other.affineMatrix;
+    this->m_affineMatrix = other.m_affineMatrix;
     this->m_isValid = other.m_isValid;
     copyRawMatrix();
   }
@@ -136,14 +139,14 @@ operator=(const AffineMatrixParameter &other) {
 *  @param other : another affine matrix to copy from.
 */
 AffineMatrixParameter::AffineMatrixParameter(const AffineMatrixParameter &other)
-    : affineMatrix(other.affineMatrix) {
+    : m_affineMatrix(other.m_affineMatrix) {
   m_isValid = other.m_isValid;
-  size_t nx = affineMatrix.numRows();
-  size_t ny = affineMatrix.numCols();
-  coord_t *tmpX = new coord_t[nx * ny];
-  rawMatrix = new coord_t *[nx];
+  size_t nx = m_affineMatrix.numRows();
+  size_t ny = m_affineMatrix.numCols();
+  m_rawMem = new coord_t[nx * ny];
+  m_rawMatrix = new coord_t *[nx];
   for (size_t i = 0; i < nx; i++)
-    rawMatrix[i] = tmpX + (i * ny);
+    m_rawMatrix[i] = m_rawMem + (i * ny);
   copyRawMatrix();
 }
 
@@ -153,11 +156,11 @@ AffineMatrixParameter::AffineMatrixParameter(const AffineMatrixParameter &other)
 * @param newMatrix : new matrix to use.
 */
 void AffineMatrixParameter::setMatrix(const AffineMatrixType newMatrix) {
-  if (newMatrix.numRows() != this->affineMatrix.numRows())
+  if (newMatrix.numRows() != this->m_affineMatrix.numRows())
     throw std::runtime_error("setMatrix(): Number of rows must match!");
-  if (newMatrix.numCols() != this->affineMatrix.numCols())
+  if (newMatrix.numCols() != this->m_affineMatrix.numCols())
     throw std::runtime_error("setMatrix(): Number of columns must match!");
-  affineMatrix = newMatrix;
+  m_affineMatrix = newMatrix;
   // Copy into the raw matrix (for speed)
   copyRawMatrix();
   this->m_isValid = true;

--- a/Code/Mantid/Framework/MDEvents/src/CoordTransformAffineParser.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/CoordTransformAffineParser.cpp
@@ -49,20 +49,20 @@ Mantid::API::CoordTransform *CoordTransformAffineParser::createTransform(
   InDimParameterParser inDimParser;
   Poco::XML::Element *parameter =
       dynamic_cast<Poco::XML::Element *>(parameters->item(0));
-  Mantid::API::InDimParameter *inDim =
-      inDimParser.createWithoutDelegation(parameter);
+  boost::shared_ptr<Mantid::API::InDimParameter>
+    inDim(inDimParser.createWithoutDelegation(parameter));
 
   // Add output dimension parameter.
   OutDimParameterParser outDimParser;
   parameter = dynamic_cast<Poco::XML::Element *>(parameters->item(1));
-  Mantid::API::OutDimParameter *outDim =
-      outDimParser.createWithoutDelegation(parameter);
+  boost::shared_ptr<Mantid::API::OutDimParameter>
+    outDim(outDimParser.createWithoutDelegation(parameter));
 
   // Add affine matrix parameter.
   AffineMatrixParameterParser affineMatrixDimParser;
   parameter = dynamic_cast<Poco::XML::Element *>(parameters->item(2));
-  AffineMatrixParameter *affineMatrix =
-      affineMatrixDimParser.createParameter(parameter);
+  boost::shared_ptr<AffineMatrixParameter>
+    affineMatrix(affineMatrixDimParser.createParameter(parameter));
 
   // Generate the coordinate transform with the matrix and return.
   CoordTransformAffine *transform =

--- a/Code/Mantid/Framework/MDEvents/src/CoordTransformDistanceParser.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/CoordTransformDistanceParser.cpp
@@ -51,32 +51,33 @@ Mantid::API::CoordTransform *CoordTransformDistanceParser::createTransform(
   InDimParameterParser inDimParamParser;
   Poco::XML::Element *parameter =
       dynamic_cast<Poco::XML::Element *>(parameters->item(0));
-  Mantid::API::InDimParameter *inDimParameter =
-      inDimParamParser.createWithoutDelegation(parameter);
+  boost::shared_ptr<Mantid::API::InDimParameter>
+    inDimParameter(inDimParamParser.createWithoutDelegation(parameter));
 
   // Parse the out dimension parameter.
   OutDimParameterParser outDimParamParser;
   parameter = dynamic_cast<Poco::XML::Element *>(parameters->item(1));
-  Mantid::API::OutDimParameter *outDimParameter =
-      outDimParamParser.createWithoutDelegation(parameter);
+  boost::shared_ptr<Mantid::API::OutDimParameter>
+    outDimParameter(outDimParamParser.createWithoutDelegation(parameter));
   UNUSED_ARG(outDimParameter); // not actually used as an input.
 
   // Parse the coordinate centre parameter.
   CoordCenterParser coordCenterParser;
   parameter = dynamic_cast<Poco::XML::Element *>(parameters->item(2));
-  Mantid::MDEvents::CoordCenterVectorParam *coordCenterParam =
-      coordCenterParser.createWithoutDelegation(parameter);
+  boost::shared_ptr<Mantid::MDEvents::CoordCenterVectorParam>
+    coordCenterParam(coordCenterParser.createWithoutDelegation(parameter));
 
   // Parse the dimensions used parameter.
   DimsUsedParser dimsUsedParser;
   parameter = dynamic_cast<Poco::XML::Element *>(parameters->item(3));
-  Mantid::MDEvents::DimensionsUsedVectorParam *dimsUsedVecParm =
-      dimsUsedParser.createWithoutDelegation(parameter);
+  boost::shared_ptr<Mantid::MDEvents::DimensionsUsedVectorParam>
+    dimsUsedVecParm(dimsUsedParser.createWithoutDelegation(parameter));
 
   ////Generate the coordinate transform and return
   CoordTransformDistance *transform = new CoordTransformDistance(
       inDimParameter->getValue(), coordCenterParam->getPointerToStart(),
       dimsUsedVecParm->getPointerToStart());
+
   return transform;
 }
 


### PR DESCRIPTION
Fixes trac issue [#11060](http://trac.mantidproject.org/mantid/ticket/11060) - a few memory leaks of supposed "high impact" but not that terrible in the end. See the ticket for a list of issues with short description.

**To test**:
- review code
- check that tests pass (these classes are in principle well tested).
