### PR TITLE
Improve integration between point and space group

### DIFF
--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -3,6 +3,7 @@
 
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Crystal/Group.h"
+#include "MantidGeometry/Crystal/PointGroup.h"
 #include "MantidGeometry/Crystal/SymmetryOperation.h"
 #include "MantidKernel/V3D.h"
 
@@ -89,11 +90,13 @@ public:
 
   bool isAllowedReflection(const Kernel::V3D &hkl) const;
 
+  PointGroup_sptr getPointGroup();
   Group_const_sptr getSiteSymmetryGroup(const Kernel::V3D &position) const;
 
 protected:
   size_t m_number;
   std::string m_hmSymbol;
+  std::string m_pointGroupSymbol;
 };
 
 typedef boost::shared_ptr<SpaceGroup> SpaceGroup_sptr;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -89,6 +89,8 @@ public:
 
   bool isAllowedReflection(const Kernel::V3D &hkl) const;
 
+  Group_const_sptr getSiteSymmetryGroup(const Kernel::V3D &position) const;
+
 protected:
   size_t m_number;
   std::string m_hmSymbol;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroup.h
@@ -90,13 +90,12 @@ public:
 
   bool isAllowedReflection(const Kernel::V3D &hkl) const;
 
-  PointGroup_sptr getPointGroup();
+  PointGroup_sptr getPointGroup() const;
   Group_const_sptr getSiteSymmetryGroup(const Kernel::V3D &position) const;
 
 protected:
   size_t m_number;
   std::string m_hmSymbol;
