### PR TITLE
Fix unstable RemoveExpDecay test

### DIFF
--- a/Code/Mantid/Framework/Algorithms/test/RemoveExpDecayTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RemoveExpDecayTest.h
@@ -9,11 +9,11 @@
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
+const std::string outputName = "MuonRemoveExpDecay_Output";
+
 class RemoveExpDecayTest : public CxxTest::TestSuite
 {
 public:
-
-  const std::string outputName = "MuonRemoveExpDecay_Output";
 
   void testInit()
   {

--- a/Code/Mantid/Framework/Algorithms/test/RemoveExpDecayTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RemoveExpDecayTest.h
@@ -3,7 +3,6 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAlgorithms/RemoveExpDecay.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -29,14 +28,13 @@ public:
 
     MuonRemoveExpDecay alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT(alg.isInitialized());
+    alg.setChild(true);
     alg.setProperty("InputWorkspace", ws);
     alg.setPropertyValue("OutputWorkspace", outputName);
     alg.setPropertyValue("Spectra", "0");
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted())
-
-    AnalysisDataService::Instance().remove(outputName);
   }
 
   void testExecuteWhereSepctraNotSet()
@@ -45,13 +43,12 @@ public:
 
     MuonRemoveExpDecay alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT(alg.isInitialized());
+    alg.setChild(true);
     alg.setProperty("InputWorkspace", ws);
     alg.setPropertyValue("OutputWorkspace", outputName);
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT(alg.isExecuted())
-
-    AnalysisDataService::Instance().remove(outputName);
   }
 
   void test_yUnitLabel()
@@ -60,15 +57,14 @@ public:
 
     MuonRemoveExpDecay alg;
     alg.initialize();
+    alg.setChild(true);
     alg.setProperty("InputWorkspace", ws);
     alg.setProperty("OutputWorkspace", outputName);
     alg.execute();
 
-    auto result = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputName);
+    MatrixWorkspace_sptr result = alg.getProperty("OutputWorkspace");
     TS_ASSERT(result);
     TS_ASSERT_EQUALS(result->YUnitLabel(), "Asymmetry");
-
-    AnalysisDataService::Instance().remove(outputName);
   }
 };
 


### PR DESCRIPTION
This is for trac ticket [#11142](http://trac.mantidproject.org/mantid/ticket/11142).

The RemoveExpDecay test is failing irregularly. This pull request simplifies the test, attempting to make it more robust, and removes the need to load data from disk, which should also improve performance.

**Testing**: Let this branch build and its tests run, and retest it at least another four times to see if the issue has been resolved.
