### PR TITLE
Enable mantidlibs scl for RHEL7 (for next branch)

### DIFF
--- a/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
+++ b/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
@@ -93,7 +93,9 @@ set ( PRE_UNINSTALL_FILE ${CMAKE_CURRENT_BINARY_DIR}/prerm )
 set ( POST_UNINSTALL_FILE ${CMAKE_CURRENT_BINARY_DIR}/postrm )
 
 if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "^Fedora" ) # RHEL/Fedora
-  if ( "${UNIX_CODENAME}" MATCHES "Santiago" ) # el6
+  if ( "${UNIX_CODENAME}" MATCHES "Santiago" OR 
+       "${UNIX_CODENAME}" MATCHES "Maipo" OR 
+       "${UNIX_CODENAME}" MATCHES "Heisenbug" )
     set ( WRAPPER_PREFIX "scl enable mantidlibs \"" )
     set ( WRAPPER_POSTFIX "\"" )
     set ( EXTRA_LDPATH "/usr/lib64/paraview" )

--- a/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
+++ b/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
@@ -98,8 +98,7 @@ set ( POST_UNINSTALL_FILE ${CMAKE_CURRENT_BINARY_DIR}/postrm )
 
 if ( "${UNIX_DIST}" MATCHES "RedHatEnterprise" OR "${UNIX_DIST}" MATCHES "^Fedora" ) # RHEL/Fedora
   if ( "${UNIX_CODENAME}" MATCHES "Santiago" OR 
-       "${UNIX_CODENAME}" MATCHES "Maipo" OR 
-       "${UNIX_CODENAME}" MATCHES "Heisenbug" )
+       "${UNIX_CODENAME}" MATCHES "Maipo" ) 
     set ( WRAPPER_PREFIX "scl enable mantidlibs \"" )
     set ( WRAPPER_POSTFIX "\"" )
     set ( EXTRA_LDPATH "/usr/lib64/paraview" )

--- a/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
+++ b/Code/Mantid/Build/CMake/LinuxPackageScripts.cmake
@@ -22,6 +22,10 @@ endif()
 
 set ( CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${LIB_DIR};${CMAKE_INSTALL_PREFIX}/${PLUGINS_DIR};${CMAKE_INSTALL_PREFIX}/${PVPLUGINS_DIR} )
 
+# Tell rpm that this package does not own /opt /usr/share/{applications,pixmaps}
+# Required for Fedora >= 18 and RHEL >= 7
+set ( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION /opt /usr/share/applications /usr/share/pixmaps )
+
 ###########################################################################
 # LD_PRELOAD TCMalloc
 ###########################################################################


### PR DESCRIPTION
This is to enable RHEL7 to use the mantidlibs software collection for the patch release.
