### PR TITLE
Replace help link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Useful links
 ------------
  * Homepage: http://www.mantidproject.org
  * Download: http://download.mantidproject.org
- * Asking for help: http://download.mantidproject.org/webmailer/index.php
+ * Asking for help: http://www.mantidproject.org/Contact
  * Issue tracking: http://trac.mantidproject.org/mantid/
  * Build server: http://builds.mantidproject.org
  * Developer site: http://developer.mantidproject.org


### PR DESCRIPTION
The previous link lead to a 404, this was the next best link I could find.

This should only need a code review.
