### PR TITLE
Fix Create1DWorkspaceConstant

### DIFF
--- a/Code/Mantid/Framework/Algorithms/test/PolarizationCorrectionTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/PolarizationCorrectionTest.h
@@ -178,6 +178,7 @@ public:
       checkAlg->setChild(true);
       checkAlg->setProperty("Workspace1", groupWS->getItem(i));
       checkAlg->setProperty("Workspace2", outWS->getItem(i));
+      checkAlg->setProperty("Tolerance", 3e-16);
       checkAlg->execute();
       const std::string result = checkAlg->getProperty("Result");
       TS_ASSERT_EQUALS("Success!", result);

--- a/Code/Mantid/Framework/CurveFitting/test/FunctionParameterDecoratorFitTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/FunctionParameterDecoratorFitTest.h
@@ -70,7 +70,7 @@ public:
 
   void testFit() {
     Workspace2D_sptr ws =
-        WorkspaceCreationHelper::Create1DWorkspaceConstant(20, 1.5, 1.5);
+        WorkspaceCreationHelper::Create1DWorkspaceConstant(20, 1.5, 0.5);
 
     FunctionParameterDecorator_sptr fn =
         boost::make_shared<SimpleFunctionParameterDecorator>();

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -84,7 +84,7 @@ Workspace2D_sptr Create1DWorkspaceConstant(int size, double value,
   y1.access().resize(size);
   std::fill(y1.access().begin(), y1.access().end(), value);
   e1.access().resize(size);
-  std::fill(y1.access().begin(), y1.access().end(), error);
+  std::fill(e1.access().begin(), e1.access().end(), error);
   Workspace2D_sptr retVal(new Workspace2D);
   retVal->initialize(1, size, size);
   retVal->setX(0, x1);

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -81,10 +81,8 @@ Workspace2D_sptr Create1DWorkspaceConstant(int size, double value,
                                            double error) {
   MantidVecPtr x1, y1, e1;
   x1.access().resize(size, 1);
-  y1.access().resize(size);
-  std::fill(y1.access().begin(), y1.access().end(), value);
-  e1.access().resize(size);
-  std::fill(e1.access().begin(), e1.access().end(), error);
+  y1.access().resize(size, value);
+  e1.access().resize(size, error);
   Workspace2D_sptr retVal(new Workspace2D);
   retVal->initialize(1, size, size);
   retVal->setX(0, x1);


### PR DESCRIPTION
This fixes [#11174](http://trac.mantidproject.org/mantid/ticket/11174).

**Testing information**
Code review should be enough, it was just a typo in the code. I had to add a tolerance of 3e-16 to CheckWorkspaces in `AlgorithmsTest.PolarizationCorrectionTest.test_run_PA_unity` to make it pass. I'm not entirely sure what causes it, my best guess is that during the various operations for creating the output workspace some floating point error accumulates.

Before these changes this did not show up because the error in Create1DWorkspaceConst was not initialized so it was 0.
