### PR TITLE
Add unit tests for ENGINX algorithms

### DIFF
--- a/Code/Mantid/Framework/API/src/MDGeometry.cpp
+++ b/Code/Mantid/Framework/API/src/MDGeometry.cpp
@@ -237,7 +237,7 @@ MDGeometry::getYDimension() const {
 boost::shared_ptr<const Mantid::Geometry::IMDDimension>
 MDGeometry::getZDimension() const {
   if (this->getNumDims() < 3)
-    throw std::runtime_error("Workspace does not have a X dimension.");
+    throw std::runtime_error("Workspace does not have a Z dimension.");
   return this->getDimension(2);
 }
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFocus.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFocus.py
@@ -16,14 +16,14 @@ class EnginXFocus(PythonAlgorithm):
         self.declareProperty(FileProperty("Filename", "", FileAction.Load),\
     		"Run to focus")
 
-        self.declareProperty(WorkspaceProperty("OutputWorkspace", "", Direction.Output),\
-    		"A workspace with focussed data")
+        self.declareProperty("Bank", 1, "Which bank to focus")
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Input,\
                 PropertyMode.Optional),\
     		"Calibrated detector positions. If not specified, default ones are used.")
 
-        self.declareProperty("Bank", 1, "Which bank to focus")
+        self.declareProperty(WorkspaceProperty("OutputWorkspace", "", Direction.Output),\
+                             "A workspace with focussed data")
 
 
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -17,6 +17,10 @@ set ( TEST_PY_FILES
   DakotaChiSquaredTest.py
   DensityOfStatesTest.py
   DSFinterpTest.py
+  EnginXCalibrateFullTest.py
+  EnginXCalibrateTest.py
+  EnginXFitPeaksTest.py
+  EnginXFocusTest.py
   FilterLogByTimeTest.py
   FindReflectometryLinesTest.py
   FlatPlatePaalmanPingsCorrectionTest.py

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -1,0 +1,23 @@
+import unittest
+from mantid.simpleapi import *
+from mantid.api import *
+
+class EnginXCalibrateFullTest(unittest.TestCase):
+
+    def test_wrong_properties(self):
+        """
+        Tests
+        """
+
+        return True
+
+    def test_runs_ok(self):
+        """
+        Tests
+        """
+
+        return True
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -52,7 +52,8 @@ class EnginXCalibrateFullTest(unittest.TestCase):
         # a correct fit is included in system tests
         tbl_name = 'det_peaks_tbl'
         det_peaks_tbl = CreateEmptyTableWorkspace()
-        self.assertRaises(EnginXCalibrateFull,
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
                           Filename="ENGINX00228061.nxs", Bank=2,
                           ExpectedPeaks='0.915, 1.257, 1.688',
                           DetectorPositions=tbl_name)

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -4,19 +4,59 @@ from mantid.api import *
 
 class EnginXCalibrateFullTest(unittest.TestCase):
 
-    def test_wrong_properties(self):
+    def test_issues_with_properties(self):
         """
-        Tests
-        """
-
-        return True
-
-    def test_runs_ok(self):
-        """
-        Tests
+        Handle in/out property errors appropriately.
         """
 
-        return True
+        # No Filename property (required)
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
+                          File='foo', Bank=1)
+
+        # Wrong filename
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
+                          File='bar_file_is_not_there.not', Bank=2)
+
+        # mispelled ExpectedPeaks
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
+                          Filename='ENGINX00228061.nxs', Bank=2, Peaks='2')
+
+        # all fine, except missing DetectorPositions (output)
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
+                          Filename='ENGINX00228061.nxs', Bank=2)
+
+    def test_wrong_fit_fails_gracefully(self):
+        """
+        Checks a bad run fails reasonably.
+        """
+
+        # This should produce fitting 'given peak center ... is outside of data range'
+        # warnings and finally raise after a 'some peaks not found' error
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
+                          Filename="ENGINX00228061.nxs", ExpectedPeaks=[0.01], Bank=1,
+                          DetectorPositions='out_det_positions_table')
+
+
+    def test_run_ok_but_bad_data(self):
+        """
+        Tests a run that doesn't go well becaus of inappropriate data is used here.
+        """
+
+        # This is not a realistic CalibrateFull run, but it just runs fine
+        # for testing purposes. A test with real (much larger) data that produces
+        # a correct fit is included in system tests
+        tbl_name = 'det_peaks_tbl'
+        det_peaks_tbl = CreateEmptyTableWorkspace()
+        self.assertRaises(EnginXCalibrateFull,
+                          Filename="ENGINX00228061.nxs", Bank=2,
+                          ExpectedPeaks='0.915, 1.257, 1.688',
+                          DetectorPositions=tbl_name)
+
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
@@ -1,0 +1,23 @@
+import unittest
+from mantid.simpleapi import *
+from mantid.api import *
+
+class EnginXCalibrateTest(unittest.TestCase):
+
+    def test_wrong_properties(self):
+        """
+        Tests
+        """
+
+        return True
+
+    def test_runs_ok(self):
+        """
+        Tests
+        """
+
+        return True
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
@@ -59,9 +59,10 @@ class EnginXCalibrateTest(unittest.TestCase):
         # There are platform specific differences in final parameter values
         # For example, debian: 369367.57492582797; win7: 369242.28850305633
         expected_difc = 369367.57492582797
