### PR TITLE
Remove default values for non essential outputs on FABADA

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/src/FABADAMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/FABADAMinimizer.cpp
@@ -64,19 +64,19 @@ FABADAMinimizer::FABADAMinimizer() {
   declareProperty(
       new API::WorkspaceProperty<>("PDF", "PDF", Kernel::Direction::Output),
       "The name to give the output workspace");
-  declareProperty(new API::WorkspaceProperty<>("Chains", "Chain",
+  declareProperty(new API::WorkspaceProperty<>("Chains", "",
                                                Kernel::Direction::Output),
                   "The name to give the output workspace");
   declareProperty(new API::WorkspaceProperty<>(
-                      "ConvergedChain", "ConvergedChain",
+                      "ConvergedChain", "",
                       Kernel::Direction::Output, API::PropertyMode::Optional),
                   "The name to give the output workspace");
   declareProperty(
       new API::WorkspaceProperty<API::ITableWorkspace>(
-          "CostFunctionTable", "CostFunction", Kernel::Direction::Output),
+          "CostFunctionTable", "", Kernel::Direction::Output),
       "The name to give the output workspace");
   declareProperty(new API::WorkspaceProperty<API::ITableWorkspace>(
-                      "Parameters", "Parameters", Kernel::Direction::Output),
+                      "Parameters", "", Kernel::Direction::Output),
                   "The name to give the output workspace");
 }
 
@@ -320,7 +320,7 @@ bool FABADAMinimizer::iterate(size_t) {
   } // for i
 
   // Update the counter, after finishing the iteration for each parameter
-  m_counter += 1; 
+  m_counter += 1;
 
   // Check if Chi square has converged for all the parameters.
   if (m_counter > lowerIterationLimit && !m_converged) {

--- a/Code/Mantid/Framework/CurveFitting/test/FABADAMinimizerTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/FABADAMinimizerTest.h
@@ -44,7 +44,9 @@ public:
     fit.setProperty("CreateOutput", true);
     fit.setProperty("MaxIterations", 100000);
     fit.setProperty("Minimizer", "FABADA,ChainLength=5000,StepsBetweenValues="
-                                 "10,ConvergenceCriteria = 0.1");
+                                 "10,ConvergenceCriteria=0.1,CostFunctionTable="
+                                 "CostFunction,Chains=Chain,ConvergedChain"
+                                 "=ConvergedChain,Parameters=Parameters");
 
     TS_ASSERT_THROWS_NOTHING(fit.execute());
 
@@ -104,9 +106,9 @@ public:
     TS_ASSERT_EQUALS(Xconv.size(), 500);
     TS_ASSERT_EQUALS(Xconv[437], 437);
 
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("chain"));
+    TS_ASSERT(AnalysisDataService::Instance().doesExist("Chain"));
     MatrixWorkspace_sptr wsChain = boost::dynamic_pointer_cast<MatrixWorkspace>(
-        API::AnalysisDataService::Instance().retrieve("chain"));
+        API::AnalysisDataService::Instance().retrieve("Chain"));
     TS_ASSERT(wsChain);
     TS_ASSERT_EQUALS(wsChain->getNumberHistograms(), n + 1);
 

--- a/Code/Mantid/docs/source/concepts/FABADA.rst
+++ b/Code/Mantid/docs/source/concepts/FABADA.rst
@@ -43,26 +43,26 @@ JumpAcceptanceRate
 FABADA Specific Outputs
 -----------------------
 
-PDF
+PDF (*required*)
   Probability Density Function for each fitted parameter and the cost function.
   This is output as a :ref:`MatrixWorkspace`.
 
-Chains
+Chains (*optional*)
   The value of each parameter and the cost function for each step taken.
   This is output as a :ref:`MatrixWorkspace`.
 
-ConvergedChain
+ConvergedChain (*optional*)
   A subset of Chains containing only the section after which the parameters have
   converged.
   This records the parameters at step intervals given by StepsBetweenValues.
   This is output as a :ref:`MatrixWorkspace`.
 
-CostFunctionTable
+CostFunctionTable (*optional*)
   Table containing the minimum and most probable values of the cost function as
   well as their reduced values.
   This is output as a TableWorkspace.
 
-Parameters
+Parameters (*optional*)
   Similar to the standard parameter table but also includes left and right
   errors for each parameter (cost function is not included).
   This is output as a TableWorkspace.


### PR DESCRIPTION
Fixes [#11582](http://trac.mantidproject.org/mantid/ticket/11582).

To test:
- Do a fit with FABADA (`irs26176_graphite002_red`, Lorentzian,Amplitude=4,PeakCentre=0,FWHM=0.04)
- Notice you only get the PDF output by default
- Give a name for some of the other outputs, run fit again
- You will get the additional outputs

Technically they were optional but an empty string cannot be passed via the minimizer property, so optional string properties must have no default values.
