### PR TITLE
Display multiple color fill plots in a tiled window.

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1373,7 +1373,8 @@ void MantidDockWidget::drawColorFillPlot()
   if( wsNames.empty() ) return;
 
   // Extract child workspace names from any WorkspaceGroups selected.
-  QSet<QString> allWsNames;
+  // Use a list to preserve workspace order.
+  QStringList allWsNames;
   foreach( const QString wsName, wsNames )
   {
     const auto wsGroup = boost::dynamic_pointer_cast<const WorkspaceGroup>(m_ads.retrieve(wsName.toStdString()));
@@ -1381,13 +1382,17 @@ void MantidDockWidget::drawColorFillPlot()
     {
       const auto children = wsGroup->getNames();
       for( auto childWsName = children.begin(); childWsName != children.end(); ++childWsName )
-        allWsNames.insert(QString::fromStdString(*childWsName));
+      {
+        auto name = QString::fromStdString(*childWsName);
+        if (allWsNames.contains(name)) continue;
+        allWsNames.append(name);
+      }
     }
     else
-      allWsNames.insert(wsName);
+      allWsNames.append(wsName);
   }
 
-  m_mantidUI->drawColorFillPlots(allWsNames.toList());
+  m_mantidUI->drawColorFillPlots(allWsNames);
 }
 
 void MantidDockWidget::treeSelectionChanged()

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3269,9 +3269,54 @@ void MantidUI::showSequentialPlot(Ui::SequentialFitDialog* ui, MantidQt::MantidW
 */
 void MantidUI::drawColorFillPlots(const QStringList & wsNames, Graph::CurveType curveType)
 {
-  for( QStringList::const_iterator cit = wsNames.begin(); cit != wsNames.end(); ++cit )
+  int nPlots = wsNames.size();
+  if ( nPlots > 1 )
   {
-    this->drawSingleColorFillPlot(*cit, curveType);
+    int nCols = 1;
+    if ( nPlots >= 16 )
+    {
+      nCols = 4;
+    }
+    else if ( nPlots >= 9 )
+    {
+      nCols = 3;
+    }
+    else if ( nPlots >= 4 )
+    {
+      nCols = 2;
+    }
+    else
+    {
+      nCols = nPlots;
+    }
+
+    int nRows = nPlots / nCols;
+    if ( nPlots % nCols != 0 )
+    {
+      ++nRows;
+    }
+
+    auto tiledWindow = new TiledWindow(appWindow(),"",appWindow()->generateUniqueName("TiledWindow"),nRows,nCols);
+    appWindow()->addMdiSubWindow(tiledWindow);
+
+    int row = 0;
+    int col = 0;
+    for( QStringList::const_iterator cit = wsNames.begin(); cit != wsNames.end(); ++cit )
+    {
+      const bool hidden = true;
+      auto plot = this->drawSingleColorFillPlot(*cit, curveType, NULL, hidden);
+      tiledWindow->addWidget(plot,row,col);
+      ++col;
+      if (col == nCols)
+      {
+        col = 0;
+        ++row;
+      }
+    }
+  }
+  else if ( nPlots == 1 )
+  {
+    this->drawSingleColorFillPlot(wsNames.front(), curveType);
   }
 }
 
@@ -3284,7 +3329,7 @@ void MantidUI::drawColorFillPlots(const QStringList & wsNames, Graph::CurveType 
 * @returns A pointer to the created plot
 */
 MultiLayer* MantidUI::drawSingleColorFillPlot(const QString & wsName, Graph::CurveType curveType,
-                                              MultiLayer* window)
+                                              MultiLayer* window, bool hidden)
 {
   auto workspace = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(getWorkspace(wsName));
   if(!workspace) return NULL;
@@ -3298,6 +3343,10 @@ MultiLayer* MantidUI::drawSingleColorFillPlot(const QString & wsName, Graph::Cur
     try
     {
       window = appWindow()->multilayerPlot(appWindow()->generateUniqueName( wsName + "-"));
+      if (hidden)
+      {
+        window->hide();
+      }
     }
     catch(std::runtime_error& e)
     {

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.h
@@ -234,7 +234,7 @@ public:
     void drawColorFillPlots(const QStringList & wsNames, Graph::CurveType curveType = Graph::ColorMap);
     /// Draw a color fill plot for the named workspace
     MultiLayer* drawSingleColorFillPlot(const QString & wsName, Graph::CurveType curveType = Graph::ColorMap,
-                                        MultiLayer* window = NULL);
+                                        MultiLayer* window = NULL, bool hidden = false);
 
     // Create a 1d graph form specified spectra in a MatrixWorkspace
     MultiLayer* plotSpectraRange(const QString& wsName, int i0, int i1, 


### PR DESCRIPTION
[#8329](http://trac.mantidproject.org/mantid/ticket/8329)

**To test**

Draw a color fill plot of a group workspace or a selection of more than 1 workspace from the workspace dock. The plots should be organised into a tiled window.
