### PR TITLE
Add help buttons to Muon ALC interface

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h
@@ -67,6 +67,7 @@ namespace CustomInterfaces
     void deleteSectionSelector(int index);
     void updateSectionSelector(int index, SectionSelector values);
     void displayError(const QString& message);
+    void help();
   // -- End of IALCBaselineModellingView interface -------------------------------------------------
 
   private slots:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.ui
@@ -92,7 +92,20 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
+          <item>
+            <widget class="QPushButton" name="help">
+              <property name="maximumSize">
+                <size>
+                  <width>25</width>
+                  <height>25</height>
+                </size>
+              </property>
+              <property name="text">
+                <string>?</string>
+              </property>
+            </widget>
+          </item>
+          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -70,6 +70,7 @@ namespace CustomInterfaces
     void setAvailablePeriods(const std::vector<std::string> &periods);
     void setWaitingCursor();
     void restoreCursor();
+    void help();
 
     // -- End of IALCDataLoadingView interface -----------------------------------------------------
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -437,6 +437,12 @@
                 <layout class="QHBoxLayout" name="horizontalLayout_3">
                   <item>
                     <widget class="QPushButton" name="help">
+                      <property name="maximumSize">
+                        <size>
+                          <width>25</width>
+                          <height>25</height>
+                        </size>
+                      </property>
                       <property name="text">
                         <string>?</string>
                       </property>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -436,6 +436,13 @@
               <item>
                 <layout class="QHBoxLayout" name="horizontalLayout_3">
                   <item>
+                    <widget class="QPushButton" name="help">
+                      <property name="text">
+                        <string>?</string>
+                      </property>
+                    </widget>
+                  </item>
+                  <item>
                     <spacer name="horizontalSpacer">
                       <property name="orientation">
                         <enum>Qt::Horizontal</enum>
@@ -498,6 +505,7 @@
     <tabstop>differential</tabstop>
     <tabstop>minTime</tabstop>
     <tabstop>maxTime</tabstop>
+    <tabstop>help</tabstop>
     <tabstop>load</tabstop>
   </tabstops>
   <resources/>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
@@ -59,6 +59,7 @@ namespace CustomInterfaces
     void setParameter(const QString& funcIndex, const QString& paramName, double value);
     void setPeakPickerEnabled(bool enabled);
     void setPeakPicker(const IPeakFunction_const_sptr& peak);
+    void help();
 
     // -- End of IALCPeakFitting interface ---------------------------------------------------------
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.ui
@@ -36,7 +36,20 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
+          <item>
+            <widget class="QPushButton" name="help">
+              <property name="maximumSize">
+                <size>
+                  <width>25</width>
+                  <height>25</height>
+                </size>
+              </property>
+              <property name="text">
+                <string>?</string>
+              </property>
+            </widget>
+          </item>
+          <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCBaselineModellingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCBaselineModellingView.h
@@ -131,6 +131,9 @@ namespace CustomInterfaces
      */
     virtual void displayError(const QString& message) = 0;
 
+    /// Links help button to wiki page
+    virtual void help() = 0;
+
   signals:
     /// Fit requested
     void fitRequested();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -109,12 +109,16 @@ namespace CustomInterfaces
     /// Restore the original cursor
     virtual void restoreCursor() = 0;
 
+    /// Opens the Mantid Wiki web page
+    virtual void help() = 0;
+
   signals:
     /// Request to load data
     void loadRequested();
 
     /// User has selected the first run
     void firstRunSelected();
+
   };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
@@ -86,6 +86,9 @@ namespace CustomInterfaces
     /// @param peak :: A new peak to represent
     virtual void setPeakPicker(const IPeakFunction_const_sptr& peak) = 0;
 
+    /// Opens the Mantid Wiki web page
+    virtual void help() = 0;
+
   signals:
     /// Request to perform peak fitting
     void fitRequested();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -6,9 +6,11 @@
 
 #include <boost/scoped_array.hpp>
 
+#include <QDesktopServices>
 #include <QMessageBox>
 #include <QMenu>
 #include <QSignalMapper>
+#include <QUrl>
 
 #include <qwt_symbol.h>
 
@@ -63,6 +65,8 @@ namespace CustomInterfaces
     connect(m_ui.sections, SIGNAL(cellChanged(int,int)), SIGNAL(sectionRowModified(int)));
 
     connect(m_selectorModifiedMapper, SIGNAL(mapped(int)), SIGNAL(sectionSelectorModified(int)));
+
+    connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
   }
 
   QString ALCBaselineModellingView::function() const
@@ -199,6 +203,11 @@ namespace CustomInterfaces
 
     selector->setMinimum(values.first);
     selector->setMaximum(values.second);
