### PR TITLE
Fix for time step issue in the VSI

### DIFF
--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -181,6 +181,7 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
       // data set. We therefore feed m_time the first time step of this source at 
       // start up.
       m_time = m_startupTimeValue;
+      m_isStartup = false;
     }
     else if (outInfo->Has(vtkStreamingDemandDrivenPipeline::UPDATE_TIME_STEP()))
     {


### PR DESCRIPTION
This fixes issue [11327](http://trac.mantidproject.org/mantid/ticket/11327)

Please find a test workspace attached  to the original ticket.

For testing:

TEST TIME PLAYER
1. Load the Workspace into the VSI
2. Switch to the standard view
3. Press the time player button
4. Confirm that the image is changing

TEST SLICE:
1. Load the workspace into the VSI
2. Press the scale filter , set it to 2 in the x direction for example
3. Press the SliceMD option. Leave the settings and press ok. 
4. Confirm that the created image looks "normal", i.e. it has color values
5. Remove the rebinning. 
6. Confirm that original source is back and also looks "normal", i.e. it has color values
