### PR TITLE
If component not found in instrument tree, mantid should not crash

### DIFF
--- a/Code/Mantid/MantidPlot/pymantidplot/proxies.py
+++ b/Code/Mantid/MantidPlot/pymantidplot/proxies.py
@@ -160,7 +160,7 @@ class QtProxyObject(QtCore.QObject):
         """
         Reroute a method call to the the stored object via
         the threadsafe call mechanism. Essentially this guarantees
-        that when the method is called it wil be on the GUI thread
+        that when the method is called it will be on the GUI thread
         """
         callable = getattr(self._getHeldObject(), attr)
         return CrossThreadCall(callable)
@@ -627,6 +627,7 @@ class InstrumentWindow(MDIWindow):
         import warnings
         warnings.warn("InstrumentWindow.selectComponent has been deprecated. Use the tree tab selectComponentByName method instead.")
         QtProxyObject.__getattr__(self, "selectComponent")(name)
+
 
 #-----------------------------------------------------------------------------
 class SliceViewerWindowProxy(QtProxyObject):

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -601,9 +601,9 @@ void InstrumentWindow::setViewDirection(const QString& input)
   repaint();
 }
 
-/** For the scripting API. Selects a component in the tree and zooms to it.
+/**
+ *  For the scripting API. Selects a component in the tree and zooms to it.
  *  @param name The name of the component
- *  @throw std::invalid_argument If the component name given does not exist in the tree
  */
 void InstrumentWindow::selectComponent(const QString & name)
 {

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowRenderTab.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowRenderTab.cpp
@@ -18,7 +18,6 @@
 #include <QAction>
 #include <QActionGroup>
 #include <QSignalMapper>
-#include <QMessageBox>
 #include <QToolTip>
 
 #include <qwt_scale_widget.h>

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowTreeTab.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowTreeTab.cpp
@@ -5,6 +5,8 @@
 #include "ProjectionSurface.h"
 #include "GLActorVisitor.h"
 
+#include <QMessageBox>
+
 InstrumentWindowTreeTab::InstrumentWindowTreeTab(InstrumentWindow* instrWindow):
 InstrumentWindowTab(instrWindow)
 {
@@ -23,7 +25,10 @@ void InstrumentWindowTreeTab::initSurface()
 }
 
 /**
-  * Find an instrument component by its name.
+  * Find an instrument component by its name. This is used from the
+  * scripting API and errors (component not found) are shown as a
+  * message box in the GUI.
+  *
   * @param name :: Name of an instrument component.
   */
 void InstrumentWindowTreeTab::selectComponentByName(const QString &name)
@@ -31,7 +36,10 @@ void InstrumentWindowTreeTab::selectComponentByName(const QString &name)
       QModelIndex component = m_instrumentTree->findComponentByName(name);
       if( !component.isValid() )
       {
-        throw std::invalid_argument("No component named \'"+name.toStdString()+"\' found");
+        QMessageBox::critical(this,"Instrument Window - Tree Tab - Error",
+                              "No component named '" +  name + "' was found in the instrument. "
+                              "Please use the name of a component from the instrument tree.");
+        return;
       }
 
       m_instrumentTree->clearSelection();


### PR DESCRIPTION
Addresses [#11092](http://trac.mantidproject.org/mantid/ticket/11092). If you try something like this before this PR:

```
instrument_view = getInstrumentView("")
instrument_view.selectComponent("component-name")
```

you'll get an "uncaught exception, save data and exit" critical error messgae box and even a crash apparently on windoze. You'll also get a warning that "InstrumentWindow.selectComponent has been deprecated. Use the tree tab selectComponentByName method instead." If you use InstrumentWindowTreeTab.selectComponentByName" you also get the uncaught exception.

The behavior of the C++ method was fine in principle, as it used to throw a std::invalid_argument exception, but as this is a method used only for the python API to control the instrument view GUI, I've replaced the throw with a QMessageBox. I did a quick check and it seems that in InstrumentWindow and related classes there are no other methods that throw unhandled exceptions that can make users panic when there's no need to. I also updated the 'Python in Mantid' course example to use `InstrumentWindowTreeTab.selectComponentByName()` and avoid the "deprecated method" warning: http://www.mantidproject.org/Instrument_View_Control.

**To test**:
- review code and see if you agree with the simple solution used here
- you can test this with something like the following script:

```
Load('/home/fedemp/mantid/TrainingCourseData/164200.nxs', OutputWorkspace='164200')

inst_view = getInstrumentView("164200")
inst_view.selectComponent("foo-inexistent")
# you should get an error message box here

tree_tab = inst_view.getTab(InstrumentWindow.TREE)
tree_tab.selectComponentByName("component-name")
# you should get an error message box here again

# but this should still work:
tree_tab.selectComponentByName("bank_1")
```
