### PR TITLE
Refactor PoldiFitPeaks2D to use EstimatePeakErrors

### DIFF
--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -5,6 +5,10 @@
 #include "MantidSINQ/DllConfig.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidAPI/IPeakFunction.h"
+
+#include "MantidKernel/Matrix.h"
+
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidSINQ/PoldiUtilities/PoldiPeakCollection.h"
 #include "MantidSINQ/PoldiUtilities/PoldiTimeTransformer.h"
@@ -57,6 +61,11 @@ public:
   virtual const std::string category() const;
 
   virtual const std::string summary() const;
+
+  boost::shared_ptr<Kernel::DblMatrix> getLocalCovarianceMatrix(
+      const boost::shared_ptr<const Kernel::DblMatrix> &covarianceMatrix,
+      size_t parameterOffset,
+      const API::IPeakFunction_sptr &profileFunction);
 
 protected:
   PoldiPeakCollection_sptr

--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -64,8 +64,7 @@ public:
 
   boost::shared_ptr<Kernel::DblMatrix> getLocalCovarianceMatrix(
       const boost::shared_ptr<const Kernel::DblMatrix> &covarianceMatrix,
-      size_t parameterOffset,
-      const API::IPeakFunction_sptr &profileFunction);
+      size_t parameterOffset, size_t nParams) const;
 
 protected:
   PoldiPeakCollection_sptr

--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -72,8 +72,7 @@ protected:
                            PoldiPeakCollection_sptr &to) const;
 
   PoldiPeakCollection_sptr
-  getPeakCollectionFromFunction(const API::IFunction_sptr &fitFunction,
-                                const API::IAlgorithm_sptr &errorAlg) const;
+  getPeakCollectionFromFunction(const API::IFunction_sptr &fitFunction);
   Poldi2DFunction_sptr getFunctionFromPeakCollection(
       const PoldiPeakCollection_sptr &peakCollection) const;
   void addBackgroundTerms(Poldi2DFunction_sptr poldi2DFunction) const;

--- a/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -72,7 +72,8 @@ protected:
                            PoldiPeakCollection_sptr &to) const;
 
   PoldiPeakCollection_sptr
-  getPeakCollectionFromFunction(const API::IFunction_sptr &fitFunction) const;
+  getPeakCollectionFromFunction(const API::IFunction_sptr &fitFunction,
+                                const API::IAlgorithm_sptr &errorAlg) const;
   Poldi2DFunction_sptr getFunctionFromPeakCollection(
       const PoldiPeakCollection_sptr &peakCollection) const;
   void addBackgroundTerms(Poldi2DFunction_sptr poldi2DFunction) const;

