### PR TITLE
Option for fractional HKL output

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
@@ -96,6 +96,7 @@ void SaveHKL::init() {
                   "The minimum Intensity");
   declareProperty(new WorkspaceProperty<PeaksWorkspace>("OutputWorkspace", "SaveHKLOutput",
                                                         Direction::Output), "Output PeaksWorkspace");
+  declareProperty("HKLDecimalPlaces", EMPTY_INT(), "Number of decimal places for fractional HKL.  Default is integer HKL.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -117,6 +118,7 @@ void SaveHKL::exec() {
   double minIsigI = getProperty("MinIsigI");
   double minIntensity = getProperty("MinIntensity");
   int widthBorder = getProperty("WidthBorder");
+  int decimalHKL = getProperty("HKLDecimalPlaces");
 
   // Sequence and run number
   int seqNum = 1;
@@ -322,8 +324,14 @@ void SaveHKL::exec() {
       banned.push_back(wi);
       continue;
     }
-    out << std::setw(4) << Utils::round(-p.getH()) << std::setw(4)
-        << Utils::round(-p.getK()) << std::setw(4) << Utils::round(-p.getL());
+    if (decimalHKL == EMPTY_INT() )
+      out << std::setw(4) << Utils::round(-p.getH())
+            << std::setw(4) << Utils::round(-p.getK())
+            << std::setw(4) << Utils::round(-p.getL());
+    else
+      out << std::setw(5+decimalHKL) << std::fixed << std::setprecision(decimalHKL) << -p.getH()
+            << std::setw(5+decimalHKL) << std::fixed << std::setprecision(decimalHKL) << -p.getK()
+            << std::setw(5+decimalHKL) << std::fixed << std::setprecision(decimalHKL) << -p.getL();
     double correc = scaleFactor;
     double relSigSpect = 0.0;
     if (bank != bankold)

--- a/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
@@ -433,7 +433,15 @@ void SaveHKL::exec() {
 
     out << std::endl;
   }
-  out << "   0   0   0    0.00    0.00   0  0.0000 0.0000      0      0 0.0000 "
+  if (decimalHKL == EMPTY_INT() )
+    out << std::setw(4) << 0
+          << std::setw(4) << 0
+          << std::setw(4) << 0;
+  else
+    out << std::setw(5+decimalHKL) << std::fixed << std::setprecision(decimalHKL) << 0.0
+          << std::setw(5+decimalHKL) << std::fixed << std::setprecision(decimalHKL) << 0.0
+          << std::setw(5+decimalHKL) << std::fixed << std::setprecision(decimalHKL) << 0.0;
+  out << "    0.00    0.00   0  0.0000 0.0000      0      0 0.0000 "
          "  0";
   out << std::endl;
 


### PR DESCRIPTION
Fixes issue [#10785](http://trac.mantidproject.org/mantid/ticket/10785)

Specify HKLDecimalPlaces in SaveHKL to test:

```
LoadIsawPeaks(Filename='natrolite.integrate', OutputWorkspace='peaks')
SaveHKL(InputWorkspace='peaks', LinearScatteringCoef=0.53300000000000003, LinearAbsorptionCoef=0.501, Radius=0.080000000000000002, Filename='new0.hkl')
SaveHKL(InputWorkspace='peaks', LinearScatteringCoef=0.53300000000000003, LinearAbsorptionCoef=0.501, Radius=0.080000000000000002, Filename='new2.hkl', HKLDecimalPlaces=2)
SaveHKL(InputWorkspace='peaks', LinearScatteringCoef=0.53300000000000003, LinearAbsorptionCoef=0.501, Radius=0.080000000000000002, Filename='new5.hkl', HKLDecimalPlaces=5)
```

cat natrolite.integrate
Version: 2.0  Facility: SNS  Instrument: MANDI  Date: 2013-03-15T00:00:01
6         L1    T0_SHIFT
7  3000.0000       0.000
4 DETNUM  NROWS  NCOLS   WIDTH   HEIGHT   DEPTH   DETD   CenterX   CenterY   CenterZ    BaseX    BaseY    BaseZ      UpX      UpY      UpZ
5     14    256    256 15.8208 15.8208   0.2000  45.50   22.6805  -24.1113  -31.2168  0.79231  0.59966  0.11248 -0.35181  0.59966 -0.71877 
5     20    256    256 15.8208 15.8208   0.2000  42.50   12.6245  -11.7146   38.8541 -0.61227  0.67972  0.40386  0.73273  0.67971 -0.03314 
5     22    256    256 15.8208 15.8208   0.2000  42.50   40.8536  -11.7146   -0.0001  0.19491  0.67972  0.70710  0.19490  0.67971 -0.70711 
5     31    256    256 15.8208 15.8208   0.2000  39.50   23.2175    0.0000   31.9562 -0.57206  0.70711  0.41563  0.57206  0.70711 -0.41563 
5     32    256    256 15.8208 15.8208   0.2000  39.50   37.5668    0.0000   12.2061 -0.21851  0.70711  0.67250  0.21851  0.70711 -0.67250 
5     33    256    256 15.8208 15.8208   0.2000  39.50   37.5667    0.0000  -12.2063  0.21851  0.70711  0.67250 -0.21851  0.70711 -0.67250 
0  NRUN DETNUM     CHI      PHI    OMEGA       MONCNT
1   276     14    0.00     0.00     0.00        60054
2   SEQN    H    K    L     COL      ROW     CHAN        L2   2_THETA        AZ         WL         D      IPK       INTI    SIGI  RFLG
3      1   25  -25    3   36.00   209.00     7370    46.126   2.44815  -0.97977   0.957147    0.5089        0      22.62   11.11   310
3      2   23  -23    3   31.00   238.00     8027    46.394   2.48670  -0.98796   1.042359    0.5504        0     239.84   22.00   310
3      3   23  -25    3   90.00   233.00     7695    46.023   2.47474  -0.86100   0.999417    0.5288        0     113.22   17.46   310
3      4   23  -27    3  144.00   227.00     7368    45.925   2.45511  -0.74864   0.956914    0.5081        0      21.57   10.88   310
