### PR TITLE
Use new correction algorithms in IDA Calc/ApplyCorr

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
@@ -39,8 +39,10 @@ namespace IDA
 
     Ui::ApplyCorr m_uiForm;
 
-    /// Pointer to the result workspace (for plotting)
-    Mantid::API::MatrixWorkspace_sptr m_outputWs;
+    /// Name of sample workspace (for plotting)
+    std::string m_sampleWsName;
+    /// Name of container workspace (for plotting)
+    std::string m_canWsName;
 
   };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
@@ -34,9 +34,13 @@ namespace IDA
     virtual bool validate();
     virtual void loadSettings(const QSettings & settings);
 
+    std::string addUnitConversionStep(Mantid::API::MatrixWorkspace_sptr ws);
+
     Ui::ApplyCorr m_uiForm;
+
     /// Pointer to the result workspace (for plotting)
     Mantid::API::MatrixWorkspace_sptr m_outputWs;
+
   };
 
 } // namespace IDA

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
@@ -35,6 +35,7 @@ namespace IDA
     virtual void loadSettings(const QSettings & settings);
 
     std::string addUnitConversionStep(Mantid::API::MatrixWorkspace_sptr ws);
+    void addInterpolationStep(Mantid::API::MatrixWorkspace_sptr toInterpolate, std::string toMatch);
 
     Ui::ApplyCorr m_uiForm;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
@@ -35,7 +35,6 @@ namespace IDA
     virtual void loadSettings(const QSettings & settings);
 
     void addRebinStep(QString toRebin, QString toMatch);
-    std::string addUnitConversionStep(Mantid::API::MatrixWorkspace_sptr ws);
     void addInterpolationStep(Mantid::API::MatrixWorkspace_sptr toInterpolate, std::string toMatch);
 
     Ui::ApplyCorr m_uiForm;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
@@ -25,20 +25,20 @@ namespace IDA
     void newData(const QString &dataName);
     /// Updates the preview mini plot
     void plotPreview(int specIndex);
+    /// Handle algorithm completion
+    void algorithmComplete(bool error);
 
   private:
     virtual void setup();
     virtual void run();
     virtual bool validate();
     virtual void loadSettings(const QSettings & settings);
-    /// ask the user if they wish to rebin the can
-    bool requireCanRebin();
 
     Ui::ApplyCorr m_uiForm;
     /// Pointer to the result workspace (for plotting)
     Mantid::API::MatrixWorkspace_sptr m_outputWs;
-
   };
+
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.h
@@ -34,6 +34,7 @@ namespace IDA
     virtual bool validate();
     virtual void loadSettings(const QSettings & settings);
 
+    void addRebinStep(QString toRebin, QString toMatch);
     std::string addUnitConversionStep(Mantid::API::MatrixWorkspace_sptr ws);
     void addInterpolationStep(Mantid::API::MatrixWorkspace_sptr toInterpolate, std::string toMatch);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.h
@@ -30,6 +30,9 @@ namespace IDA
     void getBeamWidthFromWorkspace(const QString& wsName);
 
   private:
+    void addShapeSpecificSampleOptions(Mantid::API::IAlgorithm_sptr alg, QString shape);
+    void addShapeSpecificCanOptions(Mantid::API::IAlgorithm_sptr alg, QString shape);
+
     Ui::CalcCorr m_uiForm;
 
   };

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.h
@@ -24,17 +24,14 @@ namespace IDA
     virtual void loadSettings(const QSettings & settings);
 
   private slots:
-    void shape(int index);
-    void useCanChecked(bool checked);
-    void tcSync();
-    void getBeamWidthFromWorkspace(const QString& wsname);
+    void algorithmComplete(bool error);
+    void getBeamWidthFromWorkspace(const QString& wsName);
 
   private:
     Ui::CalcCorr m_uiForm;
-    QDoubleValidator * m_dblVal;
-    QDoubleValidator * m_posDblVal;
 
   };
+
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.h
@@ -23,6 +23,8 @@ namespace IDA
     virtual bool validate();
     virtual void loadSettings(const QSettings & settings);
 
+    bool doValidation(bool silent = false);
+
   private slots:
     void algorithmComplete(bool error);
     void getBeamWidthFromWorkspace(const QString& wsName);

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -21,7 +21,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_11">
       <item row="1" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCanInput" native="true">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -59,7 +59,7 @@
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -87,7 +87,7 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="lbInputType">
         <property name="text">
          <string>Input type:</string>
         </property>
@@ -124,7 +124,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="cbShape">
+         <widget class="QComboBox" name="cbSampleShape">
           <property name="sizePolicy">
            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -143,329 +143,6 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="lbWidth">
-          <property name="text">
-           <string>Beam Width:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="leavar">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="lbAvar">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Sample Angle:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="valAvar">
-          <property name="styleSheet">
-           <string notr="true">color: rgb(255, 0, 0);</string>
-          </property>
-          <property name="text">
-           <string>*</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="lewidth">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="valWidth">
-          <property name="styleSheet">
-           <string notr="true">color: rgb(255, 0, 0);</string>
-          </property>
-          <property name="text">
-           <string>*</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="3">
-         <widget class="QStackedWidget" name="swShapeDetails">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="lineWidth">
-           <number>1</number>
-          </property>
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <widget class="QWidget" name="pageFlat">
-           <layout class="QVBoxLayout" name="verticalLayout_4">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_5_thickness" columnminimumwidth="97,0,0,0,0,0,0,0,0">
-              <item row="0" column="2">
-               <widget class="QLabel" name="valts">
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="5">
-               <widget class="QLabel" name="valtc1">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>9</width>
-                  <height>24</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="8">
-               <widget class="QLabel" name="valtc2">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>9</width>
-                  <height>24</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="7">
-               <widget class="QLineEdit" name="letc2">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QLabel" name="lbtc2">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Can Back Thickness:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="lbtc1">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Can Front Thickness:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="lbts">
-                <property name="text">
-                 <string>Thickness:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QLineEdit" name="letc1">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="lets">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-          <widget class="QWidget" name="pageCylinder">
-           <layout class="QVBoxLayout" name="cylinder_layout">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_3" columnminimumwidth="0,97,0,0,0,0,0,0,0,0">
-              <item row="0" column="1">
-               <widget class="QLabel" name="lbR1">
-                <property name="text">
-                 <string>Radius 1:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QLabel" name="lbR2">
-                <property name="text">
-                 <string>Radius 2:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="8">
-               <widget class="QLineEdit" name="ler3">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QLabel" name="valR2">
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="valR1">
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLineEdit" name="ler1">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="9">
-               <widget class="QLabel" name="valR3">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>9</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="7">
-               <widget class="QLabel" name="lbR3">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Can Radius:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="5">
-               <widget class="QLineEdit" name="ler2">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
        </layout>
       </item>
      </layout>
@@ -482,209 +159,56 @@
      <property name="title">
       <string>Sample Details</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_13">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_9" columnminimumwidth="0,0,0,0,0,9">
-        <item row="0" column="0">
-         <widget class="QLabel" name="lbsamden">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Number Density:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="abs_lblSampleInputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Cross Sections From:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="4" colspan="2">
-         <widget class="QStackedWidget" name="swSampleInputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <widget class="QWidget" name="pgSampleChemicalFormula">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_17">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_12" columnminimumwidth="0,9">
-              <item row="0" column="0">
-               <widget class="QLineEdit" name="leSampleFormula">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="valSampleFormula">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-          <widget class="QWidget" name="pgSampleCrossSections">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_16">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_8" columnminimumwidth="0,0,0,0,0,9">
-              <item row="0" column="4">
-               <widget class="QLineEdit" name="lesamsiga">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="lbsamsigs">
-                <property name="text">
-                 <string>Scattering cross-section:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLineEdit" name="lesamsigs">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="lbsamsiga">
-                <property name="text">
-                 <string>Absorption cross-section:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="valSamsigs">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="5">
-               <widget class="QLabel" name="valSamsiga">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item row="0" column="5">
-         <widget class="QLabel" name="valSamden">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">color: rgb(255, 0, 0);</string>
-          </property>
-          <property name="text">
-           <string>*</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="4">
-         <widget class="QLineEdit" name="lesamden">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1" colspan="3">
-         <widget class="QComboBox" name="cbSampleInputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <item>
-           <property name="text">
-            <string>Formula</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Input</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="spSampleNumberDensity">
+        <property name="maximum">
+         <double>9999.989999999999782</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbSampleNumberDensity">
+        <property name="text">
+         <string>Number Density:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="leSampleChemicalFormula">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lbSampleChemicalFormula">
+        <property name="text">
+         <string>Chemical Formula:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="valSampleChemicalFormula">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>*</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -703,238 +227,53 @@
      <property name="title">
       <string>Can Details</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_12">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_6" columnminimumwidth="0,0,0,0,9">
