### PR TITLE
Add preview spectrum selection to IDA Diagnostics tab

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
@@ -67,11 +67,11 @@ namespace CustomInterfaces
     virtual bool validate();
 
   private slots:
-    void slicePlotRaw();
+    void handleNewFile();
     void sliceTwoRanges(QtProperty*, bool);
     void sliceCalib(bool state);
     void rangeSelectorDropped(double, double);
-    void sliceUpdateRS(QtProperty*, double);
+    void doublePropertyChanged(QtProperty*, double);
     void setDefaultInstDetails();
     void updatePreviewPlot();
     void sliceAlgDone(bool error);
@@ -81,7 +81,6 @@ namespace CustomInterfaces
 
   private:
     Ui::ISISDiagnostics m_uiForm;
-    QString m_lastDiagFilename;
 
   };
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MWRunFiles.h
@@ -206,6 +206,8 @@ namespace MantidQt
       void findingFiles();
       /// Emitted when files have been found
       void filesFound();
+      /// Emitted when files have been found that are different to what was found last time
+      void filesFoundChanged();
       /// Emitted when file finding is finished (files may or may not have been found).
       void fileFindingFinished();
       /// Emitted when the live button is toggled
@@ -282,6 +284,8 @@ namespace MantidQt
       Ui::MWRunFiles m_uiForm;
       /// An array of valid file names derived from the entries in the leNumber LineEdit
       QStringList m_foundFiles;
+      /// An array of the last valid file names found
+      QStringList m_lastFoundFiles;
       /// The last directory viewed by the browse dialog
       QString m_lastDir;
       /// A file filter for the file browser

--- a/Code/Mantid/MantidQt/MantidWidgets/src/MWRunFiles.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/MWRunFiles.cpp
@@ -196,7 +196,7 @@ MWRunFiles::MWRunFiles(QWidget *parent)
   : MantidWidget(parent), m_findRunFiles(true), m_allowMultipleFiles(false), 
     m_isOptional(false), m_multiEntry(false), m_buttonOpt(Text), m_fileProblem(""),
     m_entryNumProblem(""), m_algorithmProperty(""), m_fileExtensions(), m_extsAsSingleOption(true),
-    m_liveButtonState(Hide), m_foundFiles(), m_lastDir(), m_fileFilter()
+    m_liveButtonState(Hide), m_foundFiles(), m_lastFoundFiles(), m_lastDir(), m_fileFilter()
 {
   m_thread = new FindFilesThread(this);
   
@@ -840,6 +840,7 @@ void MWRunFiles::inspectThreadResult()
     return;
   }
 
+  m_lastFoundFiles = m_foundFiles;
   m_foundFiles.clear();
 
   for( size_t i = 0; i < filenames.size(); ++i)
@@ -861,6 +862,7 @@ void MWRunFiles::inspectThreadResult()
 
   // Only emit the signal if file(s) were found
   if ( ! m_foundFiles.isEmpty() ) emit filesFound();
+  if ( m_lastFoundFiles != m_foundFiles ) emit filesFoundChanged();
 }
 
 /**


### PR DESCRIPTION
Fixes [#11199](http://trac.mantidproject.org/mantid/ticket/11199).

To test:
- Open IDR > Diagnostics, select IRIS
- Load `26176`
- Change preview spectrum using `Preview Spectrum` option in property browser
- Ensure that shifting focus to and from the run files entry does not cause the files and preview spectrum to be reloaded/created.
