### PR TITLE
Fix exported workspaces in ALC

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
@@ -86,6 +86,9 @@ namespace CustomInterfaces
     /// Disables points which shouldn't be used for fitting
     static void disableUnwantedPoints(MatrixWorkspace_sptr ws, const std::vector<Section>& sections);
 
+    /// Enable previously disabled points
+    static void enableDisabledPoints(MatrixWorkspace_sptr destWs, MatrixWorkspace_const_sptr sourceWs);
+
   };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
@@ -39,13 +39,13 @@ namespace CustomInterfaces
   public:
     // -- IALCBaselineModellingModel interface -----------------------------------------------------
 
-    MatrixWorkspace_const_sptr data() const { return m_data; }
+    MatrixWorkspace_const_sptr data() const;
 
     void fit(IFunction_const_sptr function, const std::vector<Section> &sections);
 
     IFunction_const_sptr fittedFunction() const { return m_fittedFunction; }
 
-    MatrixWorkspace_const_sptr correctedData() const { return m_correctedData; }
+    MatrixWorkspace_const_sptr correctedData() const;
 
     ITableWorkspace_sptr parameterTable() const { return m_parameterTable; }
 
@@ -67,11 +67,8 @@ namespace CustomInterfaces
 
 
   private:
-    /// Data to use for fitting
+    /// Data used for fitting
     MatrixWorkspace_const_sptr m_data;
