### PR TITLE
Rename S(Q, w) methods in IDR

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectSqw.ui
@@ -186,7 +186,7 @@
          </widget>
         </item>
         <item row="0" column="0">
-         <widget class="QLabel" name="lbRebinType">
+         <widget class="QLabel" name="lbMethod">
           <property name="minimumSize">
            <size>
             <width>43</width>
@@ -194,7 +194,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Rebin Type:</string>
+           <string>Method:</string>
           </property>
          </widget>
         </item>
@@ -345,7 +345,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="cbRebinType">
+         <widget class="QComboBox" name="cbMethod">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
             <horstretch>0</horstretch>
@@ -369,12 +369,12 @@
           </property>
           <item>
            <property name="text">
-            <string>Parallelepiped</string>
+            <string>Polygon</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Parallelepiped/Fractional Area</string>
+            <string>NormalisedPolygon</string>
            </property>
           </item>
          </widget>
@@ -474,7 +474,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cbRebinType</tabstop>
+  <tabstop>cbMethod</tabstop>
   <tabstop>spQLow</tabstop>
   <tabstop>spQWidth</tabstop>
   <tabstop>spQHigh</tabstop>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectSqw.cpp
@@ -63,6 +63,7 @@ namespace CustomInterfaces
     QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
     QString sqwWsName = sampleWsName.left(sampleWsName.length() - 4) + "_sqw";
     QString eRebinWsName = sampleWsName.left(sampleWsName.length() - 4) + "_r";
+    QString method = m_uiForm.cbMethod->currentText();
 
     QString rebinString = m_uiForm.spQLow->text() + "," + m_uiForm.spQWidth->text() +
       "," + m_uiForm.spQHigh->text();
@@ -87,14 +88,6 @@ namespace CustomInterfaces
     QString eFixed = getInstrumentDetails()["Efixed"];
 
     IAlgorithm_sptr sqwAlg = AlgorithmManager::Instance().create("SofQW");
-    QString rebinType = m_uiForm.cbRebinType->currentText();
-
-    if(rebinType == "Parallelepiped")
-      sqwAlg->setProperty("Method", "Polygon");
-    else if(rebinType == "Parallelepiped/Fractional Area")
-      sqwAlg->setProperty("Method", "NormalisedPolygon");
-
-    // S(Q, w) algorithm
     sqwAlg->initialize();
 
     BatchAlgorithmRunner::AlgorithmRuntimeProps sqwInputProps;
@@ -107,6 +100,7 @@ namespace CustomInterfaces
     sqwAlg->setProperty("QAxisBinning", rebinString.toStdString());
     sqwAlg->setProperty("EMode", "Indirect");
     sqwAlg->setProperty("EFixed", eFixed.toStdString());
+    sqwAlg->setProperty("Method", method.toStdString());
 
     m_batchAlgoRunner->addAlgorithm(sqwAlg, sqwInputProps);
 
@@ -116,7 +110,7 @@ namespace CustomInterfaces
 
     sampleLogAlg->setProperty("LogName", "rebin_type");
     sampleLogAlg->setProperty("LogType", "String");
-    sampleLogAlg->setProperty("LogText", rebinType.toStdString());
+    sampleLogAlg->setProperty("LogText", method.toStdString());
 
     BatchAlgorithmRunner::AlgorithmRuntimeProps inputToAddSampleLogProps;
     inputToAddSampleLogProps["Workspace"] = sqwWsName.toStdString();

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
@@ -467,8 +467,8 @@ Input
   Allows you to select a reduced NeXus file (*_red.nxs*) or workspace (*_red*) as the
   input to the algorithm.
 
-Rebin Type
-  Selects the SofQW algorithm that will be used.
+Method
+  Selects the :ref:`SofQW <algm-SofQW>` method that will be used.
 
 Q Low, Q Width & Q High
   Q binning parameters that are passed to the SofQW algorithm.


### PR DESCRIPTION
Fixes #12770.

To test:
- Open IDR, S(Q, w)
- Load an IRIS reduced (`_red`) file (there are some in system test data)
- Q binning: 0.4,0.1,1.8
- E binning: -0.5,0.01,0.5
- Run with both types, see that the correct algorithm is run (check the logs for the `SofQW` algorithm)

Release notes changes [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24237&oldid=24234).
