### PR TITLE
Warn when saving Nexus with no instrument XML

### DIFF
--- a/Code/Mantid/Framework/Geometry/src/Instrument.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument.cpp
@@ -1060,7 +1060,13 @@ void Instrument::saveNexus(::NeXus::File *file,
 
   // XML contents of instrument, as a NX note
   file->makeGroup("instrument_xml", "NXnote", true);
-  file->writeData("data", getXmlText());
+  const std::string& xmlText = getXmlText();
+  if (xmlText.empty())
+    g_log.warning() << "Saving Instrument with no XML data. Mantid might NOT be"
+                    << " able to re-open the resulting Nexus file. This should"
+                    << " never happen. Please notify the Mantid development"
+                    << " team." << std::endl;
+  file->writeData("data", xmlText);
   file->writeData("type", "text/xml"); // mimetype
   file->writeData("description", "XML contents of the instrument IDF file.");
   file->closeGroup();


### PR DESCRIPTION
This is for trac ticket [#11748](http://trac.mantidproject.org/mantid/ticket/11748).

**Testing**: Code review ought to be enough, but you can test this by loading `babylon/Public/Owen Arnold/for_harry/MAP05935_ei34.nxspe`, and then trying to save it as a nexus file.
