### PR TITLE
Sliceviewer axis swap issue

### DIFF
--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -3074,11 +3074,18 @@ void Graph::updateScale()
     updateSecondaryAxis(QwtPlot::yRight);
   }
 
-  auto firstCurve = dynamic_cast<MantidCurve*>(curve(0));
-  if (firstCurve)
+  auto mantidCurve = dynamic_cast<MantidCurve*>(curve(0));
+  auto dataCurve = dynamic_cast<DataCurve*>(curve(0));
+
+  if (mantidCurve)
   {
-    setXAxisTitle(firstCurve->mantidData()->getXAxisLabel());
-    setYAxisTitle(firstCurve->mantidData()->getYAxisLabel());
+    setXAxisTitle(mantidCurve->mantidData()->getXAxisLabel());
+    setYAxisTitle(mantidCurve->mantidData()->getYAxisLabel());
+  }
+  else if (dataCurve && dataCurve->table())
+  {
+    setXAxisTitle(dataCurve->table()->colLabel(0));
+    setYAxisTitle(dataCurve->table()->colLabel(1).section(".",0,0));
   }
 
   d_plot->replot();//TODO: avoid 2nd replot!

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -61,6 +61,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "Mantid/MantidMatrixCurve.h"
 #include "MantidQtAPI/PlotAxis.h"
+#include "MantidQtAPI/QwtRasterDataMD.h"
 #include "MantidQtAPI/QwtWorkspaceSpectrumData.h"
 #include "Mantid/ErrorBarSettings.h"
 
@@ -3086,6 +3087,21 @@ void Graph::updateScale()
   {
     setXAxisTitle(dataCurve->table()->colLabel(0));
     setYAxisTitle(dataCurve->table()->colLabel(1).section(".",0,0));
+  }
+
+  Spectrogram* spec = spectrogram();
+  if (spec)
+  {
+    auto specData = dynamic_cast<const MantidQt::API::QwtRasterDataMD*>(&spec->data());
+    if (specData)
+    {
+      Mantid::API::IMDWorkspace_const_sptr ws = specData->getWorkspace();
+      if(ws)
+      {
+        setXAxisTitle(MantidQt::API::PlotAxis(*ws, 0).title());
+        setYAxisTitle(MantidQt::API::PlotAxis(*ws, 1).title());
+      }
+    }
   }
 
   d_plot->replot();//TODO: avoid 2nd replot!

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -3074,6 +3074,13 @@ void Graph::updateScale()
     updateSecondaryAxis(QwtPlot::yRight);
   }
 
+  auto firstCurve = dynamic_cast<MantidCurve*>(curve(0));
+  if (firstCurve)
+  {
+    setXAxisTitle(firstCurve->mantidData()->getXAxisLabel());
+    setYAxisTitle(firstCurve->mantidData()->getYAxisLabel());
+  }
+
   d_plot->replot();//TODO: avoid 2nd replot!
   d_zoomer[0]->setZoomBase(false);
 }

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -617,11 +617,7 @@ MultiLayer* MantidUI::plotMDList(const QStringList& wsNames, const int plotAxis,
 
       // Using information from the first graph
       if( i == 0 && isGraphNew )
-      {
-        g->setXAxisTitle(data->getXAxisLabel());
-        g->setYAxisTitle(data->getYAxisLabel());
         g->setAutoScale();
-      }
     }
 
   }
@@ -2770,6 +2766,7 @@ void MantidUI::importNumSeriesLog(const QString &wsName, const QString &logName,
       g->setCurvePen(iFilterCurve, pn);
     }
   }
+  // THIS SECTION NEEDS TO BE FIXED REF #11710
   g->setXAxisTitle(t->colLabel(0));
   g->setYAxisTitle(t->colLabel(1).section(".",0,0));
   g->setTitle(label);
