### PR TITLE
Fix doxygen warnings in InternetHelper

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
@@ -178,10 +178,6 @@ int InternetHelper::processRelocation(const HTTPResponse &response,
 /** Performs a request using http or https depending on the url
 * @param url the address to the network resource
 * @param responseStream The stream to fill with the reply on success
-* @param headers A optional key value pair map of any additional headers to
-* include in the request.
-* @param method Generally GET (default) or POST.
-* @param body The request body to send.
 **/
 int InternetHelper::sendRequest(const std::string &url,
                                 std::ostream &responseStream) {
@@ -383,9 +379,6 @@ The answer, will be inserted at the local_file_path.
 
 @param localFilePath : Provide the destination of the file downloaded at the
 url_file.
-
-@param headers [optional] : A key value pair map of any additional headers to
-include in the request.
 
 @exception Mantid::Kernel::Exception::InternetError : For any unexpected
 behaviour.


### PR DESCRIPTION
This is a quick fix to reduce the number of doxygen warnings, ticket [#11156](http://trac.mantidproject.org/mantid/ticket/11156)

To test: this just removed a few outdated doxygen tags (those parameters were removed). Code review should be enough.
