### PR TITLE
Add unit tests for existing remote algorithms (+ SimpleJSON)

### DIFF
--- a/Code/Mantid/Framework/RemoteAlgorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/RemoteAlgorithms/CMakeLists.txt
@@ -5,12 +5,12 @@ set( SRC_FILES
   src/QueryAllRemoteJobs.cpp
   src/QueryRemoteFile.cpp
   src/QueryRemoteJob.cpp
+  src/SCARFTomoReconstruction.cpp
   src/SimpleJSON.cpp
   src/StartRemoteTransaction.cpp
   src/StopRemoteTransaction.cpp
   src/SubmitRemoteJob.cpp
   src/UploadRemoteFile.cpp
-  src/SCARFTomoReconstruction.cpp
 )
 
 set( INC_FILES
@@ -20,16 +20,27 @@ set( INC_FILES
   inc/MantidRemoteAlgorithms/QueryAllRemoteJobs.h
   inc/MantidRemoteAlgorithms/QueryRemoteJob.h
   inc/MantidRemoteAlgorithms/QueryRemoteFile.h
+  inc/MantidRemoteAlgorithms/SCARFTomoReconstruction.h
   inc/MantidRemoteAlgorithms/SimpleJSON.h
   inc/MantidRemoteAlgorithms/StartRemoteTransaction.h
   inc/MantidRemoteAlgorithms/StopRemoteTransaction.h
   inc/MantidRemoteAlgorithms/SubmitRemoteJob.h
   inc/MantidRemoteAlgorithms/UploadRemoteFile.h
-  inc/MantidRemoteAlgorithms/SCARFTomoReconstruction.h
 )
 
 set ( TEST_FILES
+  AbortRemoteJobTest.h
+  AuthenticateTest.h
+  DownloadRemoteFileTest.h
+  QueryAllRemoteJobsTest.h
+  QueryRemoteJobTest.h
+  QueryRemoteFileTest.h
   SCARFTomoReconstructionTest.h
+  SimpleJSONTest.h
+  StartRemoteTransactionTest.h
+  StopRemoteTransactionTest.h
+  SubmitRemoteJobTest.h
+  UploadRemoteFileTest.h
 )
 
 #set ( TEST_PY_FILES

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/AbortRemoteJob.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/AbortRemoteJob.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class AbortRemoteJob : public Mantid::API::Algorithm {
+class DLLExport AbortRemoteJob : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   AbortRemoteJob() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/Authenticate.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/Authenticate.h
@@ -46,7 +46,7 @@ namespace RemoteAlgorithms {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
     */
 
-class Authenticate : public Mantid::API::Algorithm {
+class DLLExport Authenticate : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   Authenticate() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/DownloadRemoteFile.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/DownloadRemoteFile.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class DownloadRemoteFile : public Mantid::API::Algorithm {
+class DLLExport DownloadRemoteFile : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   DownloadRemoteFile() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/QueryAllRemoteJobs.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/QueryAllRemoteJobs.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class QueryAllRemoteJobs : public Mantid::API::Algorithm {
+class DLLExport QueryAllRemoteJobs : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   QueryAllRemoteJobs() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/QueryRemoteFile.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/QueryRemoteFile.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class QueryRemoteFile : public Mantid::API::Algorithm {
+class DLLExport QueryRemoteFile : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   QueryRemoteFile() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/QueryRemoteJob.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/QueryRemoteJob.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class QueryRemoteJob : public Mantid::API::Algorithm {
+class DLLExport QueryRemoteJob : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   QueryRemoteJob() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SimpleJSON.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SimpleJSON.h
@@ -20,6 +20,8 @@
 #include <istream>
 #include <ostream>
 
+#include "MantidKernel/System.h"
+
 class JSONValue;
 typedef std::map<std::string, JSONValue> JSONObject;
 typedef std::vector<JSONValue> JSONArray;
@@ -40,7 +42,7 @@ void prettyPrint(const JSONObject &obj, std::ostream &ostr,
 
 class JSONException;
 
-class JSONValue {
+class DLLExport JSONValue {
 public:
   enum VALUE_TYPE { NULLTYPE, BOOL, NUMBER, STRING, ARRAY, OBJECT };
 
@@ -90,7 +92,7 @@ private:
   };
 };
 
-class JSONException : public std::exception {
+class DLLExport JSONException : public std::exception {
 public:
   JSONException(const std::string &msg) : m_msg(msg) {}
   const std::string &getMsg() const { return m_msg; }
@@ -103,17 +105,17 @@ private:
   std::string m_msg;
 };
 
-class JSONCopyException : public JSONException {
+class DLLExport JSONCopyException : public JSONException {
 public:
   JSONCopyException(const std::string &msg) : JSONException(msg) {}
 };
 
-class JSONAssignmentException : public JSONException {
+class DLLExport JSONAssignmentException : public JSONException {
 public:
   JSONAssignmentException(const std::string &msg) : JSONException(msg) {}
 };
 
-class JSONParseException : public JSONException {
+class DLLExport JSONParseException : public JSONException {
 public:
   JSONParseException(const std::string &msg) : JSONException(msg) {}
 };

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SimpleJSON.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SimpleJSON.h
@@ -31,14 +31,14 @@ typedef std::vector<JSONValue> JSONArray;
 
 // This is the "public" initialization function.  Since JSONObject
 // is just a typedef, there's no way to make it a constructor.
-void initFromStream(JSONObject &obj, std::istream &istr);
+void DLLExport initFromStream(JSONObject &obj, std::istream &istr);
 
 // A "public" function for formatted output.  It's sort of assumed
 // that ostr will actually be std::cout or std::cerr, but it can
 // be any output stream.  This function mostly exists for debugging
 // purposes.
-void prettyPrint(const JSONObject &obj, std::ostream &ostr,
-                 unsigned indentLevel);
+void DLLExport prettyPrint(const JSONObject &obj, std::ostream &ostr,
+                           unsigned indentLevel);
 
 class JSONException;
 

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/StartRemoteTransaction.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/StartRemoteTransaction.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class StartRemoteTransaction : public Mantid::API::Algorithm {
+class DLLExport StartRemoteTransaction : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   StartRemoteTransaction() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/StopRemoteTransaction.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/StopRemoteTransaction.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace RemoteAlgorithms {
 
-class StopRemoteTransaction : public Mantid::API::Algorithm {
+class DLLExport StopRemoteTransaction : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   StopRemoteTransaction() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SubmitRemoteJob.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/inc/MantidRemoteAlgorithms/SubmitRemoteJob.h
@@ -54,7 +54,7 @@ namespace RemoteAlgorithms {
     Code Documentation is available at: <http://doxygen.mantidproject.org>
     */
 
-class SubmitRemoteJob : public Mantid::API::Algorithm {
+class DLLExport SubmitRemoteJob : public Mantid::API::Algorithm {
 public:
   /// (Empty) Constructor
   SubmitRemoteJob() : Mantid::API::Algorithm() {}

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
@@ -31,12 +31,11 @@ public:
     TS_ASSERT(a = boost::make_shared<AbortRemoteJob>());
     // can cast to inherited interfaces and base classes
 
-    AbortRemoteJob alg;
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::AbortRemoteJob *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::AbortRemoteJob *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
@@ -31,7 +31,8 @@ public:
     TS_ASSERT(a = boost::make_shared<AbortRemoteJob>());
     // can cast to inherited interfaces and base classes
 
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::AbortRemoteJob *>(a.get()));
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::AbortRemoteJob *>(a.get()));
     TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
     TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
     TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
@@ -71,7 +71,7 @@ public:
     TS_ASSERT(!alg3.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     AbortRemoteJob ab;
     TS_ASSERT_THROWS_NOTHING(ab.initialize();)
     TS_ASSERT_THROWS(ab.setPropertyValue("ComputeRes", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AbortRemoteJobTest.h
@@ -1,0 +1,126 @@
+#ifndef MANTID_REMOTEALGORITHMS_ABORTREMOTEJOBTEST_H_
+#define MANTID_REMOTEALGORITHMS_ABORTREMOTEJOBTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/AbortRemoteJob.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class AbortRemoteJobTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static AbortRemoteJobTest *createSuite() { return new AbortRemoteJobTest(); }
+  static void destroySuite(AbortRemoteJobTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "AbortRemoteJob" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "AbortRemoteJob");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<AbortRemoteJob> a;
+    TS_ASSERT(a = boost::make_shared<AbortRemoteJob>());
+    // can cast to inherited interfaces and base classes
+
+    AbortRemoteJob alg;
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::AbortRemoteJob *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    AbortRemoteJob auth;
+    TS_ASSERT_THROWS_NOTHING(auth.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    AbortRemoteJob alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // id missing
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    AbortRemoteJob alg3;
+    TS_ASSERT_THROWS_NOTHING(alg3.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(alg1.setPropertyValue("JobID", "john_missing"));
+
+    TS_ASSERT_THROWS(alg3.execute(), std::runtime_error);
+    TS_ASSERT(!alg3.isExecuted());
+  }
+
+  void test_wronProperty() {
+    AbortRemoteJob ab;
+    TS_ASSERT_THROWS_NOTHING(ab.initialize();)
+    TS_ASSERT_THROWS(ab.setPropertyValue("ComputeRes", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(ab.setPropertyValue("username", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(ab.setPropertyValue("sername", "anything"),
+                     std::runtime_error);
+  }
+
+  void test_wrongResource() {
+    AbortRemoteJob ab;
+    TS_ASSERT_THROWS_NOTHING(ab.initialize());
+    // the compute resource given  does not exist:
+    TS_ASSERT_THROWS(ab.setPropertyValue("ComputeResource", "missing c r!"),
+                     std::invalid_argument);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      AbortRemoteJob ab;
+      TS_ASSERT_THROWS_NOTHING(ab.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          ab.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(ab.setPropertyValue("JobID", "000001"));
+      // TODO: this will run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(ab.execute(), std::exception);
+      TS_ASSERT(!ab.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_ABORTREMOTEJOBTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AuthenticateTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AuthenticateTest.h
@@ -31,12 +31,11 @@ public:
     TS_ASSERT(a = boost::make_shared<Authenticate>());
     // can cast to inherited interfaces and base classes
 
-    Authenticate alg;
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::Authenticate *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::Authenticate *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AuthenticateTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AuthenticateTest.h
@@ -1,0 +1,132 @@
+#ifndef MANTID_REMOTEALGORITHMS_AUTHENTICATETEST_H_
+#define MANTID_REMOTEALGORITHMS_AUTHENTICATETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/Authenticate.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class AuthenticateTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static AuthenticateTest *createSuite() { return new AuthenticateTest(); }
+  static void destroySuite(AuthenticateTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "Authenticate" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "Authenticate");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<Authenticate> a;
+    TS_ASSERT(a = boost::make_shared<Authenticate>());
+    // can cast to inherited interfaces and base classes
+
+    Authenticate alg;
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::Authenticate *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    Authenticate auth;
+    TS_ASSERT_THROWS_NOTHING(auth.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    Authenticate alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // password missing
+    TS_ASSERT_THROWS_NOTHING(alg1.setPropertyValue("UserName", "john_missing"));
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    Authenticate alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // username missing
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("Password", "LogIn"));
+    TS_ASSERT_THROWS(alg2.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+
+    Authenticate alg3;
+    TS_ASSERT_THROWS_NOTHING(alg3.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("UserName", "john_missing"));
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("Password", "LogIn"));
+
+    TS_ASSERT_THROWS(alg3.execute(), std::runtime_error);
+    TS_ASSERT(!alg3.isExecuted());
+  }
+
+  void test_wronProperty() {
+    Authenticate auth;
+    TS_ASSERT_THROWS_NOTHING(auth.initialize());
+    TS_ASSERT_THROWS(auth.setPropertyValue("usernam", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(auth.setPropertyValue("sername", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(auth.setPropertyValue("Passwo", "anything"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      Authenticate auth;
+      TS_ASSERT_THROWS_NOTHING(auth.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          auth.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(
+          auth.setPropertyValue("UserName", "john_missing"));
+      TS_ASSERT_THROWS_NOTHING(auth.setPropertyValue("Password", "LogIn"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(auth.execute(), std::exception);
+      TS_ASSERT(!auth.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_AUTHENTICATETEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/AuthenticateTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/AuthenticateTest.h
@@ -83,7 +83,7 @@ public:
     TS_ASSERT(!alg3.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     Authenticate auth;
     TS_ASSERT_THROWS_NOTHING(auth.initialize());
     TS_ASSERT_THROWS(auth.setPropertyValue("usernam", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/DownloadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/DownloadRemoteFileTest.h
@@ -88,7 +88,7 @@ public:
     TS_ASSERT(!alg3.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     DownloadRemoteFile dl;
     TS_ASSERT_THROWS_NOTHING(dl.initialize();)
     TS_ASSERT_THROWS(dl.setPropertyValue("Compute", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/DownloadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/DownloadRemoteFileTest.h
@@ -33,13 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<DownloadRemoteFile>());
 
     // can cast to inherited interfaces and base classes
-    DownloadRemoteFile alg;
     TS_ASSERT(
-        dynamic_cast<Mantid::RemoteAlgorithms::DownloadRemoteFile *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+        dynamic_cast<Mantid::RemoteAlgorithms::DownloadRemoteFile *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/DownloadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/DownloadRemoteFileTest.h
@@ -1,0 +1,138 @@
+#ifndef MANTID_REMOTEALGORITHMS_DOWNLOADREMOTEFILETEST_H_
+#define MANTID_REMOTEALGORITHMS_DOWNLOADREMOTEFILETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/DownloadRemoteFile.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class DownloadRemoteFileTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static DownloadRemoteFileTest *createSuite() {
+    return new DownloadRemoteFileTest();
+  }
+  static void destroySuite(DownloadRemoteFileTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "DownloadRemoteFile" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "DownloadRemoteFile");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<DownloadRemoteFile> a;
+    TS_ASSERT(a = boost::make_shared<DownloadRemoteFile>());
+
+    // can cast to inherited interfaces and base classes
+    DownloadRemoteFile alg;
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::DownloadRemoteFile *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    DownloadRemoteFile dl;
+    TS_ASSERT_THROWS_NOTHING(dl.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    DownloadRemoteFile alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // Transaction id missing
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS_NOTHING(
+        alg1.setPropertyValue("RemoteFileName", "file name"));
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    DownloadRemoteFile alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // file name missing
+    TS_ASSERT_THROWS(alg2.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("TransactionID", "id001"));
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+
+    DownloadRemoteFile alg3;
+    TS_ASSERT_THROWS_NOTHING(alg3.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("RemoteFileName", "file name"));
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("TransactionID", "id001"));
+
+    TS_ASSERT_THROWS(alg3.execute(), std::runtime_error);
+    TS_ASSERT(!alg3.isExecuted());
+  }
+
+  void test_wronProperty() {
+    DownloadRemoteFile dl;
+    TS_ASSERT_THROWS_NOTHING(dl.initialize();)
+    TS_ASSERT_THROWS(dl.setPropertyValue("Compute", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(dl.setPropertyValue("TransID", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(dl.setPropertyValue("FileName", "anything"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      DownloadRemoteFile dl;
+      TS_ASSERT_THROWS_NOTHING(dl.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          dl.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(
+          dl.setPropertyValue("TransactionID", "anything"));
+      TS_ASSERT_THROWS_NOTHING(
+          dl.setPropertyValue("RemoteFileName", "anything"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(dl.execute(), std::exception);
+      TS_ASSERT(!dl.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_DOWNLOADREMOTEFILETEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryAllRemoteJobsTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryAllRemoteJobsTest.h
@@ -65,7 +65,7 @@ public:
     TS_ASSERT(!qar.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     QueryAllRemoteJobs qar;
     TS_ASSERT_THROWS_NOTHING(qar.initialize();)
     TS_ASSERT_THROWS(qar.setPropertyValue("ComputeRes", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryAllRemoteJobsTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryAllRemoteJobsTest.h
@@ -1,0 +1,111 @@
+#ifndef MANTID_REMOTEALGORITHMS_QUERYALLREMOTEJOBSTEST_H_
+#define MANTID_REMOTEALGORITHMS_QUERYALLREMOTEJOBSTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/QueryAllRemoteJobs.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class QueryAllRemoteJobsTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static QueryAllRemoteJobsTest *createSuite() {
+    return new QueryAllRemoteJobsTest();
+  }
+  static void destroySuite(QueryAllRemoteJobsTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "QueryAllRemoteJobs" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "QueryAllRemoteJobs");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<QueryAllRemoteJobs> a;
+    TS_ASSERT(a = boost::make_shared<QueryAllRemoteJobs>());
+
+    // can cast to inherited interfaces and base classes
+    QueryAllRemoteJobs alg;
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::QueryAllRemoteJobs *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    QueryAllRemoteJobs qar;
+    TS_ASSERT_THROWS_NOTHING(qar.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    QueryAllRemoteJobs qar;
+    TS_ASSERT_THROWS_NOTHING(qar.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(qar.setPropertyValue("JobID", "john_missing"));
+
+    TS_ASSERT_THROWS(qar.execute(), std::runtime_error);
+    TS_ASSERT(!qar.isExecuted());
+  }
+
+  void test_wronProperty() {
+    QueryAllRemoteJobs qar;
+    TS_ASSERT_THROWS_NOTHING(qar.initialize();)
+    TS_ASSERT_THROWS(qar.setPropertyValue("ComputeRes", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(qar.setPropertyValue("TransactionID", "whatever"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(qar.setPropertyValue("ID", "whichever"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      QueryAllRemoteJobs qar;
+      TS_ASSERT_THROWS_NOTHING(qar.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          qar.setPropertyValue("ComputeResource", compName));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(qar.execute(), std::exception);
+      TS_ASSERT(!qar.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_QUERYALLREMOTEJOBSTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryAllRemoteJobsTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryAllRemoteJobsTest.h
@@ -33,13 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<QueryAllRemoteJobs>());
 
     // can cast to inherited interfaces and base classes
-    QueryAllRemoteJobs alg;
     TS_ASSERT(
-        dynamic_cast<Mantid::RemoteAlgorithms::QueryAllRemoteJobs *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+        dynamic_cast<Mantid::RemoteAlgorithms::QueryAllRemoteJobs *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteFileTest.h
@@ -74,7 +74,7 @@ public:
     TS_ASSERT(!alg2.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     QueryRemoteFile qrf;
     TS_ASSERT_THROWS_NOTHING(qrf.initialize();)
     TS_ASSERT_THROWS(qrf.setPropertyValue("Compute", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteFileTest.h
@@ -33,12 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<QueryRemoteFile>());
 
     // can cast to inherited interfaces and base classes
-    QueryRemoteFile alg;
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::QueryRemoteFile *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::QueryRemoteFile *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteFileTest.h
@@ -1,0 +1,122 @@
+#ifndef MANTID_REMOTEALGORITHMS_QUERYREMOTEFILETEST_H_
+#define MANTID_REMOTEALGORITHMS_QUERYREMOTEFILETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/QueryRemoteFile.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class QueryRemoteFileTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static QueryRemoteFileTest *createSuite() {
+    return new QueryRemoteFileTest();
+  }
+  static void destroySuite(QueryRemoteFileTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "QueryRemoteFile" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "QueryRemoteFile");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<QueryRemoteFile> a;
+    TS_ASSERT(a = boost::make_shared<QueryRemoteFile>());
+
+    // can cast to inherited interfaces and base classes
+    QueryRemoteFile alg;
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::QueryRemoteFile *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    QueryRemoteFile qrf;
+    TS_ASSERT_THROWS_NOTHING(qrf.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    QueryRemoteFile alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // Transaction id missing
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    QueryRemoteFile alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("TransactionID", "trans0001"));
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+  }
+
+  void test_wronProperty() {
+    QueryRemoteFile qrf;
+    TS_ASSERT_THROWS_NOTHING(qrf.initialize();)
+    TS_ASSERT_THROWS(qrf.setPropertyValue("Compute", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(qrf.setPropertyValue("TransID", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(qrf.setPropertyValue("ComputeResourc", "anything"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      QueryRemoteFile qrf;
+      TS_ASSERT_THROWS_NOTHING(qrf.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          qrf.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(
+          qrf.setPropertyValue("TransactionID", "anything001"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(qrf.execute(), std::exception);
+      TS_ASSERT(!qrf.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_QUERYREMOTEFILETEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteJobTest.h
@@ -31,12 +31,12 @@ public:
     TS_ASSERT(a = boost::make_shared<QueryRemoteJob>());
 
     // can cast to inherited interfaces and base classes
-    QueryRemoteJob alg;
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::QueryRemoteJob *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::QueryRemoteJob *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteJobTest.h
@@ -71,7 +71,7 @@ public:
     TS_ASSERT(!alg2.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     QueryRemoteJob qr;
     TS_ASSERT_THROWS_NOTHING(qr.initialize();)
     TS_ASSERT_THROWS(qr.setPropertyValue("job", "whatever"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/QueryRemoteJobTest.h
@@ -1,0 +1,118 @@
+#ifndef MANTID_REMOTEALGORITHMS_QUERYREMOTEJOBTEST_H_
+#define MANTID_REMOTEALGORITHMS_QUERYREMOTEJOBTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/QueryRemoteJob.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class QueryRemoteJobTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static QueryRemoteJobTest *createSuite() { return new QueryRemoteJobTest(); }
+  static void destroySuite(QueryRemoteJobTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "QueryRemoteJob" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "QueryRemoteJob");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<QueryRemoteJob> a;
+    TS_ASSERT(a = boost::make_shared<QueryRemoteJob>());
+
+    // can cast to inherited interfaces and base classes
+    QueryRemoteJob alg;
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::QueryRemoteJob *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    QueryRemoteJob qr;
+    TS_ASSERT_THROWS_NOTHING(qr.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    QueryRemoteJob alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // id missing
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    QueryRemoteJob alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("JobID", "missing001"));
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+  }
+
+  void test_wronProperty() {
+    QueryRemoteJob qr;
+    TS_ASSERT_THROWS_NOTHING(qr.initialize();)
+    TS_ASSERT_THROWS(qr.setPropertyValue("job", "whatever"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(qr.setPropertyValue("id", "whichever"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(qr.setPropertyValue("ComputeRes", "anything"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      QueryRemoteJob qr;
+      TS_ASSERT_THROWS_NOTHING(qr.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          qr.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(qr.setPropertyValue("JobID", "000001"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(qr.execute(), std::exception);
+      TS_ASSERT(!qr.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_QUERYREMOTEJOBTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
@@ -20,13 +20,19 @@ public:
     TS_ASSERT_THROWS_NOTHING(JSONValue vDbl(d));
 
     TS_ASSERT_THROWS_NOTHING(b = d);
-    TS_ASSERT_EQUALS(true, b);
-    d = 0.0;
-    TS_ASSERT_EQUALS(true, b);
 
     JSONValue vBool(b);
+    bool getBool = false;
+    TS_ASSERT_EQUALS(true, vBool.getValue(getBool));
+
     JSONValue vDbl(d);
     TS_ASSERT_THROWS_NOTHING(vBool = vDbl);
+    TS_ASSERT_EQUALS(false, vBool.getValue(getBool));
+    TS_ASSERT_EQUALS(true, getBool);
+    TS_ASSERT_THROWS_NOTHING(vDbl = 0.0);
+    TS_ASSERT_THROWS_NOTHING(vBool = vDbl);
+    TS_ASSERT_EQUALS(false, vBool.getValue(getBool));
+    TS_ASSERT_EQUALS(true, getBool);
 
     TS_ASSERT_THROWS_NOTHING(JSONValue str1(""));
     TS_ASSERT_THROWS_NOTHING(JSONValue str2("str"));

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
@@ -1,0 +1,227 @@
+#ifndef MANTID_REMOTEALGORITHMS_SIMPLEJSONTEST_H_
+#define MANTID_REMOTEALGORITHMS_SIMPLEJSONTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidRemoteAlgorithms/SimpleJSON.h"
+
+class SimpleJSONTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SimpleJSONTest *createSuite() { return new SimpleJSONTest(); }
+  static void destroySuite(SimpleJSONTest *suite) { delete suite; }
+
+  void test_JSONValue() {
+    bool b = true;
+    TS_ASSERT_THROWS_NOTHING(JSONValue vBool(b));
+
+    double d = 0.1;
+    TS_ASSERT_THROWS_NOTHING(JSONValue vDbl(d));
+
+    TS_ASSERT_THROWS_NOTHING(b = d);
+    TS_ASSERT_EQUALS(true, b);
+    d = 0.0;
+    TS_ASSERT_EQUALS(true, b);
+
+    JSONValue vBool(b);
+    JSONValue vDbl(d);
+    TS_ASSERT_THROWS_NOTHING(vBool = vDbl);
+
+    TS_ASSERT_THROWS_NOTHING(JSONValue str1(""));
+    TS_ASSERT_THROWS_NOTHING(JSONValue str2("str"));
+
+    JSONValue str1("s1");
+    JSONValue str2("s2");
+    TS_ASSERT_THROWS_NOTHING(str1 = str2);
+
+    JSONValue vs;
+    std::ostringstream out;
+    TS_ASSERT_THROWS_NOTHING(vs.prettyPrint(out, 1));
+  }
+
+  void test_JSONArray() {
+    std::string str = "json failure here";
+    std::istringstream input(str);
+    std::string res;
+
+    JSONArray ja;
+    TS_ASSERT_THROWS_NOTHING(ja.push_back(str));
+    TS_ASSERT_THROWS_NOTHING(ja.push_back(str));
+    JSONValue jv(ja);
+
+    JSONValue vBool(true);
+    TS_ASSERT_THROWS_NOTHING(vBool = ja);
+  }
+
+  void test_JSONObjectWrongStrings() {
+    std::string str = "json failure here";
+    std::istringstream input(str);
+    std::string res;
+
+    str = "";
+    JSONObject jo;
+    TS_ASSERT_THROWS(initFromStream(jo, input), JSONParseException);
+    TS_ASSERT_THROWS_NOTHING(jo["no_param"].getValue(res));
+    TS_ASSERT_EQUALS(false, jo["no_param"].getValue(res));
+    TS_ASSERT_EQUALS(res, "");
+    TS_ASSERT_EQUALS(false, jo["another_no_param"].getValue(res));
+    TS_ASSERT_EQUALS(res, "");
+
+    TS_ASSERT_THROWS(initFromStream(jo, input), JSONParseException);
+    TS_ASSERT_THROWS_NOTHING(jo["doesnt_exist"].getValue(res));
+    TS_ASSERT_EQUALS(false, jo["doesnt_exist"].getValue(res));
+    TS_ASSERT_EQUALS(res, "");
+
+    str = "{ mistake: }";
+    TS_ASSERT_THROWS(initFromStream(jo, input), JSONParseException);
+    TS_ASSERT_THROWS_NOTHING(jo["no no"].getValue(res));
+    TS_ASSERT_EQUALS(false, jo["it's not here"].getValue(res));
+    TS_ASSERT_EQUALS(res, "");
+
+    str = "{ ";
+    TS_ASSERT_THROWS(initFromStream(jo, input), JSONParseException);
+    TS_ASSERT_THROWS_NOTHING(jo["no no"].getValue(res));
+    TS_ASSERT_EQUALS(false, jo["it's not here"].getValue(res));
+    TS_ASSERT_EQUALS(res, "");
+  }
+
+  void test_JSONObjectWrongSeparator() {
+    const std::string wrongSep = ",";
+    const std::string jsonStr = "{\"" + errName + "\":\"" + errVal + wrongSep +
+                                "\"" + errName + "\":\"" + errVal + "\"}";
+    std::istringstream input(jsonStr);
+    std::string res;
+
+    JSONObject o;
+    TS_ASSERT_THROWS(initFromStream(o, input), JSONParseException);
+    TS_ASSERT_THROWS_NOTHING(o["Err_Msg"].getValue(res));
+    TS_ASSERT_EQUALS(false, o["Err_Msg"].getValue(res));
+    TS_ASSERT_EQUALS(res, "");
+  }
+
+  void test_JSONObjectCorrectStrings() {
+    const std::string name1 = "var1";
+    const std::string val1 = "value1";
+    const std::string name2 = "variable2";
+    const std::string val2 = "[0,1,2,3]";
+    const std::string sep = ",";
+    std::string jsonStr = "{\"" + name1 + "\": \"" + val1 + "\"" + sep + " \"" +
+                          name2 + "\": \"" + val2 + "\"}";
+    std::istringstream input(jsonStr);
+
+    JSONObject jo;
+    std::string res;
+    TS_ASSERT_THROWS_NOTHING(initFromStream(jo, input));
+    TS_ASSERT_THROWS_NOTHING(jo[name1].getValue(res));
+    TS_ASSERT_EQUALS(false, jo["missing var"].getValue(res));
+    TS_ASSERT_EQUALS(res, val1);
+    TS_ASSERT_EQUALS(false, jo["got ya"].getValue(res));
+    TS_ASSERT_THROWS_NOTHING(jo[name2].getValue(res));
+    TS_ASSERT_EQUALS(res, val2);
+  }
+
+  void test_JSONObjectExampleServerResponseSimple() {
+    const std::string jsonStr = "{\"" + errName + "\":\"" + errVal + "\"}";
+    std::istringstream input(jsonStr);
+    std::string res;
+
+    JSONObject o;
+    TS_ASSERT_THROWS_NOTHING(initFromStream(o, input));
+    TS_ASSERT_THROWS_NOTHING(o["doesnt_exist"].getValue(res));
+    TS_ASSERT_EQUALS(false, o["doesnt_exist"].getValue(res));
+    TS_ASSERT_THROWS_NOTHING(o[""].getValue(res));
+    TS_ASSERT_EQUALS(false, o[""].getValue(res));
+    TS_ASSERT_EQUALS(true, o[errName].getValue(res));
+    TS_ASSERT_EQUALS(res, errVal);
+  }
+
+  void test_JSONObjectExampleServerResponseLonger() {
+
+    const std::string longerJsonStr =
+        "{\"v1\": \"[1, a, 3]\",\"" + errName + "\":\"" + errVal + "\"}";
+    std::istringstream inputLong(longerJsonStr);
+    std::string res;
+
+    JSONObject ol;
+    TS_ASSERT_THROWS_NOTHING(initFromStream(ol, inputLong));
+    TS_ASSERT_THROWS_NOTHING(ol["doesnt exist"].getValue(res));
+    TS_ASSERT_EQUALS(false, ol["doesnt exist"].getValue(res));
+    TS_ASSERT_THROWS_NOTHING(ol[""].getValue(res));
+    TS_ASSERT_EQUALS(false, ol[""].getValue(res));
+    TS_ASSERT_EQUALS(true, ol[errName].getValue(res));
+    TS_ASSERT_EQUALS(res, errVal);
+
+    const std::string l2JsonStr = "{\"v1\": \"[1, a, 3]\",\"" + errName +
+                                  "\":\"" + errVal + "\", \"" + versName +
+                                  "\": \"" + versVal + "\" }"
+                                                       "\"}";
+    std::istringstream inputL2(l2JsonStr);
+
+    TS_ASSERT_THROWS_NOTHING(initFromStream(ol, inputL2));
+    TS_ASSERT_THROWS_NOTHING(ol["doesnt exist"].getValue(res));
+    TS_ASSERT_EQUALS(false, ol["doesnt exist"].getValue(res));
+    TS_ASSERT_THROWS_NOTHING(ol[""].getValue(res));
+    TS_ASSERT_EQUALS(false, ol[""].getValue(res));
+    TS_ASSERT_EQUALS(true, ol[errName].getValue(res));
+    TS_ASSERT_EQUALS(res, errVal);
+    TS_ASSERT_EQUALS(true, ol[versName].getValue(res));
+    TS_ASSERT_EQUALS(res, versVal);
+
+    const std::string l3JsonStr = "{ \"" + impName + "\": \"" + impVal +
+                                  "\", \"v1\": \"[1, a, longer str, a4]\",\"" +
+                                  errName + "\":\"" + errVal + "\", \"" +
+                                  versName + "\": \"" + versVal + "\" }"
+                                                                  "\"}";
+    std::istringstream inputL3(l3JsonStr);
+
+    TS_ASSERT_THROWS_NOTHING(initFromStream(ol, inputL3));
+    TS_ASSERT_THROWS_NOTHING(ol["doesnt exist"].getValue(res));
+    TS_ASSERT_EQUALS(false, ol["doesnt exist"].getValue(res));
+    TS_ASSERT_THROWS_NOTHING(ol[""].getValue(res));
+    TS_ASSERT_EQUALS(false, ol[""].getValue(res));
+    TS_ASSERT_EQUALS(true, ol[errName].getValue(res));
+    TS_ASSERT_EQUALS(res, errVal);
+    TS_ASSERT_EQUALS(true, ol[versName].getValue(res));
+    TS_ASSERT_EQUALS(res, versVal);
+    TS_ASSERT_EQUALS(true, ol[impName].getValue(res));
+    TS_ASSERT_EQUALS(res, impVal);
+  }
+
+  void test_prettyPrint() {
+    std::ostringstream out;
+
+    std::string str = "json failure here";
+    std::istringstream istr(str);
+    JSONObject jo;
+    TS_ASSERT_THROWS(initFromStream(jo, istr), JSONParseException);
+    TS_ASSERT_THROWS_NOTHING(prettyPrint(jo, out, 0));
+
+    std::string strOK = "{ \"key1\": \"val1\"}";
+    std::istringstream istrOK(strOK);
+    JSONObject j2;
+    TS_ASSERT_THROWS_NOTHING(initFromStream(j2, istrOK));
+    TS_ASSERT_THROWS_NOTHING(prettyPrint(j2, out, 2));
+  }
+
+private:
+  // these are example parameters used for the mantid web service
+  // (remote job submission API:
+  // http://www.mantidproject.org/Remote_Job_Submission_API)
+  static const std::string errName;
+  static const std::string errVal;
+  static const std::string versName;
+  static const std::string versVal;
+  static const std::string impName;
+  static const std::string impVal;
+};
+
+const std::string SimpleJSONTest::errName = "Err_Msg";
+const std::string SimpleJSONTest::errVal = "fake msg";
+const std::string SimpleJSONTest::versName = "API_Version";
+const std::string SimpleJSONTest::versVal = "1";
+const std::string SimpleJSONTest::impName =
+    "Implementation_Specific_Post_Variables";
+const std::string SimpleJSONTest::impVal = "example_POST_var1";
+
+#endif // MANTID_REMOTEALGORITHMS_SIMPLEJSONTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
@@ -19,8 +19,6 @@ public:
     double d = 0.1;
     TS_ASSERT_THROWS_NOTHING(JSONValue vDbl(d));
 
-    TS_ASSERT_THROWS_NOTHING(b = d);
-
     JSONValue vBool(b);
     bool getBool = false;
     TS_ASSERT_EQUALS(true, vBool.getValue(getBool));

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/StartRemoteTransactionTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/StartRemoteTransactionTest.h
@@ -1,0 +1,123 @@
+#ifndef MANTID_REMOTEALGORITHMS_STARTREMOTETRANSACTIONTEST_H_
+#define MANTID_REMOTEALGORITHMS_STARTREMOTETRANSACTIONTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/StartRemoteTransaction.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class StartRemoteTransactionTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static StartRemoteTransactionTest *createSuite() {
+    return new StartRemoteTransactionTest();
+  }
+  static void destroySuite(StartRemoteTransactionTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "StartRemoteTransaction" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "StartRemoteTransaction");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<StartRemoteTransaction> a;
+    TS_ASSERT(a = boost::make_shared<StartRemoteTransaction>());
+
+    // can cast to inherited interfaces and base classes
+    StartRemoteTransaction alg;
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::StartRemoteTransaction *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    StartRemoteTransaction start;
+    TS_ASSERT_THROWS_NOTHING(start.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    StartRemoteTransaction alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // id missing
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    StartRemoteTransaction alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("TransactionID", "john_missing"));
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+  }
+
+  void test_wronProperty() {
+    StartRemoteTransaction start;
+    TS_ASSERT_THROWS_NOTHING(start.initialize();)
+    TS_ASSERT_THROWS(start.setPropertyValue("Compute", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(start.setPropertyValue("Transaction", "whatever"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(start.setPropertyValue("ID", "whichever"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      StartRemoteTransaction start;
+      TS_ASSERT_THROWS_NOTHING(start.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          start.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(
+          start.setPropertyValue("TransactionID", "000001"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(start.execute(), std::exception);
+      TS_ASSERT(!start.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_STARTREMOTETRANSACTIONTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/StartRemoteTransactionTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/StartRemoteTransactionTest.h
@@ -75,7 +75,7 @@ public:
     TS_ASSERT(!alg2.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     StartRemoteTransaction start;
     TS_ASSERT_THROWS_NOTHING(start.initialize();)
     TS_ASSERT_THROWS(start.setPropertyValue("Compute", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/StartRemoteTransactionTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/StartRemoteTransactionTest.h
@@ -33,13 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<StartRemoteTransaction>());
 
     // can cast to inherited interfaces and base classes
-    StartRemoteTransaction alg;
-    TS_ASSERT(
-        dynamic_cast<Mantid::RemoteAlgorithms::StartRemoteTransaction *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::StartRemoteTransaction *>(
+        a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/StopRemoteTransactionTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/StopRemoteTransactionTest.h
@@ -33,13 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<StopRemoteTransaction>());
 
     // can cast to inherited interfaces and base classes
-    StopRemoteTransaction alg;
-    TS_ASSERT(
-        dynamic_cast<Mantid::RemoteAlgorithms::StopRemoteTransaction *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::StopRemoteTransaction *>(
+        a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/StopRemoteTransactionTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/StopRemoteTransactionTest.h
@@ -75,7 +75,7 @@ public:
     TS_ASSERT(!alg2.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     StopRemoteTransaction stop;
     TS_ASSERT_THROWS_NOTHING(stop.initialize();)
     TS_ASSERT_THROWS(stop.setPropertyValue("Compute", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/StopRemoteTransactionTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/StopRemoteTransactionTest.h
@@ -1,0 +1,125 @@
+#ifndef MANTID_REMOTEALGORITHMS_STOPREMOTETRANSACTIONTEST_H_
+#define MANTID_REMOTEALGORITHMS_STOPREMOTETRANSACTIONTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/StopRemoteTransaction.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class StopRemoteTransactionTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static StopRemoteTransactionTest *createSuite() {
+    return new StopRemoteTransactionTest();
+  }
+  static void destroySuite(StopRemoteTransactionTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "StopRemoteTransaction" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "StopRemoteTransaction");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<StopRemoteTransaction> a;
+    TS_ASSERT(a = boost::make_shared<StopRemoteTransaction>());
+
+    // can cast to inherited interfaces and base classes
+    StopRemoteTransaction alg;
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::StopRemoteTransaction *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    StopRemoteTransaction stop;
+    TS_ASSERT_THROWS_NOTHING(stop.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    StopRemoteTransaction alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // transaction id missing
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    StopRemoteTransaction alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("TransactionID", "john_missing"));
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+  }
+
+  void test_wronProperty() {
+    StopRemoteTransaction stop;
+    TS_ASSERT_THROWS_NOTHING(stop.initialize();)
+    TS_ASSERT_THROWS(stop.setPropertyValue("Compute", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(stop.setPropertyValue("Transaction", "whatever"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(stop.setPropertyValue("JobID", "whichever"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(stop.setPropertyValue("ID", "whichever"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+      StopRemoteTransaction stop;
+      TS_ASSERT_THROWS_NOTHING(stop.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          stop.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(
+          stop.setPropertyValue("TransactionID", "000001"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(stop.execute(), std::exception);
+      TS_ASSERT(!stop.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_STOPREMOTETRANSACTIONTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/SubmitRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/SubmitRemoteJobTest.h
@@ -1,0 +1,193 @@
+#ifndef MANTID_REMOTEALGORITHMS_SUBMITREMOTEJOBTEST_H_
+#define MANTID_REMOTEALGORITHMS_SUBMITREMOTEJOBTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/SubmitRemoteJob.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class SubmitRemoteJobTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SubmitRemoteJobTest *createSuite() {
+    return new SubmitRemoteJobTest();
+  }
+  static void destroySuite(SubmitRemoteJobTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "SubmitRemoteJob" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "SubmitRemoteJob");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<SubmitRemoteJob> a;
+    TS_ASSERT(a = boost::make_shared<SubmitRemoteJob>());
+
+    // can cast to inherited interfaces and base classes
+    SubmitRemoteJob alg;
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::SubmitRemoteJob *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    SubmitRemoteJob s;
+    TS_ASSERT_THROWS_NOTHING(s.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    SubmitRemoteJob alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // Transaction id missing
+    TS_ASSERT_THROWS_NOTHING(alg1.setPropertyValue("NumNodes", "1"));
+    TS_ASSERT_THROWS_NOTHING(alg1.setPropertyValue("CoresPerNode", "4"));
+    TS_ASSERT_THROWS_NOTHING(alg1.setPropertyValue("TaskName", "unit test"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg1.setPropertyValue("ScriptName", "test script"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg1.setPropertyValue("PythonScript", "print 'hello world'"));
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    SubmitRemoteJob alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // task name name missing
+    TS_ASSERT_THROWS(alg2.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("TransactionID", "id001"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("ScriptName", "test script"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("PythonScript", "print 'hello world'"));
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+
+    SubmitRemoteJob alg3;
+    TS_ASSERT_THROWS_NOTHING(alg3.initialize());
+    // script name name missing
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("TaskName", "unit test"));
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("TransactionID", "id001"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("PythonScript", "print 'hello world'"));
+    TS_ASSERT_THROWS(alg3.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg3.execute(), std::runtime_error);
+    TS_ASSERT(!alg3.isExecuted());
+
+    SubmitRemoteJob alg4;
+    TS_ASSERT_THROWS_NOTHING(alg4.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(alg4.setPropertyValue("TransactionID", "id001"));
+    TS_ASSERT_THROWS_NOTHING(alg4.setPropertyValue("TaskName", "unit test"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg4.setPropertyValue("ScriptName", "test script"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg4.setPropertyValue("PythonScript", "print 'hello world'"));
+
+    TS_ASSERT_THROWS(alg4.execute(), std::runtime_error);
+    TS_ASSERT(!alg4.isExecuted());
+
+    SubmitRemoteJob alg5;
+    TS_ASSERT_THROWS_NOTHING(alg5.initialize());
+    // py script missing
+    TS_ASSERT_THROWS_NOTHING(alg5.setPropertyValue("TransactionID", "id001"));
+    TS_ASSERT_THROWS_NOTHING(alg5.setPropertyValue("TaskName", "unit test"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg5.setPropertyValue("ScriptName", "test script"));
+    TS_ASSERT_THROWS(alg5.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg5.execute(), std::runtime_error);
+    TS_ASSERT(!alg5.isExecuted());
+  }
+
+  void test_wronProperty() {
+    SubmitRemoteJob s;
+    TS_ASSERT_THROWS_NOTHING(s.initialize();)
+    TS_ASSERT_THROWS(s.setPropertyValue("Compute", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(s.setPropertyValue("NumNodes", "anything"),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS(s.setPropertyValue("NumNodes", "-3"),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS(s.setPropertyValue("CoresPerNode", "anything"),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS(s.setPropertyValue("Task", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(s.setPropertyValue("Name", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(s.setPropertyValue("Transaction", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(s.setPropertyValue("ID", "anything"), std::runtime_error);
+    TS_ASSERT_THROWS(s.setPropertyValue("ScriptName", ""),
+                     std::invalid_argument);
+    TS_ASSERT_THROWS(s.setPropertyValue("Scrip", "any name"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(s.setPropertyValue("PythonScript", ""),
+                     std::invalid_argument);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+
+      SubmitRemoteJob s;
+      TS_ASSERT_THROWS_NOTHING(s.initialize());
+      TS_ASSERT_THROWS_NOTHING(s.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(s.setPropertyValue("NumNodes", "1"));
+      TS_ASSERT_THROWS_NOTHING(s.setPropertyValue("CoresPerNode", "4"));
+      TS_ASSERT_THROWS_NOTHING(s.setPropertyValue("TaskName", "unit test"));
+      TS_ASSERT_THROWS_NOTHING(s.setPropertyValue("TransactionID", "tr001"));
+      TS_ASSERT_THROWS_NOTHING(s.setPropertyValue("ScriptName", "test script"));
+      TS_ASSERT_THROWS_NOTHING(
+          s.setPropertyValue("PythonScript", "print 'hello world'"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(s.execute(), std::exception);
+      TS_ASSERT(!s.isExecuted());
+    }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_SUBMITREMOTEJOBTEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/SubmitRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/SubmitRemoteJobTest.h
@@ -125,7 +125,7 @@ public:
     TS_ASSERT(!alg5.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     SubmitRemoteJob s;
     TS_ASSERT_THROWS_NOTHING(s.initialize();)
     TS_ASSERT_THROWS(s.setPropertyValue("Compute", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/SubmitRemoteJobTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/SubmitRemoteJobTest.h
@@ -33,12 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<SubmitRemoteJob>());
 
     // can cast to inherited interfaces and base classes
-    SubmitRemoteJob alg;
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::SubmitRemoteJob *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::SubmitRemoteJob *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
@@ -1,0 +1,159 @@
+#ifndef MANTID_REMOTEALGORITHMS_UPLOADREMOTEFILETEST_H_
+#define MANTID_REMOTEALGORITHMS_UPLOADREMOTEFILETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/ConfigService.h"
+#include "MantidKernel/FacilityInfo.h"
+#include "MantidRemoteAlgorithms/UploadRemoteFile.h"
+
+using namespace Mantid::RemoteAlgorithms;
+
+class UploadRemoteFileTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static UploadRemoteFileTest *createSuite() {
+    return new UploadRemoteFileTest();
+  }
+  static void destroySuite(UploadRemoteFileTest *suite) { delete suite; }
+
+  void test_algorithm() {
+    testAlg = Mantid::API::AlgorithmManager::Instance().create(
+        "UploadRemoteFile" /*, 1*/);
+    TS_ASSERT(testAlg);
+    TS_ASSERT_EQUALS(testAlg->name(), "UploadRemoteFile");
+    TS_ASSERT_EQUALS(testAlg->version(), 1);
+  }
+
+  void test_castAlgorithm() {
+    // can create
+    boost::shared_ptr<UploadRemoteFile> a;
+    TS_ASSERT(a = boost::make_shared<UploadRemoteFile>());
+
+    // can cast to inherited interfaces and base classes
+    UploadRemoteFile alg;
+    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::UploadRemoteFile *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+  }
+
+  void test_init() {
+    if (!testAlg->isInitialized())
+      TS_ASSERT_THROWS_NOTHING(testAlg->initialize());
+
+    TS_ASSERT(testAlg->isInitialized());
+
+    UploadRemoteFile ul;
+    TS_ASSERT_THROWS_NOTHING(ul.initialize());
+  }
+
+  // TODO: when we have a RemoteJobManager capable of creating
+  // algorithms for different types of compute resources (example:
+  // Fermi@SNS and SCARF@STFC), create different algorithms for them
+  void test_propertiesMissing() {
+    UploadRemoteFile alg1;
+    TS_ASSERT_THROWS_NOTHING(alg1.initialize());
+    // Transaction id missing
+    TS_ASSERT_THROWS_NOTHING(
+        alg1.setPropertyValue("RemoteFileName", "file name"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg1.setPropertyValue("LocalFileName", "local file name"));
+    TS_ASSERT_THROWS(alg1.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg1.execute(), std::runtime_error);
+    TS_ASSERT(!alg1.isExecuted());
+
+    UploadRemoteFile alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    // remote file name missing
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("TransactionID", "id001"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg2.setPropertyValue("LocalFileName", "local file name"));
+    TS_ASSERT_THROWS(alg2.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg2.execute(), std::runtime_error);
+    TS_ASSERT(!alg2.isExecuted());
+
+    UploadRemoteFile alg3;
+    TS_ASSERT_THROWS_NOTHING(alg3.initialize());
+    // local file name missing
+    TS_ASSERT_THROWS_NOTHING(alg3.setPropertyValue("TransactionID", "id001"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg3.setPropertyValue("RemoteFileName", "remote file name"));
+    TS_ASSERT_THROWS(alg3.setPropertyValue("ComputeResource", "missing!"),
+                     std::invalid_argument);
+
+    TS_ASSERT_THROWS(alg3.execute(), std::runtime_error);
+    TS_ASSERT(!alg3.isExecuted());
+
+    UploadRemoteFile alg4;
+    TS_ASSERT_THROWS_NOTHING(alg4.initialize());
+    // compute resource missing
+    TS_ASSERT_THROWS_NOTHING(
+        alg4.setPropertyValue("RemoteFileName", "file name"));
+    TS_ASSERT_THROWS_NOTHING(alg4.setPropertyValue("TransactionID", "id001"));
+
+    TS_ASSERT_THROWS(alg4.execute(), std::runtime_error);
+    TS_ASSERT(!alg4.isExecuted());
+  }
+
+  void test_wronProperty() {
+    UploadRemoteFile ul;
+    TS_ASSERT_THROWS_NOTHING(ul.initialize();)
+    TS_ASSERT_THROWS(ul.setPropertyValue("Compute", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(ul.setPropertyValue("TransID", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(ul.setPropertyValue("RemoteFile", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(ul.setPropertyValue("FileName", "anything"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(ul.setPropertyValue("LocalFile", "anything"),
+                     std::runtime_error);
+  }
+
+  void test_propertiesOK() {
+    testFacilities.push_back(std::make_pair("SNS", "Fermi"));
+    testFacilities.push_back(std::make_pair("ISIS", "SCARF@STFC"));
+
+    const Mantid::Kernel::FacilityInfo &prevFac =
+        Mantid::Kernel::ConfigService::Instance().getFacility();
+    for (size_t fi = 0; fi < testFacilities.size(); fi++) {
+      const std::string facName = testFacilities[fi].first;
+      const std::string compName = testFacilities[fi].second;
+
+      Mantid::Kernel::ConfigService::Instance().setFacility(facName);
+
+      UploadRemoteFile ul;
+      TS_ASSERT_THROWS_NOTHING(ul.initialize());
+      TS_ASSERT_THROWS_NOTHING(
+          ul.setPropertyValue("ComputeResource", compName));
+      TS_ASSERT_THROWS_NOTHING(
+          ul.setPropertyValue("TransactionID", "anything001"));
+      TS_ASSERT_THROWS_NOTHING(
+          ul.setPropertyValue("RemoteFileName", "any name"));
+      TS_ASSERT_THROWS_NOTHING(
+          ul.setPropertyValue("LocalFileName", "any local path"));
+      // TODO: this would run the algorithm and do a remote
+      // connection. uncomment only when/if we have a mock up for this
+      // TS_ASSERT_THROWS(ul.execute(), std::exception);
+      TS_ASSERT(!ul.isExecuted());
+    }
+  }
+
+  // TODO: void test_runOK() - with a mock when we can add it.
+  // ideally, with different compute resources to check the remote job
+  // manager factory, etc.
+
+private:
+  Mantid::API::IAlgorithm_sptr testAlg;
+  std::vector<std::pair<std::string, std::string>> testFacilities;
+};
+
+#endif // MANTID_REMOTEALGORITHMS_UPLOADREMOTEFILETEST_H_

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
@@ -145,6 +145,7 @@ public:
       // TS_ASSERT_THROWS(ul.execute(), std::exception);
       TS_ASSERT(!ul.isExecuted());
     }
+    Mantid::Kernel::ConfigService::Instance().setFacility(prevFac.name());
   }
 
   // TODO: void test_runOK() - with a mock when we can add it.

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
@@ -103,7 +103,7 @@ public:
     TS_ASSERT(!alg4.isExecuted());
   }
 
-  void test_wronProperty() {
+  void test_wrongProperty() {
     UploadRemoteFile ul;
     TS_ASSERT_THROWS_NOTHING(ul.initialize();)
     TS_ASSERT_THROWS(ul.setPropertyValue("Compute", "anything"),

--- a/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
+++ b/Code/Mantid/Framework/RemoteAlgorithms/test/UploadRemoteFileTest.h
@@ -33,12 +33,12 @@ public:
     TS_ASSERT(a = boost::make_shared<UploadRemoteFile>());
 
     // can cast to inherited interfaces and base classes
-    UploadRemoteFile alg;
-    TS_ASSERT(dynamic_cast<Mantid::RemoteAlgorithms::UploadRemoteFile *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(&alg));
-    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(&alg));
+    TS_ASSERT(
+        dynamic_cast<Mantid::RemoteAlgorithms::UploadRemoteFile *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::Algorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::PropertyManagerOwner *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::API::IAlgorithm *>(a.get()));
+    TS_ASSERT(dynamic_cast<Mantid::Kernel::IPropertyManager *>(a.get()));
   }
 
   void test_init() {


### PR DESCRIPTION
This fixex trac ticket [#11122](http://trac.mantidproject.org/mantid/ticket/11122).

This is a bunch of unit tests that had been missing for a long time. Even though we canot go very far in testing these algorithms at this point, It is important to have these basic tests there as a preventive step now that there's going to be a refactoring of remote algorithms and lots of code will be rearranged and moved around (see 'blocking'  tickets for details).

Tester: make sure that the tests pass and make sense.
