### PR TITLE
Create HB3A IDF file and enable LoadSpiceXML2DDet to load instrument

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
@@ -102,6 +102,11 @@ private:
   /// Load instrument
   void loadInstrument(API::MatrixWorkspace_sptr matrixws,
                       const std::string &idffilename);
+
+  /// Get wavelength from workspace
+  bool getHB3AWavelength(API::MatrixWorkspace_sptr dataws, double &wavelength);
+
+  void setXtoLabQ(API::MatrixWorkspace_sptr dataws, const double &wavelength);
 };
 
 } // namespace DataHandling

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
@@ -4,6 +4,7 @@
 #include "MantidKernel/System.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/ITableWorkspace.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -90,6 +91,22 @@ private:
   createMatrixWorkspace(const std::vector<SpiceXMLNode> &vecxmlnode,
                         const size_t &numpixelx, const size_t &numpixely,
                         const std::string &detnodename);
+
+  /// Create output MatrixWorkspace with instrument
+  API::MatrixWorkspace_sptr
+  createInstrumentMatrixWorkspace(const std::vector<SpiceXMLNode> &vecxmlnode,
+                        const size_t &numpixelx, const size_t &numpixely,
+                        const std::string &detnodename, const std::string &idffilename);
+
+  ///
+  void setupSampleLogFromSpiceTable(API::MatrixWorkspace_sptr matrixws,
+                                    API::ITableWorkspace_sptr spicetablews, int ptnumber);
+
+  ///
+  void loadInstrument(API::MatrixWorkspace_sptr matrixws, const std::string &idffilename);
+
+
+
 };
 
 } // namespace DataHandling

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSpiceXML2DDet.h
@@ -90,23 +90,18 @@ private:
   API::MatrixWorkspace_sptr
   createMatrixWorkspace(const std::vector<SpiceXMLNode> &vecxmlnode,
                         const size_t &numpixelx, const size_t &numpixely,
-                        const std::string &detnodename);
+                        const std::string &detnodename,
+                        const bool &loadinstrument);
 
-  /// Create output MatrixWorkspace with instrument
-  API::MatrixWorkspace_sptr
-  createInstrumentMatrixWorkspace(const std::vector<SpiceXMLNode> &vecxmlnode,
-                        const size_t &numpixelx, const size_t &numpixely,
-                        const std::string &detnodename, const std::string &idffilename);
-
-  ///
+  /// Set up sample logs from table workspace loaded where SPICE data file is
+  /// loaded
   void setupSampleLogFromSpiceTable(API::MatrixWorkspace_sptr matrixws,
-                                    API::ITableWorkspace_sptr spicetablews, int ptnumber);
+                                    API::ITableWorkspace_sptr spicetablews,
+                                    int ptnumber);
 
-  ///
-  void loadInstrument(API::MatrixWorkspace_sptr matrixws, const std::string &idffilename);
-
-
-
+  /// Load instrument
+  void loadInstrument(API::MatrixWorkspace_sptr matrixws,
+                      const std::string &idffilename);
 };
 
 } // namespace DataHandling

--- a/Code/Mantid/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -6,6 +6,7 @@
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/TimeSeriesProperty.h"
 
 #include <boost/algorithm/string.hpp>
 
@@ -184,7 +185,9 @@ void LoadSpiceXML2DDet::init() {
 
   declareProperty(new WorkspaceProperty<MatrixWorkspace>("OutputWorkspace", "",
                                                          Direction::Output),
-                  "Name of output matrix workspace. ");
+                  "Name of output matrix workspace. "
+                  "Output workspace will be an X by Y Workspace2D if instrument "
+                  "is not loaded. ");
 
   declareProperty("DetectorLogName", "Detector",
                   "Log name for detector counts.");
@@ -193,6 +196,23 @@ void LoadSpiceXML2DDet::init() {
       new ArrayProperty<size_t>("DetectorGeometry"),
       "A size-2 unsigned integer array [X, Y] for detector geometry. "
       "Such that the detector contains X x Y pixels.");