@@ -2994,8 +2991,6 @@ void MantidUI::setUpBinGraph(MultiLayer* ml, const QString& Name, Mantid::API::M
   {
     xtitle = MantidQt::API::PlotAxis(*workspace, 1).title();
   }
-  g->setXAxisTitle(xtitle);
-  g->setYAxisTitle(MantidQt::API::PlotAxis(false, *workspace).title());
 }
 
 /**
@@ -3221,8 +3216,6 @@ MultiLayer* MantidUI::plot1D(const QMultiMap<QString,int>& toPlot, bool spectrum
       return NULL;
     }
 
-    g->setXAxisTitle(firstCurve->mantidData()->getXAxisLabel());
-    g->setYAxisTitle(firstCurve->mantidData()->getYAxisLabel());
     g->setAutoScale();
     /* The 'setAutoScale' above is needed to make sure that the plot initially encompasses all the
      * data points. However, this has the side-effect suggested by its name: all the axes become
@@ -3275,6 +3268,7 @@ void MantidUI::showSequentialPlot(Ui::SequentialFitDialog* ui, MantidQt::MantidW
     MultiLayer* ml = appWindow()->multilayerPlot(t,colNames,ui->cbCurveType->currentIndex());
     // set plot titles
     Graph* g = ml->activeGraph();
+    // THIS SECTION NEEDS TO BE FIXED REF #11710
     if (g)
     {
       if (ui->ckbLogPlot->isChecked())
@@ -3405,6 +3399,7 @@ MultiLayer* MantidUI::drawSingleColorFillPlot(const QString & wsName, Graph::Cur
 
   plot->setTitle(wsName);
   using MantidQt::API::PlotAxis;
+  // THIS SECTION NEEDS TO BE FIXED REF #11710
   plot->setXAxisTitle(PlotAxis(*workspace, 0).title());
   plot->setYAxisTitle(PlotAxis(*workspace, 1).title());
 

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -2766,9 +2766,6 @@ void MantidUI::importNumSeriesLog(const QString &wsName, const QString &logName,
       g->setCurvePen(iFilterCurve, pn);
     }
   }
-  // THIS SECTION NEEDS TO BE FIXED REF #11710
-  g->setXAxisTitle(t->colLabel(0));
-  g->setYAxisTitle(t->colLabel(1).section(".",0,0));
   g->setTitle(label);
   g->setAutoScale();
 

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3395,10 +3395,6 @@ MultiLayer* MantidUI::drawSingleColorFillPlot(const QString & wsName, Graph::Cur
   appWindow()->setPreferences(plot);
 
   plot->setTitle(wsName);
-  using MantidQt::API::PlotAxis;
-  // THIS SECTION NEEDS TO BE FIXED REF #11710
-  plot->setXAxisTitle(PlotAxis(*workspace, 0).title());
-  plot->setYAxisTitle(PlotAxis(*workspace, 1).title());
 
   Spectrogram *spgrm = new Spectrogram(wsName, workspace);
   plot->plotSpectrogram(spgrm, curveType);

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3265,7 +3265,6 @@ void MantidUI::showSequentialPlot(Ui::SequentialFitDialog* ui, MantidQt::MantidW
     MultiLayer* ml = appWindow()->multilayerPlot(t,colNames,ui->cbCurveType->currentIndex());
     // set plot titles
     Graph* g = ml->activeGraph();
-    // THIS SECTION NEEDS TO BE FIXED REF #11710
     if (g)
     {
       if (ui->ckbLogPlot->isChecked())


### PR DESCRIPTION
This is for trac ticket [#11710](http://trac.mantidproject.org/mantid/ticket/11710)

If the axes of a plot are transposed, any existing plots update fine, with the exception of the axis labels. This pull request ensures that axis labels are recalculated so that they're always accurate.

This has been marked as **CORE** because it significantly affects the way axis labels of MantidPlot plots are set. Behaviour should **not** visibly change except for the one known issue: When a plot's curves are edited, then the axis labels are recalculated and any changes the user may have made to the labels are discarded. This is unavoidable as QwtPlot does not allow interception of user modifications to the axis labels, or notifications that it has happened.

**Testing**:
1. View a multidimensional workspace
2. Create a line cut
3. plot the resulting line in mantidplot and keep the plot open
4. Now switch the axis in the sliceviewer
5. You can continue to draw the lines and the plots update, but the x/y labels of the plots should be updated, but don't get redrawn. 

```
CreateMDWorkspace(Dimensions='3', Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U', OutputWorkspace='ws')
FakeMDEventData(InputWorkspace='ws', UniformParams='10000')
```
