### PR TITLE
Set the yunit to intensity for SofQW algs

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/SofQW.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQW.cpp
@@ -162,6 +162,9 @@ SofQW::setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace,
   // Set the X axis title (for conversion to MD)
   outputWorkspace->getAxis(0)->title() = "Energy transfer";
 
+  outputWorkspace->setYUnit("");
+  outputWorkspace->setYUnitLabel("Intensity");
+
   return outputWorkspace;
 }
 

--- a/Code/Mantid/Framework/Algorithms/src/SofQWCentre.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWCentre.cpp
@@ -291,6 +291,9 @@ SofQWCentre::setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inputWorkspace
   // Set the X axis title (for conversion to MD)
   outputWorkspace->getAxis(0)->title() = "Energy transfer";
 
+  outputWorkspace->setYUnit("");
+  outputWorkspace->setYUnitLabel("Intensity");
+
   return outputWorkspace;
 }
 

--- a/Code/Mantid/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -411,6 +411,9 @@ SofQWNormalisedPolygon::setUpOutputWorkspace(API::MatrixWorkspace_const_sptr inp
   // Set the X axis title (for conversion to MD)
   outputWorkspace->getAxis(0)->title() = "Energy transfer";
 
+  outputWorkspace->setYUnit("");
+  outputWorkspace->setYUnitLabel("Intensity");
+
   return outputWorkspace;
 }
 


### PR DESCRIPTION
http://trac.mantidproject.org/mantid/ticket/11722
### to test

``` python
# create sample inelastic workspace for MARI instrument containing 1 at all spectra values
ws=CreateSimulationWorkspace(Instrument='MAR',BinParams='-10,1,10')
# convert workspace into MD workspace
ws=SofQW(InputWorkspace=ws,QAxisBinning='-3,0.1,3',Emode='Direct',EFixed=12)
```
1. create an SofQW workspace
2. the y unit should be intensity, this should be visible on the workspace drop down and in 1D plots
