### PR TITLE
Do not register PoldiCreatePeaksFromFile when pyparsing is not installed

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-init,invalid-name,too-few-public-methods
+# pylint: disable=no-init,invalid-name,too-few-public-methods,unused-import
 from mantid.kernel import *
 from mantid.simpleapi import *
 from mantid.api import *
@@ -213,5 +213,9 @@ class PoldiCreatePeaksFromFile(PythonAlgorithm):
 
         return compound.getName()
 
-
-AlgorithmFactory.subscribe(PoldiCreatePeaksFromFile)
+try:
+    import pyparsing
+    AlgorithmFactory.subscribe(PoldiCreatePeaksFromFile)
+except:
+    logger.debug('Failed to subscribe algorithm PoldiCreatePeaksFromFile; Python package pyparsing'\
+        'may be missing (https://pypi.python.org/pypi/pyparsing)')

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
@@ -4,217 +4,216 @@ from mantid.simpleapi import *
 from mantid.api import *
 from mantid.geometry import *
 
-from pyparsing import *
-
 import os
 
-
-class PoldiCompound(object):
-    """Small helper class to handle the results from PoldiCrystalFileParser."""
-    _name = ""
-    _spacegroup = ""
-    _atomString = ""
-    _cellDict = ""
-
-    def __init__(self, name, elements):
-        self._name = name
-
-        self.assign(elements)
-
-    def assign(self, elements):
-        for c in elements:
-            if c[0] == "atoms":
-                self._atomString = ';'.join(c[1:])
-            elif c[0] == "lattice":
-                cellNames = ['a', 'b', 'c', 'alpha', 'beta', 'gamma']
-                self._cellDict = dict(zip(cellNames, c[1:]))
-            elif c[0] == "spacegroup":
-                self._spacegroup = c[1]
-
-    def getAtomString(self):
-        return self._atomString
-
-    def getCellParameters(self):
-        return self._cellDict
-
-    def getSpaceGroup(self):
-        return self._spacegroup
-
-    def getName(self):
-        return self._name
-
-
-def raiseParseErrorException(message):
-    raise ParseException(message)
-
-
-class PoldiCrystalFileParser(object):
-    """Small parser for crystal structure files used at POLDI
-
-    This class encapsulates a small parser for crystal structure files that are used at
-    POLDI. The files contains information about the lattice, the space group and the basis (atoms
-    in the asymmetric unit).
-
-    The file format is defined as follows:
-
-        Compound_1 {
-            Lattice: [1 - 6 floats] => a, b, c, alpha, beta, gamma
-            Spacegroup: [valid space group symbol]
-            Atoms; {
-                Element x y z [occupancy [U_eq]]
-                Element x y z [occupancy [U_eq]]
-            }
-        }
-
-        Compound_2 {
-            ...
-        }
-
-    The parser returns a list of PoldiCompound objects with the compounds that were found
-    in the file. These are then processed by PoldiCreatePeaksFromFile to generate arguments
-    for calling PoldiCreatePeaksFromCell.
-    """
-    elementSymbol = Word(alphas, min=1, max=2).setFailAction(
-        lambda o, s, loc, token: raiseParseErrorException("Element symbol must be one or two characters."))
-    integerNumber = Word(nums)
-    decimalSeparator = Literal('.')
-    floatNumber = Combine(
-        integerNumber +
-        Optional(decimalSeparator + Optional(integerNumber))
-    )
-
-    whiteSpace = Suppress(White())
-
-    atomLine = Combine(
-        elementSymbol + whiteSpace +
-        delimitedList(floatNumber, delim=White()),
-        joinString=' '
-    )
-
-    keyValueSeparator = Suppress(Literal(":"))
-
-    groupOpener = Suppress(Literal('{'))
-    groupCloser = Suppress(Literal('}'))
-
-    atomsGroup = Group(CaselessLiteral("atoms") + keyValueSeparator +
-                       groupOpener + delimitedList(atomLine, delim=lineEnd) + groupCloser)
-
-    unitCell = Group(CaselessLiteral("lattice") + keyValueSeparator + delimitedList(
-        floatNumber, delim=White()))
-
-    spaceGroup = Group(CaselessLiteral("spacegroup") + keyValueSeparator + Word(
-        alphanums + "-" + ' '))
-
-    compoundContent = Each([atomsGroup, unitCell, spaceGroup]).setFailAction(
-        lambda o, s, loc, token: raiseParseErrorException(
-            "One of 'Lattice', 'SpaceGroup', 'Atoms' is missing or contains errors."))
-
-    compoundName = Word(alphanums + '_')
-
-    compound = Group(compoundName + Optional(whiteSpace) + \
-                     groupOpener + compoundContent + groupCloser)
-
-    comment = Suppress(Literal('#') + restOfLine)
-
-    compounds = Optional(comment) + OneOrMore(compound).ignore(comment) + stringEnd
-
-    def __call__(self, contentString):
-        parsedContent = None
-
-        if os.path.isfile(contentString):
-            parsedContent = self._parseFile(contentString)
-        else:
-            parsedContent = self._parseString(contentString)
-
-        return [PoldiCompound(x[0], x[1:]) for x in parsedContent]
-
-    def _parseFile(self, filename):
-        return self.compounds.parseFile(filename)
-
-    def _parseString(self, stringContent):
-        return self.compounds.parseString(stringContent)
-
-
-class PoldiCreatePeaksFromFile(PythonAlgorithm):
-    _parser = PoldiCrystalFileParser()
-
-    def category(self):
-        return "SINQ\\POLDI"
-
-    def name(self):
-        return "PoldiLoadCrystalData"
-
-    def summary(self):
-        return ("The algorithm reads a POLDI crystal structure file and creates a WorkspaceGroup that contains tables"
-                "with the expected reflections.")
-
-    def PyInit(self):
-        self.declareProperty(
-            FileProperty(name="InputFile",
-                         defaultValue="",
-                         action=FileAction.Load,
-                         extensions=["dat"]),
-            doc="A file with POLDI crystal data.")
-
-        self.declareProperty("LatticeSpacingMin", 0.5,
-                             direction=Direction.Input,
-                             doc="Lowest allowed lattice spacing.")
-
-        self.declareProperty("LatticeSpacingMax", 0.0,
-                             direction=Direction.Input,
-                             doc="Largest allowed lattice spacing.")
-
-        self.declareProperty(
-            WorkspaceProperty(name="OutputWorkspace",
-                              defaultValue="", direction=Direction.Output),
-            doc="WorkspaceGroup with reflection tables.")
-
-
-    def PyExec(self):
-        crystalFileName = self.getProperty("InputFile").value
-        try:
-            # Try parsing the supplied file using PoldiCrystalFileParser
-            compounds = self._parser(crystalFileName)
-
-            dMin = self.getProperty("LatticeSpacingMin").value
-            dMax = self.getProperty("LatticeSpacingMax").value
-
-            workspaces = []
-
-            # Go through found compounds and run "_createPeaksFromCell" for each of them
-            # If two compounds have the same name, a warning is written to the log.
-            for compound in compounds:
-                if compound.getName() in workspaces:
-                    self.log().warning("A compound with the name '" + compound.getName() + \
-                                       "' has already been created. Please check the file '" + crystalFileName + "'")
-                else:
-                    workspaces.append(self._createPeaksFromCell(compound, dMin, dMax))
-
-            self.setProperty("OutputWorkspace", GroupWorkspaces(workspaces))
-
-        # All parse errors are caught here and logged as errors
-        except ParseException as error:
-            errorString = "Could not parse input file '" + crystalFileName + "'.\n"
-            errorString += "The parser reported the following error:\n\t" + str(error)
-
-            self.log().error(errorString)
-
-
-    def _createPeaksFromCell(self, compound, dMin, dMax):
-        if not SpaceGroupFactory.isSubscribedSymbol(compound.getSpaceGroup()):
-            raise RuntimeError("SpaceGroup '" + compound.getSpaceGroup() + "' is not registered.")
-
-        PoldiCreatePeaksFromCell(SpaceGroup=compound.getSpaceGroup(),
-                                 Atoms=compound.getAtomString(),
-                                 LatticeSpacingMin=dMin,
-                                 LatticeSpacingMax=dMax,
-                                 OutputWorkspace=compound.getName(),
-                                 **compound.getCellParameters())
-
-        return compound.getName()
-
 try:
