### PR TITLE
Add missing header to InternetHelper.h

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
@@ -5,6 +5,7 @@
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/ProxyInfo.h"
 
+#include <ios>
 #include <map>
 
 namespace Poco {


### PR DESCRIPTION
This fixes issue [#11130](http://trac.mantidproject.org/mantid/ticket/11130)

InternetHelper.h is missing the "ios" header and therefore won't build on osx with AppleClang.

**testing**: code review
