### PR TITLE
Fix fit table created by ALC interface

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -331,6 +331,7 @@ set ( TEST_FILES
   ALCBaselineModellingModelTest.h
   ALCBaselineModellingPresenterTest.h
   ALCDataLoadingPresenterTest.h
+  ALCPeakFittingModelTest.h
   ALCPeakFittingPresenterTest.h
   IO_MuonGroupingTest.h
   MuonAnalysisHelperTest.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
@@ -47,6 +47,8 @@ namespace CustomInterfaces
 
     MatrixWorkspace_const_sptr correctedData() const { return m_correctedData; }
 
+    ITableWorkspace_sptr parameterTable() const { return m_parameterTable; }
+
     const std::vector<Section>& sections() const { return m_sections; }
 
     // -- End of IALCBaselineModellingModel interface ----------------------------------------------

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
@@ -74,6 +74,9 @@ namespace CustomInterfaces
     /// Result function of the last fit
     IFunction_const_sptr m_fittedFunction;
 
+    /// Fit table containing parameters and errors
+    ITableWorkspace_sptr m_parameterTable;
+
     /// Sections used for the last fit
     std::vector<Section> m_sections;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h
@@ -41,6 +41,7 @@ namespace CustomInterfaces
     // -- IALCPeakFittingModel interface -----------------------------------------------------------
     IFunction_const_sptr fittedPeaks() const { return m_fittedPeaks; }
     MatrixWorkspace_const_sptr data() const { return m_data; }
+    ITableWorkspace_sptr parameterTable() const { return m_parameterTable; }
 
     void fitPeaks(IFunction_const_sptr peaks);
     // -- End of IALCPeakFittingModel interface ----------------------------------------------------

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h
@@ -58,6 +58,9 @@ namespace CustomInterfaces
     /// The data we are fitting peaks to
     MatrixWorkspace_const_sptr m_data;
 
+    /// Parameter table containing fit results
+    ITableWorkspace_sptr m_parameterTable;
+
     /// Setter for convenience
     void setFittedPeaks(IFunction_const_sptr fittedPeaks);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -40,6 +40,7 @@ namespace CustomInterfaces
     fit->execute();
 
     MatrixWorkspace_sptr fitOutput = fit->getProperty("OutputWorkspace");
+    m_parameterTable = fit->getProperty("OutputParameters");
 
     IAlgorithm_sptr extract = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
     extract->setChild(true);
@@ -51,6 +52,7 @@ namespace CustomInterfaces
     setCorrectedData(extract->getProperty("OutputWorkspace"));
     setFittedFunction(funcToFit);
     m_sections = sections;
+
   }
 
   void ALCBaselineModellingModel::setData(MatrixWorkspace_const_sptr data)
