### PR TITLE
Include ipython notebook dependencies in OS X  bundle.

### DIFF
--- a/Code/Mantid/MantidPlot/FixMavericksBundle.cmake.in
+++ b/Code/Mantid/MantidPlot/FixMavericksBundle.cmake.in
@@ -1,3 +1,6 @@
 set ( bundle ${CMAKE_INSTALL_PREFIX}/MantidPlot.app )
 execute_process(COMMAND chmod +x make_package.rb WORKING_DIRECTORY ${bundle})
-execute_process(COMMAND ./make_package.rb WORKING_DIRECTORY ${bundle})
+execute_process(COMMAND ./make_package.rb WORKING_DIRECTORY ${bundle} RESULT_VARIABLE install_name_tool_result)
+if(NOT install_name_tool_result EQUAL 0)
+  message(FATAL_ERROR "Package script failed!!!\n")
+endif()


### PR DESCRIPTION
This fixes [#11482](http://trac.mantidproject.org/mantid/ticket/11482)

A user complained that the 10.9 package isn't allowing him to use the ipython notebook. We've tracked this down to a packaging fault. This pull request should fix this issue and make it more difficult for them to occur in the future.

Our current bundle should not require setting the `DYLD_LIBRARY_PATH` environment variable as described on the wiki. That being said, it also shouldn't hurt anything and I'm hesitant to update the documentation until after release 3.4. 

**Testing** 
- Try generating an OS X bundle after uninstalling one of the python libraries.Verify that the packaging step exits with a fatal error.
- Build an OS X bundle and install it. Verify that ipython notebook is functioning.
