### PR TITLE
Enable ConvertCWPDMDToSpectra to exclude detectors

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertCWPDMDToSpectra.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertCWPDMDToSpectra.h
@@ -136,7 +136,8 @@ private:
       API::IMDEventWorkspace_const_sptr dataws,
       API::IMDEventWorkspace_const_sptr monitorws, const std::string targetunit,
       const std::map<int, double> &map_runwavelength, const double xmin,
-      const double xmax, const double binsize, bool dolinearinterpolation);
+      const double xmax, const double binsize, bool dolinearinterpolation,
+      const std::vector<detid_t> &vec_excludeddets);
 
   /// Find the binning boundary according to detectors' positions
   void findXBoundary(API::IMDEventWorkspace_const_sptr dataws,
@@ -147,7 +148,8 @@ private:
   /// Bin signals to its 2theta position
   void binMD(API::IMDEventWorkspace_const_sptr mdws, const char &unitbit,
              const std::map<int, double> &map_runlambda,
-             const std::vector<double> &vecx, std::vector<double> &vecy);
+             const std::vector<double> &vecx, std::vector<double> &vecy,
+             const std::vector<detid_t> &vec_excludedet);
 
   /// Do linear interpolation to zero counts if bin is too small
   void linearInterpolation(API::MatrixWorkspace_sptr matrixws,
@@ -165,6 +167,9 @@ private:
   /// Convert units from 2theta to d-spacing or Q
   void convertUnits(API::MatrixWorkspace_sptr matrixws,
                     const std::string &targetunit, const double &wavelength);
+
+  bool isExcluded(const std::vector<detid_t> &vec_excludedet,
+                  const detid_t detid);
 
   /// Infinitesimal value
   double m_infitesimal;

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertSpiceDataToRealSpace.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ConvertSpiceDataToRealSpace.h
@@ -121,6 +121,16 @@ private:
                    const std::map<std::string, std::vector<double> > &logvecmap,
                    const std::vector<Kernel::DateAndTime> &vectimes);
 
+  /// Parse detector efficiency table workspace to map
+  void
+  parseDetectorEfficiencyTable(DataObjects::TableWorkspace_sptr detefftablews,
+                               std::map<detid_t, double> &deteffmap);
+
+  /// Apply the detector's efficiency correction to
+  void
+  correctByDetectorEfficiency(std::vector<API::MatrixWorkspace_sptr> vec_ws2d,
+                              const std::map<detid_t, double> &detEffMap);
+
   /// Name of instrument
   std::string m_instrumentName;
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -172,6 +172,7 @@ void ConvertCWPDMDToSpectra::exec() {
   }
 
   // Rebin
+  std::sort(excluded_detids.begin(), excluded_detids.end());
   API::MatrixWorkspace_sptr outws = reducePowderData(
       inputDataWS, inputMonitorWS, outputunit, map_runWavelength, xmin, xmax,
       binsize, doLinearInterpolation, excluded_detids);
