### PR TITLE
Lineviewer in sliceviewer  - using screen coords for 90deg snapping only

### DIFF
--- a/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
@@ -446,9 +446,9 @@ namespace SliceViewer
       double length;
       //for axis aligned angles just use respective distance for the length
       if (fmod(angle,M_PI) == 0 ) {
-        length = abs(currentDiff.x());
+        length = fabs(currentDiff.x());
       } else if (fmod(angle,M_PI) == M_PI/2 ) {
-        length = abs(currentDiff.y());
+        length = fabs(currentDiff.y());
       } else {
         length = sqrt(currentDiff.x()*currentDiff.x() + currentDiff.y()*currentDiff.y());
       }

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
@@ -9,7 +9,6 @@
 
 using namespace Mantid::Kernel;
 
-
 namespace MantidQt
 {
 namespace SliceViewer

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
@@ -160,7 +160,7 @@ namespace SliceViewer
   }
 
   //----------------------------------------------------------------------------------------------
-  /** Turn angle snap on/off
+  /** Turn angle snap on or off
    * @param angleSnap :: true for always angle snap. */
   void LineOverlay::setAngleSnapMode(bool angleSnap)
   {

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineOverlay.cpp
@@ -418,18 +418,42 @@ namespace SliceViewer
       else if (m_dragHandle == HandleB)
         currentDiff = current - m_pointA;
 
-      // Limit angles to 45 degree increments with shift pressed
+      // calculate angle
       double angle = atan2(currentDiff.y(), currentDiff.x());
-      // Round angle to closest 45 degrees, if in angle snap mode
+      
+      // Round angle to closest 45 degrees, if in angle snap mode (shift pressed)
       if (shiftPressed || m_angleSnapMode)
       {
-        // Convert the snap angle from degrees to radians
+        if (m_angleSnap == 90.0) {
+          //special case for 90 snap (axis aligned snapping)
+          //use screen coords to determine snap angle
+          QPointF currentScreenDiff;
+          if (m_dragHandle == HandleA)
+            currentScreenDiff = event->pos() - transform(m_pointB);
+          else if (m_dragHandle == HandleB)
+            currentScreenDiff = event->pos() - transform(m_pointA);
+            
+          // Limit angles to 90 based on screen coords, not data coords
+          //-y is because the screen y coords are inverted to the data coords
+          angle = atan2(-currentScreenDiff.y(), currentScreenDiff.x());
+        }
+        //convert snap angle to radians
         double angleSnapRad = m_angleSnap / (180.0 / M_PI);
+        //round current angle to snap angle
         angle = Utils::rounddbl(angle / angleSnapRad) * angleSnapRad;
       }
 
+      double length;
+      //for axis aligned angles just use respective distance for the length
+      if (fmod(angle,M_PI) == 0 ) {
+        length = abs(currentDiff.x());
+      } else if (fmod(angle,M_PI) == M_PI/2 ) {
+        length = abs(currentDiff.y());
+      } else {
+        length = sqrt(currentDiff.x()*currentDiff.x() + currentDiff.y()*currentDiff.y());
+      }
+      
       // Round length to m_snapLength, if specified
-      double length = sqrt(currentDiff.x()*currentDiff.x() + currentDiff.y()*currentDiff.y());
       if (m_snapLength > 0)
         length = Utils::rounddbl(length / m_snapLength) * m_snapLength;
 


### PR DESCRIPTION
ticket:
http://trac.mantidproject.org/mantid/ticket/11712
### To Test
1. Load a 2D workspace ideally with mismatched axes (e.g. one 5x bigger than other) I used an ARGUS workspace, but almost any would do.
2. Start sliceviewer
3. Draw a horizontal cut
4. Grab one end of the cut and move it so it should be vertical
5. It should now transition when the mouse is 45deg to the other end point
6. Known issue: problems remain if you turn on a coarse grid with axis aligned cutting (this is as before).
7. Load an MD dataset (any will do).
8. Open sliceviewer
9. create a cut
10. Play with moving the ends, using shift (snaps to 45deg angles), snap to grid etc, check the cut moves sensibly.
