### PR TITLE
refs #11714. Introduce correct scaling.

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CutMD.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CutMD.h
@@ -48,8 +48,13 @@ public:
 
   virtual void init();
   virtual void exec();
-
-private:
+  
+  static const std::string InvAngstromSymbol;
+  static const std::string RLUSymbol;
+  static const std::string CutMD::AutoMethod;
+  static const std::string CutMD::RLUMethod;
+  static const std::string CutMD::InvAngstromMethod;
+  
 };
 
 } // namespace MDAlgorithms

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CutMD.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CutMD.h
@@ -51,9 +51,9 @@ public:
   
   static const std::string InvAngstromSymbol;
   static const std::string RLUSymbol;
-  static const std::string CutMD::AutoMethod;
-  static const std::string CutMD::RLUMethod;
-  static const std::string CutMD::InvAngstromMethod;
+  static const std::string AutoMethod;
+  static const std::string RLUMethod;
+  static const std::string InvAngstromMethod;
   
 };
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
@@ -10,6 +10,7 @@
 
 #include <boost/make_shared.hpp>
 #include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
 
 
 using namespace Mantid::API;
@@ -271,9 +272,12 @@ void CutMD::init() {
       "%s : Force them to be rlu\n"
       "%s : Force them to be inverse angstroms", AutoMethod, RLUMethod, InvAngstromMethod);
 
+  std::string help(buffer);
+  boost::algorithm::trim(help);
+  std::cout << "HELP " << help << std::endl;
   declareProperty(
     "InterpretQDimensionUnits", AutoMethod,
-      boost::make_shared<StringListValidator>(propOptions), buffer
+      boost::make_shared<StringListValidator>(propOptions), help
       );
 }
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
@@ -4,8 +4,13 @@
 #include "MantidAPI/Projection.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
