### PR TITLE
Add optional q-Space output workspace to ConvertToYSpace

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/ConvertToYSpace.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/ConvertToYSpace.h
@@ -98,6 +98,7 @@ private:
 
   /// Output workspace
   API::MatrixWorkspace_sptr m_outputWS;
+  API::MatrixWorkspace_sptr m_qOutputWS;
 };
 
 } // namespace CurveFitting

--- a/Code/Mantid/Framework/CurveFitting/src/ConvertToYSpace.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/ConvertToYSpace.cpp
@@ -26,7 +26,7 @@ const double MASS_TO_MEV =
 */
 ConvertToYSpace::ConvertToYSpace()
     : Algorithm(), m_inputWS(), m_mass(0.0), m_l1(0.0), m_samplePos(),
-      m_outputWS() {}
+      m_outputWS(), m_qOutputWS() {}
 
 //----------------------------------------------------------------------------------------------
 /// Algorithm's name for identification. @see Algorithm::name
@@ -163,7 +163,7 @@ void ConvertToYSpace::init() {
   wsValidator->add<WorkspaceUnitValidator>("TOF");
   declareProperty(new WorkspaceProperty<>("InputWorkspace", "",
                                           Direction::Input, wsValidator),
-                  "An input workspace.");
+                  "The input workspace in Time of Flight");
 
   auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
@@ -173,10 +173,15 @@ void ConvertToYSpace::init() {
 
   declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
-      "An output workspace.");
+      "The output workspace in y-Space");
+
+  declareProperty(
+      new WorkspaceProperty<>("QWorkspace", "", Direction::Output, PropertyMode::Optional),
+      "The output workspace in q-Space");
 }
 
 //----------------------------------------------------------------------------------------------
