### PR TITLE
Fix valgrind memcheck warnings in DataObjects

### DIFF
--- a/Code/Mantid/Framework/API/src/BoxController.cpp
+++ b/Code/Mantid/Framework/API/src/BoxController.cpp
@@ -251,7 +251,7 @@ void BoxController::fromXMLString(const std::string &xml) {
 
   // Need to make sure that we handle box controllers which did not have the SplitTopInto 
   // attribute 
-  Poco::XML::NodeList* nodes = pBoxElement->getElementsByTagName("SplitTopInto");
+  Poco::AutoPtr<NodeList> nodes = pBoxElement->getElementsByTagName("SplitTopInto");
   if (nodes->length() > 0) {
     s = pBoxElement->getChildElement("SplitTopInto")->innerText();
     if (s.empty()) {

--- a/Code/Mantid/Framework/API/src/IMDEventWorkspace.cpp
+++ b/Code/Mantid/Framework/API/src/IMDEventWorkspace.cpp
@@ -11,7 +11,7 @@ namespace API {
 //-----------------------------------------------------------------------------------------------
 /** Empty constructor */
 IMDEventWorkspace::IMDEventWorkspace()
-    : IMDWorkspace(), m_fileNeedsUpdating(false) {}
+    : IMDWorkspace(), MultipleExperimentInfos(), m_fileNeedsUpdating(false) {}
 
 //-----------------------------------------------------------------------------------------------
 /** Copy constructor */

--- a/Code/Mantid/Framework/API/src/MDGeometry.cpp
+++ b/Code/Mantid/Framework/API/src/MDGeometry.cpp
@@ -16,16 +16,16 @@ namespace API {
 /** Constructor
  */
 MDGeometry::MDGeometry()
-    : m_originalWorkspaces(), m_transforms_FromOriginal(),
+    : m_dimensions(), m_originalWorkspaces(), m_origin(), m_transforms_FromOriginal(),
       m_transforms_ToOriginal(),
       m_delete_observer(*this, &MDGeometry::deleteNotificationReceived),
-      m_observingDelete(false), m_Wtransf(3, 3, true) {}
+      m_observingDelete(false), m_Wtransf(3, 3, true), m_basisVectors() {}
 
 //----------------------------------------------------------------------------------------------
 /** Copy Constructor
  */
 MDGeometry::MDGeometry(const MDGeometry &other)
-    : m_originalWorkspaces(), m_origin(other.m_origin),
+    : m_dimensions(), m_originalWorkspaces(), m_origin(other.m_origin),
       m_transforms_FromOriginal(), m_transforms_ToOriginal(),
       m_delete_observer(*this, &MDGeometry::deleteNotificationReceived),
       m_observingDelete(false), m_Wtransf(other.m_Wtransf),

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.h
@@ -238,7 +238,7 @@ private:
   /**Private constructor as it does not work without box controller */
   MDGridBox() {}
   /// common part of MDGridBox contstructor;
-  void initGridBox();
+  size_t initGridBox();
 };
 
 #ifndef __INTEL_COMPILER

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
@@ -4,7 +4,9 @@
 #include "MantidKernel/System.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include <algorithm>
+#include <cmath>
 #include <numeric>
+#include <string>
 #include <vector>
 
 namespace Mantid {
@@ -13,7 +15,7 @@ namespace DataObjects {
 /** Templated class holding data about a neutron detection event
  * in N-dimensions (for example, Qx, Qy, Qz, E).
  *
- *   Each neutron has a signal (a float, can be != 1) and an error. This
+ *  Each neutron has a signal (a float, can be != 1) and an error. This
  * is the same principle as the WeightedEvent in EventWorkspace's
  *
  * This class is meant to be as small in memory as possible, since there

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
@@ -2,11 +2,10 @@
 #define MANTID_DATAOBJECTS_MDLEANEVENT_H_
 
 #include "MantidKernel/System.h"
-#include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
-#include "MantidAPI/BoxController.h"
+#include <algorithm>
 #include <numeric>
-#include <cmath>
+#include <vector>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDLeanEvent.h
@@ -8,6 +8,7 @@
 #include <numeric>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/src/CoordTransformAffineParser.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/CoordTransformAffineParser.cpp
@@ -42,7 +42,7 @@ Mantid::API::CoordTransform *CoordTransformAffineParser::createTransform(
 
   Element *paramListElement =
       coordTransElement->getChildElement("ParameterList");
-  Poco::XML::NodeList *parameters =
+  Poco::AutoPtr<Poco::XML::NodeList> parameters =
       paramListElement->getElementsByTagName("Parameter");
 
   // Add input dimension parameter.

--- a/Code/Mantid/Framework/DataObjects/src/CoordTransformAligned.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/CoordTransformAligned.cpp
@@ -38,12 +38,16 @@ CoordTransformAligned::CoordTransformAligned(const size_t inD,
   m_scaling = new coord_t[outD];
   for (size_t d = 0; d < outD; d++) {
     m_dimensionToBinFrom[d] = dimensionToBinFrom[d];
-    if (m_dimensionToBinFrom[d] >= inD)
+    if (m_dimensionToBinFrom[d] >= inD) {
+      delete [] m_dimensionToBinFrom;
+      delete [] m_origin;
+      delete [] m_scaling;
       throw std::runtime_error(
           "CoordTransformAligned::ctor(): invalid entry in "
           "dimensionToBinFrom[" +
           Mantid::Kernel::Strings::toString(d) +
           "]. Cannot build the coordinate transformation.");
+    }
     m_origin[d] = origin[d];
     m_scaling[d] = scaling[d];
   }
@@ -78,12 +82,16 @@ CoordTransformAligned::CoordTransformAligned(
   m_scaling = new coord_t[outD];
   for (size_t d = 0; d < outD; d++) {
     m_dimensionToBinFrom[d] = dimensionToBinFrom[d];
-    if (m_dimensionToBinFrom[d] >= inD)
+    if (m_dimensionToBinFrom[d] >= inD) {
+      delete [] m_dimensionToBinFrom;
+      delete [] m_origin;
+      delete [] m_scaling;
       throw std::runtime_error(
           "CoordTransformAligned::ctor(): invalid entry in "
           "dimensionToBinFrom[" +
           Mantid::Kernel::Strings::toString(d) +
           "]. Cannot build the coordinate transformation.");
+    }
     m_origin[d] = origin[d];
     m_scaling[d] = scaling[d];
   }

--- a/Code/Mantid/Framework/DataObjects/src/CoordTransformDistance.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/CoordTransformDistance.cpp
@@ -112,7 +112,7 @@ std::string CoordTransformDistance::toXMLString() const {
 
   AutoPtr<Element> coordTransformTypeElement = pDoc->createElement("Type");
   coordTransformTypeElement->appendChild(
-      pDoc->createTextNode("CoordTransformDistance"));
+      AutoPtr<Text>(pDoc->createTextNode("CoordTransformDistance")));
   coordTransformElement->appendChild(coordTransformTypeElement);
 
   AutoPtr<Element> paramListElement = pDoc->createElement("ParameterList");

--- a/Code/Mantid/Framework/DataObjects/src/MDBoxBase.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDBoxBase.cpp
@@ -65,7 +65,7 @@ TMDE(MDBoxBase)::MDBoxBase(const MDBoxBase<MDE, nd> &box,
     : m_signal(box.m_signal), m_errorSquared(box.m_errorSquared),
       m_totalWeight(box.m_totalWeight), m_BoxController(otherBC),
       m_inverseVolume(box.m_inverseVolume), m_depth(box.m_depth),
-      m_parent(box.m_parent), m_fileID(box.m_fileID) {
+      m_parent(box.m_parent), m_fileID(box.m_fileID), m_dataMutex() {
 
   // Copy the extents
   for (size_t d = 0; d < nd; d++)

--- a/Code/Mantid/Framework/DataObjects/src/MDEventWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDEventWorkspace.cpp
@@ -34,7 +34,8 @@ namespace DataObjects {
 /** Default constructor
  */
 TMDE(MDEventWorkspace)::MDEventWorkspace()
-    : data(NULL), m_BoxController(new BoxController(nd)), m_coordSystem(None) {
+    : API::IMDEventWorkspace(), data(NULL),
+      m_BoxController(new BoxController(nd)), m_coordSystem(None) {
   // First box is at depth 0, and has this default boxController
   data = new MDBox<MDE, nd>(m_BoxController.get(), 0);
 }
@@ -43,8 +44,8 @@ TMDE(MDEventWorkspace)::MDEventWorkspace()
 /** Copy constructor
  */
 TMDE(MDEventWorkspace)::MDEventWorkspace(const MDEventWorkspace<MDE, nd> &other)
-    : IMDEventWorkspace(other),
-      m_BoxController(other.m_BoxController->clone()) {
+    : IMDEventWorkspace(other), data(NULL),
+      m_BoxController(other.m_BoxController->clone()), m_coordSystem(other.m_coordSystem) {
 
   const MDBox<MDE, nd> *mdbox =
       dynamic_cast<const MDBox<MDE, nd> *>(other.data);

--- a/Code/Mantid/Framework/DataObjects/src/MDGridBox.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDGridBox.cpp
@@ -42,8 +42,8 @@ TMDE(MDGridBox)::MDGridBox(
     BoxController *const bc, const uint32_t depth,
     const std::vector<
         Mantid::Geometry::MDDimensionExtents<coord_t>> &extentsVector)
-    : MDBoxBase<MDE, nd>(bc, depth, UNDEF_SIZET, extentsVector), numBoxes(0),
-      nPoints(0) {
+    : MDBoxBase<MDE, nd>(bc, depth, UNDEF_SIZET, extentsVector),
+      numBoxes(0), m_Children(), diagonalSquared(0.f), nPoints(0) {
   initGridBox();
 }
 
@@ -58,11 +58,11 @@ TMDE(MDGridBox)::MDGridBox(
     const std::vector<
         Mantid::Geometry::MDDimensionExtents<coord_t>> &extentsVector)
     : MDBoxBase<MDE, nd>(bc.get(), depth, UNDEF_SIZET, extentsVector),
-      numBoxes(0), nPoints(0) {
+      numBoxes(0), m_Children(), diagonalSquared(0.f), nPoints(0) {
   initGridBox();
 }
 /// common part of MDGridBox contstructor;
-template <typename MDE, size_t nd> void MDGridBox<MDE, nd>::initGridBox() {
+template <typename MDE, size_t nd> size_t MDGridBox<MDE, nd>::initGridBox() {
   if (!this->m_BoxController)
     throw std::runtime_error(
         "MDGridBox::ctor(): No BoxController specified in box.");
@@ -86,6 +86,7 @@ template <typename MDE, size_t nd> void MDGridBox<MDE, nd>::initGridBox() {
   if (tot == 0)
     throw std::runtime_error(
         "MDGridBox::ctor(): Invalid splitting criterion (one was zero).");
+  return tot;
 }
 
 //-----------------------------------------------------------------------------------------------
@@ -93,41 +94,18 @@ template <typename MDE, size_t nd> void MDGridBox<MDE, nd>::initGridBox() {
  * @param box :: MDBox containing the events to split
  */
 TMDE(MDGridBox)::MDGridBox(MDBox<MDE, nd> *box)
-    : MDBoxBase<MDE, nd>(*box, box->getBoxController()), numBoxes(0), nPoints(0) {
-  if (!this->m_BoxController)
-    throw std::runtime_error("MDGridBox::ctor(): constructing from box:: No "
-                             "BoxController specified in box.");
-
-  //    std::cout << "Splitting MDBox ID " << box->getId() << " with " <<
-  //    box->getNPoints() << " events into MDGridBox" << std::endl;
-
-  // How many is it split?
-  // If we are at the top level and we have a specific top level split, then set it.
-  boost::optional<std::vector<size_t>> splitTopInto = this->m_BoxController->getSplitTopInto();
-  if (this->getDepth() == 0 && splitTopInto)
-  {
-    for (size_t d = 0; d < nd; d++)
-      split[d] = splitTopInto.get()[d];
-  }
-  else
-  {
-   for (size_t d = 0; d < nd; d++)
-    split[d] = this->m_BoxController->getSplitInto(d);
-  }
-
-  // Compute sizes etc.
-  size_t tot = computeSizesFromSplit();
-  if (tot == 0)
-    throw std::runtime_error("MDGridBox::ctor(): constructing from "
-                             "box::Invalid splitting criterion (one was "
-                             "zero).");
+    : MDBoxBase<MDE, nd>(*box, box->getBoxController()), split(),
+      splitCumul(), m_SubBoxSize(), numBoxes(0), m_Children(),
+      diagonalSquared(0.f), nPoints(0)
+{
+  size_t totalSize = initGridBox();
 
   double ChildVol(1);
   for (size_t d = 0; d < nd; d++)
     ChildVol *= m_SubBoxSize[d];
 
   // Splitting an input MDBox requires creating a bunch of children
-  fillBoxShell(tot, coord_t(1. / ChildVol));
+  fillBoxShell(totalSize, coord_t(1. / ChildVol));
 
   // Prepare to distribute the events that were in the box before, this will
   // load missing events from HDD in file based ws if there are some.
@@ -210,7 +188,7 @@ void MDGridBox<MDE, nd>::fillBoxShell(const size_t tot,
  */
 TMDE(MDGridBox)::MDGridBox(const MDGridBox<MDE, nd> &other,
                            Mantid::API::BoxController *const otherBC)
-    : MDBoxBase<MDE, nd>(other, otherBC), numBoxes(other.numBoxes),
+    : MDBoxBase<MDE, nd>(other, otherBC), numBoxes(other.numBoxes), m_Children(),
       diagonalSquared(other.diagonalSquared), nPoints(other.nPoints) {
   for (size_t d = 0; d < nd; d++) 
   {
@@ -437,7 +415,7 @@ TMDE(std::vector<MDE> *MDGridBox)::getEventsCopy() {
  */
 TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
                                size_t maxDepth, bool leafOnly) {
-  // Add this box, unless we only want the leaves
+ //Add this box, unless we only want the leaves
   if (!leafOnly)
     outBoxes.push_back(this);
 

--- a/Code/Mantid/Framework/DataObjects/src/MDGridBox.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDGridBox.cpp
@@ -93,7 +93,7 @@ template <typename MDE, size_t nd> void MDGridBox<MDE, nd>::initGridBox() {
  * @param box :: MDBox containing the events to split
  */
 TMDE(MDGridBox)::MDGridBox(MDBox<MDE, nd> *box)
-    : MDBoxBase<MDE, nd>(*box, box->getBoxController()), nPoints(0) {
+    : MDBoxBase<MDE, nd>(*box, box->getBoxController()), numBoxes(0), nPoints(0) {
   if (!this->m_BoxController)
     throw std::runtime_error("MDGridBox::ctor(): constructing from box:: No "
                              "BoxController specified in box.");
@@ -1660,7 +1660,7 @@ TMDE(void MDGridBox)::buildAndAddEventUnsafe(const signal_t Signal,
  * @param event :: reference to a MDLeanEvent to add.
  * */
 TMDE(inline void MDGridBox)::addEvent(const MDE &event) {
-  size_t index = 0;
+  size_t cindex = 0;
   for (size_t d = 0; d < nd; d++) {
     coord_t x = event.getCenter(d);
     int i = int((x - this->extents[d].getMin()) / m_SubBoxSize[d]);
@@ -1668,12 +1668,14 @@ TMDE(inline void MDGridBox)::addEvent(const MDE &event) {
     // if (i < 0 || i >= int(split[d])) return;
 
     // Accumulate the index
-    index += (i * splitCumul[d]);
+    cindex += (i * splitCumul[d]);
   }
 
   // Add it to the contained box
-  if (index < numBoxes) // avoid segfaults for floating point round-off errors.
-    m_Children[index]->addEvent(event);
+  // avoid segfaults for floating point round-off errors.
+  if (cindex < numBoxes) {
+    m_Children[cindex]->addEvent(event);
+  }
 }
 //-----------------------------------------------------------------------------------------------
 /** Add a single MDLeanEvent to the grid box. If the boxes
@@ -1692,18 +1694,19 @@ TMDE(inline void MDGridBox)::addEvent(const MDE &event) {
  * @param event :: reference to a MDEvent to add.
  * */
 TMDE(inline void MDGridBox)::addEventUnsafe(const MDE &event) {
-  size_t index = 0;
+  size_t cindex = 0;
   for (size_t d = 0; d < nd; d++) {
 
     coord_t x = event.getCenter(d);
     int i = int((x - this->extents[d].getMin()) / m_SubBoxSize[d]);
     // Accumulate the index
-    index += (i * splitCumul[d]);
+    cindex += (i * splitCumul[d]);
   }
 
   // Add it to the contained box
-  if (index < numBoxes) // avoid segfaults for floating point round-off errors.
-    m_Children[index]->addEventUnsafe(event);
+  if (cindex < numBoxes) {
+    m_Children[cindex]->addEventUnsafe(event);
+  }
 }
 
 /**Sets particular child MDgridBox at the index, specified by the input

--- a/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -237,12 +237,14 @@ bool MDHistoWorkspaceIterator::next() {
   } else {
     ++m_pos;
   }
-  // Keep calling next if the current position is masked.
   bool ret = m_pos < m_max;
-  while (m_skippingPolicy->keepGoing()) {
-    ret = this->next();
-    if (!ret)
-      break;
+  if(ret) {
+    // Keep calling next if the current position is masked and still valid.
+    while (m_skippingPolicy->keepGoing()) {
+      ret = this->next();
+      if (!ret)
+        break;
+    }
   }
   // Go through every point;
   return ret;

--- a/Code/Mantid/Framework/DataObjects/test/CoordTransformAffineParserTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/CoordTransformAffineParserTest.h
@@ -43,7 +43,6 @@ public:
 
    CoordTransformAffineParser parser;
    CoordTransformAffine* transform = dynamic_cast<CoordTransformAffine*>(parser.createTransform(pRootElem));
-
    AffineMatrixType product = transform->getMatrix();
 
    //Check that matrix is recovered.

--- a/Code/Mantid/Framework/DataObjects/test/CoordTransformAffineTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/CoordTransformAffineTest.h
@@ -11,8 +11,8 @@
 #include "MantidDataObjects/CoordTransformDistance.h"
 #include "MantidDataObjects/MDEventFactory.h"
 #include <cxxtest/TestSuite.h>
-#include <iomanip>
-#include <iostream>
+
+#include <boost/scoped_ptr.hpp>
 
 using namespace Mantid;
 using namespace Mantid::Kernel;
@@ -113,7 +113,7 @@ public:
     ct.addTranslation(translation);
 
     // Clone and check the clone works
-    CoordTransform * clone = ct.clone();
+    boost::scoped_ptr<CoordTransform> clone(ct.clone());
     clone->apply(in, out);
     compare(2, out, expected);
   }
@@ -269,7 +269,9 @@ public:
     TSM_ASSERT_THROWS_ANYTHING("Null input fails.", CoordTransformAffine::combineTransformations(NULL, &ct43) );
     TSM_ASSERT_THROWS_ANYTHING("Incompatible # of dimensions", CoordTransformAffine::combineTransformations(&ct42, &ct32) );
     TSM_ASSERT_THROWS_ANYTHING("Incompatible # of dimensions", CoordTransformAffine::combineTransformations(&ct32, &ct43) );
-    TSM_ASSERT_THROWS_NOTHING("Compatible # of dimensions", CoordTransformAffine::combineTransformations(&ct43, &ct32) );
+    CoordTransformAffine *ct(NULL);
+    TSM_ASSERT_THROWS_NOTHING("Compatible # of dimensions", ct = CoordTransformAffine::combineTransformations(&ct43, &ct32) );
+    delete ct;
     coord_t center[3] = {1,2,3};
     bool bools[3] = {true, true, true};
     CoordTransformDistance ctd(3, center, bools);
@@ -291,7 +293,7 @@ public:
     CoordTransformAffine ct2(2,2);
     ct2.addTranslation(translation2);
     // Combine them
-    CoordTransformAffine * combined = CoordTransformAffine::combineTransformations(&ct1, &ct2);
+    boost::scoped_ptr<CoordTransformAffine> combined(CoordTransformAffine::combineTransformations(&ct1, &ct2));
     combined->apply(in, out);
     compare(2, out, expected);
   }
@@ -311,7 +313,7 @@ public:
     ct2->apply(out1, out2);
 
     // Combine them
-    CoordTransformAffine * combined = CoordTransformAffine::combineTransformations(ct1, ct2);
+    boost::scoped_ptr<CoordTransformAffine> combined(CoordTransformAffine::combineTransformations(ct1, ct2));
     combined->apply(in, out_combined);
 
     // Applying the combined one = same as each one in sequence
@@ -434,4 +436,3 @@ public:
 
 
 #endif /* MANTID_DATAOBJECTS_COORDTRANSFORMAFFINETEST_H_ */
-

--- a/Code/Mantid/Framework/DataObjects/test/CoordTransformAlignedTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/CoordTransformAlignedTest.h
@@ -11,6 +11,8 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidDataObjects/CoordTransformAffine.h"
 
+#include <boost/scoped_ptr.hpp>
+
 using namespace Mantid;
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
@@ -28,10 +30,12 @@ public:
     size_t dimToBinFrom[3] = {4, 1, 0};
     coord_t origin[3] = {5, 10, 15};
     coord_t scaling[3] = {1, 2, 3};
-    TSM_ASSERT_THROWS_ANYTHING( "DimtoBinFrom has too high an index", CoordTransformAligned ct(4,3, dimToBinFrom, origin, scaling); );
+    TSM_ASSERT_THROWS_ANYTHING( "DimtoBinFrom has too high an index", 
+                                 CoordTransformAligned(4,3, dimToBinFrom, origin, scaling) );
     std::vector<size_t> d(3);
     std::vector<coord_t> o(2), s(3);
-    TSM_ASSERT_THROWS_ANYTHING( "Non-matching vector lengths", CoordTransformAligned ct(3,3, d,o,s); );
+    TSM_ASSERT_THROWS_ANYTHING( "Non-matching vector lengths",
+                                 CoordTransformAligned(3,3, d,o,s) );
   }
 
   /** Construct from vector */
@@ -74,7 +78,7 @@ public:
     coord_t origin[3] = {5, 10, 15};
     coord_t scaling[3] = {1, 2, 3};
     CoordTransformAligned ct(4,3, dimToBinFrom, origin, scaling);
-    CoordTransform * clone = ct.clone();
+    boost::scoped_ptr<CoordTransform> clone(ct.clone());
 
     coord_t input[4] = {16, 11, 11111111 /*ignored*/, 6};
     coord_t output[3] = {0,0,0};

--- a/Code/Mantid/Framework/DataObjects/test/CoordTransformDistanceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/CoordTransformDistanceTest.h
@@ -9,6 +9,8 @@
 #include <iostream>
 #include "MantidAPI/CoordTransform.h"
 
+#include <boost/scoped_ptr.hpp>
+
 using namespace Mantid;
 using namespace Mantid::DataObjects;
 using Mantid::API::CoordTransform;
@@ -30,13 +32,14 @@ public:
     bool used[4] = {true, false, true, true};
     CoordTransformDistance ct(4, center, used);
     // A copy was made
-    TS_ASSERT_DIFFERS(ct.getCenter(), center);
+    const coord_t *transformCentres = ct.getCenter();
+    TS_ASSERT_DIFFERS(transformCentres, center);
+    const bool * usedDims = ct.getDimensionsUsed();
     TS_ASSERT_DIFFERS(ct.getDimensionsUsed(), used);
-
     // Contents are good
     compare(4, center, ct.getCenter());
     for (size_t i=0; i<4; i++)
-      TS_ASSERT_EQUALS( used[i], ct.getDimensionsUsed()[i]);
+      TS_ASSERT_EQUALS( used[i], usedDims[i]);
   }
 
 
@@ -48,7 +51,7 @@ public:
     bool used[2] = {true, true};
     CoordTransformDistance ct(2,center,used);
 
-    CoordTransform * clone = ct.clone();
+    boost::scoped_ptr<CoordTransform> clone(ct.clone());
     coord_t out = 0;
     coord_t in1[2] = {0, 3};
     TS_ASSERT_THROWS_NOTHING( clone->apply(in1, &out) );

--- a/Code/Mantid/Framework/DataObjects/test/MDBoxBaseTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDBoxBaseTest.h
@@ -249,6 +249,7 @@ public:
     MDBoxBaseTester<MDLeanEvent<3>,3> c(b);
     TS_ASSERT_EQUALS( c.getParent(), daddy);
 
+    delete daddy;
   }
 
   /** Setting and getting the extents;
@@ -432,15 +433,14 @@ public:
     delete [] v;
   }
 
-  void test_sortBoxesByFilePos()
+  void xtest_sortBoxesByFilePos()
   {
-    std::vector<API::IMDNode *> boxes;
-    // 10 to 1 in reverse order
-
-    for (uint64_t i=0; i<10; i++)
-    {
-      boxes.push_back(new MDBoxBaseTester<MDLeanEvent<1>,1>(10-i));
-    }
+//    std::vector<API::IMDNode *> boxes;
+//    // 10 to 1 in reverse order
+//    for (uint64_t i=0; i<10; i++)
+//    {
+//      boxes.push_back(new MDBoxBaseTester<MDLeanEvent<1>,1>(10-i));
+//    }
     //TODO:
     //Kernel::ISaveable::sortObjByFilePos(boxes);
     //// After sorting, they are in the right order 1,2,3, etc.

--- a/Code/Mantid/Framework/DataObjects/test/MDBoxFlatTreeTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDBoxFlatTreeTest.h
@@ -78,7 +78,18 @@ public:
       }
     }
 
-
+    // Clean up MDGridBoxes as they will take care of their children
+    // If we delete directly in the first loop over then the pointers later in the list
+    // become invalid
+    std::vector<size_t> gridIndices;
+    for(size_t i = 0; i < Boxes.size(); ++i) {
+      if(!Boxes[i]->isBox()) gridIndices.push_back(i);
+    }
+    for(size_t i = 0; i < gridIndices.size(); ++i) {
+      delete Boxes[gridIndices[i]];
+    }
+    
+    // Clean up file
     if(testFile.exists())
       testFile.remove();
   }

--- a/Code/Mantid/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -79,6 +79,12 @@ public:
     D212 = dynamic_cast<ibox_t *>(C21->getChild(2));
     D213 = dynamic_cast<ibox_t *>(C21->getChild(3));
   }
+  
+  void tearDown()
+  {
+    delete A->getBoxController();
+    delete A;
+  }
 
   //--------------------------------------------------------------------------------------
   void test_ctor_with_null_box_fails()
@@ -125,6 +131,8 @@ public:
     // Calling next again does not cause problems.
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_depth_limit_1()
@@ -138,6 +146,8 @@ public:
     TS_ASSERT( nextIs(it, B3) );
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_depth_limit_0()
@@ -147,6 +157,8 @@ public:
     TS_ASSERT_EQUALS( it->getBox(), A);
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_starting_deeper()
@@ -160,6 +172,8 @@ public:
     TS_ASSERT( nextIs(it, C03) );
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_leaf_only()
@@ -184,6 +198,8 @@ public:
     // No more!
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_leaf_only_depth_2()
@@ -204,6 +220,8 @@ public:
     TS_ASSERT( nextIs(it, B3) );
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_leaf_only_depth_1()
@@ -217,6 +235,8 @@ public:
     TS_ASSERT( nextIs(it, B3) );
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_leaf_only_depth_0()
@@ -227,6 +247,8 @@ public:
     TS_ASSERT_EQUALS( it->getBox(), A);
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_leaf_only_starting_deeper()
@@ -242,6 +264,8 @@ public:
     TS_ASSERT( nextIs(it, C23) );
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+    
+    delete it;
   }
 
   void test_leaf_only_starting_deeper_depth_limited()
@@ -254,6 +278,8 @@ public:
     TS_ASSERT( nextIs(it, C23) );
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   //--------------------------------------------------------------------------------------
@@ -271,6 +297,8 @@ public:
 
     BoxController *const bc = A->getBoxController();
     delete bc;
+    delete it;
+    delete A;
   }
 
   //--------------------------------------------------------------------------------------
@@ -302,7 +330,8 @@ public:
 
     BoxController *const bc = A->getBoxController();
     delete bc;
-
+    delete it;
+    delete A;
   }
   //--------------------------------------------------------------------------------------
   void test_iterator_withImplicitFunction_above11()
@@ -314,6 +343,7 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, false, func);
+    delete func;
 
     // Start with the top one
     TS_ASSERT_EQUALS( it->getBox(), A);
@@ -335,6 +365,8 @@ public:
     // No more!
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   //--------------------------------------------------------------------------------------
@@ -347,6 +379,7 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, true, func);
+    delete func;
 
     // C00-C01 are outside the range, so the first one is C02
     TS_ASSERT_EQUALS( it->getBox(), C02);
@@ -363,6 +396,8 @@ public:
     // No more!
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
 
@@ -376,6 +411,7 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, false, func);
+    delete func;
 
     // Start with the top one
     TS_ASSERT_EQUALS( it->getBox(), A);
@@ -394,6 +430,8 @@ public:
     // No more!
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
 
@@ -408,6 +446,7 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, false, func);
+    delete func;
 
     // Go down to the only two leaf boxes that are in range
     TS_ASSERT_EQUALS( it->getBox(), A);
@@ -418,6 +457,8 @@ public:
     // No more!
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   //--------------------------------------------------------------------------------------
@@ -431,6 +472,7 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, true, func);
+    delete func;
 
     // Only two leaf boxes are in range
     TS_ASSERT_EQUALS( it->getBox(), D211);
@@ -438,6 +480,8 @@ public:
     // No more!
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   //--------------------------------------------------------------------------------------
@@ -449,11 +493,14 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, false, func);
+    delete func;
 
     // Returns the first box but that's it
     TS_ASSERT_EQUALS( it->getBox(), A);
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+    
+    delete it;
   }
 
   //--------------------------------------------------------------------------------------
@@ -465,10 +512,14 @@ public:
 
     // Create an iterator
     it = new MDBoxIterator<MDLeanEvent<1>,1>(A, 20, true, func);
+    delete func;
+    
     // Nothing in the iterator!
     TS_ASSERT_EQUALS( it->getDataSize(), 0);
     TS_ASSERT( !it->next() );
     TS_ASSERT( !it->next() );
+
+    delete it;
   }
 
   void test_getIsMasked()
@@ -542,6 +593,9 @@ public:
     TSM_ASSERT_EQUALS("Should NOT have skipped to the second box", 2, evaluationIterator->getPosition());
     TS_ASSERT_THROWS_NOTHING(evaluationIterator->next());
     TSM_ASSERT_EQUALS("Should NOT have skipped to the third box", 3, evaluationIterator->getPosition());
+
+    delete setupIterator;
+    delete evaluationIterator;
   }
 
   void test_custom_skipping_policy()

--- a/Code/Mantid/Framework/DataObjects/test/MDBoxSaveableTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDBoxSaveableTest.h
@@ -1,6 +1,7 @@
 #ifndef MDBOX_SAVEABLE_TEST_H
 #define MDBOX_SAVEABLE_TEST_H
 
+#include <boost/scoped_ptr.hpp>
 #include <cxxtest/TestSuite.h>
 #include <map>
 #include <memory>
@@ -266,6 +267,8 @@ static void destroySuite(MDBoxSaveableTest * suite) { delete suite; }
     TSM_ASSERT_EQUALS( "Child is NOT on disk", b->getISaveable()->wasSaved(), false);
 
     bc->getFileIO()->closeFile();      
+    delete gb;
+    delete c;
     do_deleteNexusFile("MDGridBoxTest.nxs");
   }
 
@@ -745,7 +748,7 @@ static void destroySuite(MDBoxSaveableTest * suite) { delete suite; }
 
    
     // Create the grid box and make it file-backed.
-    MDBoxBase<MDE,2> * b = MDEventsTestHelper::makeMDGridBox<2>();
+    MDBoxBase<MDE,2> *b = MDEventsTestHelper::makeMDGridBox<2>();
     // box controlled is owned by the workspace, so here we make shared pointer from the box pointer as it is owned by this function
     BoxController_sptr spBc = boost::shared_ptr<BoxController >(b->getBoxController());
 
@@ -814,7 +817,7 @@ static void destroySuite(MDBoxSaveableTest * suite) { delete suite; }
     TSM_ASSERT_LESS_THAN("And the events were properly saved sequentially in the files.", minimumSaved, maxFilePos);
     std::cout << dbuf->getMemoryStr() << std::endl;
     
-
+    delete b;
     const std::string filename = fbc->getFileName();
     fbc->closeFile();
     if (Poco::File(filename).exists()) Poco::File(filename).remove();

--- a/Code/Mantid/Framework/DataObjects/test/MDBoxTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDBoxTest.h
@@ -390,10 +390,10 @@ static void destroySuite(MDBoxTest * suite) { delete suite; }
     b.addEvent(ev);
     b.addEvent(ev);
     b.addEvent(ev);
-    std::vector<MDLeanEvent<2> > * events;
-    events = b.getEventsCopy();
+    std::vector<MDLeanEvent<2> > * events = b.getEventsCopy();
     TS_ASSERT_EQUALS( events->size(), 3);
     TS_ASSERT_EQUALS( (*events)[2].getSignal(), 4.0);
+    delete events;
   }
 
   void test_sptr()

--- a/Code/Mantid/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -221,10 +221,13 @@ public:
     TS_ASSERT_EQUALS(it->getDataSize(), 4*4*4);
     TS_ASSERT(it->next());
     delete it;
-    it = ew->createIterator(new MDImplicitFunction());
+    auto *mdfunction = new MDImplicitFunction();
+    it = ew->createIterator(mdfunction);
     TS_ASSERT(it);
     TS_ASSERT_EQUALS(it->getDataSize(), 4*4*4);
     TS_ASSERT(it->next());
+    delete mdfunction;
+    delete it;
     delete ew;
   }
 
@@ -242,6 +245,9 @@ public:
     TS_ASSERT_EQUALS(iterators[0]->getDataSize(), 21);
     TS_ASSERT_EQUALS(iterators[1]->getDataSize(), 21);
     TS_ASSERT_EQUALS(iterators[2]->getDataSize(), 22);
+
+    for(size_t i = 0; i < 3; ++i) delete iterators[i];
+    delete ew;
   }
 
   //-------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDGridBoxTest.h
@@ -931,14 +931,14 @@ public:
           double centers[2] = {x,y};
           events.push_back( MDLeanEvent<2>(2.0, 2.0, centers) );
         }
-      //TS_ASSERT_THROWS_NOTHING( b->addEvents( events ); );
+      TS_ASSERT_THROWS_NOTHING( b->addEvents( events ); );
     }
 
     // Get the right totals again by refreshing
-    // b->refreshCache(ts);
-    // TS_ASSERT_EQUALS( b->getNPoints(), 100*num_repeat);
-    // TS_ASSERT_EQUALS( b->getSignal(), 100*num_repeat*2.0);
-    // TS_ASSERT_EQUALS( b->getErrorSquared(), 100*num_repeat*2.0);
+    b->refreshCache(ts);
+    TS_ASSERT_EQUALS( b->getNPoints(), 100*num_repeat);
+    TS_ASSERT_EQUALS( b->getSignal(), 100*num_repeat*2.0);
+    TS_ASSERT_EQUALS( b->getErrorSquared(), 100*num_repeat*2.0);
 
     // clean up  behind
     BoxController *const bcc = b->getBoxController();

--- a/Code/Mantid/Framework/DataObjects/test/MDGridBoxTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDGridBoxTest.h
@@ -44,7 +44,7 @@ using namespace testing;
 class MDGridBoxTest :    public CxxTest::TestSuite
 {
 private:
-  
+
   ///Mock type to help determine if masking is being determined correctly
     class MockMDBox : public MDBox<MDLeanEvent<1>, 1>
   {
@@ -80,7 +80,7 @@ public:
   //-------------------------------------------------------------------------------------
   void test_MDBoxConstructor()
   {
-    
+
     MDBox<MDLeanEvent<1>,1> * b = MDEventsTestHelper::makeMDBox1(10);
     TS_ASSERT_EQUALS( b->getNumDims(), 1);
     TS_ASSERT_EQUALS( b->getNPoints(), 0);
@@ -205,7 +205,7 @@ public:
       MDBox<MDLeanEvent<1>,1> * box = dynamic_cast<MDBox<MDLeanEvent<1>,1> *>(boxes[i]);
       TS_ASSERT_EQUALS(box->getNPoints(), 2);
     }
-    
+
     std::vector<signal_t> sigErr(20);
     std::vector<coord_t> coord(10);
     std::vector<uint16_t> runIndex;
@@ -271,8 +271,8 @@ public:
 
     auto boxes = box1->getBoxes();
     for(size_t i = 0; i < boxes.size(); ++i)
-    {       
-      TSM_ASSERT_EQUALS("All child boxes should have the same box controller as the parent.", newBoxController, boxes[i]->getBoxController()); 
+    {
+      TSM_ASSERT_EQUALS("All child boxes should have the same box controller as the parent.", newBoxController, boxes[i]->getBoxController());
     }
     delete newBoxController;
     delete box1;
@@ -290,7 +290,7 @@ public:
     MDGridBox<MDLeanEvent<1>,1> * g = MDEventsTestHelper::makeMDGridBox<1>(10,10,0.0, 10.0);
     // Clear the initial children
     for (size_t i = 0; i < g->getNumChildren(); i++) delete g->getChild(i);
-    
+
     BoxController *const bcc = g->getBoxController();
     std::vector<API::IMDNode *> boxes;
     for (size_t i=0; i<15; i++)
@@ -659,7 +659,7 @@ public:
     parent->getBoxes(boxes, 3, true, function);
     TSM_ASSERT_EQUALS( "Only one box is found by an infinitely thin plane", boxes.size(), 1);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = parent->getBoxController();
     delete parent;
     delete bcc;
@@ -707,7 +707,7 @@ public:
       TS_ASSERT( boxes[i]->getExtents(1).getMin() <= 3.00);
     }
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = parent->getBoxController();
     delete parent;
     delete bcc;
@@ -742,7 +742,7 @@ public:
     TS_ASSERT_DELTA( boxes[0]->getExtents(0).getMin(), 1.75, 1e-4);
     TS_ASSERT_DELTA( boxes[0]->getExtents(0).getMax(), 2.00, 1e-4);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = parent->getBoxController();
     delete parent;
     delete bcc;
@@ -775,7 +775,7 @@ public:
     TS_ASSERT_DELTA( boxes[0]->getExtents(0).getMin(), 1.75, 1e-4);
     TS_ASSERT_DELTA( boxes[0]->getExtents(0).getMax(), 2.00, 1e-4);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = parent->getBoxController();
     delete parent;
     delete bcc;
@@ -877,7 +877,7 @@ public:
     TS_ASSERT_EQUALS( b->getSignal(), 100*2.0);
     TS_ASSERT_EQUALS( b->getErrorSquared(), 100*2.0);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = b->getBoxController();
     delete b;
     delete bcc;
@@ -920,7 +920,7 @@ public:
     MDGridBox<MDLeanEvent<2>,2> * b = MDEventsTestHelper::makeMDGridBox<2>();
     int num_repeat = 1000;
 
-//    PARALLEL_FOR_NO_WSP_CHECK()
+    PARALLEL_FOR_NO_WSP_CHECK()
     for (int i=0; i < num_repeat; i++)
     {
       std::vector< MDLeanEvent<2> > events;
@@ -931,15 +931,16 @@ public:
           double centers[2] = {x,y};
           events.push_back( MDLeanEvent<2>(2.0, 2.0, centers) );
         }
-      TS_ASSERT_THROWS_NOTHING( b->addEvents( events ); );
+      //TS_ASSERT_THROWS_NOTHING( b->addEvents( events ); );
     }
-    // Get the right totals again by refreshing
-    b->refreshCache(ts);
-    TS_ASSERT_EQUALS( b->getNPoints(), 100*num_repeat);
-    TS_ASSERT_EQUALS( b->getSignal(), 100*num_repeat*2.0);
-    TS_ASSERT_EQUALS( b->getErrorSquared(), 100*num_repeat*2.0);
 
-    // clean up  behind 
+    // Get the right totals again by refreshing
+    // b->refreshCache(ts);
+    // TS_ASSERT_EQUALS( b->getNPoints(), 100*num_repeat);
+    // TS_ASSERT_EQUALS( b->getSignal(), 100*num_repeat*2.0);
+    // TS_ASSERT_EQUALS( b->getErrorSquared(), 100*num_repeat*2.0);
+
+    // clean up  behind
     BoxController *const bcc = b->getBoxController();
     delete b;
     delete bcc;
@@ -1036,7 +1037,7 @@ public:
     // We went this many levels (and no further) because recursion depth is limited
     TS_ASSERT_EQUALS(boxes[0]->getDepth(), 4);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = b0->getBoxController();
     delete b0;
     delete bcc;
@@ -1096,7 +1097,7 @@ public:
 
     }
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = b->getBoxController();
     delete b;
     delete bcc;
@@ -1255,7 +1256,7 @@ public:
     MDEventsTestHelper::feedMDBox<2>(box_ptr, 1);
     do_test_integrateSphere(box_ptr);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = box_ptr->getBoxController();
     delete box_ptr;
     delete bcc;
@@ -1268,7 +1269,7 @@ public:
     MDGridBox<MDLeanEvent<2>,2> * box_ptr = MDEventsTestHelper::makeMDGridBox<2>(10,5);
     MDEventsTestHelper::feedMDBox<2>(box_ptr, 1);
     do_test_integrateSphere(box_ptr);
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = box_ptr->getBoxController();
     delete box_ptr;
     delete bcc;
@@ -1282,7 +1283,7 @@ public:
     MDEventsTestHelper::feedMDBox<2>(box_ptr, 1);
     do_test_integrateSphere(box_ptr);
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = box_ptr->getBoxController();
     delete box_ptr;
     delete bcc;
@@ -1305,7 +1306,7 @@ public:
     do_check_integrateSphere(box, 1.0,1.0,  1.45,  1.0, "Contains one box completely");
     do_check_integrateSphere(box, 9.0,9.0,  1.45,  1.0, "Contains one box completely, at the edges");
 
-    // clean up  behind 
+    // clean up  behind
     BoxController *const bcc = box_ptr->getBoxController();
     delete box_ptr;
     delete bcc;
@@ -1507,8 +1508,8 @@ public:
     MockMDBox* a = new MockMDBox;
     MockMDBox* b = new MockMDBox;
 
-    EXPECT_CALL(*a, mask()).Times(1); 
-    EXPECT_CALL(*b, mask()).Times(1); 
+    EXPECT_CALL(*a, mask()).Times(1);
+    EXPECT_CALL(*b, mask()).Times(1);
 
     boxes.push_back(a);
     boxes.push_back(b);
@@ -1532,8 +1533,8 @@ public:
     MockMDBox* a = new MockMDBox;
     MockMDBox* b = new MockMDBox;
 
-    EXPECT_CALL(*a, unmask()).Times(1); 
-    EXPECT_CALL(*b, unmask()).Times(1); 
+    EXPECT_CALL(*a, unmask()).Times(1);
+    EXPECT_CALL(*b, unmask()).Times(1);
 
     boxes.push_back(a);
     boxes.push_back(b);
@@ -1778,4 +1779,3 @@ public:
 };
 
 #endif
-

--- a/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -8,14 +8,14 @@
 #include "MantidDataObjects/MDHistoWorkspaceIterator.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include <cxxtest/TestSuite.h>
-#include <iomanip>
-#include <iostream>
 #include "MantidKernel/VMD.h"
 #include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
 #include "MantidGeometry/MDGeometry/MDPlane.h"
 #include <boost/assign/list_of.hpp>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
+#include <boost/scoped_ptr.hpp>
+
 
 using namespace Mantid;
 using namespace Mantid::DataObjects;
@@ -67,9 +67,10 @@ public:
   void do_test_iterator(size_t nd, size_t numPoints)
   {
     MDHistoWorkspace_sptr ws = MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, nd, 10);
-    for (size_t i = 0; i < numPoints; i++)
+    for (size_t i = 0; i < numPoints; i++) {
       ws->setSignalAt(i, double(i));
-    MDHistoWorkspaceIterator * it = new MDHistoWorkspaceIterator(ws);
+    }
+    boost::scoped_ptr<MDHistoWorkspaceIterator> it(new MDHistoWorkspaceIterator(ws));
     TSM_ASSERT( "This iterator is valid at the start.", it->valid());
     size_t i = 0;
 
@@ -90,10 +91,10 @@ public:
     {
       TS_ASSERT_DELTA( it->getNormalizedSignal(), double(i) / 1.0, 1e-5);
       TS_ASSERT_DELTA( it->getNormalizedError(), 1.0, 1e-5);
-      coord_t * vertexes;
       size_t numVertices;
-      vertexes = it->getVertexesArray(numVertices);
-      TS_ASSERT( vertexes);
+      coord_t *vertexes = it->getVertexesArray(numVertices);
+      TS_ASSERT(vertexes);
+      delete [] vertexes;
       TS_ASSERT_EQUALS( it->getNumEvents(), 1);
       TS_ASSERT_EQUALS( it->getInnerDetectorID(0), 0);
       TS_ASSERT_EQUALS( it->getInnerRunIndex(0), 0);

--- a/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -164,6 +164,8 @@ public:
     it->next();
     TS_ASSERT_EQUALS(it->getNormalizedSignal(), 30.);
     TS_ASSERT( !it->next());
+
+    delete it;
   }
 
   void test_iterator_2D_implicitFunction_thatExcludesTheStart()
@@ -193,6 +195,8 @@ public:
     TS_ASSERT_EQUALS(it->getNormalizedSignal(), 13.);
     it->next();
     // And so forth....
+
+    delete it;
   }
 
   void test_iterator_2D_implicitFunction_thatExcludesEverything()
@@ -207,6 +211,8 @@ public:
     MDHistoWorkspaceIterator * it = new MDHistoWorkspaceIterator(ws, function);
 
     TSM_ASSERT( "This iterator is not valid at the start.", !it->valid());
+
+    delete it;
   }
 
   /** Create several parallel iterators */
@@ -228,7 +234,7 @@ public:
     TS_ASSERT_EQUALS( it->getDataSize(), 33);
     TS_ASSERT_DELTA( it->getInnerPosition(0,0), 0.5, 1e-5);
     TS_ASSERT_DELTA( it->getInnerPosition(0,1), 0.5, 1e-5);
-
+    
     it = iterators[1];
     TS_ASSERT_DELTA( it->getSignal(), 33.0, 1e-5);
     TS_ASSERT_EQUALS( it->getDataSize(), 33);
@@ -240,7 +246,8 @@ public:
     TS_ASSERT_EQUALS( it->getDataSize(), 34);
     TS_ASSERT_DELTA( it->getInnerPosition(0,0), 6.5, 1e-5);
     TS_ASSERT_DELTA( it->getInnerPosition(0,1), 6.5, 1e-5);
-
+    
+    for(size_t i = 0; i < 3; ++i) delete iterators[i];
   }
 
   void test_predictable_steps()
@@ -255,6 +262,7 @@ public:
       expected = current + 1;
       histoIt->next();
     }
+    delete histoIt;
   }
 
   void test_skip_masked_detectors()
@@ -279,6 +287,8 @@ public:
     histoIt->next();
     TSM_ASSERT_EQUALS("The first index hit should be 2 since that is the first unmasked one", 5,
         histoIt->getLinearIndex());
+
+    delete histoIt;
   }
 
   //template<typename ContainerType, typename ElementType>
@@ -351,6 +361,7 @@ public:
     neighbourIndexes = findNeighbourMemberFunction(it);
     TSM_ASSERT( "Neighbour at index 9 is 8", doesContainIndex(neighbourIndexes, 8));
 
+    delete it;
   }
 
   void test_neighbours_1d_face_touching()
@@ -437,6 +448,8 @@ public:
     // Is on an edge
     TSM_ASSERT( "Neighbour at index 15 is 11", doesContainIndex(neighbourIndexes, 11));
     TSM_ASSERT( "Neighbour at index 15 is 14", doesContainIndex(neighbourIndexes, 14));
+
+    delete it;
   }
 
   void test_neighbours_2d_vertex_touching()
@@ -517,6 +530,8 @@ public:
     TSM_ASSERT( "Neighbour at index 15 is 10", doesContainIndex(neighbourIndexes, 10));
     TSM_ASSERT( "Neighbour at index 15 is 11", doesContainIndex(neighbourIndexes, 11));
     TSM_ASSERT( "Neighbour at index 15 is 14", doesContainIndex(neighbourIndexes, 14));
+
+    delete it;
   }
 
   void test_neighbours_3d_face_touching()
@@ -593,6 +608,7 @@ public:
       TS_ASSERT(doesContainIndex(neighbourIndexes, *i));
     }
 
+    delete it;
   }
 
   void test_neighbours_3d_vertex_touching()
@@ -674,6 +690,7 @@ public:
       TS_ASSERT(doesContainIndex(neighbourIndexes, *i));
     }
 
+    delete it;
   }
 
   void test_neighbours_1d_with_width()
@@ -731,6 +748,8 @@ public:
       TS_ASSERT_EQUALS(2, neighbourIndexes.size());
       TSM_ASSERT( "Neighbours at index 9 includes 8", doesContainIndex(neighbourIndexes, 8));
       TSM_ASSERT( "Neighbours at index 9 includes 7", doesContainIndex(neighbourIndexes, 7));
+      
+      delete it;
   }
 
   void test_neighbours_2d_vertex_touching_by_width()
@@ -809,6 +828,8 @@ public:
     TSM_ASSERT( "Neighbour at index is 11", doesContainIndex(neighbourIndexes, 11));
     TSM_ASSERT( "Neighbour at index is 13", doesContainIndex(neighbourIndexes, 13));
     TSM_ASSERT( "Neighbour at index is 14", doesContainIndex(neighbourIndexes, 14));
+
+    delete it;
   }
 
   void test_neighbours_2d_vertex_touching_by_width_vector()
@@ -885,6 +906,8 @@ public:
     TSM_ASSERT( "Neighbour at index is 11", doesContainIndex(neighbourIndexes, 11));
     TSM_ASSERT( "Neighbour at index is 13", doesContainIndex(neighbourIndexes, 13));
     TSM_ASSERT( "Neighbour at index is 14", doesContainIndex(neighbourIndexes, 14));
+
+    delete it;
   }
 
 
@@ -940,6 +963,8 @@ public:
     TS_ASSERT(doesContainIndex(neighbourIndexes, 24));
     TS_ASSERT(doesContainIndex(neighbourIndexes, 25));
     TS_ASSERT(doesContainIndex(neighbourIndexes, 26));
+
+    delete it;
   }
 
   void test_cache()
@@ -961,6 +986,8 @@ public:
       TSM_ASSERT_EQUALS("One cache item expected", 1, it->permutationCacheSize()); // Same item, no change to cache
       it->findNeighbourIndexesByWidth(5);
       TSM_ASSERT_EQUALS("Two cache entries expected", 2, it->permutationCacheSize());
+
+      delete it;
   }
 
 

--- a/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -13,6 +13,8 @@
 #include "MantidDataObjects/MDHistoWorkspaceIterator.h"
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <cxxtest/TestSuite.h>
 #include <iomanip>
 #include <iostream>
@@ -43,6 +45,7 @@ private:
       }
       it->next(1);
     }
+    delete it;
     return numberMasked;
   }
   /// Helper method returns the size of an element in the MDHistoWorkspace
@@ -252,25 +255,24 @@ public:
     MDHistoDimension_sptr dimX(new MDHistoDimension("X", "x", "m", -10, 10, 5));
     MDHistoDimension_sptr dimY(new MDHistoDimension("Y", "y", "m", -10, 10, 5));
     MDHistoWorkspace ws(dimX, dimY);
-    coord_t * v;
     size_t numVertices, i;
 
-    v = ws.getVertexesArray(0,numVertices);
+    boost::scoped_array<coord_t> v1(ws.getVertexesArray(0,numVertices));
     TS_ASSERT_EQUALS( numVertices, 4 );
     i = 0*2;
-    TS_ASSERT_DELTA( v[i+0], -10.0, 1e-5);
-    TS_ASSERT_DELTA( v[i+1], -10.0, 1e-5);
+    TS_ASSERT_DELTA( v1[i+0], -10.0, 1e-5);
+    TS_ASSERT_DELTA( v1[i+1], -10.0, 1e-5);
     i = 3*2;
-    TS_ASSERT_DELTA( v[i+0], -6.0, 1e-5);
-    TS_ASSERT_DELTA( v[i+1], -6.0, 1e-5);
+    TS_ASSERT_DELTA( v1[i+0], -6.0, 1e-5);
+    TS_ASSERT_DELTA( v1[i+1], -6.0, 1e-5);
     // The opposite corner
-    v = ws.getVertexesArray(24,numVertices);
+    boost::scoped_array<coord_t> v2(ws.getVertexesArray(24,numVertices));
     i = 0*2;
-    TS_ASSERT_DELTA( v[i+0], 6.0, 1e-5);
-    TS_ASSERT_DELTA( v[i+1], 6.0, 1e-5);
+    TS_ASSERT_DELTA( v2[i+0], 6.0, 1e-5);
+    TS_ASSERT_DELTA( v2[i+1], 6.0, 1e-5);
     i = 3*2;
-    TS_ASSERT_DELTA( v[i+0], 10.0, 1e-5);
-    TS_ASSERT_DELTA( v[i+1], 10.0, 1e-5);
+    TS_ASSERT_DELTA( v2[i+0], 10.0, 1e-5);
+    TS_ASSERT_DELTA( v2[i+1], 10.0, 1e-5);
   }
 
   //---------------------------------------------------------------------------------------------------
@@ -280,10 +282,9 @@ public:
     MDHistoDimension_sptr dimY(new MDHistoDimension("Y", "y", "m", -9, 10, 5));
     MDHistoDimension_sptr dimZ(new MDHistoDimension("Z", "z", "m", -8, 10, 5));
     MDHistoWorkspace ws(dimX, dimY, dimZ);
-    coord_t * v;
     size_t numVertices, i;
 
-    v = ws.getVertexesArray(0,numVertices);
+    boost::scoped_array<coord_t> v(ws.getVertexesArray(0,numVertices));
     TS_ASSERT_EQUALS( numVertices, 8 );
     i = 0;
     TS_ASSERT_DELTA( v[i+0], -10.0, 1e-5);
@@ -354,8 +355,11 @@ public:
     MDHistoWorkspaceIterator * hwit = dynamic_cast<MDHistoWorkspaceIterator *>(it);
     TS_ASSERT( hwit );
     TS_ASSERT( it->next() );
-    it = ws.createIterator(new MDImplicitFunction() );
+    delete it;
+    boost::scoped_ptr<MDImplicitFunction> mdfunction(new MDImplicitFunction);
+    it = ws.createIterator(mdfunction.get());
     TS_ASSERT( it );
+    delete it;
   }
 
   //---------------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -233,16 +233,17 @@ public:
   {
     MDHistoDimension_sptr dimX(new MDHistoDimension("X", "x", "m", -10, 10, 5));
     MDHistoWorkspace ws(dimX);
-    coord_t * v;
     size_t numVertices;
-    v = ws.getVertexesArray(0,numVertices);
+    coord_t *v1 = ws.getVertexesArray(0,numVertices);
     TS_ASSERT_EQUALS( numVertices, 2 );
-    TS_ASSERT_DELTA( v[0], -10.0, 1e-5);
-    TS_ASSERT_DELTA( v[1], -6.0, 1e-5);
-
-    v = ws.getVertexesArray(4,numVertices);
-    TS_ASSERT_DELTA( v[0], 6.0, 1e-5);
-    TS_ASSERT_DELTA( v[1], 10.0, 1e-5);
+    TS_ASSERT_DELTA( v1[0], -10.0, 1e-5);
+    TS_ASSERT_DELTA( v1[1], -6.0, 1e-5);
+    delete [] v1;
+    
+    coord_t *v2 = ws.getVertexesArray(4,numVertices);
+    TS_ASSERT_DELTA( v2[0], 6.0, 1e-5);
+    TS_ASSERT_DELTA( v2[1], 10.0, 1e-5);
+    delete [] v2;
   }
 
   //---------------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/DataObjects/test/MDLeanEventTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDLeanEventTest.h
@@ -8,6 +8,8 @@
 #include <iomanip>
 #include <iostream>
 
+#include <boost/scoped_array.hpp>
+
 using namespace Mantid;
 using namespace Mantid::DataObjects;
 
@@ -43,12 +45,12 @@ public:
     TS_ASSERT_EQUALS( a.getCenter(2), 2.5);
 
     // Dynamic array
-    coord_t * coords2 = new coord_t[5];
+    boost::scoped_array<coord_t> coords2(new coord_t[5]);
     coords2[0] = 1.0;
     coords2[1] = 2.0;
     coords2[2] = 3.0;
 
-    MDLeanEvent<3> b(2.5, 1.5, coords2 );
+    MDLeanEvent<3> b(2.5, 1.5, coords2.get() );
     TS_ASSERT_EQUALS( b.getSignal(), 2.5);
     TS_ASSERT_EQUALS( b.getErrorSquared(), 1.5);
     TS_ASSERT_EQUALS( b.getCenter(0), 1);

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
@@ -206,6 +206,7 @@ makeMDGridBox(size_t split0 = 10, size_t split1 = 10,
 
   // Split
   MDGridBox<MDLeanEvent<nd>, nd> *out = new MDGridBox<MDLeanEvent<nd>, nd>(box);
+  delete box;
 
   return out;
 }

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/MDEventsTestHelper.h
@@ -305,7 +305,7 @@ static MDGridBox<MDLeanEvent<nd>, nd> *makeRecursiveMDGridBox(size_t splitInto,
   // Split into the gridbox.
   MDGridBox<MDLeanEvent<nd>, nd> *gridbox =
       new MDGridBox<MDLeanEvent<nd>, nd>(box);
-
+  delete box;
   // Now recursively split more
   recurseSplit(gridbox, 0, levels);
 

--- a/Code/Mantid/Framework/TestHelpers/src/MDEventsTestHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/MDEventsTestHelper.cpp
@@ -151,9 +151,9 @@ MDEventWorkspace3Lean::sptr makeFakeMDEventWorkspace(const std::string &wsName,
 !!!!*/
 MDBox<MDLeanEvent<1>, 1> *makeMDBox1(size_t splitInto,
                                      BoxController *splitter) {
-  if (!splitter)
+  if (!splitter) {
     splitter = (new BoxController(1));
-
+  }
   // Split at 5 events
   splitter->setSplitThreshold(5);
   // Splits into 10 boxes

--- a/Code/Tools/Valgrind/DataObjectsTest.supp
+++ b/Code/Tools/Valgrind/DataObjectsTest.supp
@@ -42,7 +42,7 @@
    fun:_ZN17MDBoxSaveableTest46test_fileBackEnd_nonConst_EventListChangesSizeEv
 }
 {
-   <gomp_false_positive_leak>
+   <gomp_false_positive_leak_workspace2d>
    Memcheck:Leak
    match-leak-kinds: possible
    fun:calloc
@@ -51,4 +51,14 @@
    fun:_ZNK6Mantid3API15MatrixWorkspace20getIntegratedSpectraERSt6vectorIdSaIdEEddb
    fun:_ZN15Workspace2DTest33testIntegrateSpectra_entire_rangeEv
    fun:_ZN71TestDescription_suite_Workspace2DTest_testIntegrateSpectra_entire_range7runTestEv
+}
+{
+   <gomp_false_positive_leak_mdgridboxtest>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:_dl_allocate_tls
+   ...
+   fun:_ZN13MDGridBoxTest28do_test_addEvents_inParallelEPN6Mantid6Kernel15ThreadSchedulerE
+   fun:_ZN13MDGridBoxTest25test_addEvents_inParallelEv
 }

--- a/Code/Tools/Valgrind/DataObjectsTest.supp
+++ b/Code/Tools/Valgrind/DataObjectsTest.supp
@@ -18,10 +18,9 @@
    ...
 }
 {
-   <HDF5_write_no_cancel>
+   <HDF5_write>
    Memcheck:Param
    write(buf)
-   fun:__write_nocancel
    ...
    fun:H5FD_write
    fun:H5F_accum_write
@@ -41,4 +40,15 @@
    fun:_ZN6Mantid6Kernel10DiskBuffer15writeOldObjectsEv
    fun:_ZN6Mantid6Kernel10DiskBuffer10flushCacheEv
    fun:_ZN17MDBoxSaveableTest46test_fileBackEnd_nonConst_EventListChangesSizeEv
+}
+{
+   <gomp_false_positive_leak>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:_dl_allocate_tls
+   ...
+   fun:_ZNK6Mantid3API15MatrixWorkspace20getIntegratedSpectraERSt6vectorIdSaIdEEddb
+   fun:_ZN15Workspace2DTest33testIntegrateSpectra_entire_rangeEv
+   fun:_ZN71TestDescription_suite_Workspace2DTest_testIntegrateSpectra_entire_range7runTestEv
 }

--- a/Code/Tools/Valgrind/DataObjectsTest.supp
+++ b/Code/Tools/Valgrind/DataObjectsTest.supp
@@ -17,3 +17,28 @@
    fun:_ZN6Mantid11DataObjects13MDBoxFlatTree21createOrOpenMDWSgroupERKSsRiS3_bRb
    ...
 }
+{
+   <HDF5_write_no_cancel>
+   Memcheck:Param
+   write(buf)
+   fun:__write_nocancel
+   ...
+   fun:H5FD_write
+   fun:H5F_accum_write
+   fun:H5F_block_write
+   ...
+   fun:H5D__flush_real
+   ...
+   fun:H5I_iterate
+   fun:H5D_flush
+   fun:H5F_flush
+   fun:H5Fflush
+   ...
+   fun:nxiflush_
+   fun:_ZN5NeXus4File5flushEv
+   fun:_ZNK6Mantid11DataObjects20BoxControllerNeXusIO9flushDataEv
+   fun:_ZNK6Mantid11DataObjects13MDBoxSaveable9flushDataEv
+   fun:_ZN6Mantid6Kernel10DiskBuffer15writeOldObjectsEv
+   fun:_ZN6Mantid6Kernel10DiskBuffer10flushCacheEv
+   fun:_ZN17MDBoxSaveableTest46test_fileBackEnd_nonConst_EventListChangesSizeEv
+}

--- a/Code/Tools/Valgrind/DataObjectsTest.supp
+++ b/Code/Tools/Valgrind/DataObjectsTest.supp
@@ -7,4 +7,13 @@
    fun:_ZN6Mantid11DataObjects14parallel_sort2INS0_8TofEventEEEvRSt6vectorIT_SaIS4_EE
    ...
 }
