### PR TITLE
Exposing shared_ptr<Quat> and vector<Quat> in python.

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
@@ -2,8 +2,9 @@
 #include "MantidKernel/V3D.h"
 #include <boost/python/class.hpp>
 #include <boost/python/operators.hpp>
-#include <boost/python/return_value_policy.hpp>
 #include <boost/python/copy_const_reference.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/return_value_policy.hpp>
 
 using Mantid::Kernel::Quat;
 using Mantid::Kernel::V3D;
@@ -22,6 +23,8 @@ using boost::python::return_value_policy;
 void export_Quat()
 // clang-format on
 {
+  boost::python::register_ptr_to_python<boost::shared_ptr<Quat> >();
+
   //Quat class
   class_< Quat >("Quat", "Quaternions are the 3D generalization of complex numbers. "
                  "Quaternions are used for roations in 3D spaces and often implemented for "

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
@@ -2,6 +2,7 @@
 
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/Quat.h"
+#include "MantidKernel/V3D.h"
 
 using Mantid::PythonInterface::std_vector_exporter;
 using Mantid::PythonInterface::std_set_exporter;
@@ -20,6 +21,7 @@ void exportStlContainers()
   std_vector_exporter<std::string>::wrap("std_vector_str");
   std_vector_exporter<Mantid::Kernel::DateAndTime>::wrap("std_vector_dateandtime");
   std_vector_exporter<Mantid::Kernel::Quat>::wrap("std_vector_quat");
+  std_vector_exporter<Mantid::Kernel::V3D>::wrap("std_vector_v3d");
   //std::set
   std_set_exporter<int>::wrap("std_set_int");
   std_set_exporter<std::string>::wrap("std_set_str");

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
@@ -1,6 +1,7 @@
 #include "MantidPythonInterface/kernel/StlExportDefinitions.h"
 
 #include "MantidKernel/DateAndTime.h"
+#include "MantidKernel/Quat.h"
 
 using Mantid::PythonInterface::std_vector_exporter;
 using Mantid::PythonInterface::std_set_exporter;
@@ -18,6 +19,7 @@ void exportStlContainers()
   std_vector_exporter<bool>::wrap("std_vector_bool");
   std_vector_exporter<std::string>::wrap("std_vector_str");
   std_vector_exporter<Mantid::Kernel::DateAndTime>::wrap("std_vector_dateandtime");
+  std_vector_exporter<Mantid::Kernel::Quat>::wrap("std_vector_quat");
   //std::set
   std_set_exporter<int>::wrap("std_set_int");
   std_set_exporter<std::string>::wrap("std_set_str");


### PR DESCRIPTION
This fixes #766. Here are the [release notes](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_Framework_Changes&diff=24126&oldid=23584).

**To test:** Try what was mentioned in the original issue and see that the error message is gone.