-        <item row="0" column="0">
-         <widget class="QLabel" name="lbCanden">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Number Density:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="lblInputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Cross Sections From:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3" colspan="2">
-         <widget class="QStackedWidget" name="swCanInputType">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <widget class="QWidget" name="pgCanChemicalFormula">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_15">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_10" columnminimumwidth="0,9">
-              <item row="0" column="0">
-               <widget class="QLineEdit" name="leCanFormula"/>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="valCanFormula">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-          <widget class="QWidget" name="pgCanCrossSections">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_14">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <layout class="QGridLayout" name="gridLayout_7" columnminimumwidth="0,0,0,0,0,0,9">
-              <item row="0" column="0">
-               <widget class="QLabel" name="lbCansigs">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Scattering cross-section:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" colspan="2">
-               <widget class="QLineEdit" name="lecansigs">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="valCansigs">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="5">
-               <widget class="QLineEdit" name="lecansiga">
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QLabel" name="valCansiga">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="styleSheet">
-                 <string notr="true">color: rgb(255, 0, 0);</string>
-                </property>
-                <property name="text">
-                 <string>*</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
-               <widget class="QLabel" name="lbCansiga">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Absorption cross-section:</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item row="0" column="4">
-         <widget class="QLabel" name="valCanden">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">color: rgb(255, 0, 0);</string>
-          </property>
-          <property name="text">
-           <string>*</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="3">
-         <widget class="QLineEdit" name="lecanden">
-          <property name="text">
-           <string/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="QComboBox" name="cbCanInputType">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <item>
-           <property name="text">
-            <string>Formula</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Input</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="lbCanNumberDensity">
+        <property name="text">
+         <string>Number Density:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="doubleSpinBox_2">
+        <property name="maximum">
+         <double>9999.989999999999782</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lbCanChemicalFormula">
+        <property name="text">
+         <string>Chemical Formula:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="leCanChemicalFormula">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="valCanChemicalFormula">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>*</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -1026,61 +365,10 @@
  </customwidgets>
  <tabstops>
   <tabstop>ckUseCan</tabstop>
-  <tabstop>cbShape</tabstop>
-  <tabstop>lets</tabstop>
-  <tabstop>letc1</tabstop>
-  <tabstop>letc2</tabstop>
-  <tabstop>ler1</tabstop>
-  <tabstop>ler2</tabstop>
-  <tabstop>ler3</tabstop>
-  <tabstop>leavar</tabstop>
-  <tabstop>lewidth</tabstop>
-  <tabstop>lesamden</tabstop>
-  <tabstop>cbSampleInputType</tabstop>
-  <tabstop>lesamsigs</tabstop>
-  <tabstop>lesamsiga</tabstop>
-  <tabstop>leSampleFormula</tabstop>
-  <tabstop>lecanden</tabstop>
-  <tabstop>cbCanInputType</tabstop>
-  <tabstop>lecansigs</tabstop>
-  <tabstop>lecansiga</tabstop>
-  <tabstop>leCanFormula</tabstop>
+  <tabstop>cbSampleShape</tabstop>
   <tabstop>cbPlotOutput</tabstop>
   <tabstop>ckSave</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>cbCanInputType</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>swCanInputType</receiver>