-
+{
+   <Leak_within_nexus_library>
+   Memcheck:Leak
+   ...
+   ...
+   fun:_ZN5NeXus4File11getNextAttrEv
+   fun:_ZN5NeXus4File7hasAttrERKSs
+   fun:_ZN6Mantid11DataObjects13MDBoxFlatTree21createOrOpenMDWSgroupERKSsRiS3_bRb
+   ...
+}


### PR DESCRIPTION
Fixes [#11512](http://trac.mantidproject.org/mantid/ticket/11512)

**Tester**
Please review the changes and, of course, ensure all of the standard tests are passing. 

If you want to run this locally then do (after merging the branch)

```
cd build
find -name '*.so' -delete
make DataObjectsTest
SUPPR_DIR=$PWD/../Code/Tools/Valgrind valgrind --leak-check=full --show-reachable=no --undef-value-errors=yes --track-origins=no --child-silent-after-fork=no --trace-children=no --demangle=no --num-callers=20 --suppressions=$SUPPR_DIR/KernelTest.supp --suppressions=$SUPPR_DIR/GeometryTest.supp --suppressions=$SUPPR_DIR/APITest.supp --suppressions=$SUPPR_DIR/DataObjectsTest.supp bin/DataObjectsTest
```

This should report 0 errors.
