### PR TITLE
Fix SumSpectra option on LoadVesuvio

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -732,14 +732,20 @@ class LoadVesuvio(PythonAlgorithm):
         # foil_out has all spectra in order specified by input
         foil_start = 0
         for idx_out in range(len(self._spectra)):
-            ws_out.setX(idx_out, self.foil_out.readX(idx_out))
+            ws_out.setX(idx_out, self.foil_out.readX(foil_start))
             summed_set = self._spectra[idx_out]
             nsummed = len(summed_set)
             y_out, e_out = ws_out.dataY(idx_out), ws_out.dataE(idx_out)
+            spec_out = ws_out.getSpectrum(idx_out)
+            spec_out.setSpectrumNo(self.foil_out.getSpectrum(foil_start).getSpectrumNo())
+            spec_out.clearDetectorIDs()
             for foil_idx in range(foil_start, foil_start+nsummed):
                 y_out += self.foil_out.readY(foil_idx)
                 foil_err = self.foil_out.readE(foil_idx)
                 e_out += foil_err*foil_err # gaussian errors
+                in_ids = self.foil_out.getSpectrum(foil_idx).getDetectorIDs()
+                for det_id in in_ids:
+                    spec_out.addDetectorID(det_id)
             #endfor
             np.sqrt(e_out, e_out)
             foil_start += nsummed

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -728,6 +728,7 @@ class LoadVesuvio(PythonAlgorithm):
         # foil_out has all spectra in order specified by input
         foil_start = 0
         for idx_out in range(len(self._spectra)):
+            ws_out.setX(idx_out, self.foil_out.readX(idx_out))
             summed_set = self._spectra[idx_out]
             nsummed = len(summed_set)
             y_out, e_out = ws_out.dataY(idx_out), ws_out.dataE(idx_out)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -153,6 +153,7 @@ class LoadVesuvio(PythonAlgorithm):
             ip_file = self.getPropertyValue(INST_PAR_PROP)
             if len(ip_file) > 0:
                 self._load_ip_file(ip_file)
+
             if self._sumspectra:
                 self._sum_all_spectra()
 
@@ -212,6 +213,9 @@ class LoadVesuvio(PythonAlgorithm):
                 dataE += np.square(raw_group[group_index].readE(ws_index))
             np.sqrt(dataE, dataE)
             foil_out.setX(ws_index, x_values)
