### PR TITLE
ElasticWindowMultiple fails when no temperature logs are found

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -328,16 +328,19 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
                 # Get temperature from log file
                 LoadLog(Workspace=ws_name, Filename=log_path)
                 run_logs = mtd[ws_name].getRun()
-                tmp = run_logs[self._sample_log_name].value
-                temp = tmp[len(tmp) - 1]
-                logger.debug('Temperature %d K found for run: %s' % (temp, run_name))
-                return temp
-
+                if self._sample_log_name in run_logs:
+                    tmp = run_logs[self._sample_log_name].value
+                    temp = tmp[len(tmp) - 1]
+                    logger.debug('Temperature %d K found for run: %s' % (temp, run_name))
+                    return temp
+                else:
+                    logger.warning('Log entry %s for run %s not found' % (self._sample_log_name, run_name))
             else:
-                # Can't find log file
                 logger.warning('Log file for run %s not found' % run_name)
-                logger.warning('No temperature found for run: %s' % run_name)
-                return None
+
+        # Can't find log file
+        logger.warning('No temperature found for run: %s' % run_name)
+        return None
 
 
 # Register algorithm with Mantid

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -150,6 +150,9 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             temp = self._get_temperature(input_ws)
             if temp is not None:
                 temperatures.append(temp)
+            else:
+                # No need to output a tmperature workspace if there are no temperatures
+                self._elt_workspace = ''
 
         logger.information('Creating Q and Q^2 workspaces')
 


### PR DESCRIPTION
Fixes [#11464](http://trac.mantidproject.org/mantid/ticket/11464).

To test:
- Copy the .log and .nsx files from `babylon5/Public/DanNixon/elwin` to you default save directory (or at least on the path somewhere)
- Open IDA > Elwin
- Load the copied runs
- Enable Normalise to Lowest Temperature
- Set the SE log name to something random
- Run, you should get warnings saying no temperatures could be found and no `_elt` workspace generated
