### PR TITLE
Plot NaNs correctly in the sliceviewer

### DIFF
--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidQwtIMDWorkspaceData.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidQwtIMDWorkspaceData.h
@@ -62,6 +62,7 @@ public:
 private:
 
   void cacheLinePlot();
+  void calculateMinMax();
   void choosePlotAxis();
 
   friend class MantidMatrixCurve;
@@ -72,8 +73,14 @@ private:
   /// Indicates that the data is plotted on a log y scale
   bool m_logScale;
 
+  /// lowest y value
+  double m_minY;
+
   /// lowest positive y value
   double m_minPositive;
+
+  /// highest y value
+  double m_maxY;
 
   /// Are we in preview mode?
   bool m_preview;

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/QwtWorkspaceBinData.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/QwtWorkspaceBinData.h
@@ -65,7 +65,6 @@ protected:
   QwtWorkspaceBinData& operator=(const QwtWorkspaceBinData&); // required by QwtData base class
 
 private:
-
   /// Initialize the object
   void init(const Mantid::API::MatrixWorkspace & workspace);
 
@@ -85,7 +84,14 @@ private:
 
   /// Indicates that the data is plotted on a log y scale
   bool m_logScale;
+
+  /// lowest y value
+  double m_minY;
+
   /// lowest positive y value
-  mutable double m_minPositive;
+  double m_minPositive;
+
+  /// highest y value
+  double m_maxY;
 };
 #endif

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/QwtWorkspaceSpectrumData.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/QwtWorkspaceSpectrumData.h
@@ -106,8 +106,12 @@ private:
   bool m_binCentres;
   /// Indicates that the data is plotted on a log y scale
   bool m_logScale;
+  /// lowest y value
+  double m_minY;
   /// lowest positive y value
-  mutable double m_minPositive;
+  double m_minPositive;
+  /// higest y value
+  double m_maxY;
   /// Is plotting as distribution
   bool m_isDistribution;
 

--- a/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -183,16 +183,17 @@ void MantidQwtIMDWorkspaceData::calculateMinMax()
     // Try and get rid any starting NaNs as soon as possible
     if ((boost::math::isnan)(curMin) || (boost::math::isinf)(curMin))
       curMin = m_Y[i];
-    if ((boost::math::isnan)(curMinPos) || (boost::math::isinf)(curMinPos))
+    if (m_Y[i] > 0 && (curMinPos <= 0 || (boost::math::isnan)(curMinPos) ||
+                       (boost::math::isinf)(curMinPos)))
       curMinPos = m_Y[i];
     if ((boost::math::isnan)(curMax) || (boost::math::isinf)(curMax))
       curMax = m_Y[i];
 
     // Update our values as appropriate
     if (m_Y[i] < curMin)
-        curMin = m_Y[i];
+      curMin = m_Y[i];
     if (m_Y[i] < curMinPos && m_Y[i] > 0)
-        curMinPos = m_Y[i];
+      curMinPos = m_Y[i];
     if (m_Y[i] > curMax)
       curMax = m_Y[i];
   }

