### PR TITLE
Mask detectors in POLDI data automatically

### DIFF
--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDILoadRunsTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDILoadRunsTest.py
@@ -4,6 +4,7 @@ from mantid.simpleapi import *
 from mantid.api import *
 import numpy as np
 
+
 class POLDILoadRunsTest(stresstesting.MantidStressTest):
     """This assembly of test cases checks that the behavior of PoldiLoadRuns is correct."""
 
@@ -132,11 +133,22 @@ class POLDILoadRunsTest(stresstesting.MantidStressTest):
 
     def checkRemoveBadDetectors(self):
         # Determine bad detectors automatically
-        twoWorkspacesMerged = PoldiLoadRuns(2013, 6903, 6904, 2, MaskBadDetectors=True)
+        twoWorkspacesMerged = PoldiLoadRuns(2013, 6903, 6904, 2, MaskBadDetectors=True,
+                                            BadDetectorThreshold=2.5)
 
         wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
         self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
-            x).isMasked()]), 76)
+            x).isMasked()]), 36)
+
+        self.clearAnalysisDataService()
+
+        # Lower threshold, more excluded detectors
+        twoWorkspacesMerged = PoldiLoadRuns(2013, 6903, 6904, 2, MaskBadDetectors=True,
+                                            BadDetectorThreshold=2.0)
+
+        wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
+        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
+            x).isMasked()]), 49)
 
         self.clearAnalysisDataService()
 

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDILoadRunsTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDILoadRunsTest.py
@@ -19,6 +19,8 @@ class POLDILoadRunsTest(stresstesting.MantidStressTest):
         self.loadWorkspacesDontOverwriteOther()
         self.loadWorkspacesOverwriteOther()
 
+        self.checkRemoveBadDetectors()
+
     def loadSingleWorkspace(self):
         singleWs = PoldiLoadRuns(2013, 6904)
 
@@ -127,6 +129,25 @@ class POLDILoadRunsTest(stresstesting.MantidStressTest):
         otherWs = PoldiLoadRuns(2013, 6904, OverwriteExistingWorkspace=False)
 
         self.assertTrue(issubclass(type(otherWs), Workspace))
+
+    def checkRemoveBadDetectors(self):
+        # Determine bad detectors automatically
+        twoWorkspacesMerged = PoldiLoadRuns(2013, 6903, 6904, 2, MaskBadDetectors=True)
+
+        wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
+        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
+            x).isMasked()]), 76)
+
+        self.clearAnalysisDataService()
+
+        # Only use those from the IDF
+        twoWorkspacesMerged = PoldiLoadRuns(2013, 6903, 6904, 2, MaskBadDetectors=False)
+
+        wsMerged = AnalysisDataService.retrieve("twoWorkspacesMerged_data_6904")
+        self.assertEquals(len([True for x in range(wsMerged.getNumberHistograms()) if wsMerged.getDetector(
+            x).isMasked()]), 12)
+
+        self.clearAnalysisDataService()
 
     def compareWorkspaces(self, left, right):
         for i in range(left.getNumberHistograms()):

--- a/Code/Mantid/docs/source/algorithms/PoldiFitPeaks2D-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiFitPeaks2D-v1.rst
@@ -156,6 +156,6 @@ The refined lattice parameter is printed at the end:
 
 .. testoutput:: ExSilicon2DPawley
 
-    Refined lattice parameter a = 5.43126 +/- 5e-05
+    Refined lattice parameter a = 5.43125 +/- 4e-05
 
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/PoldiLoadRuns-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiLoadRuns-v1.rst
@@ -9,7 +9,11 @@
 Description
 -----------
 
-This algorithm makes it easier to load POLDI data. Besides importing the raw data (:ref:`algm-LoadSINQ`), it performs the otherwise manually performed steps of instrument loading (:ref:`algm-LoadInstrument`), truncation (:ref:`algm-PoldiTruncateData`). To make the algorithm more useful, it is possible to load data from multiple runs by specifying a range. In many cases, data files need to be merged in a systematic manner, which is also covered by this algorithm. For this purpose there is a parameter that specifies how the files of the specified range should be merged. The data files are named following the scheme `group_data_run`, where `group` is the name specified in `OutputWorkspace` and `run` is the run number and placed into a WorkspaceGroup with the name given in `OutputWorkspace`.
+This algorithm makes it easier to load POLDI data. Besides importing the raw data (:ref:`algm-LoadSINQ`), it performsthe otherwise manually performed steps of instrument loading (:ref:`algm-LoadInstrument`), truncation (:ref:`algm-PoldiTruncateData`). To make the algorithm more useful, it is possible to load data from multiple runs by specifying a range. In many cases, data files need to be merged in a systematic manner, which is also covered by this algorithm. For this purpose there is a parameter that specifies how the files of the specified range should be merged. The data files are named following the scheme `group_data_run`, where `group` is the name specified in `OutputWorkspace` and `run` is the run number and placed into a WorkspaceGroup with the name given in `OutputWorkspace`.
+
+By default, detectors that show unusually large integrated intensities are excluded if the pass a certain threshold
+with respect to the median of integrated intensities in all detectors. The threshold can be adjusted using an
+additional parameter. Detectors that are masked in the instrument definition are always masked.
 
 The data loaded in this way can be used directly for further processing with :ref:`algm-PoldiAutoCorrelation`.
 


### PR DESCRIPTION
This addresses [#11607](http://trac.mantidproject.org/mantid/ticket/11607).

`PoldiLoadRuns` now optionally (it's the new default behavior) excludes detectors that deviate too much (most often because of gamma background) from the rest. It's essentially an additional call to `MedianDetectorTest`. The change is documented in the algorithm documentation.

**Testing information**
Code review. You could run the following script with varying parameters to see that the number of masked spectra changes (by using Color fill plot for example):

```
# Only the first 6 and the last 6 spectra are 0
idfMask = PoldiLoadRuns(2013, 6903, 6904, 2, MaskBadDetectors=False)

# Masking with default parameters excludes the very intense spectra around spectrum 320 and some others inbetween.
autoMask = PoldiLoadRuns(2013, 6903, 6904, 2)

# Setting the threshold higher leads to fewer detectors being masked
fewerMasked = PoldiLoadRuns(2013, 6903, 6904, 2, BadDetectorThreshold=5.0)

# The opposite happens for lower thresholds
moreMasked = PoldiLoadRuns(2013, 6903, 6904, 2, BadDetectorThreshold=1.5)
```
