### PR TITLE
Fixes for OpenCascade 6.8.0

### DIFF
--- a/Code/Mantid/Framework/Geometry/src/Rendering/OCGeometryGenerator.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Rendering/OCGeometryGenerator.cpp
@@ -44,7 +44,7 @@ GCC_DIAG_OFF(cast-qual)
 #include <TopoDS_Solid.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopExp_Explorer.hxx>
-#include <BRepMesh.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepAlgoAPI_Common.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
@@ -121,7 +121,7 @@ void OCGeometryGenerator::AnalyzeObject() {
     TopoDS_Shape Result = AnalyzeRule(const_cast<Rule *>(top));
     try {
       ObjSurface = new TopoDS_Shape(Result);
-      BRepMesh::Mesh(Result, 0.001);
+      BRepMesh_IncrementalMesh(Result, 0.001);
     } catch (StdFail_NotDone &) {
       g_log.error("Cannot build the geometry. Check the geometry definition");
     }


### PR DESCRIPTION
This fixes ticket [#11153](http://trac.mantidproject.org/mantid/ticket/11153)

OpenCascade 6.8.0 removes BRepMesh::Mesh. We need to replace it with BRepMesh_IncrementalMesh, which should behave identically. 

http://www.opencascade.org/org/forum/thread_26649/?forum=3
