### PR TITLE
make network timeouts configurable

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
@@ -172,6 +172,7 @@ private:
   Kernel::ProxyInfo m_proxyInfo;
   bool m_isProxySet;
   int m_timeout;
+  bool m_isTimeoutSet;
   std::streamsize m_contentLength;
   std::string m_method;
   std::string m_contentType;

--- a/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/InternetHelper.cpp
@@ -53,7 +53,7 @@ Logger g_log("InternetHelper");
 /** Constructor
 */
 InternetHelper::InternetHelper()
-    : m_proxyInfo(), m_isProxySet(false), m_timeout(30), m_contentLength(0),
+    : m_proxyInfo(), m_isProxySet(false), m_timeout(30), m_isTimeoutSet(false), m_contentLength(0),
       m_method(HTTPRequest::HTTP_GET), m_contentType("application/json"),
       m_body(), m_headers(), m_request(NULL),m_response(NULL) {}
 
@@ -61,7 +61,7 @@ InternetHelper::InternetHelper()
 /** Constructor
 */
 InternetHelper::InternetHelper(const Kernel::ProxyInfo &proxy)
-    : m_proxyInfo(proxy), m_isProxySet(true), m_timeout(30),
+    : m_proxyInfo(proxy), m_isProxySet(true), m_timeout(30), m_isTimeoutSet(false), m_contentLength(0),
       m_method(HTTPRequest::HTTP_GET), m_contentType("application/json"),
       m_body(), m_headers(), m_request(NULL),m_response(NULL) {}
 
