### PR TITLE
Make createWorkspace fail noisily

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -62,7 +62,10 @@ object createWorkspace() {
    "    lhs = kernel.funcreturns.process_frame(inspect.currentframe().f_back)\n"
    "    if lhs[0] > 0:\n"
    "      OutputWorkspace = lhs[1][0]\n"
-
+   "    else:\n"
+   "      raise RuntimeError('createWorkspace failed to infer a name for its"
+                             " output projection workspace. Please pass an"
+                             " OutputWorkspace parameter to it.')\n"
    "  if OutputWorkspace:\n"
    "    mtd[OutputWorkspace] = ws\n"
 


### PR DESCRIPTION
This is for trac ticket [#11474](http://trac.mantidproject.org/mantid/ticket/11474)

**Testing**: The following script reproduces the issue. If you look at `out_md`'s history, the Projection property is not set. With the changes applied, it fails and provides instructions on how to correct it.

``` python
to_cut = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", Units="U,U,U,V")
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,-0.5,0,0,0,0.1])
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,0.5,0,0,0,0.1])
SetUB(Workspace=to_cut, a=1, b=1, c=1, alpha=90, beta=90, gamma=90)
SetSpecialCoordinates(InputWorkspace=to_cut, SpecialCoordinates='HKL')

p = Projection([1,1,0], [-1,1,0])

out_md = CutMD(to_cut, Projection=p.createWorkspace(), PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
```
