### PR TITLE
Fix period numbering in monitor workspace logs for LoadRaw3

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadRaw3.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRaw3.cpp
@@ -204,6 +204,7 @@ void LoadRaw3::exec() {
 
   // Loop over the number of periods in the raw file, putting each period in a
   // separate workspace
+  
   for (int period = 0; period < m_numberOfPeriods; ++period) {
     // skipping the first spectra in each period
     skipData(file, static_cast<int>(period * (m_numberOfSpectra + 1)));
@@ -218,6 +219,22 @@ void LoadRaw3::exec() {
       if (localWorkspace) {
         localWorkspace = createWorkspace(localWorkspace);
       }
+      if (bseparateMonitors) {
+        try {
+          monitorWorkspace = createWorkspace(monitorWorkspace, monitorwsSpecs,
+                                             m_lengthIn, m_lengthIn - 1);
+        } catch (std::out_of_range &) {
+          g_log.information() << "Separate Monitors option is selected and no "
+                                 "monitors in the selected specra range."
+                              << std::endl;
+          g_log.information()
+              << "Error in creating one of the output workspaces" << std::endl;
+        } catch (std::runtime_error &) {
+          g_log.information() << "Separate Monitors option is selected,Error "
+                                 "in creating one of the output workspaces"
+                              << std::endl;
+        }
+      } // end of separate Monitors
 
       if (bLoadlogFiles) {
         const int period_number = period + 1;
@@ -239,22 +256,6 @@ void LoadRaw3::exec() {
           createPeriodLogs(period_number, monitorWorkspace);
         }
       } // end of if loop for loadlogfiles
-      if (bseparateMonitors) {
-        try {
-          monitorWorkspace = createWorkspace(monitorWorkspace, monitorwsSpecs,
-                                             m_lengthIn, m_lengthIn - 1);
-        } catch (std::out_of_range &) {
-          g_log.information() << "Separate Monitors option is selected and no "
-                                 "monitors in the selected specra range."
-                              << std::endl;
-          g_log.information()
-              << "Error in creating one of the output workspaces" << std::endl;
-        } catch (std::runtime_error &) {
-          g_log.information() << "Separate Monitors option is selected,Error "
-                                 "in creating one of the output workspaces"
-                              << std::endl;
-        }
-      } // end of separate Monitors
     }
 
     if (bexcludeMonitors) {

--- a/Code/Mantid/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadRaw3Test.h
@@ -584,8 +584,13 @@ public:
     // But the data should be different
     TS_ASSERT_DIFFERS( monoutsptr1->dataY(1)[555], monoutsptr2->dataY(1)[555] )
 
-    TS_ASSERT_EQUALS( &(monoutsptr1->run()), &(monoutsptr2->run()) )
-
+    // Same number of logs
+    const auto & monPeriod1Run = monoutsptr1->run();
+    const auto & monPeriod2Run = monoutsptr2->run();
+    TS_ASSERT_EQUALS(monPeriod1Run.getLogData().size(), monPeriod2Run.getLogData().size() );
+    TS_ASSERT(monPeriod1Run.hasProperty("period 1"))
+    TS_ASSERT(monPeriod2Run.hasProperty("period 2"))
+    
     Workspace_sptr wsSptr=AnalysisDataService::Instance().retrieve("multiperiod");
     WorkspaceGroup_sptr sptrWSGrp=boost::dynamic_pointer_cast<WorkspaceGroup>(wsSptr);
 


### PR DESCRIPTION
Fixes trac issue [#11493](http://trac.mantidproject.org/mantid/ticket/11493)

**Tester**
The ticket contains instructions for trying to reproduce the problem. Ensure you can see the problem before merging the ticket and then understand that the fix is correct and that the period logs on the monitor workspace now have to correct numbering
