### PR TITLE
Improve options for waterfall plots 

### DIFF
--- a/Code/Mantid/MantidPlot/pymantidplot/__init__.py
+++ b/Code/Mantid/MantidPlot/pymantidplot/__init__.py
@@ -338,7 +338,8 @@ def fitBrowser():
     return proxies.FitBrowserProxy(_qti.app.mantidUI.fitFunctionBrowser())
 
 #-----------------------------------------------------------------------------
-def plotBin(source, indices, error_bars = False, type = -1, window = None, clearWindow = False):
+def plotBin(source, indices, error_bars = False, type = -1, window = None, clearWindow = False,
+            waterfall = False):
     """Create a 1D Plot of bin count vs spectrum in a workspace.
 
     This puts the spectrum number as the X variable, and the
@@ -354,6 +355,7 @@ def plotBin(source, indices, error_bars = False, type = -1, window = None, clear
         type: Plot style
         window: window used for plotting. If None a new one will be created
         clearWindow: if is True, the window specified will be cleared before adding new curve
+        waterfall: if True, plot as a waterfall if there is more than 1 curve
     Returns:
         A handle to window if one was specified, otherwise a handle to the created one. None in case of error.
     """
@@ -379,7 +381,7 @@ def plotBin(source, indices, error_bars = False, type = -1, window = None, clear
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
                                           workspace_names, index_list, False, error_bars,
-                                          type, window, clearWindow))
+                                          type, window, clearWindow, waterfall))
     if graph._getHeldObject() == None:
         raise RuntimeError("Cannot create graph, see log for details.")
     else:

--- a/Code/Mantid/MantidPlot/pymantidplot/__init__.py
+++ b/Code/Mantid/MantidPlot/pymantidplot/__init__.py
@@ -201,7 +201,8 @@ def plot(source, *args, **kwargs):
         return plotSpectrum(source, *args, **kwargs)
 
 #----------------------------------------------------------------------------------------------------
-def plotSpectrum(source, indices, error_bars = False, type = -1, window = None, clearWindow = False):
+def plotSpectrum(source, indices, error_bars = False, type = -1, window = None,
+                 clearWindow = False, waterfall = False):
     """Open a 1D Plot of a spectrum in a workspace.
 
     This plots one or more spectra, with X as the bin boundaries,
@@ -214,6 +215,7 @@ def plotSpectrum(source, indices, error_bars = False, type = -1, window = None, 
         type: curve style for plot (-1: unspecified; 0: line, default; 1: scatter/dots)
         window: window used for plotting. If None a new one will be created
         clearWindow: if is True, the window specified will be cleared before adding new curve
+        waterfall: if True, plot as a waterfall if there is more than 1 curve
     Returns:
         A handle to window if one was specified, otherwise a handle to the created one. None in case of error.
     """
@@ -239,7 +241,7 @@ def plotSpectrum(source, indices, error_bars = False, type = -1, window = None, 
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
                                           workspace_names, index_list, True, error_bars,
-                                          type, window, clearWindow))
+                                          type, window, clearWindow, waterfall))
     if graph._getHeldObject() == None:
         raise RuntimeError("Cannot create graph, see log for details.")
     else:

--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -10287,6 +10287,17 @@ void ApplicationWindow::showGraphContextMenu()
     cm.insertItem(tr("&Normalization"), &normalization);
   }
 
+  QMenu plotType(this);
+  if(ag->curves() > 1)
+  {
+    QAction *waterfall = new QAction(tr("&Waterfall"), &plotType);
+    waterfall->setCheckable(true);
+    waterfall->setChecked(ag->isWaterfallPlot());
+    connect(waterfall, SIGNAL(toggled(bool)), plot, SLOT(toggleWaterfall(bool)));
+    plotType.addAction(waterfall);
+    cm.insertItem(tr("&Plot Type"), &plotType);
+  }
+
   cm.insertSeparator();
   copy.insertItem(tr("&Layer"), this, SLOT(copyActiveLayer()));
   copy.insertItem(tr("&Window"), plot, SLOT(copyAllLayers()));

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidDock.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidDock.h
@@ -11,6 +11,8 @@
 
 #include "MantidQtMantidWidgets/AlgorithmSelectorWidget.h"
 
+#include "Mantid/MantidWSIndexDialog.h"
+
 #include <QActionGroup>
 #include <QAtomicInt>
 #include <QComboBox>
@@ -165,7 +167,7 @@ public:
   void mouseDoubleClickEvent(QMouseEvent *e);
 
   QStringList getSelectedWorkspaceNames() const;
