### PR TITLE
Fix Cppcheck warning (unused variable in IntegrateEllipsoids)

### DIFF
--- a/Code/Mantid/Framework/MDEvents/src/IntegrateEllipsoids.cpp
+++ b/Code/Mantid/Framework/MDEvents/src/IntegrateEllipsoids.cpp
@@ -365,9 +365,6 @@ void IntegrateEllipsoids::exec() {
   const size_t numSpectra = wksp->getNumberHistograms();
   Progress prog(this, 0.5, 1.0, numSpectra);
 
-  // loop through the eventlists
-  std::vector<double> buffer(DIMS);
-
   if (eventWS) {
     // process as EventWorkspace
     qListFromEventWS(integrator, prog, eventWS, unitConv, qConverter);


### PR DESCRIPTION
Quick PR to kill a Cppcheck issue. I thought this doesn't merit a proper ticket.

Tester: this just removes a variable that became unused. Cppcheck has been complaining about it for several days and it currently is the only Cppcheck issue.
