### PR TITLE
Clean efixed parameters in indirect IPFs

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
@@ -159,16 +159,13 @@ class IndirectTransmission(PythonAlgorithm):
         """
         from IndirectCommon import getEfixed
 
-        ws = mtd[workspace]
-
-        # Try to get efixed from the parameters first
         try:
-            efixed = getEfixed(ws)
-        except IndexError:
-            efixed = 0.0
+            # Try to get efixed from the parameters first
+            efixed = getEfixed(workspace)
 
-        # If that fails then get it by taking from group of all detectors
-        if efixed == 0.0:
+        except ValueError:
+            # If that fails then get it by taking from group of all detectors
+            ws = mtd[workspace]
             spectra_list = range(0, ws.getNumberHistograms())
             GroupDetectors(InputWorkspace=workspace,
                            OutputWorkspace=workspace,

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/IndirectTransmission.py
@@ -157,13 +157,13 @@ class IndirectTransmission(PythonAlgorithm):
         @param workspace Name of workspace to extract from
         @return Fixed energy value
         """
+        from IndirectCommon import getEfixed
 
         ws = mtd[workspace]
 
         # Try to get efixed from the parameters first
         try:
-            instrument = ws.getInstrument()
-            efixed = instrument.getNumberParameter('efixed-val')[0]
+            efixed = getEfixed(ws)
         except IndexError:
             efixed = 0.0
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
@@ -205,7 +205,8 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
                     efixed = 0.0
                 elif unit_id == 'DeltaE':
                     emode = 'Indirect'
-                    efixed = instrument.getNumberParameter('efixed-val')[0]
+                    from IndirectCommon import getEfixed
+                    efixed = getEfixed(mtd[self._sample_ws_name])
                 else:
                     raise ValueError('Unit %s in sample workspace is not supported' % unit_id)
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -233,8 +233,8 @@ namespace CustomInterfaces
     m_uiForm.spSpectraMax->setMaximum(specMax);
     m_uiForm.spSpectraMax->setValue(specMax);
 
-    if(!instDetails["efixed-val"].isEmpty())
-      m_uiForm.leEfixed->setText(instDetails["efixed-val"]);
+    if(!instDetails["Efixed"].isEmpty())
+      m_uiForm.leEfixed->setText(instDetails["Efixed"]);
     else
       m_uiForm.leEfixed->clear();
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReduction.cpp
@@ -258,7 +258,7 @@ std::map<QString, QString> IndirectDataReduction::getInstrumentDetails()
   ipfElements.push_back("analysis-type");
   ipfElements.push_back("spectra-min");
   ipfElements.push_back("spectra-max");
-  ipfElements.push_back("efixed-val");
+  ipfElements.push_back("Efixed");
   ipfElements.push_back("peak-start");
   ipfElements.push_back("peak-end");
   ipfElements.push_back("back-start");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReduction.cpp
@@ -294,7 +294,7 @@ std::map<QString, QString> IndirectDataReduction::getInstrumentDetails()
       QString value = getInstrumentParameterFrom(instrument, key);
 
       if(value.isEmpty() && component != NULL)
-        QString value = getInstrumentParameterFrom(component, key);
+        value = getInstrumentParameterFrom(component, key);
 
       instDetails[QString::fromStdString(key)] = value;
     }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -85,7 +85,7 @@ namespace CustomInterfaces
     }
 
     // Get correct S(Q, w) algorithm
-    QString eFixed = getInstrumentDetails()["efixed-val"];
+    QString eFixed = getInstrumentDetails()["Efixed"];
 
     IAlgorithm_sptr sqwAlg;
     QString rebinType = m_uiForm.cbRebinType->currentText();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -394,10 +394,21 @@ namespace CustomInterfaces
     if(!inst)
       throw std::runtime_error("No instrument on workspace");
 
-    if(!inst->hasParameter("Efixed"))
-      throw std::runtime_error("Instrument has no efixed parameter");
+    // Try to get the parameter form the base instrument
+    if(inst->hasParameter("Efixed"))
+      return inst->getNumberParameter("Efixed")[0];
 
