### PR TITLE
Fix IndirectTransmissionMonitor doc test

### DIFF
--- a/Code/Mantid/docs/source/algorithms/IndirectTransmissionMonitor-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectTransmissionMonitor-v1.rst
@@ -26,8 +26,8 @@ Usage
 
 .. testcode:: exIRISTransmission
 
-   sample_ws = Load('IRS26176.raw')
-   can_ws = Load('IRS26173.raw')
+   sample_ws = Load('IRS26176.RAW')
+   can_ws = Load('IRS26173.RAW')
 
    transmission_ws = IndirectTransmissionMonitor(SampleWorkspace=sample_ws, CanWorkspace=can_ws)
 


### PR DESCRIPTION
Fixes [#11419](http://trac.mantidproject.org/mantid/ticket/11419).

To test, run `IndirectTransmissionMontor` test on Linux and see that it passes.
