### PR TITLE
Fix plotting issue on IDR

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -195,9 +195,9 @@ namespace CustomInterfaces
   {
     QString pyInput = "from mantidplot import plotSpectrum\n";
 
-    pyInput += "plotSpectrum('";
+    pyInput += "plotSpectrum(['";
     pyInput += workspaceNames.join("','");
-    pyInput += "', ";
+    pyInput += "'], ";
     pyInput += QString::number(specIndex);
     pyInput += ")\n";
 
@@ -234,9 +234,9 @@ namespace CustomInterfaces
   {
     QString pyInput = "from mantidplot import plotSpectrum\n";
 
-    pyInput += "plotSpectrum('";
+    pyInput += "plotSpectrum(['";
     pyInput += workspaceNames.join("','");
-    pyInput += "', range(";
+    pyInput += "'], range(";
     pyInput += QString::number(specStart);
     pyInput += ",";
     pyInput += QString::number(specEnd);
@@ -296,9 +296,9 @@ namespace CustomInterfaces
   {
     QString pyInput = "from mantidplot import plotTimeBin\n";
 
-    pyInput += "plotTimeBin('";
+    pyInput += "plotTimeBin(['";
     pyInput += workspaceNames.join("','");
-    pyInput += "', ";
+    pyInput += "'], ";
     pyInput += QString::number(specIndex);
     pyInput += ")\n";
 


### PR DESCRIPTION
Fixes [#11796](http://trac.mantidproject.org/mantid/ticket/11796).

To test:
- Open IDR > Calibration
- Select IRIS, load run 26173
- Enable resolution
- Enable smoothing
- Enable plotting
- Run

Should get the pre and post smoothing resolution curves on one plot.
