### PR TITLE
Log plot precision.

### DIFF
--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -865,7 +865,7 @@ void ApplicationWindow::initGlobalConstants()
     d_locale.setNumberOptions(QLocale::OmitGroupSeparator);
 
   d_decimal_digits = 13;
-  d_graphing_digits = 3;
+  d_graphing_digits = 13;
 
   d_extended_open_dialog = true;
   d_extended_export_dialog = true;

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2519,8 +2519,8 @@ void MantidUI::importNumSeriesLog(const QString &wsName, const QString &logName,
   {
     //Seconds offset
     t->setColName(0, "Time (sec)");
-    t->setColumnType(0, Table::Numeric); //six digits after 0
-    t->setNumericPrecision(6); //six digits after 0
+    t->setColumnType(0, Table::Numeric);
+    t->setNumericPrecision(16);   //it's the number of all digits
   }
 
   //Make the column header with the units, if any


### PR DESCRIPTION
[11443](http://trac.mantidproject.org/mantid/ticket/11443)

**To test**
- Check that sample log Field_NMR of HIFI00077855 can be plotted with sufficient precision in Sample Logs dialog.
- Check that the axis settings dialog (double click on an axis) allows you to set the scale with high precision (> 2 digits).
