### PR TITLE
Update CppCheck_Suppressions.txt

### DIFF
--- a/Code/Mantid/Build/CMake/CppCheck_Suppressions.txt
+++ b/Code/Mantid/Build/CMake/CppCheck_Suppressions.txt
@@ -4,6 +4,6 @@
 
 // suppress in all files - BE CAREFULL not to leave trailing spaces after the rule id. or empty lines
 // For a library this is not a problem per se
-unusedFunction
+// unusedFunction
 // cppcheck has problems handling the number of pre-processor definitions used in the DLL_EXPORTs
 class_X_Y


### PR DESCRIPTION
There is a cppcheck issue "Unmatched suppression: unusedFunction". This happens because we don't have unused functions and we try to suppress the "unusedFunction" warning. The suppression happens globally, in  CppCheck_Suppressions.txt
