### PR TITLE
Refs #11005 radius=mQ+b

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -103,10 +103,12 @@ void IntegratePeaksMD2::init() {
       "Only warning if all of peak outer radius is not on detector (default).\n"
       "If false, do not integrate if the outer radius is not on a detector.");
 
-  declareProperty("AdaptiveQRadius", false,
-                  "Default is false.   If true, all input radii are multiplied "
-                  "by the magnitude of Q at the peak center so each peak has a "
-                  "different integration radius.  Q includes the 2*pi factor.");
+  declareProperty("AdaptiveQBackground", false,
+      "Default is false.   If true, all background values"
+      "vary on a line so that they are"
+      "background plus AdaptiveQMultiplier multiplied"
+      "by the magnitude of Q at the peak center so each peak has a "
+      "different integration radius.  Q includes the 2*pi factor.");
 
   declareProperty("Cylinder", false,
                   "Default is sphere.  Use next five parameters for cylinder.");
@@ -142,6 +144,12 @@ void IntegratePeaksMD2::init() {
       new FileProperty("ProfilesFile", "", FileProperty::OptionalSave,
                        std::vector<std::string>(1, "profiles")),
       "Save (Optionally) as Isaw peaks file with profiles included");
+
+  declareProperty("AdaptiveQMultiplier", 0.0,
+                  "Peak integration radius varies on a line so that it is"
+                  "PeakRadius plus this value multiplied"
+                  "by the magnitude of Q at the peak center so each peak has a "
+                  "different integration radius.  Q includes the 2*pi factor.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -191,7 +199,10 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Workspace2D_sptr wsProfile2D, wsFit2D, wsDiff2D;
   size_t numSteps = 0;
   bool cylinderBool = getProperty("Cylinder");
-  bool adaptiveQRadius = getProperty("AdaptiveQRadius");
+  bool adaptiveQBackground = getProperty("AdaptiveQBackground");
+  double adaptiveQMultiplier = getProperty("AdaptiveQMultiplier");
+  double adaptiveQBackgroundMultiplier = 0.0;
+  if (adaptiveQBackground) adaptiveQBackgroundMultiplier = adaptiveQMultiplier;
   std::vector<double> PeakRadiusVector(peakWS->getNumberPeaks(), PeakRadius);
   std::vector<double> BackgroundInnerRadiusVector(peakWS->getNumberPeaks(),
                                                   BackgroundInnerRadius);
@@ -316,8 +327,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     double background_total = 0.0;
     if (!cylinderBool) {
       // modulus of Q
-      coord_t lenQpeak = 1.0;
-      if (adaptiveQRadius) {
+      coord_t lenQpeak = 0.0;
+      if (adaptiveQMultiplier > 0.0) {
         lenQpeak = 0.0;
         for (size_t d = 0; d < nd; d++) {
           lenQpeak += center[d] * center[d];
@@ -325,9 +336,9 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         lenQpeak = std::sqrt(lenQpeak);
       }
 
-      PeakRadiusVector[i] = lenQpeak * PeakRadius;
-      BackgroundInnerRadiusVector[i] = lenQpeak * BackgroundInnerRadius;
-      BackgroundOuterRadiusVector[i] = lenQpeak * BackgroundOuterRadius;
+      PeakRadiusVector[i] = adaptiveQMultiplier * lenQpeak + PeakRadius;
+      BackgroundInnerRadiusVector[i] = adaptiveQBackgroundMultiplier * lenQpeak + BackgroundInnerRadius;
+      BackgroundOuterRadiusVector[i] = adaptiveQBackgroundMultiplier * lenQpeak + BackgroundOuterRadius;
       CoordTransformDistance sphere(nd, center, dimensionsUsed);
 
       if(Peak* shapeablePeak = dynamic_cast<Peak*>(&p)){
@@ -340,7 +351,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       // Perform the integration into whatever box is contained within.
       ws->getBox()->integrateSphere(
           sphere,
-          static_cast<coord_t>(lenQpeak * PeakRadius * lenQpeak * PeakRadius),
+          static_cast<coord_t>((adaptiveQMultiplier * lenQpeak + PeakRadius) * (adaptiveQMultiplier * lenQpeak + PeakRadius)),
           signal, errorSquared);
 
       // Integrate around the background radius
@@ -348,8 +359,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       if (BackgroundOuterRadius > PeakRadius) {
         // Get the total signal inside "BackgroundOuterRadius"
         ws->getBox()->integrateSphere(
-            sphere, static_cast<coord_t>(lenQpeak * BackgroundOuterRadius *
-                                         lenQpeak * BackgroundOuterRadius),
+            sphere, static_cast<coord_t>((adaptiveQBackgroundMultiplier * lenQpeak + BackgroundOuterRadius) *
+                                         (adaptiveQBackgroundMultiplier * lenQpeak + BackgroundOuterRadius)),
             bgSignal, bgErrorSquared);
 
         // Evaluate the signal inside "BackgroundInnerRadius"
@@ -359,8 +370,8 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         // Integrate this 3rd radius, if needed
         if (BackgroundInnerRadius != PeakRadius) {
           ws->getBox()->integrateSphere(
-              sphere, static_cast<coord_t>(lenQpeak * BackgroundInnerRadius *
-                                           lenQpeak * BackgroundInnerRadius),
+              sphere, static_cast<coord_t>((adaptiveQBackgroundMultiplier * lenQpeak + BackgroundInnerRadius) *
+                                           (adaptiveQBackgroundMultiplier * lenQpeak + BackgroundInnerRadius)),
               interiorSignal, interiorErrorSquared);
         } else {
           // PeakRadius == BackgroundInnerRadius, so use the previous value


### PR DESCRIPTION
Adaptive radius option now is a line where r=mQ+b (AdaptiveQMultiplier is m; PeakRadius is b).
To test user script:

```
    Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='TOPAZ_3132_event', LoadMonitors=True)
    ConvertToMD(InputWorkspace='TOPAZ_3132_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_3132_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
    FindPeaksMD(InputWorkspace='TOPAZ_3132_md', PeakDistanceThreshold=0.37680000000000002, MaxPeaks=50, DensityThresholdFactor=100, OutputWorkspace='TOPAZ_3132_peaks')
    FindUBUsingFFT(PeaksWorkspace='TOPAZ_3132_peaks', MinD=3, MaxD=15, Tolerance=0.12)
    CopySample(InputWorkspace='TOPAZ_3132_peaks', OutputWorkspace='TOPAZ_3132_event', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
    IndexPeaks(PeaksWorkspace='TOPAZ_3132_peaks', Tolerance=0.12)
    ShowPossibleCells(PeaksWorkspace='TOPAZ_3132_peaks')
    SelectCellOfType(PeaksWorkspace='TOPAZ_3132_peaks', CellType='Orthorhombic', Apply=True)
    CopySample(InputWorkspace='TOPAZ_3132_peaks', OutputWorkspace='TOPAZ_3132_event', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
    ConvertToMD(InputWorkspace='TOPAZ_3132_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', OutputWorkspace='TOPAZ_3132_md', MinValues='-30,-30,-30', MaxValues='30,30,30', SplitInto='2,2,2', SplitThreshold=200, MaxRecursionDepth=10, MinRecursionDepth=7)
    IntegratePeaksMD(InputWorkspace='TOPAZ_3132_md', PeakRadius=0.18, BackgroundInnerRadius=0.18, BackgroundOuterRadius=0.23, PeaksWorkspace='TOPAZ_3132_peaks', OutputWorkspace='Radius0.18', CylinderLength=0.40000000000000002, PercentBackground=20)
    IntegratePeaksMD(InputWorkspace='TOPAZ_3132_md', PeakRadius=0.18, BackgroundInnerRadius=0.18, BackgroundOuterRadius=0.23, PeaksWorkspace='TOPAZ_3132_peaks', OutputWorkspace='Adaptive0.01', AdaptiveQBackground=True, AdaptiveQMultiplier=0.01)
```
