### PR TITLE
Replace custom binary search in Kernel::Interpolation

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/Interpolation.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/Interpolation.h
@@ -61,8 +61,8 @@ private:
   Unit_sptr m_yUnit;
 
 protected:
-  size_t findIndexOfNextLargerValue(const std::vector<double> &data, double key,
-                                    size_t range_start, size_t range_end) const;
+  size_t findIndexOfNextLargerValue(const std::vector<double> &data,
+                                    double key) const;
 
 public:
   /// Constructor default to linear interpolation and x-unit set to TOF

--- a/Code/Mantid/Framework/Kernel/src/Interpolation.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Interpolation.cpp
@@ -28,12 +28,7 @@ Interpolation::Interpolation() : m_method("linear") {
 
 size_t
 Interpolation::findIndexOfNextLargerValue(const std::vector<double> &data,
-                                          double key, size_t range_start,
-                                          size_t range_end) const {
-
-  UNUSED_ARG(range_start);
-  UNUSED_ARG(range_end);
-
+                                          double key) const {
   auto begin = data.begin();
   auto end = data.end();
   auto pos = std::lower_bound(begin, end, key, LessOrEqualFunctor());
@@ -84,8 +79,8 @@ double Interpolation::value(const double &at) const {
 
   try {
     // otherwise
-    // General case. Find index of next largest value by binary search.
-    size_t idx = findIndexOfNextLargerValue(m_x, at, 1, N - 1);
+    // General case. Find index of next largest value by std::lower_bound.
+    size_t idx = findIndexOfNextLargerValue(m_x, at);
     return m_y[idx - 1] +
            (at - m_x[idx - 1]) * (m_y[idx] - m_y[idx - 1]) /
                (m_x[idx] - m_x[idx - 1]);

--- a/Code/Mantid/Framework/Kernel/src/Interpolation.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Interpolation.cpp
@@ -10,6 +10,15 @@ namespace {
 Logger g_log("Interpolation");
 }
 
+/* Functor for findIndexOfNextLargerValue, used in std::lower_bound to replicate
+   the original behavior.
+*/
+struct LessOrEqualFunctor {
+    bool operator()(const double &lhs, const double &rhs) {
+        return lhs <= rhs;
+    }
+};
+
 /** Constructor default to linear interpolation and x-unit set to TOF
  */
 Interpolation::Interpolation() : m_method("linear") {
@@ -21,21 +30,19 @@ size_t
 Interpolation::findIndexOfNextLargerValue(const std::vector<double> &data,
                                           double key, size_t range_start,
                                           size_t range_end) const {
-  if (range_end < range_start) {
-    throw std::range_error("Value is outside array range.");
+
+  UNUSED_ARG(range_start);
+  UNUSED_ARG(range_end);
+
+  auto begin = data.begin();
+  auto end = data.end();
+  auto pos = std::lower_bound(begin, end, key, LessOrEqualFunctor());
+
+  if(pos == end || pos == begin) {
+      throw std::range_error("Value is not in the interpolation range.");
   }
 
-  size_t center = range_start + (range_end - range_start) / 2;
-
-  if (data[center] > key && data[center - 1] <= key) {
-    return center;
-  }
-
-  if (data[center] <= key) {
-    return findIndexOfNextLargerValue(data, key, center + 1, range_end);
-  } else {
-    return findIndexOfNextLargerValue(data, key, range_start, center - 1);
-  }
+  return std::distance(begin, pos);
 }
 
 void Interpolation::setXUnit(const std::string &unit) {

--- a/Code/Mantid/Framework/Kernel/test/InterpolationTest.h
+++ b/Code/Mantid/Framework/Kernel/test/InterpolationTest.h
@@ -170,28 +170,26 @@ public:
     {
         TestableInterpolation interpolation;
 
-        size_t N = m_tableXValues.size();
-
         // lower limit - can be treated like general case
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 200.0, 1, N - 1), 1);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 200.0), 1);
 
         // Exact interpolation points
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 201.0, 1, N - 1), 2);
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 202.0, 1, N - 1), 3);
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 203.0, 1, N - 1), 4);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 201.0), 2);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 202.0), 3);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 203.0), 4);
 
         // Arbitrary interpolation points
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 200.5, 1, N - 1), 1);
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 201.25, 1, N - 1), 2);
-        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 203.5, 1, N - 1), 4);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 200.5), 1);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 201.25), 2);
+        TS_ASSERT_EQUALS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 203.5), 4);
 
 
         // upper limit - must be covered as edge case before this can ever be called.
-        TS_ASSERT_THROWS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 204.0, 1, N - 1), std::range_error);
+        TS_ASSERT_THROWS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 204.0), std::range_error);
 
         // outside interpolation limits - edge cases as well
-        TS_ASSERT_THROWS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 199, 1, N - 1), std::range_error)
-        TS_ASSERT_THROWS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 2000.0, 1, N - 1), std::range_error)
+        TS_ASSERT_THROWS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 199), std::range_error);
+        TS_ASSERT_THROWS(interpolation.findIndexOfNextLargerValue(m_tableXValues, 2000.0), std::range_error);
     }
 
     void testInterpolationWithTooFewValues()


### PR DESCRIPTION
This fixed [#11659](http://trac.mantidproject.org/mantid/ticket/11659).

**Testing information**
Code review and making sure that all tests still pass should be enough. The unit test has not been changed except for removing the parameters that were used for recursion and are no longer required, so it should still ensure correct behaviour.
