### PR TITLE
Use a stricter regex for config file searching in EQSANSLoad

### DIFF
--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -124,7 +124,7 @@ std::string EQSANSLoad::findConfigFile(const int &run) {
 
   int max_run_number = 0;
   std::string config_file = "";
-  static boost::regex re1("eqsans_configuration\\.([0-9]+)");
+  static boost::regex re1("eqsans_configuration\\.([0-9]+)$");
   boost::smatch matches;
   for (; it != searchPaths.end(); ++it) {
     Poco::DirectoryIterator file_it(*it);


### PR DESCRIPTION
This fixes the finder behaviour when the directory paths contain a file with a matching prefix but an additional suffix, e.g. .md5.stamp

**Tester**

All tests should still pass. A code review should be sufficient.
