### PR TITLE
Use IntegrateMDHistoWorkspace in lineviewer when able

### DIFF
--- a/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -419,14 +419,10 @@ LineViewer::applyMDWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
       if (static_cast<int>(i) == axis) {
         // For the axes we're integrating along we want to re-use the existing
         // binning, rather than peforming another rebin.
-        // TODO: We can't actually do this *yet* so pass in nothing
-
-        /////////////////// F I X    M E    P L E A S E  //////////////////////
-
-        /* const double start = m_start[axis]; */
-        /* const double end = m_end[axis]; */
-        /* const double binWidth = (end - start) / static_cast<double>(m_numBins); */
-        /* pbin[i] << start << "," << binWidth << "," << end; */
+        const double start = m_start[axis];
+        const double end = m_end[axis];
+        const double binWidth = 0; // 0 denotes re-use existing widths
+        pbin[i] << start << "," << binWidth << "," << end;
       } else {
         // For other axes, the range is the value ± half the thickness
         const double base = m_start[i];


### PR DESCRIPTION
This is for trac ticket [#11626](http://trac.mantidproject.org/mantid/ticket/11626)

**Testing**:

```
CreateMDWorkspace(Dimensions=4, Extents='-10,10,-10,10,-10,10,-10,10', Names='a,b,c,d', Units='u,u,u,u', OutputWorkspace='ws')
FakeMDEventData(InputWorkspace='ws', PeakParams='10000,0,0,0,0,1')
CutMD(InputWorkspace='ws', P1Bin='1', P2Bin='1', P3Bin='1', P4Bin='1', OutputWorkspace='ws2', NoPix=True)
```
- Open the sliceviewer for `ws2` and try making some axis-aligned cuts (hold shift to snap to axis). They should use `IntegrateMDHistoWorkspace` and succeed.