-        self.assertLess(abs((expected_difc-difc)/expected_difc), 5e-3)
+        # assertLess would be nices, but only available in unittest >= 2.7
+        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 5e-3)
         expected_zero = -223297.87349744083
-        self.assertLess(abs((expected_zero-zero)/expected_zero), 5e-3)
+        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 5e-3)
 
 
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
@@ -4,19 +4,61 @@ from mantid.api import *
 
 class EnginXCalibrateTest(unittest.TestCase):
 
-    def test_wrong_properties(self):
+    def test_issues_with_properties(self):
         """
-        Tests
+        Tests proper error handling when passing wrong properties or not passing required
+        ones.
         """
 
-        return True
+        # No Filename property (required)
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrate,
+                          File='foo', Bank=1)
+
+        # Wrong filename
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrate,
+                          File='foo_is_not_there', Bank=2)
+
+        # mispelled ExpectedPeaks
+        tbl = CreateEmptyTableWorkspace(OutputWorkspace='test_table')
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrate,
+                          Filename='ENGINX00228061.nxs', DetectorPositions=tbl, Bank=2, Peaks='2')
+
+        # mispelled DetectorPositions
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrate,
+                          Filename='ENGINX00228061.nxs', Detectors=tbl, Bank=2, Peaks='2')
+
+        # There's no output workspace
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrate,
+                          File='foo', Bank=1, OutputWorkspace='nop')
+
+
+    def test_fails_gracefully(self):
+        """
+        Checks a bad run.
+        """
+
+        # This should produce 'given peak center ... is outside of data range' warnings
+        # and finally raise after a 'some peaks not found' error
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrate,
+                          Filename="ENGINX00228061.nxs", ExpectedPeaks=[0.2, 0.4], Bank=2)
+
 
     def test_runs_ok(self):
         """
-        Tests
+        Checks normal operation.
         """
 
-        return True
+        difc, zero = EnginXCalibrate(Filename="ENGINX00228061.nxs",
+                                     ExpectedPeaks=[1.6, 1.1, 1.8], Bank=2)
+        self.assertAlmostEqual(difc, 369367.57492582797)
+        self.assertAlmostEqual(zero, -223297.87349744083)
+
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
@@ -56,8 +56,12 @@ class EnginXCalibrateTest(unittest.TestCase):
 
         difc, zero = EnginXCalibrate(Filename="ENGINX00228061.nxs",
                                      ExpectedPeaks=[1.6, 1.1, 1.8], Bank=2)
-        self.assertAlmostEqual(difc, 369367.57492582797)
-        self.assertAlmostEqual(zero, -223297.87349744083)
+        # There are platform specific differences in final parameter values
+        # For example, debian: 369367.57492582797; win7: 369242.28850305633
+        expected_difc = 369367.57492582797
+        self.assertLess(abs((expected_difc-difc)/expected_difc), 5e-3)
+        expected_zero = -223297.87349744083
+        self.assertLess(abs((expected_zero-zero)/expected_zero), 5e-3)
 
 
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
@@ -155,9 +155,9 @@ class EnginXFitPeaksTest(unittest.TestCase):
         EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
         difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 0.83, 1.09])
         expected_difc = 17335.67250113934
-        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 1e-3)
+        self.assertLess(abs((expected_difc-difc)/expected_difc), 5e-3)
         expected_zero = 950.9440922621866
