### PR TITLE
reenabling LET system test

### DIFF
--- a/Code/Mantid/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
@@ -453,11 +453,6 @@ class LETReductionEvent2015Multirep(stresstesting.MantidStressTest):
     def requiredMemoryMB(self):
         """Far too slow for managed workspaces. They're tested in other places. Requires 20Gb"""
         return 20000
-    def skipTests(self):
-        '''
-        Skip this test for the time beeing
-        '''
-        return True
 
     def runTest(self):
         """

--- a/Code/Mantid/docs/source/algorithms/NormaliseByCurrent-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/NormaliseByCurrent-v1.rst
@@ -59,12 +59,12 @@ Usage
 
    #Run the Algorithm
    wsN = NormaliseByCurrent(ws)
-   #norm_factor = wsN.getRun().getLogData('NormalizationFactor').value
+   norm_factor = wsN.getRun().getLogData('NormalizationFactor').value
 
    #Print results
    print "Before normalisation", ws.readY(0);
    print "After normalisation ", wsN.readY(0);
-   #print "Normalisation factor", norm_factor;
+   print "Normalisation factor", norm_factor;
 
 
 Output:
@@ -74,5 +74,6 @@ Output:
    Good Proton Charge = 10.0
    Before normalisation [ 17.  12.]
    After normalisation  [ 1.7  1.2]
+   Normalisation factor 10.0   
 
 .. categories::


### PR DESCRIPTION
This 3-row fix reenables LET system test (issue http://trac.mantidproject.org/mantid/ticket/11761)
