### PR TITLE
Support TOSCA on IndirectTransmission

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/IndirectTransmissionTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/IndirectTransmissionTest.py
@@ -29,6 +29,29 @@ class IndirectTransmissionTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(values, ref_result, decimal=4)
 
 
+    def test_indirect_transmission_tosca_graphite_002(self):
+        """
+        Test a transmission calculation using TOSCA, graphite, 002.
+        """
+
+        instrument = "TOSCA"
+        analyser = "graphite"
+        reflection = "002"
+
+        # Using water sample
+        formula = "H2-O"
+        density = 0.1
+        thickness = 0.1
+
+        ws = IndirectTransmission(Instrument=instrument, Analyser=analyser, Reflection=reflection,
+                                  ChemicalFormula=formula, NumberDensity=density, Thickness=thickness)
+
+        # Expected values from table
+        ref_result = [5.5137, 0.680081, 2.58187, 53.5069, 56.0888, 0.1, 0.1, 0.566834, 0.429298]
+        values = ws.column(1)
+        np.testing.assert_array_almost_equal(values, ref_result, decimal=4)
+
+
     def test_indirect_transmission_basis_silicon_111(self):
         """
         Test a transmission calculation using BASIS, silicon 111.

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
@@ -37,7 +37,6 @@
           </property>
           <property name="disabledInstruments" stdset="0">
            <stringlist>
-            <string>TOSCA</string>
             <string>TFXA</string>
            </stringlist>
           </property>


### PR DESCRIPTION
Fixes [#10673](http://trac.mantidproject.org/mantid/ticket/10673).

To test:
- Open Indirect > Tools > Transmission
- Select TOSCA
- Pick a sample material, default density and thickness will work
- Run

Also try using the algorithm directly as per usage examples.

This is just taking the fixed energy of the first detector which I was not convinced was the correct way to get the energy of a detector bank but it seems to be giving the correct values as 5.5 Angstroms is about the correct position for the elastic peak on TOSCA.