@@ -207,7 +207,7 @@ int InternetHelper::sendHTTPRequest(const std::string &url,
   // Configure Poco HTTP Client Session
   try {
     Poco::Net::HTTPClientSession session(uri.getHost(), uri.getPort());
-    session.setTimeout(Poco::Timespan(m_timeout, 0)); // m_timeout seconds
+    session.setTimeout(Poco::Timespan(getTimeout(), 0)); 
 
     // configure proxy
     setupProxyOnSession(session, url);
@@ -249,7 +249,7 @@ int InternetHelper::sendHTTPSRequest(const std::string &url,
     // Create the session
     HTTPSClientSession session(uri.getHost(),
                                static_cast<Poco::UInt16>(uri.getPort()));
-    session.setTimeout(Poco::Timespan(m_timeout, 0)); // m_timeout seconds
+    session.setTimeout(Poco::Timespan(getTimeout(), 0)); 
 
     // HACK:: Currently the automatic proxy detection only supports http proxy
     // detection
@@ -413,7 +413,10 @@ int InternetHelper::downloadFile(const std::string &urlFile,
 /** Sets the timeout in seconds
 * @param seconds The value in seconds for the timeout
 **/
-void InternetHelper::setTimeout(int seconds) { m_timeout = seconds; }
+void InternetHelper::setTimeout(int seconds) {
+  m_timeout = seconds; 
+  m_isTimeoutSet = true;
+}
 
 /// Checks the HTTP status to decide if this is a relocation
 /// @param response the HTTP status
@@ -442,7 +445,15 @@ void InternetHelper::throwNotConnected(const std::string &url,
 /** Gets the timeout in seconds
 * @returns The value in seconds for the timeout
 **/
-int InternetHelper::getTimeout() { return m_timeout; }
+int InternetHelper::getTimeout() {
+  if (!m_isTimeoutSet)
+  {
+    if (!ConfigService::Instance().getValue("network.default.timeout",m_timeout)) {
+      m_timeout = 30; // the default value if the key is not found
+    }
+  }
+  return m_timeout; 
+}
 
 /** Sets the Method
 * @param method A string of GET or POST, anything other than POST is considered GET
@@ -583,6 +594,7 @@ std::map<std::string, std::string>& InternetHelper::headers() {
 void InternetHelper::reset() {
   m_headers.clear();
   m_timeout = 30;
+  m_isTimeoutSet = false;
   m_body = "";
   m_method = HTTPRequest::HTTP_GET;
   m_contentType = "application/json";

--- a/Code/Mantid/Framework/Properties/Mantid.properties.template
+++ b/Code/Mantid/Framework/Properties/Mantid.properties.template
@@ -113,6 +113,9 @@ curvefitting.defaultPeak=Gaussian
 curvefitting.findPeaksFWHM=7
 curvefitting.findPeaksTolerance=4
 
+# Network Timeouts (in seconds for various uses within Mantid
+network.default.timeout = 30
+network.scriptrepo.timeout = 5
 # Allows the system proxy to be overridden (leave commented out to use the system proxy
 # proxy.host = 
 # proxy.port = 8080

--- a/Code/Mantid/Framework/Properties/Mantid.properties.template
+++ b/Code/Mantid/Framework/Properties/Mantid.properties.template
@@ -113,10 +113,10 @@ curvefitting.defaultPeak=Gaussian
 curvefitting.findPeaksFWHM=7
 curvefitting.findPeaksTolerance=4
 
-# Network Timeouts (in seconds for various uses within Mantid
+# Network Timeouts (in seconds for various uses within Mantid)
 network.default.timeout = 30
 network.scriptrepo.timeout = 5
-# Allows the system proxy to be overridden (leave commented out to use the system proxy
+# Allows the system proxy to be overridden (leave commented out to use the system proxy)
 # proxy.host = 
 # proxy.port = 8080
 # This is to force https proxy requests to use the http proxy (current necessary)

--- a/Code/Mantid/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Code/Mantid/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1306,7 +1306,11 @@ void ScriptRepositoryImpl::doDownloadFile(const std::string &url_file,
   // Configure Poco HTTP Client Session
   try {
     Kernel::InternetHelper inetHelper;
-    inetHelper.setTimeout(3); // 3 seconds
+    int timeout;
+    if (!ConfigService::Instance().getValue("network.scriptrepo.timeout",timeout)) {
+      timeout = 5; // the default value if the key is not found
+    }
+    inetHelper.setTimeout(timeout);
     
     //std::stringstream ss;
     int status = inetHelper.downloadFile(url_file,local_file_path);

--- a/Code/Mantid/docs/source/concepts/PropertiesFile.rst
+++ b/Code/Mantid/docs/source/concepts/PropertiesFile.rst
@@ -127,6 +127,28 @@ MantidPlot Properties
 |                                      |"unwrapped" (flat) instrument views.               |                       |
 +--------------------------------------+---------------------------------------------------+-----------------------+
 
+Network Properties
+******************
+
++----------------------------------------+---------------------------------------------------+-----------------------+
+|Property                                |Description                                        |Example value          |
++========================================+===================================================+=======================+
+|network.default.timeout                 |Defines the default timeout for all network        |30                     |
+|                                        |operations (in seconds).                           |                       |
++----------------------------------------+---------------------------------------------------+-----------------------+
+|network.scriptrepo.timeout              |The timeout for network operations in the script   |5                      |
+|                                        |repository, this overrides the deafault timeout.   |                       |
++----------------------------------------+---------------------------------------------------+-----------------------+
+|proxy.host                              | Allows the system proxy to be overridden, if not  | http://www.proxy.org  |
+|                                        | set mantid will use the system proxy              |                       |
++----------------------------------------+---------------------------------------------------+-----------------------+
+|proxy.port                              | Must be set if proxy.host is set                  | 8080                  |
++----------------------------------------+---------------------------------------------------+-----------------------+
+|proxy.httpsTargetUrl                    | A sample url used to determine the system proxy to| http://www.google.com |
+|                                        | use on windows.                                   |                       |
++----------------------------------------+---------------------------------------------------+-----------------------+
+
+
 ScriptRepository Properties
 ***************************
 


### PR DESCRIPTION
http://trac.mantidproject.org/mantid/ticket/11471
### to test
1. Mainly review the code
2. You could try disconnecting from the network and seeing how long the calls take to fail.
3. the timeouts can be changed in Mantid.properties

``` json
network.default.timeout = 30
network.scriptrepo.timeout = 5
```
