### PR TITLE
Add check for run numbers

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -179,6 +179,9 @@ void PlotAsymmetryByLogValue::exec() {
   parseRunNames( firstFN, lastFN, m_filenameBase, m_filenameExt, m_filenameZeros);
   size_t is = atoi(firstFN.c_str()); // starting run number
   size_t ie = atoi(lastFN.c_str());  // last run number
+  if ( ie < is ) {
+    throw std::runtime_error("First run number is greater than last run number");
+  }
 
   // Resize vectors that will store results
   resizeVectors(ie-is+1);

--- a/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
@@ -292,6 +292,22 @@ public:
     AnalysisDataService::Instance().remove(ws);
   }
 
+  void test_invalidRunNumbers ()
+  {
+    const std::string ws = "Test_LogValueFunction";
+
+    PlotAsymmetryByLogValue alg;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+
+    alg.setPropertyValue("FirstRun", lastRun);
+    alg.setPropertyValue("LastRun", firstRun);
+    alg.setPropertyValue("OutputWorkspace", ws);
+
+    TS_ASSERT_THROWS (alg.execute(),std::runtime_error);
+    TS_ASSERT (!alg.isExecuted());
+  }
+
 private:
   std::string firstRun,lastRun;
   


### PR DESCRIPTION
Fixes [#11623](http://trac.mantidproject.org/mantid/ticket/11623)

To test: code review should be enough. PlotAsymmetryByLogValue takes two input files to analyse a set of runs. When the first run number is greater than the last run number, an exception should be thrown.
