### PR TITLE
Add XScaling parameter to TabulatedFunction

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/TabulatedFunction.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/TabulatedFunction.h
@@ -102,7 +102,7 @@ private:
   void clear() const;
 
   /// Evaluate the function for a list of arguments and given scaling factor
-  void eval(double scaling, double shift, double *out, const double *xValues,
+  void eval(double scaling, double shift, double xscale, double *out, const double *xValues,
             const size_t nData) const;
 
   /// Fill in the x and y value containers (m_xData and m_yData)

--- a/Code/Mantid/Framework/CurveFitting/test/TabulatedFunctionTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/TabulatedFunctionTest.h
@@ -50,7 +50,7 @@ public:
     UserFunction fun;
     fun.setAttributeValue("Formula","exp(-x*x)");
     fun.function( x, y );
-    
+
     std::ofstream fil(m_asciiFileName.c_str());
     for(size_t i = 0; i < x.size(); ++i)
     {
@@ -58,11 +58,11 @@ public:
     }
 
   }
-  
+
   ~TabulatedFunctionTest()
   {
     Poco::File hAscii(m_asciiFileName);
-    if( hAscii.exists() ) 
+    if( hAscii.exists() )
     {
       hAscii.remove();
     }
@@ -205,12 +205,14 @@ public:
     TS_ASSERT_EQUALS( fun.getParameter( "Scaling" ), 3.3 );
     fun.setParameter( "Shift", 0.0 );
     TS_ASSERT_EQUALS( fun.getParameter( "Shift" ), 0.0 );
+    fun.setParameter( "XScaling", 1.0 );
+    TS_ASSERT_EQUALS( fun.getParameter( "XScaling" ), 1.0 );
     FunctionDomain1DVector x(-5.0, 5.0, 83);
 
     FunctionValues y( x );
     fun.function( x, y );
 
-    Mantid::CurveFitting::Jacobian jac(x.size(),2);
+    Mantid::CurveFitting::Jacobian jac(x.size(),3);
     fun.functionDeriv(x, jac);
 
     for(size_t i = 0; i < x.size(); ++i)
@@ -239,7 +241,7 @@ public:
 
   void test_factory_create_from_file()
   {
-      std::string inif = "name=TabulatedFunction,FileName=\"" + m_nexusFileName + "\",WorkspaceIndex=17,Scaling=2,Shift=0.02";
+      std::string inif = "name=TabulatedFunction,FileName=\"" + m_nexusFileName + "\",WorkspaceIndex=17,Scaling=2,Shift=0.02,XScaling=0.2";
       auto funf = Mantid::API::FunctionFactory::Instance().createInitialized(inif);
       TS_ASSERT( funf );
       TS_ASSERT_EQUALS( funf->getAttribute("Workspace").asString(), "");
@@ -247,13 +249,14 @@ public:
       TS_ASSERT_EQUALS( funf->getAttribute("FileName").asUnquotedString(), m_nexusFileName);
       TS_ASSERT_EQUALS( funf->getParameter("Scaling"), 2.0);
       TS_ASSERT_EQUALS( funf->getParameter("Shift"), 0.02);
+      TS_ASSERT_EQUALS( funf->getParameter("XScaling"), 0.2);
   }
 
   void test_factory_create_from_workspace()
   {
       auto ws = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(Fun(),1,-5.0,5.0,0.1,false);
       AnalysisDataService::Instance().add( "TABULATEDFUNCTIONTEST_WS", ws );
-      std::string inif = "name=TabulatedFunction,Workspace=TABULATEDFUNCTIONTEST_WS,WorkspaceIndex=71,Scaling=3.14,Shift=0.02";
+      std::string inif = "name=TabulatedFunction,Workspace=TABULATEDFUNCTIONTEST_WS,WorkspaceIndex=71,Scaling=3.14,Shift=0.02,XScaling=0.2";
       auto funf = Mantid::API::FunctionFactory::Instance().createInitialized(inif);
       TS_ASSERT( funf );
       TS_ASSERT_EQUALS( funf->getAttribute("Workspace").asString(), "TABULATEDFUNCTIONTEST_WS");
@@ -261,6 +264,7 @@ public:
       TS_ASSERT_EQUALS( funf->getAttribute("FileName").asUnquotedString(), "");
       TS_ASSERT_EQUALS( funf->getParameter("Scaling"), 3.14);
       TS_ASSERT_EQUALS( funf->getParameter("Shift"), 0.02);
+      TS_ASSERT_EQUALS( funf->getParameter("XScaling"), 0.2);
       AnalysisDataService::Instance().clear();
   }
 


### PR DESCRIPTION
Fixes #12590 

To test:
- Create a sample workspace with a single peak.
- Clone it and scale the X values by a factor
- Fit one of the workspaces to the other using TabuilatedFunction
- The XScaling parameter should match the factor you scaled by
