### PR TITLE
Fix axis transposition bug in SliceViewer

### DIFF
--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/LineViewer.h
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/LineViewer.h
@@ -156,6 +156,11 @@ private:
     /// Index of the Y dimension in the 2D slice
     int m_freeDimY;
 
+    /// Index of the first selected X dimension in the 2D slice
+    int m_initFreeDimX;
+    /// Index of the first selected Y dimension in the 2D slice
+    int m_initFreeDimY;
+
     /// When True, then the bin width is fixed and the number of bins changes
     bool m_fixedBinWidthMode;
 

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -342,7 +342,7 @@ LineViewer::applyMatrixWorkspace(Mantid::API::MatrixWorkspace_sptr ws) {
     const int axisY = lineIsHorizontal ? m_freeDimY : m_freeDimX;
 
     // If necessary, swap the start and end around so that start < end
-    const bool swapEnds = m_start[axisX] > m_end[axisY];
+    const bool swapEnds = m_start[axisX] > m_end[axisX];
     const double start = swapEnds ? m_end[axisX] : m_start[axisX];
     const double end = swapEnds ? m_start[axisX] : m_end[axisX];
 

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -314,75 +314,72 @@ void LineViewer::readTextboxes() {
  */
 IAlgorithm_sptr
 LineViewer::applyMatrixWorkspace(Mantid::API::MatrixWorkspace_sptr ws) {
-  try {
-    if (getPlanarWidth() <= 0)
-      throw std::runtime_error("Planar Width must be > 0");
+  // (half-width in the plane)
+  const double planeWidth = getPlanarWidth();
 
-    IAlgorithm_sptr alg =
-        AlgorithmManager::Instance().createUnmanaged("Rebin2D");
-    alg->initialize();
+  if (planeWidth <= 0) {
+    g_log.error() << "Planar width must be > 0" << std::endl;
+    g_log.error() << "Planar width is: " << planeWidth << std::endl;
+    return IAlgorithm_sptr();
+  }
+
+  // Length of the line
+  const double lengthX = m_end[m_freeDimX] - m_start[m_freeDimX];
+  const double lengthY = m_end[m_freeDimY] - m_start[m_freeDimY];
+  const bool lineIsHorizontal = fabs(lengthX) > fabs(lengthY);
+
+  IAlgorithm_sptr alg = AlgorithmManager::Instance().createUnmanaged("Rebin2D");
+  alg->initialize();
+
+  try {
     alg->setProperty("InputWorkspace", ws);
     alg->setPropertyValue("OutputWorkspace", m_integratedWSName);
-    if (ws->id() == "RebinnedOutput") {
-      alg->setProperty("UseFractionalArea", true);
-    } else {
-      alg->setProperty("UseFractionalArea", false);
-    }
-    // (half-width in the plane)
-    double planeWidth = this->getPlanarWidth();
-    // Length of the line
-    double dx = m_end[m_freeDimX] - m_start[m_freeDimX];
-    double dy = m_end[m_freeDimY] - m_start[m_freeDimY];
-    size_t numBins = m_numBins;
+    alg->setProperty("UseFractionalArea", (ws->id() == "RebinnedOutput"));
+    alg->setProperty("Transpose", !lineIsHorizontal);
 
-    if (fabs(dx) > fabs(dy)) {
+    // Swap the axes if the line is NOT horizontal (i.e. vertical)
+    const int axisX = lineIsHorizontal ? m_freeDimX : m_freeDimY;
+    const int axisY = lineIsHorizontal ? m_freeDimY : m_freeDimX;
+
+    // If necessary, swap the start and end around so that start < end
+    const bool swapEnds = m_start[axisX] > m_end[axisY];
+    const double start = swapEnds ? m_end[axisX] : m_start[axisX];
+    const double end = swapEnds ? m_start[axisX] : m_end[axisX];
+
+    // Calculate the bin width
+    const double binWidth = (end - start) / static_cast<double>(m_numBins);
+
+    // The start value of the opposite axis
+    const double vertical = m_start[axisY];
+
+    // Output stringstreams for the binning
+    std::stringstream axis1Binning, axis2Binning;
+
+    if (binWidth <= 0)
+      return IAlgorithm_sptr();
+
+    axis1Binning << start << "," << binWidth << "," << end;
+    axis2Binning << (vertical - planeWidth) << "," << (planeWidth * 2) << ","
+                 << (vertical + planeWidth);
+
+    // If the line is vertical we swap the axes binning order
+    if (lineIsHorizontal) {
       // Horizontal line
-      double start = m_start[m_freeDimX];
-      double end = m_end[m_freeDimX];
-      if (end < start) {
-        start = end;
-        end = m_start[m_freeDimX];
-      }
-      double vertical = m_start[m_freeDimY];
-      double binWidth = (end - start) / static_cast<double>(numBins);
-      if (binWidth <= 0)
-        return IAlgorithm_sptr();
-
-      alg->setPropertyValue("Axis1Binning", Strings::toString(start) + "," +
-                                                Strings::toString(binWidth) +
-                                                "," + Strings::toString(end));
-      alg->setPropertyValue("Axis2Binning",
-                            Strings::toString(vertical - planeWidth) + "," +
-                                Strings::toString(planeWidth * 2) + "," +
-                                Strings::toString(vertical + planeWidth));
-      alg->setProperty("Transpose", false);
+      alg->setPropertyValue("Axis1Binning", axis1Binning.str());
+      alg->setPropertyValue("Axis2Binning", axis2Binning.str());
     } else {
       // Vertical line
-      double start = m_start[m_freeDimY];
-      double end = m_end[m_freeDimY];
-      if (end < start) {
-        start = end;
-        end = m_start[m_freeDimY];
-      }
-      double binWidth = (end - start) / static_cast<double>(numBins);
-
-      double vertical = m_start[m_freeDimX];
-      alg->setPropertyValue("Axis1Binning",
-                            Strings::toString(vertical - planeWidth) + "," +
-                                Strings::toString(planeWidth * 2) + "," +
-                                Strings::toString(vertical + planeWidth));
-      alg->setPropertyValue("Axis2Binning", Strings::toString(start) + "," +
-                                                Strings::toString(binWidth) +
-                                                "," + Strings::toString(end));
-      alg->setProperty("Transpose", true);
+      alg->setPropertyValue("Axis1Binning", axis2Binning.str());
+      alg->setPropertyValue("Axis2Binning", axis1Binning.str());
     }
-    return alg;
   } catch (std::exception &e) {
     // Log the error
     g_log.error() << "Invalid property passed to Rebin2D:" << std::endl;
     g_log.error() << e.what() << std::endl;
     return IAlgorithm_sptr();
   }
+
+  return alg;
 }
 
 //----------------------------------------------------------------------------------------

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -68,19 +68,18 @@ using MantidQt::API::AlgorithmRunner;
 namespace MantidQt {
 namespace SliceViewer {
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Constructor */
 SliceViewer::SliceViewer(QWidget *parent)
     : QWidget(parent), m_ws(), m_firstWorkspaceOpen(false), m_dimensions(),
       m_data(NULL), m_X(), m_Y(), m_dimX(0), m_dimY(1), m_logColor(false),
       m_fastRender(true), m_rebinMode(false), m_rebinLocked(true),
-      m_mdSettings(new MantidQt::API::MdSettings()),
-      m_logger("SliceViewer"),
+      m_mdSettings(new MantidQt::API::MdSettings()), m_logger("SliceViewer"),
       m_peaksPresenter(boost::make_shared<CompositePeaksPresenter>(this)),
       m_proxyPeaksPresenter(
-      boost::make_shared<ProxyCompositePeaksPresenter>(m_peaksPresenter)),
-      m_peaksSliderWidget(NULL){
-      
+          boost::make_shared<ProxyCompositePeaksPresenter>(m_peaksPresenter)),
+      m_peaksSliderWidget(NULL) {
+
   ui.setupUi(this);
 
   m_inf = std::numeric_limits<double>::infinity();
@@ -118,10 +117,10 @@ SliceViewer::SliceViewer(QWidget *parent)
 
   initZoomer();
 
-  //hide unused buttons
-  ui.btnZoom->hide();  // hidden for a long time
-  ui.btnRebinLock->hide();  // now replaced by auto rebin mode
-  //ui.btnClearLine->hide();  // turning off line mode now removes line
+  // hide unused buttons
+  ui.btnZoom->hide();      // hidden for a long time
+  ui.btnRebinLock->hide(); // now replaced by auto rebin mode
+  // ui.btnClearLine->hide();  // turning off line mode now removes line
 
   // ----------- Toolbar button signals ----------------
   QObject::connect(ui.btnResetZoom, SIGNAL(clicked()), this, SLOT(resetZoom()));
@@ -169,7 +168,7 @@ SliceViewer::SliceViewer(QWidget *parent)
   this->setAcceptDrops(true);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Destructor
 SliceViewer::~SliceViewer() {
   saveSettings();
@@ -177,21 +176,20 @@ SliceViewer::~SliceViewer() {
   // Don't delete Qt objects, I think these are auto-deleted
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Load QSettings from .ini-type files */
 void SliceViewer::loadSettings() {
   QSettings settings;
   settings.beginGroup("Mantid/SliceViewer");
   bool scaleType = (bool)settings.value("LogColorScale", 0).toInt();
 
-  //Load Colormap. If the file is invalid the default stored colour map is used. If the 
-  // user selected a unified color map for the SliceViewer and the VSI, then this is loaded.
-  if (m_mdSettings != NULL && m_mdSettings->getUsageGeneralMdColorMap())
-  {
+  // Load Colormap. If the file is invalid the default stored colour map is
+  // used.
+  // If the user selected a unified color map for the SliceViewer and the VSI,
+  // then this is loaded.
+  if (m_mdSettings != NULL && m_mdSettings->getUsageGeneralMdColorMap()) {
     m_currentColorMapFile = m_mdSettings->getGeneralMdColorMapFile();
-  }
-  else
-  {
+  } else {
     m_currentColorMapFile = settings.value("ColormapFile", "").toString();
   }
 
@@ -213,7 +211,7 @@ void SliceViewer::loadSettings() {
   settings.endGroup();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Save settings for next time. */
 void SliceViewer::saveSettings() {
   QSettings settings;
@@ -228,7 +226,7 @@ void SliceViewer::saveSettings() {
   settings.endGroup();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Create the menus */
 void SliceViewer::initMenus() {
   // ---------------------- Build the menu bar -------------------------
@@ -274,10 +272,9 @@ void SliceViewer::initMenus() {
   connect(action, SIGNAL(triggered()), this, SLOT(resetZoom()));
   {
     QIcon icon;
-    icon.addFile(QString::fromStdString(g_iconViewFull),
-                 QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconViewFull), QSize(), QIcon::Normal,
+                 QIcon::Off);
     action->setIcon(icon);
-
   }
   m_menuView->addAction(action);
 
@@ -314,7 +311,7 @@ void SliceViewer::initMenus() {
   m_syncRebinLock = new SyncedCheckboxes(action, ui.btnRebinLock, true);
   connect(m_syncRebinLock, SIGNAL(toggled(bool)), this,
           SLOT(RebinLock_toggled(bool)));
-  action->setVisible(false);  //hide this action
+  action->setVisible(false); // hide this action
   m_menuView->addAction(action);
 
   action = new QAction(QPixmap(), "Rebin Current View", this);
@@ -374,9 +371,8 @@ void SliceViewer::initMenus() {
   action->setIconVisibleInMenu(true);
   {
     QIcon icon;
-    icon.addFile(
-        QString::fromStdString(g_iconZoomPlus),
-        QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconZoomPlus), QSize(), QIcon::Normal,
+                 QIcon::Off);
     action->setIcon(icon);
   }
   m_menuColorOptions->addAction(action);
@@ -385,8 +381,8 @@ void SliceViewer::initMenus() {
   connect(action, SIGNAL(triggered()), this, SLOT(setColorScaleAutoFull()));
   {
     QIcon icon;
-    icon.addFile(QString::fromStdString(g_iconZoomMinus),
-                 QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconZoomMinus), QSize(),
+                 QIcon::Normal, QIcon::Off);
     action->setIcon(icon);
   }
   m_menuColorOptions->addAction(action);
@@ -452,7 +448,7 @@ void SliceViewer::initMenus() {
   bar->addMenu(m_menuHelp);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Intialize the zooming/panning tools */
 void SliceViewer::initZoomer() {
   //  QwtPlotZoomer * zoomer = new CustomZoomer(m_plot->canvas());
@@ -501,7 +497,7 @@ void SliceViewer::initZoomer() {
                    SLOT(showInfoAt(double, double)));
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Programmatically show/hide the controls (sliders etc)
  *
  * @param visible :: true if you want to show the controls.
@@ -510,7 +506,7 @@ void SliceViewer::showControls(bool visible) {
   ui.frmControls->setVisible(visible);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Add (as needed) and update DimensionSliceWidget's. */
 void SliceViewer::updateDimensionSliceWidgets() {
   // Create all necessary widgets
@@ -577,7 +573,7 @@ void SliceViewer::updateDimensionSliceWidgets() {
   }
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the displayed workspace. Updates UI.
  *
  * @param ws :: IMDWorkspace to show.
@@ -683,7 +679,7 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   emit changedShownDim(m_dimX, m_dimY);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the workspace to view using its name.
  * The workspace should be a MDHistoWorkspace or a MDEventWorkspace,
  * with at least 2 dimensions.
@@ -704,11 +700,11 @@ void SliceViewer::setWorkspace(const QString &wsName) {
   this->setWorkspace(ws);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** @return the workspace in the SliceViewer */
 Mantid::API::IMDWorkspace_sptr SliceViewer::getWorkspace() { return m_ws; }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Load a color map from a file
  *
  * @param filename :: file to open; empty to ask via a dialog box.
@@ -731,12 +727,11 @@ void SliceViewer::loadColorMap(QString filename) {
   this->updateDisplay();
 }
 
-//=================================================================================================
-//========================================== SLOTS
-//================================================
-//=================================================================================================
+//==============================================================================
+//================================ SLOTS =======================================
+//==============================================================================
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Automatically sets the min/max of the color scale,
  * using the limits in the entire data set of the workspace
  * (every bin, even those not currently visible).
@@ -747,7 +742,7 @@ void SliceViewer::setColorScaleAutoFull() {
   this->updateDisplay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Automatically sets the min/max of the color scale,
  * using the limits in the data that is currently visible
  * in the plot (only the bins in this slice and within the
@@ -759,14 +754,14 @@ void SliceViewer::setColorScaleAutoSlice() {
   this->updateDisplay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Slot called when the ColorBarWidget changes the range of colors
 void SliceViewer::colorRangeChanged() {
   m_spect->setColorMap(m_colorBar->getColorMap());
   this->updateDisplay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set whether to display 0 signal as "transparent" color.
  *
  * @param transparent :: true if you want zeros to be transparent.
@@ -780,7 +775,7 @@ void SliceViewer::setTransparentZeros(bool transparent) {
   this->updateDisplay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Slot called when changing the normalization menu
 void SliceViewer::changeNormalizationNone() {
   this->setNormalization(Mantid::API::NoNormalization, true);
@@ -794,7 +789,7 @@ void SliceViewer::changeNormalizationNumEvents() {
   this->setNormalization(Mantid::API::NumEventsNormalization, true);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the normalization mode for viewing the data
  *
  * @param norm :: MDNormalization enum. 0=none; 1=volume; 2=# of events
@@ -821,13 +816,13 @@ void SliceViewer::setNormalization(Mantid::API::MDNormalization norm,
     this->updateDisplay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** @return the current normalization */
 Mantid::API::MDNormalization SliceViewer::getNormalization() const {
   return m_data->getNormalization();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the thickness (above and below the plane) for dynamic rebinning.
  *
  * @param dim :: index of the dimension to adjust
@@ -845,7 +840,7 @@ void SliceViewer::setRebinThickness(int dim, double thickness) {
   m_dimWidgets[dim]->setThickness(thickness);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the number of bins for dynamic rebinning.
  *
  * @param xBins :: number of bins in the viewed X direction
@@ -860,7 +855,7 @@ void SliceViewer::setRebinNumBins(int xBins, int yBins) {
   m_dimWidgets[m_dimY]->setNumBins(yBins);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Sets the SliceViewer in dynamic rebin mode.
  * In this mode, the current view area (see setXYLimits()) is used as the
  * limits to rebin.
@@ -877,22 +872,22 @@ void SliceViewer::setRebinMode(bool mode, bool locked) {
   m_syncRebinLock->toggle(locked);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** When in dynamic rebinning mode, this refreshes the rebinned area to be the
  * currently viewed area. See setXYLimits(), setRebinNumBins(),
  * setRebinThickness()
  */
 void SliceViewer::refreshRebin() { this->rebinParamsChanged(); }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Slot called when the btnDoLine button is checked/unchecked
 void SliceViewer::LineMode_toggled(bool checked) {
   m_lineOverlay->setShown(checked);
-  
+
   QIcon icon;
   if (checked) {
-    icon.addFile(QString::fromStdString(g_iconCutOn),
-              QSize(), QIcon::Normal, QIcon::On);
+    icon.addFile(QString::fromStdString(g_iconCutOn), QSize(), QIcon::Normal,
+                 QIcon::On);
     ui.btnDoLine->setIcon(icon);
     QString text;
     if (m_lineOverlay->getCreationMode())
@@ -902,18 +897,17 @@ void SliceViewer::LineMode_toggled(bool checked) {
     QToolTip::showText(ui.btnDoLine->mapToGlobal(ui.btnDoLine->pos()), text,
                        this);
   }
-  if (!checked)
-  {
-    //clear the old line
+  if (!checked) {
+    // clear the old line
     clearLine();
-    icon.addFile(QString::fromStdString(g_iconCut),
-          QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconCut), QSize(), QIcon::Normal,
+                 QIcon::Off);
     ui.btnDoLine->setIcon(icon);
   }
   emit showLineViewer(checked);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Toggle "line-drawing" mode (to draw 1D lines using the mouse)
  *
  * @param lineMode :: True to go into line mode, False to exit it.
@@ -922,20 +916,19 @@ void SliceViewer::toggleLineMode(bool lineMode) {
   // This should send events to start line mode
   m_syncLineMode->toggle(lineMode);
   m_lineOverlay->setCreationMode(false);
-
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Slot called to clear the line in the line overlay
 void SliceViewer::clearLine() {
   m_lineOverlay->reset();
   m_plot->update();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Slot called when the snap to grid is checked
 void SliceViewer::SnapToGrid_toggled(bool checked) {
-  
+
   QIcon icon;
   if (checked) {
     SnapToGridDialog *dlg = new SnapToGridDialog(this);
@@ -944,25 +937,24 @@ void SliceViewer::SnapToGrid_toggled(bool checked) {
       m_lineOverlay->setSnapEnabled(true);
       m_lineOverlay->setSnapX(dlg->getSnapX());
       m_lineOverlay->setSnapY(dlg->getSnapY());
-      icon.addFile(QString::fromStdString(g_iconGridOn),
-                   QSize(), QIcon::Normal, QIcon::On);
+      icon.addFile(QString::fromStdString(g_iconGridOn), QSize(), QIcon::Normal,
+                   QIcon::On);
     } else {
       // Uncheck - the user clicked cancel
       ui.btnSnapToGrid->setChecked(false);
       m_lineOverlay->setSnapEnabled(false);
-      icon.addFile(QString::fromStdString(g_iconGrid),
-                   QSize(), QIcon::Normal, QIcon::Off);
+      icon.addFile(QString::fromStdString(g_iconGrid), QSize(), QIcon::Normal,
+                   QIcon::Off);
     }
   } else {
     m_lineOverlay->setSnapEnabled(false);
-    icon.addFile(QString::fromStdString(g_iconGrid),
-                  QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconGrid), QSize(), QIcon::Normal,
+                 QIcon::Off);
   }
   ui.btnSnapToGrid->setIcon(icon);
-  
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot called when going into or out of dynamic rebinning mode */
 void SliceViewer::RebinMode_toggled(bool checked) {
   for (size_t d = 0; d < m_dimWidgets.size(); d++)
@@ -975,8 +967,8 @@ void SliceViewer::RebinMode_toggled(bool checked) {
 
   QIcon icon;
   if (!m_rebinMode) {
-    icon.addFile(QString::fromStdString(g_iconRebin),
-                 QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconRebin), QSize(), QIcon::Normal,
+                 QIcon::Off);
     ui.btnRebinMode->setIcon(icon);
     // uncheck auto-rebin
     ui.btnAutoRebin->setChecked(false);
@@ -985,15 +977,15 @@ void SliceViewer::RebinMode_toggled(bool checked) {
     this->m_data->setOverlayWorkspace(m_overlayWS);
     this->updateDisplay();
   } else {
-    icon.addFile(QString::fromStdString(g_iconRebinOn),
-              QSize(), QIcon::Normal, QIcon::On);
+    icon.addFile(QString::fromStdString(g_iconRebinOn), QSize(), QIcon::Normal,
+                 QIcon::On);
     ui.btnRebinMode->setIcon(icon);
     // Start the rebin
     this->rebinParamsChanged();
   }
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot called when locking/unlocking the dynamically rebinned
  * overlaid workspace
  * @param checked :: DO lock the workspace in place
@@ -1005,7 +997,7 @@ void SliceViewer::RebinLock_toggled(bool checked) {
     this->rebinParamsChanged();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Slot for zooming into
 void SliceViewer::zoomInSlot() { this->zoomBy(1.1); }
 
@@ -1043,7 +1035,7 @@ void SliceViewer::helpPeaksViewer() {
       QUrl(QString("http://www.mantidproject.org/") + helpPage));
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Automatically resets the zoom view to full axes.
  * This will reset the XY limits to the full range of the workspace.
  * Use zoomBy() or setXYLimits() to modify the view range.
@@ -1059,7 +1051,7 @@ void SliceViewer::resetZoom() {
   updatePeaksOverlay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// SLOT to open a dialog to set the XY limits
 void SliceViewer::setXYLimitsDialog() {
   // Initialize the dialog with the current values
@@ -1077,7 +1069,7 @@ void SliceViewer::setXYLimitsDialog() {
   }
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot to redraw when the slice point changes */
 void SliceViewer::updateDisplaySlot(int index, double value) {
   UNUSED_ARG(index)
@@ -1088,11 +1080,11 @@ void SliceViewer::updateDisplaySlot(int index, double value) {
     this->rebinParamsChanged();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** SLOT to open a dialog to choose a file, load a color map from that file */
 void SliceViewer::loadColorMapSlot() { this->loadColorMap(QString()); }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Grab the 2D view as an image. The image is rendered at the current window
  * size, with the color scale but without the text boxes for changing them.
  *
@@ -1122,7 +1114,7 @@ QPixmap SliceViewer::getImage() {
   return pix;
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Copy the rendered 2D image to the clipboard
  */
 void SliceViewer::copyImageToClipboard() {
@@ -1148,7 +1140,7 @@ QString SliceViewer::ensurePngExtension(const QString &fname) const {
   return res;
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Save the rendered 2D slice to an image file.
  *
  * @param filename :: full path to the file to save, including extension
@@ -1178,9 +1170,9 @@ void SliceViewer::saveImage(const QString &filename) {
   pix.save(finalName);
 }
 
-//=================================================================================================
-//=================================================================================================
-//=================================================================================================
+//==============================================================================
+//==============================================================================
+//==============================================================================
 /** Zoom in or out, keeping the center of the plot in the same position.
  *
  * @param factor :: double, if > 1 : zoom in by this factor.
@@ -1207,7 +1199,7 @@ void SliceViewer::zoomBy(double factor) {
   this->updatePeaksOverlay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Manually set the center of the plot, in X Y coordinates.
  * This keeps the plot the same size as previously.
  * Use setXYLimits() to modify the size of the plot by setting the X/Y edges,
@@ -1226,7 +1218,7 @@ void SliceViewer::setXYCenter(double x, double y) {
                     y + halfWidthY);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Reset the axis and scale it
  *
  * @param axis :: int for X or Y
@@ -1237,7 +1229,7 @@ void SliceViewer::resetAxis(int axis, const IMDDimension_const_sptr &dim) {
   m_plot->setAxisTitle(axis, API::PlotAxis(*dim).title());
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /// Find the full range of values in the workspace
 void SliceViewer::findRangeFull() {
   IMDWorkspace_sptr workspace_used = m_ws;
@@ -1258,7 +1250,7 @@ void SliceViewer::findRangeFull() {
       API::SignalRange(*workspace_used, this->getNormalization()).interval();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Find the full range of values ONLY in the currently visible
 part of the workspace */
 void SliceViewer::findRangeSlice() {
@@ -1310,7 +1302,7 @@ void SliceViewer::findRangeSlice() {
     m_colorRangeSlice = m_colorRangeFull;
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot to show the mouse info at the mouse position
  *
  * @param x :: position of the mouse in plot coords
@@ -1354,7 +1346,7 @@ void SliceViewer::showInfoAt(double x, double y) {
   }
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Update the 2D plot using all the current controls settings */
 void SliceViewer::updateDisplay(bool resetAxes) {
   if (!m_ws)
@@ -1433,7 +1425,7 @@ void SliceViewer::updateDisplay(bool resetAxes) {
   emit changedSlicePoint(m_slicePoint);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** The user changed the shown dimension somewhere.
  *
  * @param index :: index of the dimension
@@ -1467,10 +1459,9 @@ void SliceViewer::changedShownDim(int index, int dim, int oldDim) {
   emit changedShownDim(m_dimX, m_dimY);
 }
 
-//=================================================================================================
-//========================================== PYTHON METHODS
-//=======================================
-//=================================================================================================
+//==============================================================================
+//================================ PYTHON METHODS ==============================
+//==============================================================================
 
 /** @return the name of the workspace selected, or a blank string
  * if no workspace is set.
@@ -1482,7 +1473,7 @@ QString SliceViewer::getWorkspaceName() const {
     return QString();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** @return the index of the dimension that is currently
  * being shown as the X axis of the plot.
  */
@@ -1493,7 +1484,7 @@ int SliceViewer::getDimX() const { return int(m_dimX); }
  */
 int SliceViewer::getDimY() const { return int(m_dimY); }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the index of the dimensions that will be shown as
  * the X and Y axis of the plot.
  * You cannot set both axes to be the same.
@@ -1531,7 +1522,7 @@ void SliceViewer::setXYDim(int indexX, int indexY) {
   emit changedShownDim(m_dimX, m_dimY);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the dimensions that will be shown as the X and Y axes
  *
  * @param dimX :: name of the X dimension. Must match the workspace dimension
@@ -1548,7 +1539,7 @@ void SliceViewer::setXYDim(const QString &dimX, const QString &dimY) {
   this->setXYDim(indexX, indexY);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Sets the slice point in the given dimension:
  * that is, what is the position of the plane in that dimension
  *
@@ -1565,7 +1556,7 @@ void SliceViewer::setSlicePoint(int dim, double value) {
   m_dimWidgets[dim]->setSlicePoint(value);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Returns the slice point in the given dimension
  *
  * @param dim :: index of the dimension
@@ -1580,7 +1571,7 @@ double SliceViewer::getSlicePoint(int dim) const {
   return m_slicePoint[dim];
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Sets the slice point in the given dimension:
  * that is, what is the position of the plane in that dimension
  *
@@ -1597,7 +1588,7 @@ void SliceViewer::setSlicePoint(const QString &dim, double value) {
   return this->setSlicePoint(index, value);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Returns the slice point in the given dimension
  *
  * @param dim :: name of the dimension
@@ -1612,7 +1603,7 @@ double SliceViewer::getSlicePoint(const QString &dim) const {
   return this->getSlicePoint(index);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the color scale limits and log mode via a method call.
  *
  * @param min :: minimum value corresponding to the lowest color on the map
@@ -1632,7 +1623,7 @@ void SliceViewer::setColorScale(double min, double max, bool log) {
   this->colorRangeChanged();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the "background" color to use in the color map. Default is white.
  *
  * This is the color that is shown when:
@@ -1651,7 +1642,7 @@ void SliceViewer::setColorMapBackground(int r, int g, int b) {
   this->colorRangeChanged();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the minimum value corresponding to the lowest color on the map
  *
  * @param min :: minimum value corresponding to the lowest color on the map
@@ -1662,7 +1653,7 @@ void SliceViewer::setColorScaleMin(double min) {
   this->setColorScale(min, this->getColorScaleMax(), this->getColorScaleLog());
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the maximum value corresponding to the lowest color on the map
  *
  * @param max :: maximum value corresponding to the lowest color on the map
@@ -1673,7 +1664,7 @@ void SliceViewer::setColorScaleMax(double max) {
   this->setColorScale(this->getColorScaleMin(), max, this->getColorScaleLog());
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set whether the color scale is logarithmic
  *
  * @param log :: true for a log color scale, false for linear
@@ -1684,7 +1675,7 @@ void SliceViewer::setColorScaleLog(bool log) {
   this->setColorScale(this->getColorScaleMin(), this->getColorScaleMax(), log);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** @return the value that corresponds to the lowest color on the color map */
 double SliceViewer::getColorScaleMin() const {
   return m_colorBar->getMinimum();
@@ -1698,7 +1689,7 @@ double SliceViewer::getColorScaleMax() const {
 /** @return True if the color scale is in logarithmic mode */
 bool SliceViewer::getColorScaleLog() const { return m_colorBar->getLog(); }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Sets whether the image should be rendered in "fast" mode, where
  * the workspace's resolution is used to guess how many pixels to render.
  *
@@ -1725,7 +1716,7 @@ void SliceViewer::setFastRender(bool fast) {
  */
 bool SliceViewer::getFastRender() const { return m_fastRender; }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Set the limits in X and Y to be shown in the plot.
  * The X and Y values are in the units of their respective dimensions.
  * You can change the mapping from X/Y in the plot to specific
@@ -1749,7 +1740,7 @@ void SliceViewer::setXYLimits(double xleft, double xright, double ybottom,
   updatePeaksOverlay();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** @return Returns the [left, right] limits of the view in the X axis. */
 QwtDoubleInterval SliceViewer::getXLimits() const {
   return m_plot->axisScaleDiv(m_spect->xAxis())->interval();
@@ -1760,7 +1751,7 @@ QwtDoubleInterval SliceViewer::getYLimits() const {
   return m_plot->axisScaleDiv(m_spect->yAxis())->interval();
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Opens a workspace and sets the view and slice points
  * given the XML from the MultiSlice view in XML format.
  *
@@ -1944,7 +1935,7 @@ void SliceViewer::openFromXML(const QString &xml) {
     this->setSlicePoint(d, slicePoint[d]);
 }
 
-//------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** This slot is called when the dynamic rebinning parameters are changed.
  * It recalculates the dynamically rebinned workspace and plots it
  */
@@ -2017,7 +2008,7 @@ void SliceViewer::rebinParamsChanged() {
   // complete.
 }
 
-//--------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot called by the observer when the BinMD call has completed.
  * This returns the execution to the main GUI thread, and
  * so can update the GUI.
@@ -2110,10 +2101,10 @@ void SliceViewer::disablePeakOverlays() {
   m_peaksPresenter->clear();
   emit showPeaksViewer(false);
   m_menuPeaks->setEnabled(false);
-  
+
   QIcon icon;
-  icon.addFile(QString::fromStdString(g_iconPeakList),
-                QSize(), QIcon::Normal, QIcon::Off);
+  icon.addFile(QString::fromStdString(g_iconPeakList), QSize(), QIcon::Normal,
+               QIcon::Off);
   ui.btnPeakOverlay->setIcon(icon);
   ui.btnPeakOverlay->setChecked(false);
 }
@@ -2188,10 +2179,10 @@ SliceViewer::setPeaksWorkspaces(const QStringList &list) {
   updatePeakOverlaySliderWidget();
   emit showPeaksViewer(true);
   m_menuPeaks->setEnabled(true);
-  
+
   QIcon icon;
-  icon.addFile(QString::fromStdString(g_iconPeakList),
-                 QSize(), QIcon::Normal, QIcon::Off);
+  icon.addFile(QString::fromStdString(g_iconPeakList), QSize(), QIcon::Normal,
+               QIcon::Off);
   ui.btnPeakOverlay->setIcon(icon);
   ui.btnPeakOverlay->setChecked(true);
   return m_proxyPeaksPresenter.get();
@@ -2204,8 +2195,9 @@ Allow user to choose a suitable input peaks workspace
 
 */
 void SliceViewer::peakOverlay_clicked() {
-  MantidQt::MantidWidgets::SelectWorkspacesDialog dlg(this, "PeaksWorkspace", "Remove All");
-  
+  MantidQt::MantidWidgets::SelectWorkspacesDialog dlg(this, "PeaksWorkspace",
+                                                      "Remove All");
+
   int ret = dlg.exec();
   if (ret == QDialog::Accepted) {
     QStringList list = dlg.getSelectedNames();
@@ -2215,18 +2207,18 @@ void SliceViewer::peakOverlay_clicked() {
     }
   }
   if (ret == MantidQt::MantidWidgets::SelectWorkspacesDialog::CustomButton) {
-        disablePeakOverlays();
+    disablePeakOverlays();
   }
   QIcon icon;
-  if (m_peaksPresenter->size()>0)  {
-    icon.addFile(QString::fromStdString(g_iconPeakListOn),
-                   QSize(), QIcon::Normal, QIcon::On);
+  if (m_peaksPresenter->size() > 0) {
+    icon.addFile(QString::fromStdString(g_iconPeakListOn), QSize(),
+                 QIcon::Normal, QIcon::On);
     ui.btnPeakOverlay->setIcon(icon);
     ui.btnPeakOverlay->setChecked(true);
-  }  else {
+  } else {
 
-    icon.addFile(QString::fromStdString(g_iconPeakList),
-                   QSize(), QIcon::Normal, QIcon::Off);
+    icon.addFile(QString::fromStdString(g_iconPeakList), QSize(), QIcon::Normal,
+                 QIcon::Off);
     ui.btnPeakOverlay->setIcon(icon);
     ui.btnPeakOverlay->setChecked(false);
   }

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewerWindow.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewerWindow.cpp
@@ -135,7 +135,7 @@ SliceViewerWindow::SliceViewerWindow(const QString &wsName,
 
 SliceViewerWindow::~SliceViewerWindow() {}
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Build the menus */
 void SliceViewerWindow::initMenus() {
   // Make File->Close() close the window
@@ -143,7 +143,7 @@ void SliceViewerWindow::initMenus() {
           SLOT(close()));
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Get the SliceViewer widget inside the SliceViewerWindow.
  * This is the main widget for controlling the 2D views
  * and slice points.
@@ -154,7 +154,7 @@ MantidQt::SliceViewer::SliceViewer *SliceViewerWindow::getSlicer() {
   return m_slicer;
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Get the LineViewer widget inside the SliceViewerWindow.
  * This is the widget for controlling the 1D line integration
  * settings.
@@ -165,31 +165,31 @@ MantidQt::SliceViewer::LineViewer *SliceViewerWindow::getLiner() {
   return m_liner;
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** @return the label that was attached to this SliceViewerWindow's title */
 const QString &SliceViewerWindow::getLabel() const { return m_label; }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 void SliceViewerWindow::resizeEvent(QResizeEvent * /*event*/) {
   //  if (m_liner->isVisible())
-    //    m_lastLinerWidth = m_liner->width();
+  //    m_lastLinerWidth = m_liner->width();
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot to close the window */
 void SliceViewerWindow::closeWindow() {
   // askOnCloseEvent(false); //(MdiSubWindow)
   close();
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot to replace the workspace being looked at. */
 void SliceViewerWindow::updateWorkspace() {
   m_liner->setWorkspace(m_ws);
   m_slicer->setWorkspace(m_ws);
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot called when the SliceViewer changes which workspace
  * is being viewed. */
 void SliceViewerWindow::slicerWorkspaceChanged() {
@@ -198,7 +198,7 @@ void SliceViewerWindow::slicerWorkspaceChanged() {
   m_liner->setWorkspace(m_ws);
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot called when the LineViewer is setting a fixed bin width mode
  *
  * @param fixed :: True for fixed bin width
@@ -214,7 +214,7 @@ void SliceViewerWindow::lineViewer_changedFixedBinWidth(bool fixed,
     m_slicer->getLineOverlay()->setSnapLength(0.0);
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Show or hide the LineViewer widget (on the right of the SliceViewer)
  *
  * @param visible :: True to show the LineViewer widget.
@@ -261,7 +261,7 @@ void SliceViewerWindow::showLineViewer(bool visible) {
   this->setUpdatesEnabled(true);
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Show or hide the LineViewer widget (on the right of the SliceViewer)
  *
  * @param visible :: True to show the PeaksViewer widget.
@@ -292,8 +292,7 @@ void SliceViewerWindow::showPeaksViewer(bool visible) {
     // Shrink the window to exclude the liner
     int w =
         this->width() - (m_peaksViewer->width() + m_splitter->handleWidth());
-    if (m_peaksViewer->width() > 0)
-    {
+    if (m_peaksViewer->width() > 0) {
       m_lastPeaksViewerWidth = m_peaksViewer->width();
     }
     m_peaksViewer->hide();
@@ -313,14 +312,14 @@ void SliceViewerWindow::showPeaksViewer(bool visible) {
   this->setUpdatesEnabled(true);
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Special slot called to resize the window
  * after some events have been processed. */
 void SliceViewerWindow::resizeWindow() {
   this->resize(m_desiredWidth, this->height());
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Using the positions from the LineOverlay, set the values in the LineViewer,
  * but don't update view. */
 void SliceViewerWindow::setLineViewerValues(QPointF start2D, QPointF end2D,
@@ -336,7 +335,7 @@ void SliceViewerWindow::setLineViewerValues(QPointF start2D, QPointF end2D,
   m_liner->setPlanarWidth(width);
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Slot called when the line overlay position is changing (being dragged) */
 void SliceViewerWindow::lineChanging(QPointF start2D, QPointF end2D,
                                      double width) {
@@ -388,7 +387,7 @@ void SliceViewerWindow::changePlanarWidth(double width) {
   m_slicer->getLineOverlay()->update();
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Signal to close this window if the workspace has just been deleted */
 void SliceViewerWindow::preDeleteHandle(
     const std::string &wsName,
@@ -409,7 +408,7 @@ void SliceViewerWindow::preDeleteHandle(
   }
 }
 
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /**
  * @brief After replace handle
  * @param oldName
@@ -419,21 +418,22 @@ void SliceViewerWindow::renameHandle(const std::string &oldName,
                                      const std::string &newName) {
 
   if (oldName == m_wsName) {
-      IMDWorkspace_sptr new_md_ws = boost::dynamic_pointer_cast<IMDWorkspace>(
-                  AnalysisDataService::Instance().retrieve(newName));
+    IMDWorkspace_sptr new_md_ws = boost::dynamic_pointer_cast<IMDWorkspace>(
+        AnalysisDataService::Instance().retrieve(newName));
     if (new_md_ws) {
       m_ws = new_md_ws;
       emit needToUpdate();
     }
 
   } else {
-        // Remove any legacy workspace widgets + presenters bearing the old name. Remember, naming is a deep copy process. So the old name is the only reference we have.
-        m_peaksViewer->removePeaksWorkspace(oldName);
+    // Remove any legacy workspace widgets + presenters bearing the old name.
+    // Remember, naming is a deep copy process. So the old name is the only
+    // reference we have.
+    m_peaksViewer->removePeaksWorkspace(oldName);
   }
 }
 
-
-//------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 /** Signal that the workspace being looked at was just replaced with a different
  * one */
 void SliceViewerWindow::afterReplaceHandle(


### PR DESCRIPTION
This is for trac ticket [#11340](http://trac.mantidproject.org/mantid/ticket/11340)

When the X and Y axes have been transposed, the slicing/integration step needs to take this into account.
