### PR TITLE
Fix rpm for Fedora >= 18 and RHEL >= 7

### DIFF
--- a/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
+++ b/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
@@ -22,6 +22,10 @@ endif()
 
 set ( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR};${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR} )
 
+# Tell rpm that this package does not own /opt /usr/share/{applications,pixmaps}
+# Required for Fedora >= 18 and RHEL >= 7
+set ( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /opt /usr/share/applications /usr/share/pixmaps )
+
 ###########################################################################
 # LD_PRELOAD libraries
 ###########################################################################


### PR DESCRIPTION
The rpm command is now more strict on these systems and requires the
package not to own system directories
Refs #10911
