### PR TITLE
Remove MDAlgorithm dependencies from DataObjectsTest

### DIFF
--- a/Code/Mantid/Framework/Algorithms/test/CheckWorkspacesMatchTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/CheckWorkspacesMatchTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAlgorithms/CheckWorkspacesMatch.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -33,6 +34,7 @@ public:
 
   CheckWorkspacesMatchTest() : ws1(WorkspaceCreationHelper::Create2DWorkspace123(2,2))
   {
+    FrameworkManager::Instance();
   }
   
   void testName()

--- a/Code/Mantid/Framework/DataObjects/test/MDEventInserterTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDEventInserterTest.h
@@ -50,12 +50,6 @@ public:
   static MDEventInserterTest *createSuite() { return new MDEventInserterTest(); }
   static void destroySuite( MDEventInserterTest *suite ) { delete suite; }
 
-  MDEventInserterTest()
-  {
-    FrameworkManager::Instance();
-  }
-
-
   void test_add_md_lean_events()
   {
     typedef MDEventWorkspace<MDLeanEvent<2>, 2> MDEW_LEAN_2D; 

--- a/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -19,7 +19,6 @@
 #include "MantidTestHelpers/NexusTestHelper.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/LogManager.h"
 
 #include <Poco/File.h>
@@ -37,12 +36,6 @@ public:
   // This means the constructor isn't called when running other tests
   static PeaksWorkspaceTest *createSuite() { return new PeaksWorkspaceTest(); }
   static void destroySuite( PeaksWorkspaceTest *suite ) { delete suite; }
-
-  PeaksWorkspaceTest()
-  {
-     FrameworkManager::Instance();
-     AlgorithmManager::Instance();
-  }
 
   /** Build a test PeaksWorkspace with one peak (others peaks can be added)
    *

--- a/Code/Mantid/Framework/TestHelpers/src/MDEventsTestHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/MDEventsTestHelper.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
+#include "MantidDataObjects/FakeMD.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
 
@@ -131,16 +132,15 @@ createDiffractionEventWorkspace(int numEvents, int numPixels, int numBins) {
 MDEventWorkspace3Lean::sptr makeFakeMDEventWorkspace(const std::string &wsName,
                                                      long numEvents, Kernel::SpecialCoordinateSystem coord) {
   // ---------- Make a file-backed MDEventWorkspace -----------------------
-  std::string snEvents = boost::lexical_cast<std::string>(numEvents);
   MDEventWorkspace3Lean::sptr ws1 =
       MDEventsTestHelper::makeMDEW<3>(10, 0.0, 10.0, 0);
   ws1->setCoordinateSystem(coord);
   ws1->getBoxController()->setSplitThreshold(100);
   API::AnalysisDataService::Instance().addOrReplace(
       wsName, boost::dynamic_pointer_cast<Mantid::API::IMDEventWorkspace>(ws1));
-  FrameworkManager::Instance().exec("FakeMDEventData", 6, "InputWorkspace",
-                                    wsName.c_str(), "UniformParams",
-                                    snEvents.c_str(), "RandomizeSignal", "1");
+  FakeMD dataFaker(std::vector<double>(1, static_cast<double>(numEvents)),
+                   std::vector<double>(), 0, true);
+  dataFaker.fill(ws1);
   return boost::dynamic_pointer_cast<MDEventWorkspace3Lean>(
       API::AnalysisDataService::Instance().retrieve(wsName));
 }


### PR DESCRIPTION
Fixes trac issue [#11497](http://trac.mantidproject.org/mantid/ticket/11497)

This will also fix the Valgrind build that relies on being able to run everything up to `DataObjects` without other dependencies.

**Tester**
You should remove all `.so`/`.dylib`/`.dll` files from your bin, bin/Release or bin/Debug directory and then just build `DataObjectsTest`. The tests should then run without a problem.
