### PR TITLE
Add error bars to PreviewPlot

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
@@ -121,6 +121,9 @@
        <property name="showLegend" stdset="0">
         <bool>true</bool>
        </property>
+       <property name="showErrorBars" stdset="0">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
@@ -58,6 +58,9 @@
          <property name="showLegend" stdset="0">
           <bool>true</bool>
          </property>
+         <property name="showErrorBars" stdset="0">
+          <bool>true</bool>
+         </property>
          <property name="canvasColour" stdset="0">
           <color>
            <red>255</red>

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
@@ -4,6 +4,7 @@
 #include "ui_PreviewPlot.h"
 
 #include "WidgetDllOption.h"
+#include "MantidQtMantidWidgets/ErrorCurve.h"
 #include "MantidQtMantidWidgets/RangeSelector.h"
 #include "MantidQtAPI/MantidWidget.h"
 
@@ -60,6 +61,7 @@ namespace MantidWidgets
 
     Q_PROPERTY(QColor canvasColour READ canvasColour WRITE setCanvasColour)
     Q_PROPERTY(bool showLegend READ legendIsShown WRITE showLegend)
+    Q_PROPERTY(bool showErrorBars READ errorBarsAreShown WRITE showErrorBars)
 
   public:
     PreviewPlot(QWidget *parent = NULL, bool init = true);
@@ -69,6 +71,7 @@ namespace MantidWidgets
     void setCanvasColour(const QColor & colour);
 
     bool legendIsShown();
+    bool errorBarsAreShown();
 
     void setAxisRange(QPair<double, double> range, int axisID = QwtPlot::xBottom);
 
@@ -101,6 +104,7 @@ namespace MantidWidgets
 
   public slots:
     void showLegend(bool show);
+    void showErrorBars(bool show);
     void togglePanTool(bool enabled);
     void toggleZoomTool(bool enabled);
     void resetView();
@@ -115,6 +119,7 @@ namespace MantidWidgets
     {
       Mantid::API::MatrixWorkspace_sptr ws;
       QwtPlotCurve *curve;
+      MantidQt::MantidWidgets::ErrorCurve *errorCurve;
       QLabel *label;
       QColor colour;
       size_t wsIndex;
@@ -126,8 +131,8 @@ namespace MantidWidgets
     void handleRemoveEvent(Mantid::API::WorkspacePreDeleteNotification_ptr pNf);
     void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
 
-    QwtPlotCurve * addCurve(Mantid::API::MatrixWorkspace_sptr ws, const size_t specIndex, const QColor & curveColour);
-    void removeCurve(QwtPlotCurve *curve);
+    void addCurve(PlotCurveConfiguration& curveConfig, Mantid::API::MatrixWorkspace_sptr ws, const size_t specIndex, const QColor & curveColour);
+    void removeCurve(QwtPlotItem *curve);
 
     QList<QAction *> addOptionsToMenus(QString menuName, QActionGroup *group, QStringList items, QString defaultItem);
 
@@ -171,6 +176,9 @@ namespace MantidWidgets
 
     /// Menu action for showing/hiding plot legend
     QAction *m_showLegendAction;
+
+    /// Menu action for showing/hiding error bars
+    QAction *m_showErrorsAction;
 
   };
 


### PR DESCRIPTION
Fixes #12817.

To test:
- Open Indirect > Data Analysis > MSDFit
- Load `Babylon5/Public/DanNixon/data/osi92762_graphite002_elwin_eq2.nxs`
- See that there are error bars
- Right click the plot and toggle with Show Errors

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24298&oldid=24297).
