### PR TITLE
Provide collision handling for the time series properties

### DIFF
--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -273,6 +273,10 @@ public:
   /// Stringize the property
   std::string toString() const;
 
+protected:
+  /// Handle the collision of two time series entries
+  virtual void handleTimeStampCollisions(TimeSeriesProperty &series);
+
 private:
   /// Sort the property into increasing times
   void sort() const;


### PR DESCRIPTION
This fixes #12726 

**Context**

When two workspaces with time series properties in their logs are added, the logs get concatenated. This means that we can end up with multiple identical time values. We detect these time stamp collisions and resolve them by shifting the time by 1ns.

**For Testing**

Please code review. 
