### PR TITLE
Expose fit parameters in JumpFit UI

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
@@ -94,6 +94,11 @@ namespace CustomInterfaces
     /// Add a SaveNexusProcessed step to the batch queue
     void addSaveWorkspaceToQueue(const QString & wsName, const QString & filename = "");
 
+    /// Gets the workspace suffix of a workspace name
+    QString getWorkspaceSuffix(const QString & wsName);
+    /// Gets the base name of a workspace
+    QString getWorkspaceBasename(const QString & wsName);
+
     /// Plot a spectrum plot with a given spectrum index
     void plotSpectrum(const QStringList & workspaceNames, int specIndex = 0);
     /// Plot a spectrum plot of a given workspace

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -37,8 +37,13 @@ private slots:
   void plotFitResult(bool error);
   /// Handles running preview algorithm
   void runPreviewAlgorithm();
+  /// Handles a fit algorithm being selected
+  void fitFunctionSelected(const QString & functionName);
 
 private:
+  /// Gets a list of parameter names for a given fit function
+  QStringList getFunctionParameters(const QString & functionName);
+
   // The UI form
   Ui::JumpFit m_uiForm;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -4,52 +4,50 @@
 #include "ui_JumpFit.h"
 #include "IndirectBayesTab.h"
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
-		class DLLExport JumpFit : public IndirectBayesTab
-		{
-			Q_OBJECT
+namespace MantidQt {
+namespace CustomInterfaces {
+class DLLExport JumpFit : public IndirectBayesTab {
+  Q_OBJECT
 
-		public:
-			JumpFit(QWidget * parent = 0);
+public:
+  JumpFit(QWidget *parent = 0);
 
-			// Inherited methods from IndirectBayesTab
-      void setup();
-			bool validate();
-			void run();
-      void runImpl(bool plot = false, bool save = false);
-			/// Load default settings into the interface
-			void loadSettings(const QSettings& settings);
+  // Inherited methods from IndirectBayesTab
+  void setup();
+  bool validate();
+  void run();
+  void runImpl(bool plot = false, bool save = false);
+  /// Load default settings into the interface
+  void loadSettings(const QSettings &settings);
 
-		private slots:
-			/// Handle when the sample input is ready
-			void handleSampleInputReady(const QString& filename);
-			/// Slot to handle plotting a different spectrum of the workspace
-			void handleWidthChange(const QString& text);
-			/// Slot for when the range on the range selector changes
-			void qRangeChanged(double min, double max);
-			/// Slot to update the guides when the range properties change
-			void updateProperties(QtProperty* prop, double val);
-			/// Find all spectra with width data in the workspace
-			void findAllWidths(Mantid::API::MatrixWorkspace_const_sptr ws);
-      /// Handles plotting results of algorithm on miniplot
-      void fitAlgDone(bool error);
-      /// Handles running preview algorithm
-      void runPreviewAlgorithm();
+private slots:
+  /// Handle when the sample input is ready
+  void handleSampleInputReady(const QString &filename);
+  /// Slot to handle plotting a different spectrum of the workspace
+  void handleWidthChange(const QString &text);
+  /// Slot for when the range on the range selector changes
+  void qRangeChanged(double min, double max);
+  /// Slot to update the guides when the range properties change
+  void updateProperties(QtProperty *prop, double val);
+  /// Find all spectra with width data in the workspace
+  void findAllWidths(Mantid::API::MatrixWorkspace_const_sptr ws);
+  /// Handles plotting results of algorithm on miniplot
+  void fitAlgDone(bool error);
+  /// Handles plotting fit result in MantidPlot
+  void plotFitResult(bool error);
+  /// Handles running preview algorithm
+  void runPreviewAlgorithm();
 
-		private:
-			// The UI form
-			Ui::JumpFit m_uiForm;
+private:
+  // The UI form
+  Ui::JumpFit m_uiForm;
 
-			// Map of axis labels to spectrum number
-			std::map<std::string, int> m_spectraList;
+  // Map of axis labels to spectrum number
+  std::map<std::string, int> m_spectraList;
 
-      Mantid::API::IAlgorithm_sptr fitAlg;
-
-		};
-	} // namespace CustomInterfaces
+  Mantid::API::IAlgorithm_sptr m_fitAlg;
+};
+} // namespace CustomInterfaces
 } // namespace MantidQt
 
 #endif

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -38,11 +38,11 @@ private slots:
   /// Handles running preview algorithm
   void runPreviewAlgorithm();
   /// Handles a fit algorithm being selected
