### PR TITLE
Allow an arbitrary trailing string on the qwt version

### DIFF
--- a/Code/Mantid/Build/CMake/FindQwt.cmake
+++ b/Code/Mantid/Build/CMake/FindQwt.cmake
@@ -18,7 +18,7 @@ find_package_handle_standard_args( Qwt DEFAULT_MSG QWT_LIBRARY QWT_INCLUDE_DIR )
 
 # Parse version string from qwt_global.h
 file ( STRINGS ${QWT_INCLUDE_DIR}/qwt_global.h QWT_VERSION 
-       REGEX "^#define[ \t]+QWT_VERSION_STR[ \t]+\"[0-9]+.[0-9]+.[0-9]+\"$" )
+       REGEX "^#define[ \t]+QWT_VERSION_STR[ \t]+\"[0-9]+.[0-9]+.[0-9]+(.*)?\"$" )
 if ( NOT QWT_VERSION )
     message ( FATAL_ERROR "Unrecognized Qwt version (cannot find QWT_VERSION_STR in qwt_global.h)" )
 endif()


### PR DESCRIPTION
Fixes trac [#10901](http://trac.mantidproject.org/mantid/ticket/10901)

_Tester_
Mantid should still find Qwt on all platforms and on debian, when version 6 is installed, it should now exit out correctly saying that we require version 5. 
