### PR TITLE
Fix issues with data with no instrument in IDA

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -221,8 +221,16 @@ class TransformToIqt(PythonAlgorithm):
         """
         from IndirectCommon import CheckHistZero, CheckHistSame, CheckAnalysers
 
+        try:
+            CheckAnalysers(self._sample, self._resolution)
+        except ValueError:
+            # A genuine error the shows that the two runs are incompatible
+            raise
+        except:
+            # Checking could not be performed due to incomplete or no instrument
+            logger.warning('Could not check for matching analyser and reflection')
+
         # Process resolution data
-        CheckAnalysers(self._sample, self._resolution)
         num_res_hist = CheckHistZero(self._resolution)[0]
         if num_res_hist > 1:
             CheckHistSame(self._sample, 'Sample', self._resolution, 'Resolution')


### PR DESCRIPTION
Fixes [#11740](http://trac.mantidproject.org/mantid/ticket/11740).

To test:
- Open some LET data in IDA > I(Q, t) (`Babylon5/Public/DanNixon/LET/*.nxs`)
- You will get the warning about resolution bins, this can be ignored
- See that you can get some data in I(Q, t) out
