### PR TITLE
Use AddSampleLogMultiple in ConvFit

### DIFF
--- a/Code/Mantid/scripts/Inelastic/IndirectDataAnalysis.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectDataAnalysis.py
@@ -98,26 +98,28 @@ def confitSeq(inputWS, func, startX, endX, ftype, bgd, temperature=None, specMin
     axis = mtd[wsname].getAxis(0)
     axis.setUnit("MomentumTransfer")
 
+    # Handle sample logs
+    temp_correction = temperature is not None
+
     CopyLogs(InputWorkspace=inputWS, OutputWorkspace=wsname)
-    AddSampleLog(Workspace=wsname, LogName='convolve_members',
-                 LogType='String', LogText=str(convolve))
-    AddSampleLog(Workspace=wsname, LogName="fit_program",
-                 LogType="String", LogText='ConvFit')
-    AddSampleLog(Workspace=wsname, LogName='background',
-                 LogType='String', LogText=str(bgd))
-    AddSampleLog(Workspace=wsname, LogName='delta_function',
-                 LogType='String', LogText=str(using_delta_func))
-    AddSampleLog(Workspace=wsname, LogName='lorentzians',
-                 LogType='String', LogText=str(lorentzians))
+
+    sample_logs = [('convolve_members', convolve),
+                   ('fit_program', 'ConvFit'),
+                   ('background', bgd),
+                   ('delta_function', using_delta_func),
+                   ('lorentzians', lorentzians),
+                   ('temperature_correction', temp_correction)]
+
+    if temp_correction:
+        sample_logs.append(('temperature_value', temperature))
+
+    log_names = [log[0] for log in sample_logs]
+    log_values = [log[1] for log in sample_logs]
+    AddSampleLogMultiple(Workspace=wsname,
+                         LogNames=log_names,
+                         LogValues=log_values)
 
     CopyLogs(InputWorkspace=wsname, OutputWorkspace=output_workspace + "_Workspaces")
-
-    temp_correction = temperature is not None
-    AddSampleLog(Workspace=wsname, LogName='temperature_correction',
-                 LogType='String', LogText=str(temp_correction))
-    if temp_correction:
-        AddSampleLog(Workspace=wsname, LogName='temperature_value',
-                     LogType='String', LogText=str(temperature))
 
     RenameWorkspace(InputWorkspace=output_workspace,
                     OutputWorkspace=output_workspace + "_Parameters")


### PR DESCRIPTION
Fixes [#11426](http://trac.mantidproject.org/mantid/ticket/11426).

To test:
- Open IDR>ConvFit
- Sample: `irs26176_graphite002_red.nxs`
- Resolution: `irs26173_graphite002_res`
- Fit Type: `Two Lorentzians`
- Run
- Open sample logs for the `_Result` workspace
- See that the `fit_program`, `convolve_members`, `delta_function`, etc. logs are present