-    return inst->getNumberParameter("Efixed")[0];
+    // Try to get it form the analyser component
+    if(inst->hasParameter("analyser"))
+    {
+      std::string analyserName = inst->getStringParameter("analyser")[0];
+      auto analyserComp = inst->getComponentByName(analyserName);
+
+      if(analyserComp && analyserComp->hasParameter("Efixed"))
+        return analyserComp->getNumberParameter("Efixed")[0];
+    }
+
+    throw std::runtime_error("Instrument has no efixed parameter");
   }
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -394,10 +394,10 @@ namespace CustomInterfaces
     if(!inst)
       throw std::runtime_error("No instrument on workspace");
 
-    if(!inst->hasParameter("efixed-val"))
+    if(!inst->hasParameter("Efixed"))
       throw std::runtime_error("Instrument has no efixed parameter");
 
-    return inst->getNumberParameter("efixed-val")[0];
+    return inst->getNumberParameter("Efixed")[0];
   }
 
 

--- a/Code/Mantid/instrument/BASIS_silicon_111_Parameters.xml
+++ b/Code/Mantid/instrument/BASIS_silicon_111_Parameters.xml
@@ -3,56 +3,55 @@
 
 <component-link name = "BASIS">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+  <parameter name="analysis-type" type="string">
+    <value val="spectroscopy" />
+  </parameter>
 
-<parameter name="spectra-min">
-	<value val="1" />
-</parameter>
+  <parameter name="spectra-min">
+    <value val="1" />
+  </parameter>
 
-<!--FIXME: This spectrum max should be bigger -->
-<parameter name="spectra-max">
-	<value val="16385" />
-</parameter>
+  <!--FIXME: This spectrum max should be bigger -->
+  <parameter name="spectra-max">
+    <value val="16385" />
+  </parameter>
 
-<parameter name="efixed-val">
-	<value val="2.082" />
-</parameter>
+  <parameter name="peak-start">
+    <value val="140400" />
+  </parameter>
 
-<parameter name="peak-start">
-	<value val="140400" />
-</parameter>
+  <parameter name="peak-end">
+    <value val="141000" />
+  </parameter>
 
-<parameter name="peak-end">
-	<value val="141000" />
-</parameter>
+  <parameter name="back-start">
+    <value val="136500" />
+  </parameter>
 
-<parameter name="back-start">
-	<value val="136500" />
-</parameter>
+  <parameter name="back-end">
+    <value val="138000" />
+  </parameter>
 
-<parameter name="back-end">
-	<value val="138000" />
-</parameter>
+  <parameter name="analyser" type="string">
+    <value val="silicon" />
+  </parameter>
 
-<parameter name="analyser" type="string">
-  <value val="silicon" />
-</parameter>
-
-<parameter name="reflection" type="string">
-  <value val="111" />
-</parameter>
+  <parameter name="reflection" type="string">
+    <value val="111" />
+  </parameter>
 
 </component-link>
 
 <component-link name="silicon">
+
   <parameter name="Efixed">
     <value val="2.082" />
   </parameter>
+
   <parameter name="resolution">
     <value val="0.0035" />
   </parameter>
+
 </component-link>
 
 </parameter-file>

--- a/Code/Mantid/instrument/IN10_Definition.xml
+++ b/Code/Mantid/instrument/IN10_Definition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- For help on the notation used to specify an Instrument Definition File 
+<!-- For help on the notation used to specify an Instrument Definition File
      see http://www.mantidproject.org/IDF -->
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="IN10" valid-from   ="1900-01-31 23:59:59"
@@ -21,7 +21,7 @@
 </defaults>
 
 <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
-  
+
 <!-- source and sample-position components -->
 
 <component type="moderator">
@@ -63,18 +63,17 @@
       <right-front-bottom-point  x="0.0125" y="0.0125" z="0.0"  />
     </cuboid>
     <algebra val="shape" />
-  </type>  
+  </type>
 
   <idlist idname="monitor1">
-    <id val="8" />  
+    <id val="8" />
   </idlist>
-  
+
 <!--  detector components -->
 
 <component type="silicon" idlist="silicon">
   <properties />
   <parameter name="Efixed"> <value val="2.08" /> </parameter>