@@ -479,8 +480,11 @@ void ConvertCWPDMDToSpectra::binMD(API::IMDEventWorkspace_const_sptr mdws,
     for (size_t iev = 0; iev < numev2; ++iev) {
       // get detector position for 2theta
       detid_t detid = mditer->getInnerDetectorID(iev);
-      if (isExcluded(vec_excludedet, detid))
+      if (isExcluded(vec_excludedet, detid)) {
+        g_log.debug() << "Detector " << detid << " is excluded.  Signal = "
+                      << mditer->getInnerSignal(iev) << "\n";
         continue;
+      }
 
       double tempx = mditer->getInnerPosition(iev, 0);
       double tempy = mditer->getInnerPosition(iev, 1);
@@ -744,10 +748,19 @@ ConvertCWPDMDToSpectra::scaleMatrixWorkspace(API::MatrixWorkspace_sptr matrixws,
   return;
 }
 
+//----------------------------------------------------------------------------------------------
+/** Check whether a detector is excluded
+ * @brief ConvertCWPDMDToSpectra::isExcluded
+ * @param vec_excludedet :: a sorted vector
+ * @param detid
+ * @return
+ */
 bool
 ConvertCWPDMDToSpectra::isExcluded(const std::vector<detid_t> &vec_excludedet,
                                    const detid_t detid) {
-  return true;
+
+  return std::find(vec_excludedet.begin(), vec_excludedet.end(), detid) !=
+         vec_excludedet.end();
 }
 
 } // namespace MDAlgorithms

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -73,6 +73,10 @@ void ConvertCWPDMDToSpectra::init() {
   declareProperty("ScaleFactor", 1.0,
                   "Scaling factor on the normalized counts.");
 
+  declareProperty(new ArrayProperty<int>("ExcludedDetectorIDs"),
+                  "A comma separated list of integers to indicate the IDs of "
+                  "the detectors that will be excluded from binning.")
+
   declareProperty("LinearInterpolateZeroCounts", true,
                   "If set to true and if a bin has zero count, a linear "
                   "interpolation will be made to set the value of this bin. It "

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertCWPDMDToSpectra.cpp
@@ -75,7 +75,7 @@ void ConvertCWPDMDToSpectra::init() {
 
   declareProperty(new ArrayProperty<int>("ExcludedDetectorIDs"),
                   "A comma separated list of integers to indicate the IDs of "
-                  "the detectors that will be excluded from binning.")
+                  "the detectors that will be excluded from binning.");
 
   declareProperty("LinearInterpolateZeroCounts", true,
                   "If set to true and if a bin has zero count, a linear "

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
@@ -90,6 +90,11 @@ void ConvertSpiceDataToRealSpace::init() {
   declareProperty(new WorkspaceProperty<IMDEventWorkspace>(
                       "OutputMonitorWorkspace", "", Direction::Output),
                   "Name to use for the output workspace.");
+
+  declareProperty(
+      new WorkspaceProperty<TableWorkspace>("DetectorEfficiencyTableWorkspace",
+                                            "", Direction::Input, Optional),
+      "Name of a table workspace containing the detectors' efficiency.")
 }
 
 //------------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
@@ -13,6 +13,7 @@
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidDataObjects/MDEvent.h"
+#include "MantidDataObjects/TableWorkspace.h"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <Poco/TemporaryFile.h>
@@ -93,8 +94,9 @@ void ConvertSpiceDataToRealSpace::init() {
 
   declareProperty(
       new WorkspaceProperty<TableWorkspace>("DetectorEfficiencyTableWorkspace",
-                                            "", Direction::Input, Optional),
-      "Name of a table workspace containing the detectors' efficiency.")
+                                            "", Direction::Input,
+                                            PropertyMode::Optional),
+      "Name of a table workspace containing the detectors' efficiency.");
 }
 
 //------------------------------------------------------------------------------------------------
@@ -105,6 +107,13 @@ void ConvertSpiceDataToRealSpace::exec() {
   DataObjects::TableWorkspace_sptr dataTableWS = getProperty("InputWorkspace");
   MatrixWorkspace_const_sptr parentWS = getProperty("RunInfoWorkspace");
   m_instrumentName = getPropertyValue("Instrument");
+
+  DataObjects::TableWorkspace_sptr detEffTableWS =
+      getProperty("DetectorEfficiencyTableWorkspace");
+  std::map<detid_t, double> detEffMap; // map for detector efficiency
+  if (detEffTableWS) {
+    parseDetectorEfficiencyTable(detEffTableWS, detEffMap);
+  }
 
   // Check whether parent workspace has run start: order (1) parent ws, (2) user
   // given (3) nothing
@@ -161,6 +170,12 @@ void ConvertSpiceDataToRealSpace::exec() {
 
   std::vector<MatrixWorkspace_sptr> vec_ws2d = convertToMatrixWorkspace(
       dataTableWS, parentWS, runstart, logvecmap, vectimes);
+
+  // Apply detector e(fficiency
+  if (detEffMap.size() > 0) {
+    correctByDetectorEfficiency(vec_ws2d,
+                                detEffMap); // std::vector<MatrixWorkspace_sptr>
+  }
 
   // check range for x/y/z
   m_numBins.resize(3);
@@ -721,5 +736,59 @@ IMDEventWorkspace_sptr ConvertSpiceDataToRealSpace::createMonitorMDWorkspace(
 
   return outWs;
 }
+
+//------------------------------------------------------------------------------------------------
+/** Parse detector efficiency from table workspace to map
+ * @brief ConvertSpiceDataToRealSpace::parseDetectorEfficiencyTable
+ * @param detefftablews
+ */
+void ConvertSpiceDataToRealSpace::parseDetectorEfficiencyTable(
+    DataObjects::TableWorkspace_sptr detefftablews,
+    std::map<detid_t, double> &deteffmap) {
+  // clear map
+  deteffmap.clear();
+
+  // check table workspace
+  size_t numcols = detefftablews->columnCount();
+  if (numcols != 2)
+    throw std::runtime_error(
+        "Input tableworkspace must have 2 and only 2 columns.");
+
+  // parse the detector
+  size_t numrows = detefftablews->rowCount();
+  for (size_t i = 0; i < numrows; ++i) {
+    detid_t detid = detefftablews->cell<detid_t>(i, 0);
+    double deteff = detefftablews->cell<double>(i, 1);
+    deteffmap.insert(std::make_pair(detid, deteff));
+  }
+
+  return;
+}
+
+//------------------------------------------------------------------------------------------------
+/** Apply the detector's efficiency correction to
+ * @brief ConvertSpiceDataToRealSpace::correctByDetectorEfficiency
+ * @param vec_ws2d
+ * @param detEffMap
+ */
+void ConvertSpiceDataToRealSpace::correctByDetectorEfficiency(
+    std::vector<MatrixWorkspace_sptr> vec_ws2d,
+    const std::map<detid_t, double> &detEffMap) {
+  std::vector<MatrixWorkspace_sptr>::iterator it;
+  std::map<detid_t, double>::const_iterator detiter;
+  for (it = vec_ws2d.begin(); it != vec_ws2d.end(); ++it) {
+    MatrixWorkspace_sptr ws = *it;
+    size_t numspec = ws->getNumberHistograms();
+    for (size_t iws = 0; iws < numspec; ++iws) {
+      detid_t detid = ws->getDetector(iws)->getID();
+      detiter = detEffMap.find(detid);
+      if (detiter != detEffMap.end())
+        ws->dataY(iws)[0] /= detiter->second;
+    }
+  }
+
+  return;
+}
+
 } // namespace DataHandling
 } // namespace Mantid

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertSpiceDataToRealSpace.cpp
@@ -172,7 +172,7 @@ void ConvertSpiceDataToRealSpace::exec() {
       dataTableWS, parentWS, runstart, logvecmap, vectimes);
 
   // Apply detector e(fficiency
-  if (detEffMap.size() > 0) {
+  if (!detEffMap.empty()){
     correctByDetectorEfficiency(vec_ws2d,
                                 detEffMap); // std::vector<MatrixWorkspace_sptr>
   }

--- a/Code/Mantid/Framework/MDAlgorithms/test/ConvertSpiceDataToRealSpaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/ConvertSpiceDataToRealSpaceTest.h
@@ -12,6 +12,8 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidAPI/TableRow.h"
 
 using Mantid::MDAlgorithms::ConvertSpiceDataToRealSpace;
 using Mantid::DataHandling::LoadInstrument;
@@ -140,6 +142,182 @@ public:
     TS_ASSERT_DELTA(y0, 125.0, 0.1);
     double yl = mditer->getInnerSignal(44 * 61 - 1);
     TS_ASSERT_DELTA(yl, 76.0, 0.1);
+
+    // Detector ID
+    Mantid::detid_t detid0 = mditer->getInnerDetectorID(0);
+    TS_ASSERT_EQUALS(detid0, 1);
+    Mantid::detid_t detid1 = mditer->getInnerDetectorID(1);
+    TS_ASSERT_EQUALS(detid1, 2);
+    Mantid::detid_t detid43 = mditer->getInnerDetectorID(43);
+    TS_ASSERT_EQUALS(detid43, 44);
+    Mantid::detid_t detid44 = mditer->getInnerDetectorID(44);
+    TS_ASSERT_EQUALS(detid44, 1);
+    Mantid::detid_t detid61 = mditer->getInnerDetectorID(61);
+    TS_ASSERT_EQUALS(detid61, 18);
+
+    // Run index
+    uint16_t run0 = mditer->getInnerRunIndex(0);
+    TS_ASSERT_EQUALS(run0, 1);
+    uint16_t run1 = mditer->getInnerRunIndex(44);
+    TS_ASSERT_EQUALS(run1, 2);
+    uint16_t runLast = mditer->getInnerRunIndex(44 * 61 - 1);
+    TS_ASSERT_EQUALS(runLast, 61);
+
+    // Verify the ldetector's position as 2theta angle
+    Mantid::coord_t x0 = mditer->getInnerPosition(0, 0);
+    Mantid::coord_t z0 = mditer->getInnerPosition(0, 2);
+    double twotheta0 = atan(x0 / z0) * 180. / M_PI;
+    TS_ASSERT_DELTA(twotheta0, 6.0, 0.0001);
+
+    // Pt.=2
+    Mantid::coord_t x1_0 = mditer->getInnerPosition(44, 0);
+    Mantid::coord_t z1_0 = mditer->getInnerPosition(44, 2);
+    double twotheta1_0 = atan(x1_0 / z1_0) * 180. / M_PI;
+    TS_ASSERT_DELTA(twotheta1_0, 6.1, 0.0001);
+    Mantid::coord_t x1_1 = mditer->getInnerPosition(45, 0);
+    Mantid::coord_t z1_1 = mditer->getInnerPosition(45, 2);
+    double twotheta1_1 = atan(x1_1 / z1_1) * 180. / M_PI;
+    TS_ASSERT_DELTA(twotheta1_1, 6.1 + 2.642, 0.0001);
+
+    // Pt.=61
+    Mantid::coord_t x60_0 = mditer->getInnerPosition(44 * 60, 0);
+    Mantid::coord_t z60_0 = mditer->getInnerPosition(44 * 60, 2);
+    double twotheta60_0 = atan(x60_0 / z60_0) * 180. / M_PI;
+    TS_ASSERT_DELTA(twotheta60_0, 12.0, 0.0001);
+
+    Mantid::coord_t lastx = mditer->getInnerPosition(44 * 61 - 1, 0);
+    Mantid::coord_t lasty = mditer->getInnerPosition(44 * 61 - 1, 1);
+    Mantid::coord_t lastz = mditer->getInnerPosition(44 * 61 - 1, 2);
+    TS_ASSERT_DELTA(lastx, 1.57956, 0.0001);
+    TS_ASSERT_DELTA(lasty, 0.00, 0.0001);
+    double last2theta = atan(lastx / lastz) * 180 / M_PI;
+    TS_ASSERT_DELTA(last2theta + 180.0, 12.0 + 115.835, 0.001);
+
+    // Experiment information
+    uint16_t numexpinfo = mdws->getNumExperimentInfo();
+    TS_ASSERT_EQUALS(numexpinfo, 61 + 1);
+
+    // Check run number
+    ExperimentInfo_const_sptr expinfo0 = mdws->getExperimentInfo(0);
+    TS_ASSERT(expinfo0);
+    TS_ASSERT_EQUALS(expinfo0->getRunNumber(), 1);
+
+    ExperimentInfo_const_sptr expinfo61 = mdws->getExperimentInfo(61);
+    TS_ASSERT(expinfo61);
+    TS_ASSERT_EQUALS(expinfo61->getRunNumber(), -1);
+
+    // Check log and comparing with run_start
+    Mantid::Kernel::Property *tempa = expinfo61->run().getProperty("temp_a");
+    TS_ASSERT(tempa);
+    Mantid::Kernel::TimeSeriesProperty<double> *timeseriestempa =
+        dynamic_cast<Mantid::Kernel::TimeSeriesProperty<double> *>(tempa);
+    TS_ASSERT(timeseriestempa);
+
+    std::vector<DateAndTime> times = timeseriestempa->timesAsVector();
+    TS_ASSERT_EQUALS(times.size(), 61);
+    DateAndTime time0 = times[0];
+    TS_ASSERT_EQUALS(time0.toFormattedString(), "2012-Aug-13 11:57:33");
+    DateAndTime time1 = times[1];
+    TS_ASSERT_EQUALS(time1.toFormattedString(), "2012-Aug-13 11:58:03");
+
+    // Examine Monitor MDWorkspace
+    IMDWorkspace_const_sptr monmdws = boost::dynamic_pointer_cast<IMDWorkspace>(
+        AnalysisDataService::Instance().retrieve("MonitorMDW"));
+
+    // Check the IMDEvent workspace generated
+    numevents = monmdws->getNEvents();
+    TS_ASSERT_EQUALS(numevents, 44 * 61);
+
+    mditer = monmdws->createIterator();
+    TS_ASSERT_EQUALS(mditer->getNumEvents(), 44 * 61);
+
+    y0 = mditer->getInnerSignal(0);
+    TS_ASSERT_DELTA(y0, 31964.000, 0.1);
+    yl = mditer->getInnerSignal(44 * 61 - 1);
+    TS_ASSERT_DELTA(yl, 31968.0, 0.1);
+
+    // Remove workspaces
+    AnalysisDataService::Instance().remove("DataTable");
+    AnalysisDataService::Instance().remove("LogParentWS");
+    AnalysisDataService::Instance().remove("HB2A_MD");
+    AnalysisDataService::Instance().remove("MonitorMDW");
+  }
+
+  //-----------------------------------------------------------------------------------------------------
+  /** Test load HB2A data corrected by detector efficiency
+   * @brief test_applyDetEfficiency
+   */
+  void test_applyDetEfficiency() {
+    LoadSpiceAscii spcloader;
+    spcloader.initialize();
+
+    // Load HB2A spice file
+    TS_ASSERT_THROWS_NOTHING(
+        spcloader.setProperty("Filename", "HB2A_exp0231_scan0001.dat"));
+    TS_ASSERT_THROWS_NOTHING(
+        spcloader.setProperty("OutputWorkspace", "DataTable"));
+    TS_ASSERT_THROWS_NOTHING(
+        spcloader.setProperty("RunInfoWorkspace", "LogParentWS"));
+    TS_ASSERT_THROWS_NOTHING(spcloader.setPropertyValue(
+        "DateAndTimeLog", "date,MM/DD/YYYY,time,HH:MM:SS AM"));
+    TS_ASSERT_THROWS_NOTHING(
+        spcloader.setProperty("IgnoreUnlistedLogs", false));
+    spcloader.execute();
+
+    // Retrieve the workspaces as the inputs of ConvertSpiceDataToRealSpace
+    ITableWorkspace_sptr datatablews =
+        boost::dynamic_pointer_cast<ITableWorkspace>(
+            AnalysisDataService::Instance().retrieve("DataTable"));
+    TS_ASSERT(datatablews);
+
+    MatrixWorkspace_sptr parentlogws =
+        boost::dynamic_pointer_cast<MatrixWorkspace>(
+            AnalysisDataService::Instance().retrieve("LogParentWS"));
+    TS_ASSERT(parentlogws);
+
+    // Create a table workspace
+    TableWorkspace_sptr deteffws = boost::make_shared<TableWorkspace>();
+    deteffws->addColumn("int", "DetectorID");
+    deteffws->addColumn("double", "Efficiency");
+    for (int i = 1; i <= 44; ++i) {
+      TableRow newrow = deteffws->appendRow();
+      newrow << i << (1 + (static_cast<double>(i) - 22) * 0.01);
+    }
+    TS_ASSERT_EQUALS(deteffws->rowCount(), 44);
+
+    // Set up ConvertSpiceDataToRealSpace
+    ConvertSpiceDataToRealSpace loader;
+    loader.initialize();
+
+    loader.setProperty("InputWorkspace", datatablews);
+    loader.setProperty("RunInfoWorkspace", parentlogws);
+    loader.setProperty("DetectorEfficiencyTableWorkspace", deteffws);
+    loader.setProperty("Instrument", "HB2A");
+    loader.setPropertyValue("OutputWorkspace", "HB2A_MD");
+    loader.setPropertyValue("OutputMonitorWorkspace", "MonitorMDW");
+
+    loader.execute();
+    TS_ASSERT(loader.isExecuted());
+
+    // Get IMDEventWorkspace
+    IMDEventWorkspace_sptr mdws =
+        boost::dynamic_pointer_cast<IMDEventWorkspace>(
+            AnalysisDataService::Instance().retrieve("HB2A_MD"));
+    TS_ASSERT(mdws);
+
+    // Check the IMDEvent workspace generated
+    size_t numevents = mdws->getNEvents();
+    TS_ASSERT_EQUALS(numevents, 44 * 61);
+
+    IMDIterator *mditer = mdws->createIterator();
+    TS_ASSERT_EQUALS(mditer->getNumEvents(), 44 * 61);
+
+    double y0 = mditer->getInnerSignal(0);
+    double eff0 = 1 + (1. - 22.) * 0.01;
+    TS_ASSERT_DELTA(y0, 125.0 / eff0, 0.1);
+    double yl = mditer->getInnerSignal(44 * 61 - 1);
+    double eff44 = 1 + (44. - 22.) * 0.01;
+    TS_ASSERT_DELTA(yl, 76.0 / eff44, 0.1);
 
     // Detector ID
     Mantid::detid_t detid0 = mditer->getInnerDetectorID(0);

--- a/Code/Mantid/docs/source/algorithms/ConvertCWPDMDToSpectra-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ConvertCWPDMDToSpectra-v1.rst
@@ -129,6 +129,14 @@ Property *LinearInterpolateZeroCounts* is used to set the flag to do linear inte
 The linear interpolation will be only applied to those zero-count bins within
 the measuring range. 
 
+Excluding detectors
+###################
+
+Detectors can be excluded from conversion process.  
+They can be specified by their *Detector ID*s via property *ExcludedDetectorIDs*.  
+If a detector is specified as being excluded, 
+all of its counts of all runs (pts) will be taken out of binning process. 
+
 
 Workflow
 --------

--- a/Code/Mantid/docs/source/algorithms/ConvertSpiceDataToRealSpace-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ConvertSpiceDataToRealSpace-v1.rst
@@ -16,6 +16,9 @@ HB2A will be supported in future.
 Inputs
 ######
 
+Required workspaces
++++++++++++++++++++
+
 There are two input Workspaces that are required for this algoriths.  
 Both of them stores the data from a SPICE file. 
 
@@ -27,6 +30,15 @@ that are created during the algorithm's execution.
 
 These two workspaces can be obtained by executing algorithm LoasSpiceAscii. 
 
+Optional workspaces
++++++++++++++++++++
+
+An optional TableWorkspace is for applying detectors' efficiency factor 
+to the raw detectors' counts. 
+It is required to a 2-column TableWorkspace.  Column 0 is of integer type for 
+detector IDs, while 
+Column 1 is of double type for detector efficiency factor (:math:`f`).  
+The corrected counts is equal to :math:`counts^{raw}/f`. 
 
 Outputs
 #######


### PR DESCRIPTION
This is original trac ticket [11495](http://trac.mantidproject.org/mantid/ticket/11495).  There are two issues to solve.  One is to allow counts to be corrected by detector efficiency.  The other is to exclude specified detectors from binning. 
