### PR TITLE
Fix typo in category of PoldiCreatePeaksFromFile

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/PoldiCreatePeaksFromFile.py
@@ -136,7 +136,7 @@ class PoldiCrystalFileParser(object):
 
 class PoldiCreatePeaksFromFile(PythonAlgorithm):
     def category(self):
-        return "SINQ\\POLDI"
+        return "SINQ\\Poldi"
 
     def name(self):
         return "PoldiLoadCrystalData"


### PR DESCRIPTION
Discovered a typo in the category of PoldiCreatePeaksFromFile, which leads to a new sub-category of SINQ in capitals.

**Testing information**
If you really want to check that there is only one sub-category for Poldi-algorithms, make sure you have python-pyparsing installed, otherwise the algorithm in question is not registered.
