### PR TITLE
Add ability to export any plot

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
@@ -47,6 +47,9 @@ namespace CustomInterfaces
     /// @return Last loaded data workspace
     MatrixWorkspace_const_sptr loadedData() const { return m_loadedData; }
 
+    /// @return Loaded data as MatrixWorkspace_sptr
+    MatrixWorkspace_sptr exportWorkspace();
+
   private slots:
     /// Load new data and update the view accordingly
     void load();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.ui
@@ -49,17 +49,17 @@
          </property>
         </spacer>
        </item>
-       <item>
+        <item>
+          <widget class="QPushButton" name="exportResults">
+            <property name="text">
+              <string>Export results...</string>
+            </property>
+          </widget>
+        </item>
+        <item>
         <widget class="QPushButton" name="nextStep">
          <property name="text">
           <string>%NEXT%</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="exportResults">
-         <property name="text">
-          <string>Export results...</string>
          </property>
         </widget>
        </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -104,69 +104,90 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace()
   {
-    IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
-    clone->setChild(true);
-    clone->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
-    clone->setProperty("OutputWorkspace", "__NotUsed");
-    clone->execute();
+    if ( m_data ) {
 
-    Workspace_sptr cloneResult = clone->getProperty("OutputWorkspace");
+      IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
+      clone->setChild(true);
+      clone->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
+      clone->setProperty("OutputWorkspace", "__NotUsed");
+      clone->execute();
 
-    Workspace_sptr baseline = ALCHelper::createWsFromFunction(m_fittedFunction, m_data->readX(0));
+      Workspace_sptr cloneResult = clone->getProperty("OutputWorkspace");
 
-    IAlgorithm_sptr join1 = AlgorithmManager::Instance().create("ConjoinWorkspaces");
-    join1->setChild(true);
-    join1->setProperty("InputWorkspace1", cloneResult);
-    join1->setProperty("InputWorkspace2", baseline);
-    join1->setProperty("CheckOverlapping", false);
-    join1->execute();
+      Workspace_sptr baseline = ALCHelper::createWsFromFunction(m_fittedFunction, m_data->readX(0));
 
-    MatrixWorkspace_sptr join1Result = join1->getProperty("InputWorkspace1");
+      IAlgorithm_sptr join1 = AlgorithmManager::Instance().create("ConjoinWorkspaces");
+      join1->setChild(true);
+      join1->setProperty("InputWorkspace1", cloneResult);
+      join1->setProperty("InputWorkspace2", baseline);
+      join1->setProperty("CheckOverlapping", false);
+      join1->execute();
 
-    IAlgorithm_sptr join2 = AlgorithmManager::Instance().create("ConjoinWorkspaces");
-    join2->setChild(true);
-    join2->setProperty("InputWorkspace1", join1Result);
-    join2->setProperty("InputWorkspace2", boost::const_pointer_cast<MatrixWorkspace>(m_correctedData));
-    join2->setProperty("CheckOverlapping", false);
-    join2->execute();
+      MatrixWorkspace_sptr join1Result = join1->getProperty("InputWorkspace1");
 
-    MatrixWorkspace_sptr result = join2->getProperty("InputWorkspace1");
+      IAlgorithm_sptr join2 = AlgorithmManager::Instance().create("ConjoinWorkspaces");
+      join2->setChild(true);
+      join2->setProperty("InputWorkspace1", join1Result);
+      join2->setProperty("InputWorkspace2", boost::const_pointer_cast<MatrixWorkspace>(m_correctedData));
+      join2->setProperty("CheckOverlapping", false);
+      join2->execute();
 
-    TextAxis* yAxis = new TextAxis(result->getNumberHistograms());
-    yAxis->setLabel(0,"Data");
-    yAxis->setLabel(1,"Baseline");
-    yAxis->setLabel(2,"Corrected");
-    result->replaceAxis(1,yAxis);
+      MatrixWorkspace_sptr result = join2->getProperty("InputWorkspace1");
 
-    return result;
+      TextAxis* yAxis = new TextAxis(result->getNumberHistograms());
+      yAxis->setLabel(0,"Data");
+      yAxis->setLabel(1,"Baseline");
+      yAxis->setLabel(2,"Corrected");
+      result->replaceAxis(1,yAxis);
+
+      return result;
+
+    } else {
+    
+      return MatrixWorkspace_sptr();
+    }
   }
 
   ITableWorkspace_sptr ALCBaselineModellingModel::exportSections()
   {
-    ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
+    if ( !m_sections.empty() ) {
 
-    table->addColumn("double", "Start X");
-    table->addColumn("double", "End X");
+      ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
 
-    for(auto it = m_sections.begin(); it != m_sections.end(); ++it)
-    {
-      TableRow newRow = table->appendRow();
-      newRow << it->first << it->second;
+      table->addColumn("double", "Start X");
+      table->addColumn("double", "End X");
+
+      for(auto it = m_sections.begin(); it != m_sections.end(); ++it)
+      {
+        TableRow newRow = table->appendRow();
+        newRow << it->first << it->second;
+      }
+
+      return table;
+
+    } else {
+
+      return ITableWorkspace_sptr();
     }
-
-    return table;
   }
 
   ITableWorkspace_sptr ALCBaselineModellingModel::exportModel()
   {
-    ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
+    if ( m_fittedFunction ) {
 
-    table->addColumn("str", "Function");
+      ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
 
-    TableRow newRow = table->appendRow();
-    newRow << m_fittedFunction->asString();
+      table->addColumn("str", "Function");
 
-    return table;
+      TableRow newRow = table->appendRow();
+      newRow << m_fittedFunction->asString();
+
+      return table;
+
+    } else {
+      
+      return ITableWorkspace_sptr();
+    }
   }
 
   void ALCBaselineModellingModel::setCorrectedData(MatrixWorkspace_const_sptr data)

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -104,7 +104,7 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace()
   {
-    if ( m_data ) {
+    if ( m_data && m_fittedFunction && m_correctedData ) {
 
       IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
       clone->setChild(true);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -169,5 +169,17 @@ namespace CustomInterfaces
     m_view->setTimeRange (ws->readX(0).front(),ws->readX(0).back());
   }
 
+   MatrixWorkspace_sptr ALCDataLoadingPresenter::exportWorkspace()
+  {
+    if ( m_loadedData ) {
+
+      return boost::const_pointer_cast<MatrixWorkspace>(m_loadedData);
+
+    } else {
+
+      return MatrixWorkspace_sptr();
+    }
+   }
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -131,13 +131,6 @@ namespace CustomInterfaces
 
   void ALCInterface::exportResults()
   {
-    // If we are able to export the results, we should be on final step, which means all the previous
-    // steps were completed succesfully
-    if (!m_peakFittingModel->fittedPeaks())
-    {
-      QMessageBox::critical(this, "Error", "Please fit some peaks first");
-      return;
-    }
 
     bool ok;
     QString label = QInputDialog::getText(this, "Results label", "Label to assign to the results: ",

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -115,7 +115,6 @@ namespace CustomInterfaces
 
     // On last step - hide next step button, but show "Export results..."
     m_ui.nextStep->setVisible(hasNextStep);
-    m_ui.exportResults->setVisible(!hasNextStep);
 
     if (hasPrevStep)
     {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -158,9 +158,11 @@ namespace CustomInterfaces
 
     for(auto it = results.begin(); it != results.end(); ++it)
     {
-      std::string wsName = groupName + "_" + it->first;
-      AnalysisDataService::Instance().addOrReplace(wsName, it->second);
-      AnalysisDataService::Instance().addToGroup(groupName, wsName);
+      if ( it->second ) {
+        std::string wsName = groupName + "_" + it->first;
+        AnalysisDataService::Instance().addOrReplace(wsName, it->second);
+        AnalysisDataService::Instance().addToGroup(groupName, wsName);
+      }
     }
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -147,6 +147,8 @@ namespace CustomInterfaces
 
     std::map<std::string, Workspace_sptr> results;
 
+    results["Loaded_Data"] = m_dataLoading->exportWorkspace();
+
     results["Baseline_Workspace"] = m_baselineModellingModel->exportWorkspace();
     results["Baseline_Sections"] = m_baselineModellingModel->exportSections();
     results["Baseline_Model"] = m_baselineModellingModel->exportModel();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -154,15 +154,29 @@ namespace CustomInterfaces
     results["Peaks_Workspace"] = m_peakFittingModel->exportWorkspace();
     results["Peaks_FitResults"] = m_peakFittingModel->exportFittedPeaks();
 
-    AnalysisDataService::Instance().addOrReplace(groupName, boost::make_shared<WorkspaceGroup>());
-
-    for(auto it = results.begin(); it != results.end(); ++it)
-    {
+    // Check if any of the above is not empty
+    for (auto it=results.begin(); it!=results.end(); ++it) {
+    
       if ( it->second ) {
-        std::string wsName = groupName + "_" + it->first;
-        AnalysisDataService::Instance().addOrReplace(wsName, it->second);
-        AnalysisDataService::Instance().addToGroup(groupName, wsName);
+        AnalysisDataService::Instance().addOrReplace(groupName, boost::make_shared<WorkspaceGroup>());
+        break;
       }
+    }
+
+    // There is something to export
+    if (AnalysisDataService::Instance().doesExist(groupName)) {
+
+      for(auto it = results.begin(); it != results.end(); ++it)
+      {
+        if ( it->second ) {
+          std::string wsName = groupName + "_" + it->first;
+          AnalysisDataService::Instance().addOrReplace(wsName, it->second);
+          AnalysisDataService::Instance().addToGroup(groupName, wsName);
+        }
+      }
+    } else {
+      // Nothing to export, show error message
+      QMessageBox::critical(this, "Error", "Nothing to export");
     }
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -21,57 +21,71 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace()
   {
-    // Create a new workspace by cloning data one
-    IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
-    clone->setChild(true); // Don't want workspaces in ADS
-    clone->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
-    clone->setProperty("OutputWorkspace", "__NotUsed");
-    clone->execute();
+    if ( m_data ) {
 
-    Workspace_sptr cloneResult = clone->getProperty("OutputWorkspace");
+      // Create a new workspace by cloning data one
+      IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
+      clone->setChild(true); // Don't want workspaces in ADS
+      clone->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
+      clone->setProperty("OutputWorkspace", "__NotUsed");
+      clone->execute();
 
-    // Calculate function values for all data X values
-    MatrixWorkspace_sptr peaks = ALCHelper::createWsFromFunction(m_fittedPeaks, m_data->readX(0));
+      Workspace_sptr cloneResult = clone->getProperty("OutputWorkspace");
 
-    // Merge two workspaces
-    IAlgorithm_sptr join = AlgorithmManager::Instance().create("ConjoinWorkspaces");
-    join->setChild(true);
-    join->setProperty("InputWorkspace1", cloneResult);
-    join->setProperty("InputWorkspace2", peaks);
-    join->setProperty("CheckOverlapping", false);
-    join->execute();
+      // Calculate function values for all data X values
+      MatrixWorkspace_sptr peaks = ALCHelper::createWsFromFunction(m_fittedPeaks, m_data->readX(0));
 
-    MatrixWorkspace_sptr result = join->getProperty("InputWorkspace1");
+      // Merge two workspaces
+      IAlgorithm_sptr join = AlgorithmManager::Instance().create("ConjoinWorkspaces");
+      join->setChild(true);
+      join->setProperty("InputWorkspace1", cloneResult);
+      join->setProperty("InputWorkspace2", peaks);
+      join->setProperty("CheckOverlapping", false);
+      join->execute();
 
-    // Update axis lables so that it's understandable what's what on workspace data view / plot
-    TextAxis* yAxis = new TextAxis(result->getNumberHistograms());
-    yAxis->setLabel(0,"Data");
-    yAxis->setLabel(1,"FittedPeaks");
-    result->replaceAxis(1,yAxis);
+      MatrixWorkspace_sptr result = join->getProperty("InputWorkspace1");
 
-    return result;
+      // Update axis lables so that it's understandable what's what on workspace data view / plot
+      TextAxis* yAxis = new TextAxis(result->getNumberHistograms());
+      yAxis->setLabel(0,"Data");
+      yAxis->setLabel(1,"FittedPeaks");
+      result->replaceAxis(1,yAxis);
+
+      return result;
+
+    } else {
+    
+      return MatrixWorkspace_sptr();
+    }
   }
 
   ITableWorkspace_sptr ALCPeakFittingModel::exportFittedPeaks()
   {
-    ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
+    if ( m_fittedPeaks ) {
 
-    table->addColumn("str", "Peaks");
+      ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
+
+      table->addColumn("str", "Peaks");
 
 
-    if (auto composite = boost::dynamic_pointer_cast<CompositeFunction const>(m_fittedPeaks))
-    {
-      for (size_t i = 0; i < composite->nFunctions(); ++i)
+      if (auto composite = boost::dynamic_pointer_cast<CompositeFunction const>(m_fittedPeaks))
       {
-        static_cast<TableRow>(table->appendRow()) << composite->getFunction(i)->asString();
+        for (size_t i = 0; i < composite->nFunctions(); ++i)
+        {
+          static_cast<TableRow>(table->appendRow()) << composite->getFunction(i)->asString();
+        }
       }
-    }
-    else
-    {
+      else
+      {
         static_cast<TableRow>(table->appendRow()) << m_fittedPeaks->asString();
-    }
+      }
 
-    return table;
+      return table;
+
+    } else {
+    
+      return ITableWorkspace_sptr();
+    }
   }
 
   void ALCPeakFittingModel::setFittedPeaks(IFunction_const_sptr fittedPeaks)

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -21,7 +21,7 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace()
   {
-    if ( m_data ) {
+    if ( m_data && m_fittedPeaks) {
 
       // Create a new workspace by cloning data one
       IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");


### PR DESCRIPTION
Fixes [#9490](http://trac.mantidproject.org/mantid/ticket/9490)

For tester: muon scientists would like to have a button to export any plot in the ALC interface. This button is currently used in the last step ("Peak fitting") only, but should be visible in the previous steps as well. To test: open the ALC interface and check that an "Export results..." button has been added. Load some data, for instance "MUSR00015189.nxs" as "First" and "MUSR00015191.nxs" as "Last". Hit "Export results..." and check that a workspace is created. Go to "Baseline modelling", add a fitting function by right-clicking on the "Function" section (a FlatBackground is enough). Right-click on "Sections" section and add a new section. Hit "Fit" and "Export results..." a new set of workspaces with information about the baseline modelling should be added to the ADS.