-  QMultiMap<QString,std::set<int> > chooseSpectrumFromSelected() const;
+  MantidWSIndexDialog::UserInput chooseSpectrumFromSelected(bool showWaterfallOpt = true) const;
   void setSortScheme(MantidItemSortScheme);
   void setSortOrder(Qt::SortOrder);
   MantidItemSortScheme getSortScheme() const;

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2985,6 +2985,7 @@ Plots the spectra from the given workspaces
 @param style :: Curve style for plot
 @param plotWindow :: Window to plot to. If NULL a new one will be created
 @param clearWindow :: Whether to clear specified plotWindow before plotting. Ignored if plotWindow == NULL
+@param waterfallPlot :: If true create a waterfall type plot
 */
 MultiLayer* MantidUI::plot1D(const QStringList& ws_names, const QList<int>& indexList, bool spectrumPlot, bool errs,
                              Graph::CurveType style, MultiLayer* plotWindow, bool clearWindow, bool waterfallPlot)
@@ -3019,6 +3020,7 @@ MultiLayer* MantidUI::plot1D(const QStringList& ws_names, const QList<int>& inde
 @param errs :: If true include the errors on the graph
 @param plotWindow :: Window to plot to. If NULL a new one will be created
 @param clearWindow :: Whether to clear specified plotWindow before plotting. Ignored if plotWindow == NULL
+@param waterfallPlot :: If true create a waterfall type plot
 @return NULL if failure. Otherwise, if plotWindow == NULL - created window, if not NULL - plotWindow
 */
 MultiLayer* MantidUI::plot1D(const QMultiMap<QString, set<int> >& toPlot, bool spectrumPlot,
@@ -3050,6 +3052,7 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString, set<int> >& toPlot, bool s
 @param errs :: If true include the errors on the graph
 @param plotWindow :: Window to plot to. If NULL a new one will be created
 @param clearWindow :: Whether to clear specified plotWindow before plotting. Ignored if plotWindow == NULL
+@param waterfallPlot :: If true create a waterfall type plot
 @return NULL if failure. Otherwise, if plotWindow == NULL - created window, if not NULL - plotWindow
 */
 MultiLayer* MantidUI::plot1D(const QString& wsName, const std::set<int>& indexList, bool spectrumPlot,
@@ -3076,6 +3079,7 @@ MultiLayer* MantidUI::plot1D(const QString& wsName, const std::set<int>& indexLi
 @param style :: curve style for plot
 @param plotWindow :: Window to plot to. If NULL a new one will be created
 @param clearWindow :: Whether to clear specified plotWindow before plotting. Ignored if plotWindow == NULL
+@param waterfallPlot :: If true create a waterfall type plot
 @return NULL if failure. Otherwise, if plotWindow == NULL - created window, if not NULL - plotWindow
 */
 MultiLayer* MantidUI::plot1D(const QMultiMap<QString,int>& toPlot, bool spectrumPlot,

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2987,7 +2987,7 @@ Plots the spectra from the given workspaces
 @param clearWindow :: Whether to clear specified plotWindow before plotting. Ignored if plotWindow == NULL
 */
 MultiLayer* MantidUI::plot1D(const QStringList& ws_names, const QList<int>& indexList, bool spectrumPlot, bool errs,
-                             Graph::CurveType style, MultiLayer* plotWindow, bool clearWindow)
+                             Graph::CurveType style, MultiLayer* plotWindow, bool clearWindow, bool waterfallPlot)
 {
   // Convert the list into a map (with the same workspace as key in each case)
   QMultiMap<QString,int> pairs;
@@ -3009,7 +3009,8 @@ MultiLayer* MantidUI::plot1D(const QStringList& ws_names, const QList<int>& inde
   }
 
   // Pass over to the overloaded method
-  return plot1D(pairs,spectrumPlot,MantidQt::DistributionDefault, errs,style,plotWindow, clearWindow);
+  return plot1D(pairs,spectrumPlot,MantidQt::DistributionDefault, errs,style,plotWindow, clearWindow,
+                waterfallPlot);
 }
 /** Create a 1D graph from the specified list of workspaces/spectra.
 @param toPlot :: Map of form ws -> [spectra_list]
@@ -3022,7 +3023,7 @@ MultiLayer* MantidUI::plot1D(const QStringList& ws_names, const QList<int>& inde
 */
 MultiLayer* MantidUI::plot1D(const QMultiMap<QString, set<int> >& toPlot, bool spectrumPlot,
                              MantidQt::DistributionFlag distr, bool errs,
-                             MultiLayer* plotWindow, bool clearWindow)
+                             MultiLayer* plotWindow, bool clearWindow, bool waterfallPlot)
 {
   // Convert the list into a map (with the same workspace as key in each case)
   QMultiMap<QString,int> pairs;
@@ -3038,7 +3039,7 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString, set<int> >& toPlot, bool s
   }
 
   // Pass over to the overloaded method
-  return plot1D(pairs,spectrumPlot,distr,errs,Graph::Unspecified,plotWindow, clearWindow);
+  return plot1D(pairs,spectrumPlot,distr,errs,Graph::Unspecified,plotWindow, clearWindow, waterfallPlot);
 }
 
 /** Create a 1d graph from the specified spectra in a MatrixWorkspace
@@ -3052,7 +3053,7 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString, set<int> >& toPlot, bool s
 @return NULL if failure. Otherwise, if plotWindow == NULL - created window, if not NULL - plotWindow
 */
 MultiLayer* MantidUI::plot1D(const QString& wsName, const std::set<int>& indexList, bool spectrumPlot,
-  MantidQt::DistributionFlag distr, bool errs, MultiLayer* plotWindow, bool clearWindow)
+  MantidQt::DistributionFlag distr, bool errs, MultiLayer* plotWindow, bool clearWindow, bool waterfallPlot)
 {
   // Convert the list into a map (with the same workspace as key in each case)
   QMultiMap<QString,int> pairs;
@@ -3064,7 +3065,7 @@ MultiLayer* MantidUI::plot1D(const QString& wsName, const std::set<int>& indexLi
   }
 
   // Pass over to the overloaded method
-  return plot1D(pairs,spectrumPlot,distr,errs,Graph::Unspecified,plotWindow, clearWindow);
+  return plot1D(pairs,spectrumPlot,distr,errs,Graph::Unspecified,plotWindow, clearWindow, waterfallPlot);
 }
 
 /** Create a 1d graph form a set of workspace-spectrum pairs
@@ -3079,7 +3080,8 @@ MultiLayer* MantidUI::plot1D(const QString& wsName, const std::set<int>& indexLi
 */
 MultiLayer* MantidUI::plot1D(const QMultiMap<QString,int>& toPlot, bool spectrumPlot,
                              MantidQt::DistributionFlag distr, bool errs,
-                             Graph::CurveType style, MultiLayer* plotWindow, bool clearWindow)
+                             Graph::CurveType style, MultiLayer* plotWindow,
+                             bool clearWindow, bool waterfallPlot)
 {
   if(toPlot.size() == 0) return NULL;
 
@@ -3094,6 +3096,8 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString,int>& toPlot, bool spectrum
     ask.exec();
     if (ask.clickedButton() != confirmButton) return NULL;
   }
