### PR TITLE
More indirect absorption correction fixes

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>575</width>
+    <width>587</width>
     <height>488</height>
    </rect>
   </property>
@@ -783,6 +783,22 @@
     <hint type="destinationlabel">
      <x>436</x>
      <y>501</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spFlatCanFrontThickness</sender>
+   <signal>valueChanged(double)</signal>
+   <receiver>spFlatCanBackThickness</receiver>
+   <slot>setValue(double)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>238</x>
+     <y>212</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>514</x>
+     <y>212</y>
     </hint>
    </hints>
   </connection>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -296,26 +296,13 @@
            </widget>
           </item>
           <item row="0" column="0">
-           <widget class="QLabel" name="lbCylSampleInnerRadius">
+           <widget class="QLabel" name="lbCylSampleOuterRadius">
             <property name="text">
-             <string>Sample Inner Radius:</string>
+             <string>Sample Radius:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="spCylSampleInnerRadius">
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>9999.989999999999782</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
            <widget class="QDoubleSpinBox" name="spCylSampleOuterRadius">
             <property name="decimals">
              <number>3</number>
@@ -328,24 +315,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lbCylSampleOuterRadius">
-            <property name="text">
-             <string>Sample Outer Radius:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="lbCylCanOuterRadius">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Container Outer Radius:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+          <item row="0" column="3">
            <widget class="QDoubleSpinBox" name="spCylCanOuterRadius">
             <property name="enabled">
              <bool>false</bool>
@@ -358,6 +328,16 @@
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbCylCanOuterRadius">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Container Radius:</string>
             </property>
            </widget>
           </item>
@@ -422,27 +402,17 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="lbAnnSampleOuterRadius">
+          <item row="1" column="0">
+           <widget class="QLabel" name="lbAnnCanOuterRadius">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
             <property name="text">
-             <string>Sample Outer Radius:</string>
+             <string>Container Outer Radius:</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="spAnnSampleOuterRadius">
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>9999.989999999999782</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
+          <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="spAnnCanOuterRadius">
             <property name="enabled">
              <bool>false</bool>
@@ -458,15 +428,35 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QLabel" name="lbAnnCanOuterRadius">
-            <property name="enabled">
-             <bool>false</bool>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="spAnnSampleOuterRadius">
+            <property name="decimals">
+             <number>3</number>
             </property>
-            <property name="text">
-             <string>Container Outer Radius:</string>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
             </property>
            </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QLabel" name="lbAnnSampleOuterRadius">
+            <property name="text">
+             <string>Sample Outer Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="lbAnnSampleInnerRadius">
+            <property name="text">
+             <string>Sample Inner Radius:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius"/>
           </item>
          </layout>
         </widget>
@@ -687,14 +677,9 @@
   <tabstop>spFlatSampleAngle</tabstop>
   <tabstop>spFlatCanFrontThickness</tabstop>
   <tabstop>spFlatCanBackThickness</tabstop>
-  <tabstop>spCylSampleInnerRadius</tabstop>
-  <tabstop>spCylSampleOuterRadius</tabstop>
-  <tabstop>spCylCanOuterRadius</tabstop>
   <tabstop>spCylBeamHeight</tabstop>
   <tabstop>spCylBeamWidth</tabstop>
   <tabstop>spCylStepSize</tabstop>
-  <tabstop>spAnnSampleOuterRadius</tabstop>
-  <tabstop>spAnnCanOuterRadius</tabstop>
   <tabstop>spAnnBeamHeight</tabstop>
   <tabstop>spAnnBeamWidth</tabstop>
   <tabstop>spAnnStepSize</tabstop>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -326,8 +326,7 @@ namespace IDA
     }
     else if(shape == "Cylinder")
     {
-      double sampleInnerRadius = m_uiForm.spCylSampleInnerRadius->value();
-      alg->setProperty("SampleInnerRadius", sampleInnerRadius);
+      alg->setProperty("SampleInnerRadius", 0.0);
 
       double sampleOuterRadius = m_uiForm.spCylSampleOuterRadius->value();
       alg->setProperty("SampleOuterRadius", sampleOuterRadius);
@@ -343,7 +342,8 @@ namespace IDA
     }
     else if(shape == "Annulus")
     {
-      alg->setProperty("SampleInnerRadius", 0.0);
+      double sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
+      alg->setProperty("SampleInnerRadius", sampleInnerRadius);
 
       double sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
       alg->setProperty("SampleOuterRadius", sampleOuterRadius);


### PR DESCRIPTION
Fixes [#11563](http://trac.mantidproject.org/mantid/ticket/11563).

To test:
- Open Indirect Data Analysis > Absorption Corrections
- Set can front thickness, can back thickness should take same value
- Switch to CalcCorr tab
- Annulus should have sample inner, sample outer and can outer radii options
- Cylinder should have only sample (outer) and can (outer) radii
