### PR TITLE
Give SliceViewer more accessible Normalization option

### DIFF
--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -178,6 +178,7 @@ public slots:
   void changeNormalizationNone();
   void changeNormalizationVolume();
   void changeNormalizationNumEvents();
+  void onNormalizationChanged(const QString& normalizationKey);
 
   // Buttons or actions
   void clearLine();
@@ -353,6 +354,10 @@ private:
 
   /// Object for choosing a PeakTransformFactory based on the workspace type.
   Mantid::API::PeakTransformSelector m_peakTransformSelector;
+
+  static const QString NoNormalizationKey;
+  static const QString VolumeNormalizationKey;
+  static const QString NumEventsNormalizationKey;
 
 };
 

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
@@ -636,7 +636,7 @@
                <string notr="true">QLabel {
  background-color : rgb(255, 255, 186);
  color : black; 
- font: 8pt;
+ font: 10px;
 }</string>
               </property>
               <property name="frameShape">
@@ -675,7 +675,7 @@
                <string notr="true">QLabel {
  background-color : rgb(255, 255, 186);
  color : black; 
- font: 8pt;
+ font: 10px;
 }</string>
               </property>
               <property name="frameShape">
@@ -717,7 +717,7 @@
                <string notr="true">QLabel {
  background-color : rgb(255, 255, 186);
  color : black; 
- font: 8pt;
+ font: 10px;
 }</string>
               </property>
               <property name="frameShape">
@@ -754,7 +754,7 @@
               </property>
               <property name="font">
                <font>
-                <pointsize>8</pointsize>
+                <pointsize>-1</pointsize>
                 <weight>50</weight>
                 <italic>false</italic>
                 <bold>false</bold>
@@ -764,7 +764,7 @@
                <string>Normalization option</string>
               </property>
               <property name="styleSheet">
-               <string notr="true">font: 8pt;</string>
+               <string notr="true">font: 10px;</string>
               </property>
              </widget>
             </item>

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
@@ -17,16 +17,7 @@
    <property name="spacing">
     <number>3</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -62,16 +53,7 @@
        <property name="sizeConstraint">
         <enum>QLayout::SetMinimumSize</enum>
        </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
       </layout>
@@ -87,16 +69,7 @@
        <property name="spacing">
         <number>2</number>
        </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item>
@@ -663,6 +636,7 @@
                <string notr="true">QLabel {
  background-color : rgb(255, 255, 186);
  color : black; 
+ font: 8pt;
 }</string>
               </property>
               <property name="frameShape">
@@ -701,6 +675,7 @@
                <string notr="true">QLabel {
  background-color : rgb(255, 255, 186);
  color : black; 
+ font: 8pt;
 }</string>
               </property>
               <property name="frameShape">
@@ -742,6 +717,7 @@
                <string notr="true">QLabel {
  background-color : rgb(255, 255, 186);
  color : black; 
+ font: 8pt;
 }</string>
               </property>
               <property name="frameShape">
@@ -765,24 +741,30 @@
             <item row="3" column="1">
              <widget class="QComboBox" name="comboNormalization">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
               <property name="minimumSize">
                <size>
-                <width>80</width>
+                <width>70</width>
                 <height>0</height>
                </size>
               </property>
               <property name="font">
                <font>
-                <pointsize>13</pointsize>
+                <pointsize>8</pointsize>
+                <weight>50</weight>
+                <italic>false</italic>
+                <bold>false</bold>
                </font>
               </property>
               <property name="toolTip">
                <string>Normalization option</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">font: 8pt;</string>
               </property>
              </widget>
             </item>
@@ -803,16 +785,7 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <property name="leftMargin">
-           <number>2</number>
-          </property>
-          <property name="topMargin">
-           <number>2</number>
-          </property>
-          <property name="rightMargin">
-           <number>2</number>
-          </property>
-          <property name="bottomMargin">
+          <property name="margin">
            <number>2</number>
           </property>
           <item>

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>3</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -53,7 +62,16 @@
        <property name="sizeConstraint">
         <enum>QLayout::SetMinimumSize</enum>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
       </layout>
@@ -69,7 +87,16 @@
        <property name="spacing">
         <number>2</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -585,9 +612,12 @@
            </widget>
           </item>
           <item>
-           <spacer name="horizontalSpacer">
+           <spacer name="horizontalSpacer_6">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Expanding</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -604,6 +634,9 @@
             </property>
             <property name="fieldGrowthPolicy">
              <enum>QFormLayout::FieldsStayAtSizeHint</enum>
+            </property>
+            <property name="verticalSpacing">
+             <number>0</number>
             </property>
             <item row="0" column="0">
              <widget class="QLabel" name="label">
@@ -683,8 +716,11 @@
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="label_3">
+              <property name="toolTip">
+               <string/>
+              </property>
               <property name="text">
-               <string>z=</string>
+               <string>Intensity=</string>
               </property>
              </widget>
             </item>
@@ -719,6 +755,37 @@
               </property>
              </widget>
             </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Norm=</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QComboBox" name="comboNormalization">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>13</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string>Normalization option</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
          </layout>
@@ -736,7 +803,16 @@
           <property name="spacing">
            <number>4</number>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>2</number>
+          </property>
+          <property name="topMargin">
+           <number>2</number>
+          </property>
+          <property name="rightMargin">
+           <number>2</number>
+          </property>
+          <property name="bottomMargin">
            <number>2</number>
           </property>
           <item>


### PR DESCRIPTION
[Original ticket](http://trac.mantidproject.org/mantid/ticket/11741)

Currently normalization options are hidden away in menus in the SliceViewer (view menu). Before we start changing the existing behaviour to programatically apply the normalization, we need to ensure that the user has a way of seeing what it is in the SliceViewer first.
- Add a dropdown menu for the normalization options
- Ensure this has the same options as in the view menu on the sliceviewer
- Make sure that the two sync, change on and the other should change

**Tester**
Ensure that the above feature is working. Especially that the syncronisation works and that changing the option yields the correct normalisation (just cross reference with the existing menu option).
