### PR TITLE
Fix names of ranges in Elwin docs

### DIFF
--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -59,13 +59,13 @@ Input File
   Specify a range of input files that are either reduced (*_red.nxs*) or
   :math:`S(Q, \omega)`.
 
-Range One
+Integration Range
   The energy range over which to integrate the values.
 
-Use Two Ranges
+Background Subtraction
   If checked a background will be calculated and subtracted from the raw data.
 
-Range Two
+Background Range
   The energy range over which a background is calculated which is subtracted from
   the raw data.
 

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
@@ -9,7 +9,7 @@ Overview
 
 The Indirect Data Reduction interface provides the initial reduction that
 is used to convert raw instrument data to S(Q, w) for analysis in the
-Indirect Data AnalPysis and Indirect Bayes interfaces.
+Indirect Data Analysis and Indirect Bayes interfaces.
 
 The tabs shown on this interface will vary depending on the current default
 facility such that only tabs that will work with data from the facility are

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
@@ -9,7 +9,7 @@ Overview
 
 The Indirect Data Reduction interface provides the initial reduction that
 is used to convert raw instrument data to S(Q, w) for analysis in the
-Indirect Data Analysis and Indirect Bayes interfaces.
+Indirect Data AnalPysis and Indirect Bayes interfaces.
 
 The tabs shown on this interface will vary depending on the current default
 facility such that only tabs that will work with data from the facility are
@@ -294,7 +294,7 @@ Use Calibration
   Allows you to select either a calibrtion file or workspace to apply to the raw
   files.
 
-Preciew Spectrum
+Preview Spectrum
   Allows selection of the spectrum to be shown in the preview plot to the right
   of the Time Slice section.
 

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
@@ -294,6 +294,10 @@ Use Calibration
   Allows you to select either a calibrtion file or workspace to apply to the raw
   files.
 
+Preciew Spectrum
+  Allows selection of the spectrum to be shown in the preview plot to the right
+  of the Time Slice section.
+
 Spectra Min & Spectra Max
   Allows selection of the range of detectors you are interested in, this is
   automatically set based on the instrument and analyser bank that are currently


### PR DESCRIPTION
See that the names are now correct and that the mission option (Preview Spectrum) is documented on ISIS Diagnostics.
