### PR TITLE
Add extra FABADA attributes to IDA

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -91,6 +91,10 @@ namespace IDA
     m_properties["FABADAChainLength"] = m_dblManager->addProperty("Chain Length");
     m_dblManager->setDecimals(m_properties["FABADAChainLength"], 0);
     m_dblManager->setValue(m_properties["FABADAChainLength"], 10000);
+    m_properties["FABADAConvergenceCriteria"] = m_dblManager->addProperty("Convergence Criteria");
+    m_dblManager->setValue(m_properties["FABADAConvergenceCriteria"], 0.1);
+    m_properties["FABADAJumpAcceptanceRate"] = m_dblManager->addProperty("Acceptance Rate");
+    m_dblManager->setValue(m_properties["FABADAJumpAcceptanceRate"], 0.25);
     m_cfTree->addProperty(m_properties["FABADA"]);
 
     // Background type
@@ -843,6 +847,13 @@ namespace IDA
 
       int chainLength = static_cast<int>(m_dblManager->value(m_properties["FABADAChainLength"]));
       minimizer += ",ChainLength=" + QString::number(chainLength);
+
+      double convergenceCriteria = m_dblManager->value(m_properties["FABADAConvergenceCriteria"]);
+      minimizer += ",ConvergenceCriteria=" + QString::number(convergenceCriteria);
+
+      double jumpAcceptanceRate = m_dblManager->value(m_properties["FABADAJumpAcceptanceRate"]);
+      minimizer += ",JumpAcceptanceRate=" + QString::number(jumpAcceptanceRate);
+
       minimizer += ",PDF=" + outputName + "_PDF";
 
       if(m_blnManager->value(m_properties["OutputFABADAChain"]))
@@ -1314,6 +1325,8 @@ namespace IDA
 
         m_properties["FABADA"]->addSubProperty(m_properties["OutputFABADAChain"]);
         m_properties["FABADA"]->addSubProperty(m_properties["FABADAChainLength"]);
+        m_properties["FABADA"]->addSubProperty(m_properties["FABADAConvergenceCriteria"]);
+        m_properties["FABADA"]->addSubProperty(m_properties["FABADAJumpAcceptanceRate"]);
       }
       else
       {
@@ -1321,6 +1334,8 @@ namespace IDA
 
         m_properties["FABADA"]->removeSubProperty(m_properties["OutputFABADAChain"]);
         m_properties["FABADA"]->removeSubProperty(m_properties["FABADAChainLength"]);
+        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAConvergenceCriteria"]);
+        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAJumpAcceptanceRate"]);
       }
     }
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -80,6 +80,10 @@ namespace IDA
     m_properties["FABADAChainLength"] = m_dblManager->addProperty("Chain Length");
     m_dblManager->setDecimals(m_properties["FABADAChainLength"], 0);
     m_dblManager->setValue(m_properties["FABADAChainLength"], 10000);
+    m_properties["FABADAConvergenceCriteria"] = m_dblManager->addProperty("Convergence Criteria");
+    m_dblManager->setValue(m_properties["FABADAConvergenceCriteria"], 0.1);
+    m_properties["FABADAJumpAcceptanceRate"] = m_dblManager->addProperty("Acceptance Rate");
+    m_dblManager->setValue(m_properties["FABADAJumpAcceptanceRate"], 0.25);
     m_ffTree->addProperty(m_properties["FABADA"]);
 
     connect(m_ffRangeManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(propertyChanged(QtProperty*, double)));
@@ -548,6 +552,8 @@ namespace IDA
 
         m_properties["FABADA"]->addSubProperty(m_properties["OutputFABADAChain"]);
         m_properties["FABADA"]->addSubProperty(m_properties["FABADAChainLength"]);
