### PR TITLE
Add JobManagerType attribute of computeResource in Facilities schema

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/ComputeResourceInfo.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ComputeResourceInfo.cpp
@@ -40,7 +40,7 @@ ComputeResourceInfo::ComputeResourceInfo(const FacilityInfo *fac,
   // default: Mantid web service API:
   // http://www.mantidproject.org/Remote_Job_Submission_API
   m_managerType = "MantidWebServiceAPIJobManager";
-  std::string type = elem->getAttribute("JobManagerType");
+  std::string type = elem->getAttribute("jobmanagertype");
   if (!type.empty()) {
     m_managerType = type;
   }

--- a/Code/Mantid/Framework/Kernel/test/ComputeResourceInfoTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ComputeResourceInfoTest.h
@@ -105,7 +105,7 @@ public:
 
   void test_normalSCARF() {
     const std::string scarf = "<computeResource name=\"" + scarfName +
-                              "\" JobManagerType=\"" + scarfType + "\">"
+                              "\" jobmanagertype=\"" + scarfType + "\">"
                                                                    "<baseURL>" +
                               scarfURL + "</baseURL>"
                                          "</computeResource>";
@@ -139,7 +139,7 @@ public:
   void test_brokenSCARF() {
     const std::string type = "SCARFLSFJobManager";
     const std::string err = "<computeResource foo=\"" + scarfName +
-                            "\" JobManagerType=\"" + type + "\">"
+                            "\" jobmanagertype=\"" + type + "\">"
                                                             "<URL>" +
                             scarfURL + "</URL>"
                                        "</computeResource>";

--- a/Code/Mantid/instrument/Facilities.xml
+++ b/Code/Mantid/instrument/Facilities.xml
@@ -6,7 +6,7 @@
     <archiveSearch plugin="ISISDataSearch" />
   </archive>
   
-  <computeResource name="SCARF@STFC" JobManagerType="SCARFLSFJobManager">
+  <computeResource name="SCARF@STFC" jobmanagertype="SCARFLSFJobManager">
     <baseURL>https://portal.scarf.rl.ac.uk</baseURL>
   </computeResource>
 

--- a/Code/Mantid/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
+++ b/Code/Mantid/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" 
            xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
   <xs:element name="facilities">
@@ -22,13 +22,12 @@
                 <xs:complexType>
                   <xs:choice maxOccurs="unbounded">
                     <xs:element name="baseURL" type="xs:string" />
-                    <xs:element name="JobManagerType" type="xs:string" />
                     <xs:element name="configFileURL" type="xs:string" />
                     <xs:element name="mpirunExecutable" type="xs:string" />
                     <xs:element name="pythonExecutable" type="xs:string" />
                   </xs:choice>
                   <xs:attribute name="name"/>
-                  <xs:attribute name="type"/>
+                  <xs:attribute name="jobmanagertype"/>
                 </xs:complexType>
               </xs:element>
               <xs:element name="catalog">

--- a/Code/Mantid/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
+++ b/Code/Mantid/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
@@ -22,6 +22,7 @@
                 <xs:complexType>
                   <xs:choice maxOccurs="unbounded">
                     <xs:element name="baseURL" type="xs:string" />
+                    <xs:element name="JobManagerType" type="xs:string" />
                     <xs:element name="configFileURL" type="xs:string" />
                     <xs:element name="mpirunExecutable" type="xs:string" />
                     <xs:element name="pythonExecutable" type="xs:string" />

--- a/Code/Mantid/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
+++ b/Code/Mantid/instrument/Schema/Facilities/1.0/FacilitiesSchema.xsd
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" attributeFormDefault="unqualified" elementFormDefault="qualified" 
            xmlns:xs="http://www.w3.org/2001/XMLSchema" version="1.0">
   <xs:element name="facilities">


### PR DESCRIPTION
This fixes [#11460](http://trac.mantidproject.org/mantid/ticket/11460) which made master_systemtests fail last night. In PR #469 I forgot to add a new attribute in the Facilities schema.

**To test**:
- make sure that system tests pass (but note that on some platforms it just seems to pass even if the schema is incomplete, and that includes the CI rhel7).
