### PR TITLE
Improve multiple file logging in indirect calibration and resolution

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init
+#pylint: disable=no-init,too-many-instance-attributes
 from mantid.kernel import *
 from mantid.api import *
 from mantid.simpleapi import *

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -15,6 +15,7 @@ class IndirectCalibration(DataProcessorAlgorithm):
     _spec_range = None
     _intensity_scale = None
     _plot = None
+    _run_numbers = None
 
 
     def category(self):
@@ -29,16 +30,19 @@ class IndirectCalibration(DataProcessorAlgorithm):
         self.declareProperty(StringArrayProperty(name='InputFiles'),
                              doc='Comma separated list of input files')
 
-        self.declareProperty(IntArrayProperty(name='DetectorRange', values=[0, 1],\
-                             validator=IntArrayMandatoryValidator()),
+        self.declareProperty(IntArrayProperty(name='DetectorRange',
+                                              values=[0, 1],
+                                              validator=IntArrayMandatoryValidator()),
                              doc='Range of detectors.')
 
-        self.declareProperty(FloatArrayProperty(name='PeakRange', values=[0.0, 100.0],\
-                             validator=FloatArrayMandatoryValidator()),
+        self.declareProperty(FloatArrayProperty(name='PeakRange',
+                                                values=[0.0, 100.0],
+                                                validator=FloatArrayMandatoryValidator()),
                              doc='Time of flight range over the peak.')
 
-        self.declareProperty(FloatArrayProperty(name='BackgroundRange', values=[0.0, 1000.0],\
-                             validator=FloatArrayMandatoryValidator()),
+        self.declareProperty(FloatArrayProperty(name='BackgroundRange',
+                                                values=[0.0, 1000.0],
+                                                validator=FloatArrayMandatoryValidator()),
                              doc='Time of flight range over the background.')
 
         self.declareProperty(name='ScaleFactor', defaultValue=1.0,
@@ -48,9 +52,8 @@ class IndirectCalibration(DataProcessorAlgorithm):
                              doc='Plot the calibration data as a spectra plot.')
 
         self.declareProperty(WorkspaceProperty('OutputWorkspace', '',
-                             direction=Direction.Output),
+                                               direction=Direction.Output),
                              doc='Output workspace for calibration data.')
-
 
 
     def validateInputs(self):
@@ -156,8 +159,12 @@ class IndirectCalibration(DataProcessorAlgorithm):
             for run in runs:
                 DeleteWorkspace(Workspace=run)
 
+        self._add_logs()
         self.setProperty('OutputWorkspace', self._out_ws)
-        self._post_process()
+
+        if self._plot:
+            from mantidplot import plotBin
+            plotBin(mtd[self._out_ws], 0)
 
 
     def _setup(self):
@@ -179,9 +186,9 @@ class IndirectCalibration(DataProcessorAlgorithm):
         self._plot = self.getProperty('Plot').value
 
 
-    def _post_process(self):
+    def _add_logs(self):
         """
-        Handles adding logs and plotting.
+        Handles adding sample logs.
         """
 
         # Add sample logs to output workspace
@@ -199,10 +206,6 @@ class IndirectCalibration(DataProcessorAlgorithm):
         AddSampleLogMultiple(Workspace=self._out_ws,
                              LogNames=[log[0] for log in sample_logs],
                              LogValues=[log[1] for log in sample_logs])
-
-        if self._plot:
-            from mantidplot import plotBin
-            plotBin(mtd[self._out_ws], 0)
 
 
 # Register algorithm with Mantid

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
@@ -19,6 +19,7 @@ class IndirectResolution(DataProcessorAlgorithm):
     _plot = None
     _save = None
 
+
     def category(self):
         return 'Workflow\\Inelastic;PythonAlgorithms;Inelastic'
 
@@ -61,8 +62,10 @@ class IndirectResolution(DataProcessorAlgorithm):
                              direction=Direction.Output),
                              doc='Output resolution workspace.')
 
+
     def PyExec(self):
         from IndirectCommon import getWSprefix
