### PR TITLE
Invoke git-add-test-data from directory other than repository root   

### DIFF
--- a/Code/Tools/Development/git/git-add-test-data
+++ b/Code/Tools/Development/git/git-add-test-data
@@ -180,7 +180,7 @@ fi
 datafiles=$*
 all_hashed_files=""
 for datafile in $datafiles; do
-  hashed_content=$(add_test_data $datafile)
+  hashed_content=$(add_test_data ${GIT_PREFIX}$datafile)
   all_hashed_files="$all_hashed_files $hashed_content"
 done
 


### PR DESCRIPTION
Fixes #12264

**Tester**
The issue contains some instructions to reproduce the original problem. These instructions should now work.