-  std::string m_pointGroupSymbol;
 };
 
 typedef boost::shared_ptr<SpaceGroup> SpaceGroup_sptr;

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroupFactory.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SpaceGroupFactory.h
@@ -12,7 +12,7 @@ namespace Mantid {
 namespace Geometry {
 
 bool MANTID_GEOMETRY_DLL
-    isValidGeneratorString(const std::string &generatorString);
+isValidGeneratorString(const std::string &generatorString);
 
 /**
  * @class AbstractSpaceGroupGenerator
@@ -58,7 +58,7 @@ private:
 };
 
 typedef boost::shared_ptr<AbstractSpaceGroupGenerator>
-    AbstractSpaceGroupGenerator_sptr;
+AbstractSpaceGroupGenerator_sptr;
 
 /// Concrete space group generator that uses space group generators as given in
 /// ITA.
@@ -142,6 +142,9 @@ public:
   std::vector<std::string> subscribedSpaceGroupSymbols(size_t number) const;
   std::vector<size_t> subscribedSpaceGroupNumbers() const;
 
+  std::vector<std::string>
+  subscribedSpaceGroupSymbols(const PointGroup_sptr &pointGroup);
+
   void unsubscribeSpaceGroup(const std::string &hmSymbol);
 
   void subscribeGeneratedSpaceGroup(size_t number, const std::string &hmSymbol,
@@ -171,8 +174,11 @@ protected:
   SpaceGroup_const_sptr
   constructFromPrototype(const SpaceGroup_const_sptr prototype) const;
 
+  void fillPointGroupMap();
+
   std::multimap<size_t, std::string> m_numberMap;
   std::map<std::string, AbstractSpaceGroupGenerator_sptr> m_generatorMap;
+  std::multimap<std::string, std::string> m_pointGroupMap;
 
   SpaceGroupFactoryImpl();
 
@@ -183,11 +189,11 @@ private:
 // This is taken from FuncMinimizerFactory
 #ifdef _WIN32
 template class MANTID_GEOMETRY_DLL
-    Mantid::Kernel::SingletonHolder<SpaceGroupFactoryImpl>;
+Mantid::Kernel::SingletonHolder<SpaceGroupFactoryImpl>;
 #endif
 
 typedef Mantid::Kernel::SingletonHolder<SpaceGroupFactoryImpl>
-    SpaceGroupFactory;
+SpaceGroupFactory;
 
 } // namespace Geometry
 } // namespace Mantid

--- a/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryElement.h
+++ b/Code/Mantid/Framework/Geometry/inc/MantidGeometry/Crystal/SymmetryElement.h
@@ -175,7 +175,8 @@ class MANTID_GEOMETRY_DLL SymmetryElementRotation
 public:
   enum RotationSense {
     Positive,
-    Negative
+    Negative,
+    None
   };
 
   SymmetryElementRotation(const std::string &symbol, const V3R &axis,

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -19,13 +19,11 @@ using namespace Kernel;
  */
 SpaceGroup::SpaceGroup(size_t itNumber, const std::string &hmSymbol,
                        const Group &group)
-    : Group(group), m_number(itNumber), m_hmSymbol(hmSymbol),
-      m_pointGroupSymbol() {}
+    : Group(group), m_number(itNumber), m_hmSymbol(hmSymbol) {}
 
 /// Copy constructor
 SpaceGroup::SpaceGroup(const SpaceGroup &other)
-    : Group(other), m_number(other.m_number), m_hmSymbol(other.m_hmSymbol),
-      m_pointGroupSymbol(other.m_pointGroupSymbol) {}
+    : Group(other), m_number(other.m_number), m_hmSymbol(other.m_hmSymbol) {}
 
 /// Assignment operator, utilizes Group's assignment operator
 SpaceGroup &SpaceGroup::operator=(const SpaceGroup &other) {
@@ -33,7 +31,6 @@ SpaceGroup &SpaceGroup::operator=(const SpaceGroup &other) {
 
   m_number = other.m_number;
   m_hmSymbol = other.m_hmSymbol;
-  m_pointGroupSymbol = other.m_pointGroupSymbol;
 
   return *this;
 }
@@ -84,24 +81,13 @@ bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
  * Returns the point group of the space group
  *
  * This method uses PointGroupFactory to create the point group of the space-
- * group. To avoid parsing the space group symbol over and over again, the
- * point group symbol is stored for subsequent calls to this function. Because
- * the factory is used for construction, a new object is returned each time
- * this method is called.
+ * group. Becausethe factory is used for construction, a new object is returned
+ * each time this method is called.
  *
  * @return :: PointGroup-object.
  */
-PointGroup_sptr SpaceGroup::getPointGroup() {
-  if (m_pointGroupSymbol.empty()) {
-    PointGroup_sptr pointGroup =
-        PointGroupFactory::Instance().createPointGroupFromSpaceGroup(*this);
-
-    m_pointGroupSymbol = pointGroup->getSymbol();
-
-    return pointGroup;
-  }
-
-  return PointGroupFactory::Instance().createPointGroup(m_pointGroupSymbol);
+PointGroup_sptr SpaceGroup::getPointGroup() const {
+  return PointGroupFactory::Instance().createPointGroupFromSpaceGroup(*this);
 }
 
 /**

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -1,4 +1,5 @@
 #include "MantidGeometry/Crystal/SpaceGroup.h"
+#include "MantidGeometry/Crystal/PointGroupFactory.h"
 
 namespace Mantid {
 namespace Geometry {
@@ -18,11 +19,13 @@ using namespace Kernel;
  */
 SpaceGroup::SpaceGroup(size_t itNumber, const std::string &hmSymbol,
                        const Group &group)
-    : Group(group), m_number(itNumber), m_hmSymbol(hmSymbol) {}
+    : Group(group), m_number(itNumber), m_hmSymbol(hmSymbol),
+      m_pointGroupSymbol() {}
 
 /// Copy constructor
 SpaceGroup::SpaceGroup(const SpaceGroup &other)
-    : Group(other), m_number(other.m_number), m_hmSymbol(other.m_hmSymbol) {}
+    : Group(other), m_number(other.m_number), m_hmSymbol(other.m_hmSymbol),
+      m_pointGroupSymbol(other.m_pointGroupSymbol) {}
 
 /// Assignment operator, utilizes Group's assignment operator
 SpaceGroup &SpaceGroup::operator=(const SpaceGroup &other) {
@@ -30,6 +33,7 @@ SpaceGroup &SpaceGroup::operator=(const SpaceGroup &other) {
 
   m_number = other.m_number;
   m_hmSymbol = other.m_hmSymbol;
+  m_pointGroupSymbol = other.m_pointGroupSymbol;
 
   return *this;
 }
@@ -74,6 +78,30 @@ bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
   }
 
   return true;
+}
+
+/**
+ * Returns the point group of the space group
+ *
+ * This method uses PointGroupFactory to create the point group of the space-
+ * group. To avoid parsing the space group symbol over and over again, the
+ * point group symbol is stored for subsequent calls to this function. Because
+ * the factory is used for construction, a new object is returned each time
+ * this method is called.
+ *
+ * @return :: PointGroup-object.
+ */
+PointGroup_sptr SpaceGroup::getPointGroup() {
+  if (m_pointGroupSymbol.empty()) {
+    PointGroup_sptr pointGroup =
+        PointGroupFactory::Instance().createPointGroupFromSpaceGroup(*this);
+
+    m_pointGroupSymbol = pointGroup->getSymbol();
+
+    return pointGroup;
+  }
+
+  return PointGroupFactory::Instance().createPointGroup(m_pointGroupSymbol);
 }
 
 /**

--- a/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/SpaceGroup.cpp
@@ -76,5 +76,30 @@ bool SpaceGroup::isAllowedReflection(const Kernel::V3D &hkl) const {
   return true;
 }
 
+/**
+ * Returns the site symmetry group
+ *
+ * The site symmetry group contains all symmetry operations of a space group
+ * that leave a point unchanged. This method probes the symmetry operations
+ * of the space group and constructs a Group-object using them.
+ *
+ * @param position :: Coordinates of the site.
+ * @return :: Site symmetry group.
+ */
+Group_const_sptr SpaceGroup::getSiteSymmetryGroup(const V3D &position) const {
+  V3D wrappedPosition = Geometry::getWrappedVector(position);
+
+  std::vector<SymmetryOperation> siteSymmetryOps;
+
+  for (auto op = m_allOperations.begin(); op != m_allOperations.end(); ++op) {
+    if (Geometry::getWrappedVector((*op) * wrappedPosition) ==
+        wrappedPosition) {
+      siteSymmetryOps.push_back(*op);
+    }
+  }
+
+  return GroupFactory::create<Group>(siteSymmetryOps);
+}
+
 } // namespace Geometry
 } // namespace Mantid

--- a/Code/Mantid/Framework/Geometry/test/SpaceGroupFactoryTest.h
+++ b/Code/Mantid/Framework/Geometry/test/SpaceGroupFactoryTest.h
@@ -8,6 +8,7 @@
 using ::testing::Return;
 
 #include "MantidGeometry/Crystal/SpaceGroupFactory.h"
+#include "MantidGeometry/Crystal/PointGroupFactory.h"
 #include "MantidGeometry/Crystal/CyclicGroup.h"
 
 using namespace  Mantid::Geometry;
@@ -159,6 +160,24 @@ public:
 
         symbols = factory.subscribedSpaceGroupSymbols(2);
         TS_ASSERT_EQUALS(symbols.size(), 2);
+    }
+
+    void testSubscribedSpaceGroupSymbolsForPointGroup() {
+        PointGroup_sptr pg = PointGroupFactory::Instance().createPointGroup("-1");
+
+        TestableSpaceGroupFactory factory;
+
+        TS_ASSERT_EQUALS(factory.subscribedSpaceGroupSymbols(pg).size(), 0);
+        TS_ASSERT(factory.m_pointGroupMap.empty());
+
+        factory.subscribeTabulatedSpaceGroup(2, "P-1", "x,y,z; -x,-y,-z");
+        TS_ASSERT_EQUALS(factory.subscribedSpaceGroupSymbols(pg).size(), 1);
+        TS_ASSERT(!factory.m_pointGroupMap.empty());
+
+        factory.subscribeTabulatedSpaceGroup(2, "F-1", "x,y,z; -x,-y,-z");
+        TS_ASSERT(factory.m_pointGroupMap.empty());
+        TS_ASSERT_EQUALS(factory.subscribedSpaceGroupSymbols(pg).size(), 2);
+        TS_ASSERT(!factory.m_pointGroupMap.empty());
     }
 
     void testUnsubscribeSymbol()

