### PR TITLE
Set default indirect diffraction UI correctly

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -95,10 +95,13 @@ void IndirectDiffractionReduction::initLayout()
 
   // Update invalid rebinning markers
   validateRebin();
+
+  // Update instrument dependant widgets
+  m_uiForm.iicInstrumentConfiguration->newInstrumentConfiguration();
 }
 
 /**
- * Runs a diffraction reduction when the user clieks Run.
+ * Runs a diffraction reduction when the user clicks Run.
  */
 void IndirectDiffractionReduction::demonRun()
 {


### PR DESCRIPTION
Refs [#11198](http://trac.mantidproject.org/mantid/ticket/11198).

To test:
- Without the fix: set default instrument to IRIS, open Indirect Diffraction.
- Should see IRIS selected as instrument but cal file and vanadium options (this is for OSIRIS diffonly only)
- Apply the fix, so the same thing, should now see rebinning options instead.
