### PR TITLE
Fix warning on FuryFit regarding numerical derivatives

### DIFF
--- a/Code/Mantid/scripts/Inelastic/IndirectDataAnalysis.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectDataAnalysis.py
@@ -301,8 +301,8 @@ def furyfitMult(inputWS, function, ftype, startx, endx, spec_min=0, spec_max=Non
 
 
 def createFuryMultiDomainFunction(function, input_ws):
-    multi= 'composite=MultiDomainFunction,NumDeriv=1;'
-    comp =    '(composite=CompositeFunction,$domains=i;' + function + ');'
+    multi= 'composite=MultiDomainFunction,NumDeriv=true;'
+    comp = '(composite=CompositeFunction,NumDeriv=true,$domains=i;' + function + ');'
 
     ties = []
     kwargs = {}
@@ -314,7 +314,7 @@ def createFuryMultiDomainFunction(function, input_ws):
         if i > 0:
             kwargs['InputWorkspace_' + str(i)] = input_ws
 
-      #tie beta for every spectrum
+            #tie beta for every spectrum
             tie = 'f%d.f1.Beta=f0.f1.Beta' % i
             ties.append(tie)
 


### PR DESCRIPTION
Fixes [#11133](http://trac.mantidproject.org/mantid/ticket/11133).

To test, see that the error is no longer emitted in system tests (just after the Fit call in `(OS)IRISFuryAndFuryFitMulti`).
