### PR TITLE
Include jsoncpp in a more portable way

### DIFF
--- a/Code/Mantid/Build/CMake/CommonSetup.cmake
+++ b/Code/Mantid/Build/CMake/CommonSetup.cmake
@@ -60,6 +60,7 @@ include_directories ( SYSTEM ${NEXUS_INCLUDE_DIR} )
 find_package ( MuParser REQUIRED )
 
 find_package ( JsonCPP REQUIRED )
+include_directories ( SYSTEM ${JSONCPP_INCLUDE_DIR} )
 
 find_package ( Doxygen ) # optional
 

--- a/Code/Mantid/Build/CMake/FindJsonCPP.cmake
+++ b/Code/Mantid/Build/CMake/FindJsonCPP.cmake
@@ -9,6 +9,14 @@
 #  JSONCPP_LIBRARY_DEBUG  - library files for linking (debug version)
 #  JSONCPP_LIBRARIES      - All required libraries, including the configuration type
 
+# Using unset here is a temporary hack to force FindJson to find the correct
+# path in an incremental build. It should be removed a day or two after the
+# branch introducing this is merged. The if is to make sure we don't break any
+# downstream builders that are setting JSONCPP_INCLUDE_DIR to a special location.
+if ( ${JSONCPP_INCLUDE_DIR} STREQUAL "/usr/include" )
+  unset ( JSONCPP_INCLUDE_DIR CACHE )
+endif()
+
 # Headers
 find_path ( JSONCPP_INCLUDE_DIR json/reader.h
             PATH_SUFFIXES jsoncpp )

--- a/Code/Mantid/Build/CMake/FindJsonCPP.cmake
+++ b/Code/Mantid/Build/CMake/FindJsonCPP.cmake
@@ -11,11 +11,8 @@
 
 # Using unset here is a temporary hack to force FindJson to find the correct
 # path in an incremental build. It should be removed a day or two after the
