### PR TITLE
CheckWorkspacesMatch should use tolerance property on NumericAxis comparison

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -65,6 +65,8 @@ public:
   virtual void setValue(const std::size_t &index, const double &value);
   size_t indexOfValue(const double value) const;
   virtual bool operator==(const Axis &) const;
+  bool equalWithinTolerance(const Axis &axis2,
+                            const double tolerance = 0.0) const;
   std::string label(const std::size_t &index) const;
   /// Create bin boundaries from the point values
   virtual std::vector<double> createBinBoundaries() const;

--- a/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -65,8 +65,8 @@ public:
   virtual void setValue(const std::size_t &index, const double &value);
   size_t indexOfValue(const double value) const;
   virtual bool operator==(const Axis &) const;
-  bool equalWithinTolerance(const Axis &axis2,
-                            const double tolerance = 0.0) const;
+  virtual bool equalWithinTolerance(const Axis &axis2,
+                                    const double tolerance = 0.0) const;
   std::string label(const std::size_t &index) const;
   /// Create bin boundaries from the point values
   virtual std::vector<double> createBinBoundaries() const;

--- a/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -66,7 +66,7 @@ public:
   size_t indexOfValue(const double value) const;
   virtual bool operator==(const Axis &) const;
   virtual bool equalWithinTolerance(const Axis &axis2,
-                                    const double tolerance = 0.0) const;
+                                    const double tolerance) const;
   std::string label(const std::size_t &index) const;
   /// Create bin boundaries from the point values
   virtual std::vector<double> createBinBoundaries() const;

--- a/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
@@ -55,7 +55,7 @@ public:
   virtual void setValue(const std::size_t &index, const double &value);
   virtual bool operator==(const Axis &) const;
   virtual bool equalWithinTolerance(const Axis &axis2,
-                                    const double tolerance = 0.0) const;
+                                    const double tolerance) const;
   virtual double getMin() const;
   virtual double getMax() const;
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
@@ -54,8 +54,8 @@ public:
                             const std::size_t &verticalIndex) const;
   virtual void setValue(const std::size_t &index, const double &value);
   virtual bool operator==(const Axis &) const;
-  bool equalWithinTolerance(const Axis &axis2,
-                            const double tolerance = 0.0) const;
+  virtual bool equalWithinTolerance(const Axis &axis2,
+                                    const double tolerance = 0.0) const;
   virtual double getMin() const;
   virtual double getMax() const;
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
@@ -54,6 +54,8 @@ public:
                             const std::size_t &verticalIndex) const;
   virtual void setValue(const std::size_t &index, const double &value);
   virtual bool operator==(const Axis &) const;
+  bool equalWithinTolerance(const Axis &axis2,
+                            const double tolerance = 0.0) const;
   virtual double getMin() const;
   virtual double getMax() const;
 