-        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 1e-3)
+        self.assertLess(abs((expected_zero-zero)/expected_zero), 5e-3)
 
 
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
@@ -133,9 +133,9 @@ class EnginXFitPeaksTest(unittest.TestCase):
         difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 1.09])
         # fitting results on some platforms (OSX) are different by ~0.07%
         expected_difc = 17395.620526173196
-        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 1e-3)
+        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 5e-3)
         expected_zero = 1050.3378284424373
-        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 1e-3)
+        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 5e-3)
 
 
     def test_runs_ok_3peaks(self):
@@ -155,9 +155,10 @@ class EnginXFitPeaksTest(unittest.TestCase):
         EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
         difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 0.83, 1.09])
         expected_difc = 17335.67250113934
-        self.assertLess(abs((expected_difc-difc)/expected_difc), 5e-3)
+        # assertLess would be nices, but only available in unittest >= 2.7
+        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 5e-3)
         expected_zero = 950.9440922621866
-        self.assertLess(abs((expected_zero-zero)/expected_zero), 5e-3)
+        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 5e-3)
 
 
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
@@ -6,17 +6,154 @@ class EnginXFitPeaksTest(unittest.TestCase):
 
     def test_wrong_properties(self):
         """
-        Tests
+        Handle in/out property issues appropriately.
         """
 
-        return True
+        ws_name = 'out_ws'
+        peak = "name=BackToBackExponential, I=5000,A=1, B=1., X0=10000, S=150"
+        sws = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction=peak,
+                                    NumBanks=1, BankPixelWidth=1, XMin=5000, XMax=30000,
+                                    BinWidth=5, OutputWorkspace=ws_name)
 
-    def test_runs_ok(self):
+        # No InputWorkspace property (required)
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          WorkspaceIndex=0, ExpectedPeaks='0.51, 0.72')
+
+        # Wrong WorkspaceIndex value
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          InputWorkspace=ws_name,
+                          WorkspaceIndex=-3, ExpectedPeaks='0.51, 0.72')
+
+        # Wrong property
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          InputWorkspace=ws_name, BankPixelFoo=33,
+                          WorkspaceIndex=0, ExpectedPeaks='0.51, 0.72')
+
+        # Wrong ExpectedPeaks value
+        self.assertRaises(ValueError,
+                          EnginXFitPeaks,
+                          InputWorkspace=ws_name,
+                          WorkspaceIndex=0, ExpectedPeaks='a')
+
+
+    def _check_output_ok(self, ws, ws_name='', y_dim_max=1, yvalues=None):
         """
-        Tests
+        Checks expected output values from the fits
         """
 
