### PR TITLE
Clean up naming of SofQW algoritithms

### DIFF
--- a/Code/Mantid/Framework/Algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/Algorithms/CMakeLists.txt
@@ -220,8 +220,9 @@ set ( SRC_FILES
 	src/SmoothNeighbours.cpp
 	src/SofQCommon.cpp
 	src/SofQW.cpp
-	src/SofQW2.cpp
-	src/SofQW3.cpp
+	src/SofQWCentre.cpp
+	src/SofQWNormalisedPolygon.cpp
+	src/SofQWPolygon.cpp
 	src/SolidAngle.cpp
 	src/SortEvents.cpp
 	src/SpatialGrouping.cpp
@@ -477,8 +478,9 @@ set ( INC_FILES
 	inc/MantidAlgorithms/SmoothNeighbours.h
 	inc/MantidAlgorithms/SofQCommon.h
 	inc/MantidAlgorithms/SofQW.h
-	inc/MantidAlgorithms/SofQW2.h
-	inc/MantidAlgorithms/SofQW3.h
+	inc/MantidAlgorithms/SofQWCentre.h
+	inc/MantidAlgorithms/SofQWNormalisedPolygon.h
+	inc/MantidAlgorithms/SofQWPolygon.h
 	inc/MantidAlgorithms/SolidAngle.h
 	inc/MantidAlgorithms/SortEvents.h
 	inc/MantidAlgorithms/SpatialGrouping.h
@@ -512,7 +514,7 @@ set ( INC_FILES
 )
 
 set(SRC_UNITY_IGNORE_FILES src/AlignDetectors.cpp
-    src/FFTSmooth.cpp 
+    src/FFTSmooth.cpp
     src/FFTSmooth2.cpp
     src/FilterBadPulses.cpp
     src/SetUncertainties.cpp
@@ -722,8 +724,9 @@ set ( TEST_FILES
 	SignalOverErrorTest.h
 	SmoothDataTest.h
 	SmoothNeighboursTest.h
-	SofQW2Test.h
-	SofQW3Test.h
+	SofQWCentreTest.h
+	SofQWNormalisedPolygonTest.h
+	SofQWPolygonTest.h
 	SofQWTest.h
 	SolidAngleTest.h
 	SortEventsTest.h
@@ -759,7 +762,7 @@ enable_precompiled_headers ( inc/MantidAlgorithms/PrecompiledHeader.h SRC_FILES 
 # Add the target for this directory
 add_library ( Algorithms ${SRC_FILES} ${INC_FILES})
 # Set the name of the generated library
-set_target_properties ( Algorithms PROPERTIES OUTPUT_NAME MantidAlgorithms ) 
+set_target_properties ( Algorithms PROPERTIES OUTPUT_NAME MantidAlgorithms )
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( Algorithms PROPERTIES INSTALL_RPATH "@loader_path/../Contents/MacOS")

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQCommon.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQCommon.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_ALGORITHMS_SOFQW_COMMON_H_
 #define MANTID_ALGORITHMS_SOFQW_COMMON_H_
 
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/IDetector.h"
 // Two small routines used by all SofQW algorithms intended to provide united
 // user interface to all SofQ algorihtms.

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
@@ -67,11 +67,8 @@ public:
   setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace,
                        const std::vector<double> &binParams,
                        std::vector<double> &newAxis);
-  /// Convert the workspace to a distribution
-  void makeDistribution(API::MatrixWorkspace_sptr outputWS,
-                        const std::vector<double> qAxis);
   /// Create the input properties on the given algorithm object
-  static void createInputProperties(API::Algorithm &alg);
+  static void createCommonInputProperties(API::Algorithm &alg);
   /// Energy to K constant
   static double energyToK();
 

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
@@ -56,12 +56,7 @@ public:
   /// Algorithm's name
   virtual const std::string name() const { return "SofQW"; }
   /// Summary of algorithms purpose
-  virtual const std::string summary() const {
-    return "Converts a 2D workspace that has axes in *units* of **DeltaE** "
-           "(energy transfer) against spectrum number to one "
-           "that gives intensity as a function of **DeltaE** against "
-           "**momentum transfer** ";
-  }
+  virtual const std::string summary() const;
 
   /// Algorithm's version
   virtual int version() const { return (1); }

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQW.h
@@ -4,6 +4,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
+#include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAlgorithms/SofQCommon.h"
 
 namespace Mantid {
@@ -47,12 +48,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport SofQW : public API::Algorithm {
+class DLLExport SofQW : public API::DataProcessorAlgorithm {
 public:
-  /// (Empty) Constructor
-  SofQW() : API::Algorithm() {}
-  /// Virtual destructor
-  virtual ~SofQW() {}
   /// Algorithm's name
   virtual const std::string name() const { return "SofQW"; }
   /// Summary of algorithms purpose

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWCentre.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWCentre.h
@@ -4,6 +4,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
+#include "MantidAPI/Algorithm.h"
 #include "MantidAlgorithms/SofQCommon.h"
 
 namespace Mantid {

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWCentre.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWCentre.h
@@ -1,0 +1,95 @@
+#ifndef MANTID_ALGORITHMS_SOFQWCENTRE_H_
+#define MANTID_ALGORITHMS_SOFQWCENTRE_H_
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidAlgorithms/SofQCommon.h"
+
+namespace Mantid {
+namespace Algorithms {
+/** Converts a 2D workspace that has axes of energy transfer against spectrum
+number to
+one that gives intensity as a function of momentum transfer against energy.
+
+Required Properties:
+<UL>
+<LI> InputWorkspace  - Reduced data in units of energy transfer. Must have
+common bins. </LI>
+<LI> OutputWorkspace - The name to use for the q-w workspace. </LI>
+<LI> QAxisBinning    - The bin parameters to use for the q axis. </LI>
+<LI> Emode           - The energy mode (direct or indirect geometry). </LI>
+<LI> Efixed          - Value of fixed energy: EI (emode=1) or EF (emode=2)
+(meV). </LI>
+</UL>
+
+@author Russell Taylor, Tessella plc
+@date 24/02/2010
+
+Copyright &copy; 2010 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
+
+This file is part of Mantid.
+
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport SofQWCentre : public API::Algorithm {
+public:
+  /// (Empty) Constructor
+  SofQWCentre() : API::Algorithm() {}
+  /// Virtual destructor
+  virtual ~SofQWCentre() {}
+  /// Algorithm's name
+  virtual const std::string name() const { return "SofQWCentre"; }
+  /// Summary of algorithms purpose
+  virtual const std::string summary() const {
+    return "Converts a 2D workspace that has axes in *units* of **DeltaE** "
+           "(energy transfer) against spectrum number to one "
+           "that gives intensity as a function of **DeltaE** against "
+           "**momentum transfer** ";
+  }
+
+  /// Algorithm's version
+  virtual int version() const { return (1); }
+  /// Algorithm's category for identification
+  virtual const std::string category() const { return "Inelastic"; }
+  /// Create the output workspace
+  static API::MatrixWorkspace_sptr
+  setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace,
+                       const std::vector<double> &binParams,
+                       std::vector<double> &newAxis);
+  /// Convert the workspace to a distribution
+  void makeDistribution(API::MatrixWorkspace_sptr outputWS,
+                        const std::vector<double> qAxis);
+  /// Create the input properties on the given algorithm object
+  static void createInputProperties(API::Algorithm &alg);
+  /// Energy to K constant
+  static double energyToK();
+
+private:
+  /// Initialization code
+  void init();
+  /// Execution code
+  void exec();
+
+  SofQCommon m_EmodeProperties;
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /*MANTID_ALGORITHMS_SOFQWCENTRE_H_*/

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWNormalisedPolygon.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWNormalisedPolygon.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_ALGORITHMS_SOFQW3_H_
-#define MANTID_ALGORITHMS_SOFQW3_H_
+#ifndef MANTID_ALGORITHMS_SOFQWNORMALISEDPOLYGON_H_
+#define MANTID_ALGORITHMS_SOFQWNORMALISEDPOLYGON_H_
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
@@ -20,8 +20,7 @@ one that gives intensity as a function of momentum transfer against energy. This
 version
 uses proper parallelpiped rebinning to compute the overlap of the various
 overlapping
-weights. WARNING: This is undergoing testing and should not be used in a
-production environment.
+weights.
 
 Required Properties:
 <UL>
@@ -57,12 +56,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SofQW3 : public Rebin2D {
+class DLLExport SofQWNormalisedPolygon : public Rebin2D {
 public:
   /// Default constructor
-  SofQW3();
+  SofQWNormalisedPolygon();
   /// Algorithm's name for identification
   virtual const std::string name() const;
+  virtual const std::string alias() const { return "SofQW3"; }
   /// Summary of algorithms purpose
   virtual const std::string summary() const {
     return "Calculate the intensity as a function of momentum transfer and "
@@ -117,4 +117,4 @@ private:
 } // namespace Algorithms
 } // namespace Mantid
 
-#endif /* MANTID_ALGORITHMS_SOFQW3_H_ */
+#endif /* MANTID_ALGORITHMS_SOFQWNORMALISEDPOLYGON_H_ */

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/SofQWPolygon.h
@@ -1,5 +1,5 @@
-#ifndef MANTID_ALGORITHMS_SOFQW2_H_
-#define MANTID_ALGORITHMS_SOFQW2_H_
+#ifndef MANTID_ALGORITHMS_SOFQWPOLYGON_H_
+#define MANTID_ALGORITHMS_SOFQWPOLYGON_H_
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
@@ -56,12 +56,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 File change history is stored at: <https://github.com/mantidproject/mantid>
 Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SofQW2 : public Rebin2D {
+class DLLExport SofQWPolygon : public Rebin2D {
 public:
   /// Default constructor
-  SofQW2();
+  SofQWPolygon();
   /// Algorithm's name for identification
-  virtual const std::string name() const { return "SofQW2"; }
+  virtual const std::string name() const { return "SofQWPolygon"; }
+  virtual const std::string alias() const { return "SofQW2"; }
   /// Summary of algorithms purpose
   virtual const std::string summary() const {
     return "Calculate the intensity as a function of momentum transfer and "
@@ -69,7 +70,7 @@ public:
   }
 
   /// Algorithm's version for identification
-  virtual int version() const { return 1; };
+  virtual int version() const { return 1; }
   /// Algorithm's category for identification
   virtual const std::string category() const { return "Inelastic"; }
 
@@ -78,22 +79,12 @@ private:
   void init();
   /// Run the algorithm
   void exec();
-  //      /// Rebin the inputQ
-  //      void rebinToOutput(const Geometry::Quadrilateral & inputQ,
-  //      API::MatrixWorkspace_const_sptr inputWS,
-  //                         const size_t i, const size_t j,
-  //                         API::MatrixWorkspace_sptr outputWS);
   /// Calculate the Q value for a direct instrument
   double calculateDirectQ(const double efixed, const double deltaE,
                           const double twoTheta, const double psi) const;
   /// Calculate the Q value for an indirect instrument
   double calculateIndirectQ(const double efixed, const double deltaE,
                             const double twoTheta, const double psi) const;
-  //      /// Find the intersect region on the output grid
-  //      bool getIntersectionRegion(API::MatrixWorkspace_const_sptr outputWS,
-  //      const Geometry::Quadrilateral & inputQ,
-  //                                 size_t &qstart, size_t &qend, size_t
-  //                                 &en_start, size_t &en_end) const;
   /// Init variables cache base on the given workspace
   void initCachedValues(API::MatrixWorkspace_const_sptr workspace);
   /// Init the theta index
@@ -112,4 +103,4 @@ private:
 } // namespace Algorithms
 } // namespace Mantid
 
-#endif /* MANTID_ALGORITHMS_SOFQW2_H_ */
+#endif /* MANTID_ALGORITHMS_SOFQWPOLYGON_H_ */

--- a/Code/Mantid/Framework/Algorithms/src/SofQCommon.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQCommon.cpp
@@ -1,4 +1,5 @@
 #include "MantidAlgorithms/SofQCommon.h"
+#include "MantidAPI/Algorithm.h"
 
 namespace Mantid {
 namespace Algorithms {

--- a/Code/Mantid/Framework/Algorithms/src/SofQW.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQW.cpp
@@ -35,6 +35,21 @@ using namespace Kernel;
 using namespace API;
 
 /**
+ * @return A summary of the algorithm
+ */
+const std::string SofQW::summary() const {
+  return "Computes S(Q,w) using a either centre point or parallel-piped "
+         "rebinning.\n"
+         "The output from each method is:\n"
+         "CentrePoint - centre-point rebin that takes no account of pixel "
+         "curvature or area overlap\n\n"
+         "Polygon - parallel-piped rebin, outputting a weighted-sum of "
+         "overlapping polygons\n\n"
+         "NormalisedPolygon - parallel-piped rebin, outputting a weighted-sum of "
+         "overlapping polygons normalised by the fractional area of each overlap";
+}
+
+/**
  * Create the input properties
  */
 void SofQW::init() { createInputProperties(*this); }

--- a/Code/Mantid/Framework/Algorithms/src/SofQWCentre.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWCentre.cpp
@@ -1,0 +1,318 @@
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include <stdexcept>
+
+#include "MantidAlgorithms/SofQWCentre.h"
+#include "MantidDataObjects/Histogram1D.h"
+#include "MantidAPI/BinEdgeAxis.h"
+#include "MantidAPI/SpectrumDetectorMapping.h"
+#include "MantidAPI/WorkspaceValidators.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/RebinParamsValidator.h"
+#include "MantidKernel/VectorHelper.h"
+#include "MantidKernel/UnitFactory.h"
+#include "MantidGeometry/Instrument/DetectorGroup.h"
+#include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/ListValidator.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(SofQWCentre)
+
+/// Energy to K constant
+double SofQWCentre::energyToK() {
+  static const double energyToK = 8.0 * M_PI * M_PI *
+                                  PhysicalConstants::NeutronMass *
+                                  PhysicalConstants::meV * 1e-20 /
+                                  (PhysicalConstants::h * PhysicalConstants::h);
+  return energyToK;
+}
+
+using namespace Kernel;
+using namespace API;
+
+/**
+ * Create the input properties
+ */
+void SofQWCentre::init() { createInputProperties(*this); }
+
+/**
+ * Create the given algorithm's input properties
+ * @param alg An algorithm object
+ */
+void SofQWCentre::createInputProperties(API::Algorithm &alg) {
+  auto wsValidator = boost::make_shared<CompositeValidator>();
+  wsValidator->add<WorkspaceUnitValidator>("DeltaE");
+  wsValidator->add<SpectraAxisValidator>();
+  wsValidator->add<CommonBinsValidator>();
+  wsValidator->add<HistogramValidator>();
+  wsValidator->add<InstrumentValidator>();
+  alg.declareProperty(new WorkspaceProperty<>("InputWorkspace", "",
+                                              Direction::Input, wsValidator),
+                      "Reduced data in units of energy transfer DeltaE.\nThe "
+                      "workspace must contain histogram data and have common "
+                      "bins across all spectra.");
+  alg.declareProperty(
+      new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
+      "The name to use for the q-omega workspace.");
+  alg.declareProperty(
+      new ArrayProperty<double>("QAxisBinning",
+                                boost::make_shared<RebinParamsValidator>()),
+      "The bin parameters to use for the q axis (in the format used by the "
+      ":ref:`algm-Rebin` algorithm).");
+
+  std::vector<std::string> propOptions;
+  propOptions.push_back("Direct");
+  propOptions.push_back("Indirect");
+  alg.declareProperty("EMode", "",
+                      boost::make_shared<StringListValidator>(propOptions),
+                      "The energy transfer analysis mode (Direct/Indirect)");
+  auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
+  mustBePositive->setLower(0.0);
+  alg.declareProperty("EFixed", 0.0, mustBePositive,
+                      "The value of fixed energy: :math:`E_i` (EMode=Direct) "
+                      "or :math:`E_f` (EMode=Indirect) (meV).\nMust be set "
+                      "here if not available in the instrument definition.");
+}
+
+void SofQWCentre::exec() {
+  using namespace Geometry;
+
+  MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
+
+  // Do the full check for common binning
+  if (!WorkspaceHelpers::commonBoundaries(inputWorkspace)) {
+    g_log.error(
+        "The input workspace must have common binning across all spectra");
+    throw std::invalid_argument(
+        "The input workspace must have common binning across all spectra");
+  }
+
+  std::vector<double> verticalAxis;
+  MatrixWorkspace_sptr outputWorkspace = setUpOutputWorkspace(
+      inputWorkspace, getProperty("QAxisBinning"), verticalAxis);
+  setProperty("OutputWorkspace", outputWorkspace);
+
+  // Holds the spectrum-detector mapping
+  std::vector<specid_t> specNumberMapping;
+  std::vector<detid_t> detIDMapping;
+
+  m_EmodeProperties.initCachedValues(inputWorkspace, this);
+  int emode = m_EmodeProperties.m_emode;
+
+  // Get a pointer to the instrument contained in the workspace
+  Instrument_const_sptr instrument = inputWorkspace->getInstrument();
+
+  // Get the distance between the source and the sample (assume in metres)
+  IComponent_const_sptr source = instrument->getSource();
+  IComponent_const_sptr sample = instrument->getSample();
+  V3D beamDir = sample->getPos() - source->getPos();
+  beamDir.normalize();
+
+  try {
+    double l1 = source->getDistance(*sample);
+    g_log.debug() << "Source-sample distance: " << l1 << std::endl;
+  } catch (Exception::NotFoundError &) {
+    g_log.error("Unable to calculate source-sample distance");
+    throw Exception::InstrumentDefinitionError(
+        "Unable to calculate source-sample distance",
+        inputWorkspace->getTitle());
+  }
+
+  // Conversion constant for E->k. k(A^-1) = sqrt(energyToK*E(meV))
+  const double energyToK = 8.0 * M_PI * M_PI * PhysicalConstants::NeutronMass *
+                           PhysicalConstants::meV * 1e-20 /
+                           (PhysicalConstants::h * PhysicalConstants::h);
+
+  // Loop over input workspace bins, reassigning data to correct bin in output
+  // qw workspace
+  const size_t numHists = inputWorkspace->getNumberHistograms();
+  const size_t numBins = inputWorkspace->blocksize();
+  Progress prog(this, 0.0, 1.0, numHists);
+  for (int64_t i = 0; i < int64_t(numHists); ++i) {
+    try {
+      // Now get the detector object for this histogram
+      IDetector_const_sptr spectrumDet = inputWorkspace->getDetector(i);
+      if (spectrumDet->isMonitor())
+        continue;
+
+      const double efixed = m_EmodeProperties.getEFixed(spectrumDet);
+
+      // For inelastic scattering the simple relationship q=4*pi*sinTheta/lambda
+      // does not hold. In order to
+      // be completely general we must calculate the momentum transfer by
+      // calculating the incident and final
+      // wave vectors and then use |q| = sqrt[(ki - kf)*(ki - kf)]
+      DetectorGroup_const_sptr detGroup =
+          boost::dynamic_pointer_cast<const DetectorGroup>(spectrumDet);
+      std::vector<IDetector_const_sptr> detectors;
+      if (detGroup) {
+        detectors = detGroup->getDetectors();
+      } else {
+        detectors.push_back(spectrumDet);
+      }
+
+      const size_t numDets = detectors.size();
+      const double numDets_d = static_cast<double>(
+          numDets); // cache to reduce number of static casts
+      const MantidVec &Y = inputWorkspace->readY(i);
+      const MantidVec &E = inputWorkspace->readE(i);
+      const MantidVec &X = inputWorkspace->readX(i);
+
+      // Loop over the detectors and for each bin calculate Q
+      for (size_t idet = 0; idet < numDets; ++idet) {
+        IDetector_const_sptr det = detectors[idet];
+        // Calculate kf vector direction and then Q for each energy bin
+        V3D scatterDir = (det->getPos() - sample->getPos());
+        scatterDir.normalize();
+        for (size_t j = 0; j < numBins; ++j) {
+          const double deltaE = 0.5 * (X[j] + X[j + 1]);
+          // Compute ki and kf wave vectors and therefore q = ki - kf
+          double ei(0.0), ef(0.0);
+          if (emode == 1) {
+            ei = efixed;
+            ef = efixed - deltaE;
+            if (ef < 0) {
+              std::string mess =
+                  "Energy transfer requested in Direct mode exceeds incident "
+                  "energy.\n Found for det ID: " +
+                  boost::lexical_cast<std::string>(idet) + " bin No " +
+                  boost::lexical_cast<std::string>(j) + " with Ei=" +
+                  boost::lexical_cast<std::string>(efixed) +
+                  " and energy transfer: " +
+                  boost::lexical_cast<std::string>(deltaE);
+              throw std::runtime_error(mess);
+            }
+          } else {
+            ei = efixed + deltaE;
+            ef = efixed;
+            if (ef < 0) {
+              std::string mess =
+                  "Incident energy of a neutron is negative. Are you trying to "
+                  "process Direct data in Indirect mode?\n Found for det ID: " +
+                  boost::lexical_cast<std::string>(idet) + " bin No " +
+                  boost::lexical_cast<std::string>(j) + " with efied=" +
+                  boost::lexical_cast<std::string>(efixed) +
+                  " and energy transfer: " +
+                  boost::lexical_cast<std::string>(deltaE);
+              throw std::runtime_error(mess);
+            }
+          }
+
+          if (ei < 0)
+            throw std::runtime_error(
+                "Negative incident energy. Check binning.");
+
+          const V3D ki = beamDir * sqrt(energyToK * ei);
+          const V3D kf = scatterDir * (sqrt(energyToK * (ef)));
+          const double q = (ki - kf).norm();
+
+          // Test whether it's in range of the Q axis
+          if (q < verticalAxis.front() || q > verticalAxis.back())
+            continue;
+          // Find which q bin this point lies in
+          const MantidVec::difference_type qIndex =
+              std::upper_bound(verticalAxis.begin(), verticalAxis.end(), q) -
+              verticalAxis.begin() - 1;
+
+          // Add this spectra-detector pair to the mapping
+          specNumberMapping.push_back(
+              outputWorkspace->getSpectrum(qIndex)->getSpectrumNo());
+          detIDMapping.push_back(det->getID());
+
+          // And add the data and it's error to that bin, taking into account
+          // the number of detectors contributing to this bin
+          outputWorkspace->dataY(qIndex)[j] += Y[j] / numDets_d;
+          // Standard error on the average
+          outputWorkspace->dataE(qIndex)[j] =
+              sqrt((pow(outputWorkspace->readE(qIndex)[j], 2) + pow(E[j], 2)) /
+                   numDets_d);
+        }
+      }
+
+    } catch (Exception::NotFoundError &) {
+      // Get to here if exception thrown when calculating distance to detector
+      // Presumably, if we get to here the spectrum will be all zeroes anyway
+      // (from conversion to E)
+      continue;
+    }
+    prog.report();
+  }
+
+  // If the input workspace was a distribution, need to divide by q bin width
+  if (inputWorkspace->isDistribution())
+    this->makeDistribution(outputWorkspace, verticalAxis);
+
+  // Set the output spectrum-detector mapping
+  SpectrumDetectorMapping outputDetectorMap(specNumberMapping, detIDMapping);
+  outputWorkspace->updateSpectraUsing(outputDetectorMap);
+}
+
+/** Creates the output workspace, setting the axes according to the input
+ * binning parameters
+ *  @param[in]  inputWorkspace The input workspace
+ *  @param[in]  binParams The bin parameters from the user
+ *  @param[out] newAxis        The 'vertical' axis defined by the given
+ * parameters
+ *  @return A pointer to the newly-created workspace
+ */
+API::MatrixWorkspace_sptr
+SofQWCentre::setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace,
+                            const std::vector<double> &binParams,
+                            std::vector<double> &newAxis) {
+  // Create vector to hold the new X axis values
+  MantidVecPtr xAxis;
+  xAxis.access() = inputWorkspace->readX(0);
+  const int xLength = static_cast<int>(xAxis->size());
+  // Create a vector to temporarily hold the vertical ('y') axis and populate
+  // that
+  const int yLength = static_cast<int>(
+      VectorHelper::createAxisFromRebinParams(binParams, newAxis));
+
+  // Create the output workspace
+  MatrixWorkspace_sptr outputWorkspace = WorkspaceFactory::Instance().create(
+      inputWorkspace, yLength - 1, xLength, xLength - 1);
+  // Create a numeric axis to replace the default vertical one
+  Axis *const verticalAxis = new BinEdgeAxis(newAxis);
+  outputWorkspace->replaceAxis(1, verticalAxis);
+
+  // Now set the axis values
+  for (int i = 0; i < yLength - 1; ++i) {
+    outputWorkspace->setX(i, xAxis);
+  }
+
+  // Set the axis units
+  verticalAxis->unit() = UnitFactory::Instance().create("MomentumTransfer");
+  verticalAxis->title() = "|Q|";
+
+  // Set the X axis title (for conversion to MD)
+  outputWorkspace->getAxis(0)->title() = "Energy transfer";
+
+  return outputWorkspace;
+}
+
+/** Divide each bin by the width of its q bin.
+ *  @param outputWS :: The output workspace
+ *  @param qAxis ::    A vector of the q bin boundaries
+ */
+void SofQWCentre::makeDistribution(API::MatrixWorkspace_sptr outputWS,
+                             const std::vector<double> qAxis) {
+  std::vector<double> widths(qAxis.size());
+  std::adjacent_difference(qAxis.begin(), qAxis.end(), widths.begin());
+
+  const size_t numQBins = outputWS->getNumberHistograms();
+  for (size_t i = 0; i < numQBins; ++i) {
+    MantidVec &Y = outputWS->dataY(i);
+    MantidVec &E = outputWS->dataE(i);
+    std::transform(Y.begin(), Y.end(), Y.begin(),
+                   std::bind2nd(std::divides<double>(), widths[i + 1]));
+    std::transform(E.begin(), E.end(), E.begin(),
+                   std::bind2nd(std::divides<double>(), widths[i + 1]));
+  }
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
-#include "MantidAlgorithms/SofQW3.h"
+#include "MantidAlgorithms/SofQWNormalisedPolygon.h"
 #include "MantidAlgorithms/SofQW.h"
 #include "MantidAPI/BinEdgeAxis.h"
 #include "MantidAPI/SpectrumDetectorMapping.h"
@@ -21,7 +21,7 @@ typedef std::map<specid_t, Mantid::Kernel::V3D> SpectraDistanceMap;
 typedef Geometry::IDetector_const_sptr DetConstPtr;
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_ALGORITHM(SofQW3)
+DECLARE_ALGORITHM(SofQWNormalisedPolygon)
 
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
@@ -35,7 +35,7 @@ using Geometry::Quadrilateral;
 using Geometry::Vertex2D;
 
 /// Default constructor
-SofQW3::SofQW3()
+SofQWNormalisedPolygon::SofQWNormalisedPolygon()
     : Rebin2D(), m_Qout(), m_thetaWidth(0.0), m_detNeighbourOffset(-1) {}
 
 //----------------------------------------------------------------------------------------------
@@ -43,27 +43,27 @@ SofQW3::SofQW3()
 /**
  * @return the name of the Algorithm
  */
-const std::string SofQW3::name() const { return "SofQW3"; }
+const std::string SofQWNormalisedPolygon::name() const { return "SofQWNormalisedPolygon"; }
 
 /**
  * @return the version number of the Algorithm
  */
-int SofQW3::version() const { return 1; }
+int SofQWNormalisedPolygon::version() const { return 1; }
 
 /**
  * @return the category list for the Algorithm
  */
-const std::string SofQW3::category() const { return "Inelastic"; }
+const std::string SofQWNormalisedPolygon::category() const { return "Inelastic"; }
 
 /**
  * Initialize the algorithm
  */
-void SofQW3::init() { SofQW::createInputProperties(*this); }
+void SofQWNormalisedPolygon::init() { SofQW::createInputProperties(*this); }
 
 /**
  * Execute the algorithm.
  */
-void SofQW3::exec() {
+void SofQWNormalisedPolygon::exec() {
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   // Do the full check for common binning
   if (!WorkspaceHelpers::commonBoundaries(inputWS)) {
@@ -197,7 +197,7 @@ void SofQW3::exec() {
  * @param azimuthal :: The value of the azimuthual angle
  * @return The value of Q
  */
-double SofQW3::calculateQ(const double efixed, int emode, const double deltaE,
+double SofQWNormalisedPolygon::calculateQ(const double efixed, int emode, const double deltaE,
                           const double twoTheta, const double azimuthal) const {
   double ki = 0.0;
   double kf = 0.0;
@@ -221,7 +221,7 @@ double SofQW3::calculateQ(const double efixed, int emode, const double deltaE,
  * values are required very frequently so the total time is more than
  * offset by this precaching step
  */
-void SofQW3::initAngularCachesNonPSD(
+void SofQWNormalisedPolygon::initAngularCachesNonPSD(
     const API::MatrixWorkspace_const_sptr &workspace) {
   const size_t nhist = workspace->getNumberHistograms();
   this->m_theta = std::vector<double>(nhist);
@@ -302,7 +302,7 @@ void SofQW3::initAngularCachesNonPSD(
  * @param workspace : the workspace containing the needed detector information
  */
 void
-SofQW3::initAngularCachesPSD(const API::MatrixWorkspace_const_sptr &workspace) {
+SofQWNormalisedPolygon::initAngularCachesPSD(const API::MatrixWorkspace_const_sptr &workspace) {
   // Trigger a build of the nearst neighbors outside the OpenMP loop
   const int numNeighbours = 4;
   const size_t nHistos = workspace->getNumberHistograms();
@@ -375,7 +375,7 @@ SofQW3::initAngularCachesPSD(const API::MatrixWorkspace_const_sptr &workspace) {
  *  @return A pointer to the newly-created workspace
  */
 RebinnedOutput_sptr
-SofQW3::setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace,
+SofQWNormalisedPolygon::setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace,
                              const std::vector<double> &binParams,
                              std::vector<double> &newAxis) {
   // Create vector to hold the new X axis values

--- a/Code/Mantid/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -58,7 +58,7 @@ const std::string SofQWNormalisedPolygon::category() const { return "Inelastic";
 /**
  * Initialize the algorithm
  */
-void SofQWNormalisedPolygon::init() { SofQW::createInputProperties(*this); }
+void SofQWNormalisedPolygon::init() { SofQW::createCommonInputProperties(*this); }
 
 /**
  * Execute the algorithm.

--- a/Code/Mantid/Framework/Algorithms/src/SofQWPolygon.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWPolygon.cpp
@@ -1,7 +1,7 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
-#include "MantidAlgorithms/SofQW2.h"
+#include "MantidAlgorithms/SofQWPolygon.h"
 #include "MantidAlgorithms/SofQW.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumDetectorMapping.h"
@@ -14,7 +14,7 @@ namespace Mantid {
 namespace Algorithms {
 
 // Register the algorithm into the AlgorithmFactory
-DECLARE_ALGORITHM(SofQW2)
+DECLARE_ALGORITHM(SofQWPolygon)
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -26,19 +26,19 @@ using Geometry::Quadrilateral;
 using Geometry::Vertex2D;
 
 /// Default constructor
-SofQW2::SofQW2() : Rebin2D(), m_Qout(), m_thetaPts(), m_thetaWidth(0.0) {}
+SofQWPolygon::SofQWPolygon() : Rebin2D(), m_Qout(), m_thetaPts(), m_thetaWidth(0.0) {}
 
 //----------------------------------------------------------------------------------------------
 
 /**
  * Initialize the algorithm
  */
-void SofQW2::init() { SofQW::createInputProperties(*this); }
+void SofQWPolygon::init() { SofQW::createInputProperties(*this); }
 
 /**
  * Execute the algorithm.
  */
-void SofQW2::exec() {
+void SofQWPolygon::exec() {
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
   // Do the full check for common binning
   if (!WorkspaceHelpers::commonBoundaries(inputWS)) {
@@ -69,12 +69,12 @@ void SofQW2::exec() {
 
   // Select the calculate Q method based on the mode
   // rather than doing this repeatedly in the loop
-  typedef double (SofQW2::*QCalculation)(double, double, double, double) const;
+  typedef double (SofQWPolygon::*QCalculation)(double, double, double, double) const;
   QCalculation qCalculator;
   if (m_EmodeProperties.m_emode == 1) {
-    qCalculator = &SofQW2::calculateDirectQ;
+    qCalculator = &SofQWPolygon::calculateDirectQ;
   } else {
-    qCalculator = &SofQW2::calculateIndirectQ;
+    qCalculator = &SofQWPolygon::calculateIndirectQ;
   }
 
   /* PARALLEL_FOR2(inputWS, outputWS) */
@@ -143,7 +143,7 @@ void SofQW2::exec() {
  * @param psi The value of the azimuth
  * @return The value of Q
  */
-double SofQW2::calculateDirectQ(const double efixed, const double deltaE,
+double SofQWPolygon::calculateDirectQ(const double efixed, const double deltaE,
                                 const double twoTheta, const double psi) const {
   const double ki = std::sqrt(efixed * SofQW::energyToK());
   const double kf = std::sqrt((efixed - deltaE) * SofQW::energyToK());
@@ -161,7 +161,7 @@ double SofQW2::calculateDirectQ(const double efixed, const double deltaE,
  * @param psi The value of the azimuth
  * @return The value of Q
  */
-double SofQW2::calculateIndirectQ(const double efixed, const double deltaE,
+double SofQWPolygon::calculateIndirectQ(const double efixed, const double deltaE,
                                   const double twoTheta,
                                   const double psi) const {
   UNUSED_ARG(psi);
@@ -176,7 +176,7 @@ double SofQW2::calculateIndirectQ(const double efixed, const double deltaE,
  * Init variables caches
  * @param workspace :: Workspace pointer
  */
-void SofQW2::initCachedValues(API::MatrixWorkspace_const_sptr workspace) {
+void SofQWPolygon::initCachedValues(API::MatrixWorkspace_const_sptr workspace) {
   m_EmodeProperties.initCachedValues(workspace, this);
   // Index theta cache
   initThetaCache(workspace);
@@ -190,7 +190,7 @@ void SofQW2::initCachedValues(API::MatrixWorkspace_const_sptr workspace) {
  * values are required very frequently so the total time is more than
  * offset by this precaching step
  */
-void SofQW2::initThetaCache(API::MatrixWorkspace_const_sptr workspace) {
+void SofQWPolygon::initThetaCache(API::MatrixWorkspace_const_sptr workspace) {
   const size_t nhist = workspace->getNumberHistograms();
   m_thetaPts = std::vector<double>(nhist);
   size_t ndets(0);

--- a/Code/Mantid/Framework/Algorithms/src/SofQWPolygon.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWPolygon.cpp
@@ -33,7 +33,7 @@ SofQWPolygon::SofQWPolygon() : Rebin2D(), m_Qout(), m_thetaPts(), m_thetaWidth(0
 /**
  * Initialize the algorithm
  */
-void SofQWPolygon::init() { SofQW::createInputProperties(*this); }
+void SofQWPolygon::init() { SofQW::createCommonInputProperties(*this); }
 
 /**
  * Execute the algorithm.

--- a/Code/Mantid/Framework/Algorithms/test/SofQWCentreTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWCentreTest.h
@@ -1,31 +1,39 @@
-#ifndef MANTID_ALGORITHMS_SOFQW3TEST_H_
-#define MANTID_ALGORITHMS_SOFQW3TEST_H_
+#ifndef SOFQWTEST_H_
+#define SOFQWTEST_H_
 
 #include <cxxtest/TestSuite.h>
-#include "MantidAlgorithms/SofQW3.h"
+#include "MantidAlgorithms/SofQWCentre.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
 
-#include <iomanip>
-
-using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
-class SofQW3Test : public CxxTest::TestSuite
+class SofQWCentreTest : public CxxTest::TestSuite
 {
 public:
-    
-  void test_Init()
+  void testName()
   {
-    SofQW3 alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_EQUALS( sqw.name(), "SofQWCentre" );
   }
 
-
-  void xtest_exec()
+  void testVersion()
   {
-    SofQW3 sqw;
-    sqw.initialize();
+    TS_ASSERT_EQUALS( sqw.version(), 1 );
+  }
+
+  void testCategory()
+  {
+    TS_ASSERT_EQUALS( sqw.category(), "Inelastic" );
+  }
+  
+  void testInit()
+  {
+    TS_ASSERT_THROWS_NOTHING( sqw.initialize() );
+    TS_ASSERT( sqw.isInitialized() );
+  }
+  
+  void testExec()
+  {
+    if (!sqw.isInitialized()) sqw.initialize();
 
     Mantid::DataHandling::LoadNexusProcessed loader;
     loader.initialize();
@@ -36,7 +44,7 @@ public:
 
     Mantid::API::MatrixWorkspace_sptr inWS;
     TS_ASSERT_THROWS_NOTHING( inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-      (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
+                                (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
     WorkspaceHelpers::makeDistribution(inWS);
 
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("InputWorkspace",inputWS) );
@@ -45,20 +53,20 @@ public:
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
-
+    
     TS_ASSERT_THROWS_NOTHING( sqw.execute() );
     TS_ASSERT( sqw.isExecuted() );
-
+    
     Mantid::API::MatrixWorkspace_sptr result;
     TS_ASSERT_THROWS_NOTHING( result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-      (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
+                                (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
 
     TS_ASSERT_EQUALS( result->getAxis(0)->length(), 1904 );
     TS_ASSERT_EQUALS( result->getAxis(0)->unit()->unitID(), "DeltaE" );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(0), -0.5590, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(999), -0.0971, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(1900), 0.5728, 0.0001 );
-
+    
     TS_ASSERT_EQUALS( result->getAxis(1)->length(), 7 );
     TS_ASSERT_EQUALS( result->getAxis(1)->unit()->unitID(), "MomentumTransfer" );
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(0), 0.5 );
@@ -66,29 +74,25 @@ public:
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(6), 2.0 );
 
     const double delta(1e-08);
-    TS_ASSERT_DELTA( result->readY(0)[1160], 17.5583314826, delta);
-    TS_ASSERT_DELTA( result->readE(0)[1160], 0.197345265992, delta);
-
-    TS_ASSERT_DELTA( result->readY(1)[1145], 4.61301046588, delta);
-    TS_ASSERT_DELTA( result->readE(1)[1145], 0.0721823446635,delta);
-
-    TS_ASSERT_DELTA( result->readY(2)[1200], 1.33394133548, delta);
-    TS_ASSERT_DELTA( result->readE(2)[1200], 0.0419839252961, delta);
-
-    TS_ASSERT_DELTA( result->readY(3)[99], 0.0446085388561, delta);
-    TS_ASSERT_DELTA( result->readE(3)[99], 0.0185049423467, delta);
-
-    TS_ASSERT_DELTA( result->readY(4)[1654], 0.0171136490957 , delta);
-    TS_ASSERT_DELTA( result->readE(4)[1654], 0.005007299861, delta);
-
-    TS_ASSERT_DELTA( result->readY(5)[1025], 0.0516113202152, delta);
-    TS_ASSERT_DELTA( result->readE(5)[1025], 0.0102893133461, delta);
-
+    TS_ASSERT_DELTA( result->readY(0)[1160], 54.85624399, delta);
+    TS_ASSERT_DELTA( result->readE(0)[1160], 0.34252858, delta);
+    TS_ASSERT_DELTA( result->readY(1)[1145], 22.72491806, delta);
+    TS_ASSERT_DELTA( result->readE(1)[1145], 0.19867742, delta);
+    TS_ASSERT_DELTA( result->readY(2)[1200], 6.76047436, delta);
+    TS_ASSERT_DELTA( result->readE(2)[1200], 0.10863549, delta);
+    TS_ASSERT_DELTA( result->readY(3)[99], 0.16439574, delta);
+    TS_ASSERT_DELTA( result->readE(3)[99], 0.03414360, delta);
+    TS_ASSERT_DELTA( result->readY(4)[1654], 0.069311442, delta);
+    TS_ASSERT_DELTA( result->readE(4)[1654], 0.007573484, delta);
+    TS_ASSERT_DELTA( result->readY(5)[1025], 0.226287179, delta);
+    TS_ASSERT_DELTA( result->readE(5)[1025], 0.02148236, delta);
+      
     AnalysisDataService::Instance().remove(inputWS);
     AnalysisDataService::Instance().remove(outputWS);    
   }
+
+private:
+  Mantid::Algorithms::SofQWCentre sqw;
 };
 
-
-#endif /* MANTID_ALGORITHMS_SOFQW2TEST_H_ */
-
+#endif /*SOFQWTEST_H_*/

--- a/Code/Mantid/Framework/Algorithms/test/SofQWCentreTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWCentreTest.h
@@ -1,9 +1,11 @@
-#ifndef SOFQWTEST_H_
-#define SOFQWTEST_H_
+#ifndef SOFQWCENTRETEST_H_
+#define SOFQWCENTRETEST_H_
 
 #include <cxxtest/TestSuite.h>
 #include "MantidAlgorithms/SofQWCentre.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
+
+#include "SofQWTest.h"
 
 using namespace Mantid::API;
 
@@ -12,61 +14,39 @@ class SofQWCentreTest : public CxxTest::TestSuite
 public:
   void testName()
   {
+    Mantid::Algorithms::SofQWCentre sqw;
     TS_ASSERT_EQUALS( sqw.name(), "SofQWCentre" );
   }
 
   void testVersion()
   {
+    Mantid::Algorithms::SofQWCentre sqw;
     TS_ASSERT_EQUALS( sqw.version(), 1 );
   }
 
   void testCategory()
   {
+    Mantid::Algorithms::SofQWCentre sqw;
     TS_ASSERT_EQUALS( sqw.category(), "Inelastic" );
   }
-  
+
   void testInit()
   {
+    Mantid::Algorithms::SofQWCentre sqw;
     TS_ASSERT_THROWS_NOTHING( sqw.initialize() );
     TS_ASSERT( sqw.isInitialized() );
   }
-  
+
   void testExec()
   {
-    if (!sqw.isInitialized()) sqw.initialize();
-
-    Mantid::DataHandling::LoadNexusProcessed loader;
-    loader.initialize();
-    loader.setProperty("Filename","IRS26173_ipg.nxs");
-    const std::string inputWS = "inputWS";
-    loader.setPropertyValue("OutputWorkspace",inputWS);
-    loader.execute();
-
-    Mantid::API::MatrixWorkspace_sptr inWS;
-    TS_ASSERT_THROWS_NOTHING( inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-                                (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
-    WorkspaceHelpers::makeDistribution(inWS);
-
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("InputWorkspace",inputWS) );
-    const std::string outputWS = "result";
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("OutputWorkspace",outputWS) );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
-    
-    TS_ASSERT_THROWS_NOTHING( sqw.execute() );
-    TS_ASSERT( sqw.isExecuted() );
-    
-    Mantid::API::MatrixWorkspace_sptr result;
-    TS_ASSERT_THROWS_NOTHING( result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-                                (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
+    auto result = SofQWTest::runSQW<Mantid::Algorithms::SofQWCentre>();
 
     TS_ASSERT_EQUALS( result->getAxis(0)->length(), 1904 );
     TS_ASSERT_EQUALS( result->getAxis(0)->unit()->unitID(), "DeltaE" );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(0), -0.5590, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(999), -0.0971, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(1900), 0.5728, 0.0001 );
-    
+
     TS_ASSERT_EQUALS( result->getAxis(1)->length(), 7 );
     TS_ASSERT_EQUALS( result->getAxis(1)->unit()->unitID(), "MomentumTransfer" );
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(0), 0.5 );
@@ -86,13 +66,9 @@ public:
     TS_ASSERT_DELTA( result->readE(4)[1654], 0.007573484, delta);
     TS_ASSERT_DELTA( result->readY(5)[1025], 0.226287179, delta);
     TS_ASSERT_DELTA( result->readE(5)[1025], 0.02148236, delta);
-      
-    AnalysisDataService::Instance().remove(inputWS);
-    AnalysisDataService::Instance().remove(outputWS);    
+
   }
 
-private:
-  Mantid::Algorithms::SofQWCentre sqw;
 };
 
 #endif /*SOFQWTEST_H_*/

--- a/Code/Mantid/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
@@ -1,39 +1,36 @@
-#ifndef SOFQWTEST_H_
-#define SOFQWTEST_H_
+#ifndef MANTID_ALGORITHMS_SOFQWNORMALISEDPOLYGONTEST_H_
+#define MANTID_ALGORITHMS_SOFQWNORMALISEDPOLYGONTEST_H_
 
 #include <cxxtest/TestSuite.h>
-#include "MantidAlgorithms/SofQW.h"
+#include "MantidAlgorithms/SofQWNormalisedPolygon.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
 
+#include <iomanip>
+
+using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
-class SofQWTest : public CxxTest::TestSuite
+class SofQWNormalisedPolygonTest : public CxxTest::TestSuite
 {
 public:
-  void testName()
+    
+  void test_Init()
   {
-    TS_ASSERT_EQUALS( sqw.name(), "SofQW" );
+    SofQWNormalisedPolygon alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
   }
 
-  void testVersion()
+  void test_Aliased_To_SofQW3()
   {
-    TS_ASSERT_EQUALS( sqw.version(), 1 );
+    SofQWNormalisedPolygon alg;
+    TS_ASSERT_EQUALS("SofQW3", alg.alias())
   }
 
-  void testCategory()
+  void xtest_exec()
   {
-    TS_ASSERT_EQUALS( sqw.category(), "Inelastic" );
-  }
-  
-  void testInit()
-  {
-    TS_ASSERT_THROWS_NOTHING( sqw.initialize() );
-    TS_ASSERT( sqw.isInitialized() );
-  }
-  
-  void testExec()
-  {
-    if (!sqw.isInitialized()) sqw.initialize();
+    SofQWNormalisedPolygon sqw;
+    sqw.initialize();
 
     Mantid::DataHandling::LoadNexusProcessed loader;
     loader.initialize();
@@ -44,7 +41,7 @@ public:
 
     Mantid::API::MatrixWorkspace_sptr inWS;
     TS_ASSERT_THROWS_NOTHING( inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-                                (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
+      (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
     WorkspaceHelpers::makeDistribution(inWS);
 
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("InputWorkspace",inputWS) );
@@ -53,20 +50,20 @@ public:
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
     TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
-    
+
     TS_ASSERT_THROWS_NOTHING( sqw.execute() );
     TS_ASSERT( sqw.isExecuted() );
-    
+
     Mantid::API::MatrixWorkspace_sptr result;
     TS_ASSERT_THROWS_NOTHING( result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-                                (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
+      (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
 
     TS_ASSERT_EQUALS( result->getAxis(0)->length(), 1904 );
     TS_ASSERT_EQUALS( result->getAxis(0)->unit()->unitID(), "DeltaE" );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(0), -0.5590, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(999), -0.0971, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(1900), 0.5728, 0.0001 );
-    
+
     TS_ASSERT_EQUALS( result->getAxis(1)->length(), 7 );
     TS_ASSERT_EQUALS( result->getAxis(1)->unit()->unitID(), "MomentumTransfer" );
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(0), 0.5 );
@@ -74,25 +71,29 @@ public:
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(6), 2.0 );
 
     const double delta(1e-08);
-    TS_ASSERT_DELTA( result->readY(0)[1160], 54.85624399, delta);
-    TS_ASSERT_DELTA( result->readE(0)[1160], 0.34252858, delta);
-    TS_ASSERT_DELTA( result->readY(1)[1145], 22.72491806, delta);
-    TS_ASSERT_DELTA( result->readE(1)[1145], 0.19867742, delta);
-    TS_ASSERT_DELTA( result->readY(2)[1200], 6.76047436, delta);
-    TS_ASSERT_DELTA( result->readE(2)[1200], 0.10863549, delta);
-    TS_ASSERT_DELTA( result->readY(3)[99], 0.16439574, delta);
-    TS_ASSERT_DELTA( result->readE(3)[99], 0.03414360, delta);
-    TS_ASSERT_DELTA( result->readY(4)[1654], 0.069311442, delta);
-    TS_ASSERT_DELTA( result->readE(4)[1654], 0.007573484, delta);
-    TS_ASSERT_DELTA( result->readY(5)[1025], 0.226287179, delta);
-    TS_ASSERT_DELTA( result->readE(5)[1025], 0.02148236, delta);
-      
+    TS_ASSERT_DELTA( result->readY(0)[1160], 17.5583314826, delta);
+    TS_ASSERT_DELTA( result->readE(0)[1160], 0.197345265992, delta);
+
+    TS_ASSERT_DELTA( result->readY(1)[1145], 4.61301046588, delta);
+    TS_ASSERT_DELTA( result->readE(1)[1145], 0.0721823446635,delta);
+
+    TS_ASSERT_DELTA( result->readY(2)[1200], 1.33394133548, delta);
+    TS_ASSERT_DELTA( result->readE(2)[1200], 0.0419839252961, delta);
+
+    TS_ASSERT_DELTA( result->readY(3)[99], 0.0446085388561, delta);
+    TS_ASSERT_DELTA( result->readE(3)[99], 0.0185049423467, delta);
+
+    TS_ASSERT_DELTA( result->readY(4)[1654], 0.0171136490957 , delta);
+    TS_ASSERT_DELTA( result->readE(4)[1654], 0.005007299861, delta);
+
+    TS_ASSERT_DELTA( result->readY(5)[1025], 0.0516113202152, delta);
+    TS_ASSERT_DELTA( result->readE(5)[1025], 0.0102893133461, delta);
+
     AnalysisDataService::Instance().remove(inputWS);
     AnalysisDataService::Instance().remove(outputWS);    
   }
-
-private:
-  Mantid::Algorithms::SofQW sqw;
 };
 
-#endif /*SOFQWTEST_H_*/
+
+#endif /* MANTID_ALGORITHMS_SOFQW2TEST_H_ */
+

--- a/Code/Mantid/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWNormalisedPolygonTest.h
@@ -3,9 +3,8 @@
 
 #include <cxxtest/TestSuite.h>
 #include "MantidAlgorithms/SofQWNormalisedPolygon.h"
-#include "MantidDataHandling/LoadNexusProcessed.h"
 
-#include <iomanip>
+#include "SofQWTest.h"
 
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
@@ -13,7 +12,7 @@ using namespace Mantid::API;
 class SofQWNormalisedPolygonTest : public CxxTest::TestSuite
 {
 public:
-    
+
   void test_Init()
   {
     SofQWNormalisedPolygon alg;
@@ -27,36 +26,9 @@ public:
     TS_ASSERT_EQUALS("SofQW3", alg.alias())
   }
 
-  void xtest_exec()
+  void test_exec()
   {
-    SofQWNormalisedPolygon sqw;
-    sqw.initialize();
-
-    Mantid::DataHandling::LoadNexusProcessed loader;
-    loader.initialize();
-    loader.setProperty("Filename","IRS26173_ipg.nxs");
-    const std::string inputWS = "inputWS";
-    loader.setPropertyValue("OutputWorkspace",inputWS);
-    loader.execute();
-
-    Mantid::API::MatrixWorkspace_sptr inWS;
-    TS_ASSERT_THROWS_NOTHING( inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-      (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
-    WorkspaceHelpers::makeDistribution(inWS);
-
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("InputWorkspace",inputWS) );
-    const std::string outputWS = "result";
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("OutputWorkspace",outputWS) );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
-
-    TS_ASSERT_THROWS_NOTHING( sqw.execute() );
-    TS_ASSERT( sqw.isExecuted() );
-
-    Mantid::API::MatrixWorkspace_sptr result;
-    TS_ASSERT_THROWS_NOTHING( result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-      (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
+    auto result = SofQWTest::runSQW<Mantid::Algorithms::SofQWNormalisedPolygon>();
 
     TS_ASSERT_EQUALS( result->getAxis(0)->length(), 1904 );
     TS_ASSERT_EQUALS( result->getAxis(0)->unit()->unitID(), "DeltaE" );
@@ -71,29 +43,26 @@ public:
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(6), 2.0 );
 
     const double delta(1e-08);
-    TS_ASSERT_DELTA( result->readY(0)[1160], 17.5583314826, delta);
-    TS_ASSERT_DELTA( result->readE(0)[1160], 0.197345265992, delta);
+    TS_ASSERT_DELTA( result->readY(0)[1160], 22.8567683273, delta);
+    TS_ASSERT_DELTA( result->readE(0)[1160], 0.2568965638, delta);
 
-    TS_ASSERT_DELTA( result->readY(1)[1145], 4.61301046588, delta);
-    TS_ASSERT_DELTA( result->readE(1)[1145], 0.0721823446635,delta);
+    TS_ASSERT_DELTA( result->readY(1)[1145], 7.5942160104, delta);
+    TS_ASSERT_DELTA( result->readE(1)[1145], 0.1490079010 ,delta);
 
-    TS_ASSERT_DELTA( result->readY(2)[1200], 1.33394133548, delta);
-    TS_ASSERT_DELTA( result->readE(2)[1200], 0.0419839252961, delta);
+    TS_ASSERT_DELTA( result->readY(2)[1200], 2.0249626546, delta);
+    TS_ASSERT_DELTA( result->readE(2)[1200], 0.0752776593, delta);
 
-    TS_ASSERT_DELTA( result->readY(3)[99], 0.0446085388561, delta);
-    TS_ASSERT_DELTA( result->readE(3)[99], 0.0185049423467, delta);
+    TS_ASSERT_DELTA( result->readY(3)[99], 0.0419939169, delta);
+    TS_ASSERT_DELTA( result->readE(3)[99], 0.0175106375, delta);
 
-    TS_ASSERT_DELTA( result->readY(4)[1654], 0.0171136490957 , delta);
-    TS_ASSERT_DELTA( result->readE(4)[1654], 0.005007299861, delta);
+    TS_ASSERT_DELTA( result->readY(4)[1654], 0.0167189448, delta);
+    TS_ASSERT_DELTA( result->readE(4)[1654], 0.0056801131, delta);
 
-    TS_ASSERT_DELTA( result->readY(5)[1025], 0.0516113202152, delta);
-    TS_ASSERT_DELTA( result->readE(5)[1025], 0.0102893133461, delta);
+    TS_ASSERT_DELTA( result->readY(5)[1025], 0.0808168496, delta);
+    TS_ASSERT_DELTA( result->readE(5)[1025], 0.0161117732, delta);
 
-    AnalysisDataService::Instance().remove(inputWS);
-    AnalysisDataService::Instance().remove(outputWS);    
   }
 };
 
 
 #endif /* MANTID_ALGORITHMS_SOFQW2TEST_H_ */
-

--- a/Code/Mantid/Framework/Algorithms/test/SofQWPolygonTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWPolygonTest.h
@@ -3,9 +3,8 @@
 
 #include <cxxtest/TestSuite.h>
 #include "MantidAlgorithms/SofQWPolygon.h"
-#include "MantidDataHandling/LoadNexusProcessed.h"
 
-#include <iomanip>
+#include "SofQWTest.h"
 
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
@@ -29,34 +28,7 @@ public:
 
   void test_exec()
   {
-    SofQWPolygon sqw;
-    sqw.initialize();
-
-    Mantid::DataHandling::LoadNexusProcessed loader;
-    loader.initialize();
-    loader.setProperty("Filename","IRS26173_ipg.nxs");
-    const std::string inputWS = "inputWS";
-    loader.setPropertyValue("OutputWorkspace",inputWS);
-    loader.execute();
-
-    Mantid::API::MatrixWorkspace_sptr inWS;
-    TS_ASSERT_THROWS_NOTHING( inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-      (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
-    WorkspaceHelpers::makeDistribution(inWS);
-
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("InputWorkspace",inputWS) );
-    const std::string outputWS = "result";
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("OutputWorkspace",outputWS) );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
-
-    TS_ASSERT_THROWS_NOTHING( sqw.execute() );
-    TS_ASSERT( sqw.isExecuted() );
-
-    Mantid::API::MatrixWorkspace_sptr result;
-    TS_ASSERT_THROWS_NOTHING( result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-      (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
+    auto result = SofQWTest::runSQW<Mantid::Algorithms::SofQWPolygon>();
 
     TS_ASSERT_EQUALS( result->getAxis(0)->length(), 1904 );
     TS_ASSERT_EQUALS( result->getAxis(0)->unit()->unitID(), "DeltaE" );
@@ -89,11 +61,8 @@ public:
     TS_ASSERT_DELTA( result->readY(5)[1025], 0.0516113202152, delta);
     TS_ASSERT_DELTA( result->readE(5)[1025], 0.0102893133461, delta);
 
-    AnalysisDataService::Instance().remove(inputWS);
-    AnalysisDataService::Instance().remove(outputWS);    
   }
 };
 
 
 #endif /* MANTID_ALGORITHMS_SofQWPolygonTEST_H_ */
-

--- a/Code/Mantid/Framework/Algorithms/test/SofQWPolygonTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWPolygonTest.h
@@ -1,8 +1,8 @@
-#ifndef MANTID_ALGORITHMS_SOFQW2TEST_H_
-#define MANTID_ALGORITHMS_SOFQW2TEST_H_
+#ifndef MANTID_ALGORITHMS_SOFQWPOLYGONTEST_H_
+#define MANTID_ALGORITHMS_SOFQWPOLYGONTEST_H_
 
 #include <cxxtest/TestSuite.h>
-#include "MantidAlgorithms/SofQW2.h"
+#include "MantidAlgorithms/SofQWPolygon.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
 
 #include <iomanip>
@@ -10,21 +10,26 @@
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
-class SofQW2Test : public CxxTest::TestSuite
+class SofQWPolygonTest : public CxxTest::TestSuite
 {
 public:
-    
+
   void test_Init()
   {
-    SofQW2 alg;
+    SofQWPolygon alg;
     TS_ASSERT_THROWS_NOTHING( alg.initialize() )
     TS_ASSERT( alg.isInitialized() )
   }
 
+  void test_Aliased_To_SofQW2()
+  {
+    SofQWPolygon alg;
+    TS_ASSERT_EQUALS("SofQW2", alg.alias())
+  }
 
   void test_exec()
   {
-    SofQW2 sqw;
+    SofQWPolygon sqw;
     sqw.initialize();
 
     Mantid::DataHandling::LoadNexusProcessed loader;
@@ -90,5 +95,5 @@ public:
 };
 
 
-#endif /* MANTID_ALGORITHMS_SOFQW2TEST_H_ */
+#endif /* MANTID_ALGORITHMS_SofQWPolygonTEST_H_ */
 

--- a/Code/Mantid/Framework/Algorithms/test/SofQWTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWTest.h
@@ -10,63 +10,69 @@ using namespace Mantid::API;
 class SofQWTest : public CxxTest::TestSuite
 {
 public:
+
+  template <typename SQWType>
+  static Mantid::API::MatrixWorkspace_sptr runSQW() {
+    Mantid::DataHandling::LoadNexusProcessed loader;
+    loader.initialize();
+    loader.setChild(true);
+    loader.setProperty("Filename","IRS26173_ipg.nxs");
+    loader.setPropertyValue("OutputWorkspace","__unused");
+    loader.execute();
+
+    Mantid::API::Workspace_sptr loadedWS = loader.getProperty("OutputWorkspace");
+    auto inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(loadedWS);
+    WorkspaceHelpers::makeDistribution(inWS);
+
+    SQWType sqw;
+    sqw.initialize();
+    sqw.setChild(true);
+    TS_ASSERT_THROWS_NOTHING( sqw.setProperty("InputWorkspace", inWS) );
+    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("OutputWorkspace", "__unused") );
+    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
+    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
+    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
+    TS_ASSERT_THROWS_NOTHING( sqw.execute() );
+    TS_ASSERT( sqw.isExecuted() );
+
+    return sqw.getProperty("OutputWorkspace");
+  }
+
   void testName()
   {
+    Mantid::Algorithms::SofQW sqw;
     TS_ASSERT_EQUALS( sqw.name(), "SofQW" );
   }
 
   void testVersion()
   {
+    Mantid::Algorithms::SofQW sqw;
     TS_ASSERT_EQUALS( sqw.version(), 1 );
   }
 
   void testCategory()
   {
+    Mantid::Algorithms::SofQW sqw;
     TS_ASSERT_EQUALS( sqw.category(), "Inelastic" );
   }
-  
+
   void testInit()
   {
+    Mantid::Algorithms::SofQW sqw;
     TS_ASSERT_THROWS_NOTHING( sqw.initialize() );
     TS_ASSERT( sqw.isInitialized() );
   }
-  
-  void testExec()
+
+  void testExecWithDefaultMethodUsesSofQWCentre()
   {
-    if (!sqw.isInitialized()) sqw.initialize();
-
-    Mantid::DataHandling::LoadNexusProcessed loader;
-    loader.initialize();
-    loader.setProperty("Filename","IRS26173_ipg.nxs");
-    const std::string inputWS = "inputWS";
-    loader.setPropertyValue("OutputWorkspace",inputWS);
-    loader.execute();
-
-    Mantid::API::MatrixWorkspace_sptr inWS;
-    TS_ASSERT_THROWS_NOTHING( inWS = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-                                (Mantid::API::AnalysisDataService::Instance().retrieve(inputWS)) );
-    WorkspaceHelpers::makeDistribution(inWS);
-
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("InputWorkspace",inputWS) );
-    const std::string outputWS = "result";
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("OutputWorkspace",outputWS) );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("QAxisBinning","0.5,0.25,2") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EMode","Indirect") );
-    TS_ASSERT_THROWS_NOTHING( sqw.setPropertyValue("EFixed","1.84") );
-    
-    TS_ASSERT_THROWS_NOTHING( sqw.execute() );
-    TS_ASSERT( sqw.isExecuted() );
-    
-    Mantid::API::MatrixWorkspace_sptr result;
-    TS_ASSERT_THROWS_NOTHING( result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>
-                                (Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)) );
+    auto result = SofQWTest::runSQW<Mantid::Algorithms::SofQW>();
 
     TS_ASSERT_EQUALS( result->getAxis(0)->length(), 1904 );
     TS_ASSERT_EQUALS( result->getAxis(0)->unit()->unitID(), "DeltaE" );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(0), -0.5590, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(999), -0.0971, 0.0001 );
     TS_ASSERT_DELTA( (*(result->getAxis(0)))(1900), 0.5728, 0.0001 );
-    
+
     TS_ASSERT_EQUALS( result->getAxis(1)->length(), 7 );
     TS_ASSERT_EQUALS( result->getAxis(1)->unit()->unitID(), "MomentumTransfer" );
     TS_ASSERT_EQUALS( (*(result->getAxis(1)))(0), 0.5 );
@@ -86,13 +92,8 @@ public:
     TS_ASSERT_DELTA( result->readE(4)[1654], 0.007573484, delta);
     TS_ASSERT_DELTA( result->readY(5)[1025], 0.226287179, delta);
     TS_ASSERT_DELTA( result->readE(5)[1025], 0.02148236, delta);
-      
-    AnalysisDataService::Instance().remove(inputWS);
-    AnalysisDataService::Instance().remove(outputWS);    
   }
 
-private:
-  Mantid::Algorithms::SofQW sqw;
 };
 
 #endif /*SOFQWTEST_H_*/

--- a/Code/Mantid/docs/source/algorithms/SofQWCentre-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SofQWCentre-v1.rst
@@ -13,13 +13,15 @@ This algorithm is for use by inelastic instruments and takes as its
 input a workspace where the data's been reduced to be in `units <http://www.mantidproject.org/Units>`_ 
 of **energy transfer** against spectrum number (which can be seen as equivalent to
 angle, with the angle being taken from the detector(s) to which the
-spectrum pertains).
+spectrum pertains). For each detector the value of **momentum transfer**
+(:math:`Q`) is calculated, and the counts for detectors and each input 
+**energy transfer** bin are added to the appropriate output :math:`(Q ;\Delta E)` bin.
 
-This algorithm can operate in one of three modes. Each mode simply runs a different algorithm to perform the computation:
 
-- *Centre*: performs a basic centre-point rebinning, see :ref:`algm-SofQWCentre`
-- *Polygon*: performs a parallel-piped rebin, taking into account the curvature of the output bins see :ref:`algm-SofQWPolygon`
-- *NormalisedPolygon*: performs the same rebin as *Polygon* but the output bins normalised by the contributing overlap area see :ref:`algm-SofQWNormalisedPolygon`
+The momentum transfer (:math:`Q`-values) obtained for each detector are calculated
+for the detector center, so the binning algorithm uses center-point binning.
+Use :ref:`algm-SofQWPolygon` and :ref:`algm-SofQWNormalisedPolygon` for more complex and precise (but slower)
+binning strategies.
 
 The energy binning will not be changed by this algorithm, so the input
 workspace should already have the desired bins (though this axis can be
@@ -36,12 +38,12 @@ Usage
 
 **Example - simple transformation of inelastic workspace:**
 
-.. testcode:: SofQW
+.. testcode:: SofQWCentre
 
    # create sample inelastic workspace for MARI instrument containing 1 at all spectra values
    ws=CreateSimulationWorkspace(Instrument='MAR',BinParams='-10,1,10')
    # convert workspace into MD workspace 
-   ws=SofQW(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
+   ws=SofQWCentre(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
    
    print "The converted X values are:"
    print ws.readX(59)[0:10]
@@ -52,14 +54,14 @@ Usage
    print ws.readY(59)[10:21]   
 
 
-.. testcleanup:: SofQW
+.. testcleanup:: SofQWCentre
 
    DeleteWorkspace(ws)
    
 **Output:**
 
 
-.. testoutput:: SofQW
+.. testoutput:: SofQWCentre
 
    The converted X values are: 
    [-10.  -9.  -8.  -7.  -6.  -5.  -4.  -3.  -2.  -1.]

--- a/Code/Mantid/docs/source/algorithms/SofQWNormalisedPolygon-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SofQWNormalisedPolygon-v1.rst
@@ -29,7 +29,7 @@ should be the number of pixels that separates two pixels at the same
 vertical position in adjacent tubes.
 
 
-See  :ref:`algm-SofQW` for centerpoint binning  or :ref:`algm-SofQW2`  
+See  :ref:`algm-SofQWCentre` for centre-point binning  or :ref:`algm-SofQWPolygon`
 for simpler and less precise but faster binning strategies.
 
 Usage
@@ -37,12 +37,12 @@ Usage
 
 **Example - simple transformation of inelastic workspace:**
 
-.. testcode:: SofQW3
+.. testcode:: SofQWNormalisedPolygon
 
    # create sample inelastic workspace for MARI instrument containing 1 at all spectra 
    ws=CreateSimulationWorkspace(Instrument='MAR',BinParams='-10,1,10')
    # convert workspace into Matrix workspace with Q-dE coordinates 
-   ws=SofQW3(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
+   ws=SofQWNormalisedPolygon(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
   
    print "The converted X-Y values are:"
    Xrow=ws.readX(59);
@@ -55,13 +55,13 @@ Usage
 
 
 
-.. testcleanup:: SofQW3
+.. testcleanup:: SofQWNormalisedPolygon
 
    DeleteWorkspace(ws)
    
 **Output:**
 
-.. testoutput:: SofQW3
+.. testoutput:: SofQWNormalisedPolygon
 
    The converted X-Y values are:
    ! -10.00   1.00  !  -9.00   1.00  !  -8.00   1.00  !  -7.00   1.00  !  -6.00   1.00  !  -5.00   1.00  !  -4.00   1.00  !  -3.00   1.00  !  -2.00   1.00  !  -1.00   1.00  !

--- a/Code/Mantid/docs/source/algorithms/SofQWPolygon-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SofQWPolygon-v1.rst
@@ -15,7 +15,7 @@ the intensity as a function of momentum transfer
 :math:`Q` and energy transfer :math:`\Delta E`. 
 
 The rebinning is done as a weighted sum of overlapping polygons. See 
-:ref:`algm-SofQW` for centerpoint binning  or :ref:`algm-SofQW3` for 
+:ref:`algm-SofQWCentre` for centre-point binning  or :ref:`algm-SofQWNormalisedPolygon` for
 more complex and precise (but slower) binning strategy.
 
 Usage
@@ -23,12 +23,12 @@ Usage
 
 **Example - simple transformation of inelastic workspace:**
 
-.. testcode:: SofQW2
+.. testcode:: SofQWPolygon
 
    # create sample inelastic workspace for MARI instrument containing 1 at all spectra values
    ws=CreateSimulationWorkspace(Instrument='MAR',BinParams='-10,1,10')
    # convert workspace into MD workspace 
-   ws=SofQW2(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
+   ws=SofQWPolygon(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
   
    print "The converted X-Y values are:"
    Xrow=ws.readX(59);
@@ -41,13 +41,13 @@ Usage
 
 
 
-.. testcleanup:: SofQW2
+.. testcleanup:: SofQWPolygon
 
    DeleteWorkspace(ws)
    
 **Output:**
 
-.. testoutput:: SofQW2
+.. testoutput:: SofQWPolygon
 
    The converted X-Y values are:
    ! -10.00  12.79  !  -9.00  17.63  !  -8.00  17.86  !  -7.00  18.12  !  -6.00  18.46  !  -5.00  18.69  !  -4.00  19.24  !  -3.00  19.67  !  -2.00  18.49  !  -1.00  12.00  !


### PR DESCRIPTION
Fixes trac issue [#11336](http://trac.mantidproject.org/mantid/ticket/11336)

**Tester**
The changes here have renamed the old `SofQW{2,3}` to `SofQWCentre`, `SofQWPolygon`, `SofQWNormalisedPolygon` and left aliases for 
- `SofQW2`->`SofQWPolygon`
- `SofQW3`->`SofQWNormalisedPolygon`
  `SofQW` itself is now a shell that defines an extra parameter to choose between the 3 options. The default is `Centre` so that running `SofQW` produces identical results as before.
  Check the documentation has been updated with the new names and that calling `SofQW` with the various options calls the correct algorithm. 
