### PR TITLE
Fix parameter map segfault

### DIFF
--- a/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
@@ -145,7 +145,7 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
     m_parmap = instr->getParameterMap();
   } else {
     sptr_instrument = instr;
-    m_parmap->clear();
+    m_parmap.reset(new ParameterMap());
   }
 }
 

--- a/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
@@ -145,6 +145,7 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
     m_parmap = instr->getParameterMap();
   } else {
     sptr_instrument = instr;
+    m_parmap->clear();
   }
 }
 

--- a/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
@@ -145,7 +145,7 @@ void ExperimentInfo::setInstrument(const Instrument_const_sptr &instr) {
     m_parmap = instr->getParameterMap();
   } else {
     sptr_instrument = instr;
-    m_parmap.reset(new ParameterMap());
+    m_parmap = boost::make_shared<ParameterMap>();
   }
 }
 

--- a/Code/Mantid/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -242,7 +242,6 @@ void LoadNXSPE::exec() {
       WorkspaceFactory::Instance().create("Workspace2D", numSpectra,
                                           energies.size(), numBins));
   // Need to get hold of the parameter map
-  Geometry::ParameterMap &pmap = outputWS->instrumentParameters();
   outputWS->getAxis(0)->unit() = UnitFactory::Instance().create("DeltaE");
   outputWS->setYUnit("SpectraNumber");
 
@@ -290,6 +289,7 @@ void LoadNXSPE::exec() {
     instrument->markAsDetector(det);
   }
 
+  Geometry::ParameterMap &pmap = outputWS->instrumentParameters();
   std::vector<double>::iterator itdata = data.begin(), iterror = error.begin(),
                                 itdataend, iterrorend;
   API::Progress prog = API::Progress(this, 0.0, 0.9, numSpectra);
@@ -302,7 +302,7 @@ void LoadNXSPE::exec() {
     {
       outputWS->dataY(i) = std::vector<double>(numBins, 0);
       outputWS->dataE(i) = std::vector<double>(numBins, 0);
-      pmap.addBool(outputWS->getDetector(i).get(), "masked", true);
+      pmap.addBool(outputWS->getDetector(i)->getComponentID(), "masked", true);
     } else {
       outputWS->dataY(i) = std::vector<double>(itdata, itdataend);
       outputWS->dataE(i) = std::vector<double>(iterror, iterrorend);


### PR DESCRIPTION
This is for trac ticket [#11749](http://trac.mantidproject.org/mantid/ticket/11749)

Running this script crashes mantid (data available from `babylon/Owen Arnold/for_harry`)

``` python
mat_ws = Load(Filename='MAP05935_ei34.nxspe')
LoadInstrument(mat_ws, InstrumentName='MAPS')
SaveNexusProcessed(mat_ws, Filename="this_will_crash.nxs")
```

The reason for the crash was because `ExperimentInfo::m_parmap` was being filled with parameters by `LoadNXSPE`, and then having its instrument changed to a non-parameterised instrument. The workspace was moving from being parameterised to non-parameterised. The problem is `m_parmap` was not being cleared, which was keeping many raw pointers to freed components. These were then read from when trying to save the nexus file, resulting in a segfault.

**Testing**:
This pull request is marked as `core`, as it affects ExperimentInfo's parameter map directly, and we are very close to release. You should be absolutely certain that this does not break any existing functionality before merging.
