### PR TITLE
Lower dimensional cuts for CutMD

### DIFF
--- a/Code/Mantid/Framework/API/src/Algorithm.cpp
+++ b/Code/Mantid/Framework/API/src/Algorithm.cpp
@@ -1593,6 +1593,8 @@ IPropertyManager::getValue<API::IAlgorithm_sptr>(
   } else {
     std::string message =
         "Attempt to assign property " + name + " to incorrect type";
+    int i = 0;
+    std::cin >> i;
     throw std::runtime_error(message);
   }
 }
@@ -1615,6 +1617,8 @@ IPropertyManager::getValue<API::IAlgorithm_const_sptr>(
   } else {
     std::string message =
         "Attempt to assign property " + name + " to incorrect type";
+    int i = 0;
+    std::cin >> i;
     throw std::runtime_error(message);
   }
 }

--- a/Code/Mantid/Framework/API/src/Algorithm.cpp
+++ b/Code/Mantid/Framework/API/src/Algorithm.cpp
@@ -1593,8 +1593,6 @@ IPropertyManager::getValue<API::IAlgorithm_sptr>(
   } else {
     std::string message =
         "Attempt to assign property " + name + " to incorrect type";
-    int i = 0;
-    std::cin >> i;
     throw std::runtime_error(message);
   }
 }
@@ -1617,8 +1615,6 @@ IPropertyManager::getValue<API::IAlgorithm_const_sptr>(
   } else {
     std::string message =
         "Attempt to assign property " + name + " to incorrect type";
-    int i = 0;
-    std::cin >> i;
     throw std::runtime_error(message);
   }
 }

--- a/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
@@ -1,5 +1,6 @@
 #include "MantidMDAlgorithms/CutMD.h"
 #include "MantidAPI/IMDEventWorkspace.h"
