### PR TITLE
Fix new plot policy

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1999,15 +1999,12 @@ void MuonAnalysis::plotSpectrum(const QString& wsName, bool logScale)
     {
       QStringList& s = acquireWindowScript; // To keep short
 
-      s << "w = graph('%WSNAME%-1')";
-      s << "if w == None:";
-      s << "  pw = newGraph('%WSNAME%', 0)";
-      s << "  w = plotSpectrum('%WSNAME%', 0, %ERRORS%, %CONNECT%, window = pw)";
-      s << "  w.setObjectName('%WSNAME%')";
-      s << "else:";
-      s << "  plotSpectrum('%WSNAME%', 0, %ERRORS%, %CONNECT%, window = w, clearWindow = True)";
-      s << "  w.show()";
-      s << "  w.setFocus()";
+      s << "pw = newGraph('%WSNAME%-1', 0)";
+      s << "w = plotSpectrum('%WSNAME%', 0, %ERRORS%, %CONNECT%, window = pw, clearWindow = True)";
+      s << "w.setName('%WSNAME%-1')";
+      s << "w.setObjectName('%WSNAME%')";
+      s << "w.show()";
+      s << "w.setFocus()";
     }
 
     QString pyS;


### PR DESCRIPTION
Fixes [#11368](http://trac.mantidproject.org/mantid/ticket/11386)

Tester: See original trac issue for a description of the problem. Check that on this branch, if you open the Muon Analysis interface, go to Settings tab and select "Create new window" in "New plot policy", then go to "Home" tab and load any muon dataset, and finally go to "Data Analysis", the fitting tool appears (fitting limits are shown) and fit results are displayed after fitting.
