### PR TITLE
Show BinWidth as attribute in DKT

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
@@ -44,12 +44,30 @@ namespace Mantid
     {
     public:
 
+      /// Constructor
+      DynamicKuboToyabe();
+
       /// Destructor
       virtual ~DynamicKuboToyabe() {}
 
       /// overwrite base class methods
       std::string name()const{return "DynamicKuboToyabe";}
       virtual const std::string category() const { return "Muon";}
+
+      /// Returns the number of attributes associated with the function
+      size_t nAttributes() const { return 1; }
+
+      /// Returns a list of attribute names
+      std::vector<std::string> getAttributeNames() const;
+
+      /// Return a value of attribute attName
+      Attribute getAttribute(const std::string &attName) const;
+
+      /// Set a value to attribute attName
+      void setAttribute(const std::string &attName, const Attribute &);
+
+      /// Check if attribute attName exists
+      bool hasAttribute(const std::string &attName) const;
 
     protected:
       virtual void function1D(double* out, const double* xValues, const size_t nData)const;
@@ -58,6 +76,9 @@ namespace Mantid
       virtual void init();
       virtual void setActiveParameter(size_t i, double value);
 
+    private:
+      /// Bin width
+      double m_eps;
     };
 
   } // namespace CurveFitting

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
@@ -83,7 +83,7 @@ namespace Mantid
 
       /// Bin width
       double m_eps;
-      double m_minEps;
+      double m_minEps, m_maxEps;
     };
 
   } // namespace CurveFitting

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
@@ -79,6 +79,7 @@ namespace Mantid
     private:
       /// Bin width
       double m_eps;
+      double m_minEps;
     };
 
   } // namespace CurveFitting

--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/DynamicKuboToyabe.h
@@ -77,6 +77,10 @@ namespace Mantid
       virtual void setActiveParameter(size_t i, double value);
 
     private:
+
+      // Evaluate DKT function for a given t, G, F, v and eps
+      double getDKT (double t, double G, double F, double v, double eps) const;
+
       /// Bin width
       double m_eps;
       double m_minEps;

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -186,7 +186,7 @@ double DynamicKuboToyabe::getDKT (double t, double G, double F, double v, double
 
   if ( (G != oldG) || (v != oldV) || (F != oldF) || (eps != oldEps)){
 
-    // If G or v or F or eps have changed with respect to the 
+    // If G or v or F or eps have changed with respect to the
     // previous call, we need to re-do the computations
 
 
@@ -279,7 +279,7 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05), m_minEps(0.003) {}
+DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05), m_minEps(0.003), m_maxEps(0.05) {}
 
 //----------------------------------------------------------------------------------------------
 /** Function to calculate derivative numerically
@@ -343,10 +343,13 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
     double newVal = att.asDouble();
 
     if (newVal < 0) {
-      throw std::invalid_argument("DynamicKuboToyabe: bin width cannot be negative.");
+      throw std::invalid_argument("DynamicKuboToyabe: bin width cannot be negative, ignoring new value.");
 
     } else if (newVal < m_minEps) {
-      throw std::invalid_argument("DynamicKuboToyabe: bin width too small.");
+      throw std::invalid_argument("DynamicKuboToyabe: bin width too small, ignoring new value.");
+
+    } else if (newVal > m_maxEps) {
+      throw std::invalid_argument("DynamicKuboToyabe: bin width too large, ignoring new value.");
     }
 
     m_eps = newVal;

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -278,16 +278,27 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
  */
 DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05) {}
 
+//----------------------------------------------------------------------------------------------
+/** Function to calculate derivative numerically
+ */
 void DynamicKuboToyabe::functionDeriv(const API::FunctionDomain& domain, API::Jacobian& jacobian)
 {
   calNumericalDeriv(domain, jacobian);
 }
 
+//----------------------------------------------------------------------------------------------
+/** Function to calculate derivative analytically
+ */
 void DynamicKuboToyabe::functionDeriv1D(API::Jacobian* , const double* , const size_t )
 {
-  throw Mantid::Kernel::Exception::NotImplementedError("functionDerivLocal is not implemented for DynamicKuboToyabe.");
+  throw Mantid::Kernel::Exception::NotImplementedError("functionDeriv1D is not implemented for DynamicKuboToyabe.");
 }
 
+//----------------------------------------------------------------------------------------------
+/** Set new value of the i-th parameter
+ * @param i :: parameter index
+ * @param value :: new value
+ */
 void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
 
   setParameter( i, fabs(value), false);
