### PR TITLE
Enable test that was accidentally disabled

### DIFF
--- a/Code/Mantid/Framework/Algorithms/test/SofQWTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SofQWTest.h
@@ -104,7 +104,7 @@ public:
     TS_ASSERT_DELTA( result->readE(5)[1025], 0.02148236, delta);
   }
 
-  void xtestExecUsingDifferentMethodChoosesDifferentAlgorithm()
+  void testExecUsingDifferentMethodChoosesDifferentAlgorithm()
   {
     auto result = SofQWTest::runSQW<Mantid::Algorithms::SofQW>("Polygon");
 


### PR DESCRIPTION
One of the `SofQWTest` methods was accidentally disabled, this just re-enables it.
