### PR TITLE
Use CutMD in the VSI

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/SlicingAlgorithmDialog.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/SlicingAlgorithmDialog.cpp
@@ -442,12 +442,12 @@ namespace MantidQt
       ui.file_backend_layout->setVisible(false);
 
       // Output workspace
-      ui.lbl_workspace_output->setVisible(false);
-      ui.txt_output->setVisible(false);
+      ui.lbl_workspace_output->setDisabled(true);
+      ui.txt_output->setDisabled(true);
 
       // Input workspace
-      ui.workspace_selector->setVisible(false);
-      ui.lbl_workspace_input->setVisible(false);
+      ui.workspace_selector->setDisabled(true);
+      ui.lbl_workspace_input->setDisabled(true);
 
       // Reset the input workspace
       ui.workspace_selector->clear();

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h
@@ -51,22 +51,21 @@ namespace Mantid
 
           void showDialog(std::string inputWorkspace, std::string outputWorkspace, std::string algorithmType);
 
-        private:
-          MantidQt::API::AlgorithmDialog* createDialog(Mantid::API::IAlgorithm_sptr algorithm, std::string inputWorkspace, std::string outputWorkspace, std::string algorithmType);
+           static const size_t BinCutOffValue;
 
-          void getPresetsForSliceMDAlgorithmDialog( std::string inputWorkspace, std::string outputWorkspace, QHash<QString, QString>& presets);
+        private:
+          MantidQt::API::AlgorithmDialog* createDialog(Mantid::API::IAlgorithm_sptr algorithm, const std::string& inputWorkspace, const std::string& outputWorkspace, const std::string& algorithmType);
 
           void setAxisDimensions(MantidQt::MantidWidgets::SlicingAlgorithmDialog* dialog,  std::string inputWorkspace);
 
-          Mantid::API::IMDEventWorkspace_sptr getWorkspace(std::string workspaceName);
+          Mantid::API::IMDEventWorkspace_sptr getWorkspace(const std::string& workspaceName);
 
           Mantid::API::IAlgorithm_sptr createAlgorithm(const std::string& algName, int version);
 
           Mantid::VATES::ADSWorkspaceProvider<Mantid::API::IMDEventWorkspace> m_adsWorkspaceProvider;
 
-          QString m_lblInputWorkspace;
-          QString m_lblOutputWorkspace;
-          size_t m_binCutOffValue;
+          const QString m_lblInputWorkspace;
+          const QString m_lblOutputWorkspace;
           QWidget* m_parent;
       };
 

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
@@ -88,9 +88,7 @@ protected slots:
   /// Invoke the ScaleWorkspace on the current dataset.
   void onScaleButtonClicked();
   /// On BinMD button clicked
-  void onBinMD();
-  /// On SliceMD button clicked
-  void onSliceMD();
+  void onRebin();
 
 private:
   Q_DISABLE_COPY(StandardView)
@@ -104,9 +102,14 @@ private:
   void setRebinAndUnbinButtons();
   /// Set up the buttons
   void setupViewButtons();
+  ///  Give the user the ability to rebin
+  void allowRebinningOptions(bool allow);
+  ///  Allow the user the ability to unbin
+  void allowUnbinOption(bool allow);
 
   QAction* m_binMDAction;
   QAction* m_sliceMDAction;
+  QAction* m_cutMDAction;
   QAction* m_unbinAction;
 };
 

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
@@ -219,7 +219,7 @@ signals:
    */
   void unbin();
   /**
-   * Singal to tell other elements that the log scale was altered programatically
+   * Signal to tell other elements that the log scale was altered programatically
    * @param state flag wheter or not to enable the 
    */
   void setLogScale(bool state);

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -43,6 +43,7 @@ namespace SimpleGui
  */
   StandardView::StandardView(QWidget *parent) : ViewBase(parent),m_binMDAction(NULL),
                                                                  m_sliceMDAction(NULL),
