### PR TITLE
Fix Warning: Z-order assignment

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/TomoReconstruction/TomoReconstruction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/TomoReconstruction/TomoReconstruction.ui
@@ -845,11 +845,6 @@
                    </layout>
                   </item>
                  </layout>
-                 <zorder></zorder>
-                 <zorder>horizontalSpacer_16</zorder>
-                 <zorder></zorder>
-                 <zorder></zorder>
-                 <zorder>layoutWidget</zorder>
                 </widget>
                </item>
               </layout>


### PR DESCRIPTION
This fixes [#11671](http://trac.mantidproject.org/mantid/ticket/11671)

The solution is to manually delete rows with 'zorder' tags. This eliminates the warning.  
http://stackoverflow.com/questions/6831546/qvision-widget-error-upon-compile

testing: code review should be sufficient.
