### PR TITLE
Fix segfault when opening slice viewer

### DIFF
--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -838,7 +838,7 @@ void SliceViewer::setNormalization(Mantid::API::MDNormalization norm,
   m_actionNormalizeNumEvents->blockSignals(false);
 
   // Sync the normalization combobox.
-  this->ui.comboNormalization->setEnabled(false); // Avoid firing signals
+  this->ui.comboNormalization->blockSignals(true);
   if(norm == Mantid::API::NoNormalization) {
       this->ui.comboNormalization->setCurrentIndex(0);
   } else if (norm == Mantid::API::VolumeNormalization) {
@@ -846,7 +846,7 @@ void SliceViewer::setNormalization(Mantid::API::MDNormalization norm,
   } else {
       this->ui.comboNormalization->setCurrentIndex(2);
   }
-  this->ui.comboNormalization->setEnabled(true);
+  this->ui.comboNormalization->blockSignals(false);
 
   m_data->setNormalization(norm);
   if (update)


### PR DESCRIPTION
Fixes [#11766](http://trac.mantidproject.org/mantid/ticket/11766).

To test:
- Load some data
- Open the slice viewer
- See that the slice viewer still works correctly (particularly the normalisation options)
