### PR TITLE
Some sample logs do not appear correctly in indirect routines

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -88,11 +88,12 @@ class IndirectCalibration(DataProcessorAlgorithm):
 
 
     def PyExec(self):
+        from IndirectCommon import get_run_number
 
         self._setup()
 
         runs = []
-        self._run_numbers = list()
+        self._run_numbers = []
         for in_file in self._input_files:
             (_, filename) = os.path.split(in_file)
             (root, _) = os.path.splitext(filename)
@@ -104,6 +105,7 @@ class IndirectCalibration(DataProcessorAlgorithm):
                      LoadLogFiles=False)
 
                 runs.append(root)
+                self._run_numbers.append(get_run_number(root))
             except (RuntimeError,ValueError) as exc:
                 logger.error('Could not load raw file "%s": %s' % (in_file, str(exc)))
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -215,7 +215,7 @@ class TransformToIqt(PythonAlgorithm):
         sample_logs = [
                 ('iqt_sample_workspace', self._sample),
                 ('iqt_resolution_workspace', self._resolution),
-                ('iqt_binning', '%d,%d,%d' % (self._e_min, self._e_width, self._e_max))
+                ('iqt_binning', '%f,%f,%f' % (self._e_min, self._e_width, self._e_max))
             ]
 
         AddSampleLogMultiple(Workspace=self._output_workspace,


### PR DESCRIPTION
Fixes #12836.

To test:
- Open Indirect > Data Analaysis > I(Q, t)
- Sample: `irs26176_graphite002_red.nxs`
- Resolution: `irs26173_graphite002_res.nxs`
- Run
- Check `_iqt` workspace for `iqt_binning` log, should match UI
- Open Indirect > Data Reduction > ISIS Calibration
- Instrument: IRIS
- Run: `27163,26174`
- Run
- Check `_calib` workspace has `calib_run_numbers` log and it contains `26173,26174`

No release note mention as this issue was likely introduced this release.
