### PR TITLE
Fix ties for FunctionParameterDecorator inside a CompositeFunction

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IFunction.h
@@ -550,6 +550,7 @@ protected:
 
   friend class ParameterTie;
   friend class CompositeFunction;
+  friend class FunctionParameterDecorator;
 
   /// Flag to hint that the function is being used in parallel computations
   bool m_isParallel;

--- a/Code/Mantid/Framework/API/src/FunctionParameterDecorator.cpp
+++ b/Code/Mantid/Framework/API/src/FunctionParameterDecorator.cpp
@@ -1,5 +1,7 @@
 #include "MantidAPI/FunctionParameterDecorator.h"
 #include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/CompositeFunction.h"
+#include "MantidAPI/ParameterReference.h"
 
 namespace Mantid {
 namespace API {
@@ -172,7 +174,15 @@ size_t FunctionParameterDecorator::getParameterIndex(
     const ParameterReference &ref) const {
   throwIfNoFunctionSet();
 
-  return m_wrappedFunction->getParameterIndex(ref);
+  if(boost::dynamic_pointer_cast<CompositeFunction>(m_wrappedFunction)) {
+      return m_wrappedFunction->getParameterIndex(ref);
+  }
+
+  if(ref.getFunction() == this && ref.getIndex() < nParams()) {
+      return ref.getIndex();
+  }
+
+  return nParams();
 }
 
 size_t FunctionParameterDecorator::nAttributes() const {
@@ -289,7 +299,11 @@ void FunctionParameterDecorator::declareParameter(
 }
 
 /// Does nothing.
-void FunctionParameterDecorator::addTie(ParameterTie *tie) { UNUSED_ARG(tie); }
+void FunctionParameterDecorator::addTie(ParameterTie *tie) {
+    throwIfNoFunctionSet();
+
+    m_wrappedFunction->addTie(tie);
+}
 
 /**
  * @brief Function that is called before the decorated function is set

--- a/Code/Mantid/Framework/API/src/FunctionParameterDecorator.cpp
+++ b/Code/Mantid/Framework/API/src/FunctionParameterDecorator.cpp
@@ -298,7 +298,7 @@ void FunctionParameterDecorator::declareParameter(
   UNUSED_ARG(description);
 }
 
-/// Does nothing.
+/// Forwads addTie-call to the decorated function.
 void FunctionParameterDecorator::addTie(ParameterTie *tie) {
     throwIfNoFunctionSet();
 

--- a/Code/Mantid/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Code/Mantid/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -288,17 +288,37 @@ public:
   }
 
   void testTiesInComposite() {
-    FunctionParameterDecorator_sptr fn1 =
+    FunctionParameterDecorator_sptr fn =
         getFunctionParameterDecoratorGaussian();
 
     CompositeFunction_sptr composite = boost::make_shared<CompositeFunction>();
-    composite->addFunction(fn1);
+    composite->addFunction(fn);
 
     TS_ASSERT_THROWS_NOTHING(composite->addTies("f0.Height=2.0*f0.Sigma"));
 
     composite->setParameter("f0.Sigma", 3.0);
     composite->applyTies();
     TS_ASSERT_EQUALS(composite->getParameter("f0.Height"), 6.0);
+  }
+
+  void testTiesInWrappedComposite() {
+    FunctionParameterDecorator_sptr outer =
+        boost::make_shared<TestableFunctionParameterDecorator>();
+    outer->setDecoratedFunction("CompositeFunction");
+
+    FunctionParameterDecorator_sptr fn =
+        getFunctionParameterDecoratorGaussian();
+
+    CompositeFunction_sptr composite =
+        boost::dynamic_pointer_cast<CompositeFunction>(
+            outer->getDecoratedFunction());
+    composite->addFunction(fn);
+
+    TS_ASSERT_THROWS_NOTHING(outer->addTies("f0.Height=2.0*f0.Sigma"));
+
+    outer->setParameter("f0.Sigma", 3.0);
+    outer->applyTies();
+    TS_ASSERT_EQUALS(outer->getParameter("f0.Height"), 6.0);
   }
 
   void testParameterNames() {

--- a/Code/Mantid/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Code/Mantid/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/FunctionParameterDecorator.h"
+#include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/ParamFunction.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -284,6 +285,20 @@ public:
 
     tie = fn->getTie(0);
     TS_ASSERT(!tie);
+  }
+
+  void testTiesInComposite() {
+    FunctionParameterDecorator_sptr fn1 =
+        getFunctionParameterDecoratorGaussian();
+
+    CompositeFunction_sptr composite = boost::make_shared<CompositeFunction>();
+    composite->addFunction(fn1);
+
+    TS_ASSERT_THROWS_NOTHING(composite->addTies("f0.Height=2.0*f0.Sigma"));
+
+    composite->setParameter("f0.Sigma", 3.0);
+    composite->applyTies();
+    TS_ASSERT_EQUALS(composite->getParameter("f0.Height"), 6.0);
   }
 
   void testParameterNames() {


### PR DESCRIPTION
This fixes [#11672](http://trac.mantidproject.org/mantid/ticket/11672).

**Testing information**
Code review, changes are covered by two new tests. If there is a better way of calling addTies on the decorated function than being a friend class of IFunction, I would really like to know. For CompositeFunction this seems to be necessary as well.
