### PR TITLE
Fix crash when selecting conjugate gradient minimizers

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/src/FRConjugateGradientMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/FRConjugateGradientMinimizer.cpp
@@ -15,10 +15,11 @@ namespace {
 Kernel::Logger g_log("FRConjugateGradientMinimizer");
 }
 
+// clang-format off
 ///@cond nodoc
-DECLARE_FUNCMINIMIZER(FRConjugateGradientMinimizer,
-                      Conjugate gradient(Fletcher - Reeves imp.))
+DECLARE_FUNCMINIMIZER(FRConjugateGradientMinimizer,Conjugate gradient (Fletcher-Reeves imp.))
 ///@endcond
+// clang-format on
 
 /// Return a concrete type to initialize m_gslSolver
 /// gsl_multimin_fdfminimizer_vector_bfgs2

--- a/Code/Mantid/Framework/CurveFitting/src/PRConjugateGradientMinimizer.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/PRConjugateGradientMinimizer.cpp
@@ -10,10 +10,12 @@
 
 namespace Mantid {
 namespace CurveFitting {
+
+// clang-format off
 ///@cond nodoc
-DECLARE_FUNCMINIMIZER(PRConjugateGradientMinimizer,
-                      Conjugate gradient(Polak - Ribiere imp.))
+DECLARE_FUNCMINIMIZER(PRConjugateGradientMinimizer,Conjugate gradient (Polak-Ribiere imp.))
 ///@endcond
+// clang-format on
 
 /// Return a concrete type to initialize m_gslSolver
 /// gsl_multimin_fdfminimizer_vector_bfgs2


### PR DESCRIPTION
This fixes [#11643](http://trac.mantidproject.org/mantid/ticket/11643).

This other PR #675 ringed the bell. It seems that clang had broken this because it feels very free to change the spaces in the name of the minimizer. I changed the name back and added the `clang-format off`, `clang-format on` tags.

**To test**:
- See that now you can select both conjugate gradient minimizers
- Check code changes and make sure that this was the issue
