### PR TITLE
Rename files with the same name.

### DIFF
--- a/Code/Mantid/Framework/DataHandling/test/LoadFullprofResolutionTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadFullprofResolutionTest.h
@@ -328,7 +328,7 @@ public:
   void test_workspace()
   {
     // Generate file
-    string filename("TestWorskpace.irf");
+    string filename("FullprofResolutionTest_TestWorkspace.irf");
     generate1BankIrfFile(filename);
 
     // Load workspace group wsName with one workspace
@@ -412,7 +412,7 @@ public:
     }
 
     // Clean
-    Poco::File("TestWorskpace.irf").remove();
+    Poco::File(filename).remove();
   }
 
  //----------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/DataHandling/test/LoadGSASInstrumentFileTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadGSASInstrumentFileTest.h
@@ -208,7 +208,7 @@ public:
   void test_workspace()
   {
     // Generate file with two banks
-    string filename("TestWorskpace.irf");
+    string filename("GSASInstrumentFileTest_TestWorkspace.irf");
     generate2BankPrmFile(filename);
 
     // Create workspace group to put parameters into
@@ -308,7 +308,7 @@ public:
     TS_ASSERT_EQUALS( fitParam.getValue( 0.0 ), 0.0);
 
     // Clean
-    Poco::File("TestWorskpace.irf").remove();
+    Poco::File(filename).remove();
     AnalysisDataService::Instance().remove("loadGSASInstrumentFileWorkspace");
   }
 


### PR DESCRIPTION
this fixes [#11458](http://trac.mantidproject.org/mantid/ticket/11458)

LoadFullProfResolutionTest is occasionally failing with an error like

libc++abi.dylib: terminating with uncaught exception of type std::invalid_argument: Invalid value for property Filename (string) "TestWorskpace.irf": File "TestWorskpace.irf" not found

@martyngigg found that both LoadGSASInstrumentFileTest and LoadFullProfResolutionTest write a file named TestWorskpace.irf. For this pull request I renamed both files so that they no longer conflict.

testing: code review & checking build servers should be sufficient. 
