### PR TITLE
Expose Group to Python interface

### DIFF
--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
@@ -134,6 +134,13 @@ public:
     Hexagonal
   };
 
+  enum GroupAxiom {
+      Closure,
+      Identity,
+      Inversion,
+      Associativity
+  };
+
   Group();
   Group(const std::string &symmetryOperationString);
   Group(const std::vector<SymmetryOperation> &symmetryOperations);
@@ -145,6 +152,7 @@ public:
   size_t order() const;
   CoordinateSystem getCoordinateSystem() const;
   std::vector<SymmetryOperation> getSymmetryOperations() const;
+  bool containsOperation(const SymmetryOperation &operation) const;
 
   Group operator*(const Group &other) const;
 
@@ -153,12 +161,20 @@ public:
   bool operator==(const Group &other) const;
   bool operator!=(const Group &other) const;
 
+  bool fulfillsAxiom(GroupAxiom axiom) const;
+  bool isGroup() const;
+
 protected:
   void setSymmetryOperations(
       const std::vector<SymmetryOperation> &symmetryOperations);
 
   CoordinateSystem getCoordinateSystemFromOperations(
       const std::vector<SymmetryOperation> &symmetryOperations) const;
+
+  bool isClosed() const;
+  bool hasIdentity() const;
+  bool eachElementHasInverse() const;
+  bool associativityHolds() const;
 
   std::vector<SymmetryOperation> m_allOperations;
   std::set<SymmetryOperation> m_operationSet;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/Group.h
@@ -135,10 +135,10 @@ public:
   };
 
   enum GroupAxiom {
-      Closure,
-      Identity,
-      Inversion,
-      Associativity
+    Closure,
+    Identity,
+    Inversion,
+    Associativity
   };
 
   Group();
@@ -190,6 +190,14 @@ namespace GroupFactory {
 template <typename T>
 Group_const_sptr create(const std::string &initializationString) {
   return boost::make_shared<const T>(initializationString);
+}
+
+/// Creates a Group sub-class of type T if T has a constructor that takes a
+/// vector of SymmetryOperations.
+template <typename T>
+Group_const_sptr
+create(const std::vector<SymmetryOperation> &symmetryOperations) {
+  return boost::make_shared<const T>(symmetryOperations);
 }
 }
 

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
@@ -170,6 +170,11 @@ protected:
   std::string m_identifier;
 };
 
+MANTID_GEOMETRY_DLL std::ostream &operator<<(
+    std::ostream &stream, const SymmetryOperation &operation);
+MANTID_GEOMETRY_DLL std::istream &operator>>(std::istream &stream,
+                                             SymmetryOperation &operation);
+
 MANTID_GEOMETRY_DLL V3R getWrappedVector(const V3R &vector);
 MANTID_GEOMETRY_DLL Kernel::V3D getWrappedVector(const Kernel::V3D &vector);
 

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
@@ -125,7 +125,7 @@ public:
   SymmetryOperation(const SymmetryOperation &other);
   SymmetryOperation &operator=(const SymmetryOperation &other);
 
-  virtual ~SymmetryOperation() {}
+  ~SymmetryOperation() {}
 
   const Kernel::IntMatrix &matrix() const;
   const V3R &vector() const;

