### PR TITLE
Don't override WriteSpectrumID in SaveAscii-v2

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveAscii2.cpp
@@ -117,8 +117,6 @@ void SaveAscii2::exec() {
   m_isHistogram = m_ws->isHistogramData();
   m_isCommonBins = m_ws->isCommonBins(); // checking for ragged workspace
   m_writeID = getProperty("WriteSpectrumID");
-  if (nSpectra != 1)
-    m_writeID = true;
 
   // Get the properties
   std::vector<int> spec_list = getProperty("SpectrumList");

--- a/Code/Mantid/docs/source/algorithms/SaveAscii-v2.rst
+++ b/Code/Mantid/docs/source/algorithms/SaveAscii-v2.rst
@@ -9,12 +9,16 @@
 Description
 -----------
 
-The workspace data are stored in the file in columns: the first column contains the X-values, followed by pairs of Y and E values. Columns are separated by commas. The resulting file can normally be loaded into a workspace by the :ref:`algm-LoadAscii` algorithm.
+The workspace data are stored in the file in columns: the first column contains
+the X-values, followed by pairs of Y and E values. Columns are separated by
+commas. The resulting file can normally be loaded into a workspace by the
+:ref:`algm-LoadAscii` algorithm.
 
 Limitations
 ###########
 
-The algorithm assumes that the workspace has common X values for all spectra (i.e. is not a `ragged workspace <Ragged Workspace>`__). Only the X values from the first spectrum in the workspace are saved out.
+The algorithm assumes that the workspace has common X values for all spectra
+(i.e. is not a `ragged workspace <Ragged Workspace>`__).
 
 Usage
 -----


### PR DESCRIPTION
This is for trac ticket [#11657](http://trac.mantidproject.org/mantid/ticket/11657).
