### PR TITLE
Add widget to select a function of LogValue

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -53,6 +53,7 @@ namespace CustomInterfaces
     std::string firstRun() const;
     std::string lastRun() const;
     std::string log() const;
+    std::string function() const;
     std::string deadTimeType() const;
     std::string deadTimeFile() const;
     std::string detectorGroupingType() const;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -26,72 +26,84 @@
                   <property name="title">
                     <string>Data</string>
                   </property>
-                  <layout class="QFormLayout" name="formLayout">
-                    <property name="fieldGrowthPolicy">
+                  <layout class="QVBoxLayout" name="formLayout">
+                    <!--<property name="fieldGrowthPolicy">
                       <enum>QFormLayout::ExpandingFieldsGrow</enum>
-                    </property>
-                    <item row="0" column="0">
-                      <widget class="QLabel" name="label">
-                        <property name="text">
-                          <string>First</string>
-                        </property>
-                      </widget>
+                    </property>-->
+                    <item>
+                      <layout class="QHBoxLayout" name="firstLayout">
+                        <item>
+                          <widget class="QLabel" name="label">
+                            <property name="text">
+                              <string>First</string>
+                            </property>
+                          </widget>
+                        </item>
+                        <item>
+                          <widget class="MantidQt::MantidWidgets::MWRunFiles" name="firstRun" native="true">
+                            <property name="sizePolicy">
+                              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                              </sizepolicy>
+                            </property>
+                            <property name="label" stdset="0">
+                              <string/>
+                            </property>
+                            <property name="multipleFiles" stdset="0">
+                              <bool>false</bool>
+                            </property>
+                          </widget>
+                        </item>
+                      </layout>
                     </item>
-                    <item row="1" column="0">
-                      <widget class="QLabel" name="label_2">
-                        <property name="text">
-                          <string>Last</string>
-                        </property>
-                      </widget>
+                    <item>
+                      <layout class="QHBoxLayout" name="lastLayout">
+                        <item>
+                          <widget class="QLabel" name="label_2">
+                            <property name="text">
+                              <string>Last</string>
+                            </property>
+                          </widget>
+                        </item>
+                        <item>
+                          <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lastRun" native="true">
+                            <property name="sizePolicy">
+                              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                              </sizepolicy>
+                            </property>
+                            <property name="label" stdset="0">
+                              <string/>
+                            </property>
+                            <property name="multipleFiles" stdset="0">
+                              <bool>false</bool>
+                            </property>
+                          </widget>
+                        </item>
+                      </layout>
                     </item>
-                    <item row="2" column="0">
-                      <widget class="QLabel" name="label_3">
-                        <property name="text">
-                          <string>Log</string>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="0" column="1">
-                      <widget class="MantidQt::MantidWidgets::MWRunFiles" name="firstRun" native="true">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="label" stdset="0">
-                          <string/>
-                        </property>
-                        <property name="multipleFiles" stdset="0">
-                          <bool>false</bool>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="1" column="1">
-                      <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lastRun" native="true">
-                        <property name="sizePolicy">
-                          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                          </sizepolicy>
-                        </property>
-                        <property name="label" stdset="0">
-                          <string/>
-                        </property>
-                        <property name="multipleFiles" stdset="0">
-                          <bool>false</bool>
-                        </property>
-                      </widget>
-                    </item>
-                    <item row="2" column="1">
-                      <widget class="QComboBox" name="log">
-                        <property name="editable">
-                          <bool>false</bool>
-                        </property>
-                        <property name="sizeAdjustPolicy">
-                          <enum>QComboBox::AdjustToContents</enum>
-                        </property>
-                      </widget>
+                    <item>
+                      <layout class="QHBoxLayout" name="logLayout">
+                        <item>
+                          <widget class="QLabel" name="label_3">
+                            <property name="text">
+                              <string>Log</string>
+                            </property>
+                          </widget>
+                        </item>
+                        <item>
+                          <widget class="QComboBox" name="log">
+                            <property name="editable">
+                              <bool>false</bool>
+                            </property>
+                            <property name="sizeAdjustPolicy">
+                              <enum>QComboBox::AdjustToContents</enum>
+                            </property>
+                          </widget>
+                        </item>
+                      </layout>
                     </item>
                   </layout>
                 </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -139,7 +139,7 @@
                             </property>
                             <item>
                               <property name="text">
-                                <string>Mean </string>
+                                <string>Mean</string>
                               </property>
                             </item>
                             <item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -103,6 +103,23 @@
                             </property>
                           </widget>
                         </item>
+                        <item>
+                          <widget class="QLabel" name="functionLabel">
+                            <property name="text">
+                              <string>Function</string>
+                            </property>
+                          </widget>
+                        </item>
+                        <item>
+                          <widget class="QComboBox" name="function">
+                            <property name="editable">
+                              <bool>false</bool>
+                            </property>
+                            <property name="sizeAdjustPolicy">
+                              <enum>QComboBox::AdjustToContents</enum>
+                            </property>
+                          </widget>
+                        </item>
                       </layout>
                     </item>
                   </layout>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -134,6 +134,9 @@
                                 <height>0</height>
                               </size>
                             </property>
+                            <property name="currentIndex">
+                              <number>4</number>
+                            </property>
                             <item>
                               <property name="text">
                                 <string>Mean </string>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -104,6 +104,19 @@
                           </widget>
                         </item>
                         <item>
+                          <spacer name="logSpacer">
+                            <property name="orientation">
+                              <enum>Qt::Horizontal</enum>
+                            </property>
+                            <property name="sizeHint" stdset="0">
+                              <size>
+                                <width>40</width>
+                                <height>20</height>
+                              </size>
+                            </property>
+                          </spacer>
+                        </item>
+                        <item>
                           <widget class="QLabel" name="functionLabel">
                             <property name="text">
                               <string>Function</string>