+
+  declareProperty("LoadInstrument", true, "Flag to load instrument to output workspace. "
+                  "HFIR's HB3A will be loaded if InstrumentFileName is not specified.");
+
+  declareProperty(
+      new FileProperty("InstrumentFilename", "", FileProperty::OptionalLoad, ".xml"),
+      "The filename (including its full or relative path) of an instrument "
+      "definition file. The file extension must either be .xml or .XML when "
+      "specifying an instrument definition file. Note Filename or "
+      "InstrumentName must be specified but not both.");
+
+
+  declareProperty(new WorkspaceProperty<ITableWorkspace>("SpiceTableWorkspace", "", Direction::Input, PropertyMode::Optional),
+                  "Table workspace loaded from SPICE file by LoadSpiceAscii.");
+
+  declareProperty("PtNumber", 0, "Pt. value for the row to get sample log from. ");
+
 }
 
 //----------------------------------------------------------------------------------------------
@@ -210,15 +230,40 @@ void LoadSpiceXML2DDet::exec() {
   size_t numpixelX = vec_pixelgeom[0];
   size_t numpixelY = vec_pixelgeom[1];
 
+  bool loadinstrument = getProperty("LoadInstrument");
+  std::string idffilename = getPropertyValue("InstrumentFilename");
+
   // Parse
   std::vector<SpiceXMLNode> vec_xmlnode;
   parseSpiceXML(xmlfilename, vec_xmlnode);
 
   // Create output workspace
-  MatrixWorkspace_sptr outws =
-      createMatrixWorkspace(vec_xmlnode, numpixelX, numpixelY, detlogname);
+  MatrixWorkspace_sptr outws;
+  if (loadinstrument)
+  {
+    outws =
+        createInstrumentMatrixWorkspace(vec_xmlnode, numpixelX, numpixelY, detlogname,
+                                        idffilename);
+  }
+  else
+  {
+    outws =
+        createMatrixWorkspace(vec_xmlnode, numpixelX, numpixelY, detlogname);
+  }
+
+  std::string spicetablewsname = getPropertyValue("SpiceTableWorkspace");
+  if (spicetablewsname.size() > 0)
+  {
+    ITableWorkspace_sptr spicetablews = getProperty("SpiceTableWorkspace");
+    int ptnumber = getProperty("PtNumber");
+    setupSampleLogFromSpiceTable(outws, spicetablews, ptnumber);    
+  }
+
+  if (loadinstrument)
+    loadInstrument(outws, idffilename);
 
   setProperty("OutputWorkspace", outws);
+
 }
 
 //----------------------------------------------------------------------------------------------
@@ -317,6 +362,119 @@ void LoadSpiceXML2DDet::parseSpiceXML(const std::string &xmlfilename,
 
   return;
 }
