### PR TITLE
Fix master_doctest

### DIFF
--- a/Code/Mantid/docs/source/algorithms/PhaseQuad-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PhaseQuad-v1.rst
@@ -40,7 +40,7 @@ Usage
 .. testcode:: ExPhaseQuadList
 
    # Load a set of spectra from a EMU file
-   ws = LoadMuonNexus('EMU00006473.nxs')
+   ws = LoadMuonNexus('emu00006473.nxs')
 
    # Create a PhaseList file with some arbitrary detector information
    import os
@@ -79,7 +79,7 @@ Output:
 .. testcode:: ExPhaseQuadTable
 
    # Load a set of spectra from a EMU file
-   ws = LoadMuonNexus('EMU00006473.nxs')
+   ws = LoadMuonNexus('emu00006473.nxs')
 
    # Create a PhaseTable with some arbitrary detector information
    tab = CreateEmptyTableWorkspace()


### PR DESCRIPTION
Fixes [#11269](http://trac.mantidproject.org/mantid/ticket/11269).

For tester: code review. Master doc tests are failing because PhaseQuad-v1.rst loads EMU00006473.nxs instead of emu00006473.nxs.
