### PR TITLE
Fix broken chain of responsibility for MDHisto in the VSI

### DIFF
--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -15,6 +15,7 @@
 #include "MantidVatesAPI/vtkMDHexFactory.h"
 #include "MantidVatesAPI/vtkMDQuadFactory.h"
 #include "MantidVatesAPI/vtkMDLineFactory.h"
+#include "MantidVatesAPI/vtkMD0DFactory.h"
 #include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/IgnoreZerosThresholdRange.h"
 
@@ -184,12 +185,14 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     FilterUpdateProgressAction<vtkMDEWSource> drawingProgressUpdate(this, "Drawing...");
 
     ThresholdRange_scptr thresholdRange(new IgnoreZerosThresholdRange());
+    vtkMD0DFactory* zeroDFactory = new vtkMD0DFactory(thresholdRange, "signal");
     vtkMDHexFactory* hexahedronFactory = new vtkMDHexFactory(thresholdRange, "signal");
     vtkMDQuadFactory* quadFactory = new vtkMDQuadFactory(thresholdRange, "signal");
     vtkMDLineFactory* lineFactory = new vtkMDLineFactory(thresholdRange, "signal");
 
     hexahedronFactory->SetSuccessor(quadFactory);
     quadFactory->SetSuccessor(lineFactory);
+    lineFactory->SetSuccessor(zeroDFactory);
 
     hexahedronFactory->setTime(m_time);
     vtkDataSet* product = m_presenter->execute(hexahedronFactory, loadingProgressUpdate, drawingProgressUpdate);

--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -17,6 +17,7 @@
 #include "MantidVatesAPI/vtkMDHistoHexFactory.h"
 #include "MantidVatesAPI/vtkMDHistoQuadFactory.h"
 #include "MantidVatesAPI/vtkMDHistoLineFactory.h"
+#include "MantidVatesAPI/vtkMD0DFactory.h"
 #include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/IgnoreZerosThresholdRange.h"
 
@@ -175,6 +176,7 @@ int vtkMDHWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     /*
     Will attempt to handle drawing in 4D case and then in 3D case if that fails, and so on down to 1D
     */
+    vtkMD0DFactory* zeroDFactory = new vtkMD0DFactory(thresholdRange, "signal");
     vtkMDHistoLineFactory* lineFactory = new vtkMDHistoLineFactory(thresholdRange, "signal");
     vtkMDHistoQuadFactory* quadFactory = new vtkMDHistoQuadFactory(thresholdRange, "signal");
     vtkMDHistoHexFactory* hexFactory = new vtkMDHistoHexFactory(thresholdRange, "signal");
@@ -183,6 +185,7 @@ int vtkMDHWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     factory->SetSuccessor(hexFactory);
     hexFactory->SetSuccessor(quadFactory);
     quadFactory->SetSuccessor(lineFactory);
+    lineFactory->SetSuccessor(zeroDFactory);
 
     vtkDataSet* product = m_presenter->execute(factory, loadingProgressUpdate, drawingProgressUpdate);
 

--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -15,6 +15,8 @@
 #include "MantidVatesAPI/TimeToTimeStep.h"
 #include "MantidVatesAPI/vtkMDHistoHex4DFactory.h"
 #include "MantidVatesAPI/vtkMDHistoHexFactory.h"
+#include "MantidVatesAPI/vtkMDHistoQuadFactory.h"
+#include "MantidVatesAPI/vtkMDHistoLineFactory.h"
 #include "MantidVatesAPI/FilteringUpdateProgressAction.h"
 #include "MantidVatesAPI/IgnoreZerosThresholdRange.h"
 
@@ -171,11 +173,16 @@ int vtkMDHWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     ThresholdRange_scptr thresholdRange(new IgnoreZerosThresholdRange());
 
     /*
-    Will attempt to handle drawing in 4D case and then in 3D case if that fails.
+    Will attempt to handle drawing in 4D case and then in 3D case if that fails, and so on down to 1D
     */
-    vtkMDHistoHexFactory* successor = new vtkMDHistoHexFactory(thresholdRange, "signal");
+    vtkMDHistoLineFactory* lineFactory = new vtkMDHistoLineFactory(thresholdRange, "signal");
+    vtkMDHistoQuadFactory* quadFactory = new vtkMDHistoQuadFactory(thresholdRange, "signal");
+    vtkMDHistoHexFactory* hexFactory = new vtkMDHistoHexFactory(thresholdRange, "signal");
     vtkMDHistoHex4DFactory<TimeToTimeStep> *factory = new vtkMDHistoHex4DFactory<TimeToTimeStep>(thresholdRange, "signal", m_time);