+
+API::MatrixWorkspace_sptr LoadSpiceXML2DDet::createInstrumentMatrixWorkspace(const std::vector<SpiceXMLNode> &vecxmlnode,
+                      const size_t &numpixelx, const size_t &numpixely,
+                      const std::string &detnodename, const std::string &idffilename)
+{
+  // Create matrix workspace
+  size_t numspec = numpixelx * numpixely;
+  MatrixWorkspace_sptr outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+      WorkspaceFactory::Instance().create("Workspace2D", numspec, 1, 1));
+
+
+  // Go through all XML nodes to process
+  size_t numxmlnodes = vecxmlnode.size();
+  bool parsedDet = false;
+  for (size_t n = 0; n < numxmlnodes; ++n) {
+    // Process node for detector's count
+    const SpiceXMLNode &xmlnode = vecxmlnode[n];
+    if (xmlnode.getName().compare(detnodename) == 0) {
+      // Get node value string (256x256 as a whole)
+      const std::string detvaluestr = xmlnode.getValue();
+
+      // Split
+      std::vector<std::string> vecLines;
+      boost::split(vecLines, detvaluestr, boost::algorithm::is_any_of("\n"));
+      g_log.debug() << "There are " << vecLines.size() << " lines"
+                    << "\n";
+
+      size_t irow = 0;
+      for (size_t i = 0; i < vecLines.size(); ++i) {
+        std::string &line = vecLines[i];
+
+        // Skip empty line
+        if (line.size() == 0) {
+          g_log.debug() << "\tFound empty Line at " << i << "\n";
+          continue;
+        }
+
+        // Check whether it exceeds boundary
+        if (irow == numspec) {
+          std::stringstream errss;
+          errss << "Number of non-empty rows (" << irow + 1
+                << ") in detector data "
+                << "exceeds user defined geometry size " << numpixely << ".";
+          throw std::runtime_error(errss.str());
+        }
+
+        // Split line
+        std::vector<std::string> veccounts;
+        boost::split(veccounts, line, boost::algorithm::is_any_of(" \t"));
+
+        // check
+        if (veccounts.size() != numpixelx) {
+          std::stringstream errss;
+          errss << "Row " << irow << " contains " << veccounts.size()
+                << " items other than " << numpixelx
+                << " counts specified by user.";
+          throw std::runtime_error(errss.str());
+        }
+
+        for (size_t j = 0; j < veccounts.size(); ++j) {
+          double y = atof(veccounts[j].c_str());
+          size_t wsindex = irow * numpixelx + j;
+          outws->dataX(wsindex)[0] = static_cast<double>(wsindex);
+          outws->dataY(wsindex)[0] = y;
+          if (y > 0)
+            outws->dataE(wsindex)[0] = sqrt(y);
+          else
+            outws->dataE(wsindex)[0] = 1.0;
+        }
+
+        // Update irow
+        irow += 1;
+      }
+
+      // Set flag
+      parsedDet = true;
+    } else {
+      // Parse to log: because there is no start time.  so all logs are single
+      // value type
+      const std::string nodename = xmlnode.getName();
+      const std::string nodevalue = xmlnode.getValue();
+      if (xmlnode.isDouble()) {
+        double dvalue = atof(nodevalue.c_str());
+        outws->mutableRun().addProperty(
+            new PropertyWithValue<double>(nodename, dvalue));
+        g_log.debug() << "Log name / xml node : " << xmlnode.getName()
+                      << " (double) value = " << dvalue << "\n";
+      } else if (xmlnode.isInteger()) {
+        int ivalue = atoi(nodevalue.c_str());
+        outws->mutableRun().addProperty(
+            new PropertyWithValue<int>(nodename, ivalue));
+        g_log.debug() << "Log name / xml node : " << xmlnode.getName()
+                      << " (int) value = " << ivalue << "\n";
+      } else {
+        outws->mutableRun().addProperty(
+            new PropertyWithValue<std::string>(nodename, nodevalue));
+        g_log.debug() << "Log name / xml node : " << xmlnode.getName()
+                      << " (string) value = " << nodevalue << "\n";
+      }
+    }
+  }
+
+  // Raise exception if no detector node is found
+  if (!parsedDet) {
+    std::stringstream errss;
+    errss << "Unable to find an XML node of name " << detnodename
+          << ". Unable to load 2D detector XML file.";
+    throw std::runtime_error(errss.str());
+  }
+
+  return outws;
+}
+
 
 //----------------------------------------------------------------------------------------------
 /** Create MatrixWorkspace from Spice XML file
@@ -436,6 +594,60 @@ MatrixWorkspace_sptr LoadSpiceXML2DDet::createMatrixWorkspace(
 
   return outws;
 }
+
+
+void LoadSpiceXML2DDet::setupSampleLogFromSpiceTable(MatrixWorkspace_sptr matrixws, ITableWorkspace_sptr spicetablews, int ptnumber)
+{
+  size_t numrows = spicetablews->rowCount();
+  std::vector<std::string> colnames = spicetablews->getColumnNames();
+  // FIXME - Shouldn't give a better value?
+  Kernel::DateAndTime anytime(1000);
+
+  for (size_t ir = 0; ir < numrows; ++ir)
+  {
+    int localpt = spicetablews->cell<int>(ir, 0);
+    if (localpt != ptnumber)
+      continue;
+
+    for (size_t ic = 1; ic < colnames.size(); ++ic)
+    {
+      double logvalue = spicetablews->cell<double>(ir, ic);
+      std::string &logname = colnames[ic];
+      TimeSeriesProperty<double>* newlogproperty = new TimeSeriesProperty<double>(logname);
+      newlogproperty->addValue(anytime, logvalue);
+      matrixws->mutableRun().addProperty(newlogproperty);
+    }
+
+    break;
+  }
+
+  return;
+}
+
+
+void LoadSpiceXML2DDet::loadInstrument(API::MatrixWorkspace_sptr matrixws, const std::string &idffilename)
+{
+  // load instrument
+  API::IAlgorithm_sptr loadinst = createChildAlgorithm("LoadInstrument");
+  loadinst->initialize();
+  loadinst->setProperty("Workspace", matrixws);
+  if (idffilename.size() > 0)
+  {
+    loadinst->setProperty("Filename", idffilename);
+  }
+  else
+    loadinst->setProperty("InstrumentName", "HB3A");
+  loadinst->setProperty("RewriteSpectraMap", true);
+  loadinst->execute();
+  if (loadinst->isExecuted())
+    matrixws = loadinst->getProperty("Workspace");
+  else
+    g_log.error("Unable to load instrument to output workspace");
+
+  return;
+}
+
+
 
 } // namespace DataHandling
 } // namespace Mantid

--- a/Code/Mantid/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadSpiceXML2DDet.cpp
@@ -519,6 +519,7 @@ void LoadSpiceXML2DDet::setupSampleLogFromSpiceTable(
   // FIXME - Shouldn't give a better value?
   Kernel::DateAndTime anytime(1000);
 
+  bool foundlog = false;
   for (size_t ir = 0; ir < numrows; ++ir) {
     int localpt = spicetablews->cell<int>(ir, 0);
     if (localpt != ptnumber)
@@ -533,8 +534,15 @@ void LoadSpiceXML2DDet::setupSampleLogFromSpiceTable(
       matrixws->mutableRun().addProperty(newlogproperty);
     }
 
+    // Break as the experiment pointer is found
+    foundlog = true;
     break;
   }
+
+  if (!foundlog)
+    g_log.warning() << "Pt. " << ptnumber
+                    << " is not found.  Log is not loaded to output workspace."
+                    << "\n";
 
   return;
 }

--- a/Code/Mantid/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -37,6 +37,7 @@ public:
     sizelist[0] = 256;
     sizelist[1] = 256;
     loader.setProperty("DetectorGeometry", sizelist);
+    loader.setProperty("LoadInstrument", false);
 
     loader.execute();
     TS_ASSERT(loader.isExecuted());
@@ -97,6 +98,35 @@ public:
     // Clean
     AnalysisDataService::Instance().remove("Exp0335_S0038");
   }
+
+  void test_LoadHB3AXML2InstrumentedWS() {
+    std::string idffname("/home/wzz/Mantid/Code/Mantid/instrument/HB3A_Definition.xml");
+
+    LoadSpiceXML2DDet loader;
+    loader.initialize();
+
+    const std::string filename("HB3A_exp355_scan0001_0522.xml");
+    TS_ASSERT_THROWS_NOTHING(loader.setProperty("Filename", filename));
+    TS_ASSERT_THROWS_NOTHING(
+        loader.setProperty("OutputWorkspace", "Exp0335_S0038"));
+    std::vector<size_t> sizelist(2);
+    sizelist[0] = 256;
+    sizelist[1] = 256;
+    loader.setProperty("DetectorGeometry", sizelist);
+    loader.setProperty("LoadInstrument", true);
+    loader.setProperty("InstrumentFilename", idffname);
+
+    loader.execute();
+    TS_ASSERT(loader.isExecuted());
+
+    // Get data
+    MatrixWorkspace_sptr outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve("Exp0335_S0038"));
+    TS_ASSERT(outws);
+
+    TS_ASSERT(outws->getInstrument());
+  }
+
 };
 
 #endif /* MANTID_DATAHANDLING_LOADSPICEXML2DDETTEST_H_ */