-  void fitFunctionSelected(const QString & functionName);
+  void fitFunctionSelected(const QString &functionName);
 
 private:
   /// Gets a list of parameter names for a given fit function
-  QStringList getFunctionParameters(const QString & functionName);
+  QStringList getFunctionParameters(const QString &functionName);
 
   // The UI form
   Ui::JumpFit m_uiForm;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
@@ -53,22 +53,22 @@
       <widget class="QComboBox" name="cbFunction">
        <item>
         <property name="text">
-         <string>Chudley-Elliott</string>
+         <string>ChudleyElliot</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Hall-Ross</string>
+         <string>HallRoss</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Fick Diffusion</string>
+         <string>FickDiffusion</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Teixeira Water</string>
+         <string>TeixeiraWater</string>
         </property>
        </item>
       </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -183,6 +183,40 @@ namespace CustomInterfaces
 
 
   /**
+   * Gets the suffix of a workspace (i.e. part after last underscore (red, sqw)).
+   *
+   * @param wsName Name of workspace
+   * @return Suffix, or empty string if no underscore
+   */
+  QString IndirectTab:: getWorkspaceSuffix(const QString & wsName)
+  {
+    int lastUnderscoreIndex = wsName.lastIndexOf("_");
+    if(lastUnderscoreIndex == -1)
+      return QString();
+
+    return wsName.right(lastUnderscoreIndex);
+  }
+
+
+  /**
+   * Returns the basename of a workspace (i.e. the part before the last underscore)
+   *
+   * e.g. basename of irs26176_graphite002_red is irs26176_graphite002
+   *
+   * @param wsName Name of workspace
+   * @return Base name, or wsName if no underscore
+   */
+  QString IndirectTab:: getWorkspaceBasename(const QString & wsName)
+  {
+    int lastUnderscoreIndex = wsName.lastIndexOf("_");
+    if(lastUnderscoreIndex == -1)
+      return QString(wsName);
+
+    return wsName.left(lastUnderscoreIndex);
+  }
+
+
+  /**
    * Creates a spectrum plot of one or more workspaces at a given spectrum
    * index.
    *
@@ -239,7 +273,7 @@ namespace CustomInterfaces
     pyInput += "'], range(";
     pyInput += QString::number(specStart);
     pyInput += ",";
-    pyInput += QString::number(specEnd);
+    pyInput += QString::number(specEnd + 1);
     pyInput += "))\n";
 
     m_pythonRunner.runPythonCode(pyInput);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -9,350 +9,338 @@
 
 using namespace Mantid::API;
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
-		JumpFit::JumpFit(QWidget * parent) :
-			IndirectBayesTab(parent)
-		{
-			m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+JumpFit::JumpFit(QWidget *parent) : IndirectBayesTab(parent) {
+  m_uiForm.setupUi(parent);
 
-      // Create range selector
-      auto qRangeSelector = m_uiForm.ppPlot->addRangeSelector("JumpFitQ");
-      connect(qRangeSelector, SIGNAL(selectionChangedLazy(double, double)), this, SLOT(qRangeChanged(double, double)));
+  // Create range selector
+  auto qRangeSelector = m_uiForm.ppPlot->addRangeSelector("JumpFitQ");
+  connect(qRangeSelector, SIGNAL(selectionChangedLazy(double, double)), this,
+          SLOT(qRangeChanged(double, double)));
 
-			// Add the properties browser to the ui form
-			m_uiForm.treeSpace->addWidget(m_propTree);
+  // Add the properties browser to the ui form
+  m_uiForm.treeSpace->addWidget(m_propTree);
 
-			m_properties["QMin"] = m_dblManager->addProperty("QMin");
-			m_properties["QMax"] = m_dblManager->addProperty("QMax");
+  m_properties["QMin"] = m_dblManager->addProperty("QMin");
+  m_properties["QMax"] = m_dblManager->addProperty("QMax");
 
-			m_dblManager->setDecimals(m_properties["QMin"], NUM_DECIMALS);
-			m_dblManager->setDecimals(m_properties["QMax"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["QMin"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["QMax"], NUM_DECIMALS);
 
-			m_propTree->addProperty(m_properties["QMin"]);
-			m_propTree->addProperty(m_properties["QMax"]);
+  m_propTree->addProperty(m_properties["QMin"]);
+  m_propTree->addProperty(m_properties["QMax"]);
 
-			m_uiForm.cbWidth->setEnabled(false);
+  m_uiForm.cbWidth->setEnabled(false);
 
-			// Connect data selector to handler method
-			connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString&)), this, SLOT(handleSampleInputReady(const QString&)));
-			// Connect width selector to handler method
-			connect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(handleWidthChange(const QString&)));
+  // Connect data selector to handler method
+  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
+          SLOT(handleSampleInputReady(const QString &)));
+  // Connect width selector to handler method
+  connect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString &)), this,
+          SLOT(handleWidthChange(const QString &)));
 
-      // Connect algorithm runner to completion handler function
-      connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(fitAlgDone(bool)));
-		}
+  // Connect algorithm runner to completion handler function
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(fitAlgDone(bool)));
+}
 
-    void JumpFit::setup()
-    {
-    }
+void JumpFit::setup() {}
 
-		/**
-		 * Validate the form to check the program can be run
-		 *
-		 * @return :: Whether the form was valid
-		 */
-		bool JumpFit::validate()
-		{
-			UserInputValidator uiv;
-			uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+/**
+ * Validate the form to check the program can be run
+ *
+ * @return :: Whether the form was valid
+ */
+bool JumpFit::validate() {
+  UserInputValidator uiv;
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
 
-			//this workspace doesn't have any valid widths
-			if(m_spectraList.size() == 0)
-			{
-				uiv.addErrorMessage("Input workspace doesn't appear to contain any width data.");
-			}
+  // this workspace doesn't have any valid widths
+  if (m_spectraList.size() == 0) {
+    uiv.addErrorMessage(
+        "Input workspace doesn't appear to contain any width data.");
+  }
 
-			QString errors = uiv.generateErrorMessage();
-			if (!errors.isEmpty())
-			{
-				emit showMessageBox(errors);
-				return false;
-			}
+  QString errors = uiv.generateErrorMessage();
+  if (!errors.isEmpty()) {
+    emit showMessageBox(errors);
+    return false;
+  }
 
-			return true;
-		}
+  return true;
+}
 
