### PR TITLE
Fix linking errors with boost 1.56+

### DIFF
--- a/Code/Mantid/Framework/API/test/PeakTransformHKLTest.h
+++ b/Code/Mantid/Framework/API/test/PeakTransformHKLTest.h
@@ -10,6 +10,16 @@ using namespace Mantid::API;
 using Mantid::Kernel::V3D;
 using namespace testing;
 
+namespace boost{
+  template<class CharType, class CharTrait>
+  std::basic_ostream<CharType, CharTrait>& operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<double> const& maybe)
+  {
+    if (maybe)
+        out << maybe;
+    return out;
+  }
+}
+
 class PeakTransformHKLTest : public CxxTest::TestSuite
 {
 public:

--- a/Code/Mantid/Framework/API/test/PeakTransformQLabTest.h
+++ b/Code/Mantid/Framework/API/test/PeakTransformQLabTest.h
@@ -11,6 +11,16 @@ using namespace Mantid;
 using Mantid::Kernel::V3D;
 using namespace testing;
 
+namespace boost{
+  template<class CharType, class CharTrait>
+  std::basic_ostream<CharType, CharTrait>& operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<double> const& maybe)
+  {
+    if (maybe)
+        out << maybe;
+    return out;
+  }
+}
+
 class PeakTransformQLabTest : public CxxTest::TestSuite
 {
 

--- a/Code/Mantid/Framework/API/test/PeakTransformQSampleTest.h
+++ b/Code/Mantid/Framework/API/test/PeakTransformQSampleTest.h
@@ -11,6 +11,17 @@ using namespace Mantid;
 using Mantid::Kernel::V3D;
 using namespace testing;
 
+
+namespace boost{
+  template<class CharType, class CharTrait>
+  std::basic_ostream<CharType, CharTrait>& operator<<(std::basic_ostream<CharType, CharTrait>& out, optional<double> const& maybe)
+  {
+    if (maybe)
+        out << maybe;
+    return out;
+  }
+}
+
 class PeakTransformQSampleTest : public CxxTest::TestSuite
 {
 


### PR DESCRIPTION
This fixes issue [#11132](http://trac.mantidproject.org/mantid/ticket/11132)

ticket #10904 introduces a number of linking errors because boost 1.56+ forward declares operator<<. We can fix this by providing a '<<' operator for boost::optionals. The same fix was used in ticket #103329.

**testing**: On a machine with boost 1.56+, verify that the unit tests build and there are no linking errors. 
