### PR TITLE
Fix SaveHKL bug

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
@@ -283,7 +283,8 @@ void SaveHKL::exec() {
     std::string bankName = p.getBankName();
     int nCols, nRows;
     sizeBanks(bankName, nCols, nRows);
-    if (widthBorder != EMPTY_INT() &&
+    // peaks with detectorID=-1 are from LoadHKL
+    if (widthBorder != EMPTY_INT() && p.getDetectorID() != -1 &&
         (p.getCol() < widthBorder || p.getRow() < widthBorder ||
          p.getCol() > (nCols - widthBorder) ||
          p.getRow() > (nRows - widthBorder))){


### PR DESCRIPTION
Fixes issue [#11609](http://trac.mantidproject.org/mantid/ticket/11609)

Fixed by not checked if peaks are near border for peaks already in file.  To test use files for UnitTests and check that 5637 peaks are in append.hkl:

```
LoadIsawPeaks(Filename='Peaks5637.integrate', OutputWorkspace='Peaks5637')
SaveHKL(InputWorkspace='Peaks5637',ScalePeaks=0.01,WidthBorder=20,Filename='append.hkl')
LoadIsawPeaks(Filename='Peaks5643.integrate', OutputWorkspace='Peaks5643')
SaveHKL(InputWorkspace='Peaks5643',ScalePeaks=0.01,WidthBorder=20,Filename='append.hkl',AppendFile=True)
```