@@ -297,7 +308,7 @@ void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
 //----------------------------------------------------------------------------------------------
 /** Get Attribute names
  * @return A list of attribute names
-*/
+ */
 std::vector<std::string> DynamicKuboToyabe::getAttributeNames() const {
   std::vector<std::string> res;
   res.push_back("eps");
@@ -336,8 +347,8 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
 
 //----------------------------------------------------------------------------------------------
 /** Check if attribute attName exists
-  * @param attName :: The attribute name.
-  */
+ * @param attName :: The attribute name.
+ */
 bool DynamicKuboToyabe::hasAttribute(const std::string &attName) const {
   return attName == "eps";
 }

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -314,7 +314,7 @@ void DynamicKuboToyabe::setActiveParameter(size_t i, double value) {
  */
 std::vector<std::string> DynamicKuboToyabe::getAttributeNames() const {
   std::vector<std::string> res;
-  res.push_back("eps");
+  res.push_back("BinWidth");
   return res;
 }
 
@@ -325,7 +325,7 @@ std::vector<std::string> DynamicKuboToyabe::getAttributeNames() const {
  */
 API::IFunction::Attribute DynamicKuboToyabe::getAttribute(const std::string &attName) const {
 
-  if (attName == "eps") {
+  if (attName == "BinWidth") {
     return Attribute(m_eps);
   }
   throw std::invalid_argument("DynamicKuboToyabe: Unknown attribute " + attName);
@@ -338,7 +338,7 @@ API::IFunction::Attribute DynamicKuboToyabe::getAttribute(const std::string &att
  */
 void DynamicKuboToyabe::setAttribute(const std::string &attName,
                               const API::IFunction::Attribute &att) {
-  if (attName == "eps") {
+  if (attName == "BinWidth") {
 
     double newVal = att.asDouble();
 
@@ -364,7 +364,7 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
  * @param attName :: The attribute name.
  */
 bool DynamicKuboToyabe::hasAttribute(const std::string &attName) const {
-  return attName == "eps";
+  return attName == "BinWidth";
 }
 
 

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -276,7 +276,7 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05) {}
+DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05), m_minEps(0.003) {}
 
 //----------------------------------------------------------------------------------------------
 /** Function to calculate derivative numerically
@@ -337,12 +337,20 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
                               const API::IFunction::Attribute &att) {
   if (attName == "eps") {
 
-    m_eps = att.asDouble();
-    if (m_eps < 0) {
+    double newVal = att.asDouble();
+
+    if (newVal < 0) {
       throw std::invalid_argument("DynamicKuboToyabe: bin width cannot be negative.");
+
+    } else if (newVal < m_minEps) {
+      throw std::invalid_argument("DynamicKuboToyabe: bin width too small.");
     }
+
+    m_eps = newVal;
+
+  } else {
+    throw std::invalid_argument("DynamicKuboToyabe: Unknown attribute " + attName);
   }
-  throw std::invalid_argument("DynamicKuboToyabe: Unknown attribute " + attName);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -175,17 +175,18 @@ double HKT (const double x, const double G, const double F) {
 }
 
 // Dynamic Kubo-Toyabe
-double getDKT (double t, double G, double F, double v, double eps){
+double DynamicKuboToyabe::getDKT (double t, double G, double F, double v, double eps) const {
 
   const int tsmax = static_cast<int>(std::ceil(32.768/eps));
 
-  static double oldG=-1., oldV=-1., oldF=-1.;
-  static std::vector<double> gStat(tsmax), gDyn(tsmax);
+  static double oldG=-1., oldV=-1., oldF=-1., oldEps=-1.;
 
+  const int maxTsmax = static_cast<int>(std::ceil(32.768/m_minEps));
+  static std::vector<double> gStat(maxTsmax), gDyn(maxTsmax);
 
-  if ( (G != oldG) || (v != oldV) || (F != oldF) ){
+  if ( (G != oldG) || (v != oldV) || (F != oldF) || (eps != oldEps)){
 
-    // If G or v or F have changed with respect to the 
+    // If G or v or F or eps have changed with respect to the 
     // previous call, we need to re-do the computations
 
 
@@ -212,6 +213,8 @@ double getDKT (double t, double G, double F, double v, double eps){
 
     // Store new v value
     oldV =v;
+    // Store new eps value
+    oldEps =eps;
 
     double hop = v*eps;
 

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -343,15 +343,25 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
     double newVal = att.asDouble();
 
     if (newVal < 0) {
-      throw std::invalid_argument("DynamicKuboToyabe: bin width cannot be negative, ignoring new value.");
+      clearAllParameters();
+      throw std::invalid_argument("DynamicKuboToyabe: bin width cannot be negative.");
 
     } else if (newVal < m_minEps) {
-      throw std::invalid_argument("DynamicKuboToyabe: bin width too small, ignoring new value.");
+      clearAllParameters();
+      std::stringstream ss;
+      ss << "DynamicKuboToyabe: bin width too small (BinWidth < " << std::setprecision(3) << m_minEps << ")";
+      throw std::invalid_argument(ss.str());
 
     } else if (newVal > m_maxEps) {
-      throw std::invalid_argument("DynamicKuboToyabe: bin width too large, ignoring new value.");
+      clearAllParameters();
+      std::stringstream ss;
+      ss << "DynamicKuboToyabe: bin width too large (BinWidth > " << std::setprecision(3) << m_maxEps << ")";
+      throw std::invalid_argument(ss.str());
     }
 
+    if ( !nParams() ) {
+      init();
+    }
     m_eps = newVal;
 
   } else {

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -279,7 +279,7 @@ void DynamicKuboToyabe::function1D(double* out, const double* xValues, const siz
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05), m_minEps(0.003), m_maxEps(0.05) {}
+DynamicKuboToyabe::DynamicKuboToyabe() : m_eps(0.05), m_minEps(0.001), m_maxEps(0.1) {}
 
 //----------------------------------------------------------------------------------------------
 /** Function to calculate derivative numerically

--- a/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/DynamicKuboToyabe.cpp
@@ -344,18 +344,18 @@ void DynamicKuboToyabe::setAttribute(const std::string &attName,
 
     if (newVal < 0) {
       clearAllParameters();
-      throw std::invalid_argument("DynamicKuboToyabe: bin width cannot be negative.");
+      throw std::invalid_argument("DKT: Attribute BinWidth cannot be negative.");
 
     } else if (newVal < m_minEps) {
       clearAllParameters();
       std::stringstream ss;
-      ss << "DynamicKuboToyabe: bin width too small (BinWidth < " << std::setprecision(3) << m_minEps << ")";
+      ss << "DKT: Attribute BinWidth too small (BinWidth < " << std::setprecision(3) << m_minEps << ")";
       throw std::invalid_argument(ss.str());
 
     } else if (newVal > m_maxEps) {
       clearAllParameters();
       std::stringstream ss;
-      ss << "DynamicKuboToyabe: bin width too large (BinWidth > " << std::setprecision(3) << m_maxEps << ")";
+      ss << "DKT: Attribute BinWidth too large (BinWidth > " << std::setprecision(3) << m_maxEps << ")";
       throw std::invalid_argument(ss.str());
     }
 

--- a/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -24,8 +24,6 @@ where :math:`g_z\left(t\right)` is the static KT function, and :math:`\nu` the m
 
 .. math:: g_z\left(t\right) = \mbox{A} \Bigg[ 1 - 2\frac{\Delta^2}{\omega_0^2}\Big(1-cos(\omega_0 t)e^{-\frac{1}{2}\Delta^2 t^2}\Big) + 2\frac{\Delta^4}{\omega_0^4}\omega_0\int_0^\tau \sin(\omega_0\tau)e^{-\frac{1}{2}\Delta^2\tau^2}d\tau \Bigg]
 
-Note: The static function in longitudinal field will be implemented soon. In the meantime, please fix the external field :math:`B_0` (F parameter) to 0.
-
 .. attributes::
 
 .. properties::

--- a/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -24,6 +24,9 @@ where :math:`g_z\left(t\right)` is the static KT function, and :math:`\nu` the m
 
 .. math:: g_z\left(t\right) = \mbox{A} \Bigg[ 1 - 2\frac{\Delta^2}{\omega_0^2}\Big(1-cos(\omega_0 t)e^{-\frac{1}{2}\Delta^2 t^2}\Big) + 2\frac{\Delta^4}{\omega_0^4}\omega_0\int_0^\tau \sin(\omega_0\tau)e^{-\frac{1}{2}\Delta^2\tau^2}d\tau \Bigg]
 
+DynamicKuboToyabe function has one attribute (non-fitting parameter), 'BinWidth', that sets the width of the step size between points for numerical integration. Note that 
+small values will lead to long calculation times, while large values will produce less accurate results. The default value is set to 0.05, and it is allowed to vary in the range [0.001,0.1].
+
 .. attributes::
 
 .. properties::


### PR DESCRIPTION
This is for [#11650](http://trac.mantidproject.org/mantid/ticket/11650)

The DynamicKuboToyabe fitting function involves the calculation of an integral. The accuracy of the result depends on the number of evaluation points, or equivalently, on the width of the step size between the points (BinWidth). Scientists often need to tune this BinWidth and use different values for different datasets. The aim of this PR is to set BinWidth as an attribute so scientists can play with different values.

For tester: I would say that checking that BinWidth is visible in the function browser is enough (plus code review). To do that, open the Muon Analysis interface, go to "Data Analysis" tab, right-click on Functions and "Add Function" -> "Muon" -> "DynamicKuboToyabe". Check that BinWidth is visible and that if you try to set it to a value outside the range [0.001,0.1] you get appropriate error messages and the fitting parameters are removed. When you set a value within those limits, parameters are shown again. There is no need to test fitting results, as that was done in previous pull requests.