-  <parameter name="efixed-val">	<value val="2.08" /></parameter>
   <location  />
 </component>
 

--- a/Code/Mantid/instrument/IN10_silicon_111_Parameters.xml
+++ b/Code/Mantid/instrument/IN10_silicon_111_Parameters.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "IN10" valid-from = "2010-07-15T00:00:00">
 
-<component-link name = "IN10">
+  <component-link name = "IN10">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="efixed-val">
-	<value val="2.082" />
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
 
+    <parameter name="reflection" type="string">
+      <value val="111" />
+    </parameter>
 
+  </component-link>
 
-<parameter name="analyser" type="string">
-  <value val="silicon" />
-</parameter>
-
-<parameter name="reflection" type="string">
-  <value val="111" />
-</parameter>
-
-</component-link>
   <component-link name="silicon">
     <parameter name="Efixed"> <value val="2.082" /> </parameter>
     <parameter name="resolution"> <value val="0.001" /> </parameter>

--- a/Code/Mantid/instrument/IN10_silicon_311_Parameters.xml
+++ b/Code/Mantid/instrument/IN10_silicon_311_Parameters.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "IN10" valid-from = "2010-07-15T00:00:00">
 
-<component-link name = "IN10">
+  <component-link name = "IN10">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="efixed-val">
-	<value val="7.627" />
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
 
+    <parameter name="reflection" type="string">
+      <value val="311" />
+    </parameter>
 
+  </component-link>
 
-<parameter name="analyser" type="string">
-  <value val="silicon" />
-</parameter>
-
-<parameter name="reflection" type="string">
-  <value val="311" />
-</parameter>
-
-</component-link>
   <component-link name="silicon">
     <parameter name="Efixed"> <value val="7.627" /> </parameter>
     <parameter name="resolution"> <value val="0.002" /> </parameter>

--- a/Code/Mantid/instrument/IN13_CaF_422_Parameters.xml
+++ b/Code/Mantid/instrument/IN13_CaF_422_Parameters.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "IN13" valid-from = "2010-07-15T00:00:00">
 
-<component-link name = "IN13">
+  <component-link name = "IN13">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="efixed-val">
-	<value val="16.45" />
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="CaF" />
+    </parameter>
 
+    <parameter name="reflection" type="string">
+      <value val="422" />
+    </parameter>
 
+  </component-link>
 
-<parameter name="analyser" type="string">
-  <value val="CaF" />
-</parameter>
-
-<parameter name="reflection" type="string">
-  <value val="422" />
-</parameter>
-
-</component-link>
   <component-link name="silicon">
     <parameter name="Efixed"> <value val="16.45" /> </parameter>
     <parameter name="resolution"> <value val="0.008" /> </parameter>

--- a/Code/Mantid/instrument/IN13_Definition.xml
+++ b/Code/Mantid/instrument/IN13_Definition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- For help on the notation used to specify an Instrument Definition File 
+<!-- For help on the notation used to specify an Instrument Definition File
      see http://www.mantidproject.org/IDF -->
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="IN13" valid-from   ="1900-01-31 23:59:59"
@@ -21,7 +21,7 @@
 </defaults>
 
 <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
-  
+
 <!-- source and sample-position components -->
 
 <component type="moderator">
@@ -63,18 +63,17 @@
       <right-front-bottom-point  x="0.0125" y="0.0125" z="0.0"  />
     </cuboid>
     <algebra val="shape" />
-  </type>  
+  </type>
 
   <idlist idname="monitor1">
-    <id val="8" />  
+    <id val="8" />
   </idlist>
-  
+
 <!--  detector components -->
 
 <component type="CaF" idlist="CaF">
   <properties />
   <parameter name="Efixed"> <value val="16.45" /> </parameter>
-  <parameter name="efixed-val">	<value val="16.45" /></parameter>
   <location  />
 </component>
 

--- a/Code/Mantid/instrument/IN16B_silicon_111_Parameters.xml
+++ b/Code/Mantid/instrument/IN16B_silicon_111_Parameters.xml
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "IN16B" valid-from = "2014-05-06T00:00:00">
 
