### PR TITLE
Remove hack from FindJsonCPP.cmake

### DIFF
--- a/Code/Mantid/Build/CMake/FindJsonCPP.cmake
+++ b/Code/Mantid/Build/CMake/FindJsonCPP.cmake
@@ -9,11 +9,6 @@
 #  JSONCPP_LIBRARY_DEBUG  - library files for linking (debug version)
 #  JSONCPP_LIBRARIES      - All required libraries, including the configuration type
 
-# Using unset here is a temporary hack to force FindJson to find the correct
-# path in an incremental build. It should be removed a day or two after the
-# branch introducing this is merged.
-unset ( JSONCPP_INCLUDE_DIR CACHE )
-
 # Headers
 find_path ( JSONCPP_INCLUDE_DIR json/reader.h
             PATH_SUFFIXES jsoncpp )


### PR DESCRIPTION
This is for trac ticket [#1411](http://trac.mantidproject.org/mantid/ticket/11411)

This has been in master for a week now, so any builders ought to have smoothly updated their JsonCPP include path by now.
