### PR TITLE
Refs #11666 set unbin button disabled for unbinned MDEvent source

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -337,7 +337,7 @@ void StandardView::activeSourceChangeListener(pqPipelineSource* source)
   else if (workspaceType.find("MDEW Source") != std::string::npos)
   {
     this->allowRebinningOptions(true);
-    this->allowUnbinOption(true);
+    this->allowUnbinOption(false);
   }
   else
   {


### PR DESCRIPTION
Fixes ticket [#11666](http://trac.mantidproject.org/mantid/ticket/11666)

**Context**
The rebin feature allows for rebinning of MDEvent data sets. Once an MDEvent data set is rebinned, it can be unbinned. In this case the option "Remove Rebinning" becomes available. Currently it is always available for MDEvent data sets, even when the data sets has not been rebinned yet.

**For testing**
Find a sample data set [here](http://trac.mantidproject.org/mantid/attachment/ticket/11666/MDEvent_Osiris.nxs)
1. Load the sample data set into the VSI
2. Make sure it is active. 
3. Click on the Rebin menu button
   - Confirm that only the options "BinMD", "SliceMD" and "CutMD" are selectable
4. Rebin the sample data set with "BinMD" (use the default settings")
5. Click on the Rebin menu button
   - Confirm that now also "Remove Rebinning" is available
6. Remove the rebinning from the rebinned data set
   - Confirm that the "Remove Rebinning" option has not available any longer