-    import pyparsing
+    from pyparsing import *
+
+    class PoldiCompound(object):
+        """Small helper class to handle the results from PoldiCrystalFileParser."""
+        _name = ""
+        _spacegroup = ""
+        _atomString = ""
+        _cellDict = ""
+
+        def __init__(self, name, elements):
+            self._name = name
+
+            self.assign(elements)
+
+        def assign(self, elements):
+            for c in elements:
+                if c[0] == "atoms":
+                    self._atomString = ';'.join(c[1:])
+                elif c[0] == "lattice":
+                    cellNames = ['a', 'b', 'c', 'alpha', 'beta', 'gamma']
+                    self._cellDict = dict(zip(cellNames, c[1:]))
+                elif c[0] == "spacegroup":
+                    self._spacegroup = c[1]
+
+        def getAtomString(self):
+            return self._atomString
+
+        def getCellParameters(self):
+            return self._cellDict
+
+        def getSpaceGroup(self):
+            return self._spacegroup
+
+        def getName(self):
+            return self._name
+
+
+    def raiseParseErrorException(message):
+        raise ParseException(message)
+
+
+    class PoldiCrystalFileParser(object):
+        """Small parser for crystal structure files used at POLDI
+
+        This class encapsulates a small parser for crystal structure files that are used at
+        POLDI. The files contains information about the lattice, the space group and the basis (atoms
+        in the asymmetric unit).
+
+        The file format is defined as follows:
+
+            Compound_1 {
+                Lattice: [1 - 6 floats] => a, b, c, alpha, beta, gamma
+                Spacegroup: [valid space group symbol]
+                Atoms; {
+                    Element x y z [occupancy [U_eq]]
+                    Element x y z [occupancy [U_eq]]
+                }
+            }
+
+            Compound_2 {
+                ...
+            }
+
+        The parser returns a list of PoldiCompound objects with the compounds that were found
+        in the file. These are then processed by PoldiCreatePeaksFromFile to generate arguments
+        for calling PoldiCreatePeaksFromCell.
+        """
+        elementSymbol = Word(alphas, min=1, max=2).setFailAction(
+            lambda o, s, loc, token: raiseParseErrorException("Element symbol must be one or two characters."))
+        integerNumber = Word(nums)
+        decimalSeparator = Literal('.')
+        floatNumber = Combine(
+            integerNumber +
+            Optional(decimalSeparator + Optional(integerNumber))
+        )
+
+        whiteSpace = Suppress(White())
+
+        atomLine = Combine(
+            elementSymbol + whiteSpace +
+            delimitedList(floatNumber, delim=White()),
+            joinString=' '
+        )
+
+        keyValueSeparator = Suppress(Literal(":"))
+
+        groupOpener = Suppress(Literal('{'))
+        groupCloser = Suppress(Literal('}'))
+
+        atomsGroup = Group(CaselessLiteral("atoms") + keyValueSeparator +
+                           groupOpener + delimitedList(atomLine, delim=lineEnd) + groupCloser)
+
+        unitCell = Group(CaselessLiteral("lattice") + keyValueSeparator + delimitedList(
+            floatNumber, delim=White()))
+
+        spaceGroup = Group(CaselessLiteral("spacegroup") + keyValueSeparator + Word(
+            alphanums + "-" + ' '))
+
+        compoundContent = Each([atomsGroup, unitCell, spaceGroup]).setFailAction(
+            lambda o, s, loc, token: raiseParseErrorException(
+                "One of 'Lattice', 'SpaceGroup', 'Atoms' is missing or contains errors."))
+
+        compoundName = Word(alphanums + '_')
+
+        compound = Group(compoundName + Optional(whiteSpace) + \
+                         groupOpener + compoundContent + groupCloser)
+
+        comment = Suppress(Literal('#') + restOfLine)
+
+        compounds = Optional(comment) + OneOrMore(compound).ignore(comment) + stringEnd
+
+        def __call__(self, contentString):
+            parsedContent = None
+
+            if os.path.isfile(contentString):
+                parsedContent = self._parseFile(contentString)
+            else:
+                parsedContent = self._parseString(contentString)
+
+            return [PoldiCompound(x[0], x[1:]) for x in parsedContent]
+
+        def _parseFile(self, filename):
+            return self.compounds.parseFile(filename)
+
+        def _parseString(self, stringContent):
+            return self.compounds.parseString(stringContent)
+
+
+    class PoldiCreatePeaksFromFile(PythonAlgorithm):
+        _parser = PoldiCrystalFileParser()
+
+        def category(self):
+            return "SINQ\\POLDI"
+
+        def name(self):
+            return "PoldiLoadCrystalData"
+
+        def summary(self):
+            return ("The algorithm reads a POLDI crystal structure file and creates a WorkspaceGroup that contains tables"
+                    "with the expected reflections.")
+
+        def PyInit(self):
+            self.declareProperty(
+                FileProperty(name="InputFile",
+                             defaultValue="",
+                             action=FileAction.Load,
+                             extensions=["dat"]),
+                doc="A file with POLDI crystal data.")
+
+            self.declareProperty("LatticeSpacingMin", 0.5,
+                                 direction=Direction.Input,
+                                 doc="Lowest allowed lattice spacing.")
+
+            self.declareProperty("LatticeSpacingMax", 0.0,
+                                 direction=Direction.Input,
+                                 doc="Largest allowed lattice spacing.")
+
+            self.declareProperty(
+                WorkspaceProperty(name="OutputWorkspace",
+                                  defaultValue="", direction=Direction.Output),
+                doc="WorkspaceGroup with reflection tables.")
+
+
+        def PyExec(self):
+            crystalFileName = self.getProperty("InputFile").value
+            try:
+                # Try parsing the supplied file using PoldiCrystalFileParser
+                compounds = self._parser(crystalFileName)
+
+                dMin = self.getProperty("LatticeSpacingMin").value
+                dMax = self.getProperty("LatticeSpacingMax").value
+
+                workspaces = []
+
+                # Go through found compounds and run "_createPeaksFromCell" for each of them
+                # If two compounds have the same name, a warning is written to the log.
+                for compound in compounds:
+                    if compound.getName() in workspaces:
+                        self.log().warning("A compound with the name '" + compound.getName() + \
+                                           "' has already been created. Please check the file '" + crystalFileName + "'")
+                    else:
+                        workspaces.append(self._createPeaksFromCell(compound, dMin, dMax))
+
+                self.setProperty("OutputWorkspace", GroupWorkspaces(workspaces))
+
+            # All parse errors are caught here and logged as errors
+            except ParseException as error:
+                errorString = "Could not parse input file '" + crystalFileName + "'.\n"
+                errorString += "The parser reported the following error:\n\t" + str(error)
+
+                self.log().error(errorString)
+
+
+        def _createPeaksFromCell(self, compound, dMin, dMax):
+            if not SpaceGroupFactory.isSubscribedSymbol(compound.getSpaceGroup()):
+                raise RuntimeError("SpaceGroup '" + compound.getSpaceGroup() + "' is not registered.")
+
+            PoldiCreatePeaksFromCell(SpaceGroup=compound.getSpaceGroup(),
+                                     Atoms=compound.getAtomString(),
+                                     LatticeSpacingMin=dMin,
+                                     LatticeSpacingMax=dMax,
+                                     OutputWorkspace=compound.getName(),
+                                     **compound.getCellParameters())
+
+            return compound.getName()
+
+
     AlgorithmFactory.subscribe(PoldiCreatePeaksFromFile)
 except:
     logger.debug('Failed to subscribe algorithm PoldiCreatePeaksFromFile; Python package pyparsing'\

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
@@ -6,215 +6,216 @@ from mantid.geometry import *
 
 import os
 
-try:
-    from pyparsing import *
 
-    class PoldiCompound(object):
-        """Small helper class to handle the results from PoldiCrystalFileParser."""
-        _name = ""
-        _spacegroup = ""
-        _atomString = ""
-        _cellDict = ""
+class PoldiCompound(object):
+    """Small helper class to handle the results from PoldiCrystalFileParser."""
 
-        def __init__(self, name, elements):
-            self._name = name
+    def __init__(self, name, elements):
+        self._spacegroup = ""
+        self._atomString = ""
+        self._cellDict = ""
+        self._name = name
 
-            self.assign(elements)
+        self.assign(elements)
 
-        def assign(self, elements):
-            for c in elements:
-                if c[0] == "atoms":
-                    self._atomString = ';'.join(c[1:])
-                elif c[0] == "lattice":
-                    cellNames = ['a', 'b', 'c', 'alpha', 'beta', 'gamma']
-                    self._cellDict = dict(zip(cellNames, c[1:]))
-                elif c[0] == "spacegroup":
-                    self._spacegroup = c[1]
+    def assign(self, elements):
+        for c in elements:
+            if c[0] == "atoms":
+                self._atomString = ';'.join(c[1:])
+            elif c[0] == "lattice":
+                cellNames = ['a', 'b', 'c', 'alpha', 'beta', 'gamma']
+                self._cellDict = dict(zip(cellNames, c[1:]))
+            elif c[0] == "spacegroup":
+                self._spacegroup = c[1]
 
-        def getAtomString(self):
-            return self._atomString
+    def getAtomString(self):
+        return self._atomString
 
-        def getCellParameters(self):
-            return self._cellDict
+    def getCellParameters(self):
+        return self._cellDict
 
-        def getSpaceGroup(self):
-            return self._spacegroup
+    def getSpaceGroup(self):
+        return self._spacegroup
 
-        def getName(self):
-            return self._name
+    def getName(self):
+        return self._name
 
 
-    def raiseParseErrorException(message):
-        raise ParseException(message)
+def raiseParseErrorException(message):
+    raise ParseException(message)
 
 
-    class PoldiCrystalFileParser(object):
-        """Small parser for crystal structure files used at POLDI
+class PoldiCrystalFileParser(object):
+    """Small parser for crystal structure files used at POLDI
 
-        This class encapsulates a small parser for crystal structure files that are used at
-        POLDI. The files contains information about the lattice, the space group and the basis (atoms
-        in the asymmetric unit).
+    This class encapsulates a small parser for crystal structure files that are used at
+    POLDI. The files contains information about the lattice, the space group and the basis (atoms
+    in the asymmetric unit).
 
-        The file format is defined as follows:
+    The file format is defined as follows:
 
-            Compound_1 {
-                Lattice: [1 - 6 floats] => a, b, c, alpha, beta, gamma
-                Spacegroup: [valid space group symbol]
-                Atoms; {
-                    Element x y z [occupancy [U_eq]]
-                    Element x y z [occupancy [U_eq]]
-                }
+        Compound_1 {
+            Lattice: [1 - 6 floats] => a, b, c, alpha, beta, gamma
+            Spacegroup: [valid space group symbol]
+            Atoms; {
+                Element x y z [occupancy [U_eq]]
+                Element x y z [occupancy [U_eq]]
             }
+        }
 
-            Compound_2 {
-                ...
-            }
+        Compound_2 {
+            ...
+        }
 
-        The parser returns a list of PoldiCompound objects with the compounds that were found
-        in the file. These are then processed by PoldiCreatePeaksFromFile to generate arguments
-        for calling PoldiCreatePeaksFromCell.
-        """
-        elementSymbol = Word(alphas, min=1, max=2).setFailAction(
+    The parser returns a list of PoldiCompound objects with the compounds that were found
+    in the file. These are then processed by PoldiCreatePeaksFromFile to generate arguments
+    for calling PoldiCreatePeaksFromCell.
+    """
+
+    def __init__(self):
+        self.elementSymbol = Word(alphas, min=1, max=2).setFailAction(
             lambda o, s, loc, token: raiseParseErrorException("Element symbol must be one or two characters."))
-        integerNumber = Word(nums)
-        decimalSeparator = Literal('.')
-        floatNumber = Combine(
-            integerNumber +
-            Optional(decimalSeparator + Optional(integerNumber))
+        self.integerNumber = Word(nums)
+        self.decimalSeparator = Literal('.')
+        self.floatNumber = Combine(
+            self.integerNumber +
+            Optional(self.decimalSeparator + Optional(self.integerNumber))
         )
 
-        whiteSpace = Suppress(White())
+        self.whiteSpace = Suppress(White())
 
-        atomLine = Combine(
-            elementSymbol + whiteSpace +
-            delimitedList(floatNumber, delim=White()),
+        self.atomLine = Combine(
+            self.elementSymbol + self.whiteSpace +
+            delimitedList(self.floatNumber, delim=White()),
             joinString=' '
         )
 
-        keyValueSeparator = Suppress(Literal(":"))
+        self.keyValueSeparator = Suppress(Literal(":"))
 
-        groupOpener = Suppress(Literal('{'))
-        groupCloser = Suppress(Literal('}'))
+        self.groupOpener = Suppress(Literal('{'))
+        self.groupCloser = Suppress(Literal('}'))
 
-        atomsGroup = Group(CaselessLiteral("atoms") + keyValueSeparator +
-                           groupOpener + delimitedList(atomLine, delim=lineEnd) + groupCloser)
+        self.atomsGroup = Group(CaselessLiteral("atoms") + self.keyValueSeparator +
+                                self.groupOpener + delimitedList(self.atomLine, delim=lineEnd) + self.groupCloser)
 
-        unitCell = Group(CaselessLiteral("lattice") + keyValueSeparator + delimitedList(
-            floatNumber, delim=White()))
+        self.unitCell = Group(CaselessLiteral("lattice") + self.keyValueSeparator + delimitedList(
+            self.floatNumber, delim=White()))
 
-        spaceGroup = Group(CaselessLiteral("spacegroup") + keyValueSeparator + Word(
+        self.spaceGroup = Group(CaselessLiteral("spacegroup") + self.keyValueSeparator + Word(
             alphanums + "-" + ' '))
 
-        compoundContent = Each([atomsGroup, unitCell, spaceGroup]).setFailAction(
+        self.compoundContent = Each([self.atomsGroup, self.unitCell, self.spaceGroup]).setFailAction(
             lambda o, s, loc, token: raiseParseErrorException(
                 "One of 'Lattice', 'SpaceGroup', 'Atoms' is missing or contains errors."))
 
-        compoundName = Word(alphanums + '_')
+        self.compoundName = Word(alphanums + '_')
 
-        compound = Group(compoundName + Optional(whiteSpace) + \
-                         groupOpener + compoundContent + groupCloser)
+        self.compound = Group(self.compoundName + Optional(self.whiteSpace) + \
+                              self.groupOpener + self.compoundContent + self.groupCloser)
 
-        comment = Suppress(Literal('#') + restOfLine)
+        self.comment = Suppress(Literal('#') + restOfLine)
 
-        compounds = Optional(comment) + OneOrMore(compound).ignore(comment) + stringEnd
+        self.compounds = Optional(self.comment) + OneOrMore(self.compound).ignore(self.comment) + stringEnd
 
-        def __call__(self, contentString):
-            parsedContent = None
+    def __call__(self, contentString):
+        parsedContent = None
 
-            if os.path.isfile(contentString):
-                parsedContent = self._parseFile(contentString)
-            else:
-                parsedContent = self._parseString(contentString)
+        if os.path.isfile(contentString):
+            parsedContent = self._parseFile(contentString)
+        else:
+            parsedContent = self._parseString(contentString)
 
-            return [PoldiCompound(x[0], x[1:]) for x in parsedContent]
+        return [PoldiCompound(x[0], x[1:]) for x in parsedContent]
 
-        def _parseFile(self, filename):
-            return self.compounds.parseFile(filename)
+    def _parseFile(self, filename):
+        return self.compounds.parseFile(filename)
 
-        def _parseString(self, stringContent):
-            return self.compounds.parseString(stringContent)
-
-
-    class PoldiCreatePeaksFromFile(PythonAlgorithm):
-        _parser = PoldiCrystalFileParser()
-
-        def category(self):
-            return "SINQ\\POLDI"
-
-        def name(self):
-            return "PoldiLoadCrystalData"
-
-        def summary(self):
-            return ("The algorithm reads a POLDI crystal structure file and creates a WorkspaceGroup that contains tables"
-                    "with the expected reflections.")
-
-        def PyInit(self):
-            self.declareProperty(
-                FileProperty(name="InputFile",
-                             defaultValue="",
-                             action=FileAction.Load,
-                             extensions=["dat"]),
-                doc="A file with POLDI crystal data.")
-
-            self.declareProperty("LatticeSpacingMin", 0.5,
-                                 direction=Direction.Input,
-                                 doc="Lowest allowed lattice spacing.")
-
-            self.declareProperty("LatticeSpacingMax", 0.0,
-                                 direction=Direction.Input,
-                                 doc="Largest allowed lattice spacing.")
-
-            self.declareProperty(
-                WorkspaceProperty(name="OutputWorkspace",
-                                  defaultValue="", direction=Direction.Output),
-                doc="WorkspaceGroup with reflection tables.")
+    def _parseString(self, stringContent):
+        return self.compounds.parseString(stringContent)
 
 
-        def PyExec(self):
-            crystalFileName = self.getProperty("InputFile").value
-            try:
-                # Try parsing the supplied file using PoldiCrystalFileParser
-                compounds = self._parser(crystalFileName)
+class PoldiCreatePeaksFromFile(PythonAlgorithm):
+    def category(self):
+        return "SINQ\\POLDI"
 
-                dMin = self.getProperty("LatticeSpacingMin").value
-                dMax = self.getProperty("LatticeSpacingMax").value
+    def name(self):
+        return "PoldiLoadCrystalData"
 
-                workspaces = []
+    def summary(self):
+        return ("The algorithm reads a POLDI crystal structure file and creates a WorkspaceGroup that contains tables"
+                "with the expected reflections.")
 
-                # Go through found compounds and run "_createPeaksFromCell" for each of them
-                # If two compounds have the same name, a warning is written to the log.
-                for compound in compounds:
-                    if compound.getName() in workspaces:
-                        self.log().warning("A compound with the name '" + compound.getName() + \
-                                           "' has already been created. Please check the file '" + crystalFileName + "'")
-                    else:
-                        workspaces.append(self._createPeaksFromCell(compound, dMin, dMax))
+    def PyInit(self):
+        self.declareProperty(
+            FileProperty(name="InputFile",
+                         defaultValue="",
+                         action=FileAction.Load,
+                         extensions=["dat"]),
+            doc="A file with POLDI crystal data.")
 
-                self.setProperty("OutputWorkspace", GroupWorkspaces(workspaces))
+        self.declareProperty("LatticeSpacingMin", 0.5,
+                             direction=Direction.Input,
+                             doc="Lowest allowed lattice spacing.")
 
-            # All parse errors are caught here and logged as errors
-            except ParseException as error:
-                errorString = "Could not parse input file '" + crystalFileName + "'.\n"
-                errorString += "The parser reported the following error:\n\t" + str(error)
+        self.declareProperty("LatticeSpacingMax", 0.0,
+                             direction=Direction.Input,
+                             doc="Largest allowed lattice spacing.")
 
-                self.log().error(errorString)
+        self.declareProperty(
+            WorkspaceProperty(name="OutputWorkspace",
+                              defaultValue="", direction=Direction.Output),
+            doc="WorkspaceGroup with reflection tables.")
+
+        self._parser = PoldiCrystalFileParser()
+
+    def PyExec(self):
+        crystalFileName = self.getProperty("InputFile").value
+        try:
+            # Try parsing the supplied file using PoldiCrystalFileParser
+            compounds = self._parser(crystalFileName)
+
+            dMin = self.getProperty("LatticeSpacingMin").value
+            dMax = self.getProperty("LatticeSpacingMax").value
+
+            workspaces = []
+
+            # Go through found compounds and run "_createPeaksFromCell" for each of them
+            # If two compounds have the same name, a warning is written to the log.
+            for compound in compounds:
+                if compound.getName() in workspaces:
+                    self.log().warning("A compound with the name '" + compound.getName() + \
+                                       "' has already been created. Please check the file '" + crystalFileName + "'")
+                else:
+                    workspaces.append(self._createPeaksFromCell(compound, dMin, dMax))
+
+            self.setProperty("OutputWorkspace", GroupWorkspaces(workspaces))
+
+        # All parse errors are caught here and logged as errors
+        except ParseException as error:
+            errorString = "Could not parse input file '" + crystalFileName + "'.\n"
+            errorString += "The parser reported the following error:\n\t" + str(error)
+
+            self.log().error(errorString)
 
 
-        def _createPeaksFromCell(self, compound, dMin, dMax):
-            if not SpaceGroupFactory.isSubscribedSymbol(compound.getSpaceGroup()):
-                raise RuntimeError("SpaceGroup '" + compound.getSpaceGroup() + "' is not registered.")
+    def _createPeaksFromCell(self, compound, dMin, dMax):
+        if not SpaceGroupFactory.isSubscribedSymbol(compound.getSpaceGroup()):
+            raise RuntimeError("SpaceGroup '" + compound.getSpaceGroup() + "' is not registered.")
 
-            PoldiCreatePeaksFromCell(SpaceGroup=compound.getSpaceGroup(),
-                                     Atoms=compound.getAtomString(),
-                                     LatticeSpacingMin=dMin,
-                                     LatticeSpacingMax=dMax,
-                                     OutputWorkspace=compound.getName(),
-                                     **compound.getCellParameters())
+        PoldiCreatePeaksFromCell(SpaceGroup=compound.getSpaceGroup(),
+                                 Atoms=compound.getAtomString(),
+                                 LatticeSpacingMin=dMin,
+                                 LatticeSpacingMax=dMax,
+                                 OutputWorkspace=compound.getName(),
+                                 **compound.getCellParameters())
 
-            return compound.getName()
+        return compound.getName()
 
+
+try:
+    from pyparsing import *
 
     AlgorithmFactory.subscribe(PoldiCreatePeaksFromFile)
 except:
-    logger.debug('Failed to subscribe algorithm PoldiCreatePeaksFromFile; Python package pyparsing'\
-        'may be missing (https://pypi.python.org/pypi/pyparsing)')
+    logger.debug('Failed to subscribe algorithm PoldiCreatePeaksFromFile; Python package pyparsing' \
+                 'may be missing (https://pypi.python.org/pypi/pyparsing)')

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/PoldiCreatePeaksFromFileTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/PoldiCreatePeaksFromFileTest.py
@@ -170,4 +170,6 @@ class PoldiCreatePeaksFromFileTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    # Only test if algorithm is registered (pyparsing dependency).
+    if AlgorithmFactory.exists("PoldiCreatePeaksFromFile"):
+        unittest.main()

--- a/Code/Mantid/docs/source/algorithms/PoldiCreatePeaksFromFile-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiCreatePeaksFromFile-v1.rst
@@ -52,6 +52,8 @@ if necessary.
 The algorithm will always produce a WorkspaceGroup which contains as many peak tables as compounds specified in the
 file.
 
+Please note that this algorithm is only available if the `pyparsing`-module is installed.
+
 Usage
 -----
 

--- a/Code/Mantid/docs/source/algorithms/PoldiCreatePeaksFromFile-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiCreatePeaksFromFile-v1.rst
@@ -46,13 +46,17 @@ block shows how such a file would look when there are two compounds:
 Note that only the atoms in the asymmetric unit need to be specified, the space group is used to generate all
 equivalent atoms. This information is used to determine systematic absences, while the space group is also used by
 some POLDI algorithms to obtain the point group to get reflection multiplicities and more. Anything that follows the
-`#`-character is considered a comment and is ignored by the parser to allow documentation of the crystal structures
+``#``-character is considered a comment and is ignored by the parser to allow documentation of the crystal structures
 if necessary.
 
 The algorithm will always produce a WorkspaceGroup which contains as many peak tables as compounds specified in the
 file.
 
-Please note that this algorithm is only available if the `pyparsing`-module is installed.
+Required
+--------
+
+This algorithm requires python package ``pyparsing``, available at the `python package index <https://pypi.python.org/pypi/pyparsing>`_
+or through the operating system's package manager. If the package is not present, this algorithm will not be available.
 
 Usage
 -----
@@ -61,7 +65,7 @@ Usage
 
 The following usage example takes up the file showed above and passes it to the algorithm.
 
-.. testcode::
+.. code-block:: python
 
     # Create two tables with expected peaks directly from a file
     compounds = PoldiCreatePeaksFromFile('PoldiCrystalFileExample.dat', LatticeSpacingMin=0.7)
@@ -76,14 +80,10 @@ The following usage example takes up the file showed above and passes it to the 
 
 The script produces a WorkspaceGroup which contains a table with reflections for each compound in the file:
 
-.. testoutput::
+.. code-block:: python
 
     Number of loaded compounds: 2
     Compound 1: Iron_FCC has 11 reflections in the resolution range.
     Compound 2: Iron_BCC has 8 reflections in the resolution range.
-
-.. testcleanup::
-
-    DeleteWorkspace('compounds')
 
 .. categories::


### PR DESCRIPTION
Fixes [#11625](http://trac.mantidproject.org/mantid/ticket/11625).

**Testing information**
This needs to be tested on a machine that does not have `pyparsing` installed. In that case the algorithm should not be present. On machines where it is installed, it should still be available. The doc-test is now a code-block, which is not executed automatically.