-        return True
+        peak_def = "name=BackToBackExponential, I=4000,A=1, B=1.5, X0=10000, S=150"
+        sws = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction=peak_def,
+                                    NumBanks=1, BankPixelWidth=1, XMin=5000, XMax=30000,
+                                    BinWidth=5)
+
+        # Missing input workspace
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          WorkspaceIndex=0, ExpectedPeaks=[0.0, 1.0])
+
+        # Wrong index
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          InputWorkspace=sws,
+                          WorkspaceIndex=-5, ExpectedPeaks=[0.0, 1.0])
+
+
+    def test_fitting_fails_ok(self):
+        """
+        Tests acceptable response (appropriate exception) when fitting doesn't work well
+        """
+
+        peak_def = "name=BackToBackExponential, I=8000, A=1, B=1.2, X0=10000, S=150"
+        sws = CreateSampleWorkspace(Function="User Defined",
+                                    UserDefinedFunction=peak_def,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=10000, XMax=30000, BinWidth=10, Random=1)
+        # these should raise because of issues with the peak center - data range
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          sws, 0, [0.5, 2.5])
+        EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[90], PrimaryFlightPath=50)
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          sws, 0, [1, 3])
+
+        # this should fail because of nan/infinity issues
+        peak_def = "name=BackToBackExponential, I=12000, A=1, B=1.5, X0=10000, S=350"
+        sws = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction=peak_def,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=10000, XMax=30000, BinWidth=10)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[35], PrimaryFlightPath=35)
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          sws, 0, [1, 2, 3])
+
+        # this should fail because FindPeaks doesn't initialize/converge well
+        peak_def = "name=BackToBackExponential, I=90000, A=0.1, B=0.5, X0=5000, S=400"
+        sws = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction=peak_def,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=2000, XMax=30000, BinWidth=10)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[90], PrimaryFlightPath=50)
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          sws, 0, [0.6])
+
+
+    def test_fails_ok_1peak(self):
+        """
+        Tests fitting a single peak, which should raise because we need at least 2 peaks to
+        fit two parameters: difc and zero
+        """
+        peak_def = "name=BackToBackExponential, I=15000, A=1, B=1.2, X0=10000, S=400"
+        sws = CreateSampleWorkspace(Function="User Defined",
+                                    UserDefinedFunction=peak_def,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=0, XMax=25000, BinWidth=10)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=45)
+        self.assertRaises(RuntimeError,
+                          EnginXFitPeaks,
+                          sws, WorkspaceIndex=0, ExpectedPeaks='0.542')
+
+
+    def test_runs_ok_2peaks(self):
+        """
+        Tests fitting a couple of peaks.
+        """
+
+        peak_def1 = "name=BackToBackExponential, I=10000, A=1, B=0.5, X0=8000, S=350"
+        peak_def2 = "name=BackToBackExponential, I=8000, A=1, B=1.7, X0=20000, S=300"
+        sws = CreateSampleWorkspace(Function="User Defined",
+                                    UserDefinedFunction=peak_def1 + ";" + peak_def2,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=5000, XMax=30000,
+                                    BinWidth=25)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
+        difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 1.09])
+        self.assertAlmostEqual(difc, 17395.620526173196)
+        self.assertAlmostEqual(zero, 1050.3378284424373)
+
+
+    def test_runs_ok_3peaks(self):
+        """
+        Tests fitting three clean peaks and different widths.
+        """
+
+        peak_def1 = "name=BackToBackExponential, I=10000, A=1, B=0.5, X0=8000, S=350"
+        peak_def2 = "name=BackToBackExponential, I=15000, A=1, B=1.7, X0=15000, S=100"
+        peak_def3 = "name=BackToBackExponential, I=8000, A=1, B=1.2, X0=20000, S=800"
+        sws = CreateSampleWorkspace(Function="User Defined",
+                                    UserDefinedFunction=
+                                    peak_def1 + ";" + peak_def2 + ";" + peak_def3,
+                                    NumBanks=1, BankPixelWidth=1,
+                                    XMin=5000, XMax=30000,
+                                    BinWidth=25)
+        EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
+        difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 0.83, 1.09])
+        self.assertAlmostEqual(difc, 17335.67250113934)
+        self.assertAlmostEqual(zero, 950.9440922621866)
+
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
@@ -131,8 +131,11 @@ class EnginXFitPeaksTest(unittest.TestCase):
                                     BinWidth=25)
         EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
         difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 1.09])
-        self.assertAlmostEqual(difc, 17395.620526173196)
-        self.assertAlmostEqual(zero, 1050.3378284424373)
+        # fitting results on some platforms (OSX) are different by ~0.07%
+        expected_difc = 17395.620526173196
+        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 1e-3)
+        expected_zero = 1050.3378284424373
+        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 1e-3)
 
 
     def test_runs_ok_3peaks(self):
@@ -151,8 +154,10 @@ class EnginXFitPeaksTest(unittest.TestCase):
                                     BinWidth=25)
         EditInstrumentGeometry(Workspace=sws, L2=[1.5], Polar=[90], PrimaryFlightPath=50)
         difc, zero = EnginXFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[0.4, 0.83, 1.09])
-        self.assertAlmostEqual(difc, 17335.67250113934)
-        self.assertAlmostEqual(zero, 950.9440922621866)
+        expected_difc = 17335.67250113934
+        self.assertTrue(abs((expected_difc-difc)/expected_difc) < 1e-3)
+        expected_zero = 950.9440922621866
+        self.assertTrue(abs((expected_zero-zero)/expected_zero) < 1e-3)
 
 
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFitPeaksTest.py
@@ -1,0 +1,23 @@
+import unittest
+from mantid.simpleapi import *
+from mantid.api import *
+
+class EnginXFitPeaksTest(unittest.TestCase):
+
+    def test_wrong_properties(self):
+        """
+        Tests
+        """
+
+        return True
+
+    def test_runs_ok(self):
+        """
+        Tests
+        """
+
+        return True
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -6,39 +6,50 @@ class EnginXFocusTest(unittest.TestCase):
 
     def test_wrong_properties(self):
         """
-        Tests proper error handling when passing wrong properties or not passing required 
-        ones
+        Tests proper error handling when passing wrong properties or not passing
+        required ones.
         """
 
