### PR TITLE
Use a higher precision for double spin boxes in indirect interfaces

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
@@ -170,6 +170,9 @@
           </item>
           <item row="5" column="1">
            <widget class="QDoubleSpinBox" name="spFlatElementSize">
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="singleStep">
              <double>0.010000000000000</double>
             </property>
@@ -183,6 +186,9 @@
             <property name="suffix">
              <string> cm</string>
             </property>
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
@@ -192,6 +198,9 @@
            <widget class="QDoubleSpinBox" name="spFlatSampleHeight">
             <property name="suffix">
              <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -210,6 +219,9 @@
             <property name="suffix">
              <string> cm</string>
             </property>
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
@@ -219,6 +231,9 @@
            <widget class="QDoubleSpinBox" name="spFlatSampleThickness">
             <property name="suffix">
              <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -244,6 +259,9 @@
             <property name="suffix">
              <string> cm</string>
             </property>
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
@@ -267,6 +285,9 @@
            <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius">
             <property name="suffix">
              <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -312,6 +333,9 @@
             <property name="suffix">
              <string> cm</string>
             </property>
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
@@ -321,6 +345,9 @@
            <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
             <property name="suffix">
              <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -338,6 +365,9 @@
            <widget class="QDoubleSpinBox" name="spAnnCanInnerRadius">
             <property name="suffix">
              <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -397,6 +427,9 @@
             <property name="suffix">
              <string> cm</string>
             </property>
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
@@ -406,6 +439,9 @@
            <widget class="QDoubleSpinBox" name="spCylCanRadius">
             <property name="suffix">
              <string> cm</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -429,6 +465,9 @@
        <widget class="QDoubleSpinBox" name="spSampleNumberDensity">
         <property name="suffix">
          <string> A^-3</string>
+        </property>
+        <property name="decimals">
+         <number>5</number>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>
@@ -474,13 +513,6 @@
       <string>Container Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="ckUseCanCorrections">
-        <property name="text">
-         <string>Use Container Corrections</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="2">
        <widget class="QLabel" name="lbCanChemicalFormula">
         <property name="text">
@@ -502,6 +534,9 @@
         </property>
         <property name="suffix">
          <string> A^-3</string>
+        </property>
+        <property name="decimals">
+         <number>5</number>
         </property>
         <property name="singleStep">
          <double>0.100000000000000</double>
@@ -529,6 +564,9 @@
         <property name="enabled">
          <bool>false</bool>
         </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
         <property name="singleStep">
          <double>0.100000000000000</double>
         </property>
@@ -538,6 +576,13 @@
        <widget class="QCheckBox" name="ckScaleCan">
         <property name="text">
          <string>Scale:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="ckUseCanCorrections">
+        <property name="text">
+         <string>Use Container Corrections</string>
         </property>
        </widget>
       </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyCorr.ui
@@ -172,8 +172,14 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
          </widget>
         </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.ui
@@ -124,6 +124,9 @@
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;FWHM to broaden peaks by.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
             <property name="maximum">
              <double>1000.000000000000000</double>
             </property>
@@ -139,6 +142,9 @@
            <widget class="QDoubleSpinBox" name="spBinWidth">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of bins to use for histogram rebinning (in eV or cm&lt;span style=&quot; vertical-align:super;&quot;&gt;-1&lt;/span&gt;).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>5</number>
             </property>
             <property name="maximum">
              <double>1000.000000000000000</double>
@@ -176,6 +182,9 @@
            <widget class="QDoubleSpinBox" name="spZeroThreshold">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Threshold intensity at below which to ignore frequencies.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
             </property>
             <property name="maximum">
              <double>1000.000000000000000</double>
@@ -421,6 +430,9 @@
                <widget class="QDoubleSpinBox" name="spTemperature">
                 <property name="suffix">
                  <string> K</string>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
                 </property>
                 <property name="maximum">
                  <double>1000.000000000000000</double>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISCalibration.ui
@@ -78,8 +78,14 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
           <property name="value">
            <double>1.000000000000000</double>
@@ -175,8 +181,14 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="decimals">
+             <number>5</number>
+            </property>
             <property name="maximum">
              <double>999.990000000000009</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
             </property>
             <property name="value">
              <double>1.000000000000000</double>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
@@ -242,6 +242,9 @@
         <property name="suffix">
          <string> K</string>
         </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
         <property name="maximum">
          <double>999.990000000000009</double>
         </property>
@@ -270,6 +273,9 @@
        <widget class="QDoubleSpinBox" name="spScaleMultiplier">
         <property name="enabled">
          <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>5</number>
         </property>
         <property name="maximum">
          <double>99.989999999999995</double>
@@ -481,11 +487,17 @@
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
+                <property name="decimals">
+                 <number>5</number>
+                </property>
                 <property name="minimum">
                  <double>-999.990000000000009</double>
                 </property>
                 <property name="maximum">
                  <double>999.990000000000009</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>
@@ -524,11 +536,17 @@
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
+                <property name="decimals">
+                 <number>5</number>
+                </property>
                 <property name="minimum">
                  <double>-999.990000000000009</double>
                 </property>
                 <property name="maximum">
                  <double>999.990000000000009</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>
@@ -567,11 +585,17 @@
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
+                <property name="decimals">
+                 <number>5</number>
+                </property>
                 <property name="minimum">
                  <double>-999.990000000000009</double>
                 </property>
                 <property name="maximum">
                  <double>999.990000000000009</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                </widget>
               </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMolDyn.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMolDyn.ui
@@ -117,8 +117,14 @@
           <property name="suffix">
            <string> meV</string>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>1000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
           <property name="value">
            <double>10.000000000000000</double>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.ui
@@ -66,8 +66,14 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>999.990000000000009</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
          </widget>
         </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
@@ -90,7 +90,7 @@
            </size>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
           <property name="minimum">
            <double>-1000.000000000000000</double>
@@ -156,7 +156,7 @@
            </size>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
           <property name="minimum">
            <double>-1000.000000000000000</double>
@@ -242,7 +242,7 @@
            </size>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
           <property name="minimum">
            <double>0.000000000000000</double>
@@ -287,7 +287,7 @@
            </sizepolicy>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
           <property name="minimum">
            <double>-1000.000000000000000</double>
@@ -309,7 +309,7 @@
            </sizepolicy>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
           <property name="minimum">
            <double>0.000000000000000</double>
@@ -331,7 +331,7 @@
            </sizepolicy>
           </property>
           <property name="decimals">
-           <number>4</number>
+           <number>5</number>
           </property>
           <property name="minimum">
            <double>-1000.000000000000000</double>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTransmissionCalc.ui
@@ -86,8 +86,14 @@
           <property name="suffix">
            <string> cm</string>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>1000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
           <property name="value">
            <double>0.100000000000000</double>
@@ -99,8 +105,14 @@
           <property name="suffix">
            <string> atoms/Å^3</string>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>10000.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>0.100000000000000</double>
           </property>
           <property name="value">
            <double>0.100000000000000</double>


### PR DESCRIPTION
Fixes [#11498](http://trac.mantidproject.org/mantid/ticket/11498).

To test:
- Code review
- Open some of the interfaces, see that you can enter a number to a higher precision than before
