### PR TITLE
Fix text wrap on script window

### DIFF
--- a/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
@@ -22,7 +22,7 @@ ScriptOutputDisplay::ScriptOutputDisplay(QWidget * parent) :
   QTextEdit(parent), m_copy(NULL), m_clear(NULL), m_save(NULL)
 {
   setReadOnly(true);
-  setLineWrapMode(QTextEdit::FixedColumnWidth);
+  setLineWrapMode(QTextEdit::WidgetWidth);
   setLineWrapColumnOrWidth(105);
   setAutoFormatting(QTextEdit::AutoNone);
   // Change to fix width font so that table formatting isn't screwed up


### PR DESCRIPTION
Fixes #12011.

To test: open the scripting window and make the result display a very long message (pasting a long line of text without spaces will do as this fails with `NameError`).
