### PR TITLE
Don't clear results when changing data

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h
@@ -73,9 +73,6 @@ namespace CustomInterfaces
     /// Updates function in the view from the model
     void updateFunction();
 
-    /// Removes all section rows / section selectors
-    void clearSections();
-
   private:
     /// Associated view
     IALCBaselineModellingView* const m_view;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -57,9 +57,6 @@ namespace CustomInterfaces
   {
     m_data = data;
     emit dataChanged();
-
-    setCorrectedData(MatrixWorkspace_const_sptr());
-    setFittedFunction(IFunction_const_sptr());
   }
 
   /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
@@ -31,7 +31,6 @@ namespace CustomInterfaces
 
     // Model updates
     connect(m_model, SIGNAL(dataChanged()), SLOT(updateDataCurve()));
-    connect(m_model, SIGNAL(dataChanged()), SLOT(clearSections()));
     connect(m_model, SIGNAL(correctedDataChanged()), SLOT(updateCorrectedCurve()));
     connect(m_model, SIGNAL(fittedFunctionChanged()), SLOT(updateFunction()));
     connect(m_model, SIGNAL(fittedFunctionChanged()), SLOT(updateBaselineCurve()));
@@ -208,16 +207,6 @@ namespace CustomInterfaces
     {
       m_view->setFunction(IFunction_const_sptr());
     }
-  }
-
-  void ALCBaselineModellingPresenter::clearSections()
-  {
-    for (int i = 0; i < m_view->noOfSectionRows(); ++i)
-    {
-      m_view->deleteSectionSelector(i);
-    }
-
-    m_view->setNoOfSectionRows(0);
   }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -15,8 +15,6 @@ namespace CustomInterfaces
   {
     m_data = newData;
     emit dataChanged();
-
-    setFittedPeaks(IFunction_const_sptr());
   }
 
   MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace()

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -152,12 +152,6 @@ public:
                                             QwtDataX(0, 1, 1E-8), QwtDataX(2, 3, 1E-8),
                                             QwtDataY(0, 2, 1E-8), QwtDataY(2, 4, 1E-8))));
 
-    // Data changed -> clear sections
-    EXPECT_CALL(*m_view, setNoOfSectionRows(0));
-    EXPECT_CALL(*m_view, deleteSectionSelector(0));
-    EXPECT_CALL(*m_view, deleteSectionSelector(1));
-    EXPECT_CALL(*m_view, deleteSectionSelector(2));
-
     m_model->changeData();
   }
 


### PR DESCRIPTION
Fixes [#9506](http://trac.mantidproject.org/mantid/ticket/9506)

In the ALC interface, fitting ranges, fitting functions and corrected data are cleared when a new set of runs are selected. Even when the user goes back to a previous step and returns to the current one without changing anything, fitting properties are cleared. Scientists would like to keep them, as they can be useful for the next analysis.

To test: 
- Open ALC, load "MUSR00015189.nxs" as "First" and "MUSR00015191.nxs" as "Last", hit "Load" and then "Baseline Modelling". Right-click on functions and add a fitting function, right-click on sections and add a new section, hit "Fit".
- Go back to "Data loading" and hit "Baseline modelling" again. The fitting function, sections and corrected data should still be there.
- Go to "Peak fitting", right-click on "Peaks" area and select a fitting function, hit "Fit". Go back to "Baseline Modelling" and forth to "Peak Fitting", the fitting function should be there.
