### PR TITLE
Fix crash on "Clear All Memory"/shutdown in MantidPlot

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.h
@@ -444,7 +444,7 @@ signals:
     void importNumSeriesLog(const QString &wsName, const QString &logname, int filter);
 
     // Clear all Mantid related memory
-    void clearAllMemory();
+    void clearAllMemory(const bool prompt = true);
     void releaseFreeMemory();
     // Ticket #672
     void saveNexusWorkspace();


### PR DESCRIPTION
Fixes issue [#11577](http://trac.mantidproject.org/mantid/ticket/11577)

**Tester**
Check you can reproduce before merging the fix. It can be reproduced by running the scripting from the issue description and then either clicking File->Clear All Memory or just quitting MantidPlot. Both should cause a crash.

Try again after merging the fix and no segfault should occur.