--- a/Code/Mantid/Framework/Geometry/src/Crystal/Group.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/Group.cpp
@@ -227,9 +227,7 @@ bool Group::eachElementHasInverse() const {
  *
  * @return True if associativity holds
  */
-bool Group::associativityHolds() const {
-
-    return true;}
+bool Group::associativityHolds() const { return true; }
 
 /// Convenience operator* for directly multiplying groups using shared
 /// pointers.

--- a/Code/Mantid/Framework/Geometry/src/Crystal/Group.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/Group.cpp
@@ -190,26 +190,10 @@ bool Group::isClosed() const {
   return true;
 }
 
-/// Returns true if the group has an identity element.
+/// Returns true if the group has the identity element.
 bool Group::hasIdentity() const {
-  // Iterate through all operations
-  for (auto op = m_allOperations.begin(); op != m_allOperations.end(); ++op) {
-
-    // Combine op with each operation, until all operations are compared.
-    auto otherOp = m_allOperations.begin();
-    while (otherOp != m_allOperations.end() &&
-           (((*op) * (*otherOp)) == (*otherOp))) {
-      ++otherOp;
-    }
-
-    // If all operations have been compared, op leaves all operations unchanged.
-    if (otherOp == m_allOperations.end()) {
-      return true;
-    }
-  }
-
-  // At this point none of the operations has left all operations unchanged.
-  return false;
+  // Since the identity element does not change, this is an easy check.
+  return containsOperation(SymmetryOperation());
 }
 
 /// Returns true if the inverse of each element is in the group
@@ -224,25 +208,28 @@ bool Group::eachElementHasInverse() const {
   return true;
 }
 
-/// Checks that associativity holds, i.e. (a*b)*c == a*(b*c)
+/**
+ * Checks that associativity holds, i.e. (a*b)*c == a*(b*c)
+ *
+ * In fact, this method returns always true, because associativity is implicitly
+ * contained in the definition of the binary operator of SymmetryOperation:
+ *
+ *      (S1 * S2) * S3
+ *      = (W1*W2, W1*w2 + w1) * S3
+ *      = (W1*W2*W3, W1*W2*w3 + W1*w2 + w1)
+ *
+ *      S1 * (S2 * S3)
+ *      = S1 * (W2*W3, W2*w3 + w2)
+ *      = (W1*W2*W3, W1*W2*w3 + W1*w2 + w1)
+ *
+ * No matter what symmetry operations are chosen, this always holds. However,
+ * for completeness the method has been added anyway.
+ *
+ * @return True if associativity holds
+ */
 bool Group::associativityHolds() const {
-  SymmetryOperation thirdOp =
-      SymmetryOperationFactory::Instance().createSymOp("-x,-y,-z");
 
-  for (auto op = m_allOperations.begin(); op != m_allOperations.end(); ++op) {
-    for (auto otherOp = m_allOperations.begin();
-         otherOp != m_allOperations.end(); ++otherOp) {
-      SymmetryOperation first = ((*op) * (*otherOp)) * thirdOp;
-      SymmetryOperation second = (*op) * ((*otherOp) * thirdOp);
-
-      if (first != second) {
-        return false;
-      }
-    }
-  }
-
-  return true;
-}
+    return true;}
 
 /// Convenience operator* for directly multiplying groups using shared
 /// pointers.

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryOperation.cpp
@@ -271,5 +271,31 @@ Kernel::V3D getWrappedVector(const Kernel::V3D &vector) {
   return wrappedVector;
 }
 
+/// Stream output operator, writes the identifier to stream.
+std::ostream &operator<<(std::ostream &stream,
+                         const SymmetryOperation &operation) {
+  stream << "[" + operation.identifier() + "]";
+
+  return stream;
+}
+
+/// Reads identifier from stream and tries to parse as a symbol.
+std::istream &operator>>(std::istream &stream, SymmetryOperation &operation) {
+  std::string identifier;
+  std::getline(stream, identifier);
+
+  size_t i = identifier.find_first_of('[');
+  size_t j = identifier.find_last_of(']');
+
+  if (i == std::string::npos || j == std::string::npos) {
+    throw std::runtime_error(
+        "Cannot construct SymmetryOperation from identifier: " + identifier);
+  }
+
+  operation = SymmetryOperation(identifier.substr(i + 1, j - i - 1));
+
+  return stream;
+}
+
 } // namespace Geometry
 } // namespace Mantid

--- a/Code/Mantid/Framework/Geometry/test/GroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/GroupTest.h
@@ -220,6 +220,76 @@ public:
     TS_ASSERT(!lessThan(v7, v1));
   }
 
