### PR TITLE
Invalid IDF written in nexus files for LET. 

### DIFF
--- a/Code/Mantid/instrument/LET_Definition.xml
+++ b/Code/Mantid/instrument/LET_Definition.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="LET" valid-from   ="1900-01-31 23:59:59"
                        valid-to     ="2014-02-10 23:59:59"
-		       last-modified="2012-03-13 00:00:00">
+		       last-modified="2015-03-09 00:00:00">
  
    <defaults>
      <length unit="meter"/>

--- a/Code/Mantid/instrument/LET_Definition_dr2to9.xml
+++ b/Code/Mantid/instrument/LET_Definition_dr2to9.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="LET" valid-from   ="2014-02-11 00:00:01"
                        valid-to     ="2014-05-01 23:59:59"
-		       last-modified="2014-05-06 00:00:00">
+		       last-modified="2015-03-09 00:00:00">
  
    <defaults>
      <length unit="meter"/>

--- a/Code/Mantid/instrument/LET_Definition_dr3to10.xml
+++ b/Code/Mantid/instrument/LET_Definition_dr3to10.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="LET" valid-from   ="2014-05-02 23:59:59"
                valid-to     ="2014-07-11 23:59:59"
-               last-modified="2014-07-16 18:27:00">
+               last-modified="2015-03-09 18:27:00">
  
    <defaults>
      <length unit="meter"/>

--- a/Code/Mantid/instrument/LET_Definition_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Definition_dr3to11.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="LET" valid-from   ="2014-07-12 00:00:01"
                valid-to     ="2014-08-31 23:59:59"
-               last-modified="2014-07-16 18:30:0">
+               last-modified="2015-03-09 18:30:0">
  
    <defaults>
      <length unit="meter"/>

--- a/Code/Mantid/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/RunDescriptor.py
@@ -974,13 +974,26 @@ class RunDescriptor(PropDescriptor):
         else:
             mon_load_option = 'Separate'
         #
+        nxs_file=False
+        file,ext = os.path.splitext(data_file)
+        if ext == '.nxs':
+            nxs_file = True
         try: # Hack: LoadEventNexus does not understand Separate at the moment and throws.
             # And event loader always loads monitors separately
             Load(Filename=data_file, OutputWorkspace=ws_name,LoadMonitors = mon_load_option)
         except ValueError:
             #mon_load_option =str(int(load_mon_with_workspace))
             Load(Filename=data_file, OutputWorkspace=ws_name,LoadMonitors = '1',MonitorsAsEvents='0')
-
+        #HACK >>> , necessary until #11565 is fixed
+        if nxs_file :
+           instr_name = RunDescriptor._holder.instr_name
+           if instr_name == 'LET' and self._run_number>14151 and self._run_number<14382:
+                FrameworkManager.clearInstruments()
+                idf_file = api.ExperimentInfo.getInstrumentFilename(instr_name)
+                idf_path,tile = os.path.split(idf_file)
+                idf_file = os.path.join(idf_path,'LET_Definition.xml')
+                LoadInstrument(ws_name,idf_file,RewriteSpectraMap='0')
+        #HACK<<<
         RunDescriptor._logger("Loaded {0}".format(data_file),'information')
 
         loaded_ws = mtd[ws_name]


### PR DESCRIPTION
this fixes issue http://trac.mantidproject.org/mantid/ticket/11576 and the fix is pretty grim though trivial. Its rather hack allowing users to reduce the data until #11565 is fixed.

The changes are trivial and affect LET only. I will discuss results with the instrument scientist.

After #11565 is fixed, the changes will be removed. 
