### PR TITLE
Fix null dereference check

### DIFF
--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -9155,7 +9155,9 @@ void ApplicationWindow::minimizeWindow(MdiSubWindow *w)
   auto wli = dynamic_cast<WindowListItem*>(lv->currentItem());
 
   if (!wli)
-    w = wli->window();
+    return;
+
+  w = wli->window();
 
   if (!w)
     return;


### PR DESCRIPTION
This is a problem I noticed whilst skimming the Coverity issues. It's worth fixing, but not worthy enough of an entire ticket.

This null pointer check is the wrong way around. It's dereferencing when null, and aborting when valid.