--- a/Code/Mantid/Framework/API/src/NumericAxis.cpp
+++ b/Code/Mantid/Framework/API/src/NumericAxis.cpp
@@ -146,14 +146,7 @@ size_t NumericAxis::indexOfValue(const double value) const {
  *  @return true if self and second axis are equal
  */
 bool NumericAxis::operator==(const Axis &axis2) const {
-  if (length() != axis2.length()) {
-    return false;
-  }
-  const NumericAxis *spec2 = dynamic_cast<const NumericAxis *>(&axis2);
-  if (!spec2) {
-    return false;
-  }
-  return std::equal(m_values.begin(), m_values.end(), spec2->m_values.begin());
+  return equalWithinTolerance(axis2, 1e-15);
 }
 
 /** Check if two numeric axis are equivalent to a given tolerance
@@ -163,21 +156,16 @@ bool NumericAxis::operator==(const Axis &axis2) const {
  */
 bool NumericAxis::equalWithinTolerance(const Axis &axis2,
                                        const double tolerance) const {
+  if (length() != axis2.length()) {
+    return false;
+  }
   const NumericAxis *spec2 = dynamic_cast<const NumericAxis *>(&axis2);
   if (!spec2) {
     return false;
   }
-
-  const std::vector<double> otherValues = spec2->getValues();
-
-  // Fail comparison if number of values differs
-  if (m_values.size() != otherValues.size()) {
-    return false;
-  }
-
   // Check each value is within tolerance
   g_tolerance = tolerance;
-  return std::equal(m_values.begin(), m_values.end(), otherValues.begin(),
+  return std::equal(m_values.begin(), m_values.end(), spec2->m_values.begin(),
                     withinTolerance);
 }
 

--- a/Code/Mantid/Framework/API/src/NumericAxis.cpp
+++ b/Code/Mantid/Framework/API/src/NumericAxis.cpp
@@ -150,6 +150,35 @@ bool NumericAxis::operator==(const Axis &axis2) const {
   return std::equal(m_values.begin(), m_values.end(), spec2->m_values.begin());
 }
 
+/** Check if two numeric axis are equivalent to a given tolerance
+ *  @param axis2 :: Reference to the axis to compare to
+ *  @param tolerance :: Tolerance to compare to
+ *  @return true if self and second axis are equal
+ */
+bool NumericAxis::equalWithinTolerance(const Axis &axis2,
+                                       const double tolerance) const {
+  const NumericAxis *spec2 = dynamic_cast<const NumericAxis *>(&axis2);
+  if (!spec2) {
+    return false;
+  }
+
+  const std::vector<double> otherValues = spec2->getValues();
+
+  // Fail comparison if number of values differs
+  if (m_values.size() != otherValues.size()) {
+    return false;
+  }
+
+  // Check each value is within tolerance
+  for (size_t i = 0; i < m_values.size(); i++) {
+    if (std::abs(m_values[i] - otherValues[i]) > tolerance) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 /** Returns a text label which shows the value at index and identifies the
  *  type of the axis.
  *  @param index :: The index of an axis value

--- a/Code/Mantid/Framework/API/src/NumericAxis.cpp
+++ b/Code/Mantid/Framework/API/src/NumericAxis.cpp
@@ -11,11 +11,14 @@
 namespace {
 Mantid::Kernel::Logger g_log("NumericAxis");
 
-// For variable tolerance comparison for axis values
-double g_tolerance;
-bool withinTolerance(double a, double b) {
-  return std::abs(a - b) <= g_tolerance;
-}
+class EqualWithinTolerance {
+public:
+  EqualWithinTolerance(double tolerance) : m_tolerance(tolerance) {};
+  bool operator()(double a, double b) { return std::abs(a - b) <= m_tolerance; }
+
+private:
+  double m_tolerance;
+};
 }
 
 namespace Mantid {
@@ -164,9 +167,9 @@ bool NumericAxis::equalWithinTolerance(const Axis &axis2,
     return false;
   }
   // Check each value is within tolerance
-  g_tolerance = tolerance;
+  EqualWithinTolerance comparison(tolerance);
   return std::equal(m_values.begin(), m_values.end(), spec2->m_values.begin(),
-                    withinTolerance);
+                    comparison);
 }
 
 /** Returns a text label which shows the value at index and identifies the

--- a/Code/Mantid/Framework/API/src/NumericAxis.cpp
+++ b/Code/Mantid/Framework/API/src/NumericAxis.cpp
@@ -6,6 +6,7 @@
 #include "MantidKernel/VectorHelper.h"
 
 #include <boost/format.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 #include "MantidKernel/Logger.h"
 namespace {
@@ -14,7 +15,13 @@ Mantid::Kernel::Logger g_log("NumericAxis");
 class EqualWithinTolerance {
 public:
   EqualWithinTolerance(double tolerance) : m_tolerance(tolerance) {};
-  bool operator()(double a, double b) { return std::abs(a - b) <= m_tolerance; }
+  bool operator()(double a, double b) {
+    if (boost::math::isnan(a) && boost::math::isnan(b))
+      return true;
+    if (boost::math::isinf(a) && boost::math::isinf(b))
+      return true;
+    return std::abs(a - b) <= m_tolerance;
+  }
 
 private:
   double m_tolerance;

--- a/Code/Mantid/Framework/API/src/NumericAxis.cpp
+++ b/Code/Mantid/Framework/API/src/NumericAxis.cpp
@@ -10,6 +10,12 @@
 #include "MantidKernel/Logger.h"
 namespace {
 Mantid::Kernel::Logger g_log("NumericAxis");
+
+// For variable tolerance comparison for axis values
+double g_tolerance;
+bool withinTolerance(double a, double b) {
+  return std::abs(a - b) <= g_tolerance;
+}
 }
 
 namespace Mantid {
@@ -170,13 +176,9 @@ bool NumericAxis::equalWithinTolerance(const Axis &axis2,
   }
 
   // Check each value is within tolerance
-  for (size_t i = 0; i < m_values.size(); i++) {
-    if (std::abs(m_values[i] - otherValues[i]) > tolerance) {
-      return false;
-    }
-  }
-
-  return true;
+  g_tolerance = tolerance;
+  return std::equal(m_values.begin(), m_values.end(), otherValues.begin(),
+                    withinTolerance);
 }
 
 /** Returns a text label which shows the value at index and identifies the

--- a/Code/Mantid/Framework/API/src/RefAxis.cpp
+++ b/Code/Mantid/Framework/API/src/RefAxis.cpp
@@ -90,6 +90,17 @@ bool RefAxis::operator==(const Axis &axis2) const {
   return true;
 }
 
+/** Check if two numeric axis are equivalent to a given tolerance
+ *  @param axis2 :: Reference to the axis to compare to
+ *  @param tolerance :: Tolerance to compare to
+ *  @return true if self and second axis are equal
+ */
+bool RefAxis::equalWithinTolerance(const Axis &axis2,
+                                   const double tolerance) const {
+  UNUSED_ARG(tolerance);
+  return this->operator==(axis2);
+}
+
 double RefAxis::getMin() const {
   throw std::runtime_error("RefAxis cannot determine minimum value. Use readX "
                            "on the workspace instead");

--- a/Code/Mantid/Framework/API/test/NumericAxisTest.h
+++ b/Code/Mantid/Framework/API/test/NumericAxisTest.h
@@ -187,6 +187,34 @@ public:
     TS_ASSERT( !axis1.equalWithinTolerance(axis2, 0.0001) );
   }
 
+  void test_equalWithinTolerance_Nan()
+  {
+    double points1[] = {1.0, 2.0, FP_NAN, 4.0, 5.0};
+    double points2[] = {1.0, 2.0, FP_NAN, 4.0, 5.0};
+    double points3[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    const size_t npoints(5);
+    NumericAxis axis1(std::vector<double>(points1, points1 + npoints));
+    NumericAxis axis2(std::vector<double>(points2, points2 + npoints));
+    NumericAxis axis3(std::vector<double>(points3, points3 + npoints));
+
+    TS_ASSERT( axis1.equalWithinTolerance(axis2, 0.01) );
+    TS_ASSERT( !axis1.equalWithinTolerance(axis3, 0.01) );
+  }
+
+  void test_equalWithinTolerance_Inf()
+  {
+    double points1[] = {1.0, 2.0, FP_INFINITE, 4.0, 5.0};
+    double points2[] = {1.0, 2.0, FP_INFINITE, 4.0, 5.0};
+    double points3[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    const size_t npoints(5);
+    NumericAxis axis1(std::vector<double>(points1, points1 + npoints));
+    NumericAxis axis2(std::vector<double>(points2, points2 + npoints));
+    NumericAxis axis3(std::vector<double>(points3, points3 + npoints));
+
+    TS_ASSERT( axis1.equalWithinTolerance(axis2, 0.01) );
+    TS_ASSERT( !axis1.equalWithinTolerance(axis3, 0.01) );
+  }
+
   //-------------------------------- Failure cases ----------------------------
 
   void test_indexOfValue_Throws_When_Input_Not_In_Axis_Range()

--- a/Code/Mantid/Framework/API/test/NumericAxisTest.h
+++ b/Code/Mantid/Framework/API/test/NumericAxisTest.h
@@ -34,12 +34,12 @@ public:
     numericAxis = new NumericAxis(5);
     numericAxis->title() = "A numeric axis";
   }
-  
+
   ~NumericAxisTest()
   {
     delete numericAxis;
   }
-  
+
   void testConstructor()
   {
     TS_ASSERT_EQUALS( numericAxis->title(), "A numeric axis" );
@@ -56,7 +56,7 @@ public:
     axistester.title() = "tester";
     axistester.unit() = UnitFactory::Instance().create("Wavelength");
     axistester.setValue(0,5.5);
-    
+
     NumericAxisTester copiedAxis = axistester;
     TS_ASSERT_EQUALS( copiedAxis.title(), "tester" );
     TS_ASSERT_EQUALS( copiedAxis.unit()->unitID(), "Wavelength" );
@@ -64,7 +64,7 @@ public:
     TS_ASSERT_EQUALS( copiedAxis(0), 5.5 );
     TS_ASSERT_THROWS( copiedAxis(1), Exception::IndexError );
   }
-  
+
   void testClone()
   {
     WorkspaceTester ws; // Fake workspace to pass to clone
@@ -72,7 +72,7 @@ public:
     TS_ASSERT_DIFFERS( newNumAxis, numericAxis );
     delete newNumAxis;
   }
-  
+
   void testCloneDifferentLength()
   {
     numericAxis->setValue(0,9.9);
@@ -124,7 +124,7 @@ public:
   {
     TS_ASSERT_THROWS( numericAxis->setValue(-1, 1.1), Exception::IndexError );
     TS_ASSERT_THROWS( numericAxis->setValue(5, 1.1), Exception::IndexError );
-    
+
     for (int i=0; i<5; ++i)
     {
       TS_ASSERT_THROWS_NOTHING( numericAxis->setValue(i, i+0.5) );
@@ -146,7 +146,7 @@ public:
     {
       axis.setValue(i, static_cast<double>(i));
     }
-    
+
     std::vector<double> boundaries = axis.createBinBoundaries();
     const size_t nvalues(boundaries.size());
     TS_ASSERT_EQUALS(nvalues, npoints + 1);
@@ -170,6 +170,21 @@ public:
     TS_ASSERT_EQUALS(3, axis.indexOfValue(3.7));
     TS_ASSERT_EQUALS(3, axis.indexOfValue(4.0)); //exact value
     TS_ASSERT_EQUALS(4, axis.indexOfValue(5.4));
+  }
+
+  void test_equalWithinTolerance()
+  {
+    double points1[] = {1.0, 2.0, 3.0, 4.0, 5.0};
+    double points2[] = {1.0, 2.0, 3.0, 4.0, 5.001};
+    const size_t npoints(5);
+    NumericAxis axis1(std::vector<double>(points1, points1 + npoints));
+    NumericAxis axis2(std::vector<double>(points2, points2 + npoints));
+
+    // Difference (0.001) < tolerance (0.01), should be equal
+    TS_ASSERT( axis1.equalWithinTolerance(axis2, 0.01) );
+
+    // Difference (0.001) > tolerance (0.0001), should not be equal
+    TS_ASSERT( !axis1.equalWithinTolerance(axis2, 0.0001) );
   }
 
   //-------------------------------- Failure cases ----------------------------

--- a/Code/Mantid/Framework/API/test/NumericAxisTest.h
+++ b/Code/Mantid/Framework/API/test/NumericAxisTest.h
@@ -172,6 +172,23 @@ public:
     TS_ASSERT_EQUALS(4, axis.indexOfValue(5.4));
   }
 
+  /**
+   * Default equality is tested to a tolerance of 1e-15.
+   */
+  void test_equal()
+  {
+    double points1[] = {1.0, 2.0, 10e-16, 4.0, 5.0};
+    double points2[] = {1.0, 2.0, 20e-16, 4.0, 5.0}; // Just inside the tolerance
+    double points3[] = {1.0, 2.0, 21e-16, 4.0, 5.0}; // Just outsie the tolerance
+    const size_t npoints(5);
+    NumericAxis axis1(std::vector<double>(points1, points1 + npoints));
+    NumericAxis axis2(std::vector<double>(points2, points2 + npoints));
+    NumericAxis axis3(std::vector<double>(points3, points3 + npoints));
+
+    TS_ASSERT( axis1 == axis2 );
+    TS_ASSERT( !(axis1 == axis3) );
+  }
+
   void test_equalWithinTolerance()
   {
     double points1[] = {1.0, 2.0, 3.0, 4.0, 5.0};

--- a/Code/Mantid/Framework/API/test/NumericAxisTest.h
+++ b/Code/Mantid/Framework/API/test/NumericAxisTest.h
@@ -206,8 +206,8 @@ public:
 
   void test_equalWithinTolerance_Nan()
   {
-    double points1[] = {1.0, 2.0, FP_NAN, 4.0, 5.0};
-    double points2[] = {1.0, 2.0, FP_NAN, 4.0, 5.0};
+    double points1[] = {1.0, 2.0, NAN, 4.0, 5.0};
+    double points2[] = {1.0, 2.0, NAN, 4.0, 5.0};
     double points3[] = {1.0, 2.0, 3.0, 4.0, 5.0};
     const size_t npoints(5);
     NumericAxis axis1(std::vector<double>(points1, points1 + npoints));
@@ -220,8 +220,8 @@ public:
 
   void test_equalWithinTolerance_Inf()
   {
-    double points1[] = {1.0, 2.0, FP_INFINITE, 4.0, 5.0};
-    double points2[] = {1.0, 2.0, FP_INFINITE, 4.0, 5.0};
+    double points1[] = {1.0, 2.0, INFINITY, 4.0, 5.0};
+    double points2[] = {1.0, 2.0, INFINITY, 4.0, 5.0};
     double points3[] = {1.0, 2.0, 3.0, 4.0, 5.0};
     const size_t npoints(5);
     NumericAxis axis1(std::vector<double>(points1, points1 + npoints));


### PR DESCRIPTION
Fixes [#11179](http://trac.mantidproject.org/mantid/ticket/11179).

To test:
- Review code changes and unit test
- Load the files attached to the Trac ticket
- Run CheckWorkspacesMatch on both pairs of workspaces, ensuring CheckAxis is enabled, CheckSpectraMap is disabled and tolerance is set to 1e-10
- On master this fails, with this fix it should pass

All being well this should fix the failing system test on OSX 10.9.
