### PR TITLE
PoldiDataAnalysis aborts when run with an empty workspace

### DIFF
--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIDataAnalysisTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIDataAnalysisTest.py
@@ -160,7 +160,7 @@ class POLDIDataAnalysisTestSiPawley(POLDIDataAnalysisTestSi):
 
 
 class POLDIDataAnalysisEmptyFile(stresstesting.MantidStressTest):
-    """This test runs PoldiDataAnalysis with Si data, using."""
+    """This test runs PoldiDataAnalysis with Si data, using an empty workspace."""
 
     def runTest(self):
         empty = PoldiLoadRuns(2015, 977)

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIDataAnalysisTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIDataAnalysisTest.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-init,invalid-name,too-many-locals
+# pylint: disable=no-init,invalid-name,too-many-locals,too-few-public-methods
 import stresstesting
 from mantid.simpleapi import *
 from mantid.api import *

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIDataAnalysisTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIDataAnalysisTest.py
@@ -29,7 +29,7 @@ class POLDIDataAnalysisTestSi(stresstesting.MantidStressTest):
 
 
 class POLDIDataAnalysisTestSiIndividual(POLDIDataAnalysisTestSi):
-    """This test runs PoldiDataAnalysis with Si data, using."""
+    """This test runs PoldiDataAnalysis with Si data, using individual peaks."""
 
     def runTest(self):
         data, expectedPeaks = self.prepareTest()
@@ -63,16 +63,17 @@ class POLDIDataAnalysisTestSiIndividual(POLDIDataAnalysisTestSi):
         # Maximum residual should not be too large
         self.assertLessThan(maxResidual / maxSum, 0.075)
 
+
 class POLDIDataAnalysisTestSiIndividualDiscardUnindexed(POLDIDataAnalysisTestSi):
     def runTest(self):
         data, expectedPeaks = self.prepareTest()
         DeleteTableRows(expectedPeaks, '8-20')
 
         output_remove = PoldiDataAnalysis(InputWorkspace=data,
-                                   MaximumPeakNumber=11,
-                                   ExpectedPeaks=expectedPeaks,
-                                   RemoveUnindexedPeaksFor2DFit=True,
-                                   PlotResult=False)
+                                          MaximumPeakNumber=11,
+                                          ExpectedPeaks=expectedPeaks,
+                                          RemoveUnindexedPeaksFor2DFit=True,
+                                          PlotResult=False)
 
         # Make sure that it's a workspace group
         self.assertTrue(isinstance(output_remove, WorkspaceGroup))
@@ -83,10 +84,10 @@ class POLDIDataAnalysisTestSiIndividualDiscardUnindexed(POLDIDataAnalysisTestSi)
 
         # Run again with option to keep unindexed peaks.
         output_keep = PoldiDataAnalysis(InputWorkspace=data,
-                                   MaximumPeakNumber=11,
-                                   ExpectedPeaks=expectedPeaks,
-                                   RemoveUnindexedPeaksFor2DFit=False,
-                                   PlotResult=False)
+                                        MaximumPeakNumber=11,
+                                        ExpectedPeaks=expectedPeaks,
+                                        RemoveUnindexedPeaksFor2DFit=False,
+                                        PlotResult=False)
 
         # Make sure that it's a workspace group
         self.assertTrue(isinstance(output_keep, WorkspaceGroup))
@@ -96,9 +97,8 @@ class POLDIDataAnalysisTestSiIndividualDiscardUnindexed(POLDIDataAnalysisTestSi)
         self.assertTrue(isinstance(refinedPeaks, WorkspaceGroup))
 
 
-
 class POLDIDataAnalysisTestSiIndividualPseudoVoigtTied(POLDIDataAnalysisTestSi):
-    """This test runs PoldiDataAnalysis with Si data, using."""
+    """This test runs PoldiDataAnalysis with Si data, using PseudoVoigt with tied mixing parameter."""
 
     def runTest(self):
         data, expectedPeaks = self.prepareTest()
@@ -133,17 +133,18 @@ class POLDIDataAnalysisTestSiIndividualPseudoVoigtTied(POLDIDataAnalysisTestSi):
 
         self.assertEquals(len(mixingValues), 1)
 
+
 class POLDIDataAnalysisTestSiPawley(POLDIDataAnalysisTestSi):
-    """This test runs PoldiDataAnalysis with Si data, using."""
+    """This test runs PoldiDataAnalysis with Si data, using the PawleyFit-option."""
 
     def runTest(self):
         data, expectedPeaks = self.prepareTest()
 
         PoldiDataAnalysis(InputWorkspace=data,
-                                   MaximumPeakNumber=11,
-                                   ExpectedPeaks=expectedPeaks,
-                                   PawleyFit=True,
-                                   PlotResult=False, OutputWorkspace='output')
+                          MaximumPeakNumber=11,
+                          ExpectedPeaks=expectedPeaks,
+                          PawleyFit=True,
+                          PlotResult=False, OutputWorkspace='output')
 
         # inspect the cell
         cell = AnalysisDataService.retrieve('poldi_data_6904_cell_refined')
@@ -156,3 +157,23 @@ class POLDIDataAnalysisTestSiPawley(POLDIDataAnalysisTestSi):
 
         self.assertLessThan(np.abs(a_err), 5.0e-5)
         self.assertLessThan(np.abs(a_val - 5.4311946) / a_err, 1.5)
+
+
+class POLDIDataAnalysisEmptyFile(stresstesting.MantidStressTest):
+    """This test runs PoldiDataAnalysis with Si data, using."""
+
+    def runTest(self):
+        empty = PoldiLoadRuns(2015, 977)
+
+        peaks = PoldiCreatePeaksFromCell(SpaceGroup='F d -3 m',
+                                         a=5.431, LatticeSpacingMin=0.7,
+                                         Atoms='Si 0 0 0 1.0 0.01',
+                                         OutputWorkspace='Si')
+        try:
+            PoldiDataAnalysis(InputWorkspace=empty.getItem(0),
+                              MaximumPeakNumber=11,
+                              ExpectedPeaks=peaks,
+                              PlotResult=False, OutputWorkspace='output')
+        except RuntimeError as error:
+            self.assertTrue("Aborting analysis since workspace empty_data_977 does not contain any counts." in str(
+                error))


### PR DESCRIPTION
This fixes #12826.

**Testing information**
There is a system test that tests the new behavior. For manual testing you could run the following script, which is derived from the system test (requires system test data):

```
empty = PoldiLoadRuns(2015, 977)

peaks = PoldiCreatePeaksFromCell(SpaceGroup='F d -3 m',
                                         a=5.431, LatticeSpacingMin=0.7,
                                         Atoms='Si 0 0 0 1.0 0.01',
                                         OutputWorkspace='Si')
analysis = PoldiDataAnalysis(InputWorkspace=empty.getItem(0),
                              MaximumPeakNumber=11,
                              ExpectedPeaks=peaks,
                              PlotResult=False, OutputWorkspace='output')
```

Before the changes in this branch the script causes Mantid to crash, after applying the changes it displays an error message that tells the user which data file is empty.
