### PR TITLE
Fix broken indirect interfaces

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.ui
@@ -97,7 +97,7 @@
          </sizepolicy>
         </property>
         <property name="autoLoad" stdset="0">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="workspaceSuffixes" stdset="0">
          <stringlist>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
@@ -60,7 +60,7 @@ namespace IDA
       geom = "cyl";
     }
 
-    QString pyInput = "from IndirectDataAnalysis import abscorFeeder, loadNexus\n";
+    QString pyInput = "from IndirectDataAnalysis import abscorFeeder\n";
 
     QString sample = m_uiForm.dsSample->getCurrentDataName();
     MatrixWorkspace_const_sptr sampleWs =  AnalysisDataService::Instance().retrieveWS<const MatrixWorkspace>(sample.toStdString());
@@ -102,16 +102,7 @@ namespace IDA
     {
       pyInput += "useCor = True\n";
       QString corrections = m_uiForm.dsCorrections->getCurrentDataName();
-      if ( !Mantid::API::AnalysisDataService::Instance().doesExist(corrections.toStdString()) )
-      {
-        pyInput +=
-          "corrections = loadNexus(r'" + m_uiForm.dsCorrections->getFullFilePath() + "')\n";
-      }
-      else
-      {
-        pyInput +=
-          "corrections = '" + corrections + "'\n";
-      }
+      pyInput += "corrections = '" + corrections + "'\n";
     }
     else
     {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Fury.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Fury.cpp
@@ -105,7 +105,6 @@ namespace IDA
     furyAlg->setProperty("NumBins", numBins);
 
     furyAlg->setProperty("Plot", plot);
-    furyAlg->setProperty("Verbose", true);
     furyAlg->setProperty("Save", save);
     furyAlg->setProperty("DryRun", false);
 
@@ -205,7 +204,6 @@ namespace IDA
     furyAlg->setProperty("NumBins", numBins);
 
     furyAlg->setProperty("Plot", false);
-    furyAlg->setProperty("Verbose", true);
     furyAlg->setProperty("Save", false);
     furyAlg->setProperty("DryRun", true);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -190,7 +190,7 @@ namespace MantidQt
 
 			pyInput += "QLRun('"+program+"','"+sampleName+"','"+resName+"','"+resNormFile+"',"+eRange+","
 										" "+nBins+","+fitOps+",'"+fixedWidthFile+"',"+sequence+", "
-										" Save="+save+", Plot='"+plot+"', Verbose=True)\n";
+										" Save="+save+", Plot='"+plot+"')\n";
 
 			runPythonScript(pyInput);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -97,7 +97,7 @@ namespace MantidQt
 			QString plot = m_uiForm.cbPlot->currentText();
 
 			pyInput += "ResNormRun('"+VanName+"', '"+ResName+"', "+ERange+", "+nBin+","
-										" Save="+save+", Plot='"+plot+"', Verbose=True)\n";
+										" Save="+save+", Plot='"+plot+"')\n";
 
 			runPythonScript(pyInput);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
@@ -126,7 +126,7 @@ namespace MantidQt
 			QString plot = m_uiForm.cbPlot->currentText();
 
 			pyInput += "QuestRun('"+sampleName+"','"+resName+"',"+betaSig+","+eRange+","+nBins+","+fitOps+","+sequence+","
-										" Save="+save+", Plot='"+plot+"', Verbose=True)\n";
+										" Save="+save+", Plot='"+plot+"')\n";
 
 			runPythonScript(pyInput);
 		}


### PR DESCRIPTION
Fixes [#11166](http://trac.mantidproject.org/mantid/ticket/11166).

To test, either:
- Build on Windows in Release mode and ensure that the ResNorm, Quasi, Stretch, Fury and Apply Corrections interfaces work.

or:
- Code review the commented changes