+
+#include <boost/make_shared.hpp>
+#include <boost/regex.hpp>
+
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -47,7 +52,7 @@ DblMatrix scaleProjection(const DblMatrix &inMatrix,
         orientedLattice.dstar(inMatrix[i][0], inMatrix[i][1], inMatrix[i][2]);
     if (inUnits[i] == outUnits[i])
       continue;
-    else if (inUnits[i] == "a") {
+    else if (inUnits[i] == Mantid::MDAlgorithms::CutMD::InvAngstromSymbol) {
       // inv angstroms to rlu
       for (size_t j = 0; j < numDims; ++j)
         ret[i][j] *= dStar;
@@ -178,6 +183,34 @@ std::vector<std::string> labelProjection(const DblMatrix &projection) {
   }
   return ret;
 }
+
+/**
+Determine the original q units. Assumes first 3 dimensions by index are r,l,d
+@param inws : Input workspace to extract dimension info from
+@param logger : logging object
+@return vector of markers
+*/
+std::vector<std::string> findOriginalQUnits(IMDWorkspace const *const inws,
+                                            Mantid::Kernel::Logger &logger) {
+  std::vector<std::string> unitMarkers(3);
+  for (size_t i = 0; i < inws->getNumDims() && i < 3; ++i) {
+    auto units = inws->getDimension(i)->getUnits();
+    const boost::regex re("A\\^-1", boost::regex::icase);
+    // Does the unit label look like it's in Angstroms?
+    std::string unitMarker;
+    if (boost::regex_match(units.ascii(), re)) {
+      unitMarker = Mantid::MDAlgorithms::CutMD::InvAngstromSymbol;
+    } else {
+      unitMarker = Mantid::MDAlgorithms::CutMD::RLUSymbol;
+    }
+    unitMarkers[i] = unitMarker;
+    logger.debug() << "In dimension with index " << i << " and units "
+                   << units.ascii() << " taken to be of type " << unitMarker
+                   << std::endl;
+  }
+  return unitMarkers;
+}
+
 } // anonymous namespace
 
 namespace Mantid {
@@ -185,6 +218,12 @@ namespace MDAlgorithms {
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(CutMD)
+
+const std::string CutMD::InvAngstromSymbol = "a";
+const std::string CutMD::RLUSymbol = "r";
+const std::string CutMD::AutoMethod = "Auto";
+const std::string CutMD::RLUMethod = "RLU";
+const std::string CutMD::InvAngstromMethod = "Q in A^-1";
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
@@ -221,6 +260,21 @@ void CutMD::init() {
                                   "as output. True to create an "
                                   "MDHistoWorkspace as output. This is DND "
                                   "only in Horace terminology.");
+
+  std::vector<std::string> propOptions;
+  propOptions.push_back(AutoMethod);
+  propOptions.push_back(RLUMethod);
+  propOptions.push_back(InvAngstromMethod);
+  char buffer[1024];
+  std::sprintf(buffer, "How will the Q units of the input workspace be interpreted? This property will disappear in future versions of Mantid\n"
+      "%s : Figure it out based on the label units\n"
+      "%s : Force them to be rlu\n"
+      "%s : Force them to be inverse angstroms", AutoMethod, RLUMethod, InvAngstromMethod);
+
+  declareProperty(
+    "InterpretQDimensionUnits", AutoMethod,
+      boost::make_shared<StringListValidator>(propOptions), buffer
+      );
 }
 
 void CutMD::exec() {
@@ -293,8 +347,18 @@ void CutMD::exec() {
 
     std::vector<std::string> targetUnits(3);
     for (size_t i = 0; i < 3; ++i)
-      targetUnits[i] = projection.getUnit(i) == RLU ? "r" : "a";
-    std::vector<std::string> originUnits(3, "r"); // TODO. This is a hack!
+      targetUnits[i] =
+          projection.getUnit(i) == RLU ? RLUSymbol : InvAngstromSymbol;
+    
+    const std::string determineUnitsMethod = this->getProperty("InterpretQDimensionUnits");
+    std::vector<std::string> originUnits; 
+    if ( determineUnitsMethod == AutoMethod ) {
+        originUnits = findOriginalQUnits(inWS.get(), g_log);
+    } else if (determineUnitsMethod == RLUMethod ) {
+      originUnits = std::vector<std::string>(3, RLUSymbol);
+    } else{
+      originUnits = std::vector<std::string>(3, InvAngstromSymbol);
+    }
 
     DblMatrix scaledProjectionMatrix =
         scaleProjection(projectionMatrix, originUnits, targetUnits, eventInWS);
@@ -333,7 +397,7 @@ void CutMD::exec() {
     }
 
     // Make labels
-    std::vector<std::string> labels = labelProjection(projectionMatrix);
+    std::vector<std::string> labels = labelProjection(scaledProjectionMatrix);
 
     // Either run RebinMD or SliceMD
     const std::string cutAlgName = noPix ? "BinMD" : "SliceMD";
@@ -356,7 +420,8 @@ void CutMD::exec() {
 
         std::vector<std::string> vec(numDims, "0");
         for (size_t j = 0; j < 3; ++j)
-          vec[j] = boost::lexical_cast<std::string>(projectionMatrix[i][j]);
+          vec[j] =
+              boost::lexical_cast<std::string>(scaledProjectionMatrix[i][j]);
         vecStr = boost::algorithm::join(vec, ", ");
       } else {
         // Always orthogonal

--- a/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CutMD.cpp
@@ -270,11 +270,10 @@ void CutMD::init() {
   std::sprintf(buffer, "How will the Q units of the input workspace be interpreted? This property will disappear in future versions of Mantid\n"
       "%s : Figure it out based on the label units\n"
       "%s : Force them to be rlu\n"
-      "%s : Force them to be inverse angstroms", AutoMethod, RLUMethod, InvAngstromMethod);
+      "%s : Force them to be inverse angstroms", AutoMethod.c_str(), RLUMethod.c_str(), InvAngstromMethod.c_str());
 
   std::string help(buffer);
   boost::algorithm::trim(help);
-  std::cout << "HELP " << help << std::endl;
   declareProperty(
     "InterpretQDimensionUnits", AutoMethod,
       boost::make_shared<StringListValidator>(propOptions), help


### PR DESCRIPTION
CutMD seems to use the Projection 'type' to calculate the extents, but it does not scale the data like it should. [#11714](http://trac.mantidproject.org/mantid/ticket/11714)

If we specify 'r' (as in r.l.u) and have our data defined with a correct UB, we should find that nuclear reflections always sit on integer HKL positions.

**Tester**

On the completed changes, we should be able to do this:

``` python

ws = Load(Filename='SXD23767.raw',OutputWorkspace='SXD23767',LoadMonitors='Exclude')

SetUB(ws, UB=[-0.15097235,  0.09164432 , 0.00519473 ,0.0831895,   0.14123681, -0.06719047, -0.0384503, -0.05534039, -0.1633801 ])
s = ws.sample()
SetGoniometer(ws)

scales =  'Q in A^-1' # 'Q in lattice units' 
HKL = ConvertToMD(InputWorkspace=ws, QConversionScales=scales, QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='HKL', OutputWorkspace='HKL', MinValues='-10,-10,-10', MaxValues='10,10,10')


HKL = mtd['HKL']
p = Projection()
p.setType(0, 'r')
p.setType(1, 'r')
p.setType(2, 'r')
proj = p.createWorkspace('proj')

cut_r = CutMD(HKL, Projection=proj, NoPix=True, PBins=[[0.1], [0.1], [0.1]])

p = Projection()
p.setType(0, 'a')
p.setType(1, 'a')
p.setType(2, 'a')
proj = p.createWorkspace('proj')

cut_a = CutMD(HKL, Projection=proj, NoPix=True, PBins=[[0.1], [0.1], [0.1]])

l = -4.0
svw1 = plotSlice(cut_r, colorscalelog=True)
svw1.setSlicePoint(2, l)
svw2 = plotSlice(cut_a, colorscalelog=True)
svw2.setSlicePoint(2, l)
```
- For svw2, the bragg peaks should show at integer positions! Not so for where projection type is 'a'
