### PR TITLE
Fix for LoadMD

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -442,7 +442,7 @@ CoordTransform *LoadMD::loadAffineMatrix(std::string entry_name) {
   outD--;
   Matrix<coord_t> mat(vec);
   CoordTransform *transform = NULL;
-  if ("CoordTransformAffine" == type) {
+  if (("CoordTransformAffine" == type)||("CoordTransformAligned" == type)) {
     CoordTransformAffine *affine = new CoordTransformAffine(inD, outD);
     affine->setMatrix(mat);
     transform = affine;


### PR DESCRIPTION
This is ticket [#10543](http://trac.mantidproject.org/mantid/ticket/10543). To test create an MD event workspace and use BinMD with axis aligned option. Save it. Load the saved file and save it again.