+  // Force waterfall option to false if only 1 curve
+  if(toPlot.size() == 1) waterfallPlot = false;
 
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
@@ -3206,7 +3210,7 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString,int>& toPlot, bool spectrum
     // happen, but it does apparently with some muon analyses.
     g->checkValuesInAxisRange(firstCurve);
   }
-
+  ml->toggleWaterfall(waterfallPlot);
   // Check if window does not contain any curves and should be closed
   ml->maybeNeedToClose();
 

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.h
@@ -212,23 +212,23 @@ public:
     // Create a 1d graph form specified MatrixWorkspace and index
   MultiLayer* plot1D(const QStringList& wsnames, const QList<int>& indexList, bool spectrumPlot,
                      bool errs=true, Graph::CurveType style = Graph::Unspecified,
-                     MultiLayer* plotWindow = NULL, bool clearWindow = false);
+                     MultiLayer* plotWindow = NULL, bool clearWindow = false, bool waterfallPlot = false);
 
   MultiLayer* plot1D(const QString& wsName, const std::set<int>& indexList, bool spectrumPlot,
                      MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
                      bool errs=false,
-                     MultiLayer* plotWindow = NULL, bool clearWindow = false);
+                     MultiLayer* plotWindow = NULL, bool clearWindow = false, bool waterfallPlot = false);
 
   MultiLayer* plot1D(const QMultiMap<QString,int>& toPlot, bool spectrumPlot,
                      MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
                      bool errs=false,
                      Graph::CurveType style = Graph::Unspecified,
-                     MultiLayer* plotWindow = NULL, bool clearWindow = false);
+                     MultiLayer* plotWindow = NULL, bool clearWindow = false, bool waterfallPlot = false);
 
   MultiLayer* plot1D(const QMultiMap<QString,std::set<int> >& toPlot, bool spectrumPlot,
                      MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
                      bool errs=false,
-                     MultiLayer* plotWindow = NULL, bool clearWindow = false);
+                     MultiLayer* plotWindow = NULL, bool clearWindow = false, bool waterfallPlot = false);
   
     /// Draw a color fill plot for each of the listed workspaces
     void drawColorFillPlots(const QStringList & wsNames, Graph::CurveType curveType = Graph::ColorMap);

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -21,6 +21,7 @@
  * @param mui :: The MantidUI area
  * @param flags :: Window flags that are passed the the QDialog constructor
  * @param wsNames :: the names of the workspaces to be plotted
