### PR TITLE
Show parameter errors in alc

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h
@@ -60,7 +60,7 @@ namespace CustomInterfaces
     void setDataCurve(const QwtData& data);
     void setCorrectedCurve(const QwtData& data);
     void setBaselineCurve(const QwtData& data);
-    void setFunction(const QString& func);
+    void setFunction(Mantid::API::IFunction_const_sptr func);
     void setNoOfSectionRows(int rows);
     void setSectionRow(int row, SectionRow values);
     void addSectionSelector(int index, SectionSelector values);

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCBaselineModellingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCBaselineModellingView.h
@@ -3,6 +3,7 @@
 
 #include "MantidKernel/System.h"
 
+#include "MantidAPI/IFunction.h"
 #include "MantidQtCustomInterfaces/DllConfig.h"
 
 #include <QObject>
@@ -90,7 +91,7 @@ namespace CustomInterfaces
      * Update displayed function
      * @param func :: New function
      */
-    virtual void setFunction(const QString& func) = 0;
+    virtual void setFunction(Mantid::API::IFunction_const_sptr func) = 0;
 
     /**
      * Resize sections table

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -49,7 +49,7 @@ namespace CustomInterfaces
     extract->execute();
 
     setCorrectedData(extract->getProperty("OutputWorkspace"));
-    setFittedFunction(FunctionFactory::Instance().createInitialized(funcToFit->asString()));
+    setFittedFunction(funcToFit);
     m_sections = sections;
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
@@ -202,12 +202,11 @@ namespace CustomInterfaces
   {
     if (IFunction_const_sptr fittedFunc = m_model->fittedFunction())
     {
-      QString funcString = QString::fromStdString(fittedFunc->asString());
-      m_view->setFunction(funcString);
+      m_view->setFunction(fittedFunc);
     }
     else
     {
-      m_view->setFunction(QString(""));
+      m_view->setFunction(IFunction_const_sptr());
     }
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -109,15 +109,24 @@ namespace CustomInterfaces
     m_ui.dataPlot->replot();
   }
 
-  void ALCBaselineModellingView::setFunction(const QString& func)
+  void ALCBaselineModellingView::setFunction(IFunction_const_sptr func)
   {
-    if (func.isEmpty())
+    if (!func)
     {
       m_ui.function->clear();
     }
     else
     {
-      m_ui.function->setFunction(func);
+      size_t nParams = func->nParams();
+      for (size_t i=0; i<nParams; i++) {
+
+        QString name = QString::fromStdString(func->parameterName(i));
+        double value = func->getParameter(i);
+        double error = func->getError(i);
+
+        m_ui.function->setParameter(name,value);
+        m_ui.function->setParamError(name,error);
+      }
     }
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -86,6 +86,7 @@ namespace CustomInterfaces
     fit->setChild(true);
     fit->setProperty("Function", peaks->asString());
     fit->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
+    fit->setProperty("CreateOutput", true);
     fit->execute();
 
     setFittedPeaks(static_cast<IFunction_sptr>(fit->getProperty("Function")));

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
@@ -76,9 +76,16 @@ void ALCPeakFittingView::setFunction(const IFunction_const_sptr& newFunction)
 {
   if (newFunction)
   {
-    // String convertion hassle to avoid const-casting - Function Browser should really accept const
-    // pointer
-    m_ui.peaks->setFunction(QString::fromStdString(newFunction->asString()));
+    size_t nParams = newFunction->nParams();
+    for (size_t i=0; i<nParams; i++) {
+
+      QString name = QString::fromStdString(newFunction->parameterName(i));
+      double value = newFunction->getParameter(i);
+      double error = newFunction->getError(i);
+
+      m_ui.peaks->setParameter(name,value);
+      m_ui.peaks->setParamError(name,error);
+    }
   }
   else
   {

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -81,6 +81,7 @@ public:
     {
       TS_ASSERT_EQUALS(fittedFunc->name(), "FlatBackground");
       TS_ASSERT_DELTA(fittedFunc->getParameter("A0"), 3, 1E-8);
+      TS_ASSERT_DELTA(fittedFunc->getError(0),0.447214,1E-6);
     }
 
     MatrixWorkspace_const_sptr corrected = m_model->correctedData();

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -34,7 +34,7 @@ public:
   MOCK_METHOD1(setDataCurve, void(const QwtData&));
   MOCK_METHOD1(setCorrectedCurve, void(const QwtData&));
   MOCK_METHOD1(setBaselineCurve, void(const QwtData&));
-  MOCK_METHOD1(setFunction, void(const QString&));
+  MOCK_METHOD1(setFunction, void(IFunction_const_sptr));
 
   MOCK_CONST_METHOD0(noOfSectionRows, int());
   MOCK_METHOD1(setNoOfSectionRows, void(int));
@@ -188,8 +188,6 @@ public:
     ON_CALL(*m_model, fittedFunction()).WillByDefault(Return(f));
     ON_CALL(*m_model, data()).WillByDefault(Return(createTestWs(3)));
 
-    EXPECT_CALL(*m_view, setFunction(QString::fromStdString(f->asString())));
-
     EXPECT_CALL(*m_view, setBaselineCurve(AllOf(Property(&QwtData::size, 3),
                                                 QwtDataX(0, 1, 1E-8), QwtDataX(2, 3, 1E-8),
                                                 QwtDataY(0, 5, 1E-8), QwtDataY(2, 5, 1E-8))));
@@ -201,7 +199,7 @@ public:
   {
     ON_CALL(*m_model, fittedFunction()).WillByDefault(Return(IFunction_const_sptr()));
 
-    EXPECT_CALL(*m_view, setFunction(QString("")));
+    EXPECT_CALL(*m_view, setFunction(IFunction_const_sptr()));
     EXPECT_CALL(*m_view, setBaselineCurve(Property(&QwtData::size, 0)));
 
     m_model->changeFittedFunction();


### PR DESCRIPTION
Fixes [#9555](http://trac.mantidproject.org/mantid/ticket/9555)

To test: Open the muon ALC interface. Load MUSR00015189.nxs as "First" and MUSR00015193.nxs as "Last". Hit the Load button. This will cause some data to be displayed on the right panel. Click on "Baseline modelling", then right-click on the blank region in the "Function" section, and add a function (for instance a flat background), then right-click  on "Sections" black area below and add a section. Hit Fit, a baseline will be displayed and parameter values will be updated. Check that parameter errors are also shown. Go to "Peak fitting", right-click on the left panel and add a peak function, for instance a Lorentzian. Write initial values for "PeakCentre" and "FWHM", 15191 and 0.5 should be ok. Hit Fit and check that parameter values are shown together with their errors.
