### PR TITLE
Space group systematic absences

### DIFF
--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -87,6 +87,8 @@ public:
     return equivalents;
   }
 
+  bool isAllowed(const Kernel::V3D &hkl) const;
+
 protected:
   size_t m_number;
   std::string m_hmSymbol;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -87,7 +87,7 @@ public:
     return equivalents;
   }
 
-  bool isAllowed(const Kernel::V3D &hkl) const;
+  bool isAllowedReflection(const Kernel::V3D &hkl) const;
 
 protected:
   size_t m_number;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
@@ -129,6 +129,7 @@ public:
 
   const Kernel::IntMatrix &matrix() const;
   const V3R &vector() const;
+  V3R reducedVector() const;
 
   size_t order() const;
   std::string identifier() const;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryOperation.h
@@ -129,7 +129,7 @@ public:
 
   const Kernel::IntMatrix &matrix() const;
   const V3R &vector() const;
-  V3R reducedVector() const;
+  const V3R &reducedVector() const;
 
   size_t order() const;
   std::string identifier() const;
@@ -163,11 +163,14 @@ protected:
   void init(const Kernel::IntMatrix &matrix, const V3R &vector);
 
   size_t getOrderFromMatrix(const Kernel::IntMatrix &matrix) const;
+  V3R getReducedVector(const Kernel::IntMatrix &matrix,
+                       const V3R &vector) const;
 
   size_t m_order;
   Kernel::IntMatrix m_matrix;
   Kernel::IntMatrix m_inverseMatrix;
   V3R m_vector;
+  V3R m_reducedVector;
   std::string m_identifier;
 };
 