-		/**
-		 * Collect the settings on the GUI and build a python
-		 * script that runs JumpFit
-		 */
-		void JumpFit::run()
-		{
-			bool save = m_uiForm.chkSave->isChecked();
-			bool plot = m_uiForm.chkPlot->isChecked();
+/**
+ * Collect the settings on the GUI and build a python
+ * script that runs JumpFit
+ */
+void JumpFit::run() {
+  bool save = m_uiForm.chkSave->isChecked();
+  bool plot = m_uiForm.chkPlot->isChecked();
 
-      runImpl(plot, save);
-		}
+  runImpl(plot, save);
+}
 
-    /**
-     * Runs the JumpFit algorithm with preview parameters to update the preview plot.
-     */
-    void JumpFit::runPreviewAlgorithm()
-    {
-      runImpl();
-    }
+/**
+ * Runs the JumpFit algorithm with preview parameters to update the preview
+ * plot.
+ */
+void JumpFit::runPreviewAlgorithm() { runImpl(); }
 
-    /**
-     * Runs algorithm.
-     *
-     * @param plot Enable/disable plotting
-     * @param save Enable/disable saving
-     */
-    void JumpFit::runImpl(bool plot, bool save)
-    {
-      // Do noting with invalid data
-			if(!m_uiForm.dsSample->isValid())
+/**
+ * Runs algorithm.
+ *
+ * @param plot Enable/disable plotting
+ * @param save Enable/disable saving
+ */
+void JumpFit::runImpl(bool plot, bool save) {
+  // Do noting with invalid data
+  if (!m_uiForm.dsSample->isValid())
+    return;
+
+  // Fit function to use
+  QString functionName = m_uiForm.cbFunction->currentText();
+  QString functionString = "name=" + functionName;
+  switch (m_uiForm.cbFunction->currentIndex()) {
+  case 0:
+    functionString += ",Tau=1.0,L=1.5";
+    break;
+  case 1:
+    functionString += ",Tau=1.0,L=1.5";
+    break;
+  case 2:
+    functionString += ",D=1.5";
+    break;
+  case 3:
+    functionString += ",Tau=1.0,L=1.5";
+    break;
+  }
+
+  std::string widthText = m_uiForm.cbWidth->currentText().toStdString();
+  int width = m_spectraList[widthText];
+  QString sample = m_uiForm.dsSample->getCurrentDataName();
+  QString outputName = sample + "_" + functionName + "_fit";
+
+  fitAlg = AlgorithmManager::Instance().create("Fit");
+  fitAlg->initialize();
+
+  fitAlg->setProperty("Function", functionString.toStdString());
+  fitAlg->setProperty("InputWorkspace", sample.toStdString());
+  fitAlg->setProperty("WorkspaceIndex", width);
+  fitAlg->setProperty("IgnoreInvalidData", true);
+  fitAlg->setProperty("StartX", m_dblManager->value(m_properties["QMin"]));
+  fitAlg->setProperty("EndX", m_dblManager->value(m_properties["QMax"]));
+  fitAlg->setProperty("CreateOutput", true);
+  fitAlg->setProperty("Output", outputName.toStdString());
+
+  if (m_batchAlgoRunner->queueLength() < 1) {
+    m_batchAlgoRunner->addAlgorithm(fitAlg);
+
+    m_batchAlgoRunner->executeBatchAsync();
+  }
+}
+
+/**
+ * Handles the JumpFit algorithm finishing, used to plot fit in miniplot.
+ *
+ * @param error True if the algorithm failed, false otherwise
+ */
+void JumpFit::fitAlgDone(bool error) {
+  // Ignore errors
+  if (error)
+    return;
+
+  std::string outWsName = fitAlg->getPropertyValue("Output") + "_Workspace";
+  MatrixWorkspace_sptr outputWorkspace =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWsName);
+  TextAxis *axis = dynamic_cast<TextAxis *>(outputWorkspace->getAxis(1));
+
+  for (unsigned int histIndex = 0;
+       histIndex < outputWorkspace->getNumberHistograms(); histIndex++) {
+    QString specName = QString::fromStdString(axis->label(histIndex));
+
+    if (specName == "Calc")
+      m_uiForm.ppPlot->addSpectrum("Fit", outputWorkspace, histIndex, Qt::red);
+
+    if (specName == "Diff")
+      m_uiForm.ppPlot->addSpectrum("Diff", outputWorkspace, histIndex,
+                                   Qt::green);
+  }
+}
+
+/**
+ * Set the data selectors to use the default save directory
+ * when browsing for input files.
+ *
+* @param settings :: The current settings
+ */
+void JumpFit::loadSettings(const QSettings &settings) {
+  m_uiForm.dsSample->readSettings(settings.group());
+}
+
+/**
+ * Plots the loaded file to the miniplot and sets the guides
+ * and the range
+ *
+ * @param filename :: The name of the workspace to plot
+ */
+void JumpFit::handleSampleInputReady(const QString &filename) {
+  // Disable things that run the preview algorithm
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(runPreviewAlgorithm()));
+  disconnect(m_uiForm.cbFunction, SIGNAL(currentIndexChanged(const QString &)),
+             this, SLOT(runPreviewAlgorithm()));
+  disconnect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString &)),
+             this, SLOT(runPreviewAlgorithm()));
+
+  // Scale to convert to HWHM
+  IAlgorithm_sptr scaleAlg = AlgorithmManager::Instance().create("Scale");
+  scaleAlg->initialize();
+  scaleAlg->setProperty("InputWorkspace", filename.toStdString());
+  scaleAlg->setProperty("OutputWorkspace", filename.toStdString());
+  scaleAlg->setProperty("Factor", 0.5);
+  scaleAlg->execute();
+
+  auto ws = Mantid::API::AnalysisDataService::Instance().retrieve(
+      filename.toStdString());
+  auto mws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
+
+  findAllWidths(mws);
+
+  auto qRangeSelector = m_uiForm.ppPlot->getRangeSelector("JumpFitQ");
+
+  if (m_spectraList.size() > 0) {
+    m_uiForm.cbWidth->setEnabled(true);
+
+    std::string currentWidth = m_uiForm.cbWidth->currentText().toStdString();
+
+    m_uiForm.ppPlot->clear();
+    m_uiForm.ppPlot->addSpectrum("Sample", filename,
+                                 m_spectraList[currentWidth]);
+
+    QPair<double, double> res;
+    QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
+
+    // Use the values from the instrument parameter file if we can
+    if (getInstrumentResolution(filename, res))
+      setRangeSelector(qRangeSelector, m_properties["QMin"],
+                       m_properties["QMax"], res);
+    else
+      setRangeSelector(qRangeSelector, m_properties["QMin"],
+                       m_properties["QMax"], range);
+
+    setPlotPropertyRange(qRangeSelector, m_properties["QMin"],
+                         m_properties["QMax"], range);
+  } else {
+    m_uiForm.cbWidth->setEnabled(false);
+    emit showMessageBox("Workspace doesn't appear to contain any width data");
+  }
+
+  // Update preview plot
+  runPreviewAlgorithm();
+
+  // Re-enable things that run the preview algorithm
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(runPreviewAlgorithm()));
+  connect(m_uiForm.cbFunction, SIGNAL(currentIndexChanged(const QString &)),
+          this, SLOT(runPreviewAlgorithm()));
+  connect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString &)), this,
+          SLOT(runPreviewAlgorithm()));
+}
+
+/**
+ * Find all of the spectra in the workspace that have width data
+ *
+ * @param ws :: The workspace to search
+ */
+void JumpFit::findAllWidths(Mantid::API::MatrixWorkspace_const_sptr ws) {
+  m_uiForm.cbWidth->clear();
+  m_spectraList.clear();
+
+  for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
+    auto axis = dynamic_cast<Mantid::API::TextAxis *>(ws->getAxis(1));
+    if (!axis)
+      return;
+
+    std::string title = axis->label(i);
+
+    // check if the axis labels indicate this spectrum is width data
+    size_t qLinesWidthIndex = title.find(".Width");
+    size_t convFitWidthIndex = title.find(".FWHM");
+
+    bool qLinesWidth = qLinesWidthIndex != std::string::npos;
+    bool convFitWidth = convFitWidthIndex != std::string::npos;
+
+    // if we get a match, add this spectrum to the combobox
+    if (convFitWidth || qLinesWidth) {
+      std::string cbItemName = "";
+      size_t substrIndex = 0;
+
+      if (qLinesWidth) {
+        substrIndex = qLinesWidthIndex;
+      } else if (convFitWidth) {
+        substrIndex = convFitWidthIndex;
+      }
+
+      cbItemName = title.substr(0, substrIndex);
+      m_spectraList[cbItemName] = static_cast<int>(i);
+      m_uiForm.cbWidth->addItem(QString(cbItemName.c_str()));
+
+      // display widths f1.f1, f2.f1 and f2.f2
+      if (m_uiForm.cbWidth->count() == 3) {
         return;
-
-			// Fit function to use
-			QString fitFunction("ChudleyElliot");
-			switch(m_uiForm.cbFunction->currentIndex())
-			{
-				case 0:
-					fitFunction = "ChudleyElliot";
-					break;
-				case 1:
-					fitFunction = "HallRoss";
-					break;
-				case 2:
-					fitFunction = "FickDiffusion";
-					break;
-				case 3:
-					fitFunction = "TeixeiraWater";
-					break;
-			}
-
-      // Loaded workspace name
-			QString sample = m_uiForm.dsSample->getCurrentDataName();
-			auto ws = Mantid::API::AnalysisDataService::Instance().retrieve(sample.toStdString());
-
-			std::string widthText = m_uiForm.cbWidth->currentText().toStdString();
-      long width = m_spectraList[widthText];
-
-      fitAlg = AlgorithmManager::Instance().create("JumpFit");
-      fitAlg->initialize();
-
-      fitAlg->setProperty("InputWorkspace", ws);
-      fitAlg->setProperty("Function", fitFunction.toStdString());
-
-      fitAlg->setProperty("Width", width);
-      fitAlg->setProperty("QMin", m_dblManager->value(m_properties["QMin"]));
-      fitAlg->setProperty("QMax", m_dblManager->value(m_properties["QMax"]));
-
-      fitAlg->setProperty("Plot", plot);
-      fitAlg->setProperty("Save", save);
-
-      if(m_batchAlgoRunner->queueLength() < 1)
-        runAlgorithm(fitAlg);
-    }
-
-    /**
-     * Handles the JumpFit algorithm finishing, used to plot fit in miniplot.
-     *
-     * @param error True if the algorithm failed, false otherwise
-     */
-    void JumpFit::fitAlgDone(bool error)
-    {
-      // Ignore errors
-      if(error)
-        return;
-
-      std::string outWsName = fitAlg->getPropertyValue("Output") + "_Workspace";
-      MatrixWorkspace_sptr outputWorkspace = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWsName);
-      TextAxis* axis = dynamic_cast<TextAxis*>(outputWorkspace->getAxis(1));
-
-      for(unsigned int histIndex = 0; histIndex < outputWorkspace->getNumberHistograms(); histIndex++)
-      {
-        QString specName = QString::fromStdString(axis->label(histIndex));
-
-        if(specName == "Calc")
-          m_uiForm.ppPlot->addSpectrum("Fit", outputWorkspace, histIndex, Qt::red);
-
-        if(specName == "Diff")
-          m_uiForm.ppPlot->addSpectrum("Diff", outputWorkspace, histIndex, Qt::green);
       }
     }
+  }
+}
 
