### PR TITLE
Keep log value when changing first run

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -139,8 +139,17 @@ namespace CustomInterfaces
 
   void ALCDataLoadingView::setAvailableLogs(const std::vector<std::string>& logs)
   {
+    // Keep the current log value
+    QString previousLog = m_ui.log->currentText();
+
     // Clear previous log list
     m_ui.log->clear();
+
+    // If previousLog is in 'logs' list, add it at the beginning
+    if ( std::find(logs.begin(), logs.end(), previousLog.toStdString()) != logs.end())
+    {
+      m_ui.log->addItem(previousLog);
+    }
 
     // Add new items
     for (auto it = logs.begin(); it != logs.end(); ++it)


### PR DESCRIPTION
Fixes [#11549](http://trac.mantidproject.org/mantid/ticket/11549)

To test: Open the Muon ALC interface and select "MUSR00015189.nxs" as "First". The ComboBox "Log" will be updated with the list of existing log values for that specific dataset, and the default log will be set to "run_number". Choose a different log value and load a different run as "First", for instance "MUSR00015190.nxs". Check that the default log does not change.
