### PR TITLE
Fix broken systemtest caused by FunctionParameterDecorator

### DIFF
--- a/Code/Mantid/Framework/API/src/FunctionParameterDecorator.cpp
+++ b/Code/Mantid/Framework/API/src/FunctionParameterDecorator.cpp
@@ -79,7 +79,9 @@ double FunctionParameterDecorator::getParameter(const std::string &name) const {
 }
 
 size_t FunctionParameterDecorator::nParams() const {
-  throwIfNoFunctionSet();
+  if(!m_wrappedFunction) {
+      return 0;
+  }
 
   return m_wrappedFunction->nParams();
 }
@@ -147,7 +149,9 @@ size_t FunctionParameterDecorator::getParameterIndex(
 }
 
 size_t FunctionParameterDecorator::nAttributes() const {
-  throwIfNoFunctionSet();
+  if(!m_wrappedFunction) {
+      return 0;
+  }
 
   return m_wrappedFunction->nAttributes();
 }

--- a/Code/Mantid/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Code/Mantid/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -127,7 +127,7 @@ public:
 
   void testNParams() {
     TestableFunctionParameterDecorator invalidFn;
-    TS_ASSERT_THROWS(invalidFn.nParams(), std::runtime_error);
+    TS_ASSERT_EQUALS(invalidFn.nParams(), 0);
 
     FunctionParameterDecorator_sptr fn =
         getFunctionParameterDecoratorGaussian();
@@ -215,7 +215,7 @@ public:
 
   void testAttributes() {
     TestableFunctionParameterDecorator invalidFn;
-    TS_ASSERT_THROWS(invalidFn.nAttributes(), std::runtime_error);
+    TS_ASSERT_EQUALS(invalidFn.nAttributes(), 0);
 
     FunctionParameterDecorator_sptr fn =
         getFunctionParameterDecoratorGaussian();


### PR DESCRIPTION
This fixes [#11219](http://trac.mantidproject.org/mantid/ticket/11219).

**Testing information**
Make sure the `CodeConventions` system test passes.
