### PR TITLE
Eraser cursor invisible

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InputController.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InputController.cpp
@@ -402,7 +402,6 @@ void InputControllerErase::drawCursor()
 {
     m_cursor->fill(QColor(255,255,255,0));
     QPainter painter( m_cursor );
-    painter.fillRect( QRect( 0, 0, m_size, m_size ), QColor(255,255,255,100) );
 
     auto pen = QPen(Qt::DashLine);
     QVector<qreal> dashPattern;

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InputController.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InputController.cpp
@@ -403,6 +403,20 @@ void InputControllerErase::drawCursor()
     m_cursor->fill(QColor(255,255,255,0));
     QPainter painter( m_cursor );
     painter.fillRect( QRect( 0, 0, m_size, m_size ), QColor(255,255,255,100) );
+
+    auto pen = QPen(Qt::DashLine);
+    QVector<qreal> dashPattern;
+    dashPattern << 4 << 4;
+    pen.setDashPattern(dashPattern);
+    pen.setColor(QColor(0,0,0));
+    painter.setPen(pen);
+    painter.drawRect( QRect( 0, 0, m_size, m_size ) );
+
+    pen.setColor(QColor(255,255,255));
+    pen.setDashOffset(4);
+    painter.setPen(pen);
+    painter.drawRect( QRect( 0, 0, m_size, m_size ) );
+
     m_rect.setSize( QSize(m_size,m_size) );
 }
 


### PR DESCRIPTION
[#11051](http://trac.mantidproject.org/mantid/ticket/11051)

To test this changes need to be merged to master first. When the nightly build is installed on the [isis data analysis computers](http://www.isis.stfc.ac.uk/groups/excitations/data-analysis-computers/connecting-to-data-analysis-computers15120.html) connect via NoMachine from a linux machine and check that the issue of the ticket is resolved. The active area of the eraser should now be outlined by a dashed rectangle.
