### PR TITLE
CanSAS reader should read in y-axis units

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadCanSAS1D.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadCanSAS1D.cpp
@@ -184,6 +184,8 @@ LoadCanSAS1D::loadEntry(Poco::XML::Node *const workspaceData,
   MantidVec &E = dataWS->dataE(0);
   MantidVec &Dx = dataWS->dataDx(0);
   int vecindex = 0;
+  std::string yUnit = "";
+  bool isCommon = true;
   // iterate through each Idata element  and get the values of "Q",
   //"I" and "Idev" text nodes and fill X,Y,E vectors
   for (unsigned long index = 0; index < nBins; ++index) {
@@ -212,6 +214,9 @@ LoadCanSAS1D::loadEntry(Poco::XML::Node *const workspaceData,
       // setting Y vector
       Element *iElem = elem->getChildElement("I");
       check(qElem, "I");
+      const std::string unit = iElem->getAttribute("unit");
+      if (index == 0) yUnit = unit;
+      else if (unit != yUnit) isCommon = false;
       nodeVal = iElem->innerText();
       std::stringstream y(nodeVal);
       y >> d;
@@ -238,6 +243,7 @@ LoadCanSAS1D::loadEntry(Poco::XML::Node *const workspaceData,
   runLoadInstrument(instname, dataWS);
 
   dataWS->getAxis(0)->setUnit("MomentumTransfer");
+  if (isCommon == true) dataWS->setYUnitLabel(yUnit);
   return dataWS;
 }
 /* This method throws not found error if a element is not found in the xml file

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -313,6 +313,8 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
             tthd_value *= math.pi / 180.0
 
         theta = math.fabs(tthd_value - thi_value) / 2.
+        if theta < 0.001:
+            logger.warning("thi and tthd are equal: is this a direct beam?")
 
         # Add the offset
         angle_offset_deg = self.getProperty("AngleOffset").value

--- a/Code/Mantid/docs/source/algorithms/EstimatePeakErrors-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EstimatePeakErrors-v1.rst
@@ -13,7 +13,7 @@ This algorithm takes a function after it has been optimized by the Fit algorithm
 
 Usage
 -----
-(*At the moment the algorithm works properly if run from C++ only.*)
+(*At the moment the algorithm works properly if run from C++ only.*)::
 
     import numpy as np
 
@@ -34,5 +34,5 @@ Usage
     # Calculate peak parameter error estimates for the two Lorentzians.
     params = EstimatePeakErrors(fun)
 
- 
+
 .. categories::

--- a/Code/Mantid/docs/source/algorithms/LRScalingFactors-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/LRScalingFactors-v1.rst
@@ -25,17 +25,16 @@ no attenuators.
 
 The normalization run for a data set taken in a given slit setting
 configuration can then be expressed in terms of the standard 0-attenuator
-data set with:
-   D_i = F_i D_0
+data set with: :math:`D_i = F_i D_0` 
 
-  Here's an example of runs and how they are related to F.
+Here's an example of runs and how they are related to F.
 
-        run: 55889, att: 0, s1: 0.26, s2: 0.26
-        run: 55890, att: 1, s1: 0.26, s2: 0.26
-        run: 55891, att: 1, s1: 0.33, s2: 0.26 --> F = 55891 / 55890
-        run: 55892, att: 1, s1: 0.45, s2: 0.26 --> F = 55892 / 55890
-        run: 55895, att: 1, s1: 0.81, s2: 0.26
-        run: 55896, att: 2, s1: 0.81, s2: 0.26
-        run: 55897, att: 2, s1: 1.05, s2: 0.35 --> F = 55897 / 55896 * 55895 / 55890
+-  run: 55889, att: 0, s1: 0.26, s2: 0.26
+-  run: 55890, att: 1, s1: 0.26, s2: 0.26
+-  run: 55891, att: 1, s1: 0.33, s2: 0.26 --> F = 55891 / 55890
+-  run: 55892, att: 1, s1: 0.45, s2: 0.26 --> F = 55892 / 55890
+-  run: 55895, att: 1, s1: 0.81, s2: 0.26
+-  run: 55896, att: 2, s1: 0.81, s2: 0.26
+-  run: 55897, att: 2, s1: 1.05, s2: 0.35 --> F = 55897 / 55896 * 55895 / 55890
 
 .. categories::

--- a/Code/Mantid/scripts/Interface/reduction_gui/widgets/sans/eqsans_instrument.py
+++ b/Code/Mantid/scripts/Interface/reduction_gui/widgets/sans/eqsans_instrument.py
@@ -235,6 +235,7 @@ class SANSInstrumentWidget(BaseWidget):
                                                             | QtGui.QFileDialog.DontResolveSymlinks)
         if output_dir:
             self._summary.output_dir_edit.setText(output_dir)
+            self._settings.emit_key_value("OUTPUT_DIR", output_dir)
 
     def _tof_clicked(self, is_checked):
         self._summary.low_tof_edit.setEnabled(not is_checked)
@@ -458,7 +459,7 @@ class SANSInstrumentWidget(BaseWidget):
         # Config Mask
         m.use_config_mask = self._summary.config_mask_chk.isChecked()
 
-       # Mask detector IDs
+        # Mask detector IDs
         m.use_mask_file = self._summary.mask_check.isChecked()
         m.mask_file = unicode(self._summary.mask_edit.text())
         m.detector_ids = self._masked_detectors
@@ -483,6 +484,7 @@ class SANSInstrumentWidget(BaseWidget):
         self._settings.data_output_dir = m.output_directory
 
         self._settings.emit_key_value("DARK_CURRENT", str(self._summary.dark_file_edit.text()))
+        self._settings.emit_key_value("OUTPUT_DIR", m.output_directory)
         return m
 
     def _show_help(self):

--- a/Code/Mantid/scripts/Interface/reduction_gui/widgets/sans/stitcher.py
+++ b/Code/Mantid/scripts/Interface/reduction_gui/widgets/sans/stitcher.py
@@ -40,7 +40,7 @@ class StitcherWidget(BaseWidget):
             settings = GeneralSettings()
         self._settings = settings
 
-       # Connect do UI data update
+        # Connect do UI data update
         self._settings.data_updated.connect(self._data_updated)
 
         self._low_q_data = None
@@ -55,7 +55,7 @@ class StitcherWidget(BaseWidget):
         self._referenceID = 0
 
         self._graph = "StitchedData"
-        self._output_dir = None
+        self._output_dir = self._settings.data_output_dir
         self._stitcher = None
         self._plotted = False
 


### PR DESCRIPTION
To test: load you favorite CanSAS file and make sure the units are loaded. 

If you change the unit on one of the y-values so that they are not all the same, the loader should not set the y unit of the output workspace.