+  void testContainsOperation() {
+    Group group("x,y,z; -x,-y,-z");
+
+    std::vector<SymmetryOperation> ops = group.getSymmetryOperations();
+    TS_ASSERT(group.containsOperation(ops[0]));
+    TS_ASSERT(group.containsOperation(ops[1]));
+
+    SymmetryOperation mirror =
+        SymmetryOperationFactory::Instance().createSymOp("x,y,-z");
+
+    TS_ASSERT(!group.containsOperation(mirror));
+  }
+
+  void testGroupAxiomClosure() {
+    Group properGroup("x,y,z; -x,-y,-z; x,y,-z; -x,-y,z");
+    TS_ASSERT(properGroup.fulfillsAxiom(Group::Closure));
+
+    // Is not closed anymore
+    Group noClosure("x,y,z; -x,-y,-z; x,y,-z");
+    TS_ASSERT(!noClosure.fulfillsAxiom(Group::Closure));
+
+    // But the other axioms still hold
+    TS_ASSERT(noClosure.fulfillsAxiom(Group::Identity));
+    TS_ASSERT(noClosure.fulfillsAxiom(Group::Inversion));
+    TS_ASSERT(noClosure.fulfillsAxiom(Group::Associativity));
+  }
+
+  void testGroupAxiomIdentity() {
+    Group properGroup("x,y,z; -x,-y,-z; x,y,-z; -x,-y,z");
+    TS_ASSERT(properGroup.fulfillsAxiom(Group::Identity));
+
+    // Is does not have identity anymore
+    Group noIdentity("-x,-y,-z; x,y,-z");
+    TS_ASSERT(!noIdentity.fulfillsAxiom(Group::Identity));
+
+    // Closure is lost as well
+    TS_ASSERT(!noIdentity.fulfillsAxiom(Group::Closure));
+
+    // While the other two still hold
+    TS_ASSERT(noIdentity.fulfillsAxiom(Group::Inversion));
+    TS_ASSERT(noIdentity.fulfillsAxiom(Group::Associativity));
+  }
+
+  void testGroupAxiomInversion() {
+    Group properGroup("x,y,z; -x,-y,-z; x,y,-z; -x,-y,z");
+    TS_ASSERT(properGroup.fulfillsAxiom(Group::Inversion));
+
+    // Is does not have the identity anymore
+    Group noInversion("x,y,z; -y,x,z");
+    TS_ASSERT(!noInversion.fulfillsAxiom(Group::Inversion));
+
+    // Closure is lost as well
+    TS_ASSERT(!noInversion.fulfillsAxiom(Group::Closure));
+
+    // While the other two still hold
+    TS_ASSERT(noInversion.fulfillsAxiom(Group::Associativity));
+    TS_ASSERT(noInversion.fulfillsAxiom(Group::Identity));
+  }
+
+  void testIsGroup() {
+    Group properGroup("x,y,z; -x,-y,-z; x,y,-z; -x,-y,z");
+    TS_ASSERT(properGroup.isGroup());
+
+    Group noClosure("x,y,z; -x,-y,-z; x,y,-z");
+    TS_ASSERT(!noClosure.isGroup());
+
+    Group noIdentity("-x,-y,-z; x,y,-z; -x,-y,z");
+    TS_ASSERT(!noIdentity.isGroup());
+  }
+
   void testSmartPointerOperators() {
     // We take pointgroup -1
     std::vector<SymmetryOperation> inversion;

--- a/Code/Mantid/Framework/Geometry/test/PointGroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/PointGroupTest.h
@@ -24,6 +24,8 @@ public:
     {
         PointGroup_sptr testedPointGroup = PointGroupFactory::Instance().createPointGroup(name);
 
+        TSM_ASSERT(name + ": Does not fulfill group axioms!", testedPointGroup->isGroup());
+
         std::vector<V3D> equivalents = testedPointGroup->getEquivalents(hkl);
         // check that the number of equivalent reflections is as expected.
         TSM_ASSERT_EQUALS(name + ": Expected " + boost::lexical_cast<std::string>(numEquiv) + " equivalents, got " + boost::lexical_cast<std::string>(equivalents.size()) + " instead.", equivalents.size(), numEquiv);

--- a/Code/Mantid/Framework/Geometry/test/SymmetryOperationTest.h
+++ b/Code/Mantid/Framework/Geometry/test/SymmetryOperationTest.h
@@ -6,6 +6,7 @@
 #include "MantidGeometry/Crystal/SymmetryOperation.h"
 #include "MantidGeometry/Crystal/SymmetryOperationSymbolParser.h"
 
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/V3D.h"
 
 #include <boost/make_shared.hpp>
@@ -274,6 +275,38 @@ public:
         TS_ASSERT_EQUALS(fourFoldZ^1, fourFoldZ);
         TS_ASSERT_EQUALS(fourFoldZ^2, twoFoldZ);
         TS_ASSERT_EQUALS(fourFoldZ^4, identity);
+    }
+
+    void testStreamOperatorOut()
+    {
+        SymmetryOperation mirror("x,-y,z");
+
+        std::stringstream stream;
+        stream << mirror;
+
+        TS_ASSERT_EQUALS(stream.str(), "[x,-y,z]");
+    }
+
+    void testStreamOperatorIn()
+    {
+        std::stringstream stream;
+        stream << "[x,-y,z]";
+
+        SymmetryOperation mirror;
+        TS_ASSERT_DIFFERS(mirror.identifier(), "x,-y,z");
+
+        TS_ASSERT_THROWS_NOTHING(stream >> mirror);
+        TS_ASSERT_EQUALS(mirror.identifier(), "x,-y,z");
+
+        // no []
+        std::stringstream invalidBrackets;
+        invalidBrackets << "x,-y,z";
+        TS_ASSERT_THROWS(invalidBrackets >> mirror, std::runtime_error);
+
+        // invalid string
+        std::stringstream invalid;
+        invalid << "[someString]";
+        TS_ASSERT_THROWS(invalid >> mirror, Exception::ParseError);
     }
 
 private:

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -32,11 +32,20 @@ void export_Group()
       .value("Orthogonal", Group::Orthogonal)
       .value("Hexagonal", Group::Hexagonal);
 
+  enum_<Group::GroupAxiom>("GroupAxiom")
+      .value("Closure", Group::Closure)
+      .value("Identity", Group::Identity)
+      .value("Inversion", Group::Inversion)
+      .value("Associativity", Group::Associativity);
+
   class_<Group>("Group")
       .def(init<std::string>("Construct a group from the provided initializer string."))
       .def(init<std::vector<SymmetryOperation> >("Construct a group from the provided symmetry operation list."))
       .def("getOrder", &Group::order, "Returns the order of the group.")
       .def("getCoordinateSystem", &Group::getCoordinateSystem, "Returns the type of coordinate system to distinguish groups with hexagonal system definition.")
       .def("getSymmetryOperations", &Group::getSymmetryOperations, "Returns the symmetry operations contained in the group.")
-      .def("getSymmetryOperationStrings", &getSymmetryOperationStrings, "Returns the x,y,z-strings for the contained symmetry operations.");
+      .def("getSymmetryOperationStrings", &getSymmetryOperationStrings, "Returns the x,y,z-strings for the contained symmetry operations.")
+      .def("containsOperation", &Group::containsOperation, "Checks whether a SymmetryOperation is included in Group.")
+      .def("isGroup", &Group::isGroup, "Checks whether the contained symmetry operations fulfill the group axioms.")
+      .def("fulfillAxiom", &Group::fulfillsAxiom, "Checks if the contained symmetry operations fulfill the specified group axiom.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -5,8 +5,10 @@
 #include <boost/python/enum.hpp>
 #include <boost/python/scope.hpp>
 #include <boost/python/list.hpp>
+#include <boost/python/stl_iterator.hpp>
+#include <boost/python/make_constructor.hpp>
 
-using Mantid::Geometry::Group;
+using namespace Mantid::Geometry;
 using Mantid::Geometry::SymmetryOperation;
 
 using namespace boost::python;
@@ -21,6 +23,16 @@ namespace {
       }
 
       return pythonSymOps;
+    }
+
+    Group * constructGroupFromPythonList(const boost::python::list &symOpList) {
+        std::vector<SymmetryOperation> operations;
+
+        for(int i = 0; i < len(symOpList); ++i) {
+            operations.push_back(boost::python::extract<SymmetryOperation>(symOpList[i]));
+        }
+
+        return new Group(operations);
     }
 }
 
