### PR TITLE
Use build copy for running doc tests on Windows

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript.bat
+++ b/Code/Mantid/Build/Jenkins/buildscript.bat
@@ -140,30 +140,21 @@ if "%BUILDPKG%" == "yes" (
 )
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-:: Run the doc tests when doing a pull request build. Run from a package
-:: from a package to have at least one Linux checks it install okay
+:: Run the doc tests when doing a pull request build.
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if not "%JOB_NAME%"=="%JOB_NAME:pull_requests=%" (
-  :: Install package
-  set SYSTEMTESTS_DIR=%WORKSPACE%\Code\Mantid\Testing\SystemTests
-  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py install %BUILD_DIR%
-
   ::Remove user properties, disable instrument updating & usage reports and add data paths
-  del /Q C:\MantidInstall\bin\Mantid.user.properties
-  echo UpdateInstrumentDefinitions.OnStartup = 0 > C:\MantidInstall\bin\Mantid.user.properties
-  echo usagereports.enabled = 0 >> C:\MantidInstall\bin\Mantid.user.properties
+  set USER_PROPS=%BUILD_DIR%\bin\%BUILD_CONFIG%\Mantid.user.properties
+  del /Q !USER_PROPS!
+  echo UpdateInstrumentDefinitions.OnStartup = 0 > !USER_PROPS!
+  echo usagereports.enabled = 0 >> !USER_PROPS!
   :: User properties file cannot contain backslash characters
   set WORKSPACE_UNIX_STYLE=%WORKSPACE:\=/%
   set DATA_ROOT=!WORKSPACE_UNIX_STYLE!/build/ExternalData/Testing/Data
-  echo datasearch.directories = !DATA_ROOT!/UnitTest;!DATA_ROOT!/DocTest;!WORKSPACE_UNIX_STYLE!/Code/Mantid/instrument >> C:\MantidInstall\bin\Mantid.user.properties
+  echo datasearch.directories = !DATA_ROOT!/UnitTest;!DATA_ROOT!/DocTest;!WORKSPACE_UNIX_STYLE!/Code/Mantid/instrument >> !USER_PROPS!
 
   :: Run tests
   cd %BUILD_DIR%\docs
-  C:\MantidInstall\bin\MantidPlot.exe -xq runsphinx_doctest.py
-  set RETCODE=!ERRORLEVEL!
-
-  :: Remove Mantid
-  cd %BUILD_DIR%
-  python !SYSTEMTESTS_DIR!\scripts\mantidinstaller.py uninstall %BUILD_DIR%
-  if !RETCODE! NEQ 0 exit /B 1
+  %BUILD_DIR%\bin\%BUILD_CONFIG%\MantidPlot.exe -xq runsphinx_doctest.py
+  if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 )


### PR DESCRIPTION
**Tester**

The Windows build should complete as expected and still produce the package as an artifact