-<component-link name = "IN16B">
+  <component-link name = "IN16B">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="efixed-val">
-  <value val="2.082" />
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
 
+    <parameter name="reflection" type="string">
+      <value val="111" />
+    </parameter>
 
+  </component-link>
 
-  <parameter name="analyser" type="string">
-    <value val="silicon" />
-  </parameter>
+  <component-link name="silicon">
+    <parameter name="Efixed"> <value val="2.082" /> </parameter>
+    <parameter name="resolution"> <value val="0.0003" /> </parameter>
+  </component-link>
 
-  <parameter name="reflection" type="string">
-    <value val="111" />
-  </parameter>
-
-</component-link>
-<component-link name="silicon">
-  <parameter name="Efixed"> <value val="2.082" /> </parameter>
-  <parameter name="resolution"> <value val="0.0003" /> </parameter>
-</component-link>
 </parameter-file>

--- a/Code/Mantid/instrument/IN16_Definition.xml
+++ b/Code/Mantid/instrument/IN16_Definition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- For help on the notation used to specify an Instrument Definition File 
+<!-- For help on the notation used to specify an Instrument Definition File
      see http://www.mantidproject.org/IDF -->
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="IN16" valid-from   ="1900-01-31 23:59:59"
@@ -21,7 +21,7 @@
 </defaults>
 
 <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
-  
+
 <!-- source and sample-position components -->
 
 <component type="moderator">
@@ -63,18 +63,17 @@
       <right-front-bottom-point  x="0.0125" y="0.0125" z="0.0"  />
     </cuboid>
     <algebra val="shape" />
-  </type>  
+  </type>
 
   <idlist idname="monitor1">
-    <id val="19" />  
+    <id val="19" />
   </idlist>
-  
+
 <!--  detector components -->
 
 <component type="silicon" idlist="silicon">
   <properties />
   <parameter name="Efixed"> <value val="2.08" /> </parameter>
-  <parameter name="efixed-val">	<value val="2.08" /></parameter>
   <location  />
 </component>
 

--- a/Code/Mantid/instrument/IN16_silicon_111_Parameters.xml
+++ b/Code/Mantid/instrument/IN16_silicon_111_Parameters.xml
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "IN16" valid-from = "2010-07-15T00:00:00">
 
-<component-link name = "IN16">
+  <component-link name = "IN16">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="efixed-val">
-  <value val="2.082" />
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
 
+    <parameter name="reflection" type="string">
+      <value val="111" />
+    </parameter>
 
+  </component-link>
 
-  <parameter name="analyser" type="string">
-    <value val="silicon" />
-  </parameter>
+  <component-link name="silicon">
+    <parameter name="Efixed"> <value val="2.082" /> </parameter>
+    <parameter name="resolution"> <value val="0.0003" /> </parameter>
+  </component-link>
 
-  <parameter name="reflection" type="string">
-    <value val="111" />
-  </parameter>
-
-</component-link>
-<component-link name="silicon">
-  <parameter name="Efixed"> <value val="2.082" /> </parameter>
-  <parameter name="resolution"> <value val="0.0003" /> </parameter>
-</component-link>
 </parameter-file>

--- a/Code/Mantid/instrument/IN16_silicon_311_Parameters.xml
+++ b/Code/Mantid/instrument/IN16_silicon_311_Parameters.xml
@@ -1,29 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "IN16" valid-from = "2010-07-15T00:00:00">
 
-<component-link name = "IN16">
+  <component-link name = "IN16">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="efixed-val">
-	<value val="7.627"/>
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
 
+    <parameter name="reflection" type="string">
+      <value val="311" />
+    </parameter>
 
+  </component-link>
 
-  <parameter name="analyser" type="string">
-    <value val="silicon" />
-  </parameter>
+  <component-link name="silicon">
+    <parameter name="Efixed"> <value val="7.627" /> </parameter>
+    <parameter name="resolution"> <value val="0.002" /> </parameter>
+  </component-link>
 
-  <parameter name="reflection" type="string">
-    <value val="311" />
-  </parameter>
-
-</component-link>
-<component-link name="silicon">
-  <parameter name="Efixed"> <value val="7.627" /> </parameter>
-  <parameter name="resolution"> <value val="0.002" /> </parameter>
-</component-link>
 </parameter-file>