-        # No Filename
+        # No Filename property
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          File='foo',
-                          Bank=1)
+                          File='foo', Bank=1, OutputWorkspace='nop')
 
-        # no bank
+        # Wrong filename
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          File='foo')
+                          File='foo_is_not_there', Bank=1, OutputWorkspace='nop')
+
+        # mispelled bank
+        self.assertRaises(RuntimeError,
+                          EnginXFocus,
+                          Filename='ENGINX00228061.nxs', bnk='2', OutputWorkspace='nop')
+
+        # mispelled DetectorsPosition
+        tbl = CreateEmptyTableWorkspace()
+        self.assertRaises(RuntimeError,
+                          EnginXFocus,
+                          Filename='ENGINX00228061.nxs', Detectors=tbl, OutputWorkspace='nop')
 
 
-    def _check_output_ok(self, ws, ws_name='', y_dim_max=1):
+    def _check_output_ok(self, ws, ws_name='', y_dim_max=1, yvalues=None):
         """
-        Checks expected types, values, etc.
+        Checks expected types, values, etc. of an output workspace from EnginXFocus.
         """
 
         self.assertTrue(isinstance(ws, MatrixWorkspace),
                         'Output workspace should be a matrix workspace.')
         self.assertEqual(ws.name(), ws_name)
-        self.assertEqual(ws.getTitle(), 'EFURS02 Creep')
+        self.assertEqual(ws.getTitle(), 'yscan;y=250.210')
         self.assertEqual(ws.isHistogramData(), True)
         self.assertEqual(ws.isDistribution(), True)
-        self.assertEqual(ws.blocksize(), 10186)
-        self.assertEqual(ws.getNEvents(), 10186)
+        self.assertEqual(ws.getNumberHistograms(), 1)
+        self.assertEqual(ws.blocksize(), 98)
+        self.assertEqual(ws.getNEvents(), 98)
         self.assertEqual(ws.getNumDims(), 2)
         self.assertEqual(ws.YUnit(), 'Counts')
         dimX = ws.getXDimension()
-        self.assertTrue( (dimX.getMaximum() - 52907.19921875) < 1e-5)
+        self.assertAlmostEqual( dimX.getMaximum(), 36938.078125)
         self.assertEqual(dimX.getName(), 'Time-of-flight')
         self.assertEqual(dimX.getUnits(), 'microsecond')
         dimY = ws.getYDimension()
@@ -46,14 +57,26 @@ class EnginXFocusTest(unittest.TestCase):
         self.assertEqual(dimY.getName(), 'Spectrum')
         self.assertEqual(dimY.getUnits(), '')
 
+        if None == yvalues:
+            raise ValueError("No y-vals provided for test")
+        xvals = [10861.958645540433, 12192.372902418168, 13522.787159295902,
+                 14853.201416173637, 24166.101214317776, 34809.415269339654]
+        for i, bin in enumerate([0, 5, 10, 15, 50, 90]):
+            self.assertAlmostEqual( ws.readX(0)[bin], xvals[i])
+            self.assertAlmostEqual( ws.readY(0)[bin], yvalues[i])
+
 
     def test_runs_ok(self):
         """
         Checks that output looks fine for normal operation conditions, (default) Bank=1
         """
 
-        out = EnginXFocus(Filename="ENGINX00213855.nxs", Bank=1)
-        self._check_output_ok(ws=out, ws_name='out', y_dim_max=1)
+        out_name = 'out'
+        out = EnginXFocus(Filename='ENGINX00228061.nxs', Bank=1, OutputWorkspace=out_name)
+
+        yvals = [0.0037582279159681957, 0.00751645583194, 0.0231963801368, 0.0720786940576,
+                 0.0615909620868, 0.00987979301753]
+        self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=yvals)
 
 
     def test_runs_ok_bank2(self):
