### PR TITLE
Use correct beam height value in Calc Corr

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/CalcCorr.cpp
@@ -295,19 +295,26 @@ namespace IDA
       return;
     }
 
-    std::string paramName = "Workflow.beam-width";
     auto instrument = ws->getInstrument();
 
-    if(instrument->hasParameter(paramName))
+    const std::string beamWidthParamName = "Workflow.beam-width";
+    if(instrument->hasParameter(beamWidthParamName))
     {
-      QString beamWidth = QString::fromStdString(instrument->getStringParameter(paramName)[0]);
+      QString beamWidth = QString::fromStdString(instrument->getStringParameter(beamWidthParamName)[0]);
       double beamWidthValue = beamWidth.toDouble();
 
       m_uiForm.spCylBeamWidth->setValue(beamWidthValue);
-      m_uiForm.spCylBeamHeight->setValue(beamWidthValue);
-
       m_uiForm.spAnnBeamWidth->setValue(beamWidthValue);
-      m_uiForm.spAnnBeamHeight->setValue(beamWidthValue);
+    }
+
+    const std::string beamHeightParamName = "Workflow.beam-height";
+    if(instrument->hasParameter(beamHeightParamName))
+    {
+      QString beamHeight = QString::fromStdString(instrument->getStringParameter(beamHeightParamName)[0]);
+      double beamHeightValue = beamHeight.toDouble();
+
+      m_uiForm.spCylBeamHeight->setValue(beamHeightValue);
+      m_uiForm.spAnnBeamHeight->setValue(beamHeightValue);
     }
   }
 


### PR DESCRIPTION
Fixes [#11661](http://trac.mantidproject.org/mantid/ticket/11661).

To test:
- Open IDA > CalcCorr
- Load a reduced (`_red.nxs`) file with a relatively up to date IPF (I'll probably have one in `Babylon5/Public/DanNixon` somewhere)
- Set shape to either Cylinder or Annulus
- See that the beam width and height values are taken from the IPF (the parameters are near the bottom of the IPF for verification)
