### PR TITLE
Skip missing runs

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -198,8 +198,10 @@ void PlotAsymmetryByLogValue::exec() {
       // Load run, apply dead time corrections and detector grouping
       Workspace_sptr loadedWs = doLoad(i);
 
-      // Analyse loadedWs
-      doAnalysis (loadedWs, i);
+      if ( loadedWs ) {
+        // Analyse loadedWs
+        doAnalysis (loadedWs, i);
+      }
     }
 
     progress.report();
@@ -367,6 +369,12 @@ Workspace_sptr PlotAsymmetryByLogValue::doLoad (int64_t runNumber ) {
   std::ostringstream fn, fnn;
   fnn << std::setw(g_filenameZeros) << std::setfill('0') << runNumber;
   fn << g_filenameBase << fnn.str() << g_filenameExt;
+
+  // Check if file exists
+  if ( !Poco::File(fn.str()).exists() ) {
+    g_log.warning() << "File " << fn.str() << " not found" << std::endl;
+    return Workspace_sptr();
+  }
 
   // Load run
   IAlgorithm_sptr load = createChildAlgorithm("LoadMuonNexus");


### PR DESCRIPTION
Fixes [#11624](http://trac.mantidproject.org/mantid/ticket/11624)

To test: PlotAsymmetryByLogValue loads a set of runs given by the first run number and the last run number. Sometimes one of the runs in the set may be missing, but scientists would like to continue with the analysis. This is a simple fix and I think code review should be enough, but you can test this branch by running PlotAsymmetryByLogValue with "MUSR00015189.nxs" as "First run" and "MUSR00015193.nxs" as "Last Run". Before running the algorithm, move temporarily one of the other files (for instance MUSR00015191.nxs") to a different directory and check that a warning message indicating that the run was not found is shown.
