### PR TITLE
Fix normalization of atoms for compounds

### DIFF
--- a/Code/Mantid/Framework/DataHandling/test/SetSampleMaterialTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/SetSampleMaterialTest.h
@@ -54,9 +54,9 @@ public:
 
 	  TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("InputWorkspace", wsName) );
     TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("ChemicalFormula","Al2-O3") );
-    TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("SampleNumberDensity","0.0236649") );
-    TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("ScatteringXSection","15.7048") );
-    TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("AttenuationXSection","0.46257") );
+    TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("SampleNumberDensity","0.1183245") );
+    TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("ScatteringXSection","3.1404") );
+    TS_ASSERT_THROWS_NOTHING( setmat->setPropertyValue("AttenuationXSection","0.0925") );
     TS_ASSERT_THROWS_NOTHING( setmat->execute() );
     TS_ASSERT( setmat->isExecuted() );
 
@@ -70,9 +70,9 @@ public:
 
 	//can get away with holding pointer as it is an inout ws property
     const Material *m_sampleMaterial = &(testWS->sample().getMaterial());
-    TS_ASSERT_DELTA( m_sampleMaterial->numberDensity(), 0.0236649, 0.0001 );
-    TS_ASSERT_DELTA( m_sampleMaterial->totalScatterXSection(NeutronAtom::ReferenceLambda), 15.7048, 0.0001);
-    TS_ASSERT_DELTA( m_sampleMaterial->absorbXSection(NeutronAtom::ReferenceLambda), 0.46257, 0.0001);
+    TS_ASSERT_DELTA( m_sampleMaterial->numberDensity(), 0.1183245, 0.0001 );
+    TS_ASSERT_DELTA( m_sampleMaterial->totalScatterXSection(NeutronAtom::ReferenceLambda), 3.1404, 0.0001);
+    TS_ASSERT_DELTA( m_sampleMaterial->absorbXSection(NeutronAtom::ReferenceLambda), 0.0925, 0.0001);
 
     checkOutputProperties(setmat,m_sampleMaterial);
 
@@ -102,7 +102,7 @@ public:
     TS_ASSERT( setmat->isExecuted() );
 
     const Material *m_sampleMaterial = &(testWS->sample().getMaterial());
-    TS_ASSERT_DELTA( m_sampleMaterial->numberDensity(), 0.0236649, 0.0001 );
+    TS_ASSERT_DELTA( m_sampleMaterial->numberDensity(), 0.1183245, 0.0001 );
     TS_ASSERT_DELTA( m_sampleMaterial->totalScatterXSection(NeutronAtom::ReferenceLambda), 3.1404, 0.0001);
     TS_ASSERT_DELTA( m_sampleMaterial->absorbXSection(NeutronAtom::ReferenceLambda), 0.0925, 0.0001);
 	  

--- a/Code/Mantid/docs/source/algorithms/SetSampleMaterial-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SetSampleMaterial-v1.rst
@@ -61,7 +61,7 @@ Number Density
 
 The number density is defined as
 
-.. math:: \rho_n = \frac{ZParameter}{UnitCellVolume}
+.. math:: \rho_n = \frac{N_{atoms}ZParameter}{UnitCellVolume}
 
 It can can be generated in one of two ways:
 
@@ -69,5 +69,22 @@ It can can be generated in one of two ways:
 2. Specifying the ``ZParameter`` and the ``UnitCellVolume`` (or letting
    the algorithm calculate it from the OrientedLattice on the 
    ``InputWorkspace``).
+   
+Linear Absorption Coefficients
+##############################
 
+.. math:: \mu_s = \rho_n \frac{1}{N_{atoms}}\sum_{i}s_{i}n_{i} \text{ units of 1/cm}
+.. math:: s = \sigma_{total scattering}
+.. math:: \mu_a = \rho_n \frac{1}{N_{atoms}}\sum_{i}a_{i}n_{i} \text{ units of 1/cm}
+.. math:: a = \sigma_{absorption} (\lambda=1.8)
+
+References
+----------
+
+The data used in this algorithm comes from the following paper.
+
+#. Varley F. Sears, *Neutron scattering lengths and cross sections*, Neutron News **3:3** (1992) 26
+   `doi: 10.1080/10448639208218770`_
+
+      
 .. categories::


### PR DESCRIPTION
Fixes #12741.  Nothing to add to release notes.

To test:

``` python
   LoadEmptyInstrument(Filename='TOPAZ_Definition_2015-01-01.xml', OutputWorkspace='topaz')
   SetSampleMaterial(InputWorkspace='topaz', ChemicalFormula='Li2 Se1', ZParameter=4, UnitCellVolume=216.7)
```

Correct answer from TOPAZ instrument scientist:
The linear absorption coefficient for total scattering is  0.204 cm^-1
The linear absorption coefficient for true absorption at 1.8 A is  2.819 cm^-1
