### PR TITLE
Fixed tabbing and annulus beam size on IDA CalcCorr

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CalcCorr.ui
@@ -456,7 +456,17 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius"/>
+           <widget class="QDoubleSpinBox" name="spAnnSampleInnerRadius">
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>9999.989999999999782</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -677,9 +687,14 @@
   <tabstop>spFlatSampleAngle</tabstop>
   <tabstop>spFlatCanFrontThickness</tabstop>
   <tabstop>spFlatCanBackThickness</tabstop>
+  <tabstop>spCylSampleOuterRadius</tabstop>
+  <tabstop>spCylCanOuterRadius</tabstop>
   <tabstop>spCylBeamHeight</tabstop>
   <tabstop>spCylBeamWidth</tabstop>
   <tabstop>spCylStepSize</tabstop>
+  <tabstop>spAnnSampleInnerRadius</tabstop>
+  <tabstop>spAnnSampleOuterRadius</tabstop>
+  <tabstop>spAnnCanOuterRadius</tabstop>
   <tabstop>spAnnBeamHeight</tabstop>
   <tabstop>spAnnBeamWidth</tabstop>
   <tabstop>spAnnStepSize</tabstop>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -302,8 +302,12 @@ namespace IDA
     {
       QString beamWidth = QString::fromStdString(instrument->getStringParameter(paramName)[0]);
       double beamWidthValue = beamWidth.toDouble();
+
       m_uiForm.spCylBeamWidth->setValue(beamWidthValue);
       m_uiForm.spCylBeamHeight->setValue(beamWidthValue);
+
+      m_uiForm.spAnnBeamWidth->setValue(beamWidthValue);
+      m_uiForm.spAnnBeamHeight->setValue(beamWidthValue);
     }
   }
 


### PR DESCRIPTION
Fixes [#11622](http://trac.mantidproject.org/mantid/ticket/11622).

To test:
- Open IDA > CalcCorr
- Check tabbing works as expected
- Load `irs26176_graphite002_red.nxs` (should be in any test data folder)
- For Annulus and Cylinder the default beam size should be set
