### PR TITLE
Extend indirect absorption correction algorithms to do can corrections

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
@@ -214,7 +214,7 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
             from IndirectImport import import_mantidplot
             mantid_plot = import_mantidplot()
             mantid_plot.plotSpectrum(plot_data, 0)
-            if self._abs_ws == '':
+            if self._abs_ws != '':
                 mantid_plot.plotSpectrum(plot_corr, 0)
 
 
@@ -260,14 +260,21 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
         self._setup()
         issues = dict()
 
-        # TODO: geometry validation
-        # can inner < sample inner < sample outer < can outer
-
         if self._use_can_corrections and self._can_chemical_formula == '':
             issues['CanChemicalFormula'] = 'Must be set to use can corrections'
 
         if self._use_can_corrections and self._can_ws_name is None:
             issues['UseCanCorrections'] = 'Must specify a can workspace to use can corections'
+
+        # Geometry validation: can inner < sample inner < sample outer < can outer
+        if self._sample_inner_radius < self._can_inner_radius:
+            issues['SampleInnerRadius'] = 'Must be greater than CanInnerRadius'
+
+        if self._sample_outer_radius < self._sample_inner_radius:
+            issues['SampleOuterRadius'] = 'Must be greater than SampleInnerRadius'
+
+        if self._can_outer_radius < self._sample_outer_radius:
+            issues['CanOuterRadius'] = 'Must be greater than SampleOuterRadius'
 
         return issues
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
@@ -1,6 +1,6 @@
 from mantid.simpleapi import *
-from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, Progress
-from mantid.kernel import StringMandatoryValidator, Direction, logger
+from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, Progress, WorkspaceGroupProperty
+from mantid.kernel import StringMandatoryValidator, Direction, logger, IntBoundedValidator, FloatBoundedValidator
 
 
 class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
@@ -14,31 +14,57 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
 
 
     def PyInit(self):
+        # Sample options
         self.declareProperty(MatrixWorkspaceProperty('SampleWorkspace', '', direction=Direction.Input),
                              doc='Sample workspace.')
 
