### PR TITLE
Add polynomial correction to ReflectometryReductionOne

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
@@ -99,9 +99,10 @@ private:
       const OptionalDouble &stitchingEndOverlapQ, const double &wavelengthStep,
       const std::string &processingCommands);
 
-  /// Perform transmission correction by generating a polynomial
+  /// Perform transmission correction using either PolynomialCorrection
+  /// or ExponentialCorrection.
   API::MatrixWorkspace_sptr
-  polynomialCorrection(API::MatrixWorkspace_sptr IvsLam);
+  algorithmicCorrection(API::MatrixWorkspace_sptr IvsLam);
 
   /// Verify spectrum maps
   void verifySpectrumMaps(API::MatrixWorkspace_const_sptr ws1,

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOne.h
@@ -99,6 +99,10 @@ private:
       const OptionalDouble &stitchingEndOverlapQ, const double &wavelengthStep,
       const std::string &processingCommands);
 
+  /// Perform transmission correction by generating a polynomial
+  API::MatrixWorkspace_sptr
+  polynomialCorrection(API::MatrixWorkspace_sptr IvsLam);
+
   /// Verify spectrum maps
   void verifySpectrumMaps(API::MatrixWorkspace_const_sptr ws1,
                           API::MatrixWorkspace_const_sptr ws2,

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -210,10 +210,10 @@ void ReflectometryReductionOne::init() {
       new PropertyWithValue<double>("C1", 0.0, Direction::Input),
       "C1 value to be passed to the ExponentialCorrection algorithm.");
 
-  setPropertyGroup("CorrectionAlgorithm", "Polynomial");
-  setPropertyGroup("Polynomial", "Polynomial");
-  setPropertyGroup("C0", "Polynomial");
-  setPropertyGroup("C1", "Polynomial");
+  setPropertyGroup("CorrectionAlgorithm", "Polynomial Corrections");
+  setPropertyGroup("Polynomial", "Polynomial Corrections");
+  setPropertyGroup("C0", "Polynomial Corrections");
+  setPropertyGroup("C1", "Polynomial Corrections");
 
   setPropertySettings("Polynomial", new Kernel::EnabledWhenProperty(
                                         "CorrectionAlgorithm", IS_EQUAL_TO,

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -689,17 +689,13 @@ ReflectometryReductionOne::polynomialCorrection(MatrixWorkspace_sptr IvsLam) {
 
   const std::string corrAlgName = getProperty("CorrectionAlgorithm");
 
-  const std::string polynomial = getProperty("Polynomial");
-  const std::string c0 = getProperty("C0");
-  const std::string c1 = getProperty("C1");
-
   IAlgorithm_sptr corrAlg = createChildAlgorithm(corrAlgName);
   corrAlg->initialize();
   if (corrAlgName == "PolynomialCorrection") {
-    corrAlg->setProperty("Coefficients", polynomial);
+    corrAlg->setPropertyValue("Coefficients", getPropertyValue("Polynomial"));
   } else if (corrAlgName == "ExponentialCorrection") {
-    corrAlg->setProperty("C0", c0);
-    corrAlg->setProperty("C1", c1);
+    corrAlg->setPropertyValue("C0", getPropertyValue("C0"));
+    corrAlg->setPropertyValue("C1", getPropertyValue("C1"));
   } else {
     throw std::runtime_error("Unknown correction algorithm: " + corrAlgName);
   }

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -548,7 +548,7 @@ void ReflectometryReductionOne::exec() {
         stitchingDelta, stitchingEnd, stitchingStartOverlap,
         stitchingEndOverlap, wavelengthStep, processingCommands);
   } else if (getPropertyValue("CorrectionAlgorithm") != "None") {
-    IvsLam = polynomialCorrection(IvsLam);
+    IvsLam = algorithmicCorrection(IvsLam);
   } else {
     g_log.warning("No transmission correction will be applied.");
   }
@@ -679,13 +679,13 @@ MatrixWorkspace_sptr ReflectometryReductionOne::transmissonCorrection(
 }
 
 /**
- * Perform Transmission Corrections Using Polynomials.
+ * Perform transmission correction using alternative correction algorithms.
  * @param IvsLam : Run workspace which is to be normalized by the results of the
  * transmission corrections.
- * @return Normalized run workspace by the generated polynomial.
+ * @return Corrected workspace
  */
 MatrixWorkspace_sptr
-ReflectometryReductionOne::polynomialCorrection(MatrixWorkspace_sptr IvsLam) {
+ReflectometryReductionOne::algorithmicCorrection(MatrixWorkspace_sptr IvsLam) {
 
   const std::string corrAlgName = getProperty("CorrectionAlgorithm");
 

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -362,50 +362,50 @@ void ReflectometryReductionOneAuto::exec() {
       refRedOne->setProperty("C1", getPropertyValue("C1"));
     } else if (correction_algorithm == "AutoDetect") {
       // Figure out what to do from the instrument
-      auto inst = in_ws->getInstrument();
+      try {
+        auto inst = in_ws->getInstrument();
 
-      const std::vector<std::string> corrVec =
-          inst->getStringParameter("correction");
-      const std::string correctionStr = !corrVec.empty() ? corrVec[0] : "";
+        const std::vector<std::string> corrVec =
+            inst->getStringParameter("correction");
+        const std::string correctionStr = !corrVec.empty() ? corrVec[0] : "";
 
-      if (correctionStr.empty())
-        throw std::runtime_error(
-            "CorrectionAlgorithm set to AutoDetect, but "
-            "could not determine correction type from "
-            "instrument. 'correction' instrument parameter "
-            "was not found.");
+        if (correctionStr.empty())
+          throw std::runtime_error(
+              "'correction' instrument parameter was not found.");
 
-      const std::vector<std::string> polyVec =
-          inst->getStringParameter("polynomial");
-      const std::string polyStr = !polyVec.empty() ? polyVec[0] : "";
+        const std::vector<std::string> polyVec =
+            inst->getStringParameter("polynomial");
+        const std::string polyStr = !polyVec.empty() ? polyVec[0] : "";
 
-      const std::vector<std::string> c0Vec = inst->getStringParameter("C0");
-      const std::string c0Str = !c0Vec.empty() ? c0Vec[0] : "";
+        const std::vector<std::string> c0Vec = inst->getStringParameter("C0");
+        const std::string c0Str = !c0Vec.empty() ? c0Vec[0] : "";
 
-      const std::vector<std::string> c1Vec = inst->getStringParameter("C1");
-      const std::string c1Str = !c1Vec.empty() ? c1Vec[0] : "";
+        const std::vector<std::string> c1Vec = inst->getStringParameter("C1");
+        const std::string c1Str = !c1Vec.empty() ? c1Vec[0] : "";
 
-      if (correctionStr == "polynomial" && polyStr.empty())
-        throw std::runtime_error(
-            "CorrectionAlgorithm set to AutoDetect, but "
-            "could not determine polynomial from "
-            "instrument. 'polynomial' instrument parameter "
-            "was not found.");
+        if (correctionStr == "polynomial" && polyStr.empty())
+          throw std::runtime_error(
+              "'polynomial' instrument parameter was not found.");
 
-      if (correctionStr == "exponential" && (c0Str.empty() || c1Str.empty()))
-        throw std::runtime_error(
-            "CorrectionAlgorithm set to AutoDetect, but "
-            "could not determine exponents from "
-            "instrument. 'C0' or 'C1' instrument parameter "
-            "was not found.");
+        if (correctionStr == "exponential" && (c0Str.empty() || c1Str.empty()))
+          throw std::runtime_error(
+              "'C0' or 'C1' instrument parameter was not found.");
 
-      if (correctionStr == "polynomial") {
-        refRedOne->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
-        refRedOne->setProperty("Polynomial", polyStr);
-      } else if (correctionStr == "exponential") {
-        refRedOne->setProperty("CorrectionAlgorithm", "ExponentialCorrection");
-        refRedOne->setProperty("C0", c0Str);
-        refRedOne->setProperty("C1", c1Str);
+        if (correctionStr == "polynomial") {
+          refRedOne->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
+          refRedOne->setProperty("Polynomial", polyStr);
+        } else if (correctionStr == "exponential") {
+          refRedOne->setProperty("CorrectionAlgorithm",
+                                 "ExponentialCorrection");
+          refRedOne->setProperty("C0", c0Str);
+          refRedOne->setProperty("C1", c1Str);
+        }
+
+      } catch (std::runtime_error &e) {
+        g_log.warning() << "Could not autodetect polynomial correction method. "
+                           "Polynomial correction will not be performed. "
+                           "Reason for failure: " << e.what() << std::endl;
+        refRedOne->setProperty("CorrectionAlgorithm", "None");
       }
 
     } else {

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -171,10 +171,10 @@ void ReflectometryReductionOneAuto::init() {
       new PropertyWithValue<double>("C1", 0.0, Direction::Input),
       "C1 value to be passed to the ExponentialCorrection algorithm.");
 
-  setPropertyGroup("CorrectionAlgorithm", "Polynomial");
-  setPropertyGroup("Polynomial", "Polynomial");
-  setPropertyGroup("C0", "Polynomial");
-  setPropertyGroup("C1", "Polynomial");
+  setPropertyGroup("CorrectionAlgorithm", "Polynomial Corrections");
+  setPropertyGroup("Polynomial", "Polynomial Corrections");
+  setPropertyGroup("C0", "Polynomial Corrections");
+  setPropertyGroup("C1", "Polynomial Corrections");
 
   setPropertySettings("Polynomial", new Kernel::EnabledWhenProperty(
                                         "CorrectionAlgorithm", IS_EQUAL_TO,

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -155,7 +155,7 @@ void ReflectometryReductionOneAuto::init() {
 
   std::vector<std::string> correctionAlgorithms = boost::assign::list_of(
       "None")("AutoDetect")("PolynomialCorrection")("ExponentialCorrection");
-  declareProperty("CorrectionAlgorithm", "None",
+  declareProperty("CorrectionAlgorithm", "AutoDetect",
                   boost::make_shared<StringListValidator>(correctionAlgorithms),
                   "The type of correction to perform.");
 

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -6,6 +6,7 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/RebinParamsValidator.h"
 #include <boost/optional.hpp>
+#include <boost/assign/list_of.hpp>
 
 namespace Mantid {
 namespace Algorithms {
@@ -152,10 +153,38 @@ void ReflectometryReductionOneAuto::init() {
                   "Strict checking between spectrum numbers in input "
                   "workspaces and transmission workspaces.");
 
-  declareProperty(new PropertyWithValue<bool>("PolynomialCorrection", false,
-                                              Direction::Input),
-                  "If no transmission workspaces are provided, perform "
-                  "polynomial correction instead.");
+  std::vector<std::string> correctionAlgorithms = boost::assign::list_of(
+      "None")("AutoDetect")("PolynomialCorrection")("ExponentialCorrection");
+  declareProperty("CorrectionAlgorithm", "None",
+                  boost::make_shared<StringListValidator>(correctionAlgorithms),
+                  "The type of correction to perform.");
+
+  declareProperty(new ArrayProperty<double>("Polynomial"),
+                  "Coefficients to be passed to the PolynomialCorrection"
+                  " algorithm.");
+
+  declareProperty(
+      new PropertyWithValue<double>("C0", 0.0, Direction::Input),
+      "C0 value to be passed to the ExponentialCorrection algorithm.");
+
+  declareProperty(
+      new PropertyWithValue<double>("C1", 0.0, Direction::Input),
+      "C1 value to be passed to the ExponentialCorrection algorithm.");
+
+  setPropertyGroup("CorrectionAlgorithm", "Polynomial");
+  setPropertyGroup("Polynomial", "Polynomial");
+  setPropertyGroup("C0", "Polynomial");
+  setPropertyGroup("C1", "Polynomial");
+
+  setPropertySettings("Polynomial", new Kernel::EnabledWhenProperty(
+                                        "CorrectionAlgorithm", IS_EQUAL_TO,
+                                        "PolynomialCorrection"));
+  setPropertySettings(
+      "C0", new Kernel::EnabledWhenProperty("CorrectionAlgorithm", IS_EQUAL_TO,
+                                            "ExponentialCorrection"));
+  setPropertySettings(
+      "C1", new Kernel::EnabledWhenProperty("CorrectionAlgorithm", IS_EQUAL_TO,
+                                            "ExponentialCorrection"));
 
   // Polarization correction inputs --------------
   std::vector<std::string> propOptions;
@@ -295,7 +324,7 @@ void ReflectometryReductionOneAuto::exec() {
 
   bool correct_positions = this->getProperty("CorrectDetectorPositions");
   bool strict_spectrum_checking = this->getProperty("StrictSpectrumChecking");
-  bool polynomial_correction = this->getProperty("PolynomialCorrection");
+  const std::string correction_algorithm = getProperty("CorrectionAlgorithm");
 
   // Pass the arguments and execute the main algorithm.
 
@@ -321,7 +350,68 @@ void ReflectometryReductionOneAuto::exec() {
                            wavelength_integration_max);
     refRedOne->setProperty("CorrectDetectorPositions", correct_positions);
     refRedOne->setProperty("StrictSpectrumChecking", strict_spectrum_checking);
-    refRedOne->setProperty("PolynomialCorrection", polynomial_correction );
+
+    if (correction_algorithm == "PolynomialCorrection") {
+      // Copy across the polynomial
+      refRedOne->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
+      refRedOne->setProperty("Polynomial", getPropertyValue("Polynomial"));
+    } else if (correction_algorithm == "ExponentialCorrection") {
+      // Copy across c0 and c1
+      refRedOne->setProperty("CorrectionAlgorithm", "ExponentialCorrection");
+      refRedOne->setProperty("C0", getPropertyValue("C0"));
+      refRedOne->setProperty("C1", getPropertyValue("C1"));
+    } else if (correction_algorithm == "AutoDetect") {
+      // Figure out what to do from the instrument
+      auto inst = in_ws->getInstrument();
+
+      const std::vector<std::string> corrVec =
+          inst->getStringParameter("correction");
+      const std::string correctionStr = !corrVec.empty() ? corrVec[0] : "";
+
+      if (correctionStr.empty())
+        throw std::runtime_error(
+            "CorrectionAlgorithm set to AutoDetect, but "
+            "could not determine correction type from "
+            "instrument. 'correction' instrument parameter "
+            "was not found.");
+
+      const std::vector<std::string> polyVec =
+          inst->getStringParameter("polynomial");
+      const std::string polyStr = !polyVec.empty() ? polyVec[0] : "";
+
+      const std::vector<std::string> c0Vec = inst->getStringParameter("C0");
+      const std::string c0Str = !c0Vec.empty() ? c0Vec[0] : "";
+
+      const std::vector<std::string> c1Vec = inst->getStringParameter("C1");
+      const std::string c1Str = !c1Vec.empty() ? c1Vec[0] : "";
+
+      if (correctionStr == "polynomial" && polyStr.empty())
+        throw std::runtime_error(
+            "CorrectionAlgorithm set to AutoDetect, but "
+            "could not determine polynomial from "
+            "instrument. 'polynomial' instrument parameter "
+            "was not found.");
+
+      if (correctionStr == "exponential" && (c0Str.empty() || c1Str.empty()))
+        throw std::runtime_error(
+            "CorrectionAlgorithm set to AutoDetect, but "
+            "could not determine exponents from "
+            "instrument. 'C0' or 'C1' instrument parameter "
+            "was not found.");
+
+      if (correctionStr == "polynomial") {
+        refRedOne->setProperty("CorrectionAlgorithm", "PolynomialCorrection");
+        refRedOne->setProperty("Polynomial", polyStr);
+      } else if (correctionStr == "exponential") {
+        refRedOne->setProperty("CorrectionAlgorithm", "ExponentialCorrection");
+        refRedOne->setProperty("C0", c0Str);
+        refRedOne->setProperty("C1", c1Str);
+      }
+
+    } else {
+      // None was selected
+      refRedOne->setProperty("CorrectionAlgorithm", "None");
+    }
 
     if (first_ws) {
       refRedOne->setProperty("FirstTransmissionRun", first_ws);

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -152,6 +152,11 @@ void ReflectometryReductionOneAuto::init() {
                   "Strict checking between spectrum numbers in input "
                   "workspaces and transmission workspaces.");
 
+  declareProperty(new PropertyWithValue<bool>("PolynomialCorrection", false,
+                                              Direction::Input),
+                  "If no transmission workspaces are provided, perform "
+                  "polynomial correction instead.");
+
   // Polarization correction inputs --------------
   std::vector<std::string> propOptions;
   propOptions.push_back(noPolarizationCorrectionMode());
@@ -290,6 +295,7 @@ void ReflectometryReductionOneAuto::exec() {
 
   bool correct_positions = this->getProperty("CorrectDetectorPositions");
   bool strict_spectrum_checking = this->getProperty("StrictSpectrumChecking");
+  bool polynomial_correction = this->getProperty("PolynomialCorrection");
 
   // Pass the arguments and execute the main algorithm.
 
@@ -315,6 +321,7 @@ void ReflectometryReductionOneAuto::exec() {
                            wavelength_integration_max);
     refRedOne->setProperty("CorrectDetectorPositions", correct_positions);
     refRedOne->setProperty("StrictSpectrumChecking", strict_spectrum_checking);
+    refRedOne->setProperty("PolynomialCorrection", polynomial_correction );
 
     if (first_ws) {
       refRedOne->setProperty("FirstTransmissionRun", first_ws);

--- a/Code/Mantid/docs/source/algorithms/ReflectometryReductionOne-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ReflectometryReductionOne-v1.rst
@@ -51,6 +51,17 @@ parameters associated with the transmission runs will also be required.
 If a single Transmission run is provided, then no stitching parameters
 will be needed.
 
+If no Transmission runs are provided, then polynomial correction can be
+performed instead. Polynomial correction is be enabled by setting the
+:literal:`PolynomialCorrection` property. If enabled, it looks at the instrument
+parameters for the :literal:`correction` parameter. If it is set to
+:literal:`polynomial`, then polynomial correction is performed using the
+:ref:`algm-PolynomialCorrection` algorithm, with the polynomial string taken
+from the instrument's :literal:`polynomial` parameter. If the
+:literal:`correction` parameter is set to :literal:`exponential` instead, then 
+the :Ref:`algm-ExponentialCorrection` algorithm is used, with C0 and C1 taken
+from the instrument parameters, :literal:`C0` and :literal:`C1`.
+
 Usage
 -----
 

--- a/Code/Mantid/docs/source/algorithms/ReflectometryReductionOne-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ReflectometryReductionOne-v1.rst
@@ -17,11 +17,6 @@ on an input theta value.
 Historically the work performed by this algorithm was known as the Quick
 script.
 
-Workflow
-########
-
-.. diagram:: ReflectometryReductionOne-v1_wkflw.dot
-
 Analysis Modes
 ##############
 
@@ -66,6 +61,11 @@ If the :literal:`CorrectionAlgorithm` property is set to
 :literal:`ExponentialCorrection`, then the :Ref:`algm-ExponentialCorrection`
 algorithm is used, with C0 and C1 taken from the :literal:`C0` and :literal:`C1`
 properties.
+
+Workflow
+########
+
+.. diagram:: ReflectometryReductionOne-v1_wkflw.dot
 
 Usage
 -----

--- a/Code/Mantid/docs/source/algorithms/ReflectometryReductionOne-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ReflectometryReductionOne-v1.rst
@@ -51,16 +51,21 @@ parameters associated with the transmission runs will also be required.
 If a single Transmission run is provided, then no stitching parameters
 will be needed.
 
+
+Polynomial Correction
+#####################
+
 If no Transmission runs are provided, then polynomial correction can be
-performed instead. Polynomial correction is be enabled by setting the
-:literal:`PolynomialCorrection` property. If enabled, it looks at the instrument
-parameters for the :literal:`correction` parameter. If it is set to
-:literal:`polynomial`, then polynomial correction is performed using the
-:ref:`algm-PolynomialCorrection` algorithm, with the polynomial string taken
-from the instrument's :literal:`polynomial` parameter. If the
-:literal:`correction` parameter is set to :literal:`exponential` instead, then 
-the :Ref:`algm-ExponentialCorrection` algorithm is used, with C0 and C1 taken
-from the instrument parameters, :literal:`C0` and :literal:`C1`.
+performed instead. Polynomial correction is enabled by setting the
+:literal:`CorrectionAlgorithm` property. If set to
+:literal:`PolynomialCorrection` it runs the :ref:`algm-PolynomialCorrection`
+algorithm, with this algorithms :literal:`Polynomial` property used as its
+:literal:`Coefficients` property.
+
+If the :literal:`CorrectionAlgorithm` property is set to
+:literal:`ExponentialCorrection`, then the :Ref:`algm-ExponentialCorrection`
+algorithm is used, with C0 and C1 taken from the :literal:`C0` and :literal:`C1`
+properties.
 
 Usage
 -----

--- a/Code/Mantid/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
@@ -36,6 +36,25 @@ The following diagram shows how the :ref:`algm-PolarizationCorrection` algorithm
 
 .. diagram:: ReflectometryReductionOneAuto-v1-PolarizationCorrection_wkflw.dot
 
+Polynomial Correction
+#####################
+
+If no Transmission runs are provided, then polynomial correction can be
+performed instead. Polynomial correction is enabled by setting the
+:literal:`CorrectionAlgorithm` property.
+
+If set to :literal:`AutoDetect`, it looks at the instrument
+parameters for the :literal:`correction` parameter. If it is set to
+:literal:`polynomial`, then polynomial correction is performed using the
+:ref:`algm-PolynomialCorrection` algorithm, with the polynomial string taken
+from the instrument's :literal:`polynomial` parameter. If the
+:literal:`correction` parameter is set to :literal:`exponential` instead, then
+the :Ref:`algm-ExponentialCorrection` algorithm is used, with C0 and C1 taken
+from the instrument parameters, :literal:`C0` and :literal:`C1`.
+
+These can be specified manually by setting the :literal:`CorrectionAlgorithm`,
+:literal:`Polynomial`, :literal:`C0`, and :literal:`C1` properties accordingly.
+
 Usage
 -----
 

--- a/Code/Mantid/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
@@ -119,4 +119,34 @@ Output:
     The first four IvsQ Y values are: [ 3.2358089327e-05 , 5.36730688015e-05 , 4.84784245605e-05 , 5.45733934596e-05 ]
     Theta out is the same as theta in: 0.7
 
+**Example - Polynomial correction**
+
+.. testcode:: ExReflRedOneAutoPoly
+
+    run = Load(Filename='INTER00013460.nxs')
+    # Set up some paramters, allowing the algorithm to automatically detect the correction to use
+    SetInstrumentParameter(run, "correction", Value="polynomial")
+    SetInstrumentParameter(run, "polynomial", Value="0,0.5,1,2,3")
+
+    IvsQ, IvsLam, thetaOut = ReflectometryReductionOneAuto(InputWorkspace=run, ThetaIn=0.7)
+
+    def findByName(histories, name):
+        return filter(lambda x: x.name() == name, histories)[0]
+
+    # Find the PolynomialCorrection entry in the workspace's history
+    algHist = IvsLam.getHistory()
+    refRedOneAutoHist = findByName(algHist.getAlgorithmHistories(), "ReflectometryReductionOneAuto")
+    refRedOneHist = findByName(refRedOneAutoHist.getChildHistories(), "ReflectometryReductionOne")
+    polyCorHist = findByName(refRedOneHist.getChildHistories(), "PolynomialCorrection")
+
+    coefProp = findByName(polyCorHist.getProperties(), "Coefficients")
+
+    print "Coefficients: '" + coefProp.value() + "'"
+
+Output:
+
+.. testoutput:: ExReflRedOneAutoPoly
+
+    Coefficients: '0,0.5,1,2,3'
+
 .. categories::

--- a/Code/Mantid/docs/source/diagrams/ReflectometryReductionOne-v1_wkflw.dot
+++ b/Code/Mantid/docs/source/diagrams/ReflectometryReductionOne-v1_wkflw.dot
@@ -11,7 +11,7 @@ digraph ReflectometryReductionOne {
     outputWorkspaceMT [label="OutputWorkspace"]
     thetaIn           [label="ThetaIn"]
     thetaOut          [label="ThetaOut"]
-    polyCorrection    [label="PolynomialCorrection"]
+    corrAlg           [label="CorrectionAlgorithm"]
   }
 
   subgraph decisions {
@@ -22,8 +22,7 @@ digraph ReflectometryReductionOne {
     checkTransUnits [label="X axis in &lambda;?"]
     checkThetaIn    [label="ThetaIn given?"]
     checkCorDetPos  [label="Correct Detector Positions?"]
-    checkPoly       [label="PolynomialCorrection\nset?"]
-    checkCorrParam  [label="Instrument\nparameter\n'correction' set?"]
+    checkCorrAlg    [label="CorrectionAlgorithm?"]
   }
 
   subgraph algorithms {
@@ -68,15 +67,14 @@ digraph ReflectometryReductionOne {
   directBeamNorm    -> divideDetMon
   divideDetMon      -> valInputDiv
   valInputDiv       -> checkTransRun
+  checkTransRun     -> checkCorrAlg     [label="No"]
   checkTransRun     -> divideTrans      [label="Yes"]
-  checkTransRun     -> checkPoly        [label="No"]
-  polyCorrection    -> checkPoly
-  checkPoly         -> checkCorrParam   [label="Yes"]
-  checkCorrParam    -> polyCorr         [label="polynomial"]
-  checkCorrParam    -> expCorr          [label="exponential"]
+  corrAlg           -> checkCorrAlg
+  checkCorrAlg      -> checkThetaIn     [label="None"]
+  checkCorrAlg      -> polyCorr         [label="PolynomialCorrection"]
+  checkCorrAlg      -> expCorr          [label="ExponentialCorrection"]
   polyCorr          -> checkThetaIn
   expCorr           -> checkThetaIn
-  checkPoly         -> checkThetaIn     [label="No"]
   firstTransRun     -> checkTransUnits
   checkTransUnits   -> valTrans         [label="Yes"]
   checkTransUnits   -> createTransWS    [label="No"]

--- a/Code/Mantid/docs/source/diagrams/ReflectometryReductionOne-v1_wkflw.dot
+++ b/Code/Mantid/docs/source/diagrams/ReflectometryReductionOne-v1_wkflw.dot
@@ -11,6 +11,7 @@ digraph ReflectometryReductionOne {
     outputWorkspaceMT [label="OutputWorkspace"]
     thetaIn           [label="ThetaIn"]
     thetaOut          [label="ThetaOut"]
+    polyCorrection    [label="PolynomialCorrection"]
   }
 
   subgraph decisions {
@@ -21,6 +22,8 @@ digraph ReflectometryReductionOne {
     checkTransUnits [label="X axis in &lambda;?"]
     checkThetaIn    [label="ThetaIn given?"]
     checkCorDetPos  [label="Correct Detector Positions?"]
+    checkPoly       [label="PolynomialCorrection\nset?"]
+    checkCorrParam  [label="Instrument\nparameter\n'correction' set?"]
   }
 
   subgraph algorithms {
@@ -33,6 +36,8 @@ digraph ReflectometryReductionOne {
     divideTrans     [label="Divide\n(InputWorkspace / TransmissionWorkspace)"]
     intMon          [label="Integrate"]
     specRefPosCor   [label="SpecularReflectionPositionCorrect"]
+    polyCorr        [label="PolynomialCorrection"]
+    expCorr         [label="ExponentialCorrection"]
   }
 
   subgraph processes {
@@ -64,7 +69,14 @@ digraph ReflectometryReductionOne {
   divideDetMon      -> valInputDiv
   valInputDiv       -> checkTransRun
   checkTransRun     -> divideTrans      [label="Yes"]
-  checkTransRun     -> checkThetaIn     [label="No"]
+  checkTransRun     -> checkPoly        [label="No"]
+  polyCorrection    -> checkPoly
+  checkPoly         -> checkCorrParam   [label="Yes"]
+  checkCorrParam    -> polyCorr         [label="polynomial"]
+  checkCorrParam    -> expCorr          [label="exponential"]
+  polyCorr          -> checkThetaIn
+  expCorr           -> checkThetaIn
+  checkPoly         -> checkThetaIn     [label="No"]
   firstTransRun     -> checkTransUnits
   checkTransUnits   -> valTrans         [label="Yes"]
   checkTransUnits   -> createTransWS    [label="No"]


### PR DESCRIPTION
Fixes #11428 

Todo:
- [x] Move instrument parameter logic to the `ReflectometryReductionOneAuto` algorithm. All values used in `ReflectometryReductionOne` should be passed as properties.
- [x] Write doc test
- [x] Update documentation to match changes made
- [x] Update release notes
  - [Updates here](http://www.mantidproject.org/ReleaseNotes_3_5_Framework_Changes#Updated_Algorithms)
