### PR TITLE
Show errors in FunctionBrowser

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FunctionBrowser.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FunctionBrowser.h
@@ -21,6 +21,7 @@ class QtStringPropertyManager;
 class QtEnumPropertyManager;
 class QtProperty;
 class QtBrowserItem;
+class ParameterPropertyManager;
 
 class QPushButton;
 class QLabel;
@@ -108,10 +109,14 @@ public:
 
   /// Update the function parameter value
   void setParameter(const QString& funcIndex, const QString& paramName, double value);
+  /// Update the function parameter error
+  void setParamError(const QString& funcIndex, const QString& paramName, double error);
   /// Get a value of a parameter
   double getParameter(const QString& funcIndex, const QString& paramName) const;
   /// Update the function parameter value
   void setParameter(const QString& paramName, double value);
+  /// Update the function parameter error
+  void setParamError(const QString& paramName, double error);
   /// Get a value of a parameter
   double getParameter(const QString& paramName) const;
   /// Update parameter values in the browser to match those of a function.
@@ -147,7 +152,7 @@ protected:
   /// Add a function property
   AProperty addFunctionProperty(QtProperty* parent, QString funName);
   /// Add a parameter property
-  AProperty addParameterProperty(QtProperty* parent, QString paramName, double paramValue);
+  AProperty addParameterProperty(QtProperty* parent, QString paramName, QString paramDesc, double paramValue);
   /// Add a attribute property
   AProperty addAttributeProperty(QtProperty* parent, QString attName, const Mantid::API::IFunction::Attribute& att);
   /// Add attribute and parameter properties to a function property
@@ -249,7 +254,7 @@ protected:
   /// Manager for function group properties
   QtGroupPropertyManager *m_functionManager;
   /// Manager for function parameter properties
-  QtDoublePropertyManager *m_parameterManager;
+  ParameterPropertyManager *m_parameterManager;
   /// Manager for function string attribute properties
   QtStringPropertyManager *m_attributeStringManager;
   /// Manager for function double attribute properties

--- a/Code/Mantid/QtPropertyBrowser/src/ButtonEditorFactory.h
+++ b/Code/Mantid/QtPropertyBrowser/src/ButtonEditorFactory.h
@@ -1,6 +1,7 @@
 #ifndef BUTTONEDITORFACTORY_H
 #define BUTTONEDITORFACTORY_H
 
+#include "ParameterPropertyManager.h"
 #include "qtpropertymanager.h"
 #include <QPushButton>
 
@@ -57,12 +58,12 @@ protected:
   }
 };
 
-class QT_QTPROPERTYBROWSER_EXPORT DoubleButtonEditorFactory: public ButtonEditorFactory<QtDoublePropertyManager>
+class QT_QTPROPERTYBROWSER_EXPORT DoubleButtonEditorFactory: public ButtonEditorFactory<ParameterPropertyManager>
 {
   Q_OBJECT
 
 public:
-  DoubleButtonEditorFactory(QObject *parent):ButtonEditorFactory<QtDoublePropertyManager>(parent){}
+  DoubleButtonEditorFactory(QObject *parent):ButtonEditorFactory<ParameterPropertyManager>(parent){}
 
 Q_SIGNALS:
   void buttonClicked(QtProperty *);


### PR DESCRIPTION
Fixes [#11452](http://trac.mantidproject.org/mantid/ticket/11452)

To test: Code review should be enough. Check the new methods setParamErrors() that will allow showing parameter errors when needed. These new methods will be used in the muon ALC interface and probably in the Multi Dataset Fitting interface.
