### PR TITLE
Allow deadtime corrections in Muon ALC

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -53,6 +53,8 @@ namespace CustomInterfaces
     std::string firstRun() const;
     std::string lastRun() const;
     std::string log() const;
+    std::string deadTimeType() const;
+    std::string deadTimeFile() const;
     std::string calculationType() const;
     boost::optional< std::pair<double,double> > timeRange() const;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -404,5 +404,6 @@
  </connections>
  <buttongroups>
   <buttongroup name="calculationType"/>
+  <buttongroup name="deadTimeCorrType"/>
  </buttongroups>
 </ui>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -109,7 +109,10 @@
                <property name="text">
                 <string>None</string>
                </property>
-               <attribute name="buttonGroup">
+                <property name="checked">
+                  <bool>true</bool>
+                </property>
+                <attribute name="buttonGroup">
                 <string notr="true">deadTimeCorrType</string>
                </attribute>
               </widget>
@@ -128,9 +131,6 @@
                <widget class="QRadioButton" name="fromCustomFile">
                  <property name="text">
                    <string>From Custom File</string>
-                 </property>
-                 <property name="checked">
-                   <bool>true</bool>
                  </property>
                  <attribute name="buttonGroup">
                    <string notr="true">deadTimeCorrType</string>
@@ -169,7 +169,7 @@
                       <bool>false</bool>
                     </property>
                     <property name="enabled">
-                      <bool>true</bool>
+                      <bool>false</bool>
                     </property>
                   </widget>
                 </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -97,6 +97,85 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="deadTimeGroup">
+         <property name="title">
+          <string>Dead Time Correction</string>
+         </property>
+          <layout class="QVBoxLayout" name="verticalLayoutDeadTime">
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayoutDeadTime">
+             <item>
+              <widget class="QRadioButton" name="none">
+               <property name="text">
+                <string>None</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">deadTimeCorrType</string>
+               </attribute>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="fromDataFile">
+               <property name="text">
+                <string>From Data File</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">deadTimeCorrType</string>
+               </attribute>
+              </widget>
+             </item>
+             <item>
+               <widget class="QRadioButton" name="fromCustomFile">
+                 <property name="text">
+                   <string>From Custom File</string>
+                 </property>
+                 <property name="checked">
+                   <bool>true</bool>
+                 </property>
+                 <attribute name="buttonGroup">
+                   <string notr="true">deadTimeCorrType</string>
+                 </attribute>
+               </widget>
+             </item>
+              <item>
+                <spacer name="horizontalSpacerDeadTime">
+                  <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                    <size>
+                      <width>40</width>
+                      <height>20</height>
+                    </size>
+                  </property>
+                </spacer>
+              </item>
+            </layout>
+          </item>
+            <item>
+              <layout class="QHBoxLayout" name="horizontalLayoutDeadTime_2">
+                <item>
+                  <widget class="MantidQt::MantidWidgets::MWRunFiles" name="deadTimeFile" native="true">
+                    <property name="sizePolicy">
+                      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                      </sizepolicy>
+                    </property>
+                    <property name="label" stdset="0">
+                      <string/>
+                    </property>
+                    <property name="multipleFiles" stdset="0">
+                      <bool>false</bool>
+                    </property>
+                  </widget>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+        <item>
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>Calculation</string>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -168,6 +168,9 @@
                     <property name="multipleFiles" stdset="0">
                       <bool>false</bool>
                     </property>
+                    <property name="enabled">
+                      <bool>true</bool>
+                    </property>
                   </widget>
                 </item>
               </layout>
@@ -392,6 +395,12 @@
     </hint>
    </hints>
   </connection>
+   <connection>
+     <sender>fromCustomFile</sender>
+     <signal>toggled(bool)</signal>
+     <receiver>deadTimeFile</receiver>
+     <slot>setEnabled(bool)</slot>
+   </connection>
  </connections>
  <buttongroups>
   <buttongroup name="calculationType"/>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -53,6 +53,12 @@ namespace CustomInterfaces
     /// @return Log name
     virtual std::string log() const = 0;
 
+    /// @return dead time correction type to use
+    virtual std::string deadTimeType() const = 0;
+
+    /// @return dead time correction file
+    virtual std::string deadTimeFile() const = 0;
+
     /// @return Selected calculation type - "Integral" or "Differential"
     virtual std::string calculationType() const = 0;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -43,12 +43,16 @@ namespace CustomInterfaces
       alg->setProperty("LastRun", m_view->lastRun());
       alg->setProperty("LogValue", m_view->log());
       alg->setProperty("Type", m_view->calculationType());
+      alg->setProperty("DeadTimeCorrType",m_view->deadTimeType());
 
       // If time limiting requested, set min/max times
       if (auto timeRange = m_view->timeRange())
       {
         alg->setProperty("TimeMin", timeRange->first);
         alg->setProperty("TimeMax", timeRange->second);
+      }
+      if (m_view->deadTimeType() == "FromSpecifiedFile") {
+        alg->setProperty("DeadTimeCorrFile",m_view->deadTimeFile());
       }
 
       alg->setPropertyValue("OutputWorkspace", "__NotUsed");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -64,6 +64,27 @@ namespace CustomInterfaces
     return m_ui.calculationType->checkedButton()->text().toStdString();
   }
 
+  std::string ALCDataLoadingView::deadTimeType() const
+  {
+    std::string checkedButton = m_ui.deadTimeCorrType->checkedButton()->text().toStdString();
+    if ( checkedButton == "From Data File" ) {
+        return std::string("FromRunData");
+    } else if ( checkedButton == "From Custom File" ) {
+      return std::string("FromSpecifiedFile");
+    } else {
+      return checkedButton;
+    }
+  }
+
+  std::string ALCDataLoadingView::deadTimeFile() const
+  {
+    if (deadTimeType()=="FromSpecifiedFile") {
+      return m_ui.deadTimeFile->getFirstFilename().toStdString();
+    } else {
+      return "";
+    }
+  }
+
   boost::optional< std::pair<double,double> > ALCDataLoadingView::timeRange() const
   {
     if (m_ui.timeLimit->isChecked())


### PR DESCRIPTION
Fixes [#9554](http://trac.mantidproject.org/mantid/ticket/9554)

To test: check code changes. See trac issue [#9489](http://trac.mantidproject.org/mantid/ticket/9489) for link where mock-ups can be found, and check that the interface looks as expected (note that some property widgets as Grouping and Periods will be added in future work). You may find the documentation (http://www.mantidproject.org/Muon_ALC) useful to check that the interface is behaving as expected.
