### PR TITLE
ValidateInputs is never called on TimeSlice

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -115,7 +115,7 @@ class TimeSlice(PythonAlgorithm):
         return ''
 
 
-    def validateInput(self):
+    def validateInputs(self):
         issues = dict()
 
         issues['SpectraRange'] = self._validate_range('SpectraRange')

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/TimeSliceTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/TimeSliceTest.py
@@ -18,6 +18,7 @@ class TimeSliceTest(unittest.TestCase):
         self.assertTrue(mtd.doesExist('SliceTestOut'))
         self.assertTrue(mtd.doesExist('irs26173_slice'))
 
+
     def test_suffix(self):
         """
         Tests to ensure that output names have a suffic appended correctly.
@@ -31,6 +32,67 @@ class TimeSliceTest(unittest.TestCase):
                   OutputWorkspace='SliceTestOut')
 
         self.assertTrue(mtd.doesExist('irs26173_graphite002_slice'))
+
+
+    def test_validation_peak_range_order(self):
+        """
+        Tests validation of the PeakRange property.
+        """
+
+        self.assertRaises(RuntimeError,
+                          TimeSlice,
+                          InputFiles=['IRS26173.raw'],
+                          SpectraRange=[3, 53],
+                          PeakRange=[65000, 62500],
+                          BackgroundRange=[59000, 61500],
+                          OutputNameSuffix='_graphite002_slice',
+                          OutputWorkspace='SliceTestOut')
+
+
+    def test_validation_peak_range_count(self):
+        """
+        Tests validation of the PeakRange property.
+        """
+
+        self.assertRaises(RuntimeError,
+                          TimeSlice,
+                          InputFiles=['IRS26173.raw'],
+                          SpectraRange=[3, 53],
+                          PeakRange=[65000],
+                          BackgroundRange=[59000, 61500],
+                          OutputNameSuffix='_graphite002_slice',
+                          OutputWorkspace='SliceTestOut')
+
+
+    def test_validation_background_range_order(self):
+        """
+        Tests validation of the BackgroundRange property.
+        """
+
+        self.assertRaises(RuntimeError,
+                          TimeSlice,
+                          InputFiles=['IRS26173.raw'],
+                          SpectraRange=[3, 53],
+                          PeakRange=[65000, 62500],
+                          BackgroundRange=[61500, 59000],
+                          OutputNameSuffix='_graphite002_slice',
+                          OutputWorkspace='SliceTestOut')
+
+
+    def test_validation_peak_range_count(self):
+        """
+        Tests validation of the BackgroundRange property.
+        """
+
+        self.assertRaises(RuntimeError,
+                          TimeSlice,
+                          InputFiles=['IRS26173.raw'],
+                          SpectraRange=[3, 53],
+                          PeakRange=[65000, 62500],
+                          BackgroundRange=[59000],
+                          OutputNameSuffix='_graphite002_slice',
+                          OutputWorkspace='SliceTestOut')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes [#11490](http://trac.mantidproject.org/mantid/ticket/11490).

Code review should be enough for testing.
