### PR TITLE
Fix Pylint issues in EnginX* algorithms

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrate.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrate.py
@@ -5,7 +5,7 @@ from mantid.api import *
 
 class EnginXCalibrate(PythonAlgorithm):
     def category(self):
-        return "Diffraction\Engineering;PythonAlgorithms"
+        return "Diffraction\\Engineering;PythonAlgorithms"
 
     def name(self):
         return "EnginXCalibrate"
@@ -22,7 +22,8 @@ class EnginXCalibrate(PythonAlgorithm):
 
         self.declareProperty("Bank", 1, "Which bank to calibrate")
 
-        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Input, PropertyMode.Optional),\
+        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "",\
+                Direction.Input, PropertyMode.Optional),\
     		"Calibrated detector positions. If not specified, default ones are used.")
 
         self.declareProperty("Difc", 0.0, direction = Direction.Output,\

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -5,7 +5,7 @@ import math
 
 class EnginXCalibrateFull(PythonAlgorithm):
     def category(self):
-        return "Diffraction\Engineering;PythonAlgorithms"
+        return "Diffraction\\Engineering;PythonAlgorithms"
 
     def name(self):
         return "EnginXCalibrateFull"
@@ -108,7 +108,8 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
     		The two_theta and phi of the detector are preserved, L2 is changed.
     	"""
-        detL2 = det.getDistance(ws.getInstrument().getSample())
+        # This is how detL2 would be calculated
+        # detL2 = det.getDistance(ws.getInstrument().getSample())
         detTwoTheta = ws.detectorTwoTheta(det)
         detPhi = det.getPhi()
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFitPeaks.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFitPeaks.py
@@ -6,13 +6,14 @@ import math
 
 class EnginXFitPeaks(PythonAlgorithm):
     def category(self):
-        return "Diffraction\Engineering;PythonAlgorithms"
+        return "Diffraction\\Engineering;PythonAlgorithms"
 
     def name(self):
         return "EnginXFitPeaks"
 
     def summary(self):
-        return "The algorithm fits an expected diffraction pattern to a workpace spectrum by performing single peak fits."
+        return ("The algorithm fits an expected diffraction pattern to a workpace spectrum by "
+                "performing single peak fits.")
 
     def PyInit(self):
         self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input),\
@@ -24,7 +25,9 @@ class EnginXFitPeaks(PythonAlgorithm):
         self.declareProperty(FloatArrayProperty("ExpectedPeaks", (self._getDefaultPeaks())),\
     		"A list of dSpacing values to be translated into TOF to find expected peaks.")
 
-        self.declareProperty(FileProperty(name="ExpectedPeaksFromFile",defaultValue="",action=FileAction.OptionalLoad,extensions = [".csv"]),"Load from file a list of dSpacing values to be translated into TOF to find expected peaks.")
+        self.declareProperty(FileProperty(name="ExpectedPeaksFromFile",defaultValue="",
+                                          action=FileAction.OptionalLoad,extensions = [".csv"]),
+                "Load from file a list of dSpacing values to be translated into TOF to find expected peaks.")
 
         self.declareProperty("Difc", 0.0, direction = Direction.Output,\
     		doc = "Fitted Difc value")
@@ -127,7 +130,9 @@ class EnginXFitPeaks(PythonAlgorithm):
 
     def _getDefaultPeaks(self):
         """ Gets default peaks for EnginX algorithm. Values from CeO2 """
-        defaultPeak = [3.1243, 2.7057, 1.9132, 1.6316, 1.5621, 1.3529, 1.2415, 1.2100, 1.1046, 1.0414, 0.9566, 0.9147, 0.9019, 0.8556, 0.8252, 0.8158, 0.7811]
+        defaultPeak = [3.1243, 2.7057, 1.9132, 1.6316, 1.5621, 1.3529, 1.2415,
+                       1.2100, 1.1046, 1.0414, 0.9566, 0.9147, 0.9019, 0.8556,
+                       0.8252, 0.8158, 0.7811]
         return defaultPeak
 
     def _fitDSpacingToTOF(self, fittedPeaksTable):
@@ -174,7 +179,7 @@ class EnginXFitPeaks(PythonAlgorithm):
         expectedPeaks = self._readInExpectedPeaks()
 
     	# Expected peak positions in TOF for the detector
-        expectedPeaksTof = map(dSpacingToTof, expectedPeaks)
+        expectedPeaksTof = [dSpacingToTof(ep) for ep in expectedPeaks]
 
         return expectedPeaksTof
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFocus.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFocus.py
@@ -4,7 +4,7 @@ from mantid.api import *
 
 class EnginXFocus(PythonAlgorithm):
     def category(self):
-        return "Diffraction\Engineering;PythonAlgorithms"
+        return "Diffraction\\Engineering;PythonAlgorithms"
 
     def name(self):
         return "EnginXFocus"
@@ -19,7 +19,8 @@ class EnginXFocus(PythonAlgorithm):
         self.declareProperty(WorkspaceProperty("OutputWorkspace", "", Direction.Output),\
     		"A workspace with focussed data")
 
-        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Input, PropertyMode.Optional),\
+        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Input,\
+                PropertyMode.Optional),\
     		"Calibrated detector positions. If not specified, default ones are used.")
 
         self.declareProperty("Bank", 1, "Which bank to focus")

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
@@ -5,7 +5,7 @@ from mantid.simpleapi import *
 class EnginXCalibrateTest(stresstesting.MantidStressTest):
 
     def __init__(self):
-        super(EnginXCalibrateTest, self).__init__()
+        stresstesting.MantidStressTest.__init__(self)
         self.difc = -1
         self.zero = -1
 

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
@@ -4,6 +4,11 @@ from mantid.simpleapi import *
 
 class EnginXCalibrateTest(stresstesting.MantidStressTest):
 
+    def __init__(self):
+        super(EnginXCalibrateTest, self).__init__()
+        self.difc = -1
+        self.zero = -1
+
     def runTest(self):
         positions = EnginXCalibrateFull(Filename = 'ENGINX00193749.nxs',
                                       Bank = 1,

--- a/Code/Mantid/scripts/Engineering/EnginXUtils.py
+++ b/Code/Mantid/scripts/Engineering/EnginXUtils.py
@@ -38,8 +38,7 @@ def getWsIndicesForBank(bank, ws):
         try:
             det = ws.getDetector(index)
             return det.getID() in detIDs
-        except:
+        except RuntimeError:
             return False
 
-    return filter(isIndexInBank, range(0, ws.getNumberHistograms()))
-
+    return [i for i in range(0, ws.getNumberHistograms()) if isIndexInBank(i)]


### PR DESCRIPTION
This fixes [#11785](http://trac.mantidproject.org/mantid/ticket/11785), just to tidy EnginX code up before more work follows.

**To test**:
- doc tests should pass for the EnginX algorithms. There are no unit tests for them, that will come in a follow-up ticket.
- The system test `EnginXCalibrateTest` should also pass.
- There should be no more pylint issues in files named EnginX*.
- code review (small changes).
