### PR TITLE
Optimise LoadNexusProcessed for multiperiod data

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -284,6 +284,11 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(
     periodWorkspace->setX(i, tempMatrixWorkspace->refX(i));
   }
 
+  // We avoid using `openEntry` or similar here because they're just wrappers
+  // around `open`. `open` is slow for large multiperiod datasets, because it
+  // does a search upon the entire HDF5 tree. `openLocal` is *much* quicker, as
+  // it only searches the current group. It does, however, require that the parent
+  // group is currently open.
   NXEntry mtdEntry(root, entryName);
   mtdEntry.openLocal();
 
@@ -363,6 +368,8 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(
     g_log.information(e.what());
   }
 
+  // We make sure to close the current entries. Failing to do this can cause
+  // strange off-by-one errors when loading the spectra.
   wsEntry.close();
   mtdEntry.close();
 


### PR DESCRIPTION
This is for trac ticket [#11505](http://trac.mantidproject.org/mantid/ticket/11505)

This pull request improved the load time of `INTER00027729.nxs` from ~745 seconds down to ~84 seconds on my machine.

**Tester**: The most important thing to check here is that the changes do not corrupt the data in some way whilst loading it. I've done some comparisons myself that I'll detail below. If data loading has been damaged in some way by this, it's highly likely that a systemtest will be broken, so don't presume they're random failures.

The first comparison I did was by running two instances of Mantid side by side, one with and one without the changes. In each I loaded `INTER00027729.nxs` and manually compared random samples of the data. I found no differences.

The second comparison I did was run the code from the `OFFSPECReflRedOneAuto` system test in a unchanged Mantid, and save a single period of the result to disk. I then loaded the changed Mantid, and ran the same systemtest code. I then loaded the saved result and used `CheckWorkspacesMatch` to check they were identical, which they were.
- Inspect/review changes
- Ensure no tests have been broken
