### PR TITLE
LoadNXSPE fails to load some Mantid nxspe files

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 #include <boost/regex.hpp>
-#include <cmath>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 namespace Mantid {
 namespace DataHandling {
@@ -297,9 +297,7 @@ void LoadNXSPE::exec() {
     itdataend = itdata + numBins;
     iterrorend = iterror + numBins;
     outputWS->dataX(i) = energies;
-    if ((std::isnan(*itdata)) ||
-        ((*itdata) == std::numeric_limits<double>::infinity())  ||
-        ((*itdata) == -std::numeric_limits<double>::infinity()) ||
+    if ((!boost::math::isfinite(*itdata))||
         (*itdata <= -1e10)) // masked bin
     {
       outputWS->dataY(i) = std::vector<double>(numBins, 0);

--- a/Code/Mantid/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 #include <boost/regex.hpp>
+#include <cmath>
 
 namespace Mantid {
 namespace DataHandling {
@@ -245,28 +246,6 @@ void LoadNXSPE::exec() {
   outputWS->getAxis(0)->unit() = UnitFactory::Instance().create("DeltaE");
   outputWS->setYUnit("SpectraNumber");
 
-  std::vector<double>::iterator itdata = data.begin(), iterror = error.begin(),
-                                itdataend, iterrorend;
-  API::Progress prog = API::Progress(this, 0.0, 0.9, numSpectra);
-  for (std::size_t i = 0; i < numSpectra; ++i) {
-    itdataend = itdata + numBins;
-    iterrorend = iterror + numBins;
-    outputWS->dataX(i) = energies;
-    if (((*itdata) == std::numeric_limits<double>::quiet_NaN()) ||
-        (*itdata <= -1e10)) // masked bin
-    {
-      outputWS->dataY(i) = std::vector<double>(numBins, 0);
-      outputWS->dataE(i) = std::vector<double>(numBins, 0);
-      pmap.addBool(outputWS->getDetector(i).get(), "masked", true);
-    } else {
-      outputWS->dataY(i) = std::vector<double>(itdata, itdataend);
-      outputWS->dataE(i) = std::vector<double>(iterror, iterrorend);
-    }
-    itdata = (itdataend);
-    iterror = (iterrorend);
-    prog.report();
-  }
-
   // add logs
   outputWS->mutableRun().addLogData(
       new PropertyWithValue<double>("Ei", fixed_energy));
@@ -310,6 +289,31 @@ void LoadNXSPE::exec() {
     instrument->add(det);
     instrument->markAsDetector(det);
   }
+
+  std::vector<double>::iterator itdata = data.begin(), iterror = error.begin(),
+                                itdataend, iterrorend;
+  API::Progress prog = API::Progress(this, 0.0, 0.9, numSpectra);
+  for (std::size_t i = 0; i < numSpectra; ++i) {
+    itdataend = itdata + numBins;
+    iterrorend = iterror + numBins;
+    outputWS->dataX(i) = energies;
+    if ((std::isnan(*itdata)) ||
+        ((*itdata) == std::numeric_limits<double>::infinity())  ||
+        ((*itdata) == -std::numeric_limits<double>::infinity()) ||
+        (*itdata <= -1e10)) // masked bin
+    {
+      outputWS->dataY(i) = std::vector<double>(numBins, 0);
+      outputWS->dataE(i) = std::vector<double>(numBins, 0);
+      pmap.addBool(outputWS->getDetector(i).get(), "masked", true);
+    } else {
+      outputWS->dataY(i) = std::vector<double>(itdata, itdataend);
+      outputWS->dataE(i) = std::vector<double>(iterror, iterrorend);
+    }
+    itdata = (itdataend);
+    iterror = (iterrorend);
+    prog.report();
+  }
+
 
   setProperty("OutputWorkspace", outputWS);
 }


### PR DESCRIPTION
This is ticket [#11472](http://trac.mantidproject.org/mantid/ticket/11472). Testing file is attached to the trac ticket. Modified so it masks on NANs and +/-INFs. Check if the last 4 spectra are masked.
