### PR TITLE
Improve error message when opening files with Load from Python scripts

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Code/Mantid/Framework/PythonInterface/mantid/simpleapi.py
@@ -86,7 +86,15 @@ def Load(*args, **kwargs):
     # Create and execute
     algm = _create_algorithm_object('Load')
     _set_logging_option(algm, kwargs)
-    algm.setProperty('Filename', filename) # Must be set first
+    try:
+        algm.setProperty('Filename', filename) # Must be set first
+    except ValueError as ve:
+        raise ValueError('Problem when setting Filename. This is the detailed error '
+                         'description: ' + str(ve) + '\nIf the file has been found '
+                         'but you got this error, you might not have read permissions '
+                         'or the file might be corrupted.\nIf the file has not been found, '
+                         'you might have forgotten to add its location in the data search '
+                         'directories.')
     # Remove from keywords so it is not set twice
     try:
         del kwargs['Filename']


### PR DESCRIPTION
This addresses ticket [#11113](http://trac.mantidproject.org/mantid/ticket/11113).

Tester:
- Review code.
- See if it is helpful.

This just gives a very verbose error message that I wrote trying to address the confusion experienced by some students in the last training course. It can be helpful to new users and especially in the training course, etc. To test it you can pick one file, for example '164198.nxs' from the training course data and set it as non-readable for you. Then run `Load('164198.nxs')`.
