### PR TITLE
Fix initialization etc. coverity issues in Framework

### DIFF
--- a/Code/Mantid/Framework/Crystal/inc/MantidCrystal/SaveIsawUB.h
+++ b/Code/Mantid/Framework/Crystal/inc/MantidCrystal/SaveIsawUB.h
@@ -64,7 +64,7 @@ private:
   void exec();
 
   // Calculates the error in the volume
-  double getErrorVolume(Geometry::OrientedLattice lattice);
+  double getErrorVolume(const Geometry::OrientedLattice &lattice);
 };
 
 } // namespace Mantid

--- a/Code/Mantid/Framework/Crystal/src/SaveIsawUB.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SaveIsawUB.cpp
@@ -54,7 +54,7 @@ void SaveIsawUB::init() {
                   "Path to an ISAW-style UB matrix text file.");
 }
 
-double SaveIsawUB::getErrorVolume(OrientedLattice lattice) {
+double SaveIsawUB::getErrorVolume(const OrientedLattice &lattice) {
   double Volume;
   double latticeParams[6] = {lattice.a(),     lattice.b(),    lattice.c(),
                              lattice.alpha(), lattice.beta(), lattice.gamma()};

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/LeBailFit.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/LeBailFit.h
@@ -253,7 +253,7 @@ private:
                         bool prevBetterRwp);
 
   ///  Limit proposed value in the specified boundary
-  double limitProposedValueInBound(Parameter param, double newvalue,
+  double limitProposedValueInBound(const Parameter &param, double newvalue,
                                    double direction, int choice);
 
   /// Book keep the (sopposed) best MC result

--- a/Code/Mantid/Framework/CurveFitting/src/LeBailFit.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/LeBailFit.cpp
@@ -2297,7 +2297,7 @@ bool LeBailFit::proposeNewValues(vector<string> mcgroup, Rfactor r,
   *
   * @return :: new value in boundary
   */
-double LeBailFit::limitProposedValueInBound(Parameter param, double newvalue,
+double LeBailFit::limitProposedValueInBound(const Parameter &param, double newvalue,
                                             double direction, int choice) {
   if (choice == 0) {
     // Half distance

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
@@ -76,7 +76,7 @@ namespace DataHandling {
 
 class DLLExport LoadFITS : public API::IFileLoader<Kernel::FileDescriptor> {
 public:
-  LoadFITS() {}
+  LoadFITS();
   virtual ~LoadFITS() {}
 
   /// Algorithm's name for identification overriding a virtual method

--- a/Code/Mantid/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadAscii2.cpp
@@ -25,7 +25,10 @@ using namespace Kernel;
 using namespace API;
 
 /// Empty constructor
-LoadAscii2::LoadAscii2() : m_columnSep(), m_separatorIndex() {}
+LoadAscii2::LoadAscii2() : m_columnSep(), m_separatorIndex(), m_comment(),
+  m_baseCols(0), m_specNo(0), m_lastBins(0), m_curBins(0), m_spectraStart(), 
+  m_spectrumIDcount(0), m_lineNo(0), m_spectra(), m_curSpectra(NULL) {
+}
 
 /**
 * Return the confidence with with this algorithm can load the file

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -932,13 +932,19 @@ private:
 //----------------------------------------------------------------------------------------------
 /** Empty default constructor
 */
-LoadEventNexus::LoadEventNexus()
-    : IFileLoader<Kernel::NexusDescriptor>(),
-    discarded_events(0),
-    m_file(NULL),
-    m_instrument_loaded_correctly(false),
-    m_logs_loaded_correctly(false),
-    event_id_is_spec(false) {}
+LoadEventNexus::LoadEventNexus() : IFileLoader<Kernel::NexusDescriptor>(),
+  m_filename(), filter_tof_min(0), filter_tof_max(0), m_specList(),
+  m_specMin(0), m_specMax(0), filter_time_start(), filter_time_stop(),
+  chunk(0), totalChunks(0), firstChunkForBank(0), eventsPerChunk(0),
+  m_tofMutex(), longest_tof(0), shortest_tof(0), bad_tofs(0),
+  discarded_events(0), precount(0), compressTolerance(0), eventVectors(),
+  m_eventVectorMutex(), eventid_max(0), pixelID_to_wi_vector(),
+  pixelID_to_wi_offset(), m_bankPulseTimes(), m_allBanksPulseTimes(),
+  m_top_entry_name(), m_file(NULL), splitProcessing(false),
+  m_haveWeights(false), weightedEventVectors(),
+  m_instrument_loaded_correctly(false), loadlogs(false),
+  m_logs_loaded_correctly(false), event_id_is_spec(false) {
+}
 
 //----------------------------------------------------------------------------------------------
 /** Destructor */

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventPreNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventPreNexus.cpp
@@ -78,8 +78,15 @@ static const double TOF_CONVERSION = .1;
 static const double CURRENT_CONVERSION = 1.e-6 / 3600.;
 
 LoadEventPreNexus::LoadEventPreNexus()
-    : Mantid::API::IFileLoader<Kernel::FileDescriptor>(), eventfile(NULL),
-      max_events(0) {}
+  : Mantid::API::IFileLoader<Kernel::FileDescriptor>(),
+  prog(NULL), spectra_list(), pulsetimes(), event_indices(), proton_charge(),
+  proton_charge_tot(0), pixel_to_wkspindex(), pixelmap(), detid_max(),
+  eventfile(NULL), num_events(0), num_pulses(0), numpixel(0),
+  num_good_events(0), num_error_events(0), num_ignored_events(0),
+  first_event(0), max_events(0), using_mapping_file(false),
+  loadOnlySomeSpectra(false), spectraLoadMap(), longest_tof(0),
+  shortest_tof(0), parallelProcessing(false) {
+}
 
 LoadEventPreNexus::~LoadEventPreNexus() { delete this->eventfile; }
 

--- a/Code/Mantid/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -224,8 +224,15 @@ int LoadEventPreNexus2::confidence(Kernel::FileDescriptor &descriptor) const {
 /** Constructor
  */
 LoadEventPreNexus2::LoadEventPreNexus2()
-    : Mantid::API::IFileLoader<Kernel::FileDescriptor>(), eventfile(NULL),
-      max_events(0) {}
+  : Mantid::API::IFileLoader<Kernel::FileDescriptor>(),
+  prog(NULL), spectra_list(), pulsetimes(), event_indices(), proton_charge(),
+  proton_charge_tot(0), pixel_to_wkspindex(), pixelmap(), detid_max(),
+  eventfile(NULL), num_events(0), num_pulses(0), numpixel(0),
+  num_good_events(0), num_error_events(0), num_ignored_events(0),
+  first_event(0), max_events(0), using_mapping_file(false),
+  loadOnlySomeSpectra(false), spectraLoadMap(), longest_tof(0),
+  shortest_tof(0), parallelProcessing(false) {
+}
 
 //----------------------------------------------------------------------------------------------
 /** Desctructor

--- a/Code/Mantid/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadFITS.cpp
@@ -41,6 +41,16 @@ namespace DataHandling {
 DECLARE_FILELOADER_ALGORITHM(LoadFITS);
 
 /**
+ * Constructor. Just initialize everything to prevent issues.
+ */
+LoadFITS::LoadFITS(): m_headerScaleKey(), m_headerOffsetKey(),
+                      m_headerBitDepthKey(), m_headerRotationKey(),
+                      m_headerImageKeyKey(), m_mapFile(),
+                      m_headerAxisNameKeys(),  m_baseName(),
+                      m_spectraCount(0), m_progress(NULL) {
+}
+
+/**
 * Return the confidence with with this algorithm can load the file
 * @param descriptor A descriptor for the file
 * @returns An integer specifying the confidence level. 0 indicates it will not
@@ -123,8 +133,6 @@ void LoadFITS::exec() {
   std::vector<std::string> paths;
   string fName = getPropertyValue("Filename");
   boost::split(paths, fName, boost::is_any_of(","));
-  m_baseName = "";
-  m_spectraCount = 0;
 
   // If paths contains a non fits file, assume (for now) that it contains
   // information about the rotations

--- a/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -51,7 +51,9 @@ LoadISISNexus2::LoadISISNexus2()
       m_monBlockInfo(), m_loadBlockInfo(), m_have_detector(false),
       m_load_selected_spectra(false), m_specInd2specNum_map(), m_spec2det_map(),
       m_entrynumber(0), m_tof_data(), m_proton_charge(0.), m_spec(),
-      m_monitors(), m_logCreator(), m_progress() {}
+      m_spec_end(NULL), m_monitors(), m_logCreator(), m_progress(),
+      m_cppFile() {
+}
 
 /**
 * Return the confidence criteria for this algorithm can load the file

--- a/Code/Mantid/Framework/DataHandling/src/LoadRaw3.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRaw3.cpp
@@ -31,8 +31,11 @@ using namespace API;
 
 /// Constructor
 LoadRaw3::LoadRaw3()
-    : m_filename(), m_noTimeRegimes(0), m_prog(0.0), m_prog_start(0.0),
-      m_prog_end(1.0), m_lengthIn(0), m_timeChannelsVec(), m_total_specs(0) {}
+  : m_filename(), m_numberOfSpectra(), m_cache_options(),
+    m_specTimeRegimes(), m_noTimeRegimes(0), m_prog(0.0),
+    m_prog_start(0.0), m_prog_end(1.0), m_lengthIn(0),
+    m_timeChannelsVec(), m_total_specs(0), m_periodList() {
+}
 
 LoadRaw3::~LoadRaw3() {}
 

--- a/Code/Mantid/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/EventWorkspace.cpp
@@ -35,7 +35,9 @@ using namespace Mantid::Kernel;
 
 //---- Constructors
 //-------------------------------------------------------------------
-EventWorkspace::EventWorkspace() : mru(new EventWorkspaceMRU) {}
+EventWorkspace::EventWorkspace() : data(), m_noVectors(),
+  mru(new EventWorkspaceMRU) {
+}
 
 EventWorkspace::~EventWorkspace() {
   delete mru;

--- a/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
@@ -45,12 +45,12 @@ Logger g_log("NexusFileIO");
 }
 
 /// Empty default constructor
-NexusFileIO::NexusFileIO() : fileID(), m_filehandle(NULL),
+NexusFileIO::NexusFileIO() : fileID(), m_filehandle(),
     m_nexuscompression(NX_COMP_LZW), m_progress(0), m_filename() {
 }
 
 /// Constructor that supplies a progress object
-NexusFileIO::NexusFileIO(Progress *prog) : fileID(), m_filehandle(NULL),
+NexusFileIO::NexusFileIO(Progress *prog) : fileID(), m_filehandle(),
     m_nexuscompression(NX_COMP_LZW), m_progress(prog), m_filename() {
 }
 

--- a/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
@@ -45,11 +45,14 @@ Logger g_log("NexusFileIO");
 }
 
 /// Empty default constructor
-NexusFileIO::NexusFileIO() : m_nexuscompression(NX_COMP_LZW), m_progress(0) {}
+NexusFileIO::NexusFileIO() : fileID(), m_filehandle(NULL),
+    m_nexuscompression(NX_COMP_LZW), m_progress(0), m_filename() {
+}
 
 /// Constructor that supplies a progress object
-NexusFileIO::NexusFileIO(Progress *prog)
-    : m_nexuscompression(NX_COMP_LZW), m_progress(prog) {}
+NexusFileIO::NexusFileIO(Progress *prog) : fileID(), m_filehandle(NULL),
+    m_nexuscompression(NX_COMP_LZW), m_progress(prog), m_filename() {
+}
 
 void NexusFileIO::resetProgress(Progress *prog) { m_progress = prog; }
 

--- a/Code/Mantid/MantidPlot/src/Interpolation.cpp
+++ b/Code/Mantid/MantidPlot/src/Interpolation.cpp
@@ -177,8 +177,8 @@ int Interpolation::sortedCurveData(QwtPlotCurve *c, double start, double end, do
     for (int i = i_start; i <= i_end; i++){
         xtemp[j] = c->x(i);
         if (i > i_start && xtemp[j] == pr_x){
-            delete (*x);
-            delete (*y);
+            delete[] (*x);
+            delete[] (*y);
             delete[] xtemp;
             delete[] ytemp;
             return -1;//this kind of data causes division by zero in GSL interpolation routines

--- a/Code/Mantid/MantidPlot/src/Plot.h
+++ b/Code/Mantid/MantidPlot/src/Plot.h
@@ -90,21 +90,21 @@ public:
 
     void axisLabelFormat(int axis, char &f, int &prec) const;
 
-	int axisLabelFormat(int axis);
-	int axisLabelPrecision(int axis);
+    int axisLabelFormat(int axis);
+    int axisLabelPrecision(int axis);
 
-	QColor frameColor();
-	const QColor & paletteBackgroundColor() const;
+    QColor frameColor();
+    const QColor & paletteBackgroundColor() const;
 
     using QwtPlot::print; // Avoid Intel compiler warning
-    void print(QPainter *, const QRect &rect, const QwtPlotPrintFilter & = QwtPlotPrintFilter());
-	void updateLayout();
+    void print(QPainter *, const QRect &rect, const QwtPlotPrintFilter & = QwtPlotPrintFilter()) const;
+    void updateLayout();
 
     void updateCurveLabels();
-  // pass through method that is public on the base class in later qwt versions
-  void updateAxes() { QwtPlot::updateAxes(); }
+    // pass through method that is public on the base class in later qwt versions
+    void updateAxes() { QwtPlot::updateAxes(); }
 
-  void reverseCurveOrder(); // Created in connection with waterfall plots. Called from Graph method of same name.
+    void reverseCurveOrder(); // Created in connection with waterfall plots. Called from Graph method of same name.
 
 signals:
   void dragMousePress(QPoint);


### PR DESCRIPTION
Fixes the issues listed in ticket [#11061](http://trac.mantidproject.org/mantid/ticket/11061).

To test: this has to do with initialization, constness and memory issues:
- Code review
- Check builds and tests.