--- a/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -156,34 +156,24 @@ PoldiPeakCollection_sptr PoldiFitPeaks2D::getPeakCollectionFromFunction(
 
       double centre = profileFunction->centre();
       double height = profileFunction->height();
+      double fwhmValue = profileFunction->fwhm();
 
-      size_t dIndex = 0;
-      size_t iIndex = 0;
-      size_t fIndex = 0;
+      ITableWorkspace_sptr errorTable =
+          errorAlg->getProperty("OutputWorkspace");
 
-      for (size_t j = 0; j < profileFunction->nParams(); ++j) {
-        if (profileFunction->getParameter(j) == centre) {
-          dIndex = j;
-        } else if (profileFunction->getParameter(j) == height) {
-          iIndex = j;
-        } else {
-          fIndex = j;
-        }
-      }
+      double centreError = errorTable->cell<double>(0, 2);
+      double heightError = errorTable->cell<double>(1, 2);
+      double fwhmError = errorTable->cell<double>(2, 2);
+
 
       // size_t dIndex = peakFunction->parameterIndex("Centre");
-      UncertainValue d(peakFunction->getParameter(dIndex),
-                       peakFunction->getError(dIndex));
+      UncertainValue d(centre, centreError);
 
       // size_t iIndex = peakFunction->parameterIndex("Area");
-      UncertainValue intensity(peakFunction->getParameter(iIndex),
-                               peakFunction->getError(iIndex));
+      UncertainValue intensity(height, heightError);
 
       // size_t fIndex = peakFunction->parameterIndex("Sigma");
-      double fwhmValue = profileFunction->fwhm();
-      UncertainValue fwhm(fwhmValue, fwhmValue /
-                                         peakFunction->getParameter(fIndex) *
-                                         peakFunction->getError(fIndex));
+      UncertainValue fwhm(fwhmValue, fwhmError);
 
       PoldiPeak_sptr peak =
           PoldiPeak::create(MillerIndices(), d, intensity, UncertainValue(1.0));

--- a/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -112,7 +112,7 @@ void PoldiFitPeaks2D::init() {
  * @return PoldiPeakCollection containing peaks with normalized intensities
  */
 PoldiPeakCollection_sptr PoldiFitPeaks2D::getPeakCollectionFromFunction(
-    const IFunction_sptr &fitFunction, const IAlgorithm_sptr &errorAlg) const {
+    const IFunction_sptr &fitFunction) {
   Poldi2DFunction_sptr poldi2DFunction =
       boost::dynamic_pointer_cast<Poldi2DFunction>(fitFunction);
 
@@ -148,7 +148,9 @@ PoldiPeakCollection_sptr PoldiFitPeaks2D::getPeakCollectionFromFunction(
 
       profileFunction->setCovarianceMatrix(localCov);
 
-      errorAlg->setProperty("Function", profileFunction);
+      IAlgorithm_sptr errorAlg = createChildAlgorithm("EstimatePeakErrors");
+      errorAlg->setProperty(
+          "Function", boost::dynamic_pointer_cast<IFunction>(profileFunction));
       errorAlg->setPropertyValue("OutputWorkspace", "Errors");
       errorAlg->execute();
 
@@ -269,10 +271,8 @@ void PoldiFitPeaks2D::exec() {
 
   MatrixWorkspace_sptr outWs1D = get1DSpectrum(fitFunction, ws);
 
-  IAlgorithm_sptr errorAlg = createChildAlgorithm("EstimatePeakErrors");
-
   PoldiPeakCollection_sptr normalizedPeaks =
-      getPeakCollectionFromFunction(fitFunction, errorAlg);
+      getPeakCollectionFromFunction(fitFunction);
   PoldiPeakCollection_sptr integralPeaks =
       getCountPeakCollection(normalizedPeaks);
 

--- a/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -6,6 +6,8 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/AlgorithmManager.h"
 
+#include "MantidKernel/Matrix.h"
+
 #include "MantidSINQ/PoldiFitPeaks2D.h"
 #include "MantidSINQ/PoldiUtilities/PoldiSpectrumDomainFunction.h"
 #include "MantidSINQ/PoldiUtilities/PoldiMockInstrumentHelpers.h"
@@ -14,6 +16,7 @@
 using namespace Mantid::Poldi;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
+using namespace Mantid::Kernel;
 
 class PoldiFitPeaks2DTest : public CxxTest::TestSuite
 {
@@ -234,6 +237,18 @@ public:
         PoldiPeakCollection_sptr peaks = PoldiPeakCollectionHelpers::createPoldiPeakCollectionNormalized();
         IFunction_sptr poldi2DFunction = spectrumCalculator.getFunctionFromPeakCollection(peaks);
 
+        size_t nParams = poldi2DFunction->nParams();
+
+        // Make a matrix with diagonal elements = 0.05 and set as covariance matrix
+        boost::shared_ptr<DblMatrix> matrix = boost::make_shared<DblMatrix>(nParams, nParams, true);
+        matrix->operator *=(0.05);
+        poldi2DFunction->setCovarianceMatrix(matrix);
+
+        // Also set errors for old behavior
+        for(size_t i = 0; i < nParams; ++i) {
+            poldi2DFunction->setError(i, sqrt(0.05));
+        }
+
         PoldiPeakCollection_sptr peaksFromFunction = spectrumCalculator.getPeakCollectionFromFunction(poldi2DFunction);
 
         TS_ASSERT_EQUALS(peaksFromFunction->peakCount(), peaks->peakCount());
@@ -241,8 +256,11 @@ public:
             PoldiPeak_sptr functionPeak = peaksFromFunction->peak(i);
             PoldiPeak_sptr referencePeak = peaks->peak(i);
 
-            TS_ASSERT_EQUALS(functionPeak->d(), referencePeak->d());
-            TS_ASSERT_EQUALS(functionPeak->fwhm(), referencePeak->fwhm());
+            TS_ASSERT_EQUALS(functionPeak->d().value(), referencePeak->d().value());
+            TS_ASSERT_EQUALS(functionPeak->fwhm().value(), referencePeak->fwhm().value());
+            TS_ASSERT_EQUALS(functionPeak->d().error(), sqrt(0.05));
+            TS_ASSERT_EQUALS(functionPeak->fwhm(PoldiPeak::AbsoluteD).error(), sqrt(0.05) * (2.0 * sqrt(2.0 * log(2.0))));
+
         }
     }
 

--- a/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -258,8 +258,8 @@ public:
 
             TS_ASSERT_EQUALS(functionPeak->d().value(), referencePeak->d().value());
             TS_ASSERT_EQUALS(functionPeak->fwhm().value(), referencePeak->fwhm().value());
-            TS_ASSERT_EQUALS(functionPeak->d().error(), sqrt(0.05));
-            TS_ASSERT_EQUALS(functionPeak->fwhm(PoldiPeak::AbsoluteD).error(), sqrt(0.05) * (2.0 * sqrt(2.0 * log(2.0))));
+            TS_ASSERT_DELTA(functionPeak->d().error(), sqrt(0.05), 1e-6);
+            TS_ASSERT_DELTA(functionPeak->fwhm(PoldiPeak::AbsoluteD).error(), sqrt(0.05) * (2.0 * sqrt(2.0 * log(2.0))), 1e-6);
 
         }
     }


### PR DESCRIPTION
This fixes [#11384](http://trac.mantidproject.org/mantid/ticket/11384).

**Testing information**
Make sure the unit and system tests for PoldiFitPeaks2D pass, this should cover these changes.
