### PR TITLE
Mantid/Kernel gitignore

### DIFF
--- a/Code/Mantid/Framework/Kernel/.gitignore
+++ b/Code/Mantid/Framework/Kernel/.gitignore
@@ -1,0 +1,3 @@
+inc/MantidKernel/PocoVersion.h
+src/MantidVersion.cpp
+src/ParaViewVersion.cpp

--- a/Code/Mantid/Framework/Kernel/src/.gitignore
+++ b/Code/Mantid/Framework/Kernel/src/.gitignore
@@ -1,3 +1,0 @@
-MantidVersion.cpp
-PocoVersion.h
-ParaViewVersion.cpp


### PR DESCRIPTION
This was originally [11161](http://trac.mantidproject.org/mantid/ticket/11161).

_To test:_ this is really a code review, but running `cmake` in your build area followed by `git status` in your source area should show that it is fixed.
