### PR TITLE
Linux build scripts should build packages

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -10,6 +10,8 @@
 # slave.
 ###############################################################################
 SCRIPT_DIR=$(dirname "$0")
+# Package by default
+BUILDPKG=true
 
 ###############################################################################
 # Print out the versions of things we are using
@@ -88,7 +90,6 @@ fi
 ###############################################################################
 if [[ ${JOB_NAME} == *clean* ]]; then
   CLEANBUILD=true
-  BUILDPKG=true
 fi
 
 if [[ -e $WORKSPACE/build/CMakeCache.txt ]]; then
@@ -97,10 +98,6 @@ if [[ -e $WORKSPACE/build/CMakeCache.txt ]]; then
   if [ ! -z "$TESTINGTOOLS_DIR"  ]; then
     rm -fr $WORKSPACE/build
   fi
-fi
-
-if [[ ${JOB_NAME} == *pull_requests* ]]; then
-  BUILDPKG=true
 fi
 
 ###############################################################################


### PR DESCRIPTION
The build scripts are not currently packaging the master incremental builds. This would be quite useful, especially for running other downstream jobs such as the squish tests.

See [#11185](http://trac.mantidproject.org/mantid/ticket/11185)

**Tester** : Look at the code, the changes are simple enough. The pull request jobs should pass and yield packages for all linux flavours.