-   <slot>setCurrentIndex(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>193</x>
-     <y>405</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>440</x>
-     <y>405</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>cbSampleInputType</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>swSampleInputType</receiver>
-   <slot>setCurrentIndex(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>193</x>
-     <y>310</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>440</x>
-     <y>310</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -121,7 +121,7 @@
          <widget class="QComboBox" name="cbSampleShape">
           <item>
            <property name="text">
-            <string>Flat</string>
+            <string>Flat Plate</string>
            </property>
           </item>
           <item>
@@ -224,13 +224,6 @@
           <property name="margin">
            <number>0</number>
           </property>
-          <item row="1" column="2">
-           <widget class="QLabel" name="lbCylCanOuterRadius">
-            <property name="text">
-             <string>Container Outer Radius:</string>
-            </property>
-           </widget>
-          </item>
           <item row="5" column="3">
            <widget class="QDoubleSpinBox" name="spCylBeamWidth">
             <property name="decimals">
@@ -248,13 +241,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lbCylCanInnerRadius">
-            <property name="text">
-             <string>Container Inner Radius:</string>
-            </property>
-           </widget>
-          </item>
           <item row="5" column="0">
            <widget class="QLabel" name="lbCylBeamHeight">
             <property name="text">
@@ -262,36 +248,10 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="spCylCanInnerRadius">
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>9999.989999999999782</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
           <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="spCylBeamHeight">
             <property name="decimals">
              <number>3</number>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>9999.989999999999782</double>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -355,6 +315,26 @@
            <widget class="QLabel" name="lbCylSampleOuterRadius">
             <property name="text">
              <string>Sample Outer Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lbCylCanOuterRadius">
+            <property name="text">
+             <string>Container Outer Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
             </property>
            </widget>
           </item>
@@ -579,6 +559,22 @@
  <tabstops>
   <tabstop>ckUseCan</tabstop>
   <tabstop>cbSampleShape</tabstop>
+  <tabstop>spFlatSampleThickness</tabstop>
+  <tabstop>spFlatSampleAngle</tabstop>
+  <tabstop>spFlatCanFrontThickness</tabstop>
+  <tabstop>spFlatCanBackThickness</tabstop>
+  <tabstop>spCylSampleInnerRadius</tabstop>
+  <tabstop>spCylSampleOuterRadius</tabstop>
+  <tabstop>spCylCanOuterRadius</tabstop>
+  <tabstop>spCylBeamHeight</tabstop>
+  <tabstop>spCylBeamWidth</tabstop>
+  <tabstop>spCylStepSize</tabstop>
+  <tabstop>spSampleNumberDensity</tabstop>
+  <tabstop>leSampleChemicalFormula</tabstop>
+  <tabstop>spCanNumberDensity</tabstop>
+  <tabstop>leCanChemicalFormula</tabstop>
+  <tabstop>cbPlotOutput</tabstop>
+  <tabstop>ckSave</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -611,6 +607,22 @@
     <hint type="destinationlabel">
      <x>330</x>
      <y>481</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ckUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>dsContainer</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>173</x>
+     <y>65</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>487</x>
+     <y>65</y>
     </hint>
    </hints>
   </connection>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -488,40 +488,10 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QLabel" name="lbPlotOutput">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
+       <widget class="QCheckBox" name="ckPlotOutput">
         <property name="text">
          <string>Plot Output</string>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="cbPlotOutput">
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Wavelength</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Angle</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Both</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item>
@@ -573,7 +543,7 @@
   <tabstop>leSampleChemicalFormula</tabstop>
   <tabstop>spCanNumberDensity</tabstop>
   <tabstop>leCanChemicalFormula</tabstop>
-  <tabstop>cbPlotOutput</tabstop>
+  <tabstop>ckPlotOutput</tabstop>
   <tabstop>ckSave</tabstop>
  </tabstops>
  <resources/>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>661</width>
-    <height>504</height>
+    <height>462</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -109,28 +109,16 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_9">
       <item>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
+       <layout class="QHBoxLayout" name="loSampleShape">
+        <item>
          <widget class="QLabel" name="lbSampleShape">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
           <property name="text">
            <string>Sample Shape:</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item>
          <widget class="QComboBox" name="cbSampleShape">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
           <item>
            <property name="text">
             <string>Flat</string>
@@ -145,11 +133,240 @@
         </item>
        </layout>
       </item>
+      <item>
+       <widget class="QStackedWidget" name="swShapeOptions">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="pgFlatPlate">
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbFlatSampleAngle">
+            <property name="text">
+             <string>Sample Angle:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="lbFlatCanFrontThickness">
+            <property name="text">
+             <string>Container Front Thickness:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QLabel" name="lbFlatCanBackThickness">
+            <property name="text">
+             <string>Container Back Thickness:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QDoubleSpinBox" name="spFlatCanBackThickness">
+            <property name="suffix">
+             <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbFlatSampleThickness">
+            <property name="text">
+             <string>Sample Thickness:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="spFlatCanFrontThickness">
+            <property name="suffix">
+             <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="spFlatSampleAngle">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
+            <property name="suffix">
+             <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="pgCylinder">
+         <layout class="QGridLayout" name="gridLayout_4">
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item row="1" column="2">
+           <widget class="QLabel" name="lbCylCanOuterRadius">
+            <property name="text">
+             <string>Container Outer Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="3">
+           <widget class="QDoubleSpinBox" name="spCylBeamWidth">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QLabel" name="lbCylBeamWidth">
+            <property name="text">
+             <string>Beam Width:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="lbCylCanInnerRadius">
+            <property name="text">
+             <string>Container Inner Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="lbCylBeamHeight">
+            <property name="text">
+             <string>Beam Height:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="spCylCanInnerRadius">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDoubleSpinBox" name="spCylBeamHeight">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="lbCylStepSize">
+            <property name="text">
+             <string>Step Size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="QDoubleSpinBox" name="spCylStepSize">
+            <property name="decimals">
+             <number>4</number>
+            </property>
+            <property name="singleStep">
+             <double>0.001000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.002000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbCylSampleInnerRadius">
+            <property name="text">
+             <string>Sample Inner Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="spCylSampleInnerRadius">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="spCylSampleOuterRadius">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbCylSampleOuterRadius">
+            <property name="text">
+             <string>Sample Outer Radius:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbSample">
+    <widget class="QGroupBox" name="gbSampleDetails">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -177,7 +394,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="2">
+       <widget class="QLabel" name="lbSampleChemicalFormula">
+        <property name="text">
+         <string>Chemical Formula:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
        <widget class="QLineEdit" name="leSampleChemicalFormula">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -190,14 +414,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lbSampleChemicalFormula">
-        <property name="text">
-         <string>Chemical Formula:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
+      <item row="0" column="4">
        <widget class="QLabel" name="valSampleChemicalFormula">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -206,7 +423,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>*</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -214,9 +431,9 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbCan">
+    <widget class="QGroupBox" name="gbCanDetails">
      <property name="enabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -235,24 +452,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QDoubleSpinBox" name="doubleSpinBox_2">
-        <property name="maximum">
-         <double>9999.989999999999782</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="lbCanChemicalFormula">
-        <property name="text">
-         <string>Chemical Formula:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
+      <item row="0" column="3">
        <widget class="QLineEdit" name="leCanChemicalFormula">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -262,7 +462,24 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="spCanNumberDensity">
+        <property name="maximum">
+         <double>9999.989999999999782</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="lbCanChemicalFormula">
+        <property name="text">
+         <string>Chemical Formula:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
        <widget class="QLabel" name="valCanChemicalFormula">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
@@ -271,7 +488,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>*</string>
+         <string/>
         </property>
        </widget>
       </item>
@@ -289,67 +506,63 @@
      <property name="title">
       <string>Output Options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_11">
+     <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <widget class="QLabel" name="lbPlotOutput">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Plot Output</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="cbPlotOutput">
         <item>
-         <widget class="QLabel" name="lbPlotOutput">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Plot Output</string>
-          </property>
-         </widget>
+         <property name="text">
+          <string>None</string>
+         </property>
         </item>
         <item>
-         <widget class="QComboBox" name="cbPlotOutput">
-          <item>
-           <property name="text">
-            <string>None</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Wavelength</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Angle</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Both</string>
-           </property>
-          </item>
-         </widget>
+         <property name="text">
+          <string>Wavelength</string>
+         </property>
         </item>
         <item>
-         <spacer name="horizontalSpacer_12">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-         </spacer>
+         <property name="text">
+          <string>Angle</string>
+         </property>
         </item>
         <item>
-         <widget class="QCheckBox" name="ckSave">
-          <property name="text">
-           <string>Save Result</string>
-          </property>
-         </widget>
+         <property name="text">
+          <string>Both</string>
+         </property>
         </item>
-       </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="ckSave">
+        <property name="text">
+         <string>Save Result</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -366,9 +579,40 @@
  <tabstops>
   <tabstop>ckUseCan</tabstop>
   <tabstop>cbSampleShape</tabstop>
-  <tabstop>cbPlotOutput</tabstop>
-  <tabstop>ckSave</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>cbSampleShape</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>swShapeOptions</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>486</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>330</x>
+     <y>239</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>ckUseCan</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gbCanDetails</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>173</x>
+     <y>65</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>330</x>
+     <y>481</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IDATab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IDATab.h
@@ -67,6 +67,8 @@ namespace IDA
     /// Check the binning between two workspaces match
     bool checkWorkspaceBinningMatches(Mantid::API::MatrixWorkspace_const_sptr left,
                                       Mantid::API::MatrixWorkspace_const_sptr right);
+    /// Adds a conversion to wavelength step to the algorithm queue
+    std::string addConvertToWavelengthStep(Mantid::API::MatrixWorkspace_sptr ws);
 
     /// DoubleEditorFactory
     DoubleEditorFactory* m_dblEdFac;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
@@ -100,6 +100,12 @@ namespace CustomInterfaces
                           QtProperty* lower, QtProperty* upper,
                           const QPair<double, double> & bounds);
 
+    /// Function to get energy mode from a workspace
+    std::string getEMode(Mantid::API::MatrixWorkspace_sptr ws);
+
+    /// Function to get eFixed from a workspace
+    double getEFixed(Mantid::API::MatrixWorkspace_sptr ws);
+
     /// Function to run an algorithm on a seperate thread
     void runAlgorithm(const Mantid::API::IAlgorithm_sptr algorithm);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
@@ -94,6 +94,13 @@ namespace CustomInterfaces
     /// Add a SaveNexusProcessed step to the batch queue
     void addSaveWorkspaceToQueue(const QString & wsName, const QString & filename = "");
 
+    /// Plot a spectrum plot given a list of workspace names
+    void plotSpectrum(const QStringList & workspaceNames, int specIndex = 0);
+    void plotSpectrum(const QString & workspaceName, int specIndex = 0);
+
+    /// Plot a contour plot of a given workspace
+    void plotContour(const QString & workspaceName);
+
     /// Function to set the range limits of the plot
     void setPlotPropertyRange(MantidQt::MantidWidgets::RangeSelector * rs,
                               QtProperty* min, QtProperty* max,

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
@@ -91,6 +91,9 @@ namespace CustomInterfaces
     /// Run the load algorithm with the given file name, output name and spectrum range
     bool loadFile(const QString& filename, const QString& outputName, const int specMin = -1, const int specMax = -1);
 
+    /// Add a SaveNexusProcessed step to the batch queue
+    void addSaveWorkspaceToQueue(const QString & wsName, const QString & filename = "");
+
     /// Function to set the range limits of the plot
     void setPlotPropertyRange(MantidQt::MantidWidgets::RangeSelector * rs,
                               QtProperty* min, QtProperty* max,

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
@@ -146,7 +146,20 @@ namespace IDA
       uiv.addErrorMessage("Must use either container subtraction or corrections");
 
     if(useCan)
+    {
       uiv.checkDataSelectorIsValid("Container", m_uiForm.dsContainer);
+
+      QString sample = m_uiForm.dsSample->getCurrentDataName();
+      QString sampleType = sample.right(sample.length() - sample.lastIndexOf("_"));
+      QString container = m_uiForm.dsContainer->getCurrentDataName();
+      QString containerType = container.right(container.length() - container.lastIndexOf("_"));
+
+      g_log.debug() << "Sample type is: " << sampleType.toStdString() << std::endl;
+      g_log.debug() << "Can type is: " << containerType.toStdString() << std::endl;
+
+      if(containerType != sampleType)
+        uiv.addErrorMessage("Sample and can workspaces must contain the same type of data.");
+    }
 
     if(useCorrections)
       uiv.checkDataSelectorIsValid("Corrections", m_uiForm.dsCorrections);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
@@ -71,7 +71,7 @@ namespace IDA
     if(sampleXUnit->caption() != "Wavelength")
     {
       g_log.information("Sample workspace not in wavelength, need to convert to continue.");
-      absCorProps["SampleWorkspace"] = addUnitConversionStep(sampleWs);
+      absCorProps["SampleWorkspace"] = addConvertToWavelengthStep(sampleWs);
     }
     else
     {
@@ -89,7 +89,7 @@ namespace IDA
       if(canXUnit->caption() != "Wavelength")
       {
         g_log.information("Container workspace not in wavelength, need to convert to continue.");
-        absCorProps["CanWorkspace"] = addUnitConversionStep(canWs);
+        absCorProps["CanWorkspace"] = addConvertToWavelengthStep(canWs);
       }
       else
       {
@@ -205,31 +205,6 @@ namespace IDA
 
     // Set the result workspace for Python script export
     m_pythonExportWsName = outputWsName.toStdString();
-  }
-
-
-  /**
-   * Adds a unit converstion step to the batch algorithm queue.
-   *
-   * @param ws Pointer to the workspace to convert
-   * @return Name of output workspace
-   */
-  std::string ApplyCorr::addUnitConversionStep(MatrixWorkspace_sptr ws)
-  {
-    std::string outputName = ws->name() + "_inWavelength";
-
-    IAlgorithm_sptr convertAlg = AlgorithmManager::Instance().create("ConvertUnits");
-    convertAlg->initialize();
-
-    convertAlg->setProperty("InputWorkspace", ws->name());
-    convertAlg->setProperty("OutputWorkspace", outputName);
-    convertAlg->setProperty("Target", "Wavelength");
-    convertAlg->setProperty("EMode", getEMode(ws));
-    convertAlg->setProperty("EFixed", getEFixed(ws));
-
-    m_batchAlgoRunner->addAlgorithm(convertAlg);
-
-    return outputName;
   }
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
@@ -290,8 +290,18 @@ namespace IDA
       return;
     }
 
+    // Handle preview plot
     m_outputWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(m_pythonExportWsName);
     plotPreview(m_uiForm.spPreviewSpec->value());
+
+    // Handle Mantid plotting
+    QString plotType = m_uiForm.cbPlotOutput->currentText();
+
+    if(plotType == "Spectra" || plotType == "Both")
+      plotSpectrum(QString::fromStdString(m_pythonExportWsName));
+
+    if(plotType == "Contour" || plotType == "Both")
+      plotContour(QString::fromStdString(m_pythonExportWsName));
   }
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyCorr.cpp
@@ -188,12 +188,19 @@ namespace IDA
         correctionType = "cyl";
         break;
     }
-    QString outputWsName = sampleWsName.left(nameCutIndex) + + "_" + correctionType + "_Corrected";
+    const QString outputWsName = sampleWsName.left(nameCutIndex) + + "_" + correctionType + "_Corrected";
 
     applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 
-    // Run the corrections algorithm
+    // Add corrections algorithm to queue
     m_batchAlgoRunner->addAlgorithm(applyCorrAlg, absCorProps);
+
+    // Add save algorithms if required
+    bool save = m_uiForm.ckSave->isChecked();
+    if(save)
+      addSaveWorkspaceToQueue(outputWsName);
+
+    // Run algorithm queue
     m_batchAlgoRunner->executeBatchAsync();
 
     // Set the result workspace for Python script export

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -105,8 +105,10 @@ namespace IDA
       addShapeSpecificCanOptions(absCorAlgo, sampleShape);
     }
 
