### PR TITLE
Clean some build artifacts on all build types

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -20,6 +20,46 @@ cmake --version
 echo "SHA1=${sha1}"
 
 ###############################################################################
+# Check job requirements from the name
+###############################################################################
+if [[ ${JOB_NAME} == *clean* ]]; then
+  CLEANBUILD=true
+fi
+
+if [[ ${JOB_NAME} == *debug* ]]; then
+  BUILD_CONFIG="Debug"
+elif [[ ${JOB_NAME} == *relwithdbg* ]]; then
+  BUILD_CONFIG="RelWithDbg"
+else
+  BUILD_CONFIG="Release"
+fi
+
+###############################################################################
+# Setup the build directory
+# For a clean build the entire thing is removed to guarantee it is clean. All
+# other build types are assumed to be incremental and the following items
+# are removed to ensure stale build objects don't interfere with each other:
+#   - build/bin/**: if libraries are removed from cmake they are not deleted
+#                   from bin and can cause random failures
+#   - build/ExternalData/**: data files will change over time and removing
+#                            the links helps keep it fresh
+###############################################################################
+BUILD_DIR=$WORKSPACE/build
+if [ -z "$BUILD_DIR" ]; then
+  echo "Build directory not set. Cannot continue"
+  exit 1
+fi
+
+if [[ "$CLEANBUILD" == true ]]; then
+  rm -rf $BUILD_DIR
+fi
+if [ -d $BUILD_DIR ]; then
+  rm -rf $BUILD_DIR/bin $BUILD_DIR/ExternalData
+else
+  mkdir $BUILD_DIR
+fi
+
+###############################################################################
 # Setup clang
 ###############################################################################
 if [[ ${JOB_NAME} == *clang* ]]; then
@@ -38,11 +78,11 @@ if [[ $USE_CLANG ]]; then
   export CXX=clang++
   #check if CMakeCache.txt exists and if so that the cxx compiler is clang++
   #only needed with incremental builds. Clean builds delete this directory in a later step. 
