### PR TITLE
Handle failure in CreateGroupingWorkspace where group count > spectra count

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -169,12 +169,18 @@ void makeGroupingByNumGroups(const std::string compName, int numGroups,
   // Get detectors for given instument component
   std::vector<IDetector_const_sptr> detectors;
   inst->getDetectorsInBank(detectors, compName);
+  size_t numDetectors = detectors.size();
+
+  // Sanity check for following calculation
+  if(numGroups > static_cast<int>(numDetectors))
+    throw std::runtime_error("Number of groups must be less than or "
+                             "equal to number of detectors");
 
   // Calculate number of detectors per group
-  int detectorsPerGroup = static_cast<int>(detectors.size()) / numGroups;
+  int detectorsPerGroup = static_cast<int>(numDetectors) / numGroups;
 
   // Map detectors to group
-  for (unsigned int detIndex = 0; detIndex < detectors.size(); detIndex++) {
+  for (unsigned int detIndex = 0; detIndex < numDetectors; detIndex++) {
     int detectorID = detectors[detIndex]->getID();
     int groupNum = (detIndex / detectorsPerGroup) + 1;
 

--- a/Code/Mantid/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -9,6 +9,7 @@
 #include <queue>
 #include <fstream>
 #include "MantidAPI/FileProperty.h"
+#include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ListValidator.h"
 
 namespace {
@@ -92,9 +93,10 @@ void CreateGroupingWorkspace::init() {
   declareProperty("MaxRecursionDepth", 5,
                   "Number of levels to search into the instrument (default=5)");
 
-  declareProperty("FixedGroupCount", 0, "Used to distribute the detectors of a "
-                                        "given component into a fixed number "
-                                        "of groups");
+  declareProperty("FixedGroupCount", 0,
+                  boost::make_shared<BoundedValidator<int> >(0, INT_MAX),
+                  "Used to distribute the detectors of a given component into "
+                  "a fixed number of groups");
   declareProperty("ComponentName", "", "Specify the instrument component to "
                                        "group into a fixed number of groups");
 

--- a/Code/Mantid/Framework/Algorithms/test/CreateGroupingWorkspaceTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/CreateGroupingWorkspaceTest.h
@@ -174,6 +174,26 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
+  void test_exec_WithFixedGroups_FailOnGroupsGreaterThanDet()
+  {
+    // Name of the output workspace.
+    std::string outWSName("CreateGroupingWorkspaceTest_OutputWS_fail");
+
+    CreateGroupingWorkspace alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("InstrumentName", "IRIS") );
+    TS_ASSERT_THROWS_NOTHING( alg.setProperty("FixedGroupCount", 52) );
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("ComponentName", "graphite") );
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", outWSName) );
+    TS_ASSERT_THROWS_NOTHING( alg.execute() );
+
+    // Should fail as IRIS graphite component has only 51 spectra
+    TS_ASSERT( !alg.isExecuted() );
+
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
 };
 
 


### PR DESCRIPTION
Fixes [#11140](http://trac.mantidproject.org/mantid/ticket/11140).

To test, review unit test and see that the failure case is now tested, try the original failure case (in the Trac description) with different group numbers with different instruments.
