### PR TITLE
 Fixing doxygen warnings in Mantid_template.doxyfile

### DIFF
--- a/Code/Mantid/Framework/Doxygen/Mantid_template.doxyfile
+++ b/Code/Mantid/Framework/Doxygen/Mantid_template.doxyfile
@@ -98,8 +98,6 @@ INPUT = @CMAKE_CURRENT_SOURCE_DIR@/../Algorithms/inc \
         @CMAKE_CURRENT_SOURCE_DIR@/../MatlabAPI/src \
         @CMAKE_CURRENT_SOURCE_DIR@/../MDAlgorithms/inc \
         @CMAKE_CURRENT_SOURCE_DIR@/../MDAlgorithms/src \
-        @CMAKE_CURRENT_SOURCE_DIR@/../MDEvents/inc \
-        @CMAKE_CURRENT_SOURCE_DIR@/../MDEvents/src \
         @CMAKE_CURRENT_SOURCE_DIR@/../Nexus/inc \
         @CMAKE_CURRENT_SOURCE_DIR@/../Nexus/src \
         @CMAKE_CURRENT_SOURCE_DIR@/../PythonInterface/inc/MantidPythonInterface/kernel \


### PR DESCRIPTION
This should fix four of the current warnings.