+        self.declareProperty(name='SampleChemicalFormula', defaultValue='',
+                             validator=StringMandatoryValidator(),
+                             doc='Chemical formula for the sample')
+        self.declareProperty(name='SampleNumberDensity', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample number density')
+        self.declareProperty(name='SampleInnerRadius', defaultValue=0.2,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample radius')
+        self.declareProperty(name='SampleOuterRadius', defaultValue=0.25,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample radius')
+
+        # Container options
         self.declareProperty(MatrixWorkspaceProperty('CanWorkspace', '', optional=PropertyMode.Optional,
                                                      direction=Direction.Input),
                              doc='Container workspace.')
+        self.declareProperty(name='UseCanCorrections', defaultValue=False,
+                             doc='Use can corrections in subtraction')
+        self.declareProperty(name='CanChemicalFormula', defaultValue='',
+                             doc='Chemical formula for the can')
+        self.declareProperty(name='CanNumberDensity', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Can number density')
+        self.declareProperty(name='CanInnerRadius', defaultValue=0.19,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample radius')
+        self.declareProperty(name='CanOuterRadius', defaultValue=0.26,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample radius')
+        self.declareProperty(name='CanScaleFactor', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Scale factor to multiply can data')
 
-        self.declareProperty(name='CanScaleFactor', defaultValue=1.0, doc='Scale factor to multiply can data')
+        # General options
+        self.declareProperty(name='Events', defaultValue=5000,
+                             validator=IntBoundedValidator(0),
+                             doc='Number of neutron events')
+        self.declareProperty(name='Plot', defaultValue=False,
+                             doc='Plot options')
 
-        self.declareProperty(name='ChemicalFormula', defaultValue='', validator=StringMandatoryValidator(),
-                             doc='Chemical formula')
-
-        self.declareProperty(name='CanInnerRadius', defaultValue=0.2, doc='Sample radius')
-        self.declareProperty(name='SampleInnerRadius', defaultValue=0.15, doc='Sample radius')
-        self.declareProperty(name='SampleOuterRadius', defaultValue=0.16, doc='Sample radius')
-        self.declareProperty(name='CanOuterRadius', defaultValue=0.22, doc='Sample radius')
-        self.declareProperty(name='SampleNumberDensity', defaultValue=0.1, doc='Sample number density')
-        self.declareProperty(name='Events', defaultValue=5000, doc='Number of neutron events')
-        self.declareProperty(name='Plot', defaultValue=False, doc='Plot options')
-
+        # Output options
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', direction=Direction.Output),
                              doc='The output corrected workspace.')
 
-        self.declareProperty(MatrixWorkspaceProperty('CorrectionsWorkspace', '', direction=Direction.Output,
-                                                     optional=PropertyMode.Optional),
+        self.declareProperty(WorkspaceGroupProperty('CorrectionsWorkspace', '', direction=Direction.Output,
+                                                    optional=PropertyMode.Optional),
                              doc='The corrections workspace for scattering and absorptions in sample.')
 
 
@@ -48,12 +74,11 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
         self._setup()
 
         # Set up progress reporting
-        n_prog_reports = 4
-        if self._can_ws is not None:
-            n_prog_reports += 2
-        prog_reporter = Progress(self, 0.0, 1.0, n_prog_reports)
+        n_prog_reports = 2
+        if self._can_ws_name is not None:
+            n_prog_reports += 1
+        prog = Progress(self, 0.0, 1.0, n_prog_reports)
 
-        prog_reporter.report('Processing sample')
         efixed = getEfixed(self._sample_ws_name)
 
         sample_wave_ws = '__sam_wave'
@@ -61,44 +86,96 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
                      Target='Wavelength', EMode='Indirect', EFixed=efixed)
 
         sample_thickness = self._sample_outer_radius - self._sample_inner_radius
+        logger.information('Sample thickness: ' + str(sample_thickness))
 
-        prog_reporter.report('Calculating sample corrections')
+        prog.report('Calculating sample corrections')
         AnnularRingAbsorption(InputWorkspace=sample_wave_ws,
                               OutputWorkspace=self._ass_ws,
                               SampleHeight=3.0,
                               SampleThickness=sample_thickness,
                               CanInnerRadius=self._can_inner_radius,
                               CanOuterRadius=self._can_outer_radius,
-                              SampleChemicalFormula=self._chemical_formula,
-                              SampleNumberDensity=self._number_density,
+                              SampleChemicalFormula=self._sample_chemical_formula,
+                              SampleNumberDensity=self._sample_number_density,
                               NumberOfWavelengthPoints=10,
                               EventsPerPoint=self._events)
 
-        plot_list = [self._output_ws, self._sample_ws_name]
+        plot_data = [self._output_ws, self._sample_ws_name]
+        plot_corr = [self._ass_ws]
+        group = self._ass_ws
 
-        if self._can_ws is not None:
-            prog_reporter.report('Processing can')
-            can_wave_ws = '__can_wave'
-            ConvertUnits(InputWorkspace=self._can_ws, OutputWorkspace=can_wave_ws,
+        if self._can_ws_name is not None:
+            can1_wave_ws = '__can1_wave'
+            can2_wave_ws = '__can2_wave'
+            ConvertUnits(InputWorkspace=self._can_ws_name, OutputWorkspace=can1_wave_ws,
                          Target='Wavelength', EMode='Indirect', EFixed=efixed)
-
             if self._can_scale != 1.0:
                 logger.information('Scaling can by: ' + str(self._can_scale))
-                Scale(InputWorkspace=can_wave_ws, OutputWorkspace=can_wave_ws, Factor=self._can_scale, Operation='Multiply')
+                Scale(InputWorkspace=can1_wave_ws, OutputWorkspace=can1_wave_ws, Factor=self._can_scale, Operation='Multiply')
+            CloneWorkspace(InputWorkspace=can1_wave_ws, OutputWorkspace=can2_wave_ws)
 
-            prog_reporter.report('Applying can corrections')
-            Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
-            DeleteWorkspace(can_wave_ws)
+            can_thickness1 = self._sample_inner_radius - self._can_inner_radius
+            can_thickness2 = self._can_outer_radius - self._sample_outer_radius
+            logger.information('Can thickness: ' + str(can_thickness1) + ' & ' + str(can_thickness2))
 
-            plot_list.append(self._can_ws)
+            if self._use_can_corrections:
+                prog.report('Calculating container corrections')
+                Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
-        prog_reporter.report('Applying corrections')
-        Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
-        ConvertUnits(InputWorkspace=sample_wave_ws, OutputWorkspace=self._output_ws, Target='DeltaE',
-                     EMode='Indirect', EFixed=efixed)
+                SetSampleMaterial(can1_wave_ws, ChemicalFormula=self._can_chemical_formula, SampleNumberDensity=self._can_number_density)
+                AnnularRingAbsorption(InputWorkspace=can1_wave_ws,
+                              OutputWorkspace='__Acc1',
+                              SampleHeight=3.0,
+                              SampleThickness=can_thickness1,
+                              CanInnerRadius=self._can_inner_radius,
+                              CanOuterRadius=self._sample_outer_radius,
+                              SampleChemicalFormula=self._can_chemical_formula,
+                              SampleNumberDensity=self._can_number_density,
+                              NumberOfWavelengthPoints=10,
+                              EventsPerPoint=self._events)
+
+                SetSampleMaterial(can2_wave_ws, ChemicalFormula=self._can_chemical_formula, SampleNumberDensity=self._can_number_density)
+                AnnularRingAbsorption(InputWorkspace=can2_wave_ws,
+                              OutputWorkspace='__Acc2',
+                              SampleHeight=3.0,
+                              SampleThickness=can_thickness2,
+                              CanInnerRadius=self._sample_inner_radius,
+                              CanOuterRadius=self._can_outer_radius,
+                              SampleChemicalFormula=self._can_chemical_formula,
+                              SampleNumberDensity=self._can_number_density,
+                              NumberOfWavelengthPoints=10,
+                              EventsPerPoint=self._events)
+
+                Multiply(LHSWorkspace='__Acc1', RHSWorkspace='__Acc2', OutputWorkspace=self._acc_ws)
+                DeleteWorkspace('__Acc1')
+                DeleteWorkspace('__Acc2')
+                Divide(LHSWorkspace=can1_wave_ws, RHSWorkspace=self._acc_ws, OutputWorkspace=can1_wave_ws)
+                Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can1_wave_ws, OutputWorkspace=sample_wave_ws)
+                plot_corr.append(self._acc_ws)
+                group += ',' + self._acc_ws
+
+            else:
+                prog.report('Calculating can scaling')
+                Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can1_wave_ws, OutputWorkspace=sample_wave_ws)
+                Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
+
+            DeleteWorkspace(can1_wave_ws)
+            DeleteWorkspace(can2_wave_ws)
+            plot_data.append(self._can_ws_name)
+
+        else:
+            Divide(LHSWorkspace=sample_wave_ws,
+                   RHSWorkspace=self._ass_ws,
+                   OutputWorkspace=sample_wave_ws)
+
+        ConvertUnits(InputWorkspace=sample_wave_ws,
+                     OutputWorkspace=self._output_ws,
+                     Target='DeltaE',
+                     EMode='Indirect',
+                     EFixed=efixed)
         DeleteWorkspace(sample_wave_ws)
 
-        prog_reporter.report('Recording sample logs')
+        prog.report('Recording sample logs')
         sample_logs = {'sample_shape': 'annulus',
                        'sample_filename': self._sample_ws_name,
                        'sample_inner': self._sample_inner_radius,
@@ -108,24 +185,33 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
         addSampleLogs(self._ass_ws, sample_logs)
         addSampleLogs(self._output_ws, sample_logs)
 
-        if self._can_ws is not None:
-            AddSampleLog(Workspace=self._ass_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws))
-            AddSampleLog(Workspace=self._output_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws))
-            AddSampleLog(Workspace=self._ass_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+        if self._can_ws_name is not None:
+            AddSampleLog(Workspace=self._output_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws_name))
             AddSampleLog(Workspace=self._output_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+            if self._use_can_corrections:
+                addSampleLogs(self._acc_ws, sample_logs)
+                AddSampleLog(Workspace=self._acc_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws_name))
+                AddSampleLog(Workspace=self._acc_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness1', LogType='String', LogText=str(can_thickness1))
+                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness2', LogType='String', LogText=str(can_thickness2))
 
         self.setProperty('OutputWorkspace', self._output_ws)
 
         # Output the Ass workspace if it is wanted, delete if not
-        if self._ass_ws == '_ass':
+        if self._abs_ws == '':
             DeleteWorkspace(self._ass_ws)
+            if self._can_ws_name is not None and self._use_can_corrections:
+                DeleteWorkspace(self._acc_ws)
         else:
-            self.setProperty('CorrectionsWorkspace', self._ass_ws)
+            GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self._abs_ws)
+            self.setProperty('CorrectionsWorkspace', self._abs_ws)
 
         if self._plot:
             from IndirectImport import import_mantidplot
             mantid_plot = import_mantidplot()
-            mantid_plot.plotSpectrum(plot_list, 0)
+            mantid_plot.plotSpectrum(plot_data, 0)
+            if self._abs_ws == '':
+                mantid_plot.plotSpectrum(plot_corr, 0)
 
 
     def _setup(self):
@@ -134,24 +220,51 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
         """
 
         self._sample_ws_name = self.getPropertyValue('SampleWorkspace')
-        self._can_scale = self.getProperty('CanScaleFactor').value
-        self._chemical_formula = self.getPropertyValue('ChemicalFormula')
-        self._number_density = self.getProperty('SampleNumberDensity').value
-        self._can_inner_radius = self.getProperty('CanInnerRadius').value
+        self._sample_chemical_formula = self.getPropertyValue('SampleChemicalFormula')
+        self._sample_number_density = self.getProperty('SampleNumberDensity').value
         self._sample_inner_radius = self.getProperty('SampleInnerRadius').value
         self._sample_outer_radius = self.getProperty('SampleOuterRadius').value
+
+        self._can_ws_name = self.getPropertyValue('CanWorkspace')
+        if self._can_ws_name == '':
+            self._can_ws_name = None
+        self._use_can_corrections = self.getProperty('UseCanCorrections').value
+        self._can_chemical_formula = self.getPropertyValue('CanChemicalFormula')
+        self._can_number_density = self.getProperty('CanNumberDensity').value
+        self._can_inner_radius = self.getProperty('CanInnerRadius').value
         self._can_outer_radius = self.getProperty('CanOuterRadius').value
+        self._can_scale = self.getProperty('CanScaleFactor').value
+
         self._events = self.getProperty('Events').value
         self._plot = self.getProperty('Plot').value
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
-        self._ass_ws = self.getPropertyValue('CorrectionsWorkspace')
-        if self._ass_ws == '':
+        self._abs_ws = self.getPropertyValue('CorrectionsWorkspace')
+        if self._abs_ws == '':
             self._ass_ws = '__ass'
+            self._acc_ws = '__acc'
+        else:
+            self._ass_ws = self._abs_ws + '_ass'
+            self._acc_ws = self._abs_ws + '_acc'
 
-        self._can_ws = self.getPropertyValue('CanWorkspace')
-        if self._can_ws == '':
-            self._can_ws = None
+
+    def validateInputs(self):
+        """
+        Validate algorithm options.
+        """
+
+        self._setup()
+        issues = dict()
+
+        # TODO: geometry validation
+
+        if self._use_can_corrections and self._can_chemical_formula == '':
+            issues['CanChemicalFormula'] = 'Must be set to use can corrections'
+
+        if self._use_can_corrections and self._can_ws_name is None:
+            issues['UseCanCorrections'] = 'Must specify a can workspace to use can corections'
+
+        return issues
 
 
 # Register algorithm with Mantid

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
@@ -172,7 +172,7 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
             sample_logs.append(('can_scale', self._can_scale))
             if self._use_can_corrections:
                 sample_log_workspaces.append(self._acc_ws)
-                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness', LogType='Number', LogText=str(can_thickness))
+                sample_logs.append(('can_thickness', can_thickness))
 
         log_names = [item[0] for item in sample_logs]
         log_values = [item[1] for item in sample_logs]

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
@@ -1,6 +1,6 @@
 from mantid.simpleapi import *
-from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, Progress
-from mantid.kernel import StringMandatoryValidator, Direction, logger
+from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, WorkspaceGroupProperty, PropertyMode
+from mantid.kernel import StringMandatoryValidator, Direction, logger, FloatBoundedValidator, IntBoundedValidator
 
 
 class IndirectCylinderAbsorption(DataProcessorAlgorithm):
@@ -14,27 +14,49 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
 
 
     def PyInit(self):
+        # Sample options
         self.declareProperty(MatrixWorkspaceProperty('SampleWorkspace', '', direction=Direction.Input),
                              doc='Sample workspace.')
+        self.declareProperty(name='SampleChemicalFormula', defaultValue='', validator=StringMandatoryValidator(),
+                             doc='Sample chemical formula')
+        self.declareProperty(name='SampleNumberDensity', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample number density')
+        self.declareProperty(name='SampleRadius', defaultValue=0.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample radius')
 
+        # Container options
         self.declareProperty(MatrixWorkspaceProperty('CanWorkspace', '', optional=PropertyMode.Optional,
                                                      direction=Direction.Input),
                              doc='Container workspace.')
+        self.declareProperty(name='UseCanCorrections', defaultValue=False,
+                             doc='Use can corrections in subtraction')
+        self.declareProperty(name='CanChemicalFormula', defaultValue='',
+                             doc='Can chemical formula')
+        self.declareProperty(name='CanNumberDensity', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Can number density')
+        self.declareProperty(name='CanRadius', defaultValue=0.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Can radius')
+        self.declareProperty(name='CanScaleFactor', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Scale factor to multiply can data')
 
-        self.declareProperty(name='CanScaleFactor', defaultValue=1.0, doc='Scale factor to multiply can data')
+        # General options
+        self.declareProperty(name='Events', defaultValue=5000,
+                             validator=IntBoundedValidator(0),
+                             doc='Number of neutron events')
+        self.declareProperty(name='Plot', defaultValue=False,
+                             doc='Plot options')
 
-        self.declareProperty(name='ChemicalFormula', defaultValue='', validator=StringMandatoryValidator(),
-                             doc='Chemical formula')
-
-        self.declareProperty(name='SampleRadius', defaultValue=0.5, doc='Sample radius')
-        self.declareProperty(name='SampleNumberDensity', defaultValue=0.1, doc='Sample number density')
-        self.declareProperty(name='Plot', defaultValue=False, doc='Plot options')
-
+        # Output options
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', direction=Direction.Output),
                              doc='The output corrected workspace.')
 
-        self.declareProperty(MatrixWorkspaceProperty('CorrectionsWorkspace', '', direction=Direction.Output,
-                                                     optional=PropertyMode.Optional),
+        self.declareProperty(WorkspaceGroupProperty('CorrectionsWorkspace', '', direction=Direction.Output,
+                                                    optional=PropertyMode.Optional),
                              doc='The corrections workspace for scattering and absorptions in sample.')
 
 
@@ -42,81 +64,105 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
         from IndirectCommon import getEfixed, addSampleLogs
 
         self._setup()
-
-        # Set up progress reporting
-        n_prog_reports = 4
-        if self._can_ws is not None:
-            n_prog_reports += 2
-        prog_reporter = Progress(self, 0.0, 1.0, n_prog_reports)
-
-        prog_reporter.report('Processing sample')
-        efixed = getEfixed(self._sample_ws)
+        efixed = getEfixed(self._sample_ws_name)
 
         sample_wave_ws = '__sam_wave'
-        ConvertUnits(InputWorkspace=self._sample_ws, OutputWorkspace=sample_wave_ws,
+        ConvertUnits(InputWorkspace=self._sample_ws_name, OutputWorkspace=sample_wave_ws,
                      Target='Wavelength', EMode='Indirect', EFixed=efixed)
 
-        SetSampleMaterial(sample_wave_ws, ChemicalFormula=self._chemical_formula, SampleNumberDensity=self._number_density)
+        SetSampleMaterial(sample_wave_ws, ChemicalFormula=self._sample_chemical_formula, SampleNumberDensity=self._sample_number_density)
 
-        prog_reporter.report('Calculating sample corrections')
         CylinderAbsorption(InputWorkspace=sample_wave_ws,
                            OutputWorkspace=self._ass_ws,
-                           SampleNumberDensity=self._number_density,
+                           SampleNumberDensity=self._sample_number_density,
                            NumberOfWavelengthPoints=10,
                            CylinderSampleHeight=3.0,
                            CylinderSampleRadius=self._sample_radius,
                            NumberOfSlices=1,
                            NumberOfAnnuli=10)
 
-        plot_list = [self._output_ws, self._sample_ws]
+        plot_data = [self._output_ws, self._sample_ws_name]
+        plot_corr = [self._ass_ws]
+        group = self._ass_ws
 
-        if self._can_ws is not None:
-            prog_reporter.report('Processing can')
+        if self._can_ws_name is not None:
             can_wave_ws = '__can_wave'
-            ConvertUnits(InputWorkspace=self._can_ws, OutputWorkspace=can_wave_ws,
+            ConvertUnits(InputWorkspace=self._can_ws_name, OutputWorkspace=can_wave_ws,
                          Target='Wavelength', EMode='Indirect', EFixed=efixed)
-
             if self._can_scale != 1.0:
                 logger.information('Scaling can by: ' + str(self._can_scale))
                 Scale(InputWorkspace=can_wave_ws, OutputWorkspace=can_wave_ws, Factor=self._can_scale, Operation='Multiply')
 
-            prog_reporter.report('Applying can corrections')
-            Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
+            can_thickness = self._can_radius - self._sample_radius
+            logger.information('Can thickness: ' + str(can_thickness))
+
+            if self._use_can_corrections:
+                Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
+
+                SetSampleMaterial(can_wave_ws, ChemicalFormula=self._can_chemical_formula, SampleNumberDensity=self._can_number_density)
+                AnnularRingAbsorption(InputWorkspace=can_wave_ws,
+                              OutputWorkspace=self._acc_ws,
+                              SampleHeight=3.0,
+                              SampleThickness=can_thickness,
+                              CanInnerRadius=0.9*self._sample_radius,
+                              CanOuterRadius=1.1*self._can_radius,
+                              SampleChemicalFormula=self._can_chemical_formula,
+                              SampleNumberDensity=self._can_number_density,
+                              NumberOfWavelengthPoints=10,
+                              EventsPerPoint=self._events)
+
+                Divide(LHSWorkspace=can_wave_ws, RHSWorkspace=self._acc_ws, OutputWorkspace=can_wave_ws)
+                Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
+                plot_corr.append(self._acc_ws)
+                group += ',' + self._acc_ws
+
+            else:
+                Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
+                Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
+
             DeleteWorkspace(can_wave_ws)
+            plot_data.append(self._can_ws_name)
 
-            plot_list.append(self._can_ws)
+        else:
+            Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
-        prog_reporter.report('Applying corrections')
-        Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
         ConvertUnits(InputWorkspace=sample_wave_ws, OutputWorkspace=self._output_ws,
                      Target='DeltaE', EMode='Indirect', EFixed=efixed)
         DeleteWorkspace(sample_wave_ws)
 
-        prog_reporter.report('Recording sample logs')
         sample_logs = {'sample_shape': 'cylinder',
-                       'sample_filename': self._sample_ws,
+                       'sample_filename': self._sample_ws_name,
                        'sample_radius': self._sample_radius}
         addSampleLogs(self._ass_ws, sample_logs)
         addSampleLogs(self._output_ws, sample_logs)
 
-        if self._can_ws is not None:
-            AddSampleLog(Workspace=self._ass_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws))
-            AddSampleLog(Workspace=self._output_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws))
-            AddSampleLog(Workspace=self._ass_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+        if self._can_ws_name is not None:
+            AddSampleLog(Workspace=self._output_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws_name))
             AddSampleLog(Workspace=self._output_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+            if self._use_can_corrections:
+                addSampleLogs(self._acc_ws, sample_logs)
+                AddSampleLog(Workspace=self._acc_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws_name))
+                AddSampleLog(Workspace=self._acc_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness', LogType='String', LogText=str(can_thickness))
 
         self.setProperty('OutputWorkspace', self._output_ws)
 
-        # Output the Ass workspace if it is wanted, delete if not
-        if self._ass_ws == '_ass':
+        # Output the Abs group workspace if it is wanted, delete if not
+        if self._abs_ws == '':
             DeleteWorkspace(self._ass_ws)
+            if self._can_ws_name is not None and self._use_can_corrections:
+                DeleteWorkspace(self._acc_ws)
+
         else:
-            self.setProperty('CorrectionsWorkspace', self._ass_ws)
+            GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self._abs_ws)
+            self.setProperty('CorrectionsWorkspace', self._abs_ws)
 
         if self._plot:
             from IndirectImport import import_mantidplot
             mantid_plot = import_mantidplot()
-            mantid_plot.plotSpectrum(plot_list, 0)
+            mantid_plot.plotSpectrum(plot_data, 0)
+            if self._abs_ws != '':
+                mantid_plot.plotSpectrum(plot_corr, 0)
 
 
     def _setup(self):
@@ -124,21 +170,52 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
         Get algorithm properties.
         """
 
-        self._sample_ws = self.getPropertyValue('SampleWorkspace')
-        self._can_scale = self.getProperty('CanScaleFactor').value
-        self._chemical_formula = self.getPropertyValue('ChemicalFormula')
-        self._number_density = self.getProperty('SampleNumberDensity').value
+        self._sample_ws_name = self.getPropertyValue('SampleWorkspace')
+        self._sample_chemical_formula = self.getPropertyValue('SampleChemicalFormula')
+        self._sample_number_density = self.getProperty('SampleNumberDensity').value
         self._sample_radius = self.getProperty('SampleRadius').value
+
+        self._can_ws_name = self.getPropertyValue('CanWorkspace')
+        if self._can_ws_name == '':
+            self._can_ws_name = None
+
+        self._use_can_corrections = self.getProperty('UseCanCorrections').value
+        self._can_chemical_formula = self.getPropertyValue('CanChemicalFormula')
+        self._can_number_density = self.getProperty('CanNumberDensity').value
+        self._can_radius = self.getProperty('CanRadius').value
+        self._can_scale = self.getProperty('CanScaleFactor').value
+        self._events = self.getPropertyValue('Events')
+
         self._plot = self.getProperty('Plot').value
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
-        self._ass_ws = self.getPropertyValue('CorrectionsWorkspace')
-        if self._ass_ws == '':
+        self._abs_ws = self.getPropertyValue('CorrectionsWorkspace')
+        if self._abs_ws == '':
             self._ass_ws = '__ass'
+            self._acc_ws = '__acc'
+        else:
+            self._ass_ws = self._abs_ws + '_ass'
+            self._acc_ws = self._abs_ws + '_acc'
 
-        self._can_ws = self.getPropertyValue('CanWorkspace')
-        if self._can_ws == '':
-            self._can_ws = None
+
+    def validateInputs(self):
+        """
+        Validate options
+        """
+
+        self._setup()
+        issues = dict()
+
+        if self._sample_radius > self._can_radius:
+            issues['CanRadius'] = 'Must be greater than SampleRadius'
+
+        if self._use_can_corrections and self._can_chemical_formula == '':
+            issues['CanChemicalFormula'] = 'Must be set to use can corrections'
+
+        if self._use_can_corrections and self._can_ws_name is None:
+            issues['UseCanCorrections'] = 'Must specify a can workspace to use can corections'
+
+        return issues
 
 
 # Register algorithm with Mantid

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
@@ -161,7 +161,7 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
         DeleteWorkspace(sample_wave_ws)
 
         # Record sample logs
-        prog.report('Recording logs')
+        prog.report('Recording sample logs')
         sample_log_workspaces = [self._output_ws, self._ass_ws]
         sample_logs = [('sample_shape', 'cylinder'),
                        ('sample_filename', self._sample_ws_name),
@@ -172,7 +172,7 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
             sample_logs.append(('can_scale', self._can_scale))
             if self._use_can_corrections:
                 sample_log_workspaces.append(self._acc_ws)
-                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness', LogType='String', LogText=str(can_thickness))
+                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness', LogType='Number', LogText=str(can_thickness))
 
         log_names = [item[0] for item in sample_logs]
         log_values = [item[1] for item in sample_logs]
@@ -236,7 +236,7 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
 
     def validateInputs(self):
         """
-        Validate options
+        Validate algorithm options.
         """
 
         self._setup()

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
@@ -5,6 +5,24 @@ from mantid.kernel import StringMandatoryValidator, Direction, logger, FloatBoun
 
 class IndirectCylinderAbsorption(DataProcessorAlgorithm):
 
+    _sample_ws_name = None
+    _sample_chemical_formula = None
+    _sample_number_density = None
+    _sample_radius = None
+    _can_ws_name = None
+    _use_can_corrections = None
+    _can_chemical_formula = None
+    _can_number_density = None
+    _can_radius = None
+    _can_scale = None
+    _events = None
+    _plot = None
+    _output_ws = None
+    _abs_ws = None
+    _ass_ws = None
+    _acc_ws = None
+
+
     def category(self):
         return "Workflow\\Inelastic;PythonAlgorithms;CorrectionFunctions\\AbsorptionCorrections;Workflow\\MIDAS"
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
@@ -182,8 +182,8 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
             sample_logs.append(('can_scale', self._can_scale))
             if self._use_can_corrections:
                 sample_log_workspaces.append(self._acc_ws)
-                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness_1', LogType='Number', LogText=str(self._can_front_thickness))
-                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness_2', LogType='Number', LogText=str(self._can_back_thickness))
+                sample_logs.append(('can_front_thickness', self. _can_front_thickness))
+                sample_logs.append(('can_back_thickness', self. _can_back_thickness))
 
         log_names = [item[0] for item in sample_logs]
         log_values = [item[1] for item in sample_logs]

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
@@ -1,9 +1,30 @@
 from mantid.simpleapi import *
-from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, Progress
-from mantid.kernel import StringMandatoryValidator, Direction, logger
+from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, Progress, WorkspaceGroupProperty
+from mantid.kernel import StringMandatoryValidator, Direction, logger, FloatBoundedValidator
 
 
 class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
+
+    _sample_ws = None
+    _sample_chemical_formula = None
+    _sample_number_density = None
+    _sample_height = None
+    _sample_width = None
+    _sample_thickness = None
+    _can_ws_name = None
+    _use_can_corrections = None
+    _can_chemical_formula = None
+    _can_number_density = None
+    _can_front_thickness = None
+    _can_back_thickness = None
+    _can_scale = None
+    _element_size = None
+    _plot = None
+    _output_ws = None
+    _abs_ws = None
+    _ass_ws = None
+    _acc_ws = None
+
 
     def category(self):
         return "Workflow\\Inelastic;PythonAlgorithms;CorrectionFunctions\\AbsorptionCorrections;Workflow\\MIDAS"
@@ -14,31 +35,61 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
 
 
     def PyInit(self):
+        # Sample
         self.declareProperty(MatrixWorkspaceProperty('SampleWorkspace', '', direction=Direction.Input),
-                             doc='Sample workspace.')
+                             doc='Sample workspace')
+        self.declareProperty(name='SampleChemicalFormula', defaultValue='',
+                             validator=StringMandatoryValidator(),
+                             doc='Chemical formula for the sample')
+        self.declareProperty(name='SampleNumberDensity', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample number density')
+        self.declareProperty(name='SampleHeight', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample height')
+        self.declareProperty(name='SampleWidth', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample width')
+        self.declareProperty(name='SampleThickness', defaultValue=0.5,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample thickness')
 
+        # Container
         self.declareProperty(MatrixWorkspaceProperty('CanWorkspace', '', optional=PropertyMode.Optional,
                                                      direction=Direction.Input),
-                             doc='Container workspace.')
+                             doc='Container workspace')
+        self.declareProperty(name='UseCanCorrections', defaultValue=False,
+                             doc='Use can corrections in subtraction')
+        self.declareProperty(name='CanChemicalFormula', defaultValue='',
+                             doc='Chemical formula for the Container')
+        self.declareProperty(name='CanNumberDensity', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Container number density')
+        self.declareProperty(name='CanFrontThickness', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Can front thickness')
+        self.declareProperty(name='CanBackThickness', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Can back thickness')
+        self.declareProperty(name='CanScaleFactor', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Scale factor to multiply can data')
 
-        self.declareProperty(name='CanScaleFactor', defaultValue=1.0, doc='Scale factor to multiply can data')
+        # General
+        self.declareProperty(name='ElementSize', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Element size in mm')
+        self.declareProperty(name='Plot', defaultValue=False,
+                             doc='Plot options')
 
-        self.declareProperty(name='ChemicalFormula', defaultValue='', validator=StringMandatoryValidator(),
-                             doc='Chemical formula')
-
-        self.declareProperty(name='SampleHeight', defaultValue=1.0, doc='Sample height')
-        self.declareProperty(name='SampleWidth', defaultValue=1.0, doc='Sample width')
-        self.declareProperty(name='SampleThickness', defaultValue=0.1, doc='Sample thickness')
-        self.declareProperty(name='ElementSize', defaultValue=0.1, doc='Element size in mm')
-        self.declareProperty(name='SampleNumberDensity', defaultValue=0.1, doc='Sample number density')
-        self.declareProperty(name='Plot', defaultValue=False, doc='Plot options')
-
+        # Output
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', direction=Direction.Output),
-                             doc='The output corrected workspace.')
+                             doc='The output corrected workspace')
 
-        self.declareProperty(MatrixWorkspaceProperty('CorrectionsWorkspace', '', direction=Direction.Output,
-                                                     optional=PropertyMode.Optional),
-                             doc='The corrections workspace for scattering and absorptions in sample.')
+        self.declareProperty(WorkspaceGroupProperty('CorrectionsWorkspace', '', direction=Direction.Output,
+                                                    optional=PropertyMode.Optional),
+                             doc='The workspace group to save correction factors')
+
 
     def PyExec(self):
         from IndirectCommon import getEfixed, addSampleLogs
@@ -46,84 +97,114 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
         self._setup()
 
         # Set up progress reporting
-        n_prog_reports = 4
-        if self._can_ws is not None:
-            n_prog_reports += 2
-        prog_reporter = Progress(self, 0.0, 1.0, n_prog_reports)
+        n_prog_reports = 2
+        if self._can_ws_name is not None:
+            n_prog_reports += 1
+        prog = Progress(self, 0.0, 1.0, n_prog_reports)
 
-        prog_reporter.report('Processing sample')
         efixed = getEfixed(self._sample_ws)
 
         sample_wave_ws = '__sam_wave'
         ConvertUnits(InputWorkspace=self._sample_ws, OutputWorkspace=sample_wave_ws,
                      Target='Wavelength', EMode='Indirect', EFixed=efixed)
 
-        SetSampleMaterial(sample_wave_ws, ChemicalFormula=self._chemical_formula, SampleNumberDensity=self._number_density)
+        SetSampleMaterial(sample_wave_ws, ChemicalFormula=self._sample_chemical_formula, SampleNumberDensity=self._sample_number_density)
 
-        prog_reporter.report('Calculating sample corrections')
+        prog.report('Calculating sample corrections')
         FlatPlateAbsorption(InputWorkspace=sample_wave_ws,
                             OutputWorkspace=self._ass_ws,
                             SampleHeight=self._sample_height,
                             SampleWidth=self._sample_width,
-                            SampleThickness=self._sample_thichness,
+                            SampleThickness=self._sample_thickness,
                             ElementSize=self._element_size,
                             EMode='Indirect',
                             EFixed=efixed,
                             NumberOfWavelengthPoints=10)
 
-        plot_list = [self._output_ws, self._sample_ws]
+        plot_data = [self._output_ws, self._sample_ws]
+        plot_corr = [self._ass_ws]
+        group = self._ass_ws
 
-        if self._can_ws is not None:
-            prog_reporter.report('Processing can')
+        if self._can_ws_name is not None:
             can_wave_ws = '__can_wave'
-            ConvertUnits(InputWorkspace=self._can_ws, OutputWorkspace=can_wave_ws,
+            ConvertUnits(InputWorkspace=self._can_ws_name, OutputWorkspace=can_wave_ws,
                          Target='Wavelength', EMode='Indirect', EFixed=efixed)
-
             if self._can_scale != 1.0:
                 logger.information('Scaling can by: ' + str(self._can_scale))
                 Scale(InputWorkspace=can_wave_ws, OutputWorkspace=can_wave_ws, Factor=self._can_scale, Operation='Multiply')
 
-            prog_reporter.report('Applying can corrections')
-            Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
+            if self._use_can_corrections:
+                prog.report('Calculating container corrections')
+                Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
+
+                SetSampleMaterial(can_wave_ws, ChemicalFormula=self._can_chemical_formula, SampleNumberDensity=self._can_number_density)
+                FlatPlateAbsorption(InputWorkspace=can_wave_ws,
+                                OutputWorkspace=self._acc_ws,
+                                SampleHeight=self._sample_height,
+                                SampleWidth=self._sample_width,
+                                SampleThickness=self._can_front_thickness + self._can_back_thickness,
+                                ElementSize=self._element_size,
+                                EMode='Indirect',
+                                EFixed=efixed,
+                                NumberOfWavelengthPoints=10)
+
+                Divide(LHSWorkspace=can_wave_ws, RHSWorkspace=self._acc_ws, OutputWorkspace=can_wave_ws)
+                Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
+                plot_corr.append(self._acc_ws)
+                group += ',' + self._acc_ws
+
+            else:
+                prog.report('Calculating container scaling')
+                Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
+                Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
+
             DeleteWorkspace(can_wave_ws)
+            plot_data.append(self._can_ws_name)
 
-            plot_list.append(self._can_ws)
+        else:
+            Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
-        prog_reporter.report('Applying corrections')
-        Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
         ConvertUnits(InputWorkspace=sample_wave_ws, OutputWorkspace=self._output_ws,
                      Target='DeltaE', EMode='Indirect', EFixed=efixed)
         DeleteWorkspace(sample_wave_ws)
 
-        prog_reporter.report('Recording sample logs')
+        prog.report('Recording samle logs')
         sample_logs = {'sample_shape': 'flatplate',
                        'sample_filename': self._sample_ws,
                        'sample_height': self._sample_height,
                        'sample_width': self._sample_width,
-                       'sample_thickness': self._sample_thichness,
+                       'sample_thickness': self._sample_thickness,
                        'element_size': self._element_size}
         addSampleLogs(self._ass_ws, sample_logs)
         addSampleLogs(self._output_ws, sample_logs)
 
-        if self._can_ws is not None:
-            AddSampleLog(Workspace=self._ass_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws))
-            AddSampleLog(Workspace=self._output_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws))
-            AddSampleLog(Workspace=self._ass_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+        if self._can_ws_name is not None:
+            AddSampleLog(Workspace=self._output_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws_name))
             AddSampleLog(Workspace=self._output_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+            if self._use_can_corrections:
+                addSampleLogs(self._acc_ws, sample_logs)
+                AddSampleLog(Workspace=self._acc_ws, LogName='can_filename', LogType='String', LogText=str(self._can_ws_name))
+                AddSampleLog(Workspace=self._acc_ws, LogName='can_scale', LogType='String', LogText=str(self._can_scale))
+                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness1', LogType='String', LogText=str(self._can_front_thickness))
+                AddSampleLog(Workspace=self._output_ws, LogName='can_thickness2', LogType='String', LogText=str(self._can_back_thickness))
 
         self.setProperty('OutputWorkspace', self._output_ws)
 
         # Output the Ass workspace if it is wanted, delete if not
-        if self._ass_ws == '_ass':
+        if self._abs_ws == '':
             DeleteWorkspace(self._ass_ws)
+            if self._can_ws_name is not None and self._use_can_corrections:
+                DeleteWorkspace(self._acc_ws)
         else:
-            self.setProperty('CorrectionsWorkspace', self._ass_ws)
+            GroupWorkspaces(InputWorkspaces=group, OutputWorkspace=self._abs_ws)
+            self.setProperty('CorrectionsWorkspace', self._abs_ws)
 
         if self._plot:
-            prog_reporter.report('Plotting')
             from IndirectImport import import_mantidplot
             mantid_plot = import_mantidplot()
-            mantid_plot.plotSpectrum(plot_list, 0)
+            mantid_plot.plotSpectrum(plot_data, 0)
+            if self._abs_ws != '':
+                mantid_plot.plotSpectrum(plot_corr, 0)
 
 
     def _setup(self):
@@ -132,23 +213,46 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
         """
 
         self._sample_ws = self.getPropertyValue('SampleWorkspace')
-        self._can_scale = self.getProperty('CanScaleFactor').value
-        self._chemical_formula = self.getPropertyValue('ChemicalFormula')
-        self._number_density = self.getProperty('SampleNumberDensity').value
+        self._sample_chemical_formula = self.getPropertyValue('SampleChemicalFormula')
+        self._sample_number_density = self.getProperty('SampleNumberDensity').value
         self._sample_height = self.getProperty('SampleHeight').value
         self._sample_width = self.getProperty('SampleWidth').value
-        self._sample_thichness = self.getProperty('SampleThickness').value
+        self._sample_thickness = self.getProperty('SampleThickness').value
+
+        self._can_ws_name = self.getPropertyValue('CanWorkspace')
+        if self._can_ws_name == '':
+            self._can_ws_name = None
+        self._use_can_corrections = self.getProperty('UseCanCorrections').value
+        self._can_chemical_formula = self.getPropertyValue('CanChemicalFormula')
+        self._can_number_density = self.getProperty('CanNumberDensity').value
+        self._can_front_thickness = self.getProperty('CanFrontThickness').value
+        self._can_back_thickness = self.getProperty('CanBackThickness').value
+        self._can_scale = self.getProperty('CanScaleFactor').value
+
         self._element_size = self.getProperty('ElementSize').value
         self._plot = self.getProperty('Plot').value
         self._output_ws = self.getPropertyValue('OutputWorkspace')
 
-        self._ass_ws = self.getPropertyValue('CorrectionsWorkspace')
-        if self._ass_ws == '':
+        self._abs_ws = self.getPropertyValue('CorrectionsWorkspace')
+        if self._abs_ws == '':
             self._ass_ws = '__ass'
+            self._acc_ws = '__acc'
+        else:
+            self._ass_ws = self._abs_ws + '_ass'
+            self._acc_ws = self._abs_ws + '_acc'
 
-        self._can_ws = self.getPropertyValue('CanWorkspace')
-        if self._can_ws == '':
-            self._can_ws = None
+
+    def validateInputs(self):
+        """
+        Validate algorithm options.
+        """
+
+        self._setup()
+        issues = dict()
+
+        # TODO
+
+        return issues
 
 
 # Register algorithm with Mantid

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/IndirectAnnulusAbsorptionTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/IndirectAnnulusAbsorptionTest.py
@@ -17,22 +17,25 @@ class IndirectAnnulusAbsorptionTest(unittest.TestCase):
         self._red_ws = red_ws
 
 
-    def _test_workspaces(self, corrected, ass):
+    def _test_workspaces(self, corrected, factor_group):
         """
         Checks the units of the Ass and corrected workspaces.
 
         @param corrected Corrected workspace
-        @param ass Assc corrections workspace
+        @param factor_group WorkspaceGroup containing factors
         """
 
+        # Test units of corrected workspace
         corrected_x_unit = corrected.getAxis(0).getUnit().unitID()
         self.assertEqual(corrected_x_unit, 'DeltaE')
 
-        ass_x_unit = ass.getAxis(0).getUnit().unitID()
-        self.assertEquals(ass_x_unit, 'Wavelength')
+        # Test units of factor workspaces
+        for ws in factor_group:
+            x_unit = ws.getAxis(0).getUnit().unitID()
+            self.assertEquals(x_unit, 'Wavelength')
 
-        ass_y_unit = ass.YUnitLabel()
-        self.assertEqual(ass_y_unit, 'Attenuation factor')
+            y_unit = ws.YUnitLabel()
+            self.assertEqual(y_unit, 'Attenuation factor')
 
 
     def test_sample_corrections_only(self):
@@ -40,15 +43,13 @@ class IndirectAnnulusAbsorptionTest(unittest.TestCase):
         Tests corrections for the sample only.
         """
 
-        corrected, ass = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
-                                                   ChemicalFormula='H2-O',
-                                                   CanInnerRadius=0.2,
-                                                   SampleInnerRadius=0.15,
-                                                   SampleOuterRadius=0.16,
-                                                   CanOuterRadius=0.22,
-                                                   Events=200)
+        corrected, fact = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
+                                                    SampleChemicalFormula='H2-O',
+                                                    Events=200,
+                                                    UseCanCorrections=False)
 
-        self._test_workspaces(corrected, ass)
+        self.assertEqual(fact.size(), 1)
+        self._test_workspaces(corrected, fact)
 
 
     def test_sample_and_can_subtraction(self):
@@ -56,16 +57,14 @@ class IndirectAnnulusAbsorptionTest(unittest.TestCase):
         Tests corrections for the sample and simple container subtraction.
         """
 
-        corrected, ass = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
-                                                   CanWorkspace=self._can_ws,
-                                                   ChemicalFormula='H2-O',
-                                                   CanInnerRadius=0.2,
-                                                   SampleInnerRadius=0.15,
-                                                   SampleOuterRadius=0.16,
-                                                   CanOuterRadius=0.22,
-                                                   Events=200)
+        corrected, fact = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
+                                                    SampleChemicalFormula='H2-O',
+                                                    CanWorkspace=self._can_ws,
+                                                    Events=200,
+                                                    UseCanCorrections=False)
 
-        self._test_workspaces(corrected, ass)
+        self.assertEqual(fact.size(), 1)
+        self._test_workspaces(corrected, fact)
 
 
     def test_sample_and_can_subtraction_with_scale(self):
@@ -74,17 +73,32 @@ class IndirectAnnulusAbsorptionTest(unittest.TestCase):
         with can scale.
         """
 
-        corrected, ass = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
-                                                   CanWorkspace=self._can_ws,
-                                                   CanScaleFactor=0.8,
-                                                   ChemicalFormula='H2-O',
-                                                   CanInnerRadius=0.2,
-                                                   SampleInnerRadius=0.15,
-                                                   SampleOuterRadius=0.16,
-                                                   CanOuterRadius=0.22,
-                                                   Events=200)
+        corrected, fact = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
+                                                    SampleChemicalFormula='H2-O',
+                                                    CanWorkspace=self._can_ws,
+                                                    CanScaleFactor=0.8,
+                                                    Events=200,
+                                                    UseCanCorrections=False)
 
-        self._test_workspaces(corrected, ass)
+        self.assertEqual(fact.size(), 1)
+        self._test_workspaces(corrected, fact)
+
+
+    def test_sample_and_can_corrections(self):
+        """
+        Tests corrections for the sample and container.
+        """
+
+        corrected, fact = IndirectAnnulusAbsorption(SampleWorkspace=self._red_ws,
+                                                    SampleChemicalFormula='H2-O',
+                                                    CanWorkspace=self._can_ws,
+                                                    CanChemicalFormula='V',
+                                                    CanScaleFactor=0.8,
+                                                    Events=200,
+                                                    UseCanCorrections=True)
+
+        self.assertEqual(fact.size(), 2)
+        self._test_workspaces(corrected, fact)
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCylinderAbsorptionTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/IndirectCylinderAbsorptionTest.py
@@ -17,22 +17,25 @@ class IndirectCylinderAbsorptionTest(unittest.TestCase):
         self._red_ws = red_ws
 
 
-    def _test_workspaces(self, corrected, ass):
+    def _test_workspaces(self, corrected, factor_group):
         """
         Checks the units of the Ass and corrected workspaces.
 
         @param corrected Corrected workspace
-        @param ass Assc corrections workspace
+        @param factor_group WorkspaceGroup containing factors
         """
 
+        # Test units of corrected workspace
         corrected_x_unit = corrected.getAxis(0).getUnit().unitID()
         self.assertEqual(corrected_x_unit, 'DeltaE')
 
-        ass_x_unit = ass.getAxis(0).getUnit().unitID()
-        self.assertEquals(ass_x_unit, 'Wavelength')
+        # Test units of factor workspaces
+        for ws in factor_group:
+            x_unit = ws.getAxis(0).getUnit().unitID()
+            self.assertEquals(x_unit, 'Wavelength')
 
-        ass_y_unit = ass.YUnitLabel()
-        self.assertEqual(ass_y_unit, 'Attenuation factor')
+            y_unit = ws.YUnitLabel()
+            self.assertEqual(y_unit, 'Attenuation factor')
 
 
     def test_sample_corrections_only(self):
@@ -40,11 +43,12 @@ class IndirectCylinderAbsorptionTest(unittest.TestCase):
         Tests corrections for the sample only.
         """
 
-        corrected, ass = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
-                                                    ChemicalFormula='H2-O',
-                                                    SampleRadius=0.2)
+        corrected, fact = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
+                                                     SampleChemicalFormula='H2-O',
+                                                     Events=500)
 
-        self._test_workspaces(corrected, ass)
+        self.assertEqual(fact.size(), 1)
+        self._test_workspaces(corrected, fact)
 
 
     def test_sample_and_can_subtraction(self):
@@ -52,12 +56,14 @@ class IndirectCylinderAbsorptionTest(unittest.TestCase):
         Tests corrections for the sample and simple container subtraction.
         """
 
-        corrected, ass = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
-                                                    CanWorkspace=self._can_ws,
-                                                    ChemicalFormula='H2-O',
-                                                    SampleRadius=0.2)
+        corrected, fact = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
+                                                     CanWorkspace=self._can_ws,
+                                                     SampleChemicalFormula='H2-O',
+                                                     UseCanCorrections=False,
+                                                     Events=500)
 
-        self._test_workspaces(corrected, ass)
+        self.assertEqual(fact.size(), 1)
+        self._test_workspaces(corrected, fact)
 
 
     def test_sample_and_can_subtraction_with_scale(self):
@@ -66,13 +72,31 @@ class IndirectCylinderAbsorptionTest(unittest.TestCase):
         with can scale.
         """
 
-        corrected, ass = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
-                                                    CanWorkspace=self._can_ws,
-                                                    CanScaleFactor=0.8,
-                                                    ChemicalFormula='H2-O',
-                                                    SampleRadius=0.2)
+        corrected, fact = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
+                                                     CanWorkspace=self._can_ws,
+                                                     CanScaleFactor=0.8,
+                                                     SampleChemicalFormula='H2-O',
+                                                     UseCanCorrections=False,
+                                                     Events=500)
 
-        self._test_workspaces(corrected, ass)
+        self.assertEqual(fact.size(), 1)
+        self._test_workspaces(corrected, fact)
+
+
+    def test_sample_and_can_corrections(self):
+        """
+        Tests corrections for the sample and container.
+        """
+
+        corrected, fact = IndirectCylinderAbsorption(SampleWorkspace=self._red_ws,
+                                                     CanWorkspace=self._can_ws,
+                                                     SampleChemicalFormula='H2-O',
+                                                     CanChemicalFormula='V',
+                                                     UseCanCorrections=True,
+                                                     Events=500)
+
+        self.assertEqual(fact.size(), 2)
+        self._test_workspaces(corrected, fact)
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/docs/source/algorithms/IndirectAnnulusAbsorption-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectAnnulusAbsorption-v1.rst
@@ -10,11 +10,12 @@ Description
 -----------
 
 Calculates and applies corrections for scattering abs absorption in a annular
-sample for a run on an indirect inelastic instrument, optionally also performing
-a simple can subtraction is a container workspace is provided.
+sample for a run on an indirect inelastic instrument, optionally allowing for
+the subtraction or corrections of the container.
 
-The corrections workspace (:math:`A_{s,s}`) is the standard Paalman and Pings
-attenuation factor for absorption and scattering in the sample.
+The correction factor workspace is a workspace group containing the correction
+factors in the Paalman and Pings format, note that only :math:`{A_{s,s}}` and
+:math:`A_{c,c}` factors are calculated by thsi algorithm.
 
 Usage
 -----
@@ -28,36 +29,81 @@ Usage
   red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
   can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
 
-  corrected, ass = IndirectAnnulusAbsorption(SampleWorkspace=red_ws,
-                                             CanWorkspace=can_ws,
-                                             CanScaleFactor=0.8,
-                                             ChemicalFormula='H2-O',
-                                             CanInnerRadius=0.2,
-                                             SampleInnerRadius=0.15,
-                                             SampleOuterRadius=0.16,
-                                             CanOuterRadius=0.22,
-                                             Events=200)
+  corrected, fact = IndirectAnnulusAbsorption(SampleWorkspace=red_ws,
+                                              SampleChemicalFormula='H2-O',
+                                              CanWorkspace=can_ws,
+                                              CanScaleFactor=0.8,
+                                              CanInnerRadius=0.19,
+                                              SampleInnerRadius=0.2,
+                                              SampleOuterRadius=0.25,
+                                              CanOuterRadius=0.26,
+                                              Events=200)
+
+  ass = fact[0]
 
   print ('Corrected workspace is intensity against %s'
         % (corrected.getAxis(0).getUnit().caption()))
 
-  print ('Corrections workspace is %s against %s'
+  print ('Ass workspace is %s against %s'
         % (ass.YUnitLabel(), ass.getAxis(0).getUnit().caption()))
-
 
 .. testcleanup:: SampleCorrectionsWithCanSubtraction
 
    DeleteWorkspace(red_ws)
    DeleteWorkspace(can_ws)
    DeleteWorkspace(corrected)
-   DeleteWorkspace(ass)
+   DeleteWorkspace(fact)
 
 **Output:**
-
 
 .. testoutput:: SampleCorrectionsWithCanSubtraction
 
   Corrected workspace is intensity against Energy transfer
-  Corrections workspace is Attenuation factor against Wavelength
+  Ass workspace is Attenuation factor against Wavelength
+
+**Example - Sample corrections for IRIS:**
+
+.. testcode:: SampleAndCanCorrections
+
+  red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
+  can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
+
+  corrected, fact = IndirectAnnulusAbsorption(SampleWorkspace=red_ws,
+                                              SampleChemicalFormula='H2-O',
+                                              CanWorkspace=can_ws,
+                                              CanChemicalFormula='H2-O',
+                                              CanInnerRadius=0.19,
+                                              SampleInnerRadius=0.2,
+                                              SampleOuterRadius=0.25,
+                                              CanOuterRadius=0.26,
+                                              Events=200,
+                                              UseCanCorrections=True)
+
+  ass = fact[0]
+  acc = fact[1]
+
+  print ('Corrected workspace is intensity against %s'
+        % (corrected.getAxis(0).getUnit().caption()))
+
+  print ('Ass workspace is %s against %s'
+        % (ass.YUnitLabel(), ass.getAxis(0).getUnit().caption()))
+
+  print ('Acc workspace is %s against %s'
+        % (acc.YUnitLabel(), acc.getAxis(0).getUnit().caption()))
+
+.. testcleanup:: SampleAndCanCorrections
+
+   DeleteWorkspace(red_ws)
+   DeleteWorkspace(can_ws)
+   DeleteWorkspace(corrected)
+   DeleteWorkspace(fact)
+
+**Output:**
+
+.. testoutput:: SampleAndCanCorrections
+
+  Corrected workspace is intensity against Energy transfer
+  Ass workspace is Attenuation factor against Wavelength
+  Acc workspace is Attenuation factor against Wavelength
 
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/IndirectCylinderAbsorption-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectCylinderAbsorption-v1.rst
@@ -9,12 +9,13 @@
 Description
 -----------
 
-Calculates and applies corrections for scattering abs absorption in a
+Calculates and applies corrections for scattering and absorption in a
 cylindrical sample for a run on an indirect inelastic instrument, optionally
-also performing a simple can subtraction is a container workspace is provided.
+allowing for the subtraction or corrections of the container.
 
-The corrections workspace (:math:`A_{s,s}`) is the standard Paalman and Pings
-attenuation factor for absorption and scattering in the sample.
+The correction factor workspace is a workspace group containing the correction
+factors in the Paalman and Pings format, note that only :math:`{A_{s,s}}` and
+:math:`A_{c,c}` factors are calculated by thsi algorithm.
 
 Usage
 -----
@@ -28,32 +29,78 @@ Usage
   red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
   can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
 
-  corrected, ass = IndirectCylinderAbsorption(SampleWorkspace=red_ws,
-                                              CanWorkspace=can_ws,
-                                              CanScaleFactor=0.8,
-                                              ChemicalFormula='H2-O',
-                                              SampleRadius=0.2)
+  corrected, fact = IndirectCylinderAbsorption(SampleWorkspace=red_ws,
+                                               SampleChemicalFormula='H2-O',
+                                               CanWorkspace=can_ws,
+                                               CanScaleFactor=0.8,
+                                               SampleRadius=0.2,
+                                               UseCanCorrections=False,
+                                               Events=100)
+
+  ass = fact[0]
 
   print ('Corrected workspace is intensity against %s'
         % (corrected.getAxis(0).getUnit().caption()))
 
-  print ('Corrections workspace is %s against %s'
+  print ('Ass workspace is %s against %s'
         % (ass.YUnitLabel(), ass.getAxis(0).getUnit().caption()))
-
 
 .. testcleanup:: SampleCorrectionsWithCanSubtraction
 
    DeleteWorkspace(red_ws)
    DeleteWorkspace(can_ws)
    DeleteWorkspace(corrected)
-   DeleteWorkspace(ass)
+   DeleteWorkspace(fact)
 
 **Output:**
 
-
 .. testoutput:: SampleCorrectionsWithCanSubtraction
 
-  Corrected workspace is intensity against Energy transfer
-  Corrections workspace is Attenuation factor against Wavelength
+   Corrected workspace is intensity against Energy transfer
+   Ass workspace is Attenuation factor against Wavelength
+
+**Example - Sample and container corrections for IRIS:**
+
+.. testcode:: SampleCorrectionsWithCanCorrections
+
+  red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
+  can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
+
+  corrected, fact = IndirectCylinderAbsorption(SampleWorkspace=red_ws,
+                                               SampleChemicalFormula='H2-O',
+                                               SampleRadius=0.2,
+                                               CanWorkspace=can_ws,
+                                               CanScaleFactor=0.8,
+                                               CanChemicalFormula='V',
+                                               CanRadius=0.22,
+                                               UseCanCorrections=True,
+                                               Events=100)
+
+  ass = fact[0]
+  acc = fact[1]
+
+  print ('Corrected workspace is intensity against %s'
+        % (corrected.getAxis(0).getUnit().caption()))
+
+  print ('Ass workspace is %s against %s'
+        % (ass.YUnitLabel(), ass.getAxis(0).getUnit().caption()))
+
+  print ('Acc workspace is %s against %s'
+        % (acc.YUnitLabel(), acc.getAxis(0).getUnit().caption()))
+
+.. testcleanup:: SampleCorrectionsWithCanCorrections
+
+   DeleteWorkspace(red_ws)
+   DeleteWorkspace(can_ws)
+   DeleteWorkspace(corrected)
+   DeleteWorkspace(fact)
+
+**Output:**
+
+.. testoutput:: SampleCorrectionsWithCanCorrections
+
+   Corrected workspace is intensity against Energy transfer
+   Ass workspace is Attenuation factor against Wavelength
+   Acc workspace is Attenuation factor against Wavelength
 
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/IndirectCylinderAbsorption-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectCylinderAbsorption-v1.rst
@@ -61,7 +61,7 @@ Usage
 
 **Example - Sample and container corrections for IRIS:**
 
-.. testcode:: SampleCorrectionsWithCanCorrections
+.. testcode:: SampleAndCanCorrections
 
   red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
   can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
@@ -88,7 +88,7 @@ Usage
   print ('Acc workspace is %s against %s'
         % (acc.YUnitLabel(), acc.getAxis(0).getUnit().caption()))
 
-.. testcleanup:: SampleCorrectionsWithCanCorrections
+.. testcleanup:: SampleAndCanCorrections
 
    DeleteWorkspace(red_ws)
    DeleteWorkspace(can_ws)
@@ -97,7 +97,7 @@ Usage
 
 **Output:**
 
-.. testoutput:: SampleCorrectionsWithCanCorrections
+.. testoutput:: SampleAndCanCorrections
 
    Corrected workspace is intensity against Energy transfer
    Ass workspace is Attenuation factor against Wavelength

--- a/Code/Mantid/docs/source/algorithms/IndirectFlatPlateAbsorption-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectFlatPlateAbsorption-v1.rst
@@ -104,5 +104,6 @@ Usage
 
    Corrected workspace is intensity against Energy transfer
    Ass workspace is Attenuation factor against Wavelength
+   Acc workspace is Attenuation factor against Wavelength
 
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/IndirectFlatPlateAbsorption-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectFlatPlateAbsorption-v1.rst
@@ -10,11 +10,12 @@ Description
 -----------
 
 Calculates and applies corrections for scattering abs absorption in a flat plate
-sample for a run on an indirect inelastic instrument, optionally also performing
-a simple can subtraction is a container workspace is provided.
+sample for a run on an indirect inelastic instrument, optionally allowing for
+the subtraction or corrections of the container.
 
-The corrections workspace (:math:`A_{s,s}`) is the standard Paalman and Pings
-attenuation factor for absorption and scattering in the sample.
+The correction factor workspace is a workspace group containing the correction
+factors in the Paalman and Pings format, note that only :math:`{A_{s,s}}` and
+:math:`A_{c,c}` factors are calculated by thsi algorithm.
 
 Usage
 -----
@@ -28,35 +29,80 @@ Usage
   red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
   can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
 
-  corrected, ass = IndirectFlatPlateAbsorption(SampleWorkspace=red_ws,
-                                               CanWorkspace=can_ws,
-                                               CanScaleFactor=0.8,
-                                               ChemicalFormula='H2-O',
-                                               SampleHeight=1,
-                                               SampleWidth=1,
-                                               SampleThickness=1,
-                                               ElementSize=1)
+  corrected, fact = IndirectFlatPlateAbsorption(SampleWorkspace=red_ws,
+                                                SampleChemicalFormula='H2-O',
+                                                CanWorkspace=can_ws,
+                                                CanScaleFactor=0.8,
+                                                SampleHeight=1,
+                                                SampleWidth=1,
+                                                SampleThickness=1,
+                                                ElementSize=1,
+                                                UseCanCorrections=False)
+
+  ass = fact[0]
 
   print ('Corrected workspace is intensity against %s'
         % (corrected.getAxis(0).getUnit().caption()))
 
-  print ('Corrections workspace is %s against %s'
+  print ('Ass workspace is %s against %s'
         % (ass.YUnitLabel(), ass.getAxis(0).getUnit().caption()))
-
 
 .. testcleanup:: SampleCorrectionsWithCanSubtraction
 
    DeleteWorkspace(red_ws)
    DeleteWorkspace(can_ws)
    DeleteWorkspace(corrected)
-   DeleteWorkspace(ass)
+   DeleteWorkspace(fact)
 
 **Output:**
 
+.. testoutput:: SampleCorrectionsWithCanSubtraction
+
+   Corrected workspace is intensity against Energy transfer
+   Ass workspace is Attenuation factor against Wavelength
+
+**Example - Sample and container corrections for IRIS:**
+
+.. testcode:: SampleCorrectionsWithCanSubtraction
+
+  red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
+  can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
+
+  corrected, fact = IndirectFlatPlateAbsorption(SampleWorkspace=red_ws,
+                                                SampleChemicalFormula='H2-O',
+                                                CanWorkspace=can_ws,
+                                                CanChemicalFormula='V',
+                                                CanScaleFactor=0.8,
+                                                SampleHeight=1,
+                                                SampleWidth=1,
+                                                SampleThickness=1,
+                                                ElementSize=1,
+                                                UseCanCorrections=True)
+
+  ass = fact[0]
+  acc = fact[1]
+
+  print ('Corrected workspace is intensity against %s'
+        % (corrected.getAxis(0).getUnit().caption()))
+
+  print ('Ass workspace is %s against %s'
+        % (ass.YUnitLabel(), ass.getAxis(0).getUnit().caption()))
+
+  print ('Acc workspace is %s against %s'
+        % (acc.YUnitLabel(), acc.getAxis(0).getUnit().caption()))
+
+.. testcleanup:: SampleCorrectionsWithCanSubtraction
+
+   DeleteWorkspace(red_ws)
+   DeleteWorkspace(can_ws)
+   DeleteWorkspace(corrected)
+   DeleteWorkspace(fact)
+
+**Output:**
 
 .. testoutput:: SampleCorrectionsWithCanSubtraction
 
-  Corrected workspace is intensity against Energy transfer
-  Corrections workspace is Attenuation factor against Wavelength
+   Corrected workspace is intensity against Energy transfer
+   Ass workspace is Attenuation factor against Wavelength
 
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/IndirectFlatPlateAbsorption-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IndirectFlatPlateAbsorption-v1.rst
@@ -63,7 +63,7 @@ Usage
 
 **Example - Sample and container corrections for IRIS:**
 
-.. testcode:: SampleCorrectionsWithCanSubtraction
+.. testcode:: SampleAndCanCorrections
 
   red_ws = LoadNexusProcessed(Filename='irs26176_graphite002_red.nxs')
   can_ws = LoadNexusProcessed(Filename='irs26173_graphite002_red.nxs')
@@ -91,7 +91,7 @@ Usage
   print ('Acc workspace is %s against %s'
         % (acc.YUnitLabel(), acc.getAxis(0).getUnit().caption()))
 
-.. testcleanup:: SampleCorrectionsWithCanSubtraction
+.. testcleanup:: SampleAndCanCorrections
 
    DeleteWorkspace(red_ws)
    DeleteWorkspace(can_ws)
@@ -100,7 +100,7 @@ Usage
 
 **Output:**
 
-.. testoutput:: SampleCorrectionsWithCanSubtraction
+.. testoutput:: SampleAndCanCorrections
 
    Corrected workspace is intensity against Energy transfer
    Ass workspace is Attenuation factor against Wavelength


### PR DESCRIPTION
Fixes [#11413](http://trac.mantidproject.org/mantid/ticket/11413).

To test:
- Review documentation
- Try with some different sample and can shapes/materials

Note that there is an issue with some combinations of sample and can shapes with the annulus algorithm, however I believe this is an issue with `AnnularRingAbsorption` and is something I'm looking into separately, this issue causes the "No intersection with sample + can" error.
