### PR TITLE
Expose to python getRot, getRelRot and getRelPos for instrument components

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -18,6 +18,8 @@ namespace
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getStringParameter,Component::getStringParameter,1,2)
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getIntParameter,Component::getIntParameter,1,2)
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterType,Component::getParameterType,1,2)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRotation,Component::getRotation,0,0)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRelativePos,Component::getRelativePos,0,0)
 
 
 }
@@ -35,6 +37,8 @@ void export_Component()
     .def("getRotationParameter", &Component::getRotationParameter, Component_getRotationParameter())
     .def("getStringParameter", &Component::getStringParameter, Component_getStringParameter())
     .def("getIntParameter", &Component::getIntParameter, Component_getIntParameter())
+    .def("getRotation", &Component::getRotation, Component_getRotation())
+    .def("getRelativePos", &Component::getRelativePos, Component_getRelativePos())
     // HACK -- python should return parameters regardless of type. this is untill rows below do not work
     .def("getParameterType", &Component::getParameterType, Component_getParameterType())
     //// this does not work for some obvious or not obvious reasons 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
@@ -2,6 +2,8 @@
 
 #include <boost/python/class.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/copy_const_reference.hpp>
+#include <boost/python/return_value_policy.hpp>
 
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
@@ -37,6 +39,7 @@ void export_IComponent()
     .def("getName", &IComponent::getName, "Returns the name of the component")
     .def("getFullName", &IComponent::getFullName,"Returns full path name of component")
     .def("type", &IComponent::type, "Returns the type of the component represented as a string")
+    .def("getRelativeRot", &IComponent::getRelativeRot,return_value_policy<copy_const_reference>(), "Returns the relative rotation as a Quat")
     ;
 
 }


### PR DESCRIPTION
This exposed some more functions for instrument components.

**To Test:**

``` python
cor=Load(Filename='CORELLI_2100')
print cor.getInstrument().getComponentByName('A1/sixteenpack').getRotation()
print cor.getInstrument().getComponentByName('A1/sixteenpack').getRelativeRot()
print cor.getInstrument().getComponentByName('A1/sixteenpack').getRelativePos()
```

[Release notes](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_Framework_Changes&diff=24128&oldid=24126)
