### PR TITLE
Change IDF name mangling to use SHA1 rather than last modified date

### DIFF
--- a/Code/Mantid/Framework/Geometry/src/Instrument/IDFObject.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument/IDFObject.cpp
@@ -1,5 +1,7 @@
 #include "MantidGeometry/Instrument/IDFObject.h"
+#include "MantidKernel/ChecksumHelper.h"
 #include <Poco/DateTimeFormatter.h>
+#include <Poco/String.h>
 
 namespace Mantid {
 namespace Geometry {
@@ -87,7 +89,9 @@ Gets the idf file as a mangled name.
 @return the idf file as a mangled name.
 */
 std::string IDFObject::getMangledName() const {
-  return this->getFileNameOnly() + this->getFormattedLastModified();
+  std::string idfText = Kernel::ChecksumHelper::loadFile(getFileFullPathStr(),true);
+  std::string checksum = Kernel::ChecksumHelper::sha1FromString(Poco::trim(idfText));
+  return this->getFileNameOnly() + checksum;
 }
 
 /**

--- a/Code/Mantid/Framework/Geometry/test/IDFObjectTest.h
+++ b/Code/Mantid/Framework/Geometry/test/IDFObjectTest.h
@@ -8,6 +8,8 @@
 #include <Poco/Path.h>
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/Thread.h>
+#include <Poco/SHA1Engine.h>
+#include <Poco/DigestStream.h>
 
 using Mantid::Geometry::IDFObject;
 using Mantid::Kernel::ConfigService;
@@ -97,9 +99,32 @@ public:
   {
     const std::string filename = ConfigService::Instance().getInstrumentDirectory() + "/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING.xml";
     
-    Poco::File file(filename);
-    auto head = "IDF_for_UNIT_TESTING.xml";
-    auto tail = Poco::DateTimeFormatter::format(file.getLastModified(), "%Y-%d-%mT%H:%M:%S");
+    Poco::Path path(filename);
+
+    using Poco::DigestEngine;
+    using Poco::SHA1Engine;
+    using Poco::DigestOutputStream;
+
+    std::ifstream filein(filename.c_str(), std::ios::in | std::ios::binary);
+    if (!filein) {
+      TS_FAIL("Cannot open file: " + filename);
+      return;
+    }
+
+    std::string contents;
+    filein.seekg(0, std::ios::end);
+    contents.resize(filein.tellg());
+    filein.seekg(0, std::ios::beg);
+    filein.read(&contents[0], contents.size());
+    filein.close();
+
+    SHA1Engine sha1;
+    DigestOutputStream outstr(sha1);
+    outstr << contents;
+    outstr.flush(); // to pass everything to the digest engine
+
+    auto head = path.getFileName();
+    auto tail = DigestEngine::digestToHex(sha1.digest());
     
     IDFObject obj(filename);
 

--- a/Code/Mantid/Framework/Geometry/test/IDFObjectTest.h
+++ b/Code/Mantid/Framework/Geometry/test/IDFObjectTest.h
@@ -9,7 +9,10 @@
 #include <Poco/DateTimeFormatter.h>
 #include <Poco/Thread.h>
 #include <Poco/SHA1Engine.h>
+#include <Poco/String.h>
 #include <Poco/DigestStream.h>
+
+#include <boost/regex.hpp>
 
 using Mantid::Geometry::IDFObject;
 using Mantid::Kernel::ConfigService;
@@ -118,10 +121,19 @@ public:
     filein.read(&contents[0], contents.size());
     filein.close();
 
+    //convert to unix line endings
+    static boost::regex eol("\\R"); // \R is Perl syntax for matching any EOL sequence
+    contents = boost::regex_replace(contents, eol, "\n"); // converts all to LF
+
+    //and trim
+    contents = Poco::trim(contents);
+
     SHA1Engine sha1;
     DigestOutputStream outstr(sha1);
     outstr << contents;
     outstr.flush(); // to pass everything to the digest engine
+
+
 
     auto head = path.getFileName();
     auto tail = DigestEngine::digestToHex(sha1.digest());

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ChecksumHelper.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ChecksumHelper.h
@@ -31,15 +31,18 @@ namespace Kernel {
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 namespace ChecksumHelper {
+//loads a file, optionally converting line endings
+MANTID_KERNEL_DLL std::string loadFile(const std::string &filepath, const bool unixEOL);
 /// create a md5 checksum from a string
 MANTID_KERNEL_DLL std::string md5FromString(const std::string &input);
-
 /// create a SHA-1 checksum from a string
 MANTID_KERNEL_DLL std::string sha1FromString(const std::string &input);
 /// create a SHA-1 checksum from a file
-MANTID_KERNEL_DLL std::string sha1FromFile(const std::string &filepath);
+MANTID_KERNEL_DLL std::string sha1FromFile(const std::string &filepath, const bool unixEOL);
 /// create a git checksum from a file (these match the git hash-object command)
 MANTID_KERNEL_DLL std::string gitSha1FromFile(const std::string &filepath);
+
+
 }
 
 } // namespace Kernel

--- a/Code/Mantid/Framework/Kernel/src/ChecksumHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ChecksumHelper.cpp
@@ -1,8 +1,6 @@
 #include "MantidKernel/ChecksumHelper.h"
 
 #include <boost/regex.hpp>
-#include <boost/shared_array.hpp>
-
 #include <Poco/MD5Engine.h>
 #include <Poco/SHA1Engine.h>
 #include <Poco/DigestStream.h>
@@ -16,30 +14,7 @@ namespace Kernel {
 namespace ChecksumHelper {
 namespace // anonymous
     {
-/**
- * Load contents of file into a string. The line endings are preserved
- * @param filepath Full path to the file to be opened
- * @param unixEOL If true convert all lineendings to Unix-style \n
- */
-std::string loadFile(const std::string &filepath, const bool unixEOL = false) {
-  std::ifstream filein(filepath.c_str(), std::ios::in | std::ios::binary);
-  if (!filein)
-    return "";
 
-  std::string contents;
-  filein.seekg(0, std::ios::end);
-  contents.resize(filein.tellg());
-  filein.seekg(0, std::ios::beg);
-  filein.read(&contents[0], contents.size());
-  filein.close();
-
-  if (unixEOL) {
-    static boost::regex eol(
-        "\\R"); // \R is Perl syntax for matching any EOL sequence
-    contents = boost::regex_replace(contents, eol, "\n"); // converts all to LF
-  }
-  return contents;
-}
 
 /**
  * Create sha1 out of data and an optional header
@@ -54,7 +29,6 @@ std::string createSHA1(const std::string &data,
 
   SHA1Engine sha1;
   DigestOutputStream outstr(sha1);
-  outstr << header << data;
   outstr.flush(); // to pass everything to the digest engine
   return DigestEngine::digestToHex(sha1.digest());
 }
@@ -95,12 +69,13 @@ std::string sha1FromString(const std::string &input) {
 
 /** Creates a SHA-1 checksum from a file
 * @param filepath The path to the file
+* @param unixEOL If true convert all lineendings to Unix-style \n
 * @returns a checksum string
 **/
-std::string sha1FromFile(const std::string &filepath) {
+std::string sha1FromFile(const std::string &filepath, const bool unixEOL = false) {
   if (filepath.empty())
     return "";
-  return ChecksumHelper::createSHA1(loadFile(filepath));
+  return ChecksumHelper::createSHA1(loadFile(filepath,unixEOL));
 }
 
 /** Creates a git checksum from a file (these match the git hash-object
@@ -117,11 +92,39 @@ std::string gitSha1FromFile(const std::string &filepath) {
   if (filepath.empty())
     return "";
   const bool unixEOL(true);
-  std::string contents = loadFile(filepath, unixEOL);
+  std::string contents = ChecksumHelper::loadFile(filepath, unixEOL);
   std::stringstream header;
   header << "blob " << contents.size() << '\0';
   return ChecksumHelper::createSHA1(contents, header.str());
 }
+
+/**
+ * Load contents of file into a string. The line endings are preserved
+ * @param filepath Full path to the file to be opened
+ * @param unixEOL If true convert all lineendings to Unix-style \n
+ */
+std::string loadFile(const std::string &filepath, const bool unixEOL = false) {
+
+  std::ifstream filein(filepath.c_str(), std::ios::in | std::ios::binary);
+  if (!filein)
+    return "";
+
+  std::string contents;
+  filein.seekg(0, std::ios::end);
+  contents.resize(filein.tellg());
+  filein.seekg(0, std::ios::beg);
+  filein.read(&contents[0], contents.size());
+  filein.close();
+
+  if (unixEOL) {
+    static boost::regex eol(
+        "\\R"); // \R is Perl syntax for matching any EOL sequence
+    contents = boost::regex_replace(contents, eol, "\n"); // converts all to LF
+  }
+  return contents;
+}
+
+
 
 } // namespace ChecksumHelper
 } // namespace Kernel

--- a/Code/Mantid/Framework/Kernel/src/ChecksumHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ChecksumHelper.cpp
@@ -29,6 +29,7 @@ std::string createSHA1(const std::string &data,
 
   SHA1Engine sha1;
   DigestOutputStream outstr(sha1);
+  outstr << header << data;
   outstr.flush(); // to pass everything to the digest engine
   return DigestEngine::digestToHex(sha1.digest());
 }

--- a/Code/Mantid/Framework/Kernel/test/ChecksumHelperTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ChecksumHelperTest.h
@@ -38,7 +38,7 @@ public:
     const std::string data = "ChecksumHelperTest_testSha1FromFile Test this string out for size in a file";
     createFile(filename,data);
 
-    std::string response = ChecksumHelper::sha1FromFile(filename);
+    std::string response = ChecksumHelper::sha1FromFile(filename,false);
     TSM_ASSERT_EQUALS("The calculated SHA-1 hash is not as expected", "363cbe9c113b8bcba9e0aa94dbe45e67856ff26b", response);
     Poco::File(filename).remove();
   }

