### PR TITLE
Fix IDR rebin default option

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
@@ -462,7 +462,7 @@
         <item>
          <widget class="QStackedWidget" name="swRebin">
           <property name="currentIndex">
-           <number>1</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="pgSingleRebin">
            <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -551,7 +551,7 @@
                  <double>999.990000000000009</double>
                 </property>
                 <property name="singleStep">
-                 <double>0.100000000000000</double>
+                 <double>0.010000000000000</double>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Fixes #12748.

To test:
- Open IDR, ISIS Energy Transfer
- Load IRIS, 26176
- Use rebinning, -0.5,0.05,0.5 (try with both single and multiple)
- Run

Release notes changes are [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24234&oldid=24179).