+  }
+
+  void ALCBaselineModellingView::help() {
+    QDesktopServices::openUrl(QUrl(QString("http://www.mantidproject.org/") +
+            "Muon_ALC:_Baseline_Modelling"));
   }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -1,6 +1,8 @@
 #include "MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h"
 
+#include <QDesktopServices>
 #include <QMessageBox>
+#include <QUrl>
 
 #include <qwt_symbol.h>
 
@@ -17,6 +19,8 @@ namespace CustomInterfaces
     m_ui.setupUi(m_widget);
     connect(m_ui.load, SIGNAL(clicked()), SIGNAL(loadRequested()));
     connect(m_ui.firstRun, SIGNAL(fileFindingFinished()), SIGNAL(firstRunSelected()));
+
+    connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
 
     m_ui.dataPlot->setCanvasBackground(Qt::white);
     m_ui.dataPlot->setAxisFont(QwtPlot::xBottom, m_widget->font());
@@ -157,6 +161,12 @@ namespace CustomInterfaces
       m_ui.redPeriod->addItem(QString::fromStdString(*it));
       m_ui.greenPeriod->addItem(QString::fromStdString(*it));
     }
+  }
+
+  void ALCDataLoadingView::help()
+  {
+    QDesktopServices::openUrl(QUrl(QString("http://www.mantidproject.org/") +
+            "Muon_ALC:_Data_Loading"));
   }
 
   void ALCDataLoadingView::setWaitingCursor()

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
@@ -1,5 +1,7 @@
 #include "MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h"
 
+#include <QDesktopServices>
+#include <QUrl>
 #include <qwt_symbol.h>
 
 namespace MantidQt
@@ -54,6 +56,8 @@ void ALCPeakFittingView::initialize()
   connect(m_ui.peaks, SIGNAL(currentFunctionChanged()), SIGNAL(currentFunctionChanged()));
   connect(m_ui.peaks, SIGNAL(parameterChanged(QString,QString)),
           SIGNAL(parameterChanged(QString,QString)));
+
+  connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
 }
 
 void ALCPeakFittingView::setDataCurve(const QwtData& data)
@@ -98,6 +102,12 @@ void ALCPeakFittingView::setPeakPicker(const IPeakFunction_const_sptr& peak)
 {
   m_peakPicker->setPeak(peak);
   m_ui.plot->replot();
+}
+
+void ALCPeakFittingView::help()
+{
+  QDesktopServices::openUrl(QUrl(QString("http://www.mantidproject.org/") +
+    "Muon_ALC:_Peak_Fitting"));
 }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -49,6 +49,8 @@ public:
   MOCK_METHOD3(updateSectionSelector, void(size_t, double, double));
 
   MOCK_METHOD1(displayError, void(const QString&));
+
+  MOCK_METHOD0(help, void());
 };
 
 class MockALCBaselineModellingModel : public IALCBaselineModellingModel

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -340,6 +340,12 @@ public:
 
     m_view->requestFit();
   }
+
+  void test_helpPage ()
+  {
+    EXPECT_CALL(*m_view, help()).Times(1);
+    m_view->help();
+  }
 };
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -50,6 +50,7 @@ public:
   MOCK_METHOD1(setAvailablePeriods, void(const std::vector<std::string>&));
   MOCK_METHOD0(setWaitingCursor, void());
   MOCK_METHOD0(restoreCursor, void());
+  MOCK_METHOD0(help, void());
 
   void requestLoading() { emit loadRequested(); }
   void selectFirstRun() { emit firstRunSelected(); }

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -261,6 +261,12 @@ public:
                            QwtDataY(2, 0.038717, 1E-6))));
     m_view->requestLoading();
   }
+
+  void test_helpPage ()
+  {
+    EXPECT_CALL(*m_view, help()).Times(1);
+    m_view->help();
+  }
 };
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -50,6 +50,7 @@ public:
   MOCK_METHOD1(setPeakPicker, void(const IPeakFunction_const_sptr&));
   MOCK_METHOD1(setFunction, void(const IFunction_const_sptr&));
   MOCK_METHOD3(setParameter, void(const QString&, const QString&, double));
+  MOCK_METHOD0(help, void());
 };
 
 class MockALCPeakFittingModel : public IALCPeakFittingModel

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -259,6 +259,12 @@ public:
 
     m_view->changeParameter(QString("f1"), QString("A0"));
   }
+
+  void test_helpPage ()
+  {
+    EXPECT_CALL(*m_view, help()).Times(1);
+    m_view->help();
+  }
 };
 
 


### PR DESCRIPTION
Fixes [#9495](http://trac.mantidproject.org/mantid/ticket/9495)

To test: check that help buttons have been added to all steps and they link to appropriate help pages.
