### PR TITLE
Make section selectors more distinguishable

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -141,6 +141,14 @@ namespace CustomInterfaces
   {
     RangeSelector* newSelector = new RangeSelector(m_ui.dataPlot);
 
+    if (index%3==0) {
+      newSelector->setColour(Qt::blue);
+    } else if ( (index-1)%3==0 ) {
+      newSelector->setColour(Qt::red);
+    } else {
+      newSelector->setColour(Qt::green);
+    }
+
     m_selectorModifiedMapper->setMapping(newSelector,index);
     connect(newSelector, SIGNAL(selectionChanged(double,double)),
             m_selectorModifiedMapper, SLOT(map()));

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -129,10 +129,10 @@ namespace CustomInterfaces
   void ALCBaselineModellingView::setSectionRow(int row, IALCBaselineModellingView::SectionRow values)
   {
     m_ui.sections->blockSignals(true); // Setting values, no need for 'modified' signals
-    m_ui.sections->setItem(row, 0, new QTableWidgetItem(values.first));
-    m_ui.sections->setItem(row, 1, new QTableWidgetItem(values.second));
     m_ui.sections->setFocus();
     m_ui.sections->selectRow(row);
+    m_ui.sections->setItem(row, 0, new QTableWidgetItem(values.first));
+    m_ui.sections->setItem(row, 1, new QTableWidgetItem(values.second));
     m_ui.sections->blockSignals(false);
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -131,6 +131,8 @@ namespace CustomInterfaces
     m_ui.sections->blockSignals(true); // Setting values, no need for 'modified' signals
     m_ui.sections->setItem(row, 0, new QTableWidgetItem(values.first));
     m_ui.sections->setItem(row, 1, new QTableWidgetItem(values.second));
+    m_ui.sections->setFocus();
+    m_ui.sections->selectRow(row);
     m_ui.sections->blockSignals(false);
   }
 


### PR DESCRIPTION
Fixes issue [#9504](http://trac.mantidproject.org/mantid/ticket/9504)

To test: Open the muon ALC interface and load for instance MUSR00015189.nxs as "First" and MUSR00015191.nxs as "Last". Hit "Load" and go to "Baseline Modelling". Right-click on the blank region in "Sections", and select "Add section", a new section will appear. To change the range covered by a section, just drag and drop any of the two corresponding vertical lines. Right-click again and add a second section. You can add as many sections as you like, but three should be enough. Check that vertical lines are colored differently and that when you drag a vertical line the corresponding row in the "Sections" table is highlighted. 

A third improvement was suggested in the trac ticket. However, I think that selectors are now distinguishable enough. Please, let me know if you disagree, and I will add a new method to compute good initial values for any new selector based on the previous ones.
