### PR TITLE
Fix workspace naming in Indirect Diffraction

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -245,8 +245,8 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction()
   try
   {
     QString nameBase = QString::fromStdString(Mantid::Kernel::MultiFileNameParsing::suggestWorkspaceName(stlFileNames));
-    tofWsName = "'" + nameBase + "_tof'";
-    drangeWsName = "'" + nameBase + "_dRange'";
+    tofWsName = nameBase + "_tof";
+    drangeWsName = nameBase + "_dRange";
   }
   catch(std::runtime_error & re)
   {


### PR DESCRIPTION
Fixes [#11664](http://trac.mantidproject.org/mantid/ticket/11664).

To test:
- Open Indirect > Diffraction
- Select OSIRIS in diffonly mode
- Load samples: OSI89813.raw, OSI89814.raw, OSI89815.raw, osi89816.raw, osi89817.raw
- Load calibration: osiris_041_RES10.cal
- Load vanadium: osi89757.raw, osi89758.raw, osi89759.raw, osi89760.raw, osi89761.raw
- Select plot spectra
- Run

Workspace names should have no single quotes and plotting should work as expected, the above steps without the fix demonstrate the original issue.
