### PR TITLE
Add broken link checker target for documentation

### DIFF
--- a/Code/Mantid/docs/CMakeLists.txt
+++ b/Code/Mantid/docs/CMakeLists.txt
@@ -83,6 +83,21 @@ if ( SPHINX_FOUND )
                            EXCLUDE_FROM_ALL 1)
   endif (DOCS_HTML)
 
+  # LINKCHECK target
+  set ( BUILDER linkcheck )
+  set ( SPHINX_CONF_DIR ${SPHINX_BUILD_DIR}/conf/${BUILDER} )
+  configure_file ( conf.py.in ${SPHINX_CONF_DIR}/conf.py @ONLY )
+  configure_file ( runsphinx.py.in runsphinx_linkcheck.py @ONLY )
+  add_custom_target ( ${TARGET_PREFIX}-linkcheck
+                      COMMAND ${DOCS_RUNNER_EXE} -xq runsphinx_linkcheck.py
+                      DEPENDS Framework MantidPlot MantidQt ${CMAKE_CURRENT_BINARY_DIR}/runsphinx_linkcheck.py ${SPHINX_CONF_DIR}/conf.py
+                      COMMENT "Checking documentation links"
+                      )
+  # Group within VS and exclude from whole build
+  set_target_properties ( ${TARGET_PREFIX}-linkcheck PROPERTIES FOLDER "Documentation"
+                          EXCLUDE_FROM_DEFAULT_BUILD 1
+                          EXCLUDE_FROM_ALL 1)
+
   ###############################################################################
   # Tests ( It would be nice to have this is a test sub directory but the
   #        configure of the runsphinx file doesn't like being in two directories.


### PR DESCRIPTION
This is for trac ticket [#11678](http://trac.mantidproject.org/mantid/ticket/11678)

This pull request adds the `docs-linkcheck` target to CMake, which generates `docs/linkcheck/output.txt` in the build directory. `output.txt` is a list of all the external links in the documentation and whether they resolved successfully or not.

Example:

```
[...redacted for brevity...]
algorithms/AlignAndFocusPowder-v1.rst:2: [local] categories/Algorithms.html
algorithms/AlignAndFocusPowder-v1.rst:2: [local] categories/Workflow.html
algorithms/AlignAndFocusPowder-v1.rst:2: [local] categories/Diffraction.html
algorithms/AlignAndFocusPowder-v1.rst:45: [broken] https://github.com/mantidproject/mantid/raw/master/Test/AutoTestData/pg3_mantid_det.cal: HTTP Error 404: Not Found
algorithms/AlignAndFocusPowder-v1.rst:45: [redirected with Found] https://github.com/mantidproject/systemtests/blob/master/Data/PG3_9830_event.nxs?raw=true to https://raw.githubusercontent.com/mantidproject/systemtests/master/Data/PG3_9830_event.nxs
algorithms/AlignDetectors-v1.rst:2: [local] categories/Algorithms.html
algorithms/AlignDetectors-v1.rst:2: [local] categories/Diffraction.html
algorithms/AlphaCalc-v1.rst:2: [local] categories/Muon.html
algorithms/AlphaCalc-v1.rst:2: [local] categories/Algorithms.html
[...redacted for brevity...]
algorithms/ConvertToDetectorFaceMD-v1.rst:2: [local] categories/Algorithms.html
algorithms/ConvertToDetectorFaceMD-v1.rst:2: [local] categories/MDAlgorithms.html
algorithms/ConvertToDetectorFaceMD-v1.rst:46: [broken] http://www.mantidproject.org/InstrumentDefinitionFile#Creating_Rectangular_Area_Detectors: Anchor 'Creating_Rectangular_Area_Detectors' not found
algorithms/ConvertToDetectorFaceMD-v1.rst:46: [broken] http://www.mantidproject.org/InstrumentDefinitionFile#Creating_Rectangular_Area_Detectors: Anchor 'Creating_Rectangular_Area_Detectors' not found
algorithms/ConvertToDetectorFaceMD-v1.rst:16: [broken] http://www.mantidproject.org/InstrumentDefinitionFile#Creating_Rectangular_Area_Detectors: Anchor 'Creating_Rectangular_Area_Detectors' not found
algorithms/ConvertToDiffractionMDWorkspace-v1.rst:62: [redirected with Found] http://mantidproject.org/SliceViewer to http://www.mantidproject.org/SliceViewer
algorithms/ConvertToDiffractionMDWorkspace-v1.rst:78: [redirected with Found] http://mantidproject.org/Workspace2D to http://docs.mantidproject.org/nightly/concepts/Workspace2D.html
[...redacted for brevity...]
```

This will allow us to catch broken links to data / references easily.
