### PR TITLE
BinMD/SliceMD axis-aligned warning

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -592,9 +592,12 @@ void SlicingAlgorithm::createAlignedTransform() {
         new DataObjects::CoordTransformAffine(inD, m_outD);
     tmp->setMatrix(mat);
     m_transformToOriginal = tmp;
-  } else
+  } else {
     // Changed # of dimensions - can't reverse the transform
     m_transformToOriginal = NULL;
+    g_log.warning("SlicingAlgorithm: Your slice will cause the output workspace to have less dimensions than the input. This will affect your ability to create subsequent slices.");
+  }
+   
 }
 
 //-----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes beta test issue [#11696](http://trac.mantidproject.org/mantid/ticket/11696#comment:1)

Following mantid-help beta test report by Jon Taylor 4th/May/2015 regarding the sliceviewer.

The problem is that for axis-aligned cuts, you can actually reduce the dimensionality of the output workspace compared to the input by ommiting the axis aligned binning information for some dimensions. If you try to slice again, then BinMD correctly identifies that the original workspace does not have the same dimensionality as the output. The following shows how this sort of slicing can be done.

``` python
CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='Q_lab_x,Q_lab_y,Q_lab_z', Units='A,A,A', OutputWorkspace='WS')
FakeMDEventData(InputWorkspace='WS', PeakParams='10000,0,0,0,0.1', RandomizeSignal=True)
BinMD(InputWorkspace='WS', AlignedDim0='Q_lab_x,-10,10,10', AlignedDim1='Q_lab_y,-10,10,10', OutputWorkspace='binned')

print 'Dims before', mtd['WS'].getNumDims()
print 'Dims after', mtd['binned'].getNumDims()
```

**Tester**
Verify that running the script above produces a warning about lower dimensional cuts.
