### PR TITLE
Update class_maker.py

### DIFF
--- a/Code/Mantid/Build/class_maker.py
+++ b/Code/Mantid/Build/class_maker.py
@@ -135,10 +135,14 @@ const std::string %s::name() const { return "%s"; }
 int %s::version() const { return 1; };
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string %s::category() const { return TODO: FILL IN A CATEGORY;}
+const std::string %s::category() const {
+  return "TODO: FILL IN A CATEGORY";
+}
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-const std::string %s::summary() const { return TODO: FILL IN A SUMMARY;};
+const std::string %s::summary() const {
+  return "TODO: FILL IN A SUMMARY";
+};
 
 //----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.

--- a/Code/Mantid/Build/class_maker.py
+++ b/Code/Mantid/Build/class_maker.py
@@ -118,46 +118,46 @@ def write_source(subproject, classname, filename, args):
     f = open(filename, 'w')
 
     algorithm_top = """
-  using Mantid::Kernel::Direction;
-  using Mantid::API::WorkspaceProperty;
+using Mantid::Kernel::Direction;
+using Mantid::API::WorkspaceProperty;
 
-  // Register the algorithm into the AlgorithmFactory
-  DECLARE_ALGORITHM(%s)
-
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(%s)
 """ % (classname)
 
     algorithm_source = """
-  //----------------------------------------------------------------------------------------------
+//----------------------------------------------------------------------------------------------
 
-  /// Algorithms name for identification. @see Algorithm::name
-  const std::string %s::name() const { return "%s"; }
+/// Algorithms name for identification. @see Algorithm::name
+const std::string %s::name() const { return "%s"; }
 
-  /// Algorithm's version for identification. @see Algorithm::version
-  int %s::version() const { return 1;};
+/// Algorithm's version for identification. @see Algorithm::version
+int %s::version() const { return 1; };
 
-  /// Algorithm's category for identification. @see Algorithm::category
-  const std::string %s::category() const { return TODO: FILL IN A CATEGORY;}
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string %s::category() const { return TODO: FILL IN A CATEGORY;}
 
-  /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-  const std::string %s::summary() const { return TODO: FILL IN A SUMMARY;};
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string %s::summary() const { return TODO: FILL IN A SUMMARY;};
 
-  //----------------------------------------------------------------------------------------------
-  /** Initialize the algorithm's properties.
-   */
-  void %s::init()
-  {
-    declareProperty(new WorkspaceProperty<>("InputWorkspace","",Direction::Input), "An input workspace.");
-    declareProperty(new WorkspaceProperty<>("OutputWorkspace","",Direction::Output), "An output workspace.");
-  }
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void %s::init() {
+  declareProperty(
+      new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
+      "An input workspace.");
+  declareProperty(
+      new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
+      "An output workspace.");
+}
 
-  //----------------------------------------------------------------------------------------------
-  /** Execute the algorithm.
-   */
-  void %s::exec()
-  {
-    // TODO Auto-generated execute stub
-  }
-
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void %s::exec() {
+  // TODO Auto-generated execute stub
+}
 """ % (classname, classname, classname, classname, classname, classname, classname)
 
     if not args.alg:
