### PR TITLE
Fix hang in Stitch1DMany

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -221,9 +221,9 @@ void Stitch1DMany::exec() {
         outName += wsName;
       }
 
-      IAlgorithm_sptr stitchAlg =
-          AlgorithmManager::Instance().create("Stitch1DMany");
+      IAlgorithm_sptr stitchAlg = createChildAlgorithm("Stitch1DMany");
       stitchAlg->initialize();
+      stitchAlg->setAlwaysStoreInADS(true);
       stitchAlg->setProperty("InputWorkspaces", toProcess);
       stitchAlg->setProperty("OutputWorkspace", outName);
       stitchAlg->setProperty("StartOverlaps", m_startOverlaps);
@@ -247,9 +247,9 @@ void Stitch1DMany::exec() {
 
     const std::string groupName = this->getProperty("OutputWorkspace");
 
-    IAlgorithm_sptr groupAlg =
-        AlgorithmManager::Instance().create("GroupWorkspaces");
+    IAlgorithm_sptr groupAlg = createChildAlgorithm("GroupWorkspaces");
     groupAlg->initialize();
+    groupAlg->setAlwaysStoreInADS(true);
     groupAlg->setProperty("InputWorkspaces", toGroup);
     groupAlg->setProperty("OutputWorkspace", groupName);
     groupAlg->execute();


### PR DESCRIPTION
This is for trac ticket [#11390](http://trac.mantidproject.org/mantid/ticket/11390)

With the script given in the ticket, Mantid would hang (deadlock) and require `kill -9` to be ended. This pull request fixes that.