@@ -170,16 +172,9 @@ namespace CustomInterfaces
 
   ITableWorkspace_sptr ALCBaselineModellingModel::exportModel()
   {
-    if ( m_fittedFunction ) {
+    if ( m_parameterTable ) {
 
-      ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
-
-      table->addColumn("str", "Function");
-
-      TableRow newRow = table->appendRow();
-      newRow << m_fittedFunction->asString();
-
-      return table;
+      return m_parameterTable;
 
     } else {
       

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -59,26 +59,9 @@ namespace CustomInterfaces
 
   ITableWorkspace_sptr ALCPeakFittingModel::exportFittedPeaks()
   {
-    if ( m_fittedPeaks ) {
+    if ( m_parameterTable ) {
 
-      ITableWorkspace_sptr table = WorkspaceFactory::Instance().createTable("TableWorkspace");
-
-      table->addColumn("str", "Peaks");
-
-
-      if (auto composite = boost::dynamic_pointer_cast<CompositeFunction const>(m_fittedPeaks))
-      {
-        for (size_t i = 0; i < composite->nFunctions(); ++i)
-        {
-          static_cast<TableRow>(table->appendRow()) << composite->getFunction(i)->asString();
-        }
-      }
-      else
-      {
-        static_cast<TableRow>(table->appendRow()) << m_fittedPeaks->asString();
-      }
-
-      return table;
+      return m_parameterTable;
 
     } else {
     
@@ -100,6 +83,8 @@ namespace CustomInterfaces
     fit->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
     fit->setProperty("CreateOutput", true);
     fit->execute();
+
+    m_parameterTable = fit->getProperty("OutputParameters");
 
     setFittedPeaks(static_cast<IFunction_sptr>(fit->getProperty("Function")));
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -98,6 +98,24 @@ public:
       TS_ASSERT_DELTA(corrected->readY(0)[8], 97, 1E-8);
     }
 
+    ITableWorkspace_sptr parameters = m_model->parameterTable();
+    TS_ASSERT(parameters);
+
+    if (parameters)
+    {
+      // Check table dimensions
+      TS_ASSERT_EQUALS(parameters->rowCount(), 2);
+      TS_ASSERT_EQUALS(parameters->columnCount(), 3);
+
+      // Check table entries
+      TS_ASSERT_EQUALS(parameters->String(0,0), "A0");
+      TS_ASSERT_EQUALS(parameters->Double(0,1), 3);
+      TS_ASSERT_DELTA (parameters->Double(0,2), 0.447214,1E-6);
+      TS_ASSERT_EQUALS(parameters->String(1,0), "Cost function value");
+      TS_ASSERT_DELTA (parameters->Double(1,1), 1.250000,1E-6);
+      TS_ASSERT_EQUALS(parameters->Double(1,2), 0);
+    }
+
     TS_ASSERT_EQUALS(m_model->sections(), sections);
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
@@ -1,0 +1,64 @@
+#ifndef MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODELTEST_H_
+#define MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODELTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include <boost/assign.hpp>
+
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/FrameworkManager.h"
+
+#include "MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h"
+
+#include <QtTest/QSignalSpy>
+
+using namespace Mantid::API;
+using namespace MantidQt::CustomInterfaces;
+
+class ALCPeakFittingModelTest : public CxxTest::TestSuite
+{
+  ALCPeakFittingModel* m_model;
+
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ALCPeakFittingModelTest *createSuite() { return new ALCPeakFittingModelTest(); }
+  static void destroySuite( ALCPeakFittingModelTest *suite ) { delete suite; }
+
+  ALCPeakFittingModelTest()
+  {
+    FrameworkManager::Instance(); // To make sure everything is initialized
+  }
+
+  void setUp()
+  {
+    m_model = new ALCPeakFittingModel();
+  }
+
+  void tearDown()
+  {
+    delete m_model;
+  }
+
+    void test_setData()
+  {
+    MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+
+    QSignalSpy spy(m_model, SIGNAL(dataChanged()));
+
+    TS_ASSERT_THROWS_NOTHING(m_model->setData(data));
+
+    TS_ASSERT_EQUALS(spy.size(), 1);
+    TS_ASSERT_EQUALS(m_model->data(), data);
+  }
+
+  void test_fit()
+  {
+  }
+
+};
+
+
+#endif /* MANTID_CUSTOMINTERFACES_ALCPEAKFITTINGMODELTEST_H_ */


### PR DESCRIPTION
Fixes [#11663](http://trac.mantidproject.org/mantid/ticket/11663)

In the ALC interface there is a button ("Export results...") to export results to a workspace. The interface is not exporting fitting results properly, only the fitting function is exported as a string to a 1x1 table, and no errors are shown. The fit table should look like the output table created by the normal fit dialog.

To test: Open the ALC interface, load "MUSR00015189.nxs" as "First" and "MUSR00015191.nxs" as "Last" and hit "Load". Go to "Baseline modelling", right-click on the "Function" blank section, and add a new function (for instance a FlatBackground), right-click on the "Sections" blank section and add a section. Hit "Fit", and then "Export results...". A workspace group will be created. Check that the workspace named *_Baseline_Model is a (n+1) x 3 table (begin n the number of fitting parameters) similar to what you obtain when using the normal fit dialog.
