### PR TITLE
Minor bug in ISIS direct inelastic reduction

### DIFF
--- a/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -1409,6 +1409,9 @@ class DirectEnergyConversion(object):
         # if normalized by monitor-2, range have to be established before
         # shifting the instrument
         self._mon2_norm_time_range = None
+        # WB may not have monitors. In this case the property have to be set to True
+        # and WB normalization will not fail but will run normalize by current
+        self.__in_white_normalization = False
         self._debug_mode = False
         self.spectra_masks = None
 


### PR DESCRIPTION
This fixes issue http://trac.mantidproject.org/mantid/ticket/11822

The fix is easer to understand by using code review then to reproduce. See the track for the script which provide error, but I may assure a tester that it works after the fix and fails before it. 
If tester decides to reproduce error -- no need to sum all files -- one input file is enough. And watch the end of the script -- I am setting my data folder there -- you should choose yours. 

Apparently, at some combination of input parameters the property in question is left uninitialized. The solution naturally is to initialize the properly in constructor.  

Changes are just trivial and work - no much to test here. 
