### PR TITLE
Fix history issue on ConjoinWorkspaces

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/ConjoinWorkspaces.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ConjoinWorkspaces.cpp
@@ -75,6 +75,8 @@ void ConjoinWorkspaces::exec() {
 
     // Both are event workspaces. Use the special method
     MatrixWorkspace_sptr output = this->execEvent();
+    // Copy the history from the original workspace
+    output->history().addHistory(ws1->getHistory());
     // Delete the second input workspace from the ADS
     AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));
     // Set the result workspace to the first input
@@ -91,6 +93,8 @@ void ConjoinWorkspaces::exec() {
   }
 
   MatrixWorkspace_sptr output = execWS2D(ws1, ws2);
+  // Copy the history from the original workspace
+  output->history().addHistory(ws1->getHistory());
 
   // Delete the second input workspace from the ADS
   AnalysisDataService::Instance().remove(getPropertyValue("InputWorkspace2"));

--- a/Code/Mantid/Framework/Algorithms/test/ConjoinWorkspacesTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ConjoinWorkspacesTest.h
@@ -111,6 +111,9 @@ public:
 
     // Check that 2nd input workspace no longer exists
     TS_ASSERT_THROWS( AnalysisDataService::Instance().retrieve("bottom"), Exception::NotFoundError );
+
+    // Check that th workspace has the correct number of history entries
+    TS_ASSERT_EQUALS(output->getHistory().size(), 3);
   }
 
   //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes [#6835](http://trac.mantidproject.org/mantid/ticket/6835).

The following script indicates the original issue:

```
ws1 = LoadNexus('irs26176_graphite002_red.nxs', SpectrumMin=2, SpectrumMax=4)
ws2 = LoadNexus('irs26173_graphite002_red.nxs', SpectrumMin=8, SpectrumMax=10)

AddSampleLog(ws1, LogName='test_id', LogText='This is workspace 1', LogType='String')
AddSampleLog(ws2, LogName='test_id', LogText='This is workspace 2', LogType='String')

ConjoinWorkspaces(ws1, ws2, False)
```

The calls to AddSampleLog are there to give a clear indication as to what is in the history, with the fix applied the last three lines should be two calls to AddSampleLog and a call to ConjoinWorkspaces.
