### PR TITLE
Refs #11641 Fix IntegrateMDHistoWorkspace

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -264,17 +264,15 @@ void IntegrateMDHistoWorkspace::exec() {
       // Maximum width vector for region in output workspace corresponding to
       // region in input workspace.
 
-      /* int(wout/win + 0.5) = n_pixels in input corresponding to 1 pixel in
-         output. Rounded up.
+      /* ceil(wout/win) = n_pixels in input corresponding to 1 pixel in output.
          The width vector is the total width. So we always need to double it to
          take account of the whole region.
-         For example, 8/4 + 0.5 = 2, but thats only 1 pixel on each side of the
-         center, we need 2 * that to give the correct
-         answer of 4.
+         For example, 8/4 = 2, but thats only 1 pixel on each side of the
+         center, we need 2 * that to give the correct answer of 4.
       */
       widthVector[i] =
-          2 * int((binWidthsOut[i] / inWS->getDimension(i)->getBinWidth()) +
-                  0.5); // round up.
+          2 * static_cast<int>(std::ceil(binWidthsOut[i] /
+                                         inWS->getDimension(i)->getBinWidth()));
 
       if (widthVector[i] % 2 == 0) {
         widthVector[i] += 1; // make it odd if not already.


### PR DESCRIPTION
This is for trac ticket [#11641](http://trac.mantidproject.org/mantid/ticket/11641)

There is a rounding error in IntegrateMDHistoWorkspace that can wreck its output, i.e. cause it to discard data by looking at the incorrect bins.

To see this, run the following:

``` python
CreateMDWorkspace(Dimensions=4, Extents='-10,10,-10,10,-10,10,-10,10', Names='a,b,c,d', Units='u,u,u,u', OutputWorkspace='ws')
FakeMDEventData(InputWorkspace='ws', PeakParams='10000,0,0,0,0,1')
CutMD(InputWorkspace='ws', P1Bin='1', P2Bin='1', P3Bin='1', P4Bin='1', OutputWorkspace='ws2', NoPix=True)
IntegrateMDHistoWorkspace(InputWorkspace='ws2', OutputWorkspace='slice', P1Bin=[-1,1], P2Bin=[0.3,0.9], P3Bin=[-0.05,0.05], P4Bin=[-0.05,0.05])
plotSlice('slice')
```

You'll get a uniform output of ~`149.5`. It should be ~`631.2`

This will be much easier to see once #655 is merged, as you get obviously incorrect output. But for now, this seems to be the simplest way to reproduce it.
