### PR TITLE
Respect qmin & qmax limits in new Reflectometry UI

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -710,27 +710,25 @@ namespace MantidQt
 
         m_tableDirty = true;
       }
-      else
-      {
-        //qmin and qmax are both set, so let's crop the workspace to them
-        //cropworkspace fails on ragged workspaces, so we have to use rebin
-        IAlgorithm_sptr algCrop = AlgorithmManager::Instance().create("Rebin");
-        algCrop->initialize();
-        algCrop->setProperty("InputWorkspace", "IvsQ_" + runNo);
-        algCrop->setProperty("OutputWorkspace", "IvsQ_" + runNo);
-        const double qmin = m_model->data(m_model->index(rowNo, COL_QMIN)).toDouble();
-        const double qmax = m_model->data(m_model->index(rowNo, COL_QMAX)).toDouble();
-        const double dqq = m_model->data(m_model->index(rowNo, COL_DQQ)).toDouble();
-        std::vector<double> params;
-        params.push_back(qmin);
-        params.push_back(-dqq);
-        params.push_back(qmax);
-        algCrop->setProperty("Params", params);
-        algCrop->execute();
 
-        if(!algCrop->isExecuted())
-          throw std::runtime_error("Failed to run Rebin algorithm");
-      }
+      //We need to make sure that qmin and qmax are respected, so we rebin to
+      //those limits here.
+      IAlgorithm_sptr algCrop = AlgorithmManager::Instance().create("Rebin");
+      algCrop->initialize();
+      algCrop->setProperty("InputWorkspace", "IvsQ_" + runNo);
+      algCrop->setProperty("OutputWorkspace", "IvsQ_" + runNo);
+      const double qmin = m_model->data(m_model->index(rowNo, COL_QMIN)).toDouble();
+      const double qmax = m_model->data(m_model->index(rowNo, COL_QMAX)).toDouble();
+      const double dqq = m_model->data(m_model->index(rowNo, COL_DQQ)).toDouble();
+      std::vector<double> params;
+      params.push_back(qmin);
+      params.push_back(-dqq);
+      params.push_back(qmax);
+      algCrop->setProperty("Params", params);
+      algCrop->execute();
+
+      if(!algCrop->isExecuted())
+        throw std::runtime_error("Failed to run Rebin algorithm");
 
       //Also fill in theta if needed
       if(m_model->data(m_model->index(rowNo, COL_ANGLE)).toString().isEmpty() && thetaGiven)

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -710,6 +710,27 @@ namespace MantidQt
 
         m_tableDirty = true;
       }
+      else
+      {
+        //qmin and qmax are both set, so let's crop the workspace to them
+        //cropworkspace fails on ragged workspaces, so we have to use rebin
+        IAlgorithm_sptr algCrop = AlgorithmManager::Instance().create("Rebin");
+        algCrop->initialize();
+        algCrop->setProperty("InputWorkspace", "IvsQ_" + runNo);
+        algCrop->setProperty("OutputWorkspace", "IvsQ_" + runNo);
+        const double qmin = m_model->data(m_model->index(rowNo, COL_QMIN)).toDouble();
+        const double qmax = m_model->data(m_model->index(rowNo, COL_QMAX)).toDouble();
+        const double dqq = m_model->data(m_model->index(rowNo, COL_DQQ)).toDouble();
+        std::vector<double> params;
+        params.push_back(qmin);
+        params.push_back(-dqq);
+        params.push_back(qmax);
+        algCrop->setProperty("Params", params);
+        algCrop->execute();
+
+        if(!algCrop->isExecuted())
+          throw std::runtime_error("Failed to run Rebin algorithm");
+      }
 
       //Also fill in theta if needed
       if(m_model->data(m_model->index(rowNo, COL_ANGLE)).toString().isEmpty() && thetaGiven)


### PR DESCRIPTION
This is for trac ticket [#11654](http://trac.mantidproject.org/mantid/ticket/11654)

If a workspace is not stitched in the new Reflectometry UI, then the qmin/qmax limits are never applied. This pull request ensures that the limits are always applied.

**Testing**:
- Open the new reflectometry UI
- Add a single row
  - run: 13460
  - angle: 0.7
  - tramission run: <blank>
  - qmin: 0.01
  - qmax: 0.06
  - dqq: 0.04 
  - scale: 1
  - group: 1
- Set instrument to INTER and hit process.

If you look at the resulting IvQ workspace, the range of x values should stay within qmin and qmax, applied by running Rebin.