+        m_properties["FABADA"]->addSubProperty(m_properties["FABADAConvergenceCriteria"]);
+        m_properties["FABADA"]->addSubProperty(m_properties["FABADAJumpAcceptanceRate"]);
       }
       else
       {
@@ -555,6 +561,8 @@ namespace IDA
 
         m_properties["FABADA"]->removeSubProperty(m_properties["OutputFABADAChain"]);
         m_properties["FABADA"]->removeSubProperty(m_properties["FABADAChainLength"]);
+        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAConvergenceCriteria"]);
+        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAJumpAcceptanceRate"]);
       }
     }
   }
@@ -611,6 +619,13 @@ namespace IDA
 
       int chainLength = static_cast<int>(m_dblManager->value(m_properties["FABADAChainLength"]));
       minimizer += ",ChainLength=" + QString::number(chainLength);
+
+      double convergenceCriteria = m_dblManager->value(m_properties["FABADAConvergenceCriteria"]);
+      minimizer += ",ConvergenceCriteria=" + QString::number(convergenceCriteria);
+
+      double jumpAcceptanceRate = m_dblManager->value(m_properties["FABADAJumpAcceptanceRate"]);
+      minimizer += ",JumpAcceptanceRate=" + QString::number(jumpAcceptanceRate);
+
       minimizer += ",PDF=" + outputName + "_PDF";
 
       if(m_blnManager->value(m_properties["OutputFABADAChain"]))

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -49,6 +49,26 @@ You may also experience issues where the starting parameters may give a reliable
 fit on one spectra but not others, in this case the best option is to reduce
 the number of spectra that are fitted in one operation.
 
+In both I(Q, t) Fit and ConvFit the following options are available when fitting
+using FABADA:
+
+Output Chain
+  Select to enable output of the FABADA chain when using FABADA as the fitting
+  minimizer.
+
+Chain Length
+  Number of further steps carried out by fitting algorithm once parameters have
+  converged (see *ChainLength* is :ref:`FABADA` documentation)
+
+Convergence Criteria
+  The minimum variation in the cost function before the parameters are
+  considered to have converged (see *ConvergenceCriteria* in :ref:`FABADA`
+  documentation)
+
+Acceptance Rate
+  The desired percentage acceptance of new parameters (see *JumpAcceptanceRate*
+  in :ref:`FABADA` documentation)
+
 Elwin
 -----
 
@@ -258,14 +278,6 @@ StartX & EndX
 Use FABADA
   Select to enable use of the :ref:`FABADA` minimizer when performing the fit.
 
-Output Chain
-  Select to enable output of the FABADA chain when using FABADA as the fitting
-  minimizer.
-
-Chain Length
-  Number of further steps carried out by fitting algorithm once parameters have
-  converged (see :ref:`FABADA` documentation)
-
 Linear Background A0
   The constant amplitude of the background (horizontal green line on the preview
   plot).
@@ -392,14 +404,6 @@ StartX & EndX
 
 Use FABADA
   Select to enable use of the :ref:`FABADA` minimizer when performing the fit.
-
-Output Chain
-  Select to enable output of the FABADA chain when using FABADA as the fitting
-  minimizer.
-
-Chain Length
-  Number of further steps carried out by fitting algorithm once parameters have
-  converged (see :ref:`FABADA` documentation)
 
 A0 & A1 (background)
   The A0 and A1 parameters as they appear in the LinearBackground fir function,


### PR DESCRIPTION
Fixes #12736.

To test:
- Load IDA, ConvFit
- Load `irs26176_graphite002_red.nxs` as sample
- Load `irs26173_graphite002_res.nxs` as resolution
- One Lorentzian
- Lorentzian 1, FWHM = 0.03
- Fit Linear
- Use FABADA
- Fit Single Spectrum (to get some relatively good parameters)
- Convergence Criteria = 1.0
- Acceptance Rate = 0.1
- Run (fill all spectra)
- Should give a reasonable fit (after up to 5 minutes)

Release notes [already](http://www.mantidproject.org/Release_Notes_3_5_Indirect_Inelastic#Bayesian_analysis_on_Indirect_Data_Analysis) document this.