+
+        if self._sumspectra:
+            self._sum_all_spectra()
 
         DeleteWorkspace(Workspace=SUMMED_WS)
         self._store_results()

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -140,6 +140,12 @@ class VesuvioTests(unittest.TestCase):
         self.assertAlmostEqual(0.6219299465, evs_raw.readE(0)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(0.676913729914, evs_raw.readE(1)[0], places=DIFF_PLACES)
 
+        # Spectrum numbers
+        self._verify_spectra_numbering(evs_raw.getSpectrum(0), 135,
+                                       range(3101,3115))
+        self._verify_spectra_numbering(evs_raw.getSpectrum(1), 152,
+                                       range(3118,3132))
+
     def test_sumspectra_set_to_true_gives_single_spectra_summed_over_all_inputs_with_foil_in(self):
         self._run_load("14188", "3-15", "FoilIn", "IP0005.dat", sum=True)
         evs_raw = mtd[self.ws_name]
@@ -152,6 +158,10 @@ class VesuvioTests(unittest.TestCase):
         self.assertAlmostEqual(2072.0, evs_raw.readY(0)[-1], places=DIFF_PLACES)
         self.assertAlmostEqual(705.49415305869115, evs_raw.readE(0)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(45.519226706964169, evs_raw.readE(0)[-1], places=DIFF_PLACES)
+
+        self._verify_spectra_numbering(evs_raw.getSpectrum(0), 3,
+                                       range(2101,2114))
+
 
     def test_sumspectra_with_multiple_groups_gives_number_output_spectra_as_input_groups_with_foil_in(self):
         self._run_load("14188", "3-15;30-50", "FoilIn", "IP0005.dat", sum=True)
@@ -167,6 +177,17 @@ class VesuvioTests(unittest.TestCase):
         self.assertAlmostEqual(1332812.0, evs_raw.readY(1)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(705.49415305869115, evs_raw.readE(0)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(1154.4747723532116, evs_raw.readE(1)[0], places=DIFF_PLACES)
+        
+        self._verify_spectra_numbering(evs_raw.getSpectrum(0), 3,
+                                       range(2101,2114))
+        self._verify_spectra_numbering(evs_raw.getSpectrum(1), 30,
+                                       range(2128,2145) + range(2201,2205))
+
+    def _verify_spectra_numbering(self, spectrum, expected_no, expected_ids):
+        self.assertEquals(expected_no, spectrum.getSpectrumNo())
+        det_ids = spectrum.getDetectorIDs()
+        for expected_id, det_id in zip(expected_ids, det_ids):
+            self.assertEqual(expected_id, det_id)
 
     def _run_load(self, runs, spectra, diff_opt, ip_file="", sum=False):
         LoadVesuvio(Filename=runs,OutputWorkspace=self.ws_name,

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -118,6 +118,8 @@ class VesuvioTests(unittest.TestCase):
 
         # Verify
         self.assertEquals(1, evs_raw.getNumberHistograms())
+        self.assertAlmostEqual(5.0, evs_raw.readX(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(599.5, evs_raw.readX(0)[-1], places=DIFF_PLACES)
         self.assertAlmostEqual(-1.5288171762918328, evs_raw.readY(0)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(-0.079412793053402098, evs_raw.readY(0)[-1], places=DIFF_PLACES)
         self.assertAlmostEqual(0.52109203357613976, evs_raw.readE(0)[0], places=DIFF_PLACES)
@@ -130,6 +132,10 @@ class VesuvioTests(unittest.TestCase):
 
         # Verify
         self.assertEquals(2, evs_raw.getNumberHistograms())
+        self.assertAlmostEqual(5.0, evs_raw.readX(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(5.0, evs_raw.readX(1)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(599.5, evs_raw.readX(0)[-1], places=DIFF_PLACES)
+        self.assertAlmostEqual(599.5, evs_raw.readX(1)[-1], places=DIFF_PLACES)
         self.assertAlmostEqual(-0.713877795283, evs_raw.readY(0)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(-3.00125465604, evs_raw.readY(1)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(0.6219299465, evs_raw.readE(0)[0], places=DIFF_PLACES)

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -127,7 +127,6 @@ class VesuvioTests(unittest.TestCase):
 
     def test_sumspectra_with_multiple_groups_gives_number_output_spectra_as_input_groups(self):
         self._run_load("14188", "135-148;152-165", "SingleDifference","IP0005.dat",sum=True)
-
         evs_raw = mtd[self.ws_name]
 
         # Verify
@@ -140,6 +139,34 @@ class VesuvioTests(unittest.TestCase):
         self.assertAlmostEqual(-3.00125465604, evs_raw.readY(1)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(0.6219299465, evs_raw.readE(0)[0], places=DIFF_PLACES)
         self.assertAlmostEqual(0.676913729914, evs_raw.readE(1)[0], places=DIFF_PLACES)
+
+    def test_sumspectra_set_to_true_gives_single_spectra_summed_over_all_inputs_with_foil_in(self):
+        self._run_load("14188", "3-15", "FoilIn", "IP0005.dat", sum=True)
+        evs_raw = mtd[self.ws_name]
+
+        # Verify
+        self.assertEquals(1, evs_raw.getNumberHistograms())
+        self.assertAlmostEqual(5.0, evs_raw.readX(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(19990.0, evs_raw.readX(0)[-1], places=DIFF_PLACES)
+        self.assertAlmostEqual(497722.0, evs_raw.readY(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(2072.0, evs_raw.readY(0)[-1], places=DIFF_PLACES)
+        self.assertAlmostEqual(705.49415305869115, evs_raw.readE(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(45.519226706964169, evs_raw.readE(0)[-1], places=DIFF_PLACES)
+
+    def test_sumspectra_with_multiple_groups_gives_number_output_spectra_as_input_groups_with_foil_in(self):
+        self._run_load("14188", "3-15;30-50", "FoilIn", "IP0005.dat", sum=True)
+        evs_raw = mtd[self.ws_name]
+
+        # Verify
+        self.assertEquals(2, evs_raw.getNumberHistograms())
+        self.assertAlmostEqual(5.0, evs_raw.readX(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(5.0, evs_raw.readX(1)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(19990.0, evs_raw.readX(0)[-1], places=DIFF_PLACES)
+        self.assertAlmostEqual(19990.0, evs_raw.readX(1)[-1], places=DIFF_PLACES)
+        self.assertAlmostEqual(497722.0, evs_raw.readY(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(1332812.0, evs_raw.readY(1)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(705.49415305869115, evs_raw.readE(0)[0], places=DIFF_PLACES)
+        self.assertAlmostEqual(1154.4747723532116, evs_raw.readE(1)[0], places=DIFF_PLACES)
 
     def _run_load(self, runs, spectra, diff_opt, ip_file="", sum=False):
         LoadVesuvio(Filename=runs,OutputWorkspace=self.ws_name,


### PR DESCRIPTION
Fixes [#11470](http://trac.mantidproject.org/mantid/ticket/11470).

To test:
- Run LoadVesuvio on a least one difference mode and one foil mode
- See that the output workspace contains a spectrum per detector range provided and that X values are valid
