### PR TITLE
Fix invalid Poco::URI path when missing trailing /.

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
@@ -147,9 +147,9 @@ public:
   sendRequest(const std::string &url, std::ostream &responseStream);
 
 protected:
-  virtual int sendHTTPSRequest(const std::string &url,
+  virtual int sendHTTPSRequest(Poco::URI &uri,
                                std::ostream &responseStream);
-  virtual int sendHTTPRequest(const std::string &url,
+  virtual int sendHTTPRequest(Poco::URI &uri,
                               std::ostream &responseStream);
   virtual int processErrorStates(const Poco::Net::HTTPResponse &res,
                                  std::istream &rs, const std::string &url);

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/InternetHelper.h
@@ -147,9 +147,9 @@ public:
   sendRequest(const std::string &url, std::ostream &responseStream);
 
 protected:
-  virtual int sendHTTPSRequest(Poco::URI &uri,
+  virtual int sendHTTPSRequest(const std::string &url,
                                std::ostream &responseStream);
-  virtual int sendHTTPRequest(Poco::URI &uri,
+  virtual int sendHTTPRequest(const std::string &url,
                               std::ostream &responseStream);
   virtual int processErrorStates(const Poco::Net::HTTPResponse &res,
                                  std::istream &rs, const std::string &url);


### PR DESCRIPTION
There is a bug in Poco when it converts a url string to Poco::URI where it doesn't get a path. [See here](http://sourceforge.net/p/poco/feature-requests/137/) This prevents DownloadFile doc test from running anywhere except ISIS.

This fixes it by checking it the path is empty, then adds `/` to the url.

**To test:**
- Can you run `DownloadFile("http://www.mantidproject.org", "download.txt")`
- Also try running the DownloadFile doc test.

**This should be tested by people at both ISIS and ORNL to check if it works with and without proxy servers**