--- a/Code/Mantid/instrument/IRIS_fmica_002_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_fmica_002_Parameters.xml
@@ -15,10 +15,6 @@
 	<value val="104" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="0.2067" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="189000" />
 </parameter>
@@ -47,5 +43,5 @@
 <parameter name="Efixed"> <value val="0.2067" /> </parameter>
 <parameter name="resolution"> <value val="0.0012" /> </parameter>
 </component-link>
-  
+
 </parameter-file>

--- a/Code/Mantid/instrument/IRIS_fmica_006_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_fmica_006_Parameters.xml
@@ -15,10 +15,6 @@
 	<value val="104" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="1.8567" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="62500" />
 </parameter>

--- a/Code/Mantid/instrument/IRIS_graphite_002_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_graphite_002_Parameters.xml
@@ -15,10 +15,6 @@
 	<value val="53" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="1.8450" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="62500" />
 </parameter>

--- a/Code/Mantid/instrument/IRIS_graphite_004_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_graphite_004_Parameters.xml
@@ -17,10 +17,6 @@
 	<value val="53" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="7.3812" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="31500" />
 </parameter>
@@ -37,15 +33,16 @@
 	<value val="27000" />
 </parameter>
 
-  <parameter name="analyser" type="string">
-    <value val="graphite" />
-  </parameter>
+<parameter name="analyser" type="string">
+  <value val="graphite" />
+</parameter>
 
-  <parameter name="reflection" type="string">
-    <value val="004" />
-  </parameter>
+<parameter name="reflection" type="string">
+  <value val="004" />
+</parameter>
 
 </component-link>
+
 <component-link name="graphite">
 <parameter name="Efixed"> <value val="7.3812" /> </parameter>
 <parameter name="resolution"> <value val="0.0545" /> </parameter>

--- a/Code/Mantid/instrument/IRIS_mica_002_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_mica_002_Parameters.xml
@@ -15,10 +15,6 @@
 	<value val="104" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="0.2067" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="189000" />
 </parameter>
@@ -35,8 +31,6 @@
 	<value val="188000" />
 </parameter>
 
-
-
 <parameter name="analyser" type="string">
   <value val="mica" />
 </parameter>
@@ -46,6 +40,7 @@
 </parameter>
 
 </component-link>
+
   <component-link name="mica">
     <parameter name="Efixed">
       <value val="0.2067" />

--- a/Code/Mantid/instrument/IRIS_mica_004_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_mica_004_Parameters.xml
@@ -15,10 +15,6 @@
 	<value val="104" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="0.8255" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="94500" />
 </parameter>
@@ -35,8 +31,6 @@
 	<value val="101500" />
 </parameter>
 
-
-
 <parameter name="analyser" type="string">
   <value val="mica" />
 </parameter>
@@ -46,6 +40,7 @@
 </parameter>
 
 </component-link>
+
   <component-link name="mica">
     <parameter name="Efixed">
       <value val="0.8255" />

--- a/Code/Mantid/instrument/IRIS_mica_006_Parameters.xml
+++ b/Code/Mantid/instrument/IRIS_mica_006_Parameters.xml
@@ -15,10 +15,6 @@
 	<value val="104" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="1.8567" />
-</parameter>
-
 <parameter name="peak-start">
 	<value val="62500" />
 </parameter>
@@ -35,16 +31,16 @@
 	<value val="61500" />
 </parameter>
 
+<parameter name="analyser" type="string">
+  <value val="mica" />
+</parameter>
 
-  <parameter name="analyser" type="string">
-    <value val="mica" />
-  </parameter>
-
-  <parameter name="reflection" type="string">
-    <value val="006" />
-  </parameter>
+<parameter name="reflection" type="string">
+  <value val="006" />
+</parameter>
 
 </component-link>
+
 <component-link name="mica">
   <parameter name="Efixed">
     <value val="1.8567" />

