### PR TITLE
Change SensorA as default log in IDA.ELWIN for BASIS

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -327,7 +327,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
                              'average': lambda x: x.mean()
                              }
             temp = value_action[self._sample_log_value](tmp)
-            logger.error('Temperature %f K found for run: %s' % (temp, run_name))
+            logger.debug('Temperature %d K found for run: %s' % (temp, run_name))
             return temp
 
         else:

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -57,6 +57,10 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
         self.declareProperty(name='SampleEnvironmentLogName', defaultValue='sample',
                              doc='Name of the sample environment log entry')
 
+        sampEnvLogVal_type = ['last value', 'average']
+        self.declareProperty('SampleEnvironmentLogValue', 'last value', StringListValidator(sampEnvLogVal_type),
+                             doc='Value selection of the sample environment log entry')
+
         self.declareProperty(WorkspaceProperty('OutputInQ', '', Direction.Output),
                              doc='Output workspace in Q')
 
@@ -260,6 +264,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
 
         self._plot = self.getProperty('Plot').value
         self._sample_log_name = self.getPropertyValue('SampleEnvironmentLogName')
+        self._sample_log_value = self.getPropertyValue('SampleEnvironmentLogValue')
 
         self._input_workspaces = self.getProperty('InputWorkspaces').value
         self._q_workspace = self.getPropertyValue('OutputInQ')
@@ -318,8 +323,11 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
         if self._sample_log_name in run:
             # Look for temperature in logs in workspace
             tmp = run[self._sample_log_name].value
-            temp = tmp[len(tmp) - 1]
-            logger.debug('Temperature %d K found for run: %s' % (temp, run_name))
+            value_action = {'last value': lambda x: x[len(x)-1],
+                             'average': lambda x: x.mean()
+                             }
+            temp = value_action[self._sample_log_value](tmp)
+            logger.error('Temperature %f K found for run: %s' % (temp, run_name))
             return temp
 
         else:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Elwin.ui
@@ -122,6 +122,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="leLogValue">
+       <item>
+        <property name="text">
+         <string>last value</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>average</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -146,6 +146,7 @@ namespace IDA
     elwinMultAlg->setProperty("OutputELF", elfWorkspace.toStdString());
 
     elwinMultAlg->setProperty("SampleEnvironmentLogName", m_uiForm.leLogName->text().toStdString());
+    elwinMultAlg->setProperty("SampleEnvironmentLogValue", m_uiForm.leLogValue->currentText().toStdString());
 
     elwinMultAlg->setProperty("Range1Start", m_dblManager->value(m_properties["IntegrationStart"]));
     elwinMultAlg->setProperty("Range1End", m_dblManager->value(m_properties["IntegrationEnd"]));
@@ -261,15 +262,25 @@ namespace IDA
   void Elwin::setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws)
   {
     auto inst = ws->getInstrument();
+    // Set sample environment log name
     auto log = inst->getStringParameter("Workflow.SE-log");
     QString logName("sample");
-
     if(log.size() > 0)
     {
       logName = QString::fromStdString(log[0]);
     }
-
     m_uiForm.leLogName->setText(logName);
+    // Set sample environment log value
+    auto logval = inst->getStringParameter("Workflow.SE-log-value");
+    if(logval.size() > 0)
+    {
+      auto logValue = QString::fromStdString(logval[0]);
+      int  index = m_uiForm.leLogValue->findText(logValue);
+      if (index >= 0)
+      {
+        m_uiForm.leLogValue->setCurrentIndex(index);
+      }
+    }
   }
 
   /**

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -78,6 +78,11 @@ SE log name
   The name of the sample environment log entry in the input files sample logs
   (defaults to sample).
 
+SE log value
+  The value to be taken from the "SE log name" data series (defaults to the
+  specified value in the intrument parameters file, and in the absence of such
+  specification, defaults to "last value")
+
 Plot Result
   If enabled will plot the result as a spectra plot.
 

--- a/Code/Mantid/instrument/BASIS_Parameters.xml
+++ b/Code/Mantid/instrument/BASIS_Parameters.xml
@@ -65,7 +65,7 @@
     <value val="AnalyserReflection" />
 </parameter>
 <parameter name="Workflow.SE-log" type="string">
-    <value val="SetpointLP1" />
+    <value val="SensorA" />
 </parameter>
 
 </component-link>

--- a/Code/Mantid/instrument/BASIS_Parameters.xml
+++ b/Code/Mantid/instrument/BASIS_Parameters.xml
@@ -67,6 +67,9 @@
 <parameter name="Workflow.SE-log" type="string">
     <value val="SensorA" />
 </parameter>
+<parameter name="Workflow.SE-log-value" type="string">
+    <value val="average" />
+</parameter>
 
 </component-link>
 


### PR DESCRIPTION
<b>Trac ticket</b> [11809](http://trac.mantidproject.org/mantid/ticket/11809)

<b>Description:</b> Parameters file now include a selection mode for the temperature value to be used in the ELWIN tab of the IDA interface. Options are 'last value' and 'average', which will select the last value or the average in the temperature series stored in the sample logs. If the selection mode is not found in the parameters file, the mode defaults to 'last value' to be backwards compatible. Algorithm ElasticWindowMultiple, the backend of the ELWIN tab, includes a new property to set the selection mode from a pulldown menu.

<b>Testing:</b> Download the series of [structure factors](https://www.dropbox.com/s/36smrak3bofb7m1/scan1.tar.gz?dl=0) representing a temperature scan from 20K to 300K (89MB). After this:
- open the ELWIN tab from the Indirect Analysis interface
- 'Browse', then highlight the nexus files, then 'Open'
- back in the interface, click the 'Plot result' box, then click in  'Run'.

The X-values of output workspace 'bss41137_silicon111_elwin_elf' should be the average temperature for each of the input workspaces bss41137_silicon111_sqw to bss41277_silicon111_sqw. For instance, open the sample logs of workspace IDA_Elwin_Input/bss41137_silicon111_sqw, select "SensorA" which records the temperature series, and the 'Mean' value should the be first X-value of workspace 'bss41137_silicon111_elwin_elf'. The second X-value should be the mean of SensorA series for run 41138, and so on.
