### PR TITLE
Fix dead time table

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
@@ -112,8 +112,7 @@ private:
 
   /// Creates Dead Time Table using all the data between begin and end
   DataObjects::TableWorkspace_sptr
-  createDeadTimeTable(std::vector<double>::const_iterator begin,
-                      std::vector<double>::const_iterator end);
+  createDeadTimeTable(std::vector<int> specToLoad, std::vector<double> deadTimes);
 
   /// Loads detector grouping information
   API::Workspace_sptr loadDetectorGrouping(Mantid::NeXus::NXRoot &root);

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -127,6 +127,9 @@ void LoadMuonNexus1::exec() {
   // Grouping info should be returned if user has set the property
   bool returnGrouping = !getPropertyValue("DetectorGroupingTable").empty();
 
+  // Call private method to validate the optional parameters, if set
+  checkOptionalProperties();
+
   Workspace_sptr loadedGrouping;
 
   // Try to load detector grouping info, if needed for auto-grouping or user
@@ -149,9 +152,6 @@ void LoadMuonNexus1::exec() {
   // If multiperiod, will need to hold the Instrument & Sample for copying
   boost::shared_ptr<Instrument> instrument;
   boost::shared_ptr<Sample> sample;
-
-  // Call private method to validate the optional parameters, if set
-  checkOptionalProperties();
 
   // Read the number of time channels (i.e. bins) from the Nexus file
   const int channelsPerSpectrum = nxload.t_ntc1;

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -323,8 +323,8 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
     // Set the spectrum list that should be loaded
     if ( m_interval || m_list ) {
       // Load only selected spectra
-      for (int i=m_spec_min; i<m_spec_max; i++) {
-        specToLoad.push_back(i);
+      for (size_t i=m_spec_min; i<m_spec_max; i++) {
+        specToLoad.push_back(static_cast<int>(i));
       }
       for (auto it=m_spec_list.begin(); it!=m_spec_list.end(); ++it) {
         specToLoad.push_back(*it);
@@ -347,13 +347,12 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
 
       // Simpliest case - one dead time for one detector
 
-      // Populate specToLoad and deadTimes
-      for (int i = 0; i < numDeadTimes; i++) {
-        deadTimes.push_back(deadTimesData[i]);
+      // Populate deadTimes
+      for (auto it=specToLoad.begin(); it!=specToLoad.end(); ++it) {
+        deadTimes.push_back(deadTimesData[*it-1]);
       }
       // Load into table
-      TableWorkspace_sptr table =
-          createDeadTimeTable(specToLoad, deadTimes);
+      TableWorkspace_sptr table = createDeadTimeTable(specToLoad, deadTimes);
       setProperty("DeadTimeTable", table);
     } else {
 
@@ -367,12 +366,15 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
 
       WorkspaceGroup_sptr tableGroup = boost::make_shared<WorkspaceGroup>();
 
-      // Populate specToLoad and deadTimes
-      for (int i = 0; i < numDeadTimes; i++) {
-        deadTimes.push_back(deadTimesData[i]);
-      }
-      // Load into table
       for (size_t i=0; i<m_numberOfPeriods; i++) {
+
+        // Populate deadTimes
+        for (auto it=specToLoad.begin(); it!=specToLoad.end(); ++it) {
+          int index = static_cast<int>(*it -1 + i*m_numberOfSpectra);
+          deadTimes.push_back(deadTimesData[index]);
+        }
+
+        // Load into table
         TableWorkspace_sptr table = createDeadTimeTable(specToLoad,deadTimes);
 
         tableGroup->addWorkspace(table);

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -472,8 +472,6 @@ LoadMuonNexus1::createDeadTimeTable(std::vector<int> specToLoad,
   deadTimeTable->addColumn("int", "spectrum");
   deadTimeTable->addColumn("double", "dead-time");
 
-  int s = 1; // Current spectrum
-
   for (size_t i = 0; i<specToLoad.size(); i++) {
     TableRow row = deadTimeTable->appendRow();
     row << specToLoad[i] << deadTimes[i];

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -122,9 +122,6 @@ void LoadMuonNexus1::exec() {
     m_numberOfPeriods = nxload.t_nper;
   }
 
-  // Try to load dead time info
-  loadDeadTimes(root);
-
   bool autoGroup = getProperty("AutoGroup");
 
   // Grouping info should be returned if user has set the property
@@ -155,6 +152,9 @@ void LoadMuonNexus1::exec() {
 
   // Call private method to validate the optional parameters, if set
   checkOptionalProperties();
+
+  // Try to load dead time info
+  loadDeadTimes(root);
 
   // Read the number of time channels (i.e. bins) from the Nexus file
   const int channelsPerSpectrum = nxload.t_ntc1;

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -543,7 +543,7 @@ void LoadMuonNexus1::loadData(size_t hist, specid_t &i, specid_t specNo, MuonNex
   // Populate the workspace. Loop starts from 1, hence i-1
 
   // Create and fill another vector for the X axis  
-  float *timeChannels = new float[lengthIn+1];
+  float *timeChannels = new float[lengthIn+1]();
   nxload.getTimeChannels(timeChannels, static_cast<const int>(lengthIn+1));
   // Put the read in array into a vector (inside a shared pointer)
   boost::shared_ptr<MantidVec> timeChannelsVec(

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -323,7 +323,7 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
     // Set the spectrum list that should be loaded
     if ( m_interval || m_list ) {
       // Load only selected spectra
-      for (size_t i=m_spec_min; i<m_spec_max; i++) {
+      for (int64_t i=m_spec_min; i<m_spec_max; i++) {
         specToLoad.push_back(static_cast<int>(i));
       }
       for (auto it=m_spec_list.begin(); it!=m_spec_list.end(); ++it) {
@@ -368,7 +368,7 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
 
       WorkspaceGroup_sptr tableGroup = boost::make_shared<WorkspaceGroup>();
 
-      for (size_t i=0; i<m_numberOfPeriods; i++) {
+      for (int64_t i=0; i<m_numberOfPeriods; i++) {
 
         // Populate deadTimes
         for (auto it=specToLoad.begin(); it!=specToLoad.end(); ++it) {

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -153,9 +153,6 @@ void LoadMuonNexus1::exec() {
   // Call private method to validate the optional parameters, if set
   checkOptionalProperties();
 
-  // Try to load dead time info
-  loadDeadTimes(root);
-
   // Read the number of time channels (i.e. bins) from the Nexus file
   const int channelsPerSpectrum = nxload.t_ntc1;
   // Read in the time bin boundaries
@@ -184,6 +181,9 @@ void LoadMuonNexus1::exec() {
     m_spec_min = 1;
     m_spec_max = m_numberOfSpectra+1; // Add +1 to iterate
   }
+
+  // Try to load dead time info
+  loadDeadTimes(root);
 
   // Create the 2D workspace for the output
   DataObjects::Workspace2D_sptr localWorkspace =
@@ -331,7 +331,9 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
       }
     } else {
       // Load all the spectra
-      for (int i=0; i<numDeadTimes; i++)
+      // Start from 1 to N+1 to be consistent with 
+      // the case where spectra are specified
+      for (int i=1; i<numDeadTimes/m_numberOfPeriods+1; i++)
         specToLoad.push_back(i);
     }
 

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -319,8 +319,21 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
 
     std::vector<int> specToLoad;
     std::vector<double> deadTimes;
-    specToLoad.reserve(numDeadTimes);
-    deadTimes.reserve(numDeadTimes);
+
+    // Set the spectrum list that should be loaded
+    if ( m_interval || m_list ) {
+      // Load only selected spectra
+      for (int i=m_spec_min; i<m_spec_max; i++) {
+        specToLoad.push_back(i);
+      }
+      for (auto it=m_spec_list.begin(); it!=m_spec_list.end(); ++it) {
+        specToLoad.push_back(*it);
+      }
+    } else {
+      // Load all the spectra
+      for (int i=0; i<numDeadTimes; i++)
+        specToLoad.push_back(i);
+    }
 
 
     if (numDeadTimes < m_numberOfSpectra) {
@@ -329,12 +342,13 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
       throw Exception::FileError(
           "Number of dead times specified is less than number of spectra",
           m_filename);
+
     } else if (numDeadTimes == m_numberOfSpectra) {
+
       // Simpliest case - one dead time for one detector
 
       // Populate specToLoad and deadTimes
       for (int i = 0; i < numDeadTimes; i++) {
-        specToLoad.push_back(i);
         deadTimes.push_back(deadTimesData[i]);
       }
       // Load into table
@@ -342,6 +356,7 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
           createDeadTimeTable(specToLoad, deadTimes);
       setProperty("DeadTimeTable", table);
     } else {
+
       // More complex case - different dead times for different periods
 
       if (numDeadTimes != m_numberOfSpectra * m_numberOfPeriods) {
@@ -354,7 +369,6 @@ void LoadMuonNexus1::loadDeadTimes(NXRoot &root) {
 
       // Populate specToLoad and deadTimes
       for (int i = 0; i < numDeadTimes; i++) {
-        specToLoad.push_back(i);
         deadTimes.push_back(deadTimesData[i]);
       }
       // Load into table

--- a/Code/Mantid/Framework/DataHandling/test/LoadMuonNexus1Test.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadMuonNexus1Test.h
@@ -308,6 +308,8 @@ public:
     LoadMuonNexus1 alg1;
     LoadMuonNexus1 alg2;
 
+    const std::string deadTimeWSName = "LoadMuonNexus1Test_DeadTimes";
+
     // Execute alg1
     // It will only load some spectra
     TS_ASSERT_THROWS_NOTHING( alg1.initialize() );
@@ -317,6 +319,7 @@ public:
     alg1.setPropertyValue("SpectrumList", "29,31");
     alg1.setPropertyValue("SpectrumMin", "5");
     alg1.setPropertyValue("SpectrumMax", "10");
+    alg1.setPropertyValue("DeadTimeTable", deadTimeWSName);
     TS_ASSERT_THROWS_NOTHING(alg1.execute());    
     TS_ASSERT( alg1.isExecuted() );    
     // Get back the saved workspace
@@ -354,6 +357,25 @@ public:
 
     AnalysisDataService::Instance().remove("outWS1");
     AnalysisDataService::Instance().remove("outWS2");
+
+    // Check dead time table
+    TableWorkspace_sptr deadTimeTable;
+    TS_ASSERT_THROWS_NOTHING( deadTimeTable = 
+      AnalysisDataService::Instance().retrieveWS<TableWorkspace>( deadTimeWSName ) );
+    TS_ASSERT( deadTimeTable );
+    // Check number of rows and columns
+    TS_ASSERT_EQUALS( deadTimeTable->columnCount(), 2 );
+    TS_ASSERT_EQUALS( deadTimeTable->rowCount(), 8 );
+    // Check spectrum numbers
+    TS_ASSERT_EQUALS( deadTimeTable->Int(0,0), 5 );
+    TS_ASSERT_EQUALS( deadTimeTable->Int(4,0), 9 );
+    TS_ASSERT_EQUALS( deadTimeTable->Int(7,0), 31);
+    // Check dead time values
+    TS_ASSERT_DELTA( deadTimeTable->Double(0,1), 0.00161112, 0.00000001 );
+    TS_ASSERT_DELTA( deadTimeTable->Double(3,1), 0.00431686, 0.00000001 );
+    TS_ASSERT_DELTA( deadTimeTable->Double(6,1), 0.00254914, 0.00000001 );
+    AnalysisDataService::Instance().remove(deadTimeWSName);
+
 
   }
 


### PR DESCRIPTION
Fixes issue [#11218](http://trac.mantidproject.org/mantid/ticket/11218)

For tester: LoadMuonNexus1 does not work properly when some spectra are selected. Specifically, the dead time table loaded when running the algorithm contains dead times for all the spectra in the nexus file, instead of having only of those that have been selected by the user. To test, run LoadMuonNexus, select any muon dataset, for instance MUSR00015189.nxs, and set SpectrumMin/Max or List. Set also DeadTimeTable, it should be correctly populated. There are additional problems related to the detector grouping that will be addressed in trac ticket #8837, so for the moment keep EntryNumber =0 and AutoGroup unchecked.
