### PR TITLE
Make ragged cropping behaviour more obvious

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/CropWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CropWorkspace.cpp
@@ -83,6 +83,10 @@ void CropWorkspace::exec() {
   m_histogram = m_inputWorkspace->isHistogramData();
   // Check for common boundaries in input workspace
   m_commonBoundaries = WorkspaceHelpers::commonBoundaries(m_inputWorkspace);
+  if (!m_commonBoundaries)
+    g_log.information("InputWorkspace has varying bin boundaries. Bins will not"
+                      " be modified, but the Y and E values for any bins "
+                      "outside XMin and XMax will be set to 0.");
 
   // Retrieve and validate the input properties
   this->checkProperties();


### PR DESCRIPTION
This is for trac ticket [#11655](http://trac.mantidproject.org/mantid/ticket/11655)

When CropWorkspace is applied to a workspace with ragged bins, it doesn't touch the bin boundaries, but instead sets the Y and E values for any bins outside XMin and XMax to 0. This confused Owen and I briefly, as we thought the algorithm was failing.

This pull request provides more information to the user about the differing behaviour at runtime.
