### PR TITLE
Don't show sample material dialog for MD workspaces

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidDock.cpp
@@ -582,7 +582,6 @@ void MantidDockWidget::addMDEventWorkspaceMenuItems(QMenu *menu, const Mantid::A
   menu->addAction(m_showHist);  // Algorithm history
   menu->addAction(m_showListData); // Show data in table
   menu->addAction(m_showLogs);
-  menu->addAction(m_showSampleMaterial); //TODO
 }
 
 void MantidDockWidget::addMDHistoWorkspaceMenuItems(QMenu *menu, const Mantid::API::IMDWorkspace_const_sptr &WS) const
@@ -604,7 +603,6 @@ void MantidDockWidget::addMDHistoWorkspaceMenuItems(QMenu *menu, const Mantid::A
   menu->addAction(m_showListData); // Show data in table
   menu->addAction(m_convertMDHistoToMatrixWorkspace);
   menu->addAction(m_showLogs);
-  menu->addAction(m_showSampleMaterial); //TODO
 }
 
 

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidSampleMaterialDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidSampleMaterialDialog.cpp
@@ -40,6 +40,9 @@ MantidSampleMaterialDialog::MantidSampleMaterialDialog(const QString & wsName, M
 void MantidSampleMaterialDialog::updateMaterial()
 {
   MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(m_wsName.toStdString());
+  if(!ws)
+    return;
+
   const Material material = ws->sample().getMaterial();
 
   m_uiForm.treeMaterialProperties->clear();


### PR DESCRIPTION
Fixes [#11290](http://trac.mantidproject.org/mantid/ticket/11290).

To test:
- See that sample material option is no longer available for MD workspaces
