### PR TITLE
alloc-dealloc-mismatch in vtkDataSetToNonOrthogonalDataSetTest

### DIFF
--- a/Code/Mantid/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/vtkDataSetToNonOrthogonalDataSetTest.h
@@ -161,12 +161,12 @@ private:
   }
 
   template<typename T>
-  T *getRangeComp(vtkDataSet *ds, std::string fieldname, int size)
+  std::vector<T> getRangeComp(vtkDataSet *ds, std::string fieldname, int size)
   {
     vtkDataArray *arr = ds->GetFieldData()->GetArray(fieldname.c_str());
     vtkTypedDataArray<T>* tarr = vtkTypedDataArray<T>::FastDownCast(arr);
-    T *vals = new T[size];
-    tarr->GetTupleValue(0, vals);
+    std::vector<T> vals(size);
+    tarr->GetTupleValue(0, &vals[0]);
     return vals;
   }
 
@@ -183,7 +183,7 @@ private:
     TS_ASSERT_DELTA(point[2], 0.8660254, eps);
     // See if the basis vectors are available
 
-    double *basisMatrix = getRangeComp<double>(grid, "ChangeOfBasisMatrix", 16);
+    std::vector<double> basisMatrix = getRangeComp<double>(grid, "ChangeOfBasisMatrix", 16);
     
     // Row by row check
 
@@ -211,8 +211,6 @@ private:
     TS_ASSERT_DELTA(basisMatrix[index++], 0.0, eps);
     TS_ASSERT_DELTA(basisMatrix[index++], 0.0, eps);
     TS_ASSERT_DELTA(basisMatrix[index++], 1.0, eps);
-
-    delete basisMatrix;
   }
 
 public:
@@ -313,7 +311,7 @@ public:
     TS_ASSERT_DELTA(point[1], 1.0, eps);
     TS_ASSERT_DELTA(point[2], 1.0, eps);
     // See if the basis vectors are available
-    double *basisMatrix = getRangeComp<double>(ds, "ChangeOfBasisMatrix", 16);
+    std::vector<double> basisMatrix = getRangeComp<double>(ds, "ChangeOfBasisMatrix", 16);
     
     // Row by row check
 
@@ -342,8 +340,6 @@ public:
     TS_ASSERT_DELTA(basisMatrix[index++], 0.0, eps);
     TS_ASSERT_DELTA(basisMatrix[index++], 1.0, eps);
 
-    delete basisMatrix;
-    
     ds->Delete();
   }
 
@@ -371,7 +367,7 @@ public:
     TS_ASSERT_DELTA(point[1], 1.0, eps);
     TS_ASSERT_DELTA(point[2], 0.75592895, eps);
     // See if the basis vectors are available
-    double *basisMatrix = getRangeComp<double>(ds, "ChangeOfBasisMatrix", 16);
+    std::vector<double> basisMatrix = getRangeComp<double>(ds, "ChangeOfBasisMatrix", 16);
 
     // Row by row check
 
@@ -400,8 +396,6 @@ public:
     TS_ASSERT_DELTA(basisMatrix[index++], 0.0, eps);
     TS_ASSERT_DELTA(basisMatrix[index++], 1.0, eps);
 
-    delete basisMatrix;
-  
     ds->Delete();
   }
 };


### PR DESCRIPTION
This fixes [#11762](http://trac.mantidproject.org/mantid/ticket/11762).

AddressSanitizer found an alloc-dealloc-mismatch in vtkDataSetToNonOrthogonalDataSetTest. The full error is in the ticket. Instead of fixing the delete, I replaced owning raw pointer with std::vector<T>. Given the size of the array (16 elements) the extra copy is very fast and probably eliminated by return value optimization.

testing: Given the size of the change, code review is sufficient. 