@@ -41,6 +53,7 @@ void export_Group()
   class_<Group>("Group")
       .def(init<std::string>("Construct a group from the provided initializer string."))
       .def(init<std::vector<SymmetryOperation> >("Construct a group from the provided symmetry operation list."))
+      .def("__init__", make_constructor(&constructGroupFromPythonList), "Construct a group from a python generated symmetry operation list.")
       .def("getOrder", &Group::order, "Returns the order of the group.")
       .def("getCoordinateSystem", &Group::getCoordinateSystem, "Returns the type of coordinate system to distinguish groups with hexagonal system definition.")
       .def("getSymmetryOperations", &Group::getSymmetryOperations, "Returns the symmetry operations contained in the group.")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -22,17 +22,6 @@ namespace {
 
       return pythonSymOps;
     }
-
-    boost::python::list getSymmetryOperations(Group &self) {
-      const std::vector<SymmetryOperation> &symOps = self.getSymmetryOperations();
-
-      boost::python::list pythonSymOps;
-      for (auto it = symOps.begin(); it != symOps.end(); ++it) {
-        pythonSymOps.append(*it);
-      }
-
-      return pythonSymOps;
-    }
 }
 
 // clang-format off
@@ -43,9 +32,11 @@ void export_Group()
       .value("Orthogonal", Group::Orthogonal)
       .value("Hexagonal", Group::Hexagonal);
 