--- a/Code/Mantid/Framework/Geometry/test/SpaceGroupTest.h
+++ b/Code/Mantid/Framework/Geometry/test/SpaceGroupTest.h
@@ -87,7 +87,7 @@ public:
         "-y,x-y,z; y,x,-z; -x,-y,-z");
     Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
 
-    SpaceGroup spaceGroup(167, "R-3c", *(group * centering));
+    SpaceGroup spaceGroup(166, "R-3m", *(group * centering));
 
     std::vector<V3D> byOperator = spaceGroup * V3D(0.5, 0.0, 0.0);
     for (size_t i = 0; i < byOperator.size(); ++i) {
@@ -110,13 +110,13 @@ public:
     /* This is just a check that isAllowedReflection behaves correctly,
      * there is a system test in place that checks more examples.
      *
-     * This test uses space group 167, R-3c, like above.
+     * This test uses space group 166, R-3m, like above.
      */
     Group_const_sptr group = GroupFactory::create<ProductOfCyclicGroups>(
         "-y,x-y,z; y,x,-z; -x,-y,-z");
     Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
 
-    SpaceGroup spaceGroup(167, "R-3c", *(group * centering));
+    SpaceGroup spaceGroup(166, "R-3m", *(group * centering));
 
     // Reflections hkl: -h + k + l = 3n
     V3D goodHKL(1, 4, 3); // -1 + 4 + 3 = 6 = 3 * 2
@@ -138,7 +138,7 @@ public:
 
     // Reflections h-hl: h + l = 3n
     V3D goodHmHL(3, -3, 6); // 3 + 9 = 9 = 3 * 3
-    V3D badHmHL(3, -3, 7); // 3 + 7 = 10
+    V3D badHmHL(3, -3, 7);  // 3 + 7 = 10
     TS_ASSERT(spaceGroup.isAllowedReflection(goodHmHL));
     TS_ASSERT(!spaceGroup.isAllowedReflection(badHmHL));
 
@@ -155,7 +155,82 @@ public:
     TS_ASSERT(!spaceGroup.isAllowedReflection(badHH0));
   }
 
