### PR TITLE
Order sample logs in ascending order by name by default

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidSampleLogDialog.cpp
@@ -462,6 +462,7 @@ void MantidSampleLogDialog::init()
   m_tree->header()->resizeSection(3, 90); //units column
   m_tree->header()->setMovable(false);
   m_tree->setSortingEnabled(true);
+  m_tree->sortByColumn(0, Qt::AscendingOrder);
 }
 
 


### PR DESCRIPTION
Fixes [#11427](http://trac.mantidproject.org/mantid/ticket/11427).

To test:
- Load a file with some logs
- Open Sample Logs UI
- See that logs are sorted by name in ascending order by default
