### PR TITLE
Add keys() method to ConfigService

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -132,7 +132,9 @@ public:
                         bool use_cache = true) const;
   /// Searches for a key in the configuration property
   std::vector<std::string> getKeys(const std::string &keyName) const;
-  /// Returns a list of all keys in the configuration property
+  /// Returns a list of all keys under a given root key
+  std::vector<std::string> getKeysRecursive(const std::string &root = "") const;
+  /// Returns a list of all full keys in the config
   std::vector<std::string> keys() const;
   /// Removes the value from a selected keyName
   void remove(const std::string &rootName) const;

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -132,6 +132,8 @@ public:
                         bool use_cache = true) const;
   /// Searches for a key in the configuration property
   std::vector<std::string> getKeys(const std::string &keyName) const;
+  /// Returns a list of all keys in the configuration property
+  std::vector<std::string> keys() const;
   /// Removes the value from a selected keyName
   void remove(const std::string &rootName) const;
   /// Checks to see whether a key has a value assigned to it

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -132,8 +132,6 @@ public:
                         bool use_cache = true) const;
   /// Searches for a key in the configuration property
   std::vector<std::string> getKeys(const std::string &keyName) const;
-  /// Returns a list of all keys under a given root key
-  std::vector<std::string> getKeysRecursive(const std::string &root = "") const;
   /// Returns a list of all full keys in the config
   std::vector<std::string> keys() const;
   /// Removes the value from a selected keyName
@@ -294,6 +292,9 @@ private:
   /// if valid
   bool addDirectoryifExists(const std::string &directoryName,
                             std::vector<std::string> &directoryList);
+  /// Returns a list of all keys under a given root key
+  void getKeysRecursive(const std::string &root,
+                        std::vector<std::string> &allKeys) const;
 
   // Forward declaration of inner class
   template <class T> class WrappedObject;

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -1008,7 +1008,7 @@ void ConfigServiceImpl::getKeysRecursive(const std::string &root,
     std::vector<std::string> &allKeys) const {
   std::vector<std::string> rootKeys = getKeys(root);
 
-  if(rootKeys.size() == 0)
+  if(rootKeys.empty())
     allKeys.push_back(root);
 
   for (auto rkIt = rootKeys.begin(); rkIt != rootKeys.end(); ++rkIt) {

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -1010,11 +1010,11 @@ std::vector<std::string> ConfigServiceImpl::keys() const {
   m_pConf->keys(rootKeys);
 
   std::vector<std::string> allKeys;
-  for(auto rkIt = rootKeys.begin(); rkIt != rootKeys.end(); ++rkIt) {
+  for (auto rkIt = rootKeys.begin(); rkIt != rootKeys.end(); ++rkIt) {
     std::vector<std::string> subKeys;
     m_pConf->keys(*rkIt, subKeys);
 
-    for(auto skIt = subKeys.begin(); skIt != subKeys.end(); ++skIt) {
+    for (auto skIt = subKeys.begin(); skIt != subKeys.end(); ++skIt) {
       allKeys.push_back(*riIt + "." + *skIt);
     }
   }

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -1000,6 +1000,28 @@ ConfigServiceImpl::getKeys(const std::string &keyName) const {
   return keyVector;
 }
 
+/**
+ * Gets a list of all config options as property.key.
+ *
+ * @return Vector containing all config options
+ */
+std::vector<std::string> ConfigServiceImpl::keys() const {
+  std::vector<std::string> rootKeys;
+  m_pConf->keys(rootKeys);
+
+  std::vector<std::string> allKeys;
+  for(auto rkIt = rootKeys.begin(); rkIt != rootKeys.end(); ++rkIt) {
+    std::vector<std::string> subKeys;
+    m_pConf->keys(*rkIt, subKeys);
+
+    for(auto skIt = subKeys.begin(); skIt != subKeys.end(); ++skIt) {
+      allKeys.push_back(*riIt + "." + *skIt);
+    }
+  }
+
+  return allKeys;
+}
+
 /** Removes a key from the memory stored properties file and inserts the key
  *into the
  *  changed key list so that when the program calls saveConfig the properties

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -1004,9 +1004,12 @@ ConfigServiceImpl::getKeys(const std::string &keyName) const {
  *
  * @return Vector containing all config options
  */
-std::vector<std::string> ConfigServiceImpl::getKeysRecursive(const std::string &root) const {
-  std::vector<std::string> allKeys;
+void ConfigServiceImpl::getKeysRecursive(const std::string &root,
+    std::vector<std::string> &allKeys) const {
   std::vector<std::string> rootKeys = getKeys(root);
+
+  if(rootKeys.size() == 0)
+    allKeys.push_back(root);
 
   for (auto rkIt = rootKeys.begin(); rkIt != rootKeys.end(); ++rkIt) {
     std::string searchString;
@@ -1016,18 +1019,8 @@ std::vector<std::string> ConfigServiceImpl::getKeysRecursive(const std::string &
       searchString = root + "." + *rkIt;
     }
 
-    std::vector<std::string> subKeys = getKeysRecursive(searchString);
-
-    if (subKeys.size() == 0) {
-      allKeys.push_back(*rkIt);
-    } else {
-      for (auto skIt = subKeys.begin(); skIt != subKeys.end(); ++skIt) {
-        allKeys.push_back(*rkIt + "." + *skIt);
-      }
-    }
+    getKeysRecursive(searchString, allKeys);
   }
-
-  return allKeys;
 }
 
 /**
@@ -1039,7 +1032,9 @@ std::vector<std::string> ConfigServiceImpl::getKeysRecursive(const std::string &
  * @return Vector containing all config options
  */
 std::vector<std::string> ConfigServiceImpl::keys() const {
-  return getKeysRecursive();
+  std::vector<std::string> allKeys;
+  getKeysRecursive("", allKeys);
+  return allKeys;
 }
 
 /** Removes a key from the memory stored properties file and inserts the key

--- a/Code/Mantid/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ConfigServiceTest.h
@@ -557,6 +557,17 @@ public:
     TS_ASSERT_EQUALS(keyVector.size(), 5);
   }
 
+  void testGetAllKeys()
+  {
+    const std::string propfilePath = ConfigService::Instance().getDirectoryOfExecutable();
+    const std::string propfile = propfilePath + "MantidTest.properties";
+    ConfigService::Instance().updateConfig(propfile);
+
+    std::vector<std::string> keys = ConfigService::Instance().keys();
+
+    TS_ASSERT_EQUALS(keys.size(), 17);
+  }
+
   void testRemovingProperty()
   {
     const std::string propfile = ConfigService::Instance().getDirectoryOfExecutable() 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -98,6 +98,8 @@ void export_ConfigService()
 
     .def("saveConfig", &ConfigServiceImpl::saveConfig, "Saves the keys that have changed from their default to the given filename")
 
+    .def("keys", &ConfigServiceImpl::keys)
+
     // Treat this as a dictionary
     .def("__getitem__", &getStringUsingCache)
     .def("__setitem__", &ConfigServiceImpl::setString)


### PR DESCRIPTION
Fixes [#9067](http://trac.mantidproject.org/mantid/ticket/9067).

Can be tested using:

```
for key in config.keys():
    line = '%s\t\t%s' % (key, config[key])
    print line
```