-# branch introducing this is merged. The if is to make sure we don't break any
-# downstream builders that are setting JSONCPP_INCLUDE_DIR to a special location.
-if ( ${JSONCPP_INCLUDE_DIR} STREQUAL "/usr/include" )
-  unset ( JSONCPP_INCLUDE_DIR CACHE )
-endif()
+# branch introducing this is merged.
+unset ( JSONCPP_INCLUDE_DIR CACHE )
 
 # Headers
 find_path ( JSONCPP_INCLUDE_DIR json/reader.h

--- a/Code/Mantid/Build/CMake/FindJsonCPP.cmake
+++ b/Code/Mantid/Build/CMake/FindJsonCPP.cmake
@@ -10,7 +10,8 @@
 #  JSONCPP_LIBRARIES      - All required libraries, including the configuration type
 
 # Headers
-find_path ( JSONCPP_INCLUDE_DIR jsoncpp/json/json.h )
+find_path ( JSONCPP_INCLUDE_DIR json/reader.h
+            PATH_SUFFIXES jsoncpp )
 
 # Libraries
 find_library ( JSONCPP_LIBRARY NAMES jsoncpp ) # optimized

--- a/Code/Mantid/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -25,7 +25,7 @@
 #endif
 
 // jsoncpp
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 // std
 #include <fstream>

--- a/Code/Mantid/Framework/DataObjects/src/NoShape.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/NoShape.cpp
@@ -1,6 +1,6 @@
 #include "MantidDataObjects/NoShape.h"
 #include <stdexcept>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/src/PeakShapeBase.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeakShapeBase.cpp
@@ -1,6 +1,6 @@
 #include "MantidDataObjects/PeakShapeBase.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -1,6 +1,6 @@
 #include "MantidDataObjects/PeakShapeEllipsoid.h"
 #include "MantidKernel/cow_ptr.h"
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeakShapeEllipsoidFactory.cpp
@@ -2,7 +2,7 @@
 #include "MantidDataObjects/PeakShapeEllipsoid.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
 
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <stdexcept>
 
 using namespace Mantid::Kernel;

--- a/Code/Mantid/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -1,6 +1,6 @@
 #include "MantidDataObjects/PeakShapeSpherical.h"
 #include <stdexcept>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/src/PeakShapeSphericalFactory.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeakShapeSphericalFactory.cpp
@@ -1,7 +1,7 @@
 #include "MantidDataObjects/PeakShapeSphericalFactory.h"
 #include "MantidDataObjects/PeakShapeSpherical.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <MantidKernel/VMD.h>
 
 namespace Mantid {

--- a/Code/Mantid/Framework/DataObjects/test/NoShapeTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/NoShapeTest.h
@@ -6,7 +6,7 @@
 #endif
 
 #include <cxxtest/TestSuite.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include "MantidDataObjects/NoShape.h"
 #include "MantidKernel/V3D.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"

--- a/Code/Mantid/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeakShapeEllipsoidFactoryTest.h
@@ -7,7 +7,7 @@
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <boost/assign/list_of.hpp>
 
 #include "MantidDataObjects/PeakShapeEllipsoid.h"

--- a/Code/Mantid/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeakShapeEllipsoidTest.h
@@ -9,7 +9,7 @@
 #include "MantidKernel/Matrix.h"
 #include <vector>
 #include <boost/assign/list_of.hpp>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 using Mantid::DataObjects::PeakShapeEllipsoid;
 using Mantid::Kernel::SpecialCoordinateSystem;

--- a/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalFactoryTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalFactoryTest.h
@@ -7,7 +7,7 @@
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include "MantidDataObjects/PeakShapeSphericalFactory.h"
 #include "MantidDataObjects/PeakShapeSpherical.h"

--- a/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeakShapeSphericalTest.h
@@ -6,7 +6,7 @@
 #endif
 
 #include <cxxtest/TestSuite.h>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 
 #include "MantidDataObjects/PeakShapeSpherical.h"
 #include "MantidKernel/V3D.h"

--- a/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/MetadataJsonManager.h
+++ b/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/MetadataJsonManager.h
@@ -1,7 +1,7 @@
 #ifndef METADATA_JSON_MANAGER_H
 #define METADATA_JSON_MANAGER_H
 
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include "MantidKernel/System.h"
 #include <string>
 namespace Mantid

--- a/Code/Mantid/Vates/VatesAPI/src/MetadataJsonManager.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/MetadataJsonManager.cpp
@@ -1,7 +1,7 @@
 #include "MantidVatesAPI/MetadataJsonManager.h"
-#include <jsoncpp/json/json.h>
-#include <jsoncpp/json/writer.h>
-#include <jsoncpp/json/reader.h>
+#include <json/json.h>
+#include <json/writer.h>
+#include <json/reader.h>
 
 namespace Mantid
 {

--- a/Code/Mantid/Vates/VatesAPI/test/MetadataJsonManagerTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/MetadataJsonManagerTest.h
@@ -10,7 +10,7 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidVatesAPI/MetadataJsonManager.h"
 #include <string>
-#include <jsoncpp/json/reader.h>
+#include <json/reader.h>
 
 
 using Mantid::VATES::MetadataJsonManager;


### PR DESCRIPTION
This is for trac ticket [#11379](http://trac.mantidproject.org/mantid/ticket/11379)

This is a small problem I located when building Mantid on Arch Linux.

The JsonCPP library is meant to be included like `#include <json/json.h>`, not `#include <jsoncpp/json/json.h>`. See: https://github.com/open-source-parsers/jsoncpp/wiki#code-example

The upstream developers intend for it to exist (on unix-like systems) at `/usr/include/json`, but to prevent naming conflicts many (but not all) systems instead place it in `/usr/include/jsoncpp/json`. This causes potential portability issues. The currently supported unix-like systems (i.e. RHEL6, Ubuntu, Fedora, etc.) all place it in `/usr/include/jsoncpp/json`, but other distributions such as Arch Linux do not.

This pull request:
- Updates Mantid's usage to be more portable
- Updates the CMake configuration to automatically locate and provide the headers, wherever they are on a system
