### PR TITLE
Export individual peaks as separate spectra

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -19,7 +19,7 @@ namespace CustomInterfaces
 
   MatrixWorkspace_sptr ALCPeakFittingModel::exportWorkspace()
   {
-    if ( m_data && m_data->getNumberHistograms() == 3 ) {
+    if ( m_data && m_data->getNumberHistograms() > 2 ) {
 
       return boost::const_pointer_cast<MatrixWorkspace>(m_data);
 
@@ -54,11 +54,11 @@ namespace CustomInterfaces
     fit->setProperty("Function", peaks->asString());
     fit->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
     fit->setProperty("CreateOutput", true);
+    fit->setProperty("OutputCompositeMembers", true);
     fit->execute();
 
     m_data = fit->getProperty("OutputWorkspace");
     m_parameterTable = fit->getProperty("OutputParameters");
-
     setFittedPeaks(static_cast<IFunction_sptr>(fit->getProperty("Function")));
   }
 


### PR DESCRIPTION
Fixes [#11782](http://trac.mantidproject.org/mantid/ticket/11782)

For tester: Open the muon ALC interface and load "HIFI00051636.nxs" as "First" and "HIFI00051786.nxs" as "Last" (you can find all the datasets from 51636 to 51786 under \ISIS\inst$\NDXHIFI\Instrument\data\cycle_13_1). Hit "Load" (this will take a couple of minutes) and then "Baseline Modelling". Fit a base line, for instance by adding a Chebyshev function (set n=2 and StartX=51636, EndX=51786) and two sections, the first one from 51636 to 51680, and the second one from 51744 to 51786, this should produce a good baseline. Go to "Peak fitting", right-click on the "Peaks" section and add a peak. Set the centre at 51700 (you can then drag the picker tool to set the width and amplitude). Add another peak with centre at 51730 (again, drag to set the width and amplitude). Hit "Fit" and then "Export Results". Check that the output workspace "ALCResults_Peaks_Workspace" has 5 spectra, with workspace indices 4 and 5 corresponding to each of the fitted peaks respectively.
