### PR TITLE
Original Workspace Issues affecting PlotMD

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/CoordTransform.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/CoordTransform.h
@@ -7,6 +7,7 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/VMD.h"
+#include <boost/shared_ptr.hpp>
 
 namespace Mantid {
 namespace API {
@@ -56,6 +57,12 @@ protected:
   /// Output number of dimensions
   size_t outD;
 };
+
+// Helper typedef for a shared pointer of this type.
+typedef boost::shared_ptr<CoordTransform> CoordTransform_sptr;
+
+// Helper typdef for a const shared pointer of this type.
+typedef boost::shared_ptr<const CoordTransform> CoordTransform_const_sptr;
 
 } // namespace Mantid
 } // namespace API

--- a/Code/Mantid/Framework/API/inc/MantidAPI/MDGeometry.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MDGeometry.h
@@ -6,6 +6,7 @@
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include <Poco/NObserver.h>
+#include <boost/shared_ptr.hpp>
 
 namespace Mantid {
 namespace API {
@@ -85,10 +86,10 @@ public:
   size_t numOriginalWorkspaces() const;
   boost::shared_ptr<Workspace> getOriginalWorkspace(size_t index = 0) const;
   void setOriginalWorkspace(boost::shared_ptr<Workspace> ws, size_t index = 0);
-  Mantid::API::CoordTransform *getTransformFromOriginal(size_t index = 0) const;
+  Mantid::API::CoordTransform const *getTransformFromOriginal(size_t index = 0) const;
   void setTransformFromOriginal(Mantid::API::CoordTransform *transform,
                                 size_t index = 0);
-  Mantid::API::CoordTransform *getTransformToOriginal(size_t index = 0) const;
+  Mantid::API::CoordTransform const *getTransformToOriginal(size_t index = 0) const;
   void setTransformToOriginal(Mantid::API::CoordTransform *transform,
                               size_t index = 0);
 
@@ -120,6 +121,11 @@ public:
   /// plane
   const Kernel::DblMatrix &getWTransf() const { return m_Wtransf; }
 
+  /// Clear transforms
+  void clearTransforms();
+  /// Clear original workspaces
+  void clearOriginalWorkspaces();
+
 protected:
   /// Function called when observer objects recieves a notification
   void deleteNotificationReceived(
@@ -138,11 +144,11 @@ protected:
 
   /// Coordinate Transformation that goes from the original workspace to this
   /// workspace's coordinates.
-  std::vector<Mantid::API::CoordTransform *> m_transforms_FromOriginal;
+  std::vector<boost::shared_ptr<const Mantid::API::CoordTransform> > m_transforms_FromOriginal;
 
   /// Coordinate Transformation that goes from this workspace's coordinates to
   /// the original workspace coordinates.
-  std::vector<Mantid::API::CoordTransform *> m_transforms_ToOriginal;
+  std::vector<boost::shared_ptr<const Mantid::API::CoordTransform> > m_transforms_ToOriginal;
 
   /// Poco delete notification observer object
   Poco::NObserver<MDGeometry, Mantid::API::WorkspacePreDeleteNotification>

--- a/Code/Mantid/Framework/API/src/MDGeometry.cpp
+++ b/Code/Mantid/Framework/API/src/MDGeometry.cpp
@@ -41,21 +41,21 @@ MDGeometry::MDGeometry(const MDGeometry &other)
   this->initGeometry(dimensions);
 
   // Perform a deep copy of the coordinate transformations
-  std::vector<CoordTransform *>::const_iterator it;
+  std::vector<CoordTransform_const_sptr>::const_iterator it;
   for (it = other.m_transforms_FromOriginal.begin();
        it != other.m_transforms_FromOriginal.end(); ++it) {
     if (*it)
-      m_transforms_FromOriginal.push_back((*it)->clone());
+      m_transforms_FromOriginal.push_back(CoordTransform_const_sptr((*it)->clone()));
     else
-      m_transforms_FromOriginal.push_back(NULL);
+      m_transforms_FromOriginal.push_back(CoordTransform_const_sptr());
   }
 
   for (it = other.m_transforms_ToOriginal.begin();
        it != other.m_transforms_ToOriginal.end(); ++it) {
     if (*it)
-      m_transforms_ToOriginal.push_back((*it)->clone());
+      m_transforms_ToOriginal.push_back(CoordTransform_const_sptr((*it)->clone()));
     else
-      m_transforms_ToOriginal.push_back(NULL);
+      m_transforms_ToOriginal.push_back(CoordTransform_const_sptr());
   }
 
   // Copy the references to the original workspaces
@@ -65,14 +65,26 @@ MDGeometry::MDGeometry(const MDGeometry &other)
     this->setOriginalWorkspace(other.m_originalWorkspaces[i], i);
 }
 
+/**
+ * Clear all transforms to and from original workspaces.
+ */
+void MDGeometry::clearTransforms() {
+    m_transforms_ToOriginal.clear();
+    m_transforms_FromOriginal.clear();
+}
+
+/**
+ * Clear the original workspaces
+ */
+void MDGeometry::clearOriginalWorkspaces() {
+    m_originalWorkspaces.clear();
+}
+
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */
 MDGeometry::~MDGeometry() {
-  for (size_t i = 0; i < m_transforms_FromOriginal.size(); i++)
-    delete m_transforms_FromOriginal[i];
-  for (size_t i = 0; i < m_transforms_ToOriginal.size(); i++)
-    delete m_transforms_ToOriginal[i];
+
   if (m_observingDelete) {
     // Stop watching once object is deleted
     API::AnalysisDataService::Instance().notificationCenter.removeObserver(
@@ -400,12 +412,12 @@ void MDGeometry::deleteNotificationReceived(
  * @return CoordTransform pointer
  * @param index :: index into the array of original workspaces
  */
-Mantid::API::CoordTransform *
+Mantid::API::CoordTransform const *
 MDGeometry::getTransformFromOriginal(size_t index) const {
   if (index >= m_transforms_FromOriginal.size())
     throw std::runtime_error(
         "MDGeometry::getTransformFromOriginal(): invalid index.");
-  return m_transforms_FromOriginal[index];
+  return m_transforms_FromOriginal[index].get();
 }
 
 //---------------------------------------------------------------------------------------------------
@@ -422,11 +434,10 @@ MDGeometry::getTransformFromOriginal(size_t index) const {
 void
 MDGeometry::setTransformFromOriginal(Mantid::API::CoordTransform *transform,
                                      size_t index) {
-  if (index >= m_transforms_FromOriginal.size())
+  if (index >= m_transforms_FromOriginal.size()) {
     m_transforms_FromOriginal.resize(index + 1);
-  if (m_transforms_FromOriginal[index])
-    delete m_transforms_FromOriginal[index];
-  m_transforms_FromOriginal[index] = transform;
+  }
+  m_transforms_FromOriginal[index] = CoordTransform_const_sptr(transform);
 }
 
 //---------------------------------------------------------------------------------------------------
@@ -441,12 +452,12 @@ MDGeometry::setTransformFromOriginal(Mantid::API::CoordTransform *transform,
  * @return CoordTransform pointer
  * @param index :: index into the array of original workspaces
  */
-Mantid::API::CoordTransform *
+Mantid::API::CoordTransform const *
 MDGeometry::getTransformToOriginal(size_t index) const {
   if (index >= m_transforms_ToOriginal.size())
     throw std::runtime_error(
         "MDGeometry::getTransformFromOriginal(): invalid index.");
-  return m_transforms_ToOriginal[index];
+  return m_transforms_ToOriginal[index].get();
 }
 
 //---------------------------------------------------------------------------------------------------
@@ -463,11 +474,10 @@ MDGeometry::getTransformToOriginal(size_t index) const {
  */
 void MDGeometry::setTransformToOriginal(Mantid::API::CoordTransform *transform,
                                         size_t index) {
-  if (index >= m_transforms_ToOriginal.size())
+  if (index >= m_transforms_ToOriginal.size()) {
     m_transforms_ToOriginal.resize(index + 1);
-  if (m_transforms_ToOriginal[index])
-    delete m_transforms_ToOriginal[index];
-  m_transforms_ToOriginal[index] = transform;
+  }
+  m_transforms_ToOriginal[index] = CoordTransform_const_sptr(transform);
 }
 
 //---------------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/API/test/MDGeometryTest.h
+++ b/Code/Mantid/Framework/API/test/MDGeometryTest.h
@@ -54,6 +54,37 @@ public:
     TS_ASSERT_DELTA( binSizes[1], 0.1, 1e-6);
   }
 
+  void test_clear_transforms_to_original()
+  {
+      MDGeometry geometry;
+      geometry.setTransformToOriginal(new NullCoordTransform, 0);
+      geometry.setTransformToOriginal(new NullCoordTransform, 1);
+      TS_ASSERT_EQUALS(2, geometry.getNumberTransformsToOriginal());
+      TS_ASSERT_THROWS_NOTHING(geometry.clearTransforms());
+      TSM_ASSERT_EQUALS("Should have no transforms", 0, geometry.getNumberTransformsToOriginal());
+  }
+
+  void test_clear_transforms_from_original()
+  {
+      MDGeometry geometry;
+      geometry.setTransformFromOriginal(new NullCoordTransform, 0);
+      geometry.setTransformFromOriginal(new NullCoordTransform, 1);
+      TS_ASSERT_EQUALS(2, geometry.getNumberTransformsFromOriginal());
+      TS_ASSERT_THROWS_NOTHING(geometry.clearTransforms());
+      TSM_ASSERT_EQUALS("Should have no transforms", 0, geometry.getNumberTransformsFromOriginal());
+  }
+
+  void test_clear_original_workspaces()
+  {
+      MDGeometry geometry;
+      boost::shared_ptr<WorkspaceTester> ws0(new WorkspaceTester());
+      boost::shared_ptr<WorkspaceTester> ws1(new WorkspaceTester());
+      geometry.setOriginalWorkspace(ws0, 0);
+      geometry.setOriginalWorkspace(ws1, 1);
+      TS_ASSERT_EQUALS(2, geometry.numOriginalWorkspaces());
+      TS_ASSERT_THROWS_NOTHING(geometry.clearOriginalWorkspaces());
+      TS_ASSERT_EQUALS(0, geometry.numOriginalWorkspaces());
+  }
 
   void test_copy_constructor()
   {

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDBoxFlatTree.h
@@ -144,7 +144,7 @@ public:
   static void saveAffineTransformMatricies(::NeXus::File *const file,
                                            API::IMDWorkspace_const_sptr ws);
   static void saveAffineTransformMatrix(::NeXus::File *const file,
-                                        API::CoordTransform *transform,
+                                        API::CoordTransform const *transform,
                                         std::string entry_name);
 
   static void saveWSGenericInfo(::NeXus::File *const file,

--- a/Code/Mantid/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -798,7 +798,7 @@ MDBoxFlatTree::saveAffineTransformMatricies(::NeXus::File *const file,
  * @param entry_name : the tag in the NeXus file to save under
  */
 void MDBoxFlatTree::saveAffineTransformMatrix(::NeXus::File *const file,
-                                              API::CoordTransform *transform,
+                                              API::CoordTransform const *transform,
                                               std::string entry_name) {
   Kernel::Matrix<coord_t> matrix = transform->makeAffineMatrix();
   g_log.debug() << "TRFM: " << matrix.str() << std::endl;

--- a/Code/Mantid/Framework/MDAlgorithms/src/BinMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/BinMD.cpp
@@ -408,6 +408,17 @@ void BinMD::exec() {
     IterateEvents = true;
   }
 
+  /*
+  We should fail noisily here. CALL_MDEVENT_FUNCTION will silently allow IMDHistoWorkspaces to cascade through to the end
+  and result in an empty output. The only way we allow InputWorkspaces to be IMDHistoWorkspaces is if they also happen to contain original workspaces
+  that are MDEventWorkspaces.
+  */
+  if(boost::dynamic_pointer_cast<IMDHistoWorkspace>(m_inWS))
+  {
+      throw std::runtime_error("Cannot rebin a workspace that is histogrammed and has no original workspace that is an MDEventWorkspace. "
+                               "Reprocess the input so that it contains full MDEvents.");
+  }
+
   CALL_MDEVENT_FUNCTION(this->binByIterating, m_inWS);
 
   // Copy the

--- a/Code/Mantid/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -197,11 +197,11 @@ void ConvertMDHistoToMatrixWorkspace::make1DWorkspace() {
   const size_t numberTransformsToOriginal =
       inputWorkspace->getNumberTransformsToOriginal();
 
-  boost::shared_ptr<CoordTransform> transform =
+  CoordTransform_const_sptr transform =
       boost::make_shared<NullCoordTransform>(inputWorkspace->getNumDims());
   if (numberTransformsToOriginal > 0) {
     const size_t indexToLastTransform = numberTransformsToOriginal - 1;
-    transform = boost::shared_ptr<CoordTransform>(
+    transform = CoordTransform_const_sptr(
         inputWorkspace->getTransformToOriginal(indexToLastTransform),
         NullDeleter());
   }

--- a/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
@@ -438,6 +438,9 @@ void CutMD::exec() {
   }
 
   auto geometry = boost::dynamic_pointer_cast<Mantid::API::MDGeometry>(sliceWS);
+
+  /* Original workspace and transformation information does not make sense for self-contained Horace-style
+   * cuts, so clear it out. */
   geometry->clearTransforms();
   geometry->clearOriginalWorkspaces();
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
@@ -437,7 +437,10 @@ void CutMD::exec() {
                                    true);
   }
 
-  // Done!
+  auto geometry = boost::dynamic_pointer_cast<Mantid::API::MDGeometry>(sliceWS);
+  geometry->clearTransforms();
+  geometry->clearOriginalWorkspaces();
+
   setProperty("OutputWorkspace", sliceWS);
 }
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/QueryMDWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/QueryMDWorkspace.cpp
@@ -241,7 +241,7 @@ void QueryMDWorkspace::exec() {
     const size_t numberOriginal = input->getNumberTransformsToOriginal();
     if (transformCoordsToOriginal && numberOriginal > 0) {
       const size_t index = numberOriginal - 1;
-      CoordTransform *transform = input->getTransformToOriginal(index);
+      CoordTransform const *transform = input->getTransformToOriginal(index);
       VMD temp = transform->applyVMD(center);
       center = temp;
     }

--- a/Code/Mantid/Framework/MDAlgorithms/src/QueryMDWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/QueryMDWorkspace.cpp
@@ -103,6 +103,8 @@ void QueryMDWorkspace::init() {
                   "  volume: Normalise by the volume.\n"
                   "  number of events: Normalise by the number of events.");
 
+  declareProperty("TransformCoordsToOriginal", true, "Output box coordinates in terms of original workspace coordinates");
+
   declareProperty(
       new WorkspaceProperty<ITableWorkspace>(
           "BoxDataTable", "", Direction::Output,
@@ -191,6 +193,9 @@ void QueryMDWorkspace::exec() {
   MDNormalization requestedNormalisation = whichNormalisation(strNormalisation);
 
   IMDWorkspace_sptr input = getProperty("InputWorkspace");
+
+  const bool transformCoordsToOriginal = getProperty("TransformCoordsToOriginal");
+
   // Define a table workspace with a specific column schema.
   ITableWorkspace_sptr output = WorkspaceFactory::Instance().createTable();
   const std::string signalColumnName = "Signal/" + strNormalisation;
@@ -234,7 +239,7 @@ void QueryMDWorkspace::exec() {
     output->cell<int>(rowCounter, cellIndex++) = int(it->getNumEvents());
     VMD center = it->getCenter();
     const size_t numberOriginal = input->getNumberTransformsToOriginal();
-    if (numberOriginal > 0) {
+    if (transformCoordsToOriginal && numberOriginal > 0) {
       const size_t index = numberOriginal - 1;
       CoordTransform *transform = input->getTransformToOriginal(index);
       VMD temp = transform->applyVMD(center);

--- a/Code/Mantid/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -219,7 +219,7 @@ void SlicingAlgorithm::makeBasisVectorFromString(const std::string &str) {
     VMD basis0(this->m_inWS->getNumDims());
     VMD basis1 = basis;
     // Convert the points to the original coordinates (from inWS to originalWS)
-    CoordTransform *toOrig = m_inWS->getTransformToOriginal();
+    CoordTransform const *toOrig = m_inWS->getTransformToOriginal();
     VMD origBasis0 = toOrig->applyVMD(basis0);
     VMD origBasis1 = toOrig->applyVMD(basis1);
     // New basis vector, now in the original workspace
@@ -378,7 +378,7 @@ void SlicingAlgorithm::createGeneralTransform() {
   // Now, convert the original vector to the coordinates of the ORIGNAL ws, if
   // any
   if (m_originalWS) {
-    CoordTransform *toOrig = m_inWS->getTransformToOriginal();
+    CoordTransform const*toOrig = m_inWS->getTransformToOriginal();
     m_translation = toOrig->applyVMD(m_translation);
   }
 
@@ -686,7 +686,7 @@ void SlicingAlgorithm::createTransform() {
   if (m_originalWS) {
     // The intermediate workspace is the MDHistoWorkspace being BINNED
     m_intermediateWS = m_inWS;
-    CoordTransform *originalToIntermediate =
+    CoordTransform const *originalToIntermediate =
         m_intermediateWS->getTransformFromOriginal();
     if (originalToIntermediate &&
         (m_originalWS->getNumDims() == m_intermediateWS->getNumDims())) {

--- a/Code/Mantid/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/BinMDTest.h
@@ -174,7 +174,7 @@ public:
     TS_ASSERT_EQUALS( out->getBasisVector(0), expectBasisX);
     if (out->getNumDims() > 1) { TS_ASSERT_EQUALS( out->getBasisVector(1), expectBasisY); }
     if (out->getNumDims() > 2) { TS_ASSERT_EQUALS( out->getBasisVector(2), expectBasisZ); }
-    const CoordTransform * ctFrom = out->getTransformFromOriginal();
+    CoordTransform const * ctFrom = out->getTransformFromOriginal();
     TS_ASSERT(ctFrom);
     // Experiment Infos were copied
     TS_ASSERT_EQUALS( out->getNumExperimentInfo(), in_ws->getNumExperimentInfo());
@@ -459,9 +459,9 @@ public:
     { TS_ASSERT_EQUALS( out->getBasisVector(1), baseY);
       TS_ASSERT_EQUALS( out->getBasisVector(2), baseZ); }
 
-    const CoordTransform * ctFrom = out->getTransformFromOriginal();
+    CoordTransform const * ctFrom = out->getTransformFromOriginal();
     TS_ASSERT(ctFrom);
-    const CoordTransform * ctTo = out->getTransformToOriginal();
+    CoordTransform const * ctTo = out->getTransformToOriginal();
     TS_ASSERT(ctTo);
     if (!ctTo) return;
 
@@ -594,8 +594,8 @@ public:
     TS_ASSERT_EQUALS( binned1->numOriginalWorkspaces(), 2);
     TS_ASSERT_EQUALS( binned1->getOriginalWorkspace(1)->name(), "binned0");
     // Transforms to/from the INTERMEDIATE workspace exist
-    CoordTransform * toIntermediate = binned1->getTransformToOriginal(1);
-    CoordTransform * fromIntermediate = binned1->getTransformFromOriginal(1);
+    CoordTransform const * toIntermediate = binned1->getTransformToOriginal(1);
+    CoordTransform const * fromIntermediate = binned1->getTransformFromOriginal(1);
     TS_ASSERT( toIntermediate);
     TS_ASSERT( fromIntermediate );
 
@@ -642,14 +642,14 @@ public:
     TS_ASSERT_EQUALS( binned1->numOriginalWorkspaces(), 2);
     TS_ASSERT_EQUALS( binned1->getOriginalWorkspace(1)->name(), "binned0");
     // Transforms to/from the INTERMEDIATE workspace exist
-    CoordTransform * toIntermediate = binned1->getTransformToOriginal(1);
-    CoordTransform * fromIntermediate = binned1->getTransformFromOriginal(1);
+    CoordTransform const * toIntermediate = binned1->getTransformToOriginal(1);
+    CoordTransform const * fromIntermediate = binned1->getTransformFromOriginal(1);
     TS_ASSERT( toIntermediate);
     TS_ASSERT( fromIntermediate );
 
     // Transforms to/from the REALLY ORIGINAL workspace exist
-    CoordTransform * toOriginal = binned1->getTransformToOriginal(0);
-    CoordTransform * fromOriginal = binned1->getTransformFromOriginal(0);
+    CoordTransform const * toOriginal = binned1->getTransformToOriginal(0);
+    CoordTransform const * fromOriginal = binned1->getTransformFromOriginal(0);
     TS_ASSERT( toOriginal);
     TS_ASSERT( fromOriginal );
 
@@ -720,14 +720,14 @@ public:
     TS_ASSERT_EQUALS( binned1->numOriginalWorkspaces(), 2);
     TS_ASSERT_EQUALS( binned1->getOriginalWorkspace(1)->name(), "binned0");
     // Transforms to/from the INTERMEDIATE workspace exist
-    CoordTransform * toIntermediate = binned1->getTransformToOriginal(1);
-    CoordTransform * fromIntermediate = binned1->getTransformFromOriginal(1);
+    CoordTransform const * toIntermediate = binned1->getTransformToOriginal(1);
+    CoordTransform const * fromIntermediate = binned1->getTransformFromOriginal(1);
     TS_ASSERT( toIntermediate);
     TS_ASSERT( fromIntermediate );
 
     // Transforms to/from the REALLY ORIGINAL workspace exist
-    CoordTransform * toOriginal = binned1->getTransformToOriginal(0);
-    CoordTransform * fromOriginal = binned1->getTransformFromOriginal(0);
+    CoordTransform const * toOriginal = binned1->getTransformToOriginal(0);
+    CoordTransform const * fromOriginal = binned1->getTransformFromOriginal(0);
     TS_ASSERT( toOriginal);
     TS_ASSERT( fromOriginal );
 
@@ -944,12 +944,12 @@ public:
 
     VMD out;
     // Check the mapping of coordinates from C to B
-    CoordTransform * transf_C_to_B = C->getTransformToOriginal(1);
+    CoordTransform const * transf_C_to_B = C->getTransformToOriginal(1);
     out = transf_C_to_B->applyVMD(VMD(-1.5, -1.5));
     TS_ASSERT_EQUALS( out, VMD(-4, -4) );
 
     // And this is the mapping to the A workspace
-    CoordTransform * transf_C_to_A = C->getTransformToOriginal(0);
+    CoordTransform const * transf_C_to_A = C->getTransformToOriginal(0);
     out = transf_C_to_A->applyVMD(VMD(-1.5, -1.5));
     TS_ASSERT_EQUALS( out, VMD(-10, -10) );
   }
@@ -988,6 +988,23 @@ public:
         "OutputBins", "10,10");
     TSM_ASSERT( "Algorithm threw an error, as expected", !alg->isExecuted())
   }
+
+  void test_throws_if_InputWorkspace_pure_IMDHistWorkspace()
+  {
+      BinMD alg;
+      alg.setChild(true);
+      alg.setRethrows(true);
+      alg.initialize();
+      // Histoworkspace with no original workspace or transforms
+      IMDHistoWorkspace_sptr inWS = MDEventsTestHelper::makeFakeMDHistoWorkspace(1 /*signal*/, 2 /*numDims*/, 10 /*numBins*/);
+
+      alg.setProperty("InputWorkspace", inWS); // Input workspace - Pure histogram
+      alg.setProperty("AlignedDim0", "x,0,10,10"); // Values not relevant to this test
+      alg.setProperty("AlignedDim1", "y,0,10,10"); // Values not relevant to this test
+      alg.setPropertyValue("OutputWorkspace", "dummy");
+      TSM_ASSERT_THROWS("Cannot allow BinMD on a pure MDHistoWorkspace. Should throw.", alg.execute(), std::runtime_error&);
+  }
+
 };
 
 
@@ -1054,7 +1071,7 @@ public:
     for (size_t i=0; i<1; i++)
       do_test("2.0,8.0, 1", true);
   }
-private: 
+
 
 };
 

--- a/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -348,7 +348,7 @@ void MantidQwtIMDWorkspaceData::setPreviewMode(bool preview)
   else
   {
     const size_t indexOfTransform = nTransformsToOriginal-1; // Get the last transform
-    CoordTransform * temp = m_workspace->getTransformToOriginal(indexOfTransform);
+    CoordTransform const * temp = m_workspace->getTransformToOriginal(indexOfTransform);
     if (temp)
           m_transform = temp->clone();
   }

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -651,7 +651,7 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   if (m_ws->hasOriginalWorkspace()) {
     IMDWorkspace_sptr origWS =
         boost::dynamic_pointer_cast<IMDWorkspace>(m_ws->getOriginalWorkspace());
-    CoordTransform *toOrig = m_ws->getTransformToOriginal();
+    auto toOrig = m_ws->getTransformToOriginal();
     if (toOrig) {
       ui.frmMouseInfo->setVisible(true);
       ui.lblOriginalWorkspace->setText(
@@ -1291,7 +1291,7 @@ void SliceViewer::showInfoAt(double x, double y) {
   if (m_ws->hasOriginalWorkspace()) {
     IMDWorkspace_sptr origWS =
         boost::dynamic_pointer_cast<IMDWorkspace>(m_ws->getOriginalWorkspace());
-    CoordTransform *toOrig = m_ws->getTransformToOriginal();
+    auto toOrig = m_ws->getTransformToOriginal();
     if (toOrig) {
       // Transform the coordinates
       VMD orig = toOrig->applyVMD(coords);

--- a/Code/Mantid/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
@@ -114,7 +114,7 @@ void vtkDataSetToNonOrthogonalDataSet::execute()
       wMatArr = run.getPropertyValueAsType<std::vector<double > >("W_MATRIX");
       try
       {
-        API::CoordTransform *transform = infoWs->getTransformToOriginal();
+        API::CoordTransform const *transform = infoWs->getTransformToOriginal();
         affMat = transform->makeAffineMatrix();
       }
       catch (std::runtime_error &)
@@ -149,7 +149,7 @@ void vtkDataSetToNonOrthogonalDataSet::execute()
       wMatArr = run.getPropertyValueAsType<std::vector<double > >("W_MATRIX");
       try
       {
-        API::CoordTransform *transform = infoWs->getTransformToOriginal();
+        API::CoordTransform const *transform = infoWs->getTransformToOriginal();
         affMat = transform->makeAffineMatrix();
       }
       catch (std::runtime_error &)

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -181,7 +181,7 @@ namespace VATES
     std::cout << tim << " to check all the signal values." << std::endl;
 
     // Get the transformation that takes the points in the TRANSFORMED space back into the ORIGINAL (not-rotated) space.
-    Mantid::API::CoordTransform* transform = NULL;
+    Mantid::API::CoordTransform const * transform = NULL;
     if (m_useTransform)
       transform = m_workspace->getTransformToOriginal();
 

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
@@ -142,7 +142,7 @@ namespace Mantid
         std::cout << tim << " to check all the signal values." << std::endl;
 
         // Get the transformation that takes the points in the TRANSFORMED space back into the ORIGINAL (not-rotated) space.
-        Mantid::API::CoordTransform* transform = NULL;
+        Mantid::API::CoordTransform const* transform = NULL;
         if (m_useTransform)
           transform = m_workspace->getTransformToOriginal();
 

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDLineFactory.cpp
@@ -86,7 +86,7 @@ namespace Mantid
         vtkIdList * linePointList = vtkIdList::New();
         linePointList->SetNumberOfIds(2);
 
-        Mantid::API::CoordTransform* transform = NULL;
+        Mantid::API::CoordTransform const* transform = NULL;
         if (m_useTransform)
         {
           transform = imdws->getTransformToOriginal();

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -82,7 +82,7 @@ namespace Mantid
         vtkIdList * quadPointList = vtkIdList::New();
         quadPointList->SetNumberOfIds(4);
 
-        Mantid::API::CoordTransform* transform = NULL;
+        Mantid::API::CoordTransform const* transform = NULL;
         if (m_useTransform)
         {
           transform = imdws->getTransformToOriginal();

--- a/Code/Mantid/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -379,7 +379,7 @@ namespace VATES
     bool do4D = doMDHisto4D(workspace);
 
     // Get the transformation that takes the points in the TRANSFORMED space back into the ORIGINAL (not-rotated) space.
-    Mantid::API::CoordTransform* transform = NULL;
+    Mantid::API::CoordTransform const* transform = NULL;
     if (m_useTransform)
     {
      transform = workspace->getTransformToOriginal();


### PR DESCRIPTION
Relates to [this](http://trac.mantidproject.org/mantid/ticket/10944) Trac issue

Here is the original issue reported by Russell Ewings

``` python
#Set things up
hkl = LoadMD(Filename='C:\Russell\Software\Mantid\VATES\VATESdemoSSC15\Templates\FeDataset.nxs' ,FileBackEnd=1)

#Create projections (equivalent of proj in Horace):
projection = CreateEmptyTableWorkspace()
projection.addColumn("double", "u")
projection.addColumn("double", "v")
projection.addColumn("double", "w")
projection.addColumn("double", "offsets")
projection.addColumn("str", "type")
projection.addRow([1, 1, 0, 0, "r"])
projection.addRow([1, -1, 0, 0, "r"]) 
projection.addRow([0, 0, 1, 0, "r"]) 

#1
#QE slice and look at it in the sliceviewer
horace_style = CutMD(hkl,projection, [-3,0.05,3], [0.9,1.1], [-0.1,0.1], [0,4,300], NoPix=True, CheckAxes=False)
sv=plotSlice(horace_style)
sv.setNormalization(2)#set norm to number of events
sv.setXYDim(0,3)#Choose the correct plot axes (0th and 3rd in Python!)
sv.setColorScaleMin(0)#set colour scale limits
sv.setColorScaleMax(1)
sv.setXYLimits(-2,2,0,200)

#If you try to make a 1d cut along (1,1,0), integrating in energy, direct in line mode in the sliceviewer, something weird happens to the integration box – it becomes a trapezium… Nevertheless, if you manage to make the 1d cut this way, and then plotMD, the result has the correct x-axis of (H,H,0).

#2
#1d Q cut direct
horace_1d=CutMD(hkl,projection, [-2,0.05,2], [0.9,1.1], [-0.1,0.1], [33,40], NoPix=True, CheckAxes=True)
pm=plotMD(horace_1d,error_bars=1,normalization=mantid.api.MDNormalization.NumEventsNormalization)

#The plotMD here has axes of (H,0,0), with the “correct” (H,H,0) not available as an option.
```
- Enhance QueryMD so that we can ignore transforms to original. This is useful for diagnostics
- Change MDGeometry so that we can clear original workspaces, and transforms to and from original coorrdinates
- Have CutMD clear historical transforms and all original workspaces. That way the PlotMD dialogs will use dimension information from the current workspace, not the original workspace from CutMD
- Fix BinMD so that it  will correctly reject inputs that are pure MDHistoWorkspaces without any MDEventWorkspaces as original workspaces rather than fail silently.

**Tester**

Run this **setup script**:

``` python
from mantid.api import Projection

to_cut = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", Units="U,U,U,V")
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,-0.5,0,0,0,0.1])
FakeMDEventData(InputWorkspace='to_cut', PeakParams=[10000,0.5,0,0,0,0.1])

SetUB(Workspace=to_cut, a=1, b=1, c=1, alpha=90, beta=90, gamma=90)
SetSpecialCoordinates(InputWorkspace=to_cut, SpecialCoordinates='HKL')

projection = Projection([1,1,0], [-1,1,0])
proj_ws = projection.createWorkspace()

# Apply the cut (PBins property sets the P1Bin, P2Bin, etc. properties for you)
out_md = CutMD(to_cut, Projection=proj_ws, PBins=([0.1], [0.1], [0.1], [-5,5]), NoPix=True)
```

This should now fail because BinMD on CutMD is not allowed

``` python
bin_md = BinMD(out_md, AxisAligned=True, AlignedDim0="['zeta', 'zeta', 0] ,-1,1, 10", AlignedDim1="['-eta', 'eta', 0],-1,1, 10", AlignedDim2="[0, 0, '2.00xi'],-1,1, 10", AlignedDim3='E,-10,10, 10')
```

Try this again, but set NoPix=False in the above script. It should now succeed.

Now run the setup script above, but replace the call to CutMD with this:

``` python
out_md = CutMD(to_cut,  PBins=([0.1], [-0.1,0.1], [-0.1,0.1], [-5,5]), NoPix=True)
plotMD(out_md)
```

You should get a plot like this with the x-axis named according to CutMD:
![screen shot 2015-04-09 at 11 33 51](https://cloud.githubusercontent.com/assets/1109536/7065128/7da683f0-deac-11e4-8087-613dd6a59157.png)