-		/**
-		 * Set the data selectors to use the default save directory
-		 * when browsing for input files.
-		 *
-     * @param settings :: The current settings
-		 */
-		void JumpFit::loadSettings(const QSettings& settings)
-		{
-			m_uiForm.dsSample->readSettings(settings.group());
-		}
+/**
+ * Plots the loaded file to the miniplot when the selected spectrum changes
+ *
+ * @param text :: The name spectrum index to plot
+ */
+void JumpFit::handleWidthChange(const QString &text) {
+  QString sampleName = m_uiForm.dsSample->getCurrentDataName();
+  QString samplePath = m_uiForm.dsSample->getFullFilePath();
 
-		/**
-		 * Plots the loaded file to the miniplot and sets the guides
-		 * and the range
-		 *
-		 * @param filename :: The name of the workspace to plot
-		 */
-		void JumpFit::handleSampleInputReady(const QString& filename)
-		{
-      // Disable things that run the preview algorithm
-      disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(runPreviewAlgorithm()));
-			disconnect(m_uiForm.cbFunction, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(runPreviewAlgorithm()));
-			disconnect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(runPreviewAlgorithm()));
-
-      // Scale to convert to HWHM
-      IAlgorithm_sptr scaleAlg = AlgorithmManager::Instance().create("Scale");
-      scaleAlg->initialize();
-      scaleAlg->setProperty("InputWorkspace", filename.toStdString());
-      scaleAlg->setProperty("OutputWorkspace", filename.toStdString());
-      scaleAlg->setProperty("Factor", 0.5);
-      scaleAlg->execute();
-
-			auto ws = Mantid::API::AnalysisDataService::Instance().retrieve(filename.toStdString());
-			auto mws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
-
-			findAllWidths(mws);
-
-      auto qRangeSelector = m_uiForm.ppPlot->getRangeSelector("JumpFitQ");
-
-			if(m_spectraList.size() > 0)
-			{
-				m_uiForm.cbWidth->setEnabled(true);
-
-				std::string currentWidth = m_uiForm.cbWidth->currentText().toStdString();
-
-        m_uiForm.ppPlot->clear();
-        m_uiForm.ppPlot->addSpectrum("Sample", filename, m_spectraList[currentWidth]);
-
-				QPair<double, double> res;
-				QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
-
-				// Use the values from the instrument parameter file if we can
-				if(getInstrumentResolution(filename, res))
-					setRangeSelector(qRangeSelector, m_properties["QMin"], m_properties["QMax"], res);
-				else
-					setRangeSelector(qRangeSelector, m_properties["QMin"], m_properties["QMax"], range);
-
-				setPlotPropertyRange(qRangeSelector, m_properties["QMin"], m_properties["QMax"], range);
-			}
-			else
-			{
-				m_uiForm.cbWidth->setEnabled(false);
-				emit showMessageBox("Workspace doesn't appear to contain any width data");
-			}
-
-      // Update preview plot
-      runPreviewAlgorithm();
-
-      // Re-enable things that run the preview algorithm
-      connect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(runPreviewAlgorithm()));
-			connect(m_uiForm.cbFunction, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(runPreviewAlgorithm()));
-			connect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(runPreviewAlgorithm()));
-		}
-
-		/**
-		 * Find all of the spectra in the workspace that have width data
-		 *
-		 * @param ws :: The workspace to search
-		 */
-		void JumpFit::findAllWidths(Mantid::API::MatrixWorkspace_const_sptr ws)
-		{
-			m_uiForm.cbWidth->clear();
-			m_spectraList.clear();
-
-			for (size_t i = 0; i < ws->getNumberHistograms(); ++i)
-			{
-				auto axis = dynamic_cast<Mantid::API::TextAxis*>(ws->getAxis(1));
-        if(!axis)
-          return;
-
-        std::string title = axis->label(i);
-
-				//check if the axis labels indicate this spectrum is width data
-				size_t qLinesWidthIndex = title.find(".Width");
-				size_t convFitWidthIndex = title.find(".FWHM");
-
-				bool qLinesWidth = qLinesWidthIndex != std::string::npos;
-				bool convFitWidth = convFitWidthIndex != std::string::npos;
-
-				//if we get a match, add this spectrum to the combobox
-				if(convFitWidth || qLinesWidth)
-				{
-					std::string cbItemName = "";
-					size_t substrIndex = 0;
-
-					if (qLinesWidth)
-					{
-						substrIndex = qLinesWidthIndex;
-					}
-					else if (convFitWidth)
-					{
-						substrIndex = convFitWidthIndex;
-					}
-
-					cbItemName = title.substr(0, substrIndex);
-					m_spectraList[cbItemName] = static_cast<int>(i);
-					m_uiForm.cbWidth->addItem(QString(cbItemName.c_str()));
-
-					//display widths f1.f1, f2.f1 and f2.f2
-					if (m_uiForm.cbWidth->count() == 3)
-					{
-						return;
-					}
-				}
-			}
-		}
-
-		/**
-		 * Plots the loaded file to the miniplot when the selected spectrum changes
-		 *
-		 * @param text :: The name spectrum index to plot
-		 */
-		void JumpFit::handleWidthChange(const QString& text)
-		{
-			QString sampleName = m_uiForm.dsSample->getCurrentDataName();
-			QString samplePath = m_uiForm.dsSample->getFullFilePath();
-
-			if(!sampleName.isEmpty() && m_spectraList.size() > 0)
-			{
-				if(validate())
-				{
-          m_uiForm.ppPlot->clear();
-          m_uiForm.ppPlot->addSpectrum("Sample", sampleName, m_spectraList[text.toStdString()]);
-				}
-			}
-		}
-
-		/**
-		 * Updates the property manager when the range selector is moved on the mini plot.
-		 *
-		 * @param min :: The new value of the lower guide
-		 * @param max :: The new value of the upper guide
-		 */
-		void JumpFit::qRangeChanged(double min, double max)
-    {
-      m_dblManager->setValue(m_properties["QMin"], min);
-			m_dblManager->setValue(m_properties["QMax"], max);
+  if (!sampleName.isEmpty() && m_spectraList.size() > 0) {
+    if (validate()) {
+      m_uiForm.ppPlot->clear();
+      m_uiForm.ppPlot->addSpectrum("Sample", sampleName,
+                                   m_spectraList[text.toStdString()]);
     }
+  }
+}
 