--- a/Code/Mantid/instrument/MolDyn_Definition.xml
+++ b/Code/Mantid/instrument/MolDyn_Definition.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- For help on the notation used to specify an Instrument Definition File 
+<!-- For help on the notation used to specify an Instrument Definition File
      see http://www.mantidproject.org/IDF -->
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="MolDyn" valid-from   ="1900-01-31 23:59:59"
@@ -21,7 +21,7 @@
 </defaults>
 
 <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
-  
+
 <!-- source and sample-position components -->
 
 <component type="moderator">
@@ -48,13 +48,12 @@
 
 <!-- LIST OF DETECTORS AND MONITORS -->
 
-  
+
 <!--  detector components -->
 
 <component type="simul" idlist="simul">
   <properties />
   <parameter name="Efixed"> <value val="2.08" /> </parameter>
-  <parameter name="efixed-val">	<value val="2.08" /></parameter>
   <location  />
 </component>
 

--- a/Code/Mantid/instrument/MolDyn_qmax_2_Parameters.xml
+++ b/Code/Mantid/instrument/MolDyn_qmax_2_Parameters.xml
@@ -7,10 +7,6 @@
   <value val="spectroscopy" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="1.8450" />
-</parameter>
-
 <parameter name="analyser" type="string">
   <value val="qmax" />
 </parameter>

--- a/Code/Mantid/instrument/MolDyn_qmax_4_Parameters.xml
+++ b/Code/Mantid/instrument/MolDyn_qmax_4_Parameters.xml
@@ -7,10 +7,6 @@
   <value val="spectroscopy" />
 </parameter>
 
-<parameter name="efixed-val">
-	<value val="7.3812" />
-</parameter>
-
 <parameter name="analyser" type="string">
   <value val="qmax" />
 </parameter>

--- a/Code/Mantid/instrument/OSIRIS_graphite_002_Parameters.xml
+++ b/Code/Mantid/instrument/OSIRIS_graphite_002_Parameters.xml
@@ -2,59 +2,55 @@
 <parameter-file instrument = "OSIRIS" valid-from = "2010-07-15T00:00:00">
 
   <component-link name = "OSIRIS">
-    
+
     <parameter name="analysis-type" type="string">
       <value val="spectroscopy" />
     </parameter>
-    
+
     <parameter name="spectra-min">
       <value val="963" />
     </parameter>
-    
+
     <parameter name="spectra-max">
       <value val="1004" />
     </parameter>
-    
-    <parameter name="efixed-val">
-      <value val="1.8450" />
-    </parameter>
-    
+
     <parameter name="peak-start">
       <value val="59000" />
     </parameter>
-    
+
     <parameter name="peak-end">
       <value val="61000" />
     </parameter>
     <parameter name="back-start">
       <value val="68000" />
     </parameter>
-    
+
     <parameter name="back-end">
       <value val="70000" />
     </parameter>
-    
+
     <parameter name="analyser" type="string">
       <value val="graphite" />
     </parameter>
-    
+
     <parameter name="reflection" type="string">
       <value val="002" />
     </parameter>
-    
+
   </component-link>
-  
+
   <component-link name="graphite">
-    
+
     <parameter name="Efixed">
       <value val="1.845" />
     </parameter>
-    
+
     <parameter name="resolution">
       <value val="0.0245" />
     </parameter>
-    
+
   </component-link>
-  
+
 </parameter-file>
 

--- a/Code/Mantid/instrument/OSIRIS_graphite_004_Parameters.xml
+++ b/Code/Mantid/instrument/OSIRIS_graphite_004_Parameters.xml
@@ -1,53 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "OSIRIS" valid-from = "2010-07-15T00:00:00">
 
-<component-link name = "OSIRIS">
+  <component-link name = "OSIRIS">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="spectra-min">
-	<value val="963" />
-</parameter>
+    <parameter name="spectra-min">
+      <value val="963" />
+    </parameter>
 
-<parameter name="spectra-max">
-	<value val="1004" />
-</parameter>
+    <parameter name="spectra-max">
+      <value val="1004" />
+    </parameter>
 
-<parameter name="efixed-val">
-	<value val="7.3812" />
-</parameter>
+    <parameter name="peak-start">
+      <value val="29500" />
+    </parameter>
 
