### PR TITLE
refs #11637. n_events weights

### DIFF
--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspaceIterator.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspaceIterator.h
@@ -103,6 +103,8 @@ public:
 
   virtual size_t getNumEvents() const;
 
+  virtual signal_t getNumEventsFraction() const;
+
   virtual uint16_t getInnerRunIndex(size_t index) const;
 
   virtual int32_t getInnerDetectorID(size_t index) const;

--- a/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -377,9 +377,16 @@ VecMDExtents MDHistoWorkspaceIterator::getBoxExtents() const
 
 //----------------------------------------------------------------------------------------------
 /// Returns the number of events/points contained in this box
-/// @return 1 always: e.g. there is one (fake) event in the middle of the box.
+/// @return truncated number of events
 size_t MDHistoWorkspaceIterator::getNumEvents() const {
-  return static_cast<size_t>(m_ws->getNumEventsAt(m_pos));
+  return static_cast<size_t>(this->getNumEventsFraction());
+}
+
+//----------------------------------------------------------------------------------------------
+/// Returns the number of events/points contained in this box
+/// @return eact number of events (weights may be applied)
+signal_t MDHistoWorkspaceIterator::getNumEventsFraction() const {
+  return m_ws->getNumEventsAt(m_pos);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -159,7 +159,7 @@ void performWeightedSum(MDHistoWorkspaceIterator const *const iterator,
   sumSignal += weight * iterator->getSignal();
   const double error = iterator->getError();
   sumSQErrors += weight * (error * error);
-  sumNEvents += weight * iterator->getNumEvents();
+  sumNEvents += weight * double(iterator->getNumEventsFraction());
 }
 }
 

--- a/Code/Mantid/docs/source/algorithms/IntegrateMDHistoWorkspace-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IntegrateMDHistoWorkspace-v1.rst
@@ -12,7 +12,15 @@ Description
 
 Provides limited integration of a :ref:`MDHistoWorkspace <MDHistoWorkspace>` in n-dimensions. Integration is always axis-aligned. Dimensions can only be integrated out, but no finer rebinning is permitted. Dimensions that do not require further rebinning will be left intact provided that the the binning parameters for those dimensions are not specified. For dimensions that are integrated, limits should be provided to give the range of the data to keep.
 
+Binning
+~~~~~~~
+
 The *P1Bin* corresponds to the first dimension of the MDHistoWorkspace, *P2Bin* to the second and so on. *P1Bin=[-1, 1]* indicates that we will integrate this dimension between -1 and 1. *P1Bins=[]* indicates that the shape of this dimension should be unchanged from the input. *P1Bins=[-1,0,1]* is a special case, the zero indicates that the same bin width as the input dimension would be used, but the minimum and maximum will also be used to crop the dimension. In this latter form, the limits may be expanded to ensure that there is no partial bins in the non-integrated dimension (see warning messages).
+
+Weights 
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The algorithm works by creating the *OutputWorkspace* in the correct shape. Each bin in the OutputWorkspace is treated in turn. For each bin in the OutputWorkspace, we find those bins in the *InputWorkspace* that overlap and therefore could contribute to the OutputBin. For any contributing bin, we calculate the fraction overlap and treat this a weighting factor. For each contributing bin *Signal*, and *:math:`Error^{2}`*, and *Number of Events* values are extracted and multiplied by the  weight. These values are summed for all contributing input bins before being assigned to the corresponding output bin. For plotting the *OutputWorkspace*, it is important to select the Number of Events normalization option to correctly account for the weights.
 
 .. figure:: /images/PreIntegrateMD.png
    :alt: PreIntegrateMD.png

--- a/Code/Mantid/docs/source/algorithms/IntegrateMDHistoWorkspace-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IntegrateMDHistoWorkspace-v1.rst
@@ -18,9 +18,9 @@ Binning
 The *P1Bin* corresponds to the first dimension of the MDHistoWorkspace, *P2Bin* to the second and so on. *P1Bin=[-1, 1]* indicates that we will integrate this dimension between -1 and 1. *P1Bins=[]* indicates that the shape of this dimension should be unchanged from the input. *P1Bins=[-1,0,1]* is a special case, the zero indicates that the same bin width as the input dimension would be used, but the minimum and maximum will also be used to crop the dimension. In this latter form, the limits may be expanded to ensure that there is no partial bins in the non-integrated dimension (see warning messages).
 
 Weights 
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~
 
-The algorithm works by creating the *OutputWorkspace* in the correct shape. Each bin in the OutputWorkspace is treated in turn. For each bin in the OutputWorkspace, we find those bins in the *InputWorkspace* that overlap and therefore could contribute to the OutputBin. For any contributing bin, we calculate the fraction overlap and treat this a weighting factor. For each contributing bin *Signal*, and *:math:`Error^{2}`*, and *Number of Events* values are extracted and multiplied by the  weight. These values are summed for all contributing input bins before being assigned to the corresponding output bin. For plotting the *OutputWorkspace*, it is important to select the Number of Events normalization option to correctly account for the weights.
+The algorithm works by creating the *OutputWorkspace* in the correct shape. Each bin in the OutputWorkspace is treated in turn. For each bin in the OutputWorkspace, we find those bins in the *InputWorkspace* that overlap and therefore could contribute to the OutputBin. For any contributing bin, we calculate the fraction overlap and treat this a weighting factor. For each contributing bin *Signal*, and :math:`Error^{2}`, and *Number of Events* values are extracted and multiplied by the  weight. These values are summed for all contributing input bins before being assigned to the corresponding output bin. For plotting the *OutputWorkspace*, it is important to select the Number of Events normalization option to correctly account for the weights.
 
 .. figure:: /images/PreIntegrateMD.png
    :alt: PreIntegrateMD.png


### PR DESCRIPTION
Bug fix affects IntegrateMDHistoWorkspace

Thus far, the contribution to each output bin is based on overlap with input bins. The fraction overlap is calculated, and used to assign a weight, which the signal and error_sq of each contributing bin is multiplied through by. I have not accounted for the number of pixels. Clearly the number of events from contributing bins needs to be accounted for.

After discussion with scientists (namely Andrei) on this, it would seem that the best way to handle this is to simply multiply the n_events from each contributing bin by the weight and assign the output to the n_events array in the output workspace. MDHisto workspace already have the n_events array concept, so we merely need to sum (n_events \* weight) for each contributing bin. 

Original ticket [here](http://trac.mantidproject.org/mantid/ticket/11637)

**Tester**
- Check documentation
- Check unit tests
- Code review