-    absCorAlgo->setProperty("EMode", getEMode(sampleWs));
-    absCorAlgo->setProperty("EFixed", getEFixed(sampleWs));
+    std::string eMode = getEMode(sampleWs);
+    absCorAlgo->setProperty("EMode", eMode);
+    if(eMode == "Indirect")
+      absCorAlgo->setProperty("EFixed", getEFixed(sampleWs));
 
     // Generate workspace names
     int nameCutIndex = sampleWsName.lastIndexOf("_");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -183,11 +183,13 @@ namespace IDA
     if(error)
     {
       emit showMessageBox("Absorption correction calculation failed.\nSee Results Log for more details.");
+      return;
     }
-    else
-    {
-      //TODO: plot correction factors (m_pythonExportWsName (all spectra))
-    }
+
+    // Handle Mantid plotting
+    bool plot = m_uiForm.ckPlotOutput->isChecked();
+    if(plot)
+      plotSpectrum(QString::fromStdString(m_pythonExportWsName));
   }
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -102,11 +102,18 @@ namespace IDA
         break;
     }
 
-    QString outputWsName = sampleWsName.left(nameCutIndex) + "_" + correctionType + "_abs";
+    const QString outputWsName = sampleWsName.left(nameCutIndex) + "_" + correctionType + "_abs";
     absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
 
-    // Run corrections algorithm
+    // Add corrections algorithm to queue
     m_batchAlgoRunner->addAlgorithm(absCorAlgo);
+
+    // Add save algorithms if required
+    bool save = m_uiForm.ckSave->isChecked();
+    if(save)
+      addSaveWorkspaceToQueue(outputWsName);
+
+    // Run algorithm queue
     m_batchAlgoRunner->executeBatchAsync();
 
     // Set the result workspace for Python script export

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -43,9 +43,10 @@ namespace IDA
   }
 
 
-  //TODO
   void CalcCorr::run()
   {
+    //TODO: check sample binning matches can binning, ask if should rebin to match
+
     // Get correct corrections algorithm
     QString sampleShape = m_uiForm.cbSampleShape->currentText();
     QString algorithmName = sampleShape.replace(" ", "") + "PaalmanPingsCorrection";

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -3,86 +3,13 @@
 #include "MantidQtCustomInterfaces/UserInputValidator.h"
 #include "MantidQtMantidWidgets/WorkspaceSelector.h"
 
-
 #include <QLineEdit>
 #include <QList>
 #include <QValidator>
 #include <QDoubleValidator>
 #include <QRegExpValidator>
 
-class QDoubleMultiRangeValidator : public QValidator
-{
-public:
-  /**
-   * Constructor.
-   *
-   * @param ranges :: a set of pairs of doubles representing the valid ranges of the input
-   * @param parent :: the parent QObject of this QObject.
-   */
-  QDoubleMultiRangeValidator(std::set<std::pair<double, double>> ranges, QObject * parent) :
-    QValidator(parent), m_ranges(ranges), m_slaveVal(NULL)
-  {
-    m_slaveVal = new QDoubleValidator(this);
-  }
-
-  ~QDoubleMultiRangeValidator() {}
-
-  /**
-   * Reimplemented from QValidator::validate().
-   *
-   * Returns Acceptable if the string input contains a double that is within at least one
-   * of the ranges and is in the correct format.
-   *
-   * Else returns Intermediate if input contains a double that is outside the ranges or is in
-   * the wrong format; e.g. with too many digits after the decimal point or is empty.
-   *
-   * Else returns Invalid - i.e. the input is not a double.
-   *
-   * @param input :: the input string to validate
-   * @param pos   :: not used.
-   */
-  virtual QValidator::State	validate( QString & input, int & pos ) const
-  {
-    UNUSED_ARG(pos);
-
-    if( m_ranges.empty() )
-      return Intermediate;
-
-    bool acceptable = false;
-    bool intermediate = false;
-
-    // For each range in the list, use the slave QDoubleValidator to find out the state.
-    for( auto range = m_ranges.begin(); range != m_ranges.end(); ++ range )
-    {
-      if(range->first >= range->second)
-        throw std::runtime_error("Invalid range");
-
-      m_slaveVal->setBottom(range->first);
-      m_slaveVal->setTop(range->second);
-
-      QValidator::State rangeState = m_slaveVal->validate(input, pos);
-
-      if( rangeState == Acceptable )
-        acceptable = true;
-      else if( rangeState == Intermediate )
-        intermediate = true;
-    }
-
-    if( acceptable )
-      return Acceptable;
-    if( intermediate )
-      return Intermediate;
-
-    return Invalid;
-  }
-
-private:
-  /// Disallow default constructor.
-  QDoubleMultiRangeValidator();
-
-  std::set<std::pair<double, double>> m_ranges;
-  QDoubleValidator * m_slaveVal;
-};
+using namespace Mantid::API;
 
 namespace
 {
@@ -96,419 +23,111 @@ namespace CustomInterfaces
 namespace IDA
 {
   CalcCorr::CalcCorr(QWidget * parent) :
-    IDATab(parent), m_dblVal(NULL), m_posDblVal(NULL)
+    IDATab(parent)
   {
     m_uiForm.setupUi(parent);
 
-    m_dblVal = new QDoubleValidator(this);
-    m_posDblVal = new QDoubleValidator(this);
-    m_posDblVal->setBottom(0.0);
-  }
-
-  void CalcCorr::setup()
-  {
-    // set signals and slot connections for F2Py Absorption routine
-    connect(m_uiForm.cbShape, SIGNAL(currentIndexChanged(int)), this, SLOT(shape(int)));
-    connect(m_uiForm.ckUseCan, SIGNAL(toggled(bool)), this, SLOT(useCanChecked(bool)));
-    connect(m_uiForm.letc1, SIGNAL(editingFinished()), this, SLOT(tcSync()));
-    connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString&)), this, SLOT(getBeamWidthFromWorkspace(const QString&)));
-
-    // Sort the fields into various lists.
-
-    QList<QLineEdit*> allFields;
-    QList<QLineEdit*> doubleFields;
-    QList<QLineEdit*> positiveDoubleFields;
-
-    positiveDoubleFields += m_uiForm.lets;  // Thickness
-    positiveDoubleFields += m_uiForm.letc1; // Front Thickness
-    positiveDoubleFields += m_uiForm.letc2; // Back Thickness
-
-    positiveDoubleFields += m_uiForm.ler1; // Radius 1
-    positiveDoubleFields += m_uiForm.ler2; // Radius 2
-    positiveDoubleFields += m_uiForm.ler3; // Radius 3
-
-    positiveDoubleFields += m_uiForm.lewidth; // Beam Width
-
-    positiveDoubleFields += m_uiForm.lesamden;  // Sample Number Density
-    positiveDoubleFields += m_uiForm.lesamsigs; // Sample Scattering Cross-Section
-    positiveDoubleFields += m_uiForm.lesamsiga; // Sample Absorption Cross-Section
-
-    positiveDoubleFields += m_uiForm.lecanden;  // Can Number Density
-    positiveDoubleFields += m_uiForm.lecansigs; // Can Scattering Cross-Section
-    positiveDoubleFields += m_uiForm.lecansiga; // Can Absorption Cross-Section
-
-    // Set appropriate validators.
-    foreach(QLineEdit * positiveDoubleField, positiveDoubleFields)
-    {
-      positiveDoubleField->setValidator(m_posDblVal);
-    }
-
-    // Deal with the slightly more complex multi-range "Can Angle to Beam" field.
-    std::set<std::pair<double, double>> angleRanges;
-    angleRanges.insert(std::make_pair(-180, -100));
-    angleRanges.insert(std::make_pair(-80, 80));
-    angleRanges.insert(std::make_pair(100, 180));
-    QDoubleMultiRangeValidator * angleValidator = new QDoubleMultiRangeValidator(angleRanges, this);
-    m_uiForm.leavar->setValidator(angleValidator); // Can Angle to Beam
-
-    allFields = positiveDoubleFields;
-    allFields += m_uiForm.leavar;
+    connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString&)), this, SLOT(getBeamWidthFromWorkspace(const QString&)));
+    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
 
     QRegExp regex("[A-Za-z0-9\\-\\(\\)]*");
     QValidator *formulaValidator = new QRegExpValidator(regex, this);
-    m_uiForm.leSampleFormula->setValidator(formulaValidator);
-    m_uiForm.leCanFormula->setValidator(formulaValidator);
-
-    // "Nudge" color of title of QGroupBox to change.
-    useCanChecked(m_uiForm.ckUseCan->isChecked());
+    m_uiForm.leSampleChemicalFormula->setValidator(formulaValidator);
+    m_uiForm.leCanChemicalFormula->setValidator(formulaValidator);
   }
