### PR TITLE
fixing windows builds which do not use precompiler headers.

### DIFF
--- a/Code/Mantid/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Math/Acomp.cpp
@@ -6,6 +6,7 @@
 #include "MantidGeometry/Math/RotCounter.h"
 #include <algorithm>
 #include <iostream>
+#include <functional>
 
 namespace Mantid {
 

--- a/Code/Mantid/Framework/Geometry/src/Math/BnId.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Math/BnId.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <algorithm>
 #include <iterator>
+#include <functional>
 
 #include "MantidGeometry/Math/BnId.h"
 

--- a/Code/Mantid/Framework/Geometry/src/Math/PolyBase.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Math/PolyBase.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <iterator>
+#include <functional>
 #include <gsl/gsl_poly.h>
 
 #include "MantidKernel/Exception.h"

--- a/Code/Mantid/Framework/Kernel/src/Statistics.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Statistics.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 #include <sstream>
 #include <stdexcept>
+#include <functional>
 
 
 namespace Mantid {


### PR DESCRIPTION
fixing issues outlined in http://trac.mantidproject.org/mantid/ticket/11613.
