### PR TITLE
error quantification in MSD Fit not correct

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Elwin.cpp
@@ -152,8 +152,8 @@ namespace IDA
 
     if(m_blnManager->value(m_properties["BackgroundSubtraction"]))
     {
-      elwinMultAlg->setProperty("Range2Start", boost::lexical_cast<std::string>(m_dblManager->value(m_properties["IntegrationStart"])));
-      elwinMultAlg->setProperty("Range2End", boost::lexical_cast<std::string>(m_dblManager->value(m_properties["IntegrationEnd"])));
+      elwinMultAlg->setProperty("Range2Start", boost::lexical_cast<std::string>(m_dblManager->value(m_properties["BackgroundStart"])));
+      elwinMultAlg->setProperty("Range2End", boost::lexical_cast<std::string>(m_dblManager->value(m_properties["BackgroundEnd"])));
     }
 
     if(m_blnManager->value(m_properties["Normalise"]))


### PR DESCRIPTION
<h4>error quantification in MSD Fit not correct</h4>


Ticket [11810](http://trac.mantidproject.org/mantid/ticket/11810)

When using the background removal tool in IDA.ELWIN, and subsequently using the output in IDA.MSDFIT, the error bars are not correctly computed. They are inordinately large. 

<b>Testing:</b> Download [test_data_t11810.tar.gz](https://www.dropbox.com/s/anwwi86x749lfbk/test_data_t11810.tar.gz?dl=0). It contains:
- testd/ directory with 10 structure factors (Nexus format)
- test.py script to run in the Script Window of MantidPlot. You should edit this file and update variable <b>rootd</b> with the absolute path to directory testd/

After running the script, MSD versus  temperature plot will popup and should look like this:

![test_msd_t11810](https://cloud.githubusercontent.com/assets/1136006/7892226/ec5260b2-0620-11e5-96c1-63c74ace3a47.png)
