### PR TITLE
Fix cppcheck warning in CorelliCrossCorrelate

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
@@ -194,20 +194,9 @@ void CorelliCrossCorrelate::exec() {
     EventList *evlist = outputWS->getEventListPtr(i);
     IDetector_const_sptr detector = inputWS->getDetector(i);
 
-    switch (evlist->getEventType()) {
-    case TOF:
-      // Switch to weights if needed.
+    // Switch to weighted if needed.
+    if (evlist->getEventType() == TOF)
       evlist->switchTo(WEIGHTED);
-    /* no break */
-    // Fall through
-    case WEIGHTED:
-      break;
-    case WEIGHTED_NOTIME:
-      // Should never get here
-      throw std::runtime_error(
-          "This event list has no pulse time information.");
-      break;
-    }
 
     std::vector<WeightedEvent> &events = evlist->getWeightedEvents();
 


### PR DESCRIPTION
Fixes [#11281](http://trac.mantidproject.org/mantid/ticket/11281)

The EventType case is not need as it is checked in validateInputs.

**To Test**: If it passes the unit tests then all good.
