### PR TITLE
Attach the history to workspaces during workflow algorithms.

### DIFF
--- a/Code/Mantid/Framework/API/src/Algorithm.cpp
+++ b/Code/Mantid/Framework/API/src/Algorithm.cpp
@@ -953,9 +953,13 @@ void Algorithm::initializeFromProxy(const AlgorithmProxy &proxy) {
 /** Fills History, Algorithm History and Algorithm Parameters
 */
 void Algorithm::fillHistory() {
-  // this is not a child algorithm. Add the history algorithm to the
-  // WorkspaceHistory object.
-  if (!isChild()) {
+  if(isRecordingHistoryForChild() && m_parentHistory) {
+    // Record the history of this in the parent algorithm
+    m_parentHistory->addChildHistory(m_history);
+  }
+  if (!isChild() || isRecordingHistoryForChild()) {
+    // Store the history as it stands in the workspace
+
     // Create two vectors to hold a list of pointers to the input & output
     // workspaces (InOut's go in both)
     std::vector<Workspace_sptr> inputWorkspaces, outputWorkspaces;
@@ -996,10 +1000,6 @@ void Algorithm::fillHistory() {
         }
       }
     }
-  }
-  // this is a child algorithm, but we still want to keep the history.
-  else if (m_recordHistoryForChild && m_parentHistory) {
-    m_parentHistory->addChildHistory(m_history);
   }
 }
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/mantid/api/AlgorithmHistoryTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/mantid/api/AlgorithmHistoryTest.py
@@ -79,7 +79,7 @@ class AlgorithmHistoryTest(unittest.TestCase):
 
     def _run_algorithm(self, algorithm_name, child_algorithm=False, record_history=True, **kwargs):
         """ Create and run an algorithm not in the simpleapi"""
-        alg = AlgorithmManager.create(algorithm_name)
+        alg = AlgorithmManager.createUnmanaged(algorithm_name)
         alg.initialize()
         alg.setChild(child_algorithm)
         alg.enableHistoryRecordingForChild(record_history)


### PR DESCRIPTION
Fixes issue [#11656](http://trac.mantidproject.org/mantid/ticket/11656)

**Tester**
This is most easily tested by running the `SNSPowderReduction` algorithm and looking at the generated python script - it should contain the list of algorithms that were run.