--- a/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -240,11 +240,14 @@ size_t MantidQwtIMDWorkspaceData::esize() const
  */
 double MantidQwtIMDWorkspaceData::getYMin() const
 {
-  auto it = std::min_element(m_Y.begin(), m_Y.end());
-  double temp = 0;
-  if(it != m_Y.end())
+  double temp = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
   {
-    temp = *it;
+    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
+      temp = m_Y[i];
+    else if (m_Y[i] < temp && !(boost::math::isnan)(m_Y[i]) &&
+        !(boost::math::isinf)(m_Y[i]))
+      temp = m_Y[i];
   }
   if (m_logScale && temp <= 0.)
   {
@@ -259,11 +262,14 @@ double MantidQwtIMDWorkspaceData::getYMin() const
  */
 double MantidQwtIMDWorkspaceData::getYMax() const
 {
-  auto it = std::max_element(m_Y.begin(), m_Y.end());
-  double temp = 0;
-  if(it != m_Y.end())
+  double temp = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
   {
-    temp = *it;
+    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
+      temp = m_Y[i];
+    else if (m_Y[i] > temp && !(boost::math::isnan)(m_Y[i]) &&
+        !(boost::math::isinf)(m_Y[i]))
+      temp = m_Y[i];
   }
   if (m_logScale && temp <= 0.)
   {
@@ -486,5 +492,4 @@ QString MantidQwtIMDWorkspaceData::getYAxisLabel() const
   }
   return "Unknown";
 }
-
 

--- a/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -44,7 +44,7 @@ MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(Mantid::API::IMDWorkspace_c
     Mantid::API::MDNormalization normalize,
     bool isDistribution)
  : m_workspace(workspace),
-   m_logScale(logScale), m_minPositive(0),
+   m_logScale(logScale),
    m_preview(false),
    m_start(start),
    m_end(end),
@@ -91,12 +91,13 @@ MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(Mantid::API::IMDWorkspace_c
   m_dir.normalize();
   // And cache the X/Y values
   this->cacheLinePlot();
+
+  this->calculateMinMax();
 }
 
 //-----------------------------------------------------------------------------
 /// Copy constructor
-MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(const MantidQwtIMDWorkspaceData& data) :
-  m_minPositive(0.0)
+MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(const MantidQwtIMDWorkspaceData& data)
 {
   this->operator =(data);
 }
@@ -166,6 +167,42 @@ void MantidQwtIMDWorkspaceData::cacheLinePlot()
 //  std::cout << "Plotting from " << m_start << " to " << m_end << std::endl;
 }
 
+//-----------------------------------------------------------------------------
+/// Calculate the MinY and MaxY values
+void MantidQwtIMDWorkspaceData::calculateMinMax()
+{
+  double curMin = m_Y[0];
+  double curMinPos = m_Y[0];
+  double curMax = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
+  {
+    // skip NaNs
+    if ((boost::math::isnan)(m_Y[i]) || (boost::math::isinf)(m_Y[i]))
+      continue;
+
+    // Try and get rid any starting NaNs as soon as possible
+    if ((boost::math::isnan)(curMin) || (boost::math::isinf)(curMin))
+      curMin = m_Y[i];
+    if ((boost::math::isnan)(curMinPos) || (boost::math::isinf)(curMinPos))
+      curMinPos = m_Y[i];
+    if ((boost::math::isnan)(curMax) || (boost::math::isinf)(curMax))
+      curMax = m_Y[i];
+
+    // Update our values as appropriate
+    if (m_Y[i] < curMin)
+        curMin = m_Y[i];
+    if (m_Y[i] < curMinPos && m_Y[i] > 0)
+        curMinPos = m_Y[i];
+    if (m_Y[i] > curMax)
+      curMax = m_Y[i];
+  }
+
+  // Save the results
+  m_minY = curMin;
+  m_minPositive = curMinPos;
+  m_maxY = curMax;
+}
+
 
 //-----------------------------------------------------------------------------
 /** Size of the data set
@@ -201,12 +238,11 @@ double MantidQwtIMDWorkspaceData::x(size_t i) const
 */
 double MantidQwtIMDWorkspaceData::y(size_t i) const
 {
-  Mantid::signal_t tmp = m_Y[i];
-  if (m_logScale && tmp <= 0.)
-  {
-    tmp = m_minPositive;
-  }
-  return tmp;
+  Mantid::signal_t val = m_Y[i];
+  if (m_logScale && val <= 0.)
+    return m_minPositive;
+  else
+    return val;
 }
 
 /// Returns the x position of the error bar for the i-th data point (bin)
@@ -241,20 +277,10 @@ size_t MantidQwtIMDWorkspaceData::esize() const
  */
 double MantidQwtIMDWorkspaceData::getYMin() const
 {
-  double temp = m_Y[0];
-  for(size_t i = 1; i < m_Y.size(); ++i)
-  {
-    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
-      temp = m_Y[i];
-    else if (m_Y[i] < temp && !(boost::math::isnan)(m_Y[i]) &&
-        !(boost::math::isinf)(m_Y[i]))
-      temp = m_Y[i];
-  }
-  if (m_logScale && temp <= 0.)
-  {
-    temp = m_minPositive;
-  }
-  return temp;
+  if (m_logScale)
+    return m_minPositive;
+  else
+    return m_minY;
 }
 
 /**
@@ -263,20 +289,10 @@ double MantidQwtIMDWorkspaceData::getYMin() const
  */
 double MantidQwtIMDWorkspaceData::getYMax() const
 {
-  double temp = m_Y[0];
-  for(size_t i = 1; i < m_Y.size(); ++i)
-  {
-    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
-      temp = m_Y[i];
-    else if (m_Y[i] > temp && !(boost::math::isnan)(m_Y[i]) &&
-        !(boost::math::isinf)(m_Y[i]))
-      temp = m_Y[i];
-  }
-  if (m_logScale && temp <= 0.)
-  {
-    temp = m_minPositive;
-  }
-  return temp;
+  if (m_logScale && m_maxY <= 0)
+    return m_minPositive;
+  else
+    return m_maxY;
 }
 
 void MantidQwtIMDWorkspaceData::setLogScale(bool on)
@@ -493,4 +509,3 @@ QString MantidQwtIMDWorkspaceData::getYAxisLabel() const
   }
   return "Unknown";
 }