+
+
+  void CalcCorr::setup()
+  {
+  }
+
 
   void CalcCorr::run()
   {
-    QString pyInput = "import IndirectAbsCor\n";
-
-    QString geom;
-    QString size;
-
-    if ( m_uiForm.cbShape->currentText() == "Flat" )
-    {
-      geom = "flt";
-      if ( m_uiForm.ckUseCan->isChecked() )
-      {
-        size = "[" + m_uiForm.lets->text() + ", " +
-        m_uiForm.letc1->text() + ", " +
-        m_uiForm.letc2->text() + "]";
-      }
-      else
-      {
-        size = "[" + m_uiForm.lets->text() + ", 0.0, 0.0]";
-      }
-    }
-    else if ( m_uiForm.cbShape->currentText() == "Cylinder" )
-    {
-      geom = "cyl";
-
-      // R3 only populated when using can. R4 is fixed to 0.0
-      if ( m_uiForm.ckUseCan->isChecked() )
-      {
-        size = "[" + m_uiForm.ler1->text() + ", " +
-          m_uiForm.ler2->text() + ", " +
-          m_uiForm.ler3->text() + ", 0.0 ]";
-      }
-      else
-      {
-        size = "[" + m_uiForm.ler1->text() + ", " +
-          m_uiForm.ler2->text() + ", 0.0, 0.0 ]";
-      }
-    }
-
-    //get beam width
-    QString width = m_uiForm.lewidth->text();
-    if (width.isEmpty()) { width = "None"; }
-
-    //get sample workspace. Load from if needed.
-    QString sampleWs = m_uiForm.dsSampleInput->getCurrentDataName();
-    pyInput += "inputws = '" + sampleWs + "'\n";
-
-    //sample absorption and scattering x sections.
-    QString sampleScatteringXSec = m_uiForm.lesamsigs->text();
-    QString sampleAbsorptionXSec = m_uiForm.lesamsiga->text();
-
-    if ( sampleScatteringXSec.isEmpty() ) { sampleScatteringXSec = "0.0"; }
-    if ( sampleAbsorptionXSec.isEmpty() ) { sampleAbsorptionXSec = "0.0"; }
-
-    //can and sample formulas
-    QString sampleFormula = m_uiForm.leSampleFormula->text();
-    QString canFormula = m_uiForm.leCanFormula->text();
-
-    if ( sampleFormula.isEmpty() )
-    {
-      sampleFormula = "None";
-    }
-    else
-    {
-      sampleFormula = "'" + sampleFormula + "'";
-    }
-
-    if ( canFormula.isEmpty() )
-    {
-      canFormula = "None";
-    }
-    else
-    {
-      canFormula = "'" + canFormula + "'";
-    }
-
-    //create python string to execute
-    if ( m_uiForm.ckUseCan->isChecked() )
-    {
-      //get sample workspace. Load from if needed.
-      QString canWs = m_uiForm.dsCanInput->getCurrentDataName();
-      pyInput += "canws = '" + canWs + "'\n";
-
-      //can absoprtion and scattering x section.
-      QString canScatteringXSec = m_uiForm.lecansigs->text();
-      QString canAbsorptionXSec = m_uiForm.lecansiga->text();
-
-      if ( canScatteringXSec.isEmpty() ) { canScatteringXSec = "0.0"; }
-      if ( canAbsorptionXSec.isEmpty() ) { canAbsorptionXSec = "0.0"; }
-
-      pyInput +=
-        "ncan = 2\n"
-        "density = [" + m_uiForm.lesamden->text() + ", " + m_uiForm.lecanden->text() + ", " + m_uiForm.lecanden->text() + "]\n"
-        "sigs = [" + sampleScatteringXSec + "," + canScatteringXSec + "," + canScatteringXSec + "]\n"
-        "siga = [" + sampleAbsorptionXSec + "," + canAbsorptionXSec + "," + canAbsorptionXSec + "]\n";
-    }
-    else
-    {
-      pyInput +=
-        "ncan = 1\n"
-        "density = [" + m_uiForm.lesamden->text() + ", 0.0, 0.0 ]\n"
-        "sigs = [" + sampleScatteringXSec + ", 0.0, 0.0]\n"
-        "siga = [" + sampleAbsorptionXSec + ", 0.0, 0.0]\n"
-        "canws = None\n";
-    }
-
-    //Output options
-    if ( m_uiForm.ckSave->isChecked() ) pyInput += "save = True\n";
-    else pyInput += "save = False\n";
-
-    pyInput +=
-      "geom = '" + geom + "'\n"
-      "beam = " + width + "\n"
-      "size = " + size + "\n"
-      "avar = " + m_uiForm.leavar->text() + "\n"
-      "plotOpt = '" + m_uiForm.cbPlotOutput->currentText() + "'\n"
-      "sampleFormula = " + sampleFormula + "\n"
-      "canFormula = " + canFormula + "\n"
-      "print IndirectAbsCor.AbsRunFeeder(inputws, canws, geom, ncan, size, avar, density, beam, sampleFormula, canFormula, sigs, siga, plot_opt=plotOpt, save=save)\n";
-
-    QString pyOutput = runPythonCode(pyInput);
+    //TODO
 
     // Set the result workspace for Python script export
-    m_pythonExportWsName = pyOutput.trimmed().toStdString();
+    m_pythonExportWsName = "";
   }
