### PR TITLE
Fix "uninitialized..." coverity issues in MantidPlot component

### DIFF
--- a/Code/Mantid/MantidPlot/src/ColorMapDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/ColorMapDialog.cpp
@@ -34,31 +34,31 @@
 #include <QLayout>
 
 ColorMapDialog::ColorMapDialog(QWidget* parent, Qt::WFlags fl)
-	: QDialog(parent, fl)
+  : QDialog(parent, fl), applyBtn(NULL), closeBtn(NULL), editor(NULL), d_matrix(NULL),
 {
-setObjectName( "ColorMapDialog" );
-setWindowTitle(tr("MantidPlot") + " - " + tr("Custom Color Map"));
-editor = new ColorMapEditor();
+  setObjectName( "ColorMapDialog" );
+  setWindowTitle(tr("MantidPlot") + " - " + tr("Custom Color Map"));
+  editor = new ColorMapEditor();
 	
-applyBtn = new QPushButton(tr("&Apply"));
-connect(applyBtn, SIGNAL(clicked()), this, SLOT(apply()));
+  applyBtn = new QPushButton(tr("&Apply"));
+  connect(applyBtn, SIGNAL(clicked()), this, SLOT(apply()));
 
-closeBtn = new QPushButton(tr("&Close"));
-connect(closeBtn, SIGNAL(clicked()), this, SLOT(reject()));
+  closeBtn = new QPushButton(tr("&Close"));
+  connect(closeBtn, SIGNAL(clicked()), this, SLOT(reject()));
 
-QHBoxLayout* hb = new QHBoxLayout();
-hb->setSpacing(5);
-hb->addStretch();
-hb->addWidget(applyBtn);
-hb->addWidget(closeBtn);
-hb->addStretch();
+  QHBoxLayout* hb = new QHBoxLayout();
+  hb->setSpacing(5);
+  hb->addStretch();
+  hb->addWidget(applyBtn);
+  hb->addWidget(closeBtn);
+  hb->addStretch();
 	
-QVBoxLayout* vl = new QVBoxLayout(this);
-vl->setSpacing(0);
-vl->addWidget(editor);	
-vl->addLayout(hb);
+  QVBoxLayout* vl = new QVBoxLayout(this);
+  vl->setSpacing(0);
+  vl->addWidget(editor);
+  vl->addLayout(hb);
 	
-setMaximumWidth(editor->width() + 20);
+  setMaximumWidth(editor->width() + 20);
 }
 
 void ColorMapDialog::setMatrix(Matrix *m)

--- a/Code/Mantid/MantidPlot/src/ColorMapDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/ColorMapDialog.cpp
@@ -34,7 +34,7 @@
 #include <QLayout>
 
 ColorMapDialog::ColorMapDialog(QWidget* parent, Qt::WFlags fl)
