### PR TITLE
VSI rebinning: more verbose action names and add tool tips

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
@@ -5,6 +5,7 @@
 #include "MantidVatesSimpleGuiViewWidgets/ViewBase.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 
+#include <QMap>
 #include <QPointer>
 #include <QWidget>
 
@@ -19,7 +20,8 @@ namespace Vates
 namespace SimpleGui
 {
 
-  class RebinnedSourcesManager;
+class RebinnedSourcesManager;
+
 /**
  *
  This class represents the initial view for the main program. It is meant to
@@ -93,6 +95,8 @@ protected slots:
 private:
   Q_DISABLE_COPY(StandardView)
 
+  QString getAlgNameFromMenuLabel(const QString &menuLbl);
+
   bool cameraReset;
   QPointer<pqPipelineSource> scaler; ///< Holder for the ScaleWorkspace
   Ui::StandardView ui; ///< The standard view's UI form
@@ -124,6 +128,8 @@ private:
   static QString g_binMDToolTipTxt;
   static QString g_sliceMDToolTipTxt;
   static QString g_cutMDToolTipTxt;
+
+  static QMap<QString, QString> g_actionToAlgName;
 };
 
 } // SimpleGui

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
@@ -111,6 +111,19 @@ private:
   QAction* m_sliceMDAction;
   QAction* m_cutMDAction;
   QAction* m_unbinAction;
+
+  // name to show for the rebin actions on the rebin menu
+  static QString g_binMDName;
+  static QString g_sliceMDName;
+  static QString g_cutMDName;
+  /// name + a bit of description
+  static QString g_binMDLbl;
+  static QString g_sliceMDLbl;
+  static QString g_cutMDLbl;
+  /// tool tip text for the rebin algorithm
+  static QString g_binMDToolTipTxt;
+  static QString g_sliceMDToolTipTxt;
+  static QString g_cutMDToolTipTxt;
 };
 
 } // SimpleGui

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -24,11 +24,13 @@
   #pragma warning enable 1170
 #endif
 
-#include <QHBoxLayout>
 #include <QAction>
+#include <QHBoxLayout>
+#include <QHelpEvent>
 #include <QMenu>
 #include <QMessageBox>
 #include <QString>
+#include <QToolTip>
 
 namespace Mantid
 {
@@ -36,6 +38,48 @@ namespace Vates
 {
 namespace SimpleGui
 {
+
+/**
+ * Simple class for a QMenu where the actions do show their tool tip
+ * strings (this does not happen by default with standard QMenu).
+ */
+class QMenuWithToolTip: public QMenu {
+public:
+  QMenuWithToolTip(QWidget *parent): QMenu(parent)
+  {
+  }
+
+  bool event(QEvent* e) {
+    if (QEvent::ToolTip == e->type()) {
+      // grab the action specific tooltip
+      QHelpEvent *he = dynamic_cast<QHelpEvent*>(e);
+      if (!he)
+        return false;
+      QAction* a = actionAt(he->pos());
+      if (a && a->toolTip() != a->text()) {
+        QToolTip::showText(he->globalPos(), a->toolTip(), this);
+        return true;
+      }
+    }
+    return QMenu::event(e);
+  }
+};
+
+QString StandardView::g_binMDName = "BinMD";
+QString StandardView::g_sliceMDName = "SliceMD";
+QString StandardView::g_cutMDName = "CutMD";
+// important: these label strings must use the name of the corresponding
+// Mantid algorithm as first token (before first space), as it will
+// be used as a parameter when emitting the signal rebin
+QString StandardView::g_binMDLbl = g_binMDName + " (histogram image only)";
+QString StandardView::g_sliceMDLbl = g_sliceMDName + " (image and observations)";
+QString StandardView::g_cutMDLbl = g_cutMDName + " (Horace style)";
+
+const QString tipBefore = "Run the ";
+const QString tipAfter = " Mantid algorithm (the algorithm dialog will show up)";
+QString StandardView::g_binMDToolTipTxt = tipBefore + g_binMDName + tipAfter;
+QString StandardView::g_sliceMDToolTipTxt = tipBefore + g_sliceMDName + tipAfter;
+QString StandardView::g_cutMDToolTipTxt = tipBefore + g_cutMDName + tipAfter;
 
 /**
  * This function sets up the UI components, adds connections for the view's
@@ -83,15 +127,18 @@ void StandardView::setupViewButtons()
 {
 
   // Populate the rebin button
-  QMenu* rebinMenu = new QMenu(this->ui.rebinToolButton);
+  QMenuWithToolTip* rebinMenu = new QMenuWithToolTip(this->ui.rebinToolButton);
 
-  m_binMDAction = new QAction("BinMD", rebinMenu);
+  m_binMDAction = new QAction(g_binMDLbl, rebinMenu);
+  m_binMDAction->setToolTip(g_binMDToolTipTxt);
   m_binMDAction->setIconVisibleInMenu(false);
   
-  m_sliceMDAction = new QAction("SliceMD", rebinMenu);
+  m_sliceMDAction = new QAction(g_sliceMDLbl, rebinMenu);
+  m_sliceMDAction->setToolTip(g_sliceMDToolTipTxt);
   m_sliceMDAction->setIconVisibleInMenu(false);
 
-  m_cutMDAction = new QAction("CutMD", rebinMenu);
+  m_cutMDAction = new QAction(g_cutMDLbl, rebinMenu);
+  m_cutMDAction->setToolTip(g_cutMDToolTipTxt);
   m_cutMDAction->setIconVisibleInMenu(false);
 
   m_unbinAction = new QAction("Remove Rebinning", rebinMenu);
@@ -281,7 +328,10 @@ void StandardView::setRebinAndUnbinButtons()
 void StandardView::onRebin()
 {
   if(QAction* action = dynamic_cast<QAction*>(sender())) {
-    emit rebin(action->text().toStdString()); }
+    // split always returns a list of at least one element
+    QString algName = action->text().split(" ").at(0);
+    emit rebin(algName.toStdString());
+  }
 }
 
 /**


### PR DESCRIPTION
This addresses [#11730](http://trac.mantidproject.org/mantid/ticket/11730).

**To test**:
- check code
- check that it works: open an MD event workspace, open the VSI with it, and in the standard view open the 'binning' menu. See that you get more verbose labels now, you can see the tooltips (you might need to leave the mouse over the label 2-3 seconds), and you can run the rebin algorithms. If you open a histo workspace you should still see the labels and tool tips but you won't be able to run the algorithms (the actions will be disabled).
