### PR TITLE
Remove files saved by indirect system tests

### DIFF
--- a/Code/Mantid/Testing/SystemTests/tests/analysis/ISISIndirectAnalysisTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/ISISIndirectAnalysisTest.py
@@ -9,23 +9,20 @@ class ElasticWindowMultipleTest(stresstesting.MantidStressTest):
 
     def runTest(self):
         Load(Filename='osi92762_graphite002_red.nxs,osi92763_graphite002_red.nxs',
-            OutputWorkspace='__ElWinMulti_InputWS')
+             OutputWorkspace='__ElWinMulti_InputWS')
 
-        ElasticWindowMultiple(
-            InputWorkspaces='__ElWinMulti_InputWS',
-            Range1Start=-0.2,
-            Range1End=0.2,
-            Range2Start='-0.24',
-            Range2End='-0.22',
-            OutputInQ='eq',
-            OutputInQSquared='eq2',
-            OutputELF='elf',
-            OutputELT='elt')
+        ElasticWindowMultiple(InputWorkspaces='__ElWinMulti_InputWS',
+                              Range1Start=-0.2,
+                              Range1End=0.2,
+                              Range2Start='-0.24',
+                              Range2End='-0.22',
+                              OutputInQ='eq',
+                              OutputInQSquared='eq2',
+                              OutputELF='elf',
+                              OutputELT='elt')
 
         GroupWorkspaces(InputWorkspaces=['elf', 'elt'],
-            OutputWorkspace='__ElWinMulti_OutputWS')
-
-        SaveNexus(Filename='__ElWinMulti_OutputWS', InputWorkspace='__ElWinMulti_OutputWS')
+                        OutputWorkspace='__ElWinMulti_OutputWS')
 
     def validate(self):
         self.tolerance = 1e-10


### PR DESCRIPTION
Fixes [#11139](http://trac.mantidproject.org/mantid/ticket/11139).

To test:
- Run system tests (or at least `ISISIndirectAnalysisTest`) and see that the `__ElWinMulti_OutputWS` file is no longer saved.

The other files mentioned in the ticket will be addressed elsewhere (they are being generated by the routines, not the tests).
