### PR TITLE
IDR ET: (OS)IRIS should be set to save Nexus by default

### DIFF
--- a/Code/Mantid/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadRaw3Test.h
@@ -399,7 +399,7 @@ public:
     TS_ASSERT_EQUALS( ptrDet->getID(), 60);
 
     Mantid::Geometry::ParameterMap& pmap = output2D->instrumentParameters();
-    TS_ASSERT_EQUALS( static_cast<int>(pmap.size()), 159);
+    TS_ASSERT_EQUALS( static_cast<int>(pmap.size()), 160);
     AnalysisDataService::Instance().remove("parameterIDF");
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -282,6 +282,12 @@ namespace CustomInterfaces
       m_uiForm.ckCm1Units->setChecked(defaultOptions);
     }
 
+    if(!instDetails["save-nexus-choice"].isEmpty())
+    {
+      bool defaultOptions = instDetails["save-nexus-choice"] == "true";
+      m_uiForm.ckSaveNexus->setChecked(defaultOptions);
+    }
+
     if(!instDetails["save-ascii-choice"].isEmpty())
     {
       bool defaultOptions = instDetails["save-ascii-choice"] == "true";

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReduction.cpp
@@ -265,6 +265,7 @@ std::map<QString, QString> IndirectDataReduction::getInstrumentDetails()
   ipfElements.push_back("back-end");
   ipfElements.push_back("rebin-default");
   ipfElements.push_back("cm-1-convert-choice");
+  ipfElements.push_back("save-nexus-choice");
   ipfElements.push_back("save-ascii-choice");
   ipfElements.push_back("fold-frames-choice");
 

--- a/Code/Mantid/instrument/IRIS_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_Parameters.xml
@@ -32,6 +32,9 @@
 <parameter name="cm-1-convert-choice" type="string">
     <value val="false" />
 </parameter>
+<parameter name="save-nexus-choice" type="string">
+    <value val="true" />
+</parameter>
 <parameter name="save-ascii-choice" type="string">
     <value val="false" />
 </parameter>

--- a/Code/Mantid/instrument/OSIRIS_Parameters.xml
+++ b/Code/Mantid/instrument/OSIRIS_Parameters.xml
@@ -24,6 +24,9 @@
 <parameter name="cm-1-convert-choice" type="string">
     <value val="false" />
 </parameter>
+<parameter name="save-nexus-choice" type="string">
+    <value val="true" />
+</parameter>
 <parameter name="save-ascii-choice" type="string">
     <value val="false" />
 </parameter>

--- a/Code/Mantid/instrument/TFXA_Parameters.xml
+++ b/Code/Mantid/instrument/TFXA_Parameters.xml
@@ -25,6 +25,10 @@
       <value val="true" />
     </parameter>
 
+    <parameter name="save-nexus-choice" type="string">
+      <value val="false" />
+    </parameter>
+
     <parameter name="save-ascii-choice" type="string">
       <value val="true" />
     </parameter>

--- a/Code/Mantid/instrument/TFXA_Parameters_Post-1993-10-06.xml
+++ b/Code/Mantid/instrument/TFXA_Parameters_Post-1993-10-06.xml
@@ -25,6 +25,10 @@
       <value val="true" />
     </parameter>
 
+    <parameter name="save-nexus-choice" type="string">
+      <value val="false" />
+    </parameter>
+
     <parameter name="save-ascii-choice" type="string">
       <value val="true" />
     </parameter>

--- a/Code/Mantid/instrument/TOSCA_Parameters.xml
+++ b/Code/Mantid/instrument/TOSCA_Parameters.xml
@@ -24,6 +24,9 @@
     <parameter name="cm-1-convert-choice" type="string">
       <value val="true" />
     </parameter>
+    <parameter name="save-nexus-choice" type="string">
+      <value val="false" />
+    </parameter>
     <parameter name="save-ascii-choice" type="string">
       <value val="true" />
     </parameter>

--- a/Code/Mantid/instrument/TOSCA_Parameters_TOSCA-1.xml
+++ b/Code/Mantid/instrument/TOSCA_Parameters_TOSCA-1.xml
@@ -22,10 +22,13 @@
 
     <!-- Available options are "Show" or "Hide". -->
     <parameter name="cm-1-convert-choice" type="string">
-      <value val="Show" />
+      <value val="true" />
     </parameter>
-    <parameter name="save-aclimax-choice" type="string">
-      <value val="Show" />
+    <parameter name="save-nexus-choice" type="string">
+      <value val="false" />
+    </parameter>
+    <parameter name="save-ascii-choice" type="string">
+      <value val="true" />
     </parameter>
     <parameter name="fold-frames-choice" type="string">
       <value val="true" />


### PR DESCRIPTION
Fixes [#11564](http://trac.mantidproject.org/mantid/ticket/11564).

To test:
- Ensure facility is set to ISIS
- Open Indirect Data Reduction > Energy Transfer
- Select IRIS or OSIRIS
- Nexus should be the only save format enabled by default
- Switch to TOSCA or TFXA
- ASCII should be the only save format enabled by default