-<parameter name="peak-start">
-	<value val="29500" />
-</parameter>
+    <parameter name="peak-end">
+      <value val="30500" />
+    </parameter>
 
-<parameter name="peak-end">
-	<value val="30500" />
-</parameter>
+    <parameter name="back-start">
+      <value val="24000" />
+    </parameter>
 
-<parameter name="back-start">
-	<value val="24000" />
-</parameter>
+    <parameter name="back-end">
+      <value val="26000" />
+    </parameter>
 
-<parameter name="back-end">
-	<value val="26000" />
-</parameter>
+    <parameter name="analyser" type="string">
+      <value val="graphite" />
+    </parameter>
 
-<parameter name="analyser" type="string">
-  <value val="graphite" />
-</parameter>
+    <parameter name="reflection" type="string">
+      <value val="004" />
+    </parameter>
 
-<parameter name="reflection" type="string">
-  <value val="004" />
-</parameter>
+  </component-link>
 
-</component-link>
+  <component-link name="graphite">
 
-<component-link name="graphite">
-<parameter name="Efixed"> <value val="7.3812" /> </parameter>
+    <parameter name="Efixed">
+      <value val="7.3812" />
+    </parameter>
 
-<parameter name="resolution"> <value val="0.100" /> </parameter>
-</component-link>
+    <parameter name="resolution">
+      <value val="0.100" />
+    </parameter>
+
+  </component-link>
+
 </parameter-file>

--- a/Code/Mantid/instrument/TFXA_graphite_002_Parameters.xml
+++ b/Code/Mantid/instrument/TFXA_graphite_002_Parameters.xml
@@ -15,10 +15,6 @@
       <value val="28" />
     </parameter>
 
-    <parameter name="efixed-val">
-      <value val="0" />
-    </parameter>
-
     <parameter name="peak-start">
       <value val="0" />
     </parameter>

--- a/Code/Mantid/instrument/TOSCA_graphite_002_Parameters.xml
+++ b/Code/Mantid/instrument/TOSCA_graphite_002_Parameters.xml
@@ -1,40 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <parameter-file instrument = "TOSCA" valid-from = "2011-01-19T00:00:00">
 
-<component-link name = "TOSCA">
+  <component-link name = "TOSCA">
 
-<parameter name="analysis-type" type="string">
-  <value val="spectroscopy" />
-</parameter>
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
 
-<parameter name="spectra-min">
-	<value val="1" />
-</parameter>
+    <parameter name="spectra-min">
+      <value val="1" />
+    </parameter>
 
-<parameter name="spectra-max">
-	<value val="140" />
-</parameter>
+    <parameter name="spectra-max">
+      <value val="140" />
+    </parameter>
 
-<parameter name="efixed-val">
-	<value val="0" />
-</parameter>
+    <parameter name="peak-start">
+      <value val="0" />
+    </parameter>
 
-<parameter name="peak-start">
-	<value val="0" />
-</parameter>
+    <parameter name="peak-end">
+      <value val="0" />
+    </parameter>
 
-<parameter name="peak-end">
-	<value val="0" />
-</parameter>
+    <parameter name="back-start">
+      <value val="0" />
+    </parameter>
 
-<parameter name="back-start">
-	<value val="0" />
-</parameter>
+    <parameter name="back-end">
+      <value val="0" />
+    </parameter>
 
-<parameter name="back-end">
-	<value val="0" />
-</parameter>
-
-</component-link>
+  </component-link>
 
 </parameter-file>

--- a/Code/Mantid/instrument/VISION_graphite_002_Parameters.xml
+++ b/Code/Mantid/instrument/VISION_graphite_002_Parameters.xml
@@ -7,9 +7,9 @@
   <value val="spectroscopy" />
 </parameter>
 
-<!-- 
-This Min/Max approach doesn't work for instruments with gaps 
-in the detector numbering! 
+<!--
+This Min/Max approach doesn't work for instruments with gaps
+in the detector numbering!
 -->
 <parameter name="spectra-min">
 	<value val="1" />

--- a/Code/Mantid/scripts/Inelastic/IndirectCommon.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectCommon.py
@@ -89,14 +89,14 @@ def getWSprefix(wsname):
 def getEfixed(workspace, detIndex=0):
     inst = mtd[workspace].getInstrument()
 
