### PR TITLE
Update LoadFlexiNexus for VISION diffraction

### DIFF
--- a/Code/Mantid/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Code/Mantid/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -127,6 +127,9 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
     spectraLength = static_cast<int>(inf.dims[1]);
   }
 
+  g_log.debug() << "Reading " << nSpectra << " spectra of length "
+                << spectraLength << "." << std::endl;
+
   // need to locate x-axis data too.....
   std::map<std::string, std::string>::const_iterator it;
   std::vector<double> xData;
@@ -158,18 +161,22 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
   ws = boost::dynamic_pointer_cast<Mantid::DataObjects::Workspace2D>(
       WorkspaceFactory::Instance().create("Workspace2D", nSpectra,
                                           spectraLength, spectraLength));
-  for (int i = 0; i < nSpectra; i++) {
-    Mantid::MantidVec &Y = ws->dataY(i);
+  for (int wsIndex = 0; wsIndex < nSpectra; wsIndex++) {
+    Mantid::MantidVec &Y = ws->dataY(wsIndex);
     for (int j = 0; j < spectraLength; j++) {
-      Y[j] = data[spectraLength * i + j];
+      Y[j] = data[spectraLength * wsIndex + j];
     }
     // Create and fill another vector for the errors, containing sqrt(count)
-    Mantid::MantidVec &E = ws->dataE(i);
+    Mantid::MantidVec &E = ws->dataE(wsIndex);
     std::transform(Y.begin(), Y.end(), E.begin(), dblSqrt);
-    ws->setX(i, xData);
+    ws->setX(wsIndex, xData);
     // Xtof		ws->getAxis(1)->spectraNo(i)= i;
-    ws->getSpectrum(i)->setSpectrumNo(static_cast<specid_t>(yData[i]));
+    ws->getSpectrum(wsIndex)
+        ->setSpectrumNo(static_cast<specid_t>(yData[wsIndex]));
+    ws->getSpectrum(wsIndex)
+        ->setDetectorID(static_cast<detid_t>(yData[wsIndex]));
   }
+
   ws->setYUnit("Counts");
 
   // assign an x-axis-name
@@ -179,6 +186,10 @@ void LoadFlexiNexus::load2DWorkspace(NeXus::File *fin) {
   } else {
     const std::string xname(it->second);
     ws->getAxis(0)->title() = xname;
+    if (xname.compare("TOF") == 0) {
+      g_log.debug() << "Setting X-unit to be TOF" << std::endl;
+      ws->getAxis(0)->setUnit("TOF");
+    }
   }
 
   addMetaData(fin, ws, (ExperimentInfo_sptr)ws);

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank15.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank15.dic
@@ -1,0 +1,7 @@
+data=/entry/bank15/data
+x-axis=/entry/bank15/time_of_flight
+y-axis=/entry/bank15/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank16.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank16.dic
@@ -1,0 +1,7 @@
+data=/entry/bank16/data
+x-axis=/entry/bank16/time_of_flight
+y-axis=/entry/bank16/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank17.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank17.dic
@@ -1,0 +1,7 @@
+data=/entry/bank17/data
+x-axis=/entry/bank17/time_of_flight
+y-axis=/entry/bank17/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank18.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank18.dic
@@ -1,0 +1,7 @@
+data=/entry/bank18/data
+x-axis=/entry/bank18/time_of_flight
+y-axis=/entry/bank18/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank19.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank19.dic
@@ -1,0 +1,7 @@
+data=/entry/bank19/data
+x-axis=/entry/bank19/time_of_flight
+y-axis=/entry/bank19/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank20.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank20.dic
@@ -1,0 +1,7 @@
+data=/entry/bank20/data
+x-axis=/entry/bank20/time_of_flight
+y-axis=/entry/bank20/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank21.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank21.dic
@@ -1,0 +1,7 @@
+data=/entry/bank21/data
+x-axis=/entry/bank21/time_of_flight
+y-axis=/entry/bank21/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank22.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank22.dic
@@ -1,0 +1,7 @@
+data=/entry/bank22/data
+x-axis=/entry/bank22/time_of_flight
+y-axis=/entry/bank22/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank23.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank23.dic
@@ -1,0 +1,7 @@
+data=/entry/bank23/data
+x-axis=/entry/bank23/time_of_flight
+y-axis=/entry/bank23/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank24.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank24.dic
@@ -1,0 +1,7 @@
+data=/entry/bank24/data
+x-axis=/entry/bank24/time_of_flight
+y-axis=/entry/bank24/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank25.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank25.dic
@@ -1,0 +1,7 @@
+data=/entry/bank25/data
+x-axis=/entry/bank25/time_of_flight
+y-axis=/entry/bank25/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank26.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank26.dic
@@ -1,0 +1,7 @@
+data=/entry/bank26/data
+x-axis=/entry/bank26/time_of_flight
+y-axis=/entry/bank26/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank27.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank27.dic
@@ -1,0 +1,7 @@
+data=/entry/bank27/data
+x-axis=/entry/bank27/time_of_flight
+y-axis=/entry/bank27/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank28.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank28.dic
@@ -1,0 +1,7 @@
+data=/entry/bank28/data
+x-axis=/entry/bank28/time_of_flight
+y-axis=/entry/bank28/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank29.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank29.dic
@@ -1,0 +1,7 @@
+data=/entry/bank29/data
+x-axis=/entry/bank29/time_of_flight
+y-axis=/entry/bank29/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name

--- a/Code/Mantid/instrument/nexusdictionaries/vision-bank30.dic
+++ b/Code/Mantid/instrument/nexusdictionaries/vision-bank30.dic
@@ -1,0 +1,7 @@
+data=/entry/bank30/data
+x-axis=/entry/bank30/time_of_flight
+y-axis=/entry/bank30/pixel_id
+x-axis-name=TOF
+title=/entry/title
+sample=/entry/sample/name
+InstrumentName=/entry/instrument/name


### PR DESCRIPTION
These changes are mainly to allow us to load the VISION diffraction detectors and convert into d-space.

Specifically:
- Sets the detector ids to be the same as the spectrum ids.
- Set the xunit to be TOF if the x-unit-name is TOF
- Add some dictionary files for the VISION diffraction detectors.

There is no real added functionality from the user perspective, so no release notes are required.

This pull request fixes #12829
