### PR TITLE
Clean up line breaks

### DIFF
--- a/Code/Mantid/Framework/LiveData/inc/MantidLiveData/Exception.h
+++ b/Code/Mantid/Framework/LiveData/inc/MantidLiveData/Exception.h
@@ -10,18 +10,15 @@ namespace Mantid {
 namespace LiveData {
 namespace Exception {
 
-/** An exception that can be thrown by an ILiveListener implementation to notify
-   LoadLiveData
-    that it is not yet ready to return data. This could be, for example, because
-   it has not
-    yet completed its initialisation step or if the instrument from which data
-   is being read
-    is not in a run. LoadLiveData will ask for data again after a short delay.
-    Other exceptions thrown by the listener will have the effect of stopping the
-   algorithm.
+/** An exception that can be thrown by an ILiveListener implementation to
+    notify LoadLiveData that it is not yet ready to return data. This could
+    be, for example, because it has not yet completed its initialisation step
+    or if the instrument from which data is being read is not in a run.
+    LoadLiveData will ask for data again after a short delay.  Other exceptions
+    thrown by the listener will have the effect of stopping the algorithm.
 
     Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
-   National Laboratory & European Spallation Source
+    National Laboratory & European Spallation Source
 
     This file is part of Mantid.
 

--- a/Code/Mantid/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
+++ b/Code/Mantid/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
@@ -63,8 +63,8 @@ public:
 
   bool isConnected();
 
-  virtual void run(); // the background thread.  What gets executed when we call
-                      // POCO::Thread::start()
+  virtual void run(); // the background thread.  What gets executed when we
+                      // call POCO::Thread::start()
 protected:
   using ADARA::Parser::rxPacket;
   // virtual bool rxPacket( const ADARA::Packet &pkt);
@@ -88,19 +88,17 @@ private:
 
   // We need data from both the geometry packet and the run status packet in
   // order to run the second part of the initialization.  Since I don't know
-  // what
-  // order the packets will arrive in, I've put the necessary code in this
-  // function.  Both rxPacket() functions will check to see if all the data is
-  // available and call this function if it is.
+  // what order the packets will arrive in, I've put the necessary code in
+  // this function.  Both rxPacket() functions will check to see if all the
+  // data is available and call this function if it is.
   void initWorkspacePart2();
 
   void initMonitorWorkspace();
 
   // Check to see if all the conditions we need for initWorkspacePart2() have
-  // been
-  // met.  Making this a function because it's starting to get a little
-  // complicated
-  // and I didn't want to be repeating the same tests in several places...
+  // been met.  Making this a function because it's starting to get a little
+  // complicated and I didn't want to be repeating the same tests in several
+  // places...
   bool readyForInitPart2() {
     if (m_instrumentXML.size() == 0)
       return false;
@@ -120,8 +118,7 @@ private:
   // tof is "Time Of Flight" and is in units of microsecondss relative to the
   // start of the pulse
   // (There's some documentation that says nanoseconds, but Russell Taylor
-  // assures me it's really
-  // is microseconds!)
+  // assures me it's really is microseconds!)
   // pulseTime is the start of the pulse relative to Jan 1, 1990.
   // Both values are designed to be passed straight into the TofEvent
   // constructor.
@@ -140,12 +137,13 @@ private:
   std::string m_instrumentName;
   std::string m_instrumentXML;
 
-  std::vector<std::string> m_requiredLogs; // Names of log values that we need
-                                           // before we can initialize
-  // m_buffer.  We get the names by parsing m_instrumentXML;
-  std::vector<std::string> m_monitorLogs; // Names of any monitor logs (these
-                                          // must be manually removed
-                                          // during the call to extractData())
+  // Names of log values that we need before we can initialize m_buffer.
+  // We get the names by parsing m_instrumentXML;
+  std::vector<std::string> m_requiredLogs;
+  
+  // Names of any monitor logs (these must be manually removed during the call
+  // to extractData())
+  std::vector<std::string> m_monitorLogs;
 
   Poco::Net::StreamSocket m_socket;
   bool m_isConnected;
@@ -153,34 +151,30 @@ private:
   Poco::Thread m_thread;
   Poco::FastMutex m_mutex; // protects m_buffer & m_status
   bool m_pauseNetRead;
-  bool
-      m_stopThread; // background thread checks this periodically.  If true, the
-                    // thread exits
+  bool m_stopThread; // background thread checks this periodically.  
+                     // If true, the thread exits
 
   Kernel::DateAndTime
       m_startTime; // The requested start time for the data stream
                    // (needed by the run() function)
 
   // Used to initialize the scan_index property if we haven't received a packet
-  // with the
-  // 'real' value by the time we call initWorkspacePart2.  (We can't delay the
-  // call to
-  // initWorkspacePart2 because we might never receive a 'real' value for that
-  // property.
+  // with the 'real' value by the time we call initWorkspacePart2.  (We can't
+  // delay the call to initWorkspacePart2 because we might never receive a
+  // 'real' value for that property.
   Kernel::DateAndTime m_dataStartTime;
 
   // These 2 determine whether or not we filter out events that arrive when
   // the run is paused.
   bool m_runPaused; // Set to true or false when we receive a pause/resume
-                    // marker in an
-  // annotation packet. (See rxPacket( const ADARA::AnnotationPkt &pkt))
+                    // marker in an annotation packet. (See
+                    // rxPacket( const ADARA::AnnotationPkt &pkt))
   int m_keepPausedEvents; // Set from a configuration property. (Should be a
-                          // bool, but
-  // appearantly, we can't read bools from the config file?!?)
+                          // bool, but appearantly, we can't read bools from
+                          // the config file?!?)
 
   // Holds on to any exceptions that were thrown in the background thread so
-  // that we
-  // can re-throw them in the forground thread
+  // that we can re-throw them in the forground thread
   boost::shared_ptr<std::runtime_error> m_backgroundException;
 
   // --- Data structures necessary for handling all the process variable info
@@ -194,16 +188,12 @@ private:
   // ---------------------------------------------------------------------------
 
   // In cases where we're replaying historical data from the SMS, we're likely
-  // to get
-  // multiple value packets for various values, but we only want to process the
-  // most
-  // recent one.  Unfortunately, the only way to do this is to hold the packets
-  // in a
-  // cache until the SMS works its way through the older data and starts sending
-  // out
-  // the data we actual want.  At that point, we need to parse whatever variable
-  // value
-  // packets we have in order to set the state of the system properly.
+  // to get multiple value packets for various values, but we only want to
+  // process the most recent one.  Unfortunately, the only way to do this is to
+  // hold the packets in a cache until the SMS works its way through the older
+  // data and starts sending out the data we actual want.  At that point, we
+  // need to parse whatever variable value packets we have in order to set the
+  // state of the system properly.
 
   // Maps the device ID / variable ID pair to the actual packet.  Using a map
   // means we will only keep one packet (the most recent one) for each variable
@@ -219,10 +209,8 @@ private:
   bool m_filterUntilRunStart;
 
   // Called by the rxPacket() functions to determine if the packet should be
-  // processed
-  // (Depending on when it last indexed its data, SMS might send us packets that
-  // are
-  // older than we requested.)
+  // processed. (Depending on when it last indexed its data, SMS might send us
+  // packets that are older than we requested.)
   // Returns false if the packet should be processed, true if is should be
   // ignored
   bool
@@ -231,9 +219,8 @@ private:
   void setRunDetails(const ADARA::RunStatusPkt &pkt);
 
   // We have to defer calling setRunDetails() at the start of a run until the
-  // foreground thread has called
-  // extractData() and retrieved the last data from the previous state (which
-  // was probably NO_RUN).
+  // foreground thread has called extractData() and retrieved the last data
+  // from the previous state (which was probably NO_RUN).
   // This holds a copy of the RunStatusPkt until we can call setRunDetails().
   boost::shared_ptr<ADARA::RunStatusPkt> m_deferredRunDetailsPkt;
 };

--- a/Code/Mantid/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Code/Mantid/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -56,9 +56,8 @@ namespace Mantid {
 namespace LiveData {
 DECLARE_LISTENER(SNSLiveEventDataListener);
 // The DECLARE_LISTENER macro seems to confuse some editors' syntax checking.
-// The
-// semi-colon limits the complaints to one line.  It has no actual effect on the
-// code.
+// The semi-colon limits the complaints to one line.  It has no actual effect
+// on the code.
 
 namespace {
 /// static logger
@@ -72,8 +71,7 @@ SNSLiveEventDataListener::SNSLiveEventDataListener()
       m_pauseNetRead(false), m_stopThread(false), m_runPaused(false),
       m_ignorePackets(true), m_filterUntilRunStart(false)
 // ADARA::Parser() will accept values for buffer size and max packet size, but
-// the
-// defaults will work fine
+// the defaults will work fine
 {
 
   // Perform all the workspace initialization steps (including actually creating
@@ -82,8 +80,7 @@ SNSLiveEventDataListener::SNSLiveEventDataListener()
 
   // Initialize m_keepPausedEvents from the config file.
   // NOTE: To the best of my knowledge, the existence of this property is not
-  // documented
-  // anywhere and this lack of documentation is deliberate.
+  // documented anywhere and this lack of documentation is deliberate.
   if (!ConfigService::Instance().getValue("livelistener.keeppausedevents",
                                           m_keepPausedEvents)) {
     // If the property hasn't been set, assume false
@@ -109,9 +106,8 @@ SNSLiveEventDataListener::~SNSLiveEventDataListener() {
       // a buffer that's going to be deleted.
       // Chose segfault - at least that's obvious.
       g_log.fatal() << "SNSLiveEventDataListener failed to shut down its "
-                       "background thread! "
-                    << "This should never happen and Mantid is pretty much "
-                       "guaranteed to crash shortly.  "
+                    << "background thread!  This should never happen and "
+                    << "Mantid is pretty much guaranteed to crash shortly.  "
                     << "Talk to the Mantid developer team." << std::endl;
     }
   }
@@ -175,11 +171,10 @@ bool SNSLiveEventDataListener::isConnected() { return m_isConnected; }
 /// Start the background thread
 
 /// Starts the background thread which reads data from the network, parses it
-/// and
-/// stores the resulting events in a temporary workspace.
+/// and stores the resulting events in a temporary workspace.
 /// @param startTime Specifies how much historical data the SMS should send
-/// before continuing
-/// the current 'live' data.  Use 0 to indicate no historical data.
+/// before continuing the current 'live' data.  Use 0 to indicate no
+/// historical data.
 void SNSLiveEventDataListener::start(Kernel::DateAndTime startTime) {
   // Save the startTime and kick off the background thread
   // (Can't really do anything else until we send the hello packet and the SMS
@@ -193,11 +188,9 @@ void SNSLiveEventDataListener::start(Kernel::DateAndTime startTime) {
     // at the start of the previous run (and it doesn't know when the previous
     // run started).  This value for a start time will cause the SMS to replay
     // all of its historical data and it will be up to us to filter out
-    // everything
-    // before the start of the previous run.
+    // everything before the start of the previous run.
     // See the description of the 'Client Hello' packet in the SNS DAS design
-    // doc
-    // for more details
+    // doc for more details
     m_filterUntilRunStart = true;
   }
   m_thread.start(*this);
@@ -206,10 +199,8 @@ void SNSLiveEventDataListener::start(Kernel::DateAndTime startTime) {
 /// The main function for the background thread
 
 /// Loops until the forground thread requests it to stop.  Reads data from the
-/// network,
-/// parses it and stores the resulting events (and other metadata) in a
-/// temporary
-/// workspace.
+/// network, parses it and stores the resulting events (and other metadata) in
+/// a temporary workspace.
 void SNSLiveEventDataListener::run() {
   try {
     if (m_isConnected == false) // sanity check
@@ -286,12 +277,10 @@ void SNSLiveEventDataListener::run() {
     // uncaught exception.  In such a case, the thread will exit and there's
     // nothing we can do about that.  We'll log an error and save a copy of the
     // exception object so that we can re-throw it from the foreground thread
-    // (which
-    // will cause the algorithm to exit).
+    // (which will cause the algorithm to exit).
     // NOTE: For the default exception handler, we actually create a new
-    // runtime_error
-    // object and throw that, since there's no exception object passed in to the
-    // handler.
+    // runtime_error object and throw that, since there's no exception object
+    // passed in to the handler.
   } catch (ADARA::invalid_packet &e) { // exception handler for invalid packets
     // For now, log it and let the thread exit.  In the future, we might
     // try to recover from this.  (A bad event packet could probably just
@@ -1369,8 +1358,7 @@ boost::shared_ptr<Workspace> SNSLiveEventDataListener::extractData() {
   // (Which won't happen until the SMS sends it the packet with the geometry
   // information in it.)
   // First wait up to 10 seconds, then if it's still not initialized throw a
-  // NotYet
-  // exception so that the user has the opportunity to cancel.
+  // NotYet exception so that the user has the opportunity to cancel.
   static const double maxBlockTime = 10.0;
   const DateAndTime endTime = DateAndTime::getCurrentTime() + maxBlockTime;
   while ((!m_workspaceInitialized) &&


### PR DESCRIPTION
At some point, an automated tool was used to limit line lengths to 80
characters.  This tool made some less-than-optimal choices about where
to break the lines.  This change cleans that up.  No actual code or
functionality changes.

Refs #11314