-  class_<Group, boost::noncopyable>("Group", no_init)
+  class_<Group>("Group")
+      .def(init<std::string>("Construct a group from the provided initializer string."))
+      .def(init<std::vector<SymmetryOperation> >("Construct a group from the provided symmetry operation list."))
       .def("getOrder", &Group::order, "Returns the order of the group.")
       .def("getCoordinateSystem", &Group::getCoordinateSystem, "Returns the type of coordinate system to distinguish groups with hexagonal system definition.")
-      .def("getSymmetryOperations", &getSymmetryOperations, "Returns the symmetry operations contained in the group.")
+      .def("getSymmetryOperations", &Group::getSymmetryOperations, "Returns the symmetry operations contained in the group.")
       .def("getSymmetryOperationStrings", &getSymmetryOperationStrings, "Returns the x,y,z-strings for the contained symmetry operations.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -60,5 +60,5 @@ void export_Group()
       .def("getSymmetryOperationStrings", &getSymmetryOperationStrings, "Returns the x,y,z-strings for the contained symmetry operations.")
       .def("containsOperation", &Group::containsOperation, "Checks whether a SymmetryOperation is included in Group.")
       .def("isGroup", &Group::isGroup, "Checks whether the contained symmetry operations fulfill the group axioms.")
-      .def("fulfillAxiom", &Group::fulfillsAxiom, "Checks if the contained symmetry operations fulfill the specified group axiom.");
+      .def("fulfillsAxiom", &Group::fulfillsAxiom, "Checks if the contained symmetry operations fulfill the specified group axiom.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
@@ -2,6 +2,7 @@
 #include "MantidGeometry/Crystal/SymmetryOperation.h"
 #include "MantidPythonInterface/kernel/Converters/PyObjectToV3D.h"
 #include "MantidPythonInterface/kernel/Converters/PyObjectToMatrix.h"
+#include "MantidPythonInterface/kernel/StlExportDefinitions.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/enum.hpp>
@@ -10,6 +11,7 @@
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::Geometry::SymmetryOperation;
+using Mantid::PythonInterface::std_vector_exporter;
 
 using namespace boost::python;
 
@@ -40,5 +42,7 @@ void export_SymmetryOperation()
           .def("transformCoordinates", &applyToCoordinates, "Returns transformed coordinates. For transforming HKLs, use transformHKL.")
           .def("transformHKL", &applyToVector, "Returns transformed HKLs. For transformation of coordinates use transformCoordinates.")
           .def("apply", &applyToVector, "An alias for transformHKL.");
+
+  std_vector_exporter<Mantid::Geometry::SymmetryOperation>::wrap("std_vector_symmetryoperation");
 }
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/test/python/mantid/geometry/CMakeLists.txt
@@ -16,6 +16,7 @@ set ( TEST_PY_FILES
   SpaceGroupTest.py
   SymmetryElementTest.py
   SymmetryOperationTest.py
+  GroupTest.py
 )
 
 check_tests_valid ( ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES} )

