### PR TITLE
Fix creation of PointGroup from trigonal SpaceGroups

### DIFF
--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
@@ -109,6 +109,11 @@ namespace Geometry {
   */
 class MANTID_GEOMETRY_DLL Group {
 public:
+  enum CoordinateSystem {
+    Orthogonal,
+    Hexagonal
+  };
+
   Group();
   Group(const std::string &symmetryOperationString);
   Group(const std::vector<SymmetryOperation> &symmetryOperations);
@@ -118,6 +123,7 @@ public:
   virtual ~Group() {}
 
   size_t order() const;
+  CoordinateSystem getCoordinateSystem() const;
   std::vector<SymmetryOperation> getSymmetryOperations() const;
 
   Group operator*(const Group &other) const;
@@ -131,8 +137,12 @@ protected:
   void setSymmetryOperations(
       const std::vector<SymmetryOperation> &symmetryOperations);
 
+  CoordinateSystem getCoordinateSystemFromOperations(
+      const std::vector<SymmetryOperation> &symmetryOperations) const;
+
   std::vector<SymmetryOperation> m_allOperations;
   std::set<SymmetryOperation> m_operationSet;
+  CoordinateSystem m_axisSystem;
 };
 
 typedef boost::shared_ptr<Group> Group_sptr;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroupFactory.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroupFactory.h
@@ -4,6 +4,7 @@
 #include "MantidGeometry/DllConfig.h"
 #include "MantidKernel/SingletonHolder.h"
 #include "MantidGeometry/Crystal/PointGroup.h"
+#include "MantidGeometry/Crystal/SpaceGroup.h"
 #include "MantidKernel/RegistrationHelper.h"
 
 #include <boost/regex.hpp>
@@ -81,7 +82,9 @@ class MANTID_GEOMETRY_DLL PointGroupFactoryImpl {
 public:
   PointGroup_sptr createPointGroup(const std::string &hmSymbol);
   PointGroup_sptr
-  createPointGroupFromSpaceGroupSymbol(const std::string &spaceGroupSymbol);
+  createPointGroupFromSpaceGroup(const SpaceGroup_const_sptr &spaceGroup);
+  PointGroup_sptr
+  createPointGroupFromSpaceGroup(const SpaceGroup &spaceGroup);
 
   bool isSubscribed(const std::string &hmSymbol) const;
 

--- a/Code/Mantid/Framework/Geometry/src/Crystal/CrystalStructure.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/CrystalStructure.cpp
@@ -247,9 +247,10 @@ void CrystalStructure::setPointGroupFromSpaceGroup(
   if (spaceGroup) {
     try {
       m_pointGroup =
-          PointGroupFactory::Instance().createPointGroupFromSpaceGroupSymbol(
-              spaceGroup->hmSymbol());
-    } catch (...) {
+          PointGroupFactory::Instance().createPointGroupFromSpaceGroup(
+              spaceGroup);
+    }
+    catch (...) {
       // do nothing - point group will be null
     }
   }

--- a/Code/Mantid/Framework/Geometry/src/Crystal/Group.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/Group.cpp
@@ -6,7 +6,7 @@ namespace Mantid {
 namespace Geometry {
 
 /// Default constructor. Creates a group with one symmetry operation (identity).
-Group::Group() : m_allOperations(), m_operationSet() {
+Group::Group() : m_allOperations(), m_operationSet(), m_axisSystem() {
   std::vector<SymmetryOperation> operation(1);
   setSymmetryOperations(operation);
 }
@@ -14,7 +14,7 @@ Group::Group() : m_allOperations(), m_operationSet() {
 /// Uses SymmetryOperationFactory to create a vector of symmetry operations from
 /// the string.
 Group::Group(const std::string &symmetryOperationString)
-    : m_allOperations(), m_operationSet() {
+    : m_allOperations(), m_operationSet(), m_axisSystem() {
   setSymmetryOperations(SymmetryOperationFactory::Instance().createSymOps(
       symmetryOperationString));
 }
@@ -22,25 +22,29 @@ Group::Group(const std::string &symmetryOperationString)
 /// Constructs a group from the symmetry operations in the vector, duplicates
 /// are removed.
 Group::Group(const std::vector<SymmetryOperation> &symmetryOperations)
-    : m_allOperations(), m_operationSet() {
+    : m_allOperations(), m_operationSet(), m_axisSystem() {
   setSymmetryOperations(symmetryOperations);
 }
 
 /// Copy constructor.
 Group::Group(const Group &other)
     : m_allOperations(other.m_allOperations),
-      m_operationSet(other.m_operationSet) {}
+      m_operationSet(other.m_operationSet), m_axisSystem(other.m_axisSystem) {}
 
 /// Assignment operator.
 Group &Group::operator=(const Group &other) {
   m_allOperations = other.m_allOperations;
   m_operationSet = other.m_operationSet;
+  m_axisSystem = other.m_axisSystem;
 
   return *this;
 }
 
 /// Returns the order of the group, which is the number of symmetry operations.
 size_t Group::order() const { return m_allOperations.size(); }
+
+/// Returns the axis system of the group (either orthogonal or hexagonal).
+Group::CoordinateSystem Group::getCoordinateSystem() const { return m_axisSystem; }
 
 /// Returns a vector with all symmetry operations.
 std::vector<SymmetryOperation> Group::getSymmetryOperations() const {
@@ -105,6 +109,22 @@ void Group::setSymmetryOperations(
                                                symmetryOperations.end());
   m_allOperations = std::vector<SymmetryOperation>(m_operationSet.begin(),
                                                    m_operationSet.end());
+  m_axisSystem = getCoordinateSystemFromOperations(m_allOperations);
+}
+
+/// Returns the axis system based on the given symmetry operations. Hexagonal
+/// systems have 4 non-zero elements in the matrix, orthogonal have 6.
+Group::CoordinateSystem Group::getCoordinateSystemFromOperations(
+    const std::vector<SymmetryOperation> &symmetryOperations) const {
+  for (auto op = symmetryOperations.begin(); op != symmetryOperations.end();
+       ++op) {
+    std::vector<int> matrix = (*op).matrix();
+    if (std::count(matrix.begin(), matrix.end(), 0) == 5) {
+      return Group::Hexagonal;
+    }
+  }
+
+  return Group::Orthogonal;
 }
 
 /// Convenience operator* for directly multiplying groups using shared pointers.

--- a/Code/Mantid/Framework/Geometry/src/Crystal/PointGroupFactory.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/PointGroupFactory.cpp
@@ -1,4 +1,5 @@
 #include "MantidGeometry/Crystal/PointGroupFactory.h"
+#include "MantidGeometry/Crystal/SpaceGroup.h"
 
 #include "MantidKernel/LibraryManager.h"
 #include <boost/algorithm/string.hpp>
@@ -18,10 +19,35 @@ PointGroupFactoryImpl::createPointGroup(const std::string &hmSymbol) {
   return constructFromPrototype(getPrototype(hmSymbol));
 }
 
-PointGroup_sptr PointGroupFactoryImpl::createPointGroupFromSpaceGroupSymbol(
-    const std::string &spaceGroupSymbol) {
-  return createPointGroup(
-      pointGroupSymbolFromSpaceGroupSymbol(spaceGroupSymbol));
+PointGroup_sptr PointGroupFactoryImpl::createPointGroupFromSpaceGroup(
+    const SpaceGroup_const_sptr &spaceGroup) {
+    return createPointGroupFromSpaceGroup(*spaceGroup);
+}
+
+PointGroup_sptr PointGroupFactoryImpl::createPointGroupFromSpaceGroup(
+    const SpaceGroup &spaceGroup) {
+  std::string pointGroupSymbol =
+      pointGroupSymbolFromSpaceGroupSymbol(spaceGroup.hmSymbol());
+
+  try {
+    PointGroup_sptr pointGroup = createPointGroup(pointGroupSymbol);
+
+    // If the crystal system is trigonal, we need to do more.
+    if (pointGroup->crystalSystem() == PointGroup::Trigonal) {
+      throw std::invalid_argument(
+          "Trigonal space groups need to be processed differently.");
+    }
+
+    return pointGroup;
+  }
+  catch (std::invalid_argument) {
+    if (spaceGroup.getCoordinateSystem() !=
+        Group::CoordinateSystem::Hexagonal) {
+      pointGroupSymbol.append(" r");
+    }
+
+    return createPointGroup(pointGroupSymbol);
+  }
 }
 
 bool PointGroupFactoryImpl::isSubscribed(const std::string &hmSymbol) const {
@@ -187,8 +213,8 @@ DECLARE_POINTGROUP("-42m", "y,-x,-z; x,-y,-z", "Tetragonal")
 DECLARE_POINTGROUP("-4m2", "y,-x,-z; y,x,-z", "Tetragonal")
 DECLARE_POINTGROUP("4/mmm", "-y,x,z; x,y,-z; x,-y,-z", "Tetragonal")
 
-DECLARE_POINTGROUP("3 h", "-y,x-y,z", "Trigonal - Hexagonal")
-DECLARE_POINTGROUP("-3 h", "y,y-x,-z", "Trigonal - Hexagonal")
+DECLARE_POINTGROUP("3", "-y,x-y,z", "Trigonal - Hexagonal")
+DECLARE_POINTGROUP("-3", "y,y-x,-z", "Trigonal - Hexagonal")
 DECLARE_POINTGROUP("321", "-y,x-y,z; x-y,-y,-z", "Trigonal - Hexagonal")
 DECLARE_POINTGROUP("312", "-y,x-y,z; x,x-y,-z", "Trigonal - Hexagonal")
 DECLARE_POINTGROUP("3m1", "-y,x-y,z; y-x,y,z", "Trigonal - Hexagonal")
@@ -196,11 +222,11 @@ DECLARE_POINTGROUP("31m", "-y,x-y,z; -x,y-x,z", "Trigonal - Hexagonal")
 DECLARE_POINTGROUP("-3m1", "y,y-x,-z; x-y,-y,-z", "Trigonal - Hexagonal")
 DECLARE_POINTGROUP("-31m", "y,y-x,-z; x,x-y,-z", "Trigonal - Hexagonal")
 
-DECLARE_POINTGROUP("3", "z,x,y", "Trigonal - Rhombohedral")
-DECLARE_POINTGROUP("-3", "-z,-x,-y", "Trigonal - Rhombohedral")
-DECLARE_POINTGROUP("32", "z,x,y; -y,-x,-z", "Trigonal - Rhombohedral")
-DECLARE_POINTGROUP("3m", "z,x,y; y,x,z", "Trigonal - Rhombohedral")
-DECLARE_POINTGROUP("-3m", "-z,-x,-y; y,x,z", "Trigonal - Rhombohedral")
+DECLARE_POINTGROUP("3 r", "z,x,y", "Trigonal - Rhombohedral")
+DECLARE_POINTGROUP("-3 r", "-z,-x,-y", "Trigonal - Rhombohedral")
+DECLARE_POINTGROUP("32 r", "z,x,y; -y,-x,-z", "Trigonal - Rhombohedral")
+DECLARE_POINTGROUP("3m r", "z,x,y; y,x,z", "Trigonal - Rhombohedral")
+DECLARE_POINTGROUP("-3m r", "-z,-x,-y; y,x,z", "Trigonal - Rhombohedral")
 
 DECLARE_POINTGROUP("6", "x-y,x,z", "Hexagonal")
 DECLARE_POINTGROUP("-6", "y-x,-x,-z", "Hexagonal")
@@ -210,7 +236,6 @@ DECLARE_POINTGROUP("6mm", "x-y,x,z; y-x,y,z", "Hexagonal")
 DECLARE_POINTGROUP("-62m", "y-x,-x,-z; x-y,-y,-z", "Hexagonal")
 DECLARE_POINTGROUP("-6m2", "y-x,-x,-z; y-x,y,z", "Hexagonal")
 DECLARE_POINTGROUP("6/mmm", "x-y,x,z; x-y,-y,-z; -x,-y,-z", "Hexagonal")
-
 
 DECLARE_POINTGROUP("23", "z,x,y; -x,-y,z; x,-y,-z", "Cubic")
 DECLARE_POINTGROUP("m-3", "-z,-x,-y; -x,-y,z; x,-y,-z", "Cubic")

--- a/Code/Mantid/Framework/Geometry/test/GroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/GroupTest.h
@@ -9,195 +9,230 @@
 
 using namespace Mantid::Geometry;
 
-class GroupTest : public CxxTest::TestSuite
-{
+class GroupTest : public CxxTest::TestSuite {
 public:
-    // This pair of boilerplate methods prevent the suite being created statically
-    // This means the constructor isn't called when running other tests
-    static GroupTest *createSuite() { return new GroupTest(); }
-    static void destroySuite( GroupTest *suite ) { delete suite; }
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static GroupTest *createSuite() { return new GroupTest(); }
+  static void destroySuite(GroupTest *suite) { delete suite; }
 
-    void testDefaultConstructor()
-    {
-        Group group;
-        TS_ASSERT_EQUALS(group.order(), 1);
-        TS_ASSERT(group.getSymmetryOperations().front().isIdentity());
-    }
+  void testDefaultConstructor() {
+    Group group;
+    TS_ASSERT_EQUALS(group.order(), 1);
+    TS_ASSERT(group.getSymmetryOperations().front().isIdentity());
+  }
 
-    void testStringConstructor()
-    {
-        Group group("x,y,z; -x,-y,-z");
+  void testStringConstructor() {
+    Group group("x,y,z; -x,-y,-z");
 
-        TS_ASSERT_EQUALS(group.order(), 2);
-    }
+    TS_ASSERT_EQUALS(group.order(), 2);
+  }
 
-    void testConstructor()
-    {
-        std::vector<SymmetryOperation> symOps;
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+  void testConstructor() {
+    std::vector<SymmetryOperation> symOps;
+    symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        TS_ASSERT_THROWS_NOTHING(Group group(symOps));
+    TS_ASSERT_THROWS_NOTHING(Group group(symOps));
 
-        Group group(symOps);
+    Group group(symOps);
 
-        std::vector<SymmetryOperation> groupOps = group.getSymmetryOperations();
-        TS_ASSERT_EQUALS(groupOps.size(), 2);
+    std::vector<SymmetryOperation> groupOps = group.getSymmetryOperations();
+    TS_ASSERT_EQUALS(groupOps.size(), 2);
 
-        std::vector<SymmetryOperation> empty;
-        TS_ASSERT_THROWS(Group group(empty), std::invalid_argument);
-    }
+    std::vector<SymmetryOperation> empty;
+    TS_ASSERT_THROWS(Group group(empty), std::invalid_argument);
+  }
 
-    void testCopyConstructor()
-    {
-        std::vector<SymmetryOperation> symOps;
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+  void testCopyConstructor() {
+    std::vector<SymmetryOperation> symOps;
+    symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        Group group(symOps);
-        Group otherGroup(group);
+    Group group(symOps);
+    Group otherGroup(group);
 
-        TS_ASSERT_EQUALS(group.order(), otherGroup.order());
-        TS_ASSERT_EQUALS(group.getSymmetryOperations(), otherGroup.getSymmetryOperations());
-    }
+    TS_ASSERT_EQUALS(group.order(), otherGroup.order());
+    TS_ASSERT_EQUALS(group.getSymmetryOperations(),
+                     otherGroup.getSymmetryOperations());
+  }
 
-    void testAssignmentOperator()
-    {
-        std::vector<SymmetryOperation> symOps;
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+  void testAssignmentOperator() {
+    std::vector<SymmetryOperation> symOps;
+    symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        Group otherGroup(symOps);
+    Group otherGroup(symOps);
 
-        Group group;
-        TS_ASSERT_DIFFERS(group.order(), otherGroup.order());
-        TS_ASSERT_DIFFERS(group.getSymmetryOperations(), otherGroup.getSymmetryOperations());
+    Group group;
+    TS_ASSERT_DIFFERS(group.order(), otherGroup.order());
+    TS_ASSERT_DIFFERS(group.getSymmetryOperations(),
+                      otherGroup.getSymmetryOperations());
 
-        group = otherGroup;
-        TS_ASSERT_EQUALS(group.order(), otherGroup.order());
-        TS_ASSERT_EQUALS(group.getSymmetryOperations(), otherGroup.getSymmetryOperations());
-    }
+    group = otherGroup;
+    TS_ASSERT_EQUALS(group.order(), otherGroup.order());
+    TS_ASSERT_EQUALS(group.getSymmetryOperations(),
+                     otherGroup.getSymmetryOperations());
+  }
 
-    void testOrder()
-    {
-        Group defaultGroup;
-        TS_ASSERT_EQUALS(defaultGroup.order(), 1);
+  void testOrder() {
+    Group defaultGroup;
+    TS_ASSERT_EQUALS(defaultGroup.order(), 1);
 
-        // Making a group of two operations gives order 2
-        std::vector<SymmetryOperation> symOps;
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+    // Making a group of two operations gives order 2
+    std::vector<SymmetryOperation> symOps;
+    symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        Group biggerGroup(symOps);
-        TS_ASSERT_EQUALS(biggerGroup.order(), 2);
+    Group biggerGroup(symOps);
+    TS_ASSERT_EQUALS(biggerGroup.order(), 2);
 
-        // Adding another one results in 3
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,y,z"));
-        Group evenBiggerGroup(symOps);
-        TS_ASSERT_EQUALS(evenBiggerGroup.order(), 3);
+    // Adding another one results in 3
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,y,z"));
+    Group evenBiggerGroup(symOps);
+    TS_ASSERT_EQUALS(evenBiggerGroup.order(), 3);
 
-        // Multiple occurences of the same operation do not count
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
-        Group sameAsBefore(symOps);
-        TS_ASSERT_EQUALS(sameAsBefore.order(), 3);
-    }
+    // Multiple occurences of the same operation do not count
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+    Group sameAsBefore(symOps);
+    TS_ASSERT_EQUALS(sameAsBefore.order(), 3);
+  }
 
-    void testComparison()
-    {
-        std::vector<SymmetryOperation> symOps;
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+  void testComparison() {
+    std::vector<SymmetryOperation> symOps;
+    symOps.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    symOps.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        Group groupOne(symOps);
-        Group groupTwo(symOps);
+    Group groupOne(symOps);
+    Group groupTwo(symOps);
 
-        TS_ASSERT(groupOne == groupTwo);
-        TS_ASSERT(groupTwo == groupOne);
+    TS_ASSERT(groupOne == groupTwo);
+    TS_ASSERT(groupTwo == groupOne);
 
-        Group defaultGroup;
-        TS_ASSERT(!(groupOne == defaultGroup));
-        TS_ASSERT(!(defaultGroup == groupOne));
-        TS_ASSERT(groupOne != defaultGroup);
-        TS_ASSERT(defaultGroup != groupOne);
-    }
+    Group defaultGroup;
+    TS_ASSERT(!(groupOne == defaultGroup));
+    TS_ASSERT(!(defaultGroup == groupOne));
+    TS_ASSERT(groupOne != defaultGroup);
+    TS_ASSERT(defaultGroup != groupOne);
+  }
 
-    void testMultiplicationOperator()
-    {
-        // We take pointgroup -1
-        std::vector<SymmetryOperation> inversion;
-        inversion.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        inversion.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+  void testMultiplicationOperator() {
+    // We take pointgroup -1
+    std::vector<SymmetryOperation> inversion;
+    inversion.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    inversion.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        // And 2 (b-axis unique)
-        std::vector<SymmetryOperation> twoFoldY;
-        twoFoldY.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        twoFoldY.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,y,-z"));
+    // And 2 (b-axis unique)
+    std::vector<SymmetryOperation> twoFoldY;
+    twoFoldY.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    twoFoldY.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,y,-z"));
 
-        Group one(inversion);
-        Group two(twoFoldY);
+    Group one(inversion);
+    Group two(twoFoldY);
 
-        // Multiplication results in 2/m
-        Group three = one * two;
-        TS_ASSERT_EQUALS(three.order(), 4);
+    // Multiplication results in 2/m
+    Group three = one * two;
+    TS_ASSERT_EQUALS(three.order(), 4);
 
-        // The multiplication created m perpendicular to b (x,-y,-z)
-        SymmetryOperation mirrorY = SymmetryOperationFactory::Instance().createSymOp("x,-y,z");
-        std::vector<SymmetryOperation> opsOfThree = three.getSymmetryOperations();
+    // The multiplication created m perpendicular to b (x,-y,-z)
+    SymmetryOperation mirrorY =
+        SymmetryOperationFactory::Instance().createSymOp("x,-y,z");
+    std::vector<SymmetryOperation> opsOfThree = three.getSymmetryOperations();
 
-        // Check that it is found in the list of symmetry operations of the new group
-        TS_ASSERT_DIFFERS(std::find(opsOfThree.begin(), opsOfThree.end(), mirrorY), opsOfThree.end());
+    // Check that it is found in the list of symmetry operations of the new
+    // group
+    TS_ASSERT_DIFFERS(std::find(opsOfThree.begin(), opsOfThree.end(), mirrorY),
+                      opsOfThree.end());
 
-        Group four = two * one;
-        TS_ASSERT(three == four);
-    }
+    Group four = two * one;
+    TS_ASSERT(three == four);
+  }
 
-    void testSmartPointerOperators()
-    {
-        // We take pointgroup -1
-        std::vector<SymmetryOperation> inversion;
-        inversion.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        inversion.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
+  void testAxisSystemOrthogonal() {
+    std::vector<SymmetryOperation> orthogonal;
+    orthogonal.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    orthogonal.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,y,-z"));
 
-        // And 2 (b-axis unique)
-        std::vector<SymmetryOperation> twoFoldY;
-        twoFoldY.push_back(SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
-        twoFoldY.push_back(SymmetryOperationFactory::Instance().createSymOp("-x,y,-z"));
+    Group two(orthogonal);
 
-        Group_const_sptr one = boost::make_shared<const Group>(inversion);
-        Group_const_sptr two = boost::make_shared<const Group>(twoFoldY);
+    TS_ASSERT_EQUALS(two.getCoordinateSystem(), Group::Orthogonal);
+  }
 
-        Group_const_sptr three = one * two;
-        TS_ASSERT_EQUALS(three->order(), 4);
+  void testAxisSystemHexagonal() {
+    std::vector<SymmetryOperation> hexagonal;
+    hexagonal.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-y,x-y,z"));
+    hexagonal.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("y,x,-z+1/2"));
 
-        SymmetryOperation mirrorY = SymmetryOperationFactory::Instance().createSymOp("x,-y,z");
-        std::vector<SymmetryOperation> opsOfThree = three->getSymmetryOperations();
+    Group two(hexagonal);
 
-        // Check that it is found in the list of symmetry operations of the new group
-        TS_ASSERT_DIFFERS(std::find(opsOfThree.begin(), opsOfThree.end(), mirrorY), opsOfThree.end());
+    TS_ASSERT_EQUALS(two.getCoordinateSystem(), Group::Hexagonal);
+  }
 
-        // Make sure that null-pointer do not work
-        Group_const_sptr null;
+  void testSmartPointerOperators() {
+    // We take pointgroup -1
+    std::vector<SymmetryOperation> inversion;
+    inversion.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    inversion.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z"));
 
-        TS_ASSERT_THROWS(null * null, std::invalid_argument);
-        //AppleClang gives a warning if we don't use the result
+    // And 2 (b-axis unique)
+    std::vector<SymmetryOperation> twoFoldY;
+    twoFoldY.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("x,y,z"));
+    twoFoldY.push_back(
+        SymmetryOperationFactory::Instance().createSymOp("-x,y,-z"));
+
+    Group_const_sptr one = boost::make_shared<const Group>(inversion);
+    Group_const_sptr two = boost::make_shared<const Group>(twoFoldY);
+
+    Group_const_sptr three = one * two;
+    TS_ASSERT_EQUALS(three->order(), 4);
+
+    SymmetryOperation mirrorY =
+        SymmetryOperationFactory::Instance().createSymOp("x,-y,z");
+    std::vector<SymmetryOperation> opsOfThree = three->getSymmetryOperations();
+
+    // Check that it is found in the list of symmetry operations of the new
+    // group
+    TS_ASSERT_DIFFERS(std::find(opsOfThree.begin(), opsOfThree.end(), mirrorY),
+                      opsOfThree.end());
+
+    // Make sure that null-pointer do not work
+    Group_const_sptr null;
+
+    TS_ASSERT_THROWS(null * null, std::invalid_argument);
+// AppleClang gives a warning if we don't use the result
 #if __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-comparison"
 #endif
-        TS_ASSERT_THROWS(null == null, std::invalid_argument);
-        TS_ASSERT_THROWS(null != null, std::invalid_argument);
+    TS_ASSERT_THROWS(null == null, std::invalid_argument);
+    TS_ASSERT_THROWS(null != null, std::invalid_argument);
 #if __clang__
 #pragma clang diagnostic pop
 #endif
-        TS_ASSERT_THROWS(three * null, std::invalid_argument);
-        TS_ASSERT_THROWS(null * three, std::invalid_argument);
+    TS_ASSERT_THROWS(three * null, std::invalid_argument);
+    TS_ASSERT_THROWS(null * three, std::invalid_argument);
 
-        Mantid::Kernel::V3D coords(0.4, 0.3, 0.1);
-        TS_ASSERT_THROWS(null * coords, std::invalid_argument);
-    }
-
-
+    Mantid::Kernel::V3D coords(0.4, 0.3, 0.1);
+    TS_ASSERT_THROWS(null * coords, std::invalid_argument);
+  }
 };
-
 
 #endif /* MANTID_GEOMETRY_GROUPTEST_H_ */

--- a/Code/Mantid/Framework/Geometry/test/PointGroupFactoryTest.h
+++ b/Code/Mantid/Framework/Geometry/test/PointGroupFactoryTest.h
@@ -12,111 +12,129 @@
 using Mantid::Geometry::PointGroupFactoryImpl;
 using namespace Mantid::Geometry;
 
-
 /* For testing the factory, three fake point groups are defined
  * and registered in the factory (see below).
  *
  * When the test is destroyed, these are explicitly unregistered,
  * so they don't interfere with other tests.
  */
-class PointGroupFactoryTest : public CxxTest::TestSuite
-{
+class PointGroupFactoryTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static PointGroupFactoryTest *createSuite() { return new PointGroupFactoryTest(); }
-  static void destroySuite( PointGroupFactoryTest *suite ) { delete suite; }
+  static PointGroupFactoryTest *createSuite() {
+    return new PointGroupFactoryTest();
+  }
+  static void destroySuite(PointGroupFactoryTest *suite) { delete suite; }
 
-  PointGroupFactoryTest()
-  {
-      PointGroupFactory::Instance().subscribePointGroup("monoclinicA", "x,y,-z", "test");
-      PointGroupFactory::Instance().subscribePointGroup("monoclinicB", "x,-y,-z", "test");
-      PointGroupFactory::Instance().subscribePointGroup("triclinic", "-x,-y,-z", "test");
+  PointGroupFactoryTest() {
+    PointGroupFactory::Instance().subscribePointGroup("monoclinicA", "x,y,-z",
+                                                      "test");
+    PointGroupFactory::Instance().subscribePointGroup("monoclinicB", "x,-y,-z",
+                                                      "test");
+    PointGroupFactory::Instance().subscribePointGroup("triclinic", "-x,-y,-z",
+                                                      "test");
   }
 
-  ~PointGroupFactoryTest()
-  {
-      // Unsubscribing the fake point groups
-      PointGroupFactory::Instance().unsubscribePointGroup("monoclinicA");
-      PointGroupFactory::Instance().unsubscribePointGroup("monoclinicB");
-      PointGroupFactory::Instance().unsubscribePointGroup("triclinic");
+  ~PointGroupFactoryTest() {
+    // Unsubscribing the fake point groups
+    PointGroupFactory::Instance().unsubscribePointGroup("monoclinicA");
+    PointGroupFactory::Instance().unsubscribePointGroup("monoclinicB");
+    PointGroupFactory::Instance().unsubscribePointGroup("triclinic");
   }
 
-  void testCreatePointGroup()
-  {
-      TS_ASSERT_THROWS_NOTHING(PointGroupFactory::Instance().createPointGroup("monoclinicA"));
-      TS_ASSERT_THROWS_NOTHING(PointGroupFactory::Instance().createPointGroup("monoclinicB"));
-      TS_ASSERT_THROWS_NOTHING(PointGroupFactory::Instance().createPointGroup("triclinic"));
+  void testCreatePointGroup() {
+    TS_ASSERT_THROWS_NOTHING(
+        PointGroupFactory::Instance().createPointGroup("monoclinicA"));
+    TS_ASSERT_THROWS_NOTHING(
+        PointGroupFactory::Instance().createPointGroup("monoclinicB"));
+    TS_ASSERT_THROWS_NOTHING(
+        PointGroupFactory::Instance().createPointGroup("triclinic"));
 
-      TS_ASSERT_THROWS(PointGroupFactory::Instance().createPointGroup("cubicC"), std::invalid_argument);
+    TS_ASSERT_THROWS(PointGroupFactory::Instance().createPointGroup("cubicC"),
+                     std::invalid_argument);
   }
 
-  void testGetAllPointGroupSymbols()
-  {
-      std::vector<std::string> symbols = PointGroupFactory::Instance().getAllPointGroupSymbols();
+  void testGetAllPointGroupSymbols() {
+    std::vector<std::string> symbols =
+        PointGroupFactory::Instance().getAllPointGroupSymbols();
 
-      TS_ASSERT_DIFFERS(findString(symbols, "monoclinicA"), symbols.end());
-      TS_ASSERT_DIFFERS(findString(symbols, "monoclinicB"), symbols.end());
-      TS_ASSERT_DIFFERS(findString(symbols, "triclinic"), symbols.end());
+    TS_ASSERT_DIFFERS(findString(symbols, "monoclinicA"), symbols.end());
+    TS_ASSERT_DIFFERS(findString(symbols, "monoclinicB"), symbols.end());
+    TS_ASSERT_DIFFERS(findString(symbols, "triclinic"), symbols.end());
   }
 
-  void testGetAllPointGroupSymbolsCrystalSystems()
-  {
-      std::vector<std::string> cubic = PointGroupFactory::Instance().getPointGroupSymbols(PointGroup::Monoclinic);
+  void testGetAllPointGroupSymbolsCrystalSystems() {
+    std::vector<std::string> cubic =
+        PointGroupFactory::Instance().getPointGroupSymbols(
+            PointGroup::Monoclinic);
 
-      TS_ASSERT_DIFFERS(findString(cubic, "monoclinicA"), cubic.end());
-      TS_ASSERT_DIFFERS(findString(cubic, "monoclinicB"), cubic.end());
+    TS_ASSERT_DIFFERS(findString(cubic, "monoclinicA"), cubic.end());
+    TS_ASSERT_DIFFERS(findString(cubic, "monoclinicB"), cubic.end());
 
-      std::vector<std::string> triclinic = PointGroupFactory::Instance().getPointGroupSymbols(PointGroup::Triclinic);
-      TS_ASSERT_DIFFERS(findString(triclinic, "triclinic"), triclinic.end());
+    std::vector<std::string> triclinic =
+        PointGroupFactory::Instance().getPointGroupSymbols(
+            PointGroup::Triclinic);
+    TS_ASSERT_DIFFERS(findString(triclinic, "triclinic"), triclinic.end());
   }
 
-  void testUnsubscribePointGroup()
-  {
-      TS_ASSERT_THROWS_NOTHING(PointGroupFactory::Instance().createPointGroup("monoclinicA"));
+  void testUnsubscribePointGroup() {
+    TS_ASSERT_THROWS_NOTHING(
+        PointGroupFactory::Instance().createPointGroup("monoclinicA"));
 
-      PointGroupFactory::Instance().unsubscribePointGroup("monoclinicA");
+    PointGroupFactory::Instance().unsubscribePointGroup("monoclinicA");
 
-      std::vector<std::string> allSymbols = PointGroupFactory::Instance().getAllPointGroupSymbols();
-      TS_ASSERT_EQUALS(findString(allSymbols, "monoclinicA"), allSymbols.end());
+    std::vector<std::string> allSymbols =
+        PointGroupFactory::Instance().getAllPointGroupSymbols();
+    TS_ASSERT_EQUALS(findString(allSymbols, "monoclinicA"), allSymbols.end());
 
-      TS_ASSERT_THROWS(PointGroupFactory::Instance().createPointGroup("monoclinicA"), std::invalid_argument);
+    TS_ASSERT_THROWS(
+        PointGroupFactory::Instance().createPointGroup("monoclinicA"),
+        std::invalid_argument);
 
-      PointGroupFactory::Instance().subscribePointGroup("monoclinicA", "x,y,-z", "test");
-      TS_ASSERT_THROWS_NOTHING(PointGroupFactory::Instance().createPointGroup("monoclinicA"));
+    PointGroupFactory::Instance().subscribePointGroup("monoclinicA", "x,y,-z",
+                                                      "test");
+    TS_ASSERT_THROWS_NOTHING(
+        PointGroupFactory::Instance().createPointGroup("monoclinicA"));
   }
 
-  void testPointGroupSymbolCreation()
-  {
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P -1"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 1 2/m 1"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 1 1 2/m"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("F d d d"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("C m c a"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 43/a m d"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("I 41/c c n"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 63/m m c"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("F d -3 m"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P -3 c 1"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P -3 1 d"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 4/a"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 62/d"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("I d -3"));
-      TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("I 4/c"));
-  }
+  void testPointGroupSymbolCreation() {
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P -1"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 1 2/m 1"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("F d d d"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("C m c e"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 42/n b c"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("I 41/a m d"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 63/m m c"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("F d -3 m"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 42/m"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P 63/m"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("F d -3"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("I 4 2 2"));
 
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P -3 c 1"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("P -3 1 c"));
+    TS_ASSERT_THROWS_NOTHING(checkSpaceGroupSymbol("R 32"));
+
+    PointGroup_sptr pointGroup = checkSpaceGroupSymbol("R 3");
+    TS_ASSERT_EQUALS(pointGroup->getCoordinateSystem(),
+                     Group::CoordinateSystem::Hexagonal);
+    TS_ASSERT_EQUALS(pointGroup->getSymbol(), "3");
+  }
 
 private:
-  std::vector<std::string>::const_iterator findString(const std::vector<std::string> &vector, const std::string &searchString)
-  {
-      return std::find(vector.begin(), vector.end(), searchString);
+  std::vector<std::string>::const_iterator
+  findString(const std::vector<std::string> &vector,
+             const std::string &searchString) {
+    return std::find(vector.begin(), vector.end(), searchString);
   }
 
-  void checkSpaceGroupSymbol(const std::string &symbol)
-  {
-      PointGroupFactory::Instance().createPointGroupFromSpaceGroupSymbol(symbol);
+  PointGroup_sptr checkSpaceGroupSymbol(const std::string &symbol) {
+    SpaceGroup_const_sptr spaceGroup =
+        SpaceGroupFactory::Instance().createSpaceGroup(symbol);
+    return PointGroupFactory::Instance().createPointGroupFromSpaceGroup(
+        spaceGroup);
   }
 };
-
 
 #endif /* MANTID_GEOMETRY_POINTGROUPFACTORYTEST_H_ */

--- a/Code/Mantid/Framework/Geometry/test/PointGroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/PointGroupTest.h
@@ -63,7 +63,7 @@ public:
     { V3D equiv[] = {V3D(1,2,3),V3D(-1,-2,3), V3D(-2,1,3), V3D(2,-1,3), V3D(-1,2,-3), V3D(1,-2,-3), V3D(2,1,-3), V3D(-2,-1,-3), V3D(-1,-2,-3), V3D(1,2,-3), V3D(2,-1,-3), V3D(-2,1,-3), V3D(1,-2,3), V3D(-1,2,3),V3D(-2,-1,3), V3D(2,1,3)};
     check_point_group("4/mmm", V3D(1,2,3), 16, equiv); }
     { V3D equiv[] = {V3D(1,2,3),V3D(2,-3,3),V3D(-3,1,3), V3D(-1,-2,-3),V3D(-2,3,-3),V3D(3,-1,-3)};
-    check_point_group("-3 h", V3D(1,2,3), 6, equiv); }
+    check_point_group("-3", V3D(1,2,3), 6, equiv); }
     { V3D equiv[] = {V3D(1,2,3),V3D(2,-3,3),V3D(-3,1,3),V3D(2,1,-3),V3D(1,-3,-3),V3D(-3,2,-3),V3D(-1,-2,-3),V3D(-2,3,-3),V3D(3,-1,-3),V3D(-2,-1,3),V3D(-1,3,3),V3D(3,-2,3)};
     check_point_group("-3m1", V3D(1,2,3), 12, equiv); }
     { V3D equiv[] = {V3D(1,2,3),V3D(2,-3,3),V3D(-3,1,3),V3D(-2,-1,-3),V3D(-1,3,-3),V3D(3,-2,-3),V3D(-1,-2,-3),V3D(-2,3,-3),V3D(3,-1,-3),V3D(2,1,3),V3D(1,-3,3),V3D(-3,2,3),};
@@ -128,19 +128,19 @@ public:
       crystalSystemsMap["-4m2"] = PointGroup::Tetragonal;
       crystalSystemsMap["4/mmm"] = PointGroup::Tetragonal;
 
-      crystalSystemsMap["3 h"] = PointGroup::Trigonal;
-      crystalSystemsMap["-3 h"] = PointGroup::Trigonal;
+      crystalSystemsMap["3"] = PointGroup::Trigonal;
+      crystalSystemsMap["-3"] = PointGroup::Trigonal;
       crystalSystemsMap["321"] = PointGroup::Trigonal;
       crystalSystemsMap["312"] = PointGroup::Trigonal;
       crystalSystemsMap["3m1"] = PointGroup::Trigonal;
       crystalSystemsMap["31m"] = PointGroup::Trigonal;
       crystalSystemsMap["-3m1"] = PointGroup::Trigonal;
       crystalSystemsMap["-31m"] = PointGroup::Trigonal;
-      crystalSystemsMap["3"] = PointGroup::Trigonal;
-      crystalSystemsMap["-3"] = PointGroup::Trigonal;
-      crystalSystemsMap["32"] = PointGroup::Trigonal;
-      crystalSystemsMap["3m"] = PointGroup::Trigonal;
-      crystalSystemsMap["-3m"] = PointGroup::Trigonal;
+      crystalSystemsMap["3 r"] = PointGroup::Trigonal;
+      crystalSystemsMap["-3 r"] = PointGroup::Trigonal;
+      crystalSystemsMap["32 r"] = PointGroup::Trigonal;
+      crystalSystemsMap["3m r"] = PointGroup::Trigonal;
+      crystalSystemsMap["-3m r"] = PointGroup::Trigonal;
 
       crystalSystemsMap["6"] = PointGroup::Hexagonal;
       crystalSystemsMap["-6"] = PointGroup::Hexagonal;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
@@ -25,6 +25,7 @@ set ( EXPORT_FILES
   src/Exports/Goniometer.cpp
   src/Exports/Object.cpp
   src/Exports/PeakShape.cpp
+  src/Exports/Group.cpp
   src/Exports/PointGroup.cpp
   src/Exports/PointGroupFactory.cpp
   src/Exports/SpaceGroup.cpp

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -1,0 +1,20 @@
+#include "MantidGeometry/Crystal/Group.h"
+
+#include <boost/python/class.hpp>
+#include <boost/python/enum.hpp>
+#include <boost/python/scope.hpp>
+
+using Mantid::Geometry::Group;
+
+using namespace boost::python;
+
+void export_Group()
+{
+  enum_<Group::CoordinateSystem>("CoordinateSystem")
+          .value("Orthogonal", Group::Orthogonal)
+          .value("Hexagonal", Group::Hexagonal);
+
+  class_<Group, boost::noncopyable>("Group", no_init)
+          .def("coordinateSystem", &Group::getCoordinateSystem);
+}
+

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -1,4 +1,4 @@
-
+#include "MantidGeometry/Crystal/Group.h"
 #include "MantidGeometry/Crystal/PointGroup.h"
 #include "MantidPythonInterface/kernel/Converters/PyObjectToV3D.h"
 
@@ -8,6 +8,7 @@
 #include <boost/python/list.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
+using Mantid::Geometry::Group;
 using Mantid::Geometry::PointGroup;
 
 using namespace boost::python;
@@ -37,7 +38,6 @@ namespace //<unnamed>
   {
     return self.getReflectionFamily(Converters::PyObjectToV3D(hkl)());
   }
-
 }
 
 void export_PointGroup()
@@ -55,7 +55,7 @@ void export_PointGroup()
           .value("Trigonal", PointGroup::Trigonal)
           .value("Cubic", PointGroup::Cubic);
 
-  class_<PointGroup, boost::noncopyable>("PointGroup", no_init)
+  class_<PointGroup, boost::noncopyable, bases<Group> >("PointGroup", no_init)
           .def("getName", &PointGroup::getName)
           .def("getSymbol", &PointGroup::getSymbol)
           .def("crystalSystem", &PointGroup::crystalSystem)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
@@ -1,4 +1,5 @@
 #include "MantidGeometry/Crystal/PointGroupFactory.h"
+#include "MantidGeometry/Crystal/SpaceGroupFactory.h"
 #include "MantidPythonInterface/kernel/PythonObjectInstantiator.h"
 
 #include <boost/python/class.hpp>
@@ -6,13 +7,26 @@
 using namespace Mantid::Geometry;
 using namespace boost::python;
 
+namespace {
+    PointGroup_sptr getPointGroupFromSpaceGroup(PointGroupFactoryImpl & self, const SpaceGroup &group)
+    {
+        return self.createPointGroupFromSpaceGroup(group);
+    }
+
+    PointGroup_sptr getPointGroupFromSpaceGroupSymbol(PointGroupFactoryImpl & self, const std::string &group)
+    {
+        return self.createPointGroupFromSpaceGroup(SpaceGroupFactory::Instance().createSpaceGroup(group));
+    }
+}
+
 void export_PointGroupFactory()
 {
 
     class_<PointGroupFactoryImpl,boost::noncopyable>("PointGroupFactoryImpl", no_init)
             .def("exists", &PointGroupFactoryImpl::isSubscribed)
             .def("createPointGroup", &PointGroupFactoryImpl::createPointGroup)
-            .def("createPointGroupFromSpaceGroupSymbol", &PointGroupFactoryImpl::createPointGroupFromSpaceGroupSymbol)
+            .def("createPointGroupFromSpaceGroup", &getPointGroupFromSpaceGroup)
+            .def("createPointGroupFromSpaceGroupSymbol", &getPointGroupFromSpaceGroupSymbol)
             .def("getAllPointGroupSymbols", &PointGroupFactoryImpl::getAllPointGroupSymbols)
             .def("getPointGroupSymbols", &PointGroupFactoryImpl::getPointGroupSymbols)
             .def("Instance", &PointGroupFactory::Instance, return_value_policy<reference_existing_object>(),

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -1,4 +1,5 @@
 
+#include "MantidGeometry/Crystal/Group.h"
 #include "MantidGeometry/Crystal/SpaceGroup.h"
 #include "MantidPythonInterface/kernel/Converters/PyObjectToV3D.h"
 
@@ -8,6 +9,7 @@
 #include <boost/python/list.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
+using Mantid::Geometry::Group;
 using Mantid::Geometry::SpaceGroup;
 using Mantid::Geometry::SymmetryOperation;
 
@@ -45,9 +47,9 @@ namespace //<unnamed>
 
 void export_SpaceGroup()
 {
-  register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
+  register_ptr_to_python<boost::shared_ptr<const SpaceGroup> >();
 
-  class_<SpaceGroup, boost::noncopyable>("SpaceGroup", no_init)
+  class_<SpaceGroup, boost::noncopyable, bases<Group> >("SpaceGroup", no_init)
           .def("order", &SpaceGroup::order)
           .def("getSymmetryOperationStrings", &getSymmetryOperationStrings)
           .def("number", &SpaceGroup::number)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -48,7 +48,6 @@ namespace //<unnamed>
 void export_SpaceGroup()
 {
   register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
-  register_ptr_to_python<boost::shared_ptr<const SpaceGroup> >();
 
   class_<SpaceGroup, boost::noncopyable, bases<Group> >("SpaceGroup", no_init)
           .def("order", &SpaceGroup::order)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -47,6 +47,7 @@ namespace //<unnamed>
 
 void export_SpaceGroup()
 {
+  register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
   register_ptr_to_python<boost::shared_ptr<const SpaceGroup> >();
 
   class_<SpaceGroup, boost::noncopyable, bases<Group> >("SpaceGroup", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -30,11 +30,9 @@ namespace
         return self.isSubscribed(number);
     }
 
-    SpaceGroup_sptr createSpaceGroup(SpaceGroupFactoryImpl &self, const std::string &symbol)
+    SpaceGroup_const_sptr createSpaceGroup(SpaceGroupFactoryImpl &self, const std::string &symbol)
     {
-        SpaceGroup_const_sptr spaceGroup = self.createSpaceGroup(symbol);
-
-        return boost::const_pointer_cast<SpaceGroup>(spaceGroup);
+        return self.createSpaceGroup(symbol);
     }
 
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -30,9 +30,10 @@ namespace
         return self.isSubscribed(number);
     }
 
-    SpaceGroup_const_sptr createSpaceGroup(SpaceGroupFactoryImpl &self, const std::string &symbol)
+    SpaceGroup_sptr createSpaceGroup(SpaceGroupFactoryImpl &self, const std::string &symbol)
     {
-        return self.createSpaceGroup(symbol);
+        SpaceGroup_const_sptr spaceGroup = self.createSpaceGroup(symbol);
+        return boost::const_pointer_cast<SpaceGroup>(spaceGroup);
     }
 
 }

--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiCreatePeaksFromCell.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiCreatePeaksFromCell.h
@@ -71,7 +71,9 @@ protected:
   Geometry::UnitCell getUnitCellFromProperties() const;
   Geometry::UnitCell getConstrainedUnitCell(
       const Geometry::UnitCell &unitCell,
-      const Geometry::PointGroup::CrystalSystem &crystalSystem) const;
+      const Geometry::PointGroup::CrystalSystem &crystalSystem,
+      const Geometry::Group::CoordinateSystem &coordinateSystem =
+          Geometry::Group::Orthogonal) const;
 
 private:
   void init();

--- a/Code/Mantid/Framework/SINQ/src/PoldiCreatePeaksFromCell.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiCreatePeaksFromCell.cpp
@@ -78,8 +78,8 @@ SpaceGroup_const_sptr PoldiCreatePeaksFromCell::getSpaceGroup(
 CompositeBraggScatterer_sptr PoldiCreatePeaksFromCell::getScatterers(
     const std::string &scattererString) const {
   boost::char_separator<char> atomSep(";");
-  boost::tokenizer<boost::char_separator<char>> tokens(scattererString,
-                                                       atomSep);
+  boost::tokenizer<boost::char_separator<char> > tokens(scattererString,
+                                                        atomSep);
 
   std::vector<BraggScatterer_sptr> scatterers;
 
@@ -104,7 +104,7 @@ BraggScatterer_sptr PoldiCreatePeaksFromCell::getScatterer(
       getCleanScattererTokens(tokens);
   std::vector<std::string> properties =
       boost::assign::list_of("Element")("Position")("Occupancy")("U")
-          .convert_to_container<std::vector<std::string>>();
+          .convert_to_container<std::vector<std::string> >();
 
   std::string initString;
   for (size_t i = 0; i < cleanScattererTokens.size(); ++i) {
@@ -233,8 +233,8 @@ void PoldiCreatePeaksFromCell::init() {
   declareProperty("Atoms", "", "Atoms in the asymmetric unit. Format: \n"
                                "Element x y z Occupancy U; ... ");
 
-  boost::shared_ptr<BoundedValidator<double>> latticeParameterEdgeValidator =
-      boost::make_shared<BoundedValidator<double>>(0.0, 0.0);
+  boost::shared_ptr<BoundedValidator<double> > latticeParameterEdgeValidator =
+      boost::make_shared<BoundedValidator<double> >(0.0, 0.0);
   latticeParameterEdgeValidator->clearUpper();
   declareProperty("a", 1.0, latticeParameterEdgeValidator,
                   "Lattice parameter a");
@@ -243,8 +243,8 @@ void PoldiCreatePeaksFromCell::init() {
   declareProperty("c", 1.0, latticeParameterEdgeValidator->clone(),
                   "Lattice parameter c");
 
-  boost::shared_ptr<BoundedValidator<double>> latticeParameterAngleValidator =
-      boost::make_shared<BoundedValidator<double>>(0.0, 180.0);
+  boost::shared_ptr<BoundedValidator<double> > latticeParameterAngleValidator =
+      boost::make_shared<BoundedValidator<double> >(0.0, 180.0);
   declareProperty("alpha", 90.0, latticeParameterAngleValidator,
                   "Lattice parameter alpha");
   declareProperty("beta", 90.0, latticeParameterAngleValidator->clone(),
@@ -252,8 +252,8 @@ void PoldiCreatePeaksFromCell::init() {
   declareProperty("gamma", 90.0, latticeParameterAngleValidator->clone(),
                   "Lattice parameter gamma");
 
-  boost::shared_ptr<BoundedValidator<double>> dValidator =
-      boost::make_shared<BoundedValidator<double>>(0.01, 0.0);
+  boost::shared_ptr<BoundedValidator<double> > dValidator =
+      boost::make_shared<BoundedValidator<double> >(0.01, 0.0);
   dValidator->clearUpper();
 
   declareProperty("LatticeSpacingMin", 0.5, dValidator,
@@ -272,8 +272,7 @@ void PoldiCreatePeaksFromCell::exec() {
   // Get all user input regarding the unit cell
   SpaceGroup_const_sptr spaceGroup = getSpaceGroup(getProperty("SpaceGroup"));
   PointGroup_sptr pointGroup =
-      PointGroupFactory::Instance().createPointGroupFromSpaceGroupSymbol(
-          spaceGroup->hmSymbol());
+      PointGroupFactory::Instance().createPointGroupFromSpaceGroup(spaceGroup);
   UnitCell unitCell = getConstrainedUnitCell(getUnitCellFromProperties(),
                                              pointGroup->crystalSystem());
   CompositeBraggScatterer_sptr scatterers = getScatterers(getProperty("Atoms"));

--- a/Code/Mantid/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
@@ -10,198 +10,191 @@ using Mantid::Poldi::PoldiCreatePeaksFromCell;
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 
-class PoldiCreatePeaksFromCellTest : public CxxTest::TestSuite
-{
+class PoldiCreatePeaksFromCellTest : public CxxTest::TestSuite {
 public:
-    // This pair of boilerplate methods prevent the suite being created statically
-    // This means the constructor isn't called when running other tests
-    static PoldiCreatePeaksFromCellTest *createSuite() { return new PoldiCreatePeaksFromCellTest(); }
-    static void destroySuite( PoldiCreatePeaksFromCellTest *suite ) { delete suite; }
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static PoldiCreatePeaksFromCellTest *createSuite() {
+    return new PoldiCreatePeaksFromCellTest();
+  }
+  static void destroySuite(PoldiCreatePeaksFromCellTest *suite) {
+    delete suite;
+  }
 
+  void test_Init() {
+    PoldiCreatePeaksFromCell alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
 
-    void test_Init()
-    {
-        PoldiCreatePeaksFromCell alg;
-        TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-                TS_ASSERT( alg.isInitialized() )
+  void test_exec() {
+    /* This test checks that the outcome of the algorithm
+     * is correct.
+     */
+    std::string outWSName("PoldiCreatePeaksFromCellTest_OutputWS");
+
+    PoldiCreatePeaksFromCell alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("SpaceGroup", "P m -3 m"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue(
+        "Atoms", "Cl 0 0 0 1.0 0.005; Cs 0.5 0.5 0.5 1.0 0.005");)
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("a", "4.126"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("LatticeSpacingMin", "0.55"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("LatticeSpacingMax", "4.0"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    Workspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance().retrieveWS<Workspace>(outWSName));
+    TS_ASSERT(ws);
+
+    ITableWorkspace_sptr tableWs =
+        boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+
+    TS_ASSERT(tableWs);
+    // There should be 68 unique reflections for this cell and d-range.
+    TS_ASSERT_EQUALS(tableWs->rowCount(), 68);
+
+    if (ws) {
+      AnalysisDataService::Instance().remove(outWSName);
     }
+  }
 
-    void test_exec()
-    {
-        /* This test checks that the outcome of the algorithm
-         * is correct.
-         */
-        std::string outWSName("PoldiCreatePeaksFromCellTest_OutputWS");
+  void testValidateInput() {
+    PoldiCreatePeaksFromCell alg;
+    alg.initialize();
 
-        PoldiCreatePeaksFromCell alg;
-        TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-        TS_ASSERT( alg.isInitialized() )
-        TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("SpaceGroup", "P m -3 m") );
-        TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("Atoms", "Cl 0 0 0 1.0 0.005; Cs 0.5 0.5 0.5 1.0 0.005");)
-        TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("a", "4.126"));
-        TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("LatticeSpacingMin", "0.55"));
-        TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("LatticeSpacingMax", "4.0"));
-        TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", outWSName) );
-        TS_ASSERT_THROWS_NOTHING( alg.execute(); );
-        TS_ASSERT( alg.isExecuted() );
+    alg.setPropertyValue("LatticeSpacingMin", "1.0");
+    alg.setPropertyValue("LatticeSpacingMax", "2.0");
 
-        // Retrieve the workspace from data service.
-        Workspace_sptr ws;
-        TS_ASSERT_THROWS_NOTHING( ws = AnalysisDataService::Instance().retrieveWS<Workspace>(outWSName) );
-        TS_ASSERT(ws);
+    // dMax is larger than dMin
+    std::map<std::string, std::string> errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 0);
 
-        ITableWorkspace_sptr tableWs = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+    alg.setPropertyValue("LatticeSpacingMax", "0.5");
+    // now it's smaller - not allowed
+    errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 1);
 
-        TS_ASSERT(tableWs);
-        // There should be 68 unique reflections for this cell and d-range.
-        TS_ASSERT_EQUALS(tableWs->rowCount(), 68);
+    errorMap.clear();
 
-        if (ws) {
-            AnalysisDataService::Instance().remove(outWSName);
-        }
-    }
+    alg.setPropertyValue("LatticeSpacingMax", "-0.5");
+    errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 1)
+  }
 
-    void testValidateInput()
-    {
-        PoldiCreatePeaksFromCell alg;
-        alg.initialize();
+  void testGetLargestDValue() {
+    // Maximum d-value is 30.0
+    UnitCell cell(10.0, 20.0, 30.0);
+    TestablePoldiCreatePeaksFromCell alg;
 
-        alg.setPropertyValue("LatticeSpacingMin", "1.0");
-        alg.setPropertyValue("LatticeSpacingMax", "2.0");
+    TS_ASSERT_EQUALS(alg.getLargestDValue(cell), 30.0);
+  }
 
-        // dMax is larger than dMin
-        std::map<std::string, std::string> errorMap = alg.validateInputs();
-        TS_ASSERT_EQUALS(errorMap.size(), 0);
+  void testGetDMaxValue() {
+    // Maximum d-value is 30.0
+    UnitCell cell(10.0, 20.0, 30.0);
 
-        alg.setPropertyValue("LatticeSpacingMax", "0.5");
-        // now it's smaller - not allowed
-        errorMap = alg.validateInputs();
-        TS_ASSERT_EQUALS(errorMap.size(), 1);
+    TestablePoldiCreatePeaksFromCell alg;
+    alg.initialize();
 
-        errorMap.clear();
+    // dMax has default value - largest d-value + 1.0 is supposed to be returned
+    TS_ASSERT_EQUALS(alg.getDMaxValue(cell), 31.0);
 
-        alg.setPropertyValue("LatticeSpacingMax", "-0.5");
-        errorMap = alg.validateInputs();
-        TS_ASSERT_EQUALS(errorMap.size(), 1)
-    }
+    // dMax has been set to a different value
+    alg.setPropertyValue("LatticeSpacingMax", "2.0");
+    TS_ASSERT_EQUALS(alg.getDMaxValue(cell), 2.0);
 
-    void testGetLargestDValue()
-    {
-        // Maximum d-value is 30.0
-        UnitCell cell(10.0, 20.0, 30.0);
-        TestablePoldiCreatePeaksFromCell alg;
+    alg.setPropertyValue("LatticeSpacingMax", "100.0");
+    TS_ASSERT_EQUALS(alg.getDMaxValue(cell), 100.0);
+  }
 
-        TS_ASSERT_EQUALS(alg.getLargestDValue(cell), 30.0);
-    }
+  void testGetUnitCellFromProperties() {
+    TestablePoldiCreatePeaksFromCell alg;
+    alg.initialize();
 
-    void testGetDMaxValue()
-    {
-        // Maximum d-value is 30.0
-        UnitCell cell(10.0, 20.0, 30.0);
+    alg.setPropertyValue("a", "3.0");
+    alg.setPropertyValue("b", "4.0");
+    alg.setPropertyValue("c", "5.0");
 
-        TestablePoldiCreatePeaksFromCell alg;
-        alg.initialize();
+    alg.setPropertyValue("alpha", "90.0");
+    alg.setPropertyValue("beta", "91.0");
+    alg.setPropertyValue("gamma", "92.0");
 
-        // dMax has default value - largest d-value + 1.0 is supposed to be returned
-        TS_ASSERT_EQUALS(alg.getDMaxValue(cell), 31.0);
+    UnitCell unitCell = alg.getUnitCellFromProperties();
 
-        // dMax has been set to a different value
-        alg.setPropertyValue("LatticeSpacingMax", "2.0");
-        TS_ASSERT_EQUALS(alg.getDMaxValue(cell), 2.0);
+    TS_ASSERT_EQUALS(unitCell.a(), 3.0);
+    TS_ASSERT_EQUALS(unitCell.b(), 4.0);
+    TS_ASSERT_EQUALS(unitCell.c(), 5.0);
+    TS_ASSERT_EQUALS(unitCell.alpha(), 90.0);
+    TS_ASSERT_EQUALS(unitCell.beta(), 91.0);
+    TS_ASSERT_EQUALS(unitCell.gamma(), 92.0);
+  }
 
-        alg.setPropertyValue("LatticeSpacingMax", "100.0");
-        TS_ASSERT_EQUALS(alg.getDMaxValue(cell), 100.0);
-    }
+  void testGetConstrainedUnitCell() {
+    TestablePoldiCreatePeaksFromCell alg;
 
-    void testGetUnitCellFromProperties()
-    {
-        TestablePoldiCreatePeaksFromCell alg;
-        alg.initialize();
+    UnitCell rawCell(2.0, 3.0, 4.0, 91.0, 92.0, 93.0);
 
-        alg.setPropertyValue("a", "3.0");
-        alg.setPropertyValue("b", "4.0");
-        alg.setPropertyValue("c", "5.0");
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Cubic), 2.0, 2.0, 2.0,
+        90.0, 90.0, 90.0, "Cubic");
 
-        alg.setPropertyValue("alpha", "90.0");
-        alg.setPropertyValue("beta", "91.0");
-        alg.setPropertyValue("gamma", "92.0");
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Tetragonal), 2.0, 2.0,
+        4.0, 90.0, 90.0, 90.0, "Tetragonal");
 
-        UnitCell unitCell = alg.getUnitCellFromProperties();
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Orthorhombic), 2.0, 3.0,
+        4.0, 90.0, 90.0, 90.0, "Orthorhombic");
 
-        TS_ASSERT_EQUALS(unitCell.a(), 3.0);
-        TS_ASSERT_EQUALS(unitCell.b(), 4.0);
-        TS_ASSERT_EQUALS(unitCell.c(), 5.0);
-        TS_ASSERT_EQUALS(unitCell.alpha(), 90.0);
-        TS_ASSERT_EQUALS(unitCell.beta(), 91.0);
-        TS_ASSERT_EQUALS(unitCell.gamma(), 92.0);
-    }
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Monoclinic), 2.0, 3.0,
+        4.0, 90.0, 92.0, 90.0, "Monoclinic");
 
-    void testGetConstrainedUnitCell()
-    {
-        TestablePoldiCreatePeaksFromCell alg;
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Triclinic), 2.0, 3.0,
+        4.0, 91.0, 92.0, 93.0, "Triclinic");
 
-        UnitCell rawCell(2.0, 3.0, 4.0, 91.0, 92.0, 93.0);
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Hexagonal), 2.0, 2.0,
+        4.0, 90.0, 90.0, 120.0, "Hexagonal");
 
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Cubic),
-                    2.0, 2.0, 2.0, 90.0, 90.0, 90.0, "Cubic"
-                    );
+    checkUnitCellParameters(
+        alg.getConstrainedUnitCell(rawCell, PointGroup::Trigonal), 2.0, 2.0,
+        2.0, 91.0, 91.0, 91.0, "Trigonal");
 
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Tetragonal),
-                    2.0, 2.0, 4.0, 90.0, 90.0, 90.0, "Tetragonal"
-                    );
-
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Orthorhombic),
-                    2.0, 3.0, 4.0, 90.0, 90.0, 90.0, "Orthorhombic"
-                    );
-
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Monoclinic),
-                    2.0, 3.0, 4.0, 90.0, 92.0, 90.0, "Monoclinic"
-                    );
-
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Triclinic),
-                    2.0, 3.0, 4.0, 91.0, 92.0, 93.0, "Triclinic"
-                    );
-
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Hexagonal),
-                    2.0, 2.0, 4.0, 90.0, 90.0, 120.0, "Hexagonal"
-                    );
-
-        checkUnitCellParameters(
-                    alg.getConstrainedUnitCell(rawCell, PointGroup::Trigonal),
-                    2.0, 2.0, 2.0, 91.0, 91.0, 91.0, "Trigonal"
-                    );
-    }
+    checkUnitCellParameters(alg.getConstrainedUnitCell(rawCell,
+                                                       PointGroup::Trigonal,
+                                                       Group::Hexagonal),
+                            2.0, 2.0, 4.0, 90.0, 90.0, 120.0, "Trigonal");
+  }
 
 private:
-    void checkUnitCellParameters(const UnitCell &cell, double a, double b, double c, double alpha, double beta, double gamma, const std::string &message)
-    {
-        TSM_ASSERT_DELTA(message, cell.a(), a, 1e-14);
-        TSM_ASSERT_DELTA(message, cell.b(), b, 1e-14);
-        TSM_ASSERT_DELTA(message, cell.c(), c, 1e-14);
+  void checkUnitCellParameters(const UnitCell &cell, double a, double b,
+                               double c, double alpha, double beta,
+                               double gamma, const std::string &message) {
+    TSM_ASSERT_DELTA(message, cell.a(), a, 1e-14);
+    TSM_ASSERT_DELTA(message, cell.b(), b, 1e-14);
+    TSM_ASSERT_DELTA(message, cell.c(), c, 1e-14);
 
-        TSM_ASSERT_DELTA(message, cell.alpha(), alpha, 1e-14);
-        TSM_ASSERT_DELTA(message, cell.beta(), beta, 1e-14);
-        TSM_ASSERT_DELTA(message, cell.gamma(), gamma, 1e-14);
-    }
+    TSM_ASSERT_DELTA(message, cell.alpha(), alpha, 1e-14);
+    TSM_ASSERT_DELTA(message, cell.beta(), beta, 1e-14);
+    TSM_ASSERT_DELTA(message, cell.gamma(), gamma, 1e-14);
+  }
 
-    class TestablePoldiCreatePeaksFromCell : public PoldiCreatePeaksFromCell
-    {
-    public:
-        TestablePoldiCreatePeaksFromCell() : PoldiCreatePeaksFromCell()
-        { }
-        ~TestablePoldiCreatePeaksFromCell() { }
+  class TestablePoldiCreatePeaksFromCell : public PoldiCreatePeaksFromCell {
+  public:
+    TestablePoldiCreatePeaksFromCell() : PoldiCreatePeaksFromCell() {}
+    ~TestablePoldiCreatePeaksFromCell() {}
 
-        friend class PoldiCreatePeaksFromCellTest;
-    };
-
-
+    friend class PoldiCreatePeaksFromCellTest;
+  };
 };
-
 
 #endif /* MANTID_SINQ_POLDICREATEPEAKSFROMCELLTEST_H_ */

--- a/Code/Mantid/docs/source/concepts/PointGroups.rst
+++ b/Code/Mantid/docs/source/concepts/PointGroups.rst
@@ -42,7 +42,7 @@ As mentioned before, point groups can describe the symmetry of a lattice, includ
 To describe the rotational and translational components of the symmetry operation, a matrix :math:`\mathbf{W}_i` and a vector :math:`\mathbf{w}_i` are used. In three dimensions :math:`\mathbf{h}` has three elements, so :math:`\mathbf{W}_i` is a :math:`3\times3`-matrix and the symmetry operation is applied like this:
 
 .. math::
-    \mathbf{h}' = \mathbf{W}_i^{-1T} \cdot \mathbf{h}
+    \mathbf{h}' = {\mathbf{W}_i^{-1}}^T \cdot \mathbf{h}
 
 Note that the translational component is not used for transforming HKLs and :math:`\mathbf{W}_i` is inverted and transposed. Coordinates :math:`\mathbf{x}` are transformed differently, they are affected by the translational component:
 
@@ -170,9 +170,11 @@ Which results in the following output:
 
 .. testoutput :: ExQueryPointGroups
 
-    All point groups: ['-1','-3','-3 h','-31m','-3m','-3m1','-4','-42m','-43m','-4m2','-6','-62m','-6m2','1','112/m','2','2/m','222','23','3','3 h','312','31m','32','321','3m','3m1','4','4/m','4/mmm','422','432','4mm','6','6/m','6/mmm','622','6mm','m','m-3','m-3m','mm2','mmm']
+    All point groups: ['-1','-3','-3 r','-31m','-3m r','-3m1','-4','-42m','-43m','-4m2','-6','-62m','-6m2','1','112/m','2','2/m','222','23','3','3 r','312','31m','32 r','321','3m r','3m1','4','4/m','4/mmm','422','432','4mm','6','6/m','6/mmm','622','6mm','m','m-3','m-3m','mm2','mmm']
     Cubic point groups: ['-43m','23','432','m-3','m-3m']
     Tetragonal point groups: ['-4','-42m','-4m2','4','4/m','4/mmm','422','4mm']
+
+The point groups with an extra ``r`` at the end are trigonal point groups with rhombohedral axes. Trigonal point groups without that additional letter use the hexagonal coordinate system.
 
 After having obtained a ``PointGroup``-object, it can be used for working with reflection data, more specifically :math:`hkl`-indices. It's possible to check whether two reflections are equivalent in a certain point group:
 


### PR DESCRIPTION
This fixes [#11432](http://trac.mantidproject.org/mantid/ticket/11432).

**Testing information**
- Code review. The unit test for PoldiCreatePeaksFromCell looks like it had a lot of changes, but that was caused by clang-format.
- Make sure all tests pass.
- The following test script will print `False` before these changes and `True` after (that's how it's supposed to be, since all trigonal space groups currently registered in Mantid are defined using hexagonal axes):

```
sg = SpaceGroupFactory.createSpaceGroup("R -3")
pg = PointGroupFactory.createPointGroupFromSpaceGroupSymbol(sg.hmSymbol())
print "Hexagonal" in pg.getName()
```
