### PR TITLE
Good starting values for time limits

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -68,6 +68,8 @@ namespace CustomInterfaces
     void displayError(const std::string &error);
     void setAvailableLogs(const std::vector<std::string> &logs);
     void setAvailablePeriods(const std::vector<std::string> &periods);
+    void setTimeLimits(double tMin, double tMax);
+    void setTimeRange (double tMin, double tMax);
     void setWaitingCursor();
     void restoreCursor();
     void help();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -394,6 +394,9 @@
                                   <property name="maximum">
                                     <double>32</double>
                                   </property>
+                                  <property name="decimals">
+                                    <number>3</number>
+                                  </property>
                                 </widget>
                               </item>
                               <item>
@@ -410,6 +413,9 @@
                                   </property>
                                   <property name="maximum">
                                     <double>32</double>
+                                  </property>
+                                  <property name="decimals">
+                                    <number>3</number>
                                   </property>
                                 </widget>
                               </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -392,7 +392,7 @@
                                     <double>-6</double>
                                   </property>
                                   <property name="maximum">
-                                    <double>32</double>
+                                    <double>33</double>
                                   </property>
                                   <property name="decimals">
                                     <number>3</number>
@@ -412,7 +412,7 @@
                                     <double>-6</double>
                                   </property>
                                   <property name="maximum">
-                                    <double>32</double>
+                                    <double>33</double>
                                   </property>
                                   <property name="decimals">
                                     <number>3</number>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -387,7 +387,14 @@
                                 </widget>
                               </item>
                               <item>
-                                <widget class="QDoubleSpinBox" name="minTime"/>
+                                <widget class="QDoubleSpinBox" name="minTime">
+                                  <property name="minimum">
+                                    <double>-6</double>
+                                  </property>
+                                  <property name="maximum">
+                                    <double>32</double>
+                                  </property>
+                                </widget>
                               </item>
                               <item>
                                 <widget class="QLabel" name="label_5">
@@ -397,7 +404,14 @@
                                 </widget>
                               </item>
                               <item>
-                                <widget class="QDoubleSpinBox" name="maxTime"/>
+                                <widget class="QDoubleSpinBox" name="maxTime">
+                                  <property name="minimum">
+                                    <double>-6</double>
+                                  </property>
+                                  <property name="maximum">
+                                    <double>32</double>
+                                  </property>
+                                </widget>
                               </item>
                             </layout>
                           </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -103,6 +103,16 @@ namespace CustomInterfaces
     /// @param periods :: New list of periods
     virtual void setAvailablePeriods(const std::vector<std::string>& periods) = 0;
 
+    /// Update the time limits
+    /// @param tMin :: Minimum X value available
+    /// @param tMax :: Maximum X value available
+    virtual void setTimeLimits(double tMin, double tMax) = 0;
+
+    /// Update the time limits
+    /// @param tMin :: Minimum X value available
+    /// @param tMax :: Maximum X value available
+    virtual void setTimeRange(double tMin, double tMax) = 0;
+
     /// Set waiting cursor for long operation
     virtual void setWaitingCursor() = 0;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -137,6 +137,7 @@ namespace CustomInterfaces
     {
       m_view->setAvailableLogs(std::vector<std::string>()); // Empty logs list
       m_view->setAvailablePeriods(std::vector<std::string>()); // Empty period list
+      m_view->setTimeLimits(0,0); // "Empty" time limits
       return;
     }
 
@@ -161,6 +162,11 @@ namespace CustomInterfaces
       periods.push_back(buffer.str());
     }
     m_view->setAvailablePeriods(periods);
+
+    // Set time limits
+    m_view->setTimeLimits(ws->readX(0).front(),ws->readX(0).back());
+    // Set allowed time range
+    m_view->setTimeRange (ws->readX(0).front(),ws->readX(0).back());
   }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -163,6 +163,22 @@ namespace CustomInterfaces
     }
   }
 
+  void ALCDataLoadingView::setTimeLimits(double tMin, double tMax)
+  {
+    // Set initial values
+    m_ui.minTime->setValue(tMin);
+    m_ui.maxTime->setValue(tMax);
+  }
+
+  void ALCDataLoadingView::setTimeRange(double tMin, double tMax)
+  {
+    // Set initial values
+    m_ui.minTime->setMinimum(tMin);
+    m_ui.minTime->setMaximum(tMax);
+    m_ui.maxTime->setMinimum(tMin);
+    m_ui.maxTime->setMaximum(tMax);
+  }
+
   void ALCDataLoadingView::help()
   {
     MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Muon_ALC"));

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -172,9 +172,10 @@ namespace CustomInterfaces
 
   void ALCDataLoadingView::setTimeRange(double tMin, double tMax)
   {
-    // Set initial values
+    // Set range for minTime
     m_ui.minTime->setMinimum(tMin);
     m_ui.minTime->setMaximum(tMax);
+    // Set range for maxTime
     m_ui.maxTime->setMinimum(tMin);
     m_ui.maxTime->setMaximum(tMax);
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -48,6 +48,8 @@ public:
   MOCK_METHOD1(displayError, void(const std::string&));
   MOCK_METHOD1(setAvailableLogs, void(const std::vector<std::string>&));
   MOCK_METHOD1(setAvailablePeriods, void(const std::vector<std::string>&));
+  MOCK_METHOD2(setTimeLimits, void(double,double));
+  MOCK_METHOD2(setTimeRange, void(double,double));
   MOCK_METHOD0(setWaitingCursor, void());
   MOCK_METHOD0(restoreCursor, void());
   MOCK_METHOD0(help, void());


### PR DESCRIPTION
Fixes [#11444](http://trac.mantidproject.org/mantid/ticket/11444)

To test: Open the Muon ALC interface. Use any muon dataset as "First", and check that the time limits are set to the minimum and maximum X values in the workspace. 
