### PR TITLE
Algorithm history script generation should ignore non WS output properties

### DIFF
--- a/Code/Mantid/Framework/API/src/ScriptBuilder.cpp
+++ b/Code/Mantid/Framework/API/src/ScriptBuilder.cpp
@@ -15,9 +15,8 @@ namespace API {
 using Mantid::Kernel::PropertyHistory_sptr;
 using Mantid::Kernel::PropertyHistory_const_sptr;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("ScriptBuilder");
+namespace {
+Mantid::Kernel::Logger g_log("ScriptBuilder");
 }
 
 ScriptBuilder::ScriptBuilder(boost::shared_ptr<HistoryView> view,
@@ -175,18 +174,19 @@ ScriptBuilder::buildPropertyString(PropertyHistory_const_sptr propHistory) {
   // No need to specify value for default properties
   if (!propHistory->isDefault()) {
     // Do not give values to output properties other than workspace properties
-    if (find(nonWorkspaceTypes.begin(), nonWorkspaceTypes.end(), propHistory->type()) != nonWorkspaceTypes.end()
-        && propHistory->direction() == Direction::Output) {
+    if (find(nonWorkspaceTypes.begin(), nonWorkspaceTypes.end(),
+             propHistory->type()) != nonWorkspaceTypes.end() &&
+        propHistory->direction() == Direction::Output) {
       g_log.debug() << "Ignoring property " << propHistory->name()
                     << " of type " << propHistory->type() << std::endl;
-    // Handle numerical properties
+      // Handle numerical properties
     } else if (propHistory->type() == "number") {
       prop = propHistory->name() + "=" + propHistory->value();
-    // Handle boolean properties
+      // Handle boolean properties
     } else if (propHistory->type() == "boolean") {
       std::string value = (propHistory->value() == "1" ? "True" : "False");
       prop = propHistory->name() + "=" + value;
-    // Handle all other property types
+      // Handle all other property types
     } else {
       std::string opener = "='";
       if (propHistory->value().find('\\') != std::string::npos) {

--- a/Code/Mantid/Framework/API/test/ScriptBuilderTest.h
+++ b/Code/Mantid/Framework/API/test/ScriptBuilderTest.h
@@ -27,7 +27,7 @@ class ScriptBuilderTest : public CxxTest::TestSuite
     const std::string workspaceMethodName() const { return "methodname"; }
     const std::string workspaceMethodOnTypes() const { return "MatrixWorkspace;ITableWorkspace"; }
     const std::string workspaceMethodInputProperty() const { return "InputWorkspace"; }
-    
+
     void init()
     {
       declareProperty("PropertyA", "Hello");
@@ -52,11 +52,12 @@ class ScriptBuilderTest : public CxxTest::TestSuite
     const std::string workspaceMethodName() const { return "methodname"; }
     const std::string workspaceMethodOnTypes() const { return "MatrixWorkspace;ITableWorkspace"; }
     const std::string workspaceMethodInputProperty() const { return "InputWorkspace"; }
-    
+
     void init()
     {
       declareProperty("PropertyA", "Hello");
       declareProperty("PropertyB", "World");
+      declareProperty("PropertyC", "", Direction::Output);
     }
     void exec()
     {
@@ -65,6 +66,7 @@ class ScriptBuilderTest : public CxxTest::TestSuite
       alg->initialize();
       alg->setProperty("PropertyA", "I Don't exist!");
       alg->execute();
+      setProperty("PropertyC", "I have been set!");
     }
   };
 
@@ -81,7 +83,7 @@ class ScriptBuilderTest : public CxxTest::TestSuite
     const std::string workspaceMethodName() const { return "methodname"; }
     const std::string workspaceMethodOnTypes() const { return "MatrixWorkspace;ITableWorkspace"; }
     const std::string workspaceMethodInputProperty() const { return "InputWorkspace"; }
-    
+
     void init()
     {
       declareProperty("PropertyA", 13);
@@ -115,7 +117,7 @@ class ScriptBuilderTest : public CxxTest::TestSuite
     const std::string workspaceMethodName() const { return "methodname"; }
     const std::string workspaceMethodOnTypes() const { return "Workspace;MatrixWorkspace;ITableWorkspace"; }
     const std::string workspaceMethodInputProperty() const { return "InputWorkspace"; }
-    
+
     void init()
     {
       declareProperty(new WorkspaceProperty<MatrixWorkspace>("InputWorkspace", "", Direction::Input));
@@ -137,7 +139,7 @@ class ScriptBuilderTest : public CxxTest::TestSuite
   };
 
 private:
-  
+
 public:
 
   void setUp()
@@ -155,7 +157,7 @@ public:
     Mantid::API::AlgorithmFactory::Instance().unsubscribe("BasicAlgorithm",1);
     Mantid::API::AlgorithmFactory::Instance().unsubscribe("SubAlgorithm",1);
   }
-  
+
   void test_Build_Simple()
   {
     std::string result[] = {
@@ -220,7 +222,7 @@ public:
     alg->setRethrows(true);
     alg->setProperty("InputWorkspace", input);
     alg->setPropertyValue("OutputWorkspace", "test_output_workspace");
-    alg->execute();    
+    alg->execute();
 
     auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("test_output_workspace");
     auto wsHist = ws->getHistory();
@@ -280,7 +282,7 @@ public:
     alg->setProperty("InputWorkspace", "test_output_workspace");
     alg->setPropertyValue("OutputWorkspace", "test_output_workspace");
     alg->execute();
-    
+
     auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("test_output_workspace");
     auto wsHist = ws->getHistory();
     auto view = wsHist.createView();
@@ -305,7 +307,7 @@ public:
     AnalysisDataService::Instance().remove("test_input_workspace");
   }
 
-    
+
   void test_Build_Simple_with_backslash()
   {
     //checks that property values with \ get prefixed with r, eg. filename=r'c:\test\data.txt'


### PR DESCRIPTION
Fixes [#11128](http://trac.mantidproject.org/mantid/ticket/11128).

To test run `grouping_ws = CreateGroupingWorkspace(InstrumentName='IRIS', FixedGroupCount=10, ComponentName='graphite')` and see that the output properties are no longer given in the generated script. Code review.
