### PR TITLE
Fix setting of active source when window focus changes in VSI

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -1140,6 +1140,15 @@ bool MdViewerWidget::eventFilter(QObject *obj, QEvent *ev)
       return true;
     }
   }
+// IMPORTANT FOR MULTIPLE VSI INSTANCES:
+// The following code block seems to be intended for use with multiple instances
+// but it introduces an undesired behaviour in its current form. This is
+// especially visible when we are dealing with source-filter chains (the active
+// source is more likely to be the filter than the underlying source).
+// Instead of setting oricSrc as the active source we need to devise an alternative
+// strategy, e.g. keep track of the last active source of the particlar
+// VSI instance and set this as the active source.
+#if 0
   if(ev->type() == QEvent::WindowActivate)
   {
     if(this->currentView)
@@ -1149,6 +1158,7 @@ bool MdViewerWidget::eventFilter(QObject *obj, QEvent *ev)
       pqActiveObjects::instance().setActiveSource(this->currentView->origSrc);
     }
   }
+#endif
   return VatesViewerInterface::eventFilter(obj, ev);
 }
 


### PR DESCRIPTION
Fixes #12751 

**Context**

Currently the active source is reset to the origSrc when changing the the focus of a window. This is an issue for source-filter chains. Also, the Splatterplot never makes use of the origSrc. 

Setting the active source (and the active view) when the window focus changs makes sense when dealing with multiple VSI instances. But the current implementation does not account for source-filter chains. In the future we might require to keep track of the last active source for a particular VSI instance.
### For testing:

Two issues were identifed:
-  The ColorEditorPanel looses its content when changing the focus of the VSI window
-  The  ColorMap selection does not work for the Splatterplot view.

**ColorEditorPanel Issue**
1. Load a sample data set into the VSI
2. Go to the Standard View
3. Add a scale filter to the source 
   - Confirm that the Scale filter is the active source
4. Open the ColorEditorPanel form the properties browser
   - Confirm that the ColorEditorPanel displays content and a color range
5. Click on the VSI 
   - Confirm that the ColorEditorPanel **still** displays content and a color range

**ColorMap Issue**
1. Load a sample MDEvent data set into the VSI
2. Go to the Splatterplot View
3. Change the color map
   - Confirm that the color map changes in the view
