### PR TITLE
Clang format python interface

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -164,6 +164,6 @@ if not "%JOB_NAME%"=="%JOB_NAME:pull_requests=%" (
 
   :: Remove Mantid
   cd %BUILD_DIR%
-  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py uninstall %BUILD_DIR%
+  start "Uninstall Mantid" /B /WAIT python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py uninstall %BUILD_DIR%
   if !RETCODE! NEQ 0 exit /B 1
 )

--- a/Code/Mantid/Framework/PythonInterface/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/CMakeLists.txt
@@ -25,37 +25,42 @@ add_definitions ( -DBOOST_DEBUG_PYTHON -DBOOST_PYTHON_NO_LIB -DNPY_NO_DEPRECATED
 set ( PYTHON_DEPS ${MPI_CXX_LIBRARIES} )
 
 ####################################################################################
-# A macro for generating the exports
-#  - MODULE_TEMPLATE: The file containing the @EXPORT_FUNCTIONS@ and @EXPORT_DECALRE@ flags to replace
+# A function for generating the exports
+#  - MODULE_TEMPLATE: The file containing the @EXPORT_FUNCTIONS@ and @EXPORT_DECLARE@ flags to replace
 #  - OUTPUT_FILE: The path to the generated output file
-#  - EXPORT_FILES: The variable containing the files to be processed
-#  - SRC_FILES: The variable containing the list of sources. Used to append the generated file.
+#  - ... The list of export files
 ####################################################################################
-MACRO( CREATE_MODULE MODULE_TEMPLATE OUTPUT_FILE EXPORT_FILES SRCS )
-  set ( EXPORT_DECLARE )
-  set ( EXPORT_FUNCTIONS )
-  foreach( CPPFILE ${${EXPORT_FILES}} )
-    file( STRINGS ${CPPFILE} EXPORTS REGEX "void *export.*()" )
-    foreach( EXPORT ${EXPORTS} )
-      string ( STRIP "${EXPORT}" EXPORT )
-      set ( EXPORT_DECLARE "${EXPORT_DECLARE}\n${EXPORT};" )
-      string( REGEX REPLACE "void " "" EXPORT "${EXPORT}" )
-      set ( EXPORT_FUNCTIONS "${EXPORT_FUNCTIONS}\n${EXPORT};" )
-    endforeach(EXPORT ${EXPORTS})
-  endforeach( CPPFILE ${${EXPORT_FILES}} )
-  string( STRIP "${EXPORT_DECLARE}" EXPORT_DECLARE )
-  string( STRIP "${EXPORT_FUNCTIONS}" EXPORT_FUNCTIONS )
+function ( CREATE_MODULE MODULE_TEMPLATE OUTPUT_FILE )
+  set ( _fwd_declarations )
+  set ( _function_calls )
+  foreach( _cppfile ${ARGN} )
+    # pull out all functions named 'void export...'
+    file ( STRINGS ${_cppfile} _definitions REGEX "( *)?void *export.*().*" )
+    foreach ( _func_definition ${_definitions} )
+      # create a forward declaration and function call
+      string ( STRIP "${_func_definition}" _func_definition )
+      string ( REGEX REPLACE "(void *export.*\\(\\)).*" "\\1" _func_declaration "${_func_definition}" )
+      # add to list of declarations
+      set ( _fwd_declarations "${_fwd_declarations}\n${_func_declaration}\;" )
+      # strip void and add to call list
+      string( REGEX REPLACE "void *" "" _func_call "${_func_declaration}" )
+      set ( _function_calls "${_function_calls}\n${_func_call}\;" )
+    endforeach ()
+  endforeach ()
+  string ( STRIP "${_fwd_declarations}" _fwd_declarations )
+  string ( STRIP "${_function_calls}" _function_calls )
 
   # Configure the final file
+  set ( EXPORT_DECLARE ${_fwd_declarations} )
+  set ( EXPORT_FUNCTIONS ${_function_calls} )
+
   configure_file( ${MODULE_TEMPLATE} ${OUTPUT_FILE} )
-  # Set the sources
-  LIST ( APPEND ${SRCS} ${${EXPORT_FILES}} ${OUTPUT_FILE} )
-ENDMACRO( )
+endfunction ()
 
 ####################################################################################
 # A function for setting the correct properties on the individual targets
 ####################################################################################
-FUNCTION( SET_PYTHON_PROPERTIES TARGET TARGET_NAME )
+function ( SET_PYTHON_PROPERTIES TARGET TARGET_NAME )
   # No library prefixes
   set_target_properties( ${TARGET} PROPERTIES PREFIX "" )
   # Library name needs to end in .pyd for Windows
@@ -74,7 +79,7 @@ FUNCTION( SET_PYTHON_PROPERTIES TARGET TARGET_NAME )
   endif ()
   # Group within VS
   set_property ( TARGET ${TARGET} PROPERTY FOLDER "MantidFramework/Python" )
-ENDFUNCTION()
+endfunction()
 
 ###########################################################################
 # mantid package

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -71,7 +71,12 @@ set ( EXPORT_FILES
   src/Exports/AlgorithmProperty.cpp
 )
 
-# Files containing additional helper code that are not related to exporting class/functions
+set ( MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/api.cpp )
+create_module ( ${MODULE_TEMPLATE} ${MODULE_DEFINITION} ${EXPORT_FILES} )
+
+#############################################################################################
+# Helper code
+#############################################################################################
 set ( SRC_FILES
   src/Algorithms/RunPythonScript.cpp
   src/FitFunctions/IFunctionAdapter.cpp
@@ -101,11 +106,6 @@ set ( PY_FILES
   _workspaceops.py
 )
 
-#############################################################################################
-# Generate a source file from the export definitions
-#############################################################################################
-create_module ( ${MODULE_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/api.cpp EXPORT_FILES
-                SRC_FILES )
 
 #############################################################################################
 # Copy over the pure Python files for the module
@@ -125,7 +125,8 @@ copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR}
 # Create the target for this directory
 #############################################################################################
 
-add_library ( PythonAPIModule ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
+add_library ( PythonAPIModule ${MODULE_DEFINITION} ${EXPORT_FILES} ${SRC_FILES} ${INC_FILES}
+              ${PYTHON_INSTALL_FILES} )
 set_python_properties( PythonAPIModule _api )
 set_target_output_directory ( PythonAPIModule ${OUTPUT_DIR} .pyd )
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -125,13 +125,13 @@ copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR}
 # Create the target for this directory
 #############################################################################################
 
-add_library ( PythonAPIModule ${MODULE_DEFINITION} ${EXPORT_FILES} ${SRC_FILES} ${INC_FILES}
+add_library ( PythonAPIModule ${EXPORT_FILES} ${MODULE_DEFINITION} ${SRC_FILES} ${INC_FILES}
               ${PYTHON_INSTALL_FILES} )
 set_python_properties( PythonAPIModule _api )
 set_target_output_directory ( PythonAPIModule ${OUTPUT_DIR} .pyd )
 
 # Add the required dependencies
-target_link_libraries ( PythonAPIModule LINK_PRIVATE 
+target_link_libraries ( PythonAPIModule LINK_PRIVATE
             PythonGeometryModule
             PythonKernelModule
             API

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Algorithms/RunPythonScript.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Algorithms/RunPythonScript.cpp
@@ -11,213 +11,219 @@
 #include <boost/python/import.hpp>
 #include <boost/regex.hpp>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
+namespace Mantid {
+namespace PythonInterface {
 
-    /// Algorithm's name for identification. @see Algorithm::name
-    const std::string RunPythonScript::name() const { return "RunPythonScript";}
+/// Algorithm's name for identification. @see Algorithm::name
+const std::string RunPythonScript::name() const { return "RunPythonScript"; }
 
-    /// Algorithm's version for identification. @see Algorithm::version
-    int RunPythonScript::version() const { return 1;}
+/// Algorithm's version for identification. @see Algorithm::version
+int RunPythonScript::version() const { return 1; }
 
-    /// Algorithm's category for identification. @see Algorithm::category
-    const std::string RunPythonScript::category() const { return "DataHandling\\LiveData\\Support"; }
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string RunPythonScript::category() const {
+  return "DataHandling\\LiveData\\Support";
+}
 
-    /// @copydoc Algorithm::summary
-    const std::string RunPythonScript::summary() const { return "Executes a snippet of Python code"; }
+/// @copydoc Algorithm::summary
+const std::string RunPythonScript::summary() const {
+  return "Executes a snippet of Python code";
+}
 
-    /** 
-     * Override standard group behaviour so that the algorithm is only
-     * called once for the whole group
-     */
-    bool RunPythonScript::checkGroups()
-    {
-      return false;
+/**
+ * Override standard group behaviour so that the algorithm is only
+ * called once for the whole group
+ */
+bool RunPythonScript::checkGroups() { return false; }
+
+/**
+ * Initialize the algorithm's properties.
+ */
+void RunPythonScript::init() {
+  using namespace API;
+  using namespace Kernel;
+
+  declareProperty(
+      new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input,
+                                       PropertyMode::Optional),
+      "An input workspace that the python code will modify."
+      "The workspace will be in the python variable named 'input'.");
+  declareProperty("Code", "", "Python code (can be on multiple lines).",
+                  boost::make_shared<MandatoryValidator<std::string>>());
+  declareProperty(
+      new WorkspaceProperty<Workspace>("OutputWorkspace", "", Direction::Output,
+                                       PropertyMode::Optional),
+      "An output workspace to be produced by the python code."
+      "The workspace will be in the python variable named 'output'.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void RunPythonScript::exec() {
+  using namespace API;
+
+  Workspace_sptr outputWS = executeScript(scriptCode());
+  setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
+}
+
+/**
+ * Builds the code string from the user input. The user script is wrapped
+ * in a tiny PythonAlgorithm to 'fool' the Python framework into
+ * creating a child algorithm for each algorithm that is run. See
+ * PythonInterface/mantid/simpleapi.py:_create_algorithm_object
+ * This has to be the case to get the workspace locking correct.
+ *
+ * The code assumes that the scope in which it is executed has defined
+ * the variables input & output.
+ *
+ * @return A string containing the code ready to execute
+ */
+std::string RunPythonScript::scriptCode() const {
+  std::string userCode = getPropertyValue("Code");
+  // Unify line endings
+  boost::regex eol("\\R"); // \R is Perl syntax for matching any EOL sequence
+  userCode = boost::regex_replace(userCode, eol, "\n"); // converts all to LF
+
+  // Wrap and indent the user code (see method documentation)
+  std::istringstream is(userCode);
+  std::ostringstream os;
+  const char *indent = "    ";
+  os << "import mantid\n"
+     << "from mantid.simpleapi import *\n"
+     << "class _DUMMY_ALG(mantid.api.PythonAlgorithm):\n" << indent
+     << "def PyExec(self, input=None,output=None):\n";
+  std::string line;
+  while (getline(is, line)) {
+    os << indent << indent << line << "\n";
+  }
+  os << indent << indent
+     << "return input,output\n"; // When executed the global scope needs to know
+                                 // about input,output so we return them
+  os << "input,output = _DUMMY_ALG().PyExec(input,output)";
+
+  if (g_log.is(Kernel::Logger::Priority::PRIO_DEBUG))
+    g_log.debug() << "Full code to be executed:\n" << os.str() << "\n";
+  return os.str();
+}
+
+/**
+ * Sets up the code context & executes it.
+ * A python dictionary of local attributes is setup to contain a reference to
+ * the input workspace
+ * & the output workspace. This together with the __main__ global dictionary
+ * defines the execution
+ * context
+ * @param script A string containing a read-to-execute script
+ * @return A pointer to the output workspace if one was generated. If one was
+ * not then this is an empty pointer
+ */
+boost::shared_ptr<API::Workspace>
+RunPythonScript::executeScript(const std::string &script) const {
+  using namespace API;
+  using namespace boost::python;
+
+  // Execution
+  Environment::GlobalInterpreterLock gil;
+  auto locals = doExecuteScript(script);
+  return extractOutputWorkspace(locals);
+}
+
+/**
+ * Uses the __main__ object to define the globals context and together with the
+ * given locals
+ * dictionary executes the script. The GIL is acquired and released during this
+ * call
+ * @param script The script code
+ * @returns A dictionary defining the input & output variables
+ */
+boost::python::dict
+RunPythonScript::doExecuteScript(const std::string &script) const {
+  // Retrieve the main module.
+  auto main = boost::python::import("__main__");
+  // Retrieve the main module's namespace
+  boost::python::object globals(main.attr("__dict__"));
+  boost::python::dict locals = buildLocals();
+  try {
+    boost::python::exec(script.c_str(), globals, locals);
+  } catch (boost::python::error_already_set &) {
+    Environment::throwRuntimeError();
+  }
+  return locals;
+}
+
+/**
+ * Creates a Python dictionary containing definitions of the 'input' & 'output'
+ * variable
+ * references that the script may use
+ * @return A Python dictionary that can be used as the locals argument for the
+ * script execution
+ */
+boost::python::dict RunPythonScript::buildLocals() const {
+  // Define the local variable names required by the script, in this case
+  // - input: Points to input workspace if one has been given
+  // - output: Will point to the output workspace if one has been given
+  using namespace boost::python;
+
+  dict locals;
+  locals["input"] = object(); // default to None
+  locals["output"] = object();
+
+  API::Workspace_sptr inputWS = getProperty("InputWorkspace");
+  if (inputWS) {
+    // We have a generic workspace ptr but the Python needs to see the derived
+    // type so
+    // that it can access the appropriate methods for that instance
+    // The ToSharedPtrWithDowncast policy is already in place for this and is
+    // used in many
+    // method exports as part of a return_value_policy struct.
+    // It is called manually here.
+    typedef Policies::ToSharedPtrWithDowncast::apply<API::Workspace_sptr>::type
+        WorkspaceDowncaster;
+    locals["input"] = object(handle<>(WorkspaceDowncaster()(inputWS)));
+  }
+  std::string outputWSName = getPropertyValue("OutputWorkspace");
+  if (!outputWSName.empty()) {
+    locals["output"] =
+        object(handle<>(to_python_value<const std::string &>()(outputWSName)));
+  }
+  return locals;
+}
+
+/**
+ * If an output workspace was created then extract it from the given dictionary
+ * @param locals A dictionary possibly containing an 'output' reference
+ * @return A pointer to the output workspace if created, otherwise an empty
+ * pointer
+ */
+boost::shared_ptr<API::Workspace> RunPythonScript::extractOutputWorkspace(
+    const boost::python::dict &locals) const {
+  using namespace API;
+  using namespace boost::python;
+
+  // Might be None, string or a workspace object
+  object pyoutput = locals["output"];
+  if (pyoutput.ptr() == Py_None)
+    return Workspace_sptr();
+
+  if (PyObject_HasAttrString(pyoutput.ptr(), "id")) {
+    const auto &entry = Registry::DowncastRegistry::retrieve(
+        call_method<std::string>(pyoutput.ptr(), "id"));
+    return boost::dynamic_pointer_cast<API::Workspace>(
+        entry.fromPythonAsSharedPtr(pyoutput));
+  } else {
+    extract<std::string> stringExtractor(pyoutput);
+    if (stringExtractor.check()) {
+      // Will raise an error if the workspace does not exist as the user
+      // requested an output workspace
+      // but didn't create one.
+      return AnalysisDataService::Instance().retrieve(stringExtractor());
+    } else {
+      throw std::runtime_error("Invalid type assigned to 'output' variable. "
+                               "Must be a string or a Workspace object");
     }
+  }
+}
 
-    /** 
-     * Initialize the algorithm's properties.
-     */
-    void RunPythonScript::init()
-    {
-      using namespace API;
-      using namespace Kernel;
-
-      declareProperty(new WorkspaceProperty<Workspace>("InputWorkspace","",Direction::Input, PropertyMode::Optional),
-          "An input workspace that the python code will modify."
-          "The workspace will be in the python variable named 'input'.");
-      declareProperty("Code", "", "Python code (can be on multiple lines).", 
-                      boost::make_shared<MandatoryValidator<std::string> >());
-      declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace","",Direction::Output, PropertyMode::Optional),
-          "An output workspace to be produced by the python code."
-          "The workspace will be in the python variable named 'output'.");
-    }
-
-    //----------------------------------------------------------------------------------------------
-    /** Execute the algorithm.
-     */
-    void RunPythonScript::exec()
-    {
-      using namespace API;
-
-      Workspace_sptr outputWS = executeScript(scriptCode());
-      setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
-    }
-
-    /**
-     * Builds the code string from the user input. The user script is wrapped
-     * in a tiny PythonAlgorithm to 'fool' the Python framework into
-     * creating a child algorithm for each algorithm that is run. See
-     * PythonInterface/mantid/simpleapi.py:_create_algorithm_object
-     * This has to be the case to get the workspace locking correct.
-     *
-     * The code assumes that the scope in which it is executed has defined
-     * the variables input & output.
-     *
-     * @return A string containing the code ready to execute
-     */
-    std::string RunPythonScript::scriptCode() const
-    {
-      std::string userCode = getPropertyValue("Code");
-      // Unify line endings
-      boost::regex eol("\\R"); // \R is Perl syntax for matching any EOL sequence
-      userCode = boost::regex_replace(userCode, eol, "\n"); // converts all to LF
-
-      // Wrap and indent the user code (see method documentation)
-      std::istringstream is(userCode);
-      std::ostringstream os;
-      const char * indent = "    ";
-      os << "import mantid\n"
-         << "from mantid.simpleapi import *\n"
-         << "class _DUMMY_ALG(mantid.api.PythonAlgorithm):\n"
-         << indent << "def PyExec(self, input=None,output=None):\n";
-      std::string line;
-      while(getline(is, line))
-      {
-        os << indent << indent << line << "\n";
-      }
-      os << indent << indent  << "return input,output\n"; // When executed the global scope needs to know about input,output so we return them
-      os << "input,output = _DUMMY_ALG().PyExec(input,output)";
-
-      if(g_log.is(Kernel::Logger::Priority::PRIO_DEBUG)) g_log.debug() << "Full code to be executed:\n" << os.str() << "\n";
-      return os.str();
-    }
-
-    /**
-     * Sets up the code context & executes it.
-     * A python dictionary of local attributes is setup to contain a reference to the input workspace
-     * & the output workspace. This together with the __main__ global dictionary defines the execution
-     * context
-     * @param script A string containing a read-to-execute script
-     * @return A pointer to the output workspace if one was generated. If one was not then this is an empty pointer
-     */
-    boost::shared_ptr<API::Workspace> RunPythonScript::executeScript(const std::string & script) const
-    {
-      using namespace API;
-      using namespace boost::python;
-
-      // Execution
-      Environment::GlobalInterpreterLock gil;
-      auto locals = doExecuteScript(script);
-      return extractOutputWorkspace(locals);
-    }
-
-    /**
-     * Uses the __main__ object to define the globals context and together with the given locals
-     * dictionary executes the script. The GIL is acquired and released during this call
-     * @param script The script code
-     * @returns A dictionary defining the input & output variables
-     */
-    boost::python::dict RunPythonScript::doExecuteScript(const std::string & script) const
-    {
-      // Retrieve the main module.
-      auto main = boost::python::import("__main__");
-      // Retrieve the main module's namespace
-      boost::python::object globals(main.attr("__dict__"));
-      boost::python::dict locals = buildLocals();
-      try
-      {
-        boost::python::exec(script.c_str(), globals, locals);
-      }
-      catch(boost::python::error_already_set &)
-      {
-        Environment::throwRuntimeError();
-      }
-      return locals;
-    }
-
-    /**
-     * Creates a Python dictionary containing definitions of the 'input' & 'output' variable
-     * references that the script may use
-     * @return A Python dictionary that can be used as the locals argument for the script execution
-     */
-    boost::python::dict RunPythonScript::buildLocals() const
-    {
-      // Define the local variable names required by the script, in this case
-      // - input: Points to input workspace if one has been given
-      // - output: Will point to the output workspace if one has been given
-      using namespace boost::python;
-
-      dict locals;
-      locals["input"] = object(); // default to None
-      locals["output"] = object();
-
-      API::Workspace_sptr inputWS = getProperty("InputWorkspace");
-      if(inputWS)
-      {
-        // We have a generic workspace ptr but the Python needs to see the derived type so
-        // that it can access the appropriate methods for that instance
-        // The ToSharedPtrWithDowncast policy is already in place for this and is used in many
-        // method exports as part of a return_value_policy struct.
-        // It is called manually here.
-        typedef Policies::ToSharedPtrWithDowncast::apply<API::Workspace_sptr>::type WorkspaceDowncaster;
-        locals["input"] = object(handle<>(WorkspaceDowncaster()(inputWS)));
-      }
-      std::string outputWSName = getPropertyValue("OutputWorkspace");
-      if(!outputWSName.empty())
-      {
-        locals["output"] = object(handle<>(to_python_value<const std::string&>()(outputWSName)));
-      }
-      return locals;
-    }
-
-
-    /**
-     * If an output workspace was created then extract it from the given dictionary
-     * @param locals A dictionary possibly containing an 'output' reference
-     * @return A pointer to the output workspace if created, otherwise an empty pointer
-     */
-    boost::shared_ptr<API::Workspace> RunPythonScript::extractOutputWorkspace(const boost::python::dict & locals) const
-    {
-      using namespace API;
-      using namespace boost::python;
-
-      // Might be None, string or a workspace object
-      object pyoutput = locals["output"];
-      if(pyoutput.ptr() == Py_None) return Workspace_sptr();
-
-      if(PyObject_HasAttrString(pyoutput.ptr(), "id"))
-      {
-	const auto & entry = Registry::DowncastRegistry::retrieve(call_method<std::string>(pyoutput.ptr(), "id"));
-	return boost::dynamic_pointer_cast<API::Workspace>(entry.fromPythonAsSharedPtr(pyoutput));
-      }
-      else
-      {
-        extract<std::string> stringExtractor(pyoutput);
-        if(stringExtractor.check())
-        {
-          // Will raise an error if the workspace does not exist as the user requested an output workspace
-          // but didn't create one.
-          return AnalysisDataService::Instance().retrieve(stringExtractor());
-        }
-        else
-        {
-          throw std::runtime_error("Invalid type assigned to 'output' variable. Must be a string or a Workspace object");
-        }
-      }
-    }
-
-  } // namespace PythonInterface
+} // namespace PythonInterface
 } // namespace Mantid

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -6,121 +6,110 @@
 
 #include <boost/python/extract.hpp>
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL API_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    using Mantid::API::MatrixWorkspace_sptr;
-    using Mantid::API::MatrixWorkspace;
-    namespace bpl = boost::python;
+namespace Mantid {
+namespace PythonInterface {
+using Mantid::API::MatrixWorkspace_sptr;
+using Mantid::API::MatrixWorkspace;
+namespace bpl = boost::python;
 
-    // ----------------------------------------------------------------------------------------------------------
-    namespace
-    {
-      /// Which data field are we extracting
-      enum DataField { XValues = 0, YValues = 1, EValues= 2, DxValues = 3 };
+// ----------------------------------------------------------------------------------------------------------
+namespace {
+/// Which data field are we extracting
+enum DataField { XValues = 0, YValues = 1, EValues = 2, DxValues = 3 };
 
-      /**
-       * Helper method for extraction to numpy.
-       * @param workspace :: A pointer to the workspace that contains the data
-       * @param field :: Which field should be extracted
-       * @param start :: The index in the workspace to start at when reading the data
-       * @param endp1 :: One past the end index in the workspace to finish at when reading the data (similar to .end() for STL)
-       *
-       */
-      PyArrayObject *cloneArray(MatrixWorkspace & workspace,
-          DataField field, const size_t start, const size_t endp1)
-      {
-        const size_t numHist = endp1 - start;
-        npy_intp stride(0);
+/**
+ * Helper method for extraction to numpy.
+ * @param workspace :: A pointer to the workspace that contains the data
+ * @param field :: Which field should be extracted
+ * @param start :: The index in the workspace to start at when reading the data
+ * @param endp1 :: One past the end index in the workspace to finish at when
+ *reading the data (similar to .end() for STL)
+ *
+ */
+PyArrayObject *cloneArray(MatrixWorkspace &workspace, DataField field,
+                          const size_t start, const size_t endp1) {
+  const size_t numHist = endp1 - start;
+  npy_intp stride(0);
 
-        // Find out which function we need to call to access the data
-        typedef const MantidVec & (MatrixWorkspace::*ArrayAccessFn)(const size_t) const;
-        ArrayAccessFn dataAccesor;
-        /**
-         * Can do better than this with a templated object that knows how to access the data
-         */
-        if( field == XValues )
-        {
-          stride = workspace.readX(0).size();
-          dataAccesor = &MatrixWorkspace::readX;
-        }
-        else if( field == DxValues)
-        {
-          stride = workspace.readDx(0).size();
-          dataAccesor = &MatrixWorkspace::readDx;
-        }
-        else
-        {
-          stride = workspace.blocksize();
-          if(field == YValues) dataAccesor = &MatrixWorkspace::readY;
-          else dataAccesor = &MatrixWorkspace::readE;
-        }
-        npy_intp arrayDims[2] = {static_cast<npy_intp>(numHist), stride};
-        PyArrayObject *nparray = (PyArrayObject *)PyArray_NewFromDescr(&PyArray_Type,
-            PyArray_DescrFromType(NPY_DOUBLE),
-            2, // rank 2
-            arrayDims, // Length in each dimension
-            NULL, NULL,
-            0, NULL);
-        double *dest = (double*)PyArray_DATA(nparray); // HEAD of the contiguous numpy data array
-        for(size_t i = start; i < endp1; ++i)
-        {
-          const MantidVec & src = (workspace.*(dataAccesor))(i);
-          std::copy(src.begin(), src.end(), dest);
-          dest += stride; // Move the ptr to the start of the next 1D array
-        }
-        return nparray;
-      }
-    }
-
-    // -------------------------------------- Cloned arrays---------------------------------------------------
-    /* Create a numpy array from the X values of the given workspace reference
-     * This acts like a python method on a Matrixworkspace object
-     * @param self :: A pointer to a PyObject representing the calling object
-     * @return A 2D numpy array created from the X values
-     */
-    PyObject * cloneX(MatrixWorkspace &self)
-    {
-      return (PyObject*)cloneArray(self, XValues, 0, self.getNumberHistograms());
-    }
-    /* Create a numpy array from the Y values of the given workspace reference
-     * This acts like a python method on a Matrixworkspace object
-     * @param self :: A pointer to a PyObject representing the calling object
-     * @return A 2D numpy array created from the Y values
-     */
-    PyObject * cloneY(MatrixWorkspace &self)
-    {
-      return (PyObject*)cloneArray(self, YValues, 0, self.getNumberHistograms());
-    }
-
-    /* Create a numpy array from the E values of the given workspace reference
-     * This acts like a python method on a Matrixworkspace object
-     * @param self :: A pointer to a PyObject representing the calling object
-     * @return A 2D numpy array created from the E values
-     */
-    PyObject * cloneE(MatrixWorkspace &self)
-    {
-      return (PyObject*)cloneArray(self, EValues, 0, self.getNumberHistograms());
-    }
-
-    /* Create a numpy array from the E values of the given workspace reference
-     * This acts like a python method on a Matrixworkspace object
-     * @param self :: A pointer to a PyObject representing the calling object
-     * @return A 2D numpy array created from the E values
-     */
-    PyObject * cloneDx(MatrixWorkspace &self)
-    {
-      return (PyObject*)cloneArray(self, DxValues, 0, self.getNumberHistograms());
-    }
-
+  // Find out which function we need to call to access the data
+  typedef const MantidVec &(MatrixWorkspace::*ArrayAccessFn)(const size_t)
+      const;
+  ArrayAccessFn dataAccesor;
+  /**
+   * Can do better than this with a templated object that knows how to access
+   * the data
+   */
+  if (field == XValues) {
+    stride = workspace.readX(0).size();
+    dataAccesor = &MatrixWorkspace::readX;
+  } else if (field == DxValues) {
+    stride = workspace.readDx(0).size();
+    dataAccesor = &MatrixWorkspace::readDx;
+  } else {
+    stride = workspace.blocksize();
+    if (field == YValues)
+      dataAccesor = &MatrixWorkspace::readY;
+    else
+      dataAccesor = &MatrixWorkspace::readE;
   }
+  npy_intp arrayDims[2] = {static_cast<npy_intp>(numHist), stride};
+  PyArrayObject *nparray = (PyArrayObject *)PyArray_NewFromDescr(
+      &PyArray_Type, PyArray_DescrFromType(NPY_DOUBLE),
+      2,         // rank 2
+      arrayDims, // Length in each dimension
+      NULL, NULL, 0, NULL);
+  double *dest = (double *)PyArray_DATA(
+      nparray); // HEAD of the contiguous numpy data array
+  for (size_t i = start; i < endp1; ++i) {
+    const MantidVec &src = (workspace.*(dataAccesor))(i);
+    std::copy(src.begin(), src.end(), dest);
+    dest += stride; // Move the ptr to the start of the next 1D array
+  }
+  return nparray;
+}
 }
 
+// -------------------------------------- Cloned
+// arrays---------------------------------------------------
+/* Create a numpy array from the X values of the given workspace reference
+ * This acts like a python method on a Matrixworkspace object
+ * @param self :: A pointer to a PyObject representing the calling object
+ * @return A 2D numpy array created from the X values
+ */
+PyObject *cloneX(MatrixWorkspace &self) {
+  return (PyObject *)cloneArray(self, XValues, 0, self.getNumberHistograms());
+}
+/* Create a numpy array from the Y values of the given workspace reference
+ * This acts like a python method on a Matrixworkspace object
+ * @param self :: A pointer to a PyObject representing the calling object
+ * @return A 2D numpy array created from the Y values
+ */
+PyObject *cloneY(MatrixWorkspace &self) {
+  return (PyObject *)cloneArray(self, YValues, 0, self.getNumberHistograms());
+}
 
+/* Create a numpy array from the E values of the given workspace reference
+ * This acts like a python method on a Matrixworkspace object
+ * @param self :: A pointer to a PyObject representing the calling object
+ * @return A 2D numpy array created from the E values
+ */
+PyObject *cloneE(MatrixWorkspace &self) {
+  return (PyObject *)cloneArray(self, EValues, 0, self.getNumberHistograms());
+}
 
+/* Create a numpy array from the E values of the given workspace reference
+ * This acts like a python method on a Matrixworkspace object
+ * @param self :: A pointer to a PyObject representing the calling object
+ * @return A 2D numpy array created from the E values
+ */
+PyObject *cloneDx(MatrixWorkspace &self) {
+  return (PyObject *)cloneArray(self, DxValues, 0, self.getNumberHistograms());
+}
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -1,9 +1,11 @@
 #ifdef _MSC_VER
-  #pragma warning( disable: 4250 ) // Disable warning regarding inheritance via dominance, we have no way around it with the design
+#pragma warning(disable : 4250) // Disable warning regarding inheritance via
+                                // dominance, we have no way around it with the
+                                // design
 #endif
 #include "MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h"
 #ifdef _MSC_VER
-  #pragma warning( default: 4250 )
+#pragma warning(default : 4250)
 #endif
 
 #include <boost/python/bases.hpp>
@@ -17,78 +19,112 @@ using Mantid::PythonInterface::AlgorithmAdapter;
 using Mantid::Kernel::Direction;
 using namespace boost::python;
 
-namespace
-{
-  typedef AlgorithmAdapter<Algorithm> PythonAlgorithm;
+namespace {
+typedef AlgorithmAdapter<Algorithm> PythonAlgorithm;
 
-  // declarePyAlgProperty(property*,doc)
-  typedef void(*declarePropertyType1)(boost::python::object & self, Mantid::Kernel::Property*, const std::string &);
-  // declarePyAlgProperty(name, defaultValue, validator, doc, direction)
-  typedef void(*declarePropertyType2)(boost::python::object & self, const std::string &, const boost::python::object &,
-                                                        const boost::python::object &, const std::string &, const int);
-  // declarePyAlgProperty(name, defaultValue, doc, direction)
-  typedef void(*declarePropertyType3)(boost::python::object & self, const std::string &, const boost::python::object &,
-                                                        const std::string &, const int);
-  // declarePyAlgProperty(name, defaultValue, direction)
-  typedef void(*declarePropertyType4)(boost::python::object & self, const std::string &, const boost::python::object &, const int);
+// declarePyAlgProperty(property*,doc)
+typedef void (*declarePropertyType1)(boost::python::object &self,
+                                     Mantid::Kernel::Property *,
+                                     const std::string &);
+// declarePyAlgProperty(name, defaultValue, validator, doc, direction)
+typedef void (*declarePropertyType2)(boost::python::object &self,
+                                     const std::string &,
+                                     const boost::python::object &,
+                                     const boost::python::object &,
+                                     const std::string &, const int);
+// declarePyAlgProperty(name, defaultValue, doc, direction)
+typedef void (*declarePropertyType3)(boost::python::object &self,
+                                     const std::string &,
+                                     const boost::python::object &,
+                                     const std::string &, const int);
+// declarePyAlgProperty(name, defaultValue, direction)
+typedef void (*declarePropertyType4)(boost::python::object &self,
+                                     const std::string &,
+                                     const boost::python::object &, const int);
 
-  // Overload types
-  BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload, PythonAlgorithm::declarePyAlgProperty, 2, 3)
-  BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload, PythonAlgorithm::declarePyAlgProperty, 3, 6)
-  BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload, PythonAlgorithm::declarePyAlgProperty, 4, 5)
+// Overload types
+BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
+                                PythonAlgorithm::declarePyAlgProperty, 2, 3)
+BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
+                                PythonAlgorithm::declarePyAlgProperty, 3, 6)
+BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
+                                PythonAlgorithm::declarePyAlgProperty, 4, 5)
 }
 
-void export_leaf_classes()
-{
+void export_leaf_classes() {
 
   register_ptr_to_python<boost::shared_ptr<Algorithm>>();
 
-  // Export Algorithm but the actual held type in Python is boost::shared_ptr<AlgorithmAdapter>
-  // See http://wiki.python.org/moin/boost.python/HowTo#ownership_of_C.2B-.2B-_object_extended_in_Python
+  // Export Algorithm but the actual held type in Python is
+  // boost::shared_ptr<AlgorithmAdapter>
+  // See
+  // http://wiki.python.org/moin/boost.python/HowTo#ownership_of_C.2B-.2B-_object_extended_in_Python
 
-  class_<Algorithm, bases<Mantid::API::IAlgorithm>, boost::shared_ptr<PythonAlgorithm>,
-         boost::noncopyable>("Algorithm", "Base class for all algorithms")
-    .def("fromString", &Algorithm::fromString, "Initialize the algorithm from a string representation")
-    .staticmethod("fromString")
+  class_<Algorithm, bases<Mantid::API::IAlgorithm>,
+         boost::shared_ptr<PythonAlgorithm>, boost::noncopyable>(
+      "Algorithm", "Base class for all algorithms")
+      .def("fromString", &Algorithm::fromString,
+           "Initialize the algorithm from a string representation")
+      .staticmethod("fromString")
 
-    .def("createChildAlgorithm", &Algorithm::createChildAlgorithm,
-         (arg("name"),arg("startProgress")=-1.0,arg("endProgress")=-1.0,
-          arg("enableLogging")=true,arg("version")=-1), "Creates and intializes a named child algorithm. Output workspaces are given a dummy name.")
+      .def("createChildAlgorithm", &Algorithm::createChildAlgorithm,
+           (arg("name"), arg("startProgress") = -1.0, arg("endProgress") = -1.0,
+            arg("enableLogging") = true, arg("version") = -1),
+           "Creates and intializes a named child algorithm. Output workspaces "
+           "are given a dummy name.")
 
-    .def("declareProperty", (declarePropertyType1)&PythonAlgorithm::declarePyAlgProperty,
-          declarePropertyType1_Overload((arg("self"), arg("prop"), arg("doc") = "")))
+      .def("declareProperty",
+           (declarePropertyType1)&PythonAlgorithm::declarePyAlgProperty,
+           declarePropertyType1_Overload(
+               (arg("self"), arg("prop"), arg("doc") = "")))
 
-    .def("enableHistoryRecordingForChild", &Algorithm::enableHistoryRecordingForChild,
-          (args("on")), "Turns history recording on or off for an algorithm.")
+      .def("enableHistoryRecordingForChild",
+           &Algorithm::enableHistoryRecordingForChild, (args("on")),
+           "Turns history recording on or off for an algorithm.")
 
-    .def("declareProperty", (declarePropertyType2)&PythonAlgorithm::declarePyAlgProperty,
-          declarePropertyType2_Overload((arg("self"), arg("name"), arg("defaultValue"), arg("validator")=object(), arg("doc")="",arg("direction")=Direction::Input),
-                                        "Declares a named property where the type is taken from "
-                                        "the type of the defaultValue and mapped to an appropriate C++ type"))
+      .def("declareProperty",
+           (declarePropertyType2)&PythonAlgorithm::declarePyAlgProperty,
+           declarePropertyType2_Overload(
+               (arg("self"), arg("name"), arg("defaultValue"),
+                arg("validator") = object(), arg("doc") = "",
+                arg("direction") = Direction::Input),
+               "Declares a named property where the type is taken from "
+               "the type of the defaultValue and mapped to an appropriate C++ "
+               "type"))
 
-    .def("declareProperty", (declarePropertyType3)&PythonAlgorithm::declarePyAlgProperty,
-         declarePropertyType3_Overload((arg("self"), arg("name"), arg("defaultValue"), arg("doc")="",arg("direction")=Direction::Input),
-                                       "Declares a named property where the type is taken from the type "
-                                       "of the defaultValue and mapped to an appropriate C++ type"))
+      .def("declareProperty",
+           (declarePropertyType3)&PythonAlgorithm::declarePyAlgProperty,
+           declarePropertyType3_Overload(
+               (arg("self"), arg("name"), arg("defaultValue"), arg("doc") = "",
+                arg("direction") = Direction::Input),
+               "Declares a named property where the type is taken from the "
+               "type "
+               "of the defaultValue and mapped to an appropriate C++ type"))
 
-    .def("declareProperty", (declarePropertyType4)&PythonAlgorithm::declarePyAlgProperty,
-        (arg("self"), arg("name"), arg("defaultValue"), arg("direction")=Direction::Input),
-         "Declares a named property where the type is taken from the type "
-         "of the defaultValue and mapped to an appropriate C++ type")
+      .def("declareProperty",
+           (declarePropertyType4)&PythonAlgorithm::declarePyAlgProperty,
+           (arg("self"), arg("name"), arg("defaultValue"),
+            arg("direction") = Direction::Input),
+           "Declares a named property where the type is taken from the type "
+           "of the defaultValue and mapped to an appropriate C++ type")
 
-    .def("getLogger", &PythonAlgorithm::getLogger, return_value_policy<reference_existing_object>(),
-         "Returns a reference to this algorithm's logger")
-    .def("log", &PythonAlgorithm::getLogger, return_value_policy<reference_existing_object>(),
-         "Returns a reference to this algorithm's logger") // Traditional name
+      .def("getLogger", &PythonAlgorithm::getLogger,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to this algorithm's logger")
+      .def("log", &PythonAlgorithm::getLogger,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to this algorithm's logger") // Traditional name
 
-    // deprecated methods
-    .def("setWikiSummary", &PythonAlgorithm::setWikiSummary, "(Deprecated.) Set summary for the help.")
-  ;
+      // deprecated methods
+      .def("setWikiSummary", &PythonAlgorithm::setWikiSummary,
+           "(Deprecated.) Set summary for the help.");
 
-  // Prior to version 3.2 there was a separate C++ PythonAlgorithm class that inherited from Algorithm and the "PythonAlgorithm"
-  // name was a distinct class in Python from the Algorithm export. In 3.2 the need for the C++ PythonAlgorithm class
-  // was removed in favour of simply adapting the Algorithm base class. A lot of client code relies on the "PythonAlgorithm" name in
+  // Prior to version 3.2 there was a separate C++ PythonAlgorithm class that
+  // inherited from Algorithm and the "PythonAlgorithm"
+  // name was a distinct class in Python from the Algorithm export. In 3.2 the
+  // need for the C++ PythonAlgorithm class
+  // was removed in favour of simply adapting the Algorithm base class. A lot of
+  // client code relies on the "PythonAlgorithm" name in
   // Python so we simply add an alias of the Algorithm name to PythonAlgorithm
   scope().attr("PythonAlgorithm") = scope().attr("Algorithm");
-
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -38,9 +38,7 @@ namespace
   BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload, PythonAlgorithm::declarePyAlgProperty, 4, 5)
 }
 
-// clang-format off
 void export_leaf_classes()
-// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<Algorithm>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -63,9 +63,7 @@ namespace
   // Python algorithm registration mutex in anonymous namespace (aka static)
   Poco::Mutex PYALG_REGISTER_MUTEX;
 
-// clang-format off
 GCC_DIAG_OFF(cast-qual)
-// clang-format on
   /**
    * A free function to subscribe a Python algorithm into the factory
    * @param obj :: A Python object that should either be a class type derived from PythonAlgorithm
@@ -103,13 +101,9 @@ GCC_DIAG_OFF(cast-qual)
 
   ///@endcond
 }
-// clang-format off
 GCC_DIAG_ON(cast-qual)
-// clang-format on
 
-// clang-format off
 void export_AlgorithmFactory()
-// clang-format on
 {
 
   class_<AlgorithmFactoryImpl,boost::noncopyable>("AlgorithmFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -9,7 +9,8 @@
 #include <boost/python/overloads.hpp>
 #include <Poco/ScopedLock.h>
 
-// Python frameobject. This is under the boost includes so that boost will have done the
+// Python frameobject. This is under the boost includes so that boost will have
+// done the
 // include of Python.h which it ensures is done correctly
 #include <frameobject.h>
 
@@ -18,107 +19,109 @@ using namespace boost::python;
 using Mantid::Kernel::AbstractInstantiator;
 using Mantid::PythonInterface::PythonObjectInstantiator;
 
-namespace
-{
-  ///@cond
+namespace {
+///@cond
 
-  //------------------------------------------------------------------------------------------------------
-  /**
-   * A Python friendly version of get_keys that returns the registered algorithms as
-   * a dictionary where the key is the algorithm name and the value is a list
-   * of version numbers
-   * @param self :: Enables it to be called as a member function on the AlgorithmFactory class
-   * @param includeHidden :: If true hidden algorithms are included
-   */
-  PyObject * getRegisteredAlgorithms(AlgorithmFactoryImpl & self, bool includeHidden)
-  {
-    // A list of strings AlgorithmName|version
-    std::vector<std::string> keys = self.getKeys(includeHidden);
-    const size_t nkeys = keys.size();
-    PyObject *registered = PyDict_New();
-    for( size_t i = 0; i < nkeys; ++i )
-    {
-      std::pair<std::string, int> algInfo = self.decodeName(keys[i]);
-      PyObject *name = PyString_FromString(algInfo.first.c_str());
-      PyObject *vers = PyInt_FromLong(algInfo.second);
-      if( PyDict_Contains(registered, name) == 1 )
-      {
-        // A list already exists, create a copy and add this version
-        PyObject *versions = PyDict_GetItem(registered, name);
-        PyList_Append(versions, vers);
-      }
-      else
-      {
-        // No entry exists, create a key and tuple
-        PyObject *versions = PyList_New(1);
-        PyList_SetItem(versions, 0, vers);
-        PyDict_SetItem(registered, name, versions);
-      }
+//------------------------------------------------------------------------------------------------------
+/**
+ * A Python friendly version of get_keys that returns the registered algorithms
+ * as
+ * a dictionary where the key is the algorithm name and the value is a list
+ * of version numbers
+ * @param self :: Enables it to be called as a member function on the
+ * AlgorithmFactory class
+ * @param includeHidden :: If true hidden algorithms are included
+ */
+PyObject *getRegisteredAlgorithms(AlgorithmFactoryImpl &self,
+                                  bool includeHidden) {
+  // A list of strings AlgorithmName|version
+  std::vector<std::string> keys = self.getKeys(includeHidden);
+  const size_t nkeys = keys.size();
+  PyObject *registered = PyDict_New();
+  for (size_t i = 0; i < nkeys; ++i) {
+    std::pair<std::string, int> algInfo = self.decodeName(keys[i]);
+    PyObject *name = PyString_FromString(algInfo.first.c_str());
+    PyObject *vers = PyInt_FromLong(algInfo.second);
+    if (PyDict_Contains(registered, name) == 1) {
+      // A list already exists, create a copy and add this version
+      PyObject *versions = PyDict_GetItem(registered, name);
+      PyList_Append(versions, vers);
+    } else {
+      // No entry exists, create a key and tuple
+      PyObject *versions = PyList_New(1);
+      PyList_SetItem(versions, 0, vers);
+      PyDict_SetItem(registered, name, versions);
     }
-    return registered;
   }
+  return registered;
+}
 
-  //--------------------------------------------- Python algorithm subscription ------------------------------------------------
+//--------------------------------------------- Python algorithm subscription
+//------------------------------------------------
 
-  // Python algorithm registration mutex in anonymous namespace (aka static)
-  Poco::Mutex PYALG_REGISTER_MUTEX;
+// Python algorithm registration mutex in anonymous namespace (aka static)
+Poco::Mutex PYALG_REGISTER_MUTEX;
 
 GCC_DIAG_OFF(cast-qual)
-  /**
-   * A free function to subscribe a Python algorithm into the factory
-   * @param obj :: A Python object that should either be a class type derived from PythonAlgorithm
-   *              or an instance of a class type derived from PythonAlgorithm
-   */
-  void subscribe(AlgorithmFactoryImpl & self, const boost::python::object & obj)
-  {
-    Poco::ScopedLock<Poco::Mutex> lock(PYALG_REGISTER_MUTEX);
+/**
+ * A free function to subscribe a Python algorithm into the factory
+ * @param obj :: A Python object that should either be a class type derived from
+ * PythonAlgorithm
+ *              or an instance of a class type derived from PythonAlgorithm
+ */
+void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
+  Poco::ScopedLock<Poco::Mutex> lock(PYALG_REGISTER_MUTEX);
 
-    static PyObject * const pyAlgClass =
-        (PyObject*)converter::registered<Algorithm>::converters.to_python_target_type();
-    // obj could be or instance/class, check instance first
-    PyObject *classObject(NULL);
-    if( PyObject_IsInstance(obj.ptr(), pyAlgClass) )
-    {
-      classObject = PyObject_GetAttrString(obj.ptr(), "__class__");
-    }
-    else if(PyObject_IsSubclass(obj.ptr(), pyAlgClass))
-    {
-      classObject = obj.ptr(); // We need to ensure the type of lifetime management so grab the raw pointer
-    }
-    else
-    {
-      throw std::invalid_argument("Cannot register an algorithm that does not derive from Algorithm.");
-    }
-    boost::python::object classType(handle<>(borrowed(classObject)));
-    // Takes ownership of instantiator and replaces any existing algorithm
-    auto descr = self.subscribe(new PythonObjectInstantiator<Algorithm>(classType), AlgorithmFactoryImpl::OverwriteCurrent);
-
-    // Python algorithms cannot yet act as loaders so remove any registered ones from the FileLoaderRegistry
-    FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
+  static PyObject *const pyAlgClass =
+      (PyObject *)
+      converter::registered<Algorithm>::converters.to_python_target_type();
+  // obj could be or instance/class, check instance first
+  PyObject *classObject(NULL);
+  if (PyObject_IsInstance(obj.ptr(), pyAlgClass)) {
+    classObject = PyObject_GetAttrString(obj.ptr(), "__class__");
+  } else if (PyObject_IsSubclass(obj.ptr(), pyAlgClass)) {
+    classObject = obj.ptr(); // We need to ensure the type of lifetime
+                             // management so grab the raw pointer
+  } else {
+    throw std::invalid_argument(
+        "Cannot register an algorithm that does not derive from Algorithm.");
   }
+  boost::python::object classType(handle<>(borrowed(classObject)));
+  // Takes ownership of instantiator and replaces any existing algorithm
+  auto descr =
+      self.subscribe(new PythonObjectInstantiator<Algorithm>(classType),
+                     AlgorithmFactoryImpl::OverwriteCurrent);
 
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
+  // Python algorithms cannot yet act as loaders so remove any registered ones
+  // from the FileLoaderRegistry
+  FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
+}
 
-  ///@endcond
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
+
+///@endcond
 }
 GCC_DIAG_ON(cast-qual)
 
-void export_AlgorithmFactory()
-{
+void export_AlgorithmFactory() {
 
-  class_<AlgorithmFactoryImpl,boost::noncopyable>("AlgorithmFactoryImpl", no_init)
+  class_<AlgorithmFactoryImpl, boost::noncopyable>("AlgorithmFactoryImpl",
+                                                   no_init)
       .def("exists", &AlgorithmFactoryImpl::exists,
-           existsOverloader((arg("name"), arg("version")=-1),
-                            "Returns true if the given algorithm exists with an option to specify the version"))
+           existsOverloader((arg("name"), arg("version") = -1),
+                            "Returns true if the given algorithm exists with "
+                            "an option to specify the version"))
 
-      .def("getRegisteredAlgorithms", &getRegisteredAlgorithms, "Returns a Python dictionary of currently registered algorithms")
+      .def("getRegisteredAlgorithms", &getRegisteredAlgorithms,
+           "Returns a Python dictionary of currently registered algorithms")
       .def("highestVersion", &AlgorithmFactoryImpl::highestVersion,
-           "Returns the highest version of the named algorithm. Throws ValueError if no algorithm can be found")
-      .def("subscribe", &subscribe, "Register a Python class derived from PythonAlgorithm into the factory")
+           "Returns the highest version of the named algorithm. Throws "
+           "ValueError if no algorithm can be found")
+      .def("subscribe", &subscribe, "Register a Python class derived from "
+                                    "PythonAlgorithm into the factory")
 
-      .def("Instance", &AlgorithmFactory::Instance, return_value_policy<reference_existing_object>(),
-        "Returns a reference to the AlgorithmFactory singleton")
-      .staticmethod("Instance")
-    ;
-
+      .def("Instance", &AlgorithmFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the AlgorithmFactory singleton")
+      .staticmethod("Instance");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -62,7 +62,10 @@ PyObject *getRegisteredAlgorithms(AlgorithmFactoryImpl &self,
 // Python algorithm registration mutex in anonymous namespace (aka static)
 Poco::Mutex PYALG_REGISTER_MUTEX;
 
+// clang-format off
 GCC_DIAG_OFF(cast-qual)
+// clang-format on
+
 /**
  * A free function to subscribe a Python algorithm into the factory
  * @param obj :: A Python object that should either be a class type derived from
@@ -101,7 +104,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
 
 ///@endcond
 }
+// clang-format off
 GCC_DIAG_ON(cast-qual)
+// clang-format on
 
 void export_AlgorithmFactory() {
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
@@ -24,13 +24,12 @@ namespace Policies = Mantid::PythonInterface::Policies;
  * @param self :: A reference to the AlgorithmHistory that called this method
  * @returns A python list created from the set of child algorithm histories
  */
-boost::python::object getChildrenAsList(boost::shared_ptr<AlgorithmHistory> self)
-{
+boost::python::object
+getChildrenAsList(boost::shared_ptr<AlgorithmHistory> self) {
   boost::python::list names;
   const auto histories = self->getChildHistories();
   Mantid::API::AlgorithmHistories::const_iterator itr = histories.begin();
-  for(; itr != histories.end(); ++itr)
-  {
+  for (; itr != histories.end(); ++itr) {
     names.append(*itr);
   }
   return names;
@@ -42,55 +41,58 @@ boost::python::object getChildrenAsList(boost::shared_ptr<AlgorithmHistory> self
  * @param self :: A reference to the AlgorithmHistory that called this method
  * @returns A python list created from the set of property histories
  */
-boost::python::object getPropertiesAsList(AlgorithmHistory& self)
-{
+boost::python::object getPropertiesAsList(AlgorithmHistory &self) {
   boost::python::list names;
   const auto histories = self.getProperties();
-  std::vector<Mantid::Kernel::PropertyHistory_sptr>::const_iterator iend = histories.end();
-  for(std::vector<Mantid::Kernel::PropertyHistory_sptr>::const_iterator itr = histories.begin(); itr != iend; ++itr)
-  {
+  std::vector<Mantid::Kernel::PropertyHistory_sptr>::const_iterator iend =
+      histories.end();
+  for (std::vector<Mantid::Kernel::PropertyHistory_sptr>::const_iterator itr =
+           histories.begin();
+       itr != iend; ++itr) {
     names.append(*itr);
   }
   return names;
 }
 
-void export_AlgorithmHistory()
-{
-  register_ptr_to_python<Mantid::API::AlgorithmHistory_sptr >();
+void export_AlgorithmHistory() {
+  register_ptr_to_python<Mantid::API::AlgorithmHistory_sptr>();
 
   class_<AlgorithmHistory>("AlgorithmHistory", no_init)
-    .def("name", &AlgorithmHistory::name, return_value_policy<copy_const_reference>(),
-         "Returns the name of the algorithm.")
-    
-    .def("version", &AlgorithmHistory::version, return_value_policy<copy_const_reference>(), 
-         "Returns the version of the algorithm.")
-    
-    .def("executionDuration", &AlgorithmHistory::executionDuration,
-         "Returns the execution duration of the algorithm.")
-    
-    .def("executionDate", &AlgorithmHistory::executionDate,
-         "Returns the execution date of the algorithm.")
-    
-    .def("execCount", &AlgorithmHistory::execCount, return_value_policy<copy_const_reference>(),
-         "Returns the execution number of the algorithm.")
-    
-    .def("childHistorySize", &AlgorithmHistory::childHistorySize,
-         "Returns the number of the child algorithms.")
-    
-    .def("getChildAlgorithmHistory", &AlgorithmHistory::getChildAlgorithmHistory, 
-         arg("index"),
-         "Returns the child algorithm at the given index in the history")
-    
-    .def("getChildHistories", &getChildrenAsList,
-         "Returns a list of child algorithm histories for this algorithm history.")
-    
-    .def("getProperties", &getPropertiesAsList,
-         "Returns properties for this algorithm history.")
+      .def("name", &AlgorithmHistory::name,
+           return_value_policy<copy_const_reference>(),
+           "Returns the name of the algorithm.")
 
-    .def("getChildAlgorithm", &AlgorithmHistory::getChildAlgorithm,
-         arg("index"),
-         "Returns the algorithm at the given index in the history")
-    // ----------------- Operators --------------------------------------
-    .def(self_ns::str(self))
-    ;
+      .def("version", &AlgorithmHistory::version,
+           return_value_policy<copy_const_reference>(),
+           "Returns the version of the algorithm.")
+
+      .def("executionDuration", &AlgorithmHistory::executionDuration,
+           "Returns the execution duration of the algorithm.")
+
+      .def("executionDate", &AlgorithmHistory::executionDate,
+           "Returns the execution date of the algorithm.")
+
+      .def("execCount", &AlgorithmHistory::execCount,
+           return_value_policy<copy_const_reference>(),
+           "Returns the execution number of the algorithm.")
+
+      .def("childHistorySize", &AlgorithmHistory::childHistorySize,
+           "Returns the number of the child algorithms.")
+
+      .def("getChildAlgorithmHistory",
+           &AlgorithmHistory::getChildAlgorithmHistory, arg("index"),
+           "Returns the child algorithm at the given index in the history")
+
+      .def("getChildHistories", &getChildrenAsList, "Returns a list of child "
+                                                    "algorithm histories for "
+                                                    "this algorithm history.")
+
+      .def("getProperties", &getPropertiesAsList,
+           "Returns properties for this algorithm history.")
+
+      .def("getChildAlgorithm", &AlgorithmHistory::getChildAlgorithm,
+           arg("index"),
+           "Returns the algorithm at the given index in the history")
+      // ----------------- Operators --------------------------------------
+      .def(self_ns::str(self));
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
@@ -54,9 +54,7 @@ boost::python::object getPropertiesAsList(AlgorithmHistory& self)
   return names;
 }
 
-// clang-format off
 void export_AlgorithmHistory()
-// clang-format on
 {
   register_ptr_to_python<Mantid::API::AlgorithmHistory_sptr >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -12,82 +12,90 @@ using Mantid::PythonInterface::AlgorithmIDProxy;
 using Mantid::PythonInterface::TrackingInstanceMethod;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Return the algorithm identified by the given ID. A wrapper version that takes a
-   * AlgorithmIDProxy that wraps a AlgorithmID
-   * @param self The calling object
-   * @param id An algorithm ID
-   */
-  IAlgorithm_sptr getAlgorithm(AlgorithmManagerImpl &self, AlgorithmIDProxy idHolder)
-  {
-    return self.getAlgorithm(idHolder.id);
-  }
-
-  /**
-   * Remove the algorithm identified by the given ID from the list of managed algorithms.
-   * A wrapper version that takes a AlgorithmIDProxy that wraps a AlgorithmID
-   * @param self The calling object
-   * @param id An algorithm ID
-   */
-  void removeById(AlgorithmManagerImpl &self, AlgorithmIDProxy idHolder)
-  {
-    return self.removeById(idHolder.id);
-  }
-
-  /**
-   * @param self A reference to the calling object
-   * @param algName The name of the algorithm
-   * @return A python list of managed algorithms that are currently running
-   */
-  boost::python::list runningInstancesOf(AlgorithmManagerImpl &self, const std::string & algName)
-  {
-    boost::python::list algs;
-    auto mgrAlgs = self.runningInstancesOf(algName);
-    for(auto iter = mgrAlgs.begin(); iter != mgrAlgs.end(); ++iter)
-    {
-      // boost 1.41 (RHEL6) can't handle registering IAlgorithm_const_sptr so we
-      // have to cast to IAlgorithm_sptr and then convert to Python
-      // The constness is pretty-irrelevant by this point anyway
-      algs.append(boost::const_pointer_cast<IAlgorithm>(*iter));
-    }
-
-    return algs;
-  }
-
-  ///@cond
-  //------------------------------------------------------------------------------------------------------
-  /// Define overload generators
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,AlgorithmManagerImpl::create, 1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,AlgorithmManagerImpl::createUnmanaged, 1,2)
-  ///@endcond
+namespace {
+/**
+ * Return the algorithm identified by the given ID. A wrapper version that takes
+ * a
+ * AlgorithmIDProxy that wraps a AlgorithmID
+ * @param self The calling object
+ * @param id An algorithm ID
+ */
+IAlgorithm_sptr getAlgorithm(AlgorithmManagerImpl &self,
+                             AlgorithmIDProxy idHolder) {
+  return self.getAlgorithm(idHolder.id);
 }
 
-void export_AlgorithmManager()
-{
-  typedef class_<AlgorithmManagerImpl,boost::noncopyable> PythonType;
+/**
+ * Remove the algorithm identified by the given ID from the list of managed
+ * algorithms.
+ * A wrapper version that takes a AlgorithmIDProxy that wraps a AlgorithmID
+ * @param self The calling object
+ * @param id An algorithm ID
+ */
+void removeById(AlgorithmManagerImpl &self, AlgorithmIDProxy idHolder) {
+  return self.removeById(idHolder.id);
+}
 
-  auto pythonClass = class_<AlgorithmManagerImpl,boost::noncopyable>("AlgorithmManagerImpl", no_init)
-    .def("create", &AlgorithmManagerImpl::create, create_overloads((arg("name"), arg("version")), "Creates a managed algorithm."))
-    .def("createUnmanaged", &AlgorithmManagerImpl::createUnmanaged,
-        createUnmanaged_overloads((arg("name"), arg("version")), "Creates an unmanaged algorithm."))
-    .def("size", &AlgorithmManagerImpl::size, "Returns the number of managed algorithms")
-    .def("setMaxAlgorithms", &AlgorithmManagerImpl::setMaxAlgorithms,
-         "Set the maximum number of allowed managed algorithms")
-    .def("getAlgorithm", &getAlgorithm,
-         "Return the algorithm instance identified by the given id.")
-    .def("removeById", &removeById, "Remove an algorithm from the managed list")
-    .def("newestInstanceOf", &AlgorithmManagerImpl::newestInstanceOf,
-         "Returns the newest created instance of the named algorithm")
-    .def("runningInstancesOf", &runningInstancesOf,
-         "Returns a list of managed algorithm instances that are currently executing")
-    .def("clear", &AlgorithmManagerImpl::clear, "Clears the current list of managed algorithms")
-    .def("cancelAll", &AlgorithmManagerImpl::cancelAll,
-         "Requests that all currently running algorithms be cancelled")
-  ;
+/**
+ * @param self A reference to the calling object
+ * @param algName The name of the algorithm
+ * @return A python list of managed algorithms that are currently running
+ */
+boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
+                                       const std::string &algName) {
+  boost::python::list algs;
+  auto mgrAlgs = self.runningInstancesOf(algName);
+  for (auto iter = mgrAlgs.begin(); iter != mgrAlgs.end(); ++iter) {
+    // boost 1.41 (RHEL6) can't handle registering IAlgorithm_const_sptr so we
+    // have to cast to IAlgorithm_sptr and then convert to Python
+    // The constness is pretty-irrelevant by this point anyway
+    algs.append(boost::const_pointer_cast<IAlgorithm>(*iter));
+  }
+
+  return algs;
+}
+
+///@cond
+//------------------------------------------------------------------------------------------------------
+/// Define overload generators
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,
+                                       AlgorithmManagerImpl::create, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
+                                       AlgorithmManagerImpl::createUnmanaged, 1,
+                                       2)
+///@endcond
+}
+
+void export_AlgorithmManager() {
+  typedef class_<AlgorithmManagerImpl, boost::noncopyable> PythonType;
+
+  auto pythonClass =
+      class_<AlgorithmManagerImpl, boost::noncopyable>("AlgorithmManagerImpl",
+                                                       no_init)
+          .def("create", &AlgorithmManagerImpl::create,
+               create_overloads((arg("name"), arg("version")),
+                                "Creates a managed algorithm."))
+          .def("createUnmanaged", &AlgorithmManagerImpl::createUnmanaged,
+               createUnmanaged_overloads((arg("name"), arg("version")),
+                                         "Creates an unmanaged algorithm."))
+          .def("size", &AlgorithmManagerImpl::size,
+               "Returns the number of managed algorithms")
+          .def("setMaxAlgorithms", &AlgorithmManagerImpl::setMaxAlgorithms,
+               "Set the maximum number of allowed managed algorithms")
+          .def("getAlgorithm", &getAlgorithm,
+               "Return the algorithm instance identified by the given id.")
+          .def("removeById", &removeById,
+               "Remove an algorithm from the managed list")
+          .def("newestInstanceOf", &AlgorithmManagerImpl::newestInstanceOf,
+               "Returns the newest created instance of the named algorithm")
+          .def("runningInstancesOf", &runningInstancesOf,
+               "Returns a list of managed algorithm instances that are "
+               "currently executing")
+          .def("clear", &AlgorithmManagerImpl::clear,
+               "Clears the current list of managed algorithms")
+          .def("cancelAll", &AlgorithmManagerImpl::cancelAll,
+               "Requests that all currently running algorithms be cancelled");
 
   // Instance method
   TrackingInstanceMethod<AlgorithmManager, PythonType>::define(pythonClass);
-
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -64,9 +64,7 @@ namespace
   ///@endcond
 }
 
-// clang-format off
 void export_AlgorithmManager()
-// clang-format on
 {
   typedef class_<AlgorithmManagerImpl,boost::noncopyable> PythonType;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp
@@ -11,47 +11,50 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::PropertyWithValueExporter;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Factory function for creating an input property with a validator and a direction
-   * @param name The name of the property
-   * @param validator A pointer to the validator passed from Python. It is cloned when passed to the framework
-   * @param direction An output/input/inout property
-   * @return A pointer to a new AlgorithmProperty object
-   */
-  AlgorithmProperty * createPropertyWithValidatorAndDirection(const std::string &name, IValidator *validator, unsigned int direction)
-  {
-    return new AlgorithmProperty(name, validator->clone(), direction);
-  }
-
-  /**
-   * Factory function for creating an input property with a validator
-   * @param name The name of the property
-   * @param validator A pointer to the validator passed from Python. It is cloned when passed to the framework
-   * @return A pointer to a new AlgorithmProperty object
-   */
-  AlgorithmProperty * createPropertyWithValidator(const std::string &name, IValidator *validator)
-  {
-    return createPropertyWithValidatorAndDirection(name, validator, Mantid::Kernel::Direction::Input);
-  }
-
+namespace {
+/**
+ * Factory function for creating an input property with a validator and a
+ * direction
+ * @param name The name of the property
+ * @param validator A pointer to the validator passed from Python. It is cloned
+ * when passed to the framework
+ * @param direction An output/input/inout property
+ * @return A pointer to a new AlgorithmProperty object
+ */
+AlgorithmProperty *createPropertyWithValidatorAndDirection(
+    const std::string &name, IValidator *validator, unsigned int direction) {
+  return new AlgorithmProperty(name, validator->clone(), direction);
 }
 
-void export_AlgorithmProperty()
-{
+/**
+ * Factory function for creating an input property with a validator
+ * @param name The name of the property
+ * @param validator A pointer to the validator passed from Python. It is cloned
+ * when passed to the framework
+ * @return A pointer to a new AlgorithmProperty object
+ */
+AlgorithmProperty *createPropertyWithValidator(const std::string &name,
+                                               IValidator *validator) {
+  return createPropertyWithValidatorAndDirection(
+      name, validator, Mantid::Kernel::Direction::Input);
+}
+}
+
+void export_AlgorithmProperty() {
   // AlgorithmProperty has base PropertyWithValue<boost::shared_ptr<IAlgorithm>>
   // which must be exported
   typedef boost::shared_ptr<IAlgorithm> HeldType;
   PropertyWithValueExporter<HeldType>::define("AlgorithmPropertyWithValue");
 
-  class_<AlgorithmProperty, bases<PropertyWithValue<HeldType>>, boost::noncopyable>("AlgorithmProperty", no_init)
-    .def(init<const std::string &>(args("name")))
-    // These variants require the validator object to be cloned
-    .def("__init__", make_constructor(&createPropertyWithValidator,
-                                      default_call_policies(), args("name", "validator")))
-    .def("__init__", make_constructor(&createPropertyWithValidatorAndDirection,
-                                      default_call_policies(), args("name", "validator", "direction")))
-    ;
+  class_<AlgorithmProperty, bases<PropertyWithValue<HeldType>>,
+         boost::noncopyable>("AlgorithmProperty", no_init)
+      .def(init<const std::string &>(args("name")))
+      // These variants require the validator object to be cloned
+      .def("__init__",
+           make_constructor(&createPropertyWithValidator,
+                            default_call_policies(), args("name", "validator")))
+      .def("__init__",
+           make_constructor(&createPropertyWithValidatorAndDirection,
+                            default_call_policies(),
+                            args("name", "validator", "direction")));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProperty.cpp
@@ -38,9 +38,7 @@ namespace
 
 }
 
-// clang-format off
 void export_AlgorithmProperty()
-// clang-format on
 {
   // AlgorithmProperty has base PropertyWithValue<boost::shared_ptr<IAlgorithm>>
   // which must be exported

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProxy.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProxy.cpp
@@ -1,5 +1,7 @@
 #ifdef _MSC_VER
-  #pragma warning( disable: 4250 ) // Disable warning regarding inheritance via dominance, we have no way around it with the design
+#pragma warning(disable : 4250) // Disable warning regarding inheritance via
+                                // dominance, we have no way around it with the
+                                // design
 #endif
 #include "MantidAPI/AlgorithmProxy.h"
 
@@ -9,16 +11,17 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
-void export_algorithm_proxy()
-{
+void export_algorithm_proxy() {
 
   register_ptr_to_python<boost::shared_ptr<AlgorithmProxy>>();
 
-  // We do not require any additional methods here but some parts of the code specifically check that a proxy has
+  // We do not require any additional methods here but some parts of the code
+  // specifically check that a proxy has
   // been returned
-  class_<AlgorithmProxy, bases<IAlgorithm>, boost::noncopyable>("AlgorithmProxy", "Proxy class returned by managed algorithms", no_init);
+  class_<AlgorithmProxy, bases<IAlgorithm>, boost::noncopyable>(
+      "AlgorithmProxy", "Proxy class returned by managed algorithms", no_init);
 }
 
 #ifdef _MSC_VER
-  #pragma warning( default: 4250 )
+#pragma warning(default : 4250)
 #endif

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProxy.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmProxy.cpp
@@ -9,9 +9,7 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
-// clang-format off
 void export_algorithm_proxy()
-// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<AlgorithmProxy>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -13,72 +13,77 @@ using Mantid::PythonInterface::TrackingInstanceMethod;
 using namespace Mantid::PythonInterface::Registry;
 using namespace boost::python;
 
+namespace {
+/**
+ * Add an item into the ADS, if it exists then an error is raised
+ * @param self A reference to the calling object
+ * @param name The name to assign to this in the service
+ * @param item A boost.python wrapped SvcHeldType object
+ */
+void addItem(AnalysisDataServiceImpl &self, const std::string &name,
+             const boost::python::object &item) {
+  const auto &entry =
+      DowncastRegistry::retrieve(call_method<std::string>(item.ptr(), "id"));
 
-namespace
-{
-  /**
-   * Add an item into the ADS, if it exists then an error is raised
-   * @param self A reference to the calling object
-   * @param name The name to assign to this in the service
-   * @param item A boost.python wrapped SvcHeldType object
-   */
-  void addItem(AnalysisDataServiceImpl& self, const std::string & name, const boost::python::object& item)
-  {
-    const auto & entry = DowncastRegistry::retrieve(call_method<std::string>(item.ptr(), "id"));
-
-    try
-    {
-      // It is VERY important that the extract type be a reference to SvcHeldType so that
-      // boost.python doesn't create a new shared_ptr and instead simply extracts the embedded one.
-      self.add(name, boost::dynamic_pointer_cast<Workspace>(entry.fromPythonAsSharedPtr(item)));
-    }
-    catch(std::exception& exc)
-    {
-      PyErr_SetString(PyExc_RuntimeError, exc.what()); // traditionally throws RuntimeError so don't break scripts
-      throw boost::python::error_already_set();
-    }
+  try {
+    // It is VERY important that the extract type be a reference to SvcHeldType
+    // so that
+    // boost.python doesn't create a new shared_ptr and instead simply extracts
+    // the embedded one.
+    self.add(name, boost::dynamic_pointer_cast<Workspace>(
+                       entry.fromPythonAsSharedPtr(item)));
+  } catch (std::exception &exc) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        exc.what()); // traditionally throws RuntimeError so don't break scripts
+    throw boost::python::error_already_set();
   }
-
-  /**
-   * Add or replace an item into the service, if it exists then an error is raised
-   * @param self A reference to the calling object
-   * @param name The name to assign to this in the service
-   * @param item A boost.python wrapped SvcHeldType object
-   */
-  void addOrReplaceItem(AnalysisDataServiceImpl& self, const std::string & name,
-                        const boost::python::object& item)
-  {
-    const auto & entry = DowncastRegistry::retrieve(call_method<std::string>(item.ptr(), "id"));
-
-    try
-    {
-      // It is VERY important that the extract type be a reference to SvcHeldType so that
-      // boost.python doesn't create a new shared_ptr and instead simply extracts the embedded one.
-      self.addOrReplace(name, boost::dynamic_pointer_cast<Workspace>(entry.fromPythonAsSharedPtr(item)));
-    }
-    catch(std::exception& exc)
-    {
-      PyErr_SetString(PyExc_RuntimeError, exc.what()); // traditionally throws RuntimeError so don't break scripts
-      throw boost::python::error_already_set();
-    }
-  }
-
 }
 
-void export_AnalysisDataService()
-{
-  typedef DataServiceExporter<AnalysisDataServiceImpl, Workspace_sptr> ADSExporter;
+/**
+ * Add or replace an item into the service, if it exists then an error is raised
+ * @param self A reference to the calling object
+ * @param name The name to assign to this in the service
+ * @param item A boost.python wrapped SvcHeldType object
+ */
+void addOrReplaceItem(AnalysisDataServiceImpl &self, const std::string &name,
+                      const boost::python::object &item) {
+  const auto &entry =
+      DowncastRegistry::retrieve(call_method<std::string>(item.ptr(), "id"));
+
+  try {
+    // It is VERY important that the extract type be a reference to SvcHeldType
+    // so that
+    // boost.python doesn't create a new shared_ptr and instead simply extracts
+    // the embedded one.
+    self.addOrReplace(name, boost::dynamic_pointer_cast<Workspace>(
+                                entry.fromPythonAsSharedPtr(item)));
+  } catch (std::exception &exc) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        exc.what()); // traditionally throws RuntimeError so don't break scripts
+    throw boost::python::error_already_set();
+  }
+}
+}
+
+void export_AnalysisDataService() {
+  typedef DataServiceExporter<AnalysisDataServiceImpl, Workspace_sptr>
+      ADSExporter;
   auto pythonClass = ADSExporter::define("AnalysisDataServiceImpl");
 
   // -- special ADS behaviour --
-  // replace the add/addOrReplace,__setitem__ methods as we need to exact the exact stored type
-  pythonClass.def("add", &addItem,
-       "Adds the given object to the service with the given name. If the name/object exists it will raise an error.");
+  // replace the add/addOrReplace,__setitem__ methods as we need to exact the
+  // exact stored type
+  pythonClass.def("add", &addItem, "Adds the given object to the service with "
+                                   "the given name. If the name/object exists "
+                                   "it will raise an error.");
   pythonClass.def("addOrReplace", &addOrReplaceItem,
-       "Adds the given object to the service with the given name. The the name exists the object is replaced.");
+                  "Adds the given object to the service with the given name. "
+                  "The the name exists the object is replaced.");
   pythonClass.def("__setitem__", &addOrReplaceItem);
 
   // Instance method
-  TrackingInstanceMethod<AnalysisDataService, ADSExporter::PythonType>::define(pythonClass);
+  TrackingInstanceMethod<AnalysisDataService, ADSExporter::PythonType>::define(
+      pythonClass);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -65,9 +65,7 @@ namespace
 
 }
 
-// clang-format off
 void export_AnalysisDataService()
-// clang-format on
 {
   typedef DataServiceExporter<AnalysisDataServiceImpl, Workspace_sptr> ADSExporter;
   auto pythonClass = ADSExporter::define("AnalysisDataServiceImpl");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -10,100 +10,96 @@
 #include <boost/python/overloads.hpp>
 #include <boost/python/ssize_t.hpp> //For Py_ssize_t. We can get rid of this when RHEL5 goes
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL API_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
-
 
 using namespace Mantid::API;
 using Mantid::Kernel::Unit_sptr;
 using Mantid::specid_t;
 using namespace boost::python;
 
-namespace
-{
-  namespace bpl = boost::python;
+namespace {
+namespace bpl = boost::python;
 
-  //------------------------------- Overload macros ---------------------------
-  // Overloads for operator() function which has 1 optional argument
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
+//------------------------------- Overload macros ---------------------------
+// Overloads for operator() function which has 1 optional argument
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
 
-  /**
-   * Extract the axis values as a sequence. A numpy array is used if the
-   * data is numerical or a simple python list is used if the data is a string type
-   * @param self A reference to the object that called this method
-   * @return A PyObject representing the array
-   */
-  PyObject * extractAxisValues(Axis &self)
-  {
-    const npy_intp nvalues = static_cast<npy_intp>(self.length());
-    npy_intp arrayDims[1] = { nvalues };
+/**
+ * Extract the axis values as a sequence. A numpy array is used if the
+ * data is numerical or a simple python list is used if the data is a string
+ * type
+ * @param self A reference to the object that called this method
+ * @return A PyObject representing the array
+ */
+PyObject *extractAxisValues(Axis &self) {
+  const npy_intp nvalues = static_cast<npy_intp>(self.length());
+  npy_intp arrayDims[1] = {nvalues};
 
-    // Pick the correct element type base on the Axis type
-    PyObject *array;
-    bool numeric(true);
-    if( self.isNumeric() || self.isSpectra() )
-    {
-      array = PyArray_SimpleNew(1, arrayDims, NPY_DOUBLE);
-    }
-    else if( self.isText() )
-    {
-      array = PyList_New((Py_ssize_t)nvalues);
-      numeric = false;
-    }
-    else
-    {
-      throw std::invalid_argument("Unknown axis type. Cannot extract to Numpy");
-    }
-
-    // Fill the array
-    for(npy_intp i = 0; i < nvalues; ++i)
-    {
-      if( numeric )
-      {
-        PyObject *value = PyFloat_FromDouble(self.getValue(static_cast<size_t>(i)));
-        void *pos = PyArray_GETPTR1((PyArrayObject *)array, i);
-        PyArray_SETITEM((PyArrayObject *)array, (char*)pos, value);
-      }
-      else
-      {
-        const std::string s = self.label(static_cast<size_t>(i));
-        PyObject *value = PyString_FromString(s.c_str());
-        PyList_SetItem(array, (Py_ssize_t)i, value);
-      }
-    }
-    return array;
+  // Pick the correct element type base on the Axis type
+  PyObject *array;
+  bool numeric(true);
+  if (self.isNumeric() || self.isSpectra()) {
+    array = PyArray_SimpleNew(1, arrayDims, NPY_DOUBLE);
+  } else if (self.isText()) {
+    array = PyList_New((Py_ssize_t)nvalues);
+    numeric = false;
+  } else {
+    throw std::invalid_argument("Unknown axis type. Cannot extract to Numpy");
   }
+
+  // Fill the array
+  for (npy_intp i = 0; i < nvalues; ++i) {
+    if (numeric) {
+      PyObject *value =
+          PyFloat_FromDouble(self.getValue(static_cast<size_t>(i)));
+      void *pos = PyArray_GETPTR1((PyArrayObject *)array, i);
+      PyArray_SETITEM((PyArrayObject *)array, (char *)pos, value);
+    } else {
+      const std::string s = self.label(static_cast<size_t>(i));
+      PyObject *value = PyString_FromString(s.c_str());
+      PyList_SetItem(array, (Py_ssize_t)i, value);
+    }
+  }
+  return array;
+}
 }
 
-
-void export_Axis()
-{
-  register_ptr_to_python<Axis*>();
+void export_Axis() {
+  register_ptr_to_python<Axis *>();
 
   // Class
-  class_< Axis, boost::noncopyable >("MantidAxis", no_init)
-    .def("length", &Axis::length, "Returns the length of the axis")
-    .def("title", (const std::string & (Axis::*)() const ) &Axis::title, return_value_policy<copy_const_reference>(),
-         "Get the axis title")
-    .def("isSpectra", &Axis::isSpectra, "Returns true if this is a SpectraAxis")
-    .def("isNumeric", &Axis::isNumeric, "Returns true if this is a NumericAxis")
-    .def("isText", &Axis::isText, "Returns true if this is a TextAxis")
-    .def("label", &Axis::label, "Return the axis label")
-    .def("getUnit", (const Unit_sptr & (Axis::*)() const) &Axis::unit, return_value_policy<copy_const_reference>(),
-         "Returns the unit object for the axis")
-    .def("getValue", &Axis::getValue,
-        Axis_getValue(args("index", "vertical_index"), "Returns the value at the given point on the Axis. The vertical axis index [default=0]")) 
-    .def("extractValues", &extractAxisValues, "Return a numpy array of the axis values")
-    .def("setUnit", & Axis::setUnit, return_value_policy<copy_const_reference>(),
-         "Set the unit for this axis by name.")
-    .def("setValue", &Axis::setValue, "Set a value at the given index")
-    .def("getMin", &Axis::getMin, "Get min value specified on the axis")
-    .def("getMax", &Axis::getMax, "Get max value specified on the axis")
-    //------------------------------------ Special methods ------------------------------------
-    .def("__len__", &Axis::length)
-    ;
+  class_<Axis, boost::noncopyable>("MantidAxis", no_init)
+      .def("length", &Axis::length, "Returns the length of the axis")
+      .def("title", (const std::string &(Axis::*)() const) & Axis::title,
+           return_value_policy<copy_const_reference>(), "Get the axis title")
+      .def("isSpectra", &Axis::isSpectra,
+           "Returns true if this is a SpectraAxis")
+      .def("isNumeric", &Axis::isNumeric,
+           "Returns true if this is a NumericAxis")
+      .def("isText", &Axis::isText, "Returns true if this is a TextAxis")
+      .def("label", &Axis::label, "Return the axis label")
+      .def("getUnit", (const Unit_sptr &(Axis::*)() const) & Axis::unit,
+           return_value_policy<copy_const_reference>(),
+           "Returns the unit object for the axis")
+      .def("getValue", &Axis::getValue,
+           Axis_getValue(args("index", "vertical_index"),
+                         "Returns the value at the given point on the Axis. "
+                         "The vertical axis index [default=0]"))
+      .def("extractValues", &extractAxisValues,
+           "Return a numpy array of the axis values")
+      .def("setUnit", &Axis::setUnit,
+           return_value_policy<copy_const_reference>(),
+           "Set the unit for this axis by name.")
+      .def("setValue", &Axis::setValue, "Set a value at the given index")
+      .def("getMin", &Axis::getMin, "Get min value specified on the axis")
+      .def("getMax", &Axis::getMax, "Get max value specified on the axis")
+      //------------------------------------ Special methods
+      //------------------------------------
+      .def("__len__", &Axis::length);
 }
 
 // --------------------------------------------------------------------------------------------
@@ -114,19 +110,17 @@ void export_Axis()
 * @param length The length of the new axis
 * @return pointer to the axis object
 */
-Axis* createNumericAxis(int length)
-{
+Axis *createNumericAxis(int length) {
   return new Mantid::API::NumericAxis(length);
 }
 
-void export_NumericAxis()
-{
-  /// Exported so that Boost.Python can give back a NumericAxis class when an Axis* is returned
-  class_< NumericAxis, bases<Axis>, boost::noncopyable >("NumericAxis", no_init)
-    .def("create", &createNumericAxis, return_internal_reference<>(), "Creates a new NumericAxis of a specified length")
-    .staticmethod("create")
-   ;
-
+void export_NumericAxis() {
+  /// Exported so that Boost.Python can give back a NumericAxis class when an
+  /// Axis* is returned
+  class_<NumericAxis, bases<Axis>, boost::noncopyable>("NumericAxis", no_init)
+      .def("create", &createNumericAxis, return_internal_reference<>(),
+           "Creates a new NumericAxis of a specified length")
+      .staticmethod("create");
 }
 
 // --------------------------------------------------------------------------------------------
@@ -138,19 +132,18 @@ void export_NumericAxis()
 * @param length The length of the new axis
 * @return pointer to the axis object
 */
-Axis* createBinEdgeAxis(int length)
-{
+Axis *createBinEdgeAxis(int length) {
   return new Mantid::API::BinEdgeAxis(length);
 }
 
-void export_BinEdgeAxis()
-{
-  /// Exported so that Boost.Python can give back a BinEdgeAxis class when an Axis* is returned
-  class_< BinEdgeAxis, bases<NumericAxis>, boost::noncopyable >("BinEdgeAxis", no_init)
-    .def("create", &createBinEdgeAxis, return_internal_reference<>(), "Creates a new BinEdgeAxis of a specified length")
-    .staticmethod("create")
-   ;
-
+void export_BinEdgeAxis() {
+  /// Exported so that Boost.Python can give back a BinEdgeAxis class when an
+  /// Axis* is returned
+  class_<BinEdgeAxis, bases<NumericAxis>, boost::noncopyable>("BinEdgeAxis",
+                                                              no_init)
+      .def("create", &createBinEdgeAxis, return_internal_reference<>(),
+           "Creates a new BinEdgeAxis of a specified length")
+      .staticmethod("create");
 }
 
 // --------------------------------------------------------------------------------------------
@@ -162,20 +155,13 @@ void export_BinEdgeAxis()
 * @param length The length of the new axis
 * @return pointer to the axis object
 */
-Axis* createTextAxis(int length)
-{
-  return new Mantid::API::TextAxis(length);
+Axis *createTextAxis(int length) { return new Mantid::API::TextAxis(length); }
+
+void export_TextAxis() {
+  class_<TextAxis, bases<Axis>, boost::noncopyable>("TextAxis", no_init)
+      .def("setLabel", &TextAxis::setLabel, "Set the label at the given entry")
+      .def("label", &TextAxis::label, "Return the label at the given position")
+      .def("create", &createTextAxis, return_internal_reference<>(),
+           "Creates a new TextAxis of a specified length")
+      .staticmethod("create");
 }
-
-
-void export_TextAxis()
-{
-  class_< TextAxis, bases<Axis>, boost::noncopyable >("TextAxis", no_init)
-    .def("setLabel", & TextAxis::setLabel, "Set the label at the given entry")
-    .def("label", & TextAxis::label, "Return the label at the given position")
-    .def("create", &createTextAxis, return_internal_reference<>(), "Creates a new TextAxis of a specified length")
-    .staticmethod("create")
-    ;
-
-}
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -78,9 +78,7 @@ namespace
 }
 
 
-// clang-format off
 void export_Axis()
-// clang-format on
 {
   register_ptr_to_python<Axis*>();
 
@@ -121,9 +119,7 @@ Axis* createNumericAxis(int length)
   return new Mantid::API::NumericAxis(length);
 }
 
-// clang-format off
 void export_NumericAxis()
-// clang-format on
 {
   /// Exported so that Boost.Python can give back a NumericAxis class when an Axis* is returned
   class_< NumericAxis, bases<Axis>, boost::noncopyable >("NumericAxis", no_init)
@@ -147,9 +143,7 @@ Axis* createBinEdgeAxis(int length)
   return new Mantid::API::BinEdgeAxis(length);
 }
 
-// clang-format off
 void export_BinEdgeAxis()
-// clang-format on
 {
   /// Exported so that Boost.Python can give back a BinEdgeAxis class when an Axis* is returned
   class_< BinEdgeAxis, bases<NumericAxis>, boost::noncopyable >("BinEdgeAxis", no_init)
@@ -174,9 +168,7 @@ Axis* createTextAxis(int length)
 }
 
 
-// clang-format off
 void export_TextAxis()
-// clang-format on
 {
   class_< TextAxis, bases<Axis>, boost::noncopyable >("TextAxis", no_init)
     .def("setLabel", & TextAxis::setLabel, "Set the label at the given entry")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -14,181 +14,214 @@
 
 namespace Policies = Mantid::PythonInterface::Policies;
 
-void export_BinaryOperations()
-{
+void export_BinaryOperations() {
   using namespace Mantid::API;
   using boost::python::return_value_policy;
 
-  //Operator overloads dispatch through the above structure. The typedefs save some typing
-  typedef IMDWorkspace_sptr(*binary_fn_md_md)(const IMDWorkspace_sptr, const IMDWorkspace_sptr, const std::string &,const std::string &,bool, bool);
-  typedef WorkspaceGroup_sptr(*binary_fn_md_gp)(const IMDWorkspace_sptr, const WorkspaceGroup_sptr, const std::string &,const std::string &,bool, bool);
-  typedef WorkspaceGroup_sptr(*binary_fn_gp_md)(const WorkspaceGroup_sptr, const IMDWorkspace_sptr, const std::string &,const std::string &,bool, bool);
-  typedef WorkspaceGroup_sptr(*binary_fn_gp_gp)(const WorkspaceGroup_sptr, const WorkspaceGroup_sptr, const std::string &,const std::string &,bool, bool);
+  // Operator overloads dispatch through the above structure. The typedefs save
+  // some typing
+  typedef IMDWorkspace_sptr (*binary_fn_md_md)(
+      const IMDWorkspace_sptr, const IMDWorkspace_sptr, const std::string &,
+      const std::string &, bool, bool);
+  typedef WorkspaceGroup_sptr (*binary_fn_md_gp)(
+      const IMDWorkspace_sptr, const WorkspaceGroup_sptr, const std::string &,
+      const std::string &, bool, bool);
+  typedef WorkspaceGroup_sptr (*binary_fn_gp_md)(
+      const WorkspaceGroup_sptr, const IMDWorkspace_sptr, const std::string &,
+      const std::string &, bool, bool);
+  typedef WorkspaceGroup_sptr (*binary_fn_gp_gp)(
+      const WorkspaceGroup_sptr, const WorkspaceGroup_sptr, const std::string &,
+      const std::string &, bool, bool);
 
-  typedef IMDHistoWorkspace_sptr(*binary_fn_mh_mh)(const IMDHistoWorkspace_sptr, const IMDHistoWorkspace_sptr, const std::string &,const std::string &,bool, bool);
+  typedef IMDHistoWorkspace_sptr (*binary_fn_mh_mh)(
+      const IMDHistoWorkspace_sptr, const IMDHistoWorkspace_sptr,
+      const std::string &, const std::string &, bool, bool);
 
-  typedef IMDWorkspace_sptr(*binary_fn_md_db)(const IMDWorkspace_sptr, double, const std::string&,const std::string &,bool,bool);
-  typedef IMDHistoWorkspace_sptr(*binary_fn_mh_db)(const IMDHistoWorkspace_sptr, double, const std::string&,const std::string &,bool,bool);
-  typedef WorkspaceGroup_sptr(*binary_fn_gp_db)(const WorkspaceGroup_sptr, double, const std::string&,const std::string &,bool,bool);
+  typedef IMDWorkspace_sptr (*binary_fn_md_db)(const IMDWorkspace_sptr, double,
+                                               const std::string &,
+                                               const std::string &, bool, bool);
+  typedef IMDHistoWorkspace_sptr (*binary_fn_mh_db)(
+      const IMDHistoWorkspace_sptr, double, const std::string &,
+      const std::string &, bool, bool);
+  typedef WorkspaceGroup_sptr (*binary_fn_gp_db)(
+      const WorkspaceGroup_sptr, double, const std::string &,
+      const std::string &, bool, bool);
 
   // Binary operations that return a workspace
   using boost::python::def;
   using Mantid::PythonInterface::performBinaryOp;
   using Mantid::PythonInterface::performBinaryOpWithDouble;
 
-  def("performBinaryOp", (binary_fn_md_md)&performBinaryOp, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-  def("performBinaryOp", (binary_fn_md_gp)&performBinaryOp, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-  def("performBinaryOp", (binary_fn_gp_md)&performBinaryOp, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-  def("performBinaryOp", (binary_fn_gp_gp)&performBinaryOp, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-  def("performBinaryOp", (binary_fn_mh_mh)&performBinaryOp, return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_md_md)&performBinaryOp,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_md_gp)&performBinaryOp,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_gp_md)&performBinaryOp,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_gp_gp)&performBinaryOp,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_mh_mh)&performBinaryOp,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
 
-  def("performBinaryOp", (binary_fn_md_db)&performBinaryOpWithDouble, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-  def("performBinaryOp", (binary_fn_mh_db)&performBinaryOpWithDouble, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-  def("performBinaryOp", (binary_fn_gp_db)&performBinaryOpWithDouble, return_value_policy<Policies::ToSharedPtrWithDowncast>());
-
+  def("performBinaryOp", (binary_fn_md_db)&performBinaryOpWithDouble,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_mh_db)&performBinaryOpWithDouble,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
+  def("performBinaryOp", (binary_fn_gp_db)&performBinaryOpWithDouble,
+      return_value_policy<Policies::ToSharedPtrWithDowncast>());
 }
 
+namespace Mantid {
+namespace PythonInterface {
+using namespace Mantid::API;
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    using namespace Mantid::API;
+/** Binary operation for two workspaces. Generic for IMDWorkspaces or
+ *MatrixWorkspaces...
+ * Called by python overloads for _binary_op (see api_exports.cpp)
+ *
+ * @param lhs :: the left hand side workspace of the operation
+ * @param rhs :: the right hand side workspace of the operation
+ * @param op :: The operation
+ * @param name :: The output name
+ * @param inplace :: is this is an inplace operation (i.e. does the output
+ *overwrite the lhs
+ * @param reverse :: Unused parameter. Here for consistent interface
+ * @returns The resulting workspace
+ */
+template <typename LHSType, typename RHSType, typename ResultType>
+ResultType performBinaryOp(const LHSType lhs, const RHSType rhs,
+                           const std::string &op, const std::string &name,
+                           bool inplace, bool reverse) {
+  std::string algoName = op;
 
-    /** Binary operation for two workspaces. Generic for IMDWorkspaces or MatrixWorkspaces...
-     * Called by python overloads for _binary_op (see api_exports.cpp)
-     *
-     * @param lhs :: the left hand side workspace of the operation
-     * @param rhs :: the right hand side workspace of the operation
-     * @param op :: The operation
-     * @param name :: The output name
-     * @param inplace :: is this is an inplace operation (i.e. does the output overwrite the lhs
-     * @param reverse :: Unused parameter. Here for consistent interface
-     * @returns The resulting workspace
-     */
-    template<typename LHSType, typename RHSType, typename ResultType>
-    ResultType performBinaryOp(const LHSType lhs, const RHSType rhs,
-                        const std::string& op, const std::string & name,
-                        bool inplace,bool reverse)
-    {
-      std::string algoName = op;
+  // ----- Determine which version of the algo should be called -----
+  MatrixWorkspace_const_sptr lhs_mat =
+      boost::dynamic_pointer_cast<const MatrixWorkspace>(lhs);
+  MatrixWorkspace_const_sptr rhs_mat =
+      boost::dynamic_pointer_cast<const MatrixWorkspace>(rhs);
+  WorkspaceGroup_const_sptr lhs_grp =
+      boost::dynamic_pointer_cast<const WorkspaceGroup>(lhs);
+  WorkspaceGroup_const_sptr rhs_grp =
+      boost::dynamic_pointer_cast<const WorkspaceGroup>(rhs);
 
-      // ----- Determine which version of the algo should be called -----
-      MatrixWorkspace_const_sptr lhs_mat = boost::dynamic_pointer_cast<const MatrixWorkspace>(lhs);
-      MatrixWorkspace_const_sptr rhs_mat = boost::dynamic_pointer_cast<const MatrixWorkspace>(rhs);
-      WorkspaceGroup_const_sptr lhs_grp = boost::dynamic_pointer_cast<const WorkspaceGroup>(lhs);
-      WorkspaceGroup_const_sptr rhs_grp = boost::dynamic_pointer_cast<const WorkspaceGroup>(rhs);
+  if ((lhs_mat || lhs_grp) && (rhs_mat || rhs_grp))
+    // Both sides are matrixworkspace - use the original algos (e..g "Plus.")
+    algoName = op;
+  else
+    // One of the workspaces must be MDHistoWorkspace or MDEventWorkspace
+    // Use the MD version, e.g. "PlusMD"
+    algoName = op + "MD";
 
-      if ( (lhs_mat || lhs_grp) && (rhs_mat || rhs_grp) )
-        // Both sides are matrixworkspace - use the original algos (e..g "Plus.")
-        algoName = op;
-      else
-        // One of the workspaces must be MDHistoWorkspace or MDEventWorkspace
-        // Use the MD version, e.g. "PlusMD"
-        algoName = op + "MD";
-
-      ResultType result;
-      std::string error("");
-      try
-      {
-        if( reverse )
-        {
-          result = API::OperatorOverloads::executeBinaryOperation<RHSType, LHSType, ResultType>(algoName, rhs, lhs, inplace, false, name, true);
-        }
-        else
-        {
-          result = API::OperatorOverloads::executeBinaryOperation<LHSType, RHSType, ResultType>(algoName, lhs, rhs, inplace, false, name, true);
-        }
-      }
-      catch(std::runtime_error & exc)
-      {
-        error = exc.what();
-        if( error.find("algorithm") == 0 )
-        {
-          error = "Unknown binary operation requested: " + op;
-          throw std::runtime_error(error);
-        }
-        else
-        {
-          throw;
-        }
-      }
-      return result;
+  ResultType result;
+  std::string error("");
+  try {
+    if (reverse) {
+      result = API::OperatorOverloads::executeBinaryOperation<
+          RHSType, LHSType, ResultType>(algoName, rhs, lhs, inplace, false,
+                                        name, true);
+    } else {
+      result = API::OperatorOverloads::executeBinaryOperation<
+          LHSType, RHSType, ResultType>(algoName, lhs, rhs, inplace, false,
+                                        name, true);
     }
-
-
-    /**
-    * Perform the given binary operation on a workspace and a double.
-    * Generic to MDWorkspaces.
-    * Called by python overloads for _binary_op (see api_exports.cpp)
-    *
-    * @param inputWS :: The input workspace
-    * @param value :: The input value
-    * @param op :: The operation
-    * @param name :: The output name
-    * @param inplace :: If true, then the lhs argument is replaced by the result of the operation.
-    * @param reverse :: If true then the double is the lhs argument
-    * @return A shared pointer to the result workspace
-    */
-    template<typename LHSType, typename ResultType>
-    ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value,
-        const std::string& op, const std::string & name,
-        bool inplace, bool reverse)
-    {
-      std::string algoName = op;
-
-      // Create the single valued workspace first so that it is run as a top-level algorithm
-      // such that it's history can be recreated
-      API::Algorithm_sptr alg = API::AlgorithmManager::Instance().createUnmanaged("CreateSingleValuedWorkspace");
-      alg->setChild(false);
-      alg->initialize();
-      alg->setProperty<double>("DataValue",value);
-      const std::string tmp_name("__tmp_binary_operation_double");
-      alg->setPropertyValue("OutputWorkspace", tmp_name);
-      alg->execute();
-      MatrixWorkspace_sptr singleValue;
-      API::AnalysisDataServiceImpl & data_store = API::AnalysisDataService::Instance();
-      if( alg->isExecuted() )
-      {
-        singleValue = boost::dynamic_pointer_cast<API::MatrixWorkspace>(data_store.retrieve(tmp_name));
-      }
-      else
-      {
-        throw std::runtime_error("performBinaryOp: Error in execution of CreateSingleValuedWorkspace");
-      }
-      // Call the function above with the signle-value workspace
-      ResultType result = performBinaryOp<LHSType, MatrixWorkspace_sptr, ResultType>(inputWS, singleValue, algoName, name, inplace, reverse);
-      // Delete the temporary
-      data_store.remove(tmp_name);
-      return result;
+  } catch (std::runtime_error &exc) {
+    error = exc.what();
+    if (error.find("algorithm") == 0) {
+      error = "Unknown binary operation requested: " + op;
+      throw std::runtime_error(error);
+    } else {
+      throw;
     }
-
-
-    // Concrete instantations
-    template IMDWorkspace_sptr performBinaryOp(const IMDWorkspace_sptr, const IMDWorkspace_sptr, const std::string& , const std::string & name,
-        bool, bool);
-    template WorkspaceGroup_sptr performBinaryOp(const IMDWorkspace_sptr, const WorkspaceGroup_sptr, const std::string& , const std::string & name,
-        bool, bool);
-    template WorkspaceGroup_sptr performBinaryOp(const WorkspaceGroup_sptr, const IMDWorkspace_sptr, const std::string& , const std::string & name,
-        bool, bool);
-    template WorkspaceGroup_sptr performBinaryOp(const WorkspaceGroup_sptr, const WorkspaceGroup_sptr, const std::string& , const std::string & name,
-        bool, bool);
-
-    template IMDHistoWorkspace_sptr performBinaryOp(const IMDHistoWorkspace_sptr, const IMDHistoWorkspace_sptr, const std::string& , const std::string & name,
-        bool, bool);
-    template IMDHistoWorkspace_sptr performBinaryOp(const IMDHistoWorkspace_sptr, const MatrixWorkspace_sptr, const std::string& , const std::string & name,
-        bool, bool);
-
-    // Double variants
-    template IMDWorkspace_sptr performBinaryOpWithDouble(const IMDWorkspace_sptr, const double, const std::string& op,
-        const std::string &, bool, bool);
-    template IMDHistoWorkspace_sptr performBinaryOpWithDouble(const IMDHistoWorkspace_sptr, const double, const std::string& op,
-        const std::string &, bool, bool);
-    template WorkspaceGroup_sptr performBinaryOpWithDouble(const WorkspaceGroup_sptr, const double, const std::string& op,
-        const std::string &, bool, bool);
-
   }
+  return result;
 }
 
+/**
+* Perform the given binary operation on a workspace and a double.
+* Generic to MDWorkspaces.
+* Called by python overloads for _binary_op (see api_exports.cpp)
+*
+* @param inputWS :: The input workspace
+* @param value :: The input value
+* @param op :: The operation
+* @param name :: The output name
+* @param inplace :: If true, then the lhs argument is replaced by the result of
+*the operation.
+* @param reverse :: If true then the double is the lhs argument
+* @return A shared pointer to the result workspace
+*/
+template <typename LHSType, typename ResultType>
+ResultType performBinaryOpWithDouble(const LHSType inputWS, const double value,
+                                     const std::string &op,
+                                     const std::string &name, bool inplace,
+                                     bool reverse) {
+  std::string algoName = op;
 
+  // Create the single valued workspace first so that it is run as a top-level
+  // algorithm
+  // such that it's history can be recreated
+  API::Algorithm_sptr alg = API::AlgorithmManager::Instance().createUnmanaged(
+      "CreateSingleValuedWorkspace");
+  alg->setChild(false);
+  alg->initialize();
+  alg->setProperty<double>("DataValue", value);
+  const std::string tmp_name("__tmp_binary_operation_double");
+  alg->setPropertyValue("OutputWorkspace", tmp_name);
+  alg->execute();
+  MatrixWorkspace_sptr singleValue;
+  API::AnalysisDataServiceImpl &data_store =
+      API::AnalysisDataService::Instance();
+  if (alg->isExecuted()) {
+    singleValue = boost::dynamic_pointer_cast<API::MatrixWorkspace>(
+        data_store.retrieve(tmp_name));
+  } else {
+    throw std::runtime_error(
+        "performBinaryOp: Error in execution of CreateSingleValuedWorkspace");
+  }
+  // Call the function above with the signle-value workspace
+  ResultType result =
+      performBinaryOp<LHSType, MatrixWorkspace_sptr, ResultType>(
+          inputWS, singleValue, algoName, name, inplace, reverse);
+  // Delete the temporary
+  data_store.remove(tmp_name);
+  return result;
+}
 
+// Concrete instantations
+template IMDWorkspace_sptr performBinaryOp(const IMDWorkspace_sptr,
+                                           const IMDWorkspace_sptr,
+                                           const std::string &,
+                                           const std::string &name, bool, bool);
+template WorkspaceGroup_sptr
+performBinaryOp(const IMDWorkspace_sptr, const WorkspaceGroup_sptr,
+                const std::string &, const std::string &name, bool, bool);
+template WorkspaceGroup_sptr
+performBinaryOp(const WorkspaceGroup_sptr, const IMDWorkspace_sptr,
+                const std::string &, const std::string &name, bool, bool);
+template WorkspaceGroup_sptr
+performBinaryOp(const WorkspaceGroup_sptr, const WorkspaceGroup_sptr,
+                const std::string &, const std::string &name, bool, bool);
+
+template IMDHistoWorkspace_sptr
+performBinaryOp(const IMDHistoWorkspace_sptr, const IMDHistoWorkspace_sptr,
+                const std::string &, const std::string &name, bool, bool);
+template IMDHistoWorkspace_sptr
+performBinaryOp(const IMDHistoWorkspace_sptr, const MatrixWorkspace_sptr,
+                const std::string &, const std::string &name, bool, bool);
+
+// Double variants
+template IMDWorkspace_sptr performBinaryOpWithDouble(const IMDWorkspace_sptr,
+                                                     const double,
+                                                     const std::string &op,
+                                                     const std::string &, bool,
+                                                     bool);
+template IMDHistoWorkspace_sptr
+performBinaryOpWithDouble(const IMDHistoWorkspace_sptr, const double,
+                          const std::string &op, const std::string &, bool,
+                          bool);
+template WorkspaceGroup_sptr
+performBinaryOpWithDouble(const WorkspaceGroup_sptr, const double,
+                          const std::string &op, const std::string &, bool,
+                          bool);
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -14,9 +14,7 @@
 
 namespace Policies = Mantid::PythonInterface::Policies;
 
-// clang-format off
 void export_BinaryOperations()
-// clang-format on
 {
   using namespace Mantid::API;
   using boost::python::return_value_policy;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BoxController.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BoxController.cpp
@@ -7,21 +7,28 @@
 using Mantid::API::BoxController;
 using namespace boost::python;
 
-void export_BoxController()
-{
+void export_BoxController() {
   register_ptr_to_python<boost::shared_ptr<BoxController>>();
 
-  class_< BoxController, boost::noncopyable >("BoxController", no_init)
-    .def("getNDims", &BoxController::getNDims, "Get # of dimensions")
-    .def("getSplitThreshold", &BoxController::getSplitThreshold, "Return the splitting threshold, in # of events")
-    .def("getSplitInto", &BoxController::getSplitInto, "Return into how many to split along a dimension")
-    .def("getMaxDepth", &BoxController::getMaxDepth, "Return the max recursion depth allowed for grid box splitting.")
-    .def("getTotalNumMDBoxes", &BoxController::getTotalNumMDBoxes, "Return the total number of MD Boxes, irrespective of depth")
-    .def("getTotalNumMDGridBoxes", &BoxController::getTotalNumMDGridBoxes, "Return the total number of MDGridBox'es, irrespective of depth")
-    .def("getAverageDepth", &BoxController::getAverageDepth, "Return the average recursion depth of gridding.")
-    .def("isFileBacked", &BoxController::isFileBacked, "Return True if the MDEventWorkspace is backed by a file ")
-    .def("getFilename", &BoxController::getFilename, "Return  the full path to the file open as the file-based back or empty string if no file back-end is initiated")
-    .def("useWriteBuffer", &BoxController::useWriteBuffer, "Return true if the MRU should be used")
-  ;
+  class_<BoxController, boost::noncopyable>("BoxController", no_init)
+      .def("getNDims", &BoxController::getNDims, "Get # of dimensions")
+      .def("getSplitThreshold", &BoxController::getSplitThreshold,
+           "Return the splitting threshold, in # of events")
+      .def("getSplitInto", &BoxController::getSplitInto,
+           "Return into how many to split along a dimension")
+      .def("getMaxDepth", &BoxController::getMaxDepth,
+           "Return the max recursion depth allowed for grid box splitting.")
+      .def("getTotalNumMDBoxes", &BoxController::getTotalNumMDBoxes,
+           "Return the total number of MD Boxes, irrespective of depth")
+      .def("getTotalNumMDGridBoxes", &BoxController::getTotalNumMDGridBoxes,
+           "Return the total number of MDGridBox'es, irrespective of depth")
+      .def("getAverageDepth", &BoxController::getAverageDepth,
+           "Return the average recursion depth of gridding.")
+      .def("isFileBacked", &BoxController::isFileBacked,
+           "Return True if the MDEventWorkspace is backed by a file ")
+      .def("getFilename", &BoxController::getFilename,
+           "Return  the full path to the file open as the file-based back or "
+           "empty string if no file back-end is initiated")
+      .def("useWriteBuffer", &BoxController::useWriteBuffer,
+           "Return true if the MRU should be used");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BoxController.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BoxController.cpp
@@ -7,9 +7,7 @@
 using Mantid::API::BoxController;
 using namespace boost::python;
 
-// clang-format off
 void export_BoxController()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<BoxController>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogManager.cpp
@@ -8,26 +8,25 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
-boost::python::object getActiveSessionsAsList(CatalogManagerImpl& self)
-{
+boost::python::object getActiveSessionsAsList(CatalogManagerImpl &self) {
   boost::python::list sessions;
   const auto vecSessions = self.getActiveSessions();
-  for(auto itr = vecSessions.begin(); itr != vecSessions.end(); ++itr)
-  {
+  for (auto itr = vecSessions.begin(); itr != vecSessions.end(); ++itr) {
     sessions.append(*itr);
   }
   return sessions;
 }
 
-void export_CatalogManager()
-{
-  register_ptr_to_python<CatalogManagerImpl*>();
+void export_CatalogManager() {
+  register_ptr_to_python<CatalogManagerImpl *>();
 
-  class_<CatalogManagerImpl,boost::noncopyable>("CatalogManagerImpl", no_init)
-    .def("numberActiveSessions", &CatalogManagerImpl::numberActiveSessions, "Number of active sessions open")
-    .def("getActiveSessions", &getActiveSessionsAsList, "Get the active sessions")
-    .def("Instance", &CatalogManager::Instance, return_value_policy<reference_existing_object>(),
-          "Returns a reference to the CatalogManger singleton")
-    .staticmethod("Instance");
-
+  class_<CatalogManagerImpl, boost::noncopyable>("CatalogManagerImpl", no_init)
+      .def("numberActiveSessions", &CatalogManagerImpl::numberActiveSessions,
+           "Number of active sessions open")
+      .def("getActiveSessions", &getActiveSessionsAsList,
+           "Get the active sessions")
+      .def("Instance", &CatalogManager::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the CatalogManger singleton")
+      .staticmethod("Instance");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogManager.cpp
@@ -19,9 +19,7 @@ boost::python::object getActiveSessionsAsList(CatalogManagerImpl& self)
   return sessions;
 }
 
-// clang-format off
 void export_CatalogManager()
-// clang-format on
 {
   register_ptr_to_python<CatalogManagerImpl*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogSession.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogSession.cpp
@@ -7,13 +7,10 @@
 using Mantid::API::CatalogSession;
 using namespace boost::python;
 
-void export_CatalogSession()
-{
-    register_ptr_to_python<boost::shared_ptr<CatalogSession> >();
+void export_CatalogSession() {
+  register_ptr_to_python<boost::shared_ptr<CatalogSession>>();
 
-
-    class_< CatalogSession, boost::noncopyable>("CatalogSession", no_init)
-      .def( "getSessionId", &CatalogSession::getSessionId, args("self"),
-          "Get the session id string.");
+  class_<CatalogSession, boost::noncopyable>("CatalogSession", no_init)
+      .def("getSessionId", &CatalogSession::getSessionId, args("self"),
+           "Get the session id string.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogSession.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/CatalogSession.cpp
@@ -7,9 +7,7 @@
 using Mantid::API::CatalogSession;
 using namespace boost::python;
 
-// clang-format off
 void export_CatalogSession()
-// clang-format on
 {
     register_ptr_to_python<boost::shared_ptr<CatalogSession> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DataProcessorAlgorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DataProcessorAlgorithm.cpp
@@ -8,69 +8,78 @@ using Mantid::Kernel::Direction;
 using Mantid::PythonInterface::DataProcessorAdapter;
 using namespace boost::python;
 
-namespace
-{
-  typedef Workspace_sptr(DataProcessorAdapter::*loadOverload1)(const std::string&);
-  typedef Workspace_sptr(DataProcessorAdapter::*loadOverload2)(const std::string&, const bool);
+namespace {
+typedef Workspace_sptr (DataProcessorAdapter::*loadOverload1)(
+    const std::string &);
+typedef Workspace_sptr (DataProcessorAdapter::*loadOverload2)(
+    const std::string &, const bool);
 }
 
-void export_DataProcessorAlgorithm()
-{
+void export_DataProcessorAlgorithm() {
   // for strings will actually create a list
   using Mantid::PythonInterface::Policies::VectorToNumpy;
 
-  class_<DataProcessorAlgorithm, bases<Algorithm>, boost::shared_ptr<DataProcessorAdapter>,
-         boost::noncopyable>("DataProcessorAlgorithm", "Base class workflow-type algorithms")
-    
-    .def("setLoadAlg", &DataProcessorAdapter::setLoadAlgProxy,
-         "Set the name of the algorithm called using the load() method [Default=Load]")
+  class_<DataProcessorAlgorithm, bases<Algorithm>,
+         boost::shared_ptr<DataProcessorAdapter>, boost::noncopyable>(
+      "DataProcessorAlgorithm", "Base class workflow-type algorithms")
 
-    .def("setLoadAlgFileProp", &DataProcessorAdapter::setLoadAlgFilePropProxy,
-         "Set the name of the file property for the load algorithm when using "
-         "the load() method [Default=Filename]")
+      .def("setLoadAlg", &DataProcessorAdapter::setLoadAlgProxy,
+           "Set the name of the algorithm called using the load() method "
+           "[Default=Load]")
 
-    .def("setAccumAlg", &DataProcessorAdapter::setAccumAlgProxy,
-         "Set the name of the algorithm called to accumulate a chunk of processed data [Default=Plus]")
+      .def("setLoadAlgFileProp", &DataProcessorAdapter::setLoadAlgFilePropProxy,
+           "Set the name of the file property for the load algorithm when "
+           "using "
+           "the load() method [Default=Filename]")
 
-    .def("determineChunk", &DataProcessorAdapter::determineChunkProxy,
-         "Return a TableWorkspace containing the information on how to split the "
-         "input file when processing in chunks")
+      .def("setAccumAlg", &DataProcessorAdapter::setAccumAlgProxy,
+           "Set the name of the algorithm called to accumulate a chunk of "
+           "processed data [Default=Plus]")
 
-    .def("loadChunk", &DataProcessorAdapter::loadChunkProxy,
-         "Load a chunk of data")
+      .def("determineChunk", &DataProcessorAdapter::determineChunkProxy,
+           "Return a TableWorkspace containing the information on how to split "
+           "the "
+           "input file when processing in chunks")
 
-    .def("load", (loadOverload1)&DataProcessorAdapter::loadProxy,
-         "Loads the given file or workspace data and returns the workspace. "
-         "The output is not stored in the AnalysisDataService.")
+      .def("loadChunk", &DataProcessorAdapter::loadChunkProxy,
+           "Load a chunk of data")
 
-    .def("load", (loadOverload2)&DataProcessorAdapter::loadProxy,
-         "Loads the given file or workspace data and returns the workspace. "
-         "If loadQuiet=True then output is not stored in the AnalysisDataService.")
+      .def("load", (loadOverload1)&DataProcessorAdapter::loadProxy,
+           "Loads the given file or workspace data and returns the workspace. "
+           "The output is not stored in the AnalysisDataService.")
 
-    .def("splitInput", &DataProcessorAdapter::splitInputProxy,
-         return_value_policy<VectorToNumpy>())
+      .def("load", (loadOverload2)&DataProcessorAdapter::loadProxy,
+           "Loads the given file or workspace data and returns the workspace. "
+           "If loadQuiet=True then output is not stored in the "
+           "AnalysisDataService.")
 
-    .def("forwardProperties", &DataProcessorAdapter::forwardPropertiesProxy)
+      .def("splitInput", &DataProcessorAdapter::splitInputProxy,
+           return_value_policy<VectorToNumpy>())
 
-    .def("getProcessProperties", &DataProcessorAdapter::getProcessPropertiesProxy,
-         "Returns the named property manager from the service or creates "
-         "a new one if it does not exist")
+      .def("forwardProperties", &DataProcessorAdapter::forwardPropertiesProxy)
 
-    .def("assemble", &DataProcessorAdapter::assembleProxy,
-         "If an MPI build, assemble the partial workspaces from all MPI processes. "
-         "Otherwise, simply returns the input workspace")
+      .def("getProcessProperties",
+           &DataProcessorAdapter::getProcessPropertiesProxy,
+           "Returns the named property manager from the service or creates "
+           "a new one if it does not exist")
 
-    .def("saveNexus", &DataProcessorAdapter::saveNexusProxy,
-         "Save a workspace as a nexus file. If this is an MPI build then saving only "
-         "happens for the main thread.")
+      .def("assemble", &DataProcessorAdapter::assembleProxy,
+           "If an MPI build, assemble the partial workspaces from all MPI "
+           "processes. "
+           "Otherwise, simply returns the input workspace")
 
-    .def("isMainThread", &DataProcessorAdapter::isMainThreadProxy,
-         "Returns true if this algorithm is the main thread for an MPI build. For "
-         "non-MPI build it always returns true")
+      .def("saveNexus", &DataProcessorAdapter::saveNexusProxy,
+           "Save a workspace as a nexus file. If this is an MPI build then "
+           "saving only "
+           "happens for the main thread.")
 
-    .def("getNThreads", &DataProcessorAdapter::getNThreadsProxy,
-         "Returns the number of running MPI processes in an MPI build or 1 for "
-         "a non-MPI build")
-  ;
+      .def("isMainThread", &DataProcessorAdapter::isMainThreadProxy,
+           "Returns true if this algorithm is the main thread for an MPI "
+           "build. For "
+           "non-MPI build it always returns true")
+
+      .def("getNThreads", &DataProcessorAdapter::getNThreadsProxy,
+           "Returns the number of running MPI processes in an MPI build or 1 "
+           "for "
+           "a non-MPI build");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DataProcessorAlgorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DataProcessorAlgorithm.cpp
@@ -14,9 +14,7 @@ namespace
   typedef Workspace_sptr(DataProcessorAdapter::*loadOverload2)(const std::string&, const bool);
 }
 
-// clang-format off
 void export_DataProcessorAlgorithm()
-// clang-format on
 {
   // for strings will actually create a list
   using Mantid::PythonInterface::Policies::VectorToNumpy;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
@@ -8,53 +8,57 @@ using Mantid::API::IAlgorithm_sptr;
 
 using namespace boost::python;
 
-namespace
-{
+namespace {
+/**
+* It is not going to be possible to directly test if an algorithm is deprecated
+*from Python. This
+* is because we only export up to API and the deprecation happens at the
+*concrete layer meaning
+* Python cannot work out that the concrete class inherits from
+*DeprecatedAlgorithm.
+*
+* To work around this we create a small DeprecatedAlgorithmTester class to
+*handle to querying the C++
+* inheritance structure
+*/
+class DeprecatedAlgorithmChecker {
+public:
   /**
-  * It is not going to be possible to directly test if an algorithm is deprecated from Python. This
-  * is because we only export up to API and the deprecation happens at the concrete layer meaning
-  * Python cannot work out that the concrete class inherits from DeprecatedAlgorithm.
-  *
-  * To work around this we create a small DeprecatedAlgorithmTester class to handle to querying the C++
-  * inheritance structure
-  */
-  class DeprecatedAlgorithmChecker
-  {
-  public:
-    /**
-     * Constructor. Throws if the algorithm does not exist
-     * @param algName The name of the algorithm
-     * @param version The algorithm version
-     */
-    DeprecatedAlgorithmChecker(const std::string & algName, int version) 
-    {
-      m_alg = AlgorithmManager::Instance().createUnmanaged(algName, version);
-    }
+   * Constructor. Throws if the algorithm does not exist
+   * @param algName The name of the algorithm
+   * @param version The algorithm version
+   */
+  DeprecatedAlgorithmChecker(const std::string &algName, int version) {
+    m_alg = AlgorithmManager::Instance().createUnmanaged(algName, version);
+  }
 
-    /// Check if the algorithm is deprecated
-    /// @returns A string containing a deprecation message if the algorithm is deprecated, empty string otherwise
-    const std::string isDeprecated() const
-    {
-      std::string deprecMessage="";
-      DeprecatedAlgorithm * depr = dynamic_cast<DeprecatedAlgorithm *>(m_alg.get());
-      if (depr)
-        deprecMessage = depr->deprecationMsg(m_alg.get());
-      return deprecMessage;
-    }
+  /// Check if the algorithm is deprecated
+  /// @returns A string containing a deprecation message if the algorithm is
+  /// deprecated, empty string otherwise
+  const std::string isDeprecated() const {
+    std::string deprecMessage = "";
+    DeprecatedAlgorithm *depr =
+        dynamic_cast<DeprecatedAlgorithm *>(m_alg.get());
+    if (depr)
+      deprecMessage = depr->deprecationMsg(m_alg.get());
+    return deprecMessage;
+  }
 
-  private:
-    /// Private default constructor
-    DeprecatedAlgorithmChecker();
-    /// Pointer to unmanaged algorithm
-    IAlgorithm_sptr m_alg;
-  };
+private:
+  /// Private default constructor
+  DeprecatedAlgorithmChecker();
+  /// Pointer to unmanaged algorithm
+  IAlgorithm_sptr m_alg;
+};
 }
 
-void export_DeprecatedAlgorithmChecker()
-{
+void export_DeprecatedAlgorithmChecker() {
   class_<DeprecatedAlgorithmChecker>("DeprecatedAlgorithmChecker", no_init)
-    .def(init<const std::string&,int>((arg("algName"),arg("version")),"Constructs a DeprecatedAlgorithmChecker for the given algorithm & version. (-1 indicates latest version)"))
-    .def("isDeprecated",&DeprecatedAlgorithmChecker::isDeprecated, "A string containing a deprecation message if the algorithm is deprecated, empty string otherwise")
-  ;
+      .def(init<const std::string &, int>(
+          (arg("algName"), arg("version")),
+          "Constructs a DeprecatedAlgorithmChecker for the given algorithm & "
+          "version. (-1 indicates latest version)"))
+      .def("isDeprecated", &DeprecatedAlgorithmChecker::isDeprecated,
+           "A string containing a deprecation message if the algorithm is "
+           "deprecated, empty string otherwise");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
@@ -50,9 +50,7 @@ namespace
   };
 }
 
-// clang-format off
 void export_DeprecatedAlgorithmChecker()
-// clang-format on
 {
   class_<DeprecatedAlgorithmChecker>("DeprecatedAlgorithmChecker", no_init)
     .def(init<const std::string&,int>((arg("algName"),arg("version")),"Constructs a DeprecatedAlgorithmChecker for the given algorithm & version. (-1 indicates latest version)"))

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -11,40 +11,51 @@ using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 using namespace boost::python;
 
 /// Overload generator for getInstrumentFilename
-BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload, ExperimentInfo::getInstrumentFilename, 1, 2)
+BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
+                                ExperimentInfo::getInstrumentFilename, 1, 2)
 
-void export_ExperimentInfo()
-{
+void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();
 
   class_<ExperimentInfo, boost::noncopyable>("ExperimentInfo", no_init)
-          .def("getInstrument", &ExperimentInfo::getInstrument, return_value_policy<RemoveConstSharedPtr>(),
-               args("self"), "Returns the instrument for this run.")
+      .def("getInstrument", &ExperimentInfo::getInstrument,
+           return_value_policy<RemoveConstSharedPtr>(), args("self"),
+           "Returns the instrument for this run.")
 
-          .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
-               getInstrumentFilename_Overload("Returns IDF",(arg("instrument"),arg("date")="")))
-          .staticmethod("getInstrumentFilename")
+      .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
+           getInstrumentFilename_Overload(
+               "Returns IDF", (arg("instrument"), arg("date") = "")))
+      .staticmethod("getInstrumentFilename")
 
-          .def("sample", &ExperimentInfo::sample, return_value_policy<reference_existing_object>(),
-               args("self"), "Return the Sample object. This cannot be modified, use mutableSample to modify.")
+      .def("sample", &ExperimentInfo::sample,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return the Sample object. This cannot be modified, use "
+           "mutableSample to modify.")
 
-          .def("mutableSample", &ExperimentInfo::mutableSample, return_value_policy<reference_existing_object>(),
-               args("self"), "Return a modifiable Sample object.")
+      .def("mutableSample", &ExperimentInfo::mutableSample,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return a modifiable Sample object.")
 
-          .def("run", &ExperimentInfo::run, return_value_policy<reference_existing_object>(),
-               args("self"), "Return the Run object. This cannot be modified, use mutableRun to modify.")
+      .def("run", &ExperimentInfo::run,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return the Run object. This cannot be modified, use mutableRun to "
+           "modify.")
 
-          .def("mutableRun", &ExperimentInfo::mutableRun, return_value_policy<reference_existing_object>(),
-               args("self"), "Return a modifiable Run object.")
+      .def("mutableRun", &ExperimentInfo::mutableRun,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return a modifiable Run object.")
 
-          .def("getRunNumber", &ExperimentInfo::getRunNumber, args("self"),
-               "Returns the run identifier for this run.")
+      .def("getRunNumber", &ExperimentInfo::getRunNumber, args("self"),
+           "Returns the run identifier for this run.")
 
-          .def("getEFixed", (double (ExperimentInfo::*)(const Mantid::detid_t) const) &ExperimentInfo::getEFixed,
-               args("self", "detId"))
+      .def("getEFixed",
+           (double (ExperimentInfo::*)(const Mantid::detid_t) const) &
+               ExperimentInfo::getEFixed,
+           args("self", "detId"))
 
-          .def("setEFixed", &ExperimentInfo::setEFixed, args("self", "detId", "value"))
+      .def("setEFixed", &ExperimentInfo::setEFixed,
+           args("self", "detId", "value"))
 
-          .def("getEMode", &ExperimentInfo::getEMode, args("self"), "Returns the energy mode.")
-          ;
+      .def("getEMode", &ExperimentInfo::getEMode, args("self"),
+           "Returns the energy mode.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -13,9 +13,7 @@ using namespace boost::python;
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload, ExperimentInfo::getInstrumentFilename, 1, 2)
 
-// clang-format off
 void export_ExperimentInfo()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -8,21 +8,24 @@ using Mantid::API::FileFinderImpl;
 using namespace boost::python;
 
 namespace {
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
 }
 
-void export_FileFinder()
-{
+void export_FileFinder() {
   class_<FileFinderImpl, boost::noncopyable>("FileFinderImpl", no_init)
-    .def("getFullPath", &FileFinderImpl::getFullPath,
-           getFullPathOverloader((arg("path"), arg("ignoreDirs")=false),
-                                 "Return a full path to the given file if it can be found within datasearch.directories paths. Directories can be ignored with ignoreDirs=True. An empty string is returned otherwise."))
-    .def("findRuns", &FileFinderImpl::findRuns, "Find a list of files file given a hint. "
-         "The hint can be a comma separated list of run numbers and can also include ranges of runs, e.g. 123-135 or equivalently 123-35"
-         "If no instrument prefix is given then the current default is used.")
-    .def("Instance", &FileFinder::Instance, return_value_policy<reference_existing_object>(),
-       "Returns a reference to the FileFinder singleton instance")
-    .staticmethod("Instance")
-         ;
+      .def("getFullPath", &FileFinderImpl::getFullPath,
+           getFullPathOverloader(
+               (arg("path"), arg("ignoreDirs") = false),
+               "Return a full path to the given file if it can be found within "
+               "datasearch.directories paths. Directories can be ignored with "
+               "ignoreDirs=True. An empty string is returned otherwise."))
+      .def("findRuns", &FileFinderImpl::findRuns,
+           "Find a list of files file given a hint. "
+           "The hint can be a comma separated list of run numbers and can also "
+           "include ranges of runs, e.g. 123-135 or equivalently 123-35"
+           "If no instrument prefix is given then the current default is used.")
+      .def("Instance", &FileFinder::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the FileFinder singleton instance")
+      .staticmethod("Instance");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -11,9 +11,7 @@ namespace {
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
 }
 
-// clang-format off
 void export_FileFinder()
-// clang-format on
 {
   class_<FileFinderImpl, boost::noncopyable>("FileFinderImpl", no_init)
     .def("getFullPath", &FileFinderImpl::getFullPath,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileProperty.cpp
@@ -11,67 +11,58 @@
 #include <boost/python/default_call_policies.hpp>
 #include <boost/python/overloads.hpp>
 
-
 using Mantid::API::FileProperty;
 using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::Converters::PySequenceToVector;
 namespace bpl = boost::python;
 
-void export_ActionEnum()
-{
+void export_ActionEnum() {
   bpl::enum_<FileProperty::FileAction>("FileAction")
-        .value("Save", FileProperty::Save)
-        .value("OptionalSave", FileProperty::OptionalSave)
-        .value("Load", FileProperty::Load)
-        .value("OptionalLoad", FileProperty::OptionalLoad)
-        .value("Directory", FileProperty::Directory)
-        .value("OptionalDirectory", FileProperty::OptionalDirectory)
-  ;
+      .value("Save", FileProperty::Save)
+      .value("OptionalSave", FileProperty::OptionalSave)
+      .value("Load", FileProperty::Load)
+      .value("OptionalLoad", FileProperty::OptionalLoad)
+      .value("Directory", FileProperty::Directory)
+      .value("OptionalDirectory", FileProperty::OptionalDirectory);
 }
 
-namespace
-{
-  /**
-   * The FileProperty constructor can take a list of extensions but we want users to be
-   * able to pass in a python list so we need a proxy function to act as a constructor
-   * @param name :: The name of the property
-   * @param defaultValue :: A default value
-   * @param action :: A file action defined by FileProperty::FileAction
-   * @param extensions :: A list of possible extensions (default = [])
-   * @param The direction of the property (default = input)
-   */
-  FileProperty * createFileProperty(const std::string & name,const std::string& defaultValue,
-                                    unsigned int action,
-                                    const bpl::object & extensions = bpl::object(),
-                                    unsigned direction = Mantid::Kernel::Direction::Input)
-  {
-    std::vector<std::string> extsAsVector;
-    if( !Mantid::PythonInterface::isNone(extensions) )
-    {
-      bpl::extract<std::string> extractor(extensions);
-      if(extractor.check())
-      {
-        extsAsVector = std::vector<std::string>(1, extractor());
-      }
-      else
-      {
-        extsAsVector = PySequenceToVector<std::string>(extensions)();
-      }
+namespace {
+/**
+ * The FileProperty constructor can take a list of extensions but we want users
+ * to be
+ * able to pass in a python list so we need a proxy function to act as a
+ * constructor
+ * @param name :: The name of the property
+ * @param defaultValue :: A default value
+ * @param action :: A file action defined by FileProperty::FileAction
+ * @param extensions :: A list of possible extensions (default = [])
+ * @param The direction of the property (default = input)
+ */
+FileProperty *
+createFileProperty(const std::string &name, const std::string &defaultValue,
+                   unsigned int action,
+                   const bpl::object &extensions = bpl::object(),
+                   unsigned direction = Mantid::Kernel::Direction::Input) {
+  std::vector<std::string> extsAsVector;
+  if (!Mantid::PythonInterface::isNone(extensions)) {
+    bpl::extract<std::string> extractor(extensions);
+    if (extractor.check()) {
+      extsAsVector = std::vector<std::string>(1, extractor());
+    } else {
+      extsAsVector = PySequenceToVector<std::string>(extensions)();
     }
-    return new FileProperty(name, defaultValue, action, extsAsVector, direction);
   }
-
+  return new FileProperty(name, defaultValue, action, extsAsVector, direction);
+}
 }
 
-void export_FileProperty()
-{
-  bpl::class_<FileProperty, bpl::bases<PropertyWithValue<std::string> >, boost::noncopyable>("FileProperty", bpl::no_init)
-    .def("__init__",
-     bpl::make_constructor(&createFileProperty, bpl::default_call_policies(),
-                           (bpl::arg("name"), bpl::arg("defaultValue"), bpl::arg("action"),
-                            bpl::arg("extensions") = bpl::object(),
-                            bpl::arg("direction") = Mantid::Kernel::Direction::Input)
-                          ))
-  ;
+void export_FileProperty() {
+  bpl::class_<FileProperty, bpl::bases<PropertyWithValue<std::string>>,
+              boost::noncopyable>("FileProperty", bpl::no_init)
+      .def("__init__",
+           bpl::make_constructor(
+               &createFileProperty, bpl::default_call_policies(),
+               (bpl::arg("name"), bpl::arg("defaultValue"), bpl::arg("action"),
+                bpl::arg("extensions") = bpl::object(),
+                bpl::arg("direction") = Mantid::Kernel::Direction::Input)));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FileProperty.cpp
@@ -17,9 +17,7 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::Converters::PySequenceToVector;
 namespace bpl = boost::python;
 
-// clang-format off
 void export_ActionEnum()
-// clang-format on
 {
   bpl::enum_<FileProperty::FileAction>("FileAction")
         .value("Save", FileProperty::Save)
@@ -65,9 +63,7 @@ namespace
 
 }
 
-// clang-format off
 void export_FileProperty()
-// clang-format on
 {
   bpl::class_<FileProperty, bpl::bases<PropertyWithValue<std::string> >, boost::noncopyable>("FileProperty", bpl::no_init)
     .def("__init__",

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -8,33 +8,41 @@ using Mantid::API::FrameworkManagerImpl;
 using Mantid::API::FrameworkManager;
 using namespace boost::python;
 
-void export_FrameworkManager()
-{
-  class_<FrameworkManagerImpl,boost::noncopyable>("FrameworkManagerImpl", no_init)
-    .def("setNumOMPThreadsToConfigValue", &FrameworkManagerImpl::setNumOMPThreadsToConfigValue,
-         "Sets the number of OpenMP threads to the value specified in the config file")
+void export_FrameworkManager() {
+  class_<FrameworkManagerImpl, boost::noncopyable>("FrameworkManagerImpl",
+                                                   no_init)
+      .def("setNumOMPThreadsToConfigValue",
+           &FrameworkManagerImpl::setNumOMPThreadsToConfigValue,
+           "Sets the number of OpenMP threads to the value specified in the "
+           "config file")
 
-     .def("setNumOMPThreads", &FrameworkManagerImpl::setNumOMPThreads,
-         "Set the number of OpenMP threads to the given value")
+      .def("setNumOMPThreads", &FrameworkManagerImpl::setNumOMPThreads,
+           "Set the number of OpenMP threads to the given value")
 
-     .def("getNumOMPThreads", &FrameworkManagerImpl::getNumOMPThreads,
-         "Returns the number of OpenMP threads that will be used.")
+      .def("getNumOMPThreads", &FrameworkManagerImpl::getNumOMPThreads,
+           "Returns the number of OpenMP threads that will be used.")
 
-    .def("clear", &FrameworkManagerImpl::clear, "Clear all memory held by Mantid")
+      .def("clear", &FrameworkManagerImpl::clear,
+           "Clear all memory held by Mantid")
 
-    .def("clearAlgorithms", &FrameworkManagerImpl::clearAlgorithms, "Clear memory held by algorithms (does not include workspaces)")
+      .def("clearAlgorithms", &FrameworkManagerImpl::clearAlgorithms,
+           "Clear memory held by algorithms (does not include workspaces)")
 
-    .def("clearData", &FrameworkManagerImpl::clearData, "Clear memory held by the data service (essentially all workspaces, including hidden)")
+      .def("clearData", &FrameworkManagerImpl::clearData,
+           "Clear memory held by the data service (essentially all workspaces, "
+           "including hidden)")
 
-    .def("clearInstruments", &FrameworkManagerImpl::clearInstruments, "Clear memory held by the cached instruments")
+      .def("clearInstruments", &FrameworkManagerImpl::clearInstruments,
+           "Clear memory held by the cached instruments")
 
-    .def("clearPropertyManagers", &FrameworkManagerImpl::clearPropertyManagers, "Clear memory held by the PropertyManagerDataService")
+      .def("clearPropertyManagers",
+           &FrameworkManagerImpl::clearPropertyManagers,
+           "Clear memory held by the PropertyManagerDataService")
 
-    .def("Instance", &FrameworkManager::Instance, return_value_policy<reference_existing_object>(),
-         "Returns a reference to the FrameworkManager singleton")
-    .staticmethod("Instance")
+      .def("Instance", &FrameworkManager::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the FrameworkManager singleton")
+      .staticmethod("Instance")
 
-    ;
-
+      ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -8,9 +8,7 @@ using Mantid::API::FrameworkManagerImpl;
 using Mantid::API::FrameworkManager;
 using namespace boost::python;
 
-// clang-format off
 void export_FrameworkManager()
-// clang-format on
 {
   class_<FrameworkManagerImpl,boost::noncopyable>("FrameworkManagerImpl", no_init)
     .def("setNumOMPThreadsToConfigValue", &FrameworkManagerImpl::setNumOMPThreadsToConfigValue,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -7,7 +7,8 @@
 #include <boost/python/class.hpp>
 #include <boost/python/def.hpp>
 
-// Python frameobject. This is under the boost includes so that boost will have done the
+// Python frameobject. This is under the boost includes so that boost will have
+// done the
 // include of Python.h which it ensures is done correctly
 #include <frameobject.h>
 
@@ -19,87 +20,86 @@ using Mantid::Kernel::AbstractInstantiator;
 
 using namespace boost::python;
 
-namespace
-{
-  ///@cond
+namespace {
+///@cond
 
-  //------------------------------------------------------------------------------------------------------
-  /**
-   * A Python friendly version that returns the registered functions as a list.
-   * @param self :: Enables it to be called as a member function on the FunctionFactory class
-   */
-  PyObject * getFunctionNames(FunctionFactoryImpl & self)
-  {
-    const std::vector<std::string>& names = self.getFunctionNames<Mantid::API::IFunction>();
+//------------------------------------------------------------------------------------------------------
+/**
+ * A Python friendly version that returns the registered functions as a list.
+ * @param self :: Enables it to be called as a member function on the
+ * FunctionFactory class
+ */
+PyObject *getFunctionNames(FunctionFactoryImpl &self) {
+  const std::vector<std::string> &names =
+      self.getFunctionNames<Mantid::API::IFunction>();
 
-    PyObject *registered = PyList_New(0);
-    for (auto name = names.begin(); name != names.end(); ++name)
-    {
-      PyObject *value = PyString_FromString(name->c_str());
-      if (PyList_Append(registered, value))
-        throw std::runtime_error("Failed to insert value into PyList");
-    }
-
-    return registered;
+  PyObject *registered = PyList_New(0);
+  for (auto name = names.begin(); name != names.end(); ++name) {
+    PyObject *value = PyString_FromString(name->c_str());
+    if (PyList_Append(registered, value))
+      throw std::runtime_error("Failed to insert value into PyList");
   }
 
-  //--------------------------------------------- Function registration ------------------------------------------------
-
-    /// Python algorithm registration mutex in anonymous namespace (aka static)
-    Poco::Mutex FUNCTION_REGISTER_MUTEX;
-
-    /**
-     * A free function to register a fit function from Python
-     * @param obj :: A Python object that should either be a class type derived from IFunction
-     *              or an instance of a class type derived from IFunction
-     */
-    void subscribe(FunctionFactoryImpl & self, const boost::python::object & obj )
-    {
-      Poco::ScopedLock<Poco::Mutex> lock(FUNCTION_REGISTER_MUTEX);
-      static PyTypeObject * baseClass =
-          const_cast<PyTypeObject*>(converter::registered<IFunction>::converters.to_python_target_type());
-
-      // obj could be or instance/class, check instance first
-      PyObject *classObject(NULL);
-      if( PyObject_IsInstance(obj.ptr(), (PyObject*)baseClass) )
-      {
-        classObject = PyObject_GetAttrString(obj.ptr(), "__class__");
-      }
-      else if(PyObject_IsSubclass(obj.ptr(), (PyObject*)baseClass))
-      {
-        classObject = obj.ptr(); // We need to ensure the type of lifetime management so grab the raw pointer
-      }
-      else
-      {
-        throw std::invalid_argument("Cannot register a function that does not derive from IFunction.");
-      }
-      //Instantiator will store a reference to the class object, so increase reference count with borrowed template
-      auto classHandle = handle<>(borrowed(classObject));
-      auto *creator =  new PythonObjectInstantiator<IFunction>(object(classHandle));
-
-      // Find the function name
-      auto func = creator->createInstance();
-
-      // Takes ownership of instantiator
-      self.subscribe(func->name(), creator, FunctionFactoryImpl::OverwriteCurrent);
-    }
-  ///@endcond
+  return registered;
 }
 
-void export_FunctionFactory()
-{
+//--------------------------------------------- Function registration
+//------------------------------------------------
 
-  class_<FunctionFactoryImpl,boost::noncopyable>("FunctionFactoryImpl", no_init)
+/// Python algorithm registration mutex in anonymous namespace (aka static)
+Poco::Mutex FUNCTION_REGISTER_MUTEX;
+
+/**
+ * A free function to register a fit function from Python
+ * @param obj :: A Python object that should either be a class type derived from
+ * IFunction
+ *              or an instance of a class type derived from IFunction
+ */
+void subscribe(FunctionFactoryImpl &self, const boost::python::object &obj) {
+  Poco::ScopedLock<Poco::Mutex> lock(FUNCTION_REGISTER_MUTEX);
+  static PyTypeObject *baseClass = const_cast<PyTypeObject *>(
+      converter::registered<IFunction>::converters.to_python_target_type());
+
+  // obj could be or instance/class, check instance first
+  PyObject *classObject(NULL);
+  if (PyObject_IsInstance(obj.ptr(), (PyObject *)baseClass)) {
+    classObject = PyObject_GetAttrString(obj.ptr(), "__class__");
+  } else if (PyObject_IsSubclass(obj.ptr(), (PyObject *)baseClass)) {
+    classObject = obj.ptr(); // We need to ensure the type of lifetime
+                             // management so grab the raw pointer
+  } else {
+    throw std::invalid_argument(
+        "Cannot register a function that does not derive from IFunction.");
+  }
+  // Instantiator will store a reference to the class object, so increase
+  // reference count with borrowed template
+  auto classHandle = handle<>(borrowed(classObject));
+  auto *creator = new PythonObjectInstantiator<IFunction>(object(classHandle));
+
+  // Find the function name
+  auto func = creator->createInstance();
+
+  // Takes ownership of instantiator
+  self.subscribe(func->name(), creator, FunctionFactoryImpl::OverwriteCurrent);
+}
+///@endcond
+}
+
+void export_FunctionFactory() {
+
+  class_<FunctionFactoryImpl, boost::noncopyable>("FunctionFactoryImpl",
+                                                  no_init)
       .def("getFunctionNames", &getFunctionNames,
            "Returns a list of the currently available functions")
       .def("createFunction", &FunctionFactoryImpl::createFunction,
            "Return a pointer to the requested function")
-      .def("subscribe", &subscribe, "Register a Python class derived from IFunction into the factory")
-      .def("unsubscribe", &FunctionFactoryImpl::unsubscribe, "Remove a type from the factory")
+      .def("subscribe", &subscribe,
+           "Register a Python class derived from IFunction into the factory")
+      .def("unsubscribe", &FunctionFactoryImpl::unsubscribe,
+           "Remove a type from the factory")
 
-      .def("Instance", &FunctionFactory::Instance, return_value_policy<reference_existing_object>(),
+      .def("Instance", &FunctionFactory::Instance,
+           return_value_policy<reference_existing_object>(),
            "Returns a reference to the FunctionFactory singleton")
-      .staticmethod("Instance")
-    ;
-
+      .staticmethod("Instance");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -86,9 +86,7 @@ namespace
   ///@endcond
 }
 
-// clang-format off
 void export_FunctionFactory()
-// clang-format on
 {
 
   class_<FunctionFactoryImpl,boost::noncopyable>("FunctionFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionProperty.cpp
@@ -8,16 +8,14 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::PropertyWithValueExporter;
 using namespace boost::python;
 
-void export_FunctionProperty()
-{
+void export_FunctionProperty() {
   // FuncitonProperty has base PropertyWithValue<boost::shared_ptr<IFunction>>
   // which must be exported
   typedef boost::shared_ptr<IFunction> HeldType;
   PropertyWithValueExporter<HeldType>::define("FunctionPropertyWithValue");
 
-
-  class_<FunctionProperty, bases<PropertyWithValue<HeldType>>, boost::noncopyable>("FunctionProperty", no_init)
-    .def(init<const std::string &>(arg("name"), "Constructs a FunctionProperty with the given name"))
-    ;
+  class_<FunctionProperty, bases<PropertyWithValue<HeldType>>,
+         boost::noncopyable>("FunctionProperty", no_init)
+      .def(init<const std::string &>(
+          arg("name"), "Constructs a FunctionProperty with the given name"));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/FunctionProperty.cpp
@@ -8,9 +8,7 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::PropertyWithValueExporter;
 using namespace boost::python;
 
-// clang-format off
 void export_FunctionProperty()
-// clang-format on
 {
   // FuncitonProperty has base PropertyWithValue<boost::shared_ptr<IFunction>>
   // which must be exported

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -1,10 +1,12 @@
 #ifdef _MSC_VER
-  #pragma warning( disable: 4250 ) // Disable warning regarding inheritance via dominance, we have no way around it with the design
+#pragma warning(disable : 4250) // Disable warning regarding inheritance via
+                                // dominance, we have no way around it with the
+                                // design
 #endif
 #include "MantidAPI/IAlgorithm.h"
 #include "MantidPythonInterface/api/AlgorithmIDProxy.h"
 #ifdef _MSC_VER
-  #pragma warning( default: 4250 )
+#pragma warning(default : 4250)
 #endif
 #include "MantidKernel/Strings.h"
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
@@ -27,300 +29,321 @@ using Mantid::PythonInterface::AlgorithmIDProxy;
 using Mantid::PythonInterface::Policies::VectorToNumpy;
 using namespace boost::python;
 
-namespace
-{
-  /***********************************************************************
-   *
-   * Useful functions within Python to have on the algorithm interface
-   *
-   ***********************************************************************/
+namespace {
+/***********************************************************************
+ *
+ * Useful functions within Python to have on the algorithm interface
+ *
+ ***********************************************************************/
 
-    ///Functor for use with sorting algorithm to put the properties that do not
-    ///have valid values first
-    struct MandatoryFirst
-    {
-      ///Comparator operator for sort algorithm, places optional properties lower in the list
-      bool operator()(const Property * p1, const Property * p2) const
-      {
-        //this is false, unless p1 is not valid and p2 is valid
-        return ( p1->isValid() != "" ) && ( p2->isValid() == "" );
-      }
-    };
-
-    //----------------------- Property ordering ------------------------------
-    /// Vector of property pointers
-    typedef std::vector<Property*> PropertyVector;
-
-   /**
-    * Returns the vector of properties ordered by the criteria defined in MandatoryFirst.
-    * A stable_sort is applied to the properties to guarantee the relative order
-    * of with respect to the original list.
-    * @return A list of Property pointers ordered by for the function API
-    */
-    PropertyVector apiOrderedProperties(const IAlgorithm& propMgr)
-    {
-      PropertyVector properties(propMgr.getProperties()); // Makes a copy so that it can be sorted
-      std::stable_sort(properties.begin(), properties.end(), MandatoryFirst());
-      return properties;
-    }
-
-    /**
-     * Returns a list of input property names that is ordered such that the
-     * mandatory properties are first followed by the optional ones. The list
-     * excludes output properties.
-     * @param self :: A pointer to the python object wrapping and Algorithm.
-     * @return A Python list of strings
-     */
-
-    PyObject * getInputPropertiesWithMandatoryFirst(IAlgorithm & self)
-    {
-      PropertyVector properties(apiOrderedProperties(self));
-
-      PropertyVector::const_iterator iend = properties.end();
-      // Build a python list
-      PyObject *names = PyList_New(0);
-      for (PropertyVector::const_iterator itr = properties.begin(); itr != iend; ++itr)
-      {
-        Property *p = *itr;
-        if (p->direction() != Direction::Output)
-        {
-          PyList_Append(names, PyString_FromString(p->name().c_str()));
-        }
-      }
-      return names;
-    }
-
-     /**
-     * Returns a list of input property names that is ordered such that the
-     * mandatory properties are first followed by the optional ones. The list
-     * also includes InOut properties.
-     * @param self :: A pointer to the python object wrapping and Algorithm.
-     * @return A Python list of strings
-     */
-    PyObject * getAlgorithmPropertiesOrdered(IAlgorithm & self)
-    {
-      PropertyVector properties(apiOrderedProperties(self));
-
-      PropertyVector::const_iterator iend = properties.end();
-      // Build a python list
-      PyObject *names = PyList_New(0);
-      for (PropertyVector::const_iterator itr = properties.begin(); itr != iend; ++itr)
-      {
-        Property *p = *itr;
-        PyList_Append(names, PyString_FromString(p->name().c_str()));
-      }
-      return names;
-    }
-
-    /**
-     * Returns a list of output property names in the order they were declared in
-     * @param self :: A pointer to the python object wrapping and Algorithm.
-     * @return A Python list of strings
-     */
-    PyObject * getOutputProperties(IAlgorithm & self)
-    {
-      const PropertyVector & properties(self.getProperties()); // No copy
-      PropertyVector::const_iterator iend = properties.end();
-      // Build the list
-      PyObject *names = PyList_New(0);
-      for( PropertyVector::const_iterator itr = properties.begin(); itr != iend;
-           ++itr )
-      {
-        Property *p = *itr;
-        if( p->direction() == Direction::Output )
-        {
-          PyList_Append(names, PyString_FromString(p->name().c_str()));
-        }
-      }
-      return names;
-    }
-
-
-  // ---------------------- Documentation -------------------------------------
-  /**
-   * Create a doc string for the simple API
-   * @param self :: A pointer to the python object wrapping and Algorithm
-   * @return A string that documents an algorithm
-   */
-  std::string createDocString(IAlgorithm & self)
-  {
-    const std::string EOL="\n";
-
-    // Put in the quick overview message
-    std::stringstream buffer;
-    std::string temp = self.summary();
-    if (temp.size() > 0)
-      buffer << temp << EOL << EOL;
-
-    // get a sorted copy of the properties
-    PropertyVector properties(apiOrderedProperties(self));
-
-    const size_t numProps(properties.size());
-
-    buffer << "Property descriptions: " << EOL << EOL;
-    // write the actual property descriptions
-    for ( size_t i = 0; i < numProps; ++i)
-    {
-      Mantid::Kernel::Property *prop = properties[i];
-      buffer << prop->name() << "("
-             << Mantid::Kernel::Direction::asText(prop->direction());
-      if (!prop->isValid().empty())
-        buffer << ":req";
-      buffer << ") *" << prop->type() << "* ";
-      std::vector<std::string> allowed = prop->allowedValues();
-      if (!prop->documentation().empty() || !allowed.empty())
-      {
-        buffer << "      " << prop->documentation();
-        if (!allowed.empty())
-        {
-          buffer << "[" << Mantid::Kernel::Strings::join(allowed.begin(), allowed.end(), ", ");
-          buffer << "]";
-        }
-        buffer << EOL;
-        if( i < numProps - 1 ) buffer << EOL;
-      }
-    }
-
-    return buffer.str();
+/// Functor for use with sorting algorithm to put the properties that do not
+/// have valid values first
+struct MandatoryFirst {
+  /// Comparator operator for sort algorithm, places optional properties lower
+  /// in the list
+  bool operator()(const Property *p1, const Property *p2) const {
+    // this is false, unless p1 is not valid and p2 is valid
+    return (p1->isValid() != "") && (p2->isValid() == "");
   }
+};
 
-  struct AllowCThreads
-  {
-    AllowCThreads() : m_tracefunc(NULL), m_tracearg(NULL), m_saved(NULL)
-    {
-      PyThreadState *curThreadState = PyThreadState_GET();
-      assert(curThreadState != NULL);
-      m_tracefunc = curThreadState->c_tracefunc;
-      m_tracearg = curThreadState->c_traceobj;
-      Py_XINCREF(m_tracearg);
-      PyEval_SetTrace(NULL,NULL);
-      m_saved = PyEval_SaveThread();
-    }
-    ~AllowCThreads()
-    {
-      PyEval_RestoreThread(m_saved);
-      PyEval_SetTrace(m_tracefunc, m_tracearg);
-      Py_XDECREF(m_tracearg);
-    }
-  private:
-    Py_tracefunc m_tracefunc;
-    PyObject *m_tracearg;
-    PyThreadState *m_saved;
-  };
+//----------------------- Property ordering ------------------------------
+/// Vector of property pointers
+typedef std::vector<Property *> PropertyVector;
 
-  /**
-   * Releases the GIL and disables any tracer functions, executes the calling algorithm object
-   * and re-acquires the GIL and resets the tracing functions.
-   * The trace functions are disabled as they can seriously hamper performance of Python algorithms
-   *
-   * As an algorithm is a potentially time-consuming operation, this allows other threads
-   * to execute python code while this thread is executing C code
-   * @param self :: A reference to the calling object
-   */
-  bool executeWhileReleasingGIL(IAlgorithm & self)
-  {
-    bool result(false);
-    AllowCThreads threadStateHolder;
-    result = self.execute();
-    return result;
-  }
-
-  /**
-   * @param self A reference to the calling object
-   * @return An AlgorithmID wrapped in a AlgorithmIDProxy container or None if there is
-   *         no ID
-   */
-  PyObject * getAlgorithmID(IAlgorithm & self)
-  {
-    AlgorithmID id = self.getAlgorithmID();
-    if(id) return to_python_value<AlgorithmIDProxy>()(AlgorithmIDProxy(id));
-    else Py_RETURN_NONE;
-  }
-
-  //--------------------------------------------------------------------------------------
-  // Deprecated wrappers
-  //--------------------------------------------------------------------------------------
-  /**
-   * @param self Reference to the calling object
-   * @return Algorithm summary
-   */
-  std::string getOptionalMessage(IAlgorithm & self)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, ".getOptionalMessage() is deprecated. Use .summary() instead.");
-    return self.summary();
-  }
-
-  /**
-   * @param self Reference to the calling object
-   * @return Algorithm summary
-   */
-  std::string getWikiSummary(IAlgorithm & self)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, ".getWikiSummary() is deprecated. Use .summary() instead.");
-    return self.summary();
-  }
-
+/**
+ * Returns the vector of properties ordered by the criteria defined in
+ * MandatoryFirst.
+ * A stable_sort is applied to the properties to guarantee the relative order
+ * of with respect to the original list.
+ * @return A list of Property pointers ordered by for the function API
+ */
+PropertyVector apiOrderedProperties(const IAlgorithm &propMgr) {
+  PropertyVector properties(
+      propMgr.getProperties()); // Makes a copy so that it can be sorted
+  std::stable_sort(properties.begin(), properties.end(), MandatoryFirst());
+  return properties;
 }
 
-void export_ialgorithm()
-{
-  class_<AlgorithmIDProxy>("AlgorithmID", no_init)
-    .def(self == self)
-  ;
+/**
+ * Returns a list of input property names that is ordered such that the
+ * mandatory properties are first followed by the optional ones. The list
+ * excludes output properties.
+ * @param self :: A pointer to the python object wrapping and Algorithm.
+ * @return A Python list of strings
+ */
 
-  // --------------------------------- IAlgorithm ------------------------------------------------
+PyObject *getInputPropertiesWithMandatoryFirst(IAlgorithm &self) {
+  PropertyVector properties(apiOrderedProperties(self));
+
+  PropertyVector::const_iterator iend = properties.end();
+  // Build a python list
+  PyObject *names = PyList_New(0);
+  for (PropertyVector::const_iterator itr = properties.begin(); itr != iend;
+       ++itr) {
+    Property *p = *itr;
+    if (p->direction() != Direction::Output) {
+      PyList_Append(names, PyString_FromString(p->name().c_str()));
+    }
+  }
+  return names;
+}
+
+/**
+* Returns a list of input property names that is ordered such that the
+* mandatory properties are first followed by the optional ones. The list
+* also includes InOut properties.
+* @param self :: A pointer to the python object wrapping and Algorithm.
+* @return A Python list of strings
+*/
+PyObject *getAlgorithmPropertiesOrdered(IAlgorithm &self) {
+  PropertyVector properties(apiOrderedProperties(self));
+
+  PropertyVector::const_iterator iend = properties.end();
+  // Build a python list
+  PyObject *names = PyList_New(0);
+  for (PropertyVector::const_iterator itr = properties.begin(); itr != iend;
+       ++itr) {
+    Property *p = *itr;
+    PyList_Append(names, PyString_FromString(p->name().c_str()));
+  }
+  return names;
+}
+
+/**
+ * Returns a list of output property names in the order they were declared in
+ * @param self :: A pointer to the python object wrapping and Algorithm.
+ * @return A Python list of strings
+ */
+PyObject *getOutputProperties(IAlgorithm &self) {
+  const PropertyVector &properties(self.getProperties()); // No copy
+  PropertyVector::const_iterator iend = properties.end();
+  // Build the list
+  PyObject *names = PyList_New(0);
+  for (PropertyVector::const_iterator itr = properties.begin(); itr != iend;
+       ++itr) {
+    Property *p = *itr;
+    if (p->direction() == Direction::Output) {
+      PyList_Append(names, PyString_FromString(p->name().c_str()));
+    }
+  }
+  return names;
+}
+
+// ---------------------- Documentation -------------------------------------
+/**
+ * Create a doc string for the simple API
+ * @param self :: A pointer to the python object wrapping and Algorithm
+ * @return A string that documents an algorithm
+ */
+std::string createDocString(IAlgorithm &self) {
+  const std::string EOL = "\n";
+
+  // Put in the quick overview message
+  std::stringstream buffer;
+  std::string temp = self.summary();
+  if (temp.size() > 0)
+    buffer << temp << EOL << EOL;
+
+  // get a sorted copy of the properties
+  PropertyVector properties(apiOrderedProperties(self));
+
+  const size_t numProps(properties.size());
+
+  buffer << "Property descriptions: " << EOL << EOL;
+  // write the actual property descriptions
+  for (size_t i = 0; i < numProps; ++i) {
+    Mantid::Kernel::Property *prop = properties[i];
+    buffer << prop->name() << "("
+           << Mantid::Kernel::Direction::asText(prop->direction());
+    if (!prop->isValid().empty())
+      buffer << ":req";
+    buffer << ") *" << prop->type() << "* ";
+    std::vector<std::string> allowed = prop->allowedValues();
+    if (!prop->documentation().empty() || !allowed.empty()) {
+      buffer << "      " << prop->documentation();
+      if (!allowed.empty()) {
+        buffer << "[" << Mantid::Kernel::Strings::join(allowed.begin(),
+                                                       allowed.end(), ", ");
+        buffer << "]";
+      }
+      buffer << EOL;
+      if (i < numProps - 1)
+        buffer << EOL;
+    }
+  }
+
+  return buffer.str();
+}
+
+struct AllowCThreads {
+  AllowCThreads() : m_tracefunc(NULL), m_tracearg(NULL), m_saved(NULL) {
+    PyThreadState *curThreadState = PyThreadState_GET();
+    assert(curThreadState != NULL);
+    m_tracefunc = curThreadState->c_tracefunc;
+    m_tracearg = curThreadState->c_traceobj;
+    Py_XINCREF(m_tracearg);
+    PyEval_SetTrace(NULL, NULL);
+    m_saved = PyEval_SaveThread();
+  }
+  ~AllowCThreads() {
+    PyEval_RestoreThread(m_saved);
+    PyEval_SetTrace(m_tracefunc, m_tracearg);
+    Py_XDECREF(m_tracearg);
+  }
+
+private:
+  Py_tracefunc m_tracefunc;
+  PyObject *m_tracearg;
+  PyThreadState *m_saved;
+};
+
+/**
+ * Releases the GIL and disables any tracer functions, executes the calling
+ *algorithm object
+ * and re-acquires the GIL and resets the tracing functions.
+ * The trace functions are disabled as they can seriously hamper performance of
+ *Python algorithms
+ *
+ * As an algorithm is a potentially time-consuming operation, this allows other
+ *threads
+ * to execute python code while this thread is executing C code
+ * @param self :: A reference to the calling object
+ */
+bool executeWhileReleasingGIL(IAlgorithm &self) {
+  bool result(false);
+  AllowCThreads threadStateHolder;
+  result = self.execute();
+  return result;
+}
+
+/**
+ * @param self A reference to the calling object
+ * @return An AlgorithmID wrapped in a AlgorithmIDProxy container or None if
+ * there is
+ *         no ID
+ */
+PyObject *getAlgorithmID(IAlgorithm &self) {
+  AlgorithmID id = self.getAlgorithmID();
+  if (id)
+    return to_python_value<AlgorithmIDProxy>()(AlgorithmIDProxy(id));
+  else
+    Py_RETURN_NONE;
+}
+
+//--------------------------------------------------------------------------------------
+// Deprecated wrappers
+//--------------------------------------------------------------------------------------
+/**
+ * @param self Reference to the calling object
+ * @return Algorithm summary
+ */
+std::string getOptionalMessage(IAlgorithm &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             ".getOptionalMessage() is deprecated. Use .summary() instead.");
+  return self.summary();
+}
+
+/**
+ * @param self Reference to the calling object
+ * @return Algorithm summary
+ */
+std::string getWikiSummary(IAlgorithm &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             ".getWikiSummary() is deprecated. Use .summary() instead.");
+  return self.summary();
+}
+}
+
+void export_ialgorithm() {
+  class_<AlgorithmIDProxy>("AlgorithmID", no_init).def(self == self);
+
+  // --------------------------------- IAlgorithm
+  // ------------------------------------------------
   register_ptr_to_python<boost::shared_ptr<IAlgorithm>>();
 
-  class_<IAlgorithm, bases<IPropertyManager>,
-         boost::noncopyable>("IAlgorithm", "Interface for all algorithms", no_init)
-    .def("name", &IAlgorithm::name, "Returns the name of the algorithm")
-    .def("alias", &IAlgorithm::alias, "Return the aliases for the algorithm")
-    .def("version", &IAlgorithm::version, "Returns the version number of the algorithm")
-    .def("cancel", &IAlgorithm::cancel, "Request that the algorithm stop running")
-    .def("category", &IAlgorithm::category, "Returns the category containing the algorithm")
-    .def("categories", &IAlgorithm::categories, "Returns the list of categories this algorithm belongs to")
-    .def("summary", &IAlgorithm::summary, "Returns a summary message describing the algorithm")
-    .def("workspaceMethodName",&IAlgorithm::workspaceMethodName,
-         "Returns a name that will be used when attached as a workspace method. Empty string indicates do not attach")
-    .def("workspaceMethodOn", &IAlgorithm::workspaceMethodOn, return_value_policy<VectorToNumpy>(), // creates a list for strings
-         "Returns a set of class names that will have the method attached. Empty list indicates all types")
-    .def("workspaceMethodInputProperty", &IAlgorithm::workspaceMethodInputProperty,
-         "Returns the name of the input workspace property used by the calling object")
-    .def("getAlgorithmID", &getAlgorithmID, "Returns a unique identifier for this algorithm object")
-    .def("docString", &createDocString, "Returns a doc string for the algorithm")
-    .def("mandatoryProperties",&getInputPropertiesWithMandatoryFirst, "Returns a list of input and in/out property names that is ordered "
-          "such that the mandatory properties are first followed by the optional ones.")
-    .def("orderedProperties", &getAlgorithmPropertiesOrdered, "Return a list of input, in/out and output properties "
-          "such that the mandatory properties are first followed by the optional ones.")
-    .def("outputProperties",&getOutputProperties, "Returns a list of the output properties on the algorithm")
-    .def("isInitialized", &IAlgorithm::isInitialized, "Returns True if the algorithm is initialized, False otherwise")
-    .def("isExecuted", &IAlgorithm::isExecuted, "Returns True if the algorithm has been executed successfully, False otherwise")
-    .def("isLogging", &IAlgorithm::isLogging, "Returns True if the algorithm's logger is turned on, False otherwise")
-    .def("isRunning", &IAlgorithm::isRunning, "Returns True if the algorithm is considered to be running, False otherwise")
-    .def("setChild", &IAlgorithm::setChild,
-        "If true this algorithm is run as a child algorithm. There will be no logging and nothing is stored in the Analysis Data Service")
-    .def("enableHistoryRecordingForChild", &IAlgorithm::enableHistoryRecordingForChild,
-         "If true then history will be recorded regardless of the child status")
-    .def("setAlgStartupLogging", &IAlgorithm::setAlgStartupLogging,
-         "If true then allow logging of start and end messages")
-    .def("getAlgStartupLogging", &IAlgorithm::getAlgStartupLogging,
-         "Returns true if logging of start and end messages")
-    .def("setAlwaysStoreInADS", &IAlgorithm::setAlwaysStoreInADS,
-        "If true then even child algorithms will have their workspaces stored in the ADS.")
-    .def("isChild", &IAlgorithm::isChild, "Returns True if the algorithm has been marked to run as a child. If True then Output workspaces "
-        "are NOT stored in the Analysis Data Service but must be retrieved from the property.")
-    .def("setLogging", &IAlgorithm::setLogging, "Toggle logging on/off.")
-    .def("setRethrows", &IAlgorithm::setRethrows)
-    .def("initialize", &IAlgorithm::initialize, "Initializes the algorithm")
-    .def("validateInputs", &IAlgorithm::validateInputs, "Cross-check all inputs and return any errors as a dictionary")
-    .def("execute", &executeWhileReleasingGIL, "Runs the algorithm and returns whether it has been successful")
-    // Special methods
-    .def("__str__", &IAlgorithm::toString)
+  class_<IAlgorithm, bases<IPropertyManager>, boost::noncopyable>(
+      "IAlgorithm", "Interface for all algorithms", no_init)
+      .def("name", &IAlgorithm::name, "Returns the name of the algorithm")
+      .def("alias", &IAlgorithm::alias, "Return the aliases for the algorithm")
+      .def("version", &IAlgorithm::version,
+           "Returns the version number of the algorithm")
+      .def("cancel", &IAlgorithm::cancel,
+           "Request that the algorithm stop running")
+      .def("category", &IAlgorithm::category,
+           "Returns the category containing the algorithm")
+      .def("categories", &IAlgorithm::categories,
+           "Returns the list of categories this algorithm belongs to")
+      .def("summary", &IAlgorithm::summary,
+           "Returns a summary message describing the algorithm")
+      .def("workspaceMethodName", &IAlgorithm::workspaceMethodName,
+           "Returns a name that will be used when attached as a workspace "
+           "method. Empty string indicates do not attach")
+      .def("workspaceMethodOn", &IAlgorithm::workspaceMethodOn,
+           return_value_policy<VectorToNumpy>(), // creates a list for strings
+           "Returns a set of class names that will have the method attached. "
+           "Empty list indicates all types")
+      .def("workspaceMethodInputProperty",
+           &IAlgorithm::workspaceMethodInputProperty,
+           "Returns the name of the input workspace property used by the "
+           "calling object")
+      .def("getAlgorithmID", &getAlgorithmID,
+           "Returns a unique identifier for this algorithm object")
+      .def("docString", &createDocString,
+           "Returns a doc string for the algorithm")
+      .def("mandatoryProperties", &getInputPropertiesWithMandatoryFirst,
+           "Returns a list of input and in/out property names that is ordered "
+           "such that the mandatory properties are first followed by the "
+           "optional ones.")
+      .def("orderedProperties", &getAlgorithmPropertiesOrdered,
+           "Return a list of input, in/out and output properties "
+           "such that the mandatory properties are first followed by the "
+           "optional ones.")
+      .def("outputProperties", &getOutputProperties,
+           "Returns a list of the output properties on the algorithm")
+      .def("isInitialized", &IAlgorithm::isInitialized,
+           "Returns True if the algorithm is initialized, False otherwise")
+      .def("isExecuted", &IAlgorithm::isExecuted,
+           "Returns True if the algorithm has been executed successfully, "
+           "False otherwise")
+      .def("isLogging", &IAlgorithm::isLogging, "Returns True if the "
+                                                "algorithm's logger is turned "
+                                                "on, False otherwise")
+      .def("isRunning", &IAlgorithm::isRunning, "Returns True if the algorithm "
+                                                "is considered to be running, "
+                                                "False otherwise")
+      .def("setChild", &IAlgorithm::setChild,
+           "If true this algorithm is run as a child algorithm. There will be "
+           "no logging and nothing is stored in the Analysis Data Service")
+      .def("enableHistoryRecordingForChild",
+           &IAlgorithm::enableHistoryRecordingForChild,
+           "If true then history will be recorded regardless of the child "
+           "status")
+      .def("setAlgStartupLogging", &IAlgorithm::setAlgStartupLogging,
+           "If true then allow logging of start and end messages")
+      .def("getAlgStartupLogging", &IAlgorithm::getAlgStartupLogging,
+           "Returns true if logging of start and end messages")
+      .def("setAlwaysStoreInADS", &IAlgorithm::setAlwaysStoreInADS,
+           "If true then even child algorithms will have their workspaces "
+           "stored in the ADS.")
+      .def("isChild", &IAlgorithm::isChild,
+           "Returns True if the algorithm has been marked to run as a child. "
+           "If True then Output workspaces "
+           "are NOT stored in the Analysis Data Service but must be retrieved "
+           "from the property.")
+      .def("setLogging", &IAlgorithm::setLogging, "Toggle logging on/off.")
+      .def("setRethrows", &IAlgorithm::setRethrows)
+      .def("initialize", &IAlgorithm::initialize, "Initializes the algorithm")
+      .def("validateInputs", &IAlgorithm::validateInputs,
+           "Cross-check all inputs and return any errors as a dictionary")
+      .def("execute", &executeWhileReleasingGIL,
+           "Runs the algorithm and returns whether it has been successful")
+      // Special methods
+      .def("__str__", &IAlgorithm::toString)
 
-    // deprecated methods
-    .def("getOptionalMessage", &getOptionalMessage,
-         "Returns the optional user message attached to the algorithm")
-    .def("getWikiSummary", &getWikiSummary,
-         "Returns the summary found on the wiki page")
-    ;
+      // deprecated methods
+      .def("getOptionalMessage", &getOptionalMessage,
+           "Returns the optional user message attached to the algorithm")
+      .def("getWikiSummary", &getWikiSummary,
+           "Returns the summary found on the wiki page");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -262,9 +262,7 @@ namespace
 
 }
 
-// clang-format off
 void export_ialgorithm()
-// clang-format on
 {
   class_<AlgorithmIDProxy>("AlgorithmID", no_init)
     .def(self == self)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include "MantidPythonInterface/kernel/Policies/VectorToNumpy.h"
 
-
 using Mantid::API::IEventList;
 using Mantid::API::EventType;
 using Mantid::API::TOF;
@@ -16,55 +15,73 @@ namespace Policies = Mantid::PythonInterface::Policies;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
-
 /// return_value_policy for copied numpy array
 typedef return_value_policy<Policies::VectorToNumpy> return_clone_numpy;
 
-void export_IEventList()
-{
+void export_IEventList() {
   register_ptr_to_python<IEventList *>();
 
   enum_<EventType>("EventType")
-    .value("TOF", TOF)
-    .value("WEIGHTED", WEIGHTED)
-    .value("WEIGHTED_NOTIME", WEIGHTED_NOTIME)
-    .export_values();
+      .value("TOF", TOF)
+      .value("WEIGHTED", WEIGHTED)
+      .value("WEIGHTED_NOTIME", WEIGHTED_NOTIME)
+      .export_values();
 
-  class_< IEventList, boost::noncopyable >("IEventList", no_init)
-    .def("getEventType", &IEventList::getEventType, args("self"), "Return the type of events stored.")
-    .def("switchTo", &IEventList::switchTo, args("self", "newType"), "Switch the event type to the one specified")
-    .def("clear", &IEventList::clear, args("self", "removeDetIDs"), "Clears the event list")
-    .def("isSortedByTof", &IEventList::isSortedByTof, args("self"), "Returns true if the list is sorted in TOF")
-    .def("getNumberEvents", &IEventList::getNumberEvents, args("self"),
-         "Returns the number of events within the list")
-    .def("getMemorySize", &IEventList::getMemorySize, args("self"), "Returns the memory size in bytes")
-    .def("integrate", &IEventList::integrate, args("self", "minX", "maxX", "entireRange"),
-         "Integrate the events between a range of X values, or all events.")
-    .def("convertTof", &IEventList::convertTof, args("self", "factor", "offset"),
-         "Convert the time of flight by tof'=tof*factor+offset")
-    .def("scaleTof", &IEventList::scaleTof, args("self", "factor"),
-         "Convert the tof units by scaling by a multiplier.")
-    .def("addTof", &IEventList::addTof, args("self", "offset"),
-         "Add an offset to the TOF of each event in the list.")
-    .def("addPulsetime", &IEventList::addPulsetime, args("self", "seconds"),
-         "Add an offset to the pulsetime (wall-clock time) of each event in the list.")
-    .def("maskTof", &IEventList::maskTof, args("self", "tofMin", "tofMax"),
-         "Mask out events that have a tof between tofMin and tofMax (inclusively)")
-    .def("getTofs", (std::vector<double>(IEventList::*)(void)const) &IEventList::getTofs, args("self"),
-         return_clone_numpy(), "Get a vector of the TOFs of the events")
-    .def("getWeights", (std::vector<double>(IEventList::*)(void)const) &IEventList::getWeights, args("self"),
-         return_clone_numpy(), "Get a vector of the weights of the events")
-    .def("getWeightErrors", (std::vector<double>(IEventList::*)(void)const) &IEventList::getWeightErrors, args("self"),
-         return_clone_numpy(), "Get a vector of the weights of the events")
-    .def("getPulseTimes", &IEventList::getPulseTimes, args("self"),
-         "Get a vector of the pulse times of the events")
-    .def("getTofMin", &IEventList::getTofMin, args("self"), "The minimum tof value for the list of the events.")
-    .def("getTofMax", &IEventList::getTofMax, args("self"), "The maximum tof value for the list of the events.")
-    .def("multiply", (void(IEventList::*)(const double,const double)) &IEventList::multiply, args("self", "value", "error"),
-        "Multiply the weights in this event list by a scalar variable with an error; though the error can be 0.0")
-    .def("divide", (void(IEventList::*)(const double,const double)) &IEventList::divide, args("self", "value", "error"),
-         "Divide the weights in this event list by a scalar with an (optional) error.")
-      ;
-
+  class_<IEventList, boost::noncopyable>("IEventList", no_init)
+      .def("getEventType", &IEventList::getEventType, args("self"),
+           "Return the type of events stored.")
+      .def("switchTo", &IEventList::switchTo, args("self", "newType"),
+           "Switch the event type to the one specified")
+      .def("clear", &IEventList::clear, args("self", "removeDetIDs"),
+           "Clears the event list")
+      .def("isSortedByTof", &IEventList::isSortedByTof, args("self"),
+           "Returns true if the list is sorted in TOF")
+      .def("getNumberEvents", &IEventList::getNumberEvents, args("self"),
+           "Returns the number of events within the list")
+      .def("getMemorySize", &IEventList::getMemorySize, args("self"),
+           "Returns the memory size in bytes")
+      .def("integrate", &IEventList::integrate,
+           args("self", "minX", "maxX", "entireRange"),
+           "Integrate the events between a range of X values, or all events.")
+      .def("convertTof", &IEventList::convertTof,
+           args("self", "factor", "offset"),
+           "Convert the time of flight by tof'=tof*factor+offset")
+      .def("scaleTof", &IEventList::scaleTof, args("self", "factor"),
+           "Convert the tof units by scaling by a multiplier.")
+      .def("addTof", &IEventList::addTof, args("self", "offset"),
+           "Add an offset to the TOF of each event in the list.")
+      .def("addPulsetime", &IEventList::addPulsetime, args("self", "seconds"),
+           "Add an offset to the pulsetime (wall-clock time) of each event in "
+           "the list.")
+      .def("maskTof", &IEventList::maskTof, args("self", "tofMin", "tofMax"),
+           "Mask out events that have a tof between tofMin and tofMax "
+           "(inclusively)")
+      .def("getTofs", (std::vector<double>(IEventList::*)(void) const) &
+                          IEventList::getTofs,
+           args("self"), return_clone_numpy(),
+           "Get a vector of the TOFs of the events")
+      .def("getWeights", (std::vector<double>(IEventList::*)(void) const) &
+                             IEventList::getWeights,
+           args("self"), return_clone_numpy(),
+           "Get a vector of the weights of the events")
+      .def("getWeightErrors", (std::vector<double>(IEventList::*)(void) const) &
+                                  IEventList::getWeightErrors,
+           args("self"), return_clone_numpy(),
+           "Get a vector of the weights of the events")
+      .def("getPulseTimes", &IEventList::getPulseTimes, args("self"),
+           "Get a vector of the pulse times of the events")
+      .def("getTofMin", &IEventList::getTofMin, args("self"),
+           "The minimum tof value for the list of the events.")
+      .def("getTofMax", &IEventList::getTofMax, args("self"),
+           "The maximum tof value for the list of the events.")
+      .def("multiply", (void (IEventList::*)(const double, const double)) &
+                           IEventList::multiply,
+           args("self", "value", "error"), "Multiply the weights in this event "
+                                           "list by a scalar variable with an "
+                                           "error; though the error can be 0.0")
+      .def("divide", (void (IEventList::*)(const double, const double)) &
+                         IEventList::divide,
+           args("self", "value", "error"), "Divide the weights in this event "
+                                           "list by a scalar with an "
+                                           "(optional) error.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
@@ -20,9 +20,7 @@ using namespace boost::python;
 /// return_value_policy for copied numpy array
 typedef return_value_policy<Policies::VectorToNumpy> return_clone_numpy;
 
-// clang-format off
 void export_IEventList()
-// clang-format on
 {
   register_ptr_to_python<IEventList *>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp
@@ -12,23 +12,26 @@ using namespace boost::python;
 /**
  * Python exports of the Mantid::API::IEventWorkspace class.
  */
-void export_IEventWorkspace()
-{
-  class_<IEventWorkspace, bases<Mantid::API::MatrixWorkspace>, boost::noncopyable>("IEventWorkspace", no_init)
-    .def("getNumberEvents", &IEventWorkspace::getNumberEvents, args("self"),
-         "Returns the number of events in the workspace")
-    .def("getTofMin", &IEventWorkspace::getTofMin, args("self"),
-         "Returns the minimum TOF value (in microseconds) held by the workspace")
-    .def("getTofMax", &IEventWorkspace::getTofMax, args("self"),
-         "Returns the maximum TOF value (in microseconds) held by the workspace")
-    .def("getEventList", (IEventList*(IEventWorkspace::*)(const int) ) &IEventWorkspace::getEventListPtr,
-         return_internal_reference<>(), args("self", "workspace_index"), "Return the event list managing the events at the given workspace index")
-    .def("clearMRU", &IEventWorkspace::clearMRU, args("self"), "Clear the most-recently-used lists")
-    ;
+void export_IEventWorkspace() {
+  class_<IEventWorkspace, bases<Mantid::API::MatrixWorkspace>,
+         boost::noncopyable>("IEventWorkspace", no_init)
+      .def("getNumberEvents", &IEventWorkspace::getNumberEvents, args("self"),
+           "Returns the number of events in the workspace")
+      .def("getTofMin", &IEventWorkspace::getTofMin, args("self"),
+           "Returns the minimum TOF value (in microseconds) held by the "
+           "workspace")
+      .def("getTofMax", &IEventWorkspace::getTofMax, args("self"),
+           "Returns the maximum TOF value (in microseconds) held by the "
+           "workspace")
+      .def("getEventList", (IEventList * (IEventWorkspace::*)(const int)) &
+                               IEventWorkspace::getEventListPtr,
+           return_internal_reference<>(), args("self", "workspace_index"),
+           "Return the event list managing the events at the given workspace "
+           "index")
+      .def("clearMRU", &IEventWorkspace::clearMRU, args("self"),
+           "Clear the most-recently-used lists");
 
   DataItemInterface<IEventWorkspace>()
-    // map IDs to this interface
-    .castFromID("EventWorkspace")
-  ;
+      // map IDs to this interface
+      .castFromID("EventWorkspace");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspace.cpp
@@ -12,9 +12,7 @@ using namespace boost::python;
 /**
  * Python exports of the Mantid::API::IEventWorkspace class.
  */
-// clang-format off
 void export_IEventWorkspace()
-// clang-format on
 {
   class_<IEventWorkspace, bases<Mantid::API::MatrixWorkspace>, boost::noncopyable>("IEventWorkspace", no_init)
     .def("getNumberEvents", &IEventWorkspace::getNumberEvents, args("self"),

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspaceProperty.cpp
@@ -1,8 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IEventWorkspace.h"
 
-void export_IEventWorkspaceProperty()
-{
+void export_IEventWorkspaceProperty() {
   using Mantid::API::IEventWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IEventWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IEventWorkspace.h"
 
-// clang-format off
 void export_IEventWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::IEventWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -9,105 +9,124 @@ using Mantid::API::IFunction;
 using Mantid::PythonInterface::IFunctionAdapter;
 using namespace boost::python;
 
-namespace
-{
-  ///@cond
+namespace {
+///@cond
 
-  //------------------------------------------------------------------------------------------------------
-  /**
-   * A Python friendly version that returns the registered functions as a list.
-   * @param self :: Enables it to be called as a member function on the FunctionFactory class
-   */
-  PyObject * getCategories(IFunction & self)
-  {
-    std::vector<std::string> categories = self.categories();
+//------------------------------------------------------------------------------------------------------
+/**
+ * A Python friendly version that returns the registered functions as a list.
+ * @param self :: Enables it to be called as a member function on the
+ * FunctionFactory class
+ */
+PyObject *getCategories(IFunction &self) {
+  std::vector<std::string> categories = self.categories();
 
-    PyObject *registered = PyList_New(0);
-    for (auto category = categories.begin(); category != categories.end(); ++category)
-    {
-      PyObject *value = PyString_FromString(category->c_str());
-      if (PyList_Append(registered, value))
-        throw std::runtime_error("Failed to insert value into PyList");
-    }
-
-    return registered;
+  PyObject *registered = PyList_New(0);
+  for (auto category = categories.begin(); category != categories.end();
+       ++category) {
+    PyObject *value = PyString_FromString(category->c_str());
+    if (PyList_Append(registered, value))
+      throw std::runtime_error("Failed to insert value into PyList");
   }
-  // -- Set property overloads --
-  // setProperty(index,value,explicit)
-  typedef void(IFunction::*setParameterType1)(size_t,const double & value,bool);
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads, setParameter, 2, 3)
-  // setProperty(index,value,explicit)
-  typedef void(IFunction::*setParameterType2)(const std::string &,const double & value,bool);
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads, setParameter, 2, 3)
 
+  return registered;
+}
+// -- Set property overloads --
+// setProperty(index,value,explicit)
+typedef void (IFunction::*setParameterType1)(size_t, const double &value, bool);
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
+                                       setParameter, 2, 3)
+// setProperty(index,value,explicit)
+typedef void (IFunction::*setParameterType2)(const std::string &,
+                                             const double &value, bool);
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
+                                       setParameter, 2, 3)
 
-  ///@endcond
+///@endcond
 }
 
-void export_IFunction()
-{
+void export_IFunction() {
 
   register_ptr_to_python<boost::shared_ptr<IFunction>>();
 
-  class_<IFunction, IFunctionAdapter, boost::noncopyable>("IFunction", "Base class for all functions", no_init)
-    .def("name", &IFunction::name, "Return the name of the function")
+  class_<IFunction, IFunctionAdapter, boost::noncopyable>(
+      "IFunction", "Base class for all functions", no_init)
+      .def("name", &IFunction::name, "Return the name of the function")
 
-    .def("category", &IFunctionAdapter::category, "Return a semi-colon(;) separated string for the categories this class should belong to. For sub-categories use a \\ separator")
+      .def("category", &IFunctionAdapter::category,
+           "Return a semi-colon(;) separated string for the categories this "
+           "class should belong to. For sub-categories use a \\ separator")
 
-    .def("initialize", &IFunction::initialize, "Declares any parameters and attributes on the function")
+      .def("initialize", &IFunction::initialize,
+           "Declares any parameters and attributes on the function")
 
-    .def("getCategories", &getCategories, "Returns a list of the categories for an algorithm")
+      .def("getCategories", &getCategories,
+           "Returns a list of the categories for an algorithm")
 
-    .def("nAttributes", &IFunction::nAttributes, "Return the number of attributes (non-fitting arguments)")
+      .def("nAttributes", &IFunction::nAttributes,
+           "Return the number of attributes (non-fitting arguments)")
 
-    .def("attributeNames", &IFunction::getAttributeNames, "The names of all the attributes")
+      .def("attributeNames", &IFunction::getAttributeNames,
+           "The names of all the attributes")
 
-    .def("nParams", &IFunction::nParams, "Return the number of parameters")
+      .def("nParams", &IFunction::nParams, "Return the number of parameters")
 
-    .def("parameterName", &IFunction::parameterName, "Return the name of the ith parameter")
+      .def("parameterName", &IFunction::parameterName,
+           "Return the name of the ith parameter")
 
-    .def("paramDescription", &IFunction::parameterDescription, "Return a description of the ith parameter")
+      .def("paramDescription", &IFunction::parameterDescription,
+           "Return a description of the ith parameter")
 
-    .def("isExplicitlySet", &IFunction::isExplicitlySet,
-         "Return whether the ith parameter needs to be explicitely set")
+      .def("isExplicitlySet", &IFunction::isExplicitlySet,
+           "Return whether the ith parameter needs to be explicitely set")
 
-    .def("getParameterValue", (double (IFunction::*)(size_t) const)&IFunction::getParameter,
-         "Get the value of the ith parameter")
+      .def("getParameterValue",
+           (double (IFunction::*)(size_t) const) & IFunction::getParameter,
+           "Get the value of the ith parameter")
 
-    .def("getParameterValue", (double (IFunction::*)(const std::string&) const)&IFunction::getParameter,
-         "Get the value of the named parameter")
+      .def("getParameterValue",
+           (double (IFunction::*)(const std::string &) const) &
+               IFunction::getParameter,
+           "Get the value of the named parameter")
 
-    .def("setParameter", (setParameterType1)&IFunction::setParameter,
-         setParameterType1_Overloads("Sets the value of the ith parameter"))
+      .def("setParameter", (setParameterType1)&IFunction::setParameter,
+           setParameterType1_Overloads("Sets the value of the ith parameter"))
 
-    .def("setParameter", (setParameterType2)&IFunction::setParameter,
-         setParameterType2_Overloads("Sets the value of the named parameter"))
+      .def("setParameter", (setParameterType2)&IFunction::setParameter,
+           setParameterType2_Overloads("Sets the value of the named parameter"))
 
-    .def("declareAttribute", &IFunctionAdapter::declareAttribute, "Declare an attribute with an initial value")
+      .def("declareAttribute", &IFunctionAdapter::declareAttribute,
+           "Declare an attribute with an initial value")
 
-    .def("getAttributeValue", (PyObject * (IFunctionAdapter::*)(const std::string &))&IFunctionAdapter::getAttributeValue,
-         "Return the value of the named attribute")
+      .def("getAttributeValue",
+           (PyObject * (IFunctionAdapter::*)(const std::string &)) &
+               IFunctionAdapter::getAttributeValue,
+           "Return the value of the named attribute")
 
-    .def("declareParameter", &IFunctionAdapter::declareFitParameter,
-          "Declare a fitting parameter settings its default value & description")
+      .def("declareParameter", &IFunctionAdapter::declareFitParameter,
+           "Declare a fitting parameter settings its default value & "
+           "description")
 
-    .def("declareParameter", &IFunctionAdapter::declareFitParameterNoDescr,
-         "Declare a fitting parameter settings its default value")
+      .def("declareParameter", &IFunctionAdapter::declareFitParameterNoDescr,
+           "Declare a fitting parameter settings its default value")
 
-    .def("declareParameter", &IFunctionAdapter::declareFitParameterZeroInit,
-         "Declare a fitting parameter settings its default value to 0.0")
+      .def("declareParameter", &IFunctionAdapter::declareFitParameterZeroInit,
+           "Declare a fitting parameter settings its default value to 0.0")
 
-    //-- Deprecated functions that have the wrong names --
-    .def("categories", &getCategories, "Returns a list of the categories for an algorithm")
-    .def("numParams", &IFunction::nParams, "Return the number of parameters")
-    .def("getParamName", &IFunction::parameterName, "Return the name of the ith parameter")
-    .def("getParamDescr", &IFunction::parameterDescription, "Return a description of the ith parameter")
-    .def("getParamExplicit", &IFunction::isExplicitlySet,
-         "Return whether the ith parameter needs to be explicitely set")
-    .def("getParamValue", (double (IFunction::*)(std::size_t) const)&IFunction::getParameter,
-         "Get the value of the ith parameter")
-    //-- Python special methods --
-    .def("__repr__", &IFunction::asString, "Return a string representation of the function")
-    ;
-
+      //-- Deprecated functions that have the wrong names --
+      .def("categories", &getCategories,
+           "Returns a list of the categories for an algorithm")
+      .def("numParams", &IFunction::nParams, "Return the number of parameters")
+      .def("getParamName", &IFunction::parameterName,
+           "Return the name of the ith parameter")
+      .def("getParamDescr", &IFunction::parameterDescription,
+           "Return a description of the ith parameter")
+      .def("getParamExplicit", &IFunction::isExplicitlySet,
+           "Return whether the ith parameter needs to be explicitely set")
+      .def("getParamValue",
+           (double (IFunction::*)(std::size_t) const) & IFunction::getParameter,
+           "Get the value of the ith parameter")
+      //-- Python special methods --
+      .def("__repr__", &IFunction::asString,
+           "Return a string representation of the function");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -44,9 +44,7 @@ namespace
   ///@endcond
 }
 
-// clang-format off
 void export_IFunction()
-// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<IFunction>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction1D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction1D.cpp
@@ -8,15 +8,16 @@ using Mantid::PythonInterface::IFunction1DAdapter;
 using Mantid::PythonInterface::IFunctionAdapter;
 using namespace boost::python;
 
-void export_IFunction1D()
-{
+void export_IFunction1D() {
   /**
    * The Python held type, boost::shared_ptr<IFunction1DAdapter>, allows
    * the class' virtual functions to be overridden in Python
    */
-  class_<IFunction1D,bases<IFunction>,boost::shared_ptr<IFunction1DAdapter>,
+  class_<IFunction1D, bases<IFunction>, boost::shared_ptr<IFunction1DAdapter>,
          boost::noncopyable>("IFunction1D", "Base class for 1D Fit functions")
-    .def("function1D", (object (IFunction1DAdapter::*)(const object &)const)&IFunction1DAdapter::function1D,
-         "Calculate the values of the function for the given x values and returns them")
-    ;
+      .def("function1D",
+           (object (IFunction1DAdapter::*)(const object &) const) &
+               IFunction1DAdapter::function1D,
+           "Calculate the values of the function for the given x values and "
+           "returns them");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction1D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IFunction1D.cpp
@@ -8,9 +8,7 @@ using Mantid::PythonInterface::IFunction1DAdapter;
 using Mantid::PythonInterface::IFunctionAdapter;
 using namespace boost::python;
 
-// clang-format off
 void export_IFunction1D()
-// clang-format on
 {
   /**
    * The Python held type, boost::shared_ptr<IFunction1DAdapter>, allows

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
@@ -8,43 +8,39 @@ using namespace Mantid::API;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 
-namespace
-{
-  // THIS NUMBER SHOULD MATCH MAX_MD_DIMENSIONS_NUM IN MDEvents/inc/MantidMDEvents/MDEventFactory
-  static const unsigned int MAX_MD_DIMS = 9;
-  static const unsigned int NUM_EVENT_TYPES = 2;
+namespace {
+// THIS NUMBER SHOULD MATCH MAX_MD_DIMENSIONS_NUM IN
+// MDEvents/inc/MantidMDEvents/MDEventFactory
+static const unsigned int MAX_MD_DIMS = 9;
+static const unsigned int NUM_EVENT_TYPES = 2;
 }
 
-void export_IMDEventWorkspace()
-{
+void export_IMDEventWorkspace() {
   // MDEventWorkspace class
-  class_< IMDEventWorkspace, bases<IMDWorkspace, MultipleExperimentInfos>,
-          boost::noncopyable >("IMDEventWorkspace", no_init)
-    .def("getNPoints", &IMDEventWorkspace::getNPoints,
-         "Returns the total number of points (events) in this workspace")
+  class_<IMDEventWorkspace, bases<IMDWorkspace, MultipleExperimentInfos>,
+         boost::noncopyable>("IMDEventWorkspace", no_init)
+      .def("getNPoints", &IMDEventWorkspace::getNPoints,
+           "Returns the total number of points (events) in this workspace")
 
-    .def("getNumDims", &IMDEventWorkspace::getNumDims,
-         "Returns the number of dimensions in this workspace")
+      .def("getNumDims", &IMDEventWorkspace::getNumDims,
+           "Returns the number of dimensions in this workspace")
 
-    .def("getBoxController", (BoxController_sptr(IMDEventWorkspace::*)() )&IMDEventWorkspace::getBoxController,
-         "Returns the BoxController used in this workspace")
-  ;
+      .def("getBoxController", (BoxController_sptr (IMDEventWorkspace::*)()) &
+                                   IMDEventWorkspace::getBoxController,
+           "Returns the BoxController used in this workspace");
 
   //-----------------------------------------------------------------------------------------------
   DataItemInterface<IMDEventWorkspace> entry;
-  // The IDs for the MDEventWorkpaces are constructed from the event types and number of dimensions
-  const char *eventTypes[NUM_EVENT_TYPES]= { "MDEvent", "MDLeanEvent" };
+  // The IDs for the MDEventWorkpaces are constructed from the event types and
+  // number of dimensions
+  const char *eventTypes[NUM_EVENT_TYPES] = {"MDEvent", "MDLeanEvent"};
 
   std::ostringstream out;
-  for(unsigned int i = 1; i <= MAX_MD_DIMS; ++i)
-  {
-    for(unsigned int j = 0; j < NUM_EVENT_TYPES; ++j)
-    {
+  for (unsigned int i = 1; i <= MAX_MD_DIMS; ++i) {
+    for (unsigned int j = 0; j < NUM_EVENT_TYPES; ++j) {
       out.str("");
       out << "MDEventWorkspace<" << eventTypes[j] << "," << i << ">";
       entry.castFromID(out.str());
     }
   }
-
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspace.cpp
@@ -15,9 +15,7 @@ namespace
   static const unsigned int NUM_EVENT_TYPES = 2;
 }
 
-// clang-format off
 void export_IMDEventWorkspace()
-// clang-format on
 {
   // MDEventWorkspace class
   class_< IMDEventWorkspace, bases<IMDWorkspace, MultipleExperimentInfos>,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspaceProperty.cpp
@@ -1,9 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 
-void export_IMDEventWorkspaceProperty()
-{
+void export_IMDEventWorkspaceProperty() {
   using Mantid::API::IMDEventWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
-  WorkspacePropertyExporter<IMDEventWorkspace>::define("IMDEventWorkspaceProperty");
+  WorkspacePropertyExporter<IMDEventWorkspace>::define(
+      "IMDEventWorkspaceProperty");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDEventWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 
-// clang-format off
 void export_IMDEventWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::IMDEventWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -6,191 +6,207 @@
 #include <boost/python/copy_non_const_reference.hpp>
 #include <boost/python/numeric.hpp>
 
-
 using namespace Mantid::API;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
-namespace
-{
-  /// Convenience typedef
-  typedef Converters::CArrayToNDArray<Mantid::signal_t, Converters::WrapReadOnly> WrapReadOnlyNumpy;
+namespace {
+/// Convenience typedef
+typedef Converters::CArrayToNDArray<Mantid::signal_t, Converters::WrapReadOnly>
+    WrapReadOnlyNumpy;
 
-  /**
-   * Determine the sizes of each dimensions
-   * @param self :: A reference to the calling object
-   * @returns A vector of the dimension sizes
-   */
-  std::vector<Py_intptr_t> countDimensions(const IMDHistoWorkspace &self)
-  {
-    size_t ndims = self.getNumDims();
-    std::vector<size_t> nd;
-    nd.reserve(ndims);
+/**
+ * Determine the sizes of each dimensions
+ * @param self :: A reference to the calling object
+ * @returns A vector of the dimension sizes
+ */
+std::vector<Py_intptr_t> countDimensions(const IMDHistoWorkspace &self) {
+  size_t ndims = self.getNumDims();
+  std::vector<size_t> nd;
+  nd.reserve(ndims);
 
-    // invert dimensions in C way, e.g. slowest changing ndim goes first 
-    for(size_t i = 0; i < ndims; ++i)
-    {
-      if(self.getDimension(ndims-i-1)->getNBins()>1)    // drop empty (integrated) dimesnions
-        nd.push_back(self.getDimension(ndims-i-1)->getNBins());
-    }
-
-    ndims = nd.size();
-    std::vector<Py_intptr_t> dims(ndims);
-    for(size_t i=0; i<ndims; ++i)
-      dims[i]=static_cast<Py_intptr_t>(nd[i]);
-    
-    return dims;
+  // invert dimensions in C way, e.g. slowest changing ndim goes first
+  for (size_t i = 0; i < ndims; ++i) {
+    if (self.getDimension(ndims - i - 1)->getNBins() >
+        1) // drop empty (integrated) dimesnions
+      nd.push_back(self.getDimension(ndims - i - 1)->getNBins());
   }
 
-  /**
-   * Returns the signal array from the workspace as a numpy array
-   * @param self :: A reference to the calling object
-   */
-  PyObject *getSignalArrayAsNumpyArray(IMDHistoWorkspace &self)
-  {
-    auto dims = countDimensions(self);
-    return WrapReadOnlyNumpy()(self.getSignalArray(), static_cast<int>(dims.size()), &dims[0]);
-  }
+  ndims = nd.size();
+  std::vector<Py_intptr_t> dims(ndims);
+  for (size_t i = 0; i < ndims; ++i)
+    dims[i] = static_cast<Py_intptr_t>(nd[i]);
 
-  /**
-   * Returns the error squared array from the workspace as a numpy array
-   * @param self :: A reference to the calling object
-   */
-  PyObject *getErrorSquaredArrayAsNumpyArray(IMDHistoWorkspace &self)
-  {
-    auto dims = countDimensions(self);
-    return WrapReadOnlyNumpy()(self.getErrorSquaredArray(), static_cast<int>(dims.size()), &dims[0]);
-  }
-
-  /**
-   * Returns the number of events array from the workspace as a numpy array
-   * @param self :: A reference to the calling object
-   */
-  PyObject *getNumEventsArrayAsNumpyArray(IMDHistoWorkspace &self)
-  {
-    auto dims = countDimensions(self);
-    return WrapReadOnlyNumpy()(self.getNumEventsArray(), static_cast<int>(dims.size()), &dims[0]);
-  }
-
-  /**
-   * Checks the size of the given array against the given MDHistoWorkspace to see if they match. Throws if not
-   * @param self :: The calling object
-   * @param signal :: The new values
-   * @param fnLabel :: A message prefix to pass if the sizes are incorrect
-   */
-  void throwIfSizeIncorrect(IMDHistoWorkspace & self, const numeric::array & signal,const std::string & fnLabel)
-  {
-    auto wsShape = countDimensions(self);
-    const size_t ndims = wsShape.size();
-    auto arrShape = signal.attr("shape");
-    if(ndims != static_cast<size_t>(len(arrShape)))
-    {
-      std::ostringstream os;
-      os << fnLabel << ": The number of  dimensions doe not match the current workspace size. Workspace="
-         << ndims << " array=" << len(arrShape);
-      throw std::invalid_argument(os.str());
-    }
-
-    for(size_t i = 0; i < ndims; ++i)
-    {
-      int arrDim = extract<int>(arrShape[i])();
-      if(wsShape[i] != arrDim )
-      {
-        std::ostringstream os;
-        os << fnLabel << ": The dimension size for the " << boost::lexical_cast<std::string>(i) << "th dimension do not match. "
-           << "Workspace dimension size=" << wsShape[i] << ", array size=" << arrDim;
-        throw std::invalid_argument(os.str());
-      }
-    }
-  }
-
-  /**
-   * Set the signal array from a numpy array. This simply loops over the array & sets each value
-   * It does not allow the workspace dimensions to be resized, it will throw if the sizes are not
-   * correct
-   */
-  void setSignalArray(IMDHistoWorkspace &self, const numeric::array & signalValues)
-  {
-    throwIfSizeIncorrect(self, signalValues, "setSignalArray");
-    object flattened = signalValues.attr("flat");
-    auto length = len(flattened);
-    for(auto i = 0; i < length; ++i)
-    {
-      self.setSignalAt(i, extract<double>(flattened[i])());
-    }
-  }
-
-  /**
-   * Set the square of the errors array from a numpy array. This simply loops over the array & sets each value
-   * It does not allow the workspace dimensions to be resized, it will throw if the sizes are not
-   * correct
-   */
-  void setErrorSquaredArray(IMDHistoWorkspace &self, const numeric::array & errorSquared)
-  {
-    throwIfSizeIncorrect(self, errorSquared, "setErrorSquaredArray");
-    object flattened = errorSquared.attr("flat");
-    auto length = len(flattened);
-    for(auto i = 0; i < length; ++i)
-    {
-      self.setErrorSquaredAt(i, extract<double>(flattened[i])());
-    }
-  }
-
-
+  return dims;
 }
 
-void export_IMDHistoWorkspace()
-{
+/**
+ * Returns the signal array from the workspace as a numpy array
+ * @param self :: A reference to the calling object
+ */
+PyObject *getSignalArrayAsNumpyArray(IMDHistoWorkspace &self) {
+  auto dims = countDimensions(self);
+  return WrapReadOnlyNumpy()(self.getSignalArray(),
+                             static_cast<int>(dims.size()), &dims[0]);
+}
+
+/**
+ * Returns the error squared array from the workspace as a numpy array
+ * @param self :: A reference to the calling object
+ */
+PyObject *getErrorSquaredArrayAsNumpyArray(IMDHistoWorkspace &self) {
+  auto dims = countDimensions(self);
+  return WrapReadOnlyNumpy()(self.getErrorSquaredArray(),
+                             static_cast<int>(dims.size()), &dims[0]);
+}
+
+/**
+ * Returns the number of events array from the workspace as a numpy array
+ * @param self :: A reference to the calling object
+ */
+PyObject *getNumEventsArrayAsNumpyArray(IMDHistoWorkspace &self) {
+  auto dims = countDimensions(self);
+  return WrapReadOnlyNumpy()(self.getNumEventsArray(),
+                             static_cast<int>(dims.size()), &dims[0]);
+}
+
+/**
+ * Checks the size of the given array against the given MDHistoWorkspace to see
+ * if they match. Throws if not
+ * @param self :: The calling object
+ * @param signal :: The new values
+ * @param fnLabel :: A message prefix to pass if the sizes are incorrect
+ */
+void throwIfSizeIncorrect(IMDHistoWorkspace &self, const numeric::array &signal,
+                          const std::string &fnLabel) {
+  auto wsShape = countDimensions(self);
+  const size_t ndims = wsShape.size();
+  auto arrShape = signal.attr("shape");
+  if (ndims != static_cast<size_t>(len(arrShape))) {
+    std::ostringstream os;
+    os << fnLabel << ": The number of  dimensions doe not match the current "
+                     "workspace size. Workspace=" << ndims
+       << " array=" << len(arrShape);
+    throw std::invalid_argument(os.str());
+  }
+
+  for (size_t i = 0; i < ndims; ++i) {
+    int arrDim = extract<int>(arrShape[i])();
+    if (wsShape[i] != arrDim) {
+      std::ostringstream os;
+      os << fnLabel << ": The dimension size for the "
+         << boost::lexical_cast<std::string>(i) << "th dimension do not match. "
+         << "Workspace dimension size=" << wsShape[i]
+         << ", array size=" << arrDim;
+      throw std::invalid_argument(os.str());
+    }
+  }
+}
+
+/**
+ * Set the signal array from a numpy array. This simply loops over the array &
+ * sets each value
+ * It does not allow the workspace dimensions to be resized, it will throw if
+ * the sizes are not
+ * correct
+ */
+void setSignalArray(IMDHistoWorkspace &self,
+                    const numeric::array &signalValues) {
+  throwIfSizeIncorrect(self, signalValues, "setSignalArray");
+  object flattened = signalValues.attr("flat");
+  auto length = len(flattened);
+  for (auto i = 0; i < length; ++i) {
+    self.setSignalAt(i, extract<double>(flattened[i])());
+  }
+}
+
+/**
+ * Set the square of the errors array from a numpy array. This simply loops over
+ * the array & sets each value
+ * It does not allow the workspace dimensions to be resized, it will throw if
+ * the sizes are not
+ * correct
+ */
+void setErrorSquaredArray(IMDHistoWorkspace &self,
+                          const numeric::array &errorSquared) {
+  throwIfSizeIncorrect(self, errorSquared, "setErrorSquaredArray");
+  object flattened = errorSquared.attr("flat");
+  auto length = len(flattened);
+  for (auto i = 0; i < length; ++i) {
+    self.setErrorSquaredAt(i, extract<double>(flattened[i])());
+  }
+}
+}
+
+void export_IMDHistoWorkspace() {
   // IMDHistoWorkspace class
-  class_< IMDHistoWorkspace, bases<IMDWorkspace,MultipleExperimentInfos>, boost::noncopyable >("IMDHistoWorkspace", no_init)
-    .def("getSignalArray", &getSignalArrayAsNumpyArray,
-         "Returns a read-only numpy array containing the signal values")
+  class_<IMDHistoWorkspace, bases<IMDWorkspace, MultipleExperimentInfos>,
+         boost::noncopyable>("IMDHistoWorkspace", no_init)
+      .def("getSignalArray", &getSignalArrayAsNumpyArray,
+           "Returns a read-only numpy array containing the signal values")
 
-    .def("getErrorSquaredArray", &getErrorSquaredArrayAsNumpyArray,
-         "Returns a read-only numpy array containing the square of the error values")
+      .def("getErrorSquaredArray", &getErrorSquaredArrayAsNumpyArray,
+           "Returns a read-only numpy array containing the square of the error "
+           "values")
 
-    .def("getNumEventsArray", &getNumEventsArrayAsNumpyArray,
-         "Returns a read-only numpy array containing the number of MD events in each bin")
+      .def("getNumEventsArray", &getNumEventsArrayAsNumpyArray,
+           "Returns a read-only numpy array containing the number of MD events "
+           "in each bin")
 
-    .def("signalAt", &IMDHistoWorkspace::signalAt, return_value_policy<copy_non_const_reference>(),
-         "Return a reference to the signal at the linear index")
+      .def("signalAt", &IMDHistoWorkspace::signalAt,
+           return_value_policy<copy_non_const_reference>(),
+           "Return a reference to the signal at the linear index")
 
-    .def("errorSquaredAt", &IMDHistoWorkspace::errorSquaredAt, return_value_policy<copy_non_const_reference>(),
-        "Return the squared-errors at the linear index")
+      .def("errorSquaredAt", &IMDHistoWorkspace::errorSquaredAt,
+           return_value_policy<copy_non_const_reference>(),
+           "Return the squared-errors at the linear index")
 
-    .def("setSignalAt", &IMDHistoWorkspace::setSignalAt, "Sets the signal at the specified index.")
+      .def("setSignalAt", &IMDHistoWorkspace::setSignalAt,
+           "Sets the signal at the specified index.")
 
-    .def("setErrorSquaredAt", &IMDHistoWorkspace::setErrorSquaredAt, "Sets the squared-error at the specified index.")
+      .def("setErrorSquaredAt", &IMDHistoWorkspace::setErrorSquaredAt,
+           "Sets the squared-error at the specified index.")
 
-    .def("setSignalArray", &setSignalArray,
-         "Sets the signal from a numpy array. The sizes must match the current workspace sizes. A ValueError is thrown if not")
+      .def("setSignalArray", &setSignalArray,
+           "Sets the signal from a numpy array. The sizes must match the "
+           "current workspace sizes. A ValueError is thrown if not")
 
-    .def("setErrorSquaredArray", &setErrorSquaredArray,
-         "Sets the square of the errors from a numpy array. The sizes must match the current workspace sizes. A ValueError is thrown if not")
+      .def("setErrorSquaredArray", &setErrorSquaredArray,
+           "Sets the square of the errors from a numpy array. The sizes must "
+           "match the current workspace sizes. A ValueError is thrown if not")
 
-    .def("setTo", &IMDHistoWorkspace::setTo, "Sets all signals/errors in the workspace to the given values")
+      .def("setTo", &IMDHistoWorkspace::setTo,
+           "Sets all signals/errors in the workspace to the given values")
 
-    .def("getInverseVolume", &IMDHistoWorkspace::getInverseVolume, return_value_policy< return_by_value >(),
-         "Return the inverse of volume of EACH cell in the workspace.")
+      .def("getInverseVolume", &IMDHistoWorkspace::getInverseVolume,
+           return_value_policy<return_by_value>(),
+           "Return the inverse of volume of EACH cell in the workspace.")
 
-    .def("getLinearIndex", (size_t(IMDHistoWorkspace::*)(size_t,size_t) const)&IMDHistoWorkspace::getLinearIndex,
-         return_value_policy< return_by_value >(), "Get the 1D linear index from the 2D array")
+      .def("getLinearIndex",
+           (size_t (IMDHistoWorkspace::*)(size_t, size_t) const) &
+               IMDHistoWorkspace::getLinearIndex,
+           return_value_policy<return_by_value>(),
+           "Get the 1D linear index from the 2D array")
 
-    .def("getLinearIndex", (size_t(IMDHistoWorkspace::*)(size_t,size_t,size_t) const)&IMDHistoWorkspace::getLinearIndex,
-        return_value_policy< return_by_value >(), "Get the 1D linear index from the 2D array")
+      .def("getLinearIndex",
+           (size_t (IMDHistoWorkspace::*)(size_t, size_t, size_t) const) &
+               IMDHistoWorkspace::getLinearIndex,
+           return_value_policy<return_by_value>(),
+           "Get the 1D linear index from the 2D array")
 
-    .def("getLinearIndex", (size_t(IMDHistoWorkspace::*)(size_t,size_t,size_t,size_t) const)&IMDHistoWorkspace::getLinearIndex,
-        return_value_policy< return_by_value >(), "Get the 1D linear index from the 2D array")
+      .def("getLinearIndex",
+           (size_t (IMDHistoWorkspace::*)(size_t, size_t, size_t, size_t)
+            const) &
+               IMDHistoWorkspace::getLinearIndex,
+           return_value_policy<return_by_value>(),
+           "Get the 1D linear index from the 2D array")
 
-    .def("getCenter", &IMDHistoWorkspace::getCenter, return_value_policy< return_by_value >(),
-         "Return the position of the center of a bin at a given position")
-  ;
+      .def("getCenter", &IMDHistoWorkspace::getCenter,
+           return_value_policy<return_by_value>(),
+           "Return the position of the center of a bin at a given position");
 
   //-------------------------------------------------------------------------------------------------
 
-  DataItemInterface<IMDHistoWorkspace>()
-    .castFromID("MDHistoWorkspace")
-  ;
+  DataItemInterface<IMDHistoWorkspace>().castFromID("MDHistoWorkspace");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -140,9 +140,7 @@ namespace
 
 }
 
-// clang-format off
 void export_IMDHistoWorkspace()
-// clang-format on
 {
   // IMDHistoWorkspace class
   class_< IMDHistoWorkspace, bases<IMDWorkspace,MultipleExperimentInfos>, boost::noncopyable >("IMDHistoWorkspace", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspaceProperty.cpp
@@ -1,9 +1,9 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 
-void export_IMDHistoWorkspaceProperty()
-{
+void export_IMDHistoWorkspaceProperty() {
   using Mantid::API::IMDHistoWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
-  WorkspacePropertyExporter<IMDHistoWorkspace>::define("IMDHistoWorkspaceProperty");
+  WorkspacePropertyExporter<IMDHistoWorkspace>::define(
+      "IMDHistoWorkspaceProperty");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
 
-// clang-format off
 void export_IMDHistoWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::IMDHistoWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
@@ -9,25 +9,29 @@ using namespace Mantid::API;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 
-void export_IMDWorkspace()
-{
+void export_IMDWorkspace() {
   boost::python::enum_<Mantid::API::MDNormalization>("MDNormalization")
-          .value("NoNormalization", Mantid::API::NoNormalization)
-          .value("VolumeNormalization", Mantid::API::VolumeNormalization)
-          .value("NumEventsNormalization", Mantid::API::NumEventsNormalization);
+      .value("NoNormalization", Mantid::API::NoNormalization)
+      .value("VolumeNormalization", Mantid::API::VolumeNormalization)
+      .value("NumEventsNormalization", Mantid::API::NumEventsNormalization);
 
-  boost::python::enum_<Mantid::Kernel::SpecialCoordinateSystem>("SpecialCoordinateSystem")
-          .value("None", Mantid::Kernel::None)
-          .value("QLab", Mantid::Kernel::QLab)
-          .value("QSample", Mantid::Kernel::QSample)
-          .value("HKL", Mantid::Kernel::HKL);
+  boost::python::enum_<Mantid::Kernel::SpecialCoordinateSystem>(
+      "SpecialCoordinateSystem")
+      .value("None", Mantid::Kernel::None)
+      .value("QLab", Mantid::Kernel::QLab)
+      .value("QSample", Mantid::Kernel::QSample)
+      .value("HKL", Mantid::Kernel::HKL);
 
   // EventWorkspace class
-  class_< IMDWorkspace, bases<Workspace, MDGeometry>, boost::noncopyable >("IMDWorkspace", no_init)
-    .def("getNPoints", &IMDWorkspace::getNPoints, args("self"), "Returns the total number of points within the workspace")
-    .def("getNEvents", &IMDWorkspace::getNEvents, args("self"), "Returns the total number of events, contributed to the workspace")
-    .def("getSpecialCoordinateSystem", &IMDWorkspace::getSpecialCoordinateSystem, args("self"), "Returns the special coordinate system of the workspace");
+  class_<IMDWorkspace, bases<Workspace, MDGeometry>, boost::noncopyable>(
+      "IMDWorkspace", no_init)
+      .def("getNPoints", &IMDWorkspace::getNPoints, args("self"),
+           "Returns the total number of points within the workspace")
+      .def("getNEvents", &IMDWorkspace::getNEvents, args("self"),
+           "Returns the total number of events, contributed to the workspace")
+      .def("getSpecialCoordinateSystem",
+           &IMDWorkspace::getSpecialCoordinateSystem, args("self"),
+           "Returns the special coordinate system of the workspace");
 
   DataItemInterface<IMDWorkspace>();
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspace.cpp
@@ -9,9 +9,7 @@ using namespace Mantid::API;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 
-// clang-format off
 void export_IMDWorkspace()
-// clang-format on
 {
   boost::python::enum_<Mantid::API::MDNormalization>("MDNormalization")
           .value("NoNormalization", Mantid::API::NoNormalization)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspaceProperty.cpp
@@ -1,8 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDWorkspace.h"
 
-void export_IMDWorkspaceProperty()
-{
+void export_IMDWorkspaceProperty() {
   using Mantid::API::IMDWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
   WorkspacePropertyExporter<IMDWorkspace>::define("IMDWorkspaceProperty");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IMDWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IMDWorkspace.h"
 
-// clang-format off
 void export_IMDWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::IMDWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -14,74 +14,117 @@ void setQLabFrame1(IPeak &peak, Mantid::Kernel::V3D qLabFrame) {
   // Set the q lab frame. No explicit detector distance.
   return peak.setQLabFrame(qLabFrame, boost::optional<double>());
 }
-void setQLabFrame2(IPeak &peak, Mantid::Kernel::V3D qLabFrame, double distance) {
+void setQLabFrame2(IPeak &peak, Mantid::Kernel::V3D qLabFrame,
+                   double distance) {
   // Set the q lab frame. Detector distance specified.
   return peak.setQLabFrame(qLabFrame, distance);
 }
 
 void setQSampleFrame1(IPeak &peak, Mantid::Kernel::V3D qSampleFrame) {
-   // Set the qsample frame. No explicit detector distance.
-   return peak.setQSampleFrame(qSampleFrame, boost::optional<double>());
+  // Set the qsample frame. No explicit detector distance.
+  return peak.setQSampleFrame(qSampleFrame, boost::optional<double>());
 }
 
-void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame, double distance) {
-    // Set the qsample frame. Detector distance specified.
-   return peak.setQSampleFrame(qSampleFrame, distance);
+void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame,
+                      double distance) {
+  // Set the qsample frame. Detector distance specified.
+  return peak.setQSampleFrame(qSampleFrame, distance);
+}
 }
 
-}
-
-void export_IPeak()
-{
-  register_ptr_to_python<IPeak*>();
+void export_IPeak() {
+  register_ptr_to_python<IPeak *>();
 
   class_<IPeak, boost::noncopyable>("IPeak", no_init)
-    .def("getDetectorID", &IPeak::getDetectorID, "Get the ID of the detector at the center of the peak")
-    .def("setDetectorID", &IPeak::setDetectorID, "Set the detector ID and look up and cache values related to it.")
-    .def("getRunNumber", &IPeak::getRunNumber, "Return the run number this peak was measured at")
-    .def("setRunNumber", &IPeak::setRunNumber, "Set the run number that measured this peak")
-    .def("getMonitorCount", &IPeak::getMonitorCount, "Get the monitor count set for this peak")
-    .def("setMonitorCount", &IPeak::setMonitorCount, "Set the monitor count for this peak")
-    .def("getH", &IPeak::getH, "Get the H index of the peak")
-    .def("getK", &IPeak::getK, "Get the K index of the peak")
-    .def("getL", &IPeak::getL, "Get the L index of the peak")
-    .def("getHKL", &IPeak::getHKL, "Get HKL as a V3D object")
-    .def("setHKL", (void (IPeak::*)(double,double,double)) &IPeak::setHKL, "Set the HKL values of this peak")
-    .def("setH", &IPeak::setH, "Get the H index of the peak")
-    .def("setK", &IPeak::setK, "Get the K index of the peak")
-    .def("setL", &IPeak::setL, "Get the L index of the peak")
-    .def("getQLabFrame", &IPeak::getQLabFrame, "Return the Q change (of the lattice, k_i - k_f) for this peak.\n"
-         "The Q is in the Lab frame: the goniometer rotation was NOT taken out.\n"
-         "Note: There is no 2*pi factor used, so \\|Q| = 1/wavelength.")
-    .def("findDetector", &IPeak::findDetector,
-         "Using the instrument set in the peak, perform ray tracing to find the exact detector.")
-    .def("getQSampleFrame", &IPeak::getQSampleFrame, "Return the Q change (of the lattice, k_i - k_f) for this peak."
-         "The Q is in the Sample frame: the goniometer rotation WAS taken out. ")
-    .def("setQLabFrame", setQLabFrame1, "Set the peak using the peak's position in reciprocal space, in the lab frame.")
-    .def("setQLabFrame", setQLabFrame2, "Set the peak using the peak's position in reciprocal space, in the lab frame. Detector distance explicitly supplied.") // two argument overload
-    .def("setQSampleFrame", setQSampleFrame1, "Set the peak using the peak's position in reciprocal space, in the sample frame.")
-    .def("setQSampleFrame", setQSampleFrame2, "Set the peak using the peak's position in reciprocal space, in the sample frame. Detector distance explicitly supplied.")
-    .def("setWavelength", &IPeak::setWavelength, "Set the incident wavelength of the neutron. Calculates the energy from this assuming elastic scattering.")
-    .def("getWavelength", &IPeak::getWavelength, "Return the incident wavelength")
-    .def("getScattering", &IPeak::getScattering, "Calculate the scattering angle of the peak")
-    .def("getDSpacing", &IPeak::getDSpacing, "Calculate the d-spacing of the peak, in 1/Angstroms")
-    .def("getTOF", &IPeak::getTOF, "Calculate the time of flight (in microseconds) of the neutrons for this peak")
-    .def("getInitialEnergy", &IPeak::getInitialEnergy, "Get the initial (incident) neutron energy")
-    .def("getFinalEnergy", &IPeak::getFinalEnergy, "Get the final neutron energy")
-    .def("setInitialEnergy", &IPeak::setInitialEnergy, "Set the initial (incident) neutron energy")
-    .def("setFinalEnergy", &IPeak::setFinalEnergy, "Set the final neutron energy")
-    .def("getIntensity", &IPeak::getIntensity, "Return the integrated peak intensity")
-    .def("getSigmaIntensity", &IPeak::getSigmaIntensity, "Return the error on the integrated peak intensity")
-    .def("setIntensity", &IPeak::setIntensity, "Set the integrated peak intensity")
-    .def("setSigmaIntensity", &IPeak::setSigmaIntensity, "Set the error on the integrated peak intensity")
-    .def("getBinCount", &IPeak::getBinCount, "Return the # of counts in the bin at its peak")
-    .def("setBinCount", &IPeak::setBinCount, "Set the # of counts in the bin at its peak")
-    .def("getRow", &IPeak::getRow, "For RectangularDetectors only, returns the row (y) of the pixel of the detector.")
-    .def("getCol", &IPeak::getCol, "For RectangularDetectors only, returns the column (x) of the pixel of the detector.")
-    .def("getDetPos", &IPeak::getDetPos, "Return the detector position vector")
-    .def("getL1", &IPeak::getL1, "Return the L1 flight path length (source to sample), in meters. ")
-    .def("getL2", &IPeak::getL2, "Return the L2 flight path length (sample to detector), in meters.")
-    .def("getPeakShape", getPeakShape, "Get the peak shape")
-    ;
+      .def("getDetectorID", &IPeak::getDetectorID,
+           "Get the ID of the detector at the center of the peak")
+      .def("setDetectorID", &IPeak::setDetectorID,
+           "Set the detector ID and look up and cache values related to it.")
+      .def("getRunNumber", &IPeak::getRunNumber,
+           "Return the run number this peak was measured at")
+      .def("setRunNumber", &IPeak::setRunNumber,
+           "Set the run number that measured this peak")
+      .def("getMonitorCount", &IPeak::getMonitorCount,
+           "Get the monitor count set for this peak")
+      .def("setMonitorCount", &IPeak::setMonitorCount,
+           "Set the monitor count for this peak")
+      .def("getH", &IPeak::getH, "Get the H index of the peak")
+      .def("getK", &IPeak::getK, "Get the K index of the peak")
+      .def("getL", &IPeak::getL, "Get the L index of the peak")
+      .def("getHKL", &IPeak::getHKL, "Get HKL as a V3D object")
+      .def("setHKL", (void (IPeak::*)(double, double, double)) & IPeak::setHKL,
+           "Set the HKL values of this peak")
+      .def("setH", &IPeak::setH, "Get the H index of the peak")
+      .def("setK", &IPeak::setK, "Get the K index of the peak")
+      .def("setL", &IPeak::setL, "Get the L index of the peak")
+      .def("getQLabFrame", &IPeak::getQLabFrame,
+           "Return the Q change (of the lattice, k_i - k_f) for this peak.\n"
+           "The Q is in the Lab frame: the goniometer rotation was NOT taken "
+           "out.\n"
+           "Note: There is no 2*pi factor used, so \\|Q| = 1/wavelength.")
+      .def("findDetector", &IPeak::findDetector,
+           "Using the instrument set in the peak, perform ray tracing to find "
+           "the exact detector.")
+      .def("getQSampleFrame", &IPeak::getQSampleFrame,
+           "Return the Q change (of the lattice, k_i - k_f) for this peak."
+           "The Q is in the Sample frame: the goniometer rotation WAS taken "
+           "out. ")
+      .def("setQLabFrame", setQLabFrame1, "Set the peak using the peak's "
+                                          "position in reciprocal space, in "
+                                          "the lab frame.")
+      .def("setQLabFrame", setQLabFrame2,
+           "Set the peak using the peak's position in reciprocal space, in the "
+           "lab frame. Detector distance explicitly supplied.") // two argument
+                                                                // overload
+      .def("setQSampleFrame", setQSampleFrame1, "Set the peak using the peak's "
+                                                "position in reciprocal space, "
+                                                "in the sample frame.")
+      .def("setQSampleFrame", setQSampleFrame2,
+           "Set the peak using the peak's position in reciprocal space, in the "
+           "sample frame. Detector distance explicitly supplied.")
+      .def("setWavelength", &IPeak::setWavelength,
+           "Set the incident wavelength of the neutron. Calculates the energy "
+           "from this assuming elastic scattering.")
+      .def("getWavelength", &IPeak::getWavelength,
+           "Return the incident wavelength")
+      .def("getScattering", &IPeak::getScattering,
+           "Calculate the scattering angle of the peak")
+      .def("getDSpacing", &IPeak::getDSpacing,
+           "Calculate the d-spacing of the peak, in 1/Angstroms")
+      .def("getTOF", &IPeak::getTOF, "Calculate the time of flight (in "
+                                     "microseconds) of the neutrons for this "
+                                     "peak")
+      .def("getInitialEnergy", &IPeak::getInitialEnergy,
+           "Get the initial (incident) neutron energy")
+      .def("getFinalEnergy", &IPeak::getFinalEnergy,
+           "Get the final neutron energy")
+      .def("setInitialEnergy", &IPeak::setInitialEnergy,
+           "Set the initial (incident) neutron energy")
+      .def("setFinalEnergy", &IPeak::setFinalEnergy,
+           "Set the final neutron energy")
+      .def("getIntensity", &IPeak::getIntensity,
+           "Return the integrated peak intensity")
+      .def("getSigmaIntensity", &IPeak::getSigmaIntensity,
+           "Return the error on the integrated peak intensity")
+      .def("setIntensity", &IPeak::setIntensity,
+           "Set the integrated peak intensity")
+      .def("setSigmaIntensity", &IPeak::setSigmaIntensity,
+           "Set the error on the integrated peak intensity")
+      .def("getBinCount", &IPeak::getBinCount,
+           "Return the # of counts in the bin at its peak")
+      .def("setBinCount", &IPeak::setBinCount,
+           "Set the # of counts in the bin at its peak")
+      .def("getRow", &IPeak::getRow, "For RectangularDetectors only, returns "
+                                     "the row (y) of the pixel of the "
+                                     "detector.")
+      .def("getCol", &IPeak::getCol, "For RectangularDetectors only, returns "
+                                     "the column (x) of the pixel of the "
+                                     "detector.")
+      .def("getDetPos", &IPeak::getDetPos,
+           "Return the detector position vector")
+      .def("getL1", &IPeak::getL1,
+           "Return the L1 flight path length (source to sample), in meters. ")
+      .def("getL2", &IPeak::getL2,
+           "Return the L2 flight path length (sample to detector), in meters.")
+      .def("getPeakShape", getPeakShape, "Get the peak shape");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -31,9 +31,7 @@ void setQSampleFrame2(IPeak &peak, Mantid::Kernel::V3D qSampleFrame, double dist
 
 }
 
-// clang-format off
 void export_IPeak()
-// clang-format on
 {
   register_ptr_to_python<IPeak*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
@@ -7,16 +7,18 @@ using Mantid::API::IPeakFunction;
 using Mantid::PythonInterface::IPeakFunctionAdapter;
 using namespace boost::python;
 
-void export_IPeakFunction()
-{
-  class_<IPeakFunction, bases<IFunction1D>, boost::shared_ptr<IPeakFunctionAdapter>,
-          boost::noncopyable>("IPeakFunction")
-      .def("functionLocal", (object (IPeakFunctionAdapter::*)(const object &)const)&IPeakFunction::functionLocal,
-           "Calculate the values of the function for the given x values. The output should be stored in the out array")
+void export_IPeakFunction() {
+  class_<IPeakFunction, bases<IFunction1D>,
+         boost::shared_ptr<IPeakFunctionAdapter>, boost::noncopyable>(
+      "IPeakFunction")
+      .def("functionLocal",
+           (object (IPeakFunctionAdapter::*)(const object &) const) &
+               IPeakFunction::functionLocal,
+           "Calculate the values of the function for the given x values. The "
+           "output should be stored in the out array")
       .def("intensity", &IPeakFunction::intensity,
            "Returns the integral intensity of the peak function.")
       .def("setIntensity", &IPeakFunction::setIntensity,
            "Changes the integral intensity of the peak function by setting its "
-           "height.")
-          ;
+           "height.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeakFunction.cpp
@@ -7,9 +7,7 @@ using Mantid::API::IPeakFunction;
 using Mantid::PythonInterface::IPeakFunctionAdapter;
 using namespace boost::python;
 
-// clang-format off
 void export_IPeakFunction()
-// clang-format on
 {
   class_<IPeakFunction, bases<IFunction1D>, boost::shared_ptr<IPeakFunctionAdapter>,
           boost::noncopyable>("IPeakFunction")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -33,9 +33,7 @@ IPeak* createPeakQLabWithDistance(IPeaksWorkspace & self, const object& data, do
 
 }
 
-// clang-format off
 void export_IPeaksWorkspace()
-// clang-format on
 {
   // IPeaksWorkspace class
   class_< IPeaksWorkspace, bases<ITableWorkspace, ExperimentInfo>, boost::noncopyable >("IPeaksWorkspace", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -14,46 +14,57 @@ using namespace boost::python;
 namespace {
 
 /// Create a peak via it's HKL value from a list or numpy array
-IPeak* createPeakHKL(IPeaksWorkspace & self, const object& data)
-{
-  return self.createPeakHKL(Mantid::PythonInterface::Converters::PyObjectToV3D(data)());
+IPeak *createPeakHKL(IPeaksWorkspace &self, const object &data) {
+  return self.createPeakHKL(
+      Mantid::PythonInterface::Converters::PyObjectToV3D(data)());
 }
 
 /// Create a peak via it's QLab value from a list or numpy array
-IPeak* createPeakQLab(IPeaksWorkspace & self, const object& data)
-{
-  return self.createPeak(Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), boost::optional<double>());
+IPeak *createPeakQLab(IPeaksWorkspace &self, const object &data) {
+  return self.createPeak(
+      Mantid::PythonInterface::Converters::PyObjectToV3D(data)(),
+      boost::optional<double>());
 }
 
 /// Create a peak via it's QLab value from a list or numpy array
-IPeak* createPeakQLabWithDistance(IPeaksWorkspace & self, const object& data, double detectorDistance)
-{
-  return self.createPeak(Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), detectorDistance);
+IPeak *createPeakQLabWithDistance(IPeaksWorkspace &self, const object &data,
+                                  double detectorDistance) {
+  return self.createPeak(
+      Mantid::PythonInterface::Converters::PyObjectToV3D(data)(),
+      detectorDistance);
+}
 }
 
-}
-
-void export_IPeaksWorkspace()
-{
+void export_IPeaksWorkspace() {
   // IPeaksWorkspace class
-  class_< IPeaksWorkspace, bases<ITableWorkspace, ExperimentInfo>, boost::noncopyable >("IPeaksWorkspace", no_init)
-    .def("getNumberPeaks", &IPeaksWorkspace::getNumberPeaks, "Returns the number of peaks within the workspace")
-    .def("addPeak", &IPeaksWorkspace::addPeak, "Add a peak to the workspace")
-    .def("removePeak", &IPeaksWorkspace::removePeak, "Remove a peak from the workspace")
-    .def("getPeak", &IPeaksWorkspace::getPeakPtr, return_internal_reference<>(), "Returns a peak at the given index" )
-    .def("createPeak", createPeakQLab, return_value_policy<manage_new_object>(), "Create a Peak and return it from its coordinates in the QLab frame")
-    .def("createPeak", createPeakQLabWithDistance, return_value_policy<manage_new_object>(), "Create a Peak and return it from its coordinates in the QLab frame, detector-sample distance explicitly provided")
-    .def("createPeakHKL", createPeakHKL, return_value_policy<manage_new_object>(), "Create a Peak and return it from its coordinates in the HKL frame")
-    .def("hasIntegratedPeaks", &IPeaksWorkspace::hasIntegratedPeaks, "Determine if the peaks have been integrated")
-    .def("getRun", &IPeaksWorkspace::mutableRun, return_internal_reference<>(),
-             "Return the Run object for this workspace")
-    .def("peakInfoNumber", &IPeaksWorkspace::peakInfoNumber, "Peak info number at Q vector for this workspace")
-      ;
+  class_<IPeaksWorkspace, bases<ITableWorkspace, ExperimentInfo>,
+         boost::noncopyable>("IPeaksWorkspace", no_init)
+      .def("getNumberPeaks", &IPeaksWorkspace::getNumberPeaks,
+           "Returns the number of peaks within the workspace")
+      .def("addPeak", &IPeaksWorkspace::addPeak, "Add a peak to the workspace")
+      .def("removePeak", &IPeaksWorkspace::removePeak,
+           "Remove a peak from the workspace")
+      .def("getPeak", &IPeaksWorkspace::getPeakPtr,
+           return_internal_reference<>(), "Returns a peak at the given index")
+      .def("createPeak", createPeakQLab,
+           return_value_policy<manage_new_object>(),
+           "Create a Peak and return it from its coordinates in the QLab frame")
+      .def("createPeak", createPeakQLabWithDistance,
+           return_value_policy<manage_new_object>(),
+           "Create a Peak and return it from its coordinates in the QLab "
+           "frame, detector-sample distance explicitly provided")
+      .def("createPeakHKL", createPeakHKL,
+           return_value_policy<manage_new_object>(),
+           "Create a Peak and return it from its coordinates in the HKL frame")
+      .def("hasIntegratedPeaks", &IPeaksWorkspace::hasIntegratedPeaks,
+           "Determine if the peaks have been integrated")
+      .def("getRun", &IPeaksWorkspace::mutableRun,
+           return_internal_reference<>(),
+           "Return the Run object for this workspace")
+      .def("peakInfoNumber", &IPeaksWorkspace::peakInfoNumber,
+           "Peak info number at Q vector for this workspace");
 
   //-------------------------------------------------------------------------------------------------
 
-  DataItemInterface<IPeaksWorkspace>()
-    .castFromID("PeaksWorkspace")
-  ;
+  DataItemInterface<IPeaksWorkspace>().castFromID("PeaksWorkspace");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspaceProperty.cpp
@@ -1,8 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 
-void export_IPeaksWorkspaceProperty()
-{
+void export_IPeaksWorkspaceProperty() {
   using Mantid::API::IPeaksWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
   WorkspacePropertyExporter<IPeaksWorkspace>::define("IPeaksWorkspaceProperty");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 
-// clang-format off
 void export_IPeaksWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::IPeaksWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
@@ -7,19 +7,24 @@ using Mantid::API::ISpectrum;
 using Mantid::detid_t;
 using namespace boost::python;
 
-void export_ISpectrum()
-{
-  register_ptr_to_python<ISpectrum*>();
+void export_ISpectrum() {
+  register_ptr_to_python<ISpectrum *>();
 
   class_<ISpectrum, boost::noncopyable>("ISpectrum", no_init)
-    .def("hasDetectorID", &ISpectrum::hasDetectorID, "Returns True if the spectrum contain the given spectrum number")
-    .def("getSpectrumNo", &ISpectrum::getSpectrumNo, "Returns the spectrum number of this spectrum")
-    .def("getDetectorIDs", (const std::set<detid_t>& (ISpectrum::*)() const)&ISpectrum::getDetectorIDs, return_value_policy<copy_const_reference>(),
-         "Returns a list of detector IDs for this spectrum")
-    .def("addDetectorID", &ISpectrum::addDetectorID, "Add a detector ID to this spectrum")
-    .def("setDetectorID", &ISpectrum::setDetectorID, "Set the given ID has the only")
-    .def("clearDetectorIDs", &ISpectrum::clearDetectorIDs, "Clear the set of detector IDs")
-    .def("setSpectrumNo", &ISpectrum::setSpectrumNo, "Set the spectrum number for this spectrum")
-    ;
+      .def("hasDetectorID", &ISpectrum::hasDetectorID,
+           "Returns True if the spectrum contain the given spectrum number")
+      .def("getSpectrumNo", &ISpectrum::getSpectrumNo,
+           "Returns the spectrum number of this spectrum")
+      .def("getDetectorIDs", (const std::set<detid_t> &(ISpectrum::*)() const) &
+                                 ISpectrum::getDetectorIDs,
+           return_value_policy<copy_const_reference>(),
+           "Returns a list of detector IDs for this spectrum")
+      .def("addDetectorID", &ISpectrum::addDetectorID,
+           "Add a detector ID to this spectrum")
+      .def("setDetectorID", &ISpectrum::setDetectorID,
+           "Set the given ID has the only")
+      .def("clearDetectorIDs", &ISpectrum::clearDetectorIDs,
+           "Clear the set of detector IDs")
+      .def("setSpectrumNo", &ISpectrum::setSpectrumNo,
+           "Set the spectrum number for this spectrum");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
@@ -7,9 +7,7 @@ using Mantid::API::ISpectrum;
 using Mantid::detid_t;
 using namespace boost::python;
 
-// clang-format off
 void export_ISpectrum()
-// clang-format on
 {
   register_ptr_to_python<ISpectrum*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
@@ -7,18 +7,21 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
-void export_IPeaksWorkspace()
-{
+void export_IPeaksWorkspace() {
   register_ptr_to_python<boost::shared_ptr<ISplittersWorkspace>>();
 
   // ISplittersWorkspace class
-  class_< ISplittersWorkspace, bases<ITableWorkspace>, boost::noncopyable >("ISplittersWorkspace", no_init)
-    .def("getNumberSplitters", &ISplittersWorkspace::getNumberSplitters, "Returns the number of splitters within the workspace")
-    .def("addSplitter", &IPeaksWorkspace::addSplitter, "Add a splitter to the workspace")
-    .def("removeSplitter", &IPeaksWorkspace::removeSplitter, "Remove splitter from the workspace")
-    .def("getSplitter", &IPeaksWorkspace::getSplitter, return_internal_reference<>(), "Returns a splitter at the given index" )
-      ;
+  class_<ISplittersWorkspace, bases<ITableWorkspace>, boost::noncopyable>(
+      "ISplittersWorkspace", no_init)
+      .def("getNumberSplitters", &ISplittersWorkspace::getNumberSplitters,
+           "Returns the number of splitters within the workspace")
+      .def("addSplitter", &IPeaksWorkspace::addSplitter,
+           "Add a splitter to the workspace")
+      .def("removeSplitter", &IPeaksWorkspace::removeSplitter,
+           "Remove splitter from the workspace")
+      .def("getSplitter", &IPeaksWorkspace::getSplitter,
+           return_internal_reference<>(),
+           "Returns a splitter at the given index");
 
   REGISTER_SINGLEVALUE_HANDLER(IPeaksWorkspace_sptr);
-
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
@@ -7,9 +7,7 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
-// clang-format off
 void export_IPeaksWorkspace()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ISplittersWorkspace>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -338,9 +338,7 @@ namespace
    }
 }
 
-// clang-format off
 void export_ITableWorkspace()
-// clang-format on
 {
   using Mantid::PythonInterface::Policies::VectorToNumpy;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -17,7 +17,8 @@
 #include <cstring>
 #include <vector>
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL API_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
@@ -26,373 +27,367 @@ using namespace Mantid::API;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 
-namespace
-{
-  namespace bpl = boost::python;
-  namespace Converters = Mantid::PythonInterface::Converters;
+namespace {
+namespace bpl = boost::python;
+namespace Converters = Mantid::PythonInterface::Converters;
 
-  /// Boost macro for "looping" over builtin types
-  #define BUILTIN_TYPES \
-    BOOST_PP_TUPLE_TO_LIST( \
-    7, (double, std::string, int, uint32_t, int64_t, float, uint64_t)    \
-    )
-  #define USER_TYPES \
-    BOOST_PP_TUPLE_TO_LIST( \
-        1, (Mantid::Kernel::V3D) \
-    )
-  #define ARRAY_TYPES \
-    BOOST_PP_TUPLE_TO_LIST( \
-        2, (std::vector<int>, std::vector<double> ) \
-    )
+/// Boost macro for "looping" over builtin types
+#define BUILTIN_TYPES                                                          \
+  BOOST_PP_TUPLE_TO_LIST(                                                      \
+      7, (double, std::string, int, uint32_t, int64_t, float, uint64_t))
+#define USER_TYPES BOOST_PP_TUPLE_TO_LIST(1, (Mantid::Kernel::V3D))
+#define ARRAY_TYPES                                                            \
+  BOOST_PP_TUPLE_TO_LIST(2, (std::vector<int>, std::vector<double>))
 
-  /**
-   * Get out the Python value from a specific cell of the supplied column. This is meant to
-   * reduce the amount of copy and pasted code in this file.
-   * @param column The column to grab the value from.
-   * @param typeID The python identifier of the column type.
-   * @param row The row to get the value from.
-   */
-  PyObject *getValue(Mantid::API::Column_const_sptr column, const std::type_info & typeID, const int row)
-  {
-    if(typeID == typeid(Mantid::API::Boolean))
-    {
-      bool res = column->cell<Mantid::API::Boolean>(row);
-      return to_python_value<const bool&>()(res);
-    }
-
-    #define GET_BUILTIN(R, _, T) \
-    else if(typeID == typeid(T)) \
-    {\
-      result = to_python_value<const T&>()(column->cell<T>(row));\
-    }
-    #define GET_USER(R, _, T) \
-    else if(strcmp(typeID.name(), typeid(T).name()) == 0) \
-    {\
-      const converter::registration *entry = converter::registry::query(typeid(T));\
-      if(!entry) throw std::invalid_argument("Cannot find converter from C++ type.");\
-      result = entry->to_python((const void *)&column->cell<T>(row));\
-    }
-    #define GET_ARRAY(R, _, T) \
-    else if(typeID == typeid(T))\
-    {\
-      result = Converters::Clone::apply<T::value_type>::create1D( column->cell<T>(row) ); \
-    }
-
-    // -- Use the boost preprocessor to generate a list of else if clause to cut out copy
-    // and pasted code.
-    PyObject *result(NULL);
-    if(false){} // So that it always falls through to the list checking
-    BOOST_PP_LIST_FOR_EACH(GET_BUILTIN, _ , BUILTIN_TYPES)
-    BOOST_PP_LIST_FOR_EACH(GET_ARRAY, _ , ARRAY_TYPES)
-    BOOST_PP_LIST_FOR_EACH(GET_USER, _ , USER_TYPES)
-    else
-    {
-      throw std::invalid_argument("Cannot convert C++ type to Python: " + column->type());
-    }
-    return result;
+/**
+ * Get out the Python value from a specific cell of the supplied column. This is
+ * meant to
+ * reduce the amount of copy and pasted code in this file.
+ * @param column The column to grab the value from.
+ * @param typeID The python identifier of the column type.
+ * @param row The row to get the value from.
+ */
+PyObject *getValue(Mantid::API::Column_const_sptr column,
+                   const std::type_info &typeID, const int row) {
+  if (typeID == typeid(Mantid::API::Boolean)) {
+    bool res = column->cell<Mantid::API::Boolean>(row);
+    return to_python_value<const bool &>()(res);
   }
 
-  /**
-   * Sets a value in a particular column and row from a python object
-   * @param column :: A pointer to the column object
-   * @param row :: The index of the row
-   * @param value :: The value to set
-   */
-  void setValue(const Column_sptr column, const int row, const bpl::object & value)
-  {
-    const auto & typeID = column->get_type_info();
-    if(typeID == typeid(Mantid::API::Boolean))
-    {
-      column->cell<Mantid::API::Boolean>(row) = bpl::extract<bool>(value)();
-      return;
-    }
-
-    #define SET_CELL(R, _, T) \
-    else if(strcmp(typeID.name(), typeid(T).name()) == 0)\
-    {\
-      column->cell<T>(row) = bpl::extract<T>(value)();\
-    }
-    #define SET_VECTOR_CELL(R, _, T) \
-    else if(typeID == typeid(T))       \
-    {\
-      if( ! PyArray_Check( value.ptr() ) ) \
-      { \
-        column->cell<T>(row) = Converters::PySequenceToVector<T::value_type>(value)(); \
-      } \
-      else \
-      { \
-        column->cell<T>(row) = Converters::NDArrayToVector<T::value_type>(value)();\
-      } \
-    }
-
-    // -- Use the boost preprocessor to generate a list of else if clause to cut out copy
-    // and pasted code.
-    if(false){} // So that it always falls through to the list checking
-    BOOST_PP_LIST_FOR_EACH(SET_CELL, _ , BUILTIN_TYPES)
-    BOOST_PP_LIST_FOR_EACH(SET_CELL, _ , USER_TYPES)
-    BOOST_PP_LIST_FOR_EACH(SET_VECTOR_CELL, _ , ARRAY_TYPES)
-    else
-    {
-      throw std::invalid_argument("Cannot convert Python type to C++: " + column->type());
-    }
+#define GET_BUILTIN(R, _, T)                                                   \
+  else if (typeID == typeid(T)) {                                              \
+    result = to_python_value<const T &>()(column->cell<T>(row));               \
+  }
+#define GET_USER(R, _, T)                                                      \
+  else if (strcmp(typeID.name(), typeid(T).name()) == 0) {                     \
+    const converter::registration *entry =                                     \
+        converter::registry::query(typeid(T));                                 \
+    if (!entry)                                                                \
+      throw std::invalid_argument("Cannot find converter from C++ type.");     \
+    result = entry->to_python((const void *)&column->cell<T>(row));            \
+  }
+#define GET_ARRAY(R, _, T)                                                     \
+  else if (typeID == typeid(T)) {                                              \
+    result = Converters::Clone::apply<T::value_type>::create1D(                \
+        column->cell<T>(row));                                                 \
   }
 
-  /** Access a cell and return a corresponding Python type
-   *  @param self A reference to the TableWorkspace python object that we were called on
-   *  @param type The data type of the column to add
-   *  @param name The name of the column to add
-   *  @return A boolean indicating success or failure. Note that this is different to the
-   *          corresponding C++ method, which returns a pointer to the newly-created column
-   *          (as the Column class is not exposed to python).
-   */
-  bool addColumn(ITableWorkspace &self, const std::string& type, const std::string& name)
-  {
-    return self.addColumn(type,name)!=0;
+  // -- Use the boost preprocessor to generate a list of else if clause to cut
+  // out copy
+  // and pasted code.
+  PyObject *result(NULL);
+  if (false) {
+  } // So that it always falls through to the list checking
+  BOOST_PP_LIST_FOR_EACH(GET_BUILTIN, _, BUILTIN_TYPES)
+  BOOST_PP_LIST_FOR_EACH(GET_ARRAY, _, ARRAY_TYPES)
+  BOOST_PP_LIST_FOR_EACH(GET_USER, _, USER_TYPES)
+  else {
+    throw std::invalid_argument("Cannot convert C++ type to Python: " +
+                                column->type());
   }
-
-  /**
-   * Access a cell and return a corresponding Python type
-   * @param self A reference to the TableWorkspace python object that we were called on
-   * @param value A python object containing a column name or index
-   */
-  PyObject * column(ITableWorkspace &self, const bpl::object & value)
-  {
-    // Find the column and row
-    Mantid::API::Column_const_sptr column;
-    if( PyString_Check(value.ptr()) )
-    {
-      column = self.getColumn( extract<std::string>(value)());
-    }
-    else
-    {
-      column = self.getColumn(extract<int>(value)());
-    }
-    const std::type_info & typeID = column->get_type_info();
-    const int numRows = static_cast<int>(column->size());
-
-    PyObject *result = PyList_New(numRows);
-    for (int i = 0; i < numRows; i++)
-    {
-      if(PyList_SetItem(result, i, getValue(column, typeID, i)))
-        throw std::runtime_error("Error while building list");
-    }
-
-    return result;
-  }
-
-  /**
-   * Access a cell and return a corresponding Python type
-   * @param self A reference to the TableWorkspace python object that we were called on
-   * @param row An integer giving the row
-   */
-  PyObject * row(ITableWorkspace &self, int row)
-  {
-    if (row < 0)
-      throw std::invalid_argument("Cannot specify negative row number");
-    if (row >= static_cast<int>(self.rowCount()))
-      throw std::invalid_argument("Cannot specify row larger than number of rows");
-
-    int numCols = static_cast<int>(self.columnCount());
-
-    PyObject *result = PyDict_New();
-
-    for (int col = 0; col < numCols; col++)
-    {
-      Mantid::API::Column_const_sptr column = self.getColumn(col);
-      const std::type_info & typeID = column->get_type_info();
-
-      if (PyDict_SetItemString(result, column->name().c_str(), getValue(column, typeID, row)))
-        throw std::runtime_error("Error while building dict");
-    }
-
-    return result;
-  }
-
-  /**
-   * Adds a new row in the table, where the items are given in a
-   * dictionary object mapping {column name:value}
-   * @param self :: A reference to the ITableWorkspace object
-   * @param rowItems :: A dictionary defining the items in the row. It must
-   * be the same length as the number of columns or the insert will fail
-   */
-  void addRowFromDict(ITableWorkspace & self, const bpl::dict & rowItems)
-  {
-    bpl::ssize_t nitems = boost::python::len(rowItems);
-    if( nitems != static_cast<bpl::ssize_t>(self.columnCount()) )
-    {
-      throw std::invalid_argument("Number of values given does not match the number of columns. Expected: " + boost::lexical_cast<std::string>(self.columnCount()));
-    }
-    const int rowIndex = static_cast<int>(self.rowCount());
-    TableRow newRow = self.appendRow();
-    boost::python::object iter = rowItems.iteritems();
-    while(true)
-    {
-      bpl::object keyValue;
-      try
-      {
-        keyValue = iter.attr("next")();
-      }
-      catch(bpl::error_already_set&)
-      {
-        PyErr_Clear(); // Clear the raised StopIteration exception
-        break;
-      }
-      const std::string columnName = boost::python::extract<std::string>(keyValue[0]);
-      const Column_sptr column = self.getColumn(columnName);
-      try
-      {
-        setValue(column, rowIndex, keyValue[1]);
-      }
-      catch(bpl::error_already_set&)
-      {
-        std::ostringstream os;
-        os << "Incorrect type passed for \"" << columnName << "\"";
-        throw std::invalid_argument(os.str());
-      }
-    }
-  }
-
-  /**
-   * Adds a new row in the table, where the items are given in a
-   * dictionary object mapping {column name:value}
-   * @param self :: A reference to the ITableWorkspace object
-   * @param rowItems :: A dictionary defining the items in the row. It must
-   * be the same length as the number of columns or the insert will fail
-   */
-  void addRowFromList(ITableWorkspace & self, const bpl::list & rowItems)
-  {
-    bpl::ssize_t nitems = boost::python::len(rowItems);
-    if( nitems != static_cast<bpl::ssize_t>(self.columnCount()) )
-    {
-      throw std::invalid_argument("Number of values given does not match the number of columns. Expected: " + boost::lexical_cast<std::string>(self.columnCount()));
-    }
-    const int rowIndex = static_cast<int>(self.rowCount());
-    TableRow newRow = self.appendRow();
-    for(bpl::ssize_t i = 0; i < nitems; ++i)
-    {
-      const Column_sptr column = self.getColumn(i);
-      try
-      {
-        setValue(column, rowIndex, rowItems[i]);
-      }
-      catch(bpl::error_already_set&)
-      {
-        std::ostringstream os;
-        os << "Incorrect type passed for item \"" << i << "\" in list";
-        throw std::invalid_argument(os.str());
-      }
-    }
-  }
-
-  /**
-   * @param self A reference to the TableWorkspace python object that we were called on
-   * @param value A python object containing either a row index or a column name
-   * @param row_or_col An integer giving the row if value is a string or the column if value is an index
-   * @param column [Out]:: The column pointer will be stored here
-   * @param rowIndex [Out]:: The row index will be stored here
-   */
-  void getCellLoc(ITableWorkspace &self, const bpl::object & col_or_row, const int row_or_col,
-                  Column_sptr &column, int &rowIndex)
-  {
-    if( PyString_Check(col_or_row.ptr()) )
-    {
-      column = self.getColumn( extract<std::string>(col_or_row)());
-      rowIndex = row_or_col;
-    }
-    else
-    {
-      rowIndex = extract<int>(col_or_row)();
-      column = self.getColumn(row_or_col);
-    }
-  }
-
-  /**
-    * Returns an appropriate Python object for the value at the given cell
-    * @param self A reference to the TableWorkspace python object that we were called on
-    * @param value A python object containing either a row index or a column name
-    * @param row_or_col An integer giving the row if value is a string or the column if value is an index
-    */
-   PyObject * cell(ITableWorkspace &self, const bpl::object & value, int row_or_col)
-   {
-     // Find the column and row
-     Mantid::API::Column_sptr column;
-     int row(-1);
-     getCellLoc(self, value, row_or_col, column, row);
-     const std::type_info & typeID = column->get_type_info();
-     return getValue(column, typeID, row);
-   }
-
-   /**
-    * Sets the value of the given cell
-    * @param self A reference to the TableWorkspace python object that we were called on
-    * @param value A python object containing either a row index or a column name
-    * @param row_or_col An integer giving the row if value is a string or the column if value is an index
-    */
-   void setCell(ITableWorkspace &self, const bpl::object & col_or_row, const int row_or_col,
-                const bpl::object & value)
-   {
-     Mantid::API::Column_sptr column;
-     int row(-1);
-     getCellLoc(self, col_or_row, row_or_col, column, row);
-     setValue(column, row, value);
-   }
+  return result;
 }
 
-void export_ITableWorkspace()
-{
+/**
+ * Sets a value in a particular column and row from a python object
+ * @param column :: A pointer to the column object
+ * @param row :: The index of the row
+ * @param value :: The value to set
+ */
+void setValue(const Column_sptr column, const int row,
+              const bpl::object &value) {
+  const auto &typeID = column->get_type_info();
+  if (typeID == typeid(Mantid::API::Boolean)) {
+    column->cell<Mantid::API::Boolean>(row) = bpl::extract<bool>(value)();
+    return;
+  }
+
+#define SET_CELL(R, _, T)                                                      \
+  else if (strcmp(typeID.name(), typeid(T).name()) == 0) {                     \
+    column->cell<T>(row) = bpl::extract<T>(value)();                           \
+  }
+#define SET_VECTOR_CELL(R, _, T)                                               \
+  else if (typeID == typeid(T)) {                                              \
+    if (!PyArray_Check(value.ptr())) {                                         \
+      column->cell<T>(row) =                                                   \
+          Converters::PySequenceToVector<T::value_type>(value)();              \
+    } else {                                                                   \
+      column->cell<T>(row) =                                                   \
+          Converters::NDArrayToVector<T::value_type>(value)();                 \
+    }                                                                          \
+  }
+
+  // -- Use the boost preprocessor to generate a list of else if clause to cut
+  // out copy
+  // and pasted code.
+  if (false) {
+  } // So that it always falls through to the list checking
+  BOOST_PP_LIST_FOR_EACH(SET_CELL, _, BUILTIN_TYPES)
+  BOOST_PP_LIST_FOR_EACH(SET_CELL, _, USER_TYPES)
+  BOOST_PP_LIST_FOR_EACH(SET_VECTOR_CELL, _, ARRAY_TYPES)
+  else {
+    throw std::invalid_argument("Cannot convert Python type to C++: " +
+                                column->type());
+  }
+}
+
+/** Access a cell and return a corresponding Python type
+ *  @param self A reference to the TableWorkspace python object that we were
+ * called on
+ *  @param type The data type of the column to add
+ *  @param name The name of the column to add
+ *  @return A boolean indicating success or failure. Note that this is different
+ * to the
+ *          corresponding C++ method, which returns a pointer to the
+ * newly-created column
+ *          (as the Column class is not exposed to python).
+ */
+bool addColumn(ITableWorkspace &self, const std::string &type,
+               const std::string &name) {
+  return self.addColumn(type, name) != 0;
+}
+
+/**
+ * Access a cell and return a corresponding Python type
+ * @param self A reference to the TableWorkspace python object that we were
+ * called on
+ * @param value A python object containing a column name or index
+ */
+PyObject *column(ITableWorkspace &self, const bpl::object &value) {
+  // Find the column and row
+  Mantid::API::Column_const_sptr column;
+  if (PyString_Check(value.ptr())) {
+    column = self.getColumn(extract<std::string>(value)());
+  } else {
+    column = self.getColumn(extract<int>(value)());
+  }
+  const std::type_info &typeID = column->get_type_info();
+  const int numRows = static_cast<int>(column->size());
+
+  PyObject *result = PyList_New(numRows);
+  for (int i = 0; i < numRows; i++) {
+    if (PyList_SetItem(result, i, getValue(column, typeID, i)))
+      throw std::runtime_error("Error while building list");
+  }
+
+  return result;
+}
+
+/**
+ * Access a cell and return a corresponding Python type
+ * @param self A reference to the TableWorkspace python object that we were
+ * called on
+ * @param row An integer giving the row
+ */
+PyObject *row(ITableWorkspace &self, int row) {
+  if (row < 0)
+    throw std::invalid_argument("Cannot specify negative row number");
+  if (row >= static_cast<int>(self.rowCount()))
+    throw std::invalid_argument(
+        "Cannot specify row larger than number of rows");
+
+  int numCols = static_cast<int>(self.columnCount());
+
+  PyObject *result = PyDict_New();
+
+  for (int col = 0; col < numCols; col++) {
+    Mantid::API::Column_const_sptr column = self.getColumn(col);
+    const std::type_info &typeID = column->get_type_info();
+
+    if (PyDict_SetItemString(result, column->name().c_str(),
+                             getValue(column, typeID, row)))
+      throw std::runtime_error("Error while building dict");
+  }
+
+  return result;
+}
+
+/**
+ * Adds a new row in the table, where the items are given in a
+ * dictionary object mapping {column name:value}
+ * @param self :: A reference to the ITableWorkspace object
+ * @param rowItems :: A dictionary defining the items in the row. It must
+ * be the same length as the number of columns or the insert will fail
+ */
+void addRowFromDict(ITableWorkspace &self, const bpl::dict &rowItems) {
+  bpl::ssize_t nitems = boost::python::len(rowItems);
+  if (nitems != static_cast<bpl::ssize_t>(self.columnCount())) {
+    throw std::invalid_argument(
+        "Number of values given does not match the number of columns. "
+        "Expected: " +
+        boost::lexical_cast<std::string>(self.columnCount()));
+  }
+  const int rowIndex = static_cast<int>(self.rowCount());
+  TableRow newRow = self.appendRow();
+  boost::python::object iter = rowItems.iteritems();
+  while (true) {
+    bpl::object keyValue;
+    try {
+      keyValue = iter.attr("next")();
+    } catch (bpl::error_already_set &) {
+      PyErr_Clear(); // Clear the raised StopIteration exception
+      break;
+    }
+    const std::string columnName =
+        boost::python::extract<std::string>(keyValue[0]);
+    const Column_sptr column = self.getColumn(columnName);
+    try {
+      setValue(column, rowIndex, keyValue[1]);
+    } catch (bpl::error_already_set &) {
+      std::ostringstream os;
+      os << "Incorrect type passed for \"" << columnName << "\"";
+      throw std::invalid_argument(os.str());
+    }
+  }
+}
+
+/**
+ * Adds a new row in the table, where the items are given in a
+ * dictionary object mapping {column name:value}
+ * @param self :: A reference to the ITableWorkspace object
+ * @param rowItems :: A dictionary defining the items in the row. It must
+ * be the same length as the number of columns or the insert will fail
+ */
+void addRowFromList(ITableWorkspace &self, const bpl::list &rowItems) {
+  bpl::ssize_t nitems = boost::python::len(rowItems);
+  if (nitems != static_cast<bpl::ssize_t>(self.columnCount())) {
+    throw std::invalid_argument(
+        "Number of values given does not match the number of columns. "
+        "Expected: " +
+        boost::lexical_cast<std::string>(self.columnCount()));
+  }
+  const int rowIndex = static_cast<int>(self.rowCount());
+  TableRow newRow = self.appendRow();
+  for (bpl::ssize_t i = 0; i < nitems; ++i) {
+    const Column_sptr column = self.getColumn(i);
+    try {
+      setValue(column, rowIndex, rowItems[i]);
+    } catch (bpl::error_already_set &) {
+      std::ostringstream os;
+      os << "Incorrect type passed for item \"" << i << "\" in list";
+      throw std::invalid_argument(os.str());
+    }
+  }
+}
+
+/**
+ * @param self A reference to the TableWorkspace python object that we were
+ * called on
+ * @param value A python object containing either a row index or a column name
+ * @param row_or_col An integer giving the row if value is a string or the
+ * column if value is an index
+ * @param column [Out]:: The column pointer will be stored here
+ * @param rowIndex [Out]:: The row index will be stored here
+ */
+void getCellLoc(ITableWorkspace &self, const bpl::object &col_or_row,
+                const int row_or_col, Column_sptr &column, int &rowIndex) {
+  if (PyString_Check(col_or_row.ptr())) {
+    column = self.getColumn(extract<std::string>(col_or_row)());
+    rowIndex = row_or_col;
+  } else {
+    rowIndex = extract<int>(col_or_row)();
+    column = self.getColumn(row_or_col);
+  }
+}
+
+/**
+  * Returns an appropriate Python object for the value at the given cell
+  * @param self A reference to the TableWorkspace python object that we were
+ * called on
+  * @param value A python object containing either a row index or a column name
+  * @param row_or_col An integer giving the row if value is a string or the
+ * column if value is an index
+  */
+PyObject *cell(ITableWorkspace &self, const bpl::object &value,
+               int row_or_col) {
+  // Find the column and row
+  Mantid::API::Column_sptr column;
+  int row(-1);
+  getCellLoc(self, value, row_or_col, column, row);
+  const std::type_info &typeID = column->get_type_info();
+  return getValue(column, typeID, row);
+}
+
+/**
+ * Sets the value of the given cell
+ * @param self A reference to the TableWorkspace python object that we were
+ * called on
+ * @param value A python object containing either a row index or a column name
+ * @param row_or_col An integer giving the row if value is a string or the
+ * column if value is an index
+ */
+void setCell(ITableWorkspace &self, const bpl::object &col_or_row,
+             const int row_or_col, const bpl::object &value) {
+  Mantid::API::Column_sptr column;
+  int row(-1);
+  getCellLoc(self, col_or_row, row_or_col, column, row);
+  setValue(column, row, value);
+}
+}
+
+void export_ITableWorkspace() {
   using Mantid::PythonInterface::Policies::VectorToNumpy;
 
-  std::string iTableWorkspace_docstring = "Most of the information from a table workspace is returned ";
-  iTableWorkspace_docstring += "as native copies. All of the column accessors return lists while the ";
-  iTableWorkspace_docstring += "rows return dicts. This object does support the idom 'for row in ";
+  std::string iTableWorkspace_docstring =
+      "Most of the information from a table workspace is returned ";
+  iTableWorkspace_docstring +=
+      "as native copies. All of the column accessors return lists while the ";
+  iTableWorkspace_docstring +=
+      "rows return dicts. This object does support the idom 'for row in ";
   iTableWorkspace_docstring += "ITableWorkspace'.";
 
-  class_<ITableWorkspace,bases<Workspace>, boost::noncopyable>("ITableWorkspace",
-         iTableWorkspace_docstring.c_str(),
-         no_init)
-    .def("addColumn", &addColumn, (arg("type"), arg("name")),
-         "Add a named column with the given type. Recognized types are: int,float,double,bool,str,V3D,long64")
+  class_<ITableWorkspace, bases<Workspace>, boost::noncopyable>(
+      "ITableWorkspace", iTableWorkspace_docstring.c_str(), no_init)
+      .def("addColumn", &addColumn, (arg("type"), arg("name")),
+           "Add a named column with the given type. Recognized types are: "
+           "int,float,double,bool,str,V3D,long64")
 
-    .def("removeColumn", &ITableWorkspace::removeColumn, (arg("name")),
-         "Remove the named column")
+      .def("removeColumn", &ITableWorkspace::removeColumn, (arg("name")),
+           "Remove the named column")
 
-    .def("columnCount", &ITableWorkspace::columnCount,
-         "Returns the number of columns in the workspace")
+      .def("columnCount", &ITableWorkspace::columnCount,
+           "Returns the number of columns in the workspace")
 
-    .def("rowCount", &ITableWorkspace::rowCount,
-         "Returns the number of rows within the workspace")
+      .def("rowCount", &ITableWorkspace::rowCount,
+           "Returns the number of rows within the workspace")
 
-    .def("setRowCount", &ITableWorkspace::setRowCount, (arg("count")),
-         "Resize the table to contain count rows")
+      .def("setRowCount", &ITableWorkspace::setRowCount, (arg("count")),
+           "Resize the table to contain count rows")
 
-    .def("__len__",  &ITableWorkspace::rowCount, "Returns the number of rows within the workspace")
+      .def("__len__", &ITableWorkspace::rowCount,
+           "Returns the number of rows within the workspace")
 
-    .def("getColumnNames",&ITableWorkspace::getColumnNames, boost::python::return_value_policy<VectorToNumpy>(),"Return a list of the column names")
+      .def("getColumnNames", &ITableWorkspace::getColumnNames,
+           boost::python::return_value_policy<VectorToNumpy>(),
+           "Return a list of the column names")
 
-    .def("keys", &ITableWorkspace::getColumnNames, boost::python::return_value_policy<VectorToNumpy>(),  "Return a list of the column names")
+      .def("keys", &ITableWorkspace::getColumnNames,
+           boost::python::return_value_policy<VectorToNumpy>(),
+           "Return a list of the column names")
 
-    .def("column", &column, "Return all values of a specific column as a list")
+      .def("column", &column,
+           "Return all values of a specific column as a list")
 
-    .def("row", &row,
-         "Return all values of a specific row as a dict")
+      .def("row", &row, "Return all values of a specific row as a dict")
 
-    .def("addRow", &addRowFromDict,
-         "Appends a row with the values from the dictionary")
+      .def("addRow", &addRowFromDict,
+           "Appends a row with the values from the dictionary")
 
-    .def("addRow", &addRowFromList, "Appends a row with the values from the given list. "
-         "It it assumed that the items are in the correct order for the defined columns")
+      .def("addRow", &addRowFromList,
+           "Appends a row with the values from the given list. "
+           "It it assumed that the items are in the correct order for the "
+           "defined columns")
 
-    .def("cell", &cell, "Return the given cell. If the first argument is a "
-         "number then it is interpreted as a row otherwise it is interpreted as a column name")
+      .def("cell", &cell, "Return the given cell. If the first argument is a "
+                          "number then it is interpreted as a row otherwise it "
+                          "is interpreted as a column name")
 
-    .def("setCell", &setCell, "Sets the value of a given cell. If the first argument is a "
-         "number then it is interpreted as a row otherwise it is interpreted as a column name")
-      ;
+      .def("setCell", &setCell,
+           "Sets the value of a given cell. If the first argument is a "
+           "number then it is interpreted as a row otherwise it is interpreted "
+           "as a column name");
 
   //-------------------------------------------------------------------------------------------------
 
-  DataItemInterface<ITableWorkspace>()
-    .castFromID("TableWorkspace")
-  ;
+  DataItemInterface<ITableWorkspace>().castFromID("TableWorkspace");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspaceProperty.cpp
@@ -1,8 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/ITableWorkspace.h"
 
-void export_ITableWorkspaceProperty()
-{
+void export_ITableWorkspaceProperty() {
   using Mantid::API::ITableWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
   WorkspacePropertyExporter<ITableWorkspace>::define("ITableWorkspaceProperty");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/ITableWorkspace.h"
 
-// clang-format off
 void export_ITableWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::ITableWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IWorkspaceProperty.cpp
@@ -1,14 +1,13 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include <boost/python/class.hpp>
 
-void export_IWorkspaceProperty()
-{
+void export_IWorkspaceProperty() {
   using namespace boost::python;
   using Mantid::API::IWorkspaceProperty;
 
   class_<IWorkspaceProperty, boost::noncopyable>("IWorkspaceProperty", no_init)
-    .def("isOptional", &IWorkspaceProperty::isOptional, "Is the input workspace property optional")
-    .def("isLocking", &IWorkspaceProperty::isLocking, "Will the workspace be locked when starting an algorithm")
-  ;
-
+      .def("isOptional", &IWorkspaceProperty::isOptional,
+           "Is the input workspace property optional")
+      .def("isLocking", &IWorkspaceProperty::isLocking,
+           "Will the workspace be locked when starting an algorithm");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/IWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidAPI/IWorkspaceProperty.h"
 #include <boost/python/class.hpp>
 
-// clang-format off
 void export_IWorkspaceProperty()
-// clang-format on
 {
   using namespace boost::python;
   using Mantid::API::IWorkspaceProperty;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/InstrumentValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/InstrumentValidator.cpp
@@ -6,14 +6,14 @@ using namespace Mantid::API;
 using Mantid::PythonInterface::TypedValidatorExporter;
 using namespace boost::python;
 
-
 // This is typed on the ExperimentInfo class
-void export_InstrumentValidator()
-{
-  TypedValidatorExporter<ExperimentInfo_sptr>::define("ExperimentInfoValidator");
+void export_InstrumentValidator() {
+  TypedValidatorExporter<ExperimentInfo_sptr>::define(
+      "ExperimentInfoValidator");
 
-  class_<InstrumentValidator, bases<Mantid::Kernel::TypedValidator<ExperimentInfo_sptr> >,
-          boost::noncopyable
-         >("InstrumentValidator", init<>("Checks that the workspace has an instrument defined"))
-   ;
+  class_<InstrumentValidator,
+         bases<Mantid::Kernel::TypedValidator<ExperimentInfo_sptr>>,
+         boost::noncopyable>(
+      "InstrumentValidator",
+      init<>("Checks that the workspace has an instrument defined"));
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/InstrumentValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/InstrumentValidator.cpp
@@ -8,9 +8,7 @@ using namespace boost::python;
 
 
 // This is typed on the ExperimentInfo class
-// clang-format off
 void export_InstrumentValidator()
-// clang-format on
 {
   TypedValidatorExporter<ExperimentInfo_sptr>::define("ExperimentInfoValidator");
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Jacobian.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Jacobian.cpp
@@ -5,16 +5,15 @@
 using Mantid::API::Jacobian;
 using namespace boost::python;
 
-void export_Jacobian()
-{
-  register_ptr_to_python<Jacobian*>();
+void export_Jacobian() {
+  register_ptr_to_python<Jacobian *>();
 
   class_<Jacobian, boost::noncopyable>("Jacobian", no_init)
-    .def("set", &Jacobian::set, (arg("iy"),arg("ip"),arg("value")),
-         "Set an element of the Jacobian matrix where iy=index of data point, ip=index of parameter.")
+      .def("set", &Jacobian::set, (arg("iy"), arg("ip"), arg("value")),
+           "Set an element of the Jacobian matrix where iy=index of data "
+           "point, ip=index of parameter.")
 
-    .def("get", &Jacobian::get, (arg("iy"),arg("ip")),
-        "Return the given element of the Jacobian matrix where iy=index of data point, ip=index of parameter.")
-    ;
+      .def("get", &Jacobian::get, (arg("iy"), arg("ip")),
+           "Return the given element of the Jacobian matrix where iy=index of "
+           "data point, ip=index of parameter.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Jacobian.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Jacobian.cpp
@@ -5,9 +5,7 @@
 using Mantid::API::Jacobian;
 using namespace boost::python;
 
-// clang-format off
 void export_Jacobian()
-// clang-format on
 {
   register_ptr_to_python<Jacobian*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
@@ -14,90 +14,113 @@ using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 using Mantid::PythonInterface::Policies::VectorToNumpy;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Pass through method to convert a std::vector<IMDimension_sptr> to a Python list
-   * of IMDimension objects
-   * @param self The calling MDGeometry object
-   * @return A python list of objects converted from the return of self.getNonIntegratedDimensions()
-   */
-  boost::python::list getNonIntegratedDimensionsAsPyList(const MDGeometry & self)
-  {
-    auto dimensions = self.getNonIntegratedDimensions();
+namespace {
+/**
+ * Pass through method to convert a std::vector<IMDimension_sptr> to a Python
+ * list
+ * of IMDimension objects
+ * @param self The calling MDGeometry object
+ * @return A python list of objects converted from the return of
+ * self.getNonIntegratedDimensions()
+ */
+boost::python::list getNonIntegratedDimensionsAsPyList(const MDGeometry &self) {
+  auto dimensions = self.getNonIntegratedDimensions();
 
-    boost::python::list nonIntegrated;
-    for(auto it = dimensions.begin(); it != dimensions.end(); ++it)
-    {
-      nonIntegrated.append(boost::const_pointer_cast<Mantid::Geometry::IMDDimension>(*it));
-    }
-    return nonIntegrated;
+  boost::python::list nonIntegrated;
+  for (auto it = dimensions.begin(); it != dimensions.end(); ++it) {
+    nonIntegrated.append(
+        boost::const_pointer_cast<Mantid::Geometry::IMDDimension>(*it));
   }
-
+  return nonIntegrated;
+}
 }
 
-void export_MDGeometry()
-{
-  class_<MDGeometry,boost::noncopyable>("MDGeometry", no_init)
-    .def("getNumDims", &MDGeometry::getNumDims, "Returns the number of dimensions present")
+void export_MDGeometry() {
+  class_<MDGeometry, boost::noncopyable>("MDGeometry", no_init)
+      .def("getNumDims", &MDGeometry::getNumDims,
+           "Returns the number of dimensions present")
 
-    .def("getDimension", &MDGeometry::getDimension, (args("index")), return_value_policy<RemoveConstSharedPtr>(),
-         "Returns the description of the dimension at the given index (starts from 0). Raises RuntimeError if index is out of range.")
+      .def("getDimension", &MDGeometry::getDimension, (args("index")),
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the description of the dimension at the given index "
+           "(starts from 0). Raises RuntimeError if index is out of range.")
 
-    .def("getDimensionWithId", &MDGeometry::getDimensionWithId, (args("id")), return_value_policy<RemoveConstSharedPtr>(),
-         "Returns the description of the dimension with the given id string. Raises ValueError if the string is not a known id.")
+      .def("getDimensionWithId", &MDGeometry::getDimensionWithId, (args("id")),
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the description of the dimension with the given id string. "
+           "Raises ValueError if the string is not a known id.")
 
-    .def("getDimensionIndexByName", &MDGeometry::getDimensionIndexByName, (args("name")),
-         "Returns the index of the dimension with the given name. Raises RuntimeError if the name does not exist.")
+      .def("getDimensionIndexByName", &MDGeometry::getDimensionIndexByName,
+           (args("name")), "Returns the index of the dimension with the given "
+                           "name. Raises RuntimeError if the name does not "
+                           "exist.")
 
-    .def("getDimensionIndexById", &MDGeometry::getDimensionIndexById, (args("id")),
-         "Returns the index of the dimension with the given ID. Raises RuntimeError if the name does not exist.")
+      .def("getDimensionIndexById", &MDGeometry::getDimensionIndexById,
+           (args("id")), "Returns the index of the dimension with the given "
+                         "ID. Raises RuntimeError if the name does not exist.")
 
-    .def("getNonIntegratedDimensions", &getNonIntegratedDimensionsAsPyList,
-         "Returns the description objects of the non-integrated dimension as a python list of IMDDimension.")
+      .def("getNonIntegratedDimensions", &getNonIntegratedDimensionsAsPyList,
+           "Returns the description objects of the non-integrated dimension as "
+           "a python list of IMDDimension.")
 
-    .def("estimateResolution", &MDGeometry::estimateResolution, return_value_policy<VectorToNumpy>(),
-         "Returns a numpy array containing the width of the smallest bin in each dimension")
+      .def("estimateResolution", &MDGeometry::estimateResolution,
+           return_value_policy<VectorToNumpy>(),
+           "Returns a numpy array containing the width of the smallest bin in "
+           "each dimension")
 
-    .def("getXDimension", &MDGeometry::getXDimension, return_value_policy<RemoveConstSharedPtr>(),
-         "Returns the dimension description mapped to X")
+      .def("getXDimension", &MDGeometry::getXDimension,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the dimension description mapped to X")
 
-    .def("getYDimension", &MDGeometry::getYDimension, return_value_policy<RemoveConstSharedPtr>(),
-         "Returns the dimension description mapped to Y")
+      .def("getYDimension", &MDGeometry::getYDimension,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the dimension description mapped to Y")
 
-    .def("getZDimension", &MDGeometry::getZDimension, return_value_policy<RemoveConstSharedPtr>(),
-          "Returns the dimension description mapped to Z")
+      .def("getZDimension", &MDGeometry::getZDimension,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the dimension description mapped to Z")
 
-    .def("getTDimension", &MDGeometry::getTDimension, return_value_policy<RemoveConstSharedPtr>(),
-         "Returns the dimension description mapped to time")
+      .def("getTDimension", &MDGeometry::getTDimension,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the dimension description mapped to time")
 
-    .def("getGeometryXML", &MDGeometry::getGeometryXML,
-         "Returns an XML representation, as a string, of the geometry of the workspace")
+      .def("getGeometryXML", &MDGeometry::getGeometryXML,
+           "Returns an XML representation, as a string, of the geometry of the "
+           "workspace")
 
-    .def("getBasisVector", (const Mantid::Kernel::VMD & (MDGeometry::*)(size_t) const)&MDGeometry::getBasisVector,
-         (args("index")), return_value_policy<copy_const_reference>(),
-         "Returns a VMD object defining the basis vector for the specified dimension")
+      .def("getBasisVector",
+           (const Mantid::Kernel::VMD &(MDGeometry::*)(size_t) const) &
+               MDGeometry::getBasisVector,
+           (args("index")), return_value_policy<copy_const_reference>(),
+           "Returns a VMD object defining the basis vector for the specified "
+           "dimension")
 
-    .def("hasOriginalWorkspace", &MDGeometry::hasOriginalWorkspace, (args("index")),
-         "Returns True if there is a source workspace at the given index")
+      .def("hasOriginalWorkspace", &MDGeometry::hasOriginalWorkspace,
+           (args("index")),
+           "Returns True if there is a source workspace at the given index")
 
-    .def("numOriginalWorkspaces", &MDGeometry::numOriginalWorkspaces,
-         "Returns the number of source workspaces attached" )
+      .def("numOriginalWorkspaces", &MDGeometry::numOriginalWorkspaces,
+           "Returns the number of source workspaces attached")
 
-    .def("getOriginalWorkspace", &MDGeometry::getOriginalWorkspace, (args("index")), 
-          return_value_policy<ToSharedPtrWithDowncast>(),
-         "Returns the source workspace attached at the given index")
+      .def("getOriginalWorkspace", &MDGeometry::getOriginalWorkspace,
+           (args("index")), return_value_policy<ToSharedPtrWithDowncast>(),
+           "Returns the source workspace attached at the given index")
 
-    .def("getOrigin", (const Mantid::Kernel::VMD & (MDGeometry::*)() const)&MDGeometry::getOrigin,
-         return_value_policy<copy_const_reference>(),
-         "Returns the vector of the origin (in the original workspace) that corresponds to 0,0,0... in this workspace")
+      .def("getOrigin", (const Mantid::Kernel::VMD &(MDGeometry::*)() const) &
+                            MDGeometry::getOrigin,
+           return_value_policy<copy_const_reference>(),
+           "Returns the vector of the origin (in the original workspace) that "
+           "corresponds to 0,0,0... in this workspace")
 
-    .def("getNumberTransformsFromOriginal", &MDGeometry::getNumberTransformsFromOriginal,
-        "Returns the number of transformations from original workspace coordinate systems")
+      .def("getNumberTransformsFromOriginal",
+           &MDGeometry::getNumberTransformsFromOriginal,
+           "Returns the number of transformations from original workspace "
+           "coordinate systems")
 
-    .def("getNumberTransformsToOriginal", &MDGeometry::getNumberTransformsToOriginal,
-        "Returns the number of transformations to original workspace coordinate systems")
+      .def("getNumberTransformsToOriginal",
+           &MDGeometry::getNumberTransformsToOriginal,
+           "Returns the number of transformations to original workspace "
+           "coordinate systems")
 
-    ;
+      ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MDGeometry.cpp
@@ -36,9 +36,7 @@ namespace
 
 }
 
-// clang-format off
 void export_MDGeometry()
-// clang-format on
 {
   class_<MDGeometry,boost::noncopyable>("MDGeometry", no_init)
     .def("getNumDims", &MDGeometry::getNumDims, "Returns the number of dimensions present")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -22,235 +22,284 @@ namespace Converters = Mantid::PythonInterface::Converters;
 namespace Policies = Mantid::PythonInterface::Policies;
 namespace Registry = Mantid::PythonInterface::Registry;
 
-namespace
-{
-  /// Typedef for data access, i.e. dataX,Y,E members
-  typedef Mantid::MantidVec&(MatrixWorkspace::*data_modifier)(const std::size_t);
+namespace {
+/// Typedef for data access, i.e. dataX,Y,E members
+typedef Mantid::MantidVec &(MatrixWorkspace::*data_modifier)(const std::size_t);
 
-  /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::VectorRefToNumpy<Converters::WrapReadOnly> > return_readonly_numpy;
-  /// return_value_policy for read-write numpy array
-  typedef return_value_policy<Policies::VectorRefToNumpy<Converters::WrapReadWrite> > return_readwrite_numpy;
+/// return_value_policy for read-only numpy array
+typedef return_value_policy<
+    Policies::VectorRefToNumpy<Converters::WrapReadOnly>> return_readonly_numpy;
+/// return_value_policy for read-write numpy array
+typedef return_value_policy<Policies::VectorRefToNumpy<
+    Converters::WrapReadWrite>> return_readwrite_numpy;
 
-  //------------------------------- Overload macros ---------------------------
-  // Overloads for binIndexOf function which has 1 optional argument
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
-                                         MatrixWorkspace::binIndexOf, 1, 2)
+//------------------------------- Overload macros ---------------------------
+// Overloads for binIndexOf function which has 1 optional argument
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
+                                       MatrixWorkspace::binIndexOf, 1, 2)
 
-  /**
-   * Set the values from an python array-style object into the given spectrum in the workspace
-   * @param self :: A reference to the calling object
-   * @param accessor :: A member-function pointer to the data{X,Y,E} member that will extract the writable values.
-   * @param wsIndex :: The workspace index for the spectrum to set
-   * @param values :: A numpy array. The length must match the size of the
-   */
-  void setSpectrumFromPyObject(MatrixWorkspace & self, data_modifier accessor,
-                               const size_t wsIndex, numeric::array values)
-  {
-    boost::python::tuple shape(values.attr("shape"));
-    if( boost::python::len(shape) != 1 )
-    {
-      throw std::invalid_argument("Invalid shape for setting 1D spectrum array, array is "
-          + boost::lexical_cast<std::string>(boost::python::len(shape)) + "D");
-    }
-    const size_t pyArrayLength = boost::python::extract<size_t>(shape[0]);
-    Mantid::MantidVec & wsArrayRef = (self.*accessor)(wsIndex);
-    const size_t wsArrayLength = wsArrayRef.size();
-
-    if(pyArrayLength != wsArrayLength)
-    {
-      throw std::invalid_argument("Length mismatch between workspace array & python array. ws="
-            + boost::lexical_cast<std::string>(wsArrayLength) + ", python=" + boost::lexical_cast<std::string>(pyArrayLength));
-    }
-    for(size_t i = 0; i < wsArrayLength; ++i)
-    {
-      wsArrayRef[i] = extract<double>(values[i]);
-    }
+/**
+ * Set the values from an python array-style object into the given spectrum in
+ * the workspace
+ * @param self :: A reference to the calling object
+ * @param accessor :: A member-function pointer to the data{X,Y,E} member that
+ * will extract the writable values.
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the
+ */
+void setSpectrumFromPyObject(MatrixWorkspace &self, data_modifier accessor,
+                             const size_t wsIndex, numeric::array values) {
+  boost::python::tuple shape(values.attr("shape"));
+  if (boost::python::len(shape) != 1) {
+    throw std::invalid_argument(
+        "Invalid shape for setting 1D spectrum array, array is " +
+        boost::lexical_cast<std::string>(boost::python::len(shape)) + "D");
   }
+  const size_t pyArrayLength = boost::python::extract<size_t>(shape[0]);
+  Mantid::MantidVec &wsArrayRef = (self.*accessor)(wsIndex);
+  const size_t wsArrayLength = wsArrayRef.size();
 
-
-  /**
-   * Set the X values from an python array-style object
-   * @param self :: A reference to the calling object
-   * @param wsIndex :: The workspace index for the spectrum to set
-   * @param values :: A numpy array. The length must match the size of the
-   */
-  void setXFromPyObject(MatrixWorkspace & self, const size_t wsIndex, numeric::array values)
-  {
-    setSpectrumFromPyObject(self, &MatrixWorkspace::dataX, wsIndex, values);
+  if (pyArrayLength != wsArrayLength) {
+    throw std::invalid_argument(
+        "Length mismatch between workspace array & python array. ws=" +
+        boost::lexical_cast<std::string>(wsArrayLength) + ", python=" +
+        boost::lexical_cast<std::string>(pyArrayLength));
   }
-
-  /**
-   * Set the Y values from an python array-style object
-   * @param self :: A reference to the calling object
-   * @param wsIndex :: The workspace index for the spectrum to set
-   * @param values :: A numpy array. The length must match the size of the
-   */
-  void setYFromPyObject(MatrixWorkspace & self, const size_t wsIndex, numeric::array values)
-  {
-    setSpectrumFromPyObject(self, &MatrixWorkspace::dataY, wsIndex, values);
+  for (size_t i = 0; i < wsArrayLength; ++i) {
+    wsArrayRef[i] = extract<double>(values[i]);
   }
+}
 
-  /**
-   * Set the E values from an python array-style object
-   * @param self :: A reference to the calling object
-   * @param wsIndex :: The workspace index for the spectrum to set
-   * @param values :: A numpy array. The length must match the size of the
-   */
-  void setEFromPyObject(MatrixWorkspace & self, const size_t wsIndex, numeric::array values)
-  {
-    setSpectrumFromPyObject(self, &MatrixWorkspace::dataE, wsIndex, values);
-  }
+/**
+ * Set the X values from an python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the
+ */
+void setXFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
+                      numeric::array values) {
+  setSpectrumFromPyObject(self, &MatrixWorkspace::dataX, wsIndex, values);
+}
 
-  /**
-   * Adds a deprecation warning to the getNumberBins call to warn about using blocksize instead
-   * @param self A reference to the calling object
-   * @returns The blocksize()
-   */
-  size_t getNumberBinsDeprecated(MatrixWorkspace & self)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, "'getNumberBins' is deprecated, use 'blocksize' instead.");
-    return self.blocksize();
-  }
+/**
+ * Set the Y values from an python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the
+ */
+void setYFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
+                      numeric::array values) {
+  setSpectrumFromPyObject(self, &MatrixWorkspace::dataY, wsIndex, values);
+}
 
-  /**
-   * Adds a deprecation warning to the getSampleDetails call to warn about using getRun instead
-   * @param self A reference to the calling object
-   * @returns getRun()
-   */
-  Mantid::API::Run & getSampleDetailsDeprecated(MatrixWorkspace & self)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, "'getSampleDetails' is deprecated, use 'getRun' instead.");
-    return self.mutableRun();
-  }
+/**
+ * Set the E values from an python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the
+ */
+void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
+                      numeric::array values) {
+  setSpectrumFromPyObject(self, &MatrixWorkspace::dataE, wsIndex, values);
+}
 
+/**
+ * Adds a deprecation warning to the getNumberBins call to warn about using
+ * blocksize instead
+ * @param self A reference to the calling object
+ * @returns The blocksize()
+ */
+size_t getNumberBinsDeprecated(MatrixWorkspace &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "'getNumberBins' is deprecated, use 'blocksize' instead.");
+  return self.blocksize();
+}
+
+/**
+ * Adds a deprecation warning to the getSampleDetails call to warn about using
+ * getRun instead
+ * @param self A reference to the calling object
+ * @returns getRun()
+ */
+Mantid::API::Run &getSampleDetailsDeprecated(MatrixWorkspace &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "'getSampleDetails' is deprecated, use 'getRun' instead.");
+  return self.mutableRun();
+}
 }
 
 /** Python exports of the Mantid::API::MatrixWorkspace class. */
-void export_MatrixWorkspace()
-{
-  /// Typedef to remove const qualifier on input detector shared_ptr. See Policies/RemoveConst.h for more details
-  typedef double (MatrixWorkspace::*getDetectorSignature)(Mantid::Geometry::IDetector_sptr det) const;
+void export_MatrixWorkspace() {
+  /// Typedef to remove const qualifier on input detector shared_ptr. See
+  /// Policies/RemoveConst.h for more details
+  typedef double (MatrixWorkspace::*getDetectorSignature)(
+      Mantid::Geometry::IDetector_sptr det) const;
 
-  class_<MatrixWorkspace, boost::python::bases<ExperimentInfo,IMDWorkspace>, boost::noncopyable>("MatrixWorkspace", no_init)
-    //--------------------------------------- Meta information -----------------------------------------------------------------------
-    .def("blocksize", &MatrixWorkspace::blocksize, args("self"), "Returns size of the Y data array")
-    .def("getNumberHistograms", &MatrixWorkspace::getNumberHistograms, args("self"), 
-         "Returns the number of spectra in the workspace")
-    .def("binIndexOf", &MatrixWorkspace::binIndexOf,
-          MatrixWorkspace_binIndexOfOverloads((arg("self"), arg("xvalue"), arg("workspaceIndex")),
-         "Returns the index of the bin containing the given xvalue. The workspace_index is optional [default=0]"))
-    .def("detectorTwoTheta", (getDetectorSignature)&MatrixWorkspace::detectorTwoTheta,
-         args("self", "det"),
-         "Returns the two theta value for a given detector")
-    .def("detectorSignedTwoTheta",(getDetectorSignature)&MatrixWorkspace::detectorSignedTwoTheta,
-         args("self", "det"),
-         "Returns the signed two theta value for given detector")
-    .def("getSpectrum", (ISpectrum * (MatrixWorkspace::*)(const size_t))&MatrixWorkspace::getSpectrum,
-         return_internal_reference<>(), args("self", "workspaceIndex"), 
-         "Return the spectra at the given workspace index.")
-    .def("getIndexFromSpectrumNumber",&MatrixWorkspace::getIndexFromSpectrumNumber,args("self"),
-          "Returns workspace index correspondent to the given spectrum number. Throws if no such spectrum is present in the workspace")
-    .def("getDetector", &MatrixWorkspace::getDetector, return_value_policy<Policies::RemoveConstSharedPtr>(),
-        args("self", "workspaceIndex"), 
-         "Return the Detector or DetectorGroup that is linked to the given workspace index")
-    .def("getRun", &MatrixWorkspace::mutableRun, return_internal_reference<>(),
-             args("self"), "Return the Run object for this workspace")
-    .def("axes", &MatrixWorkspace::axes, args("self"), "Returns the number of axes attached to the workspace")
-    .def("getAxis", &MatrixWorkspace::getAxis, return_internal_reference<>(), args("self", "axis_index"))
-    .def("isHistogramData", &MatrixWorkspace::isHistogramData, args("self"), 
-         "Returns True if this is considered to be binned data.")
-    .def("isDistribution", (const bool& (MatrixWorkspace::*)() const)&MatrixWorkspace::isDistribution,
-         return_value_policy<copy_const_reference>(), args("self"), "Returns the status of the distribution flag")
-    .def("YUnit", &MatrixWorkspace::YUnit, args("self"), 
-         "Returns the current Y unit for the data (Y axis) in the workspace")
-    .def("YUnitLabel", &MatrixWorkspace::YUnitLabel, args("self"), "Returns the caption for the Y axis")
+  class_<MatrixWorkspace, boost::python::bases<ExperimentInfo, IMDWorkspace>,
+         boost::noncopyable>("MatrixWorkspace", no_init)
+      //--------------------------------------- Meta information
+      //-----------------------------------------------------------------------
+      .def("blocksize", &MatrixWorkspace::blocksize, args("self"),
+           "Returns size of the Y data array")
+      .def("getNumberHistograms", &MatrixWorkspace::getNumberHistograms,
+           args("self"), "Returns the number of spectra in the workspace")
+      .def("binIndexOf", &MatrixWorkspace::binIndexOf,
+           MatrixWorkspace_binIndexOfOverloads(
+               (arg("self"), arg("xvalue"), arg("workspaceIndex")),
+               "Returns the index of the bin containing the given xvalue. The "
+               "workspace_index is optional [default=0]"))
+      .def("detectorTwoTheta",
+           (getDetectorSignature)&MatrixWorkspace::detectorTwoTheta,
+           args("self", "det"),
+           "Returns the two theta value for a given detector")
+      .def("detectorSignedTwoTheta",
+           (getDetectorSignature)&MatrixWorkspace::detectorSignedTwoTheta,
+           args("self", "det"),
+           "Returns the signed two theta value for given detector")
+      .def("getSpectrum", (ISpectrum * (MatrixWorkspace::*)(const size_t)) &
+                              MatrixWorkspace::getSpectrum,
+           return_internal_reference<>(), args("self", "workspaceIndex"),
+           "Return the spectra at the given workspace index.")
+      .def("getIndexFromSpectrumNumber",
+           &MatrixWorkspace::getIndexFromSpectrumNumber, args("self"),
+           "Returns workspace index correspondent to the given spectrum "
+           "number. Throws if no such spectrum is present in the workspace")
+      .def("getDetector", &MatrixWorkspace::getDetector,
+           return_value_policy<Policies::RemoveConstSharedPtr>(),
+           args("self", "workspaceIndex"), "Return the Detector or "
+                                           "DetectorGroup that is linked to "
+                                           "the given workspace index")
+      .def("getRun", &MatrixWorkspace::mutableRun,
+           return_internal_reference<>(), args("self"),
+           "Return the Run object for this workspace")
+      .def("axes", &MatrixWorkspace::axes, args("self"),
+           "Returns the number of axes attached to the workspace")
+      .def("getAxis", &MatrixWorkspace::getAxis, return_internal_reference<>(),
+           args("self", "axis_index"))
+      .def("isHistogramData", &MatrixWorkspace::isHistogramData, args("self"),
+           "Returns True if this is considered to be binned data.")
+      .def("isDistribution", (const bool &(MatrixWorkspace::*)() const) &
+                                 MatrixWorkspace::isDistribution,
+           return_value_policy<copy_const_reference>(), args("self"),
+           "Returns the status of the distribution flag")
+      .def("YUnit", &MatrixWorkspace::YUnit, args("self"),
+           "Returns the current Y unit for the data (Y axis) in the workspace")
+      .def("YUnitLabel", &MatrixWorkspace::YUnitLabel, args("self"),
+           "Returns the caption for the Y axis")
 
-    // Deprecated
-    .def("getNumberBins", &getNumberBinsDeprecated, args("self"), 
-         "Returns size of the Y data array (deprecated, use blocksize instead)")
-    .def("getSampleDetails", &getSampleDetailsDeprecated, return_internal_reference<>(), args("self"), 
-         "Return the Run object for this workspace (deprecated, use getRun instead)")
+      // Deprecated
+      .def("getNumberBins", &getNumberBinsDeprecated, args("self"),
+           "Returns size of the Y data array (deprecated, use blocksize "
+           "instead)")
+      .def("getSampleDetails", &getSampleDetailsDeprecated,
+           return_internal_reference<>(), args("self"),
+           "Return the Run object for this workspace (deprecated, use getRun "
+           "instead)")
 
-    //--------------------------------------- Setters ------------------------------------
-    .def("setYUnitLabel", &MatrixWorkspace::setYUnitLabel, args("self", "newLabel"), 
-         "Sets a new caption for the data (Y axis) in the workspace")
-    .def("setYUnit", &MatrixWorkspace::setYUnit, args("self", "newUnit"), 
-         "Sets a new unit for the data (Y axis) in the workspace")
-    .def("setDistribution", (bool& (MatrixWorkspace::*)(const bool))&MatrixWorkspace::isDistribution,
-         return_value_policy<return_by_value>(), args("self", "newVal"), 
-         "Set distribution flag. If True the workspace has been divided by the bin-width.")
-    .def("replaceAxis", &MatrixWorkspace::replaceAxis, args("self", "axisIndex", "newAxis"))
+      //--------------------------------------- Setters
+      //------------------------------------
+      .def("setYUnitLabel", &MatrixWorkspace::setYUnitLabel,
+           args("self", "newLabel"),
+           "Sets a new caption for the data (Y axis) in the workspace")
+      .def("setYUnit", &MatrixWorkspace::setYUnit, args("self", "newUnit"),
+           "Sets a new unit for the data (Y axis) in the workspace")
+      .def("setDistribution", (bool &(MatrixWorkspace::*)(const bool)) &
+                                  MatrixWorkspace::isDistribution,
+           return_value_policy<return_by_value>(), args("self", "newVal"),
+           "Set distribution flag. If True the workspace has been divided by "
+           "the bin-width.")
+      .def("replaceAxis", &MatrixWorkspace::replaceAxis,
+           args("self", "axisIndex", "newAxis"))
 
-    //--------------------------------------- Read spectrum data -------------------------
-    .def("readX", &MatrixWorkspace::readX, return_readonly_numpy(),
-          args("self", "workspaceIndex"), 
-         "Creates a read-only numpy wrapper around the original X data at the given index")
-    .def("readY", &MatrixWorkspace::readY, return_readonly_numpy(),
-         args("self", "workspaceIndex"),  
-         "Creates a read-only numpy wrapper around the original Y data at the given index")
-    .def("readE", &MatrixWorkspace::readE, return_readonly_numpy(),
-          args("self", "workspaceIndex"), 
-         "Creates a read-only numpy wrapper around the original E data at the given index")
-    .def("readDx", &MatrixWorkspace::readDx, return_readonly_numpy(),
-         args("self", "workspaceIndex"), 
-         "Creates a read-only numpy wrapper around the original Dx data at the given index")
+      //--------------------------------------- Read spectrum data
+      //-------------------------
+      .def("readX", &MatrixWorkspace::readX, return_readonly_numpy(),
+           args("self", "workspaceIndex"), "Creates a read-only numpy wrapper "
+                                           "around the original X data at the "
+                                           "given index")
+      .def("readY", &MatrixWorkspace::readY, return_readonly_numpy(),
+           args("self", "workspaceIndex"), "Creates a read-only numpy wrapper "
+                                           "around the original Y data at the "
+                                           "given index")
+      .def("readE", &MatrixWorkspace::readE, return_readonly_numpy(),
+           args("self", "workspaceIndex"), "Creates a read-only numpy wrapper "
+                                           "around the original E data at the "
+                                           "given index")
+      .def("readDx", &MatrixWorkspace::readDx, return_readonly_numpy(),
+           args("self", "workspaceIndex"), "Creates a read-only numpy wrapper "
+                                           "around the original Dx data at the "
+                                           "given index")
 
-    //--------------------------------------- Write spectrum data ------------------------
-    .def("dataX", (data_modifier)&MatrixWorkspace::dataX, return_readwrite_numpy(),
-         args("self", "workspaceIndex"), 
-         "Creates a writable numpy wrapper around the original X data at the given index")
-    .def("dataY", (data_modifier)&MatrixWorkspace::dataY, return_readwrite_numpy(),
-         args("self", "workspaceIndex"), 
-         "Creates a writable numpy wrapper around the original Y data at the given index")
-    .def("dataE", (data_modifier)&MatrixWorkspace::dataE, return_readwrite_numpy(),
-         args("self", "workspaceIndex"), 
-         "Creates a writable numpy wrapper around the original E data at the given index")
-    .def("dataDx", (data_modifier)&MatrixWorkspace::dataDx, return_readwrite_numpy(),
-        args("self", "workspaceIndex"), 
-         "Creates a writable numpy wrapper around the original Dx data at the given index")
-    .def("setX", &setXFromPyObject, args("self", "workspaceIndex", "x"), 
-         "Set X values from a python list or numpy array. It performs a simple copy into the array.")
-    .def("setY", &setYFromPyObject, args("self", "workspaceIndex", "y"), 
-         "Set Y values from a python list or numpy array. It performs a simple copy into the array.")
-    .def("setE", &setEFromPyObject, args("self", "workspaceIndex", "e"), 
-         "Set E values from a python list or numpy array. It performs a simple copy into the array.")
+      //--------------------------------------- Write spectrum data
+      //------------------------
+      .def("dataX", (data_modifier)&MatrixWorkspace::dataX,
+           return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the original X data at the "
+           "given index")
+      .def("dataY", (data_modifier)&MatrixWorkspace::dataY,
+           return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the original Y data at the "
+           "given index")
+      .def("dataE", (data_modifier)&MatrixWorkspace::dataE,
+           return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the original E data at the "
+           "given index")
+      .def("dataDx", (data_modifier)&MatrixWorkspace::dataDx,
+           return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the original Dx data at "
+           "the given index")
+      .def("setX", &setXFromPyObject, args("self", "workspaceIndex", "x"),
+           "Set X values from a python list or numpy array. It performs a "
+           "simple copy into the array.")
+      .def("setY", &setYFromPyObject, args("self", "workspaceIndex", "y"),
+           "Set Y values from a python list or numpy array. It performs a "
+           "simple copy into the array.")
+      .def("setE", &setEFromPyObject, args("self", "workspaceIndex", "e"),
+           "Set E values from a python list or numpy array. It performs a "
+           "simple copy into the array.")
 
-    // --------------------------------------- Extract data ------------------------------
-    .def("extractX", Mantid::PythonInterface::cloneX, args("self"),
-         "Extracts (copies) the X data from the workspace into a 2D numpy array. "
-         "Note: This can fail for large workspaces as numpy will require a block "
-         "of memory free that will fit all of the data.")
-    .def("extractY", Mantid::PythonInterface::cloneY, args("self"),
-         "Extracts (copies) the Y data from the workspace into a 2D numpy array. "
-         "Note: This can fail for large workspaces as numpy will require a block "
-         "of memory free that will fit all of the data.")
-    .def("extractE", Mantid::PythonInterface::cloneE, args("self"),
-         "Extracts (copies) the E data from the workspace into a 2D numpy array. "
-         "Note: This can fail for large workspaces as numpy will require a block "
-         "of memory free that will fit all of the data.")
-    .def("extractDx", Mantid::PythonInterface::cloneDx, args("self"),
-         "Extracts (copies) the E data from the workspace into a 2D numpy array. "
-         "Note: This can fail for large workspaces as numpy will require a block "
-          "of memory free that will fit all of the data.")
-    //-------------------------------------- Operators -----------------------------------
-    .def("equals", &Mantid::API::equals, args("self", "other", "tolerance"), 
-         "Performs a comparison operation on two workspaces, using the "
-         "CheckWorkspacesMatch algorithm")
-    ;
-  
+      // --------------------------------------- Extract data
+      // ------------------------------
+      .def("extractX", Mantid::PythonInterface::cloneX, args("self"),
+           "Extracts (copies) the X data from the workspace into a 2D numpy "
+           "array. "
+           "Note: This can fail for large workspaces as numpy will require a "
+           "block "
+           "of memory free that will fit all of the data.")
+      .def("extractY", Mantid::PythonInterface::cloneY, args("self"),
+           "Extracts (copies) the Y data from the workspace into a 2D numpy "
+           "array. "
+           "Note: This can fail for large workspaces as numpy will require a "
+           "block "
+           "of memory free that will fit all of the data.")
+      .def("extractE", Mantid::PythonInterface::cloneE, args("self"),
+           "Extracts (copies) the E data from the workspace into a 2D numpy "
+           "array. "
+           "Note: This can fail for large workspaces as numpy will require a "
+           "block "
+           "of memory free that will fit all of the data.")
+      .def("extractDx", Mantid::PythonInterface::cloneDx, args("self"),
+           "Extracts (copies) the E data from the workspace into a 2D numpy "
+           "array. "
+           "Note: This can fail for large workspaces as numpy will require a "
+           "block "
+           "of memory free that will fit all of the data.")
+      //-------------------------------------- Operators
+      //-----------------------------------
+      .def("equals", &Mantid::API::equals, args("self", "other", "tolerance"),
+           "Performs a comparison operation on two workspaces, using the "
+           "CheckWorkspacesMatch algorithm");
+
   //-------------------------------------------------------------------------------------------------
 
   static const int NUM_IDS = 7;
-  static const char * WORKSPACE_IDS[NUM_IDS] = {\
-      "GroupingWorkspace", "MaskWorkspace", "OffsetsWorkspace",
-      "RebinnedOutput", "SpecialWorkspace2D", "Workspace2D", "WorkspaceSingleValue"
-  };
+  static const char *WORKSPACE_IDS[NUM_IDS] = {
+      "GroupingWorkspace",   "MaskWorkspace",      "OffsetsWorkspace",
+      "RebinnedOutput",      "SpecialWorkspace2D", "Workspace2D",
+      "WorkspaceSingleValue"};
 
   Registry::DataItemInterface<MatrixWorkspace> entry;
-  for(int i = 0; i < NUM_IDS; ++i)
-  {
+  for (int i = 0; i < NUM_IDS; ++i) {
     entry.castFromID(WORKSPACE_IDS[i]);
-  }
-  ;
+  };
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -127,9 +127,7 @@ namespace
 }
 
 /** Python exports of the Mantid::API::MatrixWorkspace class. */
-// clang-format off
 void export_MatrixWorkspace()
-// clang-format on
 {
   /// Typedef to remove const qualifier on input detector shared_ptr. See Policies/RemoveConst.h for more details
   typedef double (MatrixWorkspace::*getDetectorSignature)(Mantid::Geometry::IDetector_sptr det) const;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspaceProperty.cpp
@@ -1,8 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-void export_MatrixWorkspaceProperty()
-{
+void export_MatrixWorkspaceProperty() {
   using Mantid::API::MatrixWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
   WorkspacePropertyExporter<MatrixWorkspace>::define("MatrixWorkspaceProperty");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspaceProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-// clang-format off
 void export_MatrixWorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::MatrixWorkspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
@@ -6,13 +6,14 @@ using Mantid::API::MultipleExperimentInfos;
 using Mantid::API::ExperimentInfo_sptr;
 using namespace boost::python;
 
-void export_MultipleExperimentInfos()
-{
-  class_<MultipleExperimentInfos,boost::noncopyable>("MultipleExperimentInfos", no_init)
-      .def("getExperimentInfo", (ExperimentInfo_sptr(MultipleExperimentInfos::*)(const uint16_t) ) &MultipleExperimentInfos::getExperimentInfo,
+void export_MultipleExperimentInfos() {
+  class_<MultipleExperimentInfos, boost::noncopyable>("MultipleExperimentInfos",
+                                                      no_init)
+      .def("getExperimentInfo",
+           (ExperimentInfo_sptr (MultipleExperimentInfos::*)(const uint16_t)) &
+               MultipleExperimentInfos::getExperimentInfo,
            "Return the experiment info at the given index.")
-      .def("getNumExperimentInfo", &MultipleExperimentInfos::getNumExperimentInfo,
-           "Return the number of experiment info objects,")
-    ;
+      .def("getNumExperimentInfo",
+           &MultipleExperimentInfos::getNumExperimentInfo,
+           "Return the number of experiment info objects,");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
@@ -6,9 +6,7 @@ using Mantid::API::MultipleExperimentInfos;
 using Mantid::API::ExperimentInfo_sptr;
 using namespace boost::python;
 
-// clang-format off
 void export_MultipleExperimentInfos()
-// clang-format on
 {
   class_<MultipleExperimentInfos,boost::noncopyable>("MultipleExperimentInfos", no_init)
       .def("getExperimentInfo", (ExperimentInfo_sptr(MultipleExperimentInfos::*)(const uint16_t) ) &MultipleExperimentInfos::getExperimentInfo,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
@@ -9,60 +9,55 @@ using Mantid::Kernel::PropertyWithValue;
 using Mantid::PythonInterface::PropertyWithValueExporter;
 using namespace boost::python;
 
-namespace
-{
-  /// The PropertyWithValue type
-  typedef std::vector<std::vector<std::string> > HeldType;
+namespace {
+/// The PropertyWithValue type
+typedef std::vector<std::vector<std::string>> HeldType;
 
-  /**
-   * Converts the value from a MultipleFileProperty to a python object rather than using a vector
-   * @param self :: A reference to the calling object
-   * @returns A string is there is only a single string in the Property's value, and a list if there are multiple ones
-   */
-  boost::python::object valueAsPyObject(MultipleFileProperty & self)
+/**
+ * Converts the value from a MultipleFileProperty to a python object rather than
+ * using a vector
+ * @param self :: A reference to the calling object
+ * @returns A string is there is only a single string in the Property's value,
+ * and a list if there are multiple ones
+ */
+boost::python::object valueAsPyObject(MultipleFileProperty &self) {
+  const HeldType &propValue = self();
+  boost::python::object result;
+  if (propValue.size() == 1 &&
+      propValue[0].size() == 1) // Special case, unwrap the vector
   {
-    const HeldType & propValue = self();
-    boost::python::object result;
-    if(propValue.size() == 1 && propValue[0].size() == 1) // Special case, unwrap the vector
-    {
-      result = boost::python::str(propValue[0][0]);
-    }
-    else
-    {
-      // Build a list of lists to mimic the behaviour of MultipleFileProperty
-      boost::python::list fileList;
-      for(auto outerItr = propValue.begin(); outerItr != propValue.end(); ++outerItr)
-      {
-        const std::vector<std::string> & filenames = *outerItr;
-        if(filenames.size() == 1)
-        {
-          fileList.append(filenames.front());
+    result = boost::python::str(propValue[0][0]);
+  } else {
+    // Build a list of lists to mimic the behaviour of MultipleFileProperty
+    boost::python::list fileList;
+    for (auto outerItr = propValue.begin(); outerItr != propValue.end();
+         ++outerItr) {
+      const std::vector<std::string> &filenames = *outerItr;
+      if (filenames.size() == 1) {
+        fileList.append(filenames.front());
+      } else {
+        boost::python::list groupList;
+        for (auto innerItr = filenames.begin(); innerItr != filenames.end();
+             ++innerItr) {
+          groupList.append(*innerItr);
         }
-        else
-        {
-          boost::python::list groupList;
-          for(auto innerItr = filenames.begin(); innerItr != filenames.end(); ++innerItr)
-          {
-            groupList.append(*innerItr);
-          }
-          fileList.append(groupList);
-        }
+        fileList.append(groupList);
       }
-      result = fileList;
     }
-
-    return result;
+    result = fileList;
   }
+
+  return result;
+}
 }
 
-void export_MultipleFileProperty()
-{
+void export_MultipleFileProperty() {
   typedef PropertyWithValue<HeldType> BaseClass;
-  PropertyWithValueExporter<HeldType>::define("VectorVectorStringPropertyWithValue");
+  PropertyWithValueExporter<HeldType>::define(
+      "VectorVectorStringPropertyWithValue");
 
-  class_<MultipleFileProperty, bases<BaseClass>, boost::noncopyable>("MultipleFileProperty", no_init)
-    // Override the base class one to do something more appropriate
-    .add_property("value", &valueAsPyObject)
-  ;
+  class_<MultipleFileProperty, bases<BaseClass>, boost::noncopyable>(
+      "MultipleFileProperty", no_init)
+      // Override the base class one to do something more appropriate
+      .add_property("value", &valueAsPyObject);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
@@ -55,9 +55,7 @@ namespace
   }
 }
 
-// clang-format off
 void export_MultipleFileProperty()
-// clang-format on
 {
   typedef PropertyWithValue<HeldType> BaseClass;
   PropertyWithValueExporter<HeldType>::define("VectorVectorStringPropertyWithValue");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Progress.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Progress.cpp
@@ -9,15 +9,12 @@ using Mantid::API::Algorithm;
 using Mantid::Kernel::ProgressBase;
 using namespace boost::python;
 
-void export_Progress()
-{
-  class_<Progress,
-         bases<ProgressBase>,
-         boost::noncopyable>("Progress",
-                             "Make a Progress object that is attached to the given algorithm, "
-                             "with progress between fractions [start,end] notifying a total of nreports times",
-                             init<Algorithm*,double,double,size_t>((arg("alg"),arg("start"),arg("end"),arg("nreports")))
-                            )
-    ;
+void export_Progress() {
+  class_<Progress, bases<ProgressBase>, boost::noncopyable>(
+      "Progress",
+      "Make a Progress object that is attached to the given algorithm, "
+      "with progress between fractions [start,end] notifying a total of "
+      "nreports times",
+      init<Algorithm *, double, double, size_t>(
+          (arg("alg"), arg("start"), arg("end"), arg("nreports"))));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Progress.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Progress.cpp
@@ -9,9 +9,7 @@ using Mantid::API::Algorithm;
 using Mantid::Kernel::ProgressBase;
 using namespace boost::python;
 
-// clang-format off
 void export_Progress()
-// clang-format on
 {
   class_<Progress,
          bases<ProgressBase>,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -15,9 +15,7 @@ using namespace Mantid::API;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
-// clang-format off
 GCC_DIAG_OFF(strict-aliasing)
-// clang-format on
 
 namespace {
 std::string getUnit(Projection &p, size_t nd) {
@@ -100,9 +98,7 @@ Projection_sptr projCtor3(
 
 } //anonymous namespace
 
-// clang-format off
 void export_Projection()
-// clang-format on
 {
   class_<Projection>(
     "Projection",

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -15,7 +15,9 @@ using namespace Mantid::API;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
+// clang-format off
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 
 namespace {
 std::string getUnit(Projection &p, size_t nd) {

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -31,52 +31,55 @@ void setUnit(Projection &p, size_t nd, std::string unit) {
     throw std::runtime_error("Invalid unit");
 }
 
-//This is a bit strange, but it works. The users want x = proj.createWorkspace()
-//to behave like the simpleapi, i.e. put a workspace named 'x' into the ADS for
-//them. To do that kind of black magic we have to introspect from the Python
-//side, so that's what we do.
+// This is a bit strange, but it works. The users want x =
+// proj.createWorkspace()
+// to behave like the simpleapi, i.e. put a workspace named 'x' into the ADS for
+// them. To do that kind of black magic we have to introspect from the Python
+// side, so that's what we do.
 object createWorkspace() {
-  //Create a namespace for us to add a function to
+  // Create a namespace for us to add a function to
   object main = import("__main__");
   object global(main.attr("__dict__"));
-  //Add a function to the namespace
+  // Add a function to the namespace
   object result = exec(
-   "def createWorkspace(proj, OutputWorkspace=None):\n"
-   "  '''Create a TableWorkspace using this projection'''\n"
-   "  import inspect\n"
-   "  from mantid import api, kernel\n"
-   "  ws = api.WorkspaceFactory.createTable('TableWorkspace')\n"
-   "  ws.addColumn('str', 'name')\n"
-   "  ws.addColumn('V3D', 'value')\n"
-   "  ws.addColumn('str', 'type')\n"
-   "  ws.addColumn('double', 'offset')\n"
-   "  for (name, i) in zip('uvw', range(3)):\n"
-   "    ws.addRow({\n"
-   "              'name': name,\n"
-   "              'value': proj.getAxis(i),\n"
-   "              'type': proj.getType(i),\n"
-   "              'offset': proj.getOffset(i)\n"
-   "              })\n"
+      "def createWorkspace(proj, OutputWorkspace=None):\n"
+      "  '''Create a TableWorkspace using this projection'''\n"
+      "  import inspect\n"
+      "  from mantid import api, kernel\n"
+      "  ws = api.WorkspaceFactory.createTable('TableWorkspace')\n"
+      "  ws.addColumn('str', 'name')\n"
+      "  ws.addColumn('V3D', 'value')\n"
+      "  ws.addColumn('str', 'type')\n"
+      "  ws.addColumn('double', 'offset')\n"
+      "  for (name, i) in zip('uvw', range(3)):\n"
+      "    ws.addRow({\n"
+      "              'name': name,\n"
+      "              'value': proj.getAxis(i),\n"
+      "              'type': proj.getType(i),\n"
+      "              'offset': proj.getOffset(i)\n"
+      "              })\n"
 
-   "  if OutputWorkspace is None:\n"
-   "    lhs = kernel.funcreturns.process_frame(inspect.currentframe().f_back)\n"
-   "    if lhs[0] > 0:\n"
-   "      OutputWorkspace = lhs[1][0]\n"
-   "    else:\n"
-   "      raise RuntimeError('createWorkspace failed to infer a name for its"
-                             " output projection workspace. Please pass an"
-                             " OutputWorkspace parameter to it.')\n"
-   "  if OutputWorkspace:\n"
-   "    mtd[OutputWorkspace] = ws\n"
+      "  if OutputWorkspace is None:\n"
+      "    lhs = "
+      "kernel.funcreturns.process_frame(inspect.currentframe().f_back)\n"
+      "    if lhs[0] > 0:\n"
+      "      OutputWorkspace = lhs[1][0]\n"
+      "    else:\n"
+      "      raise RuntimeError('createWorkspace failed to infer a name for its"
+      " output projection workspace. Please pass an"
+      " OutputWorkspace parameter to it.')\n"
+      "  if OutputWorkspace:\n"
+      "    mtd[OutputWorkspace] = ws\n"
 
-   "  return ws\n"
-   "\n", global, global);
-  //extract the function object from the namespace and return it so it can be
-  //bound by Boost::Python.
+      "  return ws\n"
+      "\n",
+      global, global);
+  // extract the function object from the namespace and return it so it can be
+  // bound by Boost::Python.
   return global["createWorkspace"];
 }
 
-void projSetAxis(Projection &self, size_t nd, const object& data) {
+void projSetAxis(Projection &self, size_t nd, const object &data) {
   self.setAxis(nd, Converters::PyObjectToV3D(data)());
 }
 
@@ -85,152 +88,81 @@ Projection_sptr projCtor2(const object &d1, const object &d2) {
                                         Converters::PyObjectToV3D(d2)()));
 }
 
-Projection_sptr projCtor3(
-  const object& d1,
-  const object& d2,
-  const object& d3) {
-  return Projection_sptr(new Projection(
-    Converters::PyObjectToV3D(d1)(),
-    Converters::PyObjectToV3D(d2)(),
-    Converters::PyObjectToV3D(d3)())
-  );
+Projection_sptr projCtor3(const object &d1, const object &d2,
+                          const object &d3) {
+  return Projection_sptr(new Projection(Converters::PyObjectToV3D(d1)(),
+                                        Converters::PyObjectToV3D(d2)(),
+                                        Converters::PyObjectToV3D(d3)()));
 }
 
-} //anonymous namespace
+} // anonymous namespace
 
-void export_Projection()
-{
+void export_Projection() {
   class_<Projection>(
-    "Projection",
-    init<>("Default constructor creates a two dimensional projection")
-  )
-  .def(
-    init<const V3D&,const V3D&>
-    ("Constructs a 3 dimensional projection, with w as the cross product "
-     "of u and v.", args("u","v")))
-  .def(
-    init<const V3D&,const V3D&,const V3D&>
-    ("Constructs a 3 dimensional projection", args("u","v","w")))
-  .def(
-    "__init__",
-    make_constructor(&projCtor2),
-    "Constructs a 3 dimensional projection, with w as the cross product "
-    "of u and v.")
-  .def(
-    "__init__",
-    make_constructor(&projCtor3),
-    "Constructs a 3 dimensional projection")
-  .def(
-    "getOffset",
-    &Projection::getOffset,
-    "Returns the offset for the given dimension",
-    args("dimension"))
-  .def(
-    "getAxis",
-    &Projection::getAxis,
-    "Returns the axis for the given dimension", args("dimension"))
-  .def(
-    "getType",
-    &getUnit,
-    "Returns the unit for the given dimension", args("dimension"))
-  .def(
-    "setOffset",
-    &Projection::setOffset,
-    "Sets the offset for the given dimension",
-    args("dimension", "offset"))
-  .def(
-    "setAxis",
-    &Projection::setAxis,
-    "Sets the axis for the given dimension",
-    args("dimension", "axis"))
-  .def(
-    "setAxis",
-    &projSetAxis,
-    "Sets the axis for the given dimension",
-    args("dimension", "axis")
-  )
-  .def(
-    "setType",
-    &setUnit,
-    "Sets the unit for the given dimension",
-    args("dimension", "unit")
-  )
-  .add_property("u",
-    make_function(
-      &Projection::U,
-      return_internal_reference<>(),
-      boost::mpl::vector2<V3D&, Projection&>()
-    ),
-    make_function(
-      boost::bind(&Projection::setAxis, _1, 0, _2),
-      default_call_policies(),
-      boost::mpl::vector3<void, Projection&, V3D>()
-    )
-  )
-  .add_property("v",
-    make_function(
-      &Projection::V,
-      return_internal_reference<>(),
-      boost::mpl::vector2<V3D&, Projection&>()
-    ),
-    make_function(
-      boost::bind(&Projection::setAxis, _1, 1, _2),
-      default_call_policies(),
-      boost::mpl::vector3<void, Projection&, V3D>()
-    )
-  )
-  .add_property("w",
-    make_function(
-      &Projection::W,
-      return_internal_reference<>(),
-      boost::mpl::vector2<V3D&, Projection&>()
-    ),
-    make_function(
-      boost::bind(&Projection::setAxis, _1, 2, _2),
-      default_call_policies(),
-      boost::mpl::vector3<void, Projection&, V3D>()
-    )
-  )
-  .add_property("u",
-    make_function(
-      &Projection::U,
-      return_internal_reference<>(),
-      boost::mpl::vector2<V3D&, Projection&>()
-    ),
-    make_function(
-      boost::bind(&projSetAxis, _1, 0, _2),
-      default_call_policies(),
-      boost::mpl::vector3<void, Projection&, const object&>()
-    )
-  )
-  .add_property("v",
-    make_function(
-      &Projection::V,
-      return_internal_reference<>(),
-      boost::mpl::vector2<V3D&, Projection&>()
-    ),
-    make_function(
-      boost::bind(&projSetAxis, _1, 1, _2),
-      default_call_policies(),
-      boost::mpl::vector3<void, Projection&, const object&>()
-    )
-  )
-  .add_property("w",
-    make_function(
-      &Projection::W,
-      return_internal_reference<>(),
-      boost::mpl::vector2<V3D&, Projection&>()
-    ),
-    make_function(
-      boost::bind(&projSetAxis, _1, 2, _2),
-      default_call_policies(),
-      boost::mpl::vector3<void, Projection&, const object&>()
-    )
-  )
-  .def(
-    "createWorkspace",
-    createWorkspace(),
-    "Create a TableWorkspace representing the projection"
-  )
-  ;
+      "Projection",
+      init<>("Default constructor creates a two dimensional projection"))
+      .def(init<const V3D &, const V3D &>(
+          "Constructs a 3 dimensional projection, with w as the cross product "
+          "of u and v.",
+          args("u", "v")))
+      .def(init<const V3D &, const V3D &, const V3D &>(
+          "Constructs a 3 dimensional projection", args("u", "v", "w")))
+      .def("__init__", make_constructor(&projCtor2),
+           "Constructs a 3 dimensional projection, with w as the cross product "
+           "of u and v.")
+      .def("__init__", make_constructor(&projCtor3),
+           "Constructs a 3 dimensional projection")
+      .def("getOffset", &Projection::getOffset,
+           "Returns the offset for the given dimension", args("dimension"))
+      .def("getAxis", &Projection::getAxis,
+           "Returns the axis for the given dimension", args("dimension"))
+      .def("getType", &getUnit, "Returns the unit for the given dimension",
+           args("dimension"))
+      .def("setOffset", &Projection::setOffset,
+           "Sets the offset for the given dimension",
+           args("dimension", "offset"))
+      .def("setAxis", &Projection::setAxis,
+           "Sets the axis for the given dimension", args("dimension", "axis"))
+      .def("setAxis", &projSetAxis, "Sets the axis for the given dimension",
+           args("dimension", "axis"))
+      .def("setType", &setUnit, "Sets the unit for the given dimension",
+           args("dimension", "unit"))
+      .add_property(
+           "u", make_function(&Projection::U, return_internal_reference<>(),
+                              boost::mpl::vector2<V3D &, Projection &>()),
+           make_function(boost::bind(&Projection::setAxis, _1, 0, _2),
+                         default_call_policies(),
+                         boost::mpl::vector3<void, Projection &, V3D>()))
+      .add_property(
+           "v", make_function(&Projection::V, return_internal_reference<>(),
+                              boost::mpl::vector2<V3D &, Projection &>()),
+           make_function(boost::bind(&Projection::setAxis, _1, 1, _2),
+                         default_call_policies(),
+                         boost::mpl::vector3<void, Projection &, V3D>()))
+      .add_property(
+           "w", make_function(&Projection::W, return_internal_reference<>(),
+                              boost::mpl::vector2<V3D &, Projection &>()),
+           make_function(boost::bind(&Projection::setAxis, _1, 2, _2),
+                         default_call_policies(),
+                         boost::mpl::vector3<void, Projection &, V3D>()))
+      .add_property(
+           "u", make_function(&Projection::U, return_internal_reference<>(),
+                              boost::mpl::vector2<V3D &, Projection &>()),
+           make_function(
+               boost::bind(&projSetAxis, _1, 0, _2), default_call_policies(),
+               boost::mpl::vector3<void, Projection &, const object &>()))
+      .add_property(
+           "v", make_function(&Projection::V, return_internal_reference<>(),
+                              boost::mpl::vector2<V3D &, Projection &>()),
+           make_function(
+               boost::bind(&projSetAxis, _1, 1, _2), default_call_policies(),
+               boost::mpl::vector3<void, Projection &, const object &>()))
+      .add_property(
+           "w", make_function(&Projection::W, return_internal_reference<>(),
+                              boost::mpl::vector2<V3D &, Projection &>()),
+           make_function(
+               boost::bind(&projSetAxis, _1, 2, _2), default_call_policies(),
+               boost::mpl::vector3<void, Projection &, const object &>()))
+      .def("createWorkspace", createWorkspace(),
+           "Create a TableWorkspace representing the projection");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyHistory.cpp
@@ -10,23 +10,18 @@ using Mantid::Kernel::PropertyHistory;
 using Mantid::API::IAlgorithm;
 using namespace boost::python;
 
-void export_PropertyHistory()
-{
-  register_ptr_to_python<PropertyHistory*>();
+void export_PropertyHistory() {
+  register_ptr_to_python<PropertyHistory *>();
 
   class_<PropertyHistory, boost::noncopyable>("PropertyHistory", no_init)
-    .def("name", &PropertyHistory::name, 
-         "Returns the name of the property.")
-    .def("value", &PropertyHistory::value, 
-         "Returns the value of the property.")
-    .def("type", &PropertyHistory::type, 
-         "Returns the type of the property.")
-    .def("isDefault", &PropertyHistory::isDefault, 
-         "Returns if the property value is the default value.")
-    .def("direction", &PropertyHistory::direction, 
-         "Returns the direction of the property.")
-    // ----------------- Operators --------------------------------------
-    .def(self_ns::str(self))
-    ;
+      .def("name", &PropertyHistory::name, "Returns the name of the property.")
+      .def("value", &PropertyHistory::value,
+           "Returns the value of the property.")
+      .def("type", &PropertyHistory::type, "Returns the type of the property.")
+      .def("isDefault", &PropertyHistory::isDefault,
+           "Returns if the property value is the default value.")
+      .def("direction", &PropertyHistory::direction,
+           "Returns the direction of the property.")
+      // ----------------- Operators --------------------------------------
+      .def(self_ns::str(self));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyHistory.cpp
@@ -10,9 +10,7 @@ using Mantid::Kernel::PropertyHistory;
 using Mantid::API::IAlgorithm;
 using namespace boost::python;
 
-// clang-format off
 void export_PropertyHistory()
-// clang-format on
 {
   register_ptr_to_python<PropertyHistory*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyManagerDataService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyManagerDataService.cpp
@@ -15,16 +15,15 @@ using namespace boost::python;
 /// Weak pointer to DataItem typedef
 typedef boost::weak_ptr<PropertyManager> PropertyManager_wptr;
 
-void export_PropertyManagerDataService()
-{
+void export_PropertyManagerDataService() {
 
   register_ptr_to_python<PropertyManager_wptr>();
 
-  typedef DataServiceExporter<PropertyManagerDataServiceImpl, PropertyManager_sptr> PMDExporter;
+  typedef DataServiceExporter<PropertyManagerDataServiceImpl,
+                              PropertyManager_sptr> PMDExporter;
   auto pmdType = PMDExporter::define("PropertyManagerDataServiceImpl");
-  
+
   // Instance method
-  TrackingInstanceMethod<PropertyManagerDataService, PMDExporter::PythonType>::define(pmdType);
-
+  TrackingInstanceMethod<PropertyManagerDataService,
+                         PMDExporter::PythonType>::define(pmdType);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyManagerDataService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/PropertyManagerDataService.cpp
@@ -15,9 +15,7 @@ using namespace boost::python;
 /// Weak pointer to DataItem typedef
 typedef boost::weak_ptr<PropertyManager> PropertyManager_wptr;
 
-// clang-format off
 void export_PropertyManagerDataService()
-// clang-format on
 {
 
   register_ptr_to_python<PropertyManager_wptr>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -12,149 +12,171 @@ using Mantid::API::Run;
 using Mantid::Kernel::Property;
 using namespace boost::python;
 
-namespace
-{
-  namespace bpl = boost::python;
+namespace {
+namespace bpl = boost::python;
 
-  /**
-     * Add a property with the given name and value
-     * @param self A reference to the run object that we have been called on
-     * @param name The name of the new property
-     * @param value The value of the property
-     * @param units A string representing a unit
-     * @param replace If true, replace an existing property with this one else raise an error
-     */
-    void addPropertyWithUnit(Run & self, const std::string & name, const bpl::object & value, const std::string & units, bool replace)
-    {
-      extract<Property*> extractor(value);
-      if(extractor.check())
-      {
-        Property *prop = extractor();
-        self.addProperty(prop->clone(), replace); // Clone the property as Python owns the one that is passed in
-        return;
-      }
-
-      // Use the factory
-      auto property = Mantid::PythonInterface::Registry::PropertyWithValueFactory::create(name, value, Mantid::Kernel::Direction::Input);
-      property->setUnits(units);
-      self.addProperty(property, replace);
-    }
-
-  /**
+/**
    * Add a property with the given name and value
    * @param self A reference to the run object that we have been called on
    * @param name The name of the new property
    * @param value The value of the property
-   * @param replace If true, replace an existing property with this one else raise an error
+   * @param units A string representing a unit
+   * @param replace If true, replace an existing property with this one else
+ * raise an error
    */
-  void addProperty(Run & self, const std::string & name, const bpl::object & value, bool replace)
-  {
-    addPropertyWithUnit(self, name, value, "", replace);
+void addPropertyWithUnit(Run &self, const std::string &name,
+                         const bpl::object &value, const std::string &units,
+                         bool replace) {
+  extract<Property *> extractor(value);
+  if (extractor.check()) {
+    Property *prop = extractor();
+    self.addProperty(
+        prop->clone(),
+        replace); // Clone the property as Python owns the one that is passed in
+    return;
   }
 
-  /**
-   * Add a property with the given name and value. An existing property is overwritten if it exists
-   * @param self A reference to the run object that we have been called on
-   * @param name The name of the new property
-   * @param value The value of the property
-   */
-  void addOrReplaceProperty(Run & self, const std::string & name, const bpl::object & value)
-  {
-    addProperty(self, name, value, true);
-  }
-
-
-  /**
-   * Emulate dict.get. Returns the value pointed to by the key or the default given
-   * @param self The object called on
-   * @param key The key
-   * @param default_ The default to return if it does not exist
-   */
-  bpl::object getWithDefault(bpl::object self, bpl::object key, bpl::object default_)
-  {
-    bpl::object exists(self.attr("__contains__"));
-    if( extract<bool>(exists(key))() )
-    {
-      return self.attr("__getitem__")(key);
-    }
-    else
-    {
-      return default_;
-    }
-  }
-
-  /**
-   * Emulate dict.get. Returns the value pointed to by the key or None if it doesn't exist
-   * @param self The bpl::object called on
-   * @param key The key
-   */
-  bpl::object get(bpl::object self, bpl::object key)
-  {
-    return getWithDefault(self, key, bpl::object());
-  }
-
-  /**
-   * Emulate dict.keys. Returns a list of property names know to the run object
-   * @param self :: A reference to the Run object that called this method
-   */
-  bpl::list keys(Run & self)
-  {
-    const std::vector<Mantid::Kernel::Property*> & logs = self.getProperties();
-    bpl::list names;
-    for(auto iter = logs.begin(); iter != logs.end(); ++iter)
-    {
-      names.append((*iter)->name());
-    }
-    return names;
-  }
-
-
+  // Use the factory
+  auto property =
+      Mantid::PythonInterface::Registry::PropertyWithValueFactory::create(
+          name, value, Mantid::Kernel::Direction::Input);
+  property->setUnits(units);
+  self.addProperty(property, replace);
 }
 
-void export_Run()
-{
-  //Pointer
-  register_ptr_to_python<Run*>();
-
-  //Run class
-  class_< Run,  boost::noncopyable >("Run", no_init)
-    .def("getProtonCharge", &Run::getProtonCharge, "Return the total good proton charge for the run")
-
-    .def("integrateProtonCharge", &Run::integrateProtonCharge, "Return the total good proton charge for the run")
-
-    .def("hasProperty", &Run::hasProperty, "Returns True if the given log value is contained within the run")
-
-    .def("getProperty", &Run::getProperty, return_value_policy<return_by_value>(), "Returns the named property (log value). Use '.value' to return the value.")
-
-    .def("getProperties", &Run::getProperties, return_internal_reference<>(), "Return the list of run properties managed by this object.")
-
-    .def("getLogData", (Property* (Run::*)(const std::string &) const)&Run::getLogData, return_value_policy<return_by_value>(),
-         "Returns the named log. Use '.value' to return the value. The same as getProperty.")
-
-    .def("getLogData", (const std::vector<Property*>& (Run::*)() const)&Run::getLogData, return_internal_reference<>(), 
-         "Return the list of logs for this run. The same as getProperties.")
-
-    .def("getGoniometer", (const Mantid::Geometry::Goniometer & (Run::*)() const)&Run::getGoniometer,
-         return_value_policy<reference_existing_object>(), "Get the oriented lattice for this sample")
-
-    .def("addProperty", &addProperty, "Adds a property with the given name and value. If replace=True then an existing property is overwritten")
-
-    .def("addProperty", &addPropertyWithUnit, "Adds a property with the given name, value and unit. If replace=True then an existing property is overwritten")
-
-    .def("setStartAndEndTime", &Run::setStartAndEndTime, "Set the start and end time of the run")
-
-    .def ("startTime", &Run::startTime, "Return the total starting time of the run.")
-
-    .def ("endTime", &Run::endTime, "Return the total ending time of the run.")
-
-    //--------------------------- Dictionary access----------------------------
-    .def("get", &getWithDefault, "Returns the value pointed to by the key or None if it does not exist")
-    .def("get", &get, "Returns the value pointed to by the key or the default value given")
-    .def("keys", &keys, "Returns the names of the properties as list")
-    .def("__contains__", &Run::hasProperty)
-    .def("__getitem__", &Run::getProperty, return_value_policy<return_by_value>())
-    .def("__setitem__", &addOrReplaceProperty)
-
-   ;
+/**
+ * Add a property with the given name and value
+ * @param self A reference to the run object that we have been called on
+ * @param name The name of the new property
+ * @param value The value of the property
+ * @param replace If true, replace an existing property with this one else raise
+ * an error
+ */
+void addProperty(Run &self, const std::string &name, const bpl::object &value,
+                 bool replace) {
+  addPropertyWithUnit(self, name, value, "", replace);
 }
 
+/**
+ * Add a property with the given name and value. An existing property is
+ * overwritten if it exists
+ * @param self A reference to the run object that we have been called on
+ * @param name The name of the new property
+ * @param value The value of the property
+ */
+void addOrReplaceProperty(Run &self, const std::string &name,
+                          const bpl::object &value) {
+  addProperty(self, name, value, true);
+}
+
+/**
+ * Emulate dict.get. Returns the value pointed to by the key or the default
+ * given
+ * @param self The object called on
+ * @param key The key
+ * @param default_ The default to return if it does not exist
+ */
+bpl::object getWithDefault(bpl::object self, bpl::object key,
+                           bpl::object default_) {
+  bpl::object exists(self.attr("__contains__"));
+  if (extract<bool>(exists(key))()) {
+    return self.attr("__getitem__")(key);
+  } else {
+    return default_;
+  }
+}
+
+/**
+ * Emulate dict.get. Returns the value pointed to by the key or None if it
+ * doesn't exist
+ * @param self The bpl::object called on
+ * @param key The key
+ */
+bpl::object get(bpl::object self, bpl::object key) {
+  return getWithDefault(self, key, bpl::object());
+}
+
+/**
+ * Emulate dict.keys. Returns a list of property names know to the run object
+ * @param self :: A reference to the Run object that called this method
+ */
+bpl::list keys(Run &self) {
+  const std::vector<Mantid::Kernel::Property *> &logs = self.getProperties();
+  bpl::list names;
+  for (auto iter = logs.begin(); iter != logs.end(); ++iter) {
+    names.append((*iter)->name());
+  }
+  return names;
+}
+}
+
+void export_Run() {
+  // Pointer
+  register_ptr_to_python<Run *>();
+
+  // Run class
+  class_<Run, boost::noncopyable>("Run", no_init)
+      .def("getProtonCharge", &Run::getProtonCharge,
+           "Return the total good proton charge for the run")
+
+      .def("integrateProtonCharge", &Run::integrateProtonCharge,
+           "Return the total good proton charge for the run")
+
+      .def("hasProperty", &Run::hasProperty,
+           "Returns True if the given log value is contained within the run")
+
+      .def("getProperty", &Run::getProperty,
+           return_value_policy<return_by_value>(), "Returns the named property "
+                                                   "(log value). Use '.value' "
+                                                   "to return the value.")
+
+      .def("getProperties", &Run::getProperties, return_internal_reference<>(),
+           "Return the list of run properties managed by this object.")
+
+      .def("getLogData",
+           (Property * (Run::*)(const std::string &) const) & Run::getLogData,
+           return_value_policy<return_by_value>(),
+           "Returns the named log. Use '.value' to return the value. The same "
+           "as getProperty.")
+
+      .def("getLogData",
+           (const std::vector<Property *> &(Run::*)() const) & Run::getLogData,
+           return_internal_reference<>(),
+           "Return the list of logs for this run. The same as getProperties.")
+
+      .def("getGoniometer",
+           (const Mantid::Geometry::Goniometer &(Run::*)() const) &
+               Run::getGoniometer,
+           return_value_policy<reference_existing_object>(),
+           "Get the oriented lattice for this sample")
+
+      .def("addProperty", &addProperty, "Adds a property with the given name "
+                                        "and value. If replace=True then an "
+                                        "existing property is overwritten")
+
+      .def("addProperty", &addPropertyWithUnit,
+           "Adds a property with the given name, value and unit. If "
+           "replace=True then an existing property is overwritten")
+
+      .def("setStartAndEndTime", &Run::setStartAndEndTime,
+           "Set the start and end time of the run")
+
+      .def("startTime", &Run::startTime,
+           "Return the total starting time of the run.")
+
+      .def("endTime", &Run::endTime, "Return the total ending time of the run.")
+
+      //--------------------------- Dictionary
+      // access----------------------------
+      .def("get", &getWithDefault, "Returns the value pointed to by the key or "
+                                   "None if it does not exist")
+      .def("get", &get,
+           "Returns the value pointed to by the key or the default value given")
+      .def("keys", &keys, "Returns the names of the properties as list")
+      .def("__contains__", &Run::hasProperty)
+      .def("__getitem__", &Run::getProperty,
+           return_value_policy<return_by_value>())
+      .def("__setitem__", &addOrReplaceProperty)
+
+      ;
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -111,9 +111,7 @@ namespace
 
 }
 
-// clang-format off
 void export_Run()
-// clang-format on
 {
   //Pointer
   register_ptr_to_python<Run*>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -10,32 +10,41 @@ using Mantid::Geometry::OrientedLattice;
 using Mantid::Kernel::Material;
 using namespace boost::python;
 
-void export_Sample()
-{
-  register_ptr_to_python<Sample*>();
-  register_ptr_to_python<boost::shared_ptr<Sample> >();
+void export_Sample() {
+  register_ptr_to_python<Sample *>();
+  register_ptr_to_python<boost::shared_ptr<Sample>>();
 
-
-  class_< Sample, boost::noncopyable >("Sample", no_init)
-    .def("getName", &Sample::getName, return_value_policy<copy_const_reference>(), "Returns the string name of the sample")
-    .def("getOrientedLattice", (const OrientedLattice & (Sample::*)() const)&Sample::getOrientedLattice,
-          return_value_policy<reference_existing_object>(), "Get the oriented lattice for this sample")
-    .def("hasOrientedLattice", &Sample::hasOrientedLattice, "Returns True if this sample has an oriented lattice, false otherwise")
-    .def("size", &Sample::size, "Return the number of samples contained within this sample")
-     // Required for ISIS SANS reduction until the full sample geometry is defined on loading
-    .def("getGeometryFlag", &Sample::getGeometryFlag, "Return the geometry flag.")
-    .def("getThickness", &Sample::getThickness, "Return the thickness in mm")
-    .def("getHeight", &Sample::getHeight, "Return the height in mm")
-    .def("getWidth", &Sample::getWidth, "Return the width in mm")
-    .def("getMaterial", (const Material& (Sample::*)() const)(&Sample::getMaterial),
-         return_value_policy<reference_existing_object>(), "The material the sample is composed of")
-    .def("setGeometryFlag", &Sample::setGeometryFlag, "Set the geometry flag.")
-    .def("setThickness", &Sample::setThickness, "Set the thickness in mm.")
-    .def("setHeight", &Sample::setHeight, "Set the height in mm.")
-    .def("setWidth", &Sample::setWidth, "Set the width in mm.")
-    // -------------------------Operators -------------------------------------
-    .def("__len__", &Sample::size)
-    .def("__getitem__", &Sample::operator[], return_internal_reference<>())
-   ;
+  class_<Sample, boost::noncopyable>("Sample", no_init)
+      .def("getName", &Sample::getName,
+           return_value_policy<copy_const_reference>(),
+           "Returns the string name of the sample")
+      .def("getOrientedLattice", (const OrientedLattice &(Sample::*)() const) &
+                                     Sample::getOrientedLattice,
+           return_value_policy<reference_existing_object>(),
+           "Get the oriented lattice for this sample")
+      .def("hasOrientedLattice", &Sample::hasOrientedLattice,
+           "Returns True if this sample has an oriented lattice, false "
+           "otherwise")
+      .def("size", &Sample::size,
+           "Return the number of samples contained within this sample")
+      // Required for ISIS SANS reduction until the full sample geometry is
+      // defined on loading
+      .def("getGeometryFlag", &Sample::getGeometryFlag,
+           "Return the geometry flag.")
+      .def("getThickness", &Sample::getThickness, "Return the thickness in mm")
+      .def("getHeight", &Sample::getHeight, "Return the height in mm")
+      .def("getWidth", &Sample::getWidth, "Return the width in mm")
+      .def("getMaterial",
+           (const Material &(Sample::*)() const)(&Sample::getMaterial),
+           return_value_policy<reference_existing_object>(),
+           "The material the sample is composed of")
+      .def("setGeometryFlag", &Sample::setGeometryFlag,
+           "Set the geometry flag.")
+      .def("setThickness", &Sample::setThickness, "Set the thickness in mm.")
+      .def("setHeight", &Sample::setHeight, "Set the height in mm.")
+      .def("setWidth", &Sample::setWidth, "Set the width in mm.")
+      // -------------------------Operators
+      // -------------------------------------
+      .def("__len__", &Sample::size)
+      .def("__getitem__", &Sample::operator[], return_internal_reference<>());
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -10,9 +10,7 @@ using Mantid::Geometry::OrientedLattice;
 using Mantid::Kernel::Material;
 using namespace boost::python;
 
-// clang-format off
 void export_Sample()
-// clang-format on
 {
   register_ptr_to_python<Sample*>();
   register_ptr_to_python<boost::shared_ptr<Sample> >();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepository.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepository.cpp
@@ -10,83 +10,81 @@
 using namespace Mantid::API;
 using namespace boost::python;
 
-namespace
-{
-  /** @cond */
+namespace {
+/** @cond */
 
-  //------------------------------------------------------------------------------------------------------
-  /**
-   * A Python friendly version that returns the registered functions as a list.
-   * @param self :: Enables it to be called as a member function on the FunctionFactory class
-   */
-  PyObject * getListFiles(ScriptRepository & self)
-  {
-    std::vector<std::string> files = self.listFiles();
+//------------------------------------------------------------------------------------------------------
+/**
+ * A Python friendly version that returns the registered functions as a list.
+ * @param self :: Enables it to be called as a member function on the
+ * FunctionFactory class
+ */
+PyObject *getListFiles(ScriptRepository &self) {
+  std::vector<std::string> files = self.listFiles();
 
-    PyObject *registered = PyList_New(0);
-    for (auto file = files.begin(); file != files.end(); ++file)
-    {
-      PyObject *value = PyString_FromString(file->c_str());
-      if (PyList_Append(registered, value))
-        throw std::runtime_error("Failed to insert value into PyList");
-    }
-
-    return registered;
-    }
-
-  tuple getInfo(ScriptRepository & self, const std::string & path){
-    ScriptInfo info = self.info(path);
-    return   boost::python::make_tuple<std::string>(info.author, info.pub_date.toSimpleString() );
+  PyObject *registered = PyList_New(0);
+  for (auto file = files.begin(); file != files.end(); ++file) {
+    PyObject *value = PyString_FromString(file->c_str());
+    if (PyList_Append(registered, value))
+      throw std::runtime_error("Failed to insert value into PyList");
   }
 
-  PyObject * getStatus(ScriptRepository & self, const std::string & path){
-    SCRIPTSTATUS st = self.fileStatus(path);
-    PyObject * value;
-    switch(st){
-    case BOTH_UNCHANGED:
-      value = PyString_FromString("BOTH_UNCHANGED");
-      break;
-    case REMOTE_ONLY:
-      value = PyString_FromString("REMOTE_ONLY");
-      break;
-    case LOCAL_ONLY:
-      value = PyString_FromString("LOCAL_ONLY");
-      break;
-    case REMOTE_CHANGED:
-      value = PyString_FromString("REMOTE_CHANGED");
-      break;
-    case LOCAL_CHANGED:
-      value = PyString_FromString("LOCAL_CHANGED");
-      break;
-    case BOTH_CHANGED:
-      value = PyString_FromString("BOTH_CHANGED");
-    break;
-    default:
-      value = PyString_FromString("BOTH_UNCHANGED");
-      break;
-    }
-    return value;
-  }
-
-  PyObject * getDescription(ScriptRepository & self, const std::string & path){
-    PyObject * value;
-    value = PyString_FromString(self.description(path).c_str());
-    return value;
-  }
-
-  /** @endcond */
+  return registered;
 }
 
-void export_ScriptRepository()
-{
+tuple getInfo(ScriptRepository &self, const std::string &path) {
+  ScriptInfo info = self.info(path);
+  return boost::python::make_tuple<std::string>(info.author,
+                                                info.pub_date.toSimpleString());
+}
+
+PyObject *getStatus(ScriptRepository &self, const std::string &path) {
+  SCRIPTSTATUS st = self.fileStatus(path);
+  PyObject *value;
+  switch (st) {
+  case BOTH_UNCHANGED:
+    value = PyString_FromString("BOTH_UNCHANGED");
+    break;
+  case REMOTE_ONLY:
+    value = PyString_FromString("REMOTE_ONLY");
+    break;
+  case LOCAL_ONLY:
+    value = PyString_FromString("LOCAL_ONLY");
+    break;
+  case REMOTE_CHANGED:
+    value = PyString_FromString("REMOTE_CHANGED");
+    break;
+  case LOCAL_CHANGED:
+    value = PyString_FromString("LOCAL_CHANGED");
+    break;
+  case BOTH_CHANGED:
+    value = PyString_FromString("BOTH_CHANGED");
+    break;
+  default:
+    value = PyString_FromString("BOTH_UNCHANGED");
+    break;
+  }
+  return value;
+}
+
+PyObject *getDescription(ScriptRepository &self, const std::string &path) {
+  PyObject *value;
+  value = PyString_FromString(self.description(path).c_str());
+  return value;
+}
+
+/** @endcond */
+}
+
+void export_ScriptRepository() {
 
   register_ptr_to_python<boost::shared_ptr<ScriptRepository>>();
 
   // reset the option to
- docstring_options local_docstring_options(true, true, false);
+  docstring_options local_docstring_options(true, true, false);
 
-const char * repo_desc =
-"Manage the interaction between the users and the Script folder (mantid subproject). \n\
+  const char *repo_desc =
+      "Manage the interaction between the users and the Script folder (mantid subproject). \n\
 \n\
 Inside the mantid repository (https://github.com/mantidproject) there is also a subproject \n\
 called scripts (https://github.com/mantidproject/scripts), created to allow users to share \n\
@@ -111,8 +109,8 @@ to download scripts through ::download(path), or check for updates through ::upd
 \n\
 '''NOTE:''' Upload is not implemented yet.\n";
 
-const char * list_files_desc =
-"Return an array with all the entries inside the repository. \n\
+  const char *list_files_desc =
+      "Return an array with all the entries inside the repository. \n\
 \n\
 Folder os files, locally or remotely, all will be listed together through the listFiles. \n\
 The listFiles has another function, which is related to update the internal cache about \n\
@@ -123,8 +121,8 @@ Returns:\n\
 \n\
   list: entries inside the repository.\n";
 
-const char * file_info_desc =
-"Return general information from the entries inside ScriptRepository. \n\
+  const char *file_info_desc =
+      "Return general information from the entries inside ScriptRepository. \n\
 \n\
 The author, description and publication date are available through this method. \n\
 \n\
@@ -135,8 +133,8 @@ Arguments:\n\
 Returns:\n\\n\
   - tuple: (author, last publication date)\n";
 
-const char * file_description_desc =
-"Return description of the entry inside ScriptRepository. \n\
+  const char *file_description_desc =
+      "Return description of the entry inside ScriptRepository. \n\
 \n\
 Arguments:\n\
 \n\
@@ -145,9 +143,7 @@ Arguments:\n\
 Return:\n\
    - string with the description\n";
 
-
-const char * file_status_desc =
-"Return the status of a given entry.\n\
+  const char *file_status_desc = "Return the status of a given entry.\n\
 \n\
 The following status are applied to the entries:\n\
   - REMOTE_ONLY: The file is only at the central repository\n\
@@ -167,8 +163,8 @@ Returns:\n\
 \n\
   - str: Status of the entry.\n";
 
-const char * download_desc =
-"Download from repository into your local file system.\n\
+  const char *download_desc =
+      "Download from repository into your local file system.\n\
 \n\
 You may give a file or folder. If the later is given, ScriptRepository will \n\
 download all the files inside that folder from the remote repository to you.\n\
@@ -177,17 +173,15 @@ Arguments:\n\
 \n\
    - path (str): Path for the entry do download";
 
-const char * update_desc =
-"Check for updates at the remote repository.\n\
+  const char *update_desc = "Check for updates at the remote repository.\n\
 \n\
 New versions of the files may be available, and the update method will check the \n\
 remote repository to see if there is anything new. It will not download new versions \n\
 of the available files unless you ask to do so. You should do this often to check if \n\
 there is a new script to solve your problem ;)";
 
-
-const char * install_desc =
-"Install the ScriptRepository in your local file system\n\
+  const char *install_desc =
+      "Install the ScriptRepository in your local file system\n\
 \n\
 The installation of the ScriptRepository is very simple. You must only provide a path, \n\
 existing or new folder, where the ScriptRepository will put the database it requires to \n\
@@ -200,12 +194,13 @@ Arguments:\n\
 ";
 
   ///@todo better description
-  class_<ScriptRepository,boost::noncopyable>("ScriptRepository",  repo_desc, no_init)
-    .def("install",&ScriptRepository::install, install_desc)
-    .def("listFiles",&getListFiles, list_files_desc)
-    .def("fileInfo",&getInfo,file_info_desc)
-    .def("description",&getDescription,file_description_desc)
-    .def("fileStatus",&getStatus,file_status_desc)
-    .def("download",&ScriptRepository::download,download_desc)
-    .def("update",&ScriptRepository::check4Update,update_desc);
+  class_<ScriptRepository, boost::noncopyable>("ScriptRepository", repo_desc,
+                                               no_init)
+      .def("install", &ScriptRepository::install, install_desc)
+      .def("listFiles", &getListFiles, list_files_desc)
+      .def("fileInfo", &getInfo, file_info_desc)
+      .def("description", &getDescription, file_description_desc)
+      .def("fileStatus", &getStatus, file_status_desc)
+      .def("download", &ScriptRepository::download, download_desc)
+      .def("update", &ScriptRepository::check4Update, update_desc);
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepository.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepository.cpp
@@ -77,9 +77,7 @@ namespace
   /** @endcond */
 }
 
-// clang-format off
 void export_ScriptRepository()
-// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<ScriptRepository>>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepositoryFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepositoryFactory.cpp
@@ -7,23 +7,21 @@ using Mantid::API::ScriptRepositoryFactoryImpl;
 using Mantid::API::ScriptRepositoryFactory;
 using namespace boost::python;
 
-namespace
-{
-  ///@cond
+namespace {
+///@cond
 
-  //------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------
 
-  ///@endcond
+///@endcond
 }
 
-void export_ScriptRepositoryFactory()
-{
-  class_<ScriptRepositoryFactoryImpl,boost::noncopyable>("ScriptRepositoryFactory", no_init)
+void export_ScriptRepositoryFactory() {
+  class_<ScriptRepositoryFactoryImpl, boost::noncopyable>(
+      "ScriptRepositoryFactory", no_init)
       .def("create", &ScriptRepositoryFactoryImpl::create,
            "Return a pointer to the ScriptRepository object")
-      .def("Instance", &ScriptRepositoryFactory::Instance, return_value_policy<reference_existing_object>(),
+      .def("Instance", &ScriptRepositoryFactory::Instance,
+           return_value_policy<reference_existing_object>(),
            "Returns a reference to the ScriptRepositoryFactory singleton")
-      .staticmethod("Instance")
-    ;
-
+      .staticmethod("Instance");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepositoryFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ScriptRepositoryFactory.cpp
@@ -16,9 +16,7 @@ namespace
   ///@endcond
 }
 
-// clang-format off
 void export_ScriptRepositoryFactory()
-// clang-format on
 {
   class_<ScriptRepositoryFactoryImpl,boost::noncopyable>("ScriptRepositoryFactory", no_init)
       .def("create", &ScriptRepositoryFactoryImpl::create,

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -17,9 +17,7 @@ namespace
   ///@endcond
 }
 
-// clang-format off
 void export_Workspace()
-// clang-format on
 {
   class_<Workspace, bases<DataItem>, boost::noncopyable>("Workspace", no_init)
     .def("getName", &Workspace::getName, return_value_policy<copy_const_reference>(), 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -10,27 +10,35 @@ using Mantid::Kernel::DataItem;
 using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 
-namespace
-{
-  ///@cond
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads, Workspace::isDirty, 0, 1)
-  ///@endcond
+namespace {
+///@cond
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
+                                       Workspace::isDirty, 0, 1)
+///@endcond
 }
 
-void export_Workspace()
-{
+void export_Workspace() {
   class_<Workspace, bases<DataItem>, boost::noncopyable>("Workspace", no_init)
-    .def("getName", &Workspace::getName, return_value_policy<copy_const_reference>(), 
-         args("self"), "Returns the name of the workspace. This could be an empty string")
-    .def("getTitle", &Workspace::getTitle, args("self"), "Returns the title of the workspace")
-    .def("setTitle", &Workspace::setTitle, args("self", "title"))
-    .def("getComment", &Workspace::getComment, return_value_policy<copy_const_reference>(), "Returns the comment field on the workspace")
-    .def("setComment", &Workspace::setComment, args("self", "comment"))
-    .def("isDirty", &Workspace::isDirty, Workspace_isDirtyOverloads(arg("n"), "True if the workspace has run more than n algorithms (Default=1)"))
-    .def("getMemorySize", &Workspace::getMemorySize, args("self"), "Returns the memory footprint of the workspace in KB")
-    .def("getHistory", (const WorkspaceHistory &(Workspace::*)() const)&Workspace::getHistory, return_value_policy<reference_existing_object>(),
-         args("self"), "Return read-only access to the workspace history")
-    ;
+      .def("getName", &Workspace::getName,
+           return_value_policy<copy_const_reference>(), args("self"),
+           "Returns the name of the workspace. This could be an empty string")
+      .def("getTitle", &Workspace::getTitle, args("self"),
+           "Returns the title of the workspace")
+      .def("setTitle", &Workspace::setTitle, args("self", "title"))
+      .def("getComment", &Workspace::getComment,
+           return_value_policy<copy_const_reference>(),
+           "Returns the comment field on the workspace")
+      .def("setComment", &Workspace::setComment, args("self", "comment"))
+      .def("isDirty", &Workspace::isDirty,
+           Workspace_isDirtyOverloads(arg("n"), "True if the workspace has run "
+                                                "more than n algorithms "
+                                                "(Default=1)"))
+      .def("getMemorySize", &Workspace::getMemorySize, args("self"),
+           "Returns the memory footprint of the workspace in KB")
+      .def("getHistory", (const WorkspaceHistory &(Workspace::*)() const) &
+                             Workspace::getHistory,
+           return_value_policy<reference_existing_object>(), args("self"),
+           "Return read-only access to the workspace history");
 
   //-------------------------------------------------------------------------------------------------
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -10,64 +10,78 @@ using namespace boost::python;
 using namespace Mantid::API;
 namespace Policies = Mantid::PythonInterface::Policies;
 
-namespace
-{
-  /**
-   * Creates from workspace using an existing one as a template.
-   * The C++ implementation accepts a boost::shared<const MatrixWorkspace> which
-   * we cannot currently handle. This allows a boost::shared<MatrixWorkspace> to be passed
-   * in an converted. See MantidPythonInterface/kernel/Policies/RemoveConst for the full
-   * explanation of why this is necessary
-   *
-   *  @param  parent    A shared pointer to the parent workspace
-   *  @param  NVectors  (Optional) The number of vectors/histograms/detectors in the workspace
-   *  @param  XLength   (Optional) The number of X data points/bin boundaries in each vector (must all be the same)
-   *  @param  YLength   (Optional) The number of data/error points in each vector (must all be the same)
-   *  @return A shared pointer to the newly created instance
-   *  @throw  std::out_of_range If invalid (0 or less) size arguments are given
-   *  @throw  NotFoundException If the class is not registered in the factory
-   **/
-  MatrixWorkspace_sptr createFromParentPtr(WorkspaceFactoryImpl & self, const MatrixWorkspace_sptr& parent,
-      size_t NVectors = size_t(-1), size_t XLength = size_t(-1), size_t YLength = size_t(-1))
-  {
-    return self.create(parent, NVectors, XLength, YLength);
-  }
-
-  /// Overload generator for create
-  BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr, 2, 5)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
+namespace {
+/**
+ * Creates from workspace using an existing one as a template.
+ * The C++ implementation accepts a boost::shared<const MatrixWorkspace> which
+ * we cannot currently handle. This allows a boost::shared<MatrixWorkspace> to
+ *be passed
+ * in an converted. See MantidPythonInterface/kernel/Policies/RemoveConst for
+ *the full
+ * explanation of why this is necessary
+ *
+ *  @param  parent    A shared pointer to the parent workspace
+ *  @param  NVectors  (Optional) The number of vectors/histograms/detectors in
+ *the workspace
+ *  @param  XLength   (Optional) The number of X data points/bin boundaries in
+ *each vector (must all be the same)
+ *  @param  YLength   (Optional) The number of data/error points in each vector
+ *(must all be the same)
+ *  @return A shared pointer to the newly created instance
+ *  @throw  std::out_of_range If invalid (0 or less) size arguments are given
+ *  @throw  NotFoundException If the class is not registered in the factory
+ **/
+MatrixWorkspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
+                                         const MatrixWorkspace_sptr &parent,
+                                         size_t NVectors = size_t(-1),
+                                         size_t XLength = size_t(-1),
+                                         size_t YLength = size_t(-1)) {
+  return self.create(parent, NVectors, XLength, YLength);
 }
 
-void export_WorkspaceFactory()
-{
-  const char * createFromParentDoc = "Create a workspace based on the given one. The meta-data, instrument etc are copied from the input"
-      "If the size parameters are passed then the workspace will be a different size.";
-
-  const char * createFromScratchDoc = "Create a clean new worksapce of the given size.";
-  typedef MatrixWorkspace_sptr (WorkspaceFactoryImpl::*createFromScratchPtr)
-       (const std::string&,const size_t&, const size_t&, const size_t&) const;
-
-  class_<WorkspaceFactoryImpl,boost::noncopyable>("WorkspaceFactoryImpl", no_init)
-    .def("create", &createFromParentPtr,
-         createFromParent_Overload(createFromParentDoc,
-                                   (arg("parent"), arg("NVectors")=-1,
-                                    arg("XLength")=-1,
-                                    arg("YLength")=-1))[return_value_policy<Policies::ToSharedPtrWithDowncast>()])
-
-    .def("create", (createFromScratchPtr)&WorkspaceFactoryImpl::create, 
-         return_value_policy<Policies::ToSharedPtrWithDowncast>(),
-         createFromScratchDoc, (arg("className"), arg("NVectors"), arg("XLength"), arg("YLength")))
-
-    .def("createTable", &WorkspaceFactoryImpl::createTable,
-         createTable_Overload("Creates an empty TableWorkspace", (arg("className")="TableWorkspace")))
-
-    .def("createPeaks", &WorkspaceFactoryImpl::createPeaks,
-          createPeaks_Overload("Creates an empty PeaksWorkspace", (arg("className")="PeaksWorkspace")))
-
-    .def("Instance", &WorkspaceFactory::Instance, return_value_policy<reference_existing_object>(),
-         "Returns the single instance of this class.")
-    .staticmethod("Instance")
-  ;
+/// Overload generator for create
+BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr,
+                                2, 5)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
 }
 
+void export_WorkspaceFactory() {
+  const char *createFromParentDoc = "Create a workspace based on the given "
+                                    "one. The meta-data, instrument etc are "
+                                    "copied from the input"
+                                    "If the size parameters are passed then "
+                                    "the workspace will be a different size.";
+
+  const char *createFromScratchDoc =
+      "Create a clean new worksapce of the given size.";
+  typedef MatrixWorkspace_sptr (WorkspaceFactoryImpl::*createFromScratchPtr)(
+      const std::string &, const size_t &, const size_t &, const size_t &)
+      const;
+
+  class_<WorkspaceFactoryImpl, boost::noncopyable>("WorkspaceFactoryImpl",
+                                                   no_init)
+      .def("create", &createFromParentPtr,
+           createFromParent_Overload(createFromParentDoc,
+                                     (arg("parent"), arg("NVectors") = -1,
+                                      arg("XLength") = -1, arg("YLength") = -1))
+               [return_value_policy<Policies::ToSharedPtrWithDowncast>()])
+
+      .def("create", (createFromScratchPtr)&WorkspaceFactoryImpl::create,
+           return_value_policy<Policies::ToSharedPtrWithDowncast>(),
+           createFromScratchDoc,
+           (arg("className"), arg("NVectors"), arg("XLength"), arg("YLength")))
+
+      .def("createTable", &WorkspaceFactoryImpl::createTable,
+           createTable_Overload("Creates an empty TableWorkspace",
+                                (arg("className") = "TableWorkspace")))
+
+      .def("createPeaks", &WorkspaceFactoryImpl::createPeaks,
+           createPeaks_Overload("Creates an empty PeaksWorkspace",
+                                (arg("className") = "PeaksWorkspace")))
+
+      .def("Instance", &WorkspaceFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns the single instance of this class.")
+      .staticmethod("Instance");
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -39,9 +39,7 @@ namespace
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
 }
 
-// clang-format off
 void export_WorkspaceFactory()
-// clang-format on
 {
   const char * createFromParentDoc = "Create a workspace based on the given one. The meta-data, instrument etc are copied from the input"
       "If the size parameters are passed then the workspace will be a different size.";

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -10,29 +10,38 @@ using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 namespace Policies = Mantid::PythonInterface::Policies;
 
-void export_WorkspaceGroup() 
-{
-  class_< WorkspaceGroup, bases<Workspace>, boost::noncopyable >("WorkspaceGroup", no_init)
-    .def("getNumberOfEntries", &WorkspaceGroup::getNumberOfEntries, "Returns the number of entries in the group")
-    .def("getNames", &WorkspaceGroup::getNames, "Returns the names of the entries in the group")
-    .def("contains", (bool (WorkspaceGroup::*)(const std::string & wsName) const)&WorkspaceGroup::contains, "Returns true if the given name is in the group")
-    .def("add", &WorkspaceGroup::add, "Add a name to the group")
-    .def("size", &WorkspaceGroup::size, "Returns the number of workspaces contained in the group")
-    .def("remove", &WorkspaceGroup::remove, "Remove a name from the group")
-    .def("getItem", (Workspace_sptr (WorkspaceGroup::*)(const size_t) const)&WorkspaceGroup::getItem, 
-         return_value_policy<Policies::ToWeakPtrWithDowncast>(), "Returns the item at the given index")
-    .def("isMultiPeriod", &WorkspaceGroup::isMultiperiod, "Retuns true if the workspace group is multi-period")
-    // ------------ Operators --------------------------------
-    .def("__len__", &WorkspaceGroup::getNumberOfEntries)
-    .def("__contains__", (bool (WorkspaceGroup::*)(const std::string & wsName) const)&WorkspaceGroup::contains)
-    .def("__getitem__", (Workspace_sptr (WorkspaceGroup::*)(const size_t) const)&WorkspaceGroup::getItem, 
-         return_value_policy<Policies::ToWeakPtrWithDowncast>())
-  ;
+void export_WorkspaceGroup() {
+  class_<WorkspaceGroup, bases<Workspace>, boost::noncopyable>("WorkspaceGroup",
+                                                               no_init)
+      .def("getNumberOfEntries", &WorkspaceGroup::getNumberOfEntries,
+           "Returns the number of entries in the group")
+      .def("getNames", &WorkspaceGroup::getNames,
+           "Returns the names of the entries in the group")
+      .def("contains",
+           (bool (WorkspaceGroup::*)(const std::string &wsName) const) &
+               WorkspaceGroup::contains,
+           "Returns true if the given name is in the group")
+      .def("add", &WorkspaceGroup::add, "Add a name to the group")
+      .def("size", &WorkspaceGroup::size,
+           "Returns the number of workspaces contained in the group")
+      .def("remove", &WorkspaceGroup::remove, "Remove a name from the group")
+      .def("getItem", (Workspace_sptr (WorkspaceGroup::*)(const size_t) const) &
+                          WorkspaceGroup::getItem,
+           return_value_policy<Policies::ToWeakPtrWithDowncast>(),
+           "Returns the item at the given index")
+      .def("isMultiPeriod", &WorkspaceGroup::isMultiperiod,
+           "Retuns true if the workspace group is multi-period")
+      // ------------ Operators --------------------------------
+      .def("__len__", &WorkspaceGroup::getNumberOfEntries)
+      .def("__contains__",
+           (bool (WorkspaceGroup::*)(const std::string &wsName) const) &
+               WorkspaceGroup::contains)
+      .def("__getitem__",
+           (Workspace_sptr (WorkspaceGroup::*)(const size_t) const) &
+               WorkspaceGroup::getItem,
+           return_value_policy<Policies::ToWeakPtrWithDowncast>());
 
   //-----------------------------------------------------------------------------------------------
 
-  DataItemInterface<WorkspaceGroup>()
-    .castFromID("WorkspaceGroup")
-  ;
+  DataItemInterface<WorkspaceGroup>().castFromID("WorkspaceGroup");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroup.cpp
@@ -10,9 +10,7 @@ using Mantid::PythonInterface::Registry::DataItemInterface;
 using namespace boost::python;
 namespace Policies = Mantid::PythonInterface::Policies;
 
-// clang-format off
 void export_WorkspaceGroup() 
-// clang-format on
 {
   class_< WorkspaceGroup, bases<Workspace>, boost::noncopyable >("WorkspaceGroup", no_init)
     .def("getNumberOfEntries", &WorkspaceGroup::getNumberOfEntries, "Returns the number of entries in the group")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
@@ -1,8 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
-void export_WorkspaceGroupProperty()
-{
+void export_WorkspaceGroupProperty() {
   using Mantid::API::WorkspaceGroup;
   using Mantid::PythonInterface::WorkspacePropertyExporter;
   WorkspacePropertyExporter<WorkspaceGroup>::define("WorkspaceGroupProperty");

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
@@ -1,9 +1,7 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
 #include "MantidAPI/WorkspaceGroup.h"
 
-// clang-format off
 void export_WorkspaceGroupProperty()
-// clang-format on
 {
   using Mantid::API::WorkspaceGroup;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
@@ -23,45 +23,42 @@ namespace Policies = Mantid::PythonInterface::Policies;
  * @param self :: A reference to the WorkspaceHistory that called this method
  * @returns A python list created from the set of algorithm histories
  */
-boost::python::object getHistoriesAsList(WorkspaceHistory& self)
-{
+boost::python::object getHistoriesAsList(WorkspaceHistory &self) {
   boost::python::list names;
   const auto histories = self.getAlgorithmHistories();
   Mantid::API::AlgorithmHistories::const_iterator itr = histories.begin();
-  for(; itr != histories.end(); ++itr)
-  {
+  for (; itr != histories.end(); ++itr) {
     names.append(*itr);
   }
   return names;
 }
 
-void export_WorkspaceHistory()
-{
-  register_ptr_to_python<WorkspaceHistory*>();
+void export_WorkspaceHistory() {
+  register_ptr_to_python<WorkspaceHistory *>();
 
   class_<WorkspaceHistory, boost::noncopyable>("WorkspaceHistory", no_init)
 
-    .def("getAlgorithmHistories", &getHistoriesAsList,
-         "Returns a list of algorithm histories for this workspace history.")
-    
-    .def("getAlgorithmHistory", &WorkspaceHistory::getAlgorithmHistory, 
-          arg("index"),
-          return_value_policy<Policies::RemoveConstSharedPtr>(),
-         "Returns the algorithm history at the given index in the history")
-    
-    .def("size", &WorkspaceHistory::size, 
-         "Returns the number of algorithms in the immediate history")    
+      .def("getAlgorithmHistories", &getHistoriesAsList,
+           "Returns a list of algorithm histories for this workspace history.")
 
-    .def("empty", &WorkspaceHistory::empty, 
-         "Returns whether the history has any entries")
-    
-    .def("lastAlgorithm", &WorkspaceHistory::lastAlgorithm, "Returns the last algorithm run on this workspace so that its properties can be accessed")
-    
-    .def("getAlgorithm", &WorkspaceHistory::getAlgorithm, "Returns the algorithm at the given index in the history")
-    
-    // ----------------- Operators --------------------------------------
-    .def("__getitem__", &WorkspaceHistory::getAlgorithm)
-    .def(self_ns::str(self))
-    ;
+      .def("getAlgorithmHistory", &WorkspaceHistory::getAlgorithmHistory,
+           arg("index"), return_value_policy<Policies::RemoveConstSharedPtr>(),
+           "Returns the algorithm history at the given index in the history")
+
+      .def("size", &WorkspaceHistory::size,
+           "Returns the number of algorithms in the immediate history")
+
+      .def("empty", &WorkspaceHistory::empty,
+           "Returns whether the history has any entries")
+
+      .def("lastAlgorithm", &WorkspaceHistory::lastAlgorithm,
+           "Returns the last algorithm run on this workspace so that its "
+           "properties can be accessed")
+
+      .def("getAlgorithm", &WorkspaceHistory::getAlgorithm,
+           "Returns the algorithm at the given index in the history")
+
+      // ----------------- Operators --------------------------------------
+      .def("__getitem__", &WorkspaceHistory::getAlgorithm)
+      .def(self_ns::str(self));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
@@ -35,9 +35,7 @@ boost::python::object getHistoriesAsList(WorkspaceHistory& self)
   return names;
 }
 
-// clang-format off
 void export_WorkspaceHistory()
-// clang-format on
 {
   register_ptr_to_python<WorkspaceHistory*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceProperty.cpp
@@ -2,21 +2,18 @@
 #include "MantidAPI/Workspace.h"
 #include <boost/python/enum.hpp>
 
-void export_WorkspaceProperty()
-{
+void export_WorkspaceProperty() {
   using Mantid::API::PropertyMode;
   // Property and Lock mode enums
   boost::python::enum_<PropertyMode::Type>("PropertyMode")
-    .value("Optional", PropertyMode::Optional)
-    .value("Mandatory", PropertyMode::Mandatory)
-  ;
+      .value("Optional", PropertyMode::Optional)
+      .value("Mandatory", PropertyMode::Mandatory);
 
-    using Mantid::API::LockMode;
-    // Property and Lock mode enums
-    boost::python::enum_<LockMode::Type>("LockMode")
+  using Mantid::API::LockMode;
+  // Property and Lock mode enums
+  boost::python::enum_<LockMode::Type>("LockMode")
       .value("Lock", LockMode::Lock)
-      .value("NoLock", LockMode::NoLock)
-    ;
+      .value("NoLock", LockMode::NoLock);
 
   using Mantid::API::Workspace;
   using Mantid::PythonInterface::WorkspacePropertyExporter;

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceProperty.cpp
@@ -2,9 +2,7 @@
 #include "MantidAPI/Workspace.h"
 #include <boost/python/enum.hpp>
 
-// clang-format off
 void export_WorkspaceProperty()
-// clang-format on
 {
   using Mantid::API::PropertyMode;
   // Property and Lock mode enums

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -7,57 +7,54 @@ using Mantid::PythonInterface::TypedValidatorExporter;
 using namespace boost::python;
 
 /// This is the base TypedValidator for most of the WorkspaceValidators
-void export_MatrixWorkspaceValidator()
-{
+void export_MatrixWorkspaceValidator() {
   using Mantid::API::MatrixWorkspace_sptr;
   using Mantid::API::MatrixWorkspaceValidator;
-  TypedValidatorExporter<MatrixWorkspace_sptr>::define("MatrixWorkspaceValidator");
+  TypedValidatorExporter<MatrixWorkspace_sptr>::define(
+      "MatrixWorkspaceValidator");
 
-  class_<MatrixWorkspaceValidator, 
-         bases<TypedValidator<MatrixWorkspace_sptr> >,
-         boost::noncopyable>("MatrixWorkspaceValidator", no_init)
-    ;
+  class_<MatrixWorkspaceValidator, bases<TypedValidator<MatrixWorkspace_sptr>>,
+         boost::noncopyable>("MatrixWorkspaceValidator", no_init);
 }
-/// Export a validator derived from a MatrixWorkspaceValidator that has a no-arg constructor
-#define EXPORT_WKSP_VALIDATOR_NO_ARG(ValidatorType, DocString) \
-  class_<ValidatorType, \
-          bases<MatrixWorkspaceValidator>, \
-          boost::noncopyable\
-         >(#ValidatorType, \
-          init<>(DocString))\
-   ;
-/// Export a validator derived from a MatrixWorkspaceValidator that has a single-arg constructor
-#define EXPORT_WKSP_VALIDATOR_ARG(ValidatorType, ArgType, ArgName, DocString) \
-   class_<ValidatorType, \
-          bases<MatrixWorkspaceValidator>, \
-          boost::noncopyable\
-         >(#ValidatorType, \
-          init<ArgType>(arg(ArgName), DocString))\
-   ;
-/// Export a validator derived from a MatrixWorkspaceValidator that has a single-arg constructor 
+/// Export a validator derived from a MatrixWorkspaceValidator that has a no-arg
+/// constructor
+#define EXPORT_WKSP_VALIDATOR_NO_ARG(ValidatorType, DocString)                 \
+  class_<ValidatorType, bases<MatrixWorkspaceValidator>, boost::noncopyable>(  \
+      #ValidatorType, init<>(DocString));
+/// Export a validator derived from a MatrixWorkspaceValidator that has a
+/// single-arg constructor
+#define EXPORT_WKSP_VALIDATOR_ARG(ValidatorType, ArgType, ArgName, DocString)  \
+  class_<ValidatorType, bases<MatrixWorkspaceValidator>, boost::noncopyable>(  \
+      #ValidatorType, init<ArgType>(arg(ArgName), DocString));
+/// Export a validator derived from a MatrixWorkspaceValidator that has a
+/// single-arg constructor
 /// with a default argument
-#define EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(ValidatorType, ArgType, ArgName, DefaultValue, DocString) \
-   class_<ValidatorType, \
-          bases<MatrixWorkspaceValidator>, \
-          boost::noncopyable\
-         >(#ValidatorType, \
-          init<ArgType>(arg(ArgName)=DefaultValue, DocString))\
-   ;
+#define EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(ValidatorType, ArgType, ArgName,     \
+                                          DefaultValue, DocString)             \
+  class_<ValidatorType, bases<MatrixWorkspaceValidator>, boost::noncopyable>(  \
+      #ValidatorType, init<ArgType>(arg(ArgName) = DefaultValue, DocString));
 
-void export_WorkspaceValidators()
-{
+void export_WorkspaceValidators() {
   using namespace Mantid::API;
-  
-  EXPORT_WKSP_VALIDATOR_ARG(WorkspaceUnitValidator, std::string, "unit", "Checks the workspace has the given unit along the X-axis");
-  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(HistogramValidator, bool, "mustBeHistogram", true,
-                                    "If mustBeHistogram=True then the workspace must be a histogram otherwise it must be point data.");
-  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(RawCountValidator, bool, "mustNotBeDistribution", true,
-                                    "If mustNotBeDistribution=True then the workspace must not have been divided by the bin-width");
-  EXPORT_WKSP_VALIDATOR_NO_ARG(CommonBinsValidator, "A tentative check that the bins are common across the workspace");
-  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(SpectraAxisValidator, int, "axisNumber", 1,
-                                    "Checks whether the axis specified by axisNumber is a SpectraAxis");
-  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(NumericAxisValidator, int, "axisNumber", 1,
-                                    "Checks whether the axis specified by axisNumber is a NumericAxis");
 
+  EXPORT_WKSP_VALIDATOR_ARG(
+      WorkspaceUnitValidator, std::string, "unit",
+      "Checks the workspace has the given unit along the X-axis");
+  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(HistogramValidator, bool, "mustBeHistogram",
+                                    true, "If mustBeHistogram=True then the "
+                                          "workspace must be a histogram "
+                                          "otherwise it must be point data.");
+  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(
+      RawCountValidator, bool, "mustNotBeDistribution", true,
+      "If mustNotBeDistribution=True then the workspace must not have been "
+      "divided by the bin-width");
+  EXPORT_WKSP_VALIDATOR_NO_ARG(
+      CommonBinsValidator,
+      "A tentative check that the bins are common across the workspace");
+  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(
+      SpectraAxisValidator, int, "axisNumber", 1,
+      "Checks whether the axis specified by axisNumber is a SpectraAxis");
+  EXPORT_WKSP_VALIDATOR_DEFAULT_ARG(
+      NumericAxisValidator, int, "axisNumber", 1,
+      "Checks whether the axis specified by axisNumber is a NumericAxis");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceValidators.cpp
@@ -7,9 +7,7 @@ using Mantid::PythonInterface::TypedValidatorExporter;
 using namespace boost::python;
 
 /// This is the base TypedValidator for most of the WorkspaceValidators
-// clang-format off
 void export_MatrixWorkspaceValidator()
-// clang-format on
 {
   using Mantid::API::MatrixWorkspace_sptr;
   using Mantid::API::MatrixWorkspaceValidator;
@@ -46,9 +44,7 @@ void export_MatrixWorkspaceValidator()
           init<ArgType>(arg(ArgName)=DefaultValue, DocString))\
    ;
 
-// clang-format off
 void export_WorkspaceValidators()
-// clang-format on
 {
   using namespace Mantid::API;
   

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunction1DAdapter.cpp
@@ -12,107 +12,112 @@
 //-----------------------------------------------------------------------------
 // IFunction1D definition
 //-----------------------------------------------------------------------------
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    using Environment::CallMethod1;
-    using namespace boost::python;
+namespace Mantid {
+namespace PythonInterface {
+using Environment::CallMethod1;
+using namespace boost::python;
 
-    /**
-     * Construct the "wrapper" and stores the reference to the PyObject
-     * @param self A reference to the calling Python object
-     */
-    IFunction1DAdapter::IFunction1DAdapter(PyObject* self)
-      : API::ParamFunction(), API::IFunction1D(), IFunctionAdapter(self), m_derivOveridden(false)
-    {
-      m_derivOveridden = Environment::typeHasAttribute(self, "functionDeriv1D");
-    }
+/**
+ * Construct the "wrapper" and stores the reference to the PyObject
+ * @param self A reference to the calling Python object
+ */
+IFunction1DAdapter::IFunction1DAdapter(PyObject *self)
+    : API::ParamFunction(), API::IFunction1D(), IFunctionAdapter(self),
+      m_derivOveridden(false) {
+  m_derivOveridden = Environment::typeHasAttribute(self, "functionDeriv1D");
+}
 
-    /**
-     * Translates between the C++ signature & the Python signature called by Fit
-     * @param out The 1D data array of size nData that stores the output values
-     * @param xValues The input X values
-     * @param nData The size of the two arrays
-     */
-    void IFunction1DAdapter::function1D(double* out, const double* xValues, const size_t nData) const
-    {
-      using namespace Converters;
-      // GIL must be held while numpy wrappers are destroyed as they access Python
-      // state information
-      Environment::GlobalInterpreterLock gil;
+/**
+ * Translates between the C++ signature & the Python signature called by Fit
+ * @param out The 1D data array of size nData that stores the output values
+ * @param xValues The input X values
+ * @param nData The size of the two arrays
+ */
+void IFunction1DAdapter::function1D(double *out, const double *xValues,
+                                    const size_t nData) const {
+  using namespace Converters;
+  // GIL must be held while numpy wrappers are destroyed as they access Python
+  // state information
+  Environment::GlobalInterpreterLock gil;
 
-      Py_intptr_t dims[1] = { static_cast<Py_intptr_t>(nData) };
-      PyObject *xvals = WrapReadOnly::apply<double>::createFromArray(xValues, 1,dims);
+  Py_intptr_t dims[1] = {static_cast<Py_intptr_t>(nData)};
+  PyObject *xvals =
+      WrapReadOnly::apply<double>::createFromArray(xValues, 1, dims);
 
-      // Deliberately avoids using the CallMethod wrappers. They lock the GIL again and
-      // will check for each function call whether the wrapped method exists. It also avoid unnecessary construction of
-      // boost::python::objects whn using boost::python::call_method
+  // Deliberately avoids using the CallMethod wrappers. They lock the GIL again
+  // and
+  // will check for each function call whether the wrapped method exists. It
+  // also avoid unnecessary construction of
+  // boost::python::objects whn using boost::python::call_method
 
-      PyObject *result = PyEval_CallMethod(getSelf(), "function1D", "(O)", xvals);
-      Py_DECREF(xvals);
-      if(PyErr_Occurred())
-      {
-        Py_XDECREF(result);
-        Environment::throwRuntimeError(true);
-      }
-
-      PyArrayObject *nparray = (PyArrayObject *)(result);
-      if(PyArray_TYPE(nparray) == NPY_DOUBLE) // dtype matches so use memcpy for speed
-      {
-        std::memcpy(static_cast<void*>(out), PyArray_DATA(nparray), nData*sizeof(npy_double));
-        Py_DECREF(result);
-      }
-      else
-      {
-        Py_DECREF(result);
-        PyArray_Descr *dtype=PyArray_DESCR(nparray);
-        PyObject *name = PyList_GetItem(dtype->names, 0);
-        std::ostringstream os;
-        os << "Unsupported numpy data type: '" << PyString_AsString(name) << "'. Currently only numpy.float64 is supported";
-        throw std::runtime_error(os.str());
-      }
-    }
-
-    /**
-     * Python-type signature version of above to be called directly from Python
-     * @param xvals The input X values in read-only numpy array
-     */
-    boost::python::object IFunction1DAdapter::function1D(const boost::python::object & xvals) const
-    {
-      return CallMethod1<object,object>::dispatchWithException(getSelf(), "function1D", xvals);
-    }
-
-    /**
-     * If a Python override exists then call that, otherwise call the base class method
-     * @param out The Jacobian matrix storing the partial derivatives of the function w.r.t to the parameters
-     * @param xValues The input X values
-     * @param nData The size of the two arrays
-     */
-    void IFunction1DAdapter::functionDeriv1D(API::Jacobian* out, const double* xValues, const size_t nData)
-    {
-      if(m_derivOveridden)
-      {
-        using namespace Converters;
-        // GIL must be held while numpy wrappers are destroyed as they access Python
-        // state information
-        Environment::GlobalInterpreterLock gil;
-
-        Py_intptr_t dims[1] = { static_cast<Py_intptr_t>(nData) } ;
-        PyObject *xvals = WrapReadOnly::apply<double>::createFromArray(xValues, 1,dims);
-        PyObject *jacobian = boost::python::to_python_value<API::Jacobian*>()(out);
-
-        // Deliberately avoids using the CallMethod wrappers. They lock the GIL again and
-        // will check for each function call whether the wrapped method exists. It also avoid unnecessary construction of
-        // boost::python::objects when using boost::python::call_method
-        PyEval_CallMethod(getSelf(), "functionDeriv1D", "(OO)", xvals,jacobian);
-        if(PyErr_Occurred()) Environment::throwRuntimeError(true);
-      }
-      else
-      {
-        IFunction1D::functionDeriv1D(out,xValues,nData);
-      }
-    }
-
+  PyObject *result = PyEval_CallMethod(getSelf(), "function1D", "(O)", xvals);
+  Py_DECREF(xvals);
+  if (PyErr_Occurred()) {
+    Py_XDECREF(result);
+    Environment::throwRuntimeError(true);
   }
+
+  PyArrayObject *nparray = (PyArrayObject *)(result);
+  if (PyArray_TYPE(nparray) ==
+      NPY_DOUBLE) // dtype matches so use memcpy for speed
+  {
+    std::memcpy(static_cast<void *>(out), PyArray_DATA(nparray),
+                nData * sizeof(npy_double));
+    Py_DECREF(result);
+  } else {
+    Py_DECREF(result);
+    PyArray_Descr *dtype = PyArray_DESCR(nparray);
+    PyObject *name = PyList_GetItem(dtype->names, 0);
+    std::ostringstream os;
+    os << "Unsupported numpy data type: '" << PyString_AsString(name)
+       << "'. Currently only numpy.float64 is supported";
+    throw std::runtime_error(os.str());
+  }
+}
+
+/**
+ * Python-type signature version of above to be called directly from Python
+ * @param xvals The input X values in read-only numpy array
+ */
+boost::python::object
+IFunction1DAdapter::function1D(const boost::python::object &xvals) const {
+  return CallMethod1<object, object>::dispatchWithException(
+      getSelf(), "function1D", xvals);
+}
+
+/**
+ * If a Python override exists then call that, otherwise call the base class
+ * method
+ * @param out The Jacobian matrix storing the partial derivatives of the
+ * function w.r.t to the parameters
+ * @param xValues The input X values
+ * @param nData The size of the two arrays
+ */
+void IFunction1DAdapter::functionDeriv1D(API::Jacobian *out,
+                                         const double *xValues,
+                                         const size_t nData) {
+  if (m_derivOveridden) {
+    using namespace Converters;
+    // GIL must be held while numpy wrappers are destroyed as they access Python
+    // state information
+    Environment::GlobalInterpreterLock gil;
+
+    Py_intptr_t dims[1] = {static_cast<Py_intptr_t>(nData)};
+    PyObject *xvals =
+        WrapReadOnly::apply<double>::createFromArray(xValues, 1, dims);
+    PyObject *jacobian = boost::python::to_python_value<API::Jacobian *>()(out);
+
+    // Deliberately avoids using the CallMethod wrappers. They lock the GIL
+    // again and
+    // will check for each function call whether the wrapped method exists. It
+    // also avoid unnecessary construction of
+    // boost::python::objects when using boost::python::call_method
+    PyEval_CallMethod(getSelf(), "functionDeriv1D", "(OO)", xvals, jacobian);
+    if (PyErr_Occurred())
+      Environment::throwRuntimeError(true);
+  } else {
+    IFunction1D::functionDeriv1D(out, xValues, nData);
+  }
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -3,146 +3,138 @@
 
 #include <boost/python/class.hpp>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    using Mantid::PythonInterface::Environment::CallMethod0;
-    using Mantid::PythonInterface::Environment::CallMethod1;
-    using Mantid::PythonInterface::Environment::CallMethod2;
-    using namespace boost::python;
+namespace Mantid {
+namespace PythonInterface {
+using Mantid::PythonInterface::Environment::CallMethod0;
+using Mantid::PythonInterface::Environment::CallMethod1;
+using Mantid::PythonInterface::Environment::CallMethod2;
+using namespace boost::python;
 
-    /**
-     * Construct the wrapper and stores the reference to the PyObject
-     * @param self A reference to the calling Python object
-     */
-    IFunctionAdapter::IFunctionAdapter(PyObject* self)
-      : IFunction(), m_name(self->ob_type->tp_name), m_self(self)
-    {
-    }
+/**
+ * Construct the wrapper and stores the reference to the PyObject
+ * @param self A reference to the calling Python object
+ */
+IFunctionAdapter::IFunctionAdapter(PyObject *self)
+    : IFunction(), m_name(self->ob_type->tp_name), m_self(self) {}
 
-    /**
-     * @returns The class name of the function. This cannot be overridden in Python.
-     */
-    std::string IFunctionAdapter::name() const
-    {
-      return m_name;
-    }
+/**
+ * @returns The class name of the function. This cannot be overridden in Python.
+ */
+std::string IFunctionAdapter::name() const { return m_name; }
 
-    /**
-     * Specify a category for the function
-     */
-    const std::string IFunctionAdapter::category() const
-    {
-      return CallMethod0<std::string>::dispatchWithDefaultReturn(getSelf(),"category", IFunction::category());
-    }
+/**
+ * Specify a category for the function
+ */
+const std::string IFunctionAdapter::category() const {
+  return CallMethod0<std::string>::dispatchWithDefaultReturn(
+      getSelf(), "category", IFunction::category());
+}
 
-    /**
-     */
-    void IFunctionAdapter::init()
-    {
-      CallMethod0<void>::dispatchWithException(getSelf(),"init");
-    }
+/**
+ */
+void IFunctionAdapter::init() {
+  CallMethod0<void>::dispatchWithException(getSelf(), "init");
+}
 
-    /**
-     * Declare an attribute on the given function from a python object
-     * @param name :: The name of the new attribute
-     * @param defaultValue :: The default value for the attribute 
-     */
-    void IFunctionAdapter::declareAttribute(const std::string &name, 
-                                            const object &defaultValue)
-    {
-      PyObject *rawptr = defaultValue.ptr();
-      IFunction::Attribute attr;
-      if(PyInt_Check(rawptr) == 1) attr = IFunction::Attribute(extract<int>(rawptr)());
-      else if(PyFloat_Check(rawptr) == 1)  attr = IFunction::Attribute(extract<double>(rawptr)());
-      else if(PyString_Check(rawptr) == 1) attr = IFunction::Attribute(extract<std::string>(rawptr)());
-      else if(PyBool_Check(rawptr) == 1) attr = IFunction::Attribute(extract<bool>(rawptr)());
-      else throw std::invalid_argument("Invalid attribute type. Allowed types=float,int,str,bool");
-      
-      IFunction::declareAttribute(name, attr);
-    }
+/**
+ * Declare an attribute on the given function from a python object
+ * @param name :: The name of the new attribute
+ * @param defaultValue :: The default value for the attribute
+ */
+void IFunctionAdapter::declareAttribute(const std::string &name,
+                                        const object &defaultValue) {
+  PyObject *rawptr = defaultValue.ptr();
+  IFunction::Attribute attr;
+  if (PyInt_Check(rawptr) == 1)
+    attr = IFunction::Attribute(extract<int>(rawptr)());
+  else if (PyFloat_Check(rawptr) == 1)
+    attr = IFunction::Attribute(extract<double>(rawptr)());
+  else if (PyString_Check(rawptr) == 1)
+    attr = IFunction::Attribute(extract<std::string>(rawptr)());
+  else if (PyBool_Check(rawptr) == 1)
+    attr = IFunction::Attribute(extract<bool>(rawptr)());
+  else
+    throw std::invalid_argument(
+        "Invalid attribute type. Allowed types=float,int,str,bool");
 
-    /**
-     * Get the value of the named attribute as a Python object
-     * @param name :: The name of the new attribute
-     * @returns The value of the attribute
-     */
-    PyObject * IFunctionAdapter::getAttributeValue(const std::string & name)
-    {
-      auto attr = IFunction::getAttribute(name);
-      return getAttributeValue(attr);
-    }
+  IFunction::declareAttribute(name, attr);
+}
 
+/**
+ * Get the value of the named attribute as a Python object
+ * @param name :: The name of the new attribute
+ * @returns The value of the attribute
+ */
+PyObject *IFunctionAdapter::getAttributeValue(const std::string &name) {
+  auto attr = IFunction::getAttribute(name);
+  return getAttributeValue(attr);
+}
 
-    /**
-     * Get the value of the given attribute as a Python object
-     * @param attr An attribute object
-     * @returns The value of the attribute
-     */
-    PyObject * IFunctionAdapter::getAttributeValue(const API::IFunction::Attribute & attr)
-    {
-      std::string type = attr.type();
-      PyObject *result(NULL);
-      if(type=="int") result = to_python_value<const int&>()(attr.asInt());
-      else if(type=="double") result = to_python_value<const double&>()(attr.asDouble());
-      else if(type=="std::string") result = to_python_value<const std::string&>()(attr.asString());
-      else if(type=="bool") result = to_python_value<const bool&>()(attr.asBool());
-      else throw std::runtime_error("Unknown attribute type, cannot convert C++ type to Python. Contact developement team.");
-      return result;
-    }
+/**
+ * Get the value of the given attribute as a Python object
+ * @param attr An attribute object
+ * @returns The value of the attribute
+ */
+PyObject *
+IFunctionAdapter::getAttributeValue(const API::IFunction::Attribute &attr) {
+  std::string type = attr.type();
+  PyObject *result(NULL);
+  if (type == "int")
+    result = to_python_value<const int &>()(attr.asInt());
+  else if (type == "double")
+    result = to_python_value<const double &>()(attr.asDouble());
+  else if (type == "std::string")
+    result = to_python_value<const std::string &>()(attr.asString());
+  else if (type == "bool")
+    result = to_python_value<const bool &>()(attr.asBool());
+  else
+    throw std::runtime_error("Unknown attribute type, cannot convert C++ type "
+                             "to Python. Contact developement team.");
+  return result;
+}
 
-    /**
-     * Calls setAttributeValue on the Python object if it exists otherwise calls the base class method
-     * @param attName The name of the attribute
-     * @param attr An attribute object
-     */
-    void IFunctionAdapter::setAttribute(const std::string& attName,const Attribute& attr)
-    {
-      object value = object(handle<>(getAttributeValue(attr)));
-      try
-      {
-        CallMethod2<void,std::string,object>::dispatchWithException(getSelf(), "setAttributeValue", attName,value);
-      }
-      catch(std::runtime_error &)
-      {
-        IFunction::setAttribute(attName, attr);
-      }
-    }
-
-
-    /**
-     * Value of i-th active parameter. If this functions is overridden
-     * in Python then it returns the value of the ith active Parameter
-     * If not it simple returns the base class result
-     * @param i The index of the parameter
-     */
-    double IFunctionAdapter::activeParameter(size_t i) const
-    {
-      return CallMethod1<double,size_t>::dispatchWithDefaultReturn(getSelf(), "activeParameter",
-          this->getParameter(i), i);
-    }
-
-    /**
-     * Sets the value of i-th active parameter. If this functions is overridden
-     * in Python then it should set the value of the ith active parameter.
-     * If not calls the base class function
-     * @param i The index of the parameter
-     * @param value The new value of the active parameter
-     */
-    void IFunctionAdapter::setActiveParameter(size_t i, double value)
-    {
-      try
-      {
-        CallMethod2<void,size_t,double>::dispatchWithException(getSelf(), "setActiveParameter", i,value);
-      }
-      catch(std::runtime_error&)
-      {
-        IFunction::setActiveParameter(i,value);
-      }
-
-    }
-
-
+/**
+ * Calls setAttributeValue on the Python object if it exists otherwise calls the
+ * base class method
+ * @param attName The name of the attribute
+ * @param attr An attribute object
+ */
+void IFunctionAdapter::setAttribute(const std::string &attName,
+                                    const Attribute &attr) {
+  object value = object(handle<>(getAttributeValue(attr)));
+  try {
+    CallMethod2<void, std::string, object>::dispatchWithException(
+        getSelf(), "setAttributeValue", attName, value);
+  } catch (std::runtime_error &) {
+    IFunction::setAttribute(attName, attr);
   }
+}
+
+/**
+ * Value of i-th active parameter. If this functions is overridden
+ * in Python then it returns the value of the ith active Parameter
+ * If not it simple returns the base class result
+ * @param i The index of the parameter
+ */
+double IFunctionAdapter::activeParameter(size_t i) const {
+  return CallMethod1<double, size_t>::dispatchWithDefaultReturn(
+      getSelf(), "activeParameter", this->getParameter(i), i);
+}
+
+/**
+ * Sets the value of i-th active parameter. If this functions is overridden
+ * in Python then it should set the value of the ith active parameter.
+ * If not calls the base class function
+ * @param i The index of the parameter
+ * @param value The new value of the active parameter
+ */
+void IFunctionAdapter::setActiveParameter(size_t i, double value) {
+  try {
+    CallMethod2<void, size_t, double>::dispatchWithException(
+        getSelf(), "setActiveParameter", i, value);
+  } catch (std::runtime_error &) {
+    IFunction::setActiveParameter(i, value);
+  }
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/FitFunctions/IPeakFunctionAdapter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/FitFunctions/IPeakFunctionAdapter.cpp
@@ -8,165 +8,171 @@
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
-
 //-----------------------------------------------------------------------------
 // IPeakFunction definition
 //-----------------------------------------------------------------------------
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    using Environment::CallMethod0;
-    using Environment::CallMethod1;
-    using Environment::CallMethod2;
-    using namespace boost::python;
+namespace Mantid {
+namespace PythonInterface {
+using Environment::CallMethod0;
+using Environment::CallMethod1;
+using Environment::CallMethod2;
+using namespace boost::python;
 
-    /**
-     * Construct the "wrapper" and stores the reference to the PyObject
-     * @param self A reference to the calling Python object
-     */
-    IPeakFunctionAdapter::IPeakFunctionAdapter(PyObject* self)
-      : API::IPeakFunction(), IFunctionAdapter(self), IFunction1DAdapter(self)
-    {
-    }
+/**
+ * Construct the "wrapper" and stores the reference to the PyObject
+ * @param self A reference to the calling Python object
+ */
+IPeakFunctionAdapter::IPeakFunctionAdapter(PyObject *self)
+    : API::IPeakFunction(), IFunctionAdapter(self), IFunction1DAdapter(self) {}
 
-    /**
-     */
-    double IPeakFunctionAdapter::centre() const
-    {
-      return CallMethod0<double>::dispatchWithException(getSelf(), "centre");
-    }
+/**
+ */
+double IPeakFunctionAdapter::centre() const {
+  return CallMethod0<double>::dispatchWithException(getSelf(), "centre");
+}
 
-    /**
-     */
-    double IPeakFunctionAdapter::height() const
-    {
-      return CallMethod0<double>::dispatchWithException(getSelf(), "height");
-    }
+/**
+ */
+double IPeakFunctionAdapter::height() const {
+  return CallMethod0<double>::dispatchWithException(getSelf(), "height");
+}
 
-    /**
-     * Called when the centre of the peak has been updated outside of the function
-     * @param c The centre of the peak
-     */
-    void IPeakFunctionAdapter::setCentre(const double c)
-    {
-      CallMethod1<void,double>::dispatchWithException(getSelf(), "setCentre", c);
-    }
+/**
+ * Called when the centre of the peak has been updated outside of the function
+ * @param c The centre of the peak
+ */
+void IPeakFunctionAdapter::setCentre(const double c) {
+  CallMethod1<void, double>::dispatchWithException(getSelf(), "setCentre", c);
+}
 
-    /**
-     * Called when the height of the peak has been updated outside of the function
-     * @param h The new height of the peak
-     */
-    void IPeakFunctionAdapter::setHeight(const double h)
-    {
-      CallMethod1<void,double>::dispatchWithException(getSelf(), "setHeight", h);
-    }
+/**
+ * Called when the height of the peak has been updated outside of the function
+ * @param h The new height of the peak
+ */
+void IPeakFunctionAdapter::setHeight(const double h) {
+  CallMethod1<void, double>::dispatchWithException(getSelf(), "setHeight", h);
+}
 
+/// Calls Python fwhm method
+double IPeakFunctionAdapter::fwhm() const {
+  return CallMethod0<double>::dispatchWithException(getSelf(), "fwhm");
+}
 
-    /// Calls Python fwhm method
-    double IPeakFunctionAdapter::fwhm() const
-    {
-      return CallMethod0<double>::dispatchWithException(getSelf(), "fwhm");
-    }
+/**
+ * Called when the width of the peak has been updated outside of the function
+ * @param w The new width of the peak. The function should update its parameters
+ * such that fwhm=w
+ */
+void IPeakFunctionAdapter::setFwhm(const double w) {
+  return CallMethod1<void, double>::dispatchWithException(getSelf(), "setFwhm",
+                                                          w);
+}
 
-    /**
-     * Called when the width of the peak has been updated outside of the function
-     * @param w The new width of the peak. The function should update its parameters such that fwhm=w
-     */
-    void IPeakFunctionAdapter::setFwhm(const double w)
-    {
-      return CallMethod1<void,double>::dispatchWithException(getSelf(), "setFwhm", w);
-    }
+/**
+ * Translates between the C++ signature & the Python signature and will be
+ * called by Fit
+ * @param out The 1D data array of size nData that stores the output values
+ * @param xValues The input X values
+ * @param nData The size of the two arrays
+ */
+void IPeakFunctionAdapter::functionLocal(double *out, const double *xValues,
+                                         const size_t nData) const {
+  using namespace Converters;
+  // GIL must be held while numpy wrappers are destroyed as they access Python
+  // state information
+  Environment::GlobalInterpreterLock gil;
 
+  Py_intptr_t dims[1] = {static_cast<Py_intptr_t>(nData)};
+  PyObject *xvals =
+      WrapReadOnly::apply<double>::createFromArray(xValues, 1, dims);
 
-    /**
-     * Translates between the C++ signature & the Python signature and will be called by Fit
-     * @param out The 1D data array of size nData that stores the output values
-     * @param xValues The input X values
-     * @param nData The size of the two arrays
-     */
-    void IPeakFunctionAdapter::functionLocal(double* out, const double* xValues, const size_t nData) const
-    {
-      using namespace Converters;
-      // GIL must be held while numpy wrappers are destroyed as they access Python
-      // state information
-      Environment::GlobalInterpreterLock gil;
+  // Deliberately avoids using the CallMethod wrappers. They lock the GIL again
+  // and
+  // will check for each function call whether the wrapped method exists. It
+  // also avoid unnecessary construction of
+  // boost::python::objects whn using boost::python::call_method
 
-      Py_intptr_t dims[1] = { static_cast<Py_intptr_t>(nData) };
-      PyObject *xvals = WrapReadOnly::apply<double>::createFromArray(xValues, 1,dims);
-
-      // Deliberately avoids using the CallMethod wrappers. They lock the GIL again and
-      // will check for each function call whether the wrapped method exists. It also avoid unnecessary construction of
-      // boost::python::objects whn using boost::python::call_method
-
-      PyObject *result = PyEval_CallMethod(getSelf(), "functionLocal", "(O)", xvals);
-      Py_DECREF(xvals);
-      if(PyErr_Occurred())
-      {
-        Py_DECREF(result);
-        Environment::throwRuntimeError(true);
-      }
-
-      PyArrayObject *nparray = (PyArrayObject *)(result);
-      if(PyArray_TYPE(nparray) == NPY_DOUBLE) // dtype matches so use memcpy for speed
-      {
-        std::memcpy(static_cast<void*>(out), PyArray_DATA(nparray), nData*sizeof(npy_double));
-        Py_DECREF(result);
-      }
-      else
-      {
-        Py_DECREF(result);
-        PyArray_Descr *dtype=PyArray_DESCR(nparray);
-        PyObject *name = PyList_GetItem(dtype->names, 0);
-        std::ostringstream os;
-        os << "Unsupported numpy data type: '" << PyString_AsString(name) << "'. Currently only numpy.float64 is supported";
-        throw std::runtime_error(os.str());
-      }
-    }
-
-    /**
-     * Python-type signature version of above so that users can call functionLocal directly from Python on a factory
-     * created object
-     * @param xvals The input X values in read-only numpy array
-     */
-    object IPeakFunctionAdapter::functionLocal(const boost::python::object & xvals) const
-    {
-      return CallMethod1<object,object>::dispatchWithException(getSelf(), "functionLocal", xvals);
-    }
-
-    /**
-     * Translates between the C++ signature & the Python signature and will be called by Fit
-     * @param out The Jacobian matrix storing the partial derivatives of the function w.r.t to the parameters
-     * @param xValues The input X values
-     * @param nData The size of the two arrays
-     */
-    void IPeakFunctionAdapter::functionDerivLocal(API::Jacobian* out, const double* xValues, const size_t nData)
-    {
-      using namespace Converters;
-      // GIL must be held while numpy wrappers are destroyed as they access Python
-      // state information
-      Environment::GlobalInterpreterLock gil;
-
-      Py_intptr_t dims[1] = { static_cast<Py_intptr_t>(nData) } ;
-      PyObject *xvals = WrapReadOnly::apply<double>::createFromArray(xValues, 1,dims);
-      PyObject *jacobian = boost::python::to_python_value<API::Jacobian*>()(out);
-
-      // Deliberately avoids using the CallMethod wrappers. They lock the GIL again and
-      // will check for each function call whether the wrapped method exists. It also avoid unnecessary construction of
-      // boost::python::objects when using boost::python::call_method
-      PyEval_CallMethod(getSelf(), "functionDerivLocal", "(OO)", xvals,jacobian);
-      if(PyErr_Occurred()) Environment::throwRuntimeError(true);
-    }
-
-    /**
-     * Python-type signature version of above that can be called directly from Python
-     * @param xvals The input X values in read-only numpy array
-     *  @param jacobian The Jacobian matrix storing the partial derivatives of the function w.r.t to the parameters
-     */
-    void IPeakFunctionAdapter::functionDerivLocal(const boost::python::object & xvals, boost::python::object & jacobian)
-    {
-      CallMethod2<void,object,object>::dispatchWithException(getSelf(), "functionDerivLocal", xvals, jacobian);
-    }
-
+  PyObject *result =
+      PyEval_CallMethod(getSelf(), "functionLocal", "(O)", xvals);
+  Py_DECREF(xvals);
+  if (PyErr_Occurred()) {
+    Py_DECREF(result);
+    Environment::throwRuntimeError(true);
   }
+
+  PyArrayObject *nparray = (PyArrayObject *)(result);
+  if (PyArray_TYPE(nparray) ==
+      NPY_DOUBLE) // dtype matches so use memcpy for speed
+  {
+    std::memcpy(static_cast<void *>(out), PyArray_DATA(nparray),
+                nData * sizeof(npy_double));
+    Py_DECREF(result);
+  } else {
+    Py_DECREF(result);
+    PyArray_Descr *dtype = PyArray_DESCR(nparray);
+    PyObject *name = PyList_GetItem(dtype->names, 0);
+    std::ostringstream os;
+    os << "Unsupported numpy data type: '" << PyString_AsString(name)
+       << "'. Currently only numpy.float64 is supported";
+    throw std::runtime_error(os.str());
+  }
+}
+
+/**
+ * Python-type signature version of above so that users can call functionLocal
+ * directly from Python on a factory
+ * created object
+ * @param xvals The input X values in read-only numpy array
+ */
+object
+IPeakFunctionAdapter::functionLocal(const boost::python::object &xvals) const {
+  return CallMethod1<object, object>::dispatchWithException(
+      getSelf(), "functionLocal", xvals);
+}
+
+/**
+ * Translates between the C++ signature & the Python signature and will be
+ * called by Fit
+ * @param out The Jacobian matrix storing the partial derivatives of the
+ * function w.r.t to the parameters
+ * @param xValues The input X values
+ * @param nData The size of the two arrays
+ */
+void IPeakFunctionAdapter::functionDerivLocal(API::Jacobian *out,
+                                              const double *xValues,
+                                              const size_t nData) {
+  using namespace Converters;
+  // GIL must be held while numpy wrappers are destroyed as they access Python
+  // state information
+  Environment::GlobalInterpreterLock gil;
+
+  Py_intptr_t dims[1] = {static_cast<Py_intptr_t>(nData)};
+  PyObject *xvals =
+      WrapReadOnly::apply<double>::createFromArray(xValues, 1, dims);
+  PyObject *jacobian = boost::python::to_python_value<API::Jacobian *>()(out);
+
+  // Deliberately avoids using the CallMethod wrappers. They lock the GIL again
+  // and
+  // will check for each function call whether the wrapped method exists. It
+  // also avoid unnecessary construction of
+  // boost::python::objects when using boost::python::call_method
+  PyEval_CallMethod(getSelf(), "functionDerivLocal", "(OO)", xvals, jacobian);
+  if (PyErr_Occurred())
+    Environment::throwRuntimeError(true);
+}
+
+/**
+ * Python-type signature version of above that can be called directly from
+ * Python
+ * @param xvals The input X values in read-only numpy array
+ *  @param jacobian The Jacobian matrix storing the partial derivatives of the
+ * function w.r.t to the parameters
+ */
+void
+IPeakFunctionAdapter::functionDerivLocal(const boost::python::object &xvals,
+                                         boost::python::object &jacobian) {
+  CallMethod2<void, object, object>::dispatchWithException(
+      getSelf(), "functionDerivLocal", xvals, jacobian);
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -11,318 +11,312 @@
 //-----------------------------------------------------------------------------
 // AlgorithmAdapter definition
 //-----------------------------------------------------------------------------
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    using namespace boost::python;
-    using Environment::CallMethod0;
+namespace Mantid {
+namespace PythonInterface {
+using namespace boost::python;
+using Environment::CallMethod0;
 
-    /**
-     * Construct the "wrapper" and stores the reference to the PyObject
-     * @param self A reference to the calling Python object
-     */
-    template<typename BaseAlgorithm>
-    AlgorithmAdapter<BaseAlgorithm>::AlgorithmAdapter(PyObject* self)
-      : BaseAlgorithm(), m_self(self), m_isRunningObj(NULL), m_wikiSummary("")
-    {
-      // Cache the isRunning call to save the lookup each time it is called
-      // as it is most likely called in a loop
+/**
+ * Construct the "wrapper" and stores the reference to the PyObject
+ * @param self A reference to the calling Python object
+ */
+template <typename BaseAlgorithm>
+AlgorithmAdapter<BaseAlgorithm>::AlgorithmAdapter(PyObject *self)
+    : BaseAlgorithm(), m_self(self), m_isRunningObj(NULL), m_wikiSummary("") {
+  // Cache the isRunning call to save the lookup each time it is called
+  // as it is most likely called in a loop
 
-      // If the derived class type has isRunning then use that.
-      // A standard PyObject_HasAttr will check the whole inheritance
-      // hierarchy and always return true because IAlgorithm::isRunning is present.
-      // We just want to look at the Python class
-      if(Environment::typeHasAttribute(self, "isRunning"))
-        m_isRunningObj = PyObject_GetAttrString(self, "isRunning");
-    }
+  // If the derived class type has isRunning then use that.
+  // A standard PyObject_HasAttr will check the whole inheritance
+  // hierarchy and always return true because IAlgorithm::isRunning is present.
+  // We just want to look at the Python class
+  if (Environment::typeHasAttribute(self, "isRunning"))
+    m_isRunningObj = PyObject_GetAttrString(self, "isRunning");
+}
 
-    /**
-     * Returns the name of the algorithm. This cannot be overridden in Python.
-     */
-    template<typename BaseAlgorithm>
-    const std::string AlgorithmAdapter<BaseAlgorithm>::name() const
-    {
-      return std::string(getSelf()->ob_type->tp_name);
-    }
+/**
+ * Returns the name of the algorithm. This cannot be overridden in Python.
+ */
+template <typename BaseAlgorithm>
+const std::string AlgorithmAdapter<BaseAlgorithm>::name() const {
+  return std::string(getSelf()->ob_type->tp_name);
+}
 
-    /**
-     * Returns the version of the algorithm. If not overridden
-     * it returns 1
-     */
-    template<typename BaseAlgorithm>
-    int AlgorithmAdapter<BaseAlgorithm>::version() const
-    {
-      return CallMethod0<int>::dispatchWithDefaultReturn(getSelf(), "version", defaultVersion());
-    }
+/**
+ * Returns the version of the algorithm. If not overridden
+ * it returns 1
+ */
+template <typename BaseAlgorithm>
+int AlgorithmAdapter<BaseAlgorithm>::version() const {
+  return CallMethod0<int>::dispatchWithDefaultReturn(getSelf(), "version",
+                                                     defaultVersion());
+}
 
-    /**
-     * Returns the default version of the algorithm. If not overridden
-     * it returns 1
-     */
-    template<typename BaseAlgorithm>
-    int AlgorithmAdapter<BaseAlgorithm>::defaultVersion() const
-    {
-      return 1;
-    }
+/**
+ * Returns the default version of the algorithm. If not overridden
+ * it returns 1
+ */
+template <typename BaseAlgorithm>
+int AlgorithmAdapter<BaseAlgorithm>::defaultVersion() const {
+  return 1;
+}
 
-    /**
-     * Returns checkGroups. If false, workspace groups will be treated as a whole
-     * If true, the algorithm will act on each component of the workspace group individually
-     */
-    template<typename BaseAlgorithm>
-    bool AlgorithmAdapter<BaseAlgorithm>::checkGroups()
-    {
-      return CallMethod0<bool>::dispatchWithDefaultReturn(getSelf(), "checkGroups", checkGroupsDefault());
-    }
+/**
+ * Returns checkGroups. If false, workspace groups will be treated as a whole
+ * If true, the algorithm will act on each component of the workspace group
+ * individually
+ */
+template <typename BaseAlgorithm>
+bool AlgorithmAdapter<BaseAlgorithm>::checkGroups() {
+  return CallMethod0<bool>::dispatchWithDefaultReturn(getSelf(), "checkGroups",
+                                                      checkGroupsDefault());
+}
 
-    /**
-     * Returns the default checkGroup (calls base class)
-     */
-    template<typename BaseAlgorithm>
-    bool AlgorithmAdapter<BaseAlgorithm>::checkGroupsDefault()
-    {
-      return BaseAlgorithm::checkGroups();
-    }
+/**
+ * Returns the default checkGroup (calls base class)
+ */
+template <typename BaseAlgorithm>
+bool AlgorithmAdapter<BaseAlgorithm>::checkGroupsDefault() {
+  return BaseAlgorithm::checkGroups();
+}
 
-    /**
-     * Returns the category of the algorithm. If not overridden
-     * it return defaultCategory()
-     */
-    template<typename BaseAlgorithm>
-    const std::string AlgorithmAdapter<BaseAlgorithm>::category() const
-    {
-      return CallMethod0<std::string>::dispatchWithDefaultReturn(getSelf(), "category", defaultCategory());
-    }
+/**
+ * Returns the category of the algorithm. If not overridden
+ * it return defaultCategory()
+ */
+template <typename BaseAlgorithm>
+const std::string AlgorithmAdapter<BaseAlgorithm>::category() const {
+  return CallMethod0<std::string>::dispatchWithDefaultReturn(
+      getSelf(), "category", defaultCategory());
+}
 
-    /**
-     * A default category, chosen if there is no override
-     * @returns A default category
-     */
-    template<typename BaseAlgorithm>
-    std::string AlgorithmAdapter<BaseAlgorithm>::defaultCategory() const
-    {
-      return "PythonAlgorithms";
-    }
+/**
+ * A default category, chosen if there is no override
+ * @returns A default category
+ */
+template <typename BaseAlgorithm>
+std::string AlgorithmAdapter<BaseAlgorithm>::defaultCategory() const {
+  return "PythonAlgorithms";
+}
 
-    /**
-     * Returns the summary of the algorithm. If not overridden
-     * it returns defaultSummary
-     */
-    template<typename BaseAlgorithm>
-    const std::string AlgorithmAdapter<BaseAlgorithm>::summary() const
-    {
-      return CallMethod0<std::string>::dispatchWithDefaultReturn(getSelf(), "summary", defaultSummary());
-    }
+/**
+ * Returns the summary of the algorithm. If not overridden
+ * it returns defaultSummary
+ */
+template <typename BaseAlgorithm>
+const std::string AlgorithmAdapter<BaseAlgorithm>::summary() const {
+  return CallMethod0<std::string>::dispatchWithDefaultReturn(
+      getSelf(), "summary", defaultSummary());
+}
 
-    /**
-     * A default summary, chosen if there is no override
-     * @returns A default summary
-     */
-    template<typename BaseAlgorithm>
-    std::string AlgorithmAdapter<BaseAlgorithm>::defaultSummary() const
-    {
-      return m_wikiSummary;
-    }
+/**
+ * A default summary, chosen if there is no override
+ * @returns A default summary
+ */
+template <typename BaseAlgorithm>
+std::string AlgorithmAdapter<BaseAlgorithm>::defaultSummary() const {
+  return m_wikiSummary;
+}
 
-    /**
-     * @return True if the algorithm is considered to be running
-     */
-    template<typename BaseAlgorithm>
-    bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const
-    {
-      if(!m_isRunningObj)
-      {
-        return SuperClass::isRunning();
-      }
-      else
-      {
-        Environment::GlobalInterpreterLock gil;
-        PyObject *result = PyObject_CallObject(m_isRunningObj, NULL);
-        if(PyErr_Occurred()) Environment::throwRuntimeError(true);
-        if(PyBool_Check(result)) return PyInt_AsLong(result);
-        else throw std::runtime_error("AlgorithmAdapter.isRunning - Expected bool return type.");
-      }
-    }
-
-    /**
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::cancel()
-    {
-      // No real need for eye on performance here. Use standard methods
-      if(Environment::typeHasAttribute(getSelf(), "cancel"))
-      {
-        Environment::GlobalInterpreterLock gil;
-        CallMethod0<void>::dispatchWithException(getSelf(), "cancel");
-      }
-      else SuperClass::cancel();
-    }
-
-    /**
-     * @copydoc Mantid::API::Algorithm::validateInputs
-     */
-    template<typename BaseAlgorithm>
-    std::map<std::string, std::string> AlgorithmAdapter<BaseAlgorithm>::validateInputs()
-    {
-      // variables that are needed further down
-      boost::python::dict resultDict;
-      std::map<std::string, std::string> resultMap;
-
-      // this is a modified version of CallMethod0::dispatchWithDefaultReturn
-      Environment::GlobalInterpreterLock gil;
-      if(Environment::typeHasAttribute(getSelf(), "validateInputs"))
-      {
-        try
-        {
-          resultDict = boost::python::call_method<boost::python::dict>(getSelf(),"validateInputs");
-
-          if (!bool(resultDict))
-            return resultMap;
-        }
-        catch(boost::python::error_already_set&)
-        {
-          Environment::throwRuntimeError();
-        }
-      }
-
-      // convert to a map<string,string>
-      boost::python::list keys = resultDict.keys();
-      size_t numItems = boost::python::len(keys);
-      for (size_t i = 0; i < numItems; ++i)
-      {
-        boost::python::object value = resultDict[keys[i]];
-        if (value)
-        {
-          try
-          {
-            std::string key = boost::python::extract<std::string>(keys[i]);
-            std::string value = boost::python::extract<std::string>(resultDict[keys[i]]);
-            resultMap[key] = value;
-          }
-          catch(boost::python::error_already_set &)
-          {
-            this->getLogger().error() << "In validateInputs(self): Invalid type for key/value pair "
-                                      << "detected in dict.\n"
-                                      << "All keys and values must be strings\n";
-          }
-        }
-      }
-      return resultMap;
-    }
-
-    /// Set the summary text
-    /// @param summary Wiki text
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::setWikiSummary(const std::string & summary)
-    {
-      std::string msg = \
-        "self.setWikiSummary() is deprecated and will be removed in a future release.\n"
-        "To ensure continued functionality remove the line containing 'self.setWikiSummary'\n"
-        "and add a new function outside of the current one defined like so:\n"
-        "def summary(self):\n"
-        "    \"" + summary + "\"\n";
-
-      PyErr_Warn(PyExc_DeprecationWarning, msg.c_str());
-      m_wikiSummary = summary;
-    }
-
-
-    /**
-     * Declare a preconstructed property.
-     * @param self A reference to the calling Python object
-     * @param prop :: A pointer to a property
-     * @param doc :: An optional doc string
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(boost::python::object &self, Kernel::Property *prop, const std::string & doc)
-    {
-      BaseAlgorithm & caller = extract<BaseAlgorithm&>(self);
-      // We need to clone the property so that python doesn't own the object that gets inserted
-      // into the manager
-      caller.declareProperty(prop->clone(), doc);
-    }
-
-    /**
-     * Declare a property using the type of the defaultValue, a documentation string and validator
-     * @param self A reference to the calling Python object
-     * @param name :: The name of the new property
-     * @param defaultValue :: A default value for the property. The type is mapped to a C++ type
-     * @param validator :: A validator object
-     * @param doc :: The documentation string
-     * @param direction :: The direction of the property
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(boost::python::object &self, const std::string & name, const boost::python::object & defaultValue,
-                                                               const boost::python::object & validator,
-                                                               const std::string & doc, const int direction)
-    {
-      BaseAlgorithm & caller = extract<BaseAlgorithm&>(self);
-      caller.declareProperty(Registry::PropertyWithValueFactory::create(name, defaultValue, validator, direction), doc);
-    }
-
-    /**
-     * Declare a property using the type of the defaultValue and a documentation string
-     * @param self A reference to the calling Python object
-     * @param name :: The name of the new property
-     * @param defaultValue :: A default value for the property. The type is mapped to a C++ type
-     * @param doc :: The documentation string
-     * @param direction :: The direction of the property
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(boost::python::object &self, const std::string & name, const boost::python::object & defaultValue,
-                                                               const std::string & doc, const int direction)
-    {
-      BaseAlgorithm & caller = extract<BaseAlgorithm&>(self);
-      caller.declareProperty(Registry::PropertyWithValueFactory::create(name, defaultValue, direction), doc);
-    }
-
-    /**
-     * Declare a property using the type of the defaultValue
-     * @param self A reference to the calling Python object
-     * @param name :: The name of the new property
-     * @param defaultValue :: A default value for the property. The type is mapped to a C++ type
-     * @param direction :: The direction of the property
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(boost::python::object &self, const std::string & name, const boost::python::object & defaultValue,
-                                                        const int direction)
-    {
-      declarePyAlgProperty(self, name, defaultValue, "", direction);
-    }
-
-
-    //---------------------------------------------------------------------------------------------
-    // Private members
-    //---------------------------------------------------------------------------------------------
-
-    /**
-     * Private init for this algorithm. Expected to be
-     * overridden in the subclass by a function named PyInit
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::init()
-    {
-      CallMethod0<void>::dispatchWithException(getSelf(), "PyInit");
-    }
-
-    /**
-     * Private exec for this algorithm. Expected to be
-     * overridden in the subclass by a function named PyExec
-     */
-    template<typename BaseAlgorithm>
-    void AlgorithmAdapter<BaseAlgorithm>::exec()
-    {
-      CallMethod0<void>::dispatchWithException(getSelf(), "PyExec");
-    }
-
-    //-----------------------------------------------------------------------------------------------------------------------------
-    // Concete instantiations (avoids definitions being all in the headers)
-    //-----------------------------------------------------------------------------------------------------------------------------
-    /// API::Algorithm as base
-    template class AlgorithmAdapter<API::Algorithm>;
-    /// API::DataProcesstor as base
-    template class AlgorithmAdapter<API::DataProcessorAlgorithm>;
-
+/**
+ * @return True if the algorithm is considered to be running
+ */
+template <typename BaseAlgorithm>
+bool AlgorithmAdapter<BaseAlgorithm>::isRunning() const {
+  if (!m_isRunningObj) {
+    return SuperClass::isRunning();
+  } else {
+    Environment::GlobalInterpreterLock gil;
+    PyObject *result = PyObject_CallObject(m_isRunningObj, NULL);
+    if (PyErr_Occurred())
+      Environment::throwRuntimeError(true);
+    if (PyBool_Check(result))
+      return PyInt_AsLong(result);
+    else
+      throw std::runtime_error(
+          "AlgorithmAdapter.isRunning - Expected bool return type.");
   }
+}
+
+/**
+ */
+template <typename BaseAlgorithm>
+void AlgorithmAdapter<BaseAlgorithm>::cancel() {
+  // No real need for eye on performance here. Use standard methods
+  if (Environment::typeHasAttribute(getSelf(), "cancel")) {
+    Environment::GlobalInterpreterLock gil;
+    CallMethod0<void>::dispatchWithException(getSelf(), "cancel");
+  } else
+    SuperClass::cancel();
+}
+
+/**
+ * @copydoc Mantid::API::Algorithm::validateInputs
+ */
+template <typename BaseAlgorithm>
+std::map<std::string, std::string>
+AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
+  // variables that are needed further down
+  boost::python::dict resultDict;
+  std::map<std::string, std::string> resultMap;
+
+  // this is a modified version of CallMethod0::dispatchWithDefaultReturn
+  Environment::GlobalInterpreterLock gil;
+  if (Environment::typeHasAttribute(getSelf(), "validateInputs")) {
+    try {
+      resultDict = boost::python::call_method<boost::python::dict>(
+          getSelf(), "validateInputs");
+
+      if (!bool(resultDict))
+        return resultMap;
+    } catch (boost::python::error_already_set &) {
+      Environment::throwRuntimeError();
+    }
+  }
+
+  // convert to a map<string,string>
+  boost::python::list keys = resultDict.keys();
+  size_t numItems = boost::python::len(keys);
+  for (size_t i = 0; i < numItems; ++i) {
+    boost::python::object value = resultDict[keys[i]];
+    if (value) {
+      try {
+        std::string key = boost::python::extract<std::string>(keys[i]);
+        std::string value =
+            boost::python::extract<std::string>(resultDict[keys[i]]);
+        resultMap[key] = value;
+      } catch (boost::python::error_already_set &) {
+        this->getLogger().error()
+            << "In validateInputs(self): Invalid type for key/value pair "
+            << "detected in dict.\n"
+            << "All keys and values must be strings\n";
+      }
+    }
+  }
+  return resultMap;
+}
+
+/// Set the summary text
+/// @param summary Wiki text
+template <typename BaseAlgorithm>
+void
+AlgorithmAdapter<BaseAlgorithm>::setWikiSummary(const std::string &summary) {
+  std::string msg =
+      "self.setWikiSummary() is deprecated and will be removed in a future "
+      "release.\n"
+      "To ensure continued functionality remove the line containing "
+      "'self.setWikiSummary'\n"
+      "and add a new function outside of the current one defined like so:\n"
+      "def summary(self):\n"
+      "    \"" +
+      summary + "\"\n";
+
+  PyErr_Warn(PyExc_DeprecationWarning, msg.c_str());
+  m_wikiSummary = summary;
+}
+
+/**
+ * Declare a preconstructed property.
+ * @param self A reference to the calling Python object
+ * @param prop :: A pointer to a property
+ * @param doc :: An optional doc string
+ */
+template <typename BaseAlgorithm>
+void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(
+    boost::python::object &self, Kernel::Property *prop,
+    const std::string &doc) {
+  BaseAlgorithm &caller = extract<BaseAlgorithm &>(self);
+  // We need to clone the property so that python doesn't own the object that
+  // gets inserted
+  // into the manager
+  caller.declareProperty(prop->clone(), doc);
+}
+
+/**
+ * Declare a property using the type of the defaultValue, a documentation string
+ * and validator
+ * @param self A reference to the calling Python object
+ * @param name :: The name of the new property
+ * @param defaultValue :: A default value for the property. The type is mapped
+ * to a C++ type
+ * @param validator :: A validator object
+ * @param doc :: The documentation string
+ * @param direction :: The direction of the property
+ */
+template <typename BaseAlgorithm>
+void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(
+    boost::python::object &self, const std::string &name,
+    const boost::python::object &defaultValue,
+    const boost::python::object &validator, const std::string &doc,
+    const int direction) {
+  BaseAlgorithm &caller = extract<BaseAlgorithm &>(self);
+  caller.declareProperty(Registry::PropertyWithValueFactory::create(
+                             name, defaultValue, validator, direction),
+                         doc);
+}
+
+/**
+ * Declare a property using the type of the defaultValue and a documentation
+ * string
+ * @param self A reference to the calling Python object
+ * @param name :: The name of the new property
+ * @param defaultValue :: A default value for the property. The type is mapped
+ * to a C++ type
+ * @param doc :: The documentation string
+ * @param direction :: The direction of the property
+ */
+template <typename BaseAlgorithm>
+void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(
+    boost::python::object &self, const std::string &name,
+    const boost::python::object &defaultValue, const std::string &doc,
+    const int direction) {
+  BaseAlgorithm &caller = extract<BaseAlgorithm &>(self);
+  caller.declareProperty(
+      Registry::PropertyWithValueFactory::create(name, defaultValue, direction),
+      doc);
+}
+
+/**
+ * Declare a property using the type of the defaultValue
+ * @param self A reference to the calling Python object
+ * @param name :: The name of the new property
+ * @param defaultValue :: A default value for the property. The type is mapped
+ * to a C++ type
+ * @param direction :: The direction of the property
+ */
+template <typename BaseAlgorithm>
+void AlgorithmAdapter<BaseAlgorithm>::declarePyAlgProperty(
+    boost::python::object &self, const std::string &name,
+    const boost::python::object &defaultValue, const int direction) {
+  declarePyAlgProperty(self, name, defaultValue, "", direction);
+}
+
+//---------------------------------------------------------------------------------------------
+// Private members
+//---------------------------------------------------------------------------------------------
+
+/**
+ * Private init for this algorithm. Expected to be
+ * overridden in the subclass by a function named PyInit
+ */
+template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::init() {
+  CallMethod0<void>::dispatchWithException(getSelf(), "PyInit");
+}
+
+/**
+ * Private exec for this algorithm. Expected to be
+ * overridden in the subclass by a function named PyExec
+ */
+template <typename BaseAlgorithm> void AlgorithmAdapter<BaseAlgorithm>::exec() {
+  CallMethod0<void>::dispatchWithException(getSelf(), "PyExec");
+}
+
+//-----------------------------------------------------------------------------------------------------------------------------
+// Concete instantiations (avoids definitions being all in the headers)
+//-----------------------------------------------------------------------------------------------------------------------------
+/// API::Algorithm as base
+template class AlgorithmAdapter<API::Algorithm>;
+/// API::DataProcesstor as base
+template class AlgorithmAdapter<API::DataProcessorAlgorithm>;
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/DataProcessorAdapter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/DataProcessorAdapter.cpp
@@ -3,19 +3,13 @@
 //-----------------------------------------------------------------------------
 // AlgorithmAdapter definition
 //-----------------------------------------------------------------------------
-namespace Mantid
-{
-  namespace PythonInterface
-  {
+namespace Mantid {
+namespace PythonInterface {
 
-    /**
-     * Construct the "wrapper" and stores the reference to the PyObject
-     * @param self A reference to the calling Python object
-     */
-    DataProcessorAdapter::DataProcessorAdapter(PyObject* self)
-      : SuperClass(self)
-    {
-    }
-
-  }
+/**
+ * Construct the "wrapper" and stores the reference to the PyObject
+ * @param self A reference to the calling Python object
+ */
+DataProcessorAdapter::DataProcessorAdapter(PyObject *self) : SuperClass(self) {}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
@@ -65,18 +65,18 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
   set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PYTHON_PKG_ROOT}/geometry )
 endif()
 
-copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR} 
+copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR}
                      PYTHON_INSTALL_FILES )
 
 #############################################################################################
 # Create the target for this directory
 #############################################################################################
 
-add_library ( PythonGeometryModule ${EXPORT_FILES} ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
+add_library ( PythonGeometryModule ${EXPORT_FILES} ${MODULE_DEFINITION} ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
 set_python_properties( PythonGeometryModule _geometry )
 set_target_output_directory ( PythonGeometryModule ${OUTPUT_DIR} .pyd )
 # Add the required dependencies
-target_link_libraries ( PythonGeometryModule LINK_PRIVATE 
+target_link_libraries ( PythonGeometryModule LINK_PRIVATE
             PythonKernelModule
             Geometry
             Kernel

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/CMakeLists.txt
@@ -36,22 +36,23 @@ set ( EXPORT_FILES
   src/Exports/SymmetryOperationFactory.cpp
 )
 
-set ( SRC_FILES
-)
+#############################################################################################
+# Generate a source file from the export definitions and provided template
+#############################################################################################
+set ( MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/geometry.cpp )
+create_module ( ${MODULE_TEMPLATE} ${MODULE_DEFINITION} ${EXPORT_FILES} )
 
-set ( INC_FILES
-)
+#############################################################################################
+# Helper code
+#############################################################################################
+set ( SRC_FILES )
+
+set ( INC_FILES )
 
 set ( PY_FILES
   __init__.py
   _aliases.py
 )
-
-#############################################################################################
-# Generate a source file from the export definitions and provided template
-#############################################################################################
-create_module ( ${MODULE_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/geometry.cpp EXPORT_FILES
-                SRC_FILES )
 
 #############################################################################################
 # Copy over the pure Python files for the module
@@ -71,7 +72,7 @@ copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR}
 # Create the target for this directory
 #############################################################################################
 
-add_library ( PythonGeometryModule ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
+add_library ( PythonGeometryModule ${EXPORT_FILES} ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
 set_python_properties( PythonGeometryModule _geometry )
 set_target_output_directory ( PythonGeometryModule ${OUTPUT_DIR} .pyd )
 # Add the required dependencies

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/BoundingBox.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/BoundingBox.cpp
@@ -6,35 +6,42 @@ using Mantid::Geometry::BoundingBox;
 using Mantid::Kernel::V3D;
 using namespace boost::python;
 
-void export_BoundingBox()
-{
+void export_BoundingBox() {
   class_<BoundingBox>("BoundingBox", "Constructs a zero-sized box")
-    .def(init<double, double, double, double, double, double>(
-             (arg("xmax"), arg("ymax"), arg("zmax"), arg("xmin"), arg("ymin"), arg("zmin")),
-              "Constructs a box from the six given points"))
+      .def(init<double, double, double, double, double, double>(
+          (arg("xmax"), arg("ymax"), arg("zmax"), arg("xmin"), arg("ymin"),
+           arg("zmin")),
+          "Constructs a box from the six given points"))
 
-    .def("minPoint", &BoundingBox::minPoint, return_value_policy<copy_const_reference>(),
-        "Returns a V3D containing the values of the minimum of the box. See mantid.kernel.V3D")
+      .def("minPoint", &BoundingBox::minPoint,
+           return_value_policy<copy_const_reference>(),
+           "Returns a V3D containing the values of the minimum of the box. See "
+           "mantid.kernel.V3D")
 
-    .def("maxPoint", &BoundingBox::maxPoint, return_value_policy<copy_const_reference>(),
-        "Returns a V3D containing the values of the minimum of the box. See mantid.kernel.V3D")
+      .def("maxPoint", &BoundingBox::maxPoint,
+           return_value_policy<copy_const_reference>(),
+           "Returns a V3D containing the values of the minimum of the box. See "
+           "mantid.kernel.V3D")
 
-    .def("centrePoint", &BoundingBox::centrePoint,
-        "Returns a V3D containing the coordinates of the centre point. See mantid.kernel.V3D")
+      .def("centrePoint", &BoundingBox::centrePoint,
+           "Returns a V3D containing the coordinates of the centre point. See "
+           "mantid.kernel.V3D")
 
-    .def("width", &BoundingBox::width,
-        "Returns a V3D containing the widths for each dimension. See mantid.kernel.V3D")
+      .def("width", &BoundingBox::width, "Returns a V3D containing the widths "
+                                         "for each dimension. See "
+                                         "mantid.kernel.V3D")
 
-    .def("isNull", &BoundingBox::isNull,
-         "Returns true if the box has no dimensions that have been set")
+      .def("isNull", &BoundingBox::isNull,
+           "Returns true if the box has no dimensions that have been set")
 
-    .def("isPointInside", &BoundingBox::isPointInside,
-         "Returns true if the given point is inside the object. See mantid.kernel.V3D")
+      .def("isPointInside", &BoundingBox::isPointInside,
+           "Returns true if the given point is inside the object. See "
+           "mantid.kernel.V3D")
 
-    .def("doesLineIntersect",
-         (bool (BoundingBox::*)(const V3D &, const V3D &) const)&BoundingBox::doesLineIntersect,
-         (arg("startPoint"), arg("lineDir")),
-         "Returns true if the line given by the starting point & direction vector passes through the box")
-    ;
+      .def("doesLineIntersect",
+           (bool (BoundingBox::*)(const V3D &, const V3D &) const) &
+               BoundingBox::doesLineIntersect,
+           (arg("startPoint"), arg("lineDir")),
+           "Returns true if the line given by the starting point & direction "
+           "vector passes through the box");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/BoundingBox.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/BoundingBox.cpp
@@ -6,9 +6,7 @@ using Mantid::Geometry::BoundingBox;
 using Mantid::Kernel::V3D;
 using namespace boost::python;
 
-// clang-format off
 void export_BoundingBox()
-// clang-format on
 {
   class_<BoundingBox>("BoundingBox", "Constructs a zero-sized box")
     .def(init<double, double, double, double, double, double>(

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/CompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/CompAssembly.cpp
@@ -8,11 +8,9 @@ using namespace boost::python;
 
 /**
  * Enables boost.python to automatically "cast" an object up to the
- * appropriate CompAssembly leaf type 
+ * appropriate CompAssembly leaf type
  */
-void export_CompAssembly()
-{
-  class_<CompAssembly, bases<ICompAssembly, Component>, boost::noncopyable>("CompAssembly", no_init)
-    ;
+void export_CompAssembly() {
+  class_<CompAssembly, bases<ICompAssembly, Component>, boost::noncopyable>(
+      "CompAssembly", no_init);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/CompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/CompAssembly.cpp
@@ -10,9 +10,7 @@ using namespace boost::python;
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate CompAssembly leaf type 
  */
-// clang-format off
 void export_CompAssembly()
-// clang-format on
 {
   class_<CompAssembly, bases<ICompAssembly, Component>, boost::noncopyable>("CompAssembly", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -6,47 +6,67 @@ using Mantid::Geometry::Component;
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
-namespace
-{
-  // Default parameter function overloads
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,Component::getParameterNames,0,1)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_hasParameter,Component::hasParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getNumberParameter,Component::getNumberParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getBoolParameter,Component::getBoolParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getPositionParameter,Component::getPositionParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRotationParameter,Component::getRotationParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getStringParameter,Component::getStringParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getIntParameter,Component::getIntParameter,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterType,Component::getParameterType,1,2)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRotation,Component::getRotation,0,0)
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRelativePos,Component::getRelativePos,0,0)
-
-
+namespace {
+// Default parameter function overloads
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
+                                       Component::getParameterNames, 0, 1)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_hasParameter,
+                                       Component::hasParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getNumberParameter,
+                                       Component::getNumberParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getBoolParameter,
+                                       Component::getBoolParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getPositionParameter,
+                                       Component::getPositionParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRotationParameter,
+                                       Component::getRotationParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getStringParameter,
+                                       Component::getStringParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getIntParameter,
+                                       Component::getIntParameter, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterType,
+                                       Component::getParameterType, 1, 2)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRotation,
+                                       Component::getRotation, 0, 0)
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getRelativePos,
+                                       Component::getRelativePos, 0, 0)
 }
 
-void export_Component()
-{
+void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)
-    .def("getParameterNames", &Component::getParameterNames, Component_getParameterNames())
-    .def("hasParameter", &Component::hasParameter, Component_hasParameter())
-    .def("getNumberParameter", &Component::getNumberParameter, Component_getNumberParameter())
-    .def("getBoolParameter", &Component::getBoolParameter, Component_getBoolParameter())
-    .def("getPositionParameter", &Component::getPositionParameter, Component_getPositionParameter())
-    .def("getRotationParameter", &Component::getRotationParameter, Component_getRotationParameter())
-    .def("getStringParameter", &Component::getStringParameter, Component_getStringParameter())
-    .def("getIntParameter", &Component::getIntParameter, Component_getIntParameter())
-    .def("getRotation", &Component::getRotation, Component_getRotation())
-    .def("getRelativePos", &Component::getRelativePos, Component_getRelativePos())
-    // HACK -- python should return parameters regardless of type. this is untill rows below do not work
-    .def("getParameterType", &Component::getParameterType, Component_getParameterType())
-    //// this does not work for some obvious or not obvious reasons 
-    //.def("getParameter", &Component::getNumberParameter, Component_getNumberParameter())
-    //.def("getParameter", &Component::getBoolParameter, Component_getBoolParameter())
-    //.def("getParameter", &Component::getStringParameter, Component_getStringParameter())
-    //.def("getParameter", &Component::getPositionParameter, Component_getPositionParameter())
-    //.def("getParameter", &Component::getRotationParameter, Component_getRotationParameter())
+      .def("getParameterNames", &Component::getParameterNames,
+           Component_getParameterNames())
+      .def("hasParameter", &Component::hasParameter, Component_hasParameter())
+      .def("getNumberParameter", &Component::getNumberParameter,
+           Component_getNumberParameter())
+      .def("getBoolParameter", &Component::getBoolParameter,
+           Component_getBoolParameter())
+      .def("getPositionParameter", &Component::getPositionParameter,
+           Component_getPositionParameter())
+      .def("getRotationParameter", &Component::getRotationParameter,
+           Component_getRotationParameter())
+      .def("getStringParameter", &Component::getStringParameter,
+           Component_getStringParameter())
+      .def("getIntParameter", &Component::getIntParameter,
+           Component_getIntParameter())
+      .def("getRotation", &Component::getRotation, Component_getRotation())
+      .def("getRelativePos", &Component::getRelativePos,
+           Component_getRelativePos())
+      // HACK -- python should return parameters regardless of type. this is
+      // untill rows below do not work
+      .def("getParameterType", &Component::getParameterType,
+           Component_getParameterType())
+      //// this does not work for some obvious or not obvious reasons
+      //.def("getParameter", &Component::getNumberParameter,
+      // Component_getNumberParameter())
+      //.def("getParameter", &Component::getBoolParameter,
+      // Component_getBoolParameter())
+      //.def("getParameter", &Component::getStringParameter,
+      // Component_getStringParameter())
+      //.def("getParameter", &Component::getPositionParameter,
+      // Component_getPositionParameter())
+      //.def("getParameter", &Component::getRotationParameter,
+      // Component_getRotationParameter())
 
-    ;
-
+      ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -24,9 +24,7 @@ namespace
 
 }
 
-// clang-format off
 void export_Component()
-// clang-format on
 {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)
     .def("getParameterNames", &Component::getParameterNames, Component_getParameterNames())

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
@@ -8,11 +8,9 @@ using namespace boost::python;
 
 /**
  * Enables boost.python to automatically "cast" an object up to the
- * appropriate Detector leaf type 
+ * appropriate Detector leaf type
  */
-void export_Detector()
-{
-  class_<Detector, bases<IDetector, ObjComponent>, boost::noncopyable>("Detector", no_init)
-    ;
+void export_Detector() {
+  class_<Detector, bases<IDetector, ObjComponent>, boost::noncopyable>(
+      "Detector", no_init);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Detector.cpp
@@ -10,9 +10,7 @@ using namespace boost::python;
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate Detector leaf type 
  */
-// clang-format off
 void export_Detector()
-// clang-format on
 {
   class_<Detector, bases<IDetector, ObjComponent>, boost::noncopyable>("Detector", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
@@ -5,11 +5,11 @@ using Mantid::Geometry::DetectorGroup;
 using Mantid::Geometry::IDetector;
 using namespace boost::python;
 
-void export_DetectorGroup()
-{
-  class_<DetectorGroup, bases<IDetector>, boost::noncopyable>("DetectorGroup", no_init)
-    .def("getDetectorIDs", &DetectorGroup::getDetectorIDs, "Returns the list of detector IDs within this group")
-    .def("getNameSeparator",&DetectorGroup::getNameSeparator,"Returns separator for list of names of detectors")
-    ;
+void export_DetectorGroup() {
+  class_<DetectorGroup, bases<IDetector>, boost::noncopyable>("DetectorGroup",
+                                                              no_init)
+      .def("getDetectorIDs", &DetectorGroup::getDetectorIDs,
+           "Returns the list of detector IDs within this group")
+      .def("getNameSeparator", &DetectorGroup::getNameSeparator,
+           "Returns separator for list of names of detectors");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorGroup.cpp
@@ -5,9 +5,7 @@ using Mantid::Geometry::DetectorGroup;
 using Mantid::Geometry::IDetector;
 using namespace boost::python;
 
-// clang-format off
 void export_DetectorGroup()
-// clang-format on
 {
   class_<DetectorGroup, bases<IDetector>, boost::noncopyable>("DetectorGroup", no_init)
     .def("getDetectorIDs", &DetectorGroup::getDetectorIDs, "Returns the list of detector IDs within this group")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -11,34 +11,32 @@ using Mantid::Geometry::Goniometer;
 using namespace boost::python;
 
 namespace //<unnamed>
-{
-  ///@cond
-  // define overloaded functions
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads, Goniometer::getEulerAngles, 0, 1)
-  ///@endcond
+    {
+///@cond
+// define overloaded functions
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
+                                       Goniometer::getEulerAngles, 0, 1)
+///@endcond
 
-  /// Set the U vector via a numpy array
-  void setR(Goniometer & self, const object& data)
-  {
-    self.setR(Mantid::PythonInterface::Converters::PyObjectToMatrix(data)());
-  }
+/// Set the U vector via a numpy array
+void setR(Goniometer &self, const object &data) {
+  self.setR(Mantid::PythonInterface::Converters::PyObjectToMatrix(data)());
+}
 }
 
-void export_Goniometer()
-{
+void export_Goniometer() {
 
   // return_value_policy for read-only numpy array
-  typedef return_value_policy<Mantid::PythonInterface::Policies::MatrixToNumpy< Mantid::PythonInterface::Converters::WrapReadOnly> > return_readonly_numpy;
+  typedef return_value_policy<Mantid::PythonInterface::Policies::MatrixToNumpy<
+      Mantid::PythonInterface::Converters::WrapReadOnly>> return_readonly_numpy;
 
-  class_<Goniometer>("Goniometer", init< >(arg("self")))
-    .def( init< Goniometer const & >(( arg("self"), arg("other") )) )
-    .def( init< Mantid::Kernel::DblMatrix >(( arg("self"), arg("rot") )) )
-    .def( "getEulerAngles", (&Goniometer::getEulerAngles),
-          getEulerAngles_overloads(args("self", "convention"),
-                                   "Default convention is \'YZX\'. Universal goniometer is \'YZY\'"))
-	.def("getR",&Goniometer::getR, return_readonly_numpy())
-	.def("setR", &setR)
-    ;
-
+  class_<Goniometer>("Goniometer", init<>(arg("self")))
+      .def(init<Goniometer const &>((arg("self"), arg("other"))))
+      .def(init<Mantid::Kernel::DblMatrix>((arg("self"), arg("rot"))))
+      .def("getEulerAngles", (&Goniometer::getEulerAngles),
+           getEulerAngles_overloads(args("self", "convention"),
+                                    "Default convention is \'YZX\'. Universal "
+                                    "goniometer is \'YZY\'"))
+      .def("getR", &Goniometer::getR, return_readonly_numpy())
+      .def("setR", &setR);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -24,9 +24,7 @@ namespace //<unnamed>
   }
 }
 
-// clang-format off
 void export_Goniometer()
-// clang-format on
 {
 
   // return_value_policy for read-only numpy array

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -45,9 +45,7 @@ namespace {
     }
 }
 
-// clang-format off
 void export_Group()
-// clang-format on
 {
 
   register_ptr_to_python<boost::shared_ptr<Group> >();

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -15,40 +15,43 @@ using Mantid::Geometry::SymmetryOperation;
 using namespace boost::python;
 
 namespace {
-    std::vector<std::string> getSymmetryOperationStrings(Group &self) {
-      const std::vector<SymmetryOperation> &symOps = self.getSymmetryOperations();
+std::vector<std::string> getSymmetryOperationStrings(Group &self) {
+  const std::vector<SymmetryOperation> &symOps = self.getSymmetryOperations();
 
-      std::vector<std::string> pythonSymOps;
-      for (auto it = symOps.begin(); it != symOps.end(); ++it) {
-        pythonSymOps.push_back((*it).identifier());
-      }
+  std::vector<std::string> pythonSymOps;
+  for (auto it = symOps.begin(); it != symOps.end(); ++it) {
+    pythonSymOps.push_back((*it).identifier());
+  }
 
-      return pythonSymOps;
-    }
-
-    Group_sptr constructGroupFromString(const std::string &initializerString) {
-        return boost::const_pointer_cast<Group>(GroupFactory::create<Group>(initializerString));
-    }
-
-    Group_sptr constructGroupFromVector(const std::vector<SymmetryOperation> &symOps) {
-        return boost::const_pointer_cast<Group>(GroupFactory::create<Group>(symOps));
-    }
-
-    Group_sptr constructGroupFromPythonList(const boost::python::list &symOpList) {
-        std::vector<SymmetryOperation> operations;
-
-        for(int i = 0; i < len(symOpList); ++i) {
-            operations.push_back(boost::python::extract<SymmetryOperation>(symOpList[i]));
-        }
-
-        return boost::const_pointer_cast<Group>(GroupFactory::create<Group>(operations));
-    }
+  return pythonSymOps;
 }
 
-void export_Group()
-{
+Group_sptr constructGroupFromString(const std::string &initializerString) {
+  return boost::const_pointer_cast<Group>(
+      GroupFactory::create<Group>(initializerString));
+}
 
-  register_ptr_to_python<boost::shared_ptr<Group> >();
+Group_sptr
+constructGroupFromVector(const std::vector<SymmetryOperation> &symOps) {
+  return boost::const_pointer_cast<Group>(GroupFactory::create<Group>(symOps));
+}
+
+Group_sptr constructGroupFromPythonList(const boost::python::list &symOpList) {
+  std::vector<SymmetryOperation> operations;
+
+  for (int i = 0; i < len(symOpList); ++i) {
+    operations.push_back(
+        boost::python::extract<SymmetryOperation>(symOpList[i]));
+  }
+
+  return boost::const_pointer_cast<Group>(
+      GroupFactory::create<Group>(operations));
+}
+}
+
+void export_Group() {
+
+  register_ptr_to_python<boost::shared_ptr<Group>>();
 
   enum_<Group::CoordinateSystem>("CoordinateSystem")
       .value("Orthogonal", Group::Orthogonal)
@@ -61,14 +64,25 @@ void export_Group()
       .value("Associativity", Group::Associativity);
 
   class_<Group, boost::noncopyable>("Group", no_init)
-      .def("__init__", make_constructor(&constructGroupFromString), "Construct a group from the provided initializer string.")
-      .def("__init__", make_constructor(&constructGroupFromVector), "Construct a group from the provided symmetry operation list.")
-      .def("__init__", make_constructor(&constructGroupFromPythonList), "Construct a group from a python generated symmetry operation list.")
+      .def("__init__", make_constructor(&constructGroupFromString),
+           "Construct a group from the provided initializer string.")
+      .def("__init__", make_constructor(&constructGroupFromVector),
+           "Construct a group from the provided symmetry operation list.")
+      .def("__init__", make_constructor(&constructGroupFromPythonList),
+           "Construct a group from a python generated symmetry operation list.")
       .def("getOrder", &Group::order, "Returns the order of the group.")
-      .def("getCoordinateSystem", &Group::getCoordinateSystem, "Returns the type of coordinate system to distinguish groups with hexagonal system definition.")
-      .def("getSymmetryOperations", &Group::getSymmetryOperations, "Returns the symmetry operations contained in the group.")
-      .def("getSymmetryOperationStrings", &getSymmetryOperationStrings, "Returns the x,y,z-strings for the contained symmetry operations.")
-      .def("containsOperation", &Group::containsOperation, "Checks whether a SymmetryOperation is included in Group.")
-      .def("isGroup", &Group::isGroup, "Checks whether the contained symmetry operations fulfill the group axioms.")
-      .def("fulfillsAxiom", &Group::fulfillsAxiom, "Checks if the contained symmetry operations fulfill the specified group axiom.");
+      .def("getCoordinateSystem", &Group::getCoordinateSystem,
+           "Returns the type of coordinate system to distinguish groups with "
+           "hexagonal system definition.")
+      .def("getSymmetryOperations", &Group::getSymmetryOperations,
+           "Returns the symmetry operations contained in the group.")
+      .def("getSymmetryOperationStrings", &getSymmetryOperationStrings,
+           "Returns the x,y,z-strings for the contained symmetry operations.")
+      .def("containsOperation", &Group::containsOperation,
+           "Checks whether a SymmetryOperation is included in Group.")
+      .def("isGroup", &Group::isGroup, "Checks whether the contained symmetry "
+                                       "operations fulfill the group axioms.")
+      .def("fulfillsAxiom", &Group::fulfillsAxiom,
+           "Checks if the contained symmetry operations fulfill the specified "
+           "group axiom.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ICompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ICompAssembly.cpp
@@ -6,14 +6,13 @@ using Mantid::Geometry::ICompAssembly;
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
-void export_ICompAssembly()
-{
+void export_ICompAssembly() {
   register_ptr_to_python<boost::shared_ptr<ICompAssembly>>();
 
-  class_<ICompAssembly, boost::python::bases<IComponent>, boost::noncopyable>("ICompAssembly", no_init)
-    .def("nelements", &ICompAssembly::nelements, "Returns the number of elements in the assembly")
-    .def("__getitem__", &ICompAssembly::operator[], "Return the component at the given index")
-    ;
-
+  class_<ICompAssembly, boost::python::bases<IComponent>, boost::noncopyable>(
+      "ICompAssembly", no_init)
+      .def("nelements", &ICompAssembly::nelements,
+           "Returns the number of elements in the assembly")
+      .def("__getitem__", &ICompAssembly::operator[],
+           "Return the component at the given index");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ICompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ICompAssembly.cpp
@@ -6,9 +6,7 @@ using Mantid::Geometry::ICompAssembly;
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
-// clang-format off
 void export_ICompAssembly()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ICompAssembly>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
@@ -8,37 +8,37 @@
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * A wrapper to IComponent::getDistance that accepts the second component
-   * as a "reference to a non-const" object rather than the proper "reference to
-   * const". This avoids a warning on RHEL6 in release mode:
-   *    warning: dereferencing pointer ‘p.600’ does break strict-aliasing rules
-   *
-   * @param self The calling object
-   * @param other A component that forms the other end of the line for the calculation
-   * @return The distance between self & the other component in metres
-   */
-  double getDistance(IComponent & self, IComponent & other)
-  {
-    return self.getDistance(other);
-  }
-
+namespace {
+/**
+ * A wrapper to IComponent::getDistance that accepts the second component
+ * as a "reference to a non-const" object rather than the proper "reference to
+ * const". This avoids a warning on RHEL6 in release mode:
+ *    warning: dereferencing pointer ‘p.600’ does break strict-aliasing rules
+ *
+ * @param self The calling object
+ * @param other A component that forms the other end of the line for the
+ *calculation
+ * @return The distance between self & the other component in metres
+ */
+double getDistance(IComponent &self, IComponent &other) {
+  return self.getDistance(other);
+}
 }
 
-void export_IComponent()
-{
+void export_IComponent() {
   register_ptr_to_python<boost::shared_ptr<IComponent>>();
 
   class_<IComponent, boost::noncopyable>("IComponent", no_init)
-    .def("getPos", &IComponent::getPos, "Returns the absolute position of the component")
-    .def("getDistance", &getDistance, "Returns the distance, in metres, between this and the given component")
-    .def("getName", &IComponent::getName, "Returns the name of the component")
-    .def("getFullName", &IComponent::getFullName,"Returns full path name of component")
-    .def("type", &IComponent::type, "Returns the type of the component represented as a string")
-    .def("getRelativeRot", &IComponent::getRelativeRot,return_value_policy<copy_const_reference>(), "Returns the relative rotation as a Quat")
-    ;
-
+      .def("getPos", &IComponent::getPos,
+           "Returns the absolute position of the component")
+      .def("getDistance", &getDistance, "Returns the distance, in metres, "
+                                        "between this and the given component")
+      .def("getName", &IComponent::getName, "Returns the name of the component")
+      .def("getFullName", &IComponent::getFullName,
+           "Returns full path name of component")
+      .def("type", &IComponent::type,
+           "Returns the type of the component represented as a string")
+      .def("getRelativeRot", &IComponent::getRelativeRot,
+           return_value_policy<copy_const_reference>(),
+           "Returns the relative rotation as a Quat");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
@@ -27,9 +27,7 @@ namespace
 
 }
 
-// clang-format off
 void export_IComponent()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IComponent>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
@@ -6,17 +6,23 @@ using Mantid::Geometry::IDetector;
 using Mantid::Geometry::IObjComponent;
 using namespace boost::python;
 
-void export_IDetector()
-{
+void export_IDetector() {
   register_ptr_to_python<boost::shared_ptr<IDetector>>();
-  
-  class_<IDetector, bases<IObjComponent>, boost::noncopyable>("IDetector", no_init)
-    .def("getID", &IDetector::getID, "Returns the detector ID")
-    .def("isMasked", &IDetector::isMasked, "Returns the value of the masked flag. True means ignore this detector")
-    .def("isMonitor", &IDetector::isMonitor, "Returns True if the detector is marked as a monitor in the IDF")
-    .def("solidAngle", &IDetector::solidAngle, "Return the solid angle in steradians between this detector and an observer")
-    .def("getTwoTheta", &IDetector::getTwoTheta, "Calculate the angle between this detector, another component and an axis")
-    .def("getPhi", &IDetector::getPhi, "Returns the azimuthal angle of this detector")
-  ;
-}
 
+  class_<IDetector, bases<IObjComponent>, boost::noncopyable>("IDetector",
+                                                              no_init)
+      .def("getID", &IDetector::getID, "Returns the detector ID")
+      .def("isMasked", &IDetector::isMasked, "Returns the value of the masked "
+                                             "flag. True means ignore this "
+                                             "detector")
+      .def("isMonitor", &IDetector::isMonitor,
+           "Returns True if the detector is marked as a monitor in the IDF")
+      .def("solidAngle", &IDetector::solidAngle, "Return the solid angle in "
+                                                 "steradians between this "
+                                                 "detector and an observer")
+      .def("getTwoTheta", &IDetector::getTwoTheta,
+           "Calculate the angle between this detector, another component and "
+           "an axis")
+      .def("getPhi", &IDetector::getPhi,
+           "Returns the azimuthal angle of this detector");
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IDetector.cpp
@@ -6,9 +6,7 @@ using Mantid::Geometry::IDetector;
 using Mantid::Geometry::IObjComponent;
 using namespace boost::python;
 
-// clang-format off
 void export_IDetector()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IDetector>>();
   

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -8,32 +8,36 @@ using Mantid::Geometry::IMDDimension;
 using Mantid::Geometry::IMDDimension_sptr;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * @param self A reference to the calling object
-   * @return A plain-text string giving the units
-   */
-  std::string getUnitsAsStr(IMDDimension & self)
-  {
-    return self.getUnits().ascii();
-  }
+namespace {
+/**
+ * @param self A reference to the calling object
+ * @return A plain-text string giving the units
+ */
+std::string getUnitsAsStr(IMDDimension &self) {
+  return self.getUnits().ascii();
+}
 }
 
-void export_IMDDimension()
-{
+void export_IMDDimension() {
   register_ptr_to_python<boost::shared_ptr<IMDDimension>>();
 
-  class_< IMDDimension, boost::noncopyable >("IMDDimension", no_init)
-      .def("getName", &IMDDimension::getName, "Return the name of the dimension as can be displayed along the axis")
-      .def("getMaximum", &IMDDimension::getMaximum, "Return the maximum extent of this dimension")
-      .def("getMinimum", &IMDDimension::getMinimum, "Return the maximum extent of this dimension")
-      .def("getNBins", &IMDDimension::getNBins, "Return the number of bins dimension have (an integrated has one). "
+  class_<IMDDimension, boost::noncopyable>("IMDDimension", no_init)
+      .def("getName", &IMDDimension::getName, "Return the name of the "
+                                              "dimension as can be displayed "
+                                              "along the axis")
+      .def("getMaximum", &IMDDimension::getMaximum,
+           "Return the maximum extent of this dimension")
+      .def("getMinimum", &IMDDimension::getMinimum,
+           "Return the maximum extent of this dimension")
+      .def("getNBins", &IMDDimension::getNBins,
+           "Return the number of bins dimension have (an integrated has one). "
            "A axis directed along dimension would have getNBins+1 axis points.")
-      .def("getX", &IMDDimension::getX, "Return coordinate of the axis at the given index")
-      .def("getDimensionId", &IMDDimension::getDimensionId, "Return a short name which identify the dimension among other dimension."
+      .def("getX", &IMDDimension::getX,
+           "Return coordinate of the axis at the given index")
+      .def("getDimensionId", &IMDDimension::getDimensionId,
+           "Return a short name which identify the dimension among other "
+           "dimension."
            "A dimension can be usually find by its ID and various  ")
-      .def("getUnits",  &getUnitsAsStr, "Return the units associated with this dimension.")
-      ;
+      .def("getUnits", &getUnitsAsStr,
+           "Return the units associated with this dimension.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -20,9 +20,7 @@ namespace
   }
 }
 
-// clang-format off
 void export_IMDDimension()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IMDDimension>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
@@ -7,26 +7,24 @@ using Mantid::Geometry::IObjComponent;
 using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Returns a non-const pointer to the shape object. Avoids a bug with boost python 1.43
-   * that can't register shared_ptr to const types.
-   * @param self A reference to the calling object to emulate method on Python object
-   */
-  boost::shared_ptr<Mantid::Geometry::Object> getShape(IObjComponent &self)
-  {
-    return boost::const_pointer_cast<Mantid::Geometry::Object>(self.shape());
-  }
+namespace {
+/**
+ * Returns a non-const pointer to the shape object. Avoids a bug with boost
+ * python 1.43
+ * that can't register shared_ptr to const types.
+ * @param self A reference to the calling object to emulate method on Python
+ * object
+ */
+boost::shared_ptr<Mantid::Geometry::Object> getShape(IObjComponent &self) {
+  return boost::const_pointer_cast<Mantid::Geometry::Object>(self.shape());
+}
 }
 
-void export_IObjComponent()
-{
+void export_IObjComponent() {
   register_ptr_to_python<boost::shared_ptr<IObjComponent>>();
 
-  class_< IObjComponent, boost::python::bases<IComponent>, boost::noncopyable>("IObjComponent", no_init)
-    .def("shape", &getShape, "Get the object that represents the physical shape of this component")
-    ;
-
+  class_<IObjComponent, boost::python::bases<IComponent>, boost::noncopyable>(
+      "IObjComponent", no_init)
+      .def("shape", &getShape, "Get the object that represents the physical "
+                               "shape of this component");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
@@ -20,9 +20,7 @@ namespace
   }
 }
 
-// clang-format off
 void export_IObjComponent()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IObjComponent>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -10,36 +10,46 @@ using Mantid::detid_t;
 using namespace boost::python;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 
-void export_Instrument()
-{
+void export_Instrument() {
   register_ptr_to_python<boost::shared_ptr<Instrument>>();
 
-  class_<Instrument, bases<CompAssembly>, boost::noncopyable>("Instrument", no_init)
-    .def("getSample", &Instrument::getSample, return_value_policy<RemoveConstSharedPtr>(),
-         "Return the object that represents the sample")
+  class_<Instrument, bases<CompAssembly>, boost::noncopyable>("Instrument",
+                                                              no_init)
+      .def("getSample", &Instrument::getSample,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Return the object that represents the sample")
 
-    .def("getSource", &Instrument::getSource, return_value_policy<RemoveConstSharedPtr>(),
-         "Return the object that represents the source")
+      .def("getSource", &Instrument::getSource,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Return the object that represents the source")
 
-    .def("getComponentByName", (boost::shared_ptr<IComponent> (Instrument::*)(const std::string&))&Instrument::getComponentByName,
-         "Returns the named component")
+      .def("getComponentByName",
+           (boost::shared_ptr<IComponent>(Instrument::*)(const std::string &)) &
+               Instrument::getComponentByName,
+           "Returns the named component")
 
-    .def("getDetector", (boost::shared_ptr<IDetector> (Instrument::*)(const detid_t&)const)&Instrument::getDetector, 
-         "Returns the detector with the given ID")
+      .def("getDetector", (boost::shared_ptr<IDetector>(
+                              Instrument::*)(const detid_t &) const) &
+                              Instrument::getDetector,
+           "Returns the detector with the given ID")
 
-    .def("getReferenceFrame", (boost::shared_ptr<const ReferenceFrame> (Instrument::*)())&Instrument::getReferenceFrame,
-         return_value_policy<RemoveConstSharedPtr>(),
-         "Returns the reference frame attached that defines the instrument axes")
+      .def("getReferenceFrame",
+           (boost::shared_ptr<const ReferenceFrame>(Instrument::*)()) &
+               Instrument::getReferenceFrame,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Returns the reference frame attached that defines the instrument "
+           "axes")
 
-    .def("getValidFromDate", &Instrument::getValidFromDate, "Return the valid from date of the instrument")
+      .def("getValidFromDate", &Instrument::getValidFromDate,
+           "Return the valid from date of the instrument")
 
-    .def("getValidToDate", &Instrument::getValidToDate, "Return the valid to date of the instrument")
+      .def("getValidToDate", &Instrument::getValidToDate,
+           "Return the valid to date of the instrument")
 
-    .def("getBaseInstrument", &Instrument::baseInstrument,return_value_policy<RemoveConstSharedPtr>(),
-         "Return reference to the base instrument")
-      ;
-    ;
-    
-;
+      .def("getBaseInstrument", &Instrument::baseInstrument,
+           return_value_policy<RemoveConstSharedPtr>(),
+           "Return reference to the base instrument");
+  ;
+
+  ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -10,9 +10,7 @@ using Mantid::detid_t;
 using namespace boost::python;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 
-// clang-format off
 void export_Instrument()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Instrument>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjCompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjCompAssembly.cpp
@@ -8,11 +8,9 @@ using Mantid::Geometry::ICompAssembly;
 using Mantid::Geometry::ObjComponent;
 using namespace boost::python;
 
-void export_ObjCompAssembly()
-{
+void export_ObjCompAssembly() {
   register_ptr_to_python<boost::shared_ptr<ObjCompAssembly>>();
 
-  class_<ObjCompAssembly, boost::python::bases<ICompAssembly, ObjComponent>, boost::noncopyable>("IObjCompAssembly", no_init)
-    ;
+  class_<ObjCompAssembly, boost::python::bases<ICompAssembly, ObjComponent>,
+         boost::noncopyable>("IObjCompAssembly", no_init);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjCompAssembly.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjCompAssembly.cpp
@@ -8,9 +8,7 @@ using Mantid::Geometry::ICompAssembly;
 using Mantid::Geometry::ObjComponent;
 using namespace boost::python;
 
-// clang-format off
 void export_ObjCompAssembly()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<ObjCompAssembly>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjComponent.cpp
@@ -6,9 +6,7 @@ using Mantid::Geometry::IObjComponent;
 using Mantid::Geometry::Component;
 using namespace boost::python;
 
-void export_ObjComponent()
-{
-  class_<ObjComponent, boost::python::bases<IObjComponent, Component>, boost::noncopyable>("ObjComponent", no_init)
-    ;
+void export_ObjComponent() {
+  class_<ObjComponent, boost::python::bases<IObjComponent, Component>,
+         boost::noncopyable>("ObjComponent", no_init);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjComponent.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ObjComponent.cpp
@@ -6,9 +6,7 @@ using Mantid::Geometry::IObjComponent;
 using Mantid::Geometry::Component;
 using namespace boost::python;
 
-// clang-format off
 void export_ObjComponent()
-// clang-format on
 {
   class_<ObjComponent, boost::python::bases<IObjComponent, Component>, boost::noncopyable>("ObjComponent", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Object.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Object.cpp
@@ -7,17 +7,15 @@ using Mantid::Geometry::Object;
 using Mantid::Geometry::BoundingBox;
 using namespace boost::python;
 
-void export_Object()
-{
+void export_Object() {
   register_ptr_to_python<boost::shared_ptr<Object>>();
 
   class_<Object, boost::noncopyable>("Object", no_init)
-    .def("getBoundingBox", (const BoundingBox &(Object::*)()const)&Object::getBoundingBox,
-         return_value_policy<copy_const_reference>(),
-         "Return the axis-aligned bounding box for this shape")
+      .def("getBoundingBox",
+           (const BoundingBox &(Object::*)() const) & Object::getBoundingBox,
+           return_value_policy<copy_const_reference>(),
+           "Return the axis-aligned bounding box for this shape")
 
-    .def("getShapeXML", &Object::getShapeXML, 
-         "Returns the XML that was used to create this shape.")
-    ;
+      .def("getShapeXML", &Object::getShapeXML,
+           "Returns the XML that was used to create this shape.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Object.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/Object.cpp
@@ -7,9 +7,7 @@ using Mantid::Geometry::Object;
 using Mantid::Geometry::BoundingBox;
 using namespace boost::python;
 
-// clang-format off
 void export_Object()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Object>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -12,57 +12,56 @@ using Mantid::Geometry::angDegrees;
 using namespace boost::python;
 
 namespace //<unnamed>
-{
-  using namespace Mantid::PythonInterface;
+    {
+using namespace Mantid::PythonInterface;
 
-  /// Set the U vector via a numpy array
-  void setU(OrientedLattice & self, const object& data)
-  {
-    self.setU(Converters::PyObjectToMatrix(data)());
-  }
-
-  /// Set the U vector via a numpy array
-  void setUB(OrientedLattice & self, const object& data)
-  {
-    self.setUB(Converters::PyObjectToMatrix(data)());
-  }
-
-  /// Set the U matrix from 2 Python objects representing a V3D type. This can be a V3D object, a list
-  /// or a numpy array. If the arrays are used they must be of length 3
-  void setUFromVectors(OrientedLattice & self, const object& vec1, const object& vec2)
-  {
-    self.setUFromVectors(Converters::PyObjectToV3D(vec1)(), Converters::PyObjectToV3D(vec2)());
-  }
-
-  Mantid::Kernel::V3D qFromHKL(OrientedLattice & self, const object& vec)
-  {
-    return self.qFromHKL(Converters::PyObjectToV3D(vec)());
-  }
-
-  Mantid::Kernel::V3D hklFromQ(OrientedLattice & self, const object& vec)
-  {
-    return self.hklFromQ(Converters::PyObjectToV3D(vec)());
-  }
-
+/// Set the U vector via a numpy array
+void setU(OrientedLattice &self, const object &data) {
+  self.setU(Converters::PyObjectToMatrix(data)());
 }
 
-void export_OrientedLattice()
-{
-  /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly> > return_readonly_numpy;
+/// Set the U vector via a numpy array
+void setUB(OrientedLattice &self, const object &data) {
+  self.setUB(Converters::PyObjectToMatrix(data)());
+}
 
-  class_<OrientedLattice, bases<UnitCell> >("OrientedLattice", init<>())
+/// Set the U matrix from 2 Python objects representing a V3D type. This can be
+/// a V3D object, a list
+/// or a numpy array. If the arrays are used they must be of length 3
+void setUFromVectors(OrientedLattice &self, const object &vec1,
+                     const object &vec2) {
+  self.setUFromVectors(Converters::PyObjectToV3D(vec1)(),
+                       Converters::PyObjectToV3D(vec2)());
+}
+
+Mantid::Kernel::V3D qFromHKL(OrientedLattice &self, const object &vec) {
+  return self.qFromHKL(Converters::PyObjectToV3D(vec)());
+}
+
+Mantid::Kernel::V3D hklFromQ(OrientedLattice &self, const object &vec) {
+  return self.hklFromQ(Converters::PyObjectToV3D(vec)());
+}
+}
+
+void export_OrientedLattice() {
+  /// return_value_policy for read-only numpy array
+  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly>>
+      return_readonly_numpy;
+
+  class_<OrientedLattice, bases<UnitCell>>("OrientedLattice", init<>())
       .def(init<OrientedLattice const &>((arg("other"))))
       .def(init<double, double, double>((arg("_a"), arg("_b"), arg("_c"))))
-      .def(init<double, double, double, double, double, double, optional<int> >((arg("_a"), arg("_b"), arg("_c"), arg("_alpha"), arg("_beta"), arg("_gamma"), arg("Unit") =
-              (int) (angDegrees))))
-      .def(init<UnitCell>(arg("uc"))).def("getuVector",(&OrientedLattice::getuVector))
+      .def(init<double, double, double, double, double, double, optional<int>>(
+          (arg("_a"), arg("_b"), arg("_c"), arg("_alpha"), arg("_beta"),
+           arg("_gamma"), arg("Unit") = (int)(angDegrees))))
+      .def(init<UnitCell>(arg("uc")))
+      .def("getuVector", (&OrientedLattice::getuVector))
       .def("getvVector", (&OrientedLattice::getvVector))
-      .def("getU",&OrientedLattice::getU, return_readonly_numpy()).def("setU", &setU).def("getUB",&OrientedLattice::getUB, return_readonly_numpy())
+      .def("getU", &OrientedLattice::getU, return_readonly_numpy())
+      .def("setU", &setU)
+      .def("getUB", &OrientedLattice::getUB, return_readonly_numpy())
       .def("setUB", &setUB)
-      .def("setUFromVectors",&setUFromVectors)
+      .def("setUFromVectors", &setUFromVectors)
       .def("qFromHKL", &qFromHKL, "Q vector from HKL vector")
-      .def("hklFromQ", &hklFromQ, "HKL value from Q vector")
-      ;
+      .def("hklFromQ", &hklFromQ, "HKL value from Q vector");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -46,9 +46,7 @@ namespace //<unnamed>
 
 }
 
-// clang-format off
 void export_OrientedLattice()
-// clang-format on
 {
   /// return_value_policy for read-only numpy array
   typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly> > return_readonly_numpy;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PeakShape.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PeakShape.cpp
@@ -5,15 +5,14 @@
 using Mantid::Geometry::PeakShape;
 using namespace boost::python;
 
-
-void export_PeakShape()
-{
+void export_PeakShape() {
   register_ptr_to_python<Mantid::Geometry::PeakShape_sptr>();
 
   class_<PeakShape, boost::noncopyable>("PeakShape", no_init)
-    .def("toJSON", &PeakShape::toJSON, "Serialize object to JSON")
-    .def("shapeName", &PeakShape::shapeName, "Shape name for type of shape")
-    .def("algorithmVersion", &PeakShape::algorithmVersion, "Number of source integration algorithm version")
-    .def("algorithmName", &PeakShape::algorithmName, "Name of source integration algorithm")
-    ;
+      .def("toJSON", &PeakShape::toJSON, "Serialize object to JSON")
+      .def("shapeName", &PeakShape::shapeName, "Shape name for type of shape")
+      .def("algorithmVersion", &PeakShape::algorithmVersion,
+           "Number of source integration algorithm version")
+      .def("algorithmName", &PeakShape::algorithmName,
+           "Name of source integration algorithm");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PeakShape.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PeakShape.cpp
@@ -6,9 +6,7 @@ using Mantid::Geometry::PeakShape;
 using namespace boost::python;
 
 
-// clang-format off
 void export_PeakShape()
-// clang-format on
 {
   register_ptr_to_python<Mantid::Geometry::PeakShape_sptr>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -14,53 +14,55 @@ using Mantid::Geometry::PointGroup;
 using namespace boost::python;
 
 namespace //<unnamed>
-{
-  using namespace Mantid::PythonInterface;
+    {
+using namespace Mantid::PythonInterface;
 
-  bool isEquivalent(PointGroup & self, const object& hkl1, const object& hkl2)
-  {
-    return self.isEquivalent(Converters::PyObjectToV3D(hkl1)(), Converters::PyObjectToV3D(hkl2)());
-  }
-
-  boost::python::list getEquivalents(PointGroup & self, const object& hkl)
-  {
-    const std::vector<Mantid::Kernel::V3D> &equivalents = self.getEquivalents(Converters::PyObjectToV3D(hkl)());
-
-    boost::python::list pythonEquivalents;
-    for(auto it = equivalents.begin(); it != equivalents.end(); ++it) {
-        pythonEquivalents.append(*it);
-    }
-
-    return pythonEquivalents;
-  }
-
-  Mantid::Kernel::V3D getReflectionFamily(PointGroup & self, const object& hkl)
-  {
-    return self.getReflectionFamily(Converters::PyObjectToV3D(hkl)());
-  }
+bool isEquivalent(PointGroup &self, const object &hkl1, const object &hkl2) {
+  return self.isEquivalent(Converters::PyObjectToV3D(hkl1)(),
+                           Converters::PyObjectToV3D(hkl2)());
 }
 
-void export_PointGroup()
-{
-  register_ptr_to_python<boost::shared_ptr<PointGroup> >();
+boost::python::list getEquivalents(PointGroup &self, const object &hkl) {
+  const std::vector<Mantid::Kernel::V3D> &equivalents =
+      self.getEquivalents(Converters::PyObjectToV3D(hkl)());
 
-  scope pointGroupScope = class_<PointGroup, boost::noncopyable>("PointGroup", no_init);
+  boost::python::list pythonEquivalents;
+  for (auto it = equivalents.begin(); it != equivalents.end(); ++it) {
+    pythonEquivalents.append(*it);
+  }
+
+  return pythonEquivalents;
+}
+
+Mantid::Kernel::V3D getReflectionFamily(PointGroup &self, const object &hkl) {
+  return self.getReflectionFamily(Converters::PyObjectToV3D(hkl)());
+}
+}
+
+void export_PointGroup() {
+  register_ptr_to_python<boost::shared_ptr<PointGroup>>();
+
+  scope pointGroupScope =
+      class_<PointGroup, boost::noncopyable>("PointGroup", no_init);
 
   enum_<PointGroup::CrystalSystem>("CrystalSystem")
-          .value("Triclinic", PointGroup::Triclinic)
-          .value("Monoclinic", PointGroup::Monoclinic)
-          .value("Orthorhombic", PointGroup::Orthorhombic)
-          .value("Tetragonal", PointGroup::Tetragonal)
-          .value("Hexagonal", PointGroup::Hexagonal)
-          .value("Trigonal", PointGroup::Trigonal)
-          .value("Cubic", PointGroup::Cubic);
+      .value("Triclinic", PointGroup::Triclinic)
+      .value("Monoclinic", PointGroup::Monoclinic)
+      .value("Orthorhombic", PointGroup::Orthorhombic)
+      .value("Tetragonal", PointGroup::Tetragonal)
+      .value("Hexagonal", PointGroup::Hexagonal)
+      .value("Trigonal", PointGroup::Trigonal)
+      .value("Cubic", PointGroup::Cubic);
 
-  class_<PointGroup, boost::noncopyable, bases<Group> >("PointGroup", no_init)
-          .def("getName", &PointGroup::getName)
-          .def("getHMSymbol", &PointGroup::getSymbol)
-          .def("getCrystalSystem", &PointGroup::crystalSystem)
-          .def("isEquivalent", &isEquivalent, "Check whether the two HKLs are symmetrically equivalent.")
-          .def("getEquivalents", &getEquivalents, "Returns an array with all symmetry equivalents of the supplied HKL.")
-          .def("getReflectionFamily", &getReflectionFamily, "Returns the same HKL for all symmetry equivalents.");
+  class_<PointGroup, boost::noncopyable, bases<Group>>("PointGroup", no_init)
+      .def("getName", &PointGroup::getName)
+      .def("getHMSymbol", &PointGroup::getSymbol)
+      .def("getCrystalSystem", &PointGroup::crystalSystem)
+      .def("isEquivalent", &isEquivalent,
+           "Check whether the two HKLs are symmetrically equivalent.")
+      .def("getEquivalents", &getEquivalents, "Returns an array with all "
+                                              "symmetry equivalents of the "
+                                              "supplied HKL.")
+      .def("getReflectionFamily", &getReflectionFamily,
+           "Returns the same HKL for all symmetry equivalents.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -40,9 +40,7 @@ namespace //<unnamed>
   }
 }
 
-// clang-format off
 void export_PointGroup()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<PointGroup> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
@@ -8,30 +8,39 @@ using namespace Mantid::Geometry;
 using namespace boost::python;
 
 namespace {
-    PointGroup_sptr getPointGroupFromSpaceGroup(PointGroupFactoryImpl & self, const SpaceGroup &group)
-    {
-        return self.createPointGroupFromSpaceGroup(group);
-    }
-
-    PointGroup_sptr getPointGroupFromSpaceGroupSymbol(PointGroupFactoryImpl & self, const std::string &group)
-    {
-        return self.createPointGroupFromSpaceGroup(SpaceGroupFactory::Instance().createSpaceGroup(group));
-    }
+PointGroup_sptr getPointGroupFromSpaceGroup(PointGroupFactoryImpl &self,
+                                            const SpaceGroup &group) {
+  return self.createPointGroupFromSpaceGroup(group);
 }
 
-void export_PointGroupFactory()
-{
-
-    class_<PointGroupFactoryImpl,boost::noncopyable>("PointGroupFactoryImpl", no_init)
-            .def("isSubscribed", &PointGroupFactoryImpl::isSubscribed, "Returns true of the point group with the given symbol is subscribed.")
-            .def("createPointGroup", &PointGroupFactoryImpl::createPointGroup, "Creates a point group if registered.")
-            .def("createPointGroupFromSpaceGroup", &getPointGroupFromSpaceGroup, "Creates the point group that corresponds to the given space group.")
-            .def("createPointGroupFromSpaceGroupSymbol", &getPointGroupFromSpaceGroupSymbol, "Creates a point group directly from the space group symbol.")
-            .def("getAllPointGroupSymbols", &PointGroupFactoryImpl::getAllPointGroupSymbols, "Returns all registered point group symbols.")
-            .def("getPointGroupSymbols", &PointGroupFactoryImpl::getPointGroupSymbols, "Returns all point groups registered for the given crystal system.")
-            .def("Instance", &PointGroupFactory::Instance, return_value_policy<reference_existing_object>(),
-                 "Returns a reference to the PointGroupFactory singleton")
-            .staticmethod("Instance")
-            ;
+PointGroup_sptr getPointGroupFromSpaceGroupSymbol(PointGroupFactoryImpl &self,
+                                                  const std::string &group) {
+  return self.createPointGroupFromSpaceGroup(
+      SpaceGroupFactory::Instance().createSpaceGroup(group));
+}
 }
 
+void export_PointGroupFactory() {
+
+  class_<PointGroupFactoryImpl, boost::noncopyable>("PointGroupFactoryImpl",
+                                                    no_init)
+      .def("isSubscribed", &PointGroupFactoryImpl::isSubscribed,
+           "Returns true of the point group with the given symbol is "
+           "subscribed.")
+      .def("createPointGroup", &PointGroupFactoryImpl::createPointGroup,
+           "Creates a point group if registered.")
+      .def("createPointGroupFromSpaceGroup", &getPointGroupFromSpaceGroup,
+           "Creates the point group that corresponds to the given space group.")
+      .def("createPointGroupFromSpaceGroupSymbol",
+           &getPointGroupFromSpaceGroupSymbol,
+           "Creates a point group directly from the space group symbol.")
+      .def("getAllPointGroupSymbols",
+           &PointGroupFactoryImpl::getAllPointGroupSymbols,
+           "Returns all registered point group symbols.")
+      .def("getPointGroupSymbols", &PointGroupFactoryImpl::getPointGroupSymbols,
+           "Returns all point groups registered for the given crystal system.")
+      .def("Instance", &PointGroupFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the PointGroupFactory singleton")
+      .staticmethod("Instance");
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroupFactory.cpp
@@ -19,9 +19,7 @@ namespace {
     }
 }
 
-// clang-format off
 void export_PointGroupFactory()
-// clang-format on
 {
 
     class_<PointGroupFactoryImpl,boost::noncopyable>("PointGroupFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
@@ -9,32 +9,42 @@ using namespace boost::python;
 
 /**
  * Enables boost.python to automatically "cast" an object up to the
- * appropriate Detector leaf type 
+ * appropriate Detector leaf type
  */
-void export_RectangularDetector()
-{
+void export_RectangularDetector() {
   register_ptr_to_python<boost::shared_ptr<RectangularDetector>>();
 
-  class_<RectangularDetector, bases< CompAssembly, IObjComponent>, boost::noncopyable>("RectangularDetector", no_init)
-    .def("xpixels",&RectangularDetector::xpixels, "Returns the number of pixels in the X direction")
-    .def("ypixels",&RectangularDetector::ypixels, "Returns the number of pixels in the Y direction")
-    .def("xstep",&RectangularDetector::xstep, "Returns the step size in the X direction")
-    .def("ystep",&RectangularDetector::ystep, "Returns the step size in the Y direction")
-    .def("xsize",&RectangularDetector::xsize, "Returns the size in the X direction")
-    .def("ysize",&RectangularDetector::ysize, "Returns the size in the Y direction")
-    .def("xstart",&RectangularDetector::xstart, "Returns the start position in the X direction")
-    .def("ystart",&RectangularDetector::ystart, "Returns the start position in the Y direction")
-    .def("idstart",&RectangularDetector::idstart, "Returns the idstart")
-    .def("idfillbyfirst_y",&RectangularDetector::idfillbyfirst_y, "Returns the idfillbyfirst_y")
-    .def("idstepbyrow",&RectangularDetector::idstepbyrow, "Returns the idstepbyrow")
-    .def("idstep",&RectangularDetector::idstep, "Returns the idstep")
-    .def("minDetectorID",&RectangularDetector::minDetectorID, "Returns the minimum detector id")
-    .def("maxDetectorID",&RectangularDetector::maxDetectorID, "Returns the maximum detector id")
-    ;
+  class_<RectangularDetector, bases<CompAssembly, IObjComponent>,
+         boost::noncopyable>("RectangularDetector", no_init)
+      .def("xpixels", &RectangularDetector::xpixels,
+           "Returns the number of pixels in the X direction")
+      .def("ypixels", &RectangularDetector::ypixels,
+           "Returns the number of pixels in the Y direction")
+      .def("xstep", &RectangularDetector::xstep,
+           "Returns the step size in the X direction")
+      .def("ystep", &RectangularDetector::ystep,
+           "Returns the step size in the Y direction")
+      .def("xsize", &RectangularDetector::xsize,
+           "Returns the size in the X direction")
+      .def("ysize", &RectangularDetector::ysize,
+           "Returns the size in the Y direction")
+      .def("xstart", &RectangularDetector::xstart,
+           "Returns the start position in the X direction")
+      .def("ystart", &RectangularDetector::ystart,
+           "Returns the start position in the Y direction")
+      .def("idstart", &RectangularDetector::idstart, "Returns the idstart")
+      .def("idfillbyfirst_y", &RectangularDetector::idfillbyfirst_y,
+           "Returns the idfillbyfirst_y")
+      .def("idstepbyrow", &RectangularDetector::idstepbyrow,
+           "Returns the idstepbyrow")
+      .def("idstep", &RectangularDetector::idstep, "Returns the idstep")
+      .def("minDetectorID", &RectangularDetector::minDetectorID,
+           "Returns the minimum detector id")
+      .def("maxDetectorID", &RectangularDetector::maxDetectorID,
+           "Returns the maximum detector id");
 }
 
-void export_RectangularDetectorPixel()
-{
-  class_<RectangularDetectorPixel, bases<Detector>, boost::noncopyable>("RectangularDetectorPixel", no_init)
-    ;
+void export_RectangularDetectorPixel() {
+  class_<RectangularDetectorPixel, bases<Detector>, boost::noncopyable>(
+      "RectangularDetectorPixel", no_init);
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/RectangularDetector.cpp
@@ -11,9 +11,7 @@ using namespace boost::python;
  * Enables boost.python to automatically "cast" an object up to the
  * appropriate Detector leaf type 
  */
-// clang-format off
 void export_RectangularDetector()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<RectangularDetector>>();
 
@@ -35,9 +33,7 @@ void export_RectangularDetector()
     ;
 }
 
-// clang-format off
 void export_RectangularDetectorPixel()
-// clang-format on
 {
   class_<RectangularDetectorPixel, bases<Detector>, boost::noncopyable>("RectangularDetectorPixel", no_init)
     ;

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ReferenceFrame.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ReferenceFrame.cpp
@@ -9,28 +9,25 @@ using Mantid::Geometry::ReferenceFrame;
 using Mantid::Kernel::V3D;
 using namespace boost::python;
 
-void export_ReferenceFrame()
-{
+void export_ReferenceFrame() {
   using namespace Mantid::Geometry;
 
-    register_ptr_to_python<boost::shared_ptr<ReferenceFrame>>();
+  register_ptr_to_python<boost::shared_ptr<ReferenceFrame>>();
 
-    enum_<PointingAlong>("PointingAlong")
-       .value("X", X)
-       .value("Y", Y)
-       .value("Z", Z)
-       .export_values();  
+  enum_<PointingAlong>("PointingAlong")
+      .value("X", X)
+      .value("Y", Y)
+      .value("Z", Z)
+      .export_values();
 
-    class_< ReferenceFrame, boost::noncopyable>("ReferenceFrame", no_init)
-      .def( "pointingAlongBeam", &ReferenceFrame::pointingAlongBeam)
-      .def( "pointingUp", &ReferenceFrame::pointingUp)
-      .def( "vecPointingUp", &ReferenceFrame::vecPointingUp )
-      .def( "vecPointingAlongBeam", &ReferenceFrame::vecPointingAlongBeam )
-      .def( "pointingAlongBeamAxis", &ReferenceFrame::pointingAlongBeamAxis )
-      .def( "pointingUpAxis", &ReferenceFrame::pointingUpAxis )
-      .def( "pointingHorizontalAxis", &ReferenceFrame::pointingHorizontalAxis )
+  class_<ReferenceFrame, boost::noncopyable>("ReferenceFrame", no_init)
+      .def("pointingAlongBeam", &ReferenceFrame::pointingAlongBeam)
+      .def("pointingUp", &ReferenceFrame::pointingUp)
+      .def("vecPointingUp", &ReferenceFrame::vecPointingUp)
+      .def("vecPointingAlongBeam", &ReferenceFrame::vecPointingAlongBeam)
+      .def("pointingAlongBeamAxis", &ReferenceFrame::pointingAlongBeamAxis)
+      .def("pointingUpAxis", &ReferenceFrame::pointingUpAxis)
+      .def("pointingHorizontalAxis", &ReferenceFrame::pointingHorizontalAxis)
 
-
-	;
+      ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ReferenceFrame.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/ReferenceFrame.cpp
@@ -9,9 +9,7 @@ using Mantid::Geometry::ReferenceFrame;
 using Mantid::Kernel::V3D;
 using namespace boost::python;
 
-// clang-format off
 void export_ReferenceFrame()
-// clang-format on
 {
   using namespace Mantid::Geometry;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -16,31 +16,30 @@ using Mantid::Geometry::SymmetryOperation;
 using namespace boost::python;
 
 namespace //<unnamed>
-{
-  using namespace Mantid::PythonInterface;
+    {
+using namespace Mantid::PythonInterface;
 
-  boost::python::list getEquivalentPositions(SpaceGroup & self, const object& point)
-  {
-    const std::vector<Mantid::Kernel::V3D> &equivalents = self.getEquivalentPositions(Converters::PyObjectToV3D(point)());
+boost::python::list getEquivalentPositions(SpaceGroup &self,
+                                           const object &point) {
+  const std::vector<Mantid::Kernel::V3D> &equivalents =
+      self.getEquivalentPositions(Converters::PyObjectToV3D(point)());
 
-    boost::python::list pythonEquivalents;
-    for(auto it = equivalents.begin(); it != equivalents.end(); ++it) {
-        pythonEquivalents.append(*it);
-    }
-
-    return pythonEquivalents;
+  boost::python::list pythonEquivalents;
+  for (auto it = equivalents.begin(); it != equivalents.end(); ++it) {
+    pythonEquivalents.append(*it);
   }
 
+  return pythonEquivalents;
+}
 }
 
-void export_SpaceGroup()
-{
-  register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
+void export_SpaceGroup() {
+  register_ptr_to_python<boost::shared_ptr<SpaceGroup>>();
 
-  class_<SpaceGroup, boost::noncopyable, bases<Group> >("SpaceGroup", no_init)
-          .def("getNumber", &SpaceGroup::number)
-          .def("getHMSymbol", &SpaceGroup::hmSymbol)
-          .def("getEquivalentPositions", &getEquivalentPositions, "Returns an array with all symmetry equivalents of the supplied HKL.")
-          ;
+  class_<SpaceGroup, boost::noncopyable, bases<Group>>("SpaceGroup", no_init)
+      .def("getNumber", &SpaceGroup::number)
+      .def("getHMSymbol", &SpaceGroup::hmSymbol)
+      .def("getEquivalentPositions", &getEquivalentPositions,
+           "Returns an array with all symmetry equivalents of the supplied "
+           "HKL.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -33,9 +33,7 @@ namespace //<unnamed>
 
 }
 
-// clang-format off
 void export_SpaceGroup()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -38,9 +38,7 @@ namespace
 
 }
 
-// clang-format off
 void export_SpaceGroupFactory()
-// clang-format on
 {
 
     class_<SpaceGroupFactoryImpl,boost::noncopyable>("SpaceGroupFactoryImpl", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -6,51 +6,53 @@
 using namespace Mantid::Geometry;
 using namespace boost::python;
 
-namespace
-{
-    using namespace Mantid::PythonInterface;
+namespace {
+using namespace Mantid::PythonInterface;
 
-    std::vector<std::string> allSpaceGroupSymbols(SpaceGroupFactoryImpl &self)
-    {
-        return self.subscribedSpaceGroupSymbols();
-    }
-
-    std::vector<std::string> spaceGroupSymbolsForNumber(SpaceGroupFactoryImpl &self, size_t number)
-    {
-        return self.subscribedSpaceGroupSymbols(number);
-    }
-
-    bool isSubscribedSymbol(SpaceGroupFactoryImpl &self, const std::string &symbol)
-    {
-        return self.isSubscribed(symbol);
-    }
-
-    bool isSubscribedNumber(SpaceGroupFactoryImpl &self, size_t number)
-    {
-        return self.isSubscribed(number);
-    }
-
-    SpaceGroup_sptr createSpaceGroup(SpaceGroupFactoryImpl &self, const std::string &symbol)
-    {
-        SpaceGroup_const_sptr spaceGroup = self.createSpaceGroup(symbol);
-        return boost::const_pointer_cast<SpaceGroup>(spaceGroup);
-    }
-
+std::vector<std::string> allSpaceGroupSymbols(SpaceGroupFactoryImpl &self) {
+  return self.subscribedSpaceGroupSymbols();
 }
 
-void export_SpaceGroupFactory()
-{
-
-    class_<SpaceGroupFactoryImpl,boost::noncopyable>("SpaceGroupFactoryImpl", no_init)
-            .def("isSubscribedSymbol", &isSubscribedSymbol, "Returns true if the space group the supplied symbol is subscribed.")
-            .def("isSubscribedNumber", &isSubscribedNumber, "Returns true if a space group with the given number is subscribed.")
-            .def("createSpaceGroup", &createSpaceGroup, "Creates a space group.")
-            .def("getAllSpaceGroupSymbols", &allSpaceGroupSymbols, "Returns all subscribed space group symbols.")
-            .def("getAllSpaceGroupNumbers", &SpaceGroupFactoryImpl::subscribedSpaceGroupNumbers, "Returns all subscribed space group numbers.")
-            .def("subscribedSpaceGroupSymbols", &spaceGroupSymbolsForNumber, "Returns all space group symbols that are registered under the given number.")
-            .def("Instance", &SpaceGroupFactory::Instance, return_value_policy<reference_existing_object>(),
-                 "Returns a reference to the SpaceGroupFactory singleton")
-            .staticmethod("Instance")
-            ;
+std::vector<std::string> spaceGroupSymbolsForNumber(SpaceGroupFactoryImpl &self,
+                                                    size_t number) {
+  return self.subscribedSpaceGroupSymbols(number);
 }
 
+bool isSubscribedSymbol(SpaceGroupFactoryImpl &self,
+                        const std::string &symbol) {
+  return self.isSubscribed(symbol);
+}
+
+bool isSubscribedNumber(SpaceGroupFactoryImpl &self, size_t number) {
+  return self.isSubscribed(number);
+}
+
+SpaceGroup_sptr createSpaceGroup(SpaceGroupFactoryImpl &self,
+                                 const std::string &symbol) {
+  SpaceGroup_const_sptr spaceGroup = self.createSpaceGroup(symbol);
+  return boost::const_pointer_cast<SpaceGroup>(spaceGroup);
+}
+}
+
+void export_SpaceGroupFactory() {
+
+  class_<SpaceGroupFactoryImpl, boost::noncopyable>("SpaceGroupFactoryImpl",
+                                                    no_init)
+      .def("isSubscribedSymbol", &isSubscribedSymbol,
+           "Returns true if the space group the supplied symbol is subscribed.")
+      .def("isSubscribedNumber", &isSubscribedNumber,
+           "Returns true if a space group with the given number is subscribed.")
+      .def("createSpaceGroup", &createSpaceGroup, "Creates a space group.")
+      .def("getAllSpaceGroupSymbols", &allSpaceGroupSymbols,
+           "Returns all subscribed space group symbols.")
+      .def("getAllSpaceGroupNumbers",
+           &SpaceGroupFactoryImpl::subscribedSpaceGroupNumbers,
+           "Returns all subscribed space group numbers.")
+      .def("subscribedSpaceGroupSymbols", &spaceGroupSymbolsForNumber,
+           "Returns all space group symbols that are registered under the "
+           "given number.")
+      .def("Instance", &SpaceGroupFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the SpaceGroupFactory singleton")
+      .staticmethod("Instance");
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
@@ -8,22 +8,24 @@ using namespace Mantid::Geometry;
 using namespace boost::python;
 
 namespace {
-    Mantid::Kernel::V3D getAxis(SymmetryElement & self)
-    {
-        try {
-            SymmetryElementWithAxis &axisElement = dynamic_cast<SymmetryElementWithAxis &>(self);
-            return Mantid::Kernel::V3D(axisElement.getAxis());
-        } catch(std::bad_cast) {
-            return Mantid::Kernel::V3D(0, 0, 0);
-        }
-    }
+Mantid::Kernel::V3D getAxis(SymmetryElement &self) {
+  try {
+    SymmetryElementWithAxis &axisElement =
+        dynamic_cast<SymmetryElementWithAxis &>(self);
+    return Mantid::Kernel::V3D(axisElement.getAxis());
+  } catch (std::bad_cast) {
+    return Mantid::Kernel::V3D(0, 0, 0);
+  }
+}
 }
 
-void export_SymmetryElement()
-{
-  register_ptr_to_python<boost::shared_ptr<SymmetryElement> >();  
-  scope symmetryElementScope = class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init);
+void export_SymmetryElement() {
+  register_ptr_to_python<boost::shared_ptr<SymmetryElement>>();
+  scope symmetryElementScope =
+      class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init);
   class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init)
-      .def("getHMSymbol", &SymmetryElement::hmSymbol, "Returns the Hermann-Mauguin symbol for the element.")
-      .def("getAxis", &getAxis, "Returns the symmetry axis or [0,0,0] for identiy, inversion and translations.");
+      .def("getHMSymbol", &SymmetryElement::hmSymbol,
+           "Returns the Hermann-Mauguin symbol for the element.")
+      .def("getAxis", &getAxis, "Returns the symmetry axis or [0,0,0] for "
+                                "identiy, inversion and translations.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
@@ -19,9 +19,7 @@ namespace {
     }
 }
 
-// clang-format off
 void export_SymmetryElement()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<SymmetryElement> >();  
   scope symmetryElementScope = class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init);

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElementFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElementFactory.cpp
@@ -5,12 +5,14 @@
 using namespace Mantid::Geometry;
 using namespace boost::python;
 
-void export_SymmetryElementFactory()
-{
-    class_<SymmetryElementFactoryImpl,boost::noncopyable>("SymmetryElementFactoryImpl", no_init)
-            .def("createSymElement", &SymmetryElementFactoryImpl::createSymElement, "Creates the symmetry element that corresponds to the supplied symmetry operation.")
-            .def("Instance", &SymmetryElementFactory::Instance, return_value_policy<reference_existing_object>(),
-                 "Returns a reference to the SymmetryElementFactory singleton")
-            .staticmethod("Instance")
-            ;
+void export_SymmetryElementFactory() {
+  class_<SymmetryElementFactoryImpl, boost::noncopyable>(
+      "SymmetryElementFactoryImpl", no_init)
+      .def("createSymElement", &SymmetryElementFactoryImpl::createSymElement,
+           "Creates the symmetry element that corresponds to the supplied "
+           "symmetry operation.")
+      .def("Instance", &SymmetryElementFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the SymmetryElementFactory singleton")
+      .staticmethod("Instance");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElementFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElementFactory.cpp
@@ -5,9 +5,7 @@
 using namespace Mantid::Geometry;
 using namespace boost::python;
 
-// clang-format off
 void export_SymmetryElementFactory()
-// clang-format on
 {
     class_<SymmetryElementFactoryImpl,boost::noncopyable>("SymmetryElementFactoryImpl", no_init)
             .def("createSymElement", &SymmetryElementFactoryImpl::createSymElement, "Creates the symmetry element that corresponds to the supplied symmetry operation.")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
@@ -16,31 +16,38 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 namespace //<unnamed>
-{
-  using namespace Mantid::PythonInterface;
+    {
+using namespace Mantid::PythonInterface;
 
-  Mantid::Kernel::V3D applyToVector(SymmetryOperation & self, const object& hkl)
-  {
-    return self.transformHKL(Converters::PyObjectToV3D(hkl)());
-  }
-
-  Mantid::Kernel::V3D applyToCoordinates(SymmetryOperation & self, const object& coordinates)
-  {
-    return self.operator *<Mantid::Kernel::V3D>(Converters::PyObjectToV3D(coordinates)());
-  }
+Mantid::Kernel::V3D applyToVector(SymmetryOperation &self, const object &hkl) {
+  return self.transformHKL(Converters::PyObjectToV3D(hkl)());
 }
 
-void export_SymmetryOperation()
-{
-  register_ptr_to_python<boost::shared_ptr<SymmetryOperation> >();
+Mantid::Kernel::V3D applyToCoordinates(SymmetryOperation &self,
+                                       const object &coordinates) {
+  return self.operator*<Mantid::Kernel::V3D>(
+      Converters::PyObjectToV3D(coordinates)());
+}
+}
+
+void export_SymmetryOperation() {
+  register_ptr_to_python<boost::shared_ptr<SymmetryOperation>>();
 
   class_<SymmetryOperation>("SymmetryOperation")
-          .def("getOrder", &SymmetryOperation::order, "Returns the order of the symmetry operation, which indicates how often the operation needs to be applied to a point to arrive at identity.")
-          .def("getIdentifier", &SymmetryOperation::identifier, "The identifier of the operation in x,y,z-notation.")
-          .def("transformCoordinates", &applyToCoordinates, "Returns transformed coordinates. For transforming HKLs, use transformHKL.")
-          .def("transformHKL", &applyToVector, "Returns transformed HKLs. For transformation of coordinates use transformCoordinates.")
-          .def("apply", &applyToVector, "An alias for transformHKL.");
+      .def("getOrder", &SymmetryOperation::order,
+           "Returns the order of the symmetry operation, which indicates how "
+           "often the operation needs to be applied to a point to arrive at "
+           "identity.")
+      .def("getIdentifier", &SymmetryOperation::identifier,
+           "The identifier of the operation in x,y,z-notation.")
+      .def("transformCoordinates", &applyToCoordinates,
+           "Returns transformed coordinates. For transforming HKLs, use "
+           "transformHKL.")
+      .def("transformHKL", &applyToVector, "Returns transformed HKLs. For "
+                                           "transformation of coordinates use "
+                                           "transformCoordinates.")
+      .def("apply", &applyToVector, "An alias for transformHKL.");
 
-  std_vector_exporter<Mantid::Geometry::SymmetryOperation>::wrap("std_vector_symmetryoperation");
+  std_vector_exporter<Mantid::Geometry::SymmetryOperation>::wrap(
+      "std_vector_symmetryoperation");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
@@ -30,9 +30,7 @@ namespace //<unnamed>
   }
 }
 
-// clang-format off
 void export_SymmetryOperation()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<SymmetryOperation> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperationFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperationFactory.cpp
@@ -8,29 +8,34 @@ using namespace Mantid::Geometry;
 using namespace boost::python;
 
 namespace {
-    boost::python::list createSymOps(SymmetryOperationFactoryImpl &self, const std::string &identifiers) {
-        std::vector<SymmetryOperation> symOps = self.createSymOps(identifiers);
+boost::python::list createSymOps(SymmetryOperationFactoryImpl &self,
+                                 const std::string &identifiers) {
+  std::vector<SymmetryOperation> symOps = self.createSymOps(identifiers);
 
-        boost::python::list pythonOperations;
-        for(auto it = symOps.begin(); it != symOps.end(); ++it) {
-            pythonOperations.append(*it);
-        }
+  boost::python::list pythonOperations;
+  for (auto it = symOps.begin(); it != symOps.end(); ++it) {
+    pythonOperations.append(*it);
+  }
 
-        return pythonOperations;
-    }
-
+  return pythonOperations;
+}
 }
 
-void export_SymmetryOperationFactory()
-{
-    class_<SymmetryOperationFactoryImpl,boost::noncopyable>("SymmetryOperationFactoryImpl", no_init)
-            .def("exists", &SymmetryOperationFactoryImpl::isSubscribed, "Returns true if the symmetry operation is supplied.")
-            .def("createSymOp", &SymmetryOperationFactoryImpl::createSymOp, "Creates the symmetry operation from the supplied x,y,z-identifier.")
-            .def("createSymOps", &createSymOps, "Creates a vector of SymmetryOperation objects from a semi-colon separated list of x,y,z-identifiers.")
-            .def("subscribedSymbols", &SymmetryOperationFactoryImpl::subscribedSymbols, "Return all subscribed symbols.")
-            .def("Instance", &SymmetryOperationFactory::Instance, return_value_policy<reference_existing_object>(),
-                 "Returns a reference to the SymmetryOperationFactory singleton")
-            .staticmethod("Instance")
-            ;
+void export_SymmetryOperationFactory() {
+  class_<SymmetryOperationFactoryImpl, boost::noncopyable>(
+      "SymmetryOperationFactoryImpl", no_init)
+      .def("exists", &SymmetryOperationFactoryImpl::isSubscribed,
+           "Returns true if the symmetry operation is supplied.")
+      .def("createSymOp", &SymmetryOperationFactoryImpl::createSymOp,
+           "Creates the symmetry operation from the supplied x,y,z-identifier.")
+      .def("createSymOps", &createSymOps,
+           "Creates a vector of SymmetryOperation objects from a semi-colon "
+           "separated list of x,y,z-identifiers.")
+      .def("subscribedSymbols",
+           &SymmetryOperationFactoryImpl::subscribedSymbols,
+           "Return all subscribed symbols.")
+      .def("Instance", &SymmetryOperationFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the SymmetryOperationFactory singleton")
+      .staticmethod("Instance");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperationFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperationFactory.cpp
@@ -21,9 +21,7 @@ namespace {
 
 }
 
-// clang-format off
 void export_SymmetryOperationFactory()
-// clang-format on
 {
     class_<SymmetryOperationFactoryImpl,boost::noncopyable>("SymmetryOperationFactoryImpl", no_init)
             .def("exists", &SymmetryOperationFactoryImpl::isSubscribed, "Returns true if the symmetry operation is supplied.")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -17,88 +17,125 @@ using namespace boost::python;
 
 // Functions purely to aid with wrapping
 namespace //<unnamed>
-{
-  using namespace Mantid::PythonInterface;
+    {
+using namespace Mantid::PythonInterface;
 
-  /// Pass-through function to set the unit cell from a 2D numpy array
-  void recalculateFromGstar(UnitCell & self, object values)
-  {
-    // Create a double matrix and put this in to the unit cell
-    self.recalculateFromGstar(Converters::PyObjectToMatrix(values)());
-  }
+/// Pass-through function to set the unit cell from a 2D numpy array
+void recalculateFromGstar(UnitCell &self, object values) {
+  // Create a double matrix and put this in to the unit cell
+  self.recalculateFromGstar(Converters::PyObjectToMatrix(values)());
+}
 }
 
-void export_UnitCell()
-{
+void export_UnitCell() {
   enum_<AngleUnits>("AngleUnits")
-    .value("Degrees", angDegrees)
-    .value("Radians", angRadians)
-    .export_values();     
+      .value("Degrees", angDegrees)
+      .value("Radians", angRadians)
+      .export_values();
 
   /// return_value_policy for read-only numpy array
-  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly> > return_readonly_numpy;
+  typedef return_value_policy<Policies::MatrixToNumpy<Converters::WrapReadOnly>>
+      return_readonly_numpy;
 
-  class_< UnitCell >( "UnitCell", init< >() )    
-    .def( init<UnitCell const &>(arg("other") ) )     
-    .def( init< double, double, double >(( arg("_a"), arg("_b"), arg("_c") )) )    
-    .def( init< double, double, double, double, double, double, optional< int > >(( arg("_a"), arg("_b"), arg("_c"), arg("_alpha"), arg("_beta"), arg("_gamma"), arg("Unit")=(int)(angDegrees) )) )
-    .def( "a", (double ( UnitCell::* )() const) &UnitCell::a )
-    .def( "a1", (double ( UnitCell::* )() const) &UnitCell::a1 )    
-    .def( "a2", (double ( UnitCell::* )() const) &UnitCell::a2 )    
-    .def( "a3", (double ( UnitCell::* )() const) &UnitCell::a3 )    
-    .def( "alpha", (double ( UnitCell::* )() const) &UnitCell::alpha )    
-    .def( "alpha1", (double ( UnitCell::* )() const) &UnitCell::alpha1 )    
-    .def( "alpha2", (double ( UnitCell::* )() const) &UnitCell::alpha2 )    
-    .def( "alpha3", (double ( UnitCell::* )() const) &UnitCell::alpha3 )    
-    .def( "alphastar", (double ( UnitCell::* )() const) &UnitCell::alphastar )    
-    .def( "astar", (double ( UnitCell::* )() const) &UnitCell::astar )    
-    .def( "b", (double ( UnitCell::* )() const) &UnitCell::b )    
-    .def( "b1", (double ( UnitCell::* )() const) &UnitCell::b1 )    
-    .def( "b2", (double ( UnitCell::* )() const) &UnitCell::b2 )    
-    .def( "b3", (double ( UnitCell::* )() const) &UnitCell::b3 )    
-    .def( "beta", (double ( UnitCell::* )() const) &UnitCell::beta )    
-    .def( "beta1", (double ( UnitCell::* )() const) &UnitCell::beta1 )    
-    .def( "beta2", (double ( UnitCell::* )() const) &UnitCell::beta2 )    
-    .def( "beta3", (double ( UnitCell::* )() const) &UnitCell::beta3 )    
-    .def( "betastar", (double ( UnitCell::* )() const) &UnitCell::betastar )    
-    .def( "bstar", (double ( UnitCell::* )() const) &UnitCell::bstar )    
-    .def( "c", (double ( UnitCell::* )() const) &UnitCell::c )    
-    .def( "cstar", (double ( UnitCell::* )() const) &UnitCell::cstar )    
-    .def( "d", (double ( UnitCell::* )( double,double,double ) const) &UnitCell::d, (arg("h"), arg("k"), arg("l") ))
-    .def( "d", (double ( UnitCell::* )(const V3D &) const) &UnitCell::d, (arg("hkl")))
-    .def( "dstar", (double ( UnitCell::* )( double,double,double ) const) &UnitCell::dstar , (arg("h"), arg("k"), arg("l") ))
-    .def( "errora", (double ( UnitCell::* )() const) &UnitCell::errora)
-    .def( "errorb", (double ( UnitCell::* )() const) &UnitCell::errorb)
-    .def( "errorc", (double ( UnitCell::* )() const) &UnitCell::errorc)
-    .def( "erroralpha", (double ( UnitCell::* )( int const ) const) &UnitCell::erroralpha , (arg("Unit")=(int)(angDegrees)))
-    .def( "errorbeta", (double ( UnitCell::* )( int const ) const) &UnitCell::errorbeta , (arg("Unit")=(int)(angDegrees)))
-    .def( "errorgamma", (double ( UnitCell::* )( int const ) const) &UnitCell::errorgamma , (arg("Unit")=(int)(angDegrees)))
-    .def( "gamma", (double ( UnitCell::* )() const) &UnitCell::gamma )   
-    .def( "gammastar", (double ( UnitCell::* )() const) &UnitCell::gammastar )    
-    .def( "recAngle", (double ( UnitCell::* )( double,double,double,double,double,double,int const ) const)&UnitCell::recAngle, ( arg("h1"), arg("k1"), arg("l1"), arg("h2"), arg("k2"), arg("l2"), arg("Unit")=(int)(angDegrees) ))
-    .def( "recVolume", (double ( UnitCell::* )() const) &UnitCell::recVolume )
-    .def( "set", (void ( UnitCell::* )( double,double,double,double,double,double,int const)) &UnitCell::set, ( arg("_a"), arg("_b"), arg("_c"), arg("_alpha"), arg("_beta"), arg("_gamma"), arg("Unit")=(int)(angDegrees)))
-    .def( "seta", (void ( UnitCell::* )( double ) )( &UnitCell::seta ), ( arg("_a") ) )
-    .def( "setalpha", (void ( UnitCell::* )( double,int const ) )( &UnitCell::setalpha ), ( arg("_alpha"), arg("Unit")=(int)(angDegrees) ) )
-    .def( "setb", (void ( UnitCell::* )( double ) )( &UnitCell::setb ), ( arg("_b") ) )    
-    .def( "setbeta", (void ( UnitCell::* )( double,int const ) )( &UnitCell::setbeta ), ( arg("_beta"), arg("Unit")=(int)(angDegrees) ) )
-    .def( "setc", (void ( UnitCell::* )( double ) )( &UnitCell::setc ), ( arg("_c") ) )    
-    .def( "setgamma", (void ( UnitCell::* )( double,int const ) )( &UnitCell::setgamma ), ( arg("_gamma"), arg("Unit")=(int)(angDegrees) ) )
-    .def( "setError", (void ( UnitCell::* )( double,double,double,double,double,double,int const)) &UnitCell::setError, ( arg("_aerr"), arg("_berr"), arg("_cerr"), arg("_alphaerr"), arg("_betaerr"), arg("_gammaerr"), arg("Unit")=(int)(angDegrees)))
-    .def( "setErrora", (void ( UnitCell::* )( double ) )( &UnitCell::setErrora ), ( arg("_aerr") ) )
-    .def( "setErroralpha", (void ( UnitCell::* )( double,int const ) )( &UnitCell::setErroralpha ), ( arg("_alphaerr"), arg("Unit")=(int)(angDegrees) ) )
-    .def( "setErrorb", (void ( UnitCell::* )( double ) )( &UnitCell::setErrorb ), ( arg("_berr") ) )
-    .def( "setErrorbeta", (void ( UnitCell::* )( double,int const ) )( &UnitCell::setErrorbeta ), ( arg("_betaerr"), arg("Unit")=(int)(angDegrees) ) )
-    .def( "setErrorc", (void ( UnitCell::* )( double ) )( &UnitCell::setErrorc ), ( arg("_cerr") ) )
-    .def( "setErrorgamma", (void ( UnitCell::* )( double,int const ) )( &UnitCell::setErrorgamma ), ( arg("_gammaerr"), arg("Unit")=(int)(angDegrees) ) )
-    .def( "volume", (double ( UnitCell::* )() const) &UnitCell::volume)
-    .def( "getG", &UnitCell::getG, return_readonly_numpy())
-    .def( "getGstar", &UnitCell::getGstar, return_readonly_numpy())
-    .def( "getB", &UnitCell::getB, return_readonly_numpy() )
-    .def( "recalculateFromGstar", &recalculateFromGstar)
-    ;
+  class_<UnitCell>("UnitCell", init<>())
+      .def(init<UnitCell const &>(arg("other")))
+      .def(init<double, double, double>((arg("_a"), arg("_b"), arg("_c"))))
+      .def(init<double, double, double, double, double, double, optional<int>>(
+          (arg("_a"), arg("_b"), arg("_c"), arg("_alpha"), arg("_beta"),
+           arg("_gamma"), arg("Unit") = (int)(angDegrees))))
+      .def("a", (double (UnitCell::*)() const) & UnitCell::a)
+      .def("a1", (double (UnitCell::*)() const) & UnitCell::a1)
+      .def("a2", (double (UnitCell::*)() const) & UnitCell::a2)
+      .def("a3", (double (UnitCell::*)() const) & UnitCell::a3)
+      .def("alpha", (double (UnitCell::*)() const) & UnitCell::alpha)
+      .def("alpha1", (double (UnitCell::*)() const) & UnitCell::alpha1)
+      .def("alpha2", (double (UnitCell::*)() const) & UnitCell::alpha2)
+      .def("alpha3", (double (UnitCell::*)() const) & UnitCell::alpha3)
+      .def("alphastar", (double (UnitCell::*)() const) & UnitCell::alphastar)
+      .def("astar", (double (UnitCell::*)() const) & UnitCell::astar)
+      .def("b", (double (UnitCell::*)() const) & UnitCell::b)
+      .def("b1", (double (UnitCell::*)() const) & UnitCell::b1)
+      .def("b2", (double (UnitCell::*)() const) & UnitCell::b2)
+      .def("b3", (double (UnitCell::*)() const) & UnitCell::b3)
+      .def("beta", (double (UnitCell::*)() const) & UnitCell::beta)
+      .def("beta1", (double (UnitCell::*)() const) & UnitCell::beta1)
+      .def("beta2", (double (UnitCell::*)() const) & UnitCell::beta2)
+      .def("beta3", (double (UnitCell::*)() const) & UnitCell::beta3)
+      .def("betastar", (double (UnitCell::*)() const) & UnitCell::betastar)
+      .def("bstar", (double (UnitCell::*)() const) & UnitCell::bstar)
+      .def("c", (double (UnitCell::*)() const) & UnitCell::c)
+      .def("cstar", (double (UnitCell::*)() const) & UnitCell::cstar)
+      .def("d",
+           (double (UnitCell::*)(double, double, double) const) & UnitCell::d,
+           (arg("h"), arg("k"), arg("l")))
+      .def("d", (double (UnitCell::*)(const V3D &) const) & UnitCell::d,
+           (arg("hkl")))
+      .def("dstar", (double (UnitCell::*)(double, double, double) const) &
+                        UnitCell::dstar,
+           (arg("h"), arg("k"), arg("l")))
+      .def("errora", (double (UnitCell::*)() const) & UnitCell::errora)
+      .def("errorb", (double (UnitCell::*)() const) & UnitCell::errorb)
+      .def("errorc", (double (UnitCell::*)() const) & UnitCell::errorc)
+      .def("erroralpha",
+           (double (UnitCell::*)(int const) const) & UnitCell::erroralpha,
+           (arg("Unit") = (int)(angDegrees)))
+      .def("errorbeta",
+           (double (UnitCell::*)(int const) const) & UnitCell::errorbeta,
+           (arg("Unit") = (int)(angDegrees)))
+      .def("errorgamma",
+           (double (UnitCell::*)(int const) const) & UnitCell::errorgamma,
+           (arg("Unit") = (int)(angDegrees)))
+      .def("gamma", (double (UnitCell::*)() const) & UnitCell::gamma)
+      .def("gammastar", (double (UnitCell::*)() const) & UnitCell::gammastar)
+      .def("recAngle", (double (UnitCell::*)(double, double, double, double,
+                                             double, double, int const) const) &
+                           UnitCell::recAngle,
+           (arg("h1"), arg("k1"), arg("l1"), arg("h2"), arg("k2"), arg("l2"),
+            arg("Unit") = (int)(angDegrees)))
+      .def("recVolume", (double (UnitCell::*)() const) & UnitCell::recVolume)
+      .def("set", (void (UnitCell::*)(double, double, double, double, double,
+                                      double, int const)) &
+                      UnitCell::set,
+           (arg("_a"), arg("_b"), arg("_c"), arg("_alpha"), arg("_beta"),
+            arg("_gamma"), arg("Unit") = (int)(angDegrees)))
+      .def("seta", (void (UnitCell::*)(double))(&UnitCell::seta), (arg("_a")))
+      .def("setalpha",
+           (void (UnitCell::*)(double, int const))(&UnitCell::setalpha),
+           (arg("_alpha"), arg("Unit") = (int)(angDegrees)))
+      .def("setb", (void (UnitCell::*)(double))(&UnitCell::setb), (arg("_b")))
+      .def("setbeta",
+           (void (UnitCell::*)(double, int const))(&UnitCell::setbeta),
+           (arg("_beta"), arg("Unit") = (int)(angDegrees)))
+      .def("setc", (void (UnitCell::*)(double))(&UnitCell::setc), (arg("_c")))
+      .def("setgamma",
+           (void (UnitCell::*)(double, int const))(&UnitCell::setgamma),
+           (arg("_gamma"), arg("Unit") = (int)(angDegrees)))
+      .def("setError", (void (UnitCell::*)(double, double, double, double,
+                                           double, double, int const)) &
+                           UnitCell::setError,
+           (arg("_aerr"), arg("_berr"), arg("_cerr"), arg("_alphaerr"),
+            arg("_betaerr"), arg("_gammaerr"), arg("Unit") = (int)(angDegrees)))
+      .def("setErrora", (void (UnitCell::*)(double))(&UnitCell::setErrora),
+           (arg("_aerr")))
+      .def("setErroralpha",
+           (void (UnitCell::*)(double, int const))(&UnitCell::setErroralpha),
+           (arg("_alphaerr"), arg("Unit") = (int)(angDegrees)))
+      .def("setErrorb", (void (UnitCell::*)(double))(&UnitCell::setErrorb),
+           (arg("_berr")))
+      .def("setErrorbeta",
+           (void (UnitCell::*)(double, int const))(&UnitCell::setErrorbeta),
+           (arg("_betaerr"), arg("Unit") = (int)(angDegrees)))
+      .def("setErrorc", (void (UnitCell::*)(double))(&UnitCell::setErrorc),
+           (arg("_cerr")))
+      .def("setErrorgamma",
+           (void (UnitCell::*)(double, int const))(&UnitCell::setErrorgamma),
+           (arg("_gammaerr"), arg("Unit") = (int)(angDegrees)))
+      .def("volume", (double (UnitCell::*)() const) & UnitCell::volume)
+      .def("getG", &UnitCell::getG, return_readonly_numpy())
+      .def("getGstar", &UnitCell::getGstar, return_readonly_numpy())
+      .def("getB", &UnitCell::getB, return_readonly_numpy())
+      .def("recalculateFromGstar", &recalculateFromGstar);
 
-    scope().attr("deg2rad") = Mantid::Geometry::deg2rad;
-    scope().attr("rad2deg") = Mantid::Geometry::rad2deg;
+  scope().attr("deg2rad") = Mantid::Geometry::deg2rad;
+  scope().attr("rad2deg") = Mantid::Geometry::rad2deg;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -28,9 +28,7 @@ namespace //<unnamed>
   }
 }
 
-// clang-format off
 void export_UnitCell()
-// clang-format on
 {
   enum_<AngleUnits>("AngleUnits")
     .value("Degrees", angDegrees)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -127,7 +127,7 @@ if(CMAKE_GENERATOR STREQUAL Xcode)
   set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PYTHON_PKG_ROOT}/kernel )
 endif()
 
-copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR} 
+copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR}
                      PYTHON_INSTALL_FILES )
 
 #############################################################################################
@@ -156,7 +156,7 @@ configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/${PACKAGESETUP_PY}.py.in ${CMAKE_CU
 #############################################################################################
 # Create the target for this directory
 #############################################################################################
-add_library ( PythonKernelModule ${MODULE_DEFINITION} ${EXPORT_FILES} ${SRC_FILES} ${INC_FILES}
+add_library ( PythonKernelModule ${EXPORT_FILES} ${MODULE_DEFINITION} ${SRC_FILES} ${INC_FILES}
               ${PYTHON_INSTALL_FILES} )
 set_python_properties( PythonKernelModule _kernel )
 set_target_output_directory ( PythonKernelModule ${OUTPUT_DIR} .pyd )

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -50,6 +50,12 @@ set ( EXPORT_FILES
   src/Exports/Statistics.cpp
 )
 
+set ( MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/kernel.cpp )
+create_module ( ${MODULE_TEMPLATE} ${MODULE_DEFINITION} ${EXPORT_FILES} )
+
+#############################################################################################
+# Helper code
+#############################################################################################
 set ( SRC_FILES
   src/Converters/CloneToNumpy.cpp
   src/Converters/NDArrayToVector.cpp
@@ -112,12 +118,6 @@ set ( PY_FILES
 )
 
 #############################################################################################
-# Generate a source file from the export definitions and provided template
-#############################################################################################
-create_module ( ${MODULE_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/kernel.cpp EXPORT_FILES
-                SRC_FILES )
-
-#############################################################################################
 # Add rule to copy over the pure Python files for the module
 #############################################################################################
 set ( OUTPUT_DIR ${PYTHON_PKG_ROOT}/kernel )
@@ -156,12 +156,13 @@ configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/${PACKAGESETUP_PY}.py.in ${CMAKE_CU
 #############################################################################################
 # Create the target for this directory
 #############################################################################################
-
-add_library ( PythonKernelModule ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
+add_library ( PythonKernelModule ${MODULE_DEFINITION} ${EXPORT_FILES} ${SRC_FILES} ${INC_FILES}
+              ${PYTHON_INSTALL_FILES} )
 set_python_properties( PythonKernelModule _kernel )
 set_target_output_directory ( PythonKernelModule ${OUTPUT_DIR} .pyd )
 # Add the required dependencies
-target_link_libraries ( PythonKernelModule LINK_PRIVATE Kernel ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${PYTHON_DEPS} ${POCO_LIBRARIES} )
+target_link_libraries ( PythonKernelModule LINK_PRIVATE Kernel ${Boost_LIBRARIES}
+                        ${PYTHON_LIBRARIES} ${PYTHON_DEPS} ${POCO_LIBRARIES} )
 
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties ( PythonKernelModule PROPERTIES INSTALL_RPATH "@loader_path/../../../MacOS")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/CMakeLists.txt.orig
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/CMakeLists.txt.orig
@@ -1,0 +1,180 @@
+#############################################################################################
+# _kernel Python module
+#############################################################################################
+
+set ( MODULE_TEMPLATE src/kernel.cpp.in )
+
+# Files containing export definitions, these are automatically processed
+# -- Do NOT sort this list. The order defines the order in which the export
+#    definitions occur and some depend on their base classes being exported first --
+set ( EXPORT_FILES
+  src/Exports/ConfigService.cpp
+  src/Exports/DataItem.cpp
+  src/Exports/IPropertyManager.cpp
+  src/Exports/Property.cpp
+  src/Exports/IValidator.cpp
+  src/Exports/IPropertySettings.cpp
+  src/Exports/EnabledWhenProperty.cpp
+  src/Exports/VisibleWhenProperty.cpp
+  src/Exports/PropertyWithValue.cpp
+  src/Exports/ArrayProperty.cpp
+  src/Exports/Quat.cpp
+  src/Exports/V3D.cpp
+  src/Exports/VMD.cpp
+  src/Exports/StlContainers.cpp
+  src/Exports/Logger.cpp
+  src/Exports/Unit.cpp
+  src/Exports/Units.cpp
+  src/Exports/BoundedValidator.cpp
+  src/Exports/TimeSeriesProperty.cpp
+  src/Exports/FilteredTimeSeriesProperty.cpp
+  src/Exports/DateAndTime.cpp
+  src/Exports/InstrumentInfo.cpp
+  src/Exports/FacilityInfo.cpp
+  src/Exports/NullValidator.cpp
+  src/Exports/ListValidator.cpp
+  src/Exports/ArrayLengthValidator.cpp
+  src/Exports/ArrayBoundedValidator.cpp
+  src/Exports/MandatoryValidator.cpp
+  src/Exports/CompositeValidator.cpp
+  src/Exports/LogFilter.cpp
+  src/Exports/UnitConversion.cpp
+  src/Exports/UnitFactory.cpp
+  src/Exports/UnitLabel.cpp
+  src/Exports/DeltaEMode.cpp
+  src/Exports/PropertyManager.cpp
+  src/Exports/PropertyHistory.cpp
+  src/Exports/Memory.cpp
+  src/Exports/ProgressBase.cpp
+  src/Exports/Material.cpp
+  src/Exports/Statistics.cpp
+)
+
+set ( SRC_FILES
+  src/Converters/CloneToNumpy.cpp
+  src/Converters/NDArrayToVector.cpp
+  src/Converters/NDArrayTypeIndex.cpp
+  src/Converters/NumpyFunctions.cpp
+  src/Converters/PyArrayType.cpp
+  src/Converters/PyObjectToMatrix.cpp
+  src/Converters/PyObjectToV3D.cpp
+  src/Converters/PyObjectToVMD.cpp
+  src/Converters/WrapWithNumpy.cpp
+  src/Registry/PropertyWithValueFactory.cpp
+  src/Registry/SequenceTypeHandler.cpp
+  src/Registry/TypeRegistry.cpp
+  src/Registry/DowncastRegistry.cpp
+  src/Environment/ErrorHandling.cpp
+  src/Environment/Threading.cpp
+  src/Environment/WrapperHelpers.cpp
+)
+
+set ( INC_FILES
+  ${HEADER_DIR}/kernel/Converters/CArrayToNDArray.h
+  ${HEADER_DIR}/kernel/Converters/MatrixToNDArray.h
+  ${HEADER_DIR}/kernel/Converters/NumpyFunctions.h
+  ${HEADER_DIR}/kernel/Converters/NDArrayToVector.h
+  ${HEADER_DIR}/kernel/Converters/NDArrayTypeIndex.h
+  ${HEADER_DIR}/kernel/Converters/WrapWithNumpy.h
+  ${HEADER_DIR}/kernel/Converters/VectorToNDArray.h
+  ${HEADER_DIR}/kernel/Converters/PyArrayType.h
+  ${HEADER_DIR}/kernel/Converters/PyObjectToMatrix.h
+  ${HEADER_DIR}/kernel/Converters/PyObjectToV3D.h
+  ${HEADER_DIR}/kernel/Converters/PyObjectToVMD.h
+  ${HEADER_DIR}/kernel/Converters/PySequenceToVector.h
+  ${HEADER_DIR}/kernel/Environment/CallMethod.h
+  ${HEADER_DIR}/kernel/Environment/ErrorHandling.h
+  ${HEADER_DIR}/kernel/Environment/Threading.h
+  ${HEADER_DIR}/kernel/Environment/WrapperHelpers.h
+  ${HEADER_DIR}/kernel/Policies/MatrixToNumpy.h
+  ${HEADER_DIR}/kernel/Policies/VectorToNumpy.h
+  ${HEADER_DIR}/kernel/Registry/PropertyValueHandler.h
+  ${HEADER_DIR}/kernel/Registry/PropertyWithValueFactory.h
+  ${HEADER_DIR}/kernel/Registry/SequenceTypeHandler.h
+  ${HEADER_DIR}/kernel/Registry/TypedPropertyValueHandler.h
+  ${HEADER_DIR}/kernel/Registry/TypeRegistry.h
+  ${HEADER_DIR}/kernel/Registry/DowncastRegistry.h
+  ${HEADER_DIR}/kernel/DataServiceExporter.h
+  ${HEADER_DIR}/kernel/IsNone.h
+  ${HEADER_DIR}/kernel/PropertyWithValueExporter.h
+  ${HEADER_DIR}/kernel/PythonObjectInstantiator.h
+  ${HEADER_DIR}/kernel/StlExportDefinitions.h
+  ${HEADER_DIR}/kernel/TrackingInstanceMethod.h
+  ${HEADER_DIR}/kernel/TypedValidatorExporter.h
+)
+
+set ( PY_FILES
+  __init__.py
+  _aliases.py
+  environment.py
+  funcreturns.py
+  plugins.py
+)
+
+#############################################################################################
+# Generate a source file from the export definitions and provided template
+#############################################################################################
+create_module ( ${MODULE_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/kernel.cpp EXPORT_FILES
+                SRC_FILES )
+
+#############################################################################################
+# Add rule to copy over the pure Python files for the module
+#############################################################################################
+set ( OUTPUT_DIR ${PYTHON_PKG_ROOT}/kernel )
+
+if(CMAKE_GENERATOR STREQUAL Xcode)
+  # Set the output directory for the libraries.
+  set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PYTHON_PKG_ROOT}/kernel )
+endif()
+
+copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR} 
+                     PYTHON_INSTALL_FILES )
+
+#############################################################################################
+# Generate the packagesetup module for the build & install package
+#############################################################################################
+set ( PACKAGESETUP_PY packagesetup )
+set ( NEXUSLIB ${NEXUS_C_LIBRARIES} )
+if ( WIN32 ) #.lib -> .dll
+  string ( REPLACE ".lib" ".dll" NEXUSLIB ${NEXUSLIB} )
+endif()
+
+# Build version
+configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/${PACKAGESETUP_PY}.py.in ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGESETUP_PY}.py )
+# Copy py to build directory, taking care of multi-config (MSVC) builds
+copy_files_to_dir ( ${PACKAGESETUP_PY}.py ${CMAKE_CURRENT_BINARY_DIR} ${OUTPUT_DIR}
+                    PYTHON_INSTALL_FILES )
+
+# Package version
+if ( WIN32 OR APPLE )
+  # NeXus library is in the same place relative to the Python library
+  get_filename_component ( NEXUSLIB_FILE ${NEXUSLIB} NAME )
+  set ( NEXUSLIB ../../${NEXUSLIB_FILE} )
+endif()
+configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/${PACKAGESETUP_PY}.py.in ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGESETUP_PY}.install.py )
+
+#############################################################################################
+# Create the target for this directory
+#############################################################################################
+
+add_library ( PythonKernelModule ${SRC_FILES} ${INC_FILES} ${PYTHON_INSTALL_FILES} )
+set_python_properties( PythonKernelModule _kernel )
+set_target_output_directory ( PythonKernelModule ${OUTPUT_DIR} .pyd )
+# Add the required dependencies
+target_link_libraries ( PythonKernelModule LINK_PRIVATE Kernel ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${PYTHON_DEPS} ${POCO_LIBRARIES} )
+
+if (OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties ( PythonKernelModule PROPERTIES INSTALL_RPATH "@loader_path/../../../MacOS")
+endif ()
+
+###########################################################################
+# Installation settings
+###########################################################################
+install ( TARGETS PythonKernelModule ${SYSTEM_PACKAGE_TARGET} DESTINATION
+          ${BIN_DIR}/mantid/kernel )
+
+# Pure Python files
+install ( FILES ${PY_FILES} DESTINATION ${BIN_DIR}/mantid/kernel )
+# packagesetup.py that will overwrite the ones from the built target
+install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/${PACKAGESETUP_PY}.install.py DESTINATION
+          ${BIN_DIR}/mantid/kernel RENAME ${PACKAGESETUP_PY}.py )

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/CloneToNumpy.cpp
@@ -7,130 +7,123 @@
 
 #include <string>
 
-namespace Mantid { namespace PythonInterface
-  {
-  namespace Converters
-  {
-    namespace Impl
-    {
-      /**
-       * Returns a new numpy array with the a copy of the data from 1D vector with the
-       * exception of string elements where a Python list is produced
-       * @param cvector :: A reference to the cvector to clone
-       * @return The new cloned array
-       */
-      template<typename ElementType>
-      PyObject *clone1D(const std::vector<ElementType> & cvector)
-      {
-        Py_intptr_t dims[1] = { static_cast<int>(cvector.size()) };
-        return cloneND(cvector.data(), 1, dims);
-      }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+namespace Impl {
+/**
+ * Returns a new numpy array with the a copy of the data from 1D vector with the
+ * exception of string elements where a Python list is produced
+ * @param cvector :: A reference to the cvector to clone
+ * @return The new cloned array
+ */
+template <typename ElementType>
+PyObject *clone1D(const std::vector<ElementType> &cvector) {
+  Py_intptr_t dims[1] = {static_cast<int>(cvector.size())};
+  return cloneND(cvector.data(), 1, dims);
+}
 
-      /**
-       * Specialisation for vector<bool> that stores the underlying data differently
-       * Returns a new numpy array with the a copy of the data vector of booleans
-       * @param cvector :: A reference to the cvector to clone
-       * @return The new cloned array
-       */
-      template<>
-      PyObject *clone1D(const std::vector<bool> & cvector)
-      {
-        Py_intptr_t dims[1] = { static_cast<int>(cvector.size()) };
-        int datatype = NDArrayTypeIndex<bool>::typenum;
-        PyArrayObject *nparray =
-            func_PyArray_NewFromDescr(datatype, 1, &dims[0]);
+/**
+ * Specialisation for vector<bool> that stores the underlying data differently
+ * Returns a new numpy array with the a copy of the data vector of booleans
+ * @param cvector :: A reference to the cvector to clone
+ * @return The new cloned array
+ */
+template <> PyObject *clone1D(const std::vector<bool> &cvector) {
+  Py_intptr_t dims[1] = {static_cast<int>(cvector.size())};
+  int datatype = NDArrayTypeIndex<bool>::typenum;
+  PyArrayObject *nparray = func_PyArray_NewFromDescr(datatype, 1, &dims[0]);
 
-        for(Py_intptr_t i = 0; i < dims[0]; ++i)
-        {
-          void *itemPtr = PyArray_GETPTR1(nparray, i);
-          PyArray_SETITEM(nparray, (char*)itemPtr, PyBool_FromLong(static_cast<long int>(cvector[i])));
-        }
-        return (PyObject*)nparray;
-      }
+  for (Py_intptr_t i = 0; i < dims[0]; ++i) {
+    void *itemPtr = PyArray_GETPTR1(nparray, i);
+    PyArray_SETITEM(nparray, (char *)itemPtr,
+                    PyBool_FromLong(static_cast<long int>(cvector[i])));
+  }
+  return (PyObject *)nparray;
+}
 
-      /**
-       * Returns a new numpy array with the a copy of the data from array. A specialization
-       * exists for strings so that they simply create a standard python list.
-       * @param carray :: A reference to a carray
-       * @param ndims :: The dimensionality of the array
-       * @param dims :: The length of the arrays in each dimension
-       * @return
-       */
-      template<typename ElementType>
-      PyObject *cloneND(const ElementType * carray, const int ndims, Py_intptr_t *dims)
-      {
-        int datatype = NDArrayTypeIndex<ElementType>::typenum;
-        PyArrayObject *nparray =
-            func_PyArray_NewFromDescr(datatype, ndims, &dims[0]);
-        // Compute total number of elements
-        size_t length(dims[0]);
-        if(ndims > 1)
-        {
-          for(int i = 1; i < ndims; ++i)
-          {
-            length *= dims[i];
-          }
-        }
-        void *arrayData = PyArray_DATA(nparray);
-        const void *data = static_cast<void*>(const_cast<ElementType *>(carray));
-        std::memcpy(arrayData, data, PyArray_ITEMSIZE(nparray) * length);
-        return (PyObject*)nparray;
-      }
-
-      /**
-       * Returns a new python list of strings from the given array of strings.
-       * @param carray :: A reference to a std::vector
-       * @param ndims :: The dimensionality of the array
-       * @param dims :: The length of the arrays in each dimension
-       * @return
-       */
-      template<>
-      PyObject *cloneND(const std::string * carray, const int ndims, Py_intptr_t *dims)
-      {
-        boost::python::list pystrs;
-        const std::string *iter = carray;
-        for(int i = 0; i < ndims; ++i)
-        {
-          const Py_intptr_t length = dims[i];
-          for(Py_intptr_t j = 0; j < length; ++j)
-          {
-            pystrs.append(iter->c_str());
-            ++iter;
-          }
-        }
-        PyObject *rawptr = pystrs.ptr();
-        Py_INCREF(rawptr); // Make sure it survives after the wrapper decrefs the count
-        return rawptr;
-      }
-
-      //-----------------------------------------------------------------------
-      // Explicit instantiations
-      //-----------------------------------------------------------------------
-      #define INSTANTIATE_CLONE1D(ElementType) \
-        template DLLExport PyObject *clone1D<ElementType>(const std::vector<ElementType> & cvector); \
-
-      #define INSTANTIATE_CLONEND(ElementType) \
-        template DLLExport PyObject *cloneND<ElementType>(const ElementType *, const int ndims, Py_intptr_t *dims);
-
-      #define INSTANTIATE_CLONE(ElementType) \
-        INSTANTIATE_CLONE1D(ElementType) \
-        INSTANTIATE_CLONEND(ElementType)
-
-      ///@cond Doxygen doesn't seem to like this...
-      INSTANTIATE_CLONE(int)
-      INSTANTIATE_CLONE(long)
-      INSTANTIATE_CLONE(long long)
-      INSTANTIATE_CLONE(unsigned int)
-      INSTANTIATE_CLONE(unsigned long)
-      INSTANTIATE_CLONE(unsigned long long)
-      INSTANTIATE_CLONE(double)
-      INSTANTIATE_CLONE(float)
-      // Need further 1D specialisation for string
-      INSTANTIATE_CLONE1D(std::string)
-      // Need further ND specialisation for bool
-      INSTANTIATE_CLONEND(bool)
-      ///@endcond
+/**
+ * Returns a new numpy array with the a copy of the data from array. A
+ * specialization
+ * exists for strings so that they simply create a standard python list.
+ * @param carray :: A reference to a carray
+ * @param ndims :: The dimensionality of the array
+ * @param dims :: The length of the arrays in each dimension
+ * @return
+ */
+template <typename ElementType>
+PyObject *cloneND(const ElementType *carray, const int ndims,
+                  Py_intptr_t *dims) {
+  int datatype = NDArrayTypeIndex<ElementType>::typenum;
+  PyArrayObject *nparray = func_PyArray_NewFromDescr(datatype, ndims, &dims[0]);
+  // Compute total number of elements
+  size_t length(dims[0]);
+  if (ndims > 1) {
+    for (int i = 1; i < ndims; ++i) {
+      length *= dims[i];
     }
   }
-}}
+  void *arrayData = PyArray_DATA(nparray);
+  const void *data = static_cast<void *>(const_cast<ElementType *>(carray));
+  std::memcpy(arrayData, data, PyArray_ITEMSIZE(nparray) * length);
+  return (PyObject *)nparray;
+}
 
+/**
+ * Returns a new python list of strings from the given array of strings.
+ * @param carray :: A reference to a std::vector
+ * @param ndims :: The dimensionality of the array
+ * @param dims :: The length of the arrays in each dimension
+ * @return
+ */
+template <>
+PyObject *cloneND(const std::string *carray, const int ndims,
+                  Py_intptr_t *dims) {
+  boost::python::list pystrs;
+  const std::string *iter = carray;
+  for (int i = 0; i < ndims; ++i) {
+    const Py_intptr_t length = dims[i];
+    for (Py_intptr_t j = 0; j < length; ++j) {
+      pystrs.append(iter->c_str());
+      ++iter;
+    }
+  }
+  PyObject *rawptr = pystrs.ptr();
+  Py_INCREF(
+      rawptr); // Make sure it survives after the wrapper decrefs the count
+  return rawptr;
+}
+
+//-----------------------------------------------------------------------
+// Explicit instantiations
+//-----------------------------------------------------------------------
+#define INSTANTIATE_CLONE1D(ElementType)                                       \
+  template DLLExport PyObject *clone1D<ElementType>(                           \
+      const std::vector<ElementType> &cvector);
+
+#define INSTANTIATE_CLONEND(ElementType)                                       \
+  template DLLExport PyObject *cloneND<ElementType>(                           \
+      const ElementType *, const int ndims, Py_intptr_t *dims);
+
+#define INSTANTIATE_CLONE(ElementType)                                         \
+  INSTANTIATE_CLONE1D(ElementType)                                             \
+  INSTANTIATE_CLONEND(ElementType)
+
+///@cond Doxygen doesn't seem to like this...
+INSTANTIATE_CLONE(int)
+INSTANTIATE_CLONE(long)
+INSTANTIATE_CLONE(long long)
+INSTANTIATE_CLONE(unsigned int)
+INSTANTIATE_CLONE(unsigned long)
+INSTANTIATE_CLONE(unsigned long long)
+INSTANTIATE_CLONE(double)
+INSTANTIATE_CLONE(float)
+// Need further 1D specialisation for string
+INSTANTIATE_CLONE1D(std::string)
+// Need further ND specialisation for bool
+INSTANTIATE_CLONEND(bool)
+///@endcond
+}
+}
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/MatrixToNDArray.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/MatrixToNDArray.cpp
@@ -8,44 +8,44 @@
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
-namespace Mantid { namespace PythonInterface
-{
-  namespace Converters
-  {
-    namespace Impl
-    {
-      /**
-       * Defines the wrapWithNDArray specialization for Matrix container types
-       *
-       * Wraps a vector in a numpy array structure without copying the data
-       * @param cdata :: A reference to the Matrix wrap
-       * @param mode :: A mode switch to define whether the final array is read only/read-write
-       * @return A pointer to a numpy ndarray object
-       */
-      template<typename ContainerType>
-      PyObject *wrapWithNDArray(const ContainerType & cdata, const NumpyWrapMode mode)
-      {
-        std::pair<size_t,size_t> matrixDims = cdata.size();
-        npy_intp dims[2] =  {matrixDims.first, matrixDims.second};
-        int datatype = NDArrayTypeIndex<typename ContainerType::value_type>::typenum;
-        PyObject * ndarray = PyArray_SimpleNewFromData(2, dims, datatype,(void*)&(cdata[0][0]));
-        if( mode == ReadOnly )
-        {
-          PyArrayObject * np = (PyArrayObject *)ndarray;
-          np->flags &= ~NPY_WRITEABLE;
-        }
-        return ndarray;
-      }
-      //-----------------------------------------------------------------------
-      // Explicit instantiations
-      //-----------------------------------------------------------------------
-      #define INSTANTIATE_MATRIX_WRAP(ElementType) \
-        template DLLExport PyObject * wrapWithNDArray<Kernel::Matrix<ElementType> >(const Kernel::Matrix<ElementType> &, const NumpyWrapMode);
-
-      INSTANTIATE_MATRIX_WRAP(int);
-      INSTANTIATE_MATRIX_WRAP(float);
-      INSTANTIATE_MATRIX_WRAP(double);
-
-    }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+namespace Impl {
+/**
+ * Defines the wrapWithNDArray specialization for Matrix container types
+ *
+ * Wraps a vector in a numpy array structure without copying the data
+ * @param cdata :: A reference to the Matrix wrap
+ * @param mode :: A mode switch to define whether the final array is read
+ *only/read-write
+ * @return A pointer to a numpy ndarray object
+ */
+template <typename ContainerType>
+PyObject *wrapWithNDArray(const ContainerType &cdata,
+                          const NumpyWrapMode mode) {
+  std::pair<size_t, size_t> matrixDims = cdata.size();
+  npy_intp dims[2] = {matrixDims.first, matrixDims.second};
+  int datatype = NDArrayTypeIndex<typename ContainerType::value_type>::typenum;
+  PyObject *ndarray =
+      PyArray_SimpleNewFromData(2, dims, datatype, (void *)&(cdata[0][0]));
+  if (mode == ReadOnly) {
+    PyArrayObject *np = (PyArrayObject *)ndarray;
+    np->flags &= ~NPY_WRITEABLE;
   }
-}}
+  return ndarray;
+}
+//-----------------------------------------------------------------------
+// Explicit instantiations
+//-----------------------------------------------------------------------
+#define INSTANTIATE_MATRIX_WRAP(ElementType)                                   \
+  template DLLExport PyObject *wrapWithNDArray<Kernel::Matrix<ElementType>>(   \
+      const Kernel::Matrix<ElementType> &, const NumpyWrapMode);
+
+INSTANTIATE_MATRIX_WRAP(int);
+INSTANTIATE_MATRIX_WRAP(float);
+INSTANTIATE_MATRIX_WRAP(double);
+}
+}
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -6,174 +6,151 @@
 #include <boost/python/extract.hpp>
 #include "MantidPythonInterface/kernel/Converters/NumpyFunctions.h"
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace
-    {
-      //-------------------------------------------------------------------------
-      // Template helpers
-      //-------------------------------------------------------------------------
-      /**
-       * Templated structure to fill a std::vector
-       * with values from a numpy array
-       */
-      template <typename DestElementType>
-      struct fill_vector
-      {
-        void operator()(PyArrayObject *arr, std::vector<DestElementType> & cvector)
-        {
-          // Use the iterator API to iterate through the array
-          // and assign each value to the corresponding vector
-          typedef union {
-            DestElementType* output;
-            void *input;
-          } npy_union;
-          npy_union data;
-          PyObject *iter = Converters::Impl::func_PyArray_IterNew(arr);
-          npy_intp index(0);
-          do
-          {
-            data.input = PyArray_ITER_DATA(iter);
-            cvector[index] = *data.output;
-            ++index;
-            PyArray_ITER_NEXT(iter);
-          } while (PyArray_ITER_NOTDONE(iter));
-        }
-      };
+namespace Mantid {
+namespace PythonInterface {
+namespace {
+//-------------------------------------------------------------------------
+// Template helpers
+//-------------------------------------------------------------------------
+/**
+ * Templated structure to fill a std::vector
+ * with values from a numpy array
+ */
+template <typename DestElementType> struct fill_vector {
+  void operator()(PyArrayObject *arr, std::vector<DestElementType> &cvector) {
+    // Use the iterator API to iterate through the array
+    // and assign each value to the corresponding vector
+    typedef union {
+      DestElementType *output;
+      void *input;
+    } npy_union;
+    npy_union data;
+    PyObject *iter = Converters::Impl::func_PyArray_IterNew(arr);
+    npy_intp index(0);
+    do {
+      data.input = PyArray_ITER_DATA(iter);
+      cvector[index] = *data.output;
+      ++index;
+      PyArray_ITER_NEXT(iter);
+    } while (PyArray_ITER_NOTDONE(iter));
+  }
+};
 
-      /**
-       * Specialization for a std::string to convert the values directly
-       * to the string representation
-       */
-      template <>
-      struct fill_vector<std::string>
-      {
-        void operator()(PyArrayObject *arr, std::vector<std::string> & cvector)
-        {
-          using namespace boost::python;
-          PyObject *flattened = PyArray_Ravel(arr, NPY_CORDER);
-          object nparray = object(handle<>(flattened));
-          const Py_ssize_t nelements = PyArray_Size((PyObject*)arr);
-          for(Py_ssize_t i = 0; i < nelements; ++i)
-          {
-            boost::python::object item = nparray[i];
-            PyObject *s = PyObject_Str(item.ptr());
-            cvector[i] = boost::python::extract<std::string>(s)();
-          }
-        }
-      };
-
-      /**
-       * Templated structure to check the numpy type against the C type
-       * and convert the array if necessary. It is assumed that
-       * the object points to numpy array, no checking is performed
-       */
-      template <typename DestElementType>
-      struct coerce_type
-      {
-        boost::python::object operator()(const boost::python::object &arr)
-        {
-          int sourceType = PyArray_TYPE((PyArrayObject*)arr.ptr());
-          int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
-          boost::python::object result = arr;
-          if( sourceType != destType )
-          {
-            PyObject * sameType = PyArray_Cast((PyArrayObject*)arr.ptr(), destType);
-            result = boost::python::object(boost::python::handle<>(sameType));
-          }
-          return result;
-        }
-      };
-
-      /**
-       * Specialized version for std::string as we don't need
-       * to convert the underlying representation
-       */
-      template <>
-      struct coerce_type<std::string>
-      {
-        boost::python::object operator()(const boost::python::object &arr)
-        {
-          return arr;
-        }
-      };
-    }
-
-    namespace Converters
-    {
-      //-------------------------------------------------------------------------
-      // NDArrayToVector definitions
-      //-------------------------------------------------------------------------
-
-      /**
-       * Constructor
-       * @param value :: A boost python object wrapping a numpy.ndarray
-       */
-      template<typename DestElementType>
-      NDArrayToVector<DestElementType>::
-      NDArrayToVector(const boost::python::object & value)
-      : m_arr(value)
-        {
-        typeCheck();
-        }
-
-      /**
-       * Creates a vector of the DestElementType from the numpy array of
-       * given input type
-       * @return A vector of the DestElementType created from the numpy array
-       */
-      template<typename DestElementType>
-      const std::vector<DestElementType>
-      NDArrayToVector<DestElementType>::operator()()
-      {
-        npy_intp length = PyArray_SIZE((PyArrayObject*)m_arr.ptr()); // Returns the total number of elements in the array
-        std::vector<DestElementType> cvector(length);
-        if(length > 0)
-        {
-          fill_vector<DestElementType>()((PyArrayObject*)m_arr.ptr(), cvector);
-        }
-        return cvector;
-      }
-
-      /**
-       * Checks if the python object points to a numpy.ndarray and also checks if the type
-       * is compatible with the DestElementType. If the types do not match the
-       * array is cast to the DestElementType
-       * @throws std::invalid_argument if the object is not of type numpy.ndarray
-       */
-      template<typename DestElementType>
-      void
-      NDArrayToVector<DestElementType>::typeCheck()
-      {
-        if( !PyArray_Check(m_arr.ptr()) )
-        {
-          throw std::invalid_argument(std::string("NDArrayConverter expects ndarray type, found ")
-          + m_arr.ptr()->ob_type->tp_name);
-        }
-        m_arr = coerce_type<DestElementType>()(m_arr);
-
-      }
-
-      //------------------------------------------------------------------------
-      // Explicit instantiations
-      //------------------------------------------------------------------------
-      #define INSTANTIATE_TOVECTOR(ElementType)\
-        template DLLExport struct NDArrayToVector<ElementType>;
-
-      ///@cond Doxygen doesn't seem to like this...
-      INSTANTIATE_TOVECTOR(int)
-      INSTANTIATE_TOVECTOR(long)
-      INSTANTIATE_TOVECTOR(long long)
-      INSTANTIATE_TOVECTOR(unsigned int)
-      INSTANTIATE_TOVECTOR(unsigned long)
-      INSTANTIATE_TOVECTOR(unsigned long long)
-      INSTANTIATE_TOVECTOR(double)
-      INSTANTIATE_TOVECTOR(bool)
-      INSTANTIATE_TOVECTOR(std::string)
-      ///@endcond
+/**
+ * Specialization for a std::string to convert the values directly
+ * to the string representation
+ */
+template <> struct fill_vector<std::string> {
+  void operator()(PyArrayObject *arr, std::vector<std::string> &cvector) {
+    using namespace boost::python;
+    PyObject *flattened = PyArray_Ravel(arr, NPY_CORDER);
+    object nparray = object(handle<>(flattened));
+    const Py_ssize_t nelements = PyArray_Size((PyObject *)arr);
+    for (Py_ssize_t i = 0; i < nelements; ++i) {
+      boost::python::object item = nparray[i];
+      PyObject *s = PyObject_Str(item.ptr());
+      cvector[i] = boost::python::extract<std::string>(s)();
     }
   }
+};
+
+/**
+ * Templated structure to check the numpy type against the C type
+ * and convert the array if necessary. It is assumed that
+ * the object points to numpy array, no checking is performed
+ */
+template <typename DestElementType> struct coerce_type {
+  boost::python::object operator()(const boost::python::object &arr) {
+    int sourceType = PyArray_TYPE((PyArrayObject *)arr.ptr());
+    int destType = Converters::NDArrayTypeIndex<DestElementType>::typenum;
+    boost::python::object result = arr;
+    if (sourceType != destType) {
+      PyObject *sameType = PyArray_Cast((PyArrayObject *)arr.ptr(), destType);
+      result = boost::python::object(boost::python::handle<>(sameType));
+    }
+    return result;
+  }
+};
+
+/**
+ * Specialized version for std::string as we don't need
+ * to convert the underlying representation
+ */
+template <> struct coerce_type<std::string> {
+  boost::python::object operator()(const boost::python::object &arr) {
+    return arr;
+  }
+};
 }
 
+namespace Converters {
+//-------------------------------------------------------------------------
+// NDArrayToVector definitions
+//-------------------------------------------------------------------------
+
+/**
+ * Constructor
+ * @param value :: A boost python object wrapping a numpy.ndarray
+ */
+template <typename DestElementType>
+NDArrayToVector<DestElementType>::NDArrayToVector(
+    const boost::python::object &value)
+    : m_arr(value) {
+  typeCheck();
+}
+
+/**
+ * Creates a vector of the DestElementType from the numpy array of
+ * given input type
+ * @return A vector of the DestElementType created from the numpy array
+ */
+template <typename DestElementType>
+const std::vector<DestElementType> NDArrayToVector<DestElementType>::
+operator()() {
+  npy_intp length = PyArray_SIZE(
+      (PyArrayObject *)
+      m_arr.ptr()); // Returns the total number of elements in the array
+  std::vector<DestElementType> cvector(length);
+  if (length > 0) {
+    fill_vector<DestElementType>()((PyArrayObject *)m_arr.ptr(), cvector);
+  }
+  return cvector;
+}
+
+/**
+ * Checks if the python object points to a numpy.ndarray and also checks if the
+ * type
+ * is compatible with the DestElementType. If the types do not match the
+ * array is cast to the DestElementType
+ * @throws std::invalid_argument if the object is not of type numpy.ndarray
+ */
+template <typename DestElementType>
+void NDArrayToVector<DestElementType>::typeCheck() {
+  if (!PyArray_Check(m_arr.ptr())) {
+    throw std::invalid_argument(
+        std::string("NDArrayConverter expects ndarray type, found ") +
+        m_arr.ptr()->ob_type->tp_name);
+  }
+  m_arr = coerce_type<DestElementType>()(m_arr);
+}
+
+//------------------------------------------------------------------------
+// Explicit instantiations
+//------------------------------------------------------------------------
+#define INSTANTIATE_TOVECTOR(ElementType)                                      \
+  template DLLExport struct NDArrayToVector<ElementType>;
+
+///@cond Doxygen doesn't seem to like this...
+INSTANTIATE_TOVECTOR(int)
+INSTANTIATE_TOVECTOR(long)
+INSTANTIATE_TOVECTOR(long long)
+INSTANTIATE_TOVECTOR(unsigned int)
+INSTANTIATE_TOVECTOR(unsigned long)
+INSTANTIATE_TOVECTOR(unsigned long long)
+INSTANTIATE_TOVECTOR(double)
+INSTANTIATE_TOVECTOR(bool)
+INSTANTIATE_TOVECTOR(std::string)
+///@endcond
+}
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayTypeIndex.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayTypeIndex.cpp
@@ -11,29 +11,23 @@
 #include <boost/python/type_id.hpp>
 #include <stdexcept>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Converters
-    {
-      /// Macro to define mappings between the CType and Numpy enum
-      #define DEFINE_TYPE_MAPPING(CType, NDTypeNum) \
-        template<> \
-        int NDArrayTypeIndex<CType>::typenum = NDTypeNum;\
-        template DLLExport struct NDArrayTypeIndex<CType>;\
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+/// Macro to define mappings between the CType and Numpy enum
+#define DEFINE_TYPE_MAPPING(CType, NDTypeNum)                                  \
+  template <> int NDArrayTypeIndex<CType>::typenum = NDTypeNum;                \
+  template DLLExport struct NDArrayTypeIndex<CType>;
 
-
-      DEFINE_TYPE_MAPPING(int, NPY_INT)
-      DEFINE_TYPE_MAPPING(long, NPY_LONG)
-      DEFINE_TYPE_MAPPING(long long, NPY_LONGLONG)
-      DEFINE_TYPE_MAPPING(unsigned int, NPY_UINT)
-      DEFINE_TYPE_MAPPING(unsigned long, NPY_ULONG)
-      DEFINE_TYPE_MAPPING(unsigned long long, NPY_ULONGLONG)
-      DEFINE_TYPE_MAPPING(bool, NPY_BOOL)
-      DEFINE_TYPE_MAPPING(double, NPY_DOUBLE)
-      DEFINE_TYPE_MAPPING(float, NPY_FLOAT)
-    }
-  }
+DEFINE_TYPE_MAPPING(int, NPY_INT)
+DEFINE_TYPE_MAPPING(long, NPY_LONG)
+DEFINE_TYPE_MAPPING(long long, NPY_LONGLONG)
+DEFINE_TYPE_MAPPING(unsigned int, NPY_UINT)
+DEFINE_TYPE_MAPPING(unsigned long, NPY_ULONG)
+DEFINE_TYPE_MAPPING(unsigned long long, NPY_ULONGLONG)
+DEFINE_TYPE_MAPPING(bool, NPY_BOOL)
+DEFINE_TYPE_MAPPING(double, NPY_DOUBLE)
+DEFINE_TYPE_MAPPING(float, NPY_FLOAT)
 }
-
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyArrayType.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyArrayType.cpp
@@ -3,27 +3,21 @@
 //-----------------------------------------------------------------------------
 #include "MantidPythonInterface/kernel/Converters/PyArrayType.h"
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Converters
-    {
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
 
-      /**
-       * Returns a pointer to the PyArray_Type object
-       * @return
-       */
-      PyTypeObject * getNDArrayType()
-      {
-        return &PyArray_Type;
-      }
-
-    }
-  }
+/**
+ * Returns a pointer to the PyArray_Type object
+ * @return
+ */
+PyTypeObject *getNDArrayType() { return &PyArray_Type; }
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToMatrix.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToMatrix.cpp
@@ -5,77 +5,71 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/numeric.hpp>
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Converters
-    {
-      /**
-       * Construct the converter object with the given Python object
-       * @param p :: A boost::python object that should support
-       * the __getitem__ and __len__ protocol or be a wrapped V3D object.
-       * Throws std::invalid_argument if not
-       * if that is not the case.
-       */
-      PyObjectToMatrix::PyObjectToMatrix(const boost::python::object & p)
-        : m_obj(p), m_alreadyMatrix(false)
-      {
-        // Is it an already wrapped V3D ?
-        boost::python::extract<Kernel::Matrix<double> > converter(p);
-        if( converter.check() )
-        {
-         m_alreadyMatrix = true;
-         return;
-        }
-        // Is it a 2D numpy array
-        if( !PyArray_Check(p.ptr()) )
-        {
-          throw std::invalid_argument(std::string("Cannot convert object to Matrix. Expected a numpy array found ")
-                                       + p.ptr()->ob_type->tp_name);
-        }
-      }
-
-     /**
-      * Returns a V3D object from the Python object given
-      * to the converter
-      * @returns A newly constructed V3D object converted
-      * from the PyObject.
-      */
-      Kernel::Matrix<double> PyObjectToMatrix::operator ()()
-      {
-        using namespace boost::python;
-        if(m_alreadyMatrix)
-        {
-         return extract<Kernel::Matrix<double> >(m_obj)();
-        }
-        numeric::array numarray = numeric::array(m_obj);
-        numarray = (boost::python::numeric::array) numarray.astype('d'); // Force the array to be of double type (in case it was int)
-        boost::python::tuple shape( numarray.attr("shape") );
-        if( boost::python::len(shape) != 2 )
-        {
-          std::ostringstream msg;
-          msg << "Error in conversion to Matrix. Expected an array with 2 dimensions but was given array with "
-              << boost::python::len(shape) << " dimensions.";
-          throw std::invalid_argument(msg.str());
-        }
-        size_t nx = boost::python::extract<size_t>(shape[0]);
-        size_t ny = boost::python::extract<size_t>(shape[1]);
-        Kernel::Matrix<double> matrix(nx,ny);
-        for( size_t i = 0; i < nx; i++ )
-        {
-          for( size_t j = 0; j < ny; j++ )
-          {
-             matrix[i][j] = extract<double>( numarray[boost::python::make_tuple( i, j )]);
-           }
-        }
-        return matrix;
-     }
-   }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+/**
+ * Construct the converter object with the given Python object
+ * @param p :: A boost::python object that should support
+ * the __getitem__ and __len__ protocol or be a wrapped V3D object.
+ * Throws std::invalid_argument if not
+ * if that is not the case.
+ */
+PyObjectToMatrix::PyObjectToMatrix(const boost::python::object &p)
+    : m_obj(p), m_alreadyMatrix(false) {
+  // Is it an already wrapped V3D ?
+  boost::python::extract<Kernel::Matrix<double>> converter(p);
+  if (converter.check()) {
+    m_alreadyMatrix = true;
+    return;
   }
+  // Is it a 2D numpy array
+  if (!PyArray_Check(p.ptr())) {
+    throw std::invalid_argument(
+        std::string(
+            "Cannot convert object to Matrix. Expected a numpy array found ") +
+        p.ptr()->ob_type->tp_name);
+  }
+}
+
+/**
+ * Returns a V3D object from the Python object given
+ * to the converter
+ * @returns A newly constructed V3D object converted
+ * from the PyObject.
+ */
+Kernel::Matrix<double> PyObjectToMatrix::operator()() {
+  using namespace boost::python;
+  if (m_alreadyMatrix) {
+    return extract<Kernel::Matrix<double>>(m_obj)();
+  }
+  numeric::array numarray = numeric::array(m_obj);
+  numarray = (boost::python::numeric::array)numarray.astype(
+      'd'); // Force the array to be of double type (in case it was int)
+  boost::python::tuple shape(numarray.attr("shape"));
+  if (boost::python::len(shape) != 2) {
+    std::ostringstream msg;
+    msg << "Error in conversion to Matrix. Expected an array with 2 dimensions "
+           "but was given array with " << boost::python::len(shape)
+        << " dimensions.";
+    throw std::invalid_argument(msg.str());
+  }
+  size_t nx = boost::python::extract<size_t>(shape[0]);
+  size_t ny = boost::python::extract<size_t>(shape[1]);
+  Kernel::Matrix<double> matrix(nx, ny);
+  for (size_t i = 0; i < nx; i++) {
+    for (size_t j = 0; j < ny; j++) {
+      matrix[i][j] = extract<double>(numarray[boost::python::make_tuple(i, j)]);
+    }
+  }
+  return matrix;
+}
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToV3D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToV3D.cpp
@@ -5,78 +5,67 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/numeric.hpp>
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-   namespace Converters
-   {
-     /**
-      * Construct the converter object with the given Python object
-      * @param p :: A boost::python object that should support
-      * the __getitem__ and __len__ protocol or be a wrapped V3D object.
-      * Throws std::invalid_argument if not
-      * if that is not the case.
-      */
-     PyObjectToV3D::PyObjectToV3D(const boost::python::object & p)
-       : m_obj(p), m_alreadyV3D(false)
-     {
-       // Is it an already wrapped V3D ?
-       boost::python::extract<Kernel::V3D> converter(p);
-       if( converter.check() )
-       {
-         m_alreadyV3D = true;
-         return;
-       }
-       // Is it a sequence
-       try
-       {
-         const size_t length = boost::python::len(p);
-         if( length != 3 )
-         {
-           throw std::invalid_argument("Incorrect length for conversion to V3D");
-         }
-         // Can we index the object
-         p.attr("__getitem__")(0);
-       }
-       catch(boost::python::error_already_set&)
-       {
-         throw std::invalid_argument(std::string("Cannot convert object to V3D. Expected a python sequence found ")
-                                       + p.ptr()->ob_type->tp_name);
-       }
-     }
-
-     /**
-      * Returns a V3D object from the Python object given
-      * to the converter
-      * @returns A newly constructed V3D object converted
-      * from the PyObject.
-      */
-     Kernel::V3D PyObjectToV3D::operator ()()
-     {
-       using namespace boost::python;
-       if(m_alreadyV3D)
-       {
-         return extract<Kernel::V3D>(m_obj)();
-       }
-       // Numpy arrays need to be forced to a double
-       // as extract cannot convert from a int64->double
-       boost::python::object obj = m_obj;
-       if( PyArray_Check(obj.ptr()) )
-       {
-         obj = boost::python::numeric::array(obj).astype('d');
-       }
-       // Must be a sequence
-       return Kernel::V3D(extract<double>(obj[0])(),
-                          extract<double>(obj[1])(),
-                          extract<double>(obj[2])());
-     }
-
-   }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+/**
+ * Construct the converter object with the given Python object
+ * @param p :: A boost::python object that should support
+ * the __getitem__ and __len__ protocol or be a wrapped V3D object.
+ * Throws std::invalid_argument if not
+ * if that is not the case.
+ */
+PyObjectToV3D::PyObjectToV3D(const boost::python::object &p)
+    : m_obj(p), m_alreadyV3D(false) {
+  // Is it an already wrapped V3D ?
+  boost::python::extract<Kernel::V3D> converter(p);
+  if (converter.check()) {
+    m_alreadyV3D = true;
+    return;
   }
+  // Is it a sequence
+  try {
+    const size_t length = boost::python::len(p);
+    if (length != 3) {
+      throw std::invalid_argument("Incorrect length for conversion to V3D");
+    }
+    // Can we index the object
+    p.attr("__getitem__")(0);
+  } catch (boost::python::error_already_set &) {
+    throw std::invalid_argument(
+        std::string(
+            "Cannot convert object to V3D. Expected a python sequence found ") +
+        p.ptr()->ob_type->tp_name);
+  }
+}
+
+/**
+ * Returns a V3D object from the Python object given
+ * to the converter
+ * @returns A newly constructed V3D object converted
+ * from the PyObject.
+ */
+Kernel::V3D PyObjectToV3D::operator()() {
+  using namespace boost::python;
+  if (m_alreadyV3D) {
+    return extract<Kernel::V3D>(m_obj)();
+  }
+  // Numpy arrays need to be forced to a double
+  // as extract cannot convert from a int64->double
+  boost::python::object obj = m_obj;
+  if (PyArray_Check(obj.ptr())) {
+    obj = boost::python::numeric::array(obj).astype('d');
+  }
+  // Must be a sequence
+  return Kernel::V3D(extract<double>(obj[0])(), extract<double>(obj[1])(),
+                     extract<double>(obj[2])());
+}
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/PyObjectToVMD.cpp
@@ -6,7 +6,8 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/numeric.hpp>
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
@@ -15,80 +16,67 @@
 GCC_DIAG_OFF(strict-aliasing)
 // clang-format on
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-   namespace Converters
-   {
-     /**
-      * Construct the converter object with the given Python object
-      * @param p :: A boost::python object that should support
-      * the __getitem__ and __len__ protocol or be a wrapped VMD object.
-      * Throws std::invalid_argument if not
-      * if that is not the case.
-      */
-     PyObjectToVMD::PyObjectToVMD(const boost::python::object & p)
-       : m_obj(p), m_alreadyVMD(false)
-     {
-       // Is it an already wrapped VMD ?
-       boost::python::extract<Kernel::VMD> converter(p);
-       if( converter.check() )
-       {
-         m_alreadyVMD = true;
-         return;
-       }
-       // Is it a sequence
-       try
-       {
-         const size_t length = boost::python::len(p);
-         if( length < 3 )
-         {
-           throw std::invalid_argument("Must be > 2 for conversion to VMD");
-         }
-         // Can we index the object
-         p.attr("__getitem__")(0);
-       }
-       catch(boost::python::error_already_set&)
-       {
-         throw std::invalid_argument(std::string(
-               "Cannot convert object to VMD. "
-               "Expected a python sequence found: ")
-               + p.ptr()->ob_type->tp_name);
-       }
-     }
-
-     /**
-      * Returns a VMD object from the Python object given
-      * to the converter
-      * @returns A newly constructed VMD object converted
-      * from the PyObject.
-      */
-     Kernel::VMD PyObjectToVMD::operator ()()
-     {
-       using namespace boost::python;
-       if(m_alreadyVMD)
-       {
-         return extract<Kernel::VMD>(m_obj)();
-       }
-       // Numpy arrays need to be forced to a double
-       // as extract cannot convert from a int64->double
-       boost::python::object obj = m_obj;
-       if( PyArray_Check(obj.ptr()) )
-       {
-         obj = boost::python::numeric::array(obj).astype('d');
-       }
-       // Must be a sequence
-
-       const size_t length = boost::python::len(obj);
-       Kernel::VMD ret(length);
-
-       for(size_t i = 0; i < length; ++i)
-         ret[i] = extract<float>(obj[i])();
-
-       return ret;
-     }
-
-   }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+/**
+ * Construct the converter object with the given Python object
+ * @param p :: A boost::python object that should support
+ * the __getitem__ and __len__ protocol or be a wrapped VMD object.
+ * Throws std::invalid_argument if not
+ * if that is not the case.
+ */
+PyObjectToVMD::PyObjectToVMD(const boost::python::object &p)
+    : m_obj(p), m_alreadyVMD(false) {
+  // Is it an already wrapped VMD ?
+  boost::python::extract<Kernel::VMD> converter(p);
+  if (converter.check()) {
+    m_alreadyVMD = true;
+    return;
   }
+  // Is it a sequence
+  try {
+    const size_t length = boost::python::len(p);
+    if (length < 3) {
+      throw std::invalid_argument("Must be > 2 for conversion to VMD");
+    }
+    // Can we index the object
+    p.attr("__getitem__")(0);
+  } catch (boost::python::error_already_set &) {
+    throw std::invalid_argument(
+        std::string("Cannot convert object to VMD. "
+                    "Expected a python sequence found: ") +
+        p.ptr()->ob_type->tp_name);
+  }
+}
+
+/**
+ * Returns a VMD object from the Python object given
+ * to the converter
+ * @returns A newly constructed VMD object converted
+ * from the PyObject.
+ */
+Kernel::VMD PyObjectToVMD::operator()() {
+  using namespace boost::python;
+  if (m_alreadyVMD) {
+    return extract<Kernel::VMD>(m_obj)();
+  }
+  // Numpy arrays need to be forced to a double
+  // as extract cannot convert from a int64->double
+  boost::python::object obj = m_obj;
+  if (PyArray_Check(obj.ptr())) {
+    obj = boost::python::numeric::array(obj).astype('d');
+  }
+  // Must be a sequence
+
+  const size_t length = boost::python::len(obj);
+  Kernel::VMD ret(length);
+
+  for (size_t i = 0; i < length; ++i)
+    ret[i] = extract<float>(obj[i])();
+
+  return ret;
+}
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/VectorToNDArray.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/VectorToNDArray.cpp
@@ -11,97 +11,95 @@
 
 #include <string>
 
-namespace Mantid { namespace PythonInterface
-  {
-  namespace Converters
-  {
-    namespace Impl
-    {
-      /**
-       * Defines the wrapWithNDArray specialization for vector container types
-       *
-       * Wraps a vector in a numpy array structure without copying the data
-       * @param cdata :: A reference to the std::vector to wrap
-       * @param mode :: A mode switch to define whether the final array is read only/read-write
-       * @return A pointer to a numpy ndarray object
-       */
-      template<typename ContainerType>
-      PyObject *wrapWithNDArray(const ContainerType & cdata, const NumpyWrapMode mode)
-      {
-        npy_intp dims[1] = { cdata.size() };
-        int datatype = NDArrayTypeIndex<typename ContainerType::value_type>::typenum;
-        PyObject *nparray = PyArray_SimpleNewFromData(1, dims, datatype,(void*)&(cdata[0]));
-        if( mode == ReadOnly )
-        {
-          PyArrayObject * np = (PyArrayObject *)nparray;
-          np->flags &= ~NPY_WRITEABLE;
-        }
-        return nparray;
-      }
-
-      /**
-       * Returns a new numpy array with the a copy of the data from cvector. A specialization
-       * exists for strings so that they simply create a standard python list.
-       * @param cdata :: A reference to a std::vector
-       * @return
-       */
-      template<typename ContainerType>
-      PyObject *cloneToNDArray(const ContainerType & cdata)
-      {
-        npy_intp dims[1] = { cdata.size() };
-        int datatype = NDArrayTypeIndex<typename ContainerType::value_type>::typenum;
-        PyObject *nparray =
-          PyArray_NewFromDescr(&PyArray_Type,
-                               PyArray_DescrFromType(datatype),
-                               1, // rank 1
-                               dims, // Length in each dimension
-                               NULL, NULL,
-                               0, NULL);
-
-        void *arrayData = PyArray_DATA(nparray);
-        const void *data = cdata.data();
-        std::memcpy(arrayData, data, PyArray_ITEMSIZE(nparray) * dims[0]);
-        return (PyObject*)nparray;
-      }
-
-      /**
-       * Returns a new python list of strings from the given vector
-       * exists for strings so that they simply create a standard python list.
-       * @param cdata :: A reference to a std::vector
-       * @return
-       */
-      template<>
-      PyObject *cloneToNDArray(const std::vector<std::string> & cdata)
-      {
-        boost::python::list pystrs;
-        for(auto iter = cdata.begin(); iter != cdata.end(); ++iter)
-        {
-          pystrs.append(iter->c_str());
-        }
-        PyObject *rawptr = pystrs.ptr();
-        Py_INCREF(rawptr); // Make sure it survies after the wrapper decrefs the count
-        return rawptr;
-      }
-
-      //-----------------------------------------------------------------------
-      // Explicit instantiations
-      //-----------------------------------------------------------------------
-      #define INSTANTIATE_TONDARRAY(ElementType) \
-        template DLLExport PyObject * wrapWithNDArray<std::vector<ElementType> >(const std::vector<ElementType> &, const NumpyWrapMode);\
-        template DLLExport PyObject * cloneToNDArray<std::vector<ElementType> >(const std::vector<ElementType> &);
-
-      ///@cond Doxygen doesn't seem to like this...
-      INSTANTIATE_TONDARRAY(int);
-      INSTANTIATE_TONDARRAY(long);
-      INSTANTIATE_TONDARRAY(long long);
-      INSTANTIATE_TONDARRAY(unsigned int);
-      INSTANTIATE_TONDARRAY(unsigned long);
-      INSTANTIATE_TONDARRAY(unsigned long long);
-      INSTANTIATE_TONDARRAY(double);
-      ///@endcond
-      // std::string already has clone instantiated as it is specialized
-      template DLLExport PyObject * wrapWithNDArray<std::vector<std::string> >(const std::vector<std::string> &, const NumpyWrapMode);
-    }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+namespace Impl {
+/**
+ * Defines the wrapWithNDArray specialization for vector container types
+ *
+ * Wraps a vector in a numpy array structure without copying the data
+ * @param cdata :: A reference to the std::vector to wrap
+ * @param mode :: A mode switch to define whether the final array is read
+ *only/read-write
+ * @return A pointer to a numpy ndarray object
+ */
+template <typename ContainerType>
+PyObject *wrapWithNDArray(const ContainerType &cdata,
+                          const NumpyWrapMode mode) {
+  npy_intp dims[1] = {cdata.size()};
+  int datatype = NDArrayTypeIndex<typename ContainerType::value_type>::typenum;
+  PyObject *nparray =
+      PyArray_SimpleNewFromData(1, dims, datatype, (void *)&(cdata[0]));
+  if (mode == ReadOnly) {
+    PyArrayObject *np = (PyArrayObject *)nparray;
+    np->flags &= ~NPY_WRITEABLE;
   }
-}}
+  return nparray;
+}
 
+/**
+ * Returns a new numpy array with the a copy of the data from cvector. A
+ * specialization
+ * exists for strings so that they simply create a standard python list.
+ * @param cdata :: A reference to a std::vector
+ * @return
+ */
+template <typename ContainerType>
+PyObject *cloneToNDArray(const ContainerType &cdata) {
+  npy_intp dims[1] = {cdata.size()};
+  int datatype = NDArrayTypeIndex<typename ContainerType::value_type>::typenum;
+  PyObject *nparray =
+      PyArray_NewFromDescr(&PyArray_Type, PyArray_DescrFromType(datatype),
+                           1,    // rank 1
+                           dims, // Length in each dimension
+                           NULL, NULL, 0, NULL);
+
+  void *arrayData = PyArray_DATA(nparray);
+  const void *data = cdata.data();
+  std::memcpy(arrayData, data, PyArray_ITEMSIZE(nparray) * dims[0]);
+  return (PyObject *)nparray;
+}
+
+/**
+ * Returns a new python list of strings from the given vector
+ * exists for strings so that they simply create a standard python list.
+ * @param cdata :: A reference to a std::vector
+ * @return
+ */
+template <> PyObject *cloneToNDArray(const std::vector<std::string> &cdata) {
+  boost::python::list pystrs;
+  for (auto iter = cdata.begin(); iter != cdata.end(); ++iter) {
+    pystrs.append(iter->c_str());
+  }
+  PyObject *rawptr = pystrs.ptr();
+  Py_INCREF(rawptr); // Make sure it survies after the wrapper decrefs the count
+  return rawptr;
+}
+
+//-----------------------------------------------------------------------
+// Explicit instantiations
+//-----------------------------------------------------------------------
+#define INSTANTIATE_TONDARRAY(ElementType)                                     \
+  template DLLExport PyObject *wrapWithNDArray<std::vector<ElementType>>(      \
+      const std::vector<ElementType> &, const NumpyWrapMode);                  \
+  template DLLExport PyObject *cloneToNDArray<std::vector<ElementType>>(       \
+      const std::vector<ElementType> &);
+
+///@cond Doxygen doesn't seem to like this...
+INSTANTIATE_TONDARRAY(int);
+INSTANTIATE_TONDARRAY(long);
+INSTANTIATE_TONDARRAY(long long);
+INSTANTIATE_TONDARRAY(unsigned int);
+INSTANTIATE_TONDARRAY(unsigned long);
+INSTANTIATE_TONDARRAY(unsigned long long);
+INSTANTIATE_TONDARRAY(double);
+///@endcond
+// std::string already has clone instantiated as it is specialized
+template DLLExport PyObject *
+wrapWithNDArray<std::vector<std::string>>(const std::vector<std::string> &,
+                                          const NumpyWrapMode);
+}
+}
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Converters/WrapWithNumpy.cpp
@@ -11,70 +11,69 @@
 
 #include <string>
 
-namespace Mantid { namespace PythonInterface
-  {
-  namespace Converters
-  {
-    namespace Impl
-    {
-      namespace
-      {
-        /**
-         * Flip the writable flag to ensure the array is read only
-         * Numpy v1.7 removed access to the flags fields directly
-         * and introduced the PyClear_Flags function.
-         * @param arr A pointer to a numpy array
-         */
-        void markReadOnly(PyArrayObject *arr)
-        {
-          #if NPY_API_VERSION >= 0x00000007 //(1.7)
-	    PyArray_CLEARFLAGS(arr, NPY_ARRAY_WRITEABLE);
-          #else
-            arr->flags &= ~NPY_WRITEABLE;
-          #endif  
-        }
-      }
+namespace Mantid {
+namespace PythonInterface {
+namespace Converters {
+namespace Impl {
+namespace {
+/**
+ * Flip the writable flag to ensure the array is read only
+ * Numpy v1.7 removed access to the flags fields directly
+ * and introduced the PyClear_Flags function.
+ * @param arr A pointer to a numpy array
+ */
+void markReadOnly(PyArrayObject *arr) {
+#if NPY_API_VERSION >= 0x00000007 //(1.7)
+  PyArray_CLEARFLAGS(arr, NPY_ARRAY_WRITEABLE);
+#else
+  arr->flags &= ~NPY_WRITEABLE;
+#endif
+}
+}
 
-      /**
-       * Defines the wrapWithNDArray specialization for C array types
-       *
-       * Wraps an array in a numpy array structure without copying the data
-       * @param carray :: A pointer to the HEAD of the array
-       * @param ndims :: The dimensionality of the array
-       * @param dims :: The length of the arrays in each dimension
-       * @param mode :: A mode switch to define whether the final array is read only/read-write
-       * @return A pointer to a numpy ndarray object
-       */
-      template<typename ElementType>
-      PyObject *wrapWithNDArray(const ElementType * carray, const int ndims,
-                                Py_intptr_t *dims, const NumpyWrapMode mode)
-      {
-        int datatype = NDArrayTypeIndex<ElementType>::typenum;
-        PyArrayObject *nparray = (PyArrayObject*)
-	  PyArray_SimpleNewFromData(ndims, dims, datatype,
-				    static_cast<void*>(const_cast<ElementType *>(carray)));
+/**
+ * Defines the wrapWithNDArray specialization for C array types
+ *
+ * Wraps an array in a numpy array structure without copying the data
+ * @param carray :: A pointer to the HEAD of the array
+ * @param ndims :: The dimensionality of the array
+ * @param dims :: The length of the arrays in each dimension
+ * @param mode :: A mode switch to define whether the final array is read
+ *only/read-write
+ * @return A pointer to a numpy ndarray object
+ */
+template <typename ElementType>
+PyObject *wrapWithNDArray(const ElementType *carray, const int ndims,
+                          Py_intptr_t *dims, const NumpyWrapMode mode) {
+  int datatype = NDArrayTypeIndex<ElementType>::typenum;
+  PyArrayObject *nparray = (PyArrayObject *)PyArray_SimpleNewFromData(
+      ndims, dims, datatype,
+      static_cast<void *>(const_cast<ElementType *>(carray)));
 
-        if( mode == ReadOnly ) markReadOnly(nparray);
-        return (PyObject*)nparray;
-      }
+  if (mode == ReadOnly)
+    markReadOnly(nparray);
+  return (PyObject *)nparray;
+}
 
-      //-----------------------------------------------------------------------
-      // Explicit instantiations
-      //-----------------------------------------------------------------------
-      #define INSTANTIATE_WRAPNUMPY(ElementType) \
-        template DLLExport PyObject *wrapWithNDArray<ElementType>(const ElementType*, const int ndims, Py_intptr_t *dims, const NumpyWrapMode);
+//-----------------------------------------------------------------------
+// Explicit instantiations
+//-----------------------------------------------------------------------
+#define INSTANTIATE_WRAPNUMPY(ElementType)                                     \
+  template DLLExport PyObject *wrapWithNDArray<ElementType>(                   \
+      const ElementType *, const int ndims, Py_intptr_t *dims,                 \
+      const NumpyWrapMode);
 
-      ///@cond Doxygen doesn't seem to like this...
-      INSTANTIATE_WRAPNUMPY(int)
-      INSTANTIATE_WRAPNUMPY(long)
-      INSTANTIATE_WRAPNUMPY(long long)
-      INSTANTIATE_WRAPNUMPY(unsigned int)
-      INSTANTIATE_WRAPNUMPY(unsigned long)
-      INSTANTIATE_WRAPNUMPY(unsigned long long)
-      INSTANTIATE_WRAPNUMPY(double)
-      INSTANTIATE_WRAPNUMPY(float)
-      ///@endcond
-    }
-  }
-}}
-
+///@cond Doxygen doesn't seem to like this...
+INSTANTIATE_WRAPNUMPY(int)
+INSTANTIATE_WRAPNUMPY(long)
+INSTANTIATE_WRAPNUMPY(long long)
+INSTANTIATE_WRAPNUMPY(unsigned int)
+INSTANTIATE_WRAPNUMPY(unsigned long)
+INSTANTIATE_WRAPNUMPY(unsigned long long)
+INSTANTIATE_WRAPNUMPY(double)
+INSTANTIATE_WRAPNUMPY(float)
+///@endcond
+}
+}
+}
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Environment/ErrorHandling.cpp
@@ -9,72 +9,64 @@
 #include <sstream>
 #include <stdexcept>
 
-namespace Mantid
-{
-namespace PythonInterface
-{
-namespace Environment
-{
-  namespace 
-  {
-    void tracebackToMsg(std::stringstream & msg, PyTracebackObject* traceback, bool root=true) 
-    {
-      if(traceback == NULL) return;
-      msg << "\n  ";
-      if (root)
-        msg << "at";
-      else
-        msg << "caused by";
-      
-      msg << " line " << traceback->tb_lineno
-          << " in \'" << PyString_AsString(traceback->tb_frame->f_code->co_filename) << "\'";
-      tracebackToMsg(msg, traceback->tb_next, false);
-    }
+namespace Mantid {
+namespace PythonInterface {
+namespace Environment {
+namespace {
+void tracebackToMsg(std::stringstream &msg, PyTracebackObject *traceback,
+                    bool root = true) {
+  if (traceback == NULL)
+    return;
+  msg << "\n  ";
+  if (root)
+    msg << "at";
+  else
+    msg << "caused by";
+
+  msg << " line " << traceback->tb_lineno << " in \'"
+      << PyString_AsString(traceback->tb_frame->f_code->co_filename) << "\'";
+  tracebackToMsg(msg, traceback->tb_next, false);
+}
+}
+
+/**
+ * Convert a python error state to a C++ exception
+ * @param withTrace If true then a traceback will be included in the exception
+ * message
+ * @throws std::runtime_error
+ */
+void throwRuntimeError(const bool withTrace) {
+  GlobalInterpreterLock gil;
+  if (!PyErr_Occurred()) {
+    throw std::runtime_error(
+        "ErrorHandling::throwRuntimeError - No Python error state set!");
+  }
+  PyObject *exception(NULL), *value(NULL), *traceback(NULL);
+  PyErr_Fetch(&exception, &value, &traceback);
+  PyErr_NormalizeException(&exception, &value, &traceback);
+  PyErr_Clear();
+  PyObject *str_repr = PyObject_Str(value);
+  std::stringstream msg;
+  if (value && str_repr) {
+    msg << PyString_AsString(str_repr);
+  } else {
+    msg << "Unknown exception has occurred.";
+  }
+  if (withTrace) {
+    tracebackToMsg(msg, (PyTracebackObject *)(traceback));
   }
 
-  /**
-   * Convert a python error state to a C++ exception
-   * @param withTrace If true then a traceback will be included in the exception message
-   * @throws std::runtime_error
-   */
-  void throwRuntimeError(const bool withTrace)
-  {
-    GlobalInterpreterLock gil;
-    if( !PyErr_Occurred() ) 
-    {
-      throw std::runtime_error("ErrorHandling::throwRuntimeError - No Python error state set!");
-    }
-    PyObject *exception(NULL), *value(NULL), *traceback(NULL);
-    PyErr_Fetch(&exception, &value, &traceback);
-    PyErr_NormalizeException(&exception, &value, &traceback);
-    PyErr_Clear();
-    PyObject *str_repr = PyObject_Str(value);
-    std::stringstream msg;
-    if( value && str_repr )
-    {
-      msg << PyString_AsString(str_repr);
-    }
-    else
-    {
-      msg << "Unknown exception has occurred.";
-    }
-    if (withTrace)
-    {
-      tracebackToMsg(msg, (PyTracebackObject *)(traceback));
-    }
-
-    // Ensure we decrement the reference count on the traceback and exception 
-    // objects as they hold references to local the stack variables that were
-    // present when the exception was raised. This could include child algorithms
-    // with workspaces stored that would not otherwise be cleaned up until the
-    // program exited.
-    Py_XDECREF(traceback);
-    Py_XDECREF(exception);
-    Py_XDECREF(value);
-    // Raise this error as a C++ error
-    throw std::runtime_error(msg.str());
-  }
-
+  // Ensure we decrement the reference count on the traceback and exception
+  // objects as they hold references to local the stack variables that were
+  // present when the exception was raised. This could include child algorithms
+  // with workspaces stored that would not otherwise be cleaned up until the
+  // program exited.
+  Py_XDECREF(traceback);
+  Py_XDECREF(exception);
+  Py_XDECREF(value);
+  // Raise this error as a C++ error
+  throw std::runtime_error(msg.str());
+}
 }
 }
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Environment/Threading.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Environment/Threading.cpp
@@ -2,21 +2,17 @@
 #include <Poco/Thread.h>
 
 namespace // <anonymous>
-{
-  /// The main thread state
-  PyThreadState *g_mainThreadState = NULL;
+    {
+/// The main thread state
+PyThreadState *g_mainThreadState = NULL;
 }
 
-namespace Mantid
-{
-namespace PythonInterface
-{
-namespace Environment
-{
+namespace Mantid {
+namespace PythonInterface {
+namespace Environment {
 
 /// Saves a pointer to the PyThreadState of the main thread
-void saveMainThreadState(PyThreadState *threadState)
-{
+void saveMainThreadState(PyThreadState *threadState) {
   g_mainThreadState = threadState;
 }
 
@@ -25,30 +21,25 @@ void saveMainThreadState(PyThreadState *threadState)
 //-----------------------------------------------------------------------------
 
 PythonThreadState::PythonThreadState()
-  : m_mainThreadState(NULL), m_thisThreadState(NULL)
-{
+    : m_mainThreadState(NULL), m_thisThreadState(NULL) {
   m_mainThreadState = g_mainThreadState;
   assert(m_mainThreadState);
-  if(Poco::Thread::current())
-  {
+  if (Poco::Thread::current()) {
     PyEval_AcquireLock();
-    PyInterpreterState * mainInterpreterState = m_mainThreadState->interp;
+    PyInterpreterState *mainInterpreterState = m_mainThreadState->interp;
     m_thisThreadState = PyThreadState_New(mainInterpreterState);
     PyThreadState_Swap(m_thisThreadState);
   }
 }
 
-PythonThreadState::~PythonThreadState()
-{
-  if(m_thisThreadState)
-  {
+PythonThreadState::~PythonThreadState() {
+  if (m_thisThreadState) {
     PyThreadState_Swap(m_mainThreadState);
     PyThreadState_Clear(m_thisThreadState);
     PyThreadState_Delete(m_thisThreadState);
     PyEval_ReleaseLock();
   }
 }
-
 }
 }
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Environment/WrapperHelpers.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Environment/WrapperHelpers.cpp
@@ -3,44 +3,41 @@
 //-----------------------------------------------------------------------------
 #include "MantidPythonInterface/kernel/Environment/WrapperHelpers.h"
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Environment
-    {
-      /** Checks whether the given object's type dictionary contains the named attribute.
-       *
-       * Usually boost::python::get_override is used for this check but if the 
-       * object's overridden function is declared on a superclass of the wrapped
-       * class then get_override always returns true, regardless of whether the
-       * method has been overridden in Python.
-       *
-       * An example is the algorithm hierachy. We export the IAlgorithm interface
-       * with the name method attach to it. If a class in Python does not
-       * override the name method then get_override still claims that the
-       * override exists because it has found the IAlgorithm one
-       * @param obj :: A pointer to a PyObject
-       * @param attr :: A string containin the attribute name
-       * @returns True if the type dictionary contains the attribute
-       */
-      bool typeHasAttribute(PyObject * obj, const char * attr)
-      {
-        PyObject *cls_dict = obj->ob_type->tp_dict;
-        return PyDict_Contains(cls_dict, PyString_FromString(attr)) > 0 ? true : false;
-      }
+namespace Mantid {
+namespace PythonInterface {
+namespace Environment {
+/** Checks whether the given object's type dictionary contains the named
+ *attribute.
+ *
+ * Usually boost::python::get_override is used for this check but if the
+ * object's overridden function is declared on a superclass of the wrapped
+ * class then get_override always returns true, regardless of whether the
+ * method has been overridden in Python.
+ *
+ * An example is the algorithm hierachy. We export the IAlgorithm interface
+ * with the name method attach to it. If a class in Python does not
+ * override the name method then get_override still claims that the
+ * override exists because it has found the IAlgorithm one
+ * @param obj :: A pointer to a PyObject
+ * @param attr :: A string containin the attribute name
+ * @returns True if the type dictionary contains the attribute
+ */
+bool typeHasAttribute(PyObject *obj, const char *attr) {
+  PyObject *cls_dict = obj->ob_type->tp_dict;
+  return PyDict_Contains(cls_dict, PyString_FromString(attr)) > 0 ? true
+                                                                  : false;
+}
 
-      /** Same as above but taking a wrapper reference instead
-       * @param wrapper :: A reference to a Wrapper object
-       * @param attr :: A string containin the attribute name
-       * @returns True if the type dictionary contains the attribute
-       */
-      bool typeHasAttribute(const boost::python::detail::wrapper_base & wrapper, const char * attr)
-      {
-        using namespace boost::python::detail;
-        return typeHasAttribute(wrapper_base_::get_owner(wrapper), attr);
-      }
-
-    }
-  }
+/** Same as above but taking a wrapper reference instead
+ * @param wrapper :: A reference to a Wrapper object
+ * @param attr :: A string containin the attribute name
+ * @returns True if the type dictionary contains the attribute
+ */
+bool typeHasAttribute(const boost::python::detail::wrapper_base &wrapper,
+                      const char *attr) {
+  using namespace boost::python::detail;
+  return typeHasAttribute(wrapper_base_::get_owner(wrapper), attr);
+}
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
@@ -7,29 +7,34 @@ using Mantid::Kernel::ArrayBoundedValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-namespace
-{
-  #define EXPORT_ARRAYBOUNDEDVALIDATOR(type, prefix) \
-    class_<ArrayBoundedValidator<type>, bases<IValidator>, \
-           boost::noncopyable \
-          >(#prefix"ArrayBoundedValidator") \
-      .def(init<type,type>((arg("lowerBound"),arg("upperBound")), "A validator to ensure each value is in the given range"))\
-      .def("hasLower", &ArrayBoundedValidator<type>::hasLower, "Returns true if a lower bound has been set")\
-      .def("hasUpper", &ArrayBoundedValidator<type>::hasUpper, "Returns true if an upper bound has been set")\
-      .def("lower", &ArrayBoundedValidator<type>::lower, return_value_policy<copy_const_reference>(), "Returns the lower bound")\
-      .def("upper", &ArrayBoundedValidator<type>::upper, return_value_policy<copy_const_reference>(), "Returns the upper bound")\
-      .def("setLower", &ArrayBoundedValidator<type>::setLower, "Sets the lower bound")\
-      .def("setUpper", &ArrayBoundedValidator<type>::setUpper, "Sets the upper bound")\
-      .def("clearLower", &ArrayBoundedValidator<type>::clearLower, "Clear any set lower bound")\
-      .def("clearUpper", &ArrayBoundedValidator<type>::clearUpper, "Clear any set upper bound")\
-  ;
-
-
+namespace {
+#define EXPORT_ARRAYBOUNDEDVALIDATOR(type, prefix)                             \
+  class_<ArrayBoundedValidator<type>, bases<IValidator>, boost::noncopyable>(  \
+      #prefix "ArrayBoundedValidator")                                         \
+      .def(init<type, type>(                                                   \
+          (arg("lowerBound"), arg("upperBound")),                              \
+          "A validator to ensure each value is in the given range"))           \
+      .def("hasLower", &ArrayBoundedValidator<type>::hasLower,                 \
+           "Returns true if a lower bound has been set")                       \
+      .def("hasUpper", &ArrayBoundedValidator<type>::hasUpper,                 \
+           "Returns true if an upper bound has been set")                      \
+      .def("lower", &ArrayBoundedValidator<type>::lower,                       \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the lower bound")                                          \
+      .def("upper", &ArrayBoundedValidator<type>::upper,                       \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the upper bound")                                          \
+      .def("setLower", &ArrayBoundedValidator<type>::setLower,                 \
+           "Sets the lower bound")                                             \
+      .def("setUpper", &ArrayBoundedValidator<type>::setUpper,                 \
+           "Sets the upper bound")                                             \
+      .def("clearLower", &ArrayBoundedValidator<type>::clearLower,             \
+           "Clear any set lower bound")                                        \
+      .def("clearUpper", &ArrayBoundedValidator<type>::clearUpper,             \
+           "Clear any set upper bound");
 }
 
-void export_ArrayBoundedValidator()
-{
+void export_ArrayBoundedValidator() {
   EXPORT_ARRAYBOUNDEDVALIDATOR(double, Float);
   EXPORT_ARRAYBOUNDEDVALIDATOR(long, Int);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
@@ -27,9 +27,7 @@ namespace
 
 }
 
-// clang-format off
 void export_ArrayBoundedValidator()
-// clang-format on
 {
   EXPORT_ARRAYBOUNDEDVALIDATOR(double, Float);
   EXPORT_ARRAYBOUNDEDVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayLengthValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayLengthValidator.cpp
@@ -7,37 +7,47 @@ using Mantid::Kernel::ArrayLengthValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-namespace
-{
+namespace {
 
-  #define EXPORT_LENGTHVALIDATOR(type, prefix) \
-    class_<ArrayLengthValidator<type>, bases<IValidator>, \
-           boost::noncopyable \
-          >(#prefix"ArrayLengthValidator") \
-      .def(init<int>(arg("length"), "Constructs a validator verifying that an array is of the exact length given"))\
-      .def(init<int,int>((arg("lenmin"),arg("lenmax")), "Constructs a validator verifying that the length of an array is within the range given"))\
-      .def("hasLength", &ArrayLengthValidator<type>::hasLength, "Returns true if a single length has been set")\
-      .def("hasMinLength", &ArrayLengthValidator<type>::hasMinLength, "Returns true if a minimum length has been set")\
-      .def("hasMaxLength", &ArrayLengthValidator<type>::hasMaxLength, "Returns true if a maximum length has been set")\
-      .def("getLength", &ArrayLengthValidator<type>::getLength, return_value_policy<copy_const_reference>(), \
-           "Returns the set fixed length")\
-      .def("getMinLength", &ArrayLengthValidator<type>::getMinLength, return_value_policy<copy_const_reference>(), \
-           "Returns the set minimum length")\
-      .def("getMaxLength", &ArrayLengthValidator<type>::getMaxLength, return_value_policy<copy_const_reference>(), \
-           "Returns the set maximum length")\
-      .def("setLength", &ArrayLengthValidator<type>::setLength, "Set the accepted length of an array") \
-      .def("clearLength", &ArrayLengthValidator<type>::clearLength, "Clears accepted length of an array") \
-      .def("setLengthMin", &ArrayLengthValidator<type>::setLengthMin, "Set the accepted minimum length of an array") \
-      .def("setLengthMax", &ArrayLengthValidator<type>::setLengthMax, "Set the accepted maximum length of an array") \
-      .def("clearLengthMin", &ArrayLengthValidator<type>::clearLengthMin, "Set the accepted minimum length of an array") \
-      .def("clearLengthMax", &ArrayLengthValidator<type>::clearLengthMax, "Set the accepted maximum length of an array") \
-  ;
+#define EXPORT_LENGTHVALIDATOR(type, prefix)                                   \
+  class_<ArrayLengthValidator<type>, bases<IValidator>, boost::noncopyable>(   \
+      #prefix "ArrayLengthValidator")                                          \
+      .def(init<int>(arg("length"), "Constructs a validator verifying that "   \
+                                    "an array is of the exact length given"))  \
+      .def(init<int, int>((arg("lenmin"), arg("lenmax")),                      \
+                          "Constructs a validator verifying that the length "  \
+                          "of an array is within the range given"))            \
+      .def("hasLength", &ArrayLengthValidator<type>::hasLength,                \
+           "Returns true if a single length has been set")                     \
+      .def("hasMinLength", &ArrayLengthValidator<type>::hasMinLength,          \
+           "Returns true if a minimum length has been set")                    \
+      .def("hasMaxLength", &ArrayLengthValidator<type>::hasMaxLength,          \
+           "Returns true if a maximum length has been set")                    \
+      .def("getLength", &ArrayLengthValidator<type>::getLength,                \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the set fixed length")                                     \
+      .def("getMinLength", &ArrayLengthValidator<type>::getMinLength,          \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the set minimum length")                                   \
+      .def("getMaxLength", &ArrayLengthValidator<type>::getMaxLength,          \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the set maximum length")                                   \
+      .def("setLength", &ArrayLengthValidator<type>::setLength,                \
+           "Set the accepted length of an array")                              \
+      .def("clearLength", &ArrayLengthValidator<type>::clearLength,            \
+           "Clears accepted length of an array")                               \
+      .def("setLengthMin", &ArrayLengthValidator<type>::setLengthMin,          \
+           "Set the accepted minimum length of an array")                      \
+      .def("setLengthMax", &ArrayLengthValidator<type>::setLengthMax,          \
+           "Set the accepted maximum length of an array")                      \
+      .def("clearLengthMin", &ArrayLengthValidator<type>::clearLengthMin,      \
+           "Set the accepted minimum length of an array")                      \
+      .def("clearLengthMax", &ArrayLengthValidator<type>::clearLengthMax,      \
+           "Set the accepted maximum length of an array");
 }
 
-void export_ArrayLengthValidator()
-{
+void export_ArrayLengthValidator() {
   EXPORT_LENGTHVALIDATOR(double, Float);
   EXPORT_LENGTHVALIDATOR(long, Int);
   EXPORT_LENGTHVALIDATOR(std::string, String);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayLengthValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayLengthValidator.cpp
@@ -34,9 +34,7 @@ namespace
   ;
 }
 
-// clang-format off
 void export_ArrayLengthValidator()
-// clang-format on
 {
   EXPORT_LENGTHVALIDATOR(double, Float);
   EXPORT_LENGTHVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -21,83 +21,88 @@ namespace Policies = Mantid::PythonInterface::Policies;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
-namespace
-{
-  /// return_value_policy for cloned numpy array
-  typedef return_value_policy<Policies::VectorRefToNumpy<Converters::Clone> > return_cloned_numpy;
+namespace {
+/// return_value_policy for cloned numpy array
+typedef return_value_policy<Policies::VectorRefToNumpy<Converters::Clone>>
+    return_cloned_numpy;
 
-  #define EXPORT_ARRAY_PROP(type, prefix) \
-      class_<ArrayProperty<type>, \
-             bases<PropertyWithValue<std::vector<type> > >, \
-             boost::noncopyable \
-            >(#prefix"ArrayProperty", no_init) \
-        .def(init<const std::string &, const unsigned int>((arg("name"), arg("direction") = Direction::Input), \
-                                                         "Construct an ArrayProperty of type"#type)) \
-         \
-        .def(init<const std::string &, IValidator_sptr, \
-                  const unsigned int>((arg("name"), arg("validator"), arg("direction") = Direction::Input), \
-                                      "Construct an ArrayProperty of type"#type"with a validator")) \
-         \
-         .def(init<const std::string &, const std::string &, IValidator_sptr, \
-                   const unsigned int>((arg("name"), arg("values"), arg("validator") = IValidator_sptr(new NullValidator), \
-                                        arg("direction") = Direction::Input), \
-                                       "Construct an ArrayProperty of type"#type"with a validator giving the values as a string")) \
-         .def("__init__", make_constructor(&createArrayPropertyFromList<type>, default_call_policies(), \
-                               (arg("name"), arg("values"), arg("validator") = IValidator_sptr(new NullValidator), \
-                                arg("direction") = Direction::Input) \
-                              ))\
-        .def("__init__", make_constructor(&createArrayPropertyFromNDArray<type>, default_call_policies(), \
-                              (arg("name"), arg("values"), arg("validator") = IValidator_sptr(new NullValidator), \
-                               arg("direction") = Direction::Input) \
-                             ))\
-        .add_property("value", make_function(&ArrayProperty<type>::operator(), return_cloned_numpy())) \
-      ;
+#define EXPORT_ARRAY_PROP(type, prefix)                                        \
+  class_<ArrayProperty<type>, bases<PropertyWithValue<std::vector<type>>>,     \
+         boost::noncopyable>(#prefix "ArrayProperty", no_init)                 \
+      .def(init<const std::string &, const unsigned int>(                      \
+          (arg("name"), arg("direction") = Direction::Input),                  \
+          "Construct an ArrayProperty of type" #type))                         \
+                                                                               \
+      .def(init<const std::string &, IValidator_sptr, const unsigned int>(     \
+          (arg("name"), arg("validator"),                                      \
+           arg("direction") = Direction::Input),                               \
+          "Construct an ArrayProperty of type" #type "with a validator"))      \
+                                                                               \
+      .def(init<const std::string &, const std::string &, IValidator_sptr,     \
+                const unsigned int>(                                           \
+          (arg("name"), arg("values"),                                         \
+           arg("validator") = IValidator_sptr(new NullValidator),              \
+           arg("direction") = Direction::Input),                               \
+          "Construct an ArrayProperty of type" #type                           \
+          "with a validator giving the values as a string"))                   \
+      .def("__init__",                                                         \
+           make_constructor(                                                   \
+               &createArrayPropertyFromList<type>, default_call_policies(),    \
+               (arg("name"), arg("values"),                                    \
+                arg("validator") = IValidator_sptr(new NullValidator),         \
+                arg("direction") = Direction::Input)))                         \
+      .def("__init__",                                                         \
+           make_constructor(                                                   \
+               &createArrayPropertyFromNDArray<type>, default_call_policies(), \
+               (arg("name"), arg("values"),                                    \
+                arg("validator") = IValidator_sptr(new NullValidator),         \
+                arg("direction") = Direction::Input)))                         \
+      .add_property("value", make_function(&ArrayProperty<type>::operator(),   \
+                                           return_cloned_numpy()));
 
-
-    /**
-     * Factory function to allow the initial values to be specified as a python list
-     * @param name :: The name of the property
-     * @param vec :: A boost python list of initial values
-     * @param validator :: A validator object
-     * @param direction :: A direction
-     * @return
-     */
-    template<typename T>
-    ArrayProperty<T> *
-    createArrayPropertyFromList(const std::string &name, const boost::python::list & values,
-                        IValidator_sptr validator, const unsigned int direction)
-   {
-     return new ArrayProperty<T>(name, Converters::PySequenceToVector<T>(values)(), validator, direction);
-   }
-
-   /**
-     * Factory function to allow the initial values to be specified as a numpy array
-     * @param name :: The name of the property
-     * @param vec :: A boost python array of initial values
-     * @param validator :: A validator object
-     * @param direction :: A direction
-     * @return
-     */
-    template<typename T>
-    ArrayProperty<T> *
-    createArrayPropertyFromNDArray(const std::string &name, const boost::python::numeric::array & values,
-                        IValidator_sptr validator, const unsigned int direction)
-   {
-     return new ArrayProperty<T>(name, Converters::NDArrayToVector<T>(values)(), validator, direction);
-   }
-
+/**
+ * Factory function to allow the initial values to be specified as a python list
+ * @param name :: The name of the property
+ * @param vec :: A boost python list of initial values
+ * @param validator :: A validator object
+ * @param direction :: A direction
+ * @return
+ */
+template <typename T>
+ArrayProperty<T> *createArrayPropertyFromList(const std::string &name,
+                                              const boost::python::list &values,
+                                              IValidator_sptr validator,
+                                              const unsigned int direction) {
+  return new ArrayProperty<T>(name, Converters::PySequenceToVector<T>(values)(),
+                              validator, direction);
 }
 
-void export_ArrayProperty()
-{
+/**
+  * Factory function to allow the initial values to be specified as a numpy
+ * array
+  * @param name :: The name of the property
+  * @param vec :: A boost python array of initial values
+  * @param validator :: A validator object
+  * @param direction :: A direction
+  * @return
+  */
+template <typename T>
+ArrayProperty<T> *createArrayPropertyFromNDArray(
+    const std::string &name, const boost::python::numeric::array &values,
+    IValidator_sptr validator, const unsigned int direction) {
+  return new ArrayProperty<T>(name, Converters::NDArrayToVector<T>(values)(),
+                              validator, direction);
+}
+}
+
+void export_ArrayProperty() {
   // Match the python names to their C types
-  EXPORT_ARRAY_PROP(double,Float);
+  EXPORT_ARRAY_PROP(double, Float);
   EXPORT_ARRAY_PROP(long, Int);
   EXPORT_ARRAY_PROP(std::string, String);
 
   // Needs these declarations also to ensure that properties not created in
   // Python can be seen also. Users shouldn't need this
   EXPORT_ARRAY_PROP(int, CInt);
-  EXPORT_ARRAY_PROP(size_t,UnsignedInt);
+  EXPORT_ARRAY_PROP(size_t, UnsignedInt);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayProperty.cpp
@@ -88,9 +88,7 @@ namespace
 
 }
 
-// clang-format off
 void export_ArrayProperty()
-// clang-format on
 {
   // Match the python names to their C types
   EXPORT_ARRAY_PROP(double,Float);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
@@ -10,82 +10,96 @@ using Mantid::Kernel::BoundedValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Factory function to allow more flexibility in the constructor
-   * @param lower An optional lower bound
-   * @param upper An optional upper bound
-   * @returns A pointer to a new BoundedValidator object
-   */
-  template<typename T>
-  BoundedValidator<T> * createBoundedValidator(object lower = object(), object upper = object())
-  {
-    BoundedValidator<T> * validator = new BoundedValidator<T>();
-    if(!Mantid::PythonInterface::isNone(lower))
-    {
-      validator->setLower(extract<T>(lower));
-    }
-    if(!Mantid::PythonInterface::isNone(upper))
-    {
-      validator->setUpper(extract<T>(upper));
-    }
-    return validator;
+namespace {
+/**
+ * Factory function to allow more flexibility in the constructor
+ * @param lower An optional lower bound
+ * @param upper An optional upper bound
+ * @returns A pointer to a new BoundedValidator object
+ */
+template <typename T>
+BoundedValidator<T> *createBoundedValidator(object lower = object(),
+                                            object upper = object()) {
+  BoundedValidator<T> *validator = new BoundedValidator<T>();
+  if (!Mantid::PythonInterface::isNone(lower)) {
+    validator->setLower(extract<T>(lower));
   }
-
-  /**
-   * Factory function to allow more flexibility in the constructor
-   * @param lower An optional lower bound
-   * @param upper An optional upper bound
-   * @param exclusive Optional argument specifiying if the bounds are exclusive
-   * @returns A pointer to a new BoundedValidator object
-   */
-  template<typename T>
-  BoundedValidator<T> * createExclusiveBoundedValidator(object lower = object(), object upper = object(),
-    const bool exclusive = false)
-  {
-    BoundedValidator<T> * validator = new BoundedValidator<T>();
-    if(lower.ptr() != Py_None)
-    {
-      validator->setLower(extract<T>(lower));
-      validator->setLowerExclusive(exclusive);
-    }
-    if(upper.ptr() != Py_None)
-    {
-      validator->setUpper(extract<T>(upper));
-      validator->setUpperExclusive(exclusive);
-    }
-    return validator;
+  if (!Mantid::PythonInterface::isNone(upper)) {
+    validator->setUpper(extract<T>(upper));
   }
-
-  /// A macro for generating exports for each type
-  #define EXPORT_BOUNDEDVALIDATOR(ElementType, prefix) \
-    class_<BoundedValidator<ElementType>, bases<IValidator>, \
-           boost::noncopyable>(#prefix"BoundedValidator") \
-      .def("__init__", make_constructor(&createBoundedValidator<ElementType>, \
-                                        default_call_policies(), (arg("lower")=object(), arg("upper")=object()))) \
-      .def("__init__", make_constructor(&createExclusiveBoundedValidator<ElementType>, \
-                                        default_call_policies(), (arg("lower")=object(), arg("upper")=object(), arg("exclusive")=false))) \
-      .def("setLower", &BoundedValidator<ElementType>::setLower, "Set the lower bound") \
-      .def("setUpper", &BoundedValidator<ElementType>::setUpper, "Set the upper bound" ) \
-      .def("setLowerExclusive", &BoundedValidator<ElementType>::setLowerExclusive, "Sets if the lower bound is exclusive" ) \
-      .def("setUpperExclusive", &BoundedValidator<ElementType>::setUpperExclusive, "Sets if the upper bound is exclsuive" ) \
-      .def("setExclusive", &BoundedValidator<ElementType>::setExclusive, "Sets both bounds to be inclusive/exclusive" ) \
-      .def("lower", &BoundedValidator<ElementType>::lower, return_value_policy<copy_const_reference>(), \
-           "Returns the lower bound") \
-      .def("upper", &BoundedValidator<ElementType>::upper, return_value_policy<copy_const_reference>(), \
-           "Returns the upper bound" ) \
-      .def("setBounds", &BoundedValidator<ElementType>::setBounds, "Set both bounds" ) \
-      .def("hasLower", &BoundedValidator<ElementType>::hasLower, "Returns True if a lower bound has been set" ) \
-      .def("hasUpper", &BoundedValidator<ElementType>::hasUpper, "Returns True if an upper bound has been set" ) \
-      .def("isLowerExclusive", &BoundedValidator<ElementType>::isLowerExclusive, "Returns True if the lower bound is exclusive" ) \
-      .def("isUpperExclusive", &BoundedValidator<ElementType>::isUpperExclusive, "Returns True if the upper bound is exclusive" ) \
-    ;
+  return validator;
 }
 
-void export_BoundedValidator()
-{
+/**
+ * Factory function to allow more flexibility in the constructor
+ * @param lower An optional lower bound
+ * @param upper An optional upper bound
+ * @param exclusive Optional argument specifiying if the bounds are exclusive
+ * @returns A pointer to a new BoundedValidator object
+ */
+template <typename T>
+BoundedValidator<T> *
+createExclusiveBoundedValidator(object lower = object(),
+                                object upper = object(),
+                                const bool exclusive = false) {
+  BoundedValidator<T> *validator = new BoundedValidator<T>();
+  if (lower.ptr() != Py_None) {
+    validator->setLower(extract<T>(lower));
+    validator->setLowerExclusive(exclusive);
+  }
+  if (upper.ptr() != Py_None) {
+    validator->setUpper(extract<T>(upper));
+    validator->setUpperExclusive(exclusive);
+  }
+  return validator;
+}
+
+/// A macro for generating exports for each type
+#define EXPORT_BOUNDEDVALIDATOR(ElementType, prefix)                           \
+  class_<BoundedValidator<ElementType>, bases<IValidator>,                     \
+         boost::noncopyable>(#prefix "BoundedValidator")                       \
+      .def("__init__",                                                         \
+           make_constructor(                                                   \
+               &createBoundedValidator<ElementType>, default_call_policies(),  \
+               (arg("lower") = object(), arg("upper") = object())))            \
+      .def("__init__",                                                         \
+           make_constructor(&createExclusiveBoundedValidator<ElementType>,     \
+                            default_call_policies(),                           \
+                            (arg("lower") = object(), arg("upper") = object(), \
+                             arg("exclusive") = false)))                       \
+      .def("setLower", &BoundedValidator<ElementType>::setLower,               \
+           "Set the lower bound")                                              \
+      .def("setUpper", &BoundedValidator<ElementType>::setUpper,               \
+           "Set the upper bound")                                              \
+      .def("setLowerExclusive",                                                \
+           &BoundedValidator<ElementType>::setLowerExclusive,                  \
+           "Sets if the lower bound is exclusive")                             \
+      .def("setUpperExclusive",                                                \
+           &BoundedValidator<ElementType>::setUpperExclusive,                  \
+           "Sets if the upper bound is exclsuive")                             \
+      .def("setExclusive", &BoundedValidator<ElementType>::setExclusive,       \
+           "Sets both bounds to be inclusive/exclusive")                       \
+      .def("lower", &BoundedValidator<ElementType>::lower,                     \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the lower bound")                                          \
+      .def("upper", &BoundedValidator<ElementType>::upper,                     \
+           return_value_policy<copy_const_reference>(),                        \
+           "Returns the upper bound")                                          \
+      .def("setBounds", &BoundedValidator<ElementType>::setBounds,             \
+           "Set both bounds")                                                  \
+      .def("hasLower", &BoundedValidator<ElementType>::hasLower,               \
+           "Returns True if a lower bound has been set")                       \
+      .def("hasUpper", &BoundedValidator<ElementType>::hasUpper,               \
+           "Returns True if an upper bound has been set")                      \
+      .def("isLowerExclusive",                                                 \
+           &BoundedValidator<ElementType>::isLowerExclusive,                   \
+           "Returns True if the lower bound is exclusive")                     \
+      .def("isUpperExclusive",                                                 \
+           &BoundedValidator<ElementType>::isUpperExclusive,                   \
+           "Returns True if the upper bound is exclusive");
+}
+
+void export_BoundedValidator() {
   EXPORT_BOUNDEDVALIDATOR(double, Float);
   EXPORT_BOUNDEDVALIDATOR(long, Int);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
@@ -83,9 +83,7 @@ namespace
     ;
 }
 
-// clang-format off
 void export_BoundedValidator()
-// clang-format on
 {
   EXPORT_BOUNDEDVALIDATOR(double, Float);
   EXPORT_BOUNDEDVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/CompositeValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/CompositeValidator.cpp
@@ -9,41 +9,36 @@ using Mantid::Kernel::IValidator;
 using Mantid::Kernel::IValidator_sptr;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Creates a composite validator from a python list of validators
-   */
-  CompositeValidator * createCompositeValidator(const boost::python::list & validators)
-  {
-    namespace bpl = boost::python;
-    CompositeValidator *composite = new CompositeValidator;
-    const bpl::ssize_t nitems = bpl::len(validators);
-    for(bpl::ssize_t i = 0; i < nitems; ++i)
-    {
-      try
-      {
-        composite->add(bpl::extract<IValidator_sptr>(validators[i]));
-      }
-      catch(boost::python::error_already_set &)
-      {
-        std::stringstream os;
-        os << "Cannot extract Validator from element " << i;
-        throw std::invalid_argument(os.str());
-      }
+namespace {
+/**
+ * Creates a composite validator from a python list of validators
+ */
+CompositeValidator *
+createCompositeValidator(const boost::python::list &validators) {
+  namespace bpl = boost::python;
+  CompositeValidator *composite = new CompositeValidator;
+  const bpl::ssize_t nitems = bpl::len(validators);
+  for (bpl::ssize_t i = 0; i < nitems; ++i) {
+    try {
+      composite->add(bpl::extract<IValidator_sptr>(validators[i]));
+    } catch (boost::python::error_already_set &) {
+      std::stringstream os;
+      os << "Cannot extract Validator from element " << i;
+      throw std::invalid_argument(os.str());
     }
-    return composite;
   }
+  return composite;
+}
 }
 
-void export_CompositeValidator()
-{
-  class_<CompositeValidator, bases<IValidator>, boost::noncopyable>("CompositeValidator")
-    .def("__init__", make_constructor(&createCompositeValidator, default_call_policies(),
-                                      (arg("validators"))
-                                      ))
+void export_CompositeValidator() {
+  class_<CompositeValidator, bases<IValidator>, boost::noncopyable>(
+      "CompositeValidator")
+      .def("__init__",
+           make_constructor(&createCompositeValidator, default_call_policies(),
+                            (arg("validators"))))
 
-    .def("add", (void (CompositeValidator::*)(IValidator_sptr))&CompositeValidator::add, "Add another validator to the list")
-  ;
+      .def("add", (void (CompositeValidator::*)(IValidator_sptr)) &
+                      CompositeValidator::add,
+           "Add another validator to the list");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/CompositeValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/CompositeValidator.cpp
@@ -36,9 +36,7 @@ namespace
   }
 }
 
-// clang-format off
 void export_CompositeValidator()
-// clang-format on
 {
   class_<CompositeValidator, bases<IValidator>, boost::noncopyable>("CompositeValidator")
     .def("__init__", make_constructor(&createCompositeValidator, default_call_policies(),

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -36,9 +36,7 @@ namespace
   BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
 }
 
-// clang-format off
 void export_ConfigService()
-// clang-format on
 {
   using Mantid::PythonInterface::std_vector_exporter;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -14,100 +14,125 @@ using Mantid::Kernel::ConfigServiceImpl;
 using Mantid::Kernel::FacilityInfo;
 using namespace boost::python;
 
-namespace
-{
-  /// Set directories from a python list
-  void setDataSearchDirs(ConfigServiceImpl &self, const boost::python::list & paths)
-  {
-    using namespace Mantid::PythonInterface;
-    self.setDataSearchDirs(Converters::PySequenceToVector<std::string>(paths)());
-  }
-
-
-   /// Forward call from __getitem__ to getString with use_cache_true
-   std::string getStringUsingCache(ConfigServiceImpl &self, const std::string & key)
-   {
-     return self.getString(key, true);
-   }
-
-  /// Overload generator for getInstrument
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0, 1)
-  /// Overload generator for getString
-  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
+namespace {
+/// Set directories from a python list
+void setDataSearchDirs(ConfigServiceImpl &self,
+                       const boost::python::list &paths) {
+  using namespace Mantid::PythonInterface;
+  self.setDataSearchDirs(Converters::PySequenceToVector<std::string>(paths)());
 }
 
-void export_ConfigService()
-{
+/// Forward call from __getitem__ to getString with use_cache_true
+std::string getStringUsingCache(ConfigServiceImpl &self,
+                                const std::string &key) {
+  return self.getString(key, true);
+}
+
+/// Overload generator for getInstrument
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
+                                       1)
+/// Overload generator for getString
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
+}
+
+void export_ConfigService() {
   using Mantid::PythonInterface::std_vector_exporter;
 
-  std_vector_exporter<FacilityInfo*>::wrap("std_vector_facilityinfo");
-  
+  std_vector_exporter<FacilityInfo *>::wrap("std_vector_facilityinfo");
+
   class_<ConfigServiceImpl, boost::noncopyable>("ConfigServiceImpl", no_init)
-    .def("reset", &ConfigServiceImpl::reset,
-         "Clears all user settings and removes the user properties file")
+      .def("reset", &ConfigServiceImpl::reset,
+           "Clears all user settings and removes the user properties file")
 
-    .def("getLocalFilename", &ConfigServiceImpl::getLocalFilename, "Returns the path to the system wide properties file.")
+      .def("getLocalFilename", &ConfigServiceImpl::getLocalFilename,
+           "Returns the path to the system wide properties file.")
 
-    .def("getUserFilename", &ConfigServiceImpl::getUserFilename, "Returns the path to the user properties file")
+      .def("getUserFilename", &ConfigServiceImpl::getUserFilename,
+           "Returns the path to the user properties file")
 
-    .def("getInstrumentDirectory", &ConfigServiceImpl::getInstrumentDirectory,
-         "Returns the directory used for the instrument definitions")
+      .def("getInstrumentDirectory", &ConfigServiceImpl::getInstrumentDirectory,
+           "Returns the directory used for the instrument definitions")
 
-	.def("getInstrumentDirectories", &ConfigServiceImpl::getInstrumentDirectories, return_value_policy<reference_existing_object>(), 
-         "Returns the list of directories searched for the instrument definitions")
+      .def("getInstrumentDirectories",
+           &ConfigServiceImpl::getInstrumentDirectories,
+           return_value_policy<reference_existing_object>(),
+           "Returns the list of directories searched for the instrument "
+           "definitions")
 
-    .def("getFacilityNames", &ConfigServiceImpl::getFacilityNames, "Returns the default facility")
+      .def("getFacilityNames", &ConfigServiceImpl::getFacilityNames,
+           "Returns the default facility")
 
-    .def("getFacilities", &ConfigServiceImpl::getFacilities, "Returns the default facility")
+      .def("getFacilities", &ConfigServiceImpl::getFacilities,
+           "Returns the default facility")
 
-    .def("getFacility", (const FacilityInfo&(ConfigServiceImpl::*)() const)&ConfigServiceImpl::getFacility,
-        return_value_policy<reference_existing_object>(), "Returns the default facility")
+      .def("getFacility", (const FacilityInfo &(ConfigServiceImpl::*)() const) &
+                              ConfigServiceImpl::getFacility,
+           return_value_policy<reference_existing_object>(),
+           "Returns the default facility")
 
-    .def("getFacility", (const FacilityInfo&(ConfigServiceImpl::*)(const std::string&) const)&ConfigServiceImpl::getFacility,
-         (arg("facilityName")), return_value_policy<reference_existing_object>(),
-         "Returns the named facility. Raises an RuntimeError if it does not exist")
+      .def("getFacility",
+           (const FacilityInfo &(ConfigServiceImpl::*)(const std::string &)
+            const) &
+               ConfigServiceImpl::getFacility,
+           (arg("facilityName")),
+           return_value_policy<reference_existing_object>(),
+           "Returns the named facility. Raises an RuntimeError if it does not "
+           "exist")
 
-    .def("setFacility", &ConfigServiceImpl::setFacility, "Sets the current facility to the given name")
+      .def("setFacility", &ConfigServiceImpl::setFacility,
+           "Sets the current facility to the given name")
 
-    .def("updateFacilities", &ConfigServiceImpl::updateFacilities, "Loads facility information from a provided file")
+      .def("updateFacilities", &ConfigServiceImpl::updateFacilities,
+           "Loads facility information from a provided file")
 
-    .def("getInstrument", &ConfigServiceImpl::getInstrument,
-          getInstrument_Overload("Returns the named instrument. If name = \"\" then the default.instrument is returned",
-                                 (arg("instrumentName")=""))[return_value_policy<copy_const_reference>()])
+      .def("getInstrument", &ConfigServiceImpl::getInstrument,
+           getInstrument_Overload(
+               "Returns the named instrument. If name = \"\" then the "
+               "default.instrument is returned",
+               (arg("instrumentName") =
+                    ""))[return_value_policy<copy_const_reference>()])
 
-    .def("getString", &ConfigServiceImpl::getString,
-          getString_Overload("Returns the named key's value. If use_cache = true [default] then relative paths->absolute",
-                             (arg("key"),arg("use_cache")=true)))
+      .def("getString", &ConfigServiceImpl::getString,
+           getString_Overload("Returns the named key's value. If use_cache = "
+                              "true [default] then relative paths->absolute",
+                              (arg("key"), arg("use_cache") = true)))
 
-    .def("setString", &ConfigServiceImpl::setString, "Set the given property name. "
-         "If it does not exist it is added to the current configuration")
+      .def("setString", &ConfigServiceImpl::setString,
+           "Set the given property name. "
+           "If it does not exist it is added to the current configuration")
 
-    .def("hasProperty", &ConfigServiceImpl::hasProperty)
+      .def("hasProperty", &ConfigServiceImpl::hasProperty)
 
-    .def("getDataSearchDirs",&ConfigServiceImpl::getDataSearchDirs, return_value_policy<copy_const_reference>(),
-         "Return the current list of data search paths")
+      .def("getDataSearchDirs", &ConfigServiceImpl::getDataSearchDirs,
+           return_value_policy<copy_const_reference>(),
+           "Return the current list of data search paths")
 
-    .def("appendDataSearchDir", &ConfigServiceImpl::appendDataSearchDir,
-         "Append a directory to the current list of data search paths")
+      .def("appendDataSearchDir", &ConfigServiceImpl::appendDataSearchDir,
+           "Append a directory to the current list of data search paths")
 
-    .def("setDataSearchDirs", (void (ConfigServiceImpl::*)(const std::string &))&ConfigServiceImpl::setDataSearchDirs,
-         "Set the whole datasearch.directories property from a single string. Entries should be separated by a ; character")
+      .def("setDataSearchDirs",
+           (void (ConfigServiceImpl::*)(const std::string &)) &
+               ConfigServiceImpl::setDataSearchDirs,
+           "Set the whole datasearch.directories property from a single "
+           "string. Entries should be separated by a ; character")
 
-    .def("setDataSearchDirs", &setDataSearchDirs,
-         "Set the  datasearch.directories property from a list of strings.")
+      .def("setDataSearchDirs", &setDataSearchDirs,
+           "Set the  datasearch.directories property from a list of strings.")
 
-    .def("saveConfig", &ConfigServiceImpl::saveConfig, "Saves the keys that have changed from their default to the given filename")
+      .def("saveConfig", &ConfigServiceImpl::saveConfig,
+           "Saves the keys that have changed from their default to the given "
+           "filename")
 
-    .def("keys", &ConfigServiceImpl::keys)
+      .def("keys", &ConfigServiceImpl::keys)
 
-    // Treat this as a dictionary
-    .def("__getitem__", &getStringUsingCache)
-    .def("__setitem__", &ConfigServiceImpl::setString)
-    .def("__contains__", &ConfigServiceImpl::hasProperty)
-    .def("Instance", &ConfigService::Instance,  return_value_policy<reference_existing_object>(),
-         "Returns a reference to the ConfigService")
-    .staticmethod("Instance")
+      // Treat this as a dictionary
+      .def("__getitem__", &getStringUsingCache)
+      .def("__setitem__", &ConfigServiceImpl::setString)
+      .def("__contains__", &ConfigServiceImpl::hasProperty)
+      .def("Instance", &ConfigService::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the ConfigService")
+      .staticmethod("Instance")
 
-    ;
+      ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
@@ -6,16 +6,17 @@
 using Mantid::Kernel::DataItem;
 using namespace boost::python;
 
-void export_DataItem()
-{
+void export_DataItem() {
   register_ptr_to_python<boost::shared_ptr<DataItem>>();
 
-  class_<DataItem,boost::noncopyable>("DataItem", no_init)
-    .def("id", &DataItem::id, "The string ID of the class")
-    .def("name", &DataItem::name, "The name of the object")
-    .def("threadSafe", &DataItem::threadSafe, "Returns true if the object can be accessed safely from multiple threads")
-    .def("__str__", &DataItem::name, "Returns the string name of the object if it has been stored")
-    .def("__repr__", &DataItem::toString, "Returns a description of the object")
-  ;
+  class_<DataItem, boost::noncopyable>("DataItem", no_init)
+      .def("id", &DataItem::id, "The string ID of the class")
+      .def("name", &DataItem::name, "The name of the object")
+      .def("threadSafe", &DataItem::threadSafe, "Returns true if the object "
+                                                "can be accessed safely from "
+                                                "multiple threads")
+      .def("__str__", &DataItem::name,
+           "Returns the string name of the object if it has been stored")
+      .def("__repr__", &DataItem::toString,
+           "Returns a description of the object");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
@@ -6,9 +6,7 @@
 using Mantid::Kernel::DataItem;
 using namespace boost::python;
 
-// clang-format off
 void export_DataItem()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<DataItem>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -6,50 +6,60 @@ using Mantid::Kernel::DateAndTime;
 using Mantid::Kernel::time_duration;
 using namespace boost::python;
 
-/** Circumvent a bug in IPython 1.1, which chokes on nanosecond precision datetimes.
- *  Adding a space to the string returned by the C++ method avoids it being given
+/** Circumvent a bug in IPython 1.1, which chokes on nanosecond precision
+ * datetimes.
+ *  Adding a space to the string returned by the C++ method avoids it being
+ * given
  *  the special treatment that leads to the problem.
  */
-std::string ISO8601StringPlusSpace(DateAndTime & self)
-{
-  return self.toISO8601String()+" ";
+std::string ISO8601StringPlusSpace(DateAndTime &self) {
+  return self.toISO8601String() + " ";
 }
 
-void export_DateAndTime()
-{
+void export_DateAndTime() {
   class_<DateAndTime>("DateAndTime", no_init)
-    // Constructors
-    .def(init<const std::string>("Construct from an ISO8601 string"))
-    .def(init<double,double>("Construct using a number of seconds and nanoseconds (floats)"))
-    .def(init<int64_t,int64_t>("Construct using a number of seconds and nanoseconds (integers)"))
-    .def(init<int64_t>("Construct a total number of nanoseconds"))
-    .def("total_nanoseconds", &DateAndTime::totalNanoseconds)
-    .def("totalNanoseconds", &DateAndTime::totalNanoseconds)
-    .def("setToMinimum", &DateAndTime::setToMinimum)
-    .def("__str__", &ISO8601StringPlusSpace)
-    .def("__long__", &DateAndTime::totalNanoseconds)
-    .def(self == self)
-    .def(self != self)
-    // cppcheck-suppress duplicateExpression
-    .def(self < self)
-    .def(self + int64_t())
-    .def(self += int64_t())
-    .def(self - int64_t())
-    .def(self -= int64_t())
-    .def(self - self)
-  ;
+      // Constructors
+      .def(init<const std::string>("Construct from an ISO8601 string"))
+      .def(init<double, double>(
+          "Construct using a number of seconds and nanoseconds (floats)"))
+      .def(init<int64_t, int64_t>(
+          "Construct using a number of seconds and nanoseconds (integers)"))
+      .def(init<int64_t>("Construct a total number of nanoseconds"))
+      .def("total_nanoseconds", &DateAndTime::totalNanoseconds)
+      .def("totalNanoseconds", &DateAndTime::totalNanoseconds)
+      .def("setToMinimum", &DateAndTime::setToMinimum)
+      .def("__str__", &ISO8601StringPlusSpace)
+      .def("__long__", &DateAndTime::totalNanoseconds)
+      .def(self == self)
+      .def(self != self)
+      // cppcheck-suppress duplicateExpression
+      .def(self < self)
+      .def(self + int64_t())
+      .def(self += int64_t())
+      .def(self - int64_t())
+      .def(self -= int64_t())
+      .def(self - self);
 }
 
-void export_time_duration()
-{
+void export_time_duration() {
   class_<time_duration>("time_duration", no_init)
-    .def("hours", &time_duration::hours, "Returns the normalized number of hours")
-    .def("minutes", &time_duration::minutes, "Returns the normalized number of minutes +/-(0..59)")
-    .def("seconds", &time_duration::seconds, "Returns the normalized number of seconds +/-(0..59)")
-    .def("total_seconds", &time_duration::total_seconds, "Get the total number of seconds truncating any fractional seconds")
-    .def("total_milliseconds", &time_duration::total_milliseconds, "Get the total number of milliseconds truncating any remaining digits")
-    .def("total_microseconds", &time_duration::total_microseconds, "Get the total number of microseconds truncating any remaining digits")
-    .def("total_nanoseconds", &time_duration::total_nanoseconds, "Get the total number of nanoseconds truncating any remaining digits")
+      .def("hours", &time_duration::hours,
+           "Returns the normalized number of hours")
+      .def("minutes", &time_duration::minutes,
+           "Returns the normalized number of minutes +/-(0..59)")
+      .def("seconds", &time_duration::seconds,
+           "Returns the normalized number of seconds +/-(0..59)")
+      .def("total_seconds", &time_duration::total_seconds,
+           "Get the total number of seconds truncating any fractional seconds")
+      .def("total_milliseconds", &time_duration::total_milliseconds,
+           "Get the total number of milliseconds truncating any remaining "
+           "digits")
+      .def("total_microseconds", &time_duration::total_microseconds,
+           "Get the total number of microseconds truncating any remaining "
+           "digits")
+      .def(
+          "total_nanoseconds", &time_duration::total_nanoseconds,
+          "Get the total number of nanoseconds truncating any remaining digits")
 
-    ;
+      ;
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -15,9 +15,7 @@ std::string ISO8601StringPlusSpace(DateAndTime & self)
   return self.toISO8601String()+" ";
 }
 
-// clang-format off
 void export_DateAndTime()
-// clang-format on
 {
   class_<DateAndTime>("DateAndTime", no_init)
     // Constructors
@@ -42,9 +40,7 @@ void export_DateAndTime()
   ;
 }
 
-// clang-format off
 void export_time_duration()
-// clang-format on
 {
   class_<time_duration>("time_duration", no_init)
     .def("hours", &time_duration::hours, "Returns the normalized number of hours")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DeltaEMode.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DeltaEMode.cpp
@@ -9,22 +9,20 @@ using Mantid::Kernel::DeltaEMode;
 namespace Policies = Mantid::PythonInterface::Policies;
 using namespace boost::python;
 
-void export_DeltaEMode()
-{
+void export_DeltaEMode() {
   enum_<Mantid::Kernel::DeltaEMode::Type>("DeltaEModeType")
-    .value("Elastic", DeltaEMode::Elastic)
-    .value("Direct", DeltaEMode::Direct)
-    .value("Indirect", DeltaEMode::Indirect)
-    .export_values()
-  ;
+      .value("Elastic", DeltaEMode::Elastic)
+      .value("Direct", DeltaEMode::Direct)
+      .value("Indirect", DeltaEMode::Indirect)
+      .export_values();
 
   class_<DeltaEMode, boost::noncopyable>("DeltaEMode", no_init)
-    .def("asString", &DeltaEMode::asString, "Returns the given type translated to a string")
-    .def("fromString", &DeltaEMode::fromString, "Returns the enumerated type translated from a string")
-    .def("availableTypes", &DeltaEMode::availableTypes, return_value_policy<Policies::VectorToNumpy>(),
-         "Returns a list of known delta E Modes as strings")
-    .staticmethod("availableTypes")
-  ;
-
+      .def("asString", &DeltaEMode::asString,
+           "Returns the given type translated to a string")
+      .def("fromString", &DeltaEMode::fromString,
+           "Returns the enumerated type translated from a string")
+      .def("availableTypes", &DeltaEMode::availableTypes,
+           return_value_policy<Policies::VectorToNumpy>(),
+           "Returns a list of known delta E Modes as strings")
+      .staticmethod("availableTypes");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DeltaEMode.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/DeltaEMode.cpp
@@ -9,9 +9,7 @@ using Mantid::Kernel::DeltaEMode;
 namespace Policies = Mantid::PythonInterface::Policies;
 using namespace boost::python;
 
-// clang-format off
 void export_DeltaEMode()
-// clang-format on
 {
   enum_<Mantid::Kernel::DeltaEMode::Type>("DeltaEModeType")
     .value("Elastic", DeltaEMode::Elastic)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/EnabledWhenProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/EnabledWhenProperty.cpp
@@ -5,29 +5,25 @@
 using namespace Mantid::Kernel;
 using namespace boost::python;
 
-void export_EnabledWhenProperty()
-{
+void export_EnabledWhenProperty() {
   // State enumeration
   enum_<ePropertyCriterion>("PropertyCriterion")
-    .value("IsDefault", IS_DEFAULT)
-    .value("IsNotDefault", IS_NOT_DEFAULT)
-    .value("IsEqualTo", IS_EQUAL_TO)
-    .value("IsNotEqualTo", IS_NOT_EQUAL_TO)
-    .value("IsMoreOrEqual", IS_MORE_OR_EQ)
-  ;
+      .value("IsDefault", IS_DEFAULT)
+      .value("IsNotDefault", IS_NOT_DEFAULT)
+      .value("IsEqualTo", IS_EQUAL_TO)
+      .value("IsNotEqualTo", IS_NOT_EQUAL_TO)
+      .value("IsMoreOrEqual", IS_MORE_OR_EQ);
 
-  class_<EnabledWhenProperty, bases<IPropertySettings>,
-         boost::noncopyable>("EnabledWhenProperty", no_init) // no default constructor
+  class_<EnabledWhenProperty, bases<IPropertySettings>, boost::noncopyable>(
+      "EnabledWhenProperty", no_init) // no default constructor
 
-     .def(init<std::string, ePropertyCriterion, std::string>(
-             (arg("otherPropName"), arg("when"), arg("value")),
-              "Enabled otherPropName property when value criterion meets that given by the 'when' argument")
-         )
+      .def(init<std::string, ePropertyCriterion, std::string>(
+          (arg("otherPropName"), arg("when"), arg("value")),
+          "Enabled otherPropName property when value criterion meets that "
+          "given by the 'when' argument"))
 
-     .def(init<std::string, ePropertyCriterion>(
-              (arg("otherPropName"), arg("when")),
-              "Enabled otherPropName property when criterion does not require a value, i.e isDefault")
-             )
-    ;
+      .def(init<std::string, ePropertyCriterion>(
+          (arg("otherPropName"), arg("when")),
+          "Enabled otherPropName property when criterion does not require a "
+          "value, i.e isDefault"));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/EnabledWhenProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/EnabledWhenProperty.cpp
@@ -5,9 +5,7 @@
 using namespace Mantid::Kernel;
 using namespace boost::python;
 
-// clang-format off
 void export_EnabledWhenProperty()
-// clang-format on
 {
   // State enumeration
   enum_<ePropertyCriterion>("PropertyCriterion")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
@@ -7,49 +7,62 @@ using Mantid::Kernel::FacilityInfo;
 using Mantid::Kernel::InstrumentInfo;
 using namespace boost::python;
 
-void export_FacilityInfo()
-{
+void export_FacilityInfo() {
 
-  register_ptr_to_python<FacilityInfo*>();
+  register_ptr_to_python<FacilityInfo *>();
 
   class_<FacilityInfo>("FacilityInfo", no_init)
 
-    .def("name", &FacilityInfo::name, return_value_policy<copy_const_reference>(),
-         "Returns name of the facility as definined in the Facilities.xml file")
+      .def("name", &FacilityInfo::name,
+           return_value_policy<copy_const_reference>(),
+           "Returns name of the facility as definined in the Facilities.xml "
+           "file")
 
-    .def("__str__", &FacilityInfo::name, return_value_policy<copy_const_reference>(),
-         "Returns name of the facility as definined in the Facilities.xml file")
+      .def("__str__", &FacilityInfo::name,
+           return_value_policy<copy_const_reference>(),
+           "Returns name of the facility as definined in the Facilities.xml "
+           "file")
 
-    .def("zeroPadding", &FacilityInfo::zeroPadding,
-         "Returns default zero padding for this facility")
+      .def("zeroPadding", &FacilityInfo::zeroPadding,
+           "Returns default zero padding for this facility")
 
-    .def("delimiter", &FacilityInfo::delimiter, return_value_policy<copy_const_reference>(),
-         "Returns the delimiter between the instrument name and the run number.")
+      .def("delimiter", &FacilityInfo::delimiter,
+           return_value_policy<copy_const_reference>(),
+           "Returns the delimiter between the instrument name and the run "
+           "number.")
 
-    .def("extensions", &FacilityInfo::extensions,
-         "Returns the list of file extensions that are considered as instrument data files.")
+      .def("extensions", &FacilityInfo::extensions,
+           "Returns the list of file extensions that are considered as "
+           "instrument data files.")
 
-    .def("preferredExtension",&FacilityInfo::preferredExtension, return_value_policy<copy_const_reference>(),
-         "Returns the extension that is preferred for this facility")
+      .def("preferredExtension", &FacilityInfo::preferredExtension,
+           return_value_policy<copy_const_reference>(),
+           "Returns the extension that is preferred for this facility")
 
-    .def("archiveSearch", &FacilityInfo::archiveSearch, return_value_policy<copy_const_reference>(),
-         "Return the archive search interface names")
+      .def("archiveSearch", &FacilityInfo::archiveSearch,
+           return_value_policy<copy_const_reference>(),
+           "Return the archive search interface names")
 
-    .def("instruments", (const std::vector<InstrumentInfo> & (FacilityInfo::*)()const)&FacilityInfo::instruments,
-         return_value_policy<copy_const_reference>(),
-         "Returns a list of instruments of this facility as defined in the Facilities.xml file")
+      .def("instruments",
+           (const std::vector<InstrumentInfo> &(FacilityInfo::*)() const) &
+               FacilityInfo::instruments,
+           return_value_policy<copy_const_reference>(),
+           "Returns a list of instruments of this facility as defined in the "
+           "Facilities.xml file")
 
-    .def("instruments", (std::vector<InstrumentInfo> (FacilityInfo::*)(const std::string&)const)&FacilityInfo::instruments,
-         "Returns a list of instruments of given technique")
+      .def("instruments", (std::vector<InstrumentInfo>(
+                              FacilityInfo::*)(const std::string &) const) &
+                              FacilityInfo::instruments,
+           "Returns a list of instruments of given technique")
 
-    .def("instrument", &FacilityInfo::instrument, return_value_policy<copy_const_reference>(),
-         "Returns the instrument with the given name")
+      .def("instrument", &FacilityInfo::instrument,
+           return_value_policy<copy_const_reference>(),
+           "Returns the instrument with the given name")
 
-    .def("liveListener", &FacilityInfo::liveListener, return_value_policy<copy_const_reference>(),
-         "Returns the name of the default live listener")
+      .def("liveListener", &FacilityInfo::liveListener,
+           return_value_policy<copy_const_reference>(),
+           "Returns the name of the default live listener")
 
-    .def("computeResources", &FacilityInfo::computeResources,
-         "Returns a vector of the available compute resources")
-   ;
+      .def("computeResources", &FacilityInfo::computeResources,
+           "Returns a vector of the available compute resources");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FacilityInfo.cpp
@@ -7,9 +7,7 @@ using Mantid::Kernel::FacilityInfo;
 using Mantid::Kernel::InstrumentInfo;
 using namespace boost::python;
 
-// clang-format off
 void export_FacilityInfo()
-// clang-format on
 {
 
   register_ptr_to_python<FacilityInfo*>();

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FilteredTimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FilteredTimeSeriesProperty.cpp
@@ -11,25 +11,25 @@ using Mantid::Kernel::FilteredTimeSeriesProperty;
 using Mantid::PythonInterface::Policies::RemoveConst;
 using namespace boost::python;
 
-namespace
-{
-  /// Macro to reduce copy-and-paste
-  #define EXPORT_FILTEREDTIMESERIES_PROP(TYPE, Prefix)\
-    register_ptr_to_python<FilteredTimeSeriesProperty<TYPE>*>();\
-  \
-  class_<FilteredTimeSeriesProperty<TYPE>, bases<TimeSeriesProperty<TYPE> >, boost::noncopyable>(#Prefix"FilteredTimeSeriesProperty", no_init)\
-      .def(init<TimeSeriesProperty<TYPE>*,const TimeSeriesProperty<bool>&,const bool>("Constructor",(arg("source"),arg("filter"),arg("transferOwner"))))\
-      .def("unfiltered", &FilteredTimeSeriesProperty<TYPE>::unfiltered, return_value_policy<RemoveConst>(),\
-           "Returns a time series containing the unfiltered data") \
-      ;
+namespace {
+/// Macro to reduce copy-and-paste
+#define EXPORT_FILTEREDTIMESERIES_PROP(TYPE, Prefix)                           \
+  register_ptr_to_python<FilteredTimeSeriesProperty<TYPE> *>();                \
+                                                                               \
+  class_<FilteredTimeSeriesProperty<TYPE>, bases<TimeSeriesProperty<TYPE>>,    \
+         boost::noncopyable>(#Prefix "FilteredTimeSeriesProperty", no_init)    \
+      .def(init<TimeSeriesProperty<TYPE> *, const TimeSeriesProperty<bool> &,  \
+                const bool>("Constructor", (arg("source"), arg("filter"),      \
+                                            arg("transferOwner"))))            \
+      .def("unfiltered", &FilteredTimeSeriesProperty<TYPE>::unfiltered,        \
+           return_value_policy<RemoveConst>(),                                 \
+           "Returns a time series containing the unfiltered data");
 }
 
-void export_FilteredTimeSeriesProperty()
-{
+void export_FilteredTimeSeriesProperty() {
   EXPORT_FILTEREDTIMESERIES_PROP(double, Float);
   EXPORT_FILTEREDTIMESERIES_PROP(bool, Bool);
   EXPORT_FILTEREDTIMESERIES_PROP(int32_t, Int32);
   EXPORT_FILTEREDTIMESERIES_PROP(int64_t, Int64);
   EXPORT_FILTEREDTIMESERIES_PROP(std::string, String);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FilteredTimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/FilteredTimeSeriesProperty.cpp
@@ -24,9 +24,7 @@ namespace
       ;
 }
 
-// clang-format off
 void export_FilteredTimeSeriesProperty()
-// clang-format on
 {
   EXPORT_FILTEREDTIMESERIES_PROP(double, Float);
   EXPORT_FILTEREDTIMESERIES_PROP(bool, Bool);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -14,171 +14,162 @@ using namespace Mantid::Kernel;
 namespace Registry = Mantid::PythonInterface::Registry;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Set the value of a property from the value within the
-   * boost::python object
-   * It is equivalent to a python method that starts with 'self'
-   * @param self :: A reference to the calling object
-   * @param name :: The name of the property
-   * @param value :: The value of the property as a bpl object
-   */
-  void setProperty(IPropertyManager &self, const std::string & name,
-                   const boost::python::object & value)
+namespace {
+/**
+ * Set the value of a property from the value within the
+ * boost::python object
+ * It is equivalent to a python method that starts with 'self'
+ * @param self :: A reference to the calling object
+ * @param name :: The name of the property
+ * @param value :: The value of the property as a bpl object
+ */
+void setProperty(IPropertyManager &self, const std::string &name,
+                 const boost::python::object &value) {
+  if (PyString_Check(value.ptr())) // String values can be set directly
   {
-    if( PyString_Check(value.ptr()) ) // String values can be set directly
-    {
-      self.setPropertyValue(name, boost::python::extract<std::string>(value));
-    }
-    else
-    {
-      try {
-        Mantid::Kernel::Property *p = self.getProperty(name);
-        const auto &entry  = Registry::TypeRegistry::retrieve(*(p->type_info()));
-        entry.set(&self, name, value);
-      }
-      catch (std::invalid_argument &e)
-      {
-        throw std::invalid_argument("When converting parameter \"" + name + "\": " + e.what());
-      }
+    self.setPropertyValue(name, boost::python::extract<std::string>(value));
+  } else {
+    try {
+      Mantid::Kernel::Property *p = self.getProperty(name);
+      const auto &entry = Registry::TypeRegistry::retrieve(*(p->type_info()));
+      entry.set(&self, name, value);
+    } catch (std::invalid_argument &e) {
+      throw std::invalid_argument("When converting parameter \"" + name +
+                                  "\": " + e.what());
     }
   }
-
-  /**
-   * Create a new property from the value within the boost::python object
-   * It is equivalent to a python method that starts with 'self'
-   * @param self :: A reference to the calling object
-   * @param name :: The name of the property
-   * @param value :: The value of the property as a bpl object
-   */
-  void declareProperty(IPropertyManager &self, const std::string & name,
-                       boost::python::object value)
-  {
-    Mantid::Kernel::Property *p = Registry::PropertyWithValueFactory::create(name, value, 0);
-    self.declareProperty(p);
-  }
-
-  /**
-   * Create or set a property from the value within the boost::python object
-   * It is equivalent to a python method that starts with 'self' and allows
-   * python dictionary type usage.
-   * @param self :: A reference to the calling object
-   * @param name :: The name of the property
-   * @param value :: The value of the property as a bpl object
-   */
-  void declareOrSetProperty(IPropertyManager &self, const std::string & name,
-                            boost::python::object value)
-  {
-    bool propExists = self.existsProperty(name);
-    if (propExists)
-      {
-        setProperty(self, name, value);
-      }
-    else
-      {
-        declareProperty(self, name, value);
-      }
-  }
-
-  /**
-   * Clones the given settingsManager and passes it on to the calling object as it takes ownership
-   * of the IPropertySettings object
-   * @param self The calling object
-   * @param propName A property name that will pick up the settings manager
-   * @param settingsManager The actual settings object
-   */
-  void setPropertySettings(IPropertyManager &self, const std::string & propName,
-                           IPropertySettings *settingsManager)
-  {
-    self.setPropertySettings(propName, settingsManager->clone());
-  }
-
-  void deleteProperty(IPropertyManager &self, const std::string & propName)
-  {
-    self.removeProperty(propName);
-  }
-
-  /**
-   * Return a PyList of all the keys in the IPropertyManager.
-   * @param self The calling object
-   * @return The list of keys.
-   */
-  boost::python::list getKeys(IPropertyManager &self)
-  {
-    const std::vector< Property*>& props = self.getProperties();
-    const size_t numProps = props.size();
-
-    boost::python::list result;
-    for (size_t i = 0; i < numProps; ++i)
-    {
-      result.append(props[i]->name());
-    }
-
-    return result;
-  }
-
 }
 
-void export_IPropertyManager()
-{
-  register_ptr_to_python<IPropertyManager*>();
+/**
+ * Create a new property from the value within the boost::python object
+ * It is equivalent to a python method that starts with 'self'
+ * @param self :: A reference to the calling object
+ * @param name :: The name of the property
+ * @param value :: The value of the property as a bpl object
+ */
+void declareProperty(IPropertyManager &self, const std::string &name,
+                     boost::python::object value) {
+  Mantid::Kernel::Property *p =
+      Registry::PropertyWithValueFactory::create(name, value, 0);
+  self.declareProperty(p);
+}
 
-  class_<IPropertyManager, boost::noncopyable>("IPropertyManager", no_init)
-    .def("propertyCount", &IPropertyManager::propertyCount, args("self"),
-         "Returns the number of properties being managed")
+/**
+ * Create or set a property from the value within the boost::python object
+ * It is equivalent to a python method that starts with 'self' and allows
+ * python dictionary type usage.
+ * @param self :: A reference to the calling object
+ * @param name :: The name of the property
+ * @param value :: The value of the property as a bpl object
+ */
+void declareOrSetProperty(IPropertyManager &self, const std::string &name,
+                          boost::python::object value) {
+  bool propExists = self.existsProperty(name);
+  if (propExists) {
+    setProperty(self, name, value);
+  } else {
+    declareProperty(self, name, value);
+  }
+}
 
-    .def("getProperty", &IPropertyManager::getPointerToProperty, args("self", "name"),
-         return_value_policy<return_by_value>(),
-         "Returns the property of the given name. Use .value to give the value")
+/**
+ * Clones the given settingsManager and passes it on to the calling object as it
+ * takes ownership
+ * of the IPropertySettings object
+ * @param self The calling object
+ * @param propName A property name that will pick up the settings manager
+ * @param settingsManager The actual settings object
+ */
+void setPropertySettings(IPropertyManager &self, const std::string &propName,
+                         IPropertySettings *settingsManager) {
+  self.setPropertySettings(propName, settingsManager->clone());
+}
 
-    .def("getPropertyValue", &IPropertyManager::getPropertyValue, args("self", "name"),
-         "Returns a string representation of the named property's value")
+void deleteProperty(IPropertyManager &self, const std::string &propName) {
+  self.removeProperty(propName);
+}
 
-    .def("getProperties", &IPropertyManager::getProperties, args("self"),
-         return_value_policy<copy_const_reference>(),
-         "Returns the list of properties managed by this object")
+/**
+ * Return a PyList of all the keys in the IPropertyManager.
+ * @param self The calling object
+ * @return The list of keys.
+ */
+boost::python::list getKeys(IPropertyManager &self) {
+  const std::vector<Property *> &props = self.getProperties();
+  const size_t numProps = props.size();
 
-    .def("declareProperty", &declareProperty, args("self", "name", "value"),
-         "Create a new named property")
-
-    .def("setPropertyValue", &IPropertyManager::setPropertyValue, args("self", "name", "value"),
-         "Set the value of the named property via a string")
-
-    .def("setProperty", &setProperty, args("self", "name", "value"),
-         "Set the value of the named property")
-
-    .def("setPropertySettings", &setPropertySettings, args("self", "name", "settingsManager"),
-         "Assign the given IPropertySettings object to the  named property")
-
-    .def("setPropertyGroup", &IPropertyManager::setPropertyGroup, args("self", "name", "group"),
-         "Set the group for a given property")
-
-    .def("existsProperty", &IPropertyManager::existsProperty, args("self", "name"),
-        "Returns whether a property exists")
-
-    // Special methods so that IPropertyManager acts like a dictionary
-    // __len__, __getitem__, __setitem__, __delitem__, __iter__ and __contains__
-    .def("__len__", &IPropertyManager::propertyCount, args("self"),
-         "Returns the number of properties being managed")
-    .def("__getitem__", &IPropertyManager::getPointerToProperty, args("self", "name"),
-         return_value_policy<return_by_value>(),
-         "Returns the property of the given name. Use .value to give the value")
-    .def("__setitem__", &declareOrSetProperty, args("self", "name", "value"),
-         "Set the value of the named property or create it if it doesn't exist")
-    .def("__delitem__", &deleteProperty, args("self", "name"),
-         "Delete the named property")
-    // TODO   .def("__iter__", iterator<std::vector<std::string> > ())
-    .def("__contains__", &IPropertyManager::existsProperty, args("self", "name"),
-         "Returns whether a property exists")
-
-    // Bonus methods to be even more like a dict
-    .def("has_key", &IPropertyManager::existsProperty, args("self", "name"),
-         "Returns whether a property exists")
-    .def("keys", &getKeys, args("self"))
-    .def("values", &IPropertyManager::getProperties, args("self"),
-         return_value_policy<copy_const_reference>(),
-         "Returns the list of properties managed by this object")
-    ;
+  boost::python::list result;
+  for (size_t i = 0; i < numProps; ++i) {
+    result.append(props[i]->name());
   }
 
+  return result;
+}
+}
+
+void export_IPropertyManager() {
+  register_ptr_to_python<IPropertyManager *>();
+
+  class_<IPropertyManager, boost::noncopyable>("IPropertyManager", no_init)
+      .def("propertyCount", &IPropertyManager::propertyCount, args("self"),
+           "Returns the number of properties being managed")
+
+      .def("getProperty", &IPropertyManager::getPointerToProperty,
+           args("self", "name"), return_value_policy<return_by_value>(),
+           "Returns the property of the given name. Use .value to give the "
+           "value")
+
+      .def("getPropertyValue", &IPropertyManager::getPropertyValue,
+           args("self", "name"),
+           "Returns a string representation of the named property's value")
+
+      .def("getProperties", &IPropertyManager::getProperties, args("self"),
+           return_value_policy<copy_const_reference>(),
+           "Returns the list of properties managed by this object")
+
+      .def("declareProperty", &declareProperty, args("self", "name", "value"),
+           "Create a new named property")
+
+      .def("setPropertyValue", &IPropertyManager::setPropertyValue,
+           args("self", "name", "value"),
+           "Set the value of the named property via a string")
+
+      .def("setProperty", &setProperty, args("self", "name", "value"),
+           "Set the value of the named property")
+
+      .def("setPropertySettings", &setPropertySettings,
+           args("self", "name", "settingsManager"),
+           "Assign the given IPropertySettings object to the  named property")
+
+      .def("setPropertyGroup", &IPropertyManager::setPropertyGroup,
+           args("self", "name", "group"), "Set the group for a given property")
+
+      .def("existsProperty", &IPropertyManager::existsProperty,
+           args("self", "name"), "Returns whether a property exists")
+
+      // Special methods so that IPropertyManager acts like a dictionary
+      // __len__, __getitem__, __setitem__, __delitem__, __iter__ and
+      // __contains__
+      .def("__len__", &IPropertyManager::propertyCount, args("self"),
+           "Returns the number of properties being managed")
+      .def("__getitem__", &IPropertyManager::getPointerToProperty,
+           args("self", "name"), return_value_policy<return_by_value>(),
+           "Returns the property of the given name. Use .value to give the "
+           "value")
+      .def("__setitem__", &declareOrSetProperty, args("self", "name", "value"),
+           "Set the value of the named property or create it if it doesn't "
+           "exist")
+      .def("__delitem__", &deleteProperty, args("self", "name"),
+           "Delete the named property")
+      // TODO   .def("__iter__", iterator<std::vector<std::string> > ())
+      .def("__contains__", &IPropertyManager::existsProperty,
+           args("self", "name"), "Returns whether a property exists")
+
+      // Bonus methods to be even more like a dict
+      .def("has_key", &IPropertyManager::existsProperty, args("self", "name"),
+           "Returns whether a property exists")
+      .def("keys", &getKeys, args("self"))
+      .def("values", &IPropertyManager::getProperties, args("self"),
+           return_value_policy<copy_const_reference>(),
+           "Returns the list of properties managed by this object");
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -120,9 +120,7 @@ namespace
 
 }
 
-// clang-format off
 void export_IPropertyManager()
-// clang-format on
 {
   register_ptr_to_python<IPropertyManager*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertySettings.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertySettings.cpp
@@ -6,16 +6,13 @@
 using Mantid::Kernel::IPropertySettings;
 using namespace boost::python;
 
-void export_IPropertySettings()
-{
-  register_ptr_to_python<IPropertySettings*>();
+void export_IPropertySettings() {
+  register_ptr_to_python<IPropertySettings *>();
 
-  class_<IPropertySettings,boost::noncopyable>("IPropertySettings", no_init)
-    .def("isEnabled", &IPropertySettings::isEnabled,
-         "Is the property to be shown as enabled in the GUI. Default true.")
+  class_<IPropertySettings, boost::noncopyable>("IPropertySettings", no_init)
+      .def("isEnabled", &IPropertySettings::isEnabled,
+           "Is the property to be shown as enabled in the GUI. Default true.")
 
-    .def("isVisible", &IPropertySettings::isVisible,
-         "Is the property to be shown in the GUI? Default true.")
-         ;
+      .def("isVisible", &IPropertySettings::isVisible,
+           "Is the property to be shown in the GUI? Default true.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertySettings.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertySettings.cpp
@@ -6,9 +6,7 @@
 using Mantid::Kernel::IPropertySettings;
 using namespace boost::python;
 
-// clang-format off
 void export_IPropertySettings()
-// clang-format on
 {
   register_ptr_to_python<IPropertySettings*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IValidator.cpp
@@ -5,11 +5,8 @@
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-void export_IValidator()
-{
+void export_IValidator() {
   register_ptr_to_python<boost::shared_ptr<IValidator>>();
 
-  class_<IValidator, boost::noncopyable>("IValidator", no_init)
-    ;
+  class_<IValidator, boost::noncopyable>("IValidator", no_init);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/IValidator.cpp
@@ -5,9 +5,7 @@
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-// clang-format off
 void export_IValidator()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<IValidator>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/InstrumentInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/InstrumentInfo.cpp
@@ -7,39 +7,46 @@
 using Mantid::Kernel::InstrumentInfo;
 using namespace boost::python;
 
-void export_InstrumentInfo()
-{
+void export_InstrumentInfo() {
   using namespace Mantid::PythonInterface;
   std_vector_exporter<InstrumentInfo>::wrap("std_vector_InstrumentInfo");
 
   class_<InstrumentInfo>("InstrumentInfo", no_init)
-    .def("name", &InstrumentInfo::name, ""
-         "Returns the full name of the instrument as defined in the Facilites.xml file")
+      .def("name", &InstrumentInfo::name,
+           ""
+           "Returns the full name of the instrument as defined in the "
+           "Facilites.xml file")
 
-    .def("shortName", &InstrumentInfo::shortName,
-         "Returns the abbreviated name of the instrument as definined in the Facilites.xml file")
+      .def("shortName", &InstrumentInfo::shortName,
+           "Returns the abbreviated name of the instrument as definined in the "
+           "Facilites.xml file")
 
-    .def("__str__", &InstrumentInfo::shortName,
-         "Returns the abbreviated name of the instrument as definined in the Facilites.xml file")
+      .def("__str__", &InstrumentInfo::shortName,
+           "Returns the abbreviated name of the instrument as definined in the "
+           "Facilites.xml file")
 
-    .def("zeroPadding", &InstrumentInfo::zeroPadding,
-         "Returns zero padding for this instrument")
+      .def("zeroPadding", &InstrumentInfo::zeroPadding,
+           "Returns zero padding for this instrument")
 
-    .def("filePrefix", &InstrumentInfo::filePrefix,
-          "Returns file prefix for this instrument")
+      .def("filePrefix", &InstrumentInfo::filePrefix,
+           "Returns file prefix for this instrument")
 
-    .def("delimiter", &InstrumentInfo::delimiter,
-         "Returns the delimiter between the instrument name and the run number.")
+      .def("delimiter", &InstrumentInfo::delimiter, "Returns the delimiter "
+                                                    "between the instrument "
+                                                    "name and the run number.")
 
-    .def("techniques", &InstrumentInfo::techniques, return_value_policy<copy_const_reference>(),
-         "Return list of techniques this instrument supports")
+      .def("techniques", &InstrumentInfo::techniques,
+           return_value_policy<copy_const_reference>(),
+           "Return list of techniques this instrument supports")
 
-    .def("facility", &InstrumentInfo::facility, return_value_policy<copy_const_reference>(),
-         "Returns the facility that contains this instrument.")
+      .def("facility", &InstrumentInfo::facility,
+           return_value_policy<copy_const_reference>(),
+           "Returns the facility that contains this instrument.")
 
-    .def("instdae", &InstrumentInfo::liveDataAddress, return_value_policy<copy_const_reference>(),
-         "Returns the host name and the port of the machine hosting DAE and providing port to connect to for a live data stream")
+      .def("instdae", &InstrumentInfo::liveDataAddress,
+           return_value_policy<copy_const_reference>(),
+           "Returns the host name and the port of the machine hosting DAE and "
+           "providing port to connect to for a live data stream")
 
-  ;
+      ;
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/InstrumentInfo.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/InstrumentInfo.cpp
@@ -7,9 +7,7 @@
 using Mantid::Kernel::InstrumentInfo;
 using namespace boost::python;
 
-// clang-format off
 void export_InstrumentInfo()
-// clang-format on
 {
   using namespace Mantid::PythonInterface;
   std_vector_exporter<InstrumentInfo>::wrap("std_vector_InstrumentInfo");

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ListValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ListValidator.cpp
@@ -13,35 +13,32 @@ using Mantid::Kernel::IValidator;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
-namespace
-{
+namespace {
 
-   /**
-     * Factory function to allow the allowed values to be specified as a python list
-     * @param allowedValues :: The list of allowed values
-     * @return A new ListValidator instance
-     */
-    template<typename T>
-    ListValidator<T> * createListValidator(const boost::python::list & allowedValues)
-    {
-      return new ListValidator<T>(Converters::PySequenceToVector<T>(allowedValues)());
-    }    
-
-
-  #define EXPORT_LISTVALIDATOR(type, prefix) \
-    class_<ListValidator<type>, bases<IValidator>, \
-           boost::noncopyable>(#prefix"ListValidator") \
-      .def("__init__", make_constructor(&createListValidator<type>, default_call_policies(), \
-                                        arg("allowedValues"))) \
-      .def("addAllowedValue", &ListValidator<type>::addAllowedValue, \
-           "Adds a value to the list of accepted values") \
-      ;
-
+/**
+  * Factory function to allow the allowed values to be specified as a python
+ * list
+  * @param allowedValues :: The list of allowed values
+  * @return A new ListValidator instance
+  */
+template <typename T>
+ListValidator<T> *
+createListValidator(const boost::python::list &allowedValues) {
+  return new ListValidator<T>(
+      Converters::PySequenceToVector<T>(allowedValues)());
 }
 
-void export_ListValidator()
-{
+#define EXPORT_LISTVALIDATOR(type, prefix)                                     \
+  class_<ListValidator<type>, bases<IValidator>, boost::noncopyable>(          \
+      #prefix "ListValidator")                                                 \
+      .def("__init__",                                                         \
+           make_constructor(&createListValidator<type>,                        \
+                            default_call_policies(), arg("allowedValues")))    \
+      .def("addAllowedValue", &ListValidator<type>::addAllowedValue,           \
+           "Adds a value to the list of accepted values");
+}
+
+void export_ListValidator() {
   EXPORT_LISTVALIDATOR(std::string, String);
   EXPORT_LISTVALIDATOR(long, Int);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ListValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ListValidator.cpp
@@ -39,9 +39,7 @@ namespace
 
 }
 
-// clang-format off
 void export_ListValidator()
-// clang-format on
 {
   EXPORT_LISTVALIDATOR(std::string, String);
   EXPORT_LISTVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/LogFilter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/LogFilter.cpp
@@ -8,14 +8,13 @@ using Mantid::Kernel::Property;
 
 using namespace boost::python;
 
-void export_LogFilter()
-{
-  class_<LogFilter,boost::noncopyable>("LogFilter", 
-                                        init<const Property*>("Creates a log filter using the log to be filtered"))
-    .def("data", &LogFilter::data, return_value_policy<return_by_value>(), 
-         "Returns a time series property filtered on current filter property")
+void export_LogFilter() {
+  class_<LogFilter, boost::noncopyable>(
+      "LogFilter", init<const Property *>(
+                       "Creates a log filter using the log to be filtered"))
+      .def("data", &LogFilter::data, return_value_policy<return_by_value>(),
+           "Returns a time series property filtered on current filter property")
 
-    .def("addFilter", &LogFilter::addFilter, "Adds a filter to the current list")
-    ;
+      .def("addFilter", &LogFilter::addFilter,
+           "Adds a filter to the current list");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/LogFilter.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/LogFilter.cpp
@@ -8,9 +8,7 @@ using Mantid::Kernel::Property;
 
 using namespace boost::python;
 
-// clang-format off
 void export_LogFilter()
-// clang-format on
 {
   class_<LogFilter,boost::noncopyable>("LogFilter", 
                                         init<const Property*>("Creates a log filter using the log to be filtered"))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
@@ -6,48 +6,55 @@
 using Mantid::Kernel::Logger;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   *
-   * @param name The name for the logger instance
-   * @return A new logger instance
-   */
-  boost::shared_ptr<Logger> getLogger(const std::string &name)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, "Logger.get(\"name\") is deprecated. Simply use Logger(\"name\") instead");
-    return boost::shared_ptr<Logger>(new Logger(name));
-  }
+namespace {
+/**
+ *
+ * @param name The name for the logger instance
+ * @return A new logger instance
+ */
+boost::shared_ptr<Logger> getLogger(const std::string &name) {
+  PyErr_Warn(PyExc_DeprecationWarning, "Logger.get(\"name\") is deprecated. "
+                                       "Simply use Logger(\"name\") instead");
+  return boost::shared_ptr<Logger>(new Logger(name));
+}
 }
 
-void export_Logger()
-{
+void export_Logger() {
   register_ptr_to_python<boost::shared_ptr<Logger>>();
 
   // To distinguish between the overloaded functions
   typedef void (Logger::*LogLevelFunction)(const std::string &);
 
   class_<Logger, boost::noncopyable>("Logger", init<std::string>(arg("name")))
-    .def("fatal", (LogLevelFunction)&Logger::fatal, "Send a message at fatal priority: "
-        "An unrecoverable error has occured and the application will terminate")
-    .def("error", (LogLevelFunction)&Logger::error, "Send a message at error priority: "
-        "An error has occured but the framework is able to handle it and continue")
-    .def("warning", (LogLevelFunction)&Logger::warning, "Send a message at warning priority: "
-        "Something was wrong but the framework was able to continue despite the problem.")
-    .def("notice", (LogLevelFunction)&Logger::notice, "Sends a message at notice priority: "
-        "Really important information that should be displayed to the user, "
-        "this should be minimal. The default logging level is set here unless it is altered.")
-    .def("information", (LogLevelFunction)&Logger::information, "Send a message at information priority: "
-        "Useful but not vital information to be relayed back to the user.")
-    .def("debug", (LogLevelFunction)&Logger::debug, "Send a message at debug priority:"
-        ". Anything that may be useful to understand what the code has been doing for debugging purposes.")
-    // -- deprecated  --
-    .def("get", &getLogger,"Creates the named logger. "
-         "This method is static, call as Logger.get('logger_name'). The name is used as a prefix within the "
-         "log file so that msg origins can be traced more easily.")
-     .staticmethod("get")
-     ;
-
-
+      .def("fatal", (LogLevelFunction)&Logger::fatal,
+           "Send a message at fatal priority: "
+           "An unrecoverable error has occured and the application will "
+           "terminate")
+      .def("error", (LogLevelFunction)&Logger::error,
+           "Send a message at error priority: "
+           "An error has occured but the framework is able to handle it and "
+           "continue")
+      .def("warning", (LogLevelFunction)&Logger::warning,
+           "Send a message at warning priority: "
+           "Something was wrong but the framework was able to continue despite "
+           "the problem.")
+      .def("notice", (LogLevelFunction)&Logger::notice,
+           "Sends a message at notice priority: "
+           "Really important information that should be displayed to the user, "
+           "this should be minimal. The default logging level is set here "
+           "unless it is altered.")
+      .def("information", (LogLevelFunction)&Logger::information,
+           "Send a message at information priority: "
+           "Useful but not vital information to be relayed back to the user.")
+      .def("debug", (LogLevelFunction)&Logger::debug,
+           "Send a message at debug priority:"
+           ". Anything that may be useful to understand what the code has been "
+           "doing for debugging purposes.")
+      // -- deprecated  --
+      .def("get", &getLogger,
+           "Creates the named logger. "
+           "This method is static, call as Logger.get('logger_name'). The name "
+           "is used as a prefix within the "
+           "log file so that msg origins can be traced more easily.")
+      .staticmethod("get");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
@@ -20,9 +20,7 @@ namespace
   }
 }
 
-// clang-format off
 void export_Logger()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Logger>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/MandatoryValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/MandatoryValidator.cpp
@@ -6,17 +6,14 @@ using Mantid::Kernel::MandatoryValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-namespace
-{
-  /// A macro for generating exports for each type
-  #define EXPORT_MANDATORYVALIDATOR(ElementType, prefix) \
-    class_<MandatoryValidator<ElementType>, bases<IValidator>, \
-           boost::noncopyable>(#prefix"MandatoryValidator") \
-    ;
+namespace {
+/// A macro for generating exports for each type
+#define EXPORT_MANDATORYVALIDATOR(ElementType, prefix)                         \
+  class_<MandatoryValidator<ElementType>, bases<IValidator>,                   \
+         boost::noncopyable>(#prefix "MandatoryValidator");
 }
 
-void export_MandatoryValidator()
-{
+void export_MandatoryValidator() {
   EXPORT_MANDATORYVALIDATOR(double, Float);
   EXPORT_MANDATORYVALIDATOR(long, Int);
   EXPORT_MANDATORYVALIDATOR(std::string, String);
@@ -26,5 +23,3 @@ void export_MandatoryValidator()
   EXPORT_MANDATORYVALIDATOR(std::vector<long>, IntArray);
   EXPORT_MANDATORYVALIDATOR(std::vector<std::string>, StringArray);
 }
-
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/MandatoryValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/MandatoryValidator.cpp
@@ -15,9 +15,7 @@ namespace
     ;
 }
 
-// clang-format off
 void export_MandatoryValidator()
-// clang-format on
 {
   EXPORT_MANDATORYVALIDATOR(double, Float);
   EXPORT_MANDATORYVALIDATOR(long, Int);

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -9,27 +9,32 @@ using Mantid::Kernel::Material;
 using Mantid::PhysicalConstants::NeutronAtom;
 using namespace boost::python;
 
-void export_Material()
-{
-  register_ptr_to_python<Material*>();
-  register_ptr_to_python<boost::shared_ptr<Material> >();
+void export_Material() {
+  register_ptr_to_python<Material *>();
+  register_ptr_to_python<boost::shared_ptr<Material>>();
 
-  class_<Material, boost::noncopyable >("Material", no_init)
-    .def("name", &Material::name, return_value_policy<copy_const_reference>(), "Name of the material")
-    .add_property("numberDensity", make_function(&Material::numberDensity), "Number density")
-    .add_property("temperature", make_function(&Material::temperature), "Temperature")
-    .add_property("pressure", make_function(&Material::pressure), "Pressure")
-    .def("cohScatterXSection", (double (Material::*)(double) const)(&Material::cohScatterXSection),
-         (arg("lambda")=(double)NeutronAtom::ReferenceLambda),
-         "Coherent Scattering Cross-Section")
-    .def("incohScatterXSection", (double (Material::*)(double) const)(&Material::incohScatterXSection),
-         (arg("lambda")=(double)NeutronAtom::ReferenceLambda),
-         "Incoherent Scattering Cross-Section")
-    .def("totalScatterXSection", (double (Material::*)(double) const)(&Material::totalScatterXSection),
-         (arg("lambda")=(double)NeutronAtom::ReferenceLambda),
-         "Total Scattering Cross-Section")
-    .def("absorbXSection", (double (Material::*)(double) const)(&Material::absorbXSection),
-         (arg("lambda")=(double)NeutronAtom::ReferenceLambda),
-         "Absorption Cross-Section")
-  ;
+  class_<Material, boost::noncopyable>("Material", no_init)
+      .def("name", &Material::name, return_value_policy<copy_const_reference>(),
+           "Name of the material")
+      .add_property("numberDensity", make_function(&Material::numberDensity),
+                    "Number density")
+      .add_property("temperature", make_function(&Material::temperature),
+                    "Temperature")
+      .add_property("pressure", make_function(&Material::pressure), "Pressure")
+      .def("cohScatterXSection",
+           (double (Material::*)(double) const)(&Material::cohScatterXSection),
+           (arg("lambda") = (double)NeutronAtom::ReferenceLambda),
+           "Coherent Scattering Cross-Section")
+      .def("incohScatterXSection", (double (Material::*)(double)
+                                    const)(&Material::incohScatterXSection),
+           (arg("lambda") = (double)NeutronAtom::ReferenceLambda),
+           "Incoherent Scattering Cross-Section")
+      .def("totalScatterXSection", (double (Material::*)(double)
+                                    const)(&Material::totalScatterXSection),
+           (arg("lambda") = (double)NeutronAtom::ReferenceLambda),
+           "Total Scattering Cross-Section")
+      .def("absorbXSection",
+           (double (Material::*)(double) const)(&Material::absorbXSection),
+           (arg("lambda") = (double)NeutronAtom::ReferenceLambda),
+           "Absorption Cross-Section");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -9,9 +9,7 @@ using Mantid::Kernel::Material;
 using Mantid::PhysicalConstants::NeutronAtom;
 using namespace boost::python;
 
-// clang-format off
 void export_Material()
-// clang-format on
 {
   register_ptr_to_python<Material*>();
   register_ptr_to_python<boost::shared_ptr<Material> >();

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Memory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Memory.cpp
@@ -4,19 +4,14 @@
 using Mantid::Kernel::MemoryStats;
 using namespace boost::python;
 
-void export_MemoryStats()
-{
+void export_MemoryStats() {
 
-  class_< MemoryStats>("MemoryStats", init<>("Construct MemoryStats object."))
-    .def("update", &MemoryStats::update)
-    .def("totalMem", &MemoryStats::totalMem)
-    .def("availMem", &MemoryStats::availMem)
-    .def("residentMem", &MemoryStats::residentMem)
-    .def("virtualMem", &MemoryStats::virtualMem)
-    .def("reservedMem", &MemoryStats::reservedMem)
-    .def("getFreeRatio", &MemoryStats::getFreeRatio)
-    ;
-
+  class_<MemoryStats>("MemoryStats", init<>("Construct MemoryStats object."))
+      .def("update", &MemoryStats::update)
+      .def("totalMem", &MemoryStats::totalMem)
+      .def("availMem", &MemoryStats::availMem)
+      .def("residentMem", &MemoryStats::residentMem)
+      .def("virtualMem", &MemoryStats::virtualMem)
+      .def("reservedMem", &MemoryStats::reservedMem)
+      .def("getFreeRatio", &MemoryStats::getFreeRatio);
 }
-
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Memory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Memory.cpp
@@ -4,9 +4,7 @@
 using Mantid::Kernel::MemoryStats;
 using namespace boost::python;
 
-// clang-format off
 void export_MemoryStats()
-// clang-format on
 {
 
   class_< MemoryStats>("MemoryStats", init<>("Construct MemoryStats object."))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/NullValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/NullValidator.cpp
@@ -7,11 +7,8 @@ using Mantid::Kernel::NullValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-void export_NullValidator()
-{
+void export_NullValidator() {
   register_ptr_to_python<boost::shared_ptr<NullValidator>>();
 
-  class_<NullValidator, bases<IValidator>, boost::noncopyable>("NullValidator")
-    ;
+  class_<NullValidator, bases<IValidator>, boost::noncopyable>("NullValidator");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/NullValidator.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/NullValidator.cpp
@@ -7,9 +7,7 @@ using Mantid::Kernel::NullValidator;
 using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
-// clang-format off
 void export_NullValidator()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<NullValidator>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ProgressBase.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ProgressBase.cpp
@@ -4,31 +4,38 @@
 using Mantid::Kernel::ProgressBase;
 using namespace boost::python;
 
-void export_ProgressBase()
-{
-  class_<ProgressBase,boost::noncopyable>("ProgressBase", no_init)
-    .def("report", (void (ProgressBase::*)())&ProgressBase::report, "Increment the progress by 1 and report with no message")
+void export_ProgressBase() {
+  class_<ProgressBase, boost::noncopyable>("ProgressBase", no_init)
+      .def("report", (void (ProgressBase::*)()) & ProgressBase::report,
+           "Increment the progress by 1 and report with no message")
 
-    .def("report", (void (ProgressBase::*)(const std::string&))&ProgressBase::report, (arg("msg")),
-         "Increment the progress by 1 and report along with the given message")
+      .def("report",
+           (void (ProgressBase::*)(const std::string &)) & ProgressBase::report,
+           (arg("msg")), "Increment the progress by 1 and report along with "
+                         "the given message")
 
-    .def("report", (void (ProgressBase::*)(int64_t,const std::string&))&ProgressBase::report, (arg("i"),arg("msg")),
-         "Set the progress to given amount and report along with the given message")
+      .def("report", (void (ProgressBase::*)(int64_t, const std::string &)) &
+                         ProgressBase::report,
+           (arg("i"), arg("msg")), "Set the progress to given amount and "
+                                   "report along with the given message")
 
-    .def("reportIncrement", (void (ProgressBase::*)(size_t,const std::string&))&ProgressBase::reportIncrement, (arg("i"),arg("msg")),
-         "Increment the progress by given amount and report along with the given message")
+      .def("reportIncrement",
+           (void (ProgressBase::*)(size_t, const std::string &)) &
+               ProgressBase::reportIncrement,
+           (arg("i"), arg("msg")), "Increment the progress by given amount and "
+                                   "report along with the given message")
 
-    .def("setNumSteps", &ProgressBase::setNumSteps, (arg("nsteps")),
-         "Sets a new number of steps for the current progress range")
+      .def("setNumSteps", &ProgressBase::setNumSteps, (arg("nsteps")),
+           "Sets a new number of steps for the current progress range")
 
-    .def("resetNumSteps", &ProgressBase::resetNumSteps, (arg("nsteps"),arg("start"),arg("end")),
-         "Resets the number of steps & progress range to the given values")
+      .def("resetNumSteps", &ProgressBase::resetNumSteps,
+           (arg("nsteps"), arg("start"), arg("end")),
+           "Resets the number of steps & progress range to the given values")
 
-    .def("setNotifyStep", &ProgressBase::setNotifyStep, (arg("notifyStep")),
-         "Set how often the notifications are actually reported")
+      .def("setNotifyStep", &ProgressBase::setNotifyStep, (arg("notifyStep")),
+           "Set how often the notifications are actually reported")
 
-    .def("getEstimatedTime", &ProgressBase::getEstimatedTime,
-         "Returns an estimate of the time remaining. May not be to accurate if the reporting is lumpy.")
-    ;
+      .def("getEstimatedTime", &ProgressBase::getEstimatedTime,
+           "Returns an estimate of the time remaining. May not be to accurate "
+           "if the reporting is lumpy.");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ProgressBase.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ProgressBase.cpp
@@ -4,9 +4,7 @@
 using Mantid::Kernel::ProgressBase;
 using namespace boost::python;
 
-// clang-format off
 void export_ProgressBase()
-// clang-format on
 {
   class_<ProgressBase,boost::noncopyable>("ProgressBase", no_init)
     .def("report", (void (ProgressBase::*)())&ProgressBase::report, "Increment the progress by 1 and report with no message")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -15,55 +15,68 @@ using Mantid::Kernel::Direction;
 using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
-
-void export_Property()
-{
-  register_ptr_to_python<Property*>();
+void export_Property() {
+  register_ptr_to_python<Property *>();
 
   // vector of properties
-  std_vector_exporter<Property*>::wrap("std_vector_property");
+  std_vector_exporter<Property *>::wrap("std_vector_property");
 
-  //Direction
+  // Direction
   enum_<Direction::Type>("Direction")
-    .value("Input", Direction::Input)
-    .value("Output", Direction::Output)
-    .value("InOut", Direction::InOut)
-    .value("None", Direction::None)
-    ;
+      .value("Input", Direction::Input)
+      .value("Output", Direction::Output)
+      .value("InOut", Direction::InOut)
+      .value("None", Direction::None);
 
   // Add properties as that's what old version had
   class_<Property, boost::noncopyable>("Property", no_init)
-    .add_property("name", make_function(&Property::name, return_value_policy<copy_const_reference>()),
-                  "The name of the property")
+      .add_property("name",
+                    make_function(&Property::name,
+                                  return_value_policy<copy_const_reference>()),
+                    "The name of the property")
 
-    .add_property("isValid", make_function(&Property::isValid),
-                  "An empty string if the property is valid, otherwise it contains an error message.")
+      .add_property("isValid", make_function(&Property::isValid),
+                    "An empty string if the property is valid, otherwise it "
+                    "contains an error message.")
 
-    .add_property("isDefault", make_function(&Property::isDefault), "Is the property set at the default value")
-    
-    .add_property("getDefault", make_function(&Property::getDefault), "Get the default value as a string")
+      .add_property("isDefault", make_function(&Property::isDefault),
+                    "Is the property set at the default value")
 
-    .add_property("direction", &Property::direction,
-                  "Input, Output, InOut or Unknown. See the Direction class")
+      .add_property("getDefault", make_function(&Property::getDefault),
+                    "Get the default value as a string")
 
-    .add_property("documentation", make_function(&Property::documentation, return_value_policy<copy_const_reference>()),
-                  "The property's doc string")
+      .add_property("direction", &Property::direction,
+                    "Input, Output, InOut or Unknown. See the Direction class")
 
-    .add_property("type", make_function(&Property::type), "Returns a string identifier for the type")
+      .add_property("documentation",
+                    make_function(&Property::documentation,
+                                  return_value_policy<copy_const_reference>()),
+                    "The property's doc string")
 
-    .add_property("units", make_function(&Property::units, return_value_policy<copy_const_reference>()),
-                  &Property::setUnits,
-                  "The units attached to this property")
+      .add_property("type", make_function(&Property::type),
+                    "Returns a string identifier for the type")
 
-    .add_property("valueAsStr", &Property::value, &Property::setValue, "The value of the property as a string. "
-                  "For some property types, e.g. Workspaces, it is useful to be able to refer to the string value directly")
+      .add_property("units",
+                    make_function(&Property::units,
+                                  return_value_policy<copy_const_reference>()),
+                    &Property::setUnits, "The units attached to this property")
 
-    .add_property("allowedValues", &Property::allowedValues, "A list of allowed values")
+      .add_property("valueAsStr", &Property::value, &Property::setValue,
+                    "The value of the property as a string. "
+                    "For some property types, e.g. Workspaces, it is useful to "
+                    "be able to refer to the string value directly")
 
-    .add_property("getGroup", make_function(&Property::getGroup, return_value_policy<copy_const_reference>()),
-                  "Return the 'group' of the property, that is, the header in the algorithm's list of properties.")
+      .add_property("allowedValues", &Property::allowedValues,
+                    "A list of allowed values")
 
-    .add_property("settings", make_function(&Property::getSettings, return_value_policy<return_by_value>()),
-                  "Return the object managing this property's settings")
-   ;
+      .add_property("getGroup",
+                    make_function(&Property::getGroup,
+                                  return_value_policy<copy_const_reference>()),
+                    "Return the 'group' of the property, that is, the header "
+                    "in the algorithm's list of properties.")
+
+      .add_property("settings",
+                    make_function(&Property::getSettings,
+                                  return_value_policy<return_by_value>()),
+                    "Return the object managing this property's settings");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -16,9 +16,7 @@ using Mantid::PythonInterface::std_vector_exporter;
 using namespace boost::python;
 
 
-// clang-format off
 void export_Property()
-// clang-format on
 {
   register_ptr_to_python<Property*>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyHistory.cpp
@@ -9,28 +9,28 @@
 using Mantid::Kernel::PropertyHistory;
 using namespace boost::python;
 
-void export_PropertyHistory()
-{
+void export_PropertyHistory() {
   register_ptr_to_python<Mantid::Kernel::PropertyHistory_sptr>();
 
   class_<PropertyHistory>("PropertyHistory", no_init)
-    
-    .def("name", &PropertyHistory::name, return_value_policy<copy_const_reference>(), 
-         "Returns the name of the property.")
-    
-    .def("value", &PropertyHistory::value, return_value_policy<copy_const_reference>(),
-         "Returns the value of the property.")
-    
-    .def("type", &PropertyHistory::type, return_value_policy<copy_const_reference>(),
-         "Returns the type of the property.")
-    
-    .def("isDefault", &PropertyHistory::isDefault, 
-         "Returns if the property value is the default value.")
-    
-    .def("direction", &PropertyHistory::direction, 
-         "Returns the direction of the property.")
-    // ----------------- Operators --------------------------------------
-    .def(self_ns::str(self))
-    ;
-}
 
+      .def("name", &PropertyHistory::name,
+           return_value_policy<copy_const_reference>(),
+           "Returns the name of the property.")
+
+      .def("value", &PropertyHistory::value,
+           return_value_policy<copy_const_reference>(),
+           "Returns the value of the property.")
+
+      .def("type", &PropertyHistory::type,
+           return_value_policy<copy_const_reference>(),
+           "Returns the type of the property.")
+
+      .def("isDefault", &PropertyHistory::isDefault,
+           "Returns if the property value is the default value.")
+
+      .def("direction", &PropertyHistory::direction,
+           "Returns the direction of the property.")
+      // ----------------- Operators --------------------------------------
+      .def(self_ns::str(self));
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyHistory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyHistory.cpp
@@ -9,9 +9,7 @@
 using Mantid::Kernel::PropertyHistory;
 using namespace boost::python;
 
-// clang-format off
 void export_PropertyHistory()
-// clang-format on
 {
   register_ptr_to_python<Mantid::Kernel::PropertyHistory_sptr>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
@@ -1,5 +1,7 @@
 #ifdef _MSC_VER
-  #pragma warning( disable: 4250 ) // Disable warning regarding inheritance via dominance, we have no way around it with the design
+#pragma warning(disable : 4250) // Disable warning regarding inheritance via
+                                // dominance, we have no way around it with the
+                                // design
 #endif
 
 #include "MantidKernel/IPropertyManager.h"
@@ -21,18 +23,14 @@ namespace Registry = Mantid::PythonInterface::Registry;
 
 using namespace boost::python;
 
-namespace
-{
+namespace {}
 
-}
-
-void export_PropertyManager()
-{
+void export_PropertyManager() {
   register_ptr_to_python<boost::shared_ptr<PropertyManager>>();
-  class_<PropertyManager, bases<IPropertyManager>, boost::noncopyable>("PropertyManager")
-   ;
+  class_<PropertyManager, bases<IPropertyManager>, boost::noncopyable>(
+      "PropertyManager");
 }
 
 #ifdef _MSC_VER
-  #pragma warning( default: 4250 )
+#pragma warning(default : 4250)
 #endif

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyManager.cpp
@@ -26,9 +26,7 @@ namespace
 
 }
 
-// clang-format off
 void export_PropertyManager()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<PropertyManager>>();
   class_<PropertyManager, bases<IPropertyManager>, boost::noncopyable>("PropertyManager")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyWithValue.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyWithValue.cpp
@@ -2,13 +2,12 @@
 
 using Mantid::PythonInterface::PropertyWithValueExporter;
 
-void export_BasicPropertyWithValueTypes()
-{
-  // cut down copy-and-paste code
-#define EXPORT_PROP(CType, ExportName) \
+void export_BasicPropertyWithValueTypes() {
+// cut down copy-and-paste code
+#define EXPORT_PROP(CType, ExportName)                                         \
   PropertyWithValueExporter<CType>::define(ExportName);
 
-  //ints & vectors
+  // ints & vectors
   EXPORT_PROP(int, "IntPropertyWithValue");
   EXPORT_PROP(std::vector<int>, "VectorIntPropertyWithValue");
   EXPORT_PROP(unsigned int, "UIntPropertyWithValue");
@@ -22,7 +21,8 @@ void export_BasicPropertyWithValueTypes()
   EXPORT_PROP(long long, "LongLongPropertyWithValue");
   EXPORT_PROP(std::vector<long long>, "VectorLongLongPropertyWithValue");
   EXPORT_PROP(unsigned long long, "ULongLongPropertyWithValue");
-  EXPORT_PROP(std::vector<unsigned long long>, "VectorULongLongPropertyWithValue");
+  EXPORT_PROP(std::vector<unsigned long long>,
+              "VectorULongLongPropertyWithValue");
   // double
   EXPORT_PROP(double, "FloatPropertyWithValue");
   EXPORT_PROP(std::vector<double>, "VectorFloatPropertyWithValue");
@@ -32,7 +32,6 @@ void export_BasicPropertyWithValueTypes()
   // std::string
   EXPORT_PROP(std::string, "StringPropertyWithValue");
   EXPORT_PROP(std::vector<std::string>, "VectorStringPropertyWithValue");
-
 
 #undef EXPORT_PROP
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyWithValue.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/PropertyWithValue.cpp
@@ -2,9 +2,7 @@
 
 using Mantid::PythonInterface::PropertyWithValueExporter;
 
-// clang-format off
 void export_BasicPropertyWithValueTypes()
-// clang-format on
 {
   // cut down copy-and-paste code
 #define EXPORT_PROP(CType, ExportName) \

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
@@ -19,36 +19,52 @@ using boost::python::return_value_policy;
 /**
  * Python exports of the Mantid::Kernel::Quat class.
  */
-void export_Quat()
-{
-  boost::python::register_ptr_to_python<boost::shared_ptr<Quat> >();
+void export_Quat() {
+  boost::python::register_ptr_to_python<boost::shared_ptr<Quat>>();
 
-  //Quat class
-  class_< Quat >("Quat", "Quaternions are the 3D generalization of complex numbers. "
-                 "Quaternions are used for roations in 3D spaces and often implemented for "
-                 "computer graphics applications.",
-                 init<>(args("self"), "Construct a default Quat that will perform no transformation."))
-    .def(init<double, double, double, double>(args("self", "w", "a", "b", "c"), "Constructor with values"))
-    .def(init<V3D, V3D>(args("self", "src", "dest"), "Construct a Quat between two vectors"))
-    .def(init<V3D, V3D, V3D>(args("self", "rX", "rY", "rZ"), "Construct a Quaternion that performs a reference frame rotation.\nThe initial X,Y,Z vectors are aligned as expected: X=(1,0,0), Y=(0,1,0), Z=(0,0,1)"))
-    .def(init<double,V3D>(args("self", "deg", "axis"), "Constructor from an angle(degrees) and an axis."))
-    .def("rotate", &Quat::rotate, args("self", "v"), "Rotate the quaternion by the given vector")
-    .def("real", &Quat::real, args("self"), "Returns the real part of the quaternion")
-    .def("imagI", &Quat::imagI, args("self"), "Returns the ith imaginary component")
-    .def("imagJ", &Quat::imagJ, args("self"), "Returns the jth imaginary component")
-    .def("imagK", &Quat::imagK, args("self"), "Returns the kth imaginary component")
-    .def("len", &Quat::len, args("self"), "Returns the 'length' of the quaternion")
-    .def("len2", &Quat::len2, args("self"), "Returns the square of the 'length' of the quaternion")
-    .def(self + self)
-    .def(self += self)
-    .def(self - self)
-    .def(self -= self)
-    .def(self * self)
-    .def(self *= self)
-    .def(self == self)
-    .def(self != self)
-    .def("__getitem__", (const double&(Quat::*)(int) const)&Quat::operator[], return_value_policy<copy_const_reference>())
-    .def(boost::python::self_ns::str(self))
-    ;
-
+  // Quat class
+  class_<Quat>(
+      "Quat", "Quaternions are the 3D generalization of complex numbers. "
+              "Quaternions are used for roations in 3D spaces and often "
+              "implemented for "
+              "computer graphics applications.",
+      init<>(args("self"),
+             "Construct a default Quat that will perform no transformation."))
+      .def(init<double, double, double, double>(
+          args("self", "w", "a", "b", "c"), "Constructor with values"))
+      .def(init<V3D, V3D>(args("self", "src", "dest"),
+                          "Construct a Quat between two vectors"))
+      .def(init<V3D, V3D, V3D>(args("self", "rX", "rY", "rZ"),
+                               "Construct a Quaternion that performs a "
+                               "reference frame rotation.\nThe initial X,Y,Z "
+                               "vectors are aligned as expected: X=(1,0,0), "
+                               "Y=(0,1,0), Z=(0,0,1)"))
+      .def(init<double, V3D>(args("self", "deg", "axis"),
+                             "Constructor from an angle(degrees) and an axis."))
+      .def("rotate", &Quat::rotate, args("self", "v"),
+           "Rotate the quaternion by the given vector")
+      .def("real", &Quat::real, args("self"),
+           "Returns the real part of the quaternion")
+      .def("imagI", &Quat::imagI, args("self"),
+           "Returns the ith imaginary component")
+      .def("imagJ", &Quat::imagJ, args("self"),
+           "Returns the jth imaginary component")
+      .def("imagK", &Quat::imagK, args("self"),
+           "Returns the kth imaginary component")
+      .def("len", &Quat::len, args("self"),
+           "Returns the 'length' of the quaternion")
+      .def("len2", &Quat::len2, args("self"),
+           "Returns the square of the 'length' of the quaternion")
+      .def(self + self)
+      .def(self += self)
+      .def(self - self)
+      .def(self -= self)
+      .def(self * self)
+      .def(self *= self)
+      .def(self == self)
+      .def(self != self)
+      .def("__getitem__",
+           (const double &(Quat::*)(int) const) & Quat::operator[],
+           return_value_policy<copy_const_reference>())
+      .def(boost::python::self_ns::str(self));
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Quat.cpp
@@ -19,9 +19,7 @@ using boost::python::return_value_policy;
 /**
  * Python exports of the Mantid::Kernel::Quat class.
  */
-// clang-format off
 void export_Quat()
-// clang-format on
 {
   boost::python::register_ptr_to_python<boost::shared_ptr<Quat> >();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -9,7 +9,8 @@
 #include <boost/python/return_value_policy.hpp>
 #include <boost/python/scope.hpp>
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
@@ -18,247 +19,255 @@ using Mantid::Kernel::Statistics;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
-namespace
-{
-  ///@cond
+namespace {
+///@cond
 
-  // Dummy class used to define Stats "namespace" in python
-  class Stats {};
+// Dummy class used to define Stats "namespace" in python
+class Stats {};
 
-  // For all methods below we have to extract specific types from Python to C++.
-  // We choose to support only Python float arrays (C++ double)
+// For all methods below we have to extract specific types from Python to C++.
+// We choose to support only Python float arrays (C++ double)
 
-  
-  /**
-   * Return true if the array contains float data. Equivalent to 
-   * PyArray_ISFLOAT but uses correct constness for numpy >= 1.7
-   * @param obj A pointer to a numpy array as a plain Python object
-   * @return True if the array contains float data
-   */
-  bool isFloatArray(PyObject *obj)
-  {
-    #if NPY_API_VERSION >= 0x00000007 //1.7
-      return PyArray_ISFLOAT((const PyArrayObject *)obj);
-    #else
-      return PyArray_ISFLOAT((PyArrayObject *)obj);
-    #endif  
-  }
-
-  /**
-   * Return true if the two arrays contains the same type. Equivalent
-   * to (PyARRAY_TYPE == PyArray_TYPE) but ses correct constness 
-   * for numpy >= 1.7
-   * @param first A pointer to a numpy array as a plain Python object
-   * @param second A pointer to a numpy array as a plain Python object
-   * @return True if the array contains float data
-   */
-  bool typesEqual(PyObject *first, PyObject *second)
-  {
-    #if NPY_API_VERSION >= 0x00000007 //1.7
-      const PyArrayObject *firstArray = (const PyArrayObject*)first;
-      const PyArrayObject *secondArray = (const PyArrayObject*)second;
-    #else
-      PyArrayObject *firstArray = (PyArrayObject*)first;
-      PyArrayObject *secondArray = (PyArrayObject*)second;
-    #endif  
-    return PyArray_TYPE(firstArray) != PyArray_TYPE(secondArray);
-  }
-
-  /// Custom exception type for unknown data type
-  class UnknownDataType : public std::invalid_argument
-  {
-  public:
-    UnknownDataType()
-      : std::invalid_argument("Unknown datatype. Currently only arrays of "
-                              "Python floats are supported ")
-    {}
-  };
-
-  //============================ getStatistics ============================================
-
-  /**
-   * Proxy for @see Mantid::Kernel::getStatistics so that it can accept numpy arrays,
-   */
-  Statistics getStatisticsNumpy(const numeric::array & data, const bool sorted = false)
-  {
-    using Mantid::Kernel::getStatistics;
-    using Converters::NDArrayToVector;
-
-    if(isFloatArray(data.ptr()))
-    {
-      return getStatistics(NDArrayToVector<double>(data)(), sorted);
-    }
-    else
-    {
-      throw UnknownDataType();
-    }
-  }
-  // Define an overload to handle the default argument
-  BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1, 2)
-
-  //============================ Z score ============================================
-  // Function pointer to real implementation of Zscore functions
-  typedef std::vector<double> (*ZScoreFunction)(const std::vector<double>& data, const bool sorted);
-
-  /**
-   * The implementation for getMomentsAboutOrigin & getMomentsAboutOriginMean for using
-   * numpy arrays are identical. This encapsulates that behaviour an additional parameter for
-   * specifying the actual function called along.
-   * @param momentsFunc A function pointer to the required moments function
-   * @param data Numpy array of data
-   * @param sorted True if the input data is already sorted
-   */
-  std::vector<double> getZScoreNumpyImpl(ZScoreFunction zscoreFunc, const numeric::array& data,
-      const bool sorted)
-  {
-    using Converters::NDArrayToVector;
-
-    if(isFloatArray(data.ptr()))
-    {
-      return zscoreFunc(NDArrayToVector<double>(data)(), sorted);
-    }
-    else
-    {
-      throw UnknownDataType();
-    }
-  }
-
-  /**
-   * Proxy for @see Mantid::Kernel::getZscore so that it can accept numpy arrays,
-   */
-  std::vector<double> getZscoreNumpy(const numeric::array & data, const bool sorted = false)
-  {
-    using Mantid::Kernel::getZscore;
-    return getZScoreNumpyImpl(&getZscore, data, sorted);
-  }
-  // Define an overload to handle the default argument
-  BOOST_PYTHON_FUNCTION_OVERLOADS(getZscoreOverloads, getZscoreNumpy, 1, 2)
-
-  /**
-   * Proxy for @see Mantid::Kernel::getModifiedZscore so that it can accept numpy arrays,
-   */
-  std::vector<double> getModifiedZscoreNumpy(const numeric::array & data, const bool sorted = false)
-  {
-    using Mantid::Kernel::getModifiedZscore;
-    return getZScoreNumpyImpl(&getModifiedZscore, data, sorted);
-  }
-  // Define an overload to handle the default argument
-  BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads, getModifiedZscoreNumpy, 1, 2)
-
-
-  //============================ getMoments ============================================
-
-  // Function pointer to real implementation of getMoments
-  typedef std::vector<double> (*MomentsFunction)(const std::vector<double>& indep,
-                                                 const std::vector<double>& depend, const int);
-
-  /**
-   * The implementation for getMomentsAboutOrigin & getMomentsAboutOriginMean for using
-   * numpy arrays are identical. This encapsulates that behaviour an additional parameter for
-   * specifying the actual function called along.
-   * @param momentsFunc A function pointer to the required moments function
-   * @param indep Numpy array of independent variables
-   * @param depend Numpy array of dependent variables
-   * @param maxMoment Maximum number of moments to return
-   */
-  std::vector<double> getMomentsNumpyImpl(MomentsFunction momentsFunc,const numeric::array& indep,
-                                          const numeric::array& depend, const int maxMoment)
-  {
-    using Converters::NDArrayToVector;
-
-    // Both input arrays must have the same typed data
-    if(typesEqual(indep.ptr(), depend.ptr()))
-    {
-      throw std::invalid_argument("Datatypes of input arrays must match.");
-    }
-
-    if(isFloatArray(indep.ptr()) && isFloatArray(indep.ptr()))
-    {
-      return momentsFunc(NDArrayToVector<double>(indep)(),
-                         NDArrayToVector<double>(depend)(), maxMoment);
-    }
-    else
-    {
-      throw UnknownDataType();
-    }
-  }
-
-  /**
-   * Proxy for @see Mantid::Kernel::getMomentsAboutOrigin so that it can accept numpy arrays
-   */
-  std::vector<double> getMomentsAboutOriginNumpy(const numeric::array& indep, const numeric::array& depend,
-                                                 const int maxMoment = 3)
-  {
-    using Mantid::Kernel::getMomentsAboutOrigin;
-    return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
-  }
-
-  // Define an overload to handle the default argument
-  BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads, getMomentsAboutOriginNumpy, 2, 3)
-
-  /**
-   * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept numpy arrays
-   */
-  std::vector<double> getMomentsAboutMeanNumpy(const numeric::array& indep, numeric::array& depend,
-                                               const int maxMoment = 3)
-  {
-    using Mantid::Kernel::getMomentsAboutMean;
-    return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
-  }
-
-  // Define an overload to handle the default argument
-  BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads, getMomentsAboutMeanNumpy, 2, 3)
-  ///@endcond
+/**
+ * Return true if the array contains float data. Equivalent to
+ * PyArray_ISFLOAT but uses correct constness for numpy >= 1.7
+ * @param obj A pointer to a numpy array as a plain Python object
+ * @return True if the array contains float data
+ */
+bool isFloatArray(PyObject *obj) {
+#if NPY_API_VERSION >= 0x00000007 // 1.7
+  return PyArray_ISFLOAT((const PyArrayObject *)obj);
+#else
+  return PyArray_ISFLOAT((PyArrayObject *)obj);
+#endif
 }
 
-// -------------------------------------- Exports start here --------------------------------------
+/**
+ * Return true if the two arrays contains the same type. Equivalent
+ * to (PyARRAY_TYPE == PyArray_TYPE) but ses correct constness
+ * for numpy >= 1.7
+ * @param first A pointer to a numpy array as a plain Python object
+ * @param second A pointer to a numpy array as a plain Python object
+ * @return True if the array contains float data
+ */
+bool typesEqual(PyObject *first, PyObject *second) {
+#if NPY_API_VERSION >= 0x00000007 // 1.7
+  const PyArrayObject *firstArray = (const PyArrayObject *)first;
+  const PyArrayObject *secondArray = (const PyArrayObject *)second;
+#else
+  PyArrayObject *firstArray = (PyArrayObject *)first;
+  PyArrayObject *secondArray = (PyArrayObject *)second;
+#endif
+  return PyArray_TYPE(firstArray) != PyArray_TYPE(secondArray);
+}
 
-void export_Statistics()
-{
+/// Custom exception type for unknown data type
+class UnknownDataType : public std::invalid_argument {
+public:
+  UnknownDataType()
+      : std::invalid_argument("Unknown datatype. Currently only arrays of "
+                              "Python floats are supported ") {}
+};
+
+//============================ getStatistics
+//============================================
+
+/**
+ * Proxy for @see Mantid::Kernel::getStatistics so that it can accept numpy
+ * arrays,
+ */
+Statistics getStatisticsNumpy(const numeric::array &data,
+                              const bool sorted = false) {
+  using Mantid::Kernel::getStatistics;
+  using Converters::NDArrayToVector;
+
+  if (isFloatArray(data.ptr())) {
+    return getStatistics(NDArrayToVector<double>(data)(), sorted);
+  } else {
+    throw UnknownDataType();
+  }
+}
+// Define an overload to handle the default argument
+BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
+                                2)
+
+//============================ Z score
+//============================================
+// Function pointer to real implementation of Zscore functions
+typedef std::vector<double>(*ZScoreFunction)(const std::vector<double> &data,
+                                             const bool sorted);
+
+/**
+ * The implementation for getMomentsAboutOrigin & getMomentsAboutOriginMean for
+ * using
+ * numpy arrays are identical. This encapsulates that behaviour an additional
+ * parameter for
+ * specifying the actual function called along.
+ * @param momentsFunc A function pointer to the required moments function
+ * @param data Numpy array of data
+ * @param sorted True if the input data is already sorted
+ */
+std::vector<double> getZScoreNumpyImpl(ZScoreFunction zscoreFunc,
+                                       const numeric::array &data,
+                                       const bool sorted) {
+  using Converters::NDArrayToVector;
+
+  if (isFloatArray(data.ptr())) {
+    return zscoreFunc(NDArrayToVector<double>(data)(), sorted);
+  } else {
+    throw UnknownDataType();
+  }
+}
+
+/**
+ * Proxy for @see Mantid::Kernel::getZscore so that it can accept numpy arrays,
+ */
+std::vector<double> getZscoreNumpy(const numeric::array &data,
+                                   const bool sorted = false) {
+  using Mantid::Kernel::getZscore;
+  return getZScoreNumpyImpl(&getZscore, data, sorted);
+}
+// Define an overload to handle the default argument
+BOOST_PYTHON_FUNCTION_OVERLOADS(getZscoreOverloads, getZscoreNumpy, 1, 2)
+
+/**
+ * Proxy for @see Mantid::Kernel::getModifiedZscore so that it can accept numpy
+ * arrays,
+ */
+std::vector<double> getModifiedZscoreNumpy(const numeric::array &data,
+                                           const bool sorted = false) {
+  using Mantid::Kernel::getModifiedZscore;
+  return getZScoreNumpyImpl(&getModifiedZscore, data, sorted);
+}
+// Define an overload to handle the default argument
+BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
+                                getModifiedZscoreNumpy, 1, 2)
+
+//============================ getMoments
+//============================================
+
+// Function pointer to real implementation of getMoments
+typedef std::vector<double>(*MomentsFunction)(const std::vector<double> &indep,
+                                              const std::vector<double> &depend,
+                                              const int);
+
+/**
+ * The implementation for getMomentsAboutOrigin & getMomentsAboutOriginMean for
+ * using
+ * numpy arrays are identical. This encapsulates that behaviour an additional
+ * parameter for
+ * specifying the actual function called along.
+ * @param momentsFunc A function pointer to the required moments function
+ * @param indep Numpy array of independent variables
+ * @param depend Numpy array of dependent variables
+ * @param maxMoment Maximum number of moments to return
+ */
+std::vector<double> getMomentsNumpyImpl(MomentsFunction momentsFunc,
+                                        const numeric::array &indep,
+                                        const numeric::array &depend,
+                                        const int maxMoment) {
+  using Converters::NDArrayToVector;
+
+  // Both input arrays must have the same typed data
+  if (typesEqual(indep.ptr(), depend.ptr())) {
+    throw std::invalid_argument("Datatypes of input arrays must match.");
+  }
+
+  if (isFloatArray(indep.ptr()) && isFloatArray(indep.ptr())) {
+    return momentsFunc(NDArrayToVector<double>(indep)(),
+                       NDArrayToVector<double>(depend)(), maxMoment);
+  } else {
+    throw UnknownDataType();
+  }
+}
+
+/**
+ * Proxy for @see Mantid::Kernel::getMomentsAboutOrigin so that it can accept
+ * numpy arrays
+ */
+std::vector<double> getMomentsAboutOriginNumpy(const numeric::array &indep,
+                                               const numeric::array &depend,
+                                               const int maxMoment = 3) {
+  using Mantid::Kernel::getMomentsAboutOrigin;
+  return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
+}
+
+// Define an overload to handle the default argument
+BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
+                                getMomentsAboutOriginNumpy, 2, 3)
+
+/**
+ * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
+ * numpy arrays
+ */
+std::vector<double> getMomentsAboutMeanNumpy(const numeric::array &indep,
+                                             numeric::array &depend,
+                                             const int maxMoment = 3) {
+  using Mantid::Kernel::getMomentsAboutMean;
+  return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
+}
+
+// Define an overload to handle the default argument
+BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
+                                getMomentsAboutMeanNumpy, 2, 3)
+///@endcond
+}
+
+// -------------------------------------- Exports start here
+// --------------------------------------
+
+void export_Statistics() {
   // typedef std::vector --> numpy array result converter
   typedef return_value_policy<Policies::VectorToNumpy> ReturnNumpyArray;
 
- // define a new "Statistics" scope so that everything is called as Statistics.getXXX
+  // define a new "Statistics" scope so that everything is called as
+  // Statistics.getXXX
   // this affects everything defined within the lifetime of the scope object
-  scope stats = class_<Stats>("Stats",no_init)
-    .def("getStatistics", &getStatisticsNumpy,
-         getStatisticsOverloads(args("data", "sorted"),
-                                "Determine the statistics for an array of data")
-                                 )
-    .staticmethod("getStatistics")
+  scope stats =
+      class_<Stats>("Stats", no_init)
+          .def("getStatistics", &getStatisticsNumpy,
+               getStatisticsOverloads(
+                   args("data", "sorted"),
+                   "Determine the statistics for an array of data"))
+          .staticmethod("getStatistics")
 
-    .def("getZscore", &getZscoreNumpy,
-         getZscoreOverloads(args("data", "sorted"),
-                                 "Determine the Z score for an array of data")
-                                )
-    .staticmethod("getZscore")
+          .def("getZscore", &getZscoreNumpy,
+               getZscoreOverloads(args("data", "sorted"),
+                                  "Determine the Z score for an array of data"))
+          .staticmethod("getZscore")
 
-    .def("getModifiedZscore", &getModifiedZscoreNumpy,
-        getModifiedZscoreOverloads(args("data", "sorted"),
-                                "Determine the modified Z score for an array of data")
-                               )
-    .staticmethod("getModifiedZscore")
+          .def("getModifiedZscore", &getModifiedZscoreNumpy,
+               getModifiedZscoreOverloads(
+                   args("data", "sorted"),
+                   "Determine the modified Z score for an array of data"))
+          .staticmethod("getModifiedZscore")
 
-    .def("getMomentsAboutOrigin", &getMomentsAboutOriginNumpy,
-         getMomentsAboutOriginOverloads(args("indep", "depend", "maxMoment"),
-                                        "Calculate the first n-moments (inclusive) about the origin"
-                                       )[ReturnNumpyArray()])
-    .staticmethod("getMomentsAboutOrigin")
+          .def("getMomentsAboutOrigin", &getMomentsAboutOriginNumpy,
+               getMomentsAboutOriginOverloads(
+                   args("indep", "depend", "maxMoment"),
+                   "Calculate the first n-moments (inclusive) about the origin")
+                   [ReturnNumpyArray()])
+          .staticmethod("getMomentsAboutOrigin")
 
-    .def("getMomentsAboutMean", &getMomentsAboutMeanNumpy,
-         getMomentsAboutMeanOverloads(args("indep", "depend", "maxMoment"),
-                                        "Calculate the first n-moments (inclusive) about the mean"
-                                       )[ReturnNumpyArray()])
-    .staticmethod("getMomentsAboutMean")
-  ;
+          .def("getMomentsAboutMean", &getMomentsAboutMeanNumpy,
+               getMomentsAboutMeanOverloads(
+                   args("indep", "depend", "maxMoment"),
+                   "Calculate the first n-moments (inclusive) about the mean")
+                   [ReturnNumpyArray()])
+          .staticmethod("getMomentsAboutMean");
 
-  //------------------------------ Statistics values -----------------------------------------------------
+  //------------------------------ Statistics values
+  //-----------------------------------------------------
   // Want this in the same scope as above so must be here
   class_<Statistics>("Statistics")
-    .add_property("minimum", &Statistics::minimum, "Minimum value of the data set")
-    .add_property("maximum", &Statistics::maximum, "Maximum value of the data set")
-    .add_property("mean", &Statistics::mean, "Simple mean, sum(data)/nvalues, of the data set")
-    .add_property("median", &Statistics::median, "Middle value of the data set")
-    .add_property("standard_deviation", &Statistics::standard_deviation ,"Standard width of distribution")
-  ;
+      .add_property("minimum", &Statistics::minimum,
+                    "Minimum value of the data set")
+      .add_property("maximum", &Statistics::maximum,
+                    "Maximum value of the data set")
+      .add_property("mean", &Statistics::mean,
+                    "Simple mean, sum(data)/nvalues, of the data set")
+      .add_property("median", &Statistics::median,
+                    "Middle value of the data set")
+      .add_property("standard_deviation", &Statistics::standard_deviation,
+                    "Standard width of distribution");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -213,9 +213,7 @@ namespace
 
 // -------------------------------------- Exports start here --------------------------------------
 
-// clang-format off
 void export_Statistics()
-// clang-format on
 {
   // typedef std::vector --> numpy array result converter
   typedef return_value_policy<Policies::VectorToNumpy> ReturnNumpyArray;

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
@@ -7,9 +7,7 @@
 using Mantid::PythonInterface::std_vector_exporter;
 using Mantid::PythonInterface::std_set_exporter;
 
-// clang-format off
 void exportStlContainers()
-// clang-format on
 {
     // Export some frequently used stl containers
   // std::vector

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/StlContainers.cpp
@@ -7,9 +7,8 @@
 using Mantid::PythonInterface::std_vector_exporter;
 using Mantid::PythonInterface::std_set_exporter;
 
-void exportStlContainers()
-{
-    // Export some frequently used stl containers
+void exportStlContainers() {
+  // Export some frequently used stl containers
   // std::vector
   std_vector_exporter<int>::wrap("std_vector_int");
   std_vector_exporter<long>::wrap("std_vector_long");
@@ -17,10 +16,11 @@ void exportStlContainers()
   std_vector_exporter<double>::wrap("std_vector_dbl");
   std_vector_exporter<bool>::wrap("std_vector_bool");
   std_vector_exporter<std::string>::wrap("std_vector_str");
-  std_vector_exporter<Mantid::Kernel::DateAndTime>::wrap("std_vector_dateandtime");
+  std_vector_exporter<Mantid::Kernel::DateAndTime>::wrap(
+      "std_vector_dateandtime");
   std_vector_exporter<Mantid::Kernel::Quat>::wrap("std_vector_quat");
   std_vector_exporter<Mantid::Kernel::V3D>::wrap("std_vector_v3d");
-  //std::set
+  // std::set
   std_set_exporter<int>::wrap("std_set_int");
   std_set_exporter<std::string>::wrap("std_set_str");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -13,67 +13,72 @@ using Mantid::Kernel::TimeSeriesProperty;
 using Mantid::Kernel::Property;
 using namespace boost::python;
 
-namespace
-{
+namespace {
 
-  using Mantid::PythonInterface::Policies::VectorToNumpy;
+using Mantid::PythonInterface::Policies::VectorToNumpy;
 
-  // Macro to reduce copy-and-paste
-  #define EXPORT_TIMESERIES_PROP(TYPE, Prefix)\
-    register_ptr_to_python<TimeSeriesProperty<TYPE>*>();\
-    \
-    class_<TimeSeriesProperty<TYPE>, bases<Property>, boost::noncopyable>(#Prefix"TimeSeriesProperty", init<const std::string&>())\
-      .add_property("value", make_function(&Mantid::Kernel::TimeSeriesProperty<TYPE>::valuesAsVector, return_value_policy<VectorToNumpy>())) \
-      .add_property("times", &Mantid::Kernel::TimeSeriesProperty<TYPE>::timesAsVector) \
-      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(const DateAndTime&,const TYPE))&TimeSeriesProperty<TYPE>::addValue) \
-      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(const std::string&,const TYPE))&TimeSeriesProperty<TYPE>::addValue) \
-      .def("valueAsString", &TimeSeriesProperty<TYPE>::value) \
-      .def("size", &TimeSeriesProperty<TYPE>::size)\
-      .def("firstTime", &TimeSeriesProperty<TYPE>::firstTime) \
-      .def("firstValue", &TimeSeriesProperty<TYPE>::firstValue) \
-      .def("lastTime", &TimeSeriesProperty<TYPE>::lastTime) \
-      .def("lastValue", &TimeSeriesProperty<TYPE>::lastValue) \
-      .def("nthValue", &TimeSeriesProperty<TYPE>::nthValue) \
-      .def("nthTime", &TimeSeriesProperty<TYPE>::nthTime) \
-      .def("getStatistics", &TimeSeriesProperty<TYPE>::getStatistics) \
-      .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue) \
-      ;
+// Macro to reduce copy-and-paste
+#define EXPORT_TIMESERIES_PROP(TYPE, Prefix)                                   \
+  register_ptr_to_python<TimeSeriesProperty<TYPE> *>();                        \
+                                                                               \
+  class_<TimeSeriesProperty<TYPE>, bases<Property>, boost::noncopyable>(       \
+      #Prefix "TimeSeriesProperty", init<const std::string &>())               \
+      .add_property(                                                           \
+           "value",                                                            \
+           make_function(                                                      \
+               &Mantid::Kernel::TimeSeriesProperty<TYPE>::valuesAsVector,      \
+               return_value_policy<VectorToNumpy>()))                          \
+      .add_property("times",                                                   \
+                    &Mantid::Kernel::TimeSeriesProperty<TYPE>::timesAsVector)  \
+      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(                    \
+                           const DateAndTime &, const TYPE)) &                 \
+                           TimeSeriesProperty<TYPE>::addValue)                 \
+      .def("addValue", (void (TimeSeriesProperty<TYPE>::*)(                    \
+                           const std::string &, const TYPE)) &                 \
+                           TimeSeriesProperty<TYPE>::addValue)                 \
+      .def("valueAsString", &TimeSeriesProperty<TYPE>::value)                  \
+      .def("size", &TimeSeriesProperty<TYPE>::size)                            \
+      .def("firstTime", &TimeSeriesProperty<TYPE>::firstTime)                  \
+      .def("firstValue", &TimeSeriesProperty<TYPE>::firstValue)                \
+      .def("lastTime", &TimeSeriesProperty<TYPE>::lastTime)                    \
+      .def("lastValue", &TimeSeriesProperty<TYPE>::lastValue)                  \
+      .def("nthValue", &TimeSeriesProperty<TYPE>::nthValue)                    \
+      .def("nthTime", &TimeSeriesProperty<TYPE>::nthTime)                      \
+      .def("getStatistics", &TimeSeriesProperty<TYPE>::getStatistics)          \
+      .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue);
 }
 
-void export_TimeSeriesProperty_Double()
-{
+void export_TimeSeriesProperty_Double() {
   EXPORT_TIMESERIES_PROP(double, Float);
 }
 
-void export_TimeSeriesProperty_Bool()
-{
-  EXPORT_TIMESERIES_PROP(bool, Bool);
-}
+void export_TimeSeriesProperty_Bool() { EXPORT_TIMESERIES_PROP(bool, Bool); }
 
-void export_TimeSeriesProperty_Int32()
-{
+void export_TimeSeriesProperty_Int32() {
   EXPORT_TIMESERIES_PROP(int32_t, Int32);
 }
 
-void export_TimeSeriesProperty_Int64()
-{
+void export_TimeSeriesProperty_Int64() {
   EXPORT_TIMESERIES_PROP(int64_t, Int64);
 }
 
-void export_TimeSeriesProperty_String()
-{
+void export_TimeSeriesProperty_String() {
   EXPORT_TIMESERIES_PROP(std::string, String);
 }
 
-
-void export_TimeSeriesPropertyStatistics()
-{
-  class_<Mantid::Kernel::TimeSeriesPropertyStatistics>("TimeSeriesPropertyStatistics", no_init)
-    .add_property("minimum", &Mantid::Kernel::TimeSeriesPropertyStatistics::minimum)
-    .add_property("maximum", &Mantid::Kernel::TimeSeriesPropertyStatistics::maximum)
-    .add_property("mean", &Mantid::Kernel::TimeSeriesPropertyStatistics::mean)
-    .add_property("median", &Mantid::Kernel::TimeSeriesPropertyStatistics::median)
-    .add_property("standard_deviation", &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
-    .add_property("duration", &Mantid::Kernel::TimeSeriesPropertyStatistics::duration)
-  ;
+void export_TimeSeriesPropertyStatistics() {
+  class_<Mantid::Kernel::TimeSeriesPropertyStatistics>(
+      "TimeSeriesPropertyStatistics", no_init)
+      .add_property("minimum",
+                    &Mantid::Kernel::TimeSeriesPropertyStatistics::minimum)
+      .add_property("maximum",
+                    &Mantid::Kernel::TimeSeriesPropertyStatistics::maximum)
+      .add_property("mean", &Mantid::Kernel::TimeSeriesPropertyStatistics::mean)
+      .add_property("median",
+                    &Mantid::Kernel::TimeSeriesPropertyStatistics::median)
+      .add_property(
+           "standard_deviation",
+           &Mantid::Kernel::TimeSeriesPropertyStatistics::standard_deviation)
+      .add_property("duration",
+                    &Mantid::Kernel::TimeSeriesPropertyStatistics::duration);
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -40,45 +40,33 @@ namespace
       ;
 }
 
-// clang-format off
 void export_TimeSeriesProperty_Double()
-// clang-format on
 {
   EXPORT_TIMESERIES_PROP(double, Float);
 }
 
-// clang-format off
 void export_TimeSeriesProperty_Bool()
-// clang-format on
 {
   EXPORT_TIMESERIES_PROP(bool, Bool);
 }
 
-// clang-format off
 void export_TimeSeriesProperty_Int32()
-// clang-format on
 {
   EXPORT_TIMESERIES_PROP(int32_t, Int32);
 }
 
-// clang-format off
 void export_TimeSeriesProperty_Int64()
-// clang-format on
 {
   EXPORT_TIMESERIES_PROP(int64_t, Int64);
 }
 
-// clang-format off
 void export_TimeSeriesProperty_String()
-// clang-format on
 {
   EXPORT_TIMESERIES_PROP(std::string, String);
 }
 
 
-// clang-format off
 void export_TimeSeriesPropertyStatistics()
-// clang-format on
 {
   class_<Mantid::Kernel::TimeSeriesPropertyStatistics>("TimeSeriesPropertyStatistics", no_init)
     .add_property("minimum", &Mantid::Kernel::TimeSeriesPropertyStatistics::minimum)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -7,41 +7,41 @@ using Mantid::Kernel::Unit;
 using Mantid::Kernel::Unit_sptr;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Returns the full name of the unit & raises a deprecation warning
-   * @param self A reference to calling object
-   */
-  const std::string deprecatedName(Unit & self)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, "'name' is deprecated, use 'caption' instead.");
-    return self.caption();
-  }
-
-  /**
-   * Returns the label of the unit as a std::string & raises a deprecation warning
-   * @param self A reference to calling object
-   */
-  const std::string deprecatedLabel(Unit & self)
-  {
-    PyErr_Warn(PyExc_DeprecationWarning, "'unit.label()' is deprecated, use 'str(unit.symbol())' instead.");
-    return self.label().ascii();
-  }
-
+namespace {
+/**
+ * Returns the full name of the unit & raises a deprecation warning
+ * @param self A reference to calling object
+ */
+const std::string deprecatedName(Unit &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "'name' is deprecated, use 'caption' instead.");
+  return self.caption();
 }
 
-void export_Unit()
-{
+/**
+ * Returns the label of the unit as a std::string & raises a deprecation warning
+ * @param self A reference to calling object
+ */
+const std::string deprecatedLabel(Unit &self) {
+  PyErr_Warn(PyExc_DeprecationWarning,
+             "'unit.label()' is deprecated, use 'str(unit.symbol())' instead.");
+  return self.label().ascii();
+}
+}
+
+void export_Unit() {
   register_ptr_to_python<boost::shared_ptr<Unit>>();
 
-  class_<Unit,boost::noncopyable>("Unit", no_init)
-    .def("name", &deprecatedName, "Return the full name of the unit (deprecated, use caption)")
-    .def("caption", &Unit::caption, "Return the full name of the unit")
-    .def("label", &deprecatedLabel, "Returns a plain-text label to be used as the symbol for the unit (deprecated, use symbol())")
-    .def("symbol", &Unit::label, "Returns a UnitLabel object that holds information on the symbol to use for unit")
-    .def("unitID", &Unit::unitID, "Returns the string ID of the unit. This may/may not match its name")
-  ;
-
+  class_<Unit, boost::noncopyable>("Unit", no_init)
+      .def("name", &deprecatedName,
+           "Return the full name of the unit (deprecated, use caption)")
+      .def("caption", &Unit::caption, "Return the full name of the unit")
+      .def("label", &deprecatedLabel, "Returns a plain-text label to be used "
+                                      "as the symbol for the unit (deprecated, "
+                                      "use symbol())")
+      .def("symbol", &Unit::label, "Returns a UnitLabel object that holds "
+                                   "information on the symbol to use for unit")
+      .def(
+          "unitID", &Unit::unitID,
+          "Returns the string ID of the unit. This may/may not match its name");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -31,9 +31,7 @@ namespace
 
 }
 
-// clang-format off
 void export_Unit()
-// clang-format on
 {
   register_ptr_to_python<boost::shared_ptr<Unit>>();
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitConversion.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitConversion.cpp
@@ -6,20 +6,17 @@ using Mantid::Kernel::UnitConversion;
 using Mantid::Kernel::DeltaEMode;
 using namespace boost::python;
 
-void export_UnitConversion()
-{
+void export_UnitConversion() {
   // Function pointer typedef
-  typedef double (*StringVersion)(const std::string & src, const std::string & dest,
-      const double srcValue,
-      const double l1, const double l2,
-      const double twoTheta, const DeltaEMode::Type emode, const double efixed);
+  typedef double (*StringVersion)(
+      const std::string &src, const std::string &dest, const double srcValue,
+      const double l1, const double l2, const double twoTheta,
+      const DeltaEMode::Type emode, const double efixed);
 
   class_<UnitConversion, boost::noncopyable>("UnitConversion", no_init)
-    .def("run", (StringVersion)&UnitConversion::run,
-         (arg("src"), arg("dest"), arg("srcValue"), arg("l1"), arg("l2"), arg("twoTheta"),
-          arg("emode"), arg("efixed")),
-         "Performs a unit conversion on a single value.")
-    .staticmethod("run")
-  ;
+      .def("run", (StringVersion)&UnitConversion::run,
+           (arg("src"), arg("dest"), arg("srcValue"), arg("l1"), arg("l2"),
+            arg("twoTheta"), arg("emode"), arg("efixed")),
+           "Performs a unit conversion on a single value.")
+      .staticmethod("run");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitConversion.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitConversion.cpp
@@ -6,9 +6,7 @@ using Mantid::Kernel::UnitConversion;
 using Mantid::Kernel::DeltaEMode;
 using namespace boost::python;
 
-// clang-format off
 void export_UnitConversion()
-// clang-format on
 {
   // Function pointer typedef
   typedef double (*StringVersion)(const std::string & src, const std::string & dest,

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitFactory.cpp
@@ -12,17 +12,17 @@ namespace Policies = Mantid::PythonInterface::Policies;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
-void export_UnitFactory()
-{
+void export_UnitFactory() {
   class_<UnitFactoryImpl, boost::noncopyable>("UnitFactoryImpl", no_init)
-    .def("create", &UnitFactoryImpl::create, "Creates a named unit if it exists in the factory")
+      .def("create", &UnitFactoryImpl::create,
+           "Creates a named unit if it exists in the factory")
 
-    .def("getKeys", &UnitFactoryImpl::getKeys, return_value_policy<Policies::VectorToNumpy>(),
-         "Returns a list of units available from the factory")
+      .def("getKeys", &UnitFactoryImpl::getKeys,
+           return_value_policy<Policies::VectorToNumpy>(),
+           "Returns a list of units available from the factory")
 
-    .def("Instance", &UnitFactory::Instance, return_value_policy<reference_existing_object>(),
-         "Returns a reference to the UnitFactory singleton")
-    .staticmethod("Instance")
-    ;
+      .def("Instance", &UnitFactory::Instance,
+           return_value_policy<reference_existing_object>(),
+           "Returns a reference to the UnitFactory singleton")
+      .staticmethod("Instance");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitFactory.cpp
@@ -12,9 +12,7 @@ namespace Policies = Mantid::PythonInterface::Policies;
 namespace Converters = Mantid::PythonInterface::Converters;
 using namespace boost::python;
 
-// clang-format off
 void export_UnitFactory()
-// clang-format on
 {
   class_<UnitFactoryImpl, boost::noncopyable>("UnitFactoryImpl", no_init)
     .def("create", &UnitFactoryImpl::create, "Creates a named unit if it exists in the factory")

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
@@ -10,65 +10,60 @@
 using Mantid::Kernel::UnitLabel;
 using namespace boost::python;
 
-namespace
-{
-  boost::shared_ptr<UnitLabel> createLabel(const object & ascii, const object & utf8, const object & latex)
-  {
-    PyObject *utf8Ptr = utf8.ptr();
-    if(PyUnicode_Check(utf8Ptr))
-    {
-      auto length = PyUnicode_GetSize(utf8Ptr);
-      typedef UnitLabel::Utf8String::value_type Utf8Char;
-      boost::scoped_array<Utf8Char> buffer(new Utf8Char[length]);
-      PyUnicode_AsWideChar((PyUnicodeObject*)utf8Ptr,
-                           buffer.get(), length);
+namespace {
+boost::shared_ptr<UnitLabel>
+createLabel(const object &ascii, const object &utf8, const object &latex) {
+  PyObject *utf8Ptr = utf8.ptr();
+  if (PyUnicode_Check(utf8Ptr)) {
+    auto length = PyUnicode_GetSize(utf8Ptr);
+    typedef UnitLabel::Utf8String::value_type Utf8Char;
+    boost::scoped_array<Utf8Char> buffer(new Utf8Char[length]);
+    PyUnicode_AsWideChar((PyUnicodeObject *)utf8Ptr, buffer.get(), length);
 
-      auto *rawBuffer = buffer.get();
-      return boost::make_shared<UnitLabel>(extract<std::string>(ascii)(),
-                       UnitLabel::Utf8String(rawBuffer, rawBuffer + length),extract<std::string>(latex)() );
-    }
-    else
-    {
-      throw std::invalid_argument("utf8 label is not a unicode string object. "
-                                  "Try prefixing the string with a 'u' character.");
-    }
+    auto *rawBuffer = buffer.get();
+    return boost::make_shared<UnitLabel>(
+        extract<std::string>(ascii)(),
+        UnitLabel::Utf8String(rawBuffer, rawBuffer + length),
+        extract<std::string>(latex)());
+  } else {
+    throw std::invalid_argument(
+        "utf8 label is not a unicode string object. "
+        "Try prefixing the string with a 'u' character.");
   }
-
-  /**
-   * @param self A reference to the calling object
-   * @return A new Python unicode string with the contents of the utf8 label
-   */
-  PyObject * utf8ToUnicode(UnitLabel & self)
-  {
-    const auto label = self.utf8();
-    return PyUnicode_FromWideChar(label.c_str(), label.size());
-  }
-
 }
 
-void export_UnitLabel()
-{
+/**
+ * @param self A reference to the calling object
+ * @return A new Python unicode string with the contents of the utf8 label
+ */
+PyObject *utf8ToUnicode(UnitLabel &self) {
+  const auto label = self.utf8();
+  return PyUnicode_FromWideChar(label.c_str(), label.size());
+}
+}
+
+void export_UnitLabel() {
   class_<UnitLabel>("UnitLabel", no_init)
-    .def("__init__",
-         make_constructor(createLabel, default_call_policies(),
-                          (arg("ascii"), arg("utf8"),arg("latex"))),
-         "Construct a label from a unicode object")
+      .def("__init__",
+           make_constructor(createLabel, default_call_policies(),
+                            (arg("ascii"), arg("utf8"), arg("latex"))),
+           "Construct a label from a unicode object")
 
-    .def(init<UnitLabel::AsciiString>((arg("ascii")),
-                                      "Construct a label from a plain-text string"))
+      .def(init<UnitLabel::AsciiString>(
+          (arg("ascii")), "Construct a label from a plain-text string"))
 
-    .def("ascii", &UnitLabel::ascii, return_value_policy<copy_const_reference>(),
-         "Return the label as a plain-text string")
+      .def("ascii", &UnitLabel::ascii,
+           return_value_policy<copy_const_reference>(),
+           "Return the label as a plain-text string")
 
-    .def("utf8", &utf8ToUnicode,
-         "Return the label as a unicode string")
+      .def("utf8", &utf8ToUnicode, "Return the label as a unicode string")
 
-    .def("latex", &UnitLabel::latex, return_value_policy<copy_const_reference>(),
-          "Return the label as a plain-text string with latex formatting")
+      .def("latex", &UnitLabel::latex,
+           return_value_policy<copy_const_reference>(),
+           "Return the label as a plain-text string with latex formatting")
 
-    // special functions
-    .def("__str__", &UnitLabel::ascii, return_value_policy<copy_const_reference>())
-    .def("__unicode__", &utf8ToUnicode)
-    ;
+      // special functions
+      .def("__str__", &UnitLabel::ascii,
+           return_value_policy<copy_const_reference>())
+      .def("__unicode__", &utf8ToUnicode);
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
@@ -46,9 +46,7 @@ namespace
 
 }
 
-// clang-format off
 void export_UnitLabel()
-// clang-format on
 {
   class_<UnitLabel>("UnitLabel", no_init)
     .def("__init__",

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Units.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Units.cpp
@@ -7,32 +7,31 @@ using Mantid::Kernel::UnitLabel;
 using namespace Mantid::Kernel::Units;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Proxy to construct a UnitLabel directly from a Python str without
-   * having to construct a UnitLabel object
-   * @param self The calling object
-   * @param caption The name of the unit
-   * @param label The symbol for the unit
-   */
-  void setLabelFromStdString(Label & self, const std::string & caption,const std::string & label)
-  {
-    self.setLabel(caption, label);
-  }
+namespace {
+/**
+ * Proxy to construct a UnitLabel directly from a Python str without
+ * having to construct a UnitLabel object
+ * @param self The calling object
+ * @param caption The name of the unit
+ * @param label The symbol for the unit
+ */
+void setLabelFromStdString(Label &self, const std::string &caption,
+                           const std::string &label) {
+  self.setLabel(caption, label);
+}
 }
 
 // We only export the concrete unit classes that
 // have additional functionality over the base class
-void export_Label()
-{
+void export_Label() {
   class_<Label, bases<Unit>, boost::noncopyable>("Label", no_init)
-    .def("setLabel", &setLabelFromStdString,
-         (arg("caption"),arg("label")), "Set the caption (e.g.Temperature) & label (K) on the unit")
+      .def("setLabel", &setLabelFromStdString, (arg("caption"), arg("label")),
+           "Set the caption (e.g.Temperature) & label (K) on the unit")
 
-    .def("setLabel", (void (Label::*)(const std::string&, const UnitLabel&))&Label::setLabel,
-         (arg("caption"),arg("label")), "Set the caption (e.g.Temperature) & label (K) on the unit, See the UnitLabel class")
-    ;
-
+      .def("setLabel",
+           (void (Label::*)(const std::string &, const UnitLabel &)) &
+               Label::setLabel,
+           (arg("caption"), arg("label")), "Set the caption (e.g.Temperature) "
+                                           "& label (K) on the unit, See the "
+                                           "UnitLabel class");
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Units.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Units.cpp
@@ -24,9 +24,7 @@ namespace
 
 // We only export the concrete unit classes that
 // have additional functionality over the base class
-// clang-format off
 void export_Label()
-// clang-format on
 {
   class_<Label, bases<Unit>, boost::noncopyable>("Label", no_init)
     .def("setLabel", &setLabelFromStdString,

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -6,67 +6,74 @@
 using namespace boost::python;
 using Mantid::Kernel::V3D;
 
-namespace
-{
+namespace {
 
-  /**
-   * Helper forwarding method for directionAngles to allow default argument values.
-   * @param self
-   * @return
-   */
-  V3D directionAnglesDefault(V3D & self)
-  {
-    return self.directionAngles();
-  }
+/**
+ * Helper forwarding method for directionAngles to allow default argument
+ * values.
+ * @param self
+ * @return
+ */
+V3D directionAnglesDefault(V3D &self) { return self.directionAngles(); }
 
-  long hashV3D(V3D & self)
-  {
-      boost::python::object tmpObj(self.toString());
+long hashV3D(V3D &self) {
+  boost::python::object tmpObj(self.toString());
 
-      return PyObject_Hash(tmpObj.ptr());
-  }
-
+  return PyObject_Hash(tmpObj.ptr());
+}
 }
 
-
-void export_V3D()
-{
-  //V3D class
-  class_< V3D >("V3D",init<>("Construct a V3D at the origin"))
-    .def(init<double, double, double>("Construct a V3D with X,Y,Z coordinates"))
-    .def("X", &V3D::X, return_value_policy< copy_const_reference >(), "Returns the X coordinate")
-    .def("Y", &V3D::Y, return_value_policy< copy_const_reference >(), "Returns the Y coordinate")
-    .def("Z", &V3D::Z, return_value_policy< copy_const_reference >(), "Returns the Z coordinate")
-    .def("getX", &V3D::X, return_value_policy< copy_const_reference >(), "Returns the X coordinate") // Traditional name
-    .def("getY", &V3D::Y, return_value_policy< copy_const_reference >(), "Returns the Y coordinate") // Traditional name
-    .def("getZ", &V3D::Z, return_value_policy< copy_const_reference >(), "Returns the Z coordinate") // Traditional name
-    .def("distance", &V3D::distance, "Returns the distance between this vector and another")
-    .def("angle", &V3D::angle, "Returns the angle between this vector and another")
-    .def("zenith", &V3D::zenith, "Returns the zenith between this vector and another")
-    .def("scalar_prod", &V3D::scalar_prod, "Computes the scalar product between this and another vector")
-    .def("cross_prod", &V3D::cross_prod, "Computes the cross product between this and another vector")
-    .def("norm", &V3D::norm, "Calculates the length of the vector")
-    .def("norm2", &V3D::norm2, "Calculates the squared length of the vector")
-    .def(self + self)
-    .def(self += self)
-    .def(self - self)
-    .def(self -= self)
-    .def(self * self)
-    .def(self *= self)
-    .def(self / self)
-    .def(self /= self)
-    .def(self * int())
-    .def(self *= int())
-    .def(self * double())
-    .def(self *= double())
-    // cppcheck-suppress duplicateExpression
-    .def(self < self)
-    .def(self == self)
-    .def(self != self) // must define != as Python's default is to compare object address
-    .def(self_ns::str(self))
-    .def(self_ns::repr(self))
-    .def("__hash__", &hashV3D)
-    .def("directionAngles", &V3D::directionAngles, "Calculate direction angles from direction cosines")
-    .def("directionAngles", &directionAnglesDefault, "Calculate direction angles from direction cosines")
-    ;
+void export_V3D() {
+  // V3D class
+  class_<V3D>("V3D", init<>("Construct a V3D at the origin"))
+      .def(init<double, double, double>(
+          "Construct a V3D with X,Y,Z coordinates"))
+      .def("X", &V3D::X, return_value_policy<copy_const_reference>(),
+           "Returns the X coordinate")
+      .def("Y", &V3D::Y, return_value_policy<copy_const_reference>(),
+           "Returns the Y coordinate")
+      .def("Z", &V3D::Z, return_value_policy<copy_const_reference>(),
+           "Returns the Z coordinate")
+      .def("getX", &V3D::X, return_value_policy<copy_const_reference>(),
+           "Returns the X coordinate") // Traditional name
+      .def("getY", &V3D::Y, return_value_policy<copy_const_reference>(),
+           "Returns the Y coordinate") // Traditional name
+      .def("getZ", &V3D::Z, return_value_policy<copy_const_reference>(),
+           "Returns the Z coordinate") // Traditional name
+      .def("distance", &V3D::distance,
+           "Returns the distance between this vector and another")
+      .def("angle", &V3D::angle,
+           "Returns the angle between this vector and another")
+      .def("zenith", &V3D::zenith,
+           "Returns the zenith between this vector and another")
+      .def("scalar_prod", &V3D::scalar_prod,
+           "Computes the scalar product between this and another vector")
+      .def("cross_prod", &V3D::cross_prod,
+           "Computes the cross product between this and another vector")
+      .def("norm", &V3D::norm, "Calculates the length of the vector")
+      .def("norm2", &V3D::norm2, "Calculates the squared length of the vector")
+      .def(self + self)
+      .def(self += self)
+      .def(self - self)
+      .def(self -= self)
+      .def(self * self)
+      .def(self *= self)
+      .def(self / self)
+      .def(self /= self)
+      .def(self * int())
+      .def(self *= int())
+      .def(self * double())
+      .def(self *= double())
+      // cppcheck-suppress duplicateExpression
+      .def(self < self)
+      .def(self == self)
+      .def(self != self) // must define != as Python's default is to compare
+                         // object address
+      .def(self_ns::str(self))
+      .def(self_ns::repr(self))
+      .def("__hash__", &hashV3D)
+      .def("directionAngles", &V3D::directionAngles,
+           "Calculate direction angles from direction cosines")
+      .def("directionAngles", &directionAnglesDefault,
+           "Calculate direction angles from direction cosines");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -29,9 +29,7 @@ namespace
 }
 
 
-// clang-format off
 void export_V3D()
-// clang-format on
 {
   //V3D class
   class_< V3D >("V3D",init<>("Construct a V3D at the origin"))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VMD.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VMD.cpp
@@ -10,85 +10,97 @@ using Mantid::Kernel::VMD;
 using Mantid::Kernel::VMD_t;
 using namespace boost::python;
 
-namespace
-{
-  /**
-   * Safe operator access. Returns the value at the given index
-   * checking whether the index is valid. VMD does no checking
-   * @param self The calling python object
-   * @param index An index whose value is to be returned
-   * @throws An out_of_range error if the index is out of range
-   */
-  VMD_t getItem(VMD & self, const size_t index)
-  {
-    if( index < self.getNumDims() )
-    {
-      return self[index];
-    }
-    else throw std::out_of_range("VMD index out of range. index=" + \
-        boost::lexical_cast<std::string>(index) + ", len=" + boost::lexical_cast<std::string>(self.getNumDims()));
-  }
-
-  /**
-   * Set the value at the given index
-   * @param self The calling python object
-   * @param index An index whose value is to be set
-   * @param value The new value for the index
-   * @throws An out_of_range error if the index is out of range
-   */
-  void setItem(VMD & self, const size_t index, const VMD_t value)
-  {
-    if( index < self.getNumDims() )
-    {
-      self[index] = value;
-    }
-    else throw std::out_of_range("VMD index out of range. index=" + \
-        boost::lexical_cast<std::string>(index) + ", len=" + boost::lexical_cast<std::string>(self.getNumDims()));
-  }
+namespace {
+/**
+ * Safe operator access. Returns the value at the given index
+ * checking whether the index is valid. VMD does no checking
+ * @param self The calling python object
+ * @param index An index whose value is to be returned
+ * @throws An out_of_range error if the index is out of range
+ */
+VMD_t getItem(VMD &self, const size_t index) {
+  if (index < self.getNumDims()) {
+    return self[index];
+  } else
+    throw std::out_of_range(
+        "VMD index out of range. index=" +
+        boost::lexical_cast<std::string>(index) + ", len=" +
+        boost::lexical_cast<std::string>(self.getNumDims()));
 }
 
-void export_VMD()
-{
-  class_<VMD>("VMD", init<>("Default constructor gives an object with 1 dimension"))
-    .def(init<VMD_t,VMD_t>("Constructs a 2 dimensional vector at the point given", args(("val0"),("val1"))))
-    .def(init<VMD_t,VMD_t,VMD_t>("Constructs a 3 dimensional vector at the point given", 
-                                 args(("val0"),("val1"),("val2"))))
-    .def(init<VMD_t,VMD_t,VMD_t,VMD_t>("Constructs a 4 dimensional vector at the point given", 
-                                       args(("val0"),("val1"),("val2"),("val3"))))
-    .def(init<VMD_t,VMD_t,VMD_t,VMD_t,VMD_t>("Constructs a 5 dimensional vector at the point given", 
-                                             args(("val0"),("val1"),("val2"),("val3"),("val4"))))
-    .def(init<VMD_t,VMD_t,VMD_t,VMD_t,VMD_t,VMD_t>("Constructs a 6 dimensional vector at the point given", 
-                                                   args(("val0"),("val1"),("val2"),("val3"),("val5"))))
-
-    .def("getNumDims", &VMD::getNumDims, "Returns the number of dimensions the contained in the vector")
-
-    .def("scalar_prod", &VMD::scalar_prod,
-         "Returns the scalar product of this vector with another. If the number of dimensions do not match a RuntimeError is raised")
-
-    .def("cross_prod", &VMD::cross_prod,
-         "Returns the cross product of this vector with another. If the number of dimensions do not match a RuntimeError is raised")
-
-    .def("norm", &VMD::norm, "Returns the length of the vector")
-
-    .def("norm2", &VMD::norm2, "Returns the the squared length of the vector")
-
-    .def("normalize", &VMD::normalize, "Normalizes the length of the vector to unity and returns the length before it was normalized")
-
-    .def("angle", &VMD::angle, "Returns the angle between the vectors in radians (0 < theta < pi). If the dimensions do not match a RuntimeError is raised")
-
-    //----------------------------- special methods --------------------------------
-    .def("__getitem__", &getItem)
-    .def("__setitem__", &setItem)
-    .def(self == self)
-    .def(self != self) // must define != as Python's default is to compare object address
-    .def(self + self)
-    .def(self += self)
-    .def(self - self)
-    .def(self -= self)
-    .def(self * self)
-    .def(self *= self)
-    .def(self / self)
-    .def(self /= self)
-    ;
+/**
+ * Set the value at the given index
+ * @param self The calling python object
+ * @param index An index whose value is to be set
+ * @param value The new value for the index
+ * @throws An out_of_range error if the index is out of range
+ */
+void setItem(VMD &self, const size_t index, const VMD_t value) {
+  if (index < self.getNumDims()) {
+    self[index] = value;
+  } else
+    throw std::out_of_range(
+        "VMD index out of range. index=" +
+        boost::lexical_cast<std::string>(index) + ", len=" +
+        boost::lexical_cast<std::string>(self.getNumDims()));
+}
 }
 
+void export_VMD() {
+  class_<VMD>("VMD",
+              init<>("Default constructor gives an object with 1 dimension"))
+      .def(init<VMD_t, VMD_t>(
+          "Constructs a 2 dimensional vector at the point given",
+          args(("val0"), ("val1"))))
+      .def(init<VMD_t, VMD_t, VMD_t>(
+          "Constructs a 3 dimensional vector at the point given",
+          args(("val0"), ("val1"), ("val2"))))
+      .def(init<VMD_t, VMD_t, VMD_t, VMD_t>(
+          "Constructs a 4 dimensional vector at the point given",
+          args(("val0"), ("val1"), ("val2"), ("val3"))))
+      .def(init<VMD_t, VMD_t, VMD_t, VMD_t, VMD_t>(
+          "Constructs a 5 dimensional vector at the point given",
+          args(("val0"), ("val1"), ("val2"), ("val3"), ("val4"))))
+      .def(init<VMD_t, VMD_t, VMD_t, VMD_t, VMD_t, VMD_t>(
+          "Constructs a 6 dimensional vector at the point given",
+          args(("val0"), ("val1"), ("val2"), ("val3"), ("val5"))))
+
+      .def("getNumDims", &VMD::getNumDims,
+           "Returns the number of dimensions the contained in the vector")
+
+      .def("scalar_prod", &VMD::scalar_prod,
+           "Returns the scalar product of this vector with another. If the "
+           "number of dimensions do not match a RuntimeError is raised")
+
+      .def("cross_prod", &VMD::cross_prod,
+           "Returns the cross product of this vector with another. If the "
+           "number of dimensions do not match a RuntimeError is raised")
+
+      .def("norm", &VMD::norm, "Returns the length of the vector")
+
+      .def("norm2", &VMD::norm2, "Returns the the squared length of the vector")
+
+      .def("normalize", &VMD::normalize, "Normalizes the length of the vector "
+                                         "to unity and returns the length "
+                                         "before it was normalized")
+
+      .def("angle", &VMD::angle, "Returns the angle between the vectors in "
+                                 "radians (0 < theta < pi). If the dimensions "
+                                 "do not match a RuntimeError is raised")
+
+      //----------------------------- special methods
+      //--------------------------------
+      .def("__getitem__", &getItem)
+      .def("__setitem__", &setItem)
+      .def(self == self)
+      .def(self != self) // must define != as Python's default is to compare
+                         // object address
+      .def(self + self)
+      .def(self += self)
+      .def(self - self)
+      .def(self -= self)
+      .def(self * self)
+      .def(self *= self)
+      .def(self / self)
+      .def(self /= self);
+}

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VMD.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VMD.cpp
@@ -47,9 +47,7 @@ namespace
   }
 }
 
-// clang-format off
 void export_VMD()
-// clang-format on
 {
   class_<VMD>("VMD", init<>("Default constructor gives an object with 1 dimension"))
     .def(init<VMD_t,VMD_t>("Constructs a 2 dimensional vector at the point given", args(("val0"),("val1"))))

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VisibleWhenProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VisibleWhenProperty.cpp
@@ -4,19 +4,16 @@
 using namespace Mantid::Kernel;
 using namespace boost::python;
 
-void export_VisibleWhenProperty()
-{
-  class_<VisibleWhenProperty, bases<EnabledWhenProperty>,
-         boost::noncopyable>("VisibleWhenProperty", no_init)
-    .def(init<std::string, ePropertyCriterion, std::string>(
-           (arg("otherPropName"), arg("when"), arg("value")),
-            "Enabled otherPropName property when value criterion meets that given by the 'when' argument")
-        )
+void export_VisibleWhenProperty() {
+  class_<VisibleWhenProperty, bases<EnabledWhenProperty>, boost::noncopyable>(
+      "VisibleWhenProperty", no_init)
+      .def(init<std::string, ePropertyCriterion, std::string>(
+          (arg("otherPropName"), arg("when"), arg("value")),
+          "Enabled otherPropName property when value criterion meets that "
+          "given by the 'when' argument"))
 
-    .def(init<std::string, ePropertyCriterion>(
-            (arg("otherPropName"), arg("when")),
-            "Enabled otherPropName property when criterion does not require a value, i.e isDefault")
-        )
-    ;
+      .def(init<std::string, ePropertyCriterion>(
+          (arg("otherPropName"), arg("when")),
+          "Enabled otherPropName property when criterion does not require a "
+          "value, i.e isDefault"));
 }
-

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VisibleWhenProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/VisibleWhenProperty.cpp
@@ -4,9 +4,7 @@
 using namespace Mantid::Kernel;
 using namespace boost::python;
 
-// clang-format off
 void export_VisibleWhenProperty()
-// clang-format on
 {
   class_<VisibleWhenProperty, bases<EnabledWhenProperty>,
          boost::noncopyable>("VisibleWhenProperty", no_init)

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/DowncastRegistry.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/DowncastRegistry.cpp
@@ -8,78 +8,71 @@
 #include <boost/unordered_map.hpp>
 #include <stdexcept>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Registry
+namespace Mantid {
+namespace PythonInterface {
+namespace Registry {
+namespace // <anonymous>
     {
-      namespace // <anonymous>
-      {
-        /// Typedef the map of type_info -> Downcaster objects
-        typedef boost::unordered_map<std::string, boost::shared_ptr<const DowncastDataItem>> RegistryType;
-        //typedef std::map<std::string, boost::shared_ptr<const DowncastDataItem>> RegistryType;
+/// Typedef the map of type_info -> Downcaster objects
+typedef boost::unordered_map<
+    std::string, boost::shared_ptr<const DowncastDataItem>> RegistryType;
+// typedef std::map<std::string, boost::shared_ptr<const DowncastDataItem>>
+// RegistryType;
 
-        /**
-         * Returns a reference to the static type map. Creates on first call to the function
-         * @return A reference to the type map
-         */
-        RegistryType & downcastRegistry()
-        {
-          static RegistryType registry;
-          return registry;
-        }
-      } // end <anonymous>
+/**
+ * Returns a reference to the static type map. Creates on first call to the
+ * function
+ * @return A reference to the type map
+ */
+RegistryType &downcastRegistry() {
+  static RegistryType registry;
+  return registry;
+}
+} // end <anonymous>
 
-      //-----------------------------------------------------------------------
-      // Public methods
-      //-----------------------------------------------------------------------
-      /**
-       * Throws std::invalid_argument if the item does not exist
-       * @param id A string ID from a concrete DataItem type
-       * @return The object responsible for casting and creating a Python object
-       *         from it
-       */
-      const DowncastDataItem & DowncastRegistry::retrieve(const std::string & id)
-      {
-        auto & registry = downcastRegistry();
-        auto entry = registry.find(id);
-        if(entry != registry.cend())
-        {
-          return *(entry->second);
-        }
-        else
-        {
-          throw std::invalid_argument("DowncastRegistry::retrieve - Unable to find registered "
-                                      "object with id=" + id);
-        }
-      }
-
-
-      //-----------------------------------------------------------------------
-      // Private methods
-      //-----------------------------------------------------------------------
-      /**
-       * Subscribe a caster object with a given ID
-       * @param id A string ID that will map to the object
-       * @param caster A pointer to a DowncastDataItem object. Ownership of the
-       *               object is transferred here
-       */
-      void DowncastRegistry::subscribe(const std::string & id, const DowncastDataItem * caster)
-      {
-        auto & registry = downcastRegistry();
-        if(registry.find(id) == registry.cend())
-        {
-          typedef boost::shared_ptr<const DowncastDataItem> DowncastDataItemPtr;
-          registry.insert(std::make_pair(id, DowncastDataItemPtr(caster)));
-        }
-        else
-        {
-          throw std::invalid_argument("DowncastRegistry::subscribe - object with ID=" + id + \
-                                      " has already been registered");
-        }
-      }
-
-    }
+//-----------------------------------------------------------------------
+// Public methods
+//-----------------------------------------------------------------------
+/**
+ * Throws std::invalid_argument if the item does not exist
+ * @param id A string ID from a concrete DataItem type
+ * @return The object responsible for casting and creating a Python object
+ *         from it
+ */
+const DowncastDataItem &DowncastRegistry::retrieve(const std::string &id) {
+  auto &registry = downcastRegistry();
+  auto entry = registry.find(id);
+  if (entry != registry.cend()) {
+    return *(entry->second);
+  } else {
+    throw std::invalid_argument(
+        "DowncastRegistry::retrieve - Unable to find registered "
+        "object with id=" +
+        id);
   }
+}
+
+//-----------------------------------------------------------------------
+// Private methods
+//-----------------------------------------------------------------------
+/**
+ * Subscribe a caster object with a given ID
+ * @param id A string ID that will map to the object
+ * @param caster A pointer to a DowncastDataItem object. Ownership of the
+ *               object is transferred here
+ */
+void DowncastRegistry::subscribe(const std::string &id,
+                                 const DowncastDataItem *caster) {
+  auto &registry = downcastRegistry();
+  if (registry.find(id) == registry.cend()) {
+    typedef boost::shared_ptr<const DowncastDataItem> DowncastDataItemPtr;
+    registry.insert(std::make_pair(id, DowncastDataItemPtr(caster)));
+  } else {
+    throw std::invalid_argument(
+        "DowncastRegistry::subscribe - object with ID=" + id +
+        " has already been registered");
+  }
+}
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -10,201 +10,189 @@
 
 #include <cassert>
 
+namespace Mantid {
+namespace PythonInterface {
+namespace Registry {
+namespace {
+/// Lookup map type
+typedef std::map<PyTypeObject const *, boost::shared_ptr<PropertyValueHandler>>
+    PyTypeIndex;
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Registry
-    {
-      namespace
-      {
-        /// Lookup map type
-        typedef std::map<PyTypeObject const *,
-                         boost::shared_ptr<PropertyValueHandler>> PyTypeIndex;
+/**
+ * Initialize lookup map
+ */
+void initTypeLookup(PyTypeIndex &index) {
+  assert(index.empty());
 
-        /**
-         * Initialize lookup map
-         */
-        void initTypeLookup(PyTypeIndex & index)
-        {
-          assert(index.empty());
+  // Map the Python types to the best match in C++
+  typedef TypedPropertyValueHandler<double> FloatHandler;
+  index.insert(
+      std::make_pair(&PyFloat_Type, boost::make_shared<FloatHandler>()));
 
-          // Map the Python types to the best match in C++
-          typedef TypedPropertyValueHandler<double> FloatHandler;
-          index.insert(std::make_pair(&PyFloat_Type, boost::make_shared<FloatHandler>()));
+  typedef TypedPropertyValueHandler<long> IntHandler;
+  index.insert(std::make_pair(&PyInt_Type, boost::make_shared<IntHandler>()));
 
-          typedef TypedPropertyValueHandler<long> IntHandler;
-          index.insert(std::make_pair(&PyInt_Type, boost::make_shared<IntHandler>()));
+  typedef TypedPropertyValueHandler<bool> BoolHandler;
+  index.insert(std::make_pair(&PyBool_Type, boost::make_shared<BoolHandler>()));
 
-          typedef TypedPropertyValueHandler<bool> BoolHandler;
-          index.insert(std::make_pair(&PyBool_Type, boost::make_shared<BoolHandler>()));
+  typedef TypedPropertyValueHandler<std::string> StrHandler;
+  index.insert(
+      std::make_pair(&PyString_Type, boost::make_shared<StrHandler>()));
+}
 
-          typedef TypedPropertyValueHandler<std::string> StrHandler;
-          index.insert(std::make_pair(&PyString_Type, boost::make_shared<StrHandler>()));
+/**
+ * Returns a reference to the static lookup map
+ */
+const PyTypeIndex &getTypeIndex() {
+  static PyTypeIndex index;
+  if (index.empty())
+    initTypeLookup(index);
+  return index;
+}
 
-        }
+// Lookup map for arrays
+typedef std::map<std::string, boost::shared_ptr<PropertyValueHandler>>
+    PyArrayIndex;
 
-        /**
-         * Returns a reference to the static lookup map
-         */
-        const PyTypeIndex & getTypeIndex()
-        {
-          static PyTypeIndex index;
-          if( index.empty() ) initTypeLookup(index);
-          return index;
-        }
+/**
+ * Initialize lookup map
+ */
+void initArrayLookup(PyArrayIndex &index) {
+  assert(index.empty());
 
-        // Lookup map for arrays
-        typedef std::map<std::string,
-                         boost::shared_ptr<PropertyValueHandler>> PyArrayIndex;
+  // Map the Python array types to the best match in C++
+  typedef SequenceTypeHandler<std::vector<double>> FloatArrayHandler;
+  index.insert(
+      std::make_pair("FloatArray", boost::make_shared<FloatArrayHandler>()));
 
-        /**
-         * Initialize lookup map
-         */
-        void initArrayLookup(PyArrayIndex & index)
-        {
-          assert(index.empty());
+  typedef SequenceTypeHandler<std::vector<int>> IntArrayHandler;
+  index.insert(
+      std::make_pair("IntArray", boost::make_shared<IntArrayHandler>()));
 
-          // Map the Python array types to the best match in C++
-          typedef SequenceTypeHandler<std::vector<double>> FloatArrayHandler;
-          index.insert(std::make_pair("FloatArray",
-                                      boost::make_shared<FloatArrayHandler>()));
+  typedef SequenceTypeHandler<std::vector<long>> LongIntArrayHandler;
+  index.insert(std::make_pair("LongIntArray",
+                              boost::make_shared<LongIntArrayHandler>()));
 
-          typedef SequenceTypeHandler<std::vector<int>> IntArrayHandler;
-          index.insert(std::make_pair("IntArray",
-                                      boost::make_shared<IntArrayHandler>()));
+  typedef SequenceTypeHandler<std::vector<std::string>> StringArrayHandler;
+  index.insert(
+      std::make_pair("StringArray", boost::make_shared<StringArrayHandler>()));
+}
 
-          typedef SequenceTypeHandler<std::vector<long>> LongIntArrayHandler;
-          index.insert(std::make_pair("LongIntArray",
-                                      boost::make_shared<LongIntArrayHandler>()));
+/**
+ * Returns a reference to the static array lookup map
+ */
+const PyArrayIndex &getArrayIndex() {
+  static PyArrayIndex index;
+  if (index.empty())
+    initArrayLookup(index);
+  return index;
+}
+}
 
-          typedef SequenceTypeHandler<std::vector<std::string>> StringArrayHandler;
-          index.insert(std::make_pair("StringArray",
-                                      boost::make_shared<StringArrayHandler>()));
-        }
+/**
+ * Creates a PropertyWithValue<Type> instance from the given information.
+ * The python type is mapped to a C type using the mapping defined by
+ * initPythonTypeMap()
+ * @param name :: The name of the property
+ * @param defaultValue :: A default value for this property.
+ * @param validator :: A validator object
+ * @param direction :: Specifies whether the property is Input, InOut or Output
+ * @returns A pointer to a new Property object
+ */
+Kernel::Property *PropertyWithValueFactory::create(
+    const std::string &name, const boost::python::object &defaultValue,
+    const boost::python::object &validator, const unsigned int direction) {
+  const auto &propHandle = lookup(defaultValue.ptr());
+  return propHandle.create(name, defaultValue, validator, direction);
+}
 
-        /**
-         * Returns a reference to the static array lookup map
-         */
-        const PyArrayIndex & getArrayIndex()
-        {
-          static PyArrayIndex index;
-          if( index.empty() ) initArrayLookup(index);
-          return index;
-        }
-      }
+/**
+ * Creates a PropertyWithValue<Type> instance from the given information.
+ * The python type is mapped to a C type using the mapping defined by
+ * initPythonTypeMap()
+ * @param name :: The name of the property
+ * @param defaultValue :: A default value for this property.
+ * @param direction :: Specifies whether the property is Input, InOut or Output
+ * @returns A pointer to a new Property object
+ */
+Kernel::Property *
+PropertyWithValueFactory::create(const std::string &name,
+                                 const boost::python::object &defaultValue,
+                                 const unsigned int direction) {
+  boost::python::object validator; // Default construction gives None object
+  return create(name, defaultValue, validator, direction);
+}
 
-      /**
-       * Creates a PropertyWithValue<Type> instance from the given information.
-       * The python type is mapped to a C type using the mapping defined by initPythonTypeMap()
-       * @param name :: The name of the property
-       * @param defaultValue :: A default value for this property.
-       * @param validator :: A validator object
-       * @param direction :: Specifies whether the property is Input, InOut or Output
-       * @returns A pointer to a new Property object
-       */
-      Kernel::Property *
-      PropertyWithValueFactory::create(const std::string & name , const boost::python::object & defaultValue,
-          const boost::python::object & validator, const unsigned int direction)
-      {
-        const auto &propHandle = lookup(defaultValue.ptr());
-        return propHandle.create(name, defaultValue, validator, direction);
-      }
-
-      /**
-       * Creates a PropertyWithValue<Type> instance from the given information.
-       * The python type is mapped to a C type using the mapping defined by initPythonTypeMap()
-       * @param name :: The name of the property
-       * @param defaultValue :: A default value for this property.
-       * @param direction :: Specifies whether the property is Input, InOut or Output
-       * @returns A pointer to a new Property object
-       */
-      Kernel::Property *
-      PropertyWithValueFactory::create(const std::string & name , const boost::python::object & defaultValue,
-          const unsigned int direction)
-      {
-        boost::python::object validator; // Default construction gives None object
-        return create(name, defaultValue, validator, direction);
-      }
-
-
-      //-------------------------------------------------------------------------
-      // Private methods
-      //-------------------------------------------------------------------------
-      /**
-       * Return a handler that maps the python type to a C++ type
-       * @param object :: A pointer to a PyObject that represents the type
-       * @returns A pointer to handler that can be used to instantiate a property
-       */
-      const PropertyValueHandler & PropertyWithValueFactory::lookup(PyObject * const object)
-      {
-        // Check if object is array.
-        const auto ptype = isArray(object);
-        if (!ptype.empty())
-        {
-          const PyArrayIndex &arrayIndex = getArrayIndex();
-          auto ait = arrayIndex.find(ptype);
-          if (ait != arrayIndex.end())
-          {
-            return *(ait->second);
-          }
-        }
-        // Object is not array, so check primitive types
-        const PyTypeIndex & typeIndex = getTypeIndex();
-        auto cit = typeIndex.find(object->ob_type);
-        if( cit == typeIndex.end() )
-        {
-          std::ostringstream os;
-          os << "Cannot create PropertyWithValue from Python type " << object->ob_type->tp_name << ". No converter registered in PropertyWithValueFactory.";
-          throw std::invalid_argument(os.str());
-        }
-        return *(cit->second);
-      }
-
-      /**
-       * Return a string for the array type to check the map for.
-       * @param object :: Python object to check if it's an array
-       * @return :: A string as the array type.
-       */
-      const std::string PropertyWithValueFactory::isArray(PyObject * const object)
-      {
-        if (PyList_Check(object) || PyTuple_Check(object))
-        {
-          PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
-          // Boolean can be cast to int, so check first.
-          if (PyBool_Check(item))
-          {
-            throw std::runtime_error("Unable to support extracting arrays of booleans.");
-          }
-          if (PyLong_Check(item))
-          {
-            return std::string("LongIntArray");
-          }
-          if (PyInt_Check(item))
-          {
-            return std::string("IntArray");
-          }
-          if (PyFloat_Check(item))
-          {
-            return std::string("FloatArray");
-          }
-          if (PyString_Check(item))
-          {
-            return std::string("StringArray");
-          }
-          // If we get here, we've found a sequence and we can't interpret the item type.
-          std::ostringstream os;
-          os << "Cannot create PropertyWithValue from Python type " << object->ob_type->tp_name
-             << " containing items of type " << item->ob_type << ". No converter registered in PropertyWithValueFactory.";
-
-          throw std::invalid_argument(os.str());
-        }
-        else
-        {
-          return std::string("");
-        }
-      }
+//-------------------------------------------------------------------------
+// Private methods
+//-------------------------------------------------------------------------
+/**
+ * Return a handler that maps the python type to a C++ type
+ * @param object :: A pointer to a PyObject that represents the type
+ * @returns A pointer to handler that can be used to instantiate a property
+ */
+const PropertyValueHandler &
+PropertyWithValueFactory::lookup(PyObject *const object) {
+  // Check if object is array.
+  const auto ptype = isArray(object);
+  if (!ptype.empty()) {
+    const PyArrayIndex &arrayIndex = getArrayIndex();
+    auto ait = arrayIndex.find(ptype);
+    if (ait != arrayIndex.end()) {
+      return *(ait->second);
     }
   }
+  // Object is not array, so check primitive types
+  const PyTypeIndex &typeIndex = getTypeIndex();
+  auto cit = typeIndex.find(object->ob_type);
+  if (cit == typeIndex.end()) {
+    std::ostringstream os;
+    os << "Cannot create PropertyWithValue from Python type "
+       << object->ob_type->tp_name
+       << ". No converter registered in PropertyWithValueFactory.";
+    throw std::invalid_argument(os.str());
+  }
+  return *(cit->second);
+}
+
+/**
+ * Return a string for the array type to check the map for.
+ * @param object :: Python object to check if it's an array
+ * @return :: A string as the array type.
+ */
+const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
+  if (PyList_Check(object) || PyTuple_Check(object)) {
+    PyObject *item = PySequence_Fast_GET_ITEM(object, 0);
+    // Boolean can be cast to int, so check first.
+    if (PyBool_Check(item)) {
+      throw std::runtime_error(
+          "Unable to support extracting arrays of booleans.");
+    }
+    if (PyLong_Check(item)) {
+      return std::string("LongIntArray");
+    }
+    if (PyInt_Check(item)) {
+      return std::string("IntArray");
+    }
+    if (PyFloat_Check(item)) {
+      return std::string("FloatArray");
+    }
+    if (PyString_Check(item)) {
+      return std::string("StringArray");
+    }
+    // If we get here, we've found a sequence and we can't interpret the item
+    // type.
+    std::ostringstream os;
+    os << "Cannot create PropertyWithValue from Python type "
+       << object->ob_type->tp_name << " containing items of type "
+       << item->ob_type
+       << ". No converter registered in PropertyWithValueFactory.";
+
+    throw std::invalid_argument(os.str());
+  } else {
+    return std::string("");
+  }
+}
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
@@ -6,7 +6,8 @@
 #include "MantidPythonInterface/kernel/Converters/NDArrayToVector.h"
 #include "MantidKernel/IPropertyManager.h"
 
-// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+// See
+// http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
 #define PY_ARRAY_UNIQUE_SYMBOL KERNEL_ARRAY_API
 #define NO_IMPORT_ARRAY
 #include <numpy/arrayobject.h>
@@ -14,130 +15,118 @@
 #include <boost/python/extract.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Registry
-    {
-      namespace
-      {
-        template <typename HeldType>
-        struct StdVectorExtractor
-        {
-          static std::vector<HeldType> extract(const boost::python::object & value)
-          {
-            return boost::python::extract<std::vector<HeldType>>(value.ptr());
-          }
-        };
-        template <>
-        struct StdVectorExtractor<bool>
-        {
-          static std::vector<bool> extract(const boost::python::object &)
-          {
-            throw std::runtime_error("Unable to supported extracting std::vector<bool> from python object");
-          }
-        };
-
-      }
-
-      /**
-       * Set function to handle Python -> C++ calls to a property manager and get the correct type
-       * @param alg :: A pointer to an IPropertyManager
-       * @param name :: The name of the property
-       * @param value :: A boost python object that stores the container values
-       */
-      template<typename ContainerType>
-      void SequenceTypeHandler<ContainerType>::set(Kernel::IPropertyManager* alg, const std::string &name,
-                                                   const boost::python::object & value) const
-      {
-        using boost::python::len;
-        typedef typename ContainerType::value_type DestElementType;
-
-        // Current workaround for things that still pass back wrapped vectors...
-        if(boost::starts_with(value.ptr()->ob_type->tp_name, "std_vector"))
-        {
-          alg->setProperty(name, StdVectorExtractor<DestElementType>::extract(value));
-        }
-        // numpy arrays requires special handling to extract their types. Hand-off to a more appropriate handler
-        else if( PyArray_Check(value.ptr()) )
-        {
-          alg->setProperty(name, Converters::NDArrayToVector<DestElementType>(value)());
-        }
-        else if( PySequence_Check(value.ptr()) )
-        {
-          alg->setProperty(name, Converters::PySequenceToVector<DestElementType>(value)());
-        }
-        else // assume it is a scalar and try to convert into a vector of length one
-        {
-          DestElementType scalar = boost::python::extract<DestElementType>(value.ptr());
-          alg->setProperty(name, std::vector<DestElementType>(1, scalar));
-        }
-      }
-
-      /**
-       * Create a PropertyWithValue from the given python object value
-       * @param name :: The name of the property
-       * @param defaultValue :: The defaultValue of the property. The object attempts to extract
-       * a value of type ContainerType from the python object
-       * @param validator :: A python object pointing to a validator instance, which can be None.
-       * @param direction :: The direction of the property
-       * @returns A pointer to a newly constructed property instance
-       */
-      template<typename ContainerType>
-      Kernel::Property *SequenceTypeHandler<ContainerType>::create(const std::string &name,
-                                                                   const boost::python::object &defaultValue,
-                                                                   const boost::python::object &validator,
-                                                                   const unsigned int direction) const
-      {
-        typedef typename ContainerType::value_type DestElementType;
-
-        ContainerType valueInC;
-        // Current workaround for things that still pass back wrapped vectors...
-        if(boost::starts_with(defaultValue.ptr()->ob_type->tp_name, "std_vector"))
-        {
-          valueInC = StdVectorExtractor<DestElementType>::extract(defaultValue);
-        }
-        else if( PySequence_Check(defaultValue.ptr()) )
-        {
-          valueInC = Converters::PySequenceToVector<DestElementType>(defaultValue)();
-        }
-        else // assume it is a scalar and try to convert into a vector of length one
-        {
-          DestElementType scalar = boost::python::extract<DestElementType>(defaultValue.ptr());
-          valueInC = std::vector<DestElementType>(1, scalar);
-        }
-
-        Kernel::Property *valueProp(NULL);
-        if (isNone(validator))
-        {
-          valueProp = new Kernel::PropertyWithValue<ContainerType>(name, valueInC, direction);
-        }
-        else
-        {
-          const Kernel::IValidator *propValidator = boost::python::extract<Kernel::IValidator*>(validator);
-          valueProp = new Kernel::PropertyWithValue<ContainerType>(name, valueInC, propValidator->clone(), direction);
-        }
-        return valueProp;
-      }
-
-      //-----------------------------------------------------------------------
-      // Concrete instantiations
-      //-----------------------------------------------------------------------
-      ///@cond
-      #define INSTANTIATE(ElementType)\
-        template DLLExport struct SequenceTypeHandler<std::vector<ElementType> >;
-
-      INSTANTIATE(int)
-      INSTANTIATE(long)
-      INSTANTIATE(long long)
-      INSTANTIATE(unsigned int)
-      INSTANTIATE(unsigned long)
-      INSTANTIATE(unsigned long long)
-      INSTANTIATE(double)
-      INSTANTIATE(std::string)
-      INSTANTIATE(bool)
-      ///@endcond
-    }
+namespace Mantid {
+namespace PythonInterface {
+namespace Registry {
+namespace {
+template <typename HeldType> struct StdVectorExtractor {
+  static std::vector<HeldType> extract(const boost::python::object &value) {
+    return boost::python::extract<std::vector<HeldType>>(value.ptr());
   }
+};
+template <> struct StdVectorExtractor<bool> {
+  static std::vector<bool> extract(const boost::python::object &) {
+    throw std::runtime_error(
+        "Unable to supported extracting std::vector<bool> from python object");
+  }
+};
+}
+
+/**
+ * Set function to handle Python -> C++ calls to a property manager and get the
+ * correct type
+ * @param alg :: A pointer to an IPropertyManager
+ * @param name :: The name of the property
+ * @param value :: A boost python object that stores the container values
+ */
+template <typename ContainerType>
+void SequenceTypeHandler<ContainerType>::set(
+    Kernel::IPropertyManager *alg, const std::string &name,
+    const boost::python::object &value) const {
+  using boost::python::len;
+  typedef typename ContainerType::value_type DestElementType;
+
+  // Current workaround for things that still pass back wrapped vectors...
+  if (boost::starts_with(value.ptr()->ob_type->tp_name, "std_vector")) {
+    alg->setProperty(name, StdVectorExtractor<DestElementType>::extract(value));
+  }
+  // numpy arrays requires special handling to extract their types. Hand-off to
+  // a more appropriate handler
+  else if (PyArray_Check(value.ptr())) {
+    alg->setProperty(name,
+                     Converters::NDArrayToVector<DestElementType>(value)());
+  } else if (PySequence_Check(value.ptr())) {
+    alg->setProperty(name,
+                     Converters::PySequenceToVector<DestElementType>(value)());
+  } else // assume it is a scalar and try to convert into a vector of length one
+  {
+    DestElementType scalar =
+        boost::python::extract<DestElementType>(value.ptr());
+    alg->setProperty(name, std::vector<DestElementType>(1, scalar));
+  }
+}
+
+/**
+ * Create a PropertyWithValue from the given python object value
+ * @param name :: The name of the property
+ * @param defaultValue :: The defaultValue of the property. The object attempts
+ * to extract
+ * a value of type ContainerType from the python object
+ * @param validator :: A python object pointing to a validator instance, which
+ * can be None.
+ * @param direction :: The direction of the property
+ * @returns A pointer to a newly constructed property instance
+ */
+template <typename ContainerType>
+Kernel::Property *SequenceTypeHandler<ContainerType>::create(
+    const std::string &name, const boost::python::object &defaultValue,
+    const boost::python::object &validator,
+    const unsigned int direction) const {
+  typedef typename ContainerType::value_type DestElementType;
+
+  ContainerType valueInC;
+  // Current workaround for things that still pass back wrapped vectors...
+  if (boost::starts_with(defaultValue.ptr()->ob_type->tp_name, "std_vector")) {
+    valueInC = StdVectorExtractor<DestElementType>::extract(defaultValue);
+  } else if (PySequence_Check(defaultValue.ptr())) {
+    valueInC = Converters::PySequenceToVector<DestElementType>(defaultValue)();
+  } else // assume it is a scalar and try to convert into a vector of length one
+  {
+    DestElementType scalar =
+        boost::python::extract<DestElementType>(defaultValue.ptr());
+    valueInC = std::vector<DestElementType>(1, scalar);
+  }
+
+  Kernel::Property *valueProp(NULL);
+  if (isNone(validator)) {
+    valueProp =
+        new Kernel::PropertyWithValue<ContainerType>(name, valueInC, direction);
+  } else {
+    const Kernel::IValidator *propValidator =
+        boost::python::extract<Kernel::IValidator *>(validator);
+    valueProp = new Kernel::PropertyWithValue<ContainerType>(
+        name, valueInC, propValidator->clone(), direction);
+  }
+  return valueProp;
+}
+
+//-----------------------------------------------------------------------
+// Concrete instantiations
+//-----------------------------------------------------------------------
+///@cond
+#define INSTANTIATE(ElementType)                                               \
+  template DLLExport struct SequenceTypeHandler<std::vector<ElementType>>;
+
+INSTANTIATE(int)
+INSTANTIATE(long)
+INSTANTIATE(long long)
+INSTANTIATE(unsigned int)
+INSTANTIATE(unsigned long)
+INSTANTIATE(unsigned long long)
+INSTANTIATE(double)
+INSTANTIATE(std::string)
+INSTANTIATE(bool)
+///@endcond
+}
+}
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/TypeRegistry.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Registry/TypeRegistry.cpp
@@ -7,104 +7,100 @@
 #include <map>
 #include <boost/python/type_id.hpp>
 
-namespace Mantid
-{
-  namespace PythonInterface
-  {
-    namespace Registry
+namespace Mantid {
+namespace PythonInterface {
+namespace Registry {
+namespace // <anonymous>
     {
-      namespace // <anonymous>
-      {
-        /// Typedef the map of type_info -> handler objects. We store
-        /// boost::python::type_info objects so that they work across DLL boundaries
-        /// unlike std::type_info objects
-        typedef std::map<const boost::python::type_info,
-                         boost::shared_ptr<PropertyValueHandler>> TypeIDMap;
+/// Typedef the map of type_info -> handler objects. We store
+/// boost::python::type_info objects so that they work across DLL boundaries
+/// unlike std::type_info objects
+typedef std::map<const boost::python::type_info,
+                 boost::shared_ptr<PropertyValueHandler>> TypeIDMap;
 
-        /**
-         * Returns a reference to the static type map
-         * @return A reference to the type map
-         */
-        TypeIDMap & typeRegistry()
-        {
-          static TypeIDMap typeHandlers;
-          return typeHandlers;
-        }
-      } // end <anonymous>
+/**
+ * Returns a reference to the static type map
+ * @return A reference to the type map
+ */
+TypeIDMap &typeRegistry() {
+  static TypeIDMap typeHandlers;
+  return typeHandlers;
+}
+} // end <anonymous>
 
-      //-------------------------------------------------------------------------------------------
-      // Public methods
-      //-------------------------------------------------------------------------------------------
-      /**
-       */
-      void TypeRegistry::registerBuiltins()
-      {
-        // -- Register a handler for each basic type and vector of each basic type + std::string --
-        // macro helps with keeping information in one place
-        #define SUBSCRIBE_HANDLER(Type) \
-          subscribe< TypedPropertyValueHandler<Type> >(); \
-          subscribe< SequenceTypeHandler<std::vector<Type>> >();
+//-------------------------------------------------------------------------------------------
+// Public methods
+//-------------------------------------------------------------------------------------------
+/**
+ */
+void TypeRegistry::registerBuiltins() {
+// -- Register a handler for each basic type and vector of each basic type +
+// std::string --
+// macro helps with keeping information in one place
+#define SUBSCRIBE_HANDLER(Type)                                                \
+  subscribe<TypedPropertyValueHandler<Type>>();                                \
+  subscribe<SequenceTypeHandler<std::vector<Type>>>();
 
-        // unsigned ints
-        SUBSCRIBE_HANDLER(int);
-        SUBSCRIBE_HANDLER(long);
-        SUBSCRIBE_HANDLER(long long);
-        // signed ints
-        SUBSCRIBE_HANDLER(unsigned int);
-        SUBSCRIBE_HANDLER(unsigned long);
-        SUBSCRIBE_HANDLER(unsigned long long);
-        // boolean
-        SUBSCRIBE_HANDLER(bool);
-        // double
-        SUBSCRIBE_HANDLER(double);
-        // string
-        SUBSCRIBE_HANDLER(std::string);
+  // unsigned ints
+  SUBSCRIBE_HANDLER(int);
+  SUBSCRIBE_HANDLER(long);
+  SUBSCRIBE_HANDLER(long long);
+  // signed ints
+  SUBSCRIBE_HANDLER(unsigned int);
+  SUBSCRIBE_HANDLER(unsigned long);
+  SUBSCRIBE_HANDLER(unsigned long long);
+  // boolean
+  SUBSCRIBE_HANDLER(bool);
+  // double
+  SUBSCRIBE_HANDLER(double);
+  // string
+  SUBSCRIBE_HANDLER(std::string);
 
-        #undef SUBSCRIBE_HANDLER
-        }
+#undef SUBSCRIBE_HANDLER
+}
 
-      /**
-       * Insert a new property handler for the given type_info
-       * @param typeObject :: A reference to a type object
-       * @param handler :: An object to handle to corresponding templated C++ type. Ownership is transferred here
-       * @throws std::invalid_argument if one already exists
-       */
-      void TypeRegistry::subscribe(const std::type_info& typeObject, PropertyValueHandler* handler)
-      {
-        TypeIDMap & typeHandlers = typeRegistry();
-        boost::python::type_info typeInfo(typeObject);
-        if(typeHandlers.find(typeInfo) == typeHandlers.end())
-        {
-          typeHandlers.insert(std::make_pair(typeInfo, boost::shared_ptr<PropertyValueHandler>(handler)));
-        }
-        else
-        {
-          throw std::invalid_argument(std::string("TypeRegistry::subscribe() - A handler has already registered for type '") +
-              typeInfo.name() + "'");
-        }
-      }
-
-      /**
-       * Get a PropertyValueHandler if one exists
-       * @param typeObject A pointer to a PyTypeObject
-       * @returns A pointer to a PropertyValueHandler
-       * @throws std::invalid_argument if one is not registered
-       */
-      const PropertyValueHandler & TypeRegistry::retrieve(const std::type_info& typeObject)
-      {
-        TypeIDMap & typeHandlers = typeRegistry();
-        TypeIDMap::const_iterator itr = typeHandlers.find(boost::python::type_info(typeObject));
-        if( itr != typeHandlers.end() )
-        {
-          return *(itr->second);
-        }
-        else
-        {
-          throw std::invalid_argument(std::string("TypeRegistry::retrieve(): No PropertyValueHandler registered for type '") +
-               boost::python::type_info(typeObject).name() + "'");
-        }
-      }
-
-    }
+/**
+ * Insert a new property handler for the given type_info
+ * @param typeObject :: A reference to a type object
+ * @param handler :: An object to handle to corresponding templated C++ type.
+ * Ownership is transferred here
+ * @throws std::invalid_argument if one already exists
+ */
+void TypeRegistry::subscribe(const std::type_info &typeObject,
+                             PropertyValueHandler *handler) {
+  TypeIDMap &typeHandlers = typeRegistry();
+  boost::python::type_info typeInfo(typeObject);
+  if (typeHandlers.find(typeInfo) == typeHandlers.end()) {
+    typeHandlers.insert(std::make_pair(
+        typeInfo, boost::shared_ptr<PropertyValueHandler>(handler)));
+  } else {
+    throw std::invalid_argument(
+        std::string("TypeRegistry::subscribe() - A handler has already "
+                    "registered for type '") +
+        typeInfo.name() + "'");
   }
+}
+
+/**
+ * Get a PropertyValueHandler if one exists
+ * @param typeObject A pointer to a PyTypeObject
+ * @returns A pointer to a PropertyValueHandler
+ * @throws std::invalid_argument if one is not registered
+ */
+const PropertyValueHandler &
+TypeRegistry::retrieve(const std::type_info &typeObject) {
+  TypeIDMap &typeHandlers = typeRegistry();
+  TypeIDMap::const_iterator itr =
+      typeHandlers.find(boost::python::type_info(typeObject));
+  if (itr != typeHandlers.end()) {
+    return *(itr->second);
+  } else {
+    throw std::invalid_argument(
+        std::string("TypeRegistry::retrieve(): No PropertyValueHandler "
+                    "registered for type '") +
+        boost::python::type_info(typeObject).name() + "'");
+  }
+}
+}
+}
 }


### PR DESCRIPTION
The cmake function that parses the exports has been rewritten to be more relaxed at where the braces are, allowing clang-format to be used on the export files.

This should not change any runtime behaviour.