-  if [[ -e $WORKSPACE/build/CMakeCache.txt ]] && [[ ${JOB_NAME} != *clean* ]]; then
-    COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $WORKSPACE/build/CMakeCache.txt` 
+  if [[ -e $BUILD_DIR/CMakeCache.txt ]] && [[ ${JOB_NAME} != *clean* ]]; then
+    COMPILERFILEPATH=`grep 'CMAKE_CXX_COMPILER:FILEPATH' $BUILD_DIR/CMakeCache.txt` 
     if [[ $COMPILERFILEPATH != *clang++* ]]; then 
       # Removing the build directory entirely guarantees clang is used.
-      rm -rf $WORKSPACE/build
+      rm -rf $BUILD_DIR
     fi
   fi 
 fi
@@ -90,21 +130,6 @@ if [[ ${NODE_LABELS} == *rhel7* ]]; then
 fi
 
 ###############################################################################
-# Check job requirements from the name
-###############################################################################
-if [[ ${JOB_NAME} == *clean* ]]; then
-  CLEANBUILD=true
-fi
-
-if [[ -e $WORKSPACE/build/CMakeCache.txt ]]; then
-  # Temporary while the builds flick between old & new TestingTools locations
-  TESTINGTOOLS_DIR=$(grep 'Code/Mantid/TestingTools/cxxtest' $WORKSPACE/build/CMakeCache.txt || true)
-  if [ ! -z "$TESTINGTOOLS_DIR"  ]; then
-    rm -fr $WORKSPACE/build
-  fi
-fi
-
-###############################################################################
 # Packaging options
 ###############################################################################
 if [[ "$BUILDPKG" == true ]]; then
@@ -125,30 +150,15 @@ if [[ "$BUILDPKG" == true ]]; then
 fi
 
 ###############################################################################
-# Setup the build directory
+# Work in the build directory
 ###############################################################################
-if [[ "$CLEANBUILD" == true ]]; then
-  rm -rf $WORKSPACE/build
-fi
-[ -d $WORKSPACE/build ] || mkdir $WORKSPACE/build
-cd $WORKSPACE/build
+cd $BUILD_DIR
 
 ###############################################################################
 # Clean up any artifacts from last build so that if it fails
 # they don't get archived again
 ###############################################################################
 rm -f *.dmg *.rpm *.deb *.tar.gz
-
-###############################################################################
-## Check the required build configuration
-###############################################################################
-if [[ ${JOB_NAME} == *debug* ]]; then
-  BUILD_CONFIG="Debug"
-elif [[ ${JOB_NAME} == *relwithdbg* ]]; then
-  BUILD_CONFIG="RelWithDbg"
-else
-  BUILD_CONFIG="Release"
-fi
 
 ###############################################################################
 # CMake configuration

--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -39,14 +39,29 @@ if not "%JOB_NAME%" == "%JOB_NAME:clean=%" (
   set BUILDPKG=yes
 )
 
-if EXIST %WORKSPACE%\build\CMakeCache.txt (
-  FINDSTR "Code/Mantid/TestingTools/cxxtest" %WORKSPACE%\build\CMakeCache.txt && (
-    rmdir /S /Q %WORKSPACE%\build
-  )
-)
-
 if not "%JOB_NAME%" == "%JOB_NAME:pull_requests=%" (
   set BUILDPKG=yes
+)
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Setup the build directory
+:: For a clean build the entire thing is removed to guarantee it is clean. All
+:: other build types are assumed to be incremental and the following items
+:: are removed to ensure stale build objects don't interfere with each other:
+::   - build/bin: if libraries are removed from cmake they are not deleted
+::                   from bin and can cause random failures
+::   - build/ExternalData/**: data files will change over time and removing
+::                            the links helps keep it fresh
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+set BUILD_DIR=%WORKSPACE%\build
+if "%CLEANBUILD%" == "yes" (
+  rmdir /S /Q %BUILD_DIR%
+)
+
+if EXIST %BUILD_DIR% (
+  rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData
+) else (
+  md %BUILD_DIR%
 )
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
@@ -57,14 +72,7 @@ if "%BUILDPKG%" == "yes" (
   set PACKAGE_DOCS=-DPACKAGE_DOCS=ON
 )
 
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: Setup the build directory
-:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-if "%CLEANBUILD%" == "yes" (
-  rmdir /S /Q %WORKSPACE%\build
-)
-md %WORKSPACE%\build
-cd %WORKSPACE%\build
+cd %BUILD_DIR%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Clean up any artifacts from last build so that if it fails
@@ -132,7 +140,7 @@ if "%BUILDPKG%" == "yes" (
 if not "%JOB_NAME%"=="%JOB_NAME:pull_requests=%" (
   :: Install package
   set SYSTEMTESTS_DIR=%WORKSPACE%\Code\Mantid\Testing\SystemTests
-  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py install %WORKSPACE%\build
+  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py install %BUILD_DIR%
 
   ::Remove user properties, disable instrument updating & usage reports and add data paths
   del /Q C:\MantidInstall\bin\Mantid.user.properties
@@ -144,13 +152,13 @@ if not "%JOB_NAME%"=="%JOB_NAME:pull_requests=%" (
   echo datasearch.directories = !DATA_ROOT!/UnitTest;!DATA_ROOT!/DocTest;!WORKSPACE_UNIX_STYLE!/Code/Mantid/instrument >> C:\MantidInstall\bin\Mantid.user.properties
 
   :: Run tests
-  cd %WORKSPACE%\build\docs
+  cd %BUILD_DIR%\docs
   C:\MantidInstall\bin\MantidPlot.exe -xq runsphinx_doctest.py
   set RETCODE=!ERRORLEVEL!
 
   :: Remove Mantid
-  cd %WORKSPACE%\build
-  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py uninstall %WORKSPACE%\build
+  cd %BUILD_DIR%
+  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py uninstall %BUILD_DIR%
   if !RETCODE! NEQ 0 exit /B 1
 )
 


### PR DESCRIPTION
This avoids other incremental-type builds picking up things like stale libraries etc.
