### PR TITLE
Display error bars in multi-data set fitting interface.

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -52,6 +52,7 @@ set ( SRC_FILES
     src/MultiDatasetFit/MDFLocalParameterEditor.cpp
     src/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
     src/MultiDatasetFit/MDFEditLocalParameterDialog.cpp
+    src/MultiDatasetFit/MDFErrorCurve.cpp
 	src/Muon/ALCBaselineModellingModel.cpp
 	src/Muon/ALCBaselineModellingPresenter.cpp
 	src/Muon/ALCBaselineModellingView.cpp
@@ -147,6 +148,7 @@ set ( INC_FILES
     inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
     inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
     inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
+    inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h
 	inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
 	inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h
 	inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFDatasetPlotData.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFDatasetPlotData.h
@@ -24,6 +24,7 @@ namespace CustomInterfaces
 {
 namespace MDF
 {
+class ErrorCurve;
 
 /**
  * Contains graphics for a single data set: fitting data, claculated result, difference.
@@ -36,6 +37,7 @@ public:
   void show(QwtPlot *plot);
   void hide();
   QwtDoubleRect boundingRect() const;
+  void showDataErrorBars(bool on);
 private:
   // no copying
   DatasetPlotData(const DatasetPlotData&);
@@ -43,10 +45,14 @@ private:
   void setData(const Mantid::API::MatrixWorkspace *ws, int wsIndex, const Mantid::API::MatrixWorkspace *outputWS);
   /// Curve object for the fit data (spectrum).
   QwtPlotCurve *m_dataCurve;
+  /// Error bar curve for the data
+  ErrorCurve *m_dataErrorCurve;
   /// Curve object for the calculated spectrum after a fit.
   QwtPlotCurve *m_calcCurve;
   /// Curve object for the difference spectrum.
   QwtPlotCurve *m_diffCurve;
+
+  bool m_showDataErrorBars; ///< Flag to show/hide the data error bars
 };
 
 } // MDF

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h
@@ -1,0 +1,40 @@
+#ifndef MDFERRORCURVE_H_
+#define MDFERRORCURVE_H_
+
+#include <qwt_plot_item.h>
+#include <qwt_plot_curve.h>
+
+namespace MantidQt
+{
+namespace CustomInterfaces
+{
+namespace MDF
+{
+
+/// Curve to draw error bars.
+class ErrorCurve: public QwtPlotItem
+{
+public:
+  ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>& errors = std::vector<double>());
+  /// Set error bars
+  void setErrorBars(const std::vector<double>& errors);
+  /// Number of points in the curve
+  int dataSize() const;
+  /// Draw this curve
+  void draw(QPainter *painter, 
+        const QwtScaleMap &xMap, const QwtScaleMap &yMap,
+        const QRect &canvasRect) const;
+private:
+
+  std::vector<double> m_x; ///< The x coordinates
+  std::vector<double> m_y; ///< The y coordinates
+  std::vector<double> m_e; ///< The error bars
+  QPen m_pen;
+};
+
+} // MDF
+} // CustomInterfaces
+} // MantidQt
+
+
+#endif /*MDFERRORCURVE_H_*/

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFPlotController.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFPlotController.h
@@ -59,6 +59,7 @@ public slots:
   void enablePan();
   void enableRange();
   void updateRange(int index);
+  void showDataErrors(bool);
 private slots:
   void tableUpdated();
   void prevPlot();
@@ -97,6 +98,7 @@ private:
   QPushButton *m_nextPlot;
   QMap<int,boost::shared_ptr<DatasetPlotData>> m_plotData;
   int m_currentIndex;
+  bool m_showDataErrors;
 };
 
 } // MDF

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.ui
@@ -218,6 +218,13 @@
              <property name="margin">
               <number>0</number>
              </property>
+             <item>
+              <widget class="QCheckBox" name="cbShowDataErrors">
+               <property name="text">
+                <string>Show data errors</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
            <widget class="QWidget" name="PanPage"/>
@@ -293,7 +300,7 @@
   <tabstop>cbPlotSelector</tabstop>
  </tabstops>
  <resources>
-  <include location="../../icons/CustomInterfacesIcons.qrc"/>
+  <include location="../../../icons/CustomInterfacesIcons.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.ui
@@ -227,14 +227,13 @@
              </item>
             </layout>
            </widget>
-           <widget class="QWidget" name="PanPage"/>
            <widget class="QWidget" name="RangePage">
             <layout class="QHBoxLayout" name="horizontalLayout_5">
              <property name="margin">
               <number>0</number>
              </property>
              <item>
-              <widget class="QCheckBox" name="cb_applyRangeToAll">
+              <widget class="QCheckBox" name="cbApplyRangeToAll">
                <property name="text">
                 <string>Apply to all spectra</string>
                </property>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
@@ -1,4 +1,5 @@
 #include "MantidQtCustomInterfaces/MultiDatasetFit/MDFDatasetPlotData.h"
+#include "MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h"
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -21,6 +22,7 @@ namespace MDF
 ///    If empty - ignore this workspace.
 DatasetPlotData::DatasetPlotData(const QString& wsName, int wsIndex, const QString& outputWSName):
   m_dataCurve(new QwtPlotCurve(wsName + QString(" (%1)").arg(wsIndex))),
+  m_dataErrorCurve(NULL),
   m_calcCurve(NULL),
   m_diffCurve(NULL)
 {
@@ -66,6 +68,11 @@ DatasetPlotData::~DatasetPlotData()
 {
   m_dataCurve->detach();
   delete m_dataCurve;
+  if ( m_dataErrorCurve )
+  {
+    m_dataErrorCurve->detach();
+    delete m_dataErrorCurve;
+  }
   if ( m_calcCurve )
   {
     m_calcCurve->detach();
@@ -97,6 +104,13 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws, int wsInde
   }
   m_dataCurve->setData( xValues.data(), ws->readY(wsIndex).data(), static_cast<int>(xValues.size()) );
 
+  if (m_dataErrorCurve)
+  {
+    m_dataErrorCurve->detach();
+    delete m_dataErrorCurve;
+  }
+  m_dataErrorCurve = new ErrorCurve(m_dataCurve, ws->readE(wsIndex));
+
   if ( haveFitCurves )
   {
     auto xBegin = std::lower_bound(xValues.begin(),xValues.end(), outputWS->readX(1).front());
@@ -119,6 +133,14 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws, int wsInde
 void DatasetPlotData::show(QwtPlot *plot)
 {
   m_dataCurve->attach(plot);
+  if (m_showDataErrorBars)
+  {
+    m_dataErrorCurve->attach(plot);
+  }
+  else
+  {
+    m_dataErrorCurve->detach();
+  }
   if ( m_calcCurve )
   {
     m_calcCurve->attach(plot);
@@ -133,6 +155,7 @@ void DatasetPlotData::show(QwtPlot *plot)
 void DatasetPlotData::hide()
 {
   m_dataCurve->detach();
+  m_dataErrorCurve->detach();
   if ( m_calcCurve )
   {
     m_calcCurve->detach();
@@ -156,6 +179,12 @@ QwtDoubleRect DatasetPlotData::boundingRect() const
     rect = rect.united( m_diffCurve->boundingRect() );
   }
   return rect;
+}
+
+/// Toggle the error bars on the data curve.
+void DatasetPlotData::showDataErrorBars(bool on)
+{
+  m_showDataErrorBars = on;
 }
 
 } // MDF

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFErrorCurve.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFErrorCurve.cpp
@@ -1,0 +1,94 @@
+#include "MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h"
+
+#include <QPainter>
+#include <qwt_scale_map.h>
+
+namespace MantidQt
+{
+namespace CustomInterfaces
+{
+namespace MDF
+{
+ 
+/// Create a error curve dependent on a data curve.
+/// @param dataCurve :: The curve displaying the data.
+/// @param errors :: A vector with error bars.
+ErrorCurve::ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>& errors)
+{
+  if (!dataCurve)
+  {
+    throw std::runtime_error("Null pointer to a data curve.");
+  }
+  auto n = dataCurve->dataSize();
+  m_x.resize(n);
+  m_y.resize(n);
+  for(int i = 0; i < n; ++i)
+  {
+    m_x[i] = dataCurve->x(i);
+    m_y[i] = dataCurve->y(i);
+  }
+
+  if (!errors.empty())
+  {
+    setErrorBars(errors);
+  }
+
+  setItemAttribute(QwtPlotItem::AutoScale, true);
+  m_pen = dataCurve->pen();
+}
+
+/// Set error bars
+/// @param errors :: A pointer to an array with error bars.
+/// @param n :: Number of error values. Must be the same as the number of data
+///    in the parent data curve.
+void ErrorCurve::setErrorBars(const std::vector<double>& errors)
+{
+  if (errors.size() != m_x.size())
+  {
+    throw std::runtime_error("Number of error values is different form the number of data points.");
+  }
+  m_e = errors;
+}
+
+/// Draw this curve
+void ErrorCurve::draw(QPainter *painter, 
+      const QwtScaleMap &xMap, const QwtScaleMap &yMap,
+      const QRect &canvasRect) const
+{
+  if (m_e.empty()) return;
+  painter->save();
+  painter->setPen(m_pen);
+  int n = static_cast<int>(m_x.size());
+  const double dx = 4;
+
+  for (int i = 0; i < n; ++i)
+  {
+    const double E = m_e[i];
+    if (E <= 0.0) continue;
+
+    const int xi = xMap.transform(m_x[i]);
+    const double Y = m_y[i];
+    const int yi = yMap.transform(Y);
+    const int ei1 = yMap.transform(Y - E);
+    const int ei2 = yMap.transform(Y + E);
+
+    painter->drawLine(xi, ei1, xi, yi);
+    painter->drawLine(xi-dx,ei1,xi+dx,ei1);
+
+    painter->drawLine(xi, yi, xi, ei2);
+    painter->drawLine(xi-dx,ei2,xi+dx,ei2);
+      
+  }
+
+  painter->restore();
+}
+
+/// Number of points in the curve
+int ErrorCurve::dataSize() const
+{
+  return static_cast<int>(m_x.size());
+}
+
+} // MDF
+} // CustomInterfaces
+} // MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFErrorCurve.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFErrorCurve.cpp
@@ -2,6 +2,7 @@
 
 #include <QPainter>
 #include <qwt_scale_map.h>
+#include <stdexcept>
 
 namespace MantidQt
 {
@@ -39,8 +40,6 @@ ErrorCurve::ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>&
 
 /// Set error bars
 /// @param errors :: A pointer to an array with error bars.
-/// @param n :: Number of error values. Must be the same as the number of data
-///    in the parent data curve.
 void ErrorCurve::setErrorBars(const std::vector<double>& errors)
 {
   if (errors.size() != m_x.size())
@@ -53,13 +52,13 @@ void ErrorCurve::setErrorBars(const std::vector<double>& errors)
 /// Draw this curve
 void ErrorCurve::draw(QPainter *painter, 
       const QwtScaleMap &xMap, const QwtScaleMap &yMap,
-      const QRect &canvasRect) const
+      const QRect &) const
 {
   if (m_e.empty()) return;
   painter->save();
   painter->setPen(m_pen);
   int n = static_cast<int>(m_x.size());
-  const double dx = 4;
+  const int dx = 4;
 
   for (int i = 0; i < n; ++i)
   {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -16,8 +16,7 @@
 namespace{
   // tool options pages
   const int zoomToolPage  = 0;
-  const int panToolPage   = 1;
-  const int rangeToolPage = 2;
+  const int rangeToolPage = 1;
 }
 
 namespace MantidQt
@@ -63,7 +62,7 @@ void MultiDatasetFit::initLayout()
   connect(m_dataController,SIGNAL(hasSelection(bool)),  m_uiForm.btnRemove, SLOT(setEnabled(bool)));
   connect(m_uiForm.btnAddWorkspace,SIGNAL(clicked()),m_dataController,SLOT(addWorkspace()));
   connect(m_uiForm.btnRemove,SIGNAL(clicked()),m_dataController,SLOT(removeSelectedSpectra()));
-  connect(m_uiForm.cb_applyRangeToAll,SIGNAL(toggled(bool)),m_dataController,SLOT(setFittingRangeGlobal(bool)));
+  connect(m_uiForm.cbApplyRangeToAll,SIGNAL(toggled(bool)),m_dataController,SLOT(setFittingRangeGlobal(bool)));
 
   m_plotController = new MDF::PlotController(this,
                                         m_uiForm.plot,
@@ -381,7 +380,7 @@ void MultiDatasetFit::enableZoom()
 void MultiDatasetFit::enablePan()
 {
   m_plotController->enablePan();
-  m_uiForm.toolOptions->setCurrentIndex(panToolPage);
+  m_uiForm.toolOptions->setCurrentIndex(zoomToolPage);
 }
 
 /// Enable the fitting range selection tool.
@@ -438,8 +437,10 @@ void MultiDatasetFit::loadSettings()
   QSettings settings;
   settings.beginGroup("Mantid/MultiDatasetFit");
   m_fitOptionsBrowser->loadSettings( settings );
-  bool showDataErrors = settings.value("ShowDataErrors",false).asBool();
-  m_uiForm.cbShowDataErrors->setChecked(showDataErrors);
+  bool option = settings.value("ShowDataErrors",false).asBool();
+  m_uiForm.cbShowDataErrors->setChecked(option);
+  option = settings.value("ApplyRangeToAll",false).asBool();
+  m_uiForm.cbApplyRangeToAll->setChecked(option);
 }
 
 /// Save settings
@@ -449,6 +450,7 @@ void MultiDatasetFit::saveSettings() const
   settings.beginGroup("Mantid/MultiDatasetFit");
   m_fitOptionsBrowser->saveSettings( settings );
   settings.setValue("ShowDataErrors",m_uiForm.cbShowDataErrors->isChecked());
+  settings.setValue("ApplyRangeToAll",m_uiForm.cbApplyRangeToAll->isChecked());
 }
 
 } // CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -74,6 +74,7 @@ void MultiDatasetFit::initLayout()
   connect(m_dataController,SIGNAL(dataTableUpdated()),m_plotController,SLOT(tableUpdated()));
   connect(m_dataController,SIGNAL(dataSetUpdated(int)),m_plotController,SLOT(updateRange(int)));
   connect(m_plotController,SIGNAL(fittingRangeChanged(int, double, double)),m_dataController,SLOT(setFittingRange(int, double, double)));
+  connect(m_uiForm.cbShowDataErrors,SIGNAL(toggled(bool)),m_plotController,SLOT(showDataErrors(bool)));
 
   QSplitter* splitter = new QSplitter(Qt::Vertical,this);
 
@@ -437,6 +438,8 @@ void MultiDatasetFit::loadSettings()
   QSettings settings;
   settings.beginGroup("Mantid/MultiDatasetFit");
   m_fitOptionsBrowser->loadSettings( settings );
+  bool showDataErrors = settings.value("ShowDataErrors",false).asBool();
+  m_uiForm.cbShowDataErrors->setChecked(showDataErrors);
 }
 
 /// Save settings
@@ -445,6 +448,7 @@ void MultiDatasetFit::saveSettings() const
   QSettings settings;
   settings.beginGroup("Mantid/MultiDatasetFit");
   m_fitOptionsBrowser->saveSettings( settings );
+  settings.setValue("ShowDataErrors",m_uiForm.cbShowDataErrors->isChecked());
 }
 
 } // CustomInterfaces


### PR DESCRIPTION
Fixes #11318

**To test**
1. Load some data into the interface.
2. Check that the data error bar check box is working.