+  void testSiteSymmetryGroupR3c() {
+    /* Like the test above, this test checks that getSiteSymmetryGroup works
+     * correctly. A system test checks different space groups and different
+     * positions.
+     *
+     * This test uses space group 167, R-3c. Reference data from
+     *
+     * The Bilbao Crystallographic Server
+     * (http://www.cryst.ehu.es/cgi-bin/cryst/programs//find_comp_op)
+     *
+     * M. I. Aroyo et al, "Crystallography online: Bilbao Crystallographic
+     * Server" Bulg. Chem. Commun. 43(2) 183-197 (2011).
+     *
+     * M. I. Aroyo et al, "Bilbao Crystallographic Server I: Databases and
+     * crystallographic computing programs" Z. Krist. 221, 1, 15-27 (2006)
+     *
+     * M. I. Aroyo et al, "Bilbao Crystallographic Server II: Representations
+     * of crystallographic point groups and space groups"
+     * Acta Cryst. A62, 115-128 (2006)
+     */
+    Group_const_sptr group = GroupFactory::create<ProductOfCyclicGroups>(
+        "-y,x-y,z; y,x,-z+1/2; -x,-y,-z");
+    Group_const_sptr centering = GroupFactory::create<CenteringGroup>("R");
+
+    SpaceGroup spaceGroup(167, "R-3c", *(group * centering));
+    size_t sgOrder = spaceGroup.order();
+
+    // Position 6a
+    V3D w6a(0, 0, 1. / 4.);
+    Group_const_sptr siteSymmGrp6a = spaceGroup.getSiteSymmetryGroup(w6a);
+    checkSiteSymmetryGroupPositions(w6a, siteSymmGrp6a, "6a", sgOrder / 6);
+
+    // 6b
+    V3D w6b(0, 0, 0);
+    Group_const_sptr siteSymmGrp6b = spaceGroup.getSiteSymmetryGroup(w6b);
+    checkSiteSymmetryGroupPositions(w6b, siteSymmGrp6b, "6b", sgOrder / 6);
+
+    // 12c
+    V3D w12c(0, 0, 0.342352);
+    Group_const_sptr siteSymmGrp12c = spaceGroup.getSiteSymmetryGroup(w12c);
+    checkSiteSymmetryGroupPositions(w12c, siteSymmGrp12c, "12c", sgOrder / 12);
+
+    // 18d
+    V3D w18d(1. / 2., 0, 0);
+    Group_const_sptr siteSymmGrp18d = spaceGroup.getSiteSymmetryGroup(w18d);
+    checkSiteSymmetryGroupPositions(w18d, siteSymmGrp18d, "18d", sgOrder / 18);
+
+    // 18e
+    V3D w18e(0.32411, 0, 1. / 4.);
+    Group_const_sptr siteSymmGrp18e = spaceGroup.getSiteSymmetryGroup(w18e);
+    checkSiteSymmetryGroupPositions(w18e, siteSymmGrp18e, "18e", sgOrder / 18);
+
+    // 36f
+    V3D w36f(0.32411, 0.73232, 0.5232);
+    Group_const_sptr siteSymmGrp36f = spaceGroup.getSiteSymmetryGroup(w36f);
+    checkSiteSymmetryGroupPositions(w36f, siteSymmGrp36f, "36f", sgOrder / 36);
+  }
+
 private:
