### PR TITLE
IDA ConvFit fixes

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
@@ -364,6 +364,18 @@
       </item>
       <item>
        <widget class="QComboBox" name="cbPlotType">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
         <item>
          <property name="text">
           <string>None</string>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -743,27 +743,35 @@ namespace IDA
 
     auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
 
+    //TODO
     switch ( index )
     {
       case 0:
         hwhmRangeSelector->setVisible(false);
+        m_uiForm.ckPlotGuess->setEnabled(true);
         break;
       case 1:
         m_cfTree->addProperty(m_properties["Lorentzian1"]);
         hwhmRangeSelector->setVisible(true);
+        m_uiForm.ckPlotGuess->setEnabled(true);
         break;
       case 2:
         m_cfTree->addProperty(m_properties["Lorentzian1"]);
         m_cfTree->addProperty(m_properties["Lorentzian2"]);
         hwhmRangeSelector->setVisible(true);
+        m_uiForm.ckPlotGuess->setEnabled(true);
         break;
       case 3:
         m_cfTree->addProperty(m_properties["DiffSphere"]);
         hwhmRangeSelector->setVisible(false);
+        m_uiForm.ckPlotGuess->setChecked(false);
+        m_uiForm.ckPlotGuess->setEnabled(false);
         break;
       case 4:
         m_cfTree->addProperty(m_properties["DiffRotDiscreteCircle"]);
         hwhmRangeSelector->setVisible(false);
+        m_uiForm.ckPlotGuess->setChecked(false);
+        m_uiForm.ckPlotGuess->setEnabled(false);
         break;
     }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -743,37 +743,37 @@ namespace IDA
 
     auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
 
-    //TODO
     switch ( index )
     {
       case 0:
         hwhmRangeSelector->setVisible(false);
-        m_uiForm.ckPlotGuess->setEnabled(true);
         break;
       case 1:
         m_cfTree->addProperty(m_properties["Lorentzian1"]);
         hwhmRangeSelector->setVisible(true);
-        m_uiForm.ckPlotGuess->setEnabled(true);
         break;
       case 2:
         m_cfTree->addProperty(m_properties["Lorentzian1"]);
         m_cfTree->addProperty(m_properties["Lorentzian2"]);
         hwhmRangeSelector->setVisible(true);
-        m_uiForm.ckPlotGuess->setEnabled(true);
         break;
       case 3:
         m_cfTree->addProperty(m_properties["DiffSphere"]);
         hwhmRangeSelector->setVisible(false);
         m_uiForm.ckPlotGuess->setChecked(false);
-        m_uiForm.ckPlotGuess->setEnabled(false);
+        m_blnManager->setValue(m_properties["UseDeltaFunc"], false);
         break;
       case 4:
         m_cfTree->addProperty(m_properties["DiffRotDiscreteCircle"]);
         hwhmRangeSelector->setVisible(false);
         m_uiForm.ckPlotGuess->setChecked(false);
-        m_uiForm.ckPlotGuess->setEnabled(false);
+        m_blnManager->setValue(m_properties["UseDeltaFunc"], false);
         break;
     }
+
+    // Disable Plot Guess and Use Delta Function for DiffSphere and DiffRotDiscreteCircle
+    m_uiForm.ckPlotGuess->setEnabled(index < 3);
+    m_properties["UseDeltaFunc"]->setEnabled(index < 3);
 
     updatePlotOptions();
   }


### PR DESCRIPTION
Fixes [#11552](http://trac.mantidproject.org/mantid/ticket/11552).

To test:
- Open IDA > ConvFit
- Select Fit Type, One Lorentzian
- Select Plot Output, Amplitude
- See that the test fits in the combo box correctly
- Enable Plot Guess and Use Delta Function
- Select Fit Type, DiffSphere
- Plot Guess and Use Delta Function options should be unticked and disabled
- Selecting anything other than DiffSphere and DiffCircle will re enable them
