### PR TITLE
Mari inst update to add log file parameters to choppers

### DIFF
--- a/Code/Mantid/instrument/MARI_Definition.xml
+++ b/Code/Mantid/instrument/MARI_Definition.xml
@@ -45,6 +45,12 @@
   
   <component type="fermi-chopper">
     <location y="-0.1" z="-1.689" />
+    <parameter name="Speed (Hz)">
+      <logfile id="fermi_speed" extract-single-value-as="last_value" />
+    </parameter>
+    <parameter name="Delay (us)">
+      <logfile id="fermi_delay" extract-single-value-as="last_value" />
+    </parameter>
   </component>
   <type name="fermi-chopper" is="chopper">
     <cylinder id="body">
@@ -57,6 +63,9 @@
   
   <component type="disc-chopper">
     <location y="-0.18" z="-3.0" />
+    <parameter name="Speed (Hz)">
+      <logfile id="diskchopper" extract-single-value-as="last_value" />
+    </parameter>
   </component>
   <type name="disc-chopper" is="chopper">
     <cylinder id="body">


### PR DESCRIPTION
Ticket: http://trac.mantidproject.org/mantid/ticket/11410

Simple small change to add log file reading into parameters for the choppers in MARI.
### To test (ISIS only)
1. Load up a MARI file with logs (from \isis\inst$)
   Load(Filename=r'\isis\inst$\NDXMARI\Instrument\data\cycle_14_2\MAR19531.raw', OutputWorkspace='MAR19531', LoaderName='LoadRaw', LoaderVersion=3)
2. Show instrument
3. Check Display Settings-> Display detectors only is off
4. Pick Tab
5. Run the mouse over the two choppers (grey blobs closer to the sample)
6. They should have parameters associated with them (visible in the text panel).
