### PR TITLE
Fixes for Xcode 6.3

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/Segfault.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Segfault.cpp
@@ -51,6 +51,7 @@ void Segfault::exec() {
 #if __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wc++11-compat-deprecated-writable-strings"
+#pragma clang diagnostic ignored "-Wwritable-strings"
 #endif
     // writing to read-only memory
     char *s = "hello world";

--- a/Code/Mantid/Framework/Algorithms/src/Segfault.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Segfault.cpp
@@ -48,17 +48,9 @@ void Segfault::exec() {
   g_log.error("Crashing mantid now");
 
   if (!dryrun) {
-#if __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wc++11-compat-deprecated-writable-strings"
-#pragma clang diagnostic ignored "-Wwritable-strings"
-#endif
-    // writing to read-only memory
-    char *s = "hello world";
-    *s = 'H';
-#if __clang__
-#pragma clang diagnostic pop
-#endif
+    // NULL pointer dereference
+    int *ptr = NULL;
+    *ptr = 1;
   }
 }
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -143,7 +143,7 @@ namespace Mantid
       alg->setChild(false);
       alg->initialize();
       alg->setProperty<double>("DataValue",value);
-      const std::string & tmp_name("__tmp_binary_operation_double");
+      const std::string tmp_name("__tmp_binary_operation_double");
       alg->setPropertyValue("OutputWorkspace", tmp_name);
       alg->execute();
       MatrixWorkspace_sptr singleValue;


### PR DESCRIPTION
This Fixes [#11509](http://trac.mantidproject.org/mantid/ticket/11509).

Xcode 6.3 was released today and two small changes are required for Mantid to build without errors or warnings. 

testing: Code review should be sufficient since our official OS X builds will remain on OSX 10.9 and Xcode 6.2.
