### PR TITLE
Save multiperiod workspaces in projects as a single NeXuS file

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2190,6 +2190,9 @@ QString MantidUI::saveToString(const std::string& workingDir)
 
     Workspace_sptr ws = AnalysisDataService::Instance().retrieveWS<Workspace>(wsName.toStdString());
     WorkspaceGroup_sptr group = boost::dynamic_pointer_cast<Mantid::API::WorkspaceGroup>(ws);
+    // We don't split up multiperiod workspaces for performance reasons.
+    // There's significant optimisations we can perform on load if they're a
+    // single file.
     if (ws->id() == "WorkspaceGroup" && group && !group->isMultiperiod())
     {
       wsNames+="\t";


### PR DESCRIPTION
This is for trac ticket [#11548](http://trac.mantidproject.org/mantid/ticket/11548).

Saving multiperiod workspaces this way allows us to re-open them far more quickly (~8 seconds instead of ~25-30 seconds)

**Testing**:
- Create a project
- Load some multiperiod workspaces and some regular workspaces
  - `INTER00027729.nxs` and `INTER00027731.nxs` are good multiperiod workspaces to use
- Group some of the regular workspaces
- Save as a project
- Restart mantid
- Open the project
- Verify everything has been loaded correctly
