### PR TITLE
Optimise out openPath in LoadNexusProcessed

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -359,7 +359,15 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(
     }
   }
 
-  m_cppFile->openPath(mtdEntry.path());
+  // We always start one layer too deep
+  // go from /workspace_{n}/{something} -> /workspace_{n}
+  m_cppFile->closeGroup();
+
+  // Now move to the correct period group
+  // /workspace_{n} -> /workspace_{n+1}
+  m_cppFile->closeGroup();
+  m_cppFile->openGroup(entryName, "NXentry");
+
   try {
     // This loads logs, sample, and instrument.
     periodWorkspace->loadSampleAndLogInfoNexus(m_cppFile);


### PR DESCRIPTION
This is for trac ticket [#11514](http://trac.mantidproject.org/mantid/ticket/11514)

This pull request removes the call to `NeXuS::File::openPath` in `LoadNexusProcessed`'s multiperiod loading routine, using relative group movement instead. On my machine this yields a significant performance improvement, taking ~8 seconds to open `INTER00027729.nxs` instead of ~85 seconds.

**Tester**:
- Review changes
- Ensure relevant data is not being corrupted upon load, specifically:
  - Sample logs
  - Instrument
