### PR TITLE
Fix incorrect file selection on Indirect Diffraction

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -356,6 +356,9 @@ void IndirectDiffractionReduction::instrumentSelected(const QString & instrument
 {
   UNUSED_ARG(analyserName);
 
+  // Set the search instrument for runs
+  m_uiForm.dem_rawFiles->setInstrumentOverride(instrumentName);
+
   MatrixWorkspace_sptr instWorkspace = loadInstrument(instrumentName.toStdString(), reflectionName.toStdString());
   Instrument_const_sptr instrument = instWorkspace->getInstrument();
 


### PR DESCRIPTION
Fixes [#11662](http://trac.mantidproject.org/mantid/ticket/11662).

To reproduce issue:
- Set logging to Debug
- Open Indirect > Diffraction
- Ensure default instrument is not IRIS, OSIRIS, TOSCA, TFXA or VESUVIO
- Enter a run number (e.g. 26176)
- See in the log that the incorrect instrument is searched for (the default instrument, not the one selected in the interface)