+ * @param showWaterfallOption :: If true the waterfall checkbox is created
  */
 MantidWSIndexDialog::MantidWSIndexDialog(MantidUI* mui, Qt::WFlags flags, QList<QString> wsNames, const bool showWaterfallOption) 
   : QDialog(mui->appWindow(), flags), 

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -22,10 +22,11 @@
  * @param flags :: Window flags that are passed the the QDialog constructor
  * @param wsNames :: the names of the workspaces to be plotted
  */
-MantidWSIndexDialog::MantidWSIndexDialog(MantidUI* mui, Qt::WFlags flags, QList<QString> wsNames) 
+MantidWSIndexDialog::MantidWSIndexDialog(MantidUI* mui, Qt::WFlags flags, QList<QString> wsNames, const bool showWaterfallOption) 
   : QDialog(mui->appWindow(), flags), 
   m_mantidUI(mui),
   m_spectra(false),
+  m_waterfall(showWaterfallOption),
   m_wsNames(wsNames),
   m_wsIndexIntervals(),
   m_spectraIdIntervals(),
@@ -42,6 +43,14 @@ MantidWSIndexDialog::MantidWSIndexDialog(MantidUI* mui, Qt::WFlags flags, QList<
   }
   // Set up UI.
   init();
+}
+
+MantidWSIndexDialog::UserInput MantidWSIndexDialog::getSelections() const
+{
+  UserInput options;
+  options.plots = getPlots();
+  options.waterfall = waterfallPlotRequested();
+  return options;
 }
 
 QMultiMap<QString,std::set<int> > MantidWSIndexDialog::getPlots() const
@@ -86,6 +95,11 @@ QMultiMap<QString,std::set<int> > MantidWSIndexDialog::getPlots() const
   }
 
   return plots;
+}
+
+bool MantidWSIndexDialog::waterfallPlotRequested() const
+{
+  return m_waterfallOpt->isChecked();
 }
 
 //----------------------------------
@@ -149,6 +163,7 @@ void MantidWSIndexDialog::init()
   setWindowTitle(tr("MantidPlot"));
   initSpectraBox();
   initWorkspaceBox();
+  initOptionsBoxes();
   initButtons();
   setLayout(m_outer);
 }
@@ -183,6 +198,18 @@ void MantidWSIndexDialog::initSpectraBox()
     m_outer->addItem(m_spectraBox);
 
   connect(m_spectraField->lineEdit(), SIGNAL(textEdited(const QString &)), this, SLOT(editedSpectraField()));
+}
+
+void MantidWSIndexDialog::initOptionsBoxes()
+{
+  m_optionsBox = new QHBoxLayout;
+  m_waterfallOpt = new QCheckBox("Waterfall Plot");
+  if(m_waterfall)
+    m_optionsBox->add(m_waterfallOpt);
+  else
+    m_waterfallOpt->setChecked(true);
+
+  m_outer->addItem(m_optionsBox);
 }
 
 void MantidWSIndexDialog::initButtons()

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidWSIndexDialog.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidWSIndexDialog.h
@@ -4,6 +4,7 @@
 //----------------------------------
 // Includes
 //----------------------------------
+#include <QCheckBox>
 #include <QDialog>
 #include <QString>
 #include <QList>