--- a/Code/Mantid/Framework/Geometry/src/Crystal/PointGroupFactory.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/PointGroupFactory.cpp
@@ -105,7 +105,7 @@ PointGroupFactoryImpl::subscribePointGroup(const std::string &hmSymbol,
  * space groups. Point groups don't have translational symmetry, which
  * is reflected in the symbol as well. To get the symbol of the point group
  * a certain space group belongs to, some simple string replacements are enough:
- *  1. Replace screw axes ( (2|3|4|6)[1|2|3|5] ) with rotations (first number).
+ *  1. Replace screw axes ( (2|3|4|6)[1|2|3|4|5] ) with rotations (first number).
  *  2. Replace glide planes (a|b|c|d|e|g|n) with mirror planes (m)
  *  3. Remove centering symbol.
  *  4. Remove origin choice ( :(1|2) )
@@ -126,7 +126,7 @@ std::string PointGroupFactoryImpl::pointGroupSymbolFromSpaceGroupSymbol(
 
   std::string noSpaces = boost::algorithm::erase_all_copy(noCentering, " ");
 
-  if (noSpaces.substr(0, 1) == "1" &&
+  if (noSpaces.substr(0, 1) == "1" && noSpaces.size() > 2 &&
       noSpaces.substr(noSpaces.size() - 1, 1) == "1") {
     noSpaces = noSpaces.substr(1, noSpaces.size() - 2);
   }
@@ -162,7 +162,7 @@ PointGroup_sptr PointGroupFactoryImpl::constructFromPrototype(
 /// Private default constructor.
 PointGroupFactoryImpl::PointGroupFactoryImpl()
     : m_generatorMap(), m_crystalSystemMap(),
-      m_screwAxisRegex("(2|3|4|6)[1|2|3|5]"),
+      m_screwAxisRegex("(2|3|4|6)[1|2|3|4|5]"),
       m_glidePlaneRegex("a|b|c|d|e|g|n"), m_centeringRegex("[A-Z]"),
       m_originChoiceRegex(":(1|2)") {
   Kernel::LibraryManager::Instance();

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -3,6 +3,8 @@
 namespace Mantid {
 namespace Geometry {
 
+using namespace Kernel;
+
 /**
  * Constructor
  *
@@ -37,6 +39,37 @@ size_t SpaceGroup::number() const { return m_number; }
 
 /// Returns the stored Hermann-Mauguin symbol
 std::string SpaceGroup::hmSymbol() const { return m_hmSymbol; }
+
+/**
+ * Returns whether the given reflection is allowed or not in this space group
+ *
+ * Space groups that contain translational symmetry cause certain reflections
+ * to be absent due to the contributions of symmetry equivalent atoms to the
+ * structure factor cancelling out. This method implements the procedure
+ * described in the IUCr teaching pamphlet no. 9 [1] to check whether a
+ * reflection is allowed or not according to the symmetry operations in the
+ * space group. Please note that certain arrangements of atoms can lead to
+ * additional conditions that can not be determined using a space group's
+ * symmetry operations alone. For these situations, Geometry::CrystalStructure
+ * can help.
+ *
+ * @param hkl :: HKL to be checked.
+ * @return :: true if the reflection is allowed, false otherwise.
+ */
+bool SpaceGroup::isAllowed(const Kernel::V3D &hkl) const {
+  for (auto op = m_allOperations.begin(); op != m_allOperations.end(); ++op) {
+    if ((*op).hasTranslation()) {
+
+      // Do transformation only if necessary
+      if ((fmod(hkl.scalar_prod((*op).vector()), 1.0) != 0) &&
+          ((*op).transformHKL(hkl) == hkl)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
 
 } // namespace Geometry
 } // namespace Mantid

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -46,14 +46,13 @@ std::string SpaceGroup::hmSymbol() const { return m_hmSymbol; }
  * Space groups that contain translational symmetry cause certain reflections
  * to be absent due to the contributions of symmetry equivalent atoms to the
  * structure factor cancelling out. This method implements the procedure
- * described in the IUCr teaching pamphlet no. 9 [1] to check whether a
- * reflection is allowed or not according to the symmetry operations in the
- * space group. Please note that certain arrangements of atoms can lead to
- * additional conditions that can not be determined using a space group's
- * symmetry operations alone. For these situations, Geometry::CrystalStructure
- * can help.
+ * described in ITA [1] to check whether a reflection is allowed or not
+ * according to the symmetry operations in the space group. Please note that
+ * certain arrangements of atoms can lead to additional conditions that can not
+ * be determined using a space group's symmetry operations alone. For these
+ * situations, Geometry::CrystalStructure can help.
  *
- * [1] http://www.iucr.org/education/pamphlets/9/full-text
+ * [1] International Tables for Crystallography (2006). Vol. A, ch. 12.3, p. 832
  *
  * @param hkl :: HKL to be checked.
  * @return :: true if the reflection is allowed, false otherwise.
@@ -66,8 +65,8 @@ bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
        *    | [(H . v) + delta] % 1.0 | > 1e-14 is checked
        * The transformation is only performed if necessary.
        */
-      if ((fabs(fmod(fabs(hkl.scalar_prod((*op).vector())) + 1e-15, 1.0)) >
-           1e-14) &&
+      if ((fabs(fmod(fabs(hkl.scalar_prod((*op).reducedVector())) + 1e-15,
+                     1.0)) > 1e-14) &&
           ((*op).transformHKL(hkl) == hkl)) {
         return false;
       }

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -53,10 +53,12 @@ std::string SpaceGroup::hmSymbol() const { return m_hmSymbol; }
  * symmetry operations alone. For these situations, Geometry::CrystalStructure
  * can help.
  *
+ * [1] http://www.iucr.org/education/pamphlets/9/full-text
+ *
  * @param hkl :: HKL to be checked.
  * @return :: true if the reflection is allowed, false otherwise.
  */
-bool SpaceGroup::isAllowed(const Kernel::V3D &hkl) const {
+bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
   for (auto op = m_allOperations.begin(); op != m_allOperations.end(); ++op) {
     if ((*op).hasTranslation()) {
 

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -61,9 +61,13 @@ std::string SpaceGroup::hmSymbol() const { return m_hmSymbol; }
 bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
   for (auto op = m_allOperations.begin(); op != m_allOperations.end(); ++op) {
     if ((*op).hasTranslation()) {
-
-      // Do transformation only if necessary
-      if ((fmod(hkl.scalar_prod((*op).vector()), 1.0) != 0) &&
+      /* Floating point precision problem:
+       *    (H . v) % 1.0 is not always exactly 0, so instead:
+       *    | [(H . v) + delta] % 1.0 | > 1e-14 is checked
+       * The transformation is only performed if necessary.
+       */
+      if ((fabs(fmod(fabs(hkl.scalar_prod((*op).vector())) + 1e-15, 1.0)) >
+           1e-14) &&
           ((*op).transformHKL(hkl) == hkl)) {
         return false;
       }

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryElementFactory.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryElementFactory.cpp
@@ -83,14 +83,7 @@ bool SymmetryElementInversionGenerator::canProcess(
  */
 V3R SymmetryElementWithAxisGenerator::determineTranslation(
     const SymmetryOperation &operation) const {
-  Kernel::IntMatrix translationMatrix(3, 3, false);
-
-  for (size_t i = 0; i < operation.order(); ++i) {
-    translationMatrix += (operation ^ i).matrix();
-  }
-
-  return (translationMatrix * operation.vector()) *
-         RationalNumber(1, static_cast<int>(operation.order()));
+  return operation.reducedVector();
 }
 
 /**
@@ -182,8 +175,8 @@ V3R SymmetryElementWithAxisGenerator::determineAxis(
 
   double sumOfElements = eigenVector.X() + eigenVector.Y() + eigenVector.Z();
 
-  if(sumOfElements < 0) {
-      eigenVector *= -1.0;
+  if (sumOfElements < 0) {
+    eigenVector *= -1.0;
   }
 
   gsl_matrix_free(eigenMatrix);

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryElementFactory.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryElementFactory.cpp
@@ -56,31 +56,7 @@ bool SymmetryElementInversionGenerator::canProcess(
   return operation.matrix() == inversionMatrix;
 }
 
-/**
- * @brief SymmetryElementWithAxisGenerator::determineTranslation
- *
- * According to ITA, 11.2, the translation component of a symmetry operation
- * can be termined with the following algorithm. First, a matrix \f$W\f$ is
- * calculated using the symmetry operation \f$S\f$ and its powers up to its
- * order \f$k\f$, adding the matrices of the resulting operations:
- *
- * \f[
- *  W = W_1(S^0) + W_2(S^1) + \dots + W_k(S^{k-1})
- * \f]
- *
- * The translation vector is then calculation from the vector \f$w\f$ of the
- * operation:
- *
- * \f[
- *  t = \frac{1}{k}\cdot (W \times w)
- * \f]
- *
- * For operations which do not have translation components, this algorithm
- * returns a 0-vector.
- *
- * @param operation :: Symmetry operation, possibly with translation vector.
- * @return Translation vector.
- */
+/// Returns the reduced vector of the operation.
 V3R SymmetryElementWithAxisGenerator::determineTranslation(
     const SymmetryOperation &operation) const {
   return operation.reducedVector();

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryOperation.cpp
@@ -81,6 +81,17 @@ const Kernel::IntMatrix &SymmetryOperation::matrix() const { return m_matrix; }
 /// Returns a const reference to the internall stored vector
 const V3R &SymmetryOperation::vector() const { return m_vector; }
 
+V3R SymmetryOperation::reducedVector() const {
+  Kernel::IntMatrix translationMatrix(3, 3, false);
+
+  for (size_t i = 0; i < order(); ++i) {
+    translationMatrix += ((*this) ^ i).matrix();
+  }
+
+  return (translationMatrix * m_vector) *
+         RationalNumber(1, static_cast<int>(order()));
+}
+
 /**
  * Returns the order of the symmetry operation
  *

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryOperation.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SymmetryOperation.cpp
@@ -11,7 +11,7 @@ namespace Geometry {
 SymmetryOperation::SymmetryOperation()
     : m_order(1), m_matrix(Kernel::IntMatrix(3, 3, true)),
       m_inverseMatrix(Kernel::IntMatrix(3, 3, true)), m_vector(),
-      m_identifier() {
+      m_reducedVector(), m_identifier() {
   m_identifier = SymmetryOperationSymbolParser::getNormalizedIdentifier(
       m_matrix, m_vector);
 }
@@ -44,7 +44,8 @@ SymmetryOperation::SymmetryOperation(const Kernel::IntMatrix &matrix,
 SymmetryOperation::SymmetryOperation(const SymmetryOperation &other)
     : m_order(other.m_order), m_matrix(other.m_matrix),
       m_inverseMatrix(other.m_inverseMatrix), m_vector(other.m_vector),
-      m_identifier(other.m_identifier) {}
+      m_reducedVector(other.m_reducedVector), m_identifier(other.m_identifier) {
+}
 
 /// Assignment operator
 SymmetryOperation &SymmetryOperation::
@@ -53,6 +54,7 @@ operator=(const SymmetryOperation &other) {
   m_matrix = other.m_matrix;
   m_inverseMatrix = other.m_inverseMatrix;
   m_vector = other.m_vector;
+  m_reducedVector = other.m_reducedVector;
   m_identifier = other.m_identifier;
 
   return *this;
@@ -69,10 +71,11 @@ void SymmetryOperation::init(const Kernel::IntMatrix &matrix,
   m_inverseMatrix = m_inverseMatrix.Transpose();
 
   m_vector = getWrappedVector(vector);
-
   m_order = getOrderFromMatrix(m_matrix);
   m_identifier = SymmetryOperationSymbolParser::getNormalizedIdentifier(
       m_matrix, m_vector);
+
+  m_reducedVector = getReducedVector(m_matrix, m_vector);
 }
 
 /// Returns a const reference to the internally stored matrix
@@ -81,16 +84,31 @@ const Kernel::IntMatrix &SymmetryOperation::matrix() const { return m_matrix; }
 /// Returns a const reference to the internall stored vector
 const V3R &SymmetryOperation::vector() const { return m_vector; }
 
-V3R SymmetryOperation::reducedVector() const {
-  Kernel::IntMatrix translationMatrix(3, 3, false);
-
-  for (size_t i = 0; i < order(); ++i) {
-    translationMatrix += ((*this) ^ i).matrix();
-  }
-
-  return (translationMatrix * m_vector) *
-         RationalNumber(1, static_cast<int>(order()));
-}
+/**
+ * @brief SymmetryOperation::reducedVector
+ *
+ * According to ITA, 11.2, the translation component of a symmetry operation
+ * can be termined with the following algorithm. First, a matrix \f$W\f$ is
+ * calculated using the symmetry operation \f$S\f$ and its powers up to its
+ * order \f$k\f$, adding the matrices of the resulting operations:
+ *
+ * \f[
+ *  W = W_1(S^0) + W_2(S^1) + \dots + W_k(S^{k-1})
+ * \f]
+ *
+ * The translation vector is then calculation from the vector \f$w\f$ of the
+ * operation:
+ *
+ * \f[
+ *  t = \frac{1}{k}\cdot (W \times w)
+ * \f]
+ *
+ * For operations which do not have translation components, this algorithm
+ * returns a 0-vector.
+ *
+ * @return Translation vector.
+ */
+const V3R &SymmetryOperation::reducedVector() const { return m_reducedVector; }
 
 /**
  * Returns the order of the symmetry operation
@@ -240,6 +258,24 @@ SymmetryOperation::getOrderFromMatrix(const Kernel::IntMatrix &matrix) const {
   }
 
   throw std::runtime_error("There is something wrong with supplied matrix.");
+}
+
+V3R SymmetryOperation::getReducedVector(const Kernel::IntMatrix &matrix,
+                                        const V3R &vector) const {
+  Kernel::IntMatrix translationMatrix(3, 3, false);
+
+  for (size_t i = 0; i < order(); ++i) {
+    Kernel::IntMatrix tempMatrix(3, 3, true);
+
+    for (size_t j = 0; j < i; ++j) {
+      tempMatrix *= matrix;
+    }
+
+    translationMatrix += tempMatrix;
+  }
+
+  return (translationMatrix * vector) *
+         RationalNumber(1, static_cast<int>(order()));
 }
 
 /**

--- a/Code/Mantid/Framework/Geometry/test/SpaceGroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/SpaceGroupTest.h
@@ -87,7 +87,7 @@ public:
         "-y,x-y,z; y,x,-z; -x,-y,-z");
     Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
 
-    SpaceGroup spaceGroup(167, "R-3m", *(group * centering));
+    SpaceGroup spaceGroup(167, "R-3c", *(group * centering));
 
     std::vector<V3D> byOperator = spaceGroup * V3D(0.5, 0.0, 0.0);
     for (size_t i = 0; i < byOperator.size(); ++i) {
@@ -104,6 +104,55 @@ public:
     for (size_t i = 0; i < byEquivalents.size(); ++i) {
       TS_ASSERT_EQUALS(byOperator[i], byEquivalents[i]);
     }
+  }
+
+  void testIsAllowedReflectionR3m() {
+    /* This is just a check that isAllowedReflection behaves correctly,
+     * there is a system test in place that checks more examples.
+     *
+     * This test uses space group 167, R-3c, like above.
+     */
+    Group_const_sptr group = GroupFactory::create<ProductOfCyclicGroups>(
+        "-y,x-y,z; y,x,-z; -x,-y,-z");
+    Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
+
+    SpaceGroup spaceGroup(167, "R-3c", *(group * centering));
+
+    // Reflections hkl: -h + k + l = 3n
+    V3D goodHKL(1, 4, 3); // -1 + 4 + 3 = 6 = 3 * 2
+    V3D badHKL(2, 4, 3);  // -2 + 4 + 3 = 5
+    TS_ASSERT(spaceGroup.isAllowedReflection(goodHKL));
+    TS_ASSERT(!spaceGroup.isAllowedReflection(badHKL));
+
+    // Reflections hk0: -h + k = 3n
+    V3D goodHK0(3, 9, 0); // -3 + 9 = 6 = 3 * 2
+    V3D badHK0(4, 9, 0);  // -4 + 9 = 5
+    TS_ASSERT(spaceGroup.isAllowedReflection(goodHK0));
+    TS_ASSERT(!spaceGroup.isAllowedReflection(badHK0));
+
+    // Reflections hhl: l = 3n
+    V3D goodHHL(1, 1, 6); // 6 = 3 * 2
+    V3D badHHL(1, 1, 7);
+    TS_ASSERT(spaceGroup.isAllowedReflection(goodHHL));
+    TS_ASSERT(!spaceGroup.isAllowedReflection(badHHL));
+
+    // Reflections h-hl: h + l = 3n
+    V3D goodHmHL(3, -3, 6); // 3 + 9 = 9 = 3 * 3
+    V3D badHmHL(3, -3, 7); // 3 + 7 = 10
+    TS_ASSERT(spaceGroup.isAllowedReflection(goodHmHL));
+    TS_ASSERT(!spaceGroup.isAllowedReflection(badHmHL));
+
+    // Reflections 000l: l = 3n
+    V3D good00L(0, 0, 6); // 6 = 3 * 2
+    V3D bad00L(0, 0, 7);
+    TS_ASSERT(spaceGroup.isAllowedReflection(good00L));
+    TS_ASSERT(!spaceGroup.isAllowedReflection(bad00L));
+
+    // Reflections h-h0: h = 3n
+    V3D goodHH0(3, -3, 0); // 3 = 3 * 1
+    V3D badHH0(4, -4, 0);
+    TS_ASSERT(spaceGroup.isAllowedReflection(goodHH0));
+    TS_ASSERT(!spaceGroup.isAllowedReflection(badHH0));
   }
 
 private:

--- a/Code/Mantid/Framework/Geometry/test/SymmetryElementFactoryTest.h
+++ b/Code/Mantid/Framework/Geometry/test/SymmetryElementFactoryTest.h
@@ -199,6 +199,11 @@ public:
     V3R glideVectorC = V3R(0, 0, 1) / 2;
     SymmetryOperation glidePlaneC("x,-y,z+1/2");
     TS_ASSERT_EQUALS(generator.determineTranslation(glidePlaneC), glideVectorC);
+
+    V3R screwVectorThreeFourth = V3R(3, 0, 0) / 4;
+    SymmetryOperation fourThreeScrewAxis("x+3/4,-z+3/4,y+1/4");
+    TS_ASSERT_EQUALS(generator.determineTranslation(fourThreeScrewAxis),
+                     screwVectorThreeFourth);
   }
 
   void testSymmetryElementRotationDetermineRotationSense() {

--- a/Code/Mantid/Framework/Geometry/test/SymmetryOperationTest.h
+++ b/Code/Mantid/Framework/Geometry/test/SymmetryOperationTest.h
@@ -260,6 +260,21 @@ public:
 
     }
 
+    void testReducedVector()
+    {
+        SymmetryOperation fourThreeScrewAxis("x+3/4,-z+3/4,y+1/4");
+        TS_ASSERT_EQUALS(fourThreeScrewAxis.reducedVector(),  V3R(3, 0, 0) / 4);
+
+        SymmetryOperation glidePlaneC("x,-y,z+1/2");
+        TS_ASSERT_EQUALS(glidePlaneC.reducedVector(), V3R(0, 0, 1) / 2);
+
+        SymmetryOperation noTranslation("-x,-y,-z");
+        TS_ASSERT_EQUALS(noTranslation.reducedVector(), V3R(0, 0, 0));
+
+        SymmetryOperation noTranslationShifted("-x+1/8,-y+1/8,-z+1/8");
+        TS_ASSERT_EQUALS(noTranslationShifted.reducedVector(), V3R(0, 0, 0));
+    }
+
     void testPower()
     {
         SymmetryOperation mirror("x,-y,z");

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -42,5 +42,5 @@ void export_SpaceGroup() {
       .def("getEquivalentPositions", &getEquivalentPositions,
            "Returns an array with all symmetry equivalents of the supplied "
            "HKL.")
-      .def("isAllowed", &SpaceGroup::isAllowed);
+      .def("isAllowedReflection", &SpaceGroup::isAllowedReflection);
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -34,12 +34,13 @@ boost::python::list getEquivalentPositions(SpaceGroup &self,
 }
 
 void export_SpaceGroup() {
-  register_ptr_to_python<boost::shared_ptr<SpaceGroup>>();
+  register_ptr_to_python<boost::shared_ptr<SpaceGroup> >();
 
-  class_<SpaceGroup, boost::noncopyable, bases<Group>>("SpaceGroup", no_init)
+  class_<SpaceGroup, boost::noncopyable, bases<Group> >("SpaceGroup", no_init)
       .def("getNumber", &SpaceGroup::number)
       .def("getHMSymbol", &SpaceGroup::hmSymbol)
       .def("getEquivalentPositions", &getEquivalentPositions,
            "Returns an array with all symmetry equivalents of the supplied "
-           "HKL.");
+           "HKL.")
+      .def("isAllowed", &SpaceGroup::isAllowed);
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -31,6 +31,12 @@ boost::python::list getEquivalentPositions(SpaceGroup &self,
 
   return pythonEquivalents;
 }
+
+bool isAllowedReflection(SpaceGroup &self, const object &hkl) {
+    const Mantid::Kernel::V3D &hklV3d = Converters::PyObjectToV3D(hkl)();
+
+    return self.isAllowedReflection(hklV3d);
+}
 }
 
 void export_SpaceGroup() {
@@ -42,5 +48,5 @@ void export_SpaceGroup() {
       .def("getEquivalentPositions", &getEquivalentPositions,
            "Returns an array with all symmetry equivalents of the supplied "
            "HKL.")
-      .def("isAllowedReflection", &SpaceGroup::isAllowedReflection);
+      .def("isAllowedReflection", &isAllowedReflection);
 }

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupReflectionConditionsTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupReflectionConditionsTest.py
@@ -1,0 +1,53 @@
+# pylint: disable=no-init
+import stresstesting
+import re
+from mantid.simpleapi import *
+from mantid.geometry import *
+
+
+class SpaceGroupReflectionConditionsTest(stresstesting.MantidStressTest):
+    '''
+    This test uses PoldiCreatePeaksFromCell to generate lists of reflections for fake crystal structures, one for each
+    registered space group and one atom in the general position. The algorithm uses structure factor calculation for
+    determining whether a reflection is present or not, so it also generates additional absences if atoms are on
+    special positions.
+
+    Since this is not the case in the examples, space group symmetry must account for all observed reflections, so they
+    must be allowed.
+    '''
+
+    def runTest(self):
+        sgTestDict = self.generateReflectionLists()
+
+        for sgName, hkls in sgTestDict.iteritems():
+            sg = SpaceGroupFactory.createSpaceGroup(sgName)
+
+            for hkl in hkls:
+                self.assertTrue(sg.isAllowedReflection(hkl),
+                                'Space group ' + sgName + ': problem with hkl: ' + str(hkl) + '.')
+
+    def generateReflectionLists(self):
+        # Common parameters for PoldiCreatePeaksFromCell
+        # Additional lattice parameters are ignored (e.g. all except a in cubic, all except a and c in tetragonal, etc.)
+        # so they can be supplied anyway for simplicity.
+        parameters = {
+            'Atoms': 'Fe 0.3421 0.5312 0.7222',
+            'a': 5.632, 'b': 6.121, 'c': 7.832,
+            'Alpha': 101.5, 'Beta': 102.3, 'Gamma': 100.75,
+            'LatticeSpacingMin': 0.75
+        }
+
+        # Some space groups
+        spaceGroups = SpaceGroupFactory.getAllSpaceGroupSymbols()
+        sgDict = {}
+        for sg in spaceGroups:
+            try:
+                reflectionsWs = PoldiCreatePeaksFromCell(SpaceGroup=sg, **parameters)
+
+                # extract HKLs
+                hkls = [[int(m) for m in x.split()] for x in reflectionsWs.column(0)]
+                sgDict[sg] = hkls
+            except ValueError:
+                print sg
+
+        return sgDict

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupReflectionConditionsTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupReflectionConditionsTest.py
@@ -1,6 +1,5 @@
-# pylint: disable=no-init
+# pylint: disable=no-init,invalid-name
 import stresstesting
-import re
 from mantid.simpleapi import *
 from mantid.geometry import *
 

--- a/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
+++ b/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
@@ -281,7 +281,7 @@ Because space group :math:`Fddd` contains diamond glide planes, only :math:`00l`
     [0,0,6] is allowed: False
     [0,0,8] is allowed: True
 
-:ref:`Below <Space group check>` is a more elaborate example which shows one possibility to find a likely candidate space group for a list of reflections. Please note that these reflection conditions only covers the ones listed for the "general position" in ITA. When atoms are located on special positions, there may be additional conditions that need to be fulfilled. A notable example is the :math:`222`-reflection in Silicon. It is forbidden because the silicon atom is located on the :math:`8a` position, which introduces additional reflection conditions.
+:ref:`Below <SpaceGroupCheck>` is a more elaborate example which shows one possibility to find a likely candidate space group for a list of reflections. Please note that these reflection conditions only covers the ones listed for the "general position" in ITA. When atoms are located on special positions, there may be additional conditions that need to be fulfilled. A notable example is the :math:`222`-reflection in Silicon. It is forbidden because the silicon atom is located on the :math:`8a` position, which introduces additional reflection conditions.
     
 Very similar constructions are available in C++ as well, as shown in the API documentation.
     
@@ -448,7 +448,8 @@ The script produces the following output:
 
 There are four symmmetry operations that leave the coordinates :math:`x,2x,1/4` unchanged, they fulfill the group axioms. Dividing the order of the space group by the order of the site symmetry group gives the correct site multiplicity 6.
 
-.. _Space group check:
+.. _SpaceGroupCheck:
+
 Checking a list of unique reflections for possible space groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -521,7 +522,7 @@ The script should produce the following output:
 .. testoutput:: ExSpaceGroupCheck
 
     There are 54 reflections to consider.
-    5 space groups with best match:
+    5 best matching space groups:
         F d -3 m: 0 absence violations,  3 additional absences, 51 matches
         F m -3 m: 0 absence violations,  6 additional absences, 48 matches
         P n -3 m: 0 absence violations, 31 additional absences, 23 matches


### PR DESCRIPTION
This fixes #12749.

**Testing information**
Code review. Documentation has been updated with a new usage example at the end - please check the new paragraphs and new examples. If you want to play with different space groups, the following script produces a list that can replace the `reflections` variable in the usage example:

```
# Arbitrary parameters, lattice parameters are corrected by the algorithm, i.e. only a is used for cubic etc.
parameters = {
   'Atoms': 'Fe 0.3421 0.5312 0.7222',
   'a': 5.632, 'b': 6.121, 'c': 7.832,
   'Alpha': 101.5, 'Beta': 102.3, 'Gamma': 100.75,
   'LatticeSpacingMin': 0.75
}

spaceGroup = 'P 42/n n m'
spaceGroupWithoutTranslations = 'P 4/m m m'

allReflectionsWs = PoldiCreatePeaksFromCell(SpaceGroup=spaceGroupWithoutTranslations, **parameters)
sgReflectionsWs = PoldiCreatePeaksFromCell(SpaceGroup=spaceGroup, **parameters)

allHKLs = [[int(m) for m in x.split()] for x in allReflectionsWs.column(0)]
sgHKLs = [[int(m) for m in x.split()] for x in sgReflectionsWs.column(0)]

reflections = []
for hkl in allHKLs:
   reflections.append((hkl, hkl in sgHKLs))

# Adjust space group range in usage example, for above example it would be range(123, 143)
```

This script can be adjusted to be used with all space groups registered in Mantid. You have to supply the space group for which you would like to generate the "observed status" list, in the above example `P 42/n n m`. Then you need to supply the corresponding space group with no translations (replace all screw axes by rotation axes, all glide planes by mirror planes, select primitive centering). Adjust the range of checked space groups to include all those that belong to the same point group (I realize that there should be an easier way to do this using the factory, I'll make a ticket for that later).

Other examples would be (`F d d d` or `P b c a` or `C m c m`) and `P m m m` with range `47-75`. 

If you modify the atom position to `0 0 0`, many pairs will stop working, because that is a special position in many space groups and having the atom on that position introduces additional reflection conditions, which can be mistaken as different space group. One such space group is `P b c a`, where an atom on `0 0 0` adds the condition `h+k, h+l, k+l=2n`, which is the same as for an F-centering, so the algorithm finds `F m m m` instead.
