### PR TITLE
Add a NXdata level to the saved MDHisto.

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -99,6 +99,9 @@ private:
   Kernel::SpecialCoordinateSystem m_coordSystem;
   /// load only the box structure with empty boxes but do not tload boxes events
   bool m_BoxStructureAndMethadata;
+
+  /// Version of SaveMD used to save the file
+  int SaveMDVersion ;
 };
 
 } // namespace DataObjects

--- a/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -159,7 +159,7 @@ void LoadMD::exec() {
   m_file->openGroup(entryName, "NXentry");
 
   // Check is SaveMD version 2 was used
-  int SaveMDVersion = 0;
+  SaveMDVersion = 0;
   if (m_file->hasAttr("SaveMDVersion"))
     m_file->getAttr("SaveMDVersion", SaveMDVersion);
 
@@ -261,6 +261,8 @@ void LoadMD::loadHisto() {
 
   this->loadAffineMatricies(boost::dynamic_pointer_cast<IMDWorkspace>(ws));
 
+  if (SaveMDVersion == 2 )
+    m_file->openGroup("data","NXdata");
   // Load each data slab
   this->loadSlab("signal", ws->getSignalArray(), ws, ::NeXus::FLOAT64);
   this->loadSlab("errors_squared", ws->getErrorSquaredArray(), ws,
@@ -298,6 +300,7 @@ void LoadMD::loadDimensions2() {
 
   std::string axes;
 
+  m_file->openGroup("data","NXdata");
   m_file->openData("signal");
   m_file->getAttr("axes", axes);
   m_file->closeData();
@@ -319,6 +322,7 @@ void LoadMD::loadDimensions2() {
         long_name, splitAxes[d - 1], units, static_cast<coord_t>(axis.front()),
         static_cast<coord_t>(axis.back()), axis.size() - 1));
   }
+  m_file->closeGroup();
 }
 
 /** Load the coordinate system **/

--- a/Code/Mantid/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -121,6 +121,16 @@ void SaveMD2::doSaveHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) {
     }
   }
 
+  // Write out the affine matrices
+  MDBoxFlatTree::saveAffineTransformMatricies(
+      file, boost::dynamic_pointer_cast<const IMDWorkspace>(ws));
+
+  // Check that the typedef has not been changed. The NeXus types would need
+  // changing if it does!
+  assert(sizeof(signal_t) == sizeof(double));
+
+  file->makeGroup("data", "NXdata", true);
+
   // Save each axis dimension as an array
   size_t numDims = ws->getNumDims();
   std::string axes_label;
@@ -139,14 +149,6 @@ void SaveMD2::doSaveHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) {
       axes_label.insert(0, ":");
     axes_label.insert(0, dim->getDimensionId());
   }
-
-  // Write out the affine matrices
-  MDBoxFlatTree::saveAffineTransformMatricies(
-      file, boost::dynamic_pointer_cast<const IMDWorkspace>(ws));
-
-  // Check that the typedef has not been changed. The NeXus types would need
-  // changing if it does!
-  assert(sizeof(signal_t) == sizeof(double));
 
   // Number of data points
   // Size in each dimension (in the "C" style order, so z,y,x
@@ -175,6 +177,8 @@ void SaveMD2::doSaveHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) {
   file->makeData("mask", ::NeXus::INT8, size, true);
   file->putData(ws->getMaskArray());
   file->closeData();
+
+  file->closeGroup();
 
   // TODO: Links to original workspace???
 


### PR DESCRIPTION
This adjusts the data structure a little, which should have been done in #646 and needs to fixed before the release. It adds the NXdata level to the NeXus file, in order to meet the NeXus standard.

**To test:** Do the same testing as in #646, which is
- Try saving an MDHisto workspace with SaveMD and look at how the data is stored in the nexus file.
- Make sure LoadMD can load data saved with SaveMD and SaveMDv1.
- You should check that SaveMD still works for MDEvents.