+#include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/Projection.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -198,8 +199,8 @@ CutMD::~CutMD() {}
 //----------------------------------------------------------------------------------------------
 
 void CutMD::init() {
-  declareProperty(new WorkspaceProperty<IMDEventWorkspace>("InputWorkspace", "",
-                                                           Direction::Input),
+  declareProperty(new WorkspaceProperty<IMDWorkspace>("InputWorkspace", "",
+                                                      Direction::Input),
                   "MDWorkspace to slice");
 
   declareProperty(
@@ -227,7 +228,7 @@ void CutMD::exec() {
                 "behaviour may change without warning.");
 
   // Collect input properties
-  const IMDEventWorkspace_sptr inWS = getProperty("InputWorkspace");
+  const IMDWorkspace_sptr inWS = getProperty("InputWorkspace");
   const size_t numDims = inWS->getNumDims();
   const ITableWorkspace_sptr projectionWS = getProperty("Projection");
   std::vector<std::vector<double>> pbins(5);
@@ -236,150 +237,174 @@ void CutMD::exec() {
   pbins[2] = getProperty("P3Bin");
   pbins[3] = getProperty("P4Bin");
   pbins[4] = getProperty("P5Bin");
-  const bool noPix = getProperty("NoPix");
 
-  // Check Projection format
-  Projection projection;
-  if (projectionWS)
-    projection = Projection(*projectionWS);
+  Workspace_sptr sliceWS; // output worskpace
 
-  // Check PBin properties
-  for (size_t i = 0; i < 5; ++i) {
-    if (i < numDims && pbins[i].empty())
-      throw std::runtime_error(
-          "P" + boost::lexical_cast<std::string>(i + 1) +
-          "Bin must be set when processing a workspace with " +
-          boost::lexical_cast<std::string>(numDims) + " dimensions.");
-    if (i >= numDims && !pbins[i].empty())
-      throw std::runtime_error(
-          "P" + boost::lexical_cast<std::string>(i + 1) +
-          "Bin must NOT be set when processing a workspace with " +
-          boost::lexical_cast<std::string>(numDims) + " dimensions.");
-  }
+  // Histogram workspaces can be sliced axis-aligned only.
+  if (auto histInWS = boost::dynamic_pointer_cast<IMDHistoWorkspace>(inWS)) {
 
-  // Get extents in projection
-  std::vector<MinMax> extentLimits;
-  extentLimits.push_back(getDimensionExtents(inWS, 0));
-  extentLimits.push_back(getDimensionExtents(inWS, 1));
-  extentLimits.push_back(getDimensionExtents(inWS, 2));
+    g_log.information("Integrating using binning parameters only.");
+    auto integrateAlg =
+        this->createChildAlgorithm("IntegrateMDHistoWorkspace", 0, 1);
+    integrateAlg->setProperty("InputWorkspace", histInWS);
+    integrateAlg->setProperty("P1Bin", pbins[0]);
+    integrateAlg->setProperty("P2Bin", pbins[1]);
+    integrateAlg->setProperty("P3Bin", pbins[2]);
+    integrateAlg->setProperty("P4Bin", pbins[3]);
+    integrateAlg->setProperty("P5Bin", pbins[4]);
+    integrateAlg->execute();
+    IMDHistoWorkspace_sptr temp = integrateAlg->getProperty("OutputWorkspace");
+    sliceWS = temp;
+  } else { // We are processing an MDEventWorkspace
 
-  // Scale projection
-  DblMatrix projectionMatrix(3, 3);
-  projectionMatrix.setRow(0, projection.U());
-  projectionMatrix.setRow(1, projection.V());
-  projectionMatrix.setRow(2, projection.W());
+    auto eventInWS = boost::dynamic_pointer_cast<IMDEventWorkspace>(inWS);
+    const bool noPix = getProperty("NoPix");
 
-  std::vector<std::string> targetUnits(3);
-  for (size_t i = 0; i < 3; ++i)
-    targetUnits[i] = projection.getUnit(i) == RLU ? "r" : "a";
-  std::vector<std::string> originUnits(3, "r"); // TODO. This is a hack!
+    // Check Projection format
+    Projection projection;
+    if (projectionWS)
+      projection = Projection(*projectionWS);
 
-  DblMatrix scaledProjectionMatrix =
-      scaleProjection(projectionMatrix, originUnits, targetUnits, inWS);
-
-  // Calculate extents for the first 3 dimensions
-  std::vector<MinMax> scaledExtents =
-      calculateExtents(scaledProjectionMatrix, extentLimits);
-  auto stepPair = calculateSteps(scaledExtents, pbins);
-  std::vector<MinMax> steppedExtents = stepPair.first;
-  std::vector<int> steppedBins = stepPair.second;
-
-  // Calculate extents for additional dimensions
-  for (size_t i = 3; i < numDims; ++i) {
-    const size_t nArgs = pbins[i].size();
-    const MinMax extentLimit = getDimensionExtents(inWS, i);
-    const double dimRange = extentLimit.second - extentLimit.first;
-
-    if (nArgs == 1) {
-      steppedExtents.push_back(extentLimit);
-      steppedBins.push_back(static_cast<int>(dimRange / pbins[i][0]));
-    } else if (nArgs == 2) {
-      steppedExtents.push_back(std::make_pair(pbins[i][0], pbins[i][1]));
-      steppedBins.push_back(1);
-    } else if (nArgs == 3) {
-      const double dimRange = pbins[i][2] - pbins[i][0];
-      const double stepSize = pbins[i][1] < dimRange ? pbins[i][1] : dimRange;
-      steppedExtents.push_back(std::make_pair(pbins[i][0], pbins[i][2]));
-      steppedBins.push_back(static_cast<int>(dimRange / stepSize));
+    // Check PBin properties
+    for (size_t i = 0; i < 5; ++i) {
+      if (i < numDims && pbins[i].empty())
+        throw std::runtime_error(
+            "P" + boost::lexical_cast<std::string>(i + 1) +
+            "Bin must be set when processing a workspace with " +
+            boost::lexical_cast<std::string>(numDims) + " dimensions.");
+      if (i >= numDims && !pbins[i].empty())
+        throw std::runtime_error(
+            "P" + boost::lexical_cast<std::string>(i + 1) +
+            "Bin must NOT be set when processing a workspace with " +
+            boost::lexical_cast<std::string>(numDims) + " dimensions.");
     }
 
-    // and double targetUnits' length by appending itself to itself
-    size_t preSize = targetUnits.size();
-    targetUnits.resize(preSize * 2);
-    for (size_t i = 0; i < preSize; ++i)
-      targetUnits[preSize + i] = targetUnits[i];
-  }
+    // Get extents in projection
+    std::vector<MinMax> extentLimits;
+    extentLimits.push_back(getDimensionExtents(eventInWS, 0));
+    extentLimits.push_back(getDimensionExtents(eventInWS, 1));
+    extentLimits.push_back(getDimensionExtents(eventInWS, 2));
 
-  // Make labels
-  std::vector<std::string> labels = labelProjection(projectionMatrix);
+    // Scale projection
+    DblMatrix projectionMatrix(3, 3);
+    projectionMatrix.setRow(0, projection.U());
+    projectionMatrix.setRow(1, projection.V());
+    projectionMatrix.setRow(2, projection.W());
 
-  // Either run RebinMD or SliceMD
-  const std::string cutAlgName = noPix ? "BinMD" : "SliceMD";
-  IAlgorithm_sptr cutAlg = createChildAlgorithm(cutAlgName, 0.0, 1.0);
-  cutAlg->initialize();
-  cutAlg->setProperty("InputWorkspace", inWS);
-  cutAlg->setProperty("OutputWorkspace", "sliced");
-  cutAlg->setProperty("NormalizeBasisVectors", false);
-  cutAlg->setProperty("AxisAligned", false);
+    std::vector<std::string> targetUnits(3);
+    for (size_t i = 0; i < 3; ++i)
+      targetUnits[i] = projection.getUnit(i) == RLU ? "r" : "a";
+    std::vector<std::string> originUnits(3, "r"); // TODO. This is a hack!
 
-  for (size_t i = 0; i < numDims; ++i) {
-    std::string label;
-    std::string unit;
-    std::string vecStr;
+    DblMatrix scaledProjectionMatrix =
+        scaleProjection(projectionMatrix, originUnits, targetUnits, eventInWS);
 
-    if (i < 3) {
-      // Slicing algorithms accept name as [x, y, z]
-      label = labels[i];
-      unit = targetUnits[i];
+    // Calculate extents for the first 3 dimensions
+    std::vector<MinMax> scaledExtents =
+        calculateExtents(scaledProjectionMatrix, extentLimits);
+    auto stepPair = calculateSteps(scaledExtents, pbins);
+    std::vector<MinMax> steppedExtents = stepPair.first;
+    std::vector<int> steppedBins = stepPair.second;
 
-      std::vector<std::string> vec(numDims, "0");
-      for (size_t j = 0; j < 3; ++j)
-        vec[j] = boost::lexical_cast<std::string>(projectionMatrix[i][j]);
-      vecStr = boost::algorithm::join(vec, ", ");
-    } else {
-      // Always orthogonal
-      auto dim = inWS->getDimension(i);
-      label = dim->getName();
-      unit = dim->getUnits();
-      std::vector<std::string> vec(numDims, "0");
-      vec[i] = "1";
-      vecStr = boost::algorithm::join(vec, ", ");
+    // Calculate extents for additional dimensions
+    for (size_t i = 3; i < numDims; ++i) {
+      const size_t nArgs = pbins[i].size();
+      const MinMax extentLimit = getDimensionExtents(eventInWS, i);
+      const double dimRange = extentLimit.second - extentLimit.first;
+
+      if (nArgs == 1) {
+        steppedExtents.push_back(extentLimit);
+        steppedBins.push_back(static_cast<int>(dimRange / pbins[i][0]));
+      } else if (nArgs == 2) {
+        steppedExtents.push_back(std::make_pair(pbins[i][0], pbins[i][1]));
+        steppedBins.push_back(1);
+      } else if (nArgs == 3) {
+        const double dimRange = pbins[i][2] - pbins[i][0];
+        const double stepSize = pbins[i][1] < dimRange ? pbins[i][1] : dimRange;
+        steppedExtents.push_back(std::make_pair(pbins[i][0], pbins[i][2]));
+        steppedBins.push_back(static_cast<int>(dimRange / stepSize));
+      }
+
+      // and double targetUnits' length by appending itself to itself
+      size_t preSize = targetUnits.size();
+      targetUnits.resize(preSize * 2);
+      for (size_t i = 0; i < preSize; ++i)
+        targetUnits[preSize + i] = targetUnits[i];
     }
 
-    const std::string value = label + ", " + unit + ", " + vecStr;
-    cutAlg->setProperty("BasisVector" + boost::lexical_cast<std::string>(i),
-                        value);
-  }
+    // Make labels
+    std::vector<std::string> labels = labelProjection(projectionMatrix);
 
-  // Translate extents into a single vector
-  std::vector<double> outExtents(steppedExtents.size() * 2);
-  for (size_t i = 0; i < steppedExtents.size(); ++i) {
-    outExtents[2 * i] = steppedExtents[i].first;
-    outExtents[2 * i + 1] = steppedExtents[i].second;
-  }
+    // Either run RebinMD or SliceMD
+    const std::string cutAlgName = noPix ? "BinMD" : "SliceMD";
+    IAlgorithm_sptr cutAlg = createChildAlgorithm(cutAlgName, 0.0, 1.0);
+    cutAlg->initialize();
+    cutAlg->setProperty("InputWorkspace", inWS);
+    cutAlg->setProperty("OutputWorkspace", "sliced");
+    cutAlg->setProperty("NormalizeBasisVectors", false);
+    cutAlg->setProperty("AxisAligned", false);
 
-  cutAlg->setProperty("OutputExtents", outExtents);
-  cutAlg->setProperty("OutputBins", steppedBins);
+    for (size_t i = 0; i < numDims; ++i) {
+      std::string label;
+      std::string unit;
+      std::string vecStr;
 
-  cutAlg->execute();
-  Workspace_sptr sliceWS = cutAlg->getProperty("OutputWorkspace");
-  MultipleExperimentInfos_sptr sliceInfo =
-      boost::dynamic_pointer_cast<MultipleExperimentInfos>(sliceWS);
+      if (i < 3) {
+        // Slicing algorithms accept name as [x, y, z]
+        label = labels[i];
+        unit = targetUnits[i];
 
-  if (!sliceInfo)
-    throw std::runtime_error(
-        "Could not extract experiment info from child's OutputWorkspace");
+        std::vector<std::string> vec(numDims, "0");
+        for (size_t j = 0; j < 3; ++j)
+          vec[j] = boost::lexical_cast<std::string>(projectionMatrix[i][j]);
+        vecStr = boost::algorithm::join(vec, ", ");
+      } else {
+        // Always orthogonal
+        auto dim = inWS->getDimension(i);
+        label = dim->getName();
+        unit = dim->getUnits();
+        std::vector<std::string> vec(numDims, "0");
+        vec[i] = "1";
+        vecStr = boost::algorithm::join(vec, ", ");
+      }
 
-  // Attach projection matrix to output
-  if (sliceInfo->getNumExperimentInfo() > 0) {
-    ExperimentInfo_sptr info = sliceInfo->getExperimentInfo(0);
-    info->mutableRun().addProperty("W_MATRIX", projectionMatrix.getVector(),
-                                   true);
+      const std::string value = label + ", " + unit + ", " + vecStr;
+      cutAlg->setProperty("BasisVector" + boost::lexical_cast<std::string>(i),
+                          value);
+    }
+
+    // Translate extents into a single vector
+    std::vector<double> outExtents(steppedExtents.size() * 2);
+    for (size_t i = 0; i < steppedExtents.size(); ++i) {
+      outExtents[2 * i] = steppedExtents[i].first;
+      outExtents[2 * i + 1] = steppedExtents[i].second;
+    }
+
+    cutAlg->setProperty("OutputExtents", outExtents);
+    cutAlg->setProperty("OutputBins", steppedBins);
+
+    cutAlg->execute();
+    sliceWS = cutAlg->getProperty("OutputWorkspace");
+
+    MultipleExperimentInfos_sptr sliceInfo =
+        boost::dynamic_pointer_cast<MultipleExperimentInfos>(sliceWS);
+
+    if (!sliceInfo)
+      throw std::runtime_error(
+          "Could not extract experiment info from child's OutputWorkspace");
+
+    // Attach projection matrix to output
+    if (sliceInfo->getNumExperimentInfo() > 0) {
+      ExperimentInfo_sptr info = sliceInfo->getExperimentInfo(0);
+      info->mutableRun().addProperty("W_MATRIX", projectionMatrix.getVector(),
+                                     true);
+    }
   }
 
   auto geometry = boost::dynamic_pointer_cast<Mantid::API::MDGeometry>(sliceWS);
 
-  /* Original workspace and transformation information does not make sense for self-contained Horace-style
+  /* Original workspace and transformation information does not make sense for
+   * self-contained Horace-style
    * cuts, so clear it out. */
   geometry->clearTransforms();
   geometry->clearOriginalWorkspaces();

--- a/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
@@ -156,7 +156,7 @@ Output:
 
 Output:
 
-.. testoutput:: ExampleMDhisto
+.. testoutput:: ExampleMDHisto
 
    Total signal in input = 100.00
    Half the volume should give half the signal = 50.00

--- a/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
@@ -10,9 +10,7 @@ Description
 -----------
 
 This algorithm performs slicing of multiDimensional data according to a chosen
-projection, and binning choice. The algorithm uses :ref:`algm-BinMD` or
-:ref:`algm-SliceMD` to achieve the binning of the data. The choice of child
-algorithm used for the slicing is controlled by the NoPix option.
+projection, limits and binning steps. 
 
 The synax is similar to that used by `Horace <http://horace.isis.rl.ac.uk/Manipulating_and_extracting_data_from_SQW_files_and_objects#cut_sqw>`__.
 
@@ -22,6 +20,19 @@ or the path to a workspace, or simply a workspace object in python. These will
 all then be processed sequentially with the same options. The only requirement
 is that the same number of output workspaces are also given so that CutMD knows
 what to call each output workspace created.
+
+MDEventWorkspaces
+~~~~~~~~~~~~~~~~~~~
+
+For input of type :ref:`MDEventWorkspace <MDWorkspace>` the algorithm uses :ref:`algm-BinMD` or
+:ref:`algm-SliceMD` to achieve the binning of the data. The choice of child
+algorithm used for slicing in this case is controlled by the NoPix option. 
+
+MDHistoWorkspaces
+~~~~~~~~~~~~~~~~~~~
+
+If the input is an :ref:`MDHistoWorkspace <MDHistoWorkspace>` :ref:`algm-BinMD` and :ref:`algm-SliceMD` are not made available as they needto get hold of the original MDEvents associated with an :ref:`MDEventWorkspace <MDWorkspace>` in order to perform the rebinning. As this information is missing from the MDHistoWorkspace images, those operations are forbidden. Instead, a limited subset of the operations are allowed, and are performed via :ref:`algm-IntegrateMDHistoWorkspace`. In this case, the Projection and NoPix properties are ignored. See :ref:`algm-IntegrateMDHistoWorkspace` for how the binning parameters are used.
+
 
 Creating Projections
 ~~~~~~~~~~~~~~~~~~~~

--- a/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CutMD-v1.rst
@@ -138,5 +138,27 @@ Output:
    number of dimensions not integrated 3
    min dE 5.0
    max dE -5.0
+   
+**Example - CutMD on MDHistoWorkspace:**
 
+.. testcode:: ExampleMDHisto
+
+   signal  = [1.0] * 100;
+   error=[1.0] * 100;
+   # Create Histo workspace
+   histo_ws=CreateMDHistoWorkspace(Dimensionality=2,Extents=[-10,10,-10,10],SignalInput=signal ,ErrorInput=error, NumberOfBins=[10,10], Names='X,Y', Units='Q,Q')
+              
+   # Cut the MDHistoWorkspace to give a single bin containing half the data              
+   cut= CutMD(InputWorkspace=histo_ws, PBins=[[-10, 10], [-5, 5]]) 
+
+   print 'Total signal in input = %0.2f' %  sum(signal)
+   print 'Half the volume should give half the signal = %0.2f' % cut.getSignalArray()
+
+Output:
+
+.. testoutput:: ExampleMDhisto
+
+   Total signal in input = 100.00
+   Half the volume should give half the signal = 50.00
+   
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/SliceMDHisto-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SliceMDHisto-v1.rst
@@ -9,7 +9,7 @@
 Description
 -----------
 
-SliceMDHisto extracts a hyperslab of data from a MDHistoWorkspace. Beyond 
+SliceMDHisto extracts a hyperslab of data from a :ref:`MDHistoWorkspace <MDHistoWorkspace>`. Beyond 
 the usual input and output workspace parameters, the start and end of the
 hyperslabs dimensions are required. Both  as comma separated lists with an 
 entry for each dimension of the MDHistoWorkspace. 
@@ -18,6 +18,8 @@ Example: consider an input MDHistoWorkspace with dimensions 100,100,100.
 Running SliceMDHisto with parameters Start= 20,20,20 and End= 50,50,100 
 will copy all the data between x: 20-50, y: 20-50, z:20-100 into the 
 result MDHistoWorkspace with dimensions 30,30,80.
+
+For a more up-to-date way of performing slices on a :ref:`MDHistoWorkspace <MDHistoWorkspace>` this see :ref:`algm-IntegrateMDHistoWorkspace`
 
 Usage
 -----


### PR DESCRIPTION
See original issue [#11572](http://trac.mantidproject.org/mantid/ticket/11572) this gives [CutMD](http://docs.mantidproject.org/nightly/algorithms/CutMD-v1.html) the capability to perform lower dimensional cuts via [IntegrateMDHistoWorkspace](http://docs.mantidproject.org/nightly/algorithms/IntegrateMDHistoWorkspace-v1.html). The workflow for this has been provided by Russell Ewings.

**Tester**
- Check the changes
- Ensure tests pass

This should be sufficient. I've also updated the documentation and provided a new usage example.