@@ -188,7 +189,8 @@ private:
 class MantidWSIndexDialog : public QDialog
 {
   Q_OBJECT
-/** Auxiliar class to wrap the QLine allowing to have a warn to the user for
+
+  /** Auxiliar class to wrap the QLine allowing to have a warn to the user for
  *  invalid inputs. 
 */
 class QLineEditWithErrorMark : public QWidget{
@@ -207,13 +209,26 @@ private:
 };
 
 public:
-  /// Constructor - same parameters as one of the parent constructors, along with a 
-  /// list of the names of workspaces to be plotted.
-  MantidWSIndexDialog(MantidUI* parent, Qt::WFlags flags, QList<QString> wsNames);
+  /**
+    * POD structure to hold all user-selected input
+    */
+  struct UserInput {
+    QMultiMap<QString,std::set<int> > plots;
+    bool waterfall;
+  };
 
+/// Constructor - same parameters as one of the parent constructors, along with a 
+  /// list of the names of workspaces to be plotted.
+  MantidWSIndexDialog(MantidUI* parent, Qt::WFlags flags, QList<QString> wsNames,
+                      const bool showWaterfallOption = false);
+
+  /// Returns a structure holding all of the selected options
+  UserInput getSelections() const;
   /// Returns the QMultiMap that contains all the workspaces that are to be plotted, 
   /// mapped to the set of workspace indices.
   QMultiMap<QString,std::set<int> > getPlots() const;
+  /// Returns whether the waterfall option has been selected
+  bool waterfallPlotRequested() const;
 
 private slots:
   /// Called when the OK button is pressed.
@@ -232,6 +247,8 @@ private:
   void initWorkspaceBox();
   /// Initializes the layout of the spectra ID section of the dialog
   void initSpectraBox();
+  /// Initialize the layout of the options check boxes
+  void initOptionsBoxes();
   /// Initializes the layout of the buttons
   void initButtons();
 
@@ -253,13 +270,18 @@ private:
   /// Do we allow the user to ask for a range of spectra IDs or not?
   bool m_spectra;
 
+  /// Do we allow the display of the waterfall option
+  bool m_waterfall;
+  
   /// Pointers to the obligatory Qt objects:
   QLabel *m_wsMessage, *m_spectraMessage, *m_orMessage;
   QLineEditWithErrorMark *m_wsField, *m_spectraField;
   QVBoxLayout *m_outer, *m_wsBox, *m_spectraBox; 
-  QHBoxLayout *m_buttonBox;
+  QHBoxLayout *m_optionsBox, *m_buttonBox;
+  QCheckBox *m_waterfallOpt;
   QPushButton *m_okButton, *m_cancelButton, *m_plotAllButton;
 
+  
   /// A list of names of workspaces which are to be plotted.
   QList<QString> m_wsNames;
   /// IntervalLists for the range of indices/IDs AVAILABLE to the user.

--- a/Code/Mantid/MantidPlot/src/MultiLayer.cpp
+++ b/Code/Mantid/MantidPlot/src/MultiLayer.cpp
@@ -67,6 +67,7 @@
 
 #include <gsl/gsl_vector.h>
 #include "Mantid/MantidMDCurveDialog.h"
+#include "Mantid/MantidWSIndexDialog.h"
 #include "MantidQtSliceViewer/LinePlotOptions.h"
 
 #include "TSVSerialiser.h"
@@ -1385,8 +1386,10 @@ void MultiLayer::dropOntoMatrixCurve(Graph *g, MantidMatrixCurve* originalCurve,
   }
 
   if ( tree == NULL ) return; // (shouldn't happen)
-  QMultiMap<QString,std::set<int> > toPlot = tree->chooseSpectrumFromSelected();
-
+  bool waterfallOpt = false;
+  const auto userInput = tree->chooseSpectrumFromSelected(waterfallOpt);
+  const auto toPlot = userInput.plots;
+  
   // Iterate through the selected workspaces adding a set of curves from each
   for(QMultiMap<QString,std::set<int> >::const_iterator it=toPlot.begin();it!=toPlot.end();++it)
   {

--- a/Code/Mantid/MantidPlot/src/MultiLayer.cpp
+++ b/Code/Mantid/MantidPlot/src/MultiLayer.cpp
@@ -100,7 +100,7 @@ void LayerButton::mouseDoubleClickEvent ( QMouseEvent * )
 	emit showCurvesDialog();
 }
 
-MultiLayer::MultiLayer(ApplicationWindow* parent, int layers, int rows, int cols, 
+MultiLayer::MultiLayer(ApplicationWindow* parent, int layers, int rows, int cols,
                        const QString& label, const char* name, Qt::WFlags f)
                          : MdiSubWindow(parent, label, name, f),
                          active_graph(NULL),
@@ -191,7 +191,7 @@ void MultiLayer::insertCurve(MultiLayer* ml, int i)
   if( ml== this ) return;
   Graph *current = activeGraph();
   if( !current ) return;
-  
+
   current->insertCurve(ml->activeGraph(), i);
   current->updatePlot();
 }
@@ -213,10 +213,10 @@ LayerButton* MultiLayer::addLayerButton()
 Graph* MultiLayer::addLayer(int x, int y, int width, int height)
 {
 	addLayerButton();
-	if (!width && !height){		
-		width =	canvas->width() - left_margin - right_margin - (d_cols - 1)*colsSpace; 
+	if (!width && !height){
+		width =	canvas->width() - left_margin - right_margin - (d_cols - 1)*colsSpace;
 		height = canvas->height() - top_margin - left_margin - (d_rows - 1)*rowsSpace;
-		
+
 		int layers = graphsList.size();
 		x = left_margin + (layers % d_cols)*(width + colsSpace);
 	    y = top_margin + (layers / d_cols)*(height + rowsSpace);
@@ -642,9 +642,9 @@ void MultiLayer::arrangeLayers(bool fit, bool userSize)
 
 		this->showNormal();
 		QSize size = canvas->childrenRect().size();
-		this->resize(canvas->x() + size.width() + left_margin + 2*right_margin, 
+		this->resize(canvas->x() + size.width() + left_margin + 2*right_margin,
 					canvas->y() + size.height() + bottom_margin + 2*LayerButton::btnSize());
-		
+
 		foreach (Graph *gr, graphsList)
 			gr->setIgnoreResizeEvents(ignoreResize);
 	}
@@ -917,7 +917,7 @@ void MultiLayer::printAllLayers(QPainter *painter)
 		}
 	}
 	else
-	{	
+	{
 	   	int x_margin = (pageRect.width() - canvasRect.width())/2;
 	   	int y_margin = (pageRect.height() - canvasRect.height())/2;
 		if (d_print_cropmarks)
@@ -925,7 +925,7 @@ void MultiLayer::printAllLayers(QPainter *painter)
 		int margin = (int)((1/2.54)*printer->logicalDpiY()); // 1 cm margins
 		double scaleFactorX=(double)(paperRect.width()-4*margin)/(double)canvasRect.width();
 		double scaleFactorY=(double)(paperRect.height()-4*margin)/(double)canvasRect.height();
-		
+
 		for (int i=0; i<(int)graphsList.count(); i++)
 		{
             Graph *gr = static_cast<Graph *>(graphsList.at(i));
@@ -937,7 +937,7 @@ void MultiLayer::printAllLayers(QPainter *painter)
 			int width=int(size.width()*scaleFactorX);
 			int height=int(size.height()*scaleFactorY);
 			myPlot->print(painter, QRect(pos, QSize(width,height)));
-		
+
 		}
 	}
 	if (d_print_cropmarks)
@@ -1292,10 +1292,10 @@ void MultiLayer::dragEnterEvent( QDragEnterEvent * event )
 void MultiLayer::dropEvent( QDropEvent * event )
 {
   MantidTreeWidget * tree = dynamic_cast<MantidTreeWidget*>(event->source());
-  
+
   Graph *g = this->activeGraph();
   if (!g) return; // (shouldn't happen either)
-  
+
   if(g->curves() > 0)
   {
     //Do some capability queries on the base curve.
@@ -1383,7 +1383,7 @@ void MultiLayer::dropOntoMatrixCurve(Graph *g, MantidMatrixCurve* originalCurve,
     // Else we'll just have no error bars.
     errorBars = false;
   }
-  
+
   if ( tree == NULL ) return; // (shouldn't happen)
   QMultiMap<QString,std::set<int> > toPlot = tree->chooseSpectrumFromSelected();
 
@@ -1465,6 +1465,47 @@ void MultiLayer::maybeNeedToClose()
   }
 }
 
+void MultiLayer::toggleWaterfall(bool on)
+{
+  if(on) convertToWaterfall();
+  else convertFromWaterfall();
+}
+
+/**
+ * Assume we have a standard 1D plot and convert it to a waterfall layout
+ */
+void MultiLayer::convertToWaterfall()
+{
+  Graph *active = activeGraph();
+  if(!active || active->isWaterfallPlot()) return;
+
+  hide();
+  active->setWaterfallOffset(10,20);
+  setWaterfallLayout(true);
+  // Next two lines replace the legend so that it works on reversing the curve order
+  active->removeLegend();
+  active->newLegend();
+  show();
+}
+
+/**
+ * Assume we have a waterfall 1D plot and convert it to a standard overlayed layout
+ */
+void MultiLayer::convertFromWaterfall()
+{
+  Graph *active = activeGraph();
+  if(!active || !active->isWaterfallPlot()) return;
+
+  hide();
+  const bool updateOffset(true);
+  active->setWaterfallOffset(0, 0, updateOffset);
+  setWaterfallLayout(false);
+  // Next two lines replace the legend
+  active->removeLegend();
+  active->newLegend();
+  show();
+}
+
 void MultiLayer::setWaterfallLayout(bool on)
 {
   if (graphsList.isEmpty())
@@ -1476,13 +1517,7 @@ void MultiLayer::setWaterfallLayout(bool on)
     createWaterfallBox();
     updateWaterfalls();
   } else {
-    for (int i = 0; i < waterfallBox->count(); i++){
-      QLayoutItem *item = waterfallBox->itemAt(i);
-      if (item){
-        waterfallBox->removeItem(item);
-        delete item;
-      }
-    }
+    removeWaterfallBox();
   }
 }
 
@@ -1502,6 +1537,17 @@ void MultiLayer::createWaterfallBox()
   btn = new QPushButton(tr("Fill Area..."));
   connect (btn, SIGNAL(clicked()), this, SLOT(showWaterfallFillDialog()));
   waterfallBox->addWidget(btn);
+}
+
+void MultiLayer::removeWaterfallBox()
+{
+  if (waterfallBox->count() == 0)
+    return;
+
+  QLayoutItem *child;
+  while ((child = waterfallBox->takeAt(0)) != 0) {
+    delete child->widget();
+  }
 }
 
 void MultiLayer::updateWaterfalls()
@@ -1579,7 +1625,7 @@ void MultiLayer::showWaterfallFillDialog()
   if (active_graph->curvesList().isEmpty())
     return;
 
-  new WaterfallFillDialog(this, active_graph);  
+  new WaterfallFillDialog(this, active_graph);
 }
 
 
