### PR TITLE
Refs #11244 fix xml output file

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -1669,7 +1669,7 @@ void SCDCalibratePanels::FixUpBankParameterMap(
 void writeXmlParameter(ofstream &ostream, const string &name,
                        const double value) {
   ostream << "  <parameter name =\"" << name << "\"><value val=\"" << value
-          << "\" />" << endl;
+     << "\" /> </parameter>" << endl;
 }
 
 void

--- a/Code/Mantid/docs/source/algorithms/IntegrateEllipsoids-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IntegrateEllipsoids-v1.rst
@@ -162,7 +162,7 @@ Usage
 
 **Example - IntegrateEllipsoids:**
 
-The code iteslef works but disabled from doc tests as takes too long to complete. User should provide its own 
+The code itself works but disabled from doc tests as takes too long to complete. User should provide its own 
 event nexus file instead of **TOPAZ_3132_event.nxs** used within this example. The original **TOPAZ_3132_event.nxs**
 file is availible in `Mantid system tests repository <https://github.com/mantidproject/systemtests/tree/master/Data/TOPAZ_3132_event.nxs>`_.
 

--- a/Code/Mantid/docs/source/algorithms/IntegratePeaksMD-v2.rst
+++ b/Code/Mantid/docs/source/algorithms/IntegratePeaksMD-v2.rst
@@ -129,7 +129,7 @@ Usage
 
 **Example - IntegratePeaks:**
 
-The code iteslef works but disabled from doc tests as takes too long to complete. User should provide its own 
+The code itself works but disabled from doc tests as takes too long to complete. User should provide its own 
 event nexus file instead of **TOPAZ_3132_event.nxs** used within this example. The original **TOPAZ_3132_event.nxs**
 file is availible in `Mantid system tests repository <https://github.com/mantidproject/systemtests/tree/master/Data/TOPAZ_3132_event.nxs>`_.
 

--- a/Code/Mantid/docs/source/algorithms/SCDCalibratePanels-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SCDCalibratePanels-v1.rst
@@ -95,4 +95,17 @@ algorithm. To do so select the workspace, which you have calibrated as
 the InputWorkspace and the workspace you want to copy the calibration
 to, the OutputWorkspace.
 
+Usage
+------
+
+**Example - SCDCalibratePanels:**
+
+	LoadIsawPeaks(Filename='MANDI_801.peaks', OutputWorkspace='peaks')
+	SCDCalibratePanels(PeakWorkspace='peaks',DetCalFilename='mandi_801.DetCal',XmlFilename='mandi_801.xml',a=74,b=74.5,c=99.9,alpha=90,beta=90,gamma=60)
+	Load(Filename='MANDI_801_event.nxs', OutputWorkspace='MANDI_801_event')
+	CloneWorkspace(InputWorkspace='MANDI_801_event', OutputWorkspace='MANDI_801_event_xml')
+	LoadParameterFile(Workspace='MANDI_801_event_xml', Filename='mandi_801.xml')
+	RenameWorkspace(InputWorkspace='MANDI_801_event_xml', OutputWorkspace='MANDI_801_event_DetCal')
+	LoadIsawDetCal(InputWorkspace='MANDI_801_event_DetCal', Filename='mandi_801.DetCal')
+	
 .. categories::


### PR DESCRIPTION
XML output works in LoadParameterFile now;

```
    LoadIsawPeaks(Filename='MANDI_801.peaks', OutputWorkspace='peaks')
    LoadIsawUB(InputWorkspace='peaks', Filename='MANDI_801.mat')
    SCDCalibratePanels(PeakWorkspace='peaks',DetCalFilename='mandi_801.DetCal',XmlFilename='mandi_801.xml',a=74,b=74.5,c=99.9,alpha=90,beta=90,gamma=60)
    Load(Filename='MANDI_801_event.nxs', OutputWorkspace='MANDI_801_event')
    CloneWorkspace(InputWorkspace='MANDI_801_event', OutputWorkspace='MANDI_801_event_xml')
    LoadParameterFile(Workspace='MANDI_801_event_xml', Filename='mandi_801.xml')
    RenameWorkspace(InputWorkspace='MANDI_801_event_xml', OutputWorkspace='MANDI_801_event_DetCal')
    LoadIsawDetCal(InputWorkspace='MANDI_801_event_DetCal', Filename='mandi_801.DetCal')
```

~                                                                                            
