### PR TITLE
Fix BinMD when used with a file-backed MD workspace

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/FileBackedExperimentInfo.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/FileBackedExperimentInfo.h
@@ -37,7 +37,7 @@ namespace API {
 class MANTID_API_DLL FileBackedExperimentInfo : public ExperimentInfo {
 public:
   /// Constructor
-  FileBackedExperimentInfo(::NeXus::File *file, const std::string &path);
+  FileBackedExperimentInfo(const std::string & filename, const std::string &path);
 
   ExperimentInfo *cloneExperimentInfo() const;
 
@@ -99,8 +99,8 @@ private:
   void populateFromFile() const;
 
   mutable bool m_loaded;
-  ::NeXus::File *m_file;
-  std::string m_path;
+  std::string m_filename;
+  std::string m_nxpath;
 };
 
 } // namespace API

--- a/Code/Mantid/Framework/API/src/FileBackedExperimentInfo.cpp
+++ b/Code/Mantid/Framework/API/src/FileBackedExperimentInfo.cpp
@@ -2,9 +2,12 @@
 // Includes
 //----------------------------------------------------------------------------------------------
 #include "MantidAPI/FileBackedExperimentInfo.h"
-#include <nexus/NeXusException.hpp>
 
 #include <sstream>
+
+#include <nexus/NeXusException.hpp>
+#include <nexus/NeXusFile.hpp>
+
 
 namespace Mantid {
 namespace API {
@@ -17,12 +20,12 @@ Kernel::Logger g_log("FileBackedExperimentInfo");
 
 /**
   * Create an object based on a NeXus file and path
-  * @param file A pointer to an open NeXus file object
-  * @param path Path to the location of the data
+  * @param filename The full path to the file
+  * @param nxpath Path to the location of the experiment information
   */
-FileBackedExperimentInfo::FileBackedExperimentInfo(::NeXus::File *file,
-                                                   const std::string &path)
-    : ExperimentInfo(), m_loaded(false), m_file(file), m_path(path) {}
+FileBackedExperimentInfo::FileBackedExperimentInfo(const std::string &filename,
+                                                   const std::string &nxpath)
+    : ExperimentInfo(), m_loaded(false), m_filename(filename), m_nxpath(nxpath) {}
 
 /**
  * @return A clone of the object
@@ -288,7 +291,8 @@ void FileBackedExperimentInfo::populateIfNotLoaded() const {
  */
 void FileBackedExperimentInfo::populateFromFile() const {
   try {
-    m_file->openPath(m_path);
+    ::NeXus::File nxFile(m_filename);
+    nxFile.openPath(m_nxpath);
     // The loadExperimentInfo calls things such as mutableSample()
     // and if m_loaded is not true then this function is
     // will be called recursively.
@@ -296,7 +300,7 @@ void FileBackedExperimentInfo::populateFromFile() const {
 
     std::string parameterStr;
     const_cast<FileBackedExperimentInfo *>(this)
-        ->loadExperimentInfoNexus(m_file, parameterStr);
+        ->loadExperimentInfoNexus(&nxFile, parameterStr);
     const_cast<FileBackedExperimentInfo *>(this)
         ->readParameterMap(parameterStr);
   } catch (::NeXus::Exception &exc) {

--- a/Code/Mantid/Framework/API/test/FileBackedExperimentInfoTest.h
+++ b/Code/Mantid/Framework/API/test/FileBackedExperimentInfoTest.h
@@ -33,10 +33,10 @@ public:
     }
 
     m_inMemoryExptInfo = boost::make_shared<ExperimentInfo>();
-    m_nexusFile = boost::make_shared< ::NeXus::File >(m_filename, NXACC_READ);
-    m_nexusFile->openGroup("mantid_workspace_1", "NXentry");
+    ::NeXus::File nxFile(m_filename, NXACC_READ);
+    nxFile.openGroup("mantid_workspace_1", "NXentry");
     std::string paramString;
-    m_inMemoryExptInfo->loadExperimentInfoNexus(m_nexusFile.get(), paramString);
+    m_inMemoryExptInfo->loadExperimentInfoNexus(&nxFile, paramString);
     m_inMemoryExptInfo->readParameterMap(paramString);
   }
 
@@ -215,27 +215,20 @@ public:
   // Failure tests
   //------------------------------------------------------------------------------------------------
   void test_runtime_error_generated_when_unable_to_load_from_file() {
-    // Load the file we want to use
-    ::NeXus::File nexusFile(m_filename, NXACC_READ);
-
     // Create the file backed experiment info, shouldn't be loaded yet
-    FileBackedExperimentInfo fileBacked(&nexusFile, "/not/right/path");
+    FileBackedExperimentInfo fileBacked(m_filename, "/not/right/path");
 
     TS_ASSERT_THROWS(fileBacked.toString(), std::runtime_error);
   }
 
 private:
   Mantid::API::ExperimentInfo_sptr createTestObject() {
-    // Load the file we want to use
-    ::NeXus::File nexusFile(m_filename, NXACC_READ);
     // Create the file backed experiment info, shouldn't be loaded yet.
-    // Manipulate it through
-    // the interface
-    return boost::make_shared<FileBackedExperimentInfo>(m_nexusFile.get(),
+    // Manipulate it through the interface
+    return boost::make_shared<FileBackedExperimentInfo>(m_filename,
                                                         "/mantid_workspace_1");
   }
 
-  boost::shared_ptr< ::NeXus::File > m_nexusFile;
   Mantid::API::ExperimentInfo_sptr m_inMemoryExptInfo;
   std::string m_filename;
 };

--- a/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -180,7 +180,7 @@ void LoadMD::exec() {
 
     // Now the ExperimentInfo
     bool lazyLoadExpt = fileBacked;
-    MDBoxFlatTree::loadExperimentInfos(m_file.get(), ws, lazyLoadExpt);
+    MDBoxFlatTree::loadExperimentInfos(m_file.get(), m_filename, ws, lazyLoadExpt);
 
     // Wrapper to cast to MDEventWorkspace then call the function
     CALL_MDEVENT_FUNCTION(this->doLoad, ws);
@@ -231,7 +231,7 @@ void LoadMD::loadHisto() {
   MDHistoWorkspace_sptr ws(new MDHistoWorkspace(m_dims));
 
   // Now the ExperimentInfo
-  MDBoxFlatTree::loadExperimentInfos(m_file.get(), ws);
+  MDBoxFlatTree::loadExperimentInfos(m_file.get(), m_filename, ws);
 
   // Load the WorkspaceHistory "process"
   ws->history().loadNexus(m_file.get());

--- a/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/MDBoxFlatTree.h
+++ b/Code/Mantid/Framework/MDEvents/inc/MantidMDEvents/MDBoxFlatTree.h
@@ -122,7 +122,7 @@ private:
   /// name of the event type
   std::string m_eventType;
   /// shared pointer to multiple experiment info stored within the workspace
-  boost::shared_ptr<Mantid::API::MultipleExperimentInfos> m_mEI;
+  boost::shared_ptr<API::MultipleExperimentInfos> m_mEI;
 
 public:
   static ::NeXus::File *createOrOpenMDWSgroup(const std::string &fileName,
@@ -137,7 +137,8 @@ public:
   // function
   static void loadExperimentInfos(
       ::NeXus::File *const file,
-      boost::shared_ptr<Mantid::API::MultipleExperimentInfos> ei,
+      const std::string & filename,
+      boost::shared_ptr<API::MultipleExperimentInfos> ei,
       bool lazy = false);
 
   static void saveAffineTransformMatricies(::NeXus::File *const file,

--- a/Code/Mantid/Framework/MDEvents/src/MDBoxFlatTree.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/MDBoxFlatTree.cpp
@@ -285,7 +285,7 @@ void MDBoxFlatTree::loadBoxStructure(const std::string &fileName, int &nDim,
       m_mEI = boost::make_shared<Mantid::API::MultipleExperimentInfos>(
           Mantid::API::MultipleExperimentInfos());
 
-    loadExperimentInfos(hFile.get(), m_mEI);
+    loadExperimentInfos(hFile.get(), fileName, m_mEI);
   }
 
   // close workspace group
@@ -395,13 +395,13 @@ void MDBoxFlatTree::saveExperimentInfos(::NeXus::File *const file,
 *
 * @param file :: the pointer to the properly opened nexus data file where the
 *experiment info groups can be found.
+* @param filename :: the filename of the opened NeXus file. Use for the file-backed case
 * @param mei :: MDEventWorkspace/MDHisto to load experiment infos to or rather
 *pointer to the base class of this workspaces (which is an experimentInfo)
 * @param lazy :: If true, use the FileBackedExperimentInfo class to only load
 * the data from the file when it is requested
 */
-void MDBoxFlatTree::loadExperimentInfos(
-    ::NeXus::File *const file,
+void MDBoxFlatTree::loadExperimentInfos(::NeXus::File *const file, const std::string &filename,
     boost::shared_ptr<Mantid::API::MultipleExperimentInfos> mei,
     bool lazy) {
   // First, find how many experimentX blocks there are
@@ -449,7 +449,7 @@ void MDBoxFlatTree::loadExperimentInfos(
     std::string groupName = "experiment" + Kernel::Strings::toString(*itr);
     if (lazy) {
       auto ei = boost::make_shared<API::FileBackedExperimentInfo>(
-        file, file->getPath() + "/" + groupName);
+        filename, file->getPath() + "/" + groupName);
       // And add it to the mutliple experiment info.
       mei->addExperimentInfo(ei);
      }


### PR DESCRIPTION
Fixes trac issue [#11220](http://trac.mantidproject.org/mantid/ticket/11220)

**Tester**

The following script will crash with the current version of master. After this fix the script should complete successfully. You can also run the `MDWorkspaceTest` system tests.

``` python
import os

from mantid.simpleapi import *

barefilename = "cncs.nxs"
try:
    os.remove(os.path.join(config["defaultsave.directory"], barefilename))
except OSError:
    pass

# Load then convert to Q in the lab frame
LoadEventNexus(Filename=r'CNCS_7860_event.nxs',OutputWorkspace='cncs_nxs')

ConvertToDiffractionMDWorkspace(InputWorkspace='cncs_nxs', OutputWorkspace='cncs_original', SplitInto=2)
alg = SaveMD(InputWorkspace='cncs_original', Filename=barefilename)

# Load into memory
LoadMD(Filename=barefilename,FileBackEnd='0',Memory='100',OutputWorkspace='cncs_mem')

# ======== File + mem, with write buffer ===========
LoadMD(Filename='cncs.nxs',FileBackEnd='1',Memory='100',OutputWorkspace='cncs_file')
PlusMD(LHSWorkspace="cncs_file", RHSWorkspace="cncs_mem", OutputWorkspace="cncs_file")
BinMD(InputWorkspace="cncs_file",AlignedDim0='Q_lab_x, -3, 3, 100',AlignedDim1='Q_lab_y, -3, 3, 100',AlignedDim2='Q_lab_z, -3, 3, 100',ForceOrthogonal='1',OutputWorkspace="test_binned")

DeleteWorkspace('cncs_file')
```
