### PR TITLE
Search for Qwt more rigourously

### DIFF
--- a/Code/Mantid/Build/CMake/FindQwt.cmake
+++ b/Code/Mantid/Build/CMake/FindQwt.cmake
@@ -9,7 +9,7 @@
 find_path ( QWT_INCLUDE_DIR qwt.h 
             PATHS /opt/include /usr/local/include /usr/include ${CMAKE_INCLUDE_PATH}
             PATH_SUFFIXES qwt5 qwt5-qt4 qwt-qt4 qwt )
-find_library ( QWT_LIBRARY NAMES qwt5-qt4 qwt-qt4 qwt )
+find_library ( QWT_LIBRARY NAMES qwt5-qt4 qwt-qt4 qwt5 qwt )
 find_library ( QWT_LIBRARY_DEBUG qwtd )
 
 # in REQUIRED mode: terminate if one of the above find commands failed


### PR DESCRIPTION
Some systems ship qwt 5 as `libqwt5.so`, which is currently not found by this module.

This pull request ensures that it's found in those circumstances. This is known to occur on Arch Linux.

**Testing**: Reviewing the changes and ensuring your build is not broken should be sufficient.
