### PR TITLE
Make integration time compulsory

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -365,16 +365,9 @@
                     <item>
                       <layout class="QHBoxLayout" name="horizontalLayout_2">
                         <item>
-                          <widget class="QCheckBox" name="timeLimit">
-                            <property name="text">
-                              <string>Time limit:</string>
-                            </property>
-                          </widget>
-                        </item>
-                        <item>
                           <widget class="QWidget" name="timeLimits" native="true">
                             <property name="enabled">
-                              <bool>false</bool>
+                              <bool>true</bool>
                             </property>
                             <property name="minimumSize">
                               <size>
@@ -503,29 +496,12 @@
     <tabstop>log</tabstop>
     <tabstop>integral</tabstop>
     <tabstop>differential</tabstop>
-    <tabstop>timeLimit</tabstop>
     <tabstop>minTime</tabstop>
     <tabstop>maxTime</tabstop>
     <tabstop>load</tabstop>
   </tabstops>
   <resources/>
   <connections>
-    <connection>
-      <sender>timeLimit</sender>
-      <signal>toggled(bool)</signal>
-      <receiver>timeLimits</receiver>
-      <slot>setEnabled(bool)</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>94</x>
-          <y>193</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>264</x>
-          <y>205</y>
-        </hint>
-      </hints>
-    </connection>
     <connection>
       <sender>fromCustomFile</sender>
       <signal>toggled(bool)</signal>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -39,7 +39,9 @@ namespace CustomInterfaces
     // Check time limits
     if (auto timeRange = m_view->timeRange()) {
 
-      if (timeRange->first >= timeRange->second){
+      double tmin = timeRange->first;
+      double tmax = timeRange->second;
+      if ( tmin >= tmax ){
         m_view->restoreCursor();
         m_view->displayError("Invalid time interval");
         return;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -39,8 +39,8 @@ namespace CustomInterfaces
     // Check time limits
     if (auto timeRange = m_view->timeRange()) {
 
-      double tmin = timeRange->first;
-      double tmax = timeRange->second;
+      double tmin = (*timeRange).first;
+      double tmax = (*timeRange).second;
       if ( tmin >= tmax ){
         m_view->restoreCursor();
         m_view->displayError("Invalid time interval");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -36,6 +36,20 @@ namespace CustomInterfaces
   {
     m_view->setWaitingCursor();
 
+    // Check time limits
+    if (auto timeRange = m_view->timeRange()) {
+
+      if (timeRange->first >= timeRange->second){
+        m_view->restoreCursor();
+        m_view->displayError("Invalid time interval");
+        return;
+      }
+    } else {
+      m_view->restoreCursor();
+      m_view->displayError("No time interval");
+      return;
+    }
+
     try
     {
       IAlgorithm_sptr alg = AlgorithmManager::Instance().create("PlotAsymmetryByLogValue");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -118,15 +118,8 @@ namespace CustomInterfaces
 
   boost::optional< std::pair<double,double> > ALCDataLoadingView::timeRange() const
   {
-    if (m_ui.timeLimit->isChecked())
-    {
-      auto range = std::make_pair(m_ui.minTime->value(), m_ui.maxTime->value());
-      return boost::make_optional(range);
-    }
-    else
-    {
-      return boost::none;
-    }
+    auto range = std::make_pair(m_ui.minTime->value(), m_ui.maxTime->value());
+    return boost::make_optional(range);
   }
 
   void ALCDataLoadingView::setDataCurve(const QwtData& data)

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -85,7 +85,7 @@ public:
     ON_CALL(*m_view, lastRun()).WillByDefault(Return("MUSR00015191.nxs"));
     ON_CALL(*m_view, calculationType()).WillByDefault(Return("Integral"));
     ON_CALL(*m_view, log()).WillByDefault(Return("sample_magn_field"));
-    ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::none));
+    ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::make_optional(std::make_pair(-6.0,32.0))));
     ON_CALL(*m_view, deadTimeType()).WillByDefault(Return("None"));
     ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Auto"));
     ON_CALL(*m_view, redPeriod()).WillByDefault(Return("1"));


### PR DESCRIPTION
Fixes [#9551](http://trac.mantidproject.org/mantid/ticket/9551)

For tester: Open the Muon ALC interface and check that the QSpinBox widgets in section "Calculation" are enabled. Check also that if limits are not set (i.e From=0 and  Max=0) or From>=Max an error message appears. The documentation will also be updated: http://www.mantidproject.org/Muon_ALC