--- a/Code/Mantid/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -5,6 +5,9 @@
 
 #include "MantidDataHandling/LoadSpiceXML2DDet.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidDataObjects/TableWorkspace.h"
+#include "MantidAPI/TableRow.h"
 
 using namespace Mantid;
 using namespace Mantid::API;
@@ -100,7 +103,21 @@ public:
   }
 
   void test_LoadHB3AXML2InstrumentedWS() {
-    std::string idffname("/home/wzz/Mantid/Code/Mantid/instrument/HB3A_Definition.xml");
+    std::string idffname(
+        "/home/wzz/Mantid/Code/Mantid/instrument/HB3A_Definition.xml");
+
+    // Table workspace
+    ITableWorkspace_sptr datatablews =
+        boost::dynamic_pointer_cast<ITableWorkspace>(
+            boost::make_shared<DataObjects::TableWorkspace>());
+    datatablews->addColumn("int", "Pt.");
+    datatablews->addColumn("double", "2theta");
+    AnalysisDataService::Instance().addOrReplace("SpiceDataTable", datatablews);
+
+    TableRow row0 = datatablews->appendRow();
+    row0 << 1 << 15.0;
+    TableRow row1 = datatablews->appendRow();
+    row1 << 2 << 42.709750;
 
     LoadSpiceXML2DDet loader;
     loader.initialize();
@@ -115,6 +132,7 @@ public:
     loader.setProperty("DetectorGeometry", sizelist);
     loader.setProperty("LoadInstrument", true);
     loader.setProperty("InstrumentFilename", idffname);
+    loader.setProperty("SpiceTableWorkspace", "SpiceDataTable");
 
     loader.execute();
     TS_ASSERT(loader.isExecuted());
@@ -123,10 +141,26 @@ public:
     MatrixWorkspace_sptr outws = boost::dynamic_pointer_cast<MatrixWorkspace>(
         AnalysisDataService::Instance().retrieve("Exp0335_S0038"));
     TS_ASSERT(outws);
+    TS_ASSERT_EQUALS(outws->getNumberHistograms(), 256 * 256);
 
+    // Instrument
     TS_ASSERT(outws->getInstrument());
-  }
 
