### PR TITLE
Remove hacks in ConfigService for older Poco versions

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -326,8 +326,6 @@ private:
 
   /// The list of available facilities
   std::vector<FacilityInfo *> m_facilities;
-  /// Define a flag value for a removed property
-  const std::string m_removedFlag;
 
   /// local cache of proxy details
   Kernel::ProxyInfo m_proxyInfo;

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -149,7 +149,7 @@ ConfigServiceImpl::ConfigServiceImpl()
       m_user_properties_file_name("Mantid.user.properties"),
 #endif
       m_DataSearchDirs(), m_UserSearchDirs(), m_InstrumentDirs(),
-      m_instr_prefixes(), m_removedFlag("@@REMOVED@@"), m_proxyInfo(),
+      m_instr_prefixes(), m_proxyInfo(),
       m_isProxySet(false) {
   // getting at system details
   m_pSysConfig = new WrappedObject<Poco::Util::SystemConfiguration>;
@@ -943,8 +943,6 @@ std::string ConfigServiceImpl::getString(const std::string &keyName,
   std::string retVal;
   try {
     retVal = m_pConf->getString(keyName);
-    if (retVal == m_removedFlag)
-      retVal = "";
   }
   catch (Poco::NotFoundException &) {
     g_log.debug() << "Unable to find " << keyName << " in the properties file"
@@ -966,30 +964,8 @@ std::string ConfigServiceImpl::getString(const std::string &keyName,
 std::vector<std::string>
 ConfigServiceImpl::getKeys(const std::string &keyName) const {
   std::vector<std::string> rawKeys;
-  std::vector<std::string> keyVector;
-  keyVector.reserve(rawKeys.size());
-  try {
-    m_pConf->keys(keyName, rawKeys);
-    // Work around a limitation of Poco < v1.4 which has no remove functionality
-    // so check those that have been marked with the correct flag
-    const size_t nraw = rawKeys.size();
-    for (size_t i = 0; i < nraw; ++i) {
-      const std::string key = rawKeys[i];
-      try {
-        if (m_pConf->getString(key) == m_removedFlag)
-          continue;
-      }
-      catch (Poco::NotFoundException &) {
-      }
-      keyVector.push_back(key);
-    }
-  }
-  catch (Poco::NotFoundException &) {
-    g_log.debug() << "Unable to find " << keyName << " in the properties file"
-                  << std::endl;
-    keyVector.clear();
-  }
-  return keyVector;
+  m_pConf->keys(keyName, rawKeys);
+  return rawKeys;
 }
 
 /**
@@ -1039,16 +1015,7 @@ std::vector<std::string> ConfigServiceImpl::keys() const {
  *  @param rootName :: The key that is to be deleted
  */
 void ConfigServiceImpl::remove(const std::string &rootName) const {
-  try {
-    // m_pConf->remove(rootName) will only work in Poco v >=1.4. Current Ubuntu
-    // and RHEL use 1.3.x
-    // Simulate removal by marking with a flag value
-    m_pConf->setString(rootName, m_removedFlag);
-  }
-  catch (Poco::NotFoundException &) {
-    g_log.debug() << "Unable to find " << rootName << " in the properties file"
-                  << std::endl;
-  }
+  m_pConf->remove(rootName);
   m_changed_keys.insert(rootName);
 }
 
@@ -1059,9 +1026,7 @@ void ConfigServiceImpl::remove(const std::string &rootName) const {
  *  @returns Boolean value denoting whether the exists or not.
  */
 bool ConfigServiceImpl::hasProperty(const std::string &rootName) const {
-  // Work around a limitation of Poco < v1.4 which has no remove functionality
-  return m_pConf->hasProperty(rootName) &&
-         m_pConf->getString(rootName) != m_removedFlag;
+  return m_pConf->hasProperty(rootName);
 }
 
 /** Checks to see whether the given file target is an executable one and it


### PR DESCRIPTION
Fixes trac issue [#11871](http://trac.mantidproject.org/mantid/ticket/11871)

_Tester_
Ensure all tests pass. The unit test should do most of the work here. You can also try removing things from Python and printing the keys to see the effect is the same as before.
