### PR TITLE
Fix jsoncpp include in TomoReconstruction

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/TomoReconstruction/TomoReconstruction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/TomoReconstruction/TomoReconstruction.h
@@ -8,7 +8,7 @@
 #include "MantidQtAPI/UserSubWindow.h"
 #include "MantidQtCustomInterfaces/TomoReconstruction/TomoToolConfigDialog.h"
 
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #include <QMutex>
 
 // Qt classes forward declarations


### PR DESCRIPTION
This includes jsoncpp in a more portable way for the newly added TomoReconstruction as done in #410