+    // Detector distance
+    Kernel::V3D sample = outws->getInstrument()->getSample()->getPos();
+    Kernel::V3D det0pos = outws->getDetector(0)->getPos();
+    Kernel::V3D det255pos = outws->getDetector(255)->getPos();
+    Kernel::V3D detlast = outws->getDetector(256 * 256 - 1)->getPos();
+    double dist0 = sample.distance(det0pos);
+    double dist255 = sample.distance(det255pos);
+    double distlast = sample.distance(detlast);
+
+    TS_ASSERT_DELTA(dist0, dist255, 0.0001);
+    TS_ASSERT_DELTA(dist0, distlast, 0.0001);
+
+    TS_ASSERT_DELTA(outws->readY(255)[0], 1.0, 0.0001);
+    TS_ASSERT_DELTA(outws->readY(253 * 256 + 9)[0], 1.0, 0.00001);
+  }
 };
 
 #endif /* MANTID_DATAHANDLING_LOADSPICEXML2DDETTEST_H_ */

--- a/Code/Mantid/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/LoadSpiceXML2DDetTest.h
@@ -131,7 +131,7 @@ public:
     sizelist[1] = 256;
     loader.setProperty("DetectorGeometry", sizelist);
     loader.setProperty("LoadInstrument", true);
-    loader.setProperty("InstrumentFilename", idffname);
+    // loader.setProperty("InstrumentFilename", idffname);
     loader.setProperty("SpiceTableWorkspace", "SpiceDataTable");
 
     loader.execute();