-		/**
-		 * Handles when properties in the property manager are updated.
-		 *
-		 * @param prop :: The property being updated
-		 * @param val :: The new value for the property
-		 */
-    void JumpFit::updateProperties(QtProperty* prop, double val)
-    {
-      auto qRangeSelector = m_uiForm.ppPlot->getRangeSelector("JumpFitQ");
+/**
+ * Updates the property manager when the range selector is moved on the mini
+ *plot.
+ *
+ * @param min :: The new value of the lower guide
+ * @param max :: The new value of the upper guide
+ */
+void JumpFit::qRangeChanged(double min, double max) {
+  m_dblManager->setValue(m_properties["QMin"], min);
+  m_dblManager->setValue(m_properties["QMax"], max);
+}
 
-    	if(prop == m_properties["QMin"])
-    	{
-    		updateLowerGuide(qRangeSelector, m_properties["QMin"], m_properties["QMax"], val);
-    	}
-    	else if (prop == m_properties["QMax"])
-    	{
-				updateUpperGuide(qRangeSelector, m_properties["QMin"], m_properties["QMax"], val);
-    	}
-    }
-	} // namespace CustomInterfaces
+/**
+ * Handles when properties in the property manager are updated.
+ *
+ * @param prop :: The property being updated
+ * @param val :: The new value for the property
+ */
+void JumpFit::updateProperties(QtProperty *prop, double val) {
+  auto qRangeSelector = m_uiForm.ppPlot->getRangeSelector("JumpFitQ");
+
+  if (prop == m_properties["QMin"]) {
+    updateLowerGuide(qRangeSelector, m_properties["QMin"], m_properties["QMax"],
+                     val);
+  } else if (prop == m_properties["QMax"]) {
+    updateUpperGuide(qRangeSelector, m_properties["QMin"], m_properties["QMax"],
+                     val);
+  }
+}
+} // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -103,6 +103,7 @@ void JumpFit::runPreviewAlgorithm() { runImpl(); }
 /**
  * Runs algorithm.
  *
+ * @param plot Enable/disable plotting
  * @param save Enable/disable saving
  */
 void JumpFit::runImpl(bool plot, bool save) {
@@ -443,7 +444,7 @@ void JumpFit::fitFunctionSelected(const QString &functionName) {
   for (auto it = m_properties.begin(); it != m_properties.end();) {
     if (it.key().startsWith("parameter_")) {
       delete it.value();
-      m_properties.erase(it);
+      it = m_properties.erase(it);
     } else {
       ++it;
     }

--- a/Code/Mantid/docs/source/interfaces/Indirect_Bayes.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_Bayes.rst
@@ -11,7 +11,7 @@ Overview
   :align: right
   :width: 350
 
-TODO
+Provides Bayesian analysis routines primarily for use with QENS data.
 
 Action Buttons
 --------------
@@ -226,6 +226,10 @@ Width
 
 QMin & QMax
   The Q range to perform fitting within.
+
+Fitting Parameters
+  Provides the option to change the defautl fitting parameters passed to the
+  chosen function.
 
 Verbose
   Provides more information on the Results Log.


### PR DESCRIPTION
Fixes #12734.

To test:
- Open Indirect > Bayes > JumpFit
- Load `Babylon5/Public/DanNixon/data/cf_Result.nxs`
- Fit should be generated automatically and parameters updated in property browser
- Change the fit function

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24279&oldid=24276).
