### PR TITLE
Improve colour map interaction

### DIFF
--- a/Code/Mantid/MantidPlot/src/PlotDialog.h
+++ b/Code/Mantid/MantidPlot/src/PlotDialog.h
@@ -165,6 +165,8 @@ private:
 
   void showAllLabelControls(bool show = true);
 
+  void setColorMapName();
+
   double aspect_ratio;
 
   QFont titleFont, legendFont, axesFont, numbersFont;
@@ -179,11 +181,12 @@ private:
 
   QPushButton *btnTitle, *btnAxesLabels, *btnAxesNumbers, *btnLegend;
   ColorMapEditor *colorMapEditor;
+  QLabel *mLabelCurrentColormap;
   QPushButton* mSelectColormap;
   QString mCurrentColorMap;
   QWidget *curvePlotTypeBox, *layerPage, *layerGeometryPage, *piePage, *fontsPage, *printPage, *contourLinesPage;
   QTreeWidget* listBox;
-  QCheckBox *boxAntialiasing, *boxAll, *boxScaleLayers, *boxPrintCrops;
+  QCheckBox *boxAntialiasing, *boxAll, *boxScaleLayers, *boxPrintCrops, *boxSetCMapAsDefault;
   ColorButton *boxBorderColor, *boxBackgroundColor, *boxCanvasColor, *boxCanvasFrameColor;
   QSpinBox *boxBackgroundTransparency, *boxCanvasTransparency, *boxBorderWidth, *boxMargin, *boxCanvasFrameWidth;
   QSpinBox *boxRadius;

--- a/Code/Mantid/MantidPlot/src/Spectrogram.cpp
+++ b/Code/Mantid/MantidPlot/src/Spectrogram.cpp
@@ -423,25 +423,11 @@ void Spectrogram::setGrayScale()
 
 void Spectrogram::setDefaultColorMap()
 {
-  // option 1 use last used colour map
-  QSettings settings;
-  settings.beginGroup("Mantid/2DPlotSpectrogram");
-  //Load Colormap. If the file is invalid the default stored colour map is used
-  QString lastColormapFile = settings.value("ColormapFile", "").toString();
-  settings.endGroup();
-
-  if (lastColormapFile.size() > 0)
-  {
-      mCurrentColorMap = lastColormapFile;
-      mColorMap.loadMap(lastColormapFile);
-  }
-  else
-  {
-    //option 2 use the default colormap from MantidColorMap.
-    mColorMap.setupDefaultMap();
-  }
+  MantidColorMap map = getDefaultColorMap();
   
-  setColorMap(mColorMap);
+  mCurrentColorMap = map.getFilePath();
+  mColorMap = map;
+  setColorMap(map);
       
   color_map_policy = Default;
 
@@ -453,6 +439,22 @@ void Spectrogram::setDefaultColorMap()
   if (colorAxis)
     colorAxis->setColorMap(this->data().range(), this->colorMap());
 
+}
+
+
+MantidColorMap Spectrogram::getDefaultColorMap()
+{
+  
+  QSettings settings;
+  settings.beginGroup("Mantid/2DPlotSpectrogram");
+  //Load Colormap. If the file is invalid the default stored colour map is used
+  QString lastColormapFile = settings.value("ColormapFile", "").toString();
+  settings.endGroup();
+
+  //if the file is not valid you will get the default
+  MantidColorMap retColorMap(lastColormapFile,GraphOptions::Linear);
+
+  return retColorMap;
 }
 
 void Spectrogram::loadColorMap(const QString& file)

--- a/Code/Mantid/MantidPlot/src/Spectrogram.h
+++ b/Code/Mantid/MantidPlot/src/Spectrogram.h
@@ -106,6 +106,7 @@ public:
 
   void setGrayScale();
   void setDefaultColorMap();
+  MantidColorMap getDefaultColorMap();
   static QwtLinearColorMap defaultColorMap();
 
   void loadColorMap(const QString& file);

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidColorMap.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidColorMap.h
@@ -70,6 +70,24 @@ public:
     return m_scale_type;
   }
 
+   /**
+   * Retrieve the map name
+   * @returns the map name
+   */
+  QString getName() const
+  {
+    return m_name;
+  }
+
+  /**
+   * Retrieve the map name
+   * @returns the map name
+   */
+  QString getFilePath() const
+  {
+    return m_path;
+  }
+
   /**
    * Get the number of colors in this map
    */
@@ -105,6 +123,11 @@ private:
   /// Cached NAN value
   double m_nan;
 
+  ///the name of the color map
+  QString m_name;
+
+  ///the path to the map file
+  QString m_path;
 };
 
 

--- a/Code/Mantid/MantidQt/API/src/MantidColorMap.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidColorMap.cpp
@@ -32,7 +32,7 @@ namespace
  * Default
  */
 MantidColorMap::MantidColorMap() : QwtColorMap(QwtColorMap::Indexed), m_scale_type(GraphOptions::Log10),
-				     m_colors(0), m_num_colors(0)
+				     m_colors(0), m_num_colors(0), m_name(), m_path()
 {
   m_nan = std::numeric_limits<double>::quiet_NaN();
   this->setNanColor(255,255,255);
@@ -46,7 +46,7 @@ MantidColorMap::MantidColorMap() : QwtColorMap(QwtColorMap::Indexed), m_scale_ty
  * @param type :: The scale type, currently Linear or Log10 
  */
 MantidColorMap::MantidColorMap(const QString & filename, GraphOptions::ScaleType type) : 
-  QwtColorMap(QwtColorMap::Indexed), m_scale_type(type), m_colors(0), m_num_colors(0)
+  QwtColorMap(QwtColorMap::Indexed), m_scale_type(type), m_colors(0), m_num_colors(0), m_name(), m_path()
 {
   m_nan = std::numeric_limits<double>::quiet_NaN();
   this->setNanColor(255,255,255);
@@ -132,7 +132,12 @@ bool MantidColorMap::loadMap(const QString & filename)
     m_colors = new_colormap;
     if (m_num_colors > 1)
       m_colors[0] = m_nan_color;
+    m_path = filename;
+    //set the name of the color map to the filename
+    QFileInfo fileinfo(filename);
+    m_name=fileinfo.baseName(); 
   } 
+
   return is_success;
 }
 
@@ -210,6 +215,7 @@ void MantidColorMap::setupDefaultMap()
 
   m_colors.clear();
   m_num_colors = 256;
+  m_name = QString::fromStdString("Default");
 
   std::stringstream colorstream(colorstring);
   float red(0.0f), green(0.0f), blue(0.0f);


### PR DESCRIPTION
Ticket 
http://trac.mantidproject.org/mantid/ticket/11629
### To test

Note this should only affect 2D color map plots
1. start mantidplot
2. load up some data (& rebin if event)
3. Create a color map plot
4. Double click within the plot data
5. Select Layer Details
6. Pick the colors tab
7. Play with the image colour options
8. check you can set all of the options, and for custom color maps you can set them as the default.
9. check the default is applied to new colour maps and is persisted if mantidplot closes.
