### PR TITLE
Workspace logs (metadata) is copied into the final Workspace in order to quickly retrieved infos such as proton charge

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/RefLReduction.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/RefLReduction.py
@@ -374,7 +374,8 @@ class RefLReduction(PythonAlgorithm):
         final_workspace = wks_utility.createFinalWorkspace(final_x_axis,
                                                            final_y_axis,
                                                            final_y_error_axis,
-                                                           name_output_ws)
+                                                           name_output_ws,
+                                                           ws_event_data)
 
         self.setProperty('OutputWorkspace', mtd[name_output_ws])
 

--- a/Code/Mantid/scripts/reduction/instruments/reflectometer/wks_utility.py
+++ b/Code/Mantid/scripts/reduction/instruments/reflectometer/wks_utility.py
@@ -1936,14 +1936,15 @@ def createQworkspace(q_axis, y_axis, y_error_axis):
 
     return q_workspace
 
-def createFinalWorkspace(q_axis, final_y_axis, final_error_axis, name_output_ws):
+def createFinalWorkspace(q_axis, final_y_axis, final_error_axis, name_output_ws, parent_workspace):
 
     final_workspace = CreateWorkspace(OutputWorkspace=name_output_ws,
                                       DataX=q_axis,
                                       DataY=final_y_axis,
                                       DataE=final_error_axis,
                                       Nspec=1,
-                                      UnitX="Wavelength")
+                                      UnitX="Wavelength",
+                                      ParentWorkspace=parent_workspace)
     final_workspace.setDistribution(True)
 
     return final_workspace


### PR DESCRIPTION
As part of the final scaling of the data in quickNXS, proton charge of the data is needed to estimate error bars of 0 counts (1/proton_charge). The work done here retrieves all the metadata of the data workspace (NeXus) and pass them to the final data set (Reduced data). 

To test this work, the best way will be to run a full reduction via REFLreduction GUI using the following config file
_/SNS/REF_L/IPTS-11428/shared/REFL_119194.xml_

The reduced data should look like this ->
![screen shot 2015-02-19 at 12 03 28 pm](https://cloud.githubusercontent.com/assets/1138324/6271555/5bfd2180-b82f-11e4-9af1-c1d830a9a0a1.png)

Then check that any of the **reflectivity_#** workspace has an non-empty sample logs (right click and select **Sample logs …**).
