### PR TITLE
Validate ConvertToDistribution inputs

### DIFF
--- a/Code/Mantid/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Code/Mantid/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -553,6 +553,12 @@ void WorkspaceHelpers::makeDistribution(MatrixWorkspace_sptr workspace,
   if (workspace->isDistribution() == forwards)
     return;
 
+  // If we're not able to get a writable reference to Y, then this is an event
+  // workspace, which we can't operate on.
+  if (workspace->id() == "EventWorkspace")
+    throw std::runtime_error("Event workspaces cannot be directly converted "
+                             "into distributions.");
+
   const size_t numberOfSpectra = workspace->getNumberHistograms();
 
   std::vector<double> widths(workspace->readX(0).size());

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ConvertToDistribution.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ConvertToDistribution.h
@@ -64,6 +64,8 @@ private:
   void init();
   /// Execution code
   void exec();
+  /// Validate inputs
+  std::map<std::string, std::string> validateInputs();
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/src/ConvertToDistribution.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ConvertToDistribution.cpp
@@ -27,5 +27,16 @@ void ConvertToDistribution::exec() {
   WorkspaceHelpers::makeDistribution(workspace);
 }
 
+std::map<std::string, std::string> ConvertToDistribution::validateInputs() {
+  std::map<std::string, std::string> errors;
+
+  MatrixWorkspace_sptr workspace = getProperty("Workspace");
+  if (workspace->id() == "EventWorkspace")
+    errors["Workspace"] = "Event workspaces cannot be directly converted to "
+                          "distributions.";
+
+  return errors;
+}
+
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/docs/source/algorithms/ConvertToDistribution-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ConvertToDistribution-v1.rst
@@ -14,7 +14,9 @@ Makes a histogram workspace a distribution i.e. divides by the bin width.
 Restrictions on the input workspace
 ###################################
 
-The workspace to convert must contain histogram data which is not already flagged as a distribution.
+The workspace to convert must contain histogram data which is not already
+flagged as a distribution.
+It cannot be an :ref:`EventWorkspace <EventWorkspace>`.
 
 Usage
 -----


### PR DESCRIPTION
This is for trac ticket [#11668](http://trac.mantidproject.org/mantid/ticket/11668)

ConvertToDistribution fails when given an event workspace, emitting a cryptic error message. It should be more obvious why it has failed: it doesn't make sense to convert an event workspace to a distribution.

To reproduce:

``` python
hist = CreateSampleWorkspace()
event = ConvertToEventWorkspace(hist)
ConvertToDistribution(event)
```
