### PR TITLE
Horace style for cutmd

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Code/Mantid/Framework/PythonInterface/mantid/simpleapi.py
@@ -355,6 +355,10 @@ def CutMD(*args, **kwargs):
         algm.setProperty('OutputWorkspace', out_names[i])
         algm.execute()
 
+    #Get the workspace objects so we can return them
+    for i in range(len(out_names)):
+        out_names[i] = _api.AnalysisDataService[out_names[i]]
+
     #We should only return a list if we're handling multiple workspaces
     if handling_multiple_workspaces:
         return out_names

--- a/Code/Mantid/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Code/Mantid/Framework/PythonInterface/mantid/simpleapi.py
@@ -260,7 +260,7 @@ def FitDialog(*args, **kwargs):
 
 def CutMD(*args, **kwargs):
     """
-    Description TODO
+    Slices multidimensional workspaces using input projection information and binning limits.
     """
     (in_wss,) = _get_mandatory_args('CutMD', ["InputWorkspace"], *args, **kwargs)
 
@@ -285,10 +285,8 @@ def CutMD(*args, **kwargs):
     #Take what we were given
     if "OutputWorkspace" in kwargs:
         out_names = kwargs["OutputWorkspace"]
-        print "taking from kwargs"
     else:
         out_names = list(lhs[1])
-        print "taking from lhs: " + str(out_names)
 
     #Ensure the output names we were given are valid
     if handling_multiple_workspaces:

--- a/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
@@ -9,10 +9,19 @@
 Description
 -----------
 
-This algorithm performs slicing of multiDimensional data according to a chosen projection, and binning choice. The algorithm uses :ref:`algm-BinMD` or 
-:ref:`algm-SliceMD` to achieve the binning of the data. The choice of child algorithm used for the slicing is controlled by the NoPix option.
+This algorithm performs slicing of multiDimensional data according to a chosen
+projection, and binning choice. The algorithm uses :ref:`algm-BinMD` or
+:ref:`algm-SliceMD` to achieve the binning of the data. The choice of child
+algorithm used for the slicing is controlled by the NoPix option.
 
 The synax is similar to that used by `Horace <http://horace.isis.rl.ac.uk/Manipulating_and_extracting_data_from_SQW_files_and_objects#cut_sqw>`__.
+
+Unlike most Mantid algorithms, CutMD can accept a list of workspaces as the
+input workspace, given as the name of a workspace in the analysis data service
+or the path to a workspace, or simply a workspace object in python. These will
+all then be processed sequentially with the same options. The only requirement
+is that the same number of output workspaces are also given so that CutMD knows
+what to call each output workspace created.
 
 Usage
 -----
@@ -39,6 +48,10 @@ Usage
    
    # Apply the cut (PBins property sets the P1Bin, P2Bin, etc. properties for you)
    out_md = CutMD(to_cut, Projection=proj_ws, PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
+
+   #Another way we can call CutMD:
+   #[out1, out2, out3] = CutMD([to_cut, "some_other_file.nxs", "some_workspace_name"], ...)
+
    print 'number of dimensions', out_md.getNumDims()
    print 'number of dimensions not integrated', len(out_md.getNonIntegratedDimensions())
    dim_dE = out_md.getDimension(3)


### PR DESCRIPTION
This is for trac ticket [#11354](http://trac.mantidproject.org/mantid/ticket/11354).

**Testing**: I've been using the following script during development to check multiple calling styles work:

``` python
a = Load("example_md_a.nxs")
Load("example_md_b.nxs", OutputWorkspace="example_md_b")
projection = Projection([1,1,0], [-1,1,0])
proj_ws = projection.createWorkspace()

print "first run"
[out_1_a,out_1_b,out_1_c] = CutMD([a, "example_md_b", "example_md_c.nxs"], Projection=proj_ws, PBins=[[-0.5, 0.1, 0.5], [0.1], [0.1]], NoPix=True)

print "second run"
out_2_a = CutMD(a, Projection=proj_ws, PBins=[[-0.5, 0.1, 0.5], [0.1], [0.1]], NoPix=True)

print "third run"
CutMD("example_md_b", OutputWorkspace="out_3_b", Projection=proj_ws, PBins=[[-0.5, 0.1, 0.5], [0.1], [0.1]], NoPix=True)

print "fourth run"
out_4_a,out_4_b = CutMD([a, "example_md_b"], Projection=proj_ws, PBins=[[-0.5, 0.1, 0.5], [0.1], [0.1]], NoPix=True)

print "fifth run"
(out_5_a,out_5_b) = CutMD([a, "example_md_b"], Projection=proj_ws, PBins=[[-0.5, 0.1, 0.5], [0.1], [0.1]], NoPix=True)
```