-

--- a/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -8,6 +8,7 @@
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
 #include <QStringBuilder>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid::Kernel;
 using namespace Mantid::Geometry;

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
@@ -89,11 +89,14 @@ size_t QwtWorkspaceBinData::esize() const
  */
 double QwtWorkspaceBinData::getYMin() const
 {
-  auto it = std::min_element(m_Y.begin(), m_Y.end());
-  double temp = 0;
-  if(it != m_Y.end())
+  double temp = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
   {
-    temp = *it;
+    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
+      temp = m_Y[i];
+    else if (m_Y[i] < temp && !(boost::math::isnan)(m_Y[i]) &&
+        !(boost::math::isinf)(m_Y[i]))
+      temp = m_Y[i];
   }
   if (m_logScale && temp <= 0.)
   {
@@ -108,11 +111,14 @@ double QwtWorkspaceBinData::getYMin() const
  */
 double QwtWorkspaceBinData::getYMax() const
 {
-  auto it = std::max_element(m_Y.begin(), m_Y.end());
-  double temp = 0;
-  if(it != m_Y.end())
+  double temp = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
   {
-    temp = *it;
+    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
+      temp = m_Y[i];
+    else if (m_Y[i] > temp && !(boost::math::isnan)(m_Y[i]) &&
+        !(boost::math::isinf)(m_Y[i]))
+      temp = m_Y[i];
   }
   if (m_logScale && temp <= 0.)
   {

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
@@ -7,8 +7,7 @@
 /// Constructor
 QwtWorkspaceBinData::QwtWorkspaceBinData(const Mantid::API::MatrixWorkspace &workspace, int binIndex, const bool logScale)
  : m_binIndex(binIndex), m_X(), m_Y(), m_E(), m_xTitle(), m_yTitle(),
-   m_logScale(logScale),
-   m_minPositive(0)
+   m_logScale(logScale)
 {
   init(workspace);
 }
@@ -53,12 +52,11 @@ Return the y value of data point i
 */
 double QwtWorkspaceBinData::y(size_t i) const
 {
-  double tmp = m_Y[i];
-  if (m_logScale && tmp <= 0.)
-  {
-    tmp = m_minPositive;
-  }
-  return tmp;
+  Mantid::signal_t val = m_Y[i];
+  if (m_logScale && val <= 0.)
+    return m_minPositive;
+  else
+    return val;
 }
 
 double QwtWorkspaceBinData::ex(size_t i) const
@@ -90,20 +88,10 @@ size_t QwtWorkspaceBinData::esize() const
  */
 double QwtWorkspaceBinData::getYMin() const
 {
-  double temp = m_Y[0];
-  for(size_t i = 1; i < m_Y.size(); ++i)
-  {
-    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
-      temp = m_Y[i];
-    else if (m_Y[i] < temp && !(boost::math::isnan)(m_Y[i]) &&
-        !(boost::math::isinf)(m_Y[i]))
-      temp = m_Y[i];
-  }
-  if (m_logScale && temp <= 0.)
-  {
-    temp = m_minPositive;
-  }
-  return temp;
+  if (m_logScale)
+    return m_minPositive;
+  else
+    return m_minY;
 }
 
 /**
@@ -112,20 +100,10 @@ double QwtWorkspaceBinData::getYMin() const
  */
 double QwtWorkspaceBinData::getYMax() const
 {
-  double temp = m_Y[0];
-  for(size_t i = 1; i < m_Y.size(); ++i)
-  {
-    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
-      temp = m_Y[i];
-    else if (m_Y[i] > temp && !(boost::math::isnan)(m_Y[i]) &&
-        !(boost::math::isinf)(m_Y[i]))
-      temp = m_Y[i];
-  }
-  if (m_logScale && temp <= 0.)
-  {
-    temp = m_minPositive;
-  }
-  return temp;
+  if (m_logScale && m_maxY <= 0)
+    return m_minPositive;
+  else
+    return m_maxY;
 }
 
 /**
@@ -215,4 +193,37 @@ void QwtWorkspaceBinData::init(const Mantid::API::MatrixWorkspace &workspace)
   // meta data
   m_xTitle = MantidQt::API::PlotAxis(workspace, 1).title();
   m_yTitle = MantidQt::API::PlotAxis(false, workspace).title();
+
+
+  // Calculate the min and max values
+  double curMin = m_Y[0];
+  double curMinPos = m_Y[0];
+  double curMax = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
+  {
+    // skip NaNs
+    if ((boost::math::isnan)(m_Y[i]) || (boost::math::isinf)(m_Y[i]))
+      continue;
+
+    // Try and get rid any starting NaNs as soon as possible
+    if ((boost::math::isnan)(curMin) || (boost::math::isinf)(curMin))
+      curMin = m_Y[i];
+    if ((boost::math::isnan)(curMinPos) || (boost::math::isinf)(curMinPos))
+      curMinPos = m_Y[i];
+    if ((boost::math::isnan)(curMax) || (boost::math::isinf)(curMax))
+      curMax = m_Y[i];
+
+    // Update our values as appropriate
+    if (m_Y[i] < curMin)
+        curMin = m_Y[i];
+    if (m_Y[i] < curMinPos && m_Y[i] > 0)
+        curMinPos = m_Y[i];
+    if (m_Y[i] > curMax)
+      curMax = m_Y[i];
+  }
+
+  // Save the results
+  m_minY = curMin;
+  m_minPositive = curMinPos;
+  m_maxY = curMax;
 }

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
@@ -2,6 +2,7 @@
 #include "MantidQtAPI/PlotAxis.h"
 
 #include <QStringBuilder>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 /// Constructor
 QwtWorkspaceBinData::QwtWorkspaceBinData(const Mantid::API::MatrixWorkspace &workspace, int binIndex, const bool logScale)

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceBinData.cpp
@@ -208,16 +208,17 @@ void QwtWorkspaceBinData::init(const Mantid::API::MatrixWorkspace &workspace)
     // Try and get rid any starting NaNs as soon as possible
     if ((boost::math::isnan)(curMin) || (boost::math::isinf)(curMin))
       curMin = m_Y[i];
-    if ((boost::math::isnan)(curMinPos) || (boost::math::isinf)(curMinPos))
+    if (m_Y[i] > 0 && (curMinPos <= 0 || (boost::math::isnan)(curMinPos) ||
+                       (boost::math::isinf)(curMinPos)))
       curMinPos = m_Y[i];
     if ((boost::math::isnan)(curMax) || (boost::math::isinf)(curMax))
       curMax = m_Y[i];
 
     // Update our values as appropriate
     if (m_Y[i] < curMin)
-        curMin = m_Y[i];
+      curMin = m_Y[i];
     if (m_Y[i] < curMinPos && m_Y[i] > 0)
-        curMinPos = m_Y[i];
+      curMinPos = m_Y[i];
     if (m_Y[i] > curMax)
       curMax = m_Y[i];
   }

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
@@ -2,6 +2,7 @@
 #include "MantidQtAPI/PlotAxis.h"
 
 #include <QStringBuilder>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 /**
  * Construct a QwtWorkspaceSpectrumData object with a source workspace

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
@@ -123,11 +123,14 @@ size_t QwtWorkspaceSpectrumData::esize() const
  */
 double QwtWorkspaceSpectrumData::getYMin() const
 {
-  auto it = std::min_element(m_Y.begin(), m_Y.end());
-  double temp = 0;
-  if(it != m_Y.end())
+  double temp = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
   {
-    temp = *it;
+    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
+      temp = m_Y[i];
+    else if (m_Y[i] < temp && !(boost::math::isnan)(m_Y[i]) &&
+        !(boost::math::isinf)(m_Y[i]))
+      temp = m_Y[i];
   }
   if (m_logScale && temp <= 0.)
   {
@@ -142,11 +145,14 @@ double QwtWorkspaceSpectrumData::getYMin() const
  */
 double QwtWorkspaceSpectrumData::getYMax() const
 {
-  auto it = std::max_element(m_Y.begin(), m_Y.end());
-  double temp = 0;
-  if(it != m_Y.end())
+  double temp = m_Y[0];
+  for(size_t i = 1; i < m_Y.size(); ++i)
   {
-    temp = *it;
+    if ((boost::math::isnan)(temp) || (boost::math::isinf)(temp))
+      temp = m_Y[i];
+    else if (m_Y[i] > temp && !(boost::math::isnan)(m_Y[i]) &&
+        !(boost::math::isinf)(m_Y[i]))
+      temp = m_Y[i];
   }
   if (m_logScale && temp <= 0.)
   {

--- a/Code/Mantid/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
+++ b/Code/Mantid/MantidQt/API/src/QwtWorkspaceSpectrumData.cpp
@@ -44,16 +44,17 @@ QwtWorkspaceSpectrumData::QwtWorkspaceSpectrumData(const Mantid::API::MatrixWork
     // Try and get rid any starting NaNs as soon as possible
     if ((boost::math::isnan)(curMin) || (boost::math::isinf)(curMin))
       curMin = m_Y[i];
-    if ((boost::math::isnan)(curMinPos) || (boost::math::isinf)(curMinPos))
+    if (m_Y[i] > 0 && (curMinPos <= 0 || (boost::math::isnan)(curMinPos) ||
+                       (boost::math::isinf)(curMinPos)))
       curMinPos = m_Y[i];
     if ((boost::math::isnan)(curMax) || (boost::math::isinf)(curMax))
       curMax = m_Y[i];
 
     // Update our values as appropriate
     if (m_Y[i] < curMin)
-        curMin = m_Y[i];
+      curMin = m_Y[i];
     if (m_Y[i] < curMinPos && m_Y[i] > 0)
-        curMinPos = m_Y[i];
+      curMinPos = m_Y[i];
     if (m_Y[i] > curMax)
       curMax = m_Y[i];
   }

--- a/Code/Mantid/MantidQt/API/test/QwtWorkspaceBinDataTest.h
+++ b/Code/Mantid/MantidQt/API/test/QwtWorkspaceBinDataTest.h
@@ -72,7 +72,7 @@ public:
     QwtWorkspaceBinData data(*ws, 2, true);
     TS_ASSERT_DELTA( data.y(1), 5.0, 1e-6);
     TS_ASSERT_DELTA( data.e(1), 7.0, 1e-6);
-    TS_ASSERT_DELTA( data.y(2), 0.0, 1e-6);
+    TS_ASSERT_DELTA( data.y(2), 4.0, 1e-6);
     // Errors should also be zero-ed out.
     TS_ASSERT_DELTA( data.e(2), 0.0, 1e-6);
   }

--- a/Code/Mantid/MantidQt/API/test/QwtWorkspaceSpectrumDataTest.h
+++ b/Code/Mantid/MantidQt/API/test/QwtWorkspaceSpectrumDataTest.h
@@ -75,7 +75,7 @@ public:
     QwtWorkspaceSpectrumData data(*ws, 0, true, false);
     TS_ASSERT_DELTA( data.y(1), 2.0, 1e-6);
     TS_ASSERT_DELTA( data.e(1), 3.0, 1e-6);
-    TS_ASSERT_DELTA( data.y(2), 0.0, 1e-6);
+    TS_ASSERT_DELTA( data.y(2), 2.0, 1e-6);
     // Errors should also be zero-ed out.
     TS_ASSERT_DELTA( data.e(2), 0.0, 1e-6);
   }

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -962,25 +962,6 @@ int LineViewer::getPlotAxis() const { return m_lineOptions->getPlotAxis(); }
 // ==============================================================================================
 
 /**
- * Helper method to get the positive min value.
- * @param curveData : CurveData to look through the data of.
- * @param from : Start value
- * @return : Positive min value.
- */
-double getPositiveMin(const MantidQwtWorkspaceData &curveData,
-                      const double from) {
-  double yPositiveMin = from;
-  size_t n = curveData.size();
-  for (size_t i = 0; i < n; ++i) {
-    double y = curveData.y(i);
-    if (y > 0 && y < yPositiveMin) {
-      yPositiveMin = y;
-    }
-  }
-  return yPositiveMin;
-}
-
-/**
  * Set up the appropriate scale engine.
  * Uses the isLogScaled method to work out which scale engine to make.
  * @param curveData : Curve Data to read.


### PR DESCRIPTION
This is for trac ticket [#11704](http://trac.mantidproject.org/mantid/ticket/11704)

In the sliceviewer's integrated lineviewer, if any of the Y values were `nan` or `inf` then the plot's axes would be wrecked, resulting in a useless plot. A regular mantid plot would work fine though. This pull request adjusts the behaviour of the integrated plot to be the same as a regular mantid plot.

The bug was a result of `std::min_element` and `std::max_element` taking `nan` to be their minimum/maximum. We now figure this out for ourselves, making sure to avoid using such values.