-    if inst.hasParameter('Efixed')
+    if inst.hasParameter('Efixed'):
         return inst.getNumberParameter('EFixed')[0]
 
     if inst.hasParameter('analyser'):
         analyser_name = inst.getStringParameter('analyser')[0]
         analyser_comp = inst.getComponentByName(analyser_name)
 
-        if analyser_comp.hasParameter('Efixed')
+        if analyser_comp.hasParameter('Efixed'):
             return analyser_comp.getNumberParameter('EFixed')[0]
 
     raise ValueError('No Efixed parameter found')

--- a/Code/Mantid/scripts/Inelastic/IndirectCommon.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectCommon.py
@@ -88,7 +88,18 @@ def getWSprefix(wsname):
 
 def getEfixed(workspace, detIndex=0):
     inst = mtd[workspace].getInstrument()
-    return inst.getNumberParameter("efixed-val")[0]
+
+    if inst.hasParameter('Efixed')
+        return inst.getNumberParameter('EFixed')[0]
+
+    if inst.hasParameter('analyser'):
+        analyser_name = inst.getStringParameter('analyser')[0]
+        analyser_comp = inst.getComponentByName(analyser_name)
+
+        if analyser_comp.hasParameter('Efixed')
+            return analyser_comp.getNumberParameter('EFixed')[0]
+
+    raise ValueError('No Efixed parameter found')
 
 
 def checkUnitIs(ws, unit_id, axis_index=0):

--- a/Code/Mantid/scripts/Inelastic/IndirectNeutron.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectNeutron.py
@@ -5,7 +5,7 @@ from IndirectImport import *
 from mantid.simpleapi import *
 from mantid import config, logger, mtd, FileFinder
 import sys, math, os.path, numpy as np
-from IndirectCommon import StartTime, EndTime, ExtractFloat, ExtractInt
+from IndirectCommon import StartTime, EndTime, ExtractFloat, ExtractInt, getEfixed
 MTD_PLOT = import_mantidplot()
 
 #  Routines for Ascii file of raw data
@@ -447,7 +447,7 @@ def RunParas(ascWS,instr,run,title):
     AddSampleLog(Workspace=ascWS, LogName="facility", LogType="String", LogText="ILL")
     ws.getRun()['run_number'] = run
     ws.getRun()['run_title'] = title
-    efixed = inst.getNumberParameter('efixed-val')[0]
+    efixed = getEfixed(ws)
 
     facility = ws.getRun().getLogData('facility').value
     logger.information('Facility is ' +facility)

--- a/Code/Mantid/scripts/Inelastic/IndirectNeutron.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectNeutron.py
@@ -447,7 +447,7 @@ def RunParas(ascWS,instr,run,title):
     AddSampleLog(Workspace=ascWS, LogName="facility", LogType="String", LogText="ILL")
     ws.getRun()['run_number'] = run
     ws.getRun()['run_title'] = title
-    efixed = getEfixed(ws)
+    efixed = getEfixed(ascWS)
 
     facility = ws.getRun().getLogData('facility').value
     logger.information('Facility is ' +facility)

--- a/Code/Mantid/scripts/test/IndirectCommonTests.py
+++ b/Code/Mantid/scripts/test/IndirectCommonTests.py
@@ -69,7 +69,7 @@ class IndirectCommonTests(unittest.TestCase):
 
     def test_getEFixed_failure(self):
         ws = CreateSampleWorkspace()
-        self.assertRaises(IndexError, indirect_common.getEfixed, ws.name())
+        self.assertRaises(ValueError, indirect_common.getEfixed, ws.name())
 
     def test_getDefaultWorkingDirectory(self):
         config['defaultsave.directory'] = os.path.expanduser('~')


### PR DESCRIPTION
Fixes [#11638](http://trac.mantidproject.org/mantid/ticket/11638).

To test:
- Open Indirect Data Reduction
- Select any instrument configuration
- See that the Efixed value is updated with the parameter from the correct IPF

The correct value will be the one in the `[INSTRUMENT]_[ANALYSER][REFLECTION]_Parameters.xml` file
