### PR TITLE
clang-format disable comments.

### DIFF
--- a/Code/Mantid/Framework/API/test/WorkspaceHistoryIOTest.h
+++ b/Code/Mantid/Framework/API/test/WorkspaceHistoryIOTest.h
@@ -152,11 +152,15 @@ public:
       testHistory.addHistory(boost::make_shared<AlgorithmHistory>(algHist));
     }
 
+    // clang-format off
     auto savehandle = boost::make_shared< ::NeXus::File >("WorkspaceHistoryTest_test_SaveNexus.nxs",NXACC_CREATE5);
+    // clang-format on
     TS_ASSERT_THROWS_NOTHING(testHistory.saveNexus(savehandle.get()));
     savehandle->close();
 
+    // clang-format off
     auto loadhandle = boost::make_shared< ::NeXus::File >("WorkspaceHistoryTest_test_SaveNexus.nxs");
+    // clang-format on
     std::string rootstring = "/process/";
     for (int i = 1; i < 5; i++)
     {
@@ -181,11 +185,15 @@ public:
     algHist.addChildHistory(boost::make_shared<AlgorithmHistory>(childHist));
     testHistory.addHistory(boost::make_shared<AlgorithmHistory>(algHist));
 
+    // clang-format off
     auto savehandle = boost::make_shared< ::NeXus::File >("WorkspaceHistoryTest_test_SaveNexus.nxs",NXACC_CREATE5);
+    // clang-format on
     TS_ASSERT_THROWS_NOTHING(testHistory.saveNexus(savehandle.get()));
     savehandle->close();
 
+    // clang-format off
     auto loadhandle = boost::make_shared< ::NeXus::File >("WorkspaceHistoryTest_test_SaveNexus.nxs");
+    // clang-format on
     std::string rootstring = "/process/";
     TS_ASSERT_THROWS_NOTHING(loadhandle->openPath(rootstring + "MantidAlgorithm_1/"));
     TS_ASSERT_THROWS_NOTHING(loadhandle->openPath(rootstring + "MantidAlgorithm_1/author"));
@@ -205,11 +213,15 @@ public:
   {
     WorkspaceHistory testHistory;
 
+    // clang-format off
     auto savehandle = boost::make_shared< ::NeXus::File >("WorkspaceHistoryTest_test_SaveNexus.nxs",NXACC_CREATE5);
+    // clang-format on
     TS_ASSERT_THROWS_NOTHING(testHistory.saveNexus(savehandle.get()));
     savehandle->close();
 
+    // clang-format off
     auto loadhandle = boost::make_shared< ::NeXus::File >("WorkspaceHistoryTest_test_SaveNexus.nxs");
+    // clang-format on
     std::string rootstring = "/process/";
     TS_ASSERT_THROWS_NOTHING(loadhandle->openPath(rootstring));
     TS_ASSERT_THROWS_NOTHING(loadhandle->openPath(rootstring + "MantidEnvironment"));
@@ -222,7 +234,9 @@ public:
   void test_LoadNexus()
   {
     std::string filename = FileFinder::Instance().getFullPath("GEM38370_Focussed_Legacy.nxs");
+    // clang-format off
     auto loadhandle = boost::make_shared< ::NeXus::File >(filename);
+    // clang-format on
     loadhandle->openPath("/mantid_workspace_1");
 
     WorkspaceHistory emptyHistory;
@@ -243,7 +257,9 @@ public:
   void test_LoadNexus_NestedHistory()
   {
     std::string filename = FileFinder::Instance().getFullPath("HistoryTest_CreateTransmissionAuto.nxs");
+    // clang-format off
     auto loadhandle = boost::make_shared< ::NeXus::File >(filename);
+    // clang-format on
     loadhandle->openPath("/mantid_workspace_1");
 
     WorkspaceHistory wsHistory;

--- a/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef @MULTIPLYDIVIDETEST_CLASS@_H_
 #define @MULTIPLYDIVIDETEST_CLASS@_H_
 

--- a/Code/Mantid/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -1,3 +1,4 @@
+// clang-format off
 #ifndef @PLUSMINUSTEST_CLASS@_H_
 #define @PLUSMINUSTEST_CLASS@_H_
 #include <cxxtest/TestSuite.h>

--- a/Code/Mantid/Framework/Algorithms/test/RebinByPulseTimesTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RebinByPulseTimesTest.h
@@ -154,7 +154,9 @@ public:
 //=====================================================================================
 // Performance Tests
 //=====================================================================================
+// clang-format off
 class RebinByPulseTimesTestPerformance : public CxxTest::TestSuite, public RebinByTimeBaseTestPerformance<RebinByPulseTimes>
+// clang-format on
 {
 
 public:

--- a/Code/Mantid/Framework/Algorithms/test/RebinByTimeAtSampleTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RebinByTimeAtSampleTest.h
@@ -268,8 +268,10 @@ public:
 //=====================================================================================
 // Performance Tests
 //=====================================================================================
+// clang-format off
 class RebinByTimeAtSampleTestPerformance: public CxxTest::TestSuite,
     public RebinByTimeBaseTestPerformance<RebinByTimeAtSample>
+// clang-format on
 {
 
 public:

--- a/Code/Mantid/Framework/Algorithms/test/SpecularReflectionCalculateThetaTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SpecularReflectionCalculateThetaTest.h
@@ -11,8 +11,10 @@
 using namespace Mantid::Algorithms;
 using namespace Mantid::API;
 
+// clang-format off
 class SpecularReflectionCalculateThetaTest: public CxxTest::TestSuite,
     public SpecularReflectionAlgorithmTest
+// clang-format on
 {
 
 private:

--- a/Code/Mantid/Framework/Algorithms/test/SpecularReflectionPositionCorrectTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/SpecularReflectionPositionCorrectTest.h
@@ -16,8 +16,10 @@ using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;
 
+// clang-format off
 class SpecularReflectionPositionCorrectTest: public CxxTest::TestSuite,
     public SpecularReflectionAlgorithmTest
+// clang-format on
 {
 
 public:

--- a/Code/Mantid/Framework/Crystal/test/IntegratePeaksUsingClustersTest.h
+++ b/Code/Mantid/Framework/Crystal/test/IntegratePeaksUsingClustersTest.h
@@ -256,7 +256,9 @@ public:
 //=====================================================================================
 // Performance Tests
 //=====================================================================================
+// clang-format off
 class IntegratePeaksUsingClustersTestPerformance : public CxxTest::TestSuite, public ClusterIntegrationBaseTest
+// clang-format on
 {
 
 private:

--- a/Code/Mantid/Framework/CurveFitting/src/LevenbergMarquardtMDMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/LevenbergMarquardtMDMinimizer.cpp
@@ -22,7 +22,9 @@ namespace {
 Kernel::Logger g_log("LevenbergMarquardMD");
 }
 
+// clang-format off
 DECLARE_FUNCMINIMIZER(LevenbergMarquardtMDMinimizer, Levenberg-MarquardtMD)
+// clang-format on
 
 /// Constructor
 LevenbergMarquardtMDMinimizer::LevenbergMarquardtMDMinimizer()

--- a/Code/Mantid/Framework/CurveFitting/src/LevenbergMarquardtMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/LevenbergMarquardtMinimizer.cpp
@@ -22,7 +22,9 @@ namespace {
 Kernel::Logger g_log("LevenbergMarquardtMinimizer");
 }
 
+// clang-format off
 DECLARE_FUNCMINIMIZER(LevenbergMarquardtMinimizer, Levenberg-Marquardt)
+// clang-format on
 
 LevenbergMarquardtMinimizer::LevenbergMarquardtMinimizer()
     : m_data(NULL), gslContainer(), m_gslSolver(NULL), m_function(),

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadISISNexus2.h
@@ -233,7 +233,9 @@ private:
   static double dblSqrt(double in);
 
   // C++ interface to the NXS file
+  // clang-format off
   boost::scoped_ptr< ::NeXus::File> m_cppFile;
+  // clang-format on
 
   bool findSpectraDetRangeInFile(
       NeXus::NXEntry &entry, boost::shared_array<int> &spectrum_index,

--- a/Code/Mantid/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -7,11 +7,13 @@
 #include "MantidDataObjects/MDEventFactory.h"
 #include <Poco/File.h>
 
+// clang-format off
 #if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr< ::NeXus::File> file_holder_type;
 #else
 typedef std::auto_ptr< ::NeXus::File> file_holder_type;
 #endif
+// clang-format on
 
 namespace Mantid {
 namespace DataObjects {

--- a/Code/Mantid/Framework/DataObjects/src/MDGridBox.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDGridBox.cpp
@@ -1293,7 +1293,9 @@ TMDE(void MDGridBox)::centroidSphere(CoordTransform &radiusTransform,
   } // (for each box)
 }
 //-----------------------------------------------------------------------------------------------
+// clang-format off
 GCC_DIAG_OFF(array-bounds)
+// clang-format on
 /** Integrate the signal within a sphere; for example, to perform single-crystal
  * peak integration.
  * The CoordTransform object could be used for more complex shapes, e.g.
@@ -1494,7 +1496,9 @@ TMDE(void MDGridBox)::integrateCylinder(
   delete[] verticesContained;
   delete[] boxMightTouch;
 }
+// clang-format off
 GCC_DIAG_ON(array-bounds)
+// clang-format on
 
 /**
 Getter for the masking status of the gridded box.

--- a/Code/Mantid/Framework/Geometry/src/Rendering/OCGeometryGenerator.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Rendering/OCGeometryGenerator.cpp
@@ -32,7 +32,9 @@
 #endif
 
 GCC_DIAG_OFF(conversion)
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
+// clang-format on
 #include <gp_Trsf.hxx>
 #include <gp_Vec.hxx>
 #include <gp_Dir.hxx>
@@ -58,7 +60,9 @@ GCC_DIAG_OFF(cast-qual)
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
 GCC_DIAG_ON(conversion)
+// clang-format off
 GCC_DIAG_ON(cast-qual)
+// clang-format on
 
 #ifdef __INTEL_COMPILER
 #pragma warning enable 191

--- a/Code/Mantid/Framework/Geometry/src/Rendering/OCGeometryRenderer.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Rendering/OCGeometryRenderer.cpp
@@ -21,7 +21,9 @@
 #endif
 
 GCC_DIAG_OFF(conversion)
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
+// clang-format on
 #include <gp_Pnt.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Shape.hxx>
@@ -32,7 +34,9 @@ GCC_DIAG_OFF(cast-qual)
 #include <TColgp_Array1OfPnt.hxx>
 #include <Poly_Triangulation.hxx>
 GCC_DIAG_ON(conversion)
+// clang-format off
 GCC_DIAG_ON(cast-qual)
+// clang-format on
 
 #ifdef __INTEL_COMPILER
 #pragma warning enable 191

--- a/Code/Mantid/Framework/ICat/src/CatalogSearch.cpp
+++ b/Code/Mantid/Framework/ICat/src/CatalogSearch.cpp
@@ -1,9 +1,13 @@
 #if GCC_VERSION >= 40800 // 4.8.0
+// clang-format off
 GCC_DIAG_OFF(literal-suffix)
+// clang-format on
 #endif
 #include "MantidICat/CatalogSearch.h"
 #if GCC_VERSION >= 40800 // 4.8.0
+// clang-format off
 GCC_DIAG_ON(literal-suffix)
+// clang-format on
 #endif
 
 #include "MantidAPI/CatalogManager.h"

--- a/Code/Mantid/Framework/ICat/src/GSoap.cpp
+++ b/Code/Mantid/Framework/ICat/src/GSoap.cpp
@@ -4,14 +4,18 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
 GCC_DIAG_OFF(conversion)
 GCC_DIAG_OFF(unused-parameter)
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 GCC_DIAG_OFF(format)
 GCC_DIAG_OFF(vla)
 #if GCC_VERSION >= 40800 // 4.8.0
+// clang-format off
 GCC_DIAG_OFF(literal-suffix)
+// clang-format on
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Code/Mantid/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
+++ b/Code/Mantid/Framework/ICat/src/ICat3/ICat3GSoapGenerated.cpp
@@ -4,14 +4,18 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
 GCC_DIAG_OFF(conversion)
 GCC_DIAG_OFF(unused-parameter)
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 GCC_DIAG_OFF(format)
 GCC_DIAG_OFF(vla)
 #if GCC_VERSION >= 40800 // 4.8.0
+// clang-format off
 GCC_DIAG_OFF(literal-suffix)
+// clang-format on
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Code/Mantid/Framework/ICat/src/ICat3/ICat3Helper.cpp
+++ b/Code/Mantid/Framework/ICat/src/ICat3/ICat3Helper.cpp
@@ -2,7 +2,9 @@
 // Poco-related compilation error on Windows
 #include "MantidAPI/WorkspaceFactory.h"
 #if GCC_VERSION >= 40800 // 4.8.0
+// clang-format off
 GCC_DIAG_OFF(literal-suffix)
+// clang-format on
 #endif
 #include "MantidICat/ICat3/ICat3Helper.h"
 #include "MantidICat/ICat3/ICat3ErrorHandling.h"

--- a/Code/Mantid/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
+++ b/Code/Mantid/Framework/ICat/src/ICat4/ICat4GSoapGenerated.cpp
@@ -4,14 +4,18 @@
 // disable some warnings that we understand but do not want to touch as
 // it is automatically generated code
 //------------------------------------------------------------------------------
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
 GCC_DIAG_OFF(conversion)
 GCC_DIAG_OFF(unused-parameter)
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 GCC_DIAG_OFF(format)
 GCC_DIAG_OFF(vla)
 #if GCC_VERSION >= 40800 // 4.8.0
+// clang-format off
 GCC_DIAG_OFF(literal-suffix)
+// clang-format on
 #endif
 #ifdef _WIN32
 #pragma warning(disable : 4100)

--- a/Code/Mantid/Framework/Kernel/test/HermitePolynomialsTest.h
+++ b/Code/Mantid/Framework/Kernel/test/HermitePolynomialsTest.h
@@ -13,7 +13,9 @@ public:
   static HermitePolynomialsTest *createSuite() { return new HermitePolynomialsTest(); }
   static void destroySuite( HermitePolynomialsTest *suite ) { delete suite; }
 
+  // clang-format off
   void test_hermitePoly_With_SingleValue_Returns_Expected_Values_For_First_Few_Terms()
+  // clang-format on
   {
     using namespace Mantid::Kernel;
     static const unsigned int npoly(6);
@@ -28,7 +30,9 @@ public:
     }
   }
 
+  // clang-format off
   void test_hermitePoly_With_Array_Values_Returns_Expected_Values_For_First_Few_Terms()
+  // clang-format on
   {
     using namespace Mantid::Kernel;
 

--- a/Code/Mantid/Framework/LiveData/src/ISISHistoDataListener.cpp
+++ b/Code/Mantid/Framework/LiveData/src/ISISHistoDataListener.cpp
@@ -17,7 +17,9 @@
 #ifdef GCC_VERSION
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
+// clang-format off
 GCC_DIAG_OFF(unused-variable)
+// clang-format on
 #endif
 #include "LoadDAE/idc.h"
 

--- a/Code/Mantid/Framework/LiveData/src/ISISLiveEventDataListener.cpp
+++ b/Code/Mantid/Framework/LiveData/src/ISISLiveEventDataListener.cpp
@@ -15,7 +15,9 @@
 #ifdef GCC_VERSION
 // Avoid compiler warnings on gcc from unused static constants in
 // isisds_command.h
+// clang-format off
 GCC_DIAG_OFF(unused-variable)
+// clang-format on
 #endif
 #include "LoadDAE/idc.h"
 

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -85,7 +85,9 @@ private:
   API::CoordTransform *loadAffineMatrix(std::string entry_name);
 
   /// Open file handle
+  // clang-format off
   boost::scoped_ptr< ::NeXus::File> m_file;
+  // clang-format on
 
   /// Name of that file
   std::string m_filename;

--- a/Code/Mantid/Framework/MDAlgorithms/src/MDTransfModQ.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/MDTransfModQ.cpp
@@ -4,7 +4,9 @@
 namespace Mantid {
 namespace MDAlgorithms {
 // register the class, whith conversion factory under ModQ name
+// clang-format off
 DECLARE_MD_TRANSFID(MDTransfModQ, |Q|)
+// clang-format on
 
 /**method calculates the units, the transformation expects the input ws to be
 in. If the input ws is in different units,

--- a/Code/Mantid/Framework/MDAlgorithms/src/MergeMDFiles.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/MergeMDFiles.cpp
@@ -314,8 +314,10 @@ void MergeMDFiles::finalizeOutput(const std::string &outputFile) {
     // create or open WS group and put there additional information about WS and
     // its dimensions
     bool old_data_there;
+    // clang-format off
     boost::scoped_ptr< ::NeXus::File> file(MDBoxFlatTree::createOrOpenMDWSgroup(
         outputFile, m_nDims, m_MDEventType, false, old_data_there));
+    // clang-format on
     this->progress(0.94, "Saving ws history and dimensions");
     MDBoxFlatTree::saveWSGenericInfo(file.get(), m_OutIWS);
     // Save each ExperimentInfo to a spot in the file

--- a/Code/Mantid/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -15,11 +15,13 @@
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 
+// clang-format off
 #if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr< ::NeXus::File> file_holder_type;
 #else
 typedef std::auto_ptr< ::NeXus::File> file_holder_type;
 #endif
+// clang-format on
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Code/Mantid/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -15,11 +15,13 @@
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 
+// clang-format off
 #if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr< ::NeXus::File> file_holder_type;
 #else
 typedef std::auto_ptr< ::NeXus::File> file_holder_type;
 #endif
+// clang-format on
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Code/Mantid/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Code/Mantid/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -128,7 +128,9 @@ public:
 
 private:
   /// C++ API file handle
+  // clang-format off
   boost::shared_ptr< ::NeXus::File> m_filehandle;
+  // clang-format on
   /// Nexus compression method
   int m_nexuscompression;
   /// Allow an externally supplied progress object to be used

--- a/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
@@ -106,7 +106,9 @@ void NexusFileIO::openNexusWrite(const std::string &fileName,
       throw Exception::FileError("Unable to open File:", fileName);
     }
     ::NeXus::File *file = new ::NeXus::File(fileID, true);
+    // clang-format off
     m_filehandle = boost::shared_ptr< ::NeXus::File>(file);
+    // clang-format on
   }
 
   //
@@ -1032,7 +1034,9 @@ int NexusFileIO::getWorkspaceSize(int &numberOfSpectra, int &numberOfChannels,
 bool NexusFileIO::checkAttributeName(const std::string &target) const {
   // see if the given attribute name is in the current level
   // return true if it is.
+  // clang-format off
   const std::vector< ::NeXus::AttrInfo> infos = m_filehandle->getAttrInfos();
+  // clang-format on
   for (auto it = infos.begin(); it != infos.end(); ++it) {
     if (target.compare(it->name) == 0)
       return true;

--- a/Code/Mantid/Framework/Nexus/test/NexusAPITest.h
+++ b/Code/Mantid/Framework/Nexus/test/NexusAPITest.h
@@ -193,7 +193,9 @@ public:
     const string SDS("SDS");
     // top level file information
     ::NeXus::File file(filename);
+    // clang-format off
     vector< ::NeXus::AttrInfo> attr_infos = file.getAttrInfos();
+    // clang-format on
     // check group attributes
     file.openGroup("entry", "NXentry");
 

--- a/Code/Mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NumpyFunctions.h
+++ b/Code/Mantid/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NumpyFunctions.h
@@ -28,13 +28,19 @@
 
 #include <boost/python/list.hpp>
 #include "MantidKernel/WarningSuppressions.h"
-GCC_DIAG_OFF(cast - qual)
+
+// clang-format off
+GCC_DIAG_OFF(cast-qual)
+// clang-format on
+
 // See
 // http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
-GCC_DIAG_ON(cast - qual)
+// clang-format off
+GCC_DIAG_ON(cast-qual)
+// clang-format on
 
 /**functions containing numpy macros. We put them in a separate header file to
   *suppress the warning

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -38,7 +38,9 @@ namespace
   BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload, PythonAlgorithm::declarePyAlgProperty, 4, 5)
 }
 
+// clang-format off
 void export_leaf_classes()
+// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<Algorithm>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -107,7 +107,9 @@ GCC_DIAG_OFF(cast-qual)
 GCC_DIAG_ON(cast-qual)
 // clang-format on
 
+// clang-format off
 void export_AlgorithmFactory()
+// clang-format on
 {
 
   class_<AlgorithmFactoryImpl,boost::noncopyable>("AlgorithmFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -63,7 +63,9 @@ namespace
   // Python algorithm registration mutex in anonymous namespace (aka static)
   Poco::Mutex PYALG_REGISTER_MUTEX;
 
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
+// clang-format on
   /**
    * A free function to subscribe a Python algorithm into the factory
    * @param obj :: A Python object that should either be a class type derived from PythonAlgorithm
@@ -101,7 +103,9 @@ GCC_DIAG_OFF(cast-qual)
 
   ///@endcond
 }
+// clang-format off
 GCC_DIAG_ON(cast-qual)
+// clang-format on
 
 void export_AlgorithmFactory()
 {

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
@@ -54,7 +54,9 @@ boost::python::object getPropertiesAsList(AlgorithmHistory& self)
   return names;
 }
 
+// clang-format off
 void export_AlgorithmHistory()
+// clang-format on
 {
   register_ptr_to_python<Mantid::API::AlgorithmHistory_sptr >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -64,7 +64,9 @@ namespace
   ///@endcond
 }
 
+// clang-format off
 void export_AlgorithmManager()
+// clang-format on
 {
   typedef class_<AlgorithmManagerImpl,boost::noncopyable> PythonType;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp
@@ -38,7 +38,9 @@ namespace
 
 }
 
+// clang-format off
 void export_AlgorithmProperty()
+// clang-format on
 {
   // AlgorithmProperty has base PropertyWithValue<boost::shared_ptr<IAlgorithm>>
   // which must be exported

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProxy.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProxy.cpp
@@ -9,7 +9,9 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
+// clang-format off
 void export_algorithm_proxy()
+// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<AlgorithmProxy>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -65,7 +65,9 @@ namespace
 
 }
 
+// clang-format off
 void export_AnalysisDataService()
+// clang-format on
 {
   typedef DataServiceExporter<AnalysisDataServiceImpl, Workspace_sptr> ADSExporter;
   auto pythonClass = ADSExporter::define("AnalysisDataServiceImpl");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -78,7 +78,9 @@ namespace
 }
 
 
+// clang-format off
 void export_Axis()
+// clang-format on
 {
   register_ptr_to_python<Axis*>();
 
@@ -119,7 +121,9 @@ Axis* createNumericAxis(int length)
   return new Mantid::API::NumericAxis(length);
 }
 
+// clang-format off
 void export_NumericAxis()
+// clang-format on
 {
   /// Exported so that Boost.Python can give back a NumericAxis class when an Axis* is returned
   class_< NumericAxis, bases<Axis>, boost::noncopyable >("NumericAxis", no_init)
@@ -143,7 +147,9 @@ Axis* createBinEdgeAxis(int length)
   return new Mantid::API::BinEdgeAxis(length);
 }
 
+// clang-format off
 void export_BinEdgeAxis()
+// clang-format on
 {
   /// Exported so that Boost.Python can give back a BinEdgeAxis class when an Axis* is returned
   class_< BinEdgeAxis, bases<NumericAxis>, boost::noncopyable >("BinEdgeAxis", no_init)
@@ -168,7 +174,9 @@ Axis* createTextAxis(int length)
 }
 
 
+// clang-format off
 void export_TextAxis()
+// clang-format on
 {
   class_< TextAxis, bases<Axis>, boost::noncopyable >("TextAxis", no_init)
     .def("setLabel", & TextAxis::setLabel, "Set the label at the given entry")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -14,7 +14,9 @@
 
 namespace Policies = Mantid::PythonInterface::Policies;
 
+// clang-format off
 void export_BinaryOperations()
+// clang-format on
 {
   using namespace Mantid::API;
   using boost::python::return_value_policy;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BoxController.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BoxController.cpp
@@ -7,7 +7,9 @@
 using Mantid::API::BoxController;
 using namespace boost::python;
 
+// clang-format off
 void export_BoxController()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<BoxController>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogManager.cpp
@@ -19,7 +19,9 @@ boost::python::object getActiveSessionsAsList(CatalogManagerImpl& self)
   return sessions;
 }
 
+// clang-format off
 void export_CatalogManager()
+// clang-format on
 {
   register_ptr_to_python<CatalogManagerImpl*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogSession.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogSession.cpp
@@ -7,7 +7,9 @@
 using Mantid::API::CatalogSession;
 using namespace boost::python;
 
+// clang-format off
 void export_CatalogSession()
+// clang-format on
 {
     register_ptr_to_python<boost::shared_ptr<CatalogSession> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DataProcessorAlgorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DataProcessorAlgorithm.cpp
@@ -14,7 +14,9 @@ namespace
   typedef Workspace_sptr(DataProcessorAdapter::*loadOverload2)(const std::string&, const bool);
 }
 
+// clang-format off
 void export_DataProcessorAlgorithm()
+// clang-format on
 {
   // for strings will actually create a list
   using Mantid::PythonInterface::Policies::VectorToNumpy;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
@@ -50,7 +50,9 @@ namespace
   };
 }
 
+// clang-format off
 void export_DeprecatedAlgorithmChecker()
+// clang-format on
 {
   class_<DeprecatedAlgorithmChecker>("DeprecatedAlgorithmChecker", no_init)
     .def(init<const std::string&,int>((arg("algName"),arg("version")),"Constructs a DeprecatedAlgorithmChecker for the given algorithm & version. (-1 indicates latest version)"))

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -13,7 +13,9 @@ using namespace boost::python;
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload, ExperimentInfo::getInstrumentFilename, 1, 2)
 
+// clang-format off
 void export_ExperimentInfo()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -11,7 +11,9 @@ namespace {
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
 }
 
+// clang-format off
 void export_FileFinder()
+// clang-format on
 {
   class_<FileFinderImpl, boost::noncopyable>("FileFinderImpl", no_init)
     .def("getFullPath", &FileFinderImpl::getFullPath,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileProperty.cpp
@@ -17,7 +17,9 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::Converters::PySequenceToVector;
 namespace bpl = boost::python;
 
+// clang-format off
 void export_ActionEnum()
+// clang-format on
 {
   bpl::enum_<FileProperty::FileAction>("FileAction")
         .value("Save", FileProperty::Save)
@@ -63,7 +65,9 @@ namespace
 
 }
 
+// clang-format off
 void export_FileProperty()
+// clang-format on
 {
   bpl::class_<FileProperty, bpl::bases<PropertyWithValue<std::string> >, boost::noncopyable>("FileProperty", bpl::no_init)
     .def("__init__",

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -8,7 +8,9 @@ using Mantid::API::FrameworkManagerImpl;
 using Mantid::API::FrameworkManager;
 using namespace boost::python;
 
+// clang-format off
 void export_FrameworkManager()
+// clang-format on
 {
   class_<FrameworkManagerImpl,boost::noncopyable>("FrameworkManagerImpl", no_init)
     .def("setNumOMPThreadsToConfigValue", &FrameworkManagerImpl::setNumOMPThreadsToConfigValue,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -86,7 +86,9 @@ namespace
   ///@endcond
 }
 
+// clang-format off
 void export_FunctionFactory()
+// clang-format on
 {
 
   class_<FunctionFactoryImpl,boost::noncopyable>("FunctionFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionProperty.cpp
@@ -8,7 +8,9 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::PropertyWithValueExporter;
 using namespace boost::python;
 
+// clang-format off
 void export_FunctionProperty()
+// clang-format on
 {
   // FuncitonProperty has base PropertyWithValue<boost::shared_ptr<IFunction>>
   // which must be exported

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -262,7 +262,9 @@ namespace
 
 }
 
+// clang-format off
 void export_ialgorithm()
+// clang-format on
 {
   class_<AlgorithmIDProxy>("AlgorithmID", no_init)
     .def(self == self)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
@@ -20,7 +20,9 @@ using namespace boost::python;
 /// return_value_policy for copied numpy array
 typedef return_value_policy<Policies::VectorToNumpy> return_clone_numpy;
 
+// clang-format off
 void export_IEventList()
+// clang-format on
 {
   register_ptr_to_python<IEventList *>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp
@@ -12,7 +12,9 @@ using namespace boost::python;
 /**
  * Python exports of the Mantid::API::IEventWorkspace class.
  */
+// clang-format off
 void export_IEventWorkspace()
+// clang-format on
 {
   class_<IEventWorkspace, bases<Mantid::API::MatrixWorkspace>, boost::noncopyable>("IEventWorkspace", no_init)
     .def("getNumberEvents", &IEventWorkspace::getNumberEvents, args("self"),

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IEventWorkspace.h"
 
+// clang-format off
 void export_IEventWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::IEventWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -44,7 +44,9 @@ namespace
   ///@endcond
 }
 
+// clang-format off
 void export_IFunction()
+// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<IFunction>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction1D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction1D.cpp
@@ -8,7 +8,9 @@ using Mantid::PythonInterface::IFunction1DAdapter;
 using Mantid::PythonInterface::IFunctionAdapter;
 using namespace boost::python;
 
+// clang-format off
 void export_IFunction1D()
+// clang-format on
 {
   /**
    * The Python held type, boost::shared_ptr<IFunction1DAdapter>, allows

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
@@ -15,7 +15,9 @@ namespace
   static const unsigned int NUM_EVENT_TYPES = 2;
 }
 
+// clang-format off
 void export_IMDEventWorkspace()
+// clang-format on
 {
   // MDEventWorkspace class
   class_< IMDEventWorkspace, bases<IMDWorkspace, MultipleExperimentInfos>,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 
+// clang-format off
 void export_IMDEventWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::IMDEventWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -140,7 +140,9 @@ namespace
 
 }
 
+// clang-format off
 void export_IMDHistoWorkspace()
+// clang-format on
 {
   // IMDHistoWorkspace class
   class_< IMDHistoWorkspace, bases<IMDWorkspace,MultipleExperimentInfos>, boost::noncopyable >("IMDHistoWorkspace", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 
+// clang-format off
 void export_IMDHistoWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::IMDHistoWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
@@ -9,7 +9,9 @@ using namespace Mantid::API;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 
+// clang-format off
 void export_IMDWorkspace()
+// clang-format on
 {
   boost::python::enum_<Mantid::API::MDNormalization>("MDNormalization")
           .value("NoNormalization", Mantid::API::NoNormalization)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDWorkspace.h"
 
+// clang-format off
 void export_IMDWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::IMDWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -31,7 +31,9 @@ void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame, double dist
 
 }
 
+// clang-format off
 void export_IPeak()
+// clang-format on
 {
   register_ptr_to_python<IPeak*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
@@ -7,7 +7,9 @@ using Mantid::API::IPeakFunction;
 using Mantid::PythonInterface::IPeakFunctionAdapter;
 using namespace boost::python;
 
+// clang-format off
 void export_IPeakFunction()
+// clang-format on
 {
   class_<IPeakFunction, bases<IFunction1D>, boost::shared_ptr<IPeakFunctionAdapter>,
           boost::noncopyable>("IPeakFunction")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -33,7 +33,9 @@ IPeak* createPeakQLabWithDistance(IPeaksWorkspace & self, const object& data, do
 
 }
 
+// clang-format off
 void export_IPeaksWorkspace()
+// clang-format on
 {
   // IPeaksWorkspace class
   class_< IPeaksWorkspace, bases<ITableWorkspace, ExperimentInfo>, boost::noncopyable >("IPeaksWorkspace", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 
+// clang-format off
 void export_IPeaksWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::IPeaksWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
@@ -7,7 +7,9 @@ using Mantid::API::ISpectrum;
 using Mantid::detid_t;
 using namespace boost::python;
 
+// clang-format off
 void export_ISpectrum()
+// clang-format on
 {
   register_ptr_to_python<ISpectrum*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
@@ -7,7 +7,9 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
+// clang-format off
 void export_IPeaksWorkspace()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ISplittersWorkspace>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -338,7 +338,9 @@ namespace
    }
 }
 
+// clang-format off
 void export_ITableWorkspace()
+// clang-format on
 {
   using Mantid::PythonInterface::Policies::VectorToNumpy;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/ITableWorkspace.h"
 
+// clang-format off
 void export_ITableWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::ITableWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include <boost/python/class.hpp>
 
+// clang-format off
 void export_IWorkspaceProperty()
+// clang-format on
 {
   using namespace boost::python;
   using Mantid::API::IWorkspaceProperty;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/InstrumentValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/InstrumentValidator.cpp
@@ -8,7 +8,9 @@ using namespace boost::python;
 
 
 // This is typed on the ExperimentInfo class
+// clang-format off
 void export_InstrumentValidator()
+// clang-format on
 {
   TypedValidatorExporter<ExperimentInfo_sptr>::define("ExperimentInfoValidator");
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Jacobian.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Jacobian.cpp
@@ -5,7 +5,9 @@
 using Mantid::API::Jacobian;
 using namespace boost::python;
 
+// clang-format off
 void export_Jacobian()
+// clang-format on
 {
   register_ptr_to_python<Jacobian*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
@@ -36,7 +36,9 @@ namespace
 
 }
 
+// clang-format off
 void export_MDGeometry()
+// clang-format on
 {
   class_<MDGeometry,boost::noncopyable>("MDGeometry", no_init)
     .def("getNumDims", &MDGeometry::getNumDims, "Returns the number of dimensions present")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -127,7 +127,9 @@ namespace
 }
 
 /** Python exports of the Mantid::API::MatrixWorkspace class. */
+// clang-format off
 void export_MatrixWorkspace()
+// clang-format on
 {
   /// Typedef to remove const qualifier on input detector shared_ptr. See Policies/RemoveConst.h for more details
   typedef double (MatrixWorkspace::*getDetectorSignature)(Mantid::Geometry::IDetector_sptr det) const;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspaceProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
+// clang-format off
 void export_MatrixWorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::MatrixWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
@@ -6,7 +6,9 @@ using Mantid::API::MultipleExperimentInfos;
 using Mantid::API::ExperimentInfo_sptr;
 using namespace boost::python;
 
+// clang-format off
 void export_MultipleExperimentInfos()
+// clang-format on
 {
   class_<MultipleExperimentInfos,boost::noncopyable>("MultipleExperimentInfos", no_init)
       .def("getExperimentInfo", (ExperimentInfo_sptr(MultipleExperimentInfos::*)(const uint16_t) ) &MultipleExperimentInfos::getExperimentInfo,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
@@ -55,7 +55,9 @@ namespace
   }
 }
 
+// clang-format off
 void export_MultipleFileProperty()
+// clang-format on
 {
   typedef PropertyWithValue<HeldType> BaseClass;
   PropertyWithValueExporter<HeldType>::define("VectorVectorStringPropertyWithValue");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Progress.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Progress.cpp
@@ -9,7 +9,9 @@ using Mantid::API::Algorithm;
 using Mantid::Kernel::ProgressBase;
 using namespace boost::python;
 
+// clang-format off
 void export_Progress()
+// clang-format on
 {
   class_<Progress,
          bases<ProgressBase>,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -100,7 +100,9 @@ Projection_sptr projCtor3(
 
 } //anonymous namespace
 
+// clang-format off
 void export_Projection()
+// clang-format on
 {
   class_<Projection>(
     "Projection",

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -15,7 +15,9 @@ using namespace Mantid::API;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
+// clang-format off
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 
 namespace {
 std::string getUnit(Projection &p, size_t nd) {

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyHistory.cpp
@@ -10,7 +10,9 @@ using Mantid::Kernel::PropertyHistory;
 using Mantid::API::IAlgorithm;
 using namespace boost::python;
 
+// clang-format off
 void export_PropertyHistory()
+// clang-format on
 {
   register_ptr_to_python<PropertyHistory*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyManagerDataService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyManagerDataService.cpp
@@ -15,7 +15,9 @@ using namespace boost::python;
 /// Weak pointer to DataItem typedef
 typedef boost::weak_ptr<PropertyManager> PropertyManager_wptr;
 
+// clang-format off
 void export_PropertyManagerDataService()
+// clang-format on
 {
 
   register_ptr_to_python<PropertyManager_wptr>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -111,7 +111,9 @@ namespace
 
 }
 
+// clang-format off
 void export_Run()
+// clang-format on
 {
   //Pointer
   register_ptr_to_python<Run*>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -10,7 +10,9 @@ using Mantid::Geometry::OrientedLattice;
 using Mantid::Kernel::Material;
 using namespace boost::python;
 
+// clang-format off
 void export_Sample()
+// clang-format on
 {
   register_ptr_to_python<Sample*>();
   register_ptr_to_python<boost::shared_ptr<Sample> >();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepository.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepository.cpp
@@ -77,7 +77,9 @@ namespace
   /** @endcond */
 }
 
+// clang-format off
 void export_ScriptRepository()
+// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<ScriptRepository>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepositoryFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepositoryFactory.cpp
@@ -16,7 +16,9 @@ namespace
   ///@endcond
 }
 
+// clang-format off
 void export_ScriptRepositoryFactory()
+// clang-format on
 {
   class_<ScriptRepositoryFactoryImpl,boost::noncopyable>("ScriptRepositoryFactory", no_init)
       .def("create", &ScriptRepositoryFactoryImpl::create,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -17,7 +17,9 @@ namespace
   ///@endcond
 }
 
+// clang-format off
 void export_Workspace()
+// clang-format on
 {
   class_<Workspace, bases<DataItem>, boost::noncopyable>("Workspace", no_init)
     .def("getName", &Workspace::getName, return_value_policy<copy_const_reference>(), 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -39,7 +39,9 @@ namespace
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
 }
 
+// clang-format off
 void export_WorkspaceFactory()
+// clang-format on
 {
   const char * createFromParentDoc = "Create a workspace based on the given one. The meta-data, instrument etc are copied from the input"
       "If the size parameters are passed then the workspace will be a different size.";

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -10,7 +10,9 @@ using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 namespace Policies = Mantid::PythonInterface::Policies;
 
+// clang-format off
 void export_WorkspaceGroup() 
+// clang-format on
 {
   class_< WorkspaceGroup, bases<Workspace>, boost::noncopyable >("WorkspaceGroup", no_init)
     .def("getNumberOfEntries", &WorkspaceGroup::getNumberOfEntries, "Returns the number of entries in the group")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
@@ -1,7 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
+// clang-format off
 void export_WorkspaceGroupProperty()
+// clang-format on
 {
   using Mantid::API::WorkspaceGroup;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
@@ -35,7 +35,9 @@ boost::python::object getHistoriesAsList(WorkspaceHistory& self)
   return names;
 }
 
+// clang-format off
 void export_WorkspaceHistory()
+// clang-format on
 {
   register_ptr_to_python<WorkspaceHistory*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceProperty.cpp
@@ -2,7 +2,9 @@
 #include "MantidAPI/Workspace.h"
 #include <boost/python/enum.hpp>
 
+// clang-format off
 void export_WorkspaceProperty()
+// clang-format on
 {
   using Mantid::API::PropertyMode;
   // Property and Lock mode enums

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -7,7 +7,9 @@ using Mantid::PythonInterface::TypedValidatorExporter;
 using namespace boost::python;
 
 /// This is the base TypedValidator for most of the WorkspaceValidators
+// clang-format off
 void export_MatrixWorkspaceValidator()
+// clang-format on
 {
   using Mantid::API::MatrixWorkspace_sptr;
   using Mantid::API::MatrixWorkspaceValidator;
@@ -44,7 +46,9 @@ void export_MatrixWorkspaceValidator()
           init<ArgType>(arg(ArgName)=DefaultValue, DocString))\
    ;
 
+// clang-format off
 void export_WorkspaceValidators()
+// clang-format on
 {
   using namespace Mantid::API;
   

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/BoundingBox.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/BoundingBox.cpp
@@ -6,7 +6,9 @@ using Mantid::Geometry::BoundingBox;
 using Mantid::Kernel::V3D;
 using namespace boost::python;
 
+// clang-format off
 void export_BoundingBox()
+// clang-format on
 {
   class_<BoundingBox>("BoundingBox", "Constructs a zero-sized box")
     .def(init<double, double, double, double, double, double>(

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/CompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/CompAssembly.cpp
@@ -10,7 +10,9 @@ using namespace boost::python;
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate CompAssembly leaf type 
  */
+// clang-format off
 void export_CompAssembly()
+// clang-format on
 {
   class_<CompAssembly, bases<ICompAssembly, Component>, boost::noncopyable>("CompAssembly", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -22,7 +22,9 @@ namespace
 
 }
 
+// clang-format off
 void export_Component()
+// clang-format on
 {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)
     .def("getParameterNames", &Component::getParameterNames, Component_getParameterNames())

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
@@ -10,7 +10,9 @@ using namespace boost::python;
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate Detector leaf type 
  */
+// clang-format off
 void export_Detector()
+// clang-format on
 {
   class_<Detector, bases<IDetector, ObjComponent>, boost::noncopyable>("Detector", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
@@ -5,7 +5,9 @@ using Mantid::Geometry::DetectorGroup;
 using Mantid::Geometry::IDetector;
 using namespace boost::python;
 
+// clang-format off
 void export_DetectorGroup()
+// clang-format on
 {
   class_<DetectorGroup, bases<IDetector>, boost::noncopyable>("DetectorGroup", no_init)
     .def("getDetectorIDs", &DetectorGroup::getDetectorIDs, "Returns the list of detector IDs within this group")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -24,7 +24,9 @@ namespace //<unnamed>
   }
 }
 
+// clang-format off
 void export_Goniometer()
+// clang-format on
 {
 
   // return_value_policy for read-only numpy array

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -23,7 +23,9 @@ namespace {
     }
 }
 
+// clang-format off
 void export_Group()
+// clang-format on
 {
   enum_<Group::CoordinateSystem>("CoordinateSystem")
       .value("Orthogonal", Group::Orthogonal)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ICompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ICompAssembly.cpp
@@ -6,7 +6,9 @@ using Mantid::Geometry::ICompAssembly;
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
+// clang-format off
 void export_ICompAssembly()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ICompAssembly>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
@@ -25,7 +25,9 @@ namespace
 
 }
 
+// clang-format off
 void export_IComponent()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IComponent>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
@@ -6,7 +6,9 @@ using Mantid::Geometry::IDetector;
 using Mantid::Geometry::IObjComponent;
 using namespace boost::python;
 
+// clang-format off
 void export_IDetector()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IDetector>>();
   

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -20,7 +20,9 @@ namespace
   }
 }
 
+// clang-format off
 void export_IMDDimension()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IMDDimension>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
@@ -20,7 +20,9 @@ namespace
   }
 }
 
+// clang-format off
 void export_IObjComponent()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IObjComponent>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -10,7 +10,9 @@ using Mantid::detid_t;
 using namespace boost::python;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 
+// clang-format off
 void export_Instrument()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Instrument>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjCompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjCompAssembly.cpp
@@ -8,7 +8,9 @@ using Mantid::Geometry::ICompAssembly;
 using Mantid::Geometry::ObjComponent;
 using namespace boost::python;
 
+// clang-format off
 void export_ObjCompAssembly()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ObjCompAssembly>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjComponent.cpp
@@ -6,7 +6,9 @@ using Mantid::Geometry::IObjComponent;
 using Mantid::Geometry::Component;
 using namespace boost::python;
 
+// clang-format off
 void export_ObjComponent()
+// clang-format on
 {
   class_<ObjComponent, boost::python::bases<IObjComponent, Component>, boost::noncopyable>("ObjComponent", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Object.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Object.cpp
@@ -7,7 +7,9 @@ using Mantid::Geometry::Object;
 using Mantid::Geometry::BoundingBox;
 using namespace boost::python;
 
+// clang-format off
 void export_Object()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Object>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -46,7 +46,9 @@ namespace //<unnamed>
 
 }
 
+// clang-format off
 void export_OrientedLattice()
+// clang-format on
 {
   /// return_value_policy for read-only numpy array
   typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly> > return_readonly_numpy;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PeakShape.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PeakShape.cpp
@@ -6,7 +6,9 @@ using Mantid::Geometry::PeakShape;
 using namespace boost::python;
 
 
+// clang-format off
 void export_PeakShape()
+// clang-format on
 {
   register_ptr_to_python<Mantid::Geometry::PeakShape_sptr>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -40,7 +40,9 @@ namespace //<unnamed>
   }
 }
 
+// clang-format off
 void export_PointGroup()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<PointGroup> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
@@ -19,7 +19,9 @@ namespace {
     }
 }
 
+// clang-format off
 void export_PointGroupFactory()
+// clang-format on
 {
 
     class_<PointGroupFactoryImpl,boost::noncopyable>("PointGroupFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
@@ -11,7 +11,9 @@ using namespace boost::python;
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate Detector leaf type 
  */
+// clang-format off
 void export_RectangularDetector()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<RectangularDetector>>();
 
@@ -33,7 +35,9 @@ void export_RectangularDetector()
     ;
 }
 
+// clang-format off
 void export_RectangularDetectorPixel()
+// clang-format on
 {
   class_<RectangularDetectorPixel, bases<Detector>, boost::noncopyable>("RectangularDetectorPixel", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ReferenceFrame.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ReferenceFrame.cpp
@@ -9,7 +9,9 @@ using Mantid::Geometry::ReferenceFrame;
 using Mantid::Kernel::V3D;
 using namespace boost::python;
 
+// clang-format off
 void export_ReferenceFrame()
+// clang-format on
 {
   using namespace Mantid::Geometry;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -33,7 +33,9 @@ namespace //<unnamed>
 
 }
 
+// clang-format off
 void export_SpaceGroup()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -38,7 +38,9 @@ namespace
 
 }
 
+// clang-format off
 void export_SpaceGroupFactory()
+// clang-format on
 {
 
     class_<SpaceGroupFactoryImpl,boost::noncopyable>("SpaceGroupFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
@@ -19,7 +19,9 @@ namespace {
     }
 }
 
+// clang-format off
 void export_SymmetryElement()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<SymmetryElement> >();  
   scope symmetryElementScope = class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init);

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElementFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElementFactory.cpp
@@ -5,7 +5,9 @@
 using namespace Mantid::Geometry;
 using namespace boost::python;
 
+// clang-format off
 void export_SymmetryElementFactory()
+// clang-format on
 {
     class_<SymmetryElementFactoryImpl,boost::noncopyable>("SymmetryElementFactoryImpl", no_init)
             .def("createSymElement", &SymmetryElementFactoryImpl::createSymElement, "Creates the symmetry element that corresponds to the supplied symmetry operation.")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
@@ -28,7 +28,9 @@ namespace //<unnamed>
   }
 }
 
+// clang-format off
 void export_SymmetryOperation()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<SymmetryOperation> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperationFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperationFactory.cpp
@@ -21,7 +21,9 @@ namespace {
 
 }
 
+// clang-format off
 void export_SymmetryOperationFactory()
+// clang-format on
 {
     class_<SymmetryOperationFactoryImpl,boost::noncopyable>("SymmetryOperationFactoryImpl", no_init)
             .def("exists", &SymmetryOperationFactoryImpl::isSubscribed, "Returns true if the symmetry operation is supplied.")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -28,7 +28,9 @@ namespace //<unnamed>
   }
 }
 
+// clang-format off
 void export_UnitCell()
+// clang-format on
 {
   enum_<AngleUnits>("AngleUnits")
     .value("Degrees", angDegrees)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
@@ -11,7 +11,9 @@
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
+// clang-format off
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 
 namespace Mantid
 {

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
@@ -27,7 +27,9 @@ namespace
 
 }
 
+// clang-format off
 void export_ArrayBoundedValidator()
+// clang-format on
 {
   EXPORT_ARRAYBOUNDEDVALIDATOR(double, Float);
   EXPORT_ARRAYBOUNDEDVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayLengthValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayLengthValidator.cpp
@@ -34,7 +34,9 @@ namespace
   ;
 }
 
+// clang-format off
 void export_ArrayLengthValidator()
+// clang-format on
 {
   EXPORT_LENGTHVALIDATOR(double, Float);
   EXPORT_LENGTHVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -88,7 +88,9 @@ namespace
 
 }
 
+// clang-format off
 void export_ArrayProperty()
+// clang-format on
 {
   // Match the python names to their C types
   EXPORT_ARRAY_PROP(double,Float);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
@@ -83,7 +83,9 @@ namespace
     ;
 }
 
+// clang-format off
 void export_BoundedValidator()
+// clang-format on
 {
   EXPORT_BOUNDEDVALIDATOR(double, Float);
   EXPORT_BOUNDEDVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/CompositeValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/CompositeValidator.cpp
@@ -36,7 +36,9 @@ namespace
   }
 }
 
+// clang-format off
 void export_CompositeValidator()
+// clang-format on
 {
   class_<CompositeValidator, bases<IValidator>, boost::noncopyable>("CompositeValidator")
     .def("__init__", make_constructor(&createCompositeValidator, default_call_policies(),

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -36,7 +36,9 @@ namespace
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
 }
 
+// clang-format off
 void export_ConfigService()
+// clang-format on
 {
   using Mantid::PythonInterface::std_vector_exporter;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
@@ -6,7 +6,9 @@
 using Mantid::Kernel::DataItem;
 using namespace boost::python;
 
+// clang-format off
 void export_DataItem()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<DataItem>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -15,7 +15,9 @@ std::string ISO8601StringPlusSpace(DateAndTime & self)
   return self.toISO8601String()+" ";
 }
 
+// clang-format off
 void export_DateAndTime()
+// clang-format on
 {
   class_<DateAndTime>("DateAndTime", no_init)
     // Constructors
@@ -39,7 +41,9 @@ void export_DateAndTime()
   ;
 }
 
+// clang-format off
 void export_time_duration()
+// clang-format on
 {
   class_<time_duration>("time_duration", no_init)
     .def("hours", &time_duration::hours, "Returns the normalized number of hours")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DeltaEMode.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DeltaEMode.cpp
@@ -9,7 +9,9 @@ using Mantid::Kernel::DeltaEMode;
 namespace Policies = Mantid::PythonInterface::Policies;
 using namespace boost::python;
 
+// clang-format off
 void export_DeltaEMode()
+// clang-format on
 {
   enum_<Mantid::Kernel::DeltaEMode::Type>("DeltaEModeType")
     .value("Elastic", DeltaEMode::Elastic)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/EnabledWhenProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/EnabledWhenProperty.cpp
@@ -5,7 +5,9 @@
 using namespace Mantid::Kernel;
 using namespace boost::python;
 
+// clang-format off
 void export_EnabledWhenProperty()
+// clang-format on
 {
   // State enumeration
   enum_<ePropertyCriterion>("PropertyCriterion")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
@@ -7,7 +7,9 @@ using Mantid::Kernel::FacilityInfo;
 using Mantid::Kernel::InstrumentInfo;
 using namespace boost::python;
 
+// clang-format off
 void export_FacilityInfo()
+// clang-format on
 {
 
   register_ptr_to_python<FacilityInfo*>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FilteredTimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FilteredTimeSeriesProperty.cpp
@@ -24,7 +24,9 @@ namespace
       ;
 }
 
+// clang-format off
 void export_FilteredTimeSeriesProperty()
+// clang-format on
 {
   EXPORT_FILTEREDTIMESERIES_PROP(double, Float);
   EXPORT_FILTEREDTIMESERIES_PROP(bool, Bool);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -120,7 +120,9 @@ namespace
 
 }
 
+// clang-format off
 void export_IPropertyManager()
+// clang-format on
 {
   register_ptr_to_python<IPropertyManager*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertySettings.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertySettings.cpp
@@ -6,7 +6,9 @@
 using Mantid::Kernel::IPropertySettings;
 using namespace boost::python;
 
+// clang-format off
 void export_IPropertySettings()
+// clang-format on
 {
   register_ptr_to_python<IPropertySettings*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IValidator.cpp
@@ -5,7 +5,9 @@
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
+// clang-format off
 void export_IValidator()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IValidator>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/InstrumentInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/InstrumentInfo.cpp
@@ -7,7 +7,9 @@
 using Mantid::Kernel::InstrumentInfo;
 using namespace boost::python;
 
+// clang-format off
 void export_InstrumentInfo()
+// clang-format on
 {
   using namespace Mantid::PythonInterface;
   std_vector_exporter<InstrumentInfo>::wrap("std_vector_InstrumentInfo");

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ListValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ListValidator.cpp
@@ -39,7 +39,9 @@ namespace
 
 }
 
+// clang-format off
 void export_ListValidator()
+// clang-format on
 {
   EXPORT_LISTVALIDATOR(std::string, String);
   EXPORT_LISTVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/LogFilter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/LogFilter.cpp
@@ -8,7 +8,9 @@ using Mantid::Kernel::Property;
 
 using namespace boost::python;
 
+// clang-format off
 void export_LogFilter()
+// clang-format on
 {
   class_<LogFilter,boost::noncopyable>("LogFilter", 
                                         init<const Property*>("Creates a log filter using the log to be filtered"))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
@@ -20,7 +20,9 @@ namespace
   }
 }
 
+// clang-format off
 void export_Logger()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Logger>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/MandatoryValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/MandatoryValidator.cpp
@@ -15,7 +15,9 @@ namespace
     ;
 }
 
+// clang-format off
 void export_MandatoryValidator()
+// clang-format on
 {
   EXPORT_MANDATORYVALIDATOR(double, Float);
   EXPORT_MANDATORYVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -9,7 +9,9 @@ using Mantid::Kernel::Material;
 using Mantid::PhysicalConstants::NeutronAtom;
 using namespace boost::python;
 
+// clang-format off
 void export_Material()
+// clang-format on
 {
   register_ptr_to_python<Material*>();
   register_ptr_to_python<boost::shared_ptr<Material> >();

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Memory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Memory.cpp
@@ -4,7 +4,9 @@
 using Mantid::Kernel::MemoryStats;
 using namespace boost::python;
 
+// clang-format off
 void export_MemoryStats()
+// clang-format on
 {
 
   class_< MemoryStats>("MemoryStats", init<>("Construct MemoryStats object."))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/NullValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/NullValidator.cpp
@@ -7,7 +7,9 @@ using Mantid::Kernel::NullValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
+// clang-format off
 void export_NullValidator()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<NullValidator>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ProgressBase.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ProgressBase.cpp
@@ -4,7 +4,9 @@
 using Mantid::Kernel::ProgressBase;
 using namespace boost::python;
 
+// clang-format off
 void export_ProgressBase()
+// clang-format on
 {
   class_<ProgressBase,boost::noncopyable>("ProgressBase", no_init)
     .def("report", (void (ProgressBase::*)())&ProgressBase::report, "Increment the progress by 1 and report with no message")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -16,7 +16,9 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 
+// clang-format off
 void export_Property()
+// clang-format on
 {
   register_ptr_to_python<Property*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyHistory.cpp
@@ -9,7 +9,9 @@
 using Mantid::Kernel::PropertyHistory;
 using namespace boost::python;
 
+// clang-format off
 void export_PropertyHistory()
+// clang-format on
 {
   register_ptr_to_python<Mantid::Kernel::PropertyHistory_sptr>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
@@ -26,7 +26,9 @@ namespace
 
 }
 
+// clang-format off
 void export_PropertyManager()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<PropertyManager>>();
   class_<PropertyManager, bases<IPropertyManager>, boost::noncopyable>("PropertyManager")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyWithValue.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyWithValue.cpp
@@ -2,7 +2,9 @@
 
 using Mantid::PythonInterface::PropertyWithValueExporter;
 
+// clang-format off
 void export_BasicPropertyWithValueTypes()
+// clang-format on
 {
   // cut down copy-and-paste code
 #define EXPORT_PROP(CType, ExportName) \

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
@@ -18,7 +18,9 @@ using boost::python::return_value_policy;
 /**
  * Python exports of the Mantid::Kernel::Quat class.
  */
+// clang-format off
 void export_Quat()
+// clang-format on
 {
   //Quat class
   class_< Quat >("Quat", "Quaternions are the 3D generalization of complex numbers. "

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -213,7 +213,9 @@ namespace
 
 // -------------------------------------- Exports start here --------------------------------------
 
+// clang-format off
 void export_Statistics()
+// clang-format on
 {
   // typedef std::vector --> numpy array result converter
   typedef return_value_policy<Policies::VectorToNumpy> ReturnNumpyArray;

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
@@ -5,7 +5,9 @@
 using Mantid::PythonInterface::std_vector_exporter;
 using Mantid::PythonInterface::std_set_exporter;
 
+// clang-format off
 void exportStlContainers()
+// clang-format on
 {
     // Export some frequently used stl containers
   // std::vector

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -40,33 +40,45 @@ namespace
       ;
 }
 
+// clang-format off
 void export_TimeSeriesProperty_Double()
+// clang-format on
 {
   EXPORT_TIMESERIES_PROP(double, Float);
 }
 
+// clang-format off
 void export_TimeSeriesProperty_Bool()
+// clang-format on
 {
   EXPORT_TIMESERIES_PROP(bool, Bool);
 }
 
+// clang-format off
 void export_TimeSeriesProperty_Int32()
+// clang-format on
 {
   EXPORT_TIMESERIES_PROP(int32_t, Int32);
 }
 
+// clang-format off
 void export_TimeSeriesProperty_Int64()
+// clang-format on
 {
   EXPORT_TIMESERIES_PROP(int64_t, Int64);
 }
 
+// clang-format off
 void export_TimeSeriesProperty_String()
+// clang-format on
 {
   EXPORT_TIMESERIES_PROP(std::string, String);
 }
 
 
+// clang-format off
 void export_TimeSeriesPropertyStatistics()
+// clang-format on
 {
   class_<Mantid::Kernel::TimeSeriesPropertyStatistics>("TimeSeriesPropertyStatistics", no_init)
     .add_property("minimum", &Mantid::Kernel::TimeSeriesPropertyStatistics::minimum)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -31,7 +31,9 @@ namespace
 
 }
 
+// clang-format off
 void export_Unit()
+// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Unit>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitConversion.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitConversion.cpp
@@ -6,7 +6,9 @@ using Mantid::Kernel::UnitConversion;
 using Mantid::Kernel::DeltaEMode;
 using namespace boost::python;
 
+// clang-format off
 void export_UnitConversion()
+// clang-format on
 {
   // Function pointer typedef
   typedef double (*StringVersion)(const std::string & src, const std::string & dest,

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitFactory.cpp
@@ -12,7 +12,9 @@ namespace Policies = Mantid::PythonInterface::Policies;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
+// clang-format off
 void export_UnitFactory()
+// clang-format on
 {
   class_<UnitFactoryImpl, boost::noncopyable>("UnitFactoryImpl", no_init)
     .def("create", &UnitFactoryImpl::create, "Creates a named unit if it exists in the factory")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
@@ -46,7 +46,9 @@ namespace
 
 }
 
+// clang-format off
 void export_UnitLabel()
+// clang-format on
 {
   class_<UnitLabel>("UnitLabel", no_init)
     .def("__init__",

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Units.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Units.cpp
@@ -24,7 +24,9 @@ namespace
 
 // We only export the concrete unit classes that
 // have additional functionality over the base class
+// clang-format off
 void export_Label()
+// clang-format on
 {
   class_<Label, bases<Unit>, boost::noncopyable>("Label", no_init)
     .def("setLabel", &setLabelFromStdString,

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -29,7 +29,9 @@ namespace
 }
 
 
+// clang-format off
 void export_V3D()
+// clang-format on
 {
   //V3D class
   class_< V3D >("V3D",init<>("Construct a V3D at the origin"))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VMD.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VMD.cpp
@@ -47,7 +47,9 @@ namespace
   }
 }
 
+// clang-format off
 void export_VMD()
+// clang-format on
 {
   class_<VMD>("VMD", init<>("Default constructor gives an object with 1 dimension"))
     .def(init<VMD_t,VMD_t>("Constructs a 2 dimensional vector at the point given", args(("val0"),("val1"))))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VisibleWhenProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VisibleWhenProperty.cpp
@@ -4,7 +4,9 @@
 using namespace Mantid::Kernel;
 using namespace boost::python;
 
+// clang-format off
 void export_VisibleWhenProperty()
+// clang-format on
 {
   class_<VisibleWhenProperty, bases<EnabledWhenProperty>,
          boost::noncopyable>("VisibleWhenProperty", no_init)


### PR DESCRIPTION
This adds comments in Framework to disable `clang-format` in places where it will create broken code. This `clang-format` option is described [here](http://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code) but this only works for `clang-format` version `>= 3.6`

No real code changes, just adding comments so nothing to test.