-    factory->SetSuccessor(successor);
+
+    factory->SetSuccessor(hexFactory);
+    hexFactory->SetSuccessor(quadFactory);
+    quadFactory->SetSuccessor(lineFactory);
 
     vtkDataSet* product = m_presenter->execute(factory, loadingProgressUpdate, drawingProgressUpdate);
 

--- a/Code/Mantid/Vates/VatesAPI/CMakeLists.txt
+++ b/Code/Mantid/Vates/VatesAPI/CMakeLists.txt
@@ -144,6 +144,7 @@ test/vtkMDHistoHex4DFactoryTest.h
 test/vtkMDHistoHexFactoryTest.h
 test/vtkMDHistoLineFactoryTest.h
 test/vtkMDHistoQuadFactoryTest.h
+test/vtkMD0DFactoryTest.h
 test/FieldDataToMetadataTest.h
 test/FilteringUpdateProgressActionTest.h
 test/LoadVTKTest.h

--- a/Code/Mantid/Vates/VatesAPI/CMakeLists.txt
+++ b/Code/Mantid/Vates/VatesAPI/CMakeLists.txt
@@ -46,6 +46,7 @@ src/vtkDataSetToWsLocation.cpp
 src/vtkEllipsoidTransformer.cpp
 src/vtkMDLineFactory.cpp
 src/vtkMDQuadFactory.cpp
+src/vtkMD0DFactory.cpp
 src/vtkNullUnstructuredGrid.cpp
 src/vtkSplatterPlotFactory.cpp
 src/vtkMDHexFactory.cpp
@@ -113,6 +114,7 @@ inc/MantidVatesAPI/vtkEllipsoidTransformer.h
 inc/MantidVatesAPI/vtkMDLineFactory.h
 inc/MantidVatesAPI/vtkMDQuadFactory.h
 inc/MantidVatesAPI/vtkMDHexFactory.h
+inc/MantidVatesAPI/vtkMD0DFactory.h
 inc/MantidVatesAPI/vtkNullUnstructuredGrid.h
 inc/MantidVatesAPI/vtkSplatterPlotFactory.h
 inc/MantidVatesAPI/vtkPeakMarkerFactory.h

--- a/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/vtkMD0DFactory.h
+++ b/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/vtkMD0DFactory.h
@@ -1,0 +1,75 @@
+#ifndef MANTID_VATES_VTK_MD_0D_FACTORY_H_
+#define MANTID_VATES_VTK_MD_0D_FACTORY_H_
+
+#include "MantidKernel/System.h"
+#include "MantidVatesAPI/vtkDataSetFactory.h"
+#include "MantidAPI/IMDWorkspace.h"
+#include "vtkUnstructuredGrid.h"
+#include "MantidVatesAPI/ThresholdRange.h"
+
+namespace Mantid
+{
+  namespace VATES
+  {
+
+/** 0D Factory. This type is responsible for rendering IMDWorkspaces with 0D.
+
+ Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+
+ This file is part of Mantid.
+
+ Mantid is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+
+ Mantid is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ File change history is stored at: <https://github.com/mantidproject/mantid>
+ Code Documentation is available at: <http://doxygen.mantidproject.org>
+ */
+    class DLLExport vtkMD0DFactory : public vtkDataSetFactory
+    {
+    public:
+
+      /// Constructor
+      vtkMD0DFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName);
+
+      /// Assignment operator
+      vtkMD0DFactory& operator=(const vtkMD0DFactory& other);
+
+      /// Copy constructor.
+      vtkMD0DFactory(const vtkMD0DFactory& other);
+
+      /// Destructor
+      virtual ~vtkMD0DFactory();
+
+      /// Factory Method.
+      virtual vtkDataSet* create(ProgressAction& progressUpdating) const;
+
+      virtual void initialize(Mantid::API::Workspace_sptr);
+
+      virtual std::string getFactoryTypeName() const
+      {
+        return "vtkMD0DFactory";
+      }
+
+    protected:
+        virtual void validate() const;
+
+    private:
+      std::string m_scalarName;
+
+      mutable ThresholdRange_scptr m_thresholdRange;
+    
+    };
+    
+  }
+}
+#endif

--- a/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/vtkMD0DFactory.h
+++ b/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/vtkMD0DFactory.h
@@ -64,10 +64,8 @@ namespace Mantid
         virtual void validate() const;
 
     private:
-      std::string m_scalarName;
-
       mutable ThresholdRange_scptr m_thresholdRange;
-    
+      std::string m_scalarName;
     };
     
   }

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
@@ -1,6 +1,7 @@
 #include "MantidVatesAPI/vtkMD0DFactory.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidVatesAPI/vtkNullUnstructuredGrid.h"
+#include "MantidVatesAPI/ProgressAction.h"
 
 using namespace Mantid::API;
 
@@ -29,6 +30,7 @@ namespace Mantid
     */
     vtkDataSet* vtkMD0DFactory::create(ProgressAction& progressUpdating) const
     {
+      (void) progressUpdating;
       vtkNullUnstructuredGrid nullGrid;
       vtkUnstructuredGrid *visualDataSet = nullGrid.createNullData();
       return visualDataSet;

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
@@ -22,7 +22,6 @@ namespace Mantid
     */
     vtkMD0DFactory::vtkMD0DFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
     {
-      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /// Destructor
@@ -37,6 +36,7 @@ namespace Mantid
     */
     vtkDataSet* vtkMD0DFactory::create(ProgressAction& progressUpdating) const
     {
+      g_log.warning() << "Factory " << this->getFactoryTypeName() << " is being used. You are viewing data with less than three dimensions in the VSI. \n";
       (void) progressUpdating;
       vtkNullUnstructuredGrid nullGrid;
       vtkUnstructuredGrid *visualDataSet = nullGrid.createNullData();

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
@@ -1,0 +1,47 @@
+#include "MantidVatesAPI/vtkMD0DFactory.h"
+#include "MantidAPI/IMDWorkspace.h"
+#include "MantidVatesAPI/vtkNullUnstructuredGrid.h"
+
+using namespace Mantid::API;
+
+namespace Mantid
+{
+  namespace VATES
+  {
+    /**
+    Constructor
+    @param thresholdRange : Thresholding range functor
+    @param scalarName : Name to give to signal
+    */
+    vtkMD0DFactory::vtkMD0DFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
+    {
+    }
+
+    /// Destructor
+    vtkMD0DFactory::~vtkMD0DFactory()
+    {
+    }
+
+    /**
+    Create the vtkStructuredGrid from the provided workspace
+    @param progressUpdating: Reporting object to pass progress information up the stack.
+    @return fully constructed vtkDataSet.
+    */
+    vtkDataSet* vtkMD0DFactory::create(ProgressAction& progressUpdating) const
+    {
+      vtkNullUnstructuredGrid nullGrid;
+      vtkUnstructuredGrid *visualDataSet = nullGrid.createNullData();
+      return visualDataSet;
+    }
+
+    /// Initalize with a target workspace.
+    void vtkMD0DFactory::initialize(Mantid::API::Workspace_sptr ws)
+    {
+    }
+
+   /// Validate the workspace 
+   void vtkMD0DFactory::validate() const
+   {
+   }
+  }
+}

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
@@ -2,8 +2,14 @@
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidVatesAPI/vtkNullUnstructuredGrid.h"
 #include "MantidVatesAPI/ProgressAction.h"
+#include "MantidKernel/Logger.h"
 
 using namespace Mantid::API;
+
+namespace
+{
+  Mantid::Kernel::Logger g_log("vtkMD0DFactory");
+}
 
 namespace Mantid
 {
@@ -16,6 +22,7 @@ namespace Mantid
     */
     vtkMD0DFactory::vtkMD0DFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
     {
+      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /// Destructor

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMD0DFactory.cpp
@@ -34,17 +34,16 @@ namespace Mantid
     @param progressUpdating: Reporting object to pass progress information up the stack.
     @return fully constructed vtkDataSet.
     */
-    vtkDataSet* vtkMD0DFactory::create(ProgressAction& progressUpdating) const
+    vtkDataSet* vtkMD0DFactory::create(ProgressAction&) const
     {
       g_log.warning() << "Factory " << this->getFactoryTypeName() << " is being used. You are viewing data with less than three dimensions in the VSI. \n";
-      (void) progressUpdating;
       vtkNullUnstructuredGrid nullGrid;
       vtkUnstructuredGrid *visualDataSet = nullGrid.createNullData();
       return visualDataSet;
     }
 
     /// Initalize with a target workspace.
-    void vtkMD0DFactory::initialize(Mantid::API::Workspace_sptr ws)
+    void vtkMD0DFactory::initialize(Mantid::API::Workspace_sptr)
     {
     }
 

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoLineFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoLineFactory.cpp
@@ -12,10 +12,16 @@
 #include "MantidAPI/NullCoordTransform.h"
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidKernel/ReadLock.h"
+#include "MantidKernel/Logger.h"
 
 using Mantid::API::IMDWorkspace;
 using Mantid::DataObjects::MDHistoWorkspace;
 using Mantid::API::NullCoordTransform;
+
+namespace
+{
+  Mantid::Kernel::Logger g_log("vtkMDHistoLineFactory");
+}
 
 namespace Mantid
 {
@@ -26,6 +32,7 @@ namespace Mantid
     vtkMDHistoLineFactory::vtkMDHistoLineFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_scalarName(scalarName),
       m_thresholdRange(thresholdRange)
     {
+      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /**

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoLineFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoLineFactory.cpp
@@ -32,7 +32,6 @@ namespace Mantid
     vtkMDHistoLineFactory::vtkMDHistoLineFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_scalarName(scalarName),
       m_thresholdRange(thresholdRange)
     {
-      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /**
@@ -76,6 +75,8 @@ namespace Mantid
       }
       else
       {
+        g_log.warning() << "Factory " << this->getFactoryTypeName() << " is being used. You are viewing data with less than three dimensions in the VSI. \n";
+
         Mantid::Kernel::ReadLock lock(*m_workspace);
         const int nBinsX = static_cast<int>( m_workspace->getXDimension()->getNBins() );
 

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
@@ -31,7 +31,6 @@ namespace Mantid
   {
     vtkMDHistoQuadFactory::vtkMDHistoQuadFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_scalarName(scalarName), m_thresholdRange(thresholdRange)
     {
-      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /**
@@ -75,6 +74,8 @@ namespace Mantid
       }
       else
       {
+        g_log.warning() << "Factory " << this->getFactoryTypeName() << " is being used. You are viewing data with less than three dimensions in the VSI. \n";
+
         Mantid::Kernel::ReadLock lock(*m_workspace);
         CPUTimer tim;
         const int nBinsX = static_cast<int>( m_workspace->getXDimension()->getNBins() );

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDHistoQuadFactory.cpp
@@ -13,19 +13,25 @@
 #include "vtkSmartPointer.h" 
 #include <vector>
 #include "MantidKernel/ReadLock.h"
+#include "MantidKernel/Logger.h"
 
 using Mantid::API::IMDWorkspace;
 using Mantid::Kernel::CPUTimer;
 using Mantid::DataObjects::MDHistoWorkspace;
+
+namespace
+{
+  Mantid::Kernel::Logger g_log("vtkMDHistoQuadFactory");
+}
 
 namespace Mantid
 {
 
   namespace VATES
   {
-
     vtkMDHistoQuadFactory::vtkMDHistoQuadFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_scalarName(scalarName), m_thresholdRange(thresholdRange)
     {
+      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /**

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDLineFactory.cpp
@@ -13,8 +13,14 @@
 #include <vtkLine.h>
 #include <vtkCellData.h>
 #include "MantidKernel/ReadLock.h"
+#include "MantidKernel/Logger.h"
 
 using namespace Mantid::API;
+
+namespace
+{
+  Mantid::Kernel::Logger g_log("vtkMDLineFactory");
+}
 
 namespace Mantid
 {
@@ -27,6 +33,7 @@ namespace Mantid
     */
     vtkMDLineFactory::vtkMDLineFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
     {
+      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /// Destructor

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDLineFactory.cpp
@@ -33,7 +33,6 @@ namespace Mantid
     */
     vtkMDLineFactory::vtkMDLineFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
     {
-      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /// Destructor
@@ -55,6 +54,8 @@ namespace Mantid
       }
       else
       {
+        g_log.warning() << "Factory " << this->getFactoryTypeName() << " is being used. You are viewing data with less than three dimensions in the VSI. \n";
+
         IMDEventWorkspace_sptr imdws = doInitialize<IMDEventWorkspace, 1>(m_workspace);
         // Acquire a scoped read-only lock to the workspace (prevent segfault from algos modifying ws)
         Mantid::Kernel::ReadLock lock(*imdws);

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -13,8 +13,14 @@
 #include <vtkQuad.h>
 #include <vtkCellData.h>
 #include "MantidKernel/ReadLock.h"
+#include "MantidKernel/Logger.h"
 
 using namespace Mantid::API;
+
+namespace
+{
+  Mantid::Kernel::Logger g_log("vtkMDQuadFactory");
+}
 
 namespace Mantid
 {
@@ -23,6 +29,7 @@ namespace Mantid
     /// Constructor
     vtkMDQuadFactory::vtkMDQuadFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
     {
+      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /// Destructor

--- a/Code/Mantid/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -29,7 +29,6 @@ namespace Mantid
     /// Constructor
     vtkMDQuadFactory::vtkMDQuadFactory(ThresholdRange_scptr thresholdRange, const std::string& scalarName) : m_thresholdRange(thresholdRange), m_scalarName(scalarName)
     {
-      g_log.warning() << "Creating factory " << this->getFactoryTypeName() << ". You are viewing data with less than three dimensions in the VSI. \n";
     }
 
     /// Destructor
@@ -51,6 +50,8 @@ namespace Mantid
       }
       else
       {
+        g_log.warning() << "Factory " << this->getFactoryTypeName() << " is being used. You are viewing data with less than three dimensions in the VSI. \n";
+
         IMDEventWorkspace_sptr imdws = this->castAndCheck<IMDEventWorkspace, 2>(m_workspace);
         // Acquire a scoped read-only lock to the workspace (prevent segfault from algos modifying ws)
         Mantid::Kernel::ReadLock lock(*imdws);

--- a/Code/Mantid/Vates/VatesAPI/test/vtkMD0DFactoryTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/vtkMD0DFactoryTest.h
@@ -1,0 +1,43 @@
+#ifndef VTK_MD_0D_FACTORY_TEST
+#define VTK_MD_0D_FACTORY_TEST
+#include <cxxtest/TestSuite.h>
+
+#include "MantidVatesAPI/vtkMD0DFactory.h"
+#include "MantidTestHelpers/MDEventsTestHelper.h"
+#include "MantidVatesAPI/UserDefinedThresholdRange.h"
+#include "MantidVatesAPI/NoThresholdRange.h"
+
+#include "MockObjects.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "MantidVatesAPI/vtkStructuredGrid_Silent.h"
+
+using namespace Mantid;
+using namespace Mantid::VATES;
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace testing;
+
+
+class vtkMD0DFactoryTest : public CxxTest::TestSuite
+{
+public:
+
+  void testCreatesA0DDataSet()
+  {
+    // Arrange
+    FakeProgressAction progressUpdater;
+    vtkMD0DFactory factory(ThresholdRange_scptr(new UserDefinedThresholdRange(0, 1)), "signal");
+
+    vtkDataSet* dataSet = NULL;
+
+    // Assert
+    TSM_ASSERT_THROWS_NOTHING("0D factory should create data set without exceptions", dataSet  = factory.create(progressUpdater));
+    TSM_ASSERT("Should have exactly one point", dataSet->GetNumberOfPoints() == 1);
+    TSM_ASSERT("Should have exactly one cell", dataSet->GetNumberOfCells() == 1);
+  }
+};
+
+
+#endif


### PR DESCRIPTION
This fixes ticket [#11690](http://trac.mantidproject.org/mantid/ticket/11690)

**Context**

The BinMD option allows to integrate out dimensions of a workspace. Our vtkDataFactories are set up as a chain of responsibility handling reduced dimensionality. This chain was broken for dimensions < 3  for MDHisto workspaces. 

We enabled this chain and added a dummy data factory for 0D rebinning.
### For testing

The sample data set can be found [here](http://trac.mantidproject.org/mantid/attachment/ticket/11690/MDEvent_Osiris.nxs) .
This is a 4D data set. Before using run SliceMD against it and leave the last dimension blank, this will create a 3D data set.

**Bin to lower dimensions**
1. Load the 3D sample data set into the VSI
2. Use BinMD, use the default settings, except for the first dimension and set the number of bins to 1 for it.
- Confirm that there is no exception.
  - Confirm that there is a warning message in the log window which lets you know that you are viewing data with a dimension < 3. The mentioned factory should be the vtkMDHistoQuadFactory.
  - Remove the rebinning
- Confirm that the old data set is rendered again
  1. Repeat step 2, but set the number of bins for the first two dimensions to 1
- Confirm the same as in 2, except that the mentioned factory should be the vtkMDHistoLineFactory.
  1. Remove the rebinning
- Confirm that the old data set is rendered again
  1. Repeat step 2, but set the number of bins for all dimensions to 1
- Confirm the same as in 2, except that the mentioned factory should be the vtkMD0DFactory.
