### PR TITLE
Fix doxygen warnings in LoadSavuTomoConfig and InternetHelper

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadSavuTomoConfig.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadSavuTomoConfig.cpp
@@ -102,14 +102,16 @@ bool LoadSavuTomoConfig::checkOpenFile(std::string fname,
  * Loads a tomography parameterization file into a newly created table
  * workspace. The file must have the following syntax:
  *
- * <NXentry name="entry1">
- *   <NXprocess name="processing">
- *     <NXnote name="id">
- *       <values id="ID VALUE" params="..." name="..." cite="...">
- *       </values>
- *     </NXnote>
- *   </NXprocess>
- * </NXentry>
+ * @verbatim
+ <NXentry name="entry1">
+   <NXprocess name="processing">
+     <NXnote name="id">
+       <values id="ID VALUE" params="..." name="..." cite="...">
+       </values>
+     </NXnote>
+   </NXprocess>
+ </NXentry>
+@endverbatim
  *
  * @param fname name of the parameterization file
  * @param wsName name of workspace where to load the file data

--- a/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
@@ -416,7 +416,7 @@ int InternetHelper::downloadFile(const std::string &urlFile,
 void InternetHelper::setTimeout(int seconds) { m_timeout = seconds; }
 
 /// Checks the HTTP status to decide if this is a relocation
-/// @response the HTTP status
+/// @param response the HTTP status
 /// @returns true if the return code is considered a relocation
 bool InternetHelper::isRelocated(const int response) {
   return ((response == HTTP_FOUND) ||


### PR DESCRIPTION
This is a quick PR to fix a few doxygen warnings. The commits refer to the tickets/branches were these come from: [#11067](http://trac.mantidproject.org/mantid/ticket/11067), and #[10889](http://trac.mantidproject.org/mantid/ticket/10889)

To test: code review would be enough.
