### PR TITLE
Protect access to instrument data service

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadInstrument.h
@@ -117,6 +117,9 @@ private:
 
   /// Name of the instrument
   std::string m_instName;
+
+  /// Mutex to avoid simultaneous access
+  static Poco::Mutex m_mutex;
 };
 
 } // namespace DataHandling


### PR DESCRIPTION
Fixes trac issue [#11382](http://trac.mantidproject.org/mantid/ticket/11382)

Tester: just check code & ensure that all tests pass. This ticket is part of a series of tickets dealing with PlotAsymmetryByLogValue (and Muon ALC Interface). PlotAsymmetryByLogValue will have different threads trying to add the instrument to the Instrument Data Service, hence a mutex has been added to avoid simultaneous access resulting in an error message.
