### PR TITLE
Fix graph zooming after context menu is shown

### DIFF
--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -5360,9 +5360,11 @@ void Graph::enablePanningMagnifier(bool on)
     delete d_panner;
 
   QwtPlotCanvas *cnvs =d_plot->canvas(); //canvas();
-  if (on){
+  if (on) {
     cnvs->setCursor(Qt::pointingHandCursor);
     d_magnifier = new QwtPlotMagnifier(cnvs);
+    // Disable the mouse button as it causes issues with the context menu
+    d_magnifier->setMouseButton(Qt::NoButton);
     d_magnifier->setAxisEnabled(QwtPlot::yRight,false);
     d_magnifier->setZoomInKey(Qt::Key_Plus, Qt::ShiftModifier);
 


### PR DESCRIPTION
Fixes [#11424](http://trac.mantidproject.org/mantid/ticket/11424).

To reproduce original issue on master:
- Plot some data on a standard Mantid plot
- Enable the Pan tool
- Right click on the plot
- Click back on the plot
- Move the mouse
- Notice zooming is enabled by default and has to be cancelled by clicking on the plot a second time

Now do this with the fix applied, the plot should not do anything unexpected when the context menu is closed.