+
 
   bool CalcCorr::validate()
   {
     UserInputValidator uiv;
-    bool useCan = m_uiForm.ckUseCan->isChecked();
 
-    // Input files/workspaces
-    uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSampleInput);
+    uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+
+    if(uiv.checkFieldIsNotEmpty("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula, m_uiForm.valSampleChemicalFormula))
+      uiv.checkFieldIsValid("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula, m_uiForm.valSampleChemicalFormula);
+
+    bool useCan = m_uiForm.ckUseCan->isChecked();
     if (useCan)
     {
-      uiv.checkDataSelectorIsValid("Can", m_uiForm.dsCanInput);
+      uiv.checkDataSelectorIsValid("Can", m_uiForm.dsContainer);
 
-      QString sample = m_uiForm.dsSampleInput->getCurrentDataName();
+      if(uiv.checkFieldIsNotEmpty("Can Chemical Formula", m_uiForm.leCanChemicalFormula, m_uiForm.valCanChemicalFormula))
+        uiv.checkFieldIsValid("Can Chemical Formula", m_uiForm.leCanChemicalFormula, m_uiForm.valCanChemicalFormula);
+
+      QString sample = m_uiForm.dsSample->getCurrentDataName();
       QString sampleType = sample.right(sample.length() - sample.lastIndexOf("_"));
-      QString container = m_uiForm.dsCanInput->getCurrentDataName();
+      QString container = m_uiForm.dsContainer->getCurrentDataName();
       QString containerType = container.right(container.length() - container.lastIndexOf("_"));
 
       g_log.debug() << "Sample type is: " << sampleType.toStdString() << std::endl;
       g_log.debug() << "Can type is: " << containerType.toStdString() << std::endl;
 
       if(containerType != sampleType)
-      {
         uiv.addErrorMessage("Sample and can workspaces must contain the same type of data.");
-      }
     }
 
-    uiv.checkFieldIsValid("Beam Width", m_uiForm.lewidth, m_uiForm.valWidth);
+    // Show error mssage if needed
+    if(!uiv.isAllInputValid())
+      emit showMessageBox(uiv.generateErrorMessage());
 
-    if ( m_uiForm.cbShape->currentText() == "Flat" )
-    {
-      // Flat Geometry
-      uiv.checkFieldIsValid("Thickness", m_uiForm.lets, m_uiForm.valts);
-
-      if ( useCan )
-      {
-        uiv.checkFieldIsValid("Front Thickness", m_uiForm.letc1, m_uiForm.valtc1);
-        uiv.checkFieldIsValid("Back Thickness",  m_uiForm.letc2, m_uiForm.valtc2);
-      }
-
-      uiv.checkFieldIsValid("Can Angle to Beam must be in the range [-180 to -100], [-80 to 80] or [100 to 180].", m_uiForm.leavar,  m_uiForm.valAvar);
-    }
-
-    if ( m_uiForm.cbShape->currentText() == "Cylinder" )
-    {
-      // Cylinder geometry
-      uiv.checkFieldIsValid("Radius 1", m_uiForm.ler1, m_uiForm.valR1);
-      uiv.checkFieldIsValid("Radius 2", m_uiForm.ler2, m_uiForm.valR2);
-
-      double radius1 = m_uiForm.ler1->text().toDouble();
-      double radius2 = m_uiForm.ler2->text().toDouble();
-      if( radius1 >= radius2 )
-        uiv.addErrorMessage("Radius 1 should be less than Radius 2.");
-
-      // R3 only relevant when using can
-      if ( useCan )
-      {
-        uiv.checkFieldIsValid("Radius 3", m_uiForm.ler3, m_uiForm.valR3);
-
-        double radius3 = m_uiForm.ler3->text().toDouble();
-        if( radius2 >= radius3 )
-          uiv.addErrorMessage("Radius 2 should be less than Radius 3.");
-
-      }
-
-      uiv.checkFieldIsValid("Step Size", m_uiForm.leavar,  m_uiForm.valAvar);
-
-      double stepSize = m_uiForm.leavar->text().toDouble();
-      if( stepSize >= (radius2 - radius1) )
-        uiv.addErrorMessage("Step size should be less than (Radius 2 - Radius 1).");
-    }
-
-    // Sample details
-    uiv.checkFieldIsValid("Sample Number Density", m_uiForm.lesamden, m_uiForm.valSamden);
-
-    switch(m_uiForm.cbSampleInputType->currentIndex())
-    {
-      case 0:
-        //input using formula
-        uiv.checkFieldIsValid("Sample Formula", m_uiForm.leSampleFormula, m_uiForm.valSampleFormula);
-        break;
-      case 1:
-        //using direct input
-        uiv.checkFieldIsValid("Sample Scattering Cross-Section", m_uiForm.lesamsigs, m_uiForm.valSamsigs);
-        uiv.checkFieldIsValid("Sample Absorption Cross-Section", m_uiForm.lesamsiga, m_uiForm.valSamsiga);
-        break;
-    }
-
-
-    // Can details (only test if "Use Can" is checked)
-    if ( m_uiForm.ckUseCan->isChecked() )
-    {
-      QString canFile = m_uiForm.dsCanInput->getCurrentDataName();
-      if(canFile.isEmpty())
-      {
-        uiv.addErrorMessage("You must select a Sample file or workspace.");
-      }
-
-      uiv.checkFieldIsValid("Can Number Density",m_uiForm.lecanden,m_uiForm.valCanden);
-
-      switch(m_uiForm.cbCanInputType->currentIndex())
-      {
-        case 0:
-          //input using formula
-          uiv.checkFieldIsValid("Can Formula", m_uiForm.leCanFormula, m_uiForm.valCanFormula);
-          break;
-        case 1:
-          // using direct input
-          uiv.checkFieldIsValid("Can Scattering Cross-Section", m_uiForm.lecansigs, m_uiForm.valCansigs);
-          uiv.checkFieldIsValid("Can Absorption Cross-Section", m_uiForm.lecansiga, m_uiForm.valCansiga);
-          break;
-      }
-    }
-
-    QString error = uiv.generateErrorMessage();
-    showMessageBox(error);
-
-    return error.isEmpty();
+    return uiv.isAllInputValid();
   }
+
+
+  /**
+   * Handles completion of the correction algorithm.
+   *
+   * @param error True of the algorithm failed
+   */
+  void CalcCorr::algorithmComplete(bool error)
+  {
+    if(error)
+    {
+      emit showMessageBox("Absorption correction calculation failed.\nSee Results Log for more details.");
+    }
+  }
+
 
   void CalcCorr::loadSettings(const QSettings & settings)
   {
-    m_uiForm.dsSampleInput->readSettings(settings.group());
-    m_uiForm.dsCanInput->readSettings(settings.group());
+    m_uiForm.dsSample->readSettings(settings.group());
+    m_uiForm.dsContainer->readSettings(settings.group());
   }
 
-  void CalcCorr::shape(int index)
+
+  void CalcCorr::getBeamWidthFromWorkspace(const QString& wsName)
   {
-    m_uiForm.swShapeDetails->setCurrentIndex(index);
-    // Meaning of the "avar" variable changes depending on shape selection
-    if ( index == 0 ) { m_uiForm.lbAvar->setText("Sample Angle:"); }
-    else if ( index == 1 ) { m_uiForm.lbAvar->setText("Step Size:"); }
-  }
+    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName.toStdString());
 
-  void CalcCorr::useCanChecked(bool checked)
-  {
-
-    // Disable "Can Details" group and asterisks.
-    m_uiForm.gbCan->setEnabled(checked);
-    m_uiForm.valCanden->setVisible(checked);
-    m_uiForm.lbtc1->setEnabled(checked);
-    m_uiForm.lbtc2->setEnabled(checked);
-    m_uiForm.letc1->setEnabled(checked);
-    m_uiForm.letc2->setEnabled(checked);
-    m_uiForm.lbR3->setEnabled(checked);
-    m_uiForm.ler3->setEnabled(checked);
-
-    QString value;
-    (checked ? value = "*" : value =  " ");
-
-    m_uiForm.valCansigs->setText(value);
-    m_uiForm.valCansiga->setText(value);
-    m_uiForm.valCanFormula->setText(value);
-
-    // Disable thickness fields/labels/asterisks.
-    m_uiForm.valtc1->setText(value);
-    m_uiForm.valtc2->setText(value);
-
-    // // Disable R3 field/label/asterisk.
-    m_uiForm.valR3->setText(value);
-
-    if (checked)
+    if(!ws)
     {
-      UserInputValidator uiv;
-      uiv.checkFieldIsValid("",m_uiForm.lecansigs, m_uiForm.valCansigs);
-      uiv.checkFieldIsValid("",m_uiForm.lecansiga, m_uiForm.valCansiga);
-      uiv.checkFieldIsValid("",m_uiForm.letc1, m_uiForm.valtc1);
-      uiv.checkFieldIsValid("",m_uiForm.letc2, m_uiForm.valtc2);
-      uiv.checkFieldIsValid("",m_uiForm.ler3, m_uiForm.valR3);
-    }
-
-    m_uiForm.dsCanInput->setEnabled(checked);
-
-    // Workaround for "disabling" title of the QGroupBox.
-    QPalette palette;
-    if(checked)
-      palette.setColor(
-        QPalette::Disabled,
-        QPalette::WindowText,
-        QApplication::palette().color(QPalette::Disabled, QPalette::WindowText));
-    else
-      palette.setColor(
-        QPalette::Active,
-        QPalette::WindowText,
-        QApplication::palette().color(QPalette::Active, QPalette::WindowText));
-
-    m_uiForm.gbCan->setPalette(palette);
-  }
-
-  void CalcCorr::tcSync()
-  {
-    if ( m_uiForm.letc2->text() == "" )
-    {
-      QString val = m_uiForm.letc1->text();
-      m_uiForm.letc2->setText(val);
-    }
-  }
-
-  void CalcCorr::getBeamWidthFromWorkspace(const QString& wsname)
-  {
-    using namespace Mantid::API;
-    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsname.toStdString());
-
-    if (!ws)
-    {
-      showMessageBox("Failed to find workspace " + wsname);
+      g_log.warning() << "Failed to find workspace " << wsName.toStdString() << std::endl;
       return;
     }
 
     std::string paramName = "Workflow.beam-width";
     auto instrument = ws->getInstrument();
-    if (instrument->hasParameter(paramName))
+    if(instrument->hasParameter(paramName))
     {
       std::string beamWidth = instrument->getStringParameter(paramName)[0];
-      m_uiForm.lewidth->setText(QString::fromUtf8(beamWidth.c_str()));
+      //TODO
     }
-    else
-    {
-      m_uiForm.lewidth->setText("");
-    }
-
   }
+
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IDATab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IDATab.cpp
@@ -94,8 +94,12 @@ namespace IDA
     convertAlg->setProperty("InputWorkspace", ws->name());
     convertAlg->setProperty("OutputWorkspace", outputName);
     convertAlg->setProperty("Target", "Wavelength");
-    convertAlg->setProperty("EMode", getEMode(ws));
-    convertAlg->setProperty("EFixed", getEFixed(ws));
+
+    std::string eMode = getEMode(ws);
+    convertAlg->setProperty("EMode", eMode);
+
+    if(eMode == "Indirect")
+      convertAlg->setProperty("EFixed", getEFixed(ws));
 
     m_batchAlgoRunner->addAlgorithm(convertAlg);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IDATab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IDATab.cpp
@@ -32,6 +32,7 @@ namespace IDA
     m_blnEdFac = new QtCheckBoxFactory(this);
   }
 
+
   /**
    * Loads the tab's settings.
    *
@@ -44,6 +45,7 @@ namespace IDA
     loadSettings(settings);
   }
 
+
   /**
    * Slot that can be called when a user edits an input.
    */
@@ -51,6 +53,7 @@ namespace IDA
   {
     validate();
   }
+
 
   /**
   * Check that the binning between two workspaces matches.
@@ -72,6 +75,31 @@ namespace IDA
     {
       throw std::runtime_error("IDATab: One of the operands is an invalid MatrixWorkspace pointer");
     }
+  }
+
+
+  /**
+   * Adds a unit converstion into wavelength step to the batch algorithm queue.
+   *
+   * @param ws Pointer to the workspace to convert
+   * @return Name of output workspace
+   */
+  std::string IDATab::addConvertToWavelengthStep(MatrixWorkspace_sptr ws)
+  {
+    std::string outputName = ws->name() + "_inWavelength";
+
+    IAlgorithm_sptr convertAlg = AlgorithmManager::Instance().create("ConvertUnits");
+    convertAlg->initialize();
+
+    convertAlg->setProperty("InputWorkspace", ws->name());
+    convertAlg->setProperty("OutputWorkspace", outputName);
+    convertAlg->setProperty("Target", "Wavelength");
+    convertAlg->setProperty("EMode", getEMode(ws));
+    convertAlg->setProperty("EFixed", getEFixed(ws));
+
+    m_batchAlgoRunner->addAlgorithm(convertAlg);
+
+    return outputName;
   }
 
 } // namespace IDA

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReductionTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReductionTab.cpp
@@ -188,7 +188,7 @@ namespace CustomInterfaces
     loadParamAlg->execute();
     energyWs = loadParamAlg->getProperty("Workspace");
 
