### PR TITLE
Fix curve properties dialog

### DIFF
--- a/Code/Mantid/MantidPlot/src/PlotDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/PlotDialog.cpp
@@ -1596,15 +1596,14 @@ void PlotDialog::updateTabWindow(QTreeWidgetItem *currentItem, QTreeWidgetItem *
   if (currentItem->type() == CurveTreeItem::PlotCurveTreeItem)
   {
     CurveTreeItem *curveItem = dynamic_cast<CurveTreeItem *>(currentItem);
-    if (!curveItem)
+    if (!curveItem) {
+      boxPlotType->blockSignals(false);
       return;
+    }
 
     CurveTreeItem *pi = dynamic_cast<CurveTreeItem *>(previousItem);
-    if (!pi)
-      return;
-
     if (previousItem->type() != CurveTreeItem::PlotCurveTreeItem
-        || pi->plotItemType() != curveItem->plotItemType()
+        || (pi && pi->plotItemType() != curveItem->plotItemType())
         || forceClearTabs)
     {
       clearTabWidget();


### PR DESCRIPTION
Fixes issue [#11407](http://trac.mantidproject.org/mantid/ticket/11407)

**Tester**

The instructions below should now allow you to change the curve properties, e.g. style etc. Before the fix they will not have worked.
- run CreateSampleWorkspace and plot the first spectrum
- right-click on the graph and select properties
- try to select the first curve under "Layer 1". You should see that the dialog does not update to show the properties of that curve, it stays on the properties of the layer
