### PR TITLE
Fitting with no peaks

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
@@ -59,6 +59,7 @@ namespace CustomInterfaces
     void setParameter(const QString& funcIndex, const QString& paramName, double value);
     void setPeakPickerEnabled(bool enabled);
     void setPeakPicker(const IPeakFunction_const_sptr& peak);
+    void displayError(const QString& message);
     void help();
 
     // -- End of IALCPeakFitting interface ---------------------------------------------------------

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
@@ -86,6 +86,12 @@ namespace CustomInterfaces
     /// @param peak :: A new peak to represent
     virtual void setPeakPicker(const IPeakFunction_const_sptr& peak) = 0;
 
+    /**
+     * Pops-up an error box
+     * @param message :: Error message to display
+     */
+    virtual void displayError(const QString& message) = 0;
+
     /// Opens the Mantid Wiki web page
     virtual void help() = 0;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
@@ -31,7 +31,12 @@ namespace CustomInterfaces
 
   void ALCPeakFittingPresenter::fit()
   {
-    m_model->fitPeaks(m_view->function(""));
+    IFunction_const_sptr func = m_view->function("");
+    if ( func ) {
+      m_model->fitPeaks(func);
+    } else {
+       m_view->displayError("Couldn't fit an empty function");
+    }
   }
 
   void ALCPeakFittingPresenter::onCurrentFunctionChanged()

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
@@ -2,6 +2,8 @@
 
 #include "MantidQtAPI/HelpWindow.h"
 
+#include <QMessageBox>
+
 #include <qwt_symbol.h>
 
 namespace MantidQt
@@ -107,6 +109,11 @@ void ALCPeakFittingView::setPeakPicker(const IPeakFunction_const_sptr& peak)
 void ALCPeakFittingView::help()
 {
   MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Muon_ALC"));
+}
+
+void ALCPeakFittingView::displayError(const QString& message)
+{
+  QMessageBox::critical(m_widget, "Error", message);
 }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -50,6 +50,7 @@ public:
   MOCK_METHOD1(setPeakPicker, void(const IPeakFunction_const_sptr&));
   MOCK_METHOD1(setFunction, void(const IFunction_const_sptr&));
   MOCK_METHOD3(setParameter, void(const QString&, const QString&, double));
+  MOCK_METHOD1(displayError, void(const QString&));
   MOCK_METHOD0(help, void());
 };
 
@@ -125,6 +126,14 @@ public:
     ALCPeakFittingPresenter presenter(&view, &model);
     EXPECT_CALL(view, initialize()).Times(1);
     presenter.initialize();
+  }
+
+  void test_fitEmptyFunction()
+  {
+    ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(IFunction_const_sptr()));
+    EXPECT_CALL(*m_view, displayError(QString("Couldn't fit an empty function"))).Times(1);
+
+    m_view->requestFit();
   }
 
   void test_fit()


### PR DESCRIPTION
Fixes [#9505](http://trac.mantidproject.org/mantid/ticket/9505)

To test: open the muon ALC interface and go to the PeakFitting step (first you'll need to load a set of runs, for instance MUSR0015189.nxs as "First" and MUSR00015191.nxs as "Last", hit "Load" and then "Baseline Model", select a baseline function (a FlatBackground should be enough), add a section by right-clicking on the blank region in "Sections", hit "Fit" and then "Peak fitting"). Hit "Fit" without adding any peaks and check that an error message is displayed indicating that you are trying to fit an empty function.
