### PR TITLE
Log filtering for initial setup periods.

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/ISISRunLogs.h
@@ -52,6 +52,8 @@ public:
   void addStatusLog(API::Run &exptRun);
   /// Adds period related logs
   void addPeriodLogs(const int period, API::Run &exptRun);
+  /// Add 'period i' log.
+  void addPeriodLog(const int i, API::Run &exptRun);
 
 private:
   DISABLE_DEFAULT_CONSTRUCT(ISISRunLogs)

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
@@ -106,6 +106,7 @@ private:
   void runLoadMappingTable(DataObjects::Workspace2D_sptr);
   void runLoadLog(DataObjects::Workspace2D_sptr);
   void loadRunDetails(DataObjects::Workspace2D_sptr localWorkspace);
+  void addPeriodLog(DataObjects::Workspace2D_sptr localWorkspace, int64_t period);
 
   /// Loads dead time table for the detector
   void loadDeadTimes(Mantid::NeXus::NXRoot &root);

--- a/Code/Mantid/Framework/DataHandling/src/ISISRunLogs.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/ISISRunLogs.cpp
@@ -86,5 +86,14 @@ void ISISRunLogs::addPeriodLogs(const int period, API::Run &exptRun) {
   }
 }
 
+/**
+ * Add the period log to a run.
+ * @param period :: A period number.
+ * @param exptRun :: The run to add the log to.
+ */
+void ISISRunLogs::addPeriodLog(const int period, API::Run &exptRun) {
+  exptRun.addLogData(m_logParser->createPeriodLog(period));
+}
+
 } // namespace DataHandling
 } // namespace Mantid

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -1,11 +1,13 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
+#include "MantidDataHandling/LoadMuonNexus1.h"
+
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidDataHandling/LoadMuonNexus1.h"
+#include "MantidDataHandling/ISISRunLogs.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidGeometry/Instrument/Detector.h"
@@ -232,6 +234,7 @@ void LoadMuonNexus1::exec() {
       localWorkspace->setTitle(title);
       localWorkspace->setComment(notes);
     }
+    addPeriodLog(localWorkspace,period);
 
     size_t counter = 0;
     for (int64_t i = m_spec_min; i < m_spec_max; ++i) {
@@ -707,6 +710,32 @@ void LoadMuonNexus1::runLoadLog(DataObjects::Workspace2D_sptr localWorkspace) {
     }
   } catch (...) {
     setProperty("MainFieldDirection", "Longitudinal");
+  }
+
+  auto &run = localWorkspace->mutableRun();
+  int n = static_cast<int>(m_numberOfPeriods);
+  ISISRunLogs runLogs(run, n);
+  runLogs.addStatusLog(run);
+}
+
+/**
+ * Add the 'period i' log to a workspace.
+ * @param localWorkspace A workspace to add the log to.
+ * @param period A period for this workspace.
+ */
+void LoadMuonNexus1::addPeriodLog(DataObjects::Workspace2D_sptr localWorkspace, int64_t period)
+{
+  auto &run = localWorkspace->mutableRun();
+  int n = static_cast<int>(m_numberOfPeriods);
+  ISISRunLogs runLogs(run, n);
+  if ( period == 0 )
+  {
+    runLogs.addPeriodLogs(1, run);
+  }
+  else
+  {
+    run.removeLogData("period 1");
+    runLogs.addPeriodLog(static_cast<int>(period) + 1, run);
   }
 }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -157,7 +157,7 @@ public:
   void test_updateAvailableLogs()
   {
     EXPECT_CALL(*m_view, firstRun()).WillRepeatedly(Return("MUSR00015189.nxs"));
-    EXPECT_CALL(*m_view, setAvailableLogs(AllOf(Property(&std::vector<std::string>::size, 33),
+    EXPECT_CALL(*m_view, setAvailableLogs(AllOf(Property(&std::vector<std::string>::size, 37),
                                                 Contains("run_number"),
                                                 Contains("sample_magn_field"),
                                                 Contains("Field_Danfysik"))));


### PR DESCRIPTION
Ticket [#11584](http://trac.mantidproject.org/mantid/ticket/11584)

**To test**
- Load MUSR52965. Open its sample logs dialog.
- Import the Temp_sample log filtered by status or by status and period.
- Check that values at times < 0 are filtered out.
- Check with other data sets that the log plotting isn't broken.