-  : QDialog(parent, fl), applyBtn(NULL), closeBtn(NULL), editor(NULL), d_matrix(NULL),
+  : QDialog(parent, fl), applyBtn(NULL), closeBtn(NULL), editor(NULL), d_matrix(NULL)
 {
   setObjectName( "ColorMapDialog" );
   setWindowTitle(tr("MantidPlot") + " - " + tr("Custom Color Map"));

--- a/Code/Mantid/MantidPlot/src/ContourLinesEditor.cpp
+++ b/Code/Mantid/MantidPlot/src/ContourLinesEditor.cpp
@@ -45,9 +45,21 @@
 
 ContourLinesEditor::ContourLinesEditor(const QLocale& locale, int precision, QWidget* parent)
 				: QWidget(parent),
-				d_spectrogram(NULL),
-				d_locale(locale),
-				d_precision(precision)
+                                  table(NULL),
+                                  insertBtn(NULL),
+                                  deleteBtn(NULL),
+                                  d_spectrogram(NULL),
+                                  d_locale(locale),
+                                  d_precision(precision),
+                                  penDialog(NULL),
+                                  penColorBox(NULL),
+                                  penStyleBox(NULL),
+                                  penWidthBox(NULL),
+                                  applyAllColorBox(NULL),
+                                  applyAllWidthBox(NULL),
+                                  applyAllStyleBox(NULL),
+                                  d_pen_index(0),
+                                  d_pen_list()
 {
 	table = new QTableWidget();
 	table->setColumnCount(2);

--- a/Code/Mantid/MantidPlot/src/CurveRangeDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/CurveRangeDialog.cpp
@@ -39,43 +39,43 @@
 #include <QSpinBox>
 
 CurveRangeDialog::CurveRangeDialog(QWidget* parent, Qt::WFlags fl )
-    : QDialog( parent, fl )
+  : QDialog( parent, fl ), d_curve(NULL), d_graph(NULL)
 {
-	setWindowTitle(tr("MantidPlot - Plot range"));
+    setWindowTitle(tr("MantidPlot - Plot range"));
     setName( "CurveRangeDialog" );
 
     QGroupBox *gb1 = new QGroupBox();
     QGridLayout *gl1 = new QGridLayout(gb1);
-	gl1->addWidget(new QLabel(tr("Data set: ")), 0, 0);
+    gl1->addWidget(new QLabel(tr("Data set: ")), 0, 0);
 
-	boxName = new QLabel();
-	gl1->addWidget(boxName, 0, 1);
+    boxName = new QLabel();
+    gl1->addWidget(boxName, 0, 1);
 
-	gl1->addWidget(new QLabel(tr("From row number")), 1, 0);
-	boxStart = new QSpinBox();
-	boxStart->setMinValue(1);
-	gl1->addWidget(boxStart, 1, 1);
+    gl1->addWidget(new QLabel(tr("From row number")), 1, 0);
+    boxStart = new QSpinBox();
+    boxStart->setMinValue(1);
+    gl1->addWidget(boxStart, 1, 1);
 
-	gl1->addWidget(new QLabel(tr("To row number")), 2, 0);
-	boxEnd = new QSpinBox();
-	boxEnd->setMinValue(1);
+    gl1->addWidget(new QLabel(tr("To row number")), 2, 0);
+    boxEnd = new QSpinBox();
+    boxEnd->setMinValue(1);
     gl1->addWidget(boxEnd, 2, 1);
     gl1->setRowStretch(3, 1);
 
-	buttonOK = new QPushButton(tr( "&OK" ));
+    buttonOK = new QPushButton(tr( "&OK" ));
     buttonOK->setDefault( true );
     buttonCancel = new QPushButton(tr( "&Close" ));
 
     QHBoxLayout *hl = new QHBoxLayout();
-	hl->addStretch();
- 	hl->addWidget(buttonOK);
-	hl->addWidget(buttonCancel);
+    hl->addStretch();
+    hl->addWidget(buttonOK);
+    hl->addWidget(buttonCancel);
 
     QVBoxLayout *vb = new QVBoxLayout(this);
     vb->addWidget(gb1);
     vb->addLayout(hl);
 
-	connect( buttonOK, SIGNAL( clicked() ), this, SLOT( accept() ) );
+    connect( buttonOK, SIGNAL( clicked() ), this, SLOT( accept() ) );
     connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
 }
 

--- a/Code/Mantid/MantidPlot/src/DataSetDialog.h
+++ b/Code/Mantid/MantidPlot/src/DataSetDialog.h
@@ -62,13 +62,12 @@ private:
   ApplicationWindow* d_app;
   Graph *d_graph;
   ApplicationWindow::Analysis d_operation;
-	QString windowTitle;
+  QString windowTitle;
 
-    QPushButton* buttonOk;
-	QPushButton* buttonCancel;
-    QGroupBox* groupBox1;
-    QCheckBox* boxShowFormula;
-	QComboBox* boxName;
+  QPushButton* buttonOk;
+  QPushButton* buttonCancel;
+  QGroupBox* groupBox1;
+  QComboBox* boxName;
 };
 
 #endif

--- a/Code/Mantid/MantidPlot/src/ExpDecayDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/ExpDecayDialog.cpp
@@ -41,8 +41,11 @@
 #include <QLineEdit>
 #include <QComboBox>
 
-	ExpDecayDialog::ExpDecayDialog(int type, QWidget* parent, Qt::WFlags fl )
-: QDialog( parent, fl )
+ExpDecayDialog::ExpDecayDialog(int type, QWidget* parent, Qt::WFlags fl )
+  : QDialog( parent, fl ), fitter(NULL), graph(NULL),
+    buttonFit(NULL), buttonCancel(NULL), boxName(NULL), boxAmplitude(NULL),
+    boxFirst(NULL), boxSecond(NULL), boxThird(NULL), boxStart(NULL), boxYOffset(NULL),
+    thirdLabel(NULL), dampingLabel(NULL), boxColor(NULL)
 {
     setName( "ExpDecayDialog" );
 

--- a/Code/Mantid/MantidPlot/src/FFTDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/FFTDialog.cpp
@@ -49,67 +49,70 @@
 #include <QApplication>
 
 FFTDialog::FFTDialog(int type, QWidget* parent, Qt::WFlags fl )
-: QDialog( parent, fl )
+  : QDialog( parent, fl ),
+    buttonOK(NULL), buttonCancel(NULL), forwardBtn(NULL), backwardBtn(NULL),
+    boxName(NULL), boxReal(NULL), boxImaginary(NULL),
+    boxSampling(NULL), boxNormalize(NULL), boxOrder(NULL)
 {
-	setWindowTitle(tr("MantidPlot - FFT Options"));
+    setWindowTitle(tr("MantidPlot - FFT Options"));
 
     d_matrix = 0;
-	d_table = 0;
-	graph = 0;
-	d_type = type;
+    d_table = 0;
+    graph = 0;
+    d_type = type;
 
-	forwardBtn = new QRadioButton(tr("&Forward"));
-	forwardBtn->setChecked( true );
-	backwardBtn = new QRadioButton(tr("&Inverse"));
+    forwardBtn = new QRadioButton(tr("&Forward"));
+    forwardBtn->setChecked( true );
+    backwardBtn = new QRadioButton(tr("&Inverse"));
 
-	QHBoxLayout *hbox1 = new QHBoxLayout();
+    QHBoxLayout *hbox1 = new QHBoxLayout();
     hbox1->addWidget(forwardBtn);
     hbox1->addWidget(backwardBtn);
 
-	QGroupBox *gb1 = new QGroupBox();
+    QGroupBox *gb1 = new QGroupBox();
     gb1->setLayout(hbox1);
 
-	QGridLayout *gl1 = new QGridLayout();
-	if (d_type == onGraph)
-	    gl1->addWidget(new QLabel(tr("Curve")), 0, 0);
-	else if (d_type == onTable)
-		gl1->addWidget(new QLabel(tr("Sampling")), 0, 0);
+    QGridLayout *gl1 = new QGridLayout();
+    if (d_type == onGraph)
+      gl1->addWidget(new QLabel(tr("Curve")), 0, 0);
+    else if (d_type == onTable)
+      gl1->addWidget(new QLabel(tr("Sampling")), 0, 0);
 
     if (d_type != onMatrix){
-        boxName = new QComboBox();
-        connect( boxName, SIGNAL( activated(const QString&) ), this, SLOT( activateCurve(const QString&) ) );
-        gl1->addWidget(boxName, 0, 1);
-        setFocusProxy(boxName);
+      boxName = new QComboBox();
+      connect( boxName, SIGNAL( activated(const QString&) ), this, SLOT( activateCurve(const QString&) ) );
+      gl1->addWidget(boxName, 0, 1);
+      setFocusProxy(boxName);
     }
 
     boxSampling = new QLineEdit();
-	if (d_type == onTable || d_type == onMatrix){
-		gl1->addWidget(new QLabel(tr("Real")), 1, 0);
-		boxReal = new QComboBox();
-		gl1->addWidget(boxReal, 1, 1);
+    if (d_type == onTable || d_type == onMatrix){
+      gl1->addWidget(new QLabel(tr("Real")), 1, 0);
+      boxReal = new QComboBox();
+      gl1->addWidget(boxReal, 1, 1);
 
-		gl1->addWidget(new QLabel(tr("Imaginary")), 2, 0);
-		boxImaginary = new QComboBox();
-		gl1->addWidget(boxImaginary, 2, 1);
+      gl1->addWidget(new QLabel(tr("Imaginary")), 2, 0);
+      boxImaginary = new QComboBox();
+      gl1->addWidget(boxImaginary, 2, 1);
 
-        if (d_type == onTable){
-            gl1->addWidget(new QLabel(tr("Sampling Interval")), 3, 0);
-            gl1->addWidget(boxSampling, 3, 1);
-        }
+      if (d_type == onTable){
+        gl1->addWidget(new QLabel(tr("Sampling Interval")), 3, 0);
+        gl1->addWidget(boxSampling, 3, 1);
+      }
     } else if (d_type == onGraph){
-        gl1->addWidget(new QLabel(tr("Sampling Interval")), 1, 0);
-		gl1->addWidget(boxSampling, 1, 1);
+      gl1->addWidget(new QLabel(tr("Sampling Interval")), 1, 0);
+      gl1->addWidget(boxSampling, 1, 1);
     }
 
- 	QGroupBox *gb2 = new QGroupBox();
+    QGroupBox *gb2 = new QGroupBox();
     gb2->setLayout(gl1);
 
-	boxNormalize = new QCheckBox(tr( "&Normalize Amplitude" ));
-	boxNormalize->setChecked(true);
+    boxNormalize = new QCheckBox(tr( "&Normalize Amplitude" ));
+    boxNormalize->setChecked(true);
 
     if (d_type != onMatrix){
-        boxOrder = new QCheckBox(tr( "&Shift Results" ));
-        boxOrder->setChecked(true);
+      boxOrder = new QCheckBox(tr( "&Shift Results" ));
+      boxOrder->setChecked(true);
     }
 
     QVBoxLayout *vbox1 = new QVBoxLayout();
@@ -117,14 +120,14 @@ FFTDialog::FFTDialog(int type, QWidget* parent, Qt::WFlags fl )
     vbox1->addWidget(gb2);
     vbox1->addWidget(boxNormalize);
     if (d_type != onMatrix)
-        vbox1->addWidget(boxOrder);
-	vbox1->addStretch();
+      vbox1->addWidget(boxOrder);
+    vbox1->addStretch();
 
     buttonOK = new QPushButton(tr("&OK"));
-	buttonOK->setDefault( true );
-	buttonCancel = new QPushButton(tr("&Close"));
+    buttonOK->setDefault( true );
+    buttonCancel = new QPushButton(tr("&Close"));
 
-	QVBoxLayout *vbox2 = new QVBoxLayout();
+    QVBoxLayout *vbox2 = new QVBoxLayout();
     vbox2->addWidget(buttonOK);
     vbox2->addWidget(buttonCancel);
     vbox2->addStretch();
@@ -133,9 +136,9 @@ FFTDialog::FFTDialog(int type, QWidget* parent, Qt::WFlags fl )
     hbox2->addLayout(vbox1);
     hbox2->addLayout(vbox2);
 
-	// signals and slots connections
-	connect( buttonOK, SIGNAL( clicked() ), this, SLOT( accept() ) );
-	connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
+    // signals and slots connections
+    connect( buttonOK, SIGNAL( clicked() ), this, SLOT( accept() ) );
+    connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
 }
 
 void FFTDialog::accept()

--- a/Code/Mantid/MantidPlot/src/FilterDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/FilterDialog.cpp
@@ -42,72 +42,73 @@
 #include <QComboBox>
 
 FilterDialog::FilterDialog(int type, QWidget* parent, Qt::WFlags fl )
-    : QDialog( parent, fl )
+  : QDialog( parent, fl ), graph(NULL), buttonFilter(NULL), buttonCancel(NULL),
+    boxName(NULL), boxOffset(NULL), boxStart(NULL), boxEnd(NULL), boxColor(NULL)
 {
-	setWindowTitle(tr("MantidPlot - Filter options"));
+    setWindowTitle(tr("MantidPlot - Filter options"));
     filter_type = type;
 
     setName( "FilterDialog" );
 
     QGroupBox *gb1 = new QGroupBox();
     QGridLayout *gl1 = new QGridLayout(gb1);
-	gl1->addWidget(new QLabel(tr("Filter curve: ")), 0, 0);
+    gl1->addWidget(new QLabel(tr("Filter curve: ")), 0, 0);
 
-	boxName = new QComboBox();
-	gl1->addWidget(boxName, 0, 1);
+    boxName = new QComboBox();
+    gl1->addWidget(boxName, 0, 1);
 
-	if (type <= FFTFilter::HighPass)
-		gl1->addWidget(new QLabel(tr("Frequency cutoff (Hz)")), 1, 0);
-	else
-		gl1->addWidget(new QLabel(tr("Low Frequency (Hz)")), 1, 0);
+    if (type <= FFTFilter::HighPass)
+      gl1->addWidget(new QLabel(tr("Frequency cutoff (Hz)")), 1, 0);
+    else
+      gl1->addWidget(new QLabel(tr("Low Frequency (Hz)")), 1, 0);
 
-	boxStart = new QLineEdit();
-	boxStart->setText(tr("0"));
-	gl1->addWidget(boxStart, 1, 1);
+    boxStart = new QLineEdit();
+    boxStart->setText(tr("0"));
+    gl1->addWidget(boxStart, 1, 1);
 
-	boxColor = new ColorBox();
-	boxColor->setColor(QColor(Qt::red));
-	if (type >= FFTFilter::BandPass)
-		{
-	    gl1->addWidget(new QLabel(tr("High Frequency (Hz)")), 2, 0);
+    boxColor = new ColorBox();
+    boxColor->setColor(QColor(Qt::red));
+    if (type >= FFTFilter::BandPass)
+    {
+        gl1->addWidget(new QLabel(tr("High Frequency (Hz)")), 2, 0);
 
-		boxEnd = new QLineEdit();
-		boxEnd->setText(tr("0"));
+        boxEnd = new QLineEdit();
+        boxEnd->setText(tr("0"));
         gl1->addWidget(boxEnd, 2, 1);
 
-		if (type == FFTFilter::BandPass)
-		    gl1->addWidget(new QLabel(tr("Add DC Offset")), 3, 0);
-		else
-		    gl1->addWidget(new QLabel(tr("Substract DC Offset")), 3, 0);
+        if (type == FFTFilter::BandPass)
+          gl1->addWidget(new QLabel(tr("Add DC Offset")), 3, 0);
+        else
+          gl1->addWidget(new QLabel(tr("Substract DC Offset")), 3, 0);
 
-		boxOffset = new QCheckBox();
-		gl1->addWidget(boxOffset, 3, 1);
+        boxOffset = new QCheckBox();
+        gl1->addWidget(boxOffset, 3, 1);
 
-		gl1->addWidget(new QLabel(tr("Color")), 4, 0);
-		gl1->addWidget(boxColor, 4, 1);
+        gl1->addWidget(new QLabel(tr("Color")), 4, 0);
+        gl1->addWidget(boxColor, 4, 1);
         gl1->setRowStretch(5, 1);
-		}
+    }
     else
-        {
+    {
         gl1->addWidget(new QLabel(tr("Color")), 2, 0);
-		gl1->addWidget(boxColor, 2, 1);
+        gl1->addWidget(boxColor, 2, 1);
         gl1->setRowStretch(3, 1);
-        }
+    }
 
-	buttonFilter = new QPushButton(tr( "&Filter" ));
+    buttonFilter = new QPushButton(tr( "&Filter" ));
     buttonFilter->setDefault( true );
     buttonCancel = new QPushButton(tr( "&Close" ));
 
     QVBoxLayout *vl = new QVBoxLayout();
- 	vl->addWidget(buttonFilter);
-	vl->addWidget(buttonCancel);
+    vl->addWidget(buttonFilter);
+    vl->addWidget(buttonCancel);
     vl->addStretch();
 
     QHBoxLayout *hb = new QHBoxLayout(this);
     hb->addWidget(gb1);
     hb->addLayout(vl);
 
-	connect( buttonFilter, SIGNAL( clicked() ), this, SLOT( filter() ) );
+    connect( buttonFilter, SIGNAL( clicked() ), this, SLOT( filter() ) );
     connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
 }
 

--- a/Code/Mantid/MantidPlot/src/FunctionDialog.h
+++ b/Code/Mantid/MantidPlot/src/FunctionDialog.h
@@ -55,7 +55,6 @@ protected:
     QComboBox* boxPolarRadius;
     QComboBox* boxPolarTheta;
     QComboBox* boxType;
-    QLabel* textFunction;
     QLineEdit* boxFrom;
     QLineEdit* boxTo;
 	QLineEdit* boxParameter;

--- a/Code/Mantid/MantidPlot/src/ImageDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/ImageDialog.cpp
@@ -33,7 +33,7 @@
 #include <QLabel>
 
 ImageDialog::ImageDialog( QWidget* parent, Qt::WFlags fl )
-    : QDialog( parent, fl )
+  : QDialog( parent, fl ), aspect_ratio(1.)
 {
 	setName( "ImageDialog" );
 	setWindowTitle( tr( "MantidPlot - Image Geometry" ) );

--- a/Code/Mantid/MantidPlot/src/InterpolationDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/InterpolationDialog.cpp
@@ -42,63 +42,63 @@
 #include <QLayout>
 
 InterpolationDialog::InterpolationDialog( QWidget* parent, Qt::WFlags fl )
-    : QDialog( parent, fl )
+  : QDialog( parent, fl ), graph(NULL)
 {
     setName( "InterpolationDialog" );
-	setWindowTitle(tr("MantidPlot - Interpolation Options"));
+    setWindowTitle(tr("MantidPlot - Interpolation Options"));
 
     QGroupBox *gb1 = new QGroupBox();
-	QGridLayout *gl1 = new QGridLayout(gb1);
-	gl1->addWidget(new QLabel(tr("Make curve from")), 0, 0);
+    QGridLayout *gl1 = new QGridLayout(gb1);
+    gl1->addWidget(new QLabel(tr("Make curve from")), 0, 0);
 
-	boxName = new QComboBox();
-	gl1->addWidget(boxName, 0, 1);
+    boxName = new QComboBox();
+    gl1->addWidget(boxName, 0, 1);
 
-	gl1->addWidget(new QLabel(tr("Spline")), 1, 0);
-	boxMethod = new QComboBox();
-	boxMethod->insertItem(tr("Linear"));
+    gl1->addWidget(new QLabel(tr("Spline")), 1, 0);
+    boxMethod = new QComboBox();
+    boxMethod->insertItem(tr("Linear"));
     boxMethod->insertItem(tr("Cubic"));
     boxMethod->insertItem(tr("Non-rounded Akima"));
-	gl1->addWidget(boxMethod, 1, 1);
+    gl1->addWidget(boxMethod, 1, 1);
 
-	gl1->addWidget(new QLabel(tr("Points")), 2, 0);
-	boxPoints = new QSpinBox();
-	boxPoints->setRange(3,100000);
-	boxPoints->setSingleStep(10);
-	boxPoints->setValue(1000);
-	gl1->addWidget(boxPoints, 2, 1);
+    gl1->addWidget(new QLabel(tr("Points")), 2, 0);
+    boxPoints = new QSpinBox();
+    boxPoints->setRange(3,100000);
+    boxPoints->setSingleStep(10);
+    boxPoints->setValue(1000);
+    gl1->addWidget(boxPoints, 2, 1);
 
-	gl1->addWidget(new QLabel(tr("From Xmin")), 3, 0);
-	boxStart = new QLineEdit();
-	boxStart->setText(tr("0"));
-	gl1->addWidget(boxStart, 3, 1);
+    gl1->addWidget(new QLabel(tr("From Xmin")), 3, 0);
+    boxStart = new QLineEdit();
+    boxStart->setText(tr("0"));
+    gl1->addWidget(boxStart, 3, 1);
 
-	gl1->addWidget(new QLabel(tr("To Xmax")), 4, 0);
-	boxEnd = new QLineEdit();
-	gl1->addWidget(boxEnd, 4, 1);
+    gl1->addWidget(new QLabel(tr("To Xmax")), 4, 0);
+    boxEnd = new QLineEdit();
+    gl1->addWidget(boxEnd, 4, 1);
 
-	gl1->addWidget(new QLabel(tr("Color")), 5, 0);
+    gl1->addWidget(new QLabel(tr("Color")), 5, 0);
 
-	boxColor = new ColorBox();
-	boxColor->setColor(QColor(Qt::red));
-	gl1->addWidget(boxColor, 5, 1);
-	gl1->setRowStretch(6, 1);
+    boxColor = new ColorBox();
+    boxColor->setColor(QColor(Qt::red));
+    gl1->addWidget(boxColor, 5, 1);
+    gl1->setRowStretch(6, 1);
 
-	buttonFit = new QPushButton(tr( "&Make" ));
+    buttonFit = new QPushButton(tr( "&Make" ));
     buttonFit->setDefault( true );
     buttonCancel = new QPushButton(tr( "&Close" ));
 
-	QVBoxLayout *vl = new QVBoxLayout();
- 	vl->addWidget(buttonFit);
-	vl->addWidget(buttonCancel);
+    QVBoxLayout *vl = new QVBoxLayout();
+    vl->addWidget(buttonFit);
+    vl->addWidget(buttonCancel);
     vl->addStretch();
 
     QHBoxLayout *hb = new QHBoxLayout(this);
     hb->addWidget(gb1);
     hb->addLayout(vl);
 
-	connect( boxName, SIGNAL(activated(const QString&)), this, SLOT( activateCurve(const QString&)));
-	connect( buttonFit, SIGNAL( clicked() ), this, SLOT( interpolate() ) );
+    connect( boxName, SIGNAL(activated(const QString&)), this, SLOT( activateCurve(const QString&)));
+    connect( buttonFit, SIGNAL( clicked() ), this, SLOT( interpolate() ) );
     connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
 }
 

--- a/Code/Mantid/MantidPlot/src/LayerDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/LayerDialog.cpp
@@ -41,155 +41,155 @@
 #include <QMessageBox>
 
 LayerDialog::LayerDialog( QWidget* parent, Qt::WFlags fl )
-: QDialog( parent, fl )
+  : QDialog( parent, fl ), multi_layer(NULL)
 {
     setName("LayerDialog");
-	setWindowTitle(tr( "MantidPlot - Arrange Layers" ));
+    setWindowTitle(tr( "MantidPlot - Arrange Layers" ));
 
     QGroupBox *gb1 = new QGroupBox(tr("Layers"));
-	QGridLayout *gl1 = new QGridLayout(gb1);
-	gl1->addWidget(new QLabel(tr("Number")), 0, 0);
-	layersBox = new QSpinBox();
-	layersBox->setRange(0, 100);
-	gl1->addWidget(layersBox, 0, 1);
+    QGridLayout *gl1 = new QGridLayout(gb1);
+    gl1->addWidget(new QLabel(tr("Number")), 0, 0);
+    layersBox = new QSpinBox();
+    layersBox->setRange(0, 100);
+    gl1->addWidget(layersBox, 0, 1);
 
-	fitBox = new QCheckBox(tr("Automatic &layout"));
-	fitBox->setChecked(false);
-	gl1->addWidget(fitBox, 1, 1);
-	gl1->setRowStretch(2, 1);
+    fitBox = new QCheckBox(tr("Automatic &layout"));
+    fitBox->setChecked(false);
+    gl1->addWidget(fitBox, 1, 1);
+    gl1->setRowStretch(2, 1);
 
     QGroupBox *gb2 = new QGroupBox(tr("Alignment"));
-	QGridLayout *gl2 = new QGridLayout(gb2);
-	gl2->addWidget(new QLabel(tr("Horizontal")), 0, 0);
+    QGridLayout *gl2 = new QGridLayout(gb2);
+    gl2->addWidget(new QLabel(tr("Horizontal")), 0, 0);
 
-	alignHorBox = new QComboBox( );
-	alignHorBox->insertItem( tr( "Center" ) );
-	alignHorBox->insertItem( tr( "Left" ) );
-	alignHorBox->insertItem( tr( "Right" ) );
-	gl2->addWidget(alignHorBox, 0, 1);
+    alignHorBox = new QComboBox( );
+    alignHorBox->insertItem( tr( "Center" ) );
+    alignHorBox->insertItem( tr( "Left" ) );
+    alignHorBox->insertItem( tr( "Right" ) );
+    gl2->addWidget(alignHorBox, 0, 1);
 
-	gl2->addWidget(new QLabel( tr( "Vertical" )), 1, 0 );
-	alignVertBox = new QComboBox();
-	alignVertBox->insertItem( tr( "Center" ) );
-	alignVertBox->insertItem( tr( "Top" ) );
-	alignVertBox->insertItem( tr( "Bottom" ) );
-	gl2->addWidget(alignVertBox, 1, 1);
-	gl2->setRowStretch(2, 1);
+    gl2->addWidget(new QLabel( tr( "Vertical" )), 1, 0 );
+    alignVertBox = new QComboBox();
+    alignVertBox->insertItem( tr( "Center" ) );
+    alignVertBox->insertItem( tr( "Top" ) );
+    alignVertBox->insertItem( tr( "Bottom" ) );
+    gl2->addWidget(alignVertBox, 1, 1);
+    gl2->setRowStretch(2, 1);
 
     GroupGrid = new QGroupBox(tr("Grid"));
-	QGridLayout *gl3 = new QGridLayout(GroupGrid);
-	gl3->addWidget(new QLabel(tr("Columns")), 0, 0);
-	boxX = new QSpinBox();
-	boxX->setRange(1, 100);
-	gl3->addWidget(boxX, 0, 1);
-	gl3->addWidget(new QLabel( tr( "Rows" )), 1, 0);
-	boxY = new QSpinBox();
-	boxY->setRange(1, 100);
-	gl3->addWidget(boxY, 1, 1);
+    QGridLayout *gl3 = new QGridLayout(GroupGrid);
+    gl3->addWidget(new QLabel(tr("Columns")), 0, 0);
+    boxX = new QSpinBox();
+    boxX->setRange(1, 100);
+    gl3->addWidget(boxX, 0, 1);
+    gl3->addWidget(new QLabel( tr( "Rows" )), 1, 0);
+    boxY = new QSpinBox();
+    boxY->setRange(1, 100);
+    gl3->addWidget(boxY, 1, 1);
 
-	GroupCanvasSize = new QGroupBox(tr("&Layer Canvas Size"));
-	GroupCanvasSize->setCheckable(true);
-	GroupCanvasSize->setChecked(false);
+    GroupCanvasSize = new QGroupBox(tr("&Layer Canvas Size"));
+    GroupCanvasSize->setCheckable(true);
+    GroupCanvasSize->setChecked(false);
 
-	QGridLayout *gl5 = new QGridLayout(GroupCanvasSize);
-	gl5->addWidget(new QLabel(tr("Width")), 0, 0);
-	boxCanvasWidth = new QSpinBox();
-	boxCanvasWidth->setRange(0, 10000);
-	boxCanvasWidth->setSingleStep(50);
-	boxCanvasWidth->setSuffix(tr(" pixels"));
-	gl5->addWidget(boxCanvasWidth, 0, 1);
-	gl5->addWidget(new QLabel( tr( "Height" )), 1, 0);
-	boxCanvasHeight = new QSpinBox();
-	boxCanvasHeight->setRange(0, 10000);
-	boxCanvasHeight->setSingleStep(50);
-	boxCanvasHeight->setSuffix(tr(" pixels"));
-	gl5->addWidget(boxCanvasHeight, 1, 1);
+    QGridLayout *gl5 = new QGridLayout(GroupCanvasSize);
+    gl5->addWidget(new QLabel(tr("Width")), 0, 0);
+    boxCanvasWidth = new QSpinBox();
+    boxCanvasWidth->setRange(0, 10000);
+    boxCanvasWidth->setSingleStep(50);
+    boxCanvasWidth->setSuffix(tr(" pixels"));
+    gl5->addWidget(boxCanvasWidth, 0, 1);
+    gl5->addWidget(new QLabel( tr( "Height" )), 1, 0);
+    boxCanvasHeight = new QSpinBox();
+    boxCanvasHeight->setRange(0, 10000);
+    boxCanvasHeight->setSingleStep(50);
+    boxCanvasHeight->setSuffix(tr(" pixels"));
+    gl5->addWidget(boxCanvasHeight, 1, 1);
 
     QGroupBox *gb4 = new QGroupBox(tr("Spacing"));
-	QGridLayout *gl4 = new QGridLayout(gb4);
-	gl4->addWidget(new QLabel(tr("Columns gap")), 0, 0);
-	boxColsGap = new QSpinBox();
-	boxColsGap->setRange(0, 1000);
-	boxColsGap->setSingleStep(5);
-	boxColsGap->setSuffix(tr(" pixels"));
-	gl4->addWidget(boxColsGap, 0, 1);
-	gl4->addWidget(new QLabel( tr( "Rows gap" )), 1, 0);
-	boxRowsGap = new QSpinBox();
-	boxRowsGap->setRange(0, 1000);
-	boxRowsGap->setSingleStep(5);
-	boxRowsGap->setSuffix(tr(" pixels"));
-	gl4->addWidget(boxRowsGap, 1, 1);
-	gl4->addWidget(new QLabel( tr( "Left margin" )), 2, 0);
-	boxLeftSpace = new QSpinBox();
-	boxLeftSpace->setRange(0, 1000);
-	boxLeftSpace->setSingleStep(5);
-	boxLeftSpace->setSuffix(tr(" pixels"));
-	gl4->addWidget(boxLeftSpace, 2, 1);
-	gl4->addWidget(new QLabel( tr( "Right margin" )), 3, 0);
-	boxRightSpace = new QSpinBox();
-	boxRightSpace->setRange(0, 1000);
-	boxRightSpace->setSingleStep(5);
-	boxRightSpace->setSuffix(tr(" pixels"));
-	gl4->addWidget(boxRightSpace, 3, 1);
-	gl4->addWidget(new QLabel( tr( "Top margin" )), 4, 0);
-	boxTopSpace = new QSpinBox();
-	boxTopSpace->setRange(0, 1000);
-	boxTopSpace->setSingleStep(5);
-	boxTopSpace->setSuffix(tr(" pixels"));
-	gl4->addWidget(boxTopSpace, 4, 1);
-	gl4->addWidget(new QLabel( tr( "Bottom margin") ), 5, 0);
-	boxBottomSpace = new QSpinBox();
-	boxBottomSpace->setRange(0, 1000);
-	boxBottomSpace->setSingleStep(5);
-	boxBottomSpace->setSuffix(tr(" pixels"));
-	gl4->addWidget(boxBottomSpace, 5, 1);
+    QGridLayout *gl4 = new QGridLayout(gb4);
+    gl4->addWidget(new QLabel(tr("Columns gap")), 0, 0);
+    boxColsGap = new QSpinBox();
+    boxColsGap->setRange(0, 1000);
+    boxColsGap->setSingleStep(5);
+    boxColsGap->setSuffix(tr(" pixels"));
+    gl4->addWidget(boxColsGap, 0, 1);
+    gl4->addWidget(new QLabel( tr( "Rows gap" )), 1, 0);
+    boxRowsGap = new QSpinBox();
+    boxRowsGap->setRange(0, 1000);
+    boxRowsGap->setSingleStep(5);
+    boxRowsGap->setSuffix(tr(" pixels"));
+    gl4->addWidget(boxRowsGap, 1, 1);
+    gl4->addWidget(new QLabel( tr( "Left margin" )), 2, 0);
+    boxLeftSpace = new QSpinBox();
+    boxLeftSpace->setRange(0, 1000);
+    boxLeftSpace->setSingleStep(5);
+    boxLeftSpace->setSuffix(tr(" pixels"));
+    gl4->addWidget(boxLeftSpace, 2, 1);
+    gl4->addWidget(new QLabel( tr( "Right margin" )), 3, 0);
+    boxRightSpace = new QSpinBox();
+    boxRightSpace->setRange(0, 1000);
+    boxRightSpace->setSingleStep(5);
+    boxRightSpace->setSuffix(tr(" pixels"));
+    gl4->addWidget(boxRightSpace, 3, 1);
+    gl4->addWidget(new QLabel( tr( "Top margin" )), 4, 0);
+    boxTopSpace = new QSpinBox();
+    boxTopSpace->setRange(0, 1000);
+    boxTopSpace->setSingleStep(5);
+    boxTopSpace->setSuffix(tr(" pixels"));
+    gl4->addWidget(boxTopSpace, 4, 1);
+    gl4->addWidget(new QLabel( tr( "Bottom margin") ), 5, 0);
+    boxBottomSpace = new QSpinBox();
+    boxBottomSpace->setRange(0, 1000);
+    boxBottomSpace->setSingleStep(5);
+    boxBottomSpace->setSuffix(tr(" pixels"));
+    gl4->addWidget(boxBottomSpace, 5, 1);
 
-	QVBoxLayout *vbox1 = new QVBoxLayout();
-	vbox1->addWidget(GroupGrid);
-	vbox1->addWidget(GroupCanvasSize);
+    QVBoxLayout *vbox1 = new QVBoxLayout();
+    vbox1->addWidget(GroupGrid);
+    vbox1->addWidget(GroupCanvasSize);
 
-	buttonApply = new QPushButton(tr( "&Apply" ));
-	buttonOk = new QPushButton(tr( "&OK" ));
-	buttonCancel = new QPushButton(tr( "&Cancel" ));
+    buttonApply = new QPushButton(tr( "&Apply" ));
+    buttonOk = new QPushButton(tr( "&OK" ));
+    buttonCancel = new QPushButton(tr( "&Cancel" ));
 
-	QHBoxLayout *hbox1 = new QHBoxLayout();
+    QHBoxLayout *hbox1 = new QHBoxLayout();
     hbox1->addStretch();
-	hbox1->addWidget(buttonApply);
-	hbox1->addWidget(buttonOk);
-	hbox1->addWidget(buttonCancel);
+    hbox1->addWidget(buttonApply);
+    hbox1->addWidget(buttonOk);
+    hbox1->addWidget(buttonCancel);
 
-	QGroupBox *gb5 = new QGroupBox(tr("Swap Layers"));
-	QHBoxLayout *hbox2 = new QHBoxLayout(gb5);
-	hbox2->addWidget(new QLabel( tr( "Source Layer") ));
+    QGroupBox *gb5 = new QGroupBox(tr("Swap Layers"));
+    QHBoxLayout *hbox2 = new QHBoxLayout(gb5);
+    hbox2->addWidget(new QLabel( tr( "Source Layer") ));
 
-	boxLayerSrc = new QSpinBox();
-	hbox2->addWidget(boxLayerSrc);
+    boxLayerSrc = new QSpinBox();
+    hbox2->addWidget(boxLayerSrc);
 
-	hbox2->addWidget(new QLabel( tr( "Destination Layer") ));
-	boxLayerDest = new QSpinBox();
-	hbox2->addWidget(boxLayerDest);
+    hbox2->addWidget(new QLabel( tr( "Destination Layer") ));
+    boxLayerDest = new QSpinBox();
+    hbox2->addWidget(boxLayerDest);
 
-	buttonSwapLayers = new QPushButton(tr( "&Swap" ));
-	hbox2->addWidget(buttonSwapLayers);
+    buttonSwapLayers = new QPushButton(tr( "&Swap" ));
+    hbox2->addWidget(buttonSwapLayers);
 
-	QGridLayout *gl6 = new QGridLayout();
-	gl6->addWidget(gb1, 0, 0);
-	gl6->addWidget(gb2, 0, 1);
-	gl6->addLayout(vbox1, 1, 0);
-	gl6->addWidget(gb4, 1, 1);
-	gl6->setRowStretch(2, 1);
+    QGridLayout *gl6 = new QGridLayout();
+    gl6->addWidget(gb1, 0, 0);
+    gl6->addWidget(gb2, 0, 1);
+    gl6->addLayout(vbox1, 1, 0);
+    gl6->addWidget(gb4, 1, 1);
+    gl6->setRowStretch(2, 1);
 
-	QVBoxLayout *vbox2 = new QVBoxLayout(this);
-	vbox2->addLayout(gl6);
-	vbox2->addWidget(gb5);
-	vbox2->addStretch();
-	vbox2->addLayout(hbox1);
+    QVBoxLayout *vbox2 = new QVBoxLayout(this);
+    vbox2->addLayout(gl6);
+    vbox2->addWidget(gb5);
+    vbox2->addStretch();
+    vbox2->addLayout(hbox1);
 
-	connect( buttonSwapLayers, SIGNAL( clicked() ), this, SLOT( swapLayers() ) );
-	connect( buttonOk, SIGNAL( clicked() ), this, SLOT( accept() ) );
-	connect( buttonApply, SIGNAL( clicked() ), this, SLOT(update() ) );
-	connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
-	connect( fitBox, SIGNAL( toggled(bool) ), this, SLOT(enableLayoutOptions(bool) ) );
+    connect( buttonSwapLayers, SIGNAL( clicked() ), this, SLOT( swapLayers() ) );
+    connect( buttonOk, SIGNAL( clicked() ), this, SLOT( accept() ) );
+    connect( buttonApply, SIGNAL( clicked() ), this, SLOT(update() ) );
+    connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
+    connect( fitBox, SIGNAL( toggled(bool) ), this, SLOT(enableLayoutOptions(bool) ) );
 }
 
 void LayerDialog::enableLayoutOptions(bool ok)

--- a/Code/Mantid/MantidPlot/src/LegendWidget.cpp
+++ b/Code/Mantid/MantidPlot/src/LegendWidget.cpp
@@ -51,7 +51,8 @@ LegendWidget::LegendWidget(Plot *plot):QWidget(plot),
 	d_plot(plot),
 	d_frame (0),
 	d_angle(0),
-	d_fixed_coordinates(false)
+        d_x(0.), d_y(0.),
+        d_fixed_coordinates(false)
 {
 	setAttribute(Qt::WA_DeleteOnClose);
 

--- a/Code/Mantid/MantidPlot/src/Mantid/ImportWorkspaceDlg.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/ImportWorkspaceDlg.cpp
@@ -4,7 +4,8 @@
 
 #include "ImportWorkspaceDlg.h"
 
-ImportWorkspaceDlg::ImportWorkspaceDlg(QWidget *parent, size_t num) : QDialog(parent), numHists(num),minValue(0),maxValue(100.)
+ImportWorkspaceDlg::ImportWorkspaceDlg(QWidget *parent, size_t num) :
+  QDialog(parent), numHists(num), lowerLimit(0), upperLimit(0), filtered(false), minValue(0), maxValue(100.)
 {
 	label = new QLabel(tr("Set Histogram Range to Load (Max Number = " + QString::number(numHists) + "):"));
 	

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
@@ -18,7 +18,7 @@
   * @param minPositiveValue A minimum positive value for the Log10 scale
   */
 ColorMapWidget::ColorMapWidget(int type,QWidget* parent,const double& minPositiveValue):
-QFrame(parent),m_minPositiveValue(minPositiveValue),m_dragging(false)
+  QFrame(parent), m_minPositiveValue(minPositiveValue), m_dragging(false), m_y(0), m_dtype()
 {
   m_scaleWidget = new QwtScaleWidget(QwtScaleDraw::RightScale);
   m_scaleWidget->setColorBarEnabled(true);

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/DetXMLFile.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/DetXMLFile.cpp
@@ -39,6 +39,7 @@ DetXMLFile::DetXMLFile(const QList<int>& dets, Option opt, const QString& fname)
     if (dets.empty())
     {
       m_fileName = "";
+      m_delete = false;
       return;
     }
 

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentTreeWidget.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentTreeWidget.cpp
@@ -14,7 +14,7 @@
 #include <cfloat>
 #include <iostream>
 
-InstrumentTreeWidget::InstrumentTreeWidget(QWidget *w):QTreeView(w), m_treeModel(0) 
+InstrumentTreeWidget::InstrumentTreeWidget(QWidget *w):QTreeView(w), m_instrActor(NULL), m_treeModel(NULL)
 {
   connect(this,SIGNAL(clicked(const QModelIndex)),this,SLOT(sendComponentSelectedSignal(const QModelIndex)));
 }

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowMaskTab.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowMaskTab.cpp
@@ -62,7 +62,12 @@ InstrumentWindowMaskTab::InstrumentWindowMaskTab(InstrumentWindow* instrWindow):
 InstrumentWindowTab(instrWindow),
 m_activity(Select),
 m_hasMaskToApply(false),
-m_userEditing(true)
+m_userEditing(true),
+m_groupManager(NULL),
+m_stringManager(NULL),
+m_doubleManager(NULL),
+m_browser(NULL),
+m_left(NULL), m_top(NULL), m_right(NULL), m_bottom(NULL)
 {
 
   // main layout

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/XIntegrationControl.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/XIntegrationControl.cpp
@@ -24,6 +24,8 @@ m_resizingLeft(false),
 m_resizingRight(false),
 m_moving(false),
 m_changed(false),
+m_x(0),
+m_width(0),
 m_minimum(0.0),
 m_maximum(1.0)
 {

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1505,6 +1505,7 @@ MantidTreeWidget::MantidTreeWidget(MantidDockWidget *w, MantidUI *mui)
 {
   setObjectName("WorkspaceTree");
   setSelectionMode(QAbstractItemView::ExtendedSelection);
+  setSortOrder(Qt::AscendingOrder);
   setAcceptDrops(true);
 }
 

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -1131,6 +1131,7 @@ void MantidMatrixModel::setup(const Mantid::API::MatrixWorkspace* ws,
   m_workspace = ws;
   m_rows = rows;
   m_cols = cols;
+  m_colNumCorr = 1;
   m_startRow = start >= 0? start : 0;
   m_mon_color = QColor(255,255,204);
   if (ws->blocksize() != 0)

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidMatrix.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidMatrix.h
@@ -269,8 +269,6 @@ protected:
   //MantidMatrixFunction m_funct;
   int m_column_width;
 
-  QAction *m_actionShowX;
-
 private:
   //name of the underlying workspace
   std::string m_strName;

--- a/Code/Mantid/MantidPlot/src/MatrixValuesDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/MatrixValuesDialog.cpp
@@ -47,91 +47,91 @@
 #endif
 
 MatrixValuesDialog::MatrixValuesDialog( ScriptingEnv *env, QWidget* parent, Qt::WFlags fl )
-: QDialog( parent, fl ), Scripted(env)
+  : QDialog( parent, fl ), Scripted(env), matrix(NULL)
 {
     setName( "MatrixValuesDialog" );
-	setWindowTitle( tr( "MantidPlot - Set Matrix Values" ) );
-	setSizeGripEnabled(true);
+    setWindowTitle( tr( "MantidPlot - Set Matrix Values" ) );
+    setSizeGripEnabled(true);
 
-	QGridLayout *gl1 = new QGridLayout();
+    QGridLayout *gl1 = new QGridLayout();
     gl1->addWidget(new QLabel(tr("For row (i)")), 0, 0);
-	startRow = new QSpinBox();
-	startRow->setRange(1, 1000000);
+    startRow = new QSpinBox();
+    startRow->setRange(1, 1000000);
     gl1->addWidget(startRow, 0, 1);
-	gl1->addWidget(new QLabel(tr("to")), 0, 2);
-	endRow =  new QSpinBox();
-	endRow->setRange(1, 1000000);
-	gl1->addWidget(endRow, 0, 3);
-	gl1->addWidget(new QLabel(tr("For col (j)")), 1, 0);
-	startCol = new QSpinBox();
-	startCol->setRange(1, 1000000);
-	gl1->addWidget(startCol, 1, 1);
-	gl1->addWidget(new QLabel(tr("to")), 1, 2);
-	endCol = new QSpinBox();
-	endCol->setRange(1, 1000000);
-	gl1->addWidget(endCol, 1, 3);
+    gl1->addWidget(new QLabel(tr("to")), 0, 2);
+    endRow =  new QSpinBox();
+    endRow->setRange(1, 1000000);
+    gl1->addWidget(endRow, 0, 3);
+    gl1->addWidget(new QLabel(tr("For col (j)")), 1, 0);
+    startCol = new QSpinBox();
+    startCol->setRange(1, 1000000);
+    gl1->addWidget(startCol, 1, 1);
+    gl1->addWidget(new QLabel(tr("to")), 1, 2);
+    endCol = new QSpinBox();
+    endCol->setRange(1, 1000000);
+    gl1->addWidget(endCol, 1, 3);
 
-	QVBoxLayout *vbox1 = new QVBoxLayout();
+    QVBoxLayout *vbox1 = new QVBoxLayout();
     vbox1->addLayout(gl1);
-	QGroupBox *gb = new QGroupBox();
+    QGroupBox *gb = new QGroupBox();
     gb->setLayout(vbox1);
     gb->setSizePolicy(QSizePolicy (QSizePolicy::Maximum, QSizePolicy::Preferred));
 
-	QHBoxLayout *hbox3 = new QHBoxLayout();
-	commands = new ScriptEditor(this, scriptingEnv()->createCodeLexer());
-	commands->setFocus();
-	hbox3->addWidget(commands);
+    QHBoxLayout *hbox3 = new QHBoxLayout();
+    commands = new ScriptEditor(this, scriptingEnv()->createCodeLexer());
+    commands->setFocus();
+    hbox3->addWidget(commands);
 
-	QVBoxLayout *vbox2 = new QVBoxLayout();
-	btnApply = new QPushButton(tr( "&Apply" ));
+    QVBoxLayout *vbox2 = new QVBoxLayout();
+    btnApply = new QPushButton(tr( "&Apply" ));
     vbox2->addWidget(btnApply);
-	btnCancel = new QPushButton(tr( "&Close" ));
+    btnCancel = new QPushButton(tr( "&Close" ));
     vbox2->addWidget(btnCancel);
     vbox2->addStretch();
 
-	QHBoxLayout *hbox2 = new QHBoxLayout();
-	hbox2->addWidget(gb);
-	hbox2->addLayout(vbox2);
+    QHBoxLayout *hbox2 = new QHBoxLayout();
+    hbox2->addWidget(gb);
+    hbox2->addLayout(vbox2);
 
-	QVBoxLayout* vbox3 = new QVBoxLayout(this);
-	vbox3->addLayout(hbox2);
-	vbox3->addWidget(new QLabel(tr( "Cell(i,j)=" )));
-	vbox3->addLayout(hbox3);
+    QVBoxLayout* vbox3 = new QVBoxLayout(this);
+    vbox3->addLayout(hbox2);
+    vbox3->addWidget(new QLabel(tr( "Cell(i,j)=" )));
+    vbox3->addLayout(hbox3);
 
-	connect(btnApply, SIGNAL(clicked()), this, SLOT(apply()));
-	connect(btnCancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(btnApply, SIGNAL(clicked()), this, SLOT(apply()));
+    connect(btnCancel, SIGNAL(clicked()), this, SLOT(close()));
 }
 
 QSize MatrixValuesDialog::sizeHint() const
 {
-	return QSize( 400, 190 );
+    return QSize( 400, 190 );
 }
 
 void MatrixValuesDialog::customEvent(QEvent *e)
 {
-	if (e->type() == SCRIPTING_CHANGE_EVENT)
-    scriptingChangeEvent(dynamic_cast<ScriptingChangeEvent*>(e));
+    if (e->type() == SCRIPTING_CHANGE_EVENT)
+        scriptingChangeEvent(dynamic_cast<ScriptingChangeEvent*>(e));
 }
 
 bool MatrixValuesDialog::apply()
 {
-	QString formula = commands->text();
-	QString oldFormula = matrix->formula();
+    QString formula = commands->text();
+    QString oldFormula = matrix->formula();
 
-	matrix->setFormula(formula);
+    matrix->setFormula(formula);
 	
-	bool useMuParser = true;
+    bool useMuParser = true;
 	
-	if (matrix->canCalculate(useMuParser)){
-		matrix->undoStack()->push(new MatrixSetFormulaCommand(matrix, oldFormula, formula,
+    if (matrix->canCalculate(useMuParser)){
+        matrix->undoStack()->push(new MatrixSetFormulaCommand(matrix, oldFormula, formula,
 							tr("Set New Formula") + " \"" + formula + "\""));
 
-		if (matrix->calculate(startRow->value()-1, endRow->value()-1, 
-			startCol->value()-1, endCol->value()-1, useMuParser))
-			return true;
+        if (matrix->calculate(startRow->value()-1, endRow->value()-1,
+                              startCol->value()-1, endCol->value()-1, useMuParser))
+            return true;
 	}
-	matrix->setFormula(oldFormula);
-	return false;
+    matrix->setFormula(oldFormula);
+    return false;
 }
 
 void MatrixValuesDialog::setMatrix(Matrix* m)
@@ -139,8 +139,8 @@ void MatrixValuesDialog::setMatrix(Matrix* m)
     if (!m)
         return;
 
-	matrix = m;
-	commands->setText(m->formula());
+    matrix = m;
+    commands->setText(m->formula());
 
     endCol->setValue(m->numCols());
     endRow->setValue(m->numRows());

--- a/Code/Mantid/MantidPlot/src/MultiLayer.cpp
+++ b/Code/Mantid/MantidPlot/src/MultiLayer.cpp
@@ -121,6 +121,7 @@ MultiLayer::MultiLayer(ApplicationWindow* parent, int layers, int rows, int cols
                          vert_align(VCenter),
                          d_scale_on_print(true),
                          d_print_cropmarks(false),
+                         d_close_on_empty(false),
                          d_is_waterfall_plot(false),
                          d_waterfall_fill_color(/*Invalid color*/)
 {

--- a/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -1,6 +1,9 @@
 //-----------------------------------------------------
 // Includes
 //-----------------------------------------------------
+// std
+#include <stdexcept>
+
 #include "ApplicationWindow.h"
 #include "ScriptFileInterpreter.h"
 
@@ -22,9 +25,6 @@
 #include <QListWidget>
 #include <QSpinBox>
 #include <QFontDatabase>
-
-// std
-#include <stdexcept>
 
 //***************************************************************************
 //

--- a/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.h
+++ b/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.h
@@ -228,8 +228,6 @@ private:
   enum { MaxRecentScripts = 5 };
   /// List of recent scripts, with most recent at the top
   QStringList m_recentScriptList;
-  /// Flag to indicate whether stdout should be redirected
-  bool m_capturePrint;
   /// A pointer to the Null object
   NullScriptFileInterpreter *m_nullScript;
   /// A pointer to the current interpreter

--- a/Code/Mantid/MantidPlot/src/PlotWizard.cpp
+++ b/Code/Mantid/MantidPlot/src/PlotWizard.cpp
@@ -44,7 +44,7 @@
 #include <QComboBox>
 
 PlotWizard::PlotWizard( QWidget* parent, Qt::WFlags fl )
-: QDialog( parent, fl )
+  : QDialog( parent, fl )
 {
 	setWindowTitle( tr("MantidPlot - Select Columns to Plot") );
 

--- a/Code/Mantid/MantidPlot/src/PlotWizard.h
+++ b/Code/Mantid/MantidPlot/src/PlotWizard.h
@@ -70,11 +70,7 @@ private:
 				//! Button "<->Z"
 				*buttonZ;
 				//! Button group defining the layout
-    QGroupBox*  groupBox1,
-				//! Button group defining the layout
-				*groupBox2,
-				//! Button group defining the layout
-				*groupBox3;
+    QGroupBox*  groupBox1;
 				//! Combo box to select the table
     QComboBox* boxTables;
 				//! List of the columns in the selected table

--- a/Code/Mantid/MantidPlot/src/PolynomFitDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/PolynomFitDialog.cpp
@@ -43,67 +43,67 @@
 #include <QComboBox>
 
 PolynomFitDialog::PolynomFitDialog( QWidget* parent, Qt::WFlags fl )
-: QDialog( parent, fl )
+  : QDialog( parent, fl ), graph(NULL)
 {
     setName( "PolynomFitDialog" );
-	setWindowTitle(tr("MantidPlot - Polynomial Fit Options"));
+    setWindowTitle(tr("MantidPlot - Polynomial Fit Options"));
     setSizeGripEnabled( true );
 
     QGroupBox *gb1 = new QGroupBox();
-	QGridLayout *gl1 = new QGridLayout(gb1);
-	gl1->addWidget(new QLabel(tr("Polynomial Fit of")), 0, 0);
+    QGridLayout *gl1 = new QGridLayout(gb1);
+    gl1->addWidget(new QLabel(tr("Polynomial Fit of")), 0, 0);
 
-	boxName = new QComboBox();
+    boxName = new QComboBox();
     gl1->addWidget(boxName, 0, 1);
 
     gl1->addWidget(new QLabel( tr("Order (1 - 9, 1 = linear)")), 1, 0);
-	boxOrder = new QSpinBox();
+    boxOrder = new QSpinBox();
     boxOrder->setRange(1, 9);
-	boxOrder->setValue(2);
+    boxOrder->setValue(2);
     gl1->addWidget(boxOrder, 1, 1);
 
     gl1->addWidget(new QLabel( tr("Fit curve # pts")), 2, 0);
-	boxPoints = new QSpinBox();
+    boxPoints = new QSpinBox();
     boxPoints->setRange(1, 1000);
     boxPoints->setSingleStep(50);
     boxPoints->setSpecialValueText(tr("Not enough points"));
     gl1->addWidget(boxPoints, 2, 1);
 
     gl1->addWidget(new QLabel( tr("Fit curve Xmin")), 3, 0);
-	boxStart = new QLineEdit(tr("0"));
+    boxStart = new QLineEdit(tr("0"));
     gl1->addWidget(boxStart, 3, 1);
 
-    gl1->addWidget(	new QLabel( tr("Fit curve Xmax")), 4, 0);
-	boxEnd = new QLineEdit();
+    gl1->addWidget(new QLabel( tr("Fit curve Xmax")), 4, 0);
+    boxEnd = new QLineEdit();
     gl1->addWidget(boxEnd, 4, 1);
 
     gl1->addWidget(new QLabel( tr("Color")), 5, 0);
-	boxColor = new ColorBox();
-	boxColor->setColor(QColor(Qt::red));
+    boxColor = new ColorBox();
+    boxColor->setColor(QColor(Qt::red));
     gl1->addWidget(boxColor, 5, 1);
 
-	boxShowFormula = new QCheckBox(tr( "Show Formula on Graph?" ));
-	boxShowFormula->setChecked( false );
+    boxShowFormula = new QCheckBox(tr( "Show Formula on Graph?" ));
+    boxShowFormula->setChecked( false );
     gl1->addWidget(boxShowFormula, 6, 1);
     gl1->setRowStretch(7, 1);
 
-	buttonFit = new QPushButton(tr( "&Fit" ));
-	buttonFit->setDefault( true );
+    buttonFit = new QPushButton(tr( "&Fit" ));
+    buttonFit->setDefault( true );
 
-	buttonCancel = new QPushButton(tr( "&Close" ));
+    buttonCancel = new QPushButton(tr( "&Close" ));
 
     QVBoxLayout* vl = new QVBoxLayout();
     vl->addWidget(buttonFit);
     vl->addWidget(buttonCancel);
     vl->addStretch();
 
-	QHBoxLayout* hlayout = new QHBoxLayout(this);
-	hlayout->addWidget(gb1);
-	hlayout->addLayout(vl);
+    QHBoxLayout* hlayout = new QHBoxLayout(this);
+    hlayout->addWidget(gb1);
+    hlayout->addLayout(vl);
 
-	connect( buttonFit, SIGNAL( clicked() ), this, SLOT( fit() ) );
-	connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
-	connect( boxName, SIGNAL( activated(const QString&) ), this, SLOT(activateCurve(const QString&)));
+    connect( buttonFit, SIGNAL( clicked() ), this, SLOT( fit() ) );
+    connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
+    connect( boxName, SIGNAL( activated(const QString&) ), this, SLOT(activateCurve(const QString&)));
 }
 
 void PolynomFitDialog::fit()
@@ -125,7 +125,7 @@ void PolynomFitDialog::fit()
     {
         fitter->setColor(boxColor->currentItem());
         fitter->setOutputPrecision(app->fit_output_precision);
-		fitter->generateFunction(app->generateUniformFitPoints, app->fitPoints);
+	fitter->generateFunction(app->generateUniformFitPoints, app->fitPoints);
         fitter->fit();
         delete fitter;
 	}

--- a/Code/Mantid/MantidPlot/src/QwtHistogram.cpp
+++ b/Code/Mantid/MantidPlot/src/QwtHistogram.cpp
@@ -45,7 +45,7 @@ QwtHistogram::QwtHistogram(Table *t, const QString& xColName, const QString& nam
 
 QwtHistogram::QwtHistogram(Matrix *m)
   : QwtBarCurve(QwtBarCurve::Vertical, NULL, "matrix", (m != NULL ? m->objectName() : QString() ), 0, 0),
-    d_bin_size(0.0), d_begin(0.0), d_end(0.0),
+    d_matrix(NULL), d_autoBin(false), d_bin_size(0.0), d_begin(0.0), d_end(0.0),
     d_mean(0.0), d_standard_deviation(0.0), d_min(0.0), d_max(0.0)
 {
     if (m){

--- a/Code/Mantid/MantidPlot/src/RangeSelectorTool.cpp
+++ b/Code/Mantid/MantidPlot/src/RangeSelectorTool.cpp
@@ -43,52 +43,53 @@
 
 RangeSelectorTool::RangeSelectorTool(Graph *graph, const QObject *status_target, const char *status_slot)
 	: QwtPlotPicker(graph->plotWidget()->canvas()),
-	PlotToolInterface(graph)
+          PlotToolInterface(graph), d_active_point(0), d_inactive_point(0), d_selected_curve(NULL),
+          d_enabled(false), d_visible(false)
 {
-	d_selected_curve = NULL;
-	for (int i=d_graph->curves(); i>=0; --i) {
-		d_selected_curve = d_graph->curve(i);
-		if (d_selected_curve && d_selected_curve->rtti() == QwtPlotItem::Rtti_PlotCurve
-				&& d_selected_curve->dataSize() > 0)
-			break;
-		d_selected_curve = NULL;
-	}
-	if (!d_selected_curve) {
-		QMessageBox::critical(d_graph, tr("MantidPlot - Warning"),
-				tr("All the curves on this plot are empty!"));
-		return;
-	}
+  d_selected_curve = NULL;
+  for (int i=d_graph->curves(); i>=0; --i) {
+    d_selected_curve = d_graph->curve(i);
+    if (d_selected_curve && d_selected_curve->rtti() == QwtPlotItem::Rtti_PlotCurve
+        && d_selected_curve->dataSize() > 0)
+      break;
+    d_selected_curve = NULL;
+  }
+  if (!d_selected_curve) {
+    QMessageBox::critical(d_graph, tr("MantidPlot - Warning"),
+                          tr("All the curves on this plot are empty!"));
+    return;
+  }
 
-    d_enabled = true;
-	d_visible = true;
-	d_active_point = 0;
-	d_inactive_point = d_selected_curve->dataSize() - 1;
-	int marker_size = 20;
+  d_enabled = true;
+  d_visible = true;
+  d_active_point = 0;
+  d_inactive_point = d_selected_curve->dataSize() - 1;
+  int marker_size = 20;
 
-	d_active_marker.setSymbol(QwtSymbol(QwtSymbol::Cross, QBrush(QColor(255,255,255,0)),//QBrush(QColor(255,255,0,128)),
-				QPen(Qt::red,2), QSize(marker_size,marker_size)));
-	d_active_marker.setLineStyle(QwtPlotMarker::VLine);
-	d_active_marker.setLinePen(QPen(Qt::red, 1, Qt::DashLine));
-	d_inactive_marker.setSymbol(QwtSymbol(QwtSymbol::Cross, QBrush(QColor(255,255,255,0)), //QBrush(QColor(255,255,0,128)),
-				QPen(Qt::black,2), QSize(marker_size,marker_size)));
-	d_inactive_marker.setLineStyle(QwtPlotMarker::VLine);
-	d_inactive_marker.setLinePen(QPen(Qt::black, 1, Qt::DashLine));
-	d_active_marker.setValue(d_selected_curve->x(d_active_point),
-			d_selected_curve->y(d_active_point));
-	d_inactive_marker.setValue(d_selected_curve->x(d_inactive_point),
-			d_selected_curve->y(d_inactive_point));
-	d_active_marker.attach(d_graph->plotWidget());
-	d_inactive_marker.attach(d_graph->plotWidget());
+  d_active_marker.setSymbol(QwtSymbol(QwtSymbol::Cross, QBrush(QColor(255,255,255,0)),//QBrush(QColor(255,255,0,128)),
+                                      QPen(Qt::red,2), QSize(marker_size,marker_size)));
+  d_active_marker.setLineStyle(QwtPlotMarker::VLine);
+  d_active_marker.setLinePen(QPen(Qt::red, 1, Qt::DashLine));
+  d_inactive_marker.setSymbol(QwtSymbol(QwtSymbol::Cross, QBrush(QColor(255,255,255,0)), //QBrush(QColor(255,255,0,128)),
+                                        QPen(Qt::black,2), QSize(marker_size,marker_size)));
+  d_inactive_marker.setLineStyle(QwtPlotMarker::VLine);
+  d_inactive_marker.setLinePen(QPen(Qt::black, 1, Qt::DashLine));
+  d_active_marker.setValue(d_selected_curve->x(d_active_point),
+                           d_selected_curve->y(d_active_point));
+  d_inactive_marker.setValue(d_selected_curve->x(d_inactive_point),
+                             d_selected_curve->y(d_inactive_point));
+  d_active_marker.attach(d_graph->plotWidget());
+  d_inactive_marker.attach(d_graph->plotWidget());
 
-	setTrackerMode(QwtPicker::AlwaysOn);
-	setSelectionFlags(QwtPicker::PointSelection | QwtPicker::ClickSelection);
-	d_graph->plotWidget()->canvas()->setCursor(QCursor(getQPixmap("vizor_xpm"), -1, -1));
-	d_graph->plotWidget()->canvas()->setFocus();
-	d_graph->plotWidget()->replot();
+  setTrackerMode(QwtPicker::AlwaysOn);
+  setSelectionFlags(QwtPicker::PointSelection | QwtPicker::ClickSelection);
+  d_graph->plotWidget()->canvas()->setCursor(QCursor(getQPixmap("vizor_xpm"), -1, -1));
+  d_graph->plotWidget()->canvas()->setFocus();
+  d_graph->plotWidget()->replot();
 
-	if (status_target)
-		connect(this, SIGNAL(statusText(const QString&)), status_target, status_slot);
-	emit statusText(tr("Click or use Ctrl+arrow key to select range (arrows select active cursor)!"));
+  if (status_target)
+    connect(this, SIGNAL(statusText(const QString&)), status_target, status_slot);
+  emit statusText(tr("Click or use Ctrl+arrow key to select range (arrows select active cursor)!"));
 }
 
 RangeSelectorTool::~RangeSelectorTool()

--- a/Code/Mantid/MantidPlot/src/RenameWindowDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/RenameWindowDialog.cpp
@@ -44,52 +44,54 @@
 RenameWindowDialog::RenameWindowDialog(QWidget* parent, Qt::WFlags fl )
     : QDialog( parent, fl )
 {
-	setWindowTitle(tr("MantidPlot - Rename Window"));
+  setWindowTitle(tr("MantidPlot - Rename Window"));
 
-	QGridLayout * leftLayout = new QGridLayout();
-	QVBoxLayout * rightLayout = new QVBoxLayout();
+  QGridLayout * leftLayout = new QGridLayout();
+  QVBoxLayout * rightLayout = new QVBoxLayout();
 
-	groupBox1 = new QGroupBox(tr("Window Title"));
-	groupBox1->setLayout(leftLayout);
+  groupBox1 = new QGroupBox(tr("Window Title"));
+  groupBox1->setLayout(leftLayout);
 
-	boxName = new QRadioButton(tr("&Name (single word)"));
-	leftLayout->addWidget(boxName, 0, 0);
-	boxNameLine = new QLineEdit();
-	leftLayout->addWidget(boxNameLine, 0, 1);
-	setFocusProxy(boxNameLine);
+  boxName = new QRadioButton(tr("&Name (single word)"));
+  leftLayout->addWidget(boxName, 0, 0);
+  boxNameLine = new QLineEdit();
+  leftLayout->addWidget(boxNameLine, 0, 1);
+  setFocusProxy(boxNameLine);
 
-	boxLabel = new QRadioButton(tr("&Label"));
-	leftLayout->addWidget(boxLabel, 2, 0);
-	boxLabelEdit = new QTextEdit();
-	leftLayout->addWidget(boxLabelEdit, 1, 1, 3, 1);
-	boxLabelEdit->setMaximumHeight(100);
-	boxLabelEdit->setMinimumHeight(100);
+  boxLabel = new QRadioButton(tr("&Label"));
+  leftLayout->addWidget(boxLabel, 2, 0);
+  boxLabelEdit = new QTextEdit();
+  leftLayout->addWidget(boxLabelEdit, 1, 1, 3, 1);
+  boxLabelEdit->setMaximumHeight(100);
+  boxLabelEdit->setMinimumHeight(100);
 
-	boxBoth = new QRadioButton(tr("&Both Name and Label"));
-	leftLayout->addWidget(boxBoth, 4, 0);
+  boxBoth = new QRadioButton(tr("&Both Name and Label"));
+  leftLayout->addWidget(boxBoth, 4, 0);
 
-	buttons = new QButtonGroup(this);
-	buttons->addButton(boxName);
-	buttons->addButton(boxLabel);
-	buttons->addButton(boxBoth);
+  buttons = new QButtonGroup(this);
+  buttons->addButton(boxName);
+  buttons->addButton(boxLabel);
+  buttons->addButton(boxBoth);
 
-	buttonOk = new QPushButton(tr( "&OK" ));
-    buttonOk->setAutoDefault( true );
-    buttonOk->setDefault( true );
-	rightLayout->addWidget(buttonOk);
+  buttonOk = new QPushButton(tr( "&OK" ));
+  buttonOk->setAutoDefault( true );
+  buttonOk->setDefault( true );
+  rightLayout->addWidget(buttonOk);
 
-    buttonCancel = new QPushButton(tr( "&Cancel" ));
-    buttonCancel->setAutoDefault( true );
-	rightLayout->addWidget(buttonCancel);
-	rightLayout->addStretch();
+  buttonCancel = new QPushButton(tr( "&Cancel" ));
+  buttonCancel->setAutoDefault( true );
+  rightLayout->addWidget(buttonCancel);
+  rightLayout->addStretch();
 
-	QHBoxLayout * mainLayout = new QHBoxLayout(this);
-    mainLayout->addWidget(groupBox1);
-	mainLayout->addLayout(rightLayout);
+  QHBoxLayout * mainLayout = new QHBoxLayout(this);
+  mainLayout->addWidget(groupBox1);
+  mainLayout->addLayout(rightLayout);
 
-    // signals and slots connections
-    connect( buttonOk, SIGNAL( clicked() ), this, SLOT( accept() ) );
-    connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
+  window = NULL;
+
+  // signals and slots connections
+  connect( buttonOk, SIGNAL( clicked() ), this, SLOT( accept() ) );
+  connect( buttonCancel, SIGNAL( clicked() ), this, SLOT( reject() ) );
 }
 
 void RenameWindowDialog::setWidget(MdiSubWindow *w)

--- a/Code/Mantid/MantidPlot/src/SmoothCurveDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/SmoothCurveDialog.cpp
@@ -42,78 +42,79 @@
 #include <QLayout>
 
 SmoothCurveDialog::SmoothCurveDialog(int method, QWidget* parent, Qt::WFlags fl )
-    : QDialog( parent, fl )
+  : QDialog( parent, fl ), graph(NULL), boxPointsLeft(NULL), boxPointsRight(NULL),
+    boxOrder(NULL)
 {
-	smooth_method = method;
+  smooth_method = method;
 
-    setName( "SmoothCurveDialog" );
-	setWindowTitle(tr("MantidPlot - Smoothing Options"));
+  setName( "SmoothCurveDialog" );
+  setWindowTitle(tr("MantidPlot - Smoothing Options"));
 
-    QGroupBox *gb1 = new QGroupBox();
-    QGridLayout *gl1 = new QGridLayout(gb1);
-	gl1->addWidget(new QLabel(tr("Curve")), 0, 0);
+  QGroupBox *gb1 = new QGroupBox();
+  QGridLayout *gl1 = new QGridLayout(gb1);
+  gl1->addWidget(new QLabel(tr("Curve")), 0, 0);
 
-    boxName = new QComboBox();
-	gl1->addWidget(boxName, 0, 1);
+  boxName = new QComboBox();
+  gl1->addWidget(boxName, 0, 1);
 
-	boxColor = new ColorBox();
-	boxColor->setColor(QColor(Qt::red));
+  boxColor = new ColorBox();
+  boxColor->setColor(QColor(Qt::red));
 
-	if (method == SmoothFilter::SavitzkyGolay)
-		{
-        gl1->addWidget(new QLabel(tr("Polynomial Order")), 1, 0);
-		boxOrder = new QSpinBox();
-		boxOrder->setRange(0, 9);
-		boxOrder->setValue(2);
-		gl1->addWidget(boxOrder, 1, 1);
+  if (method == SmoothFilter::SavitzkyGolay)
+  {
+      gl1->addWidget(new QLabel(tr("Polynomial Order")), 1, 0);
+      boxOrder = new QSpinBox();
+      boxOrder->setRange(0, 9);
+      boxOrder->setValue(2);
+      gl1->addWidget(boxOrder, 1, 1);
 
-		gl1->addWidget(new QLabel(tr("Points to the Left")), 2, 0);
-		boxPointsLeft = new QSpinBox();
-		boxPointsLeft->setRange(1, 25);
-		boxPointsLeft->setValue(2);
-		gl1->addWidget(boxPointsLeft, 2, 1);
+      gl1->addWidget(new QLabel(tr("Points to the Left")), 2, 0);
+      boxPointsLeft = new QSpinBox();
+      boxPointsLeft->setRange(1, 25);
+      boxPointsLeft->setValue(2);
+      gl1->addWidget(boxPointsLeft, 2, 1);
 
-		gl1->addWidget(new QLabel(tr("Points to the Right")), 3, 0);
-		boxPointsRight = new QSpinBox();
-		boxPointsRight->setRange(1, 25);
-		boxPointsRight->setValue(2);
-		gl1->addWidget(boxPointsRight, 3, 1);
+      gl1->addWidget(new QLabel(tr("Points to the Right")), 3, 0);
+      boxPointsRight = new QSpinBox();
+      boxPointsRight->setRange(1, 25);
+      boxPointsRight->setValue(2);
+      gl1->addWidget(boxPointsRight, 3, 1);
 
-		gl1->addWidget(new QLabel(tr("Color")), 4, 0);
-		gl1->addWidget(boxColor, 4, 1);
-        gl1->setRowStretch(5, 1);
-		}
-	else
-		{
-		gl1->addWidget(new QLabel(tr("Points")), 1, 0);
-		boxPointsLeft = new QSpinBox();
-		boxPointsLeft->setRange(1, 1000000);
-		boxPointsLeft->setSingleStep(10);
-		boxPointsLeft->setValue(5);
-		gl1->addWidget(boxPointsLeft, 1, 1);
+      gl1->addWidget(new QLabel(tr("Color")), 4, 0);
+      gl1->addWidget(boxColor, 4, 1);
+      gl1->setRowStretch(5, 1);
+  }
+  else
+  {
+      gl1->addWidget(new QLabel(tr("Points")), 1, 0);
+      boxPointsLeft = new QSpinBox();
+      boxPointsLeft->setRange(1, 1000000);
+      boxPointsLeft->setSingleStep(10);
+      boxPointsLeft->setValue(5);
+      gl1->addWidget(boxPointsLeft, 1, 1);
 
-		gl1->addWidget(new QLabel(tr("Color")), 2, 0);
-		gl1->addWidget(boxColor, 2, 1);
-        gl1->setRowStretch(3, 1);
-		}
-    gl1->setColStretch(2, 1);
+      gl1->addWidget(new QLabel(tr("Color")), 2, 0);
+      gl1->addWidget(boxColor, 2, 1);
+      gl1->setRowStretch(3, 1);
+  }
+  gl1->setColStretch(2, 1);
 
-	btnSmooth = new QPushButton(tr( "&Smooth" ));
-    btnSmooth->setDefault(true);
-    buttonCancel = new QPushButton(tr( "&Close" ));
+  btnSmooth = new QPushButton(tr( "&Smooth" ));
+  btnSmooth->setDefault(true);
+  buttonCancel = new QPushButton(tr( "&Close" ));
 
-	QVBoxLayout *vl = new QVBoxLayout();
- 	vl->addWidget(btnSmooth);
-	vl->addWidget(buttonCancel);
-    vl->addStretch();
+  QVBoxLayout *vl = new QVBoxLayout();
+  vl->addWidget(btnSmooth);
+  vl->addWidget(buttonCancel);
+  vl->addStretch();
 
-    QHBoxLayout *hb = new QHBoxLayout(this);
-    hb->addWidget(gb1);
-    hb->addLayout(vl);
+  QHBoxLayout *hb = new QHBoxLayout(this);
+  hb->addWidget(gb1);
+  hb->addLayout(vl);
 
-	connect( btnSmooth, SIGNAL(clicked()), this, SLOT( smooth()));
-    connect( buttonCancel, SIGNAL(clicked()), this, SLOT( reject()));
-	connect( boxName, SIGNAL(activated(const QString&)), this, SLOT(activateCurve(const QString&)));
+  connect( btnSmooth, SIGNAL(clicked()), this, SLOT( smooth()));
+  connect( buttonCancel, SIGNAL(clicked()), this, SLOT( reject()));
+  connect( boxName, SIGNAL(activated(const QString&)), this, SLOT(activateCurve(const QString&)));
 }
 
 void SmoothCurveDialog::smooth()

--- a/Code/Mantid/MantidPlot/src/SortDialog.h
+++ b/Code/Mantid/MantidPlot/src/SortDialog.h
@@ -53,7 +53,6 @@ signals:
 private:
   QPushButton* buttonOk;
   QPushButton* buttonCancel;
-  QPushButton* buttonHelp;
   QComboBox* boxType;
   QComboBox* boxOrder;
   QComboBox *columnsList;

--- a/Code/Mantid/MantidPlot/src/TextDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/TextDialog.cpp
@@ -48,7 +48,7 @@
 #include <qwt_scale_widget.h>
 
 TextDialog::TextDialog(TextType type, QWidget* parent, Qt::WFlags fl)
-	: QDialog( parent, fl)
+  : QDialog( parent, fl)
 {
 	setAttribute(Qt::WA_DeleteOnClose);
 	setWindowTitle( tr( "MantidPlot - Text options" ) );
@@ -82,6 +82,7 @@ TextDialog::TextDialog(TextType type, QWidget* parent, Qt::WFlags fl)
 	buttonApply->setDefault( true );
 	topLayout->addWidget( buttonApply, 1, 3 );
 
+        alignmentBox = NULL;
 	if (textType != TextDialog::TextMarker){
 		topLayout->addWidget(new QLabel(tr("Alignment")), 2, 0);
 		alignmentBox = new QComboBox();

--- a/Code/Mantid/MantidPlot/src/TextDialog.h
+++ b/Code/Mantid/MantidPlot/src/TextDialog.h
@@ -109,9 +109,8 @@ protected:
 	QPushButton *buttonCancel;
 	QPushButton *buttonApply;
 	QPushButton *buttonDefault;
-	QComboBox *rotateBox;
 	QTextEdit *textEditBox;
-	QGroupBox *groupBox1, *groupBox2;
+	QGroupBox *groupBox1;
 	QComboBox *alignmentBox;
 	TextFormatButtons *formatButtons;
 	QSpinBox *boxBackgroundTransparency;

--- a/Code/Mantid/MantidPlot/src/TranslateCurveTool.cpp
+++ b/Code/Mantid/MantidPlot/src/TranslateCurveTool.cpp
@@ -44,6 +44,9 @@
 TranslateCurveTool::TranslateCurveTool(Graph *graph, ApplicationWindow *app, Direction dir, const QObject *status_target, const char *status_slot)
 	: PlotToolInterface(graph),
 	d_dir(dir),
+        d_sub_tool(NULL),
+        d_selected_curve(NULL),
+        d_curve_point(),
 	d_app(app)
 {
 	if (status_target)

--- a/Code/Mantid/MantidPlot/src/VectorCurve.cpp
+++ b/Code/Mantid/MantidPlot/src/VectorCurve.cpp
@@ -35,14 +35,15 @@
 VectorCurve::VectorCurve(VectorStyle style, Table *t, const QString& xColName, const char *name,
 				const QString& endCol1, const QString& endCol2, int startRow, int endRow):
     DataCurve(t, xColName, name, startRow, endRow),
-	pen(QPen(Qt::black, 1, Qt::SolidLine)),
-	filledArrow (true),
-	d_style (style),
-	d_headLength (4),
-	d_headAngle (45),
-	d_position (Tail),
-	d_end_x_a (endCol1),
-	d_end_y_m (endCol2)
+    vectorEnd(NULL),
+    pen(QPen(Qt::black, 1, Qt::SolidLine)),
+    filledArrow(true),
+    d_style(style),
+    d_headLength(4),
+    d_headAngle(45),
+    d_position(Tail),
+    d_end_x_a(endCol1),
+    d_end_y_m(endCol2)
 {
 	if (style == XYXY)
 		setType(Graph::VectXYXY);

--- a/Code/Mantid/MantidPlot/src/lib/src/ExtensibleFileDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/lib/src/ExtensibleFileDialog.cpp
@@ -38,6 +38,7 @@ ExtensibleFileDialog::ExtensibleFileDialog(QWidget *parent, bool extended, Qt::W
   : QFileDialog(parent, flags)
 {
   d_extension = 0;
+  d_extension_row = 0;
 
   d_extension_toggle = new QPushButton();
   d_extension_toggle->setCheckable(true);

--- a/Code/Mantid/MantidPlot/src/origin/OPJFile.h
+++ b/Code/Mantid/MantidPlot/src/origin/OPJFile.h
@@ -304,19 +304,19 @@ struct vectorProperties
 	int const_magnitude;
 
 	vectorProperties()
-	:	color(0)
-	,	width(0.0)
-	,	arrow_lenght(0.0)
+        :	color(0)
+        ,	width(0.0)
+        ,	arrow_lenght(0)
         ,	arrow_angle(0)
-	,	arrow_closed(false)
-	,	endXColName()
-	,	endYColName()
+        ,	arrow_closed(false)
+        ,	endXColName()
+        ,	endYColName()
         ,	position(0)
         ,	angleColName()
         ,	magnitudeColName(0)
         ,	multiplier(1.0)
-	,	const_angle(0)
-	,	const_magnitude(0)
+        ,	const_angle(0)
+        ,	const_magnitude(0)
 	{};
 };
 

--- a/Code/Mantid/MantidPlot/src/origin/OPJFile.h
+++ b/Code/Mantid/MantidPlot/src/origin/OPJFile.h
@@ -85,6 +85,7 @@ struct originWindow {
 	originWindow(std::string _name="", std::string _label="", bool _bHidden=false)
 	:	name(_name)
 	,	label(_label)
+	,	objectID(0)
 	,	bHidden(_bHidden)
 	,	state(Normal)
 	,	title(Both)
@@ -144,10 +145,12 @@ struct spreadSheet : public originWindow {
 	bool bMultisheet;
 	std::vector <spreadColumn> column;
 	spreadSheet(std::string _name="")
-	:	originWindow(_name)
+        :	originWindow(_name)
+        ,	maxRows(0)
 	,	bLoose(true)
 	,	bMultisheet(false)
-	{};
+	,	column()          
+        {};
 };
 
 struct excel : public originWindow {
@@ -178,7 +181,9 @@ struct matrix : public originWindow {
 	HeaderViewType header;
 	std::vector <double> data;
 	matrix(std::string _name="", int _index=0)
-	:	originWindow(_name)
+        :	originWindow(_name)
+        ,       nr_rows(0)
+        ,       nr_cols(0)
 	,	value_type_specification(0)
 	,	significant_digits(6)
 	,	decimal_places(6)
@@ -223,7 +228,15 @@ struct text {
 
 	text(const std::string& _txt="")
 		:	txt(_txt)
-	{};
+		,	clientRect()
+                ,	color(0)
+                ,	fontsize(0)
+                ,	rotation(0)
+                ,	tab(0)
+                ,	border_type(0)
+                ,	attach(0)
+        {};
+
 	text(const std::string& _txt, const rect& _clientRect, int _color, int _fontsize, int _rotation, int _tab, int _border_type, int _attach)
 		:	txt(_txt)
 		,	clientRect(_clientRect)
@@ -256,13 +269,21 @@ struct pieProperties
 	unsigned short distance;
 
 	pieProperties()
-	:	clockwise_rotation(false)
+	:	view_angle(0)
+	,	thickness(0)
+	,	clockwise_rotation(false)
+	,	rotation(0)
+	,	radius(0)
+	,	horizontal_offset(0)
+	,	displaced_sections(0)
+	,	displacement(0)
 	,	format_automatic(false)
 	,	format_values(false)
 	,	format_percentages(false)
 	,	format_categories(false)
 	,	position_associate(false)
-	{};
+	,	distance(0)
+        {};
 };
 
 struct vectorProperties
@@ -283,9 +304,17 @@ struct vectorProperties
 	int const_magnitude;
 
 	vectorProperties()
-	:	arrow_closed(false)
-	,	position(0)
-	,	multiplier(1.0)
+	:	color(0)
+	,	width(0.0)
+	,	arrow_lenght(0.0)
+        ,	arrow_angle(0)
+	,	arrow_closed(false)
+	,	endXColName()
+	,	endYColName()
+        ,	position(0)
+        ,	angleColName()
+        ,	magnitudeColName(0)
+        ,	multiplier(1.0)
 	,	const_angle(0)
 	,	const_magnitude(0)
 	{};
@@ -343,7 +372,15 @@ struct graphAxisBreak {
 	unsigned char minor_ticks_after;
 
 	graphAxisBreak()
-	:	show(false)
+	:   show(false)
+          , log10(false)
+          , from(0.0)
+          , to(0.0)
+          , position(0)
+          , scale_increment_before(0)
+          , scale_increment_after(0)
+          , minor_ticks_before(0)
+          , minor_ticks_after(0)
 	{
 	}
 };
@@ -484,7 +521,9 @@ struct graph : public originWindow {
 
 	graph(std::string _name="")
 	:	originWindow(_name)
-	{};
+        ,	width(0)
+        ,	height(0)
+        {};
 };
 
 struct note : public originWindow {

--- a/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidQwtIMDWorkspaceData.cpp
@@ -44,6 +44,9 @@ MantidQwtIMDWorkspaceData::MantidQwtIMDWorkspaceData(Mantid::API::IMDWorkspace_c
     bool isDistribution)
  : m_workspace(workspace),
    m_logScale(logScale),
+   m_minY(DBL_MAX),
+   m_minPositive(DBL_MAX),
+   m_maxY(-DBL_MAX),
    m_preview(false),
    m_start(start),
    m_end(end),

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/DataComparison.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/DataComparison.cpp
@@ -33,6 +33,9 @@ DataComparison::DataComparison(QWidget *parent) :
   UserSubWindow(parent),
   WorkspaceObserver(),
   m_plot(new QwtPlot(parent)),
+  m_zoomTool(NULL),
+  m_panTool(NULL),
+  m_magnifyTool(NULL),
   m_diffWorkspaceNames(qMakePair(QString(), QString()))
 {
   observeAfterReplace();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReductionTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReductionTab.cpp
@@ -21,7 +21,7 @@ namespace CustomInterfaces
   /** Constructor
    */
   IndirectDataReductionTab::IndirectDataReductionTab(IndirectDataReduction *idrUI, QObject *parent) :
-    IndirectTab(parent), m_idrUI(idrUI)
+    IndirectTab(parent), m_idrUI(idrUI), m_tabRunning(false)
   {
     connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(tabExecutionComplete(bool)));
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -31,7 +31,8 @@ DECLARE_SUBWINDOW(MultiDatasetFit)
 /// Constructor
 /// @param parent :: The parent widget
 MultiDatasetFit::MultiDatasetFit(QWidget *parent)
-:UserSubWindow(parent)
+:UserSubWindow(parent), m_plotController(NULL), m_dataController(NULL), m_functionBrowser(NULL),
+ m_fitOptionsBrowser(NULL)
 {
 }
 

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
@@ -120,7 +120,7 @@ namespace MantidWidgets
       size_t wsIndex;
 
       PlotCurveConfiguration():
-        curve(NULL), label(NULL) {}
+        curve(NULL), label(NULL), colour(), wsIndex(0) {}
     };
 
     void handleRemoveEvent(Mantid::API::WorkspacePreDeleteNotification_ptr pNf);

--- a/Code/Mantid/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
@@ -87,7 +87,16 @@ namespace MantidWidgets
  */
 FitPropertyBrowser::FitPropertyBrowser(QWidget *parent, QObject* mantidui):
   QDockWidget("Fit Function",parent),
+  m_workspaceIndex(NULL),
+  m_startX(NULL),
+  m_endX(NULL),
+  m_output(NULL),
+  m_minimizer(NULL),
+  m_ignoreInvalidData(NULL),
+  m_costFunction(NULL),
+  m_maxIterations(NULL),
   m_logValue(NULL),
+  m_plotDiff(NULL),
   m_plotCompositeMembers(NULL),
   m_convolveMembers(NULL),
   m_rawData(NULL),

--- a/Code/Mantid/MantidQt/MantidWidgets/src/IndirectInstrumentConfig.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/IndirectInstrumentConfig.cpp
@@ -24,7 +24,9 @@ namespace MantidQt
 
     IndirectInstrumentConfig::IndirectInstrumentConfig(QWidget *parent): API::MantidWidget(parent),
       m_algRunner(),
-      m_disabledInstruments()
+      m_disabledInstruments(),
+      m_removeDiffraction(false),
+      m_forceDiffraction(false)
     {
       m_uiForm.setupUi(this);
 

--- a/Code/Mantid/MantidQt/MantidWidgets/src/SelectWorkspacesDialog.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/SelectWorkspacesDialog.cpp
@@ -53,7 +53,7 @@ namespace MantidWidgets
 */
 SelectWorkspacesDialog::SelectWorkspacesDialog(QWidget* parent, const std::string& typeFilter,
                                                const std::string& customButtonLabel) :
-QDialog(parent)
+  QDialog(parent), m_wsList(NULL), m_okButton(NULL), m_customButton(NULL)
 {
   setWindowTitle("MantidPlot - Select workspace");
   m_wsList = new QListWidget(parent);


### PR DESCRIPTION
This fixes [#11826](http://trac.mantidproject.org/mantid/ticket/11826).

In general, this adds many missing data member initializations, and removes a few unused members.

**To test**:
- Tests should pass and the MantidPlot GUI should behave as usual.
- Code review.
