### PR TITLE
Fix broken doctest for RecordPythonScript

### DIFF
--- a/Code/Mantid/docs/source/algorithms/RecordPythonScript-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/RecordPythonScript-v1.rst
@@ -66,7 +66,7 @@ Output:
     :options: +NORMALIZE_WHITESPACE
 
     The result file has the following python recorded
-    CreateSampleWorkspace(OutputWorkspace='ws',WorkspaceType='Event',Function='Multiple Peaks',UserDefinedFunction='',NumBanks='2',BankPixelWidth='10',NumEvents='1000',Random='0',XUnit='TOF',XMin='0',XMax='20000',BinWidth='200')
+    CreateSampleWorkspace(OutputWorkspace='ws',WorkspaceType='Event',Function='Multiple Peaks',UserDefinedFunction='',NumBanks='2',BankPixelWidth='10',NumEvents='1000',Random='0',XUnit='TOF',XMin='0',XMax='20000',BinWidth='200',PixelSpacing='0.0080000000000000002',BankDistanceFromSample='5')
     CreateFlatEventWorkspace(InputWorkspace='ws',RangeStart='15000',RangeEnd='18000',OutputWorkspace='wsOut')
     RebinToWorkspace(WorkspaceToRebin='wsOut',WorkspaceToMatch='ws',OutputWorkspace='wsOut',PreserveEvents='1')
 


### PR DESCRIPTION
As part of [#9052](http://trac.mantidproject.org/mantid/ticket/9052) I updated CreateSampleWorkspace, on of the doctests writes out the history of running this algorithm as part of it's expected output. Since I added two new properties, the expected and actual results no longer match. See [#11307](http://trac.mantidproject.org/mantid/ticket/11307)
