### PR TITLE
Optimise findNeighbours

### DIFF
--- a/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -536,7 +536,8 @@ MDHistoWorkspaceIterator::findNeighbourIndexesByWidth(const std::vector<int>& wi
 
   // Filter out indexes that are are not actually neighbours.
   // Accumulate neighbour indexes.
-  std::vector<size_t> neighbourIndexes;
+  std::vector<size_t> neighbourIndexes(permutationsVertexTouching.size());
+  size_t nextFree = 0;
   for (size_t i = 0; i < permutationsVertexTouching.size(); ++i) {
     if (permutationsVertexTouching[i] == 0) {
       continue;
@@ -546,9 +547,10 @@ MDHistoWorkspaceIterator::findNeighbourIndexesByWidth(const std::vector<int>& wi
     if (neighbour_index < m_ws->getNPoints() &&
         Utils::isNeighbourOfSubject(m_nd, neighbour_index, m_index,
                                     m_indexMaker, m_indexMax, widths) ) {
-      neighbourIndexes.push_back(neighbour_index);
+      neighbourIndexes[nextFree++] = neighbour_index;
     }
   }
+  neighbourIndexes.resize(nextFree);
 
   // Remove duplicates
   std::sort(neighbourIndexes.begin(), neighbourIndexes.end());

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/Utils.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/Utils.h
@@ -289,23 +289,18 @@ inline void getIndicesFromLinearIndex(const size_t linear_index,
  * @param widths : width in pixels per dimension
  * @return True if the are neighbours, otherwise false.
  */
-inline bool isNeighbourOfSubject(const size_t ndims,
-                                 const size_t neighbour_linear_index,
-                                 const size_t *subject_indices,
-                                 const size_t *num_bins,
-                                 const size_t *index_max, const std::vector<int>& widths) {
-  std::vector<size_t> neighbour_indices(ndims);
-  Utils::NestedForLoop::GetIndicesFromLinearIndex(ndims, neighbour_linear_index,
-                                                  num_bins, index_max,
-                                                  &neighbour_indices.front());
-
+inline bool
+isNeighbourOfSubject(const size_t ndims, const size_t neighbour_linear_index,
+                     const size_t *subject_indices, const size_t *num_bins,
+                     const size_t *index_max, const std::vector<int> &widths) {
   for (size_t ind = 0; ind < ndims; ++ind) {
-    long double diff =
-        std::abs(static_cast<long double>(subject_indices[ind]) -
-                 static_cast<long double>(neighbour_indices[ind]));
-    if (diff > widths[ind]/2) {
+    size_t neigh_index =
+        (neighbour_linear_index / num_bins[ind]) % index_max[ind];
+    const long double subj = static_cast<long double>(subject_indices[ind]);
+    const long double neigh = static_cast<long double>(neigh_index);
+    const long double diff = std::abs(subj - neigh);
+    if (diff > widths[ind] / 2)
       return false;
-    }
   }
   return true;
 }


### PR DESCRIPTION
This is for trac ticket [#11574](http://trac.mantidproject.org/mantid/ticket/11574)

This should _not_ make any functional changes, only performance improvements.

On my machine the average time taken to run `./bin/DataObjectsTest MDHistoWorkspaceIteratorTest` increased from `1.30s` to `0.83s`, almost a 40% improvement.
- [33b61d6] prevents us from having to re-allocate the indices vector as it grows, and removes the cost of `push_back`.
- [4441d12] does two things:
  - Removes an expensive `std::vector<size_t>` allocation/deallocation
  - Merges the work done by the `GetIndicesFromLinearIndex` function into the main loop. This halves the number of loop iterations, and uses the cache more efficiently.

**Testing**
- Verify performance improvements
- Verify that no tests fail
