### PR TITLE
Fixes compilation error with boost 1.58

### DIFF
--- a/Code/Mantid/Framework/Geometry/src/Crystal/CrystalStructure.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/CrystalStructure.cpp
@@ -220,7 +220,7 @@ CrystalStructure::getDValues(const std::vector<V3D> &hkls) const {
 
   std::vector<double> dValues(hkls.size());
   std::transform(hkls.begin(), hkls.end(), dValues.begin(),
-                 boost::bind<double>(&CrystalStructure::getDValue, this, _1));
+                 boost::bind(&CrystalStructure::getDValue, this, _1));
 
   return dValues;
 }

--- a/Code/Mantid/Framework/SINQ/src/PoldiPeakSearch.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiPeakSearch.cpp
@@ -632,7 +632,7 @@ void PoldiPeakSearch::exec() {
   auto newEnd = std::remove_copy_if(
       peakCoordinates.begin(), peakCoordinates.end(),
       intensityFilteredPeaks.begin(),
-      boost::bind<bool>(&PoldiPeakSearch::isLessThanMinimum, this, _1));
+      boost::bind(&PoldiPeakSearch::isLessThanMinimum, this, _1));
   intensityFilteredPeaks.resize(
       std::distance(intensityFilteredPeaks.begin(), newEnd));
 

--- a/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiAutoCorrelationCore.cpp
@@ -205,7 +205,7 @@ DataObjects::Workspace2D_sptr PoldiAutoCorrelationCore::calculate(
     std::transform(
         rawCorrelatedIntensities.begin(), rawCorrelatedIntensities.end(),
         m_weightsForD.begin(), correctedCorrelatedIntensities.rbegin(),
-        boost::bind<double>(&PoldiAutoCorrelationCore::correctedIntensity, this,
+        boost::bind(&PoldiAutoCorrelationCore::correctedIntensity, this,
                             _1, _2));
 
     /* The algorithm performs some finalization. In the default case the
@@ -315,7 +315,7 @@ PoldiAutoCorrelationCore::getRawCorrelatedIntensity(double dValue,
        */
       std::vector<UncertainValue> cmess(m_detector->elementCount());
       std::transform(m_indices.begin(), m_indices.end(), cmess.begin(),
-                     boost::bind<UncertainValue>(
+                     boost::bind(
                          &PoldiAutoCorrelationCore::getCMessAndCSigma, this,
                          dValue, *slitOffset, _1));
 
@@ -589,7 +589,7 @@ std::vector<double> PoldiAutoCorrelationCore::getTofsFor1Angstrom(
   std::vector<double> twoThetas(elements.size());
   std::transform(
       elements.begin(), elements.end(), twoThetas.begin(),
-      boost::bind<double>(&PoldiAbstractDetector::twoTheta, m_detector, _1));
+      boost::bind(&PoldiAbstractDetector::twoTheta, m_detector, _1));
 
   // We will need sin(Theta) anyway, so we might just calculate those as well
   std::vector<double> sinThetas;
@@ -607,7 +607,7 @@ std::vector<double> PoldiAutoCorrelationCore::getTofsFor1Angstrom(
   std::vector<double> tofFor1Angstrom(elements.size());
   std::transform(distances.begin(), distances.end(), sinThetas.begin(),
                  tofFor1Angstrom.begin(),
-                 boost::bind<double>(&Conversions::dtoTOF, 1.0, _1, _2));
+                 boost::bind(&Conversions::dtoTOF, 1.0, _1, _2));
 
   return tofFor1Angstrom;
 }

--- a/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiBasicChopper.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiBasicChopper.cpp
@@ -77,7 +77,7 @@ void PoldiBasicChopper::initializeVariableParameters(double rotationSpeed) {
   m_slitTimes.resize(m_slitPositions.size());
   std::transform(m_slitPositions.begin(), m_slitPositions.end(),
                  m_slitTimes.begin(),
-                 boost::bind<double>(
+                 boost::bind(
                      &PoldiBasicChopper::slitPositionToTimeFraction, this, _1));
 }
 

--- a/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiDeadWireDecorator.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiDeadWireDecorator.cpp
@@ -68,7 +68,7 @@ PoldiDeadWireDecorator::getGoodElements(std::vector<int> rawElements) {
     std::vector<int> goodElements(newElementCount);
     std::remove_copy_if(
         rawElements.begin(), rawElements.end(), goodElements.begin(),
-        boost::bind<bool>(&PoldiDeadWireDecorator::isDeadElement, this, _1));
+        boost::bind(&PoldiDeadWireDecorator::isDeadElement, this, _1));
 
     return goodElements;
   }

--- a/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiPeak.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiUtilities/PoldiPeak.cpp
@@ -127,18 +127,18 @@ bool PoldiPeak::greaterThan(const PoldiPeak_sptr &first,
                             const PoldiPeak_sptr &second,
                             UncertainValue (PoldiPeak::*function)() const) {
   return static_cast<double>(
-             boost::bind<UncertainValue>(function, first.get())()) >
+             boost::bind(function, first.get())()) >
          static_cast<double>(
-             boost::bind<UncertainValue>(function, second.get())());
+             boost::bind(function, second.get())());
 }
 
 bool PoldiPeak::lessThan(const PoldiPeak_sptr &first,
                          const PoldiPeak_sptr &second,
                          UncertainValue (PoldiPeak::*function)() const) {
   return static_cast<double>(
-             boost::bind<UncertainValue>(function, first.get())()) <
+             boost::bind(function, first.get())()) <
          static_cast<double>(
-             boost::bind<UncertainValue>(function, second.get())());
+             boost::bind(function, second.get())());
 }
 
 PoldiPeak::PoldiPeak(UncertainValue d, UncertainValue intensity,


### PR DESCRIPTION
Minor changes: template specifications have been removed from the boost::bind statements to fix the compilation error with boost 1.58.
