### PR TITLE
Fix segfault when closing ISIS SANS interface

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSDiagnostics.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSDiagnostics.cpp
@@ -1247,8 +1247,12 @@ namespace MantidQt
     ///save settings
     void SANSDiagnostics::saveSettings()
     {
-      m_dataDir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("datasearch.directories"));
-      m_dataDir = m_dataDir.split(";", QString::SkipEmptyParts)[0];
+      if( Mantid::Kernel::ConfigService::Instance().hasProperty("datasearch.directories") )
+      {
+        m_dataDir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("datasearch.directories"));
+        if( !m_dataDir.isEmpty() )
+          m_dataDir = m_dataDir.split(";", QString::SkipEmptyParts)[0];
+      }
       QSettings settings;
       m_settingsGroup="CustomInterfaces/SANSRunWindow/SANSDiagnostics";
       settings.beginGroup(m_settingsGroup);


### PR DESCRIPTION
Fixes [#11765](http://trac.mantidproject.org/mantid/ticket/11765).

To test:
- Remove all directories from `datasearch.directories`
- Open ISIS SANS
- Close ISIS SANS
- See that there is no segfault