@@ -61,8 +84,15 @@ class EnginXFocusTest(unittest.TestCase):
         Checks that output looks fine for normal operation conditions, Bank=2
         """
 
-        out_bank2 = EnginXFocus(Filename="ENGINX00213855.nxs", Bank=2)
-        self._check_output_ok(ws=out_bank2, ws_name='out_bank2', y_dim_max=1201)
+        out_name = 'out_bank2'
+        out_bank2 = EnginXFocus(Filename="ENGINX00228061.nxs", Bank=2,
+                                OutputWorkspace=out_name)
+
+        yvals = [0, 0.0112746837479, 0.0394536605073, 0.0362013481777,
+                 0.0728500403862, 0.000870882282987]
+        self._check_output_ok(ws=out_bank2, ws_name=out_name, y_dim_max=1201,
+                              yvalues=yvals)
+
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -1,0 +1,69 @@
+import unittest
+from mantid.simpleapi import *
+from mantid.api import *
+
+class EnginXFocusTest(unittest.TestCase):
+
+    def test_wrong_properties(self):
+        """
+        Tests proper error handling when passing wrong properties or not passing required 
+        ones
+        """
+
+        # No Filename
+        self.assertRaises(RuntimeError,
+                          EnginXFocus,
+                          File='foo',
+                          Bank=1)
+
+        # no bank
+        self.assertRaises(RuntimeError,
+                          EnginXFocus,
+                          File='foo')
+
+
+    def _check_output_ok(self, ws, ws_name='', y_dim_max=1):
+        """
+        Checks expected types, values, etc.
+        """
+
+        self.assertTrue(isinstance(ws, MatrixWorkspace),
+                        'Output workspace should be a matrix workspace.')
+        self.assertEqual(ws.name(), ws_name)
+        self.assertEqual(ws.getTitle(), 'EFURS02 Creep')
+        self.assertEqual(ws.isHistogramData(), True)
+        self.assertEqual(ws.isDistribution(), True)
+        self.assertEqual(ws.blocksize(), 10186)
+        self.assertEqual(ws.getNEvents(), 10186)
+        self.assertEqual(ws.getNumDims(), 2)
+        self.assertEqual(ws.YUnit(), 'Counts')
+        dimX = ws.getXDimension()
+        self.assertTrue( (dimX.getMaximum() - 52907.19921875) < 1e-5)
+        self.assertEqual(dimX.getName(), 'Time-of-flight')
+        self.assertEqual(dimX.getUnits(), 'microsecond')
+        dimY = ws.getYDimension()
+        self.assertEqual(dimY.getMaximum(), y_dim_max)
+        self.assertEqual(dimY.getName(), 'Spectrum')
+        self.assertEqual(dimY.getUnits(), '')
+
+
+    def test_runs_ok(self):
+        """
+        Checks that output looks fine for normal operation conditions, (default) Bank=1
+        """
+
+        out = EnginXFocus(Filename="ENGINX00213855.nxs", Bank=1)
+        self._check_output_ok(ws=out, ws_name='out', y_dim_max=1)
+
+
+    def test_runs_ok_bank2(self):
+        """
+        Checks that output looks fine for normal operation conditions, Bank=2
+        """
+
+        out_bank2 = EnginXFocus(Filename="ENGINX00213855.nxs", Bank=2)
+        self._check_output_ok(ws=out_bank2, ws_name='out_bank2', y_dim_max=1201)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/Mantid/Testing/Data/UnitTest/ENGINX00228061.nxs.md5
+++ b/Code/Mantid/Testing/Data/UnitTest/ENGINX00228061.nxs.md5
@@ -1,0 +1,1 @@
+7607c04f6cbc9fbb7a6c205bbe97c01d

--- a/Code/Mantid/docs/source/algorithms/EnginXFocus-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXFocus-v1.rst
@@ -14,8 +14,10 @@ Description
    This algorithm is being developed for a specific instrument. It might get changed or even 
    removed without a notification, should instrument scientists decide to do so.
 
-Performs a TOF to dSpacing conversion using calibrated pixel positions, focuses the values in dSpacing
-and then converts them back to TOF.
+Performs a TOF to dSpacing conversion using calibrated pixel
+positions, focuses the values in dSpacing and then converts them back
+to TOF. The output workspace produced by this algorithm has one
+spectrum.
 
 Usage
 -----


### PR DESCRIPTION
This fixes [#10921](http://trac.mantidproject.org/mantid/ticket/10921).

**To test:** 
- Make sure that tests pass. These new tests might be extended but are already a good shield before more work happens around EnginX algorithms
- Code review.