+  void checkSiteSymmetryGroupPositions(const V3D &position,
+                                       const Group_const_sptr &siteSymmGroup,
+                                       const std::string &wPosName,
+                                       size_t siteSymmGroupOrder) {
+    std::vector<V3D> equivalents = (*siteSymmGroup) * position;
+    for (auto eq = equivalents.begin(); eq != equivalents.end(); ++eq) {
+      TSM_ASSERT_EQUALS("Problem with Wyckoff-position " + wPosName +
+                            ". Expected " + position.toString() + ", got " +
+                            (*eq).toString() + ".",
+                        *eq, position);
+    }
+
+    TSM_ASSERT_EQUALS("Problem with Wyckoff-position " + wPosName +
+                          ", order of site symmetry group is incorrect.",
+                      siteSymmGroup->order(), siteSymmGroupOrder);
+  }
+
   class TestableSpaceGroup : public SpaceGroup {
     friend class SpaceGroupTest;
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -37,6 +37,17 @@ bool isAllowedReflection(SpaceGroup &self, const object &hkl) {
 
     return self.isAllowedReflection(hklV3d);
 }
+
+Mantid::Geometry::Group_sptr getSiteSymmetryGroup(
+        SpaceGroup &self,
+        const object &position) {
+    const Mantid::Kernel::V3D &posV3d = Converters::PyObjectToV3D(position)();
+
+    Mantid::Geometry::Group_sptr group = boost::const_pointer_cast<Group>(
+                self.getSiteSymmetryGroup(posV3d));
+
+    return group;
+}
 }
 
 void export_SpaceGroup() {
@@ -48,5 +59,6 @@ void export_SpaceGroup() {
       .def("getEquivalentPositions", &getEquivalentPositions,
            "Returns an array with all symmetry equivalents of the supplied "
            "HKL.")
-      .def("isAllowedReflection", &isAllowedReflection);
+      .def("isAllowedReflection", &isAllowedReflection)
+      .def("getSiteSymmetryGroup", &getSiteSymmetryGroup);
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -59,6 +59,11 @@ void export_SpaceGroup() {
       .def("getEquivalentPositions", &getEquivalentPositions,
            "Returns an array with all symmetry equivalents of the supplied "
            "HKL.")
-      .def("isAllowedReflection", &isAllowedReflection)
-      .def("getSiteSymmetryGroup", &getSiteSymmetryGroup);
+      .def("isAllowedReflection", &isAllowedReflection,
+           "Returns True if the supplied reflection is allowed with respect to "
+           "space group symmetry operations.")
+      .def("getPointGroup", &SpaceGroup::getPointGroup,
+           "Returns the point group of the space group.")
+      .def("getSiteSymmetryGroup", &getSiteSymmetryGroup,
+           "Returns the site symmetry group for supplied point coordinates.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -18,6 +18,12 @@ std::vector<std::string> spaceGroupSymbolsForNumber(SpaceGroupFactoryImpl &self,
   return self.subscribedSpaceGroupSymbols(number);
 }
 
+std::vector<std::string>
+spaceGroupSymbolsForPointGroup(SpaceGroupFactoryImpl &self,
+                               const PointGroup_sptr &pointGroup) {
+  return self.subscribedSpaceGroupSymbols(pointGroup);
+}
+
 bool isSubscribedSymbol(SpaceGroupFactoryImpl &self,
                         const std::string &symbol) {
   return self.isSubscribed(symbol);
@@ -51,6 +57,7 @@ void export_SpaceGroupFactory() {
       .def("subscribedSpaceGroupSymbols", &spaceGroupSymbolsForNumber,
            "Returns all space group symbols that are registered under the "
            "given number.")
+      .def("getSpaceGroupsForPointGroup", &spaceGroupSymbolsForPointGroup)
       .def("Instance", &SpaceGroupFactory::Instance,
            return_value_policy<reference_existing_object>(),
            "Returns a reference to the SpaceGroupFactory singleton")

--- a/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryElement.cpp
@@ -1,6 +1,7 @@
 #include "MantidGeometry/Crystal/SymmetryElement.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/enum.hpp>
 #include <boost/python/scope.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
@@ -13,19 +14,42 @@ Mantid::Kernel::V3D getAxis(SymmetryElement &self) {
     SymmetryElementWithAxis &axisElement =
         dynamic_cast<SymmetryElementWithAxis &>(self);
     return Mantid::Kernel::V3D(axisElement.getAxis());
-  } catch (std::bad_cast) {
+  }
+  catch (std::bad_cast) {
     return Mantid::Kernel::V3D(0, 0, 0);
+  }
+}
+
+SymmetryElementRotation::RotationSense getRotationSense(SymmetryElement &self) {
+  try {
+    SymmetryElementRotation &rotationElement =
+        dynamic_cast<SymmetryElementRotation &>(self);
+    return rotationElement.getRotationSense();
+  }
+  catch (std::bad_cast) {
+    return SymmetryElementRotation::None;
   }
 }
 }
 
 void export_SymmetryElement() {
-  register_ptr_to_python<boost::shared_ptr<SymmetryElement>>();
+  register_ptr_to_python<boost::shared_ptr<SymmetryElement> >();
+
   scope symmetryElementScope =
       class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init);
+
+  enum_<SymmetryElementRotation::RotationSense>("RotationSense")
+      .value("Positive", SymmetryElementRotation::Positive)
+      .value("Negative", SymmetryElementRotation::Negative)
+      .value("None", SymmetryElementRotation::None);
+
   class_<SymmetryElement, boost::noncopyable>("SymmetryElement", no_init)
       .def("getHMSymbol", &SymmetryElement::hmSymbol,
            "Returns the Hermann-Mauguin symbol for the element.")
       .def("getAxis", &getAxis, "Returns the symmetry axis or [0,0,0] for "
-                                "identiy, inversion and translations.");
+                                "identiy, inversion and translations.")
+      .def("getRotationSense", &getRotationSense,
+           "Returns the rotation sense"
+           "of a rotation axis or None"
+           "if the element is not a rotation.");
 }

--- a/Code/Mantid/Framework/PythonInterface/test/python/mantid/geometry/SymmetryElementTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/mantid/geometry/SymmetryElementTest.py
@@ -8,22 +8,39 @@ class SymmetryElementTest(unittest.TestCase):
     def test_creation_axis(self):
         symOp = SymmetryOperationFactory.createSymOp("x,y,-z")
         symEle = SymmetryElementFactory.createSymElement(symOp)
-	
-	self.assertEquals(symEle.getHMSymbol(), "m")
-	self.assertEquals(symEle.getAxis(), V3D(0,0,1))
-	
-	rotation = SymmetryOperationFactory.createSymOp("x,-y,-z")
+
+        self.assertEquals(symEle.getHMSymbol(), "m")
+        self.assertEquals(symEle.getAxis(), V3D(0,0,1))
+
+        rotation = SymmetryOperationFactory.createSymOp("x,-y,-z")
         rotationElement = SymmetryElementFactory.createSymElement(rotation)
-	
-	self.assertEquals(rotationElement.getHMSymbol(), "2")
-	self.assertEquals(rotationElement.getAxis(), V3D(1,0,0))
+
+        self.assertEquals(rotationElement.getHMSymbol(), "2")
+        self.assertEquals(rotationElement.getAxis(), V3D(1,0,0))
 
     def test_creation_no_axis(self):
         symOp = SymmetryOperationFactory.createSymOp("-x,-y,-z")
         symEle = SymmetryElementFactory.createSymElement(symOp)
-	
-	self.assertEquals(symEle.getHMSymbol(), "-1")
-	self.assertEquals(symEle.getAxis(), V3D(0,0,0))
+
+        self.assertEquals(symEle.getHMSymbol(), "-1")
+        self.assertEquals(symEle.getAxis(), V3D(0,0,0))
+
+    def test_creation_rotation(self):
+        symOpPlus = SymmetryOperationFactory.createSymOp("-y,x-y,z")
+        symElePlus = SymmetryElementFactory.createSymElement(symOpPlus)
+
+        self.assertEquals(symElePlus.getRotationSense(), SymmetryElement.RotationSense.Positive)
+
+        symOpMinus = SymmetryOperationFactory.createSymOp("-x+y,-x,z")
+        symEleMinus = SymmetryElementFactory.createSymElement(symOpMinus)
+
+        self.assertEquals(symEleMinus.getRotationSense(), SymmetryElement.RotationSense.Negative)
+
+    def test_creation_no_rotation(self):
+        symOpNone = SymmetryOperationFactory.createSymOp("-x,-y,-z")
+        symEleNone = SymmetryElementFactory.createSymElement(symOpNone)
+
+        self.assertEquals(symEleNone.getRotationSense(), SymmetryElement.RotationSense.None)
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupFactoryTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SpaceGroupFactoryTest.py
@@ -21,6 +21,8 @@ class SpaceGroupFactoryTest(stresstesting.MantidStressTest):
     def checkSpaceGroup(self, symbol):
         group = SpaceGroupFactory.createSpaceGroup(symbol)
 
+        self.checkPointGroupOfSpaceGroup(group)
+
         self.assertTrue(group.isGroup(),
                         ("Space group " + str(group.getNumber()) + " (" + symbol + ") does not "
                         "fulfill group axioms"))
@@ -38,9 +40,22 @@ class SpaceGroupFactoryTest(stresstesting.MantidStressTest):
         self.assertTrue(groupOperations == referenceOperations,
                         "Problem in space group " + str(group.getNumber()) + " (" + symbol + ")")
 
+    def checkPointGroupOfSpaceGroup(self, spaceGroup):
+        # Get all space group operations, remove translations - resulting group is the point group
+        allOperations = spaceGroup.getSymmetryOperationStrings()
+        translationMatcher = re.compile(r"(\-|\+)(\d\/\d)")
+        onlyMatrices = Group(';'.join([translationMatcher.sub('', x) for x in allOperations]))
+
+        pointGroup = spaceGroup.getPointGroup()
+
+        self.assertFalse(
+            set(onlyMatrices.getSymmetryOperationStrings()).isdisjoint(pointGroup.getSymmetryOperationStrings()),
+            ("Point group of space group " + spaceGroup.getHMSymbol() + " does not match group obtained from"
+            " matrices of symmetry operations."))
+
     def loadReferenceData(self):
         from mantid.api import FileFinder
-        # Reference data.
+        # Reference data, generated using sginfo (http://cci.lbl.gov/sginfo/)
         # Dictionary has a string set for each space group number.
         separatorMatcher = re.compile(r"(\d+)")
 

--- a/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
+++ b/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
@@ -283,24 +283,30 @@ The group contains three symmetry operations:
 
 An extended example below shows an algorithm to derive the site symmetry group.
 
-Furthermore, it is possible to create a PointGroup-object from a SpaceGroup object in order to obtain information about the crystal system and to perform the Miller index operations provided by PointGroup. For this, PointGroupFactory has a special method:
+Furthermore, it is possible to create a PointGroup-object from a SpaceGroup object in order to obtain information about the crystal system and to perform the Miller index operations provided by PointGroup. For this, PointGroupFactory has a special method, but the point group can also be conveniently created directly from the space group object:
 
 .. testcode:: ExPointGroupFromSpaceGroup
 
     from mantid.geometry import PointGroupFactory, SpaceGroupFactory
 
     # Create space group Fd-3m (for example silicon or diamond)
-    sg = SpaceGroupFactory.createSpaceGroup("F d -3 m")
-    
-    pg = PointGroupFactory.createPointGroupFromSpaceGroup(sg)
-    
-    print "Space group no.", sg.getNumber(), "has point group:", pg.getHMSymbol()
+    sg_diamond = SpaceGroupFactory.createSpaceGroup("F d -3 m")
+    pg_diamond = PointGroupFactory.createPointGroupFromSpaceGroup(sg_diamond)
+
+    print "Space group no.", sg_diamond.getNumber(), "has point group:", pg_diamond.getHMSymbol()
+
+    # Related space group F-43m (sphalerite)
+    sg_zincblende = SpaceGroupFactory.createSpaceGroup("F -4 3 m")
+    pg_zincblende = sg_zincblende.getPointGroup()
+
+    print "Space group no.", sg_zincblende.getNumber(), "has point group:", pg_zincblende.getHMSymbol()
     
 The script prints the point group of the space group in question:
     
 .. testoutput:: ExPointGroupFromSpaceGroup
 
     Space group no. 227 has point group: m-3m
+    Space group no. 216 has point group: -43m
     
 While PointGroup offers useful methods to handle reflections, some information can only be obtained from the space group. The presence of translational symmetry causes the contributions from symmetrically equivalent atoms to the structure factor of certain reflections to cancel out completely so that it can not be observed. These systematically absent reflections are characteristic for each space group, a fact that can be used to determine the space group from measured reflection intensities. The following script shows how to check a few reflections:
 

--- a/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
+++ b/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
@@ -238,7 +238,51 @@ Please note that for hexagonal and trigonal space groups, where translations of 
     2: [0.333333,0.666667,0.75]
     3: [0.666667,0.333333,0.25]
     4: [0.666667,0.333333,0.75]
-    
+
+Closely related to the generation of equivalent coordinates is the site symmetry group, which leaves a point unchanged:
+
+.. testcode:: ExSiteSymmetryGroupInBuilt
+
+    from mantid.geometry import SpaceGroupFactory, SymmetryElementFactory, SymmetryElement
+
+    def getFullElementSymbol(symmetryElement):
+    # Dictionary for mapping enum values to short strings
+        rotationSenseDict = {
+                                SymmetryElement.RotationSense.Positive: '+',
+                                SymmetryElement.RotationSense.Negative: '-',
+                                SymmetryElement.RotationSense.None: ''
+                            }
+        hmSymbol = element.getHMSymbol()
+        rotationSense = rotationSenseDict[element.getRotationSense()]
+        axis = str(element.getAxis())
+
+        return hmSymbol + rotationSense + ' ' + axis
+
+
+
+    sg = SpaceGroupFactory.createSpaceGroup("P 6/m")
+
+    position = [1./3., 2./3., 0.25]
+    siteSymmetryGroup = sg.getSiteSymmetryGroup(position)
+
+    print "Order of the site symmetry group:", siteSymmetryGroup.getOrder()
+    print "Group elements:"
+    for i, op in enumerate(siteSymmetryGroup.getSymmetryOperations()):
+        element = SymmetryElementFactory.createSymElement(op)
+        print str(i + 1) + ":", op.getIdentifier(), "(" + getFullElementSymbol(element) + ")"
+
+The group contains three symmetry operations:
+
+.. testoutput:: ExSiteSymmetryGroupInBuilt
+
+    Order of the site symmetry group: 3
+    Group elements:
+    1: -x+y,-x,z (3- [0,0,1])
+    2: -y,x-y,z (3+ [0,0,1])
+    3: x,y,z (1 [0,0,0])
+
+An extended example below shows an algorithm to derive the site symmetry group.
+
 Furthermore, it is possible to create a PointGroup-object from a SpaceGroup object in order to obtain information about the crystal system and to perform the Miller index operations provided by PointGroup. For this, PointGroupFactory has a special method:
 
 .. testcode:: ExPointGroupFromSpaceGroup

--- a/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
+++ b/Code/Mantid/docs/source/concepts/PointAndSpaceGroups.rst
@@ -307,7 +307,23 @@ The script prints the point group of the space group in question:
 
     Space group no. 227 has point group: m-3m
     Space group no. 216 has point group: -43m
-    
+
+Sometimes it's useful to reverse the above process - which is not exactly possible, because several space groups may map to the same point group. The space group factory does however provide a way to get all space group symbols that belong to a certain point group:
+
+.. testcode:: ExSpaceGroupFactoryPointGroup
+
+    from mantid.geometry import PointGroupFactory, SpaceGroupFactory
+
+    pg = PointGroupFactory.createPointGroup("m-3")
+
+    print "Space groups with point group m-3:", SpaceGroupFactory.getSpaceGroupsForPointGroup(pg)
+
+The example produces the following output:
+
+.. testoutput:: ExSpaceGroupFactoryPointGroup
+
+    Space groups with point group m-3: ['F d -3','F m -3','I a -3','I m -3','P a -3','P m -3','P n -3']
+
 While PointGroup offers useful methods to handle reflections, some information can only be obtained from the space group. The presence of translational symmetry causes the contributions from symmetrically equivalent atoms to the structure factor of certain reflections to cancel out completely so that it can not be observed. These systematically absent reflections are characteristic for each space group, a fact that can be used to determine the space group from measured reflection intensities. The following script shows how to check a few reflections:
 
 .. testcode:: ExSpaceGroupReflectionIsAllowed
@@ -507,7 +523,7 @@ Building on the example above which showed how to check whether a reflection is 
 
 .. testcode:: ExSpaceGroupCheck
 
-    from mantid.geometry import SpaceGroupFactory
+    from mantid.geometry import SpaceGroupFactory, PointGroupFactory
 
     # Small helper function that distinguishes three cases:
     #   0: The reflection is observed and allowed or not observed and not allowed
@@ -550,11 +566,10 @@ Building on the example above which showed how to check whether a reflection is 
     # Check space groups and store results in a list
     spaceGroupMatchList = []
 
-    # Cubic space groups start at number 195 and go to 230.
-    # Those that belong to Laue class m-3m start at 221, so 10 space groups need to be checked.
-    for n in range(221, 231):
-        # In this example only the first space group is used if more than one are registered for this number.
-        sgSymbol = SpaceGroupFactory.subscribedSpaceGroupSymbols(n)[0]
+    # As described above, point group m-3m is assumed
+    pg = PointGroupFactory.createPointGroup("m-3m")
+    possibleSpaceGroups = SpaceGroupFactory.getSpaceGroupsForPointGroup(pg)
+    for sgSymbol in possibleSpaceGroups:
         sgObject = SpaceGroupFactory.createSpaceGroup(sgSymbol)
 
         # For each (hkl, observed) pair obtain whether this matches the space group's conditions

--- a/Code/Mantid/docs/source/concepts/SymmetryGroups.rst
+++ b/Code/Mantid/docs/source/concepts/SymmetryGroups.rst
@@ -195,7 +195,7 @@ Symmetry elements
 
 Sometimes it's easier to describe symmetry in terms of the symmetry element that is associated to an operation. Several notation systems exist for these elements, but Hermann-Mauguin symbols are most commonly used in crystallography. Information on how to read these symbols can be found in ITA. Except identity, inversions and translations, all symmetry elements have a characteristic axis. In case of mirror and glide planes, this axis is perpendicular to the plane.
 
-Section 11.2 in the same book describes how to derive symmetry elements from matrix and vector pairs. The algorithms from that text are implemented in Mantid as well, so after a symmetry operation has been created using the factory, another factory can be used to generate the symmetry element corresponding to the operation. The resulting object can be queried for its Hermann-Mauguin symbol and its axis. For identity, inversion and translation this returns ``[0, 0, 0]``.
+Section 11.2 in the same book describes how to derive symmetry elements from matrix and vector pairs. The algorithms from that text are implemented in Mantid as well, so after a symmetry operation has been created using the factory, another factory can be used to generate the symmetry element corresponding to the operation. The resulting object can be queried for its Hermann-Mauguin symbol, its axis and its rotation sense (only for rotation axes). For identity, inversion and translation this returns ``[0, 0, 0]``.
 
 .. testcode :: ExSymmetryElement
 
@@ -206,6 +206,7 @@ Section 11.2 in the same book describes how to derive symmetry elements from mat
 
     print "The element corresponding to 'x,y,-z' has the following symbol:", element.getHMSymbol()
     print "The mirror plane is perpendicular to:", element.getAxis()
+    print "Sense of rotation (or None):", element.getRotationSense()
     
 In this case, it's a mirror plane perpendicular to the :math:`z`-axis:
     
@@ -213,6 +214,7 @@ In this case, it's a mirror plane perpendicular to the :math:`z`-axis:
 
     The element corresponding to 'x,y,-z' has the following symbol: m
     The mirror plane is perpendicular to: [0,0,1]
+    Sense of rotation (or None): None
     
 Symmetry groups
 ---------------


### PR DESCRIPTION
This fixes #12779.

The following changes have been made:
- It's now possible to obtain the rotation sense of rotation axes in Python as well.
- The site symmetry group (`PointAndSpaceGroups`-page) usage example has been implemented as a method in the SpaceGroup-class, exposed to Python.
- `PointGroup`-objects can be created directly from `SpaceGroup`-objects, without going through the factory, this has also been exposed to Python.
- `SpaceGroupFactory` returns all space groups with a certain point group (exported to Python).

**Testing information**
Code review. Check the additions to the documentation, a new usage example has been added to the `PointAndSpaceGroups` concept page.