+
 /** Execute the algorithm.
 */
 void ConvertToYSpace::exec() {
@@ -192,11 +197,12 @@ void ConvertToYSpace::exec() {
     PARALLEL_START_INTERUPT_REGION
 
     if (!convert(i)) {
-
       g_log.warning("No detector defined for index=" +
                     boost::lexical_cast<std::string>(i) +
                     ". Zeroing spectrum.");
       m_outputWS->maskWorkspaceIndex(i);
+      if(m_qOutputWS)
+        m_qOutputWS->maskWorkspaceIndex(i);
     }
 
     PARALLEL_END_INTERUPT_REGION
@@ -204,6 +210,9 @@ void ConvertToYSpace::exec() {
   PARALLEL_CHECK_INTERUPT_REGION
 
   setProperty("OutputWorkspace", m_outputWS);
+
+  if(m_qOutputWS)
+    setProperty("QWorkspace", m_qOutputWS);
 }
 
 /**
@@ -238,6 +247,11 @@ bool ConvertToYSpace::convert(const size_t index) {
       const double prefactor = qs / pow(ei, 0.1);
       outY[outIndex] = prefactor * inY[j];
       outE[outIndex] = prefactor * inE[j];
+
+      if(m_qOutputWS) {
+        m_qOutputWS->dataX(index)[outIndex] = ys;
+        m_qOutputWS->dataY(index)[outIndex] = qs;
+      }
     }
     return true;
   } catch (Exception::NotFoundError &) {
@@ -258,12 +272,21 @@ void ConvertToYSpace::retrieveInputs() {
 * Create & cache output workspaces
 */
 void ConvertToYSpace::createOutputWorkspace() {
+  // y-Space output workspace
   m_outputWS = WorkspaceFactory::Instance().create(m_inputWS);
-  // Units
+
   auto xLabel = boost::make_shared<Units::Label>("Momentum", "A^-1");
   m_outputWS->getAxis(0)->unit() = xLabel;
   m_outputWS->setYUnit("");
   m_outputWS->setYUnitLabel("");
+
+  // q-Space output workspace
+  if(getPropertyValue("QWorkspace") != "") {
+    m_qOutputWS = WorkspaceFactory::Instance().create(m_inputWS);
+
+    m_qOutputWS->setYUnit("");
+    m_qOutputWS->setYUnitLabel("");
+  }
 }
 
 /**

--- a/Code/Mantid/Framework/CurveFitting/src/ConvertToYSpace.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/ConvertToYSpace.cpp
@@ -236,8 +236,7 @@ bool ConvertToYSpace::convert(const size_t index) {
     const auto &inE = m_inputWS->readE(index);
 
     // The t->y mapping flips the order of the axis so we need to reverse it to
-    // have a monotonically
-    // increasing axis
+    // have a monotonically increasing axis
     const size_t npts = inY.size();
     for (size_t j = 0; j < npts; ++j) {
       double ys(0.0), qs(0.0), ei(0.0);
@@ -284,6 +283,7 @@ void ConvertToYSpace::createOutputWorkspace() {
   if(getPropertyValue("QWorkspace") != "") {
     m_qOutputWS = WorkspaceFactory::Instance().create(m_inputWS);
 
+    m_qOutputWS->getAxis(0)->unit() = xLabel;
     m_qOutputWS->setYUnit("");
     m_qOutputWS->setYUnitLabel("");
   }

--- a/Code/Mantid/Framework/CurveFitting/test/ConvertToYSpaceTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/ConvertToYSpaceTest.h
@@ -23,45 +23,71 @@ public:
     TS_ASSERT_THROWS_NOTHING( alg.initialize() )
     TS_ASSERT( alg.isInitialized() )
   }
+
   // --------------------------------- Success cases -----------------------------------
-  
+
   void test_exec_with_TOF_input_gives_correct_X_values()
   {
     using namespace Mantid::API;
 
     auto alg = createAlgorithm();
     double x0(50.0),x1(300.0),dx(0.5);
-    auto testWS = ComptonProfileTestHelpers::createTestWorkspace(1,x0,x1,dx, true,true);
+    auto testWS = ComptonProfileTestHelpers::createTestWorkspace(1, x0, x1, dx, true, true);
     alg->setProperty("InputWorkspace", testWS);
     alg->setProperty("Mass", 1.0097);
+    alg->setProperty("QWorkspace", "ConvertToYSpace_Test_qSpace");
     alg->execute();
     TS_ASSERT(alg->isExecuted());
 
-    MatrixWorkspace_sptr outputWS = alg->getProperty("OutputWorkspace");
-    TS_ASSERT(outputWS != 0)
+    // Get the y-Space output workspace
+    MatrixWorkspace_sptr ySpOutputWs = alg->getProperty("OutputWorkspace");
+    TS_ASSERT(ySpOutputWs != 0)
+    TS_ASSERT_EQUALS(testWS->getNumberHistograms(), ySpOutputWs->getNumberHistograms());
 
-    TS_ASSERT_EQUALS(testWS->getNumberHistograms(), outputWS->getNumberHistograms());
+    // Get the q-Space output workspace
+    MatrixWorkspace_sptr qSpOutputWs = alg->getProperty("QWorkspace");
+    TS_ASSERT(qSpOutputWs != 0)
+    TS_ASSERT_EQUALS(testWS->getNumberHistograms(), qSpOutputWs->getNumberHistograms());
 
-    // Test a few values
-    const auto &outX = outputWS->readX(0);
-    const auto &outY = outputWS->readY(0);
-    const auto &outE = outputWS->readE(0);
-    const size_t npts = outputWS->blocksize();
+    const size_t npts = ySpOutputWs->blocksize();
+
+    // Test a few y-Space values
+    const auto &ySpOutX = ySpOutputWs->readX(0);
+    const auto &ySpOutY = ySpOutputWs->readY(0);
+    const auto &ySpOutE = ySpOutputWs->readE(0);
 
     // X
-    TS_ASSERT_DELTA(-18.71348856, outX.front(), 1e-08);
-    TS_ASSERT_DELTA(-1.670937938, outX[npts/2], 1e-08);
-    TS_ASSERT_DELTA(17.99449408, outX.back(), 1e-08);
+    TS_ASSERT_DELTA(-18.71348856, ySpOutX.front(), 1e-08);
+    TS_ASSERT_DELTA(-1.670937938, ySpOutX[npts/2], 1e-08);
+    TS_ASSERT_DELTA(17.99449408, ySpOutX.back(), 1e-08);
     // Y
-    TS_ASSERT_DELTA(-0.01152733, outY.front(), 1e-08);
-    TS_ASSERT_DELTA(5.56667697, outY[npts/2], 1e-08);
-    TS_ASSERT_DELTA(-0.35141703, outY.back(), 1e-08);
+    TS_ASSERT_DELTA(-0.01152733, ySpOutY.front(), 1e-08);
+    TS_ASSERT_DELTA(5.56667697, ySpOutY[npts/2], 1e-08);
+    TS_ASSERT_DELTA(-0.35141703, ySpOutY.back(), 1e-08);
     // E
-    TS_ASSERT_DELTA(25.14204252, outE.front(), 1e-08);
-    TS_ASSERT_DELTA(36.99940026, outE[npts/2], 1e-08);
-    TS_ASSERT_DELTA(138.38603736, outE.back(), 1e-08);
+    TS_ASSERT_DELTA(25.14204252, ySpOutE.front(), 1e-08);
+    TS_ASSERT_DELTA(36.99940026, ySpOutE[npts/2], 1e-08);
+    TS_ASSERT_DELTA(138.38603736, ySpOutE.back(), 1e-08);
+
+    // Test a few q-Space values
+    const auto &qSpOutX = qSpOutputWs->readX(0);
+    const auto &qSpOutY = qSpOutputWs->readY(0);
+    const auto &qSpOutE = qSpOutputWs->readE(0);
+
+    // X
+    TS_ASSERT_DELTA(-18.71348856, qSpOutX.front(), 1e-08);
+    TS_ASSERT_DELTA(-1.670937938, qSpOutX[npts/2], 1e-08);
+    TS_ASSERT_DELTA(17.99449408, qSpOutX.back(), 1e-08);
+    // Y
+    TS_ASSERT_DELTA(61.71776650, qSpOutY.front(), 1e-08);
+    TS_ASSERT_DELTA(102.09566873, qSpOutY[npts/2], 1e-08);
+    TS_ASSERT_DELTA(524.16435679, qSpOutY.back(), 1e-08);
+    // E (in q-Space error is not required)
+    TS_ASSERT_DELTA(0.0, qSpOutE.front(), 1e-08);
+    TS_ASSERT_DELTA(0.0, qSpOutE[npts/2], 1e-08);
+    TS_ASSERT_DELTA(0.0, qSpOutE.back(), 1e-08);
   }
-  
+
   // --------------------------------- Failure cases -----------------------------------
 
   void test_Negative_Or_Zero_Mass_Throws_Error()


### PR DESCRIPTION
Fixes [#11667](http://trac.mantidproject.org/mantid/ticket/11667).

To test:
- Load some VESUVIO data
- Run ConvertToYSpace
- Inspect the q workspace

An example of a good run would be 17094 with mass 207.2.

This just uses the q values calculated in order to do the conversion into y-Space.
The fact that the q workspace has no errors is intentional, after checking with the VESUVIO scientists they decided it was not required.

There is also an algorithm from Giovanni that cuts out a lot of work in loading, converting and visualising the data that I have added the q-Space output to, it's in `Bablyon5/Public/DanNixon/VESUVIO/joy.py`, it just needs an instrument parameter file (there is one in the same directory).
