### PR TITLE
Use FileBackedExperimentInfo class in LoadMD

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -179,7 +179,8 @@ void LoadMD::exec() {
         MDEventFactory::CreateMDWorkspace(m_numDims, eventType);
 
     // Now the ExperimentInfo
-    MDBoxFlatTree::loadExperimentInfos(m_file.get(), ws);
+    bool lazyLoadExpt = fileBacked;
+    MDBoxFlatTree::loadExperimentInfos(m_file.get(), ws, lazyLoadExpt);
 
     // Wrapper to cast to MDEventWorkspace then call the function
     CALL_MDEVENT_FUNCTION(this->doLoad, ws);

--- a/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/MDBoxFlatTree.h
+++ b/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/MDBoxFlatTree.h
@@ -137,7 +137,8 @@ public:
   // function
   static void loadExperimentInfos(
       ::NeXus::File *const file,
-      boost::shared_ptr<Mantid::API::MultipleExperimentInfos> ei);
+      boost::shared_ptr<Mantid::API::MultipleExperimentInfos> ei,
+      bool lazy = false);
 
   static void saveAffineTransformMatricies(::NeXus::File *const file,
                                            API::IMDWorkspace_const_sptr ws);

--- a/Code/Mantid/Framework/MDEvents/src/MDBoxFlatTree.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/MDBoxFlatTree.cpp
@@ -3,7 +3,7 @@
 #include "MantidMDEvents/MDEvent.h"
 #include "MantidMDEvents/MDLeanEvent.h"
 #include "MantidAPI/BoxController.h"
-#include "MantidAPI/ExperimentInfo.h"
+#include "MantidAPI/FileBackedExperimentInfo.h"
 #include "MantidMDEvents/MDEventFactory.h"
 #include <Poco/File.h>
 
@@ -397,10 +397,13 @@ void MDBoxFlatTree::saveExperimentInfos(::NeXus::File *const file,
 *experiment info groups can be found.
 * @param mei :: MDEventWorkspace/MDHisto to load experiment infos to or rather
 *pointer to the base class of this workspaces (which is an experimentInfo)
+* @param lazy :: If true, use the FileBackedExperimentInfo class to only load
+* the data from the file when it is requested
 */
 void MDBoxFlatTree::loadExperimentInfos(
     ::NeXus::File *const file,
-    boost::shared_ptr<Mantid::API::MultipleExperimentInfos> mei) {
+    boost::shared_ptr<Mantid::API::MultipleExperimentInfos> mei,
+    bool lazy) {
   // First, find how many experimentX blocks there are
   std::map<std::string, std::string> entries;
   file->getEntries(entries);
@@ -443,25 +446,30 @@ void MDBoxFlatTree::loadExperimentInfos(
   // Now go through in order, loading and adding
   itr = ExperimentBlockNum.begin();
   for (; itr != ExperimentBlockNum.end(); itr++) {
-
     std::string groupName = "experiment" + Kernel::Strings::toString(*itr);
-
-    file->openGroup(groupName, "NXgroup");
-    API::ExperimentInfo_sptr ei(new API::ExperimentInfo);
-    std::string parameterStr;
-    try {
-      // Get the sample, logs, instrument
-      ei->loadExperimentInfoNexus(file, parameterStr);
-      // Now do the parameter map
-      ei->readParameterMap(parameterStr);
-      // And add it to the mutliple experiment info.
-      mei->addExperimentInfo(ei);
-    } catch (std::exception &e) {
-      g_log.information("Error loading section '" + groupName +
-                        "' of nxs file.");
-      g_log.information(e.what());
+    if (lazy) {
+      auto ei = boost::make_shared<API::FileBackedExperimentInfo>(
+        file, file->getPath() + "/" + groupName
+        );
+     }
+    else {
+      auto ei = boost::make_shared<API::ExperimentInfo>();
+      file->openGroup(groupName, "NXgroup");
+      std::string parameterStr;
+      try {
+        // Get the sample, logs, instrument
+        ei->loadExperimentInfoNexus(file, parameterStr);
+        // Now do the parameter map
+        ei->readParameterMap(parameterStr);
+        // And add it to the mutliple experiment info.
+        mei->addExperimentInfo(ei);
+      } catch (std::exception &e) {
+        g_log.information("Error loading section '" + groupName +
+                          "' of nxs file.");
+        g_log.information(e.what());
+      }
+      file->closeGroup();
     }
-    file->closeGroup();
   }
 }
 /**Export existing experiment info defined in the box structure to target

--- a/Code/Mantid/Framework/MDEvents/src/MDBoxFlatTree.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/MDBoxFlatTree.cpp
@@ -449,8 +449,9 @@ void MDBoxFlatTree::loadExperimentInfos(
     std::string groupName = "experiment" + Kernel::Strings::toString(*itr);
     if (lazy) {
       auto ei = boost::make_shared<API::FileBackedExperimentInfo>(
-        file, file->getPath() + "/" + groupName
-        );
+        file, file->getPath() + "/" + groupName);
+      // And add it to the mutliple experiment info.
+      mei->addExperimentInfo(ei);
      }
     else {
       auto ei = boost::make_shared<API::ExperimentInfo>();


### PR DESCRIPTION
Fixes trac issue [#11111](http://trac.mantidproject.org/mantid/ticket/11111)

**Tester**

The major work was completed in ~~#307~~. This simply uses the new class in `LoadMD` when the `FileBackend` option is set to true. The best way to test is to see the time difference in loading a large MD file before and after the changes. A 24Gb test file can be found on the Vates file share at ISIS. Let me know if you want me to point you at it.