--- a/Code/Mantid/Framework/PythonInterface/test/python/mantid/geometry/GroupTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/mantid/geometry/GroupTest.py
@@ -1,0 +1,33 @@
+#pylint: disable=no-init,invalid-name,too-many-public-methods
+import unittest
+from mantid.geometry import Group, SpaceGroupFactory
+
+class GroupTest(unittest.TestCase):
+    def test_creationFromString(self):
+        group = Group('x,y,z')
+        self.assertEqual(group.getOrder(), 1)
+
+        self.assertRaises(RuntimeError, Group, 'invalid')
+
+    def test_creationFromVector(self):
+        spaceGroup = SpaceGroupFactory.createSpaceGroup("P 63/m m c")
+        symOps = spaceGroup.getSymmetryOperations()
+
+        group = Group(symOps)
+        self.assertEqual(group.getOrder(), spaceGroup.getOrder())
+
+    def test_creationFromPythonList(self):
+        spaceGroup = SpaceGroupFactory.createSpaceGroup("P 63/m m c")
+
+        # Construct python list of only certain symmetry operations
+        symOps = [x for x in spaceGroup.getSymmetryOperations() if x.getOrder() == 6]
+
+        group = Group(symOps)
+        self.assertEqual(group.getOrder(), len(symOps))
+
+        # But the constructed group is not actually a group
+        self.assertFalse(group.isGroup())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupFactoryTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupFactoryTest.py
@@ -21,6 +21,10 @@ class SpaceGroupFactoryTest(stresstesting.MantidStressTest):
     def checkSpaceGroup(self, symbol):
         group = SpaceGroupFactory.createSpaceGroup(symbol)
 
+        self.assertTrue(group.isGroup(),
+                        ("Space group " + str(group.getNumber()) + " (" + symbol + ") does not "
+                        "fulfill group axioms"))
+
         groupOperations = set(group.getSymmetryOperationStrings())
         referenceOperations = self.spaceGroupData[group.getNumber()]
 

--- a/Code/Mantid/docs/source/concepts/SymmetryGroups.rst
+++ b/Code/Mantid/docs/source/concepts/SymmetryGroups.rst
@@ -255,8 +255,74 @@ As more operations are added to a group, it can be useful to display the group i
       - :math:`2`
       - :math:`\bar{1}`
       - :math:`1`