-
-    /// Corrected data of the last fit
-    MatrixWorkspace_const_sptr m_correctedData;
 
     /// Result function of the last fit
     IFunction_const_sptr m_fittedFunction;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -96,7 +96,7 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace()
   {
-    if ( m_data->getNumberHistograms() == 3 ) {
+    if ( m_data && m_data->getNumberHistograms() == 3 ) {
 
       // Export results only if data have been fit, that is,
       // if m_data has three histograms

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -39,8 +39,10 @@ namespace CustomInterfaces
     fit->setProperty("CreateOutput", true);
     fit->execute();
 
-    MatrixWorkspace_const_sptr fitOutput = fit->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr fitOutput = fit->getProperty("OutputWorkspace");
     m_parameterTable = fit->getProperty("OutputParameters");
+
+    enableDisabledPoints(fitOutput,m_data);
 
     setCorrectedData(fitOutput);
     setFittedFunction(funcToFit);
@@ -92,6 +94,18 @@ namespace CustomInterfaces
         ws->dataE(0)[i] = DISABLED_ERR;
       }
     }
+  }
+
+  /**
+   * Enable points that were disabled for fit
+   * @param destWs :: Workspace to enable points in
+   * @param sourceWs :: Workspace with original errors
+   */
+  void ALCBaselineModellingModel::enableDisabledPoints (MatrixWorkspace_sptr destWs, MatrixWorkspace_const_sptr sourceWs)
+  {
+    // Unwanted points were disabled by setting their errors to very high values.
+    // We recover here the original errors stored in sourceWs
+    destWs->dataE(0) = sourceWs->readE(0);
   }
 
   MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace()

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -19,37 +19,9 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace()
   {
-    if ( m_data && m_fittedPeaks) {
+    if ( m_data->getNumberHistograms() == 3 ) {
 
-      // Create a new workspace by cloning data one
-      IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
-      clone->setChild(true); // Don't want workspaces in ADS
-      clone->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
-      clone->setProperty("OutputWorkspace", "__NotUsed");
-      clone->execute();
-
-      Workspace_sptr cloneResult = clone->getProperty("OutputWorkspace");
-
-      // Calculate function values for all data X values
-      MatrixWorkspace_sptr peaks = ALCHelper::createWsFromFunction(m_fittedPeaks, m_data->readX(0));
-
-      // Merge two workspaces
-      IAlgorithm_sptr join = AlgorithmManager::Instance().create("ConjoinWorkspaces");
-      join->setChild(true);
-      join->setProperty("InputWorkspace1", cloneResult);
-      join->setProperty("InputWorkspace2", peaks);
-      join->setProperty("CheckOverlapping", false);
-      join->execute();
-
-      MatrixWorkspace_sptr result = join->getProperty("InputWorkspace1");
-
-      // Update axis lables so that it's understandable what's what on workspace data view / plot
-      TextAxis* yAxis = new TextAxis(result->getNumberHistograms());
-      yAxis->setLabel(0,"Data");
-      yAxis->setLabel(1,"FittedPeaks");
-      result->replaceAxis(1,yAxis);
-
-      return result;
+      return boost::const_pointer_cast<MatrixWorkspace>(m_data);
 
     } else {
     
@@ -84,6 +56,7 @@ namespace CustomInterfaces
     fit->setProperty("CreateOutput", true);
     fit->execute();
 
+    m_data = fit->getProperty("OutputWorkspace");
     m_parameterTable = fit->getProperty("OutputParameters");
 
     setFittedPeaks(static_cast<IFunction_sptr>(fit->getProperty("Function")));

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -19,7 +19,7 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace()
   {
-    if ( m_data->getNumberHistograms() == 3 ) {
+    if ( m_data && m_data->getNumberHistograms() == 3 ) {
 
       return boost::const_pointer_cast<MatrixWorkspace>(m_data);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -131,17 +131,17 @@ public:
 
   void test_exportWorkspace()
   {
-    // TODO: implement
+    TS_ASSERT_THROWS_NOTHING(m_model->exportWorkspace());
   }
 
   void test_exportTable()
   {
-    // TODO: implement
+    TS_ASSERT_THROWS_NOTHING(m_model->exportSections());
   }
 
   void test_exportModel()
   {
-    // TODO: implement
+    TS_ASSERT_THROWS_NOTHING(m_model->exportModel());
   }
 
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -44,14 +44,24 @@ public:
 
   void test_setData()
   {
-    MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+    std::vector<double> y = boost::assign::list_of(100)(1)(2)(100)(100)(3)(4)(5)(100);
+    std::vector<double> x = boost::assign::list_of(1)(2)(3)(4)(5)(6)(7)(8)(9);
+
+    MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create("Workspace2D", 1, y.size(), y.size());
+    data->dataY(0) = y;
+    data->dataX(0) = x;
 
     QSignalSpy spy(m_model, SIGNAL(dataChanged()));
 
     TS_ASSERT_THROWS_NOTHING(m_model->setData(data));
 
     TS_ASSERT_EQUALS(spy.size(), 1);
-    TS_ASSERT_EQUALS(m_model->data(), data);
+
+    MatrixWorkspace_const_sptr modelData = m_model->data();
+
+    TS_ASSERT_EQUALS(modelData->readX(0), data->readX(0));
+    TS_ASSERT_EQUALS(modelData->readY(0), data->readY(0));
+    TS_ASSERT_EQUALS(modelData->readE(0), data->readE(0));
   }
 
   void test_fit()

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCPeakFittingModelTest.h
@@ -98,6 +98,11 @@ public:
 
   }
 
+  void test_exportWorkspace()
+  {
+    TS_ASSERT_THROWS_NOTHING (m_model->exportWorkspace());
+  }
+
 };
 
 


### PR DESCRIPTION
Fixes [#11711](http://trac.mantidproject.org/mantid/ticket/11711)

For tester: 
- Code review: make sure you understand the problem reported by scientists (see original trac issue and documentation) and the fix.
- Reproduce the problem on the master branch: open ALC, load "MUSR00015189.nxs" as "First" and "MUSR00015193.nxs" as "Last", hit "Load", go to "Baseline Modelling", right-click on the "Function" blank region and add a LinearBackground, right-click on "Sections" blank section and add a section, hit "Fit", hit "Export results...", a WorkspaceGroup will be created. Right-click on "ALCResults_Baseline_Workspace" -> "Plot spectrum with errors" -> enter "0-1". Errors are huge for the "Baseline" curve.
- On this branch, repeat the same steps. Check that errors in "Baseline" are reasonable.
