### PR TITLE
Deprecate PerformIndexOperations

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PerformIndexOperations.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PerformIndexOperations.h
@@ -3,6 +3,7 @@
 
 #include "MantidKernel/System.h"
 #include "MantidAPI/DataProcessorAlgorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -31,7 +32,8 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport PerformIndexOperations : public API::DataProcessorAlgorithm {
+class DLLExport PerformIndexOperations : public API::DataProcessorAlgorithm,
+                                         public API::DeprecatedAlgorithm {
 public:
   PerformIndexOperations();
   virtual ~PerformIndexOperations();

--- a/Code/Mantid/Framework/Algorithms/src/CreateTransmissionWorkspaceAuto.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateTransmissionWorkspaceAuto.cpp
@@ -93,9 +93,8 @@ void CreateTransmissionWorkspaceAuto::init() {
 
   declareProperty(new PropertyWithValue<std::string>("ProcessingInstructions",
                                                      "", Direction::Input),
-                  "Processing instructions on workspace indexes to yield only "
-                  "the detectors of interest. See [[PerformIndexOperations]] "
-                  "for details.");
+                  "Grouping pattern on workspace indexes to yield only "
+                  "the detectors of interest. See GroupDetectors for details.");
 
   declareProperty("WavelengthMin", Mantid::EMPTY_DBL(),
                   "Wavelength Min in angstroms", Direction::Input);

--- a/Code/Mantid/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -257,7 +257,9 @@ DECLARE_ALGORITHM(PerformIndexOperations)
 //------------------------------------------------------------------------------
 /** Constructor
  */
-PerformIndexOperations::PerformIndexOperations() {}
+PerformIndexOperations::PerformIndexOperations() {
+  useAlgorithm("GroupDetectors", 2);
+}
 
 //------------------------------------------------------------------------------
 /** Destructor
@@ -341,6 +343,11 @@ VecCommands interpret(const std::string &processingInstructions) {
 /** Execute the algorithm.
  */
 void PerformIndexOperations::exec() {
+  g_log.error("PerformIndexOperations has been deprecated. It will be "
+              "removed in the next release of Mantid. The same functionality "
+              "is provided by GroupDetectors-v2. Its GroupingPattern "
+              "property accepts the same syntax as PerformIndexOperations' "
+              "ProcessingInstructions property.");
   MatrixWorkspace_sptr inputWorkspace = this->getProperty("InputWorkspace");
   const std::string processingInstructions =
       this->getProperty("ProcessingInstructions");

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryWorkflowBase.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryWorkflowBase.cpp
@@ -53,9 +53,8 @@ void ReflectometryWorkflowBase::initIndexInputs() {
                       "ProcessingInstructions", "",
                       boost::make_shared<MandatoryValidator<std::string>>(),
                       Direction::Input),
-                  "Processing instructions on workspace indexes to yield only "
-                  "the detectors of interest. See [[PerformIndexOperations]] "
-                  "for details.");
+                  "Grouping pattern on workspace indexes to yield only "
+                  "the detectors of interest. See GroupDetectors for details.");
 }
 
 /**
@@ -408,9 +407,9 @@ ReflectometryWorkflowBase::toLamDetector(const std::string &processingCommands,
                                          const double &wavelengthStep) {
   // Process the input workspace according to the processingCommands to get a
   // detector workspace
-  auto performIndexAlg = this->createChildAlgorithm("PerformIndexOperations");
+  auto performIndexAlg = this->createChildAlgorithm("GroupDetectors");
   performIndexAlg->initialize();
-  performIndexAlg->setProperty("ProcessingInstructions", processingCommands);
+  performIndexAlg->setProperty("GroupingPattern", processingCommands);
   performIndexAlg->setProperty("InputWorkspace", toConvert);
   performIndexAlg->execute();
   MatrixWorkspace_sptr detectorWS =

--- a/Code/Mantid/Framework/Algorithms/test/CreateTransmissionWorkspaceTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/CreateTransmissionWorkspaceTest.h
@@ -180,13 +180,6 @@ public:
     TS_ASSERT_THROWS(alg->execute(), std::invalid_argument);
   }
 
-  void test_workspace_index_list_min_max_pairs_throw_if_min_greater_than_max()
-  {
-    auto alg = construct_standard_algorithm();
-    alg->setProperty("ProcessingInstructions", "1, 0"); //1 > 0.
-    TS_ASSERT_THROWS(alg->execute(), std::out_of_range);
-  }
-
   void test_execute_one_tranmission()
   {
 

--- a/Code/Mantid/Framework/Algorithms/test/ReflectometryReductionOneAutoTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ReflectometryReductionOneAutoTest.h
@@ -143,7 +143,7 @@ public:
     alg->setProperty("MonitorBackgroundWavelengthMax", 1.0);
     alg->setProperty("MonitorIntegrationWavelengthMin", 0.0);
     alg->setProperty("MonitorIntegrationWavelengthMax", 1.0);
-    alg->setPropertyValue("ProcessingInstructions", "0, 1");
+    alg->setPropertyValue("ProcessingInstructions", "0");
     alg->setPropertyValue("OutputWorkspace", outWSQName);
     alg->setPropertyValue("OutputWorkspaceWavelength", outWSLamName);
     alg->setRethrows(true);
@@ -263,13 +263,6 @@ public:
     TS_ASSERT_THROWS(alg->execute(), std::invalid_argument);
   }
 
-  void test_workspace_index_list_min_max_pairs_throw_if_min_greater_than_max()
-  {
-    auto alg = construct_standard_algorithm();
-    alg->setProperty("ProcessingInstructions", "1, 0"); //1 > 0.
-    TS_ASSERT_THROWS(alg->execute(), std::out_of_range);
-  }
-
   void test_cannot_set_direct_beam_region_of_interest_without_multidetector_run()
   {
     auto alg = construct_standard_algorithm();
@@ -304,14 +297,14 @@ public:
   {
     auto alg = construct_standard_algorithm();
     alg->setProperty("DetectorComponentName", "made-up");
-    TS_ASSERT_THROWS(alg->execute(), std::out_of_range);
+    TS_ASSERT_THROWS(alg->execute(), std::runtime_error);
   }
 
   void test_bad_sample_component_name_throws()
   {
     auto alg = construct_standard_algorithm();
     alg->setProperty("SampleComponentName", "made-up");
-    TS_ASSERT_THROWS(alg->execute(), std::out_of_range);
+    TS_ASSERT_THROWS(alg->execute(), std::runtime_error);
   }
 
 

--- a/Code/Mantid/docs/source/algorithms/GroupDetectors-v2.rst
+++ b/Code/Mantid/docs/source/algorithms/GroupDetectors-v2.rst
@@ -27,8 +27,12 @@ To create a single group the list of spectra can be identified using a
 list of either spectrum numbers, detector IDs or workspace indices. The
 list should be set against the appropriate property.
 
+MapFile
+#######
+
 An input file allows the specification of many groups. The file has the
 following format::
+
  [number of groups in file]
  
  [first group's number]
@@ -88,19 +92,29 @@ In addition the following XML grouping format is also supported
 
 where is used to specify spectra IDs and detector IDs.
 
+GroupingPattern
+###############
+
 Grouping can also be specified using the GroupingPattern property. Its syntax
 is as follows:
 
-The pattern consists of a list of numbers that refer to spectra 0 to n-1 and various operators ',',':','+' and '-'.
+The pattern consists of a list of numbers that refer to workspace indexes and
+various operators: :literal:`,:+-`.
 
-To remove spectra, list those you want to keep. The ':' symbol indicates a continuous range of spectra, sparing you the need to list every spectrum.
-For example if you have 100 spectra (0 to 99) and want to remove the first and last 10 spectra along with spectrum 12,
-you would use the pattern '10,13:89'. This says keep spectrum 10 along with spectra 13 to 89 inclusive.
+To remove spectra, you list the workspace indexes that you want to keep. The
+:literal:`:` operator indicates a continuous range, sparing you the need to list
+every one. For example if you have 100 spectra (with workspace indexes from 0 to
+99) and want to remove the first and last 10 spectra along with the 12th, you
+would use the pattern :literal:`10,13:89`. This says keep workspace indices 10
+along with 13 to 89 inclusive.
 
-To add spectra, use '+' to add two spectra or '-' to add a range. For example you may with to add spectrum 10 to 12 and ignore the rest, you would use '10+12'.
-If you were adding five groups of 20, you would use '0-19,20-39,40-59,60-79,80-99'.
+To add spectra, use :literal:`+` to add two spectra or :literal:`-` to add a
+range. For example you may with to add 10 to 12 and ignore the rest, you would
+use :literal:`10+12`. If you were adding five groups of 20, you would use
+:literal:`0-19,20-39,40-59,60-79,80-99`.
 
-One could combine the two, for example '10+12,13:89' would list the sum of spectra 10 and 12 followed by spectra 13 to 89.
+One could combine the two, for example :literal:`10+12,13:89` would list the sum
+of 10 and 12 followed by 13 to 89.
 
 Previous Versions
 -----------------


### PR DESCRIPTION
Fixes #12721 

This pull request deprecates the now redundant PerformIndexOperations, moving all its uses in Mantid over to GroupDetectors v2, and tidies up the GroupDetectors v2 documentation a little.