+                                                                 m_cutMDAction(NULL),
                                                                  m_unbinAction(NULL)
 {
   this->ui.setupUi(this);
@@ -77,6 +78,7 @@ StandardView::~StandardView()
 
 void StandardView::setupViewButtons()
 {
+
   // Populate the rebin button
   QMenu* rebinMenu = new QMenu(this->ui.rebinToolButton);
 
@@ -86,21 +88,26 @@ void StandardView::setupViewButtons()
   m_sliceMDAction = new QAction("SliceMD", rebinMenu);
   m_sliceMDAction->setIconVisibleInMenu(false);
 
+  m_cutMDAction = new QAction("CutMD", rebinMenu);
+  m_cutMDAction->setIconVisibleInMenu(false);
 
   m_unbinAction = new QAction("Remove Rebinning", rebinMenu);
   m_unbinAction->setIconVisibleInMenu(false);
 
   rebinMenu->addAction(m_binMDAction);
   rebinMenu->addAction(m_sliceMDAction);
+  rebinMenu->addAction(m_cutMDAction);
   rebinMenu->addAction(m_unbinAction);
 
   this->ui.rebinToolButton->setPopupMode(QToolButton::InstantPopup);
   this->ui.rebinToolButton->setMenu(rebinMenu);
 
   QObject::connect(m_binMDAction, SIGNAL(triggered()),
-                   this, SLOT(onBinMD()), Qt::QueuedConnection);
+                   this, SLOT(onRebin()), Qt::QueuedConnection);
   QObject::connect(m_sliceMDAction, SIGNAL(triggered()),
-                   this, SLOT(onSliceMD()), Qt::QueuedConnection);
+                   this, SLOT(onRebin()), Qt::QueuedConnection);
+  QObject::connect(m_cutMDAction, SIGNAL(triggered()),
+                   this, SLOT(onRebin()), Qt::QueuedConnection);
   // Set the unbinbutton to remove the rebinning on a workspace
   // which was binned in the VSI
   QObject::connect(m_unbinAction, SIGNAL(triggered()),
@@ -252,55 +259,50 @@ void StandardView::setRebinAndUnbinButtons()
   {
     if (isTemporaryWorkspace(*source))
     {
-      numberOfTemporaryWorkspaces++;
+      ++numberOfTemporaryWorkspaces;
     } else if (isMDHistoWorkspace(*source))
     {
-      numberOfTrueMDHistoWorkspaces++;
+      ++numberOfTrueMDHistoWorkspaces;
     }
     else if (isPeaksWorkspace(*source))
     {
-      numberOfPeakWorkspaces++;
+      ++numberOfPeakWorkspaces;
     }
   }
 
   // If there are any true MDHisto workspaces then the rebin button should be disabled
-  if (numberOfTrueMDHistoWorkspaces > 0 || numberOfPeakWorkspaces > 0)
-  {
-    this->m_binMDAction->setEnabled(false);
-    this->m_sliceMDAction->setEnabled(false);
-  }
-  else 
-  {
-    this->m_binMDAction->setEnabled(true);
-    this->m_sliceMDAction->setEnabled(true);
-  }
+  bool allowRebinning = numberOfTrueMDHistoWorkspaces > 0 || numberOfPeakWorkspaces > 0;
+  this->allowRebinningOptions(allowRebinning);
 
   // If there are no temporary workspaces the button should be disabled.
-  if (numberOfTemporaryWorkspaces == 0)
-  {
-    this->m_unbinAction->setEnabled(false);
-  }
-  else
-  {
-    this->m_unbinAction->setEnabled(true);
-  }
+  const bool allowUnbin = !( numberOfTemporaryWorkspaces == 0 );
+  allowUnbinOption(allowUnbin);
 }
 
 
 /**
  * Reacts to the user selecting the BinMD algorithm
  */ 
-void StandardView::onBinMD()
+void StandardView::onRebin()
 {
-  emit rebin("BinMD");
+  if(QAction* action = dynamic_cast<QAction*>(sender())) {
+    emit rebin(action->text().toStdString()); }
 }
 
 /**
- * Reacts to the user selecting the SliceMD algorithm
- */ 
-void StandardView::onSliceMD()
-{
-  emit rebin("SliceMD");
+Disable rebinning options
+*/
+void StandardView::allowRebinningOptions(bool allow) {
+    this->m_binMDAction->setEnabled(allow);
+    this->m_sliceMDAction->setEnabled(allow);
+    this->m_cutMDAction->setEnabled(allow);
+}
+
+/**
+Enable unbin option
+*/
+void StandardView::allowUnbinOption(bool allow) {
+  this->m_unbinAction->setEnabled(allow);
 }
 
 
@@ -313,8 +315,7 @@ void StandardView::activeSourceChangeListener(pqPipelineSource* source)
   // If there is no active source, then we do not allow rebinning
   if (!source)
   {
-    this->m_binMDAction->setEnabled(false);
-    this->m_sliceMDAction->setEnabled(false);
+    this->allowRebinningOptions(false);
     this->m_unbinAction->setEnabled(false);
     return;
   }
@@ -334,21 +335,18 @@ void StandardView::activeSourceChangeListener(pqPipelineSource* source)
   std::string workspaceType(localSource->getProxy()->GetXMLName());
   if (isTemporaryWorkspace(localSource))
   {
-    this->m_binMDAction->setEnabled(true);
-    this->m_sliceMDAction->setEnabled(true);
-    this->m_unbinAction->setEnabled(true);
+    this->allowRebinningOptions(true);
+    this->allowUnbinOption(true);
   }
   else if (workspaceType.find("MDEW Source") != std::string::npos)
   {
-    this->m_binMDAction->setEnabled(true);
-    this->m_sliceMDAction->setEnabled(true);
-    this->m_unbinAction->setEnabled(false);
+    this->allowRebinningOptions(true);
+    this->allowUnbinOption(true);
   }
   else
   {
-    this->m_binMDAction->setEnabled(false);
-    this->m_sliceMDAction->setEnabled(false);
-    this->m_unbinAction->setEnabled(false);
+    this->allowRebinningOptions(false);
+    this->allowUnbinOption(false);
   }
 }
 


### PR DESCRIPTION
see original ticket [here](http://trac.mantidproject.org/mantid/ticket/11630)

**tester** The cutmd option should work in a similar way to the existing binmd and slicemd options. Original behaviour for those options should be unchanged. 

1) Load the MDEvent_Osiris dataset
2) Run this in MantidPlot

``` python
p = Projection()
p.u = [1,1,0]
p.v = [-1,1,0]
p.createWorkspace('proj')
```

3) Load the MDEventWorkspace in the VSI
4) Rebin the Workspace via CutMD just set the first 3 entries to be 0.1 and the 4th to be 1. Leave projection blank. Set cube axis shown.
5) Unbin
6) Do the same as 4 but set the projection to be proj. You will see that the data has been rotated 45 degrees.