+
         self._setup()
 
         ISISIndirectEnergyTransfer(Instrument=self._instrument,
@@ -77,13 +80,20 @@ class IndirectResolution(DataProcessorAlgorithm):
         icon_ws = mtd['__et_ws_group'].getItem(0).getName()
 
         if self._scale_factor != 1.0:
-            Scale(InputWorkspace=icon_ws, OutputWorkspace=icon_ws, Factor=self._scale_factor)
+            Scale(InputWorkspace=icon_ws,
+                  OutputWorkspace=icon_ws,
+                  Factor=self._scale_factor)
 
-        CalculateFlatBackground(InputWorkspace=icon_ws, OutputWorkspace=self._out_ws,
-                                StartX=self._background[0], EndX=self._background[1],
-                                Mode='Mean', OutputMode='Subtract Background')
+        CalculateFlatBackground(InputWorkspace=icon_ws,
+                                OutputWorkspace=self._out_ws,
+                                StartX=self._background[0],
+                                EndX=self._background[1],
+                                Mode='Mean',
+                                OutputMode='Subtract Background')
 
-        Rebin(InputWorkspace=self._out_ws, OutputWorkspace=self._out_ws, Params=self._rebin_string)
+        Rebin(InputWorkspace=self._out_ws,
+              OutputWorkspace=self._out_ws,
+              Params=self._rebin_string)
 
         self._post_process()
         self.setProperty('OutputWorkspace', self._out_ws)
@@ -115,31 +125,27 @@ class IndirectResolution(DataProcessorAlgorithm):
         Handles adding logs, saving and plotting.
         """
 
-        use_scale_factor = self._scale_factor == 1.0
-        AddSampleLog(Workspace=self._out_ws, LogName='scale',
-                     LogType='String', LogText=str(use_scale_factor))
-        if use_scale_factor:
-            AddSampleLog(Workspace=self._out_ws, LogName='scale_factor',
-                         LogType='Number', LogText=str(self._scale_factor))
+        sample_logs = [
+                ('res_back_start', self._background[0]),
+                ('res_back_end', self._background[1])
+            ]
 
-        AddSampleLog(Workspace=self._out_ws, LogName='back_start',
-                     LogType='Number', LogText=str(self._background[0]))
-        AddSampleLog(Workspace=self._out_ws, LogName='back_end',
-                     LogType='Number', LogText=str(self._background[1]))
+        if self._scale_factor != 1.0:
+            sample_logs.append(('res_scale_factor', self._scale_factor))
 
         rebin_params = self._rebin_string.split(',')
         if len(rebin_params) == 3:
-            AddSampleLog(Workspace=self._out_ws, LogName='rebin_low',
-                         LogType='Number', LogText=rebin_params[0])
-            AddSampleLog(Workspace=self._out_ws, LogName='rebin_width',
-                         LogType='Number', LogText=rebin_params[1])
-            AddSampleLog(Workspace=self._out_ws, LogName='rebin_high',
-                         LogType='Number', LogText=rebin_params[2])
+            sample_logs.append(('rebin_low', rebin_params[0]))
+            sample_logs.append(('rebin_width', rebin_params[1]))
+            sample_logs.append(('rebin_high', rebin_params[2]))
+
+        AddSampleLogMultiple(Workspace=self._out_ws,
+                             LogNames=[log[0] for log in sample_logs],
+                             LogValues=[log[1] for log in sample_logs])
 
         self.setProperty('OutputWorkspace', self._out_ws)
 
         if self._save:
-            logger.information("Resolution file saved to default save directory.")
             SaveNexusProcessed(InputWorkspace=self._out_ws, Filename=self._out_ws + '.nxs')
 
         if self._plot:

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -156,7 +156,8 @@ namespace CustomInterfaces
   {
     // Get properties
     QString firstFile = m_uiForm.leRunNo->getFirstFilename();
-    QString filenames = m_uiForm.leRunNo->getFilenames().join(",");
+    QStringList filenameList = m_uiForm.leRunNo->getFilenames();
+    QString filenames = filenameList.join(",");
 
     auto instDetails = getInstrumentDetails();
     QString instDetectorRange = instDetails["spectra-min"] + "," + instDetails["spectra-max"];
@@ -168,7 +169,10 @@ namespace CustomInterfaces
     QString outputWorkspaceNameStem = firstFileInfo.baseName() + "_" + getInstrumentConfiguration()->getAnalyserName()
                                       + getInstrumentConfiguration()->getReflectionName();
 
-    QString calibrationWsName = outputWorkspaceNameStem + "_calib";
+    QString calibrationWsName = outputWorkspaceNameStem;
+    if(filenameList.size() > 1)
+        calibrationWsName += "_multi";
+    calibrationWsName += "_calib";
 
     // Configure the calibration algorithm
     IAlgorithm_sptr calibrationAlg = AlgorithmManager::Instance().create("IndirectCalibration");
@@ -209,7 +213,10 @@ namespace CustomInterfaces
     // Configure the resolution algorithm
     if(m_uiForm.ckCreateResolution->isChecked())
     {
-      QString resolutionWsName = outputWorkspaceNameStem + "_res";
+      QString resolutionWsName = outputWorkspaceNameStem;
+      if(filenameList.size() > 1)
+        resolutionWsName += "_multi";
+      resolutionWsName += "_res";
 
       QString resDetectorRange = QString::number(m_dblManager->value(m_properties["ResSpecMin"])) + ","
           + QString::number(m_dblManager->value(m_properties["ResSpecMax"]));


### PR DESCRIPTION
Fixes [#11701](http://trac.mantidproject.org/mantid/ticket/11701).

To test:
- Set facility to ISIS
- Open Indirect Data Reduction > ISIS Calibration
- Select IRIS as instrument
- Load runs `26173,26174`
- Enable Resolution
- Run

Both workspace names should contain `_multi_` to signify they were created from the sum of multiple runs and have a list of the original workspaces in the sample logs (`multi_run_numbers` for resolution (this log actually comes from `ISISIndirectEnergyTransfer`), `calib_run_numbers` for calibration).

(no release note entry)
