### PR TITLE
DataSelector only emit dataReady signal when data changed

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/DataSelector.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/DataSelector.cpp
@@ -24,7 +24,7 @@ namespace MantidQt
       connect(m_uiForm.pbLoadFile, SIGNAL(clicked()), this, SIGNAL(loadClicked()));
 
       //data selected changes
-      connect(m_uiForm.rfFileInput, SIGNAL(filesFound()), this, SLOT(handleFileInput()));
+      connect(m_uiForm.rfFileInput, SIGNAL(filesFoundChanged()), this, SLOT(handleFileInput()));
       connect(m_uiForm.wsWorkspaceInput, SIGNAL(currentIndexChanged(int)), this, SLOT(handleWorkspaceInput()));
       connect(m_uiForm.pbLoadFile, SIGNAL(clicked()), this, SLOT(handleFileInput()));
 
@@ -66,7 +66,7 @@ namespace MantidQt
     /**
      * Get if the file selector is currently being shown.
      *
-     * @return :: true if it is visible, otherwise false 
+     * @return :: true if it is visible, otherwise false
      */
     bool DataSelector::isFileSelectorVisible() const
     {
@@ -77,7 +77,7 @@ namespace MantidQt
     /**
      * Get if the workspace selector is currently being shown.
      *
-     * @return :: true if it is visible, otherwise false 
+     * @return :: true if it is visible, otherwise false
      */
     bool DataSelector::isWorkspaceSelectorVisible() const
     {
@@ -107,7 +107,7 @@ namespace MantidQt
         if(isValid && m_autoLoad)
         {
           const QString wsName = getCurrentDataName();
-          
+
           if(!AnalysisDataService::Instance().doesExist(wsName.toStdString()))
           {
             //attempt to reload if we can
@@ -118,9 +118,9 @@ namespace MantidQt
             loadAlg->setProperty("Filename", filepath.toStdString());
             loadAlg->setProperty("OutputWorkspace", wsName.toStdString());
             loadAlg->execute();
-            
+
             isValid = AnalysisDataService::Instance().doesExist(wsName.toStdString());
-            
+
             if(!isValid)
             {
               m_uiForm.rfFileInput->setFileProblem("The specified workspace is missing from the analysis data service");
@@ -448,18 +448,18 @@ namespace MantidQt
      */
     void DataSelector::dropEvent(QDropEvent *de)
     {
-      const QMimeData *mimeData = de->mimeData();  
+      const QMimeData *mimeData = de->mimeData();
       auto before_action = de->dropAction();
 
       if (de->mimeData() && mimeData->text().contains(" = mtd[\"")){
         m_uiForm.wsWorkspaceInput->dropEvent(de);
-        if (de->dropAction() == before_action){    
+        if (de->dropAction() == before_action){
           m_uiForm.cbInputType->setCurrentIndex(1);
           return;
         }
-        de->setDropAction(before_action);    
+        de->setDropAction(before_action);
       }
-  
+
       m_uiForm.rfFileInput->dropEvent(de);
       if (de->dropAction() == before_action){
         m_uiForm.cbInputType->setCurrentIndex(0);


### PR DESCRIPTION
Fixes [#11377](http://trac.mantidproject.org/mantid/ticket/11377).

To reproduce:
- Open IDR > Transmission
- Select IRIS
- Sample: 26176
- Can: 26173
- Preview should show when text boxes lose focus
- Put cursor back into text box
- Switch tabs
- Results log shows that algorithm is executing again as text box loses focus

To test, do the above and see that the algorithm does not re run when text boxes lose focus unless the contents have been changed (to something valid).