@@ -167,28 +167,19 @@ def write_source(subproject, classname, filename, args):
     # ------- Now the normal class text ------------------------------
     s = """#include "Mantid%s/%s%s.h"
 
-namespace Mantid
-{
-namespace %s
-{
+namespace Mantid {
+namespace %s {
 %s
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+%s::%s() {}
 
-  //----------------------------------------------------------------------------------------------
-  /** Constructor
-   */
-  %s::%s()
-  {
-  }
-
-  //----------------------------------------------------------------------------------------------
-  /** Destructor
-   */
-  %s::~%s()
-  {
-  }
-
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+%s::~%s() {}
 %s
-
 } // namespace %s
 } // namespace Mantid""" % (
         subproject, args.subfolder, classname, subproject, algorithm_top,

--- a/Code/Mantid/Build/class_maker.py
+++ b/Code/Mantid/Build/class_maker.py
@@ -27,15 +27,14 @@ def write_header(subproject, classname, filename, args):
 
     # Create an Algorithm header; will not use it if not an algo
     algorithm_header = """
-    virtual const std::string name() const;
-    virtual int version() const;
-    virtual const std::string category() const;
-    virtual const std::string summary() const;
+  virtual const std::string name() const;
+  virtual int version() const;
+  virtual const std::string category() const;
+  virtual const std::string summary() const;
 
-  private:
-    void init();
-    void exec();
-
+private:
+  void init();
+  void exec();
 """
 
     # ---- Find the author, default to blank string ----
@@ -59,47 +58,42 @@ def write_header(subproject, classname, filename, args):
 
 #include "MantidKernel/System.h"
 %s
+namespace Mantid {
+namespace %s {
 
-namespace Mantid
-{
-namespace %s
-{
+/** %s : TODO: DESCRIPTION
 
-  /** %s : TODO: DESCRIPTION
+  Copyright &copy; %s ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
 
-    Copyright &copy; %s ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+  This file is part of Mantid.
 
-    This file is part of Mantid.
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
 
-    Mantid is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-    Mantid is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-    File change history is stored at: <https://github.com/mantidproject/mantid>
-    Code Documentation is available at: <http://doxygen.mantidproject.org>
-  */
-  class DLLExport %s %s
-  {
-  public:
-    %s();
-    virtual ~%s();
-    %s
-  };
-
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport %s%s {
+public:
+  %s();
+  virtual ~%s();
+%s};
 
 } // namespace %s
 } // namespace Mantid
 
-#endif  /* %s */""" % (guard, guard,
+#endif /* %s */""" % (guard, guard,
        alg_include, subproject, classname,
        datetime.datetime.now().date().year, classname, alg_class_declare,
        classname, classname, algorithm_header, subproject, guard)

--- a/Code/Mantid/Build/class_maker.py
+++ b/Code/Mantid/Build/class_maker.py
@@ -241,8 +241,7 @@ def write_test(subproject, classname, filename, args):
 using Mantid::%s::%s;
 using namespace Mantid::API;
 
-class %sTest : public CxxTest::TestSuite
-{
+class %sTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests

--- a/Code/Mantid/Build/class_maker.py
+++ b/Code/Mantid/Build/class_maker.py
@@ -367,6 +367,13 @@ def generate(subproject, classname, overwrite, args):
 
     print "\n   Files were added to Framework/%s/CMakeLists.txt !" % (subproject)
     print
+
+    if args.alg:
+        print "Note: if this is a WorkflowAlgorithm, please subclass DataProcessorAlgorithm"
+        print "Note: if this algorithm operates on a WorkspaceGroup, please override processGroups()"
+        print
+
+
 #    if not test_only:
 #        print "\tsrc/%s.cpp" % (classname)
 #        print "\tinc/Mantid%s/%s.h" % (subproject, classname)

--- a/Code/Mantid/Framework/Algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/Algorithms/CMakeLists.txt
@@ -244,7 +244,9 @@ set ( SRC_FILES
 	src/SumSpectra.cpp
 	src/TOFSANSResolution.cpp
 	src/TOFSANSResolutionByPixel.cpp
+	src/TestAlg.cpp
 	src/Transpose.cpp
+	src/Ttest.cpp
 	src/UnGroupWorkspace.cpp
 	src/UnaryOperation.cpp
 	src/UnwrapMonitor.cpp
@@ -505,7 +507,9 @@ set ( INC_FILES
 	inc/MantidAlgorithms/SumSpectra.h
 	inc/MantidAlgorithms/TOFSANSResolution.h
 	inc/MantidAlgorithms/TOFSANSResolutionByPixel.h
+	inc/MantidAlgorithms/TestAlg.h
 	inc/MantidAlgorithms/Transpose.h
+	inc/MantidAlgorithms/Ttest.h
 	inc/MantidAlgorithms/UnGroupWorkspace.h
 	inc/MantidAlgorithms/UnaryOperation.h
 	inc/MantidAlgorithms/UnwrapMonitor.h
@@ -752,7 +756,9 @@ set ( TEST_FILES
 	SumRowColumnTest.h
 	SumSpectraTest.h
 	TOFSANSResolutionByPixelTest.h
+	TestAlgTest.h
 	TransposeTest.h
+	TtestTest.h
 	UnGroupWorkspaceTest.h
 	UnaryOperationTest.h
 	UnwrapSNSTest.h

--- a/Code/Mantid/Framework/Algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/Algorithms/CMakeLists.txt
@@ -244,9 +244,7 @@ set ( SRC_FILES
 	src/SumSpectra.cpp
 	src/TOFSANSResolution.cpp
 	src/TOFSANSResolutionByPixel.cpp
-	src/TestAlg.cpp
 	src/Transpose.cpp
-	src/Ttest.cpp
 	src/UnGroupWorkspace.cpp
 	src/UnaryOperation.cpp
 	src/UnwrapMonitor.cpp
@@ -507,9 +505,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/SumSpectra.h
 	inc/MantidAlgorithms/TOFSANSResolution.h
 	inc/MantidAlgorithms/TOFSANSResolutionByPixel.h
-	inc/MantidAlgorithms/TestAlg.h
 	inc/MantidAlgorithms/Transpose.h
-	inc/MantidAlgorithms/Ttest.h
 	inc/MantidAlgorithms/UnGroupWorkspace.h
 	inc/MantidAlgorithms/UnaryOperation.h
 	inc/MantidAlgorithms/UnwrapMonitor.h
@@ -756,9 +752,7 @@ set ( TEST_FILES
 	SumRowColumnTest.h
 	SumSpectraTest.h
 	TOFSANSResolutionByPixelTest.h
-	TestAlgTest.h
 	TransposeTest.h
-	TtestTest.h
 	UnGroupWorkspaceTest.h
 	UnaryOperationTest.h
 	UnwrapSNSTest.h


### PR DESCRIPTION
Fixes [#11754](http://trac.mantidproject.org/mantid/ticket/11754)

This PR is to update the class_maker script to generate code following the current standards. Specifically there are three points to have a look at: clang format, naming convention and definitions in cpp files (see original trac ticket).

**For tester**: 

I have updated class_maker.py according to clang format. To test, run the script (run with --h for help) to create a new class and check that it is formatted according to clang standards. Check the same for a new algorithm (run with --alg).

Regarding naming conventions and methods in header and source files (http://www.mantidproject.org/C%2B%2B_Coding_Standards), I have not modified or updated anything as the script was already generating code with the appropriate standards. Ensure this is correct (for instance, if a new algorithm is created there are some methods that must be overridden http://www.mantidproject.org/Algorithm_Documentation).
