### PR TITLE
Problems with Error Bars 

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/LoadSQW.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/LoadSQW.cpp
@@ -276,10 +276,10 @@ void
           interpretAs<float>(Buffer, current_pix + column_size),
           interpretAs<float>(Buffer, current_pix + column_size_2),
           interpretAs<float>(Buffer, current_pix + column_size_3)};
-      float error = interpretAs<float>(Buffer, current_pix + column_size_8);
+      const float errorSQ = interpretAs<float>(Buffer, current_pix + column_size_8);
       ws->addEvent(MDEvent<4>(
           interpretAs<float>(Buffer, current_pix + column_size_7), // Signal
-          error * error,                                           // Error sq
+          errorSQ,                                           // Error sq
           static_cast<uint16_t>(interpretAs<float>(
               Buffer, current_pix + column_size_6)), // run Index
           static_cast<int32_t>(interpretAs<float>(

--- a/Code/Mantid/Framework/MDAlgorithms/test/CreateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/CreateMDHistoWorkspaceTest.h
@@ -81,6 +81,16 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
+  void test_throws_if_wrong_number_of_nevents()
+  {
+    std::string outWSName = "test_ws";
+    IAlgorithm_sptr alg = make_standard_algorithm(outWSName);
+    alg->setProperty("NumberOfEvents", "1"); //Only one number of events value provided, but NumberOfBins set to 5!
+    TS_ASSERT_THROWS(alg->execute(), std::invalid_argument);
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+
   void test_exec_1D()
   {
     // Name of the output workspace.


### PR DESCRIPTION
See the [original trac issue #11348](http://trac.mantidproject.org/mantid/ticket/11348) to see the detailed issue and full discussion surrounding the problem, as well as and the determination of the fix required.

**Tester**
- Unit tests and system tests should pass. This is the most important thing to check.
- If you have the computing power, you could also run the following and compare the result against the outputs recorded from the equivalent horace cuts in the ticket  [#11348](http://trac.mantidproject.org/mantid/ticket/11348). Ask me for the file if required.

``` python
from mantid.api import MDNormalization
data = Load("Fe_ei200.sqw")
cut = CutMD(data,NoPix=True,PBins=[[2.5,0.1,6],[-0.05,0.05],[-0.05,0.05],[56,64]])
plotMD(cut, normalization=MDNormalization.NumEventsNormalization)
```
