### PR TITLE
IDA CalcCor UI issues

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -209,7 +209,7 @@
            <number>1</number>
           </property>
           <property name="currentIndex">
-           <number>1</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="pageFlat">
            <layout class="QVBoxLayout" name="verticalLayout_4">

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -365,13 +365,13 @@ namespace IDA
     switch(m_uiForm.cbSampleInputType->currentIndex())
     {
       case 0:
-          //using direct input
-          uiv.checkFieldIsValid("Sample Scattering Cross-Section", m_uiForm.lesamsigs, m_uiForm.valSamsigs);
-          uiv.checkFieldIsValid("Sample Absorption Cross-Section", m_uiForm.lesamsiga, m_uiForm.valSamsiga);
+        //input using formula
+        uiv.checkFieldIsValid("Sample Formula", m_uiForm.leSampleFormula, m_uiForm.valSampleFormula);
         break;
       case 1:
-          //input using formula
-          uiv.checkFieldIsValid("Sample Formula", m_uiForm.leSampleFormula, m_uiForm.valSampleFormula);
+        //using direct input
+        uiv.checkFieldIsValid("Sample Scattering Cross-Section", m_uiForm.lesamsigs, m_uiForm.valSamsigs);
+        uiv.checkFieldIsValid("Sample Absorption Cross-Section", m_uiForm.lesamsiga, m_uiForm.valSamsiga);
         break;
     }
 
@@ -390,13 +390,13 @@ namespace IDA
       switch(m_uiForm.cbCanInputType->currentIndex())
       {
         case 0:
-            // using direct input
-            uiv.checkFieldIsValid("Can Scattering Cross-Section", m_uiForm.lecansigs, m_uiForm.valCansigs);
-            uiv.checkFieldIsValid("Can Absorption Cross-Section", m_uiForm.lecansiga, m_uiForm.valCansiga);
+          //input using formula
+          uiv.checkFieldIsValid("Can Formula", m_uiForm.leCanFormula, m_uiForm.valCanFormula);
           break;
         case 1:
-            //input using formula
-            uiv.checkFieldIsValid("Can Formula", m_uiForm.leCanFormula, m_uiForm.valCanFormula);
+          // using direct input
+          uiv.checkFieldIsValid("Can Scattering Cross-Section", m_uiForm.lecansigs, m_uiForm.valCansigs);
+          uiv.checkFieldIsValid("Can Absorption Cross-Section", m_uiForm.lecansiga, m_uiForm.valCansiga);
           break;
       }
     }


### PR DESCRIPTION
Fixes [#11253](http://trac.mantidproject.org/mantid/ticket/11253).

To test:
- See that the default Shape Details matches the Sample Shape option (default is Flat, which should show thickness options)
- Do a simple test using the following data/options, the validation for cross sections should work correctly

Options:
- Sample: irs26176_graphite002_red
- Can: irs26173_graphite002_red
- Flat
- Thickness: 0.1
- Can Front Thickness: 0.1
- Can Back Thickness: 0.1
- Sample Number Density: 0.1
- Can Number Density: 0.1

and either:
- Sample Formula: H2-O
- Can Formula: V

or:
- Sample Scattering Cross Section: 0.1
- Sample Absorption Cross Section: 0.1
- Can Scattering Cross Section: 0.1
- Can Absorption Cross Section: 0.1
