### PR TITLE
Change CorelliCrossCorrelate to use MotorSpeed instead of TDC for chopper period

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
@@ -84,6 +84,10 @@ std::map<std::string, std::string> CorelliCrossCorrelate::validateInputs() {
   else if (!inputWS->run().hasProperty("chopper4_TDC"))
     errors["InputWorkspace"] = "Workspace is missing chopper4 TDCs.";
 
+  // Must include the chopper4 MotorSpeed.
+  else if (!inputWS->run().hasProperty("BL9:Chop:Skf4:MotorSpeed"))
+    errors["InputWorkspace"] = "Workspace is missing chopper4 Motor Speed.";
+
   // Check if input workspace is sorted.
   else if (inputWS->getSortType() == UNSORTED)
     errors["InputWorkspace"] = "The workspace needs to be a sorted.";
@@ -161,10 +165,10 @@ void CorelliCrossCorrelate::exec() {
   for (unsigned long i = 0; i < tdc.size(); ++i)
     tdc[i] += offset;
 
-  // Determine period from TDC.
-  double period = static_cast<double>(tdc[tdc.size() - 1].totalNanoseconds() -
-                                      tdc[1].totalNanoseconds()) /
-                  double(tdc.size() - 2);
+  // Determine period from chopper frequency.
+  auto motorSpeed = dynamic_cast<TimeSeriesProperty<double> *>(
+      inputWS->run().getProperty("BL9:Chop:Skf4:MotorSpeed"));
+  double period = 1e9 / static_cast<double>(motorSpeed->timeAverageValue());
   g_log.information() << "Frequency = " << 1e9 / period
                       << "Hz Period = " << period << "ns\n";
 

--- a/Code/Mantid/Framework/Algorithms/test/CorelliCrossCorrelateTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/CorelliCrossCorrelateTest.h
@@ -68,6 +68,11 @@ public:
     }
     ws->mutableRun().addLogData(tdc);
 
+    // Add motorSpeed to the workspace
+    auto motorSpeed = new TimeSeriesProperty<double>("BL9:Chop:Skf4:MotorSpeed");
+    motorSpeed->addValue(startTime,293.383);
+    ws->mutableRun().addLogData(motorSpeed);
+
     CorelliCrossCorrelate alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())


### PR DESCRIPTION
The CorelliCrossCorrelate function fails to execute correctly when a run was `paused` because of the way the chopper period was calculated. This fixes that.

**To test:**

``` python
ws=Load("CORELLI_11555") #This file has part of the run paused.
LoadInstrument(ws,InstrumentName='CORELLI')
cc=CorelliCrossCorrelate(ws)
```

Have a look at the Information log output. It should report the correct frequency and period `Frequency = 293.398Hz Period = 3.40834e+06ns`. You can also look at the instrument view to see if the output now looks good.
No release notes
