### PR TITLE
Improve log(y) plots on PreviewPlot

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
@@ -26,6 +26,7 @@ using namespace Mantid::API;
 namespace
 {
   Mantid::Kernel::Logger g_log("PreviewPlot");
+  bool isNegative(double v) { return v <= 0.0; }
 }
 
 
@@ -604,14 +605,14 @@ QwtPlotCurve * PreviewPlot::addCurve(MatrixWorkspace_sptr ws, const size_t specI
   {
     // Remove negative data in order to search for minimum positive value
     std::vector<double> validData(wsDataY.size());
-    auto it = std::remove_copy_if(wsDataY.begin(), wsDataY.end(), validData.begin(), [](double v){ return v<= 0.0; } );
+    auto it = std::remove_copy_if(wsDataY.begin(), wsDataY.end(), validData.begin(), isNegative);
     validData.resize(std::distance(validData.begin(), it));
 
     // Get minimum positive value
     double minY = *std::min_element(validData.begin(), validData.end());
 
     // Set all negative values to minimum positive value
-    std::replace_if(wsDataY.begin(), wsDataY.end(), [](double v){return v <= 0.0; }, minY);
+    std::replace_if(wsDataY.begin(), wsDataY.end(), isNegative, minY);
   }
 
   // Create the Qwt data

--- a/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
@@ -596,10 +596,11 @@ QwtPlotCurve * PreviewPlot::addCurve(MatrixWorkspace_sptr ws, const size_t specI
   }
 
   // Create the plot data
-  QwtWorkspaceSpectrumData wsData(*ws, static_cast<int>(specIndex), false, false);
+  bool logYScale = getAxisType(QwtPlot::yLeft) == "Logarithmic";
+  QwtWorkspaceSpectrumData wsData(*ws, static_cast<int>(specIndex), logYScale, false);
 
   // Create the new curve
-  QwtPlotCurve *curve = new QwtPlotCurve();
+  QwtPlotCurve * curve = new QwtPlotCurve();
   curve->setData(wsData);
   curve->setPen(curveColour);
   curve->attach(m_uiForm.plot);


### PR DESCRIPTION
Fixes [#11389](http://trac.mantidproject.org/mantid/ticket/11389).

To test:
- Load `irs26173_graphite002_red`
- `Scale` it by adding -0.1 to get some negative values
- Open Indirect Data Analysis > ConvFit and load the scaled workspace as the sample
- Switch Y axis to Logarithmic (right click plot to open menu)
- Notice negative values are replaced with lowest positive values
