### PR TITLE
Fix crash when using IDA ConvFit with no instrument

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -591,7 +591,14 @@ namespace IDA
     {
       Mantid::Geometry::Instrument_const_sptr inst =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName)->getInstrument();
-      std::string analyser = inst->getStringParameter("analyser")[0];
+      std::vector<std::string> analysers = inst->getStringParameter("analyser");
+      if(analysers.empty())
+      {
+        g_log.warning("Could not load instrument resolution from parameter file");
+        return 0.0;
+      }
+
+      std::string analyser = analysers[0];
       std::string idfDirectory = Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory");
 
       // If the analyser component is not already in the data file the laod it from the parameter file
@@ -607,7 +614,7 @@ namespace IDA
 
         if(!loadParamFile->isExecuted())
         {
-          g_log.error("Could not load parameter file, ensure instrument directory is in data search paths.");
+          g_log.warning("Could not load parameter file, ensure instrument directory is in data search paths.");
           return 0.0;
         }
 
@@ -620,7 +627,7 @@ namespace IDA
     {
       UNUSED_ARG(e);
 
-      g_log.error("Could not load instrument resolution from parameter file");
+      g_log.warning("Could not load instrument resolution from parameter file");
       resolution = 0.0;
     }
 

--- a/Code/Mantid/scripts/Inelastic/IndirectCommon.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectCommon.py
@@ -43,9 +43,11 @@ def getInstrRun(ws_name):
             raise RuntimeError("Could not find run number associated with workspace.")
 
     instrument = workspace.getInstrument().getName()
-    facility = config.getFacility()
-    instrument = facility.instrument(instrument).filePrefix(int(run_number))
-    instrument = instrument.lower()
+    if instrument != '':
+        facility = config.getFacility()
+        instrument = facility.instrument(instrument).filePrefix(int(run_number))
+        instrument = instrument.lower()
+
     return instrument, run_number
 
 


### PR DESCRIPTION
Fixes [#11734](http://trac.mantidproject.org/mantid/ticket/11734).

To test:
- Open IDA > ConvFit
- Load `Babylon5/Public/DanNixon/LET/LET19975_3.91meV_sqw.nxs` as both sample and resolution (this is the only data I have for LET but is good enough for demonstration)
- Add a function
- Run in single and sequential fit modes

Note that the result workspace does not have the instrument prefix any more, this is intentional as there is no instrument associated with the workspace.

Really the user should run LoadInstrument first (for ConvFit the instrument is not technically required, for other tabs on IDA it is), this just fixes the case when they don't.
