### PR TITLE
Move MDFErrorCurve to MantidWidgets

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -52,7 +52,6 @@ set ( SRC_FILES
     src/MultiDatasetFit/MDFLocalParameterEditor.cpp
     src/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
     src/MultiDatasetFit/MDFEditLocalParameterDialog.cpp
-    src/MultiDatasetFit/MDFErrorCurve.cpp
 	src/Muon/ALCBaselineModellingModel.cpp
 	src/Muon/ALCBaselineModellingPresenter.cpp
 	src/Muon/ALCBaselineModellingView.cpp
@@ -148,7 +147,6 @@ set ( INC_FILES
     inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
     inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
     inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
-    inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h
 	inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
 	inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h
 	inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFDatasetPlotData.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFDatasetPlotData.h
@@ -17,6 +17,13 @@ namespace API
 }
 }
 
+namespace MantidQt
+{
+namespace MantidWidgets
+{
+  class ErrorCurve;
+}
+}
 
 namespace MantidQt
 {
@@ -24,7 +31,6 @@ namespace CustomInterfaces
 {
 namespace MDF
 {
-class ErrorCurve;
 
 /**
  * Contains graphics for a single data set: fitting data, claculated result, difference.
@@ -46,7 +52,7 @@ private:
   /// Curve object for the fit data (spectrum).
   QwtPlotCurve *m_dataCurve;
   /// Error bar curve for the data
-  ErrorCurve *m_dataErrorCurve;
+  MantidQt::MantidWidgets::ErrorCurve *m_dataErrorCurve;
   /// Curve object for the calculated spectrum after a fit.
   QwtPlotCurve *m_calcCurve;
   /// Curve object for the difference spectrum.

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDatasetPlotData.cpp
@@ -1,5 +1,5 @@
 #include "MantidQtCustomInterfaces/MultiDatasetFit/MDFDatasetPlotData.h"
-#include "MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h"
+#include "MantidQtMantidWidgets/ErrorCurve.h"
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -110,7 +110,7 @@ void DatasetPlotData::setData(const Mantid::API::MatrixWorkspace *ws, int wsInde
     m_dataErrorCurve->detach();
     delete m_dataErrorCurve;
   }
-  m_dataErrorCurve = new ErrorCurve(m_dataCurve, ws->readE(wsIndex));
+  m_dataErrorCurve = new MantidQt::MantidWidgets::ErrorCurve(m_dataCurve, ws->readE(wsIndex));
 
   if ( haveFitCurves )
   {

--- a/Code/Mantid/MantidQt/MantidWidgets/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/MantidWidgets/CMakeLists.txt
@@ -6,6 +6,7 @@ set ( SRC_FILES
     src/CheckboxHeader.cpp
     src/DataSelector.cpp
     src/DiagResults.cpp
+    src/ErrorCurve.cpp
     src/FilenameDialogEditor.cpp
     src/FindDialog.cpp
     src/FindReplaceDialog.cpp
@@ -101,6 +102,7 @@ set ( INC_FILES
     ${MOC_FILES}
     inc/MantidQtMantidWidgets/AlgorithmHintStrategy.h
     inc/MantidQtMantidWidgets/CatalogHelper.h
+    inc/MantidQtMantidWidgets/ErrorCurve.h
     inc/MantidQtMantidWidgets/WidgetDllOption.h
     inc/MantidQtMantidWidgets/HintStrategy.h
 )

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ErrorCurve.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ErrorCurve.h
@@ -1,20 +1,21 @@
-#ifndef MDFERRORCURVE_H_
-#define MDFERRORCURVE_H_
+#ifndef MANTIDWIDGETS_ERRORCURVE_H
+#define MANTIDWIDGETS_ERRORCURVE_H
 
+#include "WidgetDllOption.h"
 #include <qwt_plot_item.h>
 #include <qwt_plot_curve.h>
 
 namespace MantidQt
 {
-namespace CustomInterfaces
-{
-namespace MDF
+namespace MantidWidgets
 {
 
 /// Curve to draw error bars.
-class ErrorCurve: public QwtPlotItem
+class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS ErrorCurve: public QwtPlotItem
 {
+
 public:
+  //ErrorCurve(QwtPlotCurve* dataCurve, const std::vector<double>& errors = std::vector<double>());
   ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>& errors = std::vector<double>());
   /// Set error bars
   void setErrorBars(const std::vector<double>& errors);
@@ -32,9 +33,7 @@ private:
   QPen m_pen;
 };
 
-} // MDF
-} // CustomInterfaces
+} // MantidWidgets
 } // MantidQt
 
-
-#endif /*MDFERRORCURVE_H_*/
+#endif /* MANTIDWIDGETS_ERRORCURVE_H */

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ErrorCurve.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ErrorCurve.h
@@ -15,7 +15,6 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS ErrorCurve: public QwtPlotItem
 {
 
 public:
-  //ErrorCurve(QwtPlotCurve* dataCurve, const std::vector<double>& errors = std::vector<double>());
   ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>& errors = std::vector<double>());
   /// Set error bars
   void setErrorBars(const std::vector<double>& errors);

--- a/Code/Mantid/MantidQt/MantidWidgets/src/ErrorCurve.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/ErrorCurve.cpp
@@ -1,4 +1,4 @@
-#include "MantidQtCustomInterfaces/MultiDatasetFit/MDFErrorCurve.h"
+#include "MantidQtMantidWidgets/ErrorCurve.h"
 
 #include <QPainter>
 #include <qwt_scale_map.h>
@@ -6,15 +6,14 @@
 
 namespace MantidQt
 {
-namespace CustomInterfaces
+namespace MantidWidgets
 {
-namespace MDF
-{
- 
+
 /// Create a error curve dependent on a data curve.
 /// @param dataCurve :: The curve displaying the data.
 /// @param errors :: A vector with error bars.
 ErrorCurve::ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>& errors)
+//ErrorCurve::ErrorCurve(QwtPlotCurve* dataCurve, const std::vector<double>& errors)
 {
   if (!dataCurve)
   {
@@ -44,6 +43,7 @@ void ErrorCurve::setErrorBars(const std::vector<double>& errors)
 {
   if (errors.size() != m_x.size())
   {
+    std::cout << "ERROR POINTS " << errors.size() << " DATA POINTS " << m_x.size() << "\n";
     throw std::runtime_error("Number of error values is different form the number of data points.");
   }
   m_e = errors;
@@ -88,6 +88,6 @@ int ErrorCurve::dataSize() const
   return static_cast<int>(m_x.size());
 }
 
-} // MDF
-} // CustomInterfaces
+} // MantidWidgets
 } // MantidQt
+

--- a/Code/Mantid/MantidQt/MantidWidgets/src/ErrorCurve.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/ErrorCurve.cpp
@@ -13,7 +13,6 @@ namespace MantidWidgets
 /// @param dataCurve :: The curve displaying the data.
 /// @param errors :: A vector with error bars.
 ErrorCurve::ErrorCurve(const QwtPlotCurve* dataCurve, const std::vector<double>& errors)
-//ErrorCurve::ErrorCurve(QwtPlotCurve* dataCurve, const std::vector<double>& errors)
 {
   if (!dataCurve)
   {
@@ -43,7 +42,6 @@ void ErrorCurve::setErrorBars(const std::vector<double>& errors)
 {
   if (errors.size() != m_x.size())
   {
-    std::cout << "ERROR POINTS " << errors.size() << " DATA POINTS " << m_x.size() << "\n";
     throw std::runtime_error("Number of error values is different form the number of data points.");
   }
   m_e = errors;


### PR DESCRIPTION
Fixes #12816 

Tester: review code changes and ensure the MDF interface is working as before when checking/unchecking "Show data errors".