-    double efixed = energyWs->getInstrument()->getNumberParameter("efixed-val")[0];
+    double efixed = getEFixed(energyWs);
 
     auto spectrum = energyWs->getSpectrum(0);
     spectrum->setSpectrumNo(3);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -44,12 +44,14 @@ namespace CustomInterfaces
     connect(&m_pythonRunner, SIGNAL(runAsPythonScript(const QString&, bool)), this, SIGNAL(runAsPythonScript(const QString&, bool)));
   }
 
+
   //----------------------------------------------------------------------------------------------
   /** Destructor
    */
   IndirectTab::~IndirectTab()
   {
   }
+
 
   void IndirectTab::runTab()
   {
@@ -64,15 +66,18 @@ namespace CustomInterfaces
     }
   }
 
+
   void IndirectTab::setupTab()
   {
     setup();
   }
 
+
   bool IndirectTab::validateTab()
   {
     return validate();
   }
+
 
   /**
    * Handles generating a Python script for the algorithms run on the current tab.
@@ -114,6 +119,7 @@ namespace CustomInterfaces
     dlg->activateWindow();
   }
 
+
   /**
    * Run the load algorithm with the supplied filename and spectrum range
    *
@@ -144,6 +150,7 @@ namespace CustomInterfaces
     return load->isExecuted();
   }
 
+
   /**
    * Sets the edge bounds of plot to prevent the user inputting invalid values
    * Also sets limits for range selector movement
@@ -163,6 +170,7 @@ namespace CustomInterfaces
     rs->setRange(bounds.first, bounds.second);
   }
 
+
   /**
    * Set the position of the range selectors on the mini plot
    *
@@ -179,6 +187,45 @@ namespace CustomInterfaces
     rs->setMinimum(bounds.first);
     rs->setMaximum(bounds.second);
   }
+
+
+  /**
+   * Gets the energy mode from a workspace based on the X unit.
+   *
+   * Units of dSpacing typically denote diffraction, hence Elastic.
+   * All other units default to spectroscopy, therefore Indirect.
+   *
+   * @param ws Pointer to the workspace
+   * @return Energy mode
+   */
+  std::string IndirectTab::getEMode(Mantid::API::MatrixWorkspace_sptr ws)
+  {
+    Mantid::Kernel::Unit_sptr xUnit = ws->getAxis(0)->unit();
+    if(xUnit->caption() == "dSpacing")
+      return "Elastic";
+
+    return "Indirect";
+  }
+
+
+  /**
+   * Gets the eFixed value from the workspace using the instrument parameters.
+   *
+   * @param ws Pointer to the workspace
+   * @return eFixed value
+   */
+  double IndirectTab::getEFixed(Mantid::API::MatrixWorkspace_sptr ws)
+  {
+    Mantid::Geometry::Instrument_const_sptr inst = ws->getInstrument();
+    if(!inst)
+      throw std::runtime_error("No instrument on workspace");
+
+    if(!inst->hasParameter("efixed-val"))
+      throw std::runtime_error("Instrument has no efixed parameter");
+
+    return inst->getNumberParameter("efixed-val")[0];
+  }
+
 
   /**
    * Runs an algorithm async
@@ -198,6 +245,7 @@ namespace CustomInterfaces
     m_batchAlgoRunner->executeBatchAsync();
   }
 
+
   /**
    * Handles getting the results of an algorithm running async
    *
@@ -212,6 +260,7 @@ namespace CustomInterfaces
       emit showMessageBox("Error running algorithm. \nSee results log for details.");
     }
   }
+
 
   /**
    * Run Python code and return anything printed to stdout.

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -6,6 +6,8 @@
 #include "MantidQtAPI/InterfaceManager.h"
 #include "MantidQtMantidWidgets/RangeSelector.h"
 
+#include <boost/algorithm/string/find.hpp>
+
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -287,7 +289,11 @@ namespace CustomInterfaces
   std::string IndirectTab::getEMode(Mantid::API::MatrixWorkspace_sptr ws)
   {
     Mantid::Kernel::Unit_sptr xUnit = ws->getAxis(0)->unit();
-    if(xUnit->caption() == "dSpacing")
+    std::string xUnitName = xUnit->caption();
+
+    g_log.debug() << "X unit name is: " << xUnitName << std::endl;
+
+    if(boost::algorithm::find_first(xUnitName, "d-Spacing"))
       return "Elastic";
 
     return "Indirect";

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -146,7 +146,7 @@ namespace CustomInterfaces
 
     load->execute();
 
-    //If reloading fails we're out of options
+    // If reloading fails we're out of options
     return load->isExecuted();
   }
 
@@ -154,6 +154,8 @@ namespace CustomInterfaces
   /**
    * Configures the SaveNexusProcessed algorithm to save a workspace in the default
    * save directory and adds the algorithm to the batch queue.
+   *
+   * This uses the plotSpectrum function from the Python API.
    *
    * @param wsName Name of workspace to save
    * @param filename Name of file to save as (including extension)
@@ -175,6 +177,63 @@ namespace CustomInterfaces
 
     // Add the save algorithm to the batch
     m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+  }
+
+
+  /**
+   * Creates a spectrum plot of one or more workspaces at a given spectrum
+   * index.
+   *
+   * This uses the plotSpectrum function from the Python API.
+   *
+   * @param workspaceNames List of names of workspaces to plot
+   * @param specIndex Index of spectrum from each workspace to plot
+   */
+  void IndirectTab::plotSpectrum(const QStringList & workspaceNames, int specIndex)
+  {
+    QString pyInput = "from mantidplot import plotSpectrum\n";
+
+    pyInput += "plotSpectrum('";
+    pyInput += workspaceNames.join("','");
+    pyInput += "', ";
+    pyInput += QString::number(specIndex);
+    pyInput += ")\n";
+
+    m_pythonRunner.runPythonCode(pyInput);
+  }
+
+
+  /**
+   * Creates a spectrum plot of a single workspace at a given spectrum
+   * index.
+   *
+   * @param workspaceName Names of workspace to plot
+   * @param specIndex Index of spectrum to plot
+   */
+  void IndirectTab::plotSpectrum(const QString & workspaceName, int specIndex)
+  {
+    QStringList workspaceNames;
+    workspaceNames << workspaceName;
+    plotSpectrum(workspaceNames, specIndex);
+  }
+
+
+  /**
+   * Plots a contour (2D) plot of a given workspace.
+   *
+   * This uses the plot2D function from the Python API.
+   *
+   * @param workspaceName Name of workspace to plot
+   */
+  void IndirectTab::plotContour(const QString & workspaceName)
+  {
+    QString pyInput = "from mantidplot import plot2D\n";
+
+    pyInput += "plot2D('";
+    pyInput += workspaceName;
+    pyInput += "')\n";
+
+    m_pythonRunner.runPythonCode(pyInput);
   }
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -152,6 +152,33 @@ namespace CustomInterfaces
 
 
   /**
+   * Configures the SaveNexusProcessed algorithm to save a workspace in the default
+   * save directory and adds the algorithm to the batch queue.
+   *
+   * @param wsName Name of workspace to save
+   * @param filename Name of file to save as (including extension)
+   */
+  void IndirectTab::addSaveWorkspaceToQueue(const QString & wsName, const QString & filename)
+  {
+    // Setup the input workspace property
+    API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
+    saveProps["InputWorkspace"] = wsName.toStdString();
+
+    // Setup the algorithm
+    IAlgorithm_sptr saveAlgo = AlgorithmManager::Instance().create("SaveNexusProcessed");
+    saveAlgo->initialize();
+
+    if(filename.isEmpty())
+      saveAlgo->setProperty("Filename", wsName.toStdString() + ".nxs");
+    else
+      saveAlgo->setProperty("Filename", filename.toStdString());
+
+    // Add the save algorithm to the batch
+    m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+  }
+
+
+  /**
    * Sets the edge bounds of plot to prevent the user inputting invalid values
    * Also sets limits for range selector movement
    *

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -127,9 +127,6 @@ Plot Spectrum
 Spectra Range
   The spectra range over which to perform sequential fitting.
 
-Verbose
-  Enables outputting additional information to the Results Log.
-
 Plot Result
   If enabled will plot the result as a spectra plot.
 
@@ -163,9 +160,6 @@ ELow, EHigh
 SampleBinning
   The ratio at which to decrease the number of bins by through merging of
   intensities from neighbouring bins.
-
-Verbose
-  Enables outputting additional information to the Results Log.
 
 Plot Result
   If enabled will plot the result as a spectra plot.
@@ -326,9 +320,6 @@ Plot Spectrum
 Spectra Range
   The spectra range over which to perform sequential fitting.
 
-Verbose
-  Enables outputting additional information to the Results Log.
-
 Plot Output
   Allows plotting spectra plots of fitting parameters, the options available
   will depend on the type of fit chosen.
@@ -400,9 +391,6 @@ Plot Spectrum
 
 Spectra Range
   The spectra range over which to perform sequential fitting.
-
-Verbose
-  Enables outputting additional information to the Results Log.
 
 Plot Output
   Allows plotting spectra plots of fitting parameters, the options available
@@ -506,13 +494,12 @@ References:
 Calculate Corrections
 ---------------------
 
-.. warning:: This interface is only available on Windows
-
 .. interface:: Data Analysis
   :widget: tabCalcCorr
 
-Calculates absorption corrections that could be applied to the data when given
-information about the sample (and optionally can) geometry.
+Calculates absorption corrections in the Paalman & Pings absorption factors that
+could be applied to the data when given information about the sample (and
+optionally can) geometry.
 
 Options
 ~~~~~~~
@@ -527,16 +514,18 @@ Use Can
   \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
 
 Sample Shape
-  Sets the shape of the sample, this affects the options for the sample details,
-  see below.
+  Sets the shape of the sample, this affects the options for the shape details
+  (see below).
 
-Beam Width
-  Width of the incident beam.
+Sample/Can Number Density
+  Density of the sample or container.
 
-Verbose
-  Enables outputting additional information to the Results Log.
+Sample/Can Chemical Formula
+  Chemical formula of the sample or can material. This must be provided in the
+  format expected by the :ref:`SetSampleMaterial <algm-SetSampleMaterial>`
+  algorithm.
 
-Plot Result
+Plot Output
   Plots the :math:`A_{s,s}`, :math:`A_{s,sc}`, :math:`A_{c,sc}` and
   :math:`A_{c,c}` workspaces as spectra plots.
 
@@ -544,20 +533,27 @@ Save Result
   If enabled the result will be saved as a NeXus file in the default save
   directory.
 
-Sample Details
-~~~~~~~~~~~~~~
+Shape Details
+~~~~~~~~~~~~~
 
 Depending on the shape of the sample different parameters for the sample
 dimension are required and are detailed below.
 
-Flat
-####
+Flat Plate
+##########
 
 .. interface:: Data Analysis
-  :widget: pageFlat
+  :widget: pgFlatPlate
 
-Thickness
+The calculation for a flat plate geometry is performed by the
+:ref:`FlatPlatePaalmanPingsCorrection <algm-FlatPlatePaalmanPingsCorrection>`
+algorithm.
+
+Sample Thickness
   Thickness of sample (cm).
+
+Sample Angle
+  Sample angle (degrees).
 
 Can Front Thickness
   Thickness of front container (cm).
@@ -565,39 +561,46 @@ Can Front Thickness
 Can Back Thickness
   Thickness of back container (cm).
 
-Sample Angle
-  Sample angle (degrees).
-
 Cylinder
 ########
 
+.. warning:: This mode is only available on Windows
+
 .. interface:: Data Analysis
-  :widget: pageCylinder
+  :widget: pgCylinder
 
-Radius 1
-  Sample radius 1 (cm).
+The calculation for a cylindrical geometry is performed by the
+:ref:`CylinderPaalmanPingsCorrection <algm-CylinderPaalmanPingsCorrection>`
+algorithm, this algorithm is currently only available on Windows as it uses
+FORTRAN code dependant of F2Py.
 
-Radius 2
-  Sample radius 2 (cm).
+Sample Inner Radius
+  Radius of the inner wall of the sample (cm).
 
-Can Radius
-  Radius of inside of the container (cm).
+Sample Outer Radius
+  Radius of the outer wall of the sample (cm).
+
+Container Outer Radius
+  Radius of outer wall of the container (cm).
+
+Beam Height
+  Height of incident beam (cm).
+
+Beam Width
+  Width of incident beam (cm).
 
 Step Size
   Step size used in calculation.
 
-Theory
-~~~~~~
+Background
+~~~~~~~~~~
 
 The main correction to be applied to neutron scattering data is that for
 absorption both in the sample and its container, when present. For flat plate
 geometry, the corrections can be analytical and have been discussed for example
 by Carlile [1]. The situation for cylindrical geometry is more complex and
 requires numerical integration. These techniques are well known and used in
-liquid and amorphous diffraction, and are described in the ATLAS manual [2]. The
-routines used here have been developed from the corrections programs in the
-ATLAS suite and take into account the wavelength variation of both the
-absorption and the scattering cross-sections for the inelastic flight paths.
+liquid and amorphous diffraction, and are described in the ATLAS manual [2].
 
 The absorption corrections use the formulism of Paalman and Pings [3] and
 involve the attenuation factors :math:`A_{i,j}` where :math:`i` refers to
@@ -608,9 +611,7 @@ plus container. If the scattering cross sections for sample and container are
 scattering from the empty container is :math:`I_{c} = \Sigma_{c}A_{c,c}` and
 that from the sample plus container is :math:`I_{sc} = \Sigma_{s}A_{s,sc} +
 \Sigma_{c}A_{c,sc}`, thus :math:`\Sigma_{s} = (I_{sc} - I_{c}A_{c,sc}/A_{c,c}) /
-A_{s,sc}`.  In the package, the program Acorn calculates the attenuation
-coefficients :math:`A_{i,j}` and the routine Analyse uses them to calculate Σs
-which we identify with :math:`S(Q, \omega)`.
+A_{s,sc}`.
 
 References:
 
@@ -628,12 +629,29 @@ Apply Corrections
 The Apply Corrections tab applies the corrections calculated in the Calculate
 Corrections tab of the Indirect Data Analysis interface.
 
-This tab will expect to find the ass file generated in the previous tab. If Use
-Can is selected, it will also expect the assc, acsc and acc files. It will take
-the run number from the sample file, and geometry from the option you select.
+This uses the :ref:`ApplyPaalmanPingsCorrection
+<algm-ApplyPaalmanPingsCorrection>` algorithm to apply absorption corrections in
+the form of the Paalman & Pings correction factors. When *Use Can* is disabled
+only the :math:`A_{s,s}` factor must be provided, when using a container the
+additional factors must be provided: :math:`A_{c,sc}`, :math:`A_{s,sc}` and
+:math:`A_{c,c}`.
 
 Once run the corrected output and can correction is shown in the preview plot,
-the Spectrum spin box can be used to scroll through each spectrum.
+the Spectrum spin box can be used to scroll through each spectrum. Note that
+when this plot shows the result of a calculation the X axis is always in
+wavelength, however when data is initially selected the X axis unit matches that
+of the sample workspace.
+
+The input and container workspaces will be converted to wavelength (using
+:ref:`ConvertUnits <algm-ConvertUnits>`) if they do not already have wavelength
+as their X unit.
+
+The binning of the sample, container and corrections factor workspace must all
+match, if the sample and container do not match you will be given the option to
+rebin (using :ref:`RebinToWorkspace <algm-RebinToWorkspace>`) the sample to
+match the container, if the correction factors do not match you will be given
+the option to interpolate (:ref:`SplineInterpolation
+<algm-SplineInterpolation>`) the correction factor to match the sample.
 
 Options
 ~~~~~~~
@@ -651,12 +669,14 @@ Use Can
   either a reduced file (*_red.nxs*) or workspace (*_red*) or an :math:`S(Q,
   \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
 
-Corrections File
-  The output file (_Abs.nxs) or workspace group (_Abs) generated by Calculate
-  Corrections.
+Scale Can by factor
+  Allows the container intensity to be scaled by a given scale factor before
+  being used in the corrections calculation.
 
-Verbose
-  Enables outputting additional information to the Results Log.
+Use Corrections
+  The Paalman & Pings correction factors to use in the calculation, note that
+  the file or workspace name must end in either *_flt_abs* or *_cyl_abs* for the
+  flat plate and cylinder geometries respectively.
 
 Plot Output
   Gives the option to create either a spectra or contour plot (or both) of the


### PR DESCRIPTION
Fixes [#11326](http://trac.mantidproject.org/mantid/ticket/11326).

To test:
- Review the CalcCorr and ApplyCorr documentation (`?` button)
- Try running with some combinations of data and corrections below (will need to be on Windows in Release build for Cylinder)

Data: Reduced (meV)
- Sample: `irs26176_graphite002_red.nxs`
- Can: `irs26173_graphite002_red.nxs`

Data: Reduced (A)
- Sample: `wl_irs26176_graphite002_red.nxs`
- Can: `wl_irs26173_graphite002_red.nxs`

Data: S(Q, w)
- Sample: `irs26176_graphite002_sqw.nxs`
- Can: `irs26173_graphite002_sqw.nxs`

Data: Diffraction
- Sample: `irs26176_diffspec_red.nxs`
- Can: `irs26173_diffspec_red.nxs`

Corrections: Flat Plate
- Sample Thickness: 0.01
- Sample Angle: 45
- Can Front: 0.1
- Can Back: 0.1

Corrections: Cylinder
- Can Inner: 0.19
- Sample Inner: 0.2
- Sample Outer: 0.25
- Can Outer: 0.26
- Beam Height/Width: 2.1 (should be populated automatically for most data)
- Step Size: 0.002

Common Options
- Sample Number Density: 0.1
- Sample Chemical Formula: H2-O
- Can Number Density: 0.1
- Can Chemical Formula: V

There is a Mantid project in `babylon5/Public/DanNixon/abscor` that will load all the sample data.
