### PR TITLE
Fix qlimits issue in old reflectometry GUI

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Stitch1D.cpp
@@ -501,8 +501,8 @@ void Stitch1D::exec() {
   const double intersectionMin = intesectionXRegion.get<0>();
   const double intersectionMax = intesectionXRegion.get<1>();
 
-  const double startOverlap = getStartOverlap(intersectionMin, intersectionMax);
-  const double endOverlap = getEndOverlap(intersectionMin, intersectionMax);
+  double startOverlap = getStartOverlap(intersectionMin, intersectionMax);
+  double endOverlap = getEndOverlap(intersectionMin, intersectionMax);
 
   if (startOverlap > endOverlap) {
     std::string message = boost::str(
@@ -517,6 +517,12 @@ void Stitch1D::exec() {
 
   const double &xMin = params.front();
   const double &xMax = params.back();
+
+  if (std::abs(xMin - startOverlap) < 1E-6)
+    startOverlap = xMin;
+
+  if (std::abs(xMax - endOverlap) < 1E-6)
+    endOverlap = xMax;
 
   if (startOverlap < xMin) {
     std::string message = boost::str(

--- a/Code/Mantid/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/Code/Mantid/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -809,6 +809,12 @@ class ReflGui(QtGui.QMainWindow, refl_window.Ui_windowRefl):
                                 Qmin = min(w1.readX(0))
                                 Qmax = max(w2.readX(0))
 
+                                if len(self.tableMain.item(row, i * 5 + 3).text()) > 0:
+                                    Qmin = float(self.tableMain.item(row, i * 5 + 3).text())
+
+                                if len(self.tableMain.item(row, i * 5 + 4).text()) > 0:
+                                    Qmax = float(self.tableMain.item(row, i * 5 + 4).text())
+
                                 wcomb = combineDataMulti(wksp, outputwksp, overlapLow, overlapHigh, Qmin, Qmax, -dqq, 1, keep=True)
 
 


### PR DESCRIPTION
This is for trac ticket [#11688](http://trac.mantidproject.org/mantid/ticket/11688)

When stitching is enabled, the old reflectometry GUI does not respect/obey the `qmin` and `qmax` settings. This pull request ensures that they are enforced.