@@ -1591,30 +1637,30 @@ void MultiLayer::setWaterfallFillColor(const QColor& c)
 }
 
 
-WaterfallFillDialog::WaterfallFillDialog(MultiLayer *parent, Graph *active_graph) 
+WaterfallFillDialog::WaterfallFillDialog(MultiLayer *parent, Graph *active_graph)
 {
   this->setParent(parent);
   this->m_active_graph = active_graph;
   QDialog *waterfallFillDialog = new QDialog(this);
   waterfallFillDialog->setWindowTitle(tr("Fill Curves"));
-  
+
   QGroupBox *enableFillGroup = new QGroupBox(tr("Enable Fill"), waterfallFillDialog);
   enableFillGroup->setCheckable(true);
-  
-  QGridLayout *enableFillLayout =  new QGridLayout(enableFillGroup);  
+
+  QGridLayout *enableFillLayout =  new QGridLayout(enableFillGroup);
 
   // use line colour
   QRadioButton *rLineC = new QRadioButton("Use Line Colour", enableFillGroup);
   this->m_lineRadioButton = rLineC;
   enableFillLayout->addWidget(rLineC,0,0);
-  
+
   // use solid colour
   QRadioButton *rSolidC = new QRadioButton("Use Solid Colour", enableFillGroup);
   this->m_solidRadioButton = rSolidC;
   enableFillLayout->addWidget(rSolidC, 1,0);
 
-  QGroupBox *colourModeGroup = new QGroupBox( tr("Fill with Colour"), enableFillGroup);  
-  
+  QGroupBox *colourModeGroup = new QGroupBox( tr("Fill with Colour"), enableFillGroup);
+
   QGridLayout *hl1 = new QGridLayout(colourModeGroup);
   hl1->addWidget(new QLabel(tr("Colour")), 0, 0);
   ColorButton *fillColourBox = new ColorButton(colourModeGroup);
@@ -1624,26 +1670,26 @@ WaterfallFillDialog::WaterfallFillDialog(MultiLayer *parent, Graph *active_graph
   enableFillLayout->addWidget(colourModeGroup,2,0);
 
   QCheckBox *sideLinesBox = new QCheckBox(tr("Side Lines"), enableFillGroup);
-  enableFillLayout->addWidget(sideLinesBox, 3, 0); 
+  enableFillLayout->addWidget(sideLinesBox, 3, 0);
 
   QBrush brush = active_graph->curve(0)->brush();
 
   // check if all curve colours are the same (= solid fill)
   bool same = brush.style() != Qt::NoBrush; // check isn't first run against graph
-  
+
   if(same)
   {
     int n = active_graph->curvesList().size();
     for (int i = 0; i < n; i++)
     {
-      same = same && (active_graph->curve(i)->brush().color() == brush.color());    
+      same = same && (active_graph->curve(i)->brush().color() == brush.color());
     }
   }
   // set which is toggled
   enableFillGroup->setChecked(brush.style() != Qt::NoBrush);
 
   if(same)
-  {   
+  {
     rSolidC->toggle();
     if(enableFillGroup->isChecked())
       fillColourBox->setColor(brush.color());
@@ -1652,22 +1698,22 @@ WaterfallFillDialog::WaterfallFillDialog(MultiLayer *parent, Graph *active_graph
   {
     rLineC->toggle();
     if(enableFillGroup->isChecked())
-      active_graph->updateWaterfallFill(true);  
+      active_graph->updateWaterfallFill(true);
   }
 
   // If sidelines previously enabled, check it.
   PlotCurve *c = dynamic_cast<PlotCurve*>(active_graph->curve(0));
-  sideLinesBox->setChecked(c->sideLinesEnabled());   
-  
-  colourModeGroup->setEnabled(rSolidC->isChecked() && enableFillGroup->isChecked());  
-  
-  connect(enableFillGroup, SIGNAL(toggled(bool)), this, SLOT(enableFill(bool))); 
+  sideLinesBox->setChecked(c->sideLinesEnabled());
+
+  colourModeGroup->setEnabled(rSolidC->isChecked() && enableFillGroup->isChecked());
+
+  connect(enableFillGroup, SIGNAL(toggled(bool)), this, SLOT(enableFill(bool)));
   connect(fillColourBox, SIGNAL(colorChanged(const QColor&)), active_graph, SLOT(setWaterfallFillColor(const QColor&)));
-  connect(sideLinesBox, SIGNAL(toggled(bool)), active_graph, SLOT(setWaterfallSideLines(bool)));  
-  connect(rSolidC, SIGNAL(toggled(bool)), colourModeGroup, SLOT(setEnabled(bool)));  
-  connect(rSolidC, SIGNAL(toggled(bool)), this, SLOT(setFillMode())); 
-  connect(rLineC, SIGNAL(toggled(bool)), this, SLOT(setFillMode())); 
-  
+  connect(sideLinesBox, SIGNAL(toggled(bool)), active_graph, SLOT(setWaterfallSideLines(bool)));
+  connect(rSolidC, SIGNAL(toggled(bool)), colourModeGroup, SLOT(setEnabled(bool)));
+  connect(rSolidC, SIGNAL(toggled(bool)), this, SLOT(setFillMode()));
+  connect(rLineC, SIGNAL(toggled(bool)), this, SLOT(setFillMode()));
+
   QPushButton *closeBtn = new QPushButton(tr("&Close"),waterfallFillDialog);
   connect(closeBtn, SIGNAL(clicked()), waterfallFillDialog, SLOT(reject()));
 
@@ -1690,19 +1736,19 @@ void WaterfallFillDialog::enableFill(bool b)
   else
   {
     m_active_graph->curve(0)->setBrush(Qt::BrushStyle::NoBrush);
-    m_active_graph->updateWaterfallFill(false);     
+    m_active_graph->updateWaterfallFill(false);
   }
 }
 
 void WaterfallFillDialog::setFillMode()
 {
-  if( m_solidRadioButton->isChecked() ) 
-  {                  
+  if( m_solidRadioButton->isChecked() )
+  {
     m_active_graph->setWaterfallFillColor(this->m_colourBox->color());
-  }    
+  }
   else if( m_lineRadioButton->isChecked() )
-  {       
-    m_active_graph->updateWaterfallFill(true); 
+  {
+    m_active_graph->updateWaterfallFill(true);
   }
 }
 

--- a/Code/Mantid/MantidPlot/src/MultiLayer.h
+++ b/Code/Mantid/MantidPlot/src/MultiLayer.h
@@ -172,6 +172,9 @@ public slots:
 
   //! \name Waterfall Plots
   //@{
+  void toggleWaterfall(bool on);
+  void convertToWaterfall();
+  void convertFromWaterfall();
   void showWaterfallOffsetDialog();
   void reverseWaterfallOrder();
   void showWaterfallFillDialog();
@@ -227,6 +230,7 @@ private:
   void removeLayerSelectionFrame();
 
   void createWaterfallBox();
+  void removeWaterfallBox();
 
 	Graph* active_graph;
 	//! Used for resizing of layers.
@@ -276,7 +280,7 @@ class WaterfallFillDialog : QDialog
 public:
     WaterfallFillDialog(MultiLayer *parent, Graph *active_graph);
 
-public slots:    
+public slots:
   void setFillMode();
   void enableFill(bool b);
 

--- a/Code/Mantid/MantidPlot/src/qti.sip
+++ b/Code/Mantid/MantidPlot/src/qti.sip
@@ -1678,7 +1678,8 @@ sipClass=sipFindClass(sipCpp->className());
 public:
   // Plotting methods
   MultiLayer* plot1D(const QList<QString>& wsnames, const QList<int>&, bool spectrumPlot, bool errs=false,
-    Graph::CurveType style = Graph::Unspecified, MultiLayer* window = NULL, bool clearWindow = false);
+    Graph::CurveType style = Graph::Unspecified, MultiLayer* window = NULL,
+                     bool clearWindow = false, bool waterfallPlot = false);
 
   MultiLayer* drawSingleColorFillPlot(const QString & name, Graph::CurveType style = Graph::ColorMap,
                                       MultiLayer* window = NULL);


### PR DESCRIPTION
Fixes trac issue [#11559](http://trac.mantidproject.org/mantid/ticket/11559)

**Tester**
Create a workspace with multiple spectra, `CreateSampleWorkspace` is useful for this. Right click and select _Plot Spectrum_. There is a new option: _Waterfall Plot_. Checking this option and entering multiple spectra should directly create a waterfall plot.

Once you have the plot, right click on it and see a new option called _Plot Type_. You should be able to check & uncheck the _waterfall_ option and see the current graph change between the two types: standard and waterfall.

A new option in `plotSpectrum` & `plotBin` is also available: `waterfall=True/False`. Passing this option will create a waterfall plot if requested directly from Python.