-      
-Combining the symmetry operations does not result into any new operations, so the group is closed. Each element has an inverse (in this case, each element is its own inverse). :math:` and an identity element exists (all elements in the first row are the same as in the header row).
+
+Combining the symmetry operations does not result into any new operations, so the group is closed. Each element has an inverse (in this case, each element is its own inverse). :math:` and an identity element exists (all elements in the first row are the same as in the header row). Groups are available through the Python interface of Mantid. The following code generates the group in the table above (with the y-axis being characteristic for rotation and mirror symmetry) and checks whether this set of symmetry operations is indeed a Group:
+
+.. testcode:: ExSymmetryGroup
+
+    from mantid.geometry import Group
+
+    group = Group("x,y,z; -x,-y,-z; -x,y,-z; x,-y,z")
+
+    print "Order of group:", group.getOrder()
+    print "Fulfills group axioms:", group.isGroup()
+
+This code confirms what was demonstrated by the group table above, the specified set of symmetry operations fulfills the group axioms:
+
+.. testoutput:: ExSymmetryGroup
+
+    Order of group: 4
+    Fulfills group axioms: True
+
+For more fine-grained information, the four axioms can also be checked separately. Please note that the associativity axiom is always fulfilled due to the way the binary operation for symmetry operations is defined, it's included for completeness reasons. In the next example, the inversion operation is removed and the four axioms are checked:
+
+.. testcode:: ExSymmetryGroupAxioms
+
+    from mantid.geometry import Group, GroupAxiom
+
+    group = Group("x,y,z; -x,y,-z; x,-y,z")
+
+    print "Group axioms fulfilled:"
+    print "  1. Closure:", group.fulfillsAxiom(GroupAxiom.Closure)
+    print "  2. Associativity:", group.fulfillsAxiom(GroupAxiom.Associativity)
+    print "  3. Identity:", group.fulfillsAxiom(GroupAxiom.Identity)
+    print "  4. Inversion:", group.fulfillsAxiom(GroupAxiom.Inversion)
+
+The code reveals that axioms 2 - 4 are fulfilled, but that the group is not closed:
+
+.. testoutput:: ExSymmetryGroupAxioms
+
+    Group axioms fulfilled:
+      1. Closure: False
+      2. Associativity: True
+      3. Identity: True
+      4. Inversion: True
+
+Looking into the group table above shows the reason: The combination of a mirror plane and a two-fold rotation axis implies the the presence of an inversion center. Similarly, the identity can be removed:
+
+.. testcode:: ExSymmetryGroupAxiomsIdentity
+
+    from mantid.geometry import Group, GroupAxiom
+
+    group = Group("-x,-y,-z; -x,y,-z; x,-y,z")
+
+    print "Group axioms fulfilled:"
+    print "  1. Closure:", group.fulfillsAxiom(GroupAxiom.Closure)
+    print "  2. Associativity:", group.fulfillsAxiom(GroupAxiom.Associativity)
+    print "  3. Identity:", group.fulfillsAxiom(GroupAxiom.Identity)
+    print "  4. Inversion:", group.fulfillsAxiom(GroupAxiom.Inversion)
+
+In contrast to removing the inversion, the group now also lacks an identity element:
+
+.. testoutput:: ExSymmetryGroupAxiomsIdentity
+
+    Group axioms fulfilled:
+      1. Closure: False
+      2. Associativity: True
+      3. Identity: False
+      4. Inversion: True
+
+Using these specific checks can be helpful for finding out why a certain set of symmetry operations is not a group.
 
 Some groups are so called cyclic groups, all elements of the group can be expressed as powers of one symmetry operation (which are explained above) from 0 to :math:`k-1`, where `k` is the order of the operation. The group with elements :math:`1` and :math:`2` is an example for such a cyclic group, it can be expressed as :math:`2^0 = 1` and :math:`2^1 = 2`.
 


### PR DESCRIPTION
This fixes [#11830](http://trac.mantidproject.org/mantid/ticket/11830).

Since it is now possible to construct groups from lists of symmetry operations, code to check the group axioms was added (this is now also used in the point/space group tests to make sure). Group is directly exposed via the Python interface, the documentation has been updated.

**Testing information**
Code review. Read the additions to the documentation. The new usage example in the point and space group documentation can be checked using the [WYCKPOS](http://www.cryst.ehu.es/cryst/get_wp.html)-tool from the Bilbao Crystallographic Server. Choose space group no. 194 and proceed with standard settings (left button). Enter the coordinates from the example (x=0.31, y=0.62, z=0.25) and check that there are 4 symmetry operations. You could add the following to the usage example to compare the symmetry operations:

```
for op in siteSymmGroup.getSymmetryOperations():
    print op.getIdentifier()
```

The order of the operations may differ, but the operations should be the same. If you like, you could play with different space groups/positions.
