### PR TITLE
Undo some pylint changes that broke systemtests. 

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/ConjoinFiles.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/ConjoinFiles.py
@@ -1,1 +1,67 @@
 #pylint: disable=no-init,invalid-name
+from mantid.api import *
+from mantid.kernel import *
+from mantid.simpleapi import *
+import os
+
+class ConjoinFiles(PythonAlgorithm):
+    def category(self):
+        return "DataHandling;PythonAlgorithms"
+
+    def name(self):
+        return "ConjoinFiles"
+
+    def summary(self):
+        return "Conjoin two file-based workspaces."
+    
+    def __load(self, directory, instr, run, loader, exts, wksp):
+        filename = None
+        for ext in exts:
+            filename = "%s_%s%s" % (instr, str(run), ext)
+            if len(directory) > 0:
+                filename = os.path.join(directory, filename)
+                if not os.path.exists(filename):
+                    continue
+            try:
+                self.log().information("Trying to load '%s'" % filename)
+                loader(Filename=filename, OutputWorkspace=wksp)
+                return
+            except Exception, e:
+                logger.information(str(e))
+        raise RuntimeError("Failed to load run %s from file %s" % (str(run), filename))
+
+    def PyInit(self):
+        greaterThanZero = IntArrayBoundedValidator()
+        greaterThanZero.setLower(0)
+        self.declareProperty(IntArrayProperty("RunNumbers",values=[0], validator=greaterThanZero), doc="Run numbers")
+        self.declareProperty(WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
+        self.declareProperty(FileProperty("Directory", "", FileAction.OptionalDirectory))
+    
+    def PyExec(self):
+        # generic stuff for running
+        wksp = self.getPropertyValue("OutputWorkspace")
+        runs = self.getProperty("RunNumbers")
+        instr = config.getInstrument().shortName()
+        directory = self.getPropertyValue("Directory").strip()
+
+        # change here if you want something other than gsas files
+        exts = ['.txt', '.gsa']
+        loader = LoadGSS
+
+        # load things and conjoin them
+        first = True
+        for run in runs.value:
+            run = str(run)
+            if first:
+                self.__load(directory, instr, run, loader, exts, wksp)
+                first = False
+            else:
+                self.__load(directory, instr, run, loader, exts, run)
+                ConjoinWorkspaces(InputWorkspace1=wksp, InputWorkspace2=run, CheckOverlapping=False)
+                if mtd.doesExist(run):
+                    DeleteWorkspace(run)
+
+        self.setProperty("OutputWorkspace", mtd[wksp])
+
+AlgorithmFactory.subscribe(ConjoinFiles)
+

--- a/Code/Mantid/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
+++ b/Code/Mantid/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
@@ -1,35 +1,35 @@
-#pylint: disable=invalid-name
+#pylint: disable=invalid-name,unused-import
 """
     Command set for EQSANS reduction
 """
-# Import the specific commands that we need
+# Import the specific commands that we need - some of these are used in systemtests
 from reduction_workflow.command_interface import *
 
-#from hfir_command_interface import DarkCurrent, NoDarkCurrent, NoNormalization
-from hfir_command_interface import SolidAngle#, NoSolidAngle
-#from hfir_command_interface import DirectBeamCenter, ScatteringBeamCenter
+from hfir_command_interface import DarkCurrent, NoDarkCurrent, NoNormalization
+from hfir_command_interface import SolidAngle, NoSolidAngle
+from hfir_command_interface import DirectBeamCenter, ScatteringBeamCenter
 from hfir_command_interface import SetBeamCenter as BaseSetBeamCenter
 
-#from hfir_command_interface import SensitivityCorrection, SetSensitivityBeamCenter
-#from hfir_command_interface import SensitivityDirectBeamCenter, SensitivityScatteringBeamCenter
-#from hfir_command_interface import NoSensitivityCorrection, DivideByThickness
+from hfir_command_interface import SensitivityCorrection, SetSensitivityBeamCenter
+from hfir_command_interface import SensitivityDirectBeamCenter, SensitivityScatteringBeamCenter
+from hfir_command_interface import NoSensitivityCorrection, DivideByThickness
 
-#from hfir_command_interface import IQxQy, NoIQxQy, SaveIq, NoSaveIq, SaveIqAscii
+from hfir_command_interface import IQxQy, NoIQxQy, SaveIq, NoSaveIq, SaveIqAscii
 
-#from hfir_command_interface import DirectBeamTransmission, TransmissionDarkCurrent
-#from hfir_command_interface import ThetaDependentTransmission
-#from hfir_command_interface import SetTransmissionBeamCenter, TransmissionDirectBeamCenter
-#from hfir_command_interface import SetTransmission, NoTransmission
+from hfir_command_interface import DirectBeamTransmission, TransmissionDarkCurrent
+from hfir_command_interface import ThetaDependentTransmission
+from hfir_command_interface import SetTransmissionBeamCenter, TransmissionDirectBeamCenter
+from hfir_command_interface import SetTransmission, NoTransmission
 
-#from hfir_command_interface import Background, NoBackground, NoBckTransmission
-#from hfir_command_interface import SetBckTransmission, BckDirectBeamTransmission
-#from hfir_command_interface import SetBckTransmissionBeamCenter, BckThetaDependentTransmission
-#from hfir_command_interface import BckTransmissionDirectBeamCenter, BckTransmissionDarkCurrent
+from hfir_command_interface import Background, NoBackground, NoBckTransmission
+from hfir_command_interface import SetBckTransmission, BckDirectBeamTransmission
+from hfir_command_interface import SetBckTransmissionBeamCenter, BckThetaDependentTransmission
+from hfir_command_interface import BckTransmissionDirectBeamCenter, BckTransmissionDarkCurrent
 
-#from hfir_command_interface import SetSampleDetectorOffset, SetSampleDetectorDistance
-#from hfir_command_interface import Mask, MaskRectangle, MaskDetectors, MaskDetectorSide
-#from hfir_command_interface import SetAbsoluteScale, SetDirectBeamAbsoluteScale
-#from hfir_command_interface import Stitch
+from hfir_command_interface import SetSampleDetectorOffset, SetSampleDetectorDistance
+from hfir_command_interface import Mask, MaskRectangle, MaskDetectors, MaskDetectorSide
+from hfir_command_interface import SetAbsoluteScale, SetDirectBeamAbsoluteScale
+from hfir_command_interface import Stitch
 
 #from mantid.api import AlgorithmManager
 #from mantid.kernel import Logger


### PR DESCRIPTION
This is ticket [#11154](http://trac.mantidproject.org/mantid/ticket/11154)
I accidentally deleted the content of ConjoinFiles algorithm. It was not picked up by the unittests since there is none for this algorithm.
The sns_command_interface has a lot of unused imports. But those are passed on to be used in the systemtests.