@@ -115,9 +128,37 @@
                             <property name="editable">
                               <bool>false</bool>
                             </property>
-                            <property name="sizeAdjustPolicy">
-                              <enum>QComboBox::AdjustToContents</enum>
+                            <property name="minimumSize">
+                              <size>
+                                <width>75</width>
+                                <height>0</height>
+                              </size>
                             </property>
+                            <item>
+                              <property name="text">
+                                <string>Mean </string>
+                              </property>
+                            </item>
+                            <item>
+                              <property name="text">
+                                <string>Min</string>
+                              </property>
+                            </item>
+                            <item>
+                              <property name="text">
+                                <string>Max</string>
+                              </property>
+                            </item>
+                            <item>
+                              <property name="text">
+                                <string>First</string>
+                              </property>
+                            </item>
+                            <item>
+                              <property name="text">
+                                <string>Last</string>
+                              </property>
+                            </item>
                           </widget>
                         </item>
                       </layout>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -53,6 +53,10 @@ namespace CustomInterfaces
     /// @return Log name
     virtual std::string log() const = 0;
 
+    /// Returns the function to apply
+    /// @return Log function
+    virtual std::string function() const = 0;
+
     /// @return dead time correction type to use
     virtual std::string deadTimeType() const = 0;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -61,6 +61,7 @@ namespace CustomInterfaces
       alg->setProperty("FirstRun", m_view->firstRun());
       alg->setProperty("LastRun", m_view->lastRun());
       alg->setProperty("LogValue", m_view->log());
+      alg->setProperty("Function", m_view->function());
       alg->setProperty("Type", m_view->calculationType());
       alg->setProperty("DeadTimeCorrType",m_view->deadTimeType());
       alg->setProperty("Red",m_view->redPeriod());

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -61,6 +61,11 @@ namespace CustomInterfaces
     return m_ui.log->currentText().toStdString();
   }
 
+  std::string ALCDataLoadingView::function() const
+  {
+    return m_ui.function->currentText().toStdString();
+  }
+
   std::string ALCDataLoadingView::calculationType() const
   {
     // XXX: "text" property of the buttons should be set correctly, as accepted by

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -32,6 +32,7 @@ public:
   MOCK_CONST_METHOD0(firstRun, std::string());
   MOCK_CONST_METHOD0(lastRun, std::string());
   MOCK_CONST_METHOD0(log, std::string());
+  MOCK_CONST_METHOD0(function, std::string());
   MOCK_CONST_METHOD0(calculationType, std::string());
   MOCK_CONST_METHOD0(timeRange, boost::optional<PAIR_OF_DOUBLES>());
   MOCK_CONST_METHOD0(deadTimeType, std::string());
@@ -88,6 +89,7 @@ public:
     ON_CALL(*m_view, lastRun()).WillByDefault(Return("MUSR00015191.nxs"));
     ON_CALL(*m_view, calculationType()).WillByDefault(Return("Integral"));
     ON_CALL(*m_view, log()).WillByDefault(Return("sample_magn_field"));
+    ON_CALL(*m_view, function()).WillByDefault(Return("Last"));
     ON_CALL(*m_view, timeRange()).WillByDefault(Return(boost::make_optional(std::make_pair(-6.0,32.0))));
     ON_CALL(*m_view, deadTimeType()).WillByDefault(Return("None"));
     ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Auto"));
@@ -261,6 +263,20 @@ public:
                            QwtDataX(1, 1360, 1E-8), QwtDataX(2, 1370, 1E-8),
                            QwtDataY(0, 0.012884, 1E-6), QwtDataY(1, 0.022489, 1E-6),
                            QwtDataY(2, 0.038717, 1E-6))));
+    m_view->requestLoading();
+  }
+
+  void test_logFunction ()
+  {
+    ON_CALL(*m_view, function()).WillByDefault(Return("First"));
+    ON_CALL(*m_view, log()).WillByDefault(Return("Field_Danfysik"));
+    EXPECT_CALL(*m_view, setDataCurve(AllOf(Property(&QwtData::size,3),
+                                            QwtDataX(0, 1398.090, 1E-3),
+                                            QwtDataX(1, 1360.200, 1E-3),
+                                            QwtDataX(2, 1364.520, 1E-3),
+                                            QwtDataY(0, 0.15004, 1E-5),
+                                            QwtDataY(1, 0.14289, 1E-5),
+                                            QwtDataY(2, 0.12837, 1E-5))));
     m_view->requestLoading();
   }
 

--- a/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
+++ b/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
@@ -41,6 +41,9 @@ Last
 Log
   Log value to use as X parameter
 
+Function
+  The function to apply to the Log value: Mean/Min/Max/First/Last
+
 Dead Time Correction
   Type of dead time corrections to apply. Options are *None*, in which case no 
   corrections will be applied, *From Data File*, to load corrections from 

--- a/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
+++ b/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
@@ -42,7 +42,7 @@ Log
   Log value to use as X parameter
 
 Function
-  The function to apply to the Log value: Mean/Min/Max/First/Last
+  The function to apply to the time series log: Mean/Min/Max/First/Last
 
 Dead Time Correction
   Type of dead time corrections to apply. Options are *None*, in which case no 


### PR DESCRIPTION
This fixes [#11727](http://trac.mantidproject.org/mantid/ticket/11727)

PlotAsymmetryByLogValue (PABLV) has a widget to select a function (Mean/Min/Max/First/Last) to apply to the time series log and plot the muon asymmetry versus the selected log. This PR is to add a widget in the ALC interface (which uses PABLV) to select the function of the log as in PABLV.

To test: code review should be enough, but you can also open the ALC interface and check that a combo box has been added and that it allows the user to select different functions of the log.
