### PR TITLE
Impove documentation for ExportSampleLogsToCSVFile

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/ExportSampleLogsToCSVFile.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/ExportSampleLogsToCSVFile.py
@@ -58,11 +58,14 @@ class ExportSampleLogsToCSVFile(PythonAlgorithm):
         timezones = ["UTC", "America/New_York", "Asia/Shanghai", "Australia/Sydney", "Europe/London", "GMT+0",\
                 "Europe/Paris", "Europe/Copenhagen"]
 
-        self.declareProperty("TimeZone", "America/New_York", StringListValidator(timezones))
+        description = "Sample logs recorded in NeXus files (in SNS) are in UTC time.  TimeZone " + \
+            "can allow the algorithm to output the log with local time."
+        self.declareProperty("TimeZone", "America/New_York", StringListValidator(timezones), description)
 
         # Log time tolerance
         self.declareProperty("TimeTolerance", 0.01,
-                             "If any 2 log entries with log times within the time tolerance, they will be recorded in one line. Unit is second. ")
+                             "If any 2 log entries with log times within the time tolerance, " + \
+                             "they will be recorded in one line. Unit is second. ")
 
         return
 

--- a/Code/Mantid/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
@@ -29,9 +29,9 @@ to be exported.
 
 Here is the definition for the columns. 
 
--  Column 0: Absolute time in second
--  Column 1: Relative to first log entry's time
--  Column 2 to (2 + n) - 1: log values in the order determined by input
+-  Column 1: Absolute time (with respect to the Unix epoch) in seconds
+-  Column 2: Relative to first log entry's time
+-  Column 3 to (2 + n): log values in the order determined by input
    *SampleLogNames*
 
 Header file
@@ -40,9 +40,9 @@ Header file
 A sample log header file can be generated optionally.  
 It contains theree lines described as below. 
 
--  Line 0: Test date: [Test date in string]
--  Line 1: Test description: [Description of this log file]
--  Line 2: Header content given by user via input property *Header*.
+-  Line 1: Test date: [Test date in string]
+-  Line 2: Test description: [Description of this log file]
+-  Line 3: Header content given by user via input property *Header*.
    Usually it is the column names in the .csv file
 
 Time Zone

--- a/Code/Mantid/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
@@ -20,9 +20,11 @@ except in the situation that two entries with time stamps within time tolerance.
 Time Zone
 ---------
 
-The time stamps of sample logs are recorded as UTC time.
+The time stamps of sample logs are recorded as UTC time in SNS.
 Some users wants to see the exported sample log as the neutron facility's local time.
 So the input property 'TimeZone' is for this purpose.
+
+For 
 
 
 Header file

--- a/Code/Mantid/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExportSampleLogsToCSVFile-v1.rst
@@ -9,39 +9,63 @@
 Description
 -----------
 
-Algorithm 'LoadSampleLogsToCSVFile' exports a specified set of sample logs
+Algorithm *LoadSampleLogsToCSVFile* exports a specified set of sample logs
 , which are stored in a MatrixWorkspace, to a CSV file.
+The header for the sample log csv file can also 
+be created by this algorithm in a seperate *header* file. 
+
+CSV File format
+===============
+
+Sample logs are written to a csv file.   
+A tab separates any two adjacent values. 
 
 Each entry of each exported sample log will be an individual entry in the
 output CSV file,
 except in the situation that two entries with time stamps within time tolerance.
 
+The output CSV file has 2+n columns, where n is the number of sample logs 
+to be exported. 
 
-Time Zone
----------
+Here is the definition for the columns. 
 
-The time stamps of sample logs are recorded as UTC time in SNS.
-Some users wants to see the exported sample log as the neutron facility's local time.
-So the input property 'TimeZone' is for this purpose.
-
-For 
-
+-  Column 0: Absolute time in second
+-  Column 1: Relative to first log entry's time
+-  Column 2 to (2 + n) - 1: log values in the order determined by input
+   *SampleLogNames*
 
 Header file
------------
+===========
+
+A sample log header file can be generated optionally.  
+It contains theree lines described as below. 
 
 -  Line 0: Test date: [Test date in string]
 -  Line 1: Test description: [Description of this log file]
 -  Line 2: Header content given by user via input property *Header*.
    Usually it is the column names in the .csv file
 
-CSV File format
----------------
+Time Zone
+=========
 
--  Column 0: Absolute time in second
--  Column 1: Relative to first log entry's time
--  Column 2 to (2 + n) - 1: log values in the order determined by input
-   *SampleLogNames*
+The time stamps of sample logs are recorded as UTC time in SNS.
+Some users wants to see the exported sample log as the neutron facility's local time.
+So the input property 'TimeZone' is for this purpose.
+
+Property *TimeZone* does not support all the time zones
+but only those with facilities that use Mantid. 
+
+Here is the list of all time zones that are allowed by this algorithm.
+- UTC
+- GMT+0
+- America/New_York
+- Asia/Shanghai
+- Australia/Sydney
+- Europe/London
+- Europe/Paris
+- Europe/Copenhagen
+
+
 
 Usage
 -----


### PR DESCRIPTION
It was original trac ticket [#10891](http://trac.mantidproject.org/mantid/ticket/10891). 

The documentation of algorithm ExportSampleLogsToCSVFile has been improved, especially about property TimeZone.  