--- a/Code/Mantid/docs/source/algorithms/LoadSpiceXML2DDet-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/LoadSpiceXML2DDet-v1.rst
@@ -47,6 +47,20 @@ Output Worskpaces
 
 The output from this algorithm is a MatrixWorskpaces. 
 
+MatrixWorskpace with instrument loaded
+++++++++++++++++++++++++++++++++++++++
+
+For a 2D detector with :math:`n\times m` pixels, the output MatrixWorkspace
+will have :math:`n \times m` spectrum.
+Each spectrum has 1 data point corresponding to 1 detector's count.  
+
+All experiment information, sample environment devices' readings and monitor counts,
+which are recorded in XML files,
+are converted to the properties in output MatrixWorkspace's sample log. 
+
+MatrixWorkspace without instrument loaded
++++++++++++++++++++++++++++++++++++++++++
+
 For a 2D detector with :math:`n\times m` pixels, the output MatrixWorkspace
 will have :math:`n` spectrum, each of which has a vector of length equal to :math:`m`. 
 It can be mapped to the raw data as :math:`WS.readY(i)[j] = X(i+1,j+1)`. 
@@ -61,15 +75,12 @@ Workflow
 
 Algorithm *LoadSpiceXML2DDet* is one of a series of algorithms that are implemented to 
 reduced HFIR HB3A data collected from Anger camera. 
-It will be called at the first step in the complete workflow.  
-
-Instrument will not be loaded to its output workspace. 
-
+It will be called next to *LoadSpiceAscii* to load the detector's reading. 
 
 Usage
 -----
 
-**Example - load a HB3A SPICE .xml file:**
+**Example - load a HB3A SPICE .xml file without loading instrument:**
 
 .. testcode:: ExLoadHB3AXMLData
 

--- a/Code/Mantid/docs/source/algorithms/LoadSpiceXML2DDet-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/LoadSpiceXML2DDet-v1.rst
@@ -75,7 +75,8 @@ Usage
 
   # Load data by LoadSpiceXML2DDet()
   LoadSpiceXML2DDet(Filename='HB3A_exp355_scan0001_0522.xml', 
-      OutputWorkspace='s0001_0522', DetectorGeometry='256,256')    
+      OutputWorkspace='s0001_0522', DetectorGeometry='256,256',
+      LoadInstrument=False)    
 
   # Access output workspace and print out some result
   ws = mtd["s0001_0522"]

--- a/Code/Mantid/instrument/Facilities.xml
+++ b/Code/Mantid/instrument/Facilities.xml
@@ -305,6 +305,11 @@
       <technique>Triple Axis Spectroscopy</technique>
    </instrument> 
    
+   <instrument name="HB3A"> 
+      <technique>technique</technique>
+   </instrument> 
+   
+   
    <instrument name="GPSANS"> 
       <technique>Small Angle Scattering</technique>
    </instrument> 

--- a/Code/Mantid/instrument/HB3A_Definition.xml
+++ b/Code/Mantid/instrument/HB3A_Definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-14 09:49:45.211024" name="HB3A" valid-from="2015-05-14 09:49:45" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-18 10:35:21.877396" name="HB3A" valid-from="2015-05-18 10:35:21" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Wenduo Zhou-->
   <!--SOURCE-->
   <component type="moderator">
@@ -15,7 +15,7 @@
   <component idfillbyfirst="x" idstart="1" idstepbyrow="256" type="panel">
     <location name="bank1">
       <parameter name="r-position">