--- a/Code/Mantid/docs/source/concepts/InstrumentDefinitionFile.rst
+++ b/Code/Mantid/docs/source/concepts/InstrumentDefinitionFile.rst
@@ -172,10 +172,9 @@ which must be included. An example is
                   xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
                   name="ARCS"
                   valid-from="1900-01-31 23:59:59"
-                  valid-to="2100-01-31 23:59:59"
-                  last-modified="2010-10-12 08:54:07.279621">
+                  valid-to="2100-01-31 23:59:59">
 
-Of the four attributes in the example above
+Of the attributes in the example above
 
 -  xmlns, xmlns:xsi, xsi:schemaLocation are required attributes that can
    be copied verbatim as above
@@ -186,9 +185,6 @@ Of the four attributes in the example above
    23:59:01
 -  valid-to may optionally be added to indicate the date to which the
    IDF is valid to. If not used, the file is permanently valid. (+)
--  last-modified is optional. Changing it can be used as an alternative
-   to force MantidPlot to reload the IDF, which e.g. might be useful
-   during the build up of an IDF
 
 (+) Both valid-from and valid-to are required to be set using the ISO
 8601 date-time format, i.e. as YYYY-MM-DD HH:MM:SS or


### PR DESCRIPTION
http://trac.mantidproject.org/mantid/ticket/11569
## To test
1. Start with a code review, and ensure that all unit and system tests pass
2. Manually load a RAW file (use Load, not LoadEmptyInstrument).
3. Look to see where the instrument file was loaded from by dropping down the details of the workspace.
   ![image](https://cloud.githubusercontent.com/assets/1017173/7727894/bd505568-ff03-11e4-9694-08f7bea4667d.png)
4. Go into the instrument directory and  make a visible change (like move a bank vertically). Do not change the last-modified date.
5. without closing mantid, reload the same file into a different workspace.
6. look at the instrument views of both workspaces, check the 2nd one got the updated image.
7. MAKE SURE YOU DO NOT COMMIT THE CHANGE TO THE IDF.