-        <value val="1.0"/>
+        <value val="0.3518"/>
       </parameter>
       <parameter name="t-position">
         <logfile eq="-1.0*value+0.0" id="2theta"/>
@@ -28,13 +28,13 @@
       </parameter>
     </location>
   </component>
-  <type is="rectangular_detector" name="panel" type="pixel" xpixels="256" xstart="0.078795" xstep="-0.000618" ypixels="256" ystart="-0.078795" ystep="0.000618"/>
+  <type is="rectangular_detector" name="panel" type="pixel" xpixels="256" xstart="0.02530078125" xstep="-0.0001984375" ypixels="256" ystart="0.02530078125" ystep="-0.0001984375"/>
   <type is="detector" name="pixel">
     <cuboid id="pixel-shape">
-      <left-front-bottom-point x="-0.000309" y="-0.000309" z="0.0"/>
-      <left-front-top-point x="-0.000309" y="0.000309" z="0.0"/>
-      <left-back-bottom-point x="-0.000309" y="-0.000309" z="-0.0001"/>
-      <right-front-bottom-point x="0.000309" y="-0.000309" z="0.0"/>
+      <left-front-bottom-point x="-9.921875e-05" y="-9.921875e-05" z="0.0"/>
+      <left-front-top-point x="-9.921875e-05" y="9.921875e-05" z="0.0"/>
+      <left-back-bottom-point x="-9.921875e-05" y="-9.921875e-05" z="-0.0001"/>
+      <right-front-bottom-point x="9.921875e-05" y="-9.921875e-05" z="0.0"/>
     </cuboid>
     <algebra val="pixel-shape"/>
   </type>

--- a/Code/Mantid/instrument/HB3A_Definition.xml
+++ b/Code/Mantid/instrument/HB3A_Definition.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='ASCII'?>
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2015-05-14 09:49:45.211024" name="HB3A" valid-from="2015-05-14 09:49:45" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+  <!--Created by Wenduo Zhou-->
+  <!--SOURCE-->
+  <component type="moderator">
+    <location z="-2.0"/>
+  </component>
+  <type is="Source" name="moderator"/>
+  <!--SAMPLE-->
+  <component type="sample-position">
+    <location x="0.0" y="0.0" z="0.0"/>
+  </component>
+  <type is="SamplePos" name="sample-position"/>
+  <!--PANEL-->
+  <component idfillbyfirst="x" idstart="1" idstepbyrow="256" type="panel">
+    <location name="bank1">
+      <parameter name="r-position">
+        <value val="1.0"/>
+      </parameter>
+      <parameter name="t-position">
+        <logfile eq="-1.0*value+0.0" id="2theta"/>
+      </parameter>
+      <parameter name="p-position">
+        <value val="0.0"/>
+      </parameter>
+      <parameter name="roty">
+        <logfile eq="-1.0*value+0.0" id="2theta"/>
+      </parameter>
+    </location>
+  </component>
+  <type is="rectangular_detector" name="panel" type="pixel" xpixels="256" xstart="0.078795" xstep="-0.000618" ypixels="256" ystart="-0.078795" ystep="0.000618"/>
+  <type is="detector" name="pixel">
+    <cuboid id="pixel-shape">
+      <left-front-bottom-point x="-0.000309" y="-0.000309" z="0.0"/>
+      <left-front-top-point x="-0.000309" y="0.000309" z="0.0"/>
+      <left-back-bottom-point x="-0.000309" y="-0.000309" z="-0.0001"/>
+      <right-front-bottom-point x="0.000309" y="-0.000309" z="0.0"/>
+    </cuboid>
+    <algebra val="pixel-shape"/>
+  </type>
+</instrument>


### PR DESCRIPTION
This is originally ticket [11190](http://trac.mantidproject.org/mantid/ticket/11190). 
