### PR TITLE
Fix bin edge spectrum axis in PlotPeakByLogValue parameter table

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/src/PlotPeakByLogValue.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/PlotPeakByLogValue.cpp
@@ -26,6 +26,7 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/BinEdgeAxis.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
 
@@ -227,7 +228,13 @@ void PlotPeakByLogValue::exec() {
       double logValue = 0;
       if (logName.empty()) {
         API::Axis *axis = data.ws->getAxis(1);
-        logValue = (*axis)(j);
+        if(dynamic_cast<BinEdgeAxis *>(axis)) {
+          double lowerEdge((*axis)(j));
+          double upperEdge((*axis)(j+1));
+          logValue = lowerEdge + (upperEdge - lowerEdge) / 2;
+        }
+        else
+          logValue = (*axis)(j);
       } else if (logName != "SourceName") {
         Kernel::Property *prop = data.ws->run().getLogData(logName);
         if (!prop) {

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/MSDFit.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/MSDFit.py
@@ -99,13 +99,18 @@ class MSDFit(DataProcessorAlgorithm):
         input_params = [self._input_ws + ',i%d' % i for i in xrange(self._spec_range[0],
                                                                     self._spec_range[1] + 1)]
         input_params = ';'.join(input_params)
-        PlotPeakByLogValue(Input=input_params, OutputWorkspace=self._output_msd_ws,
-                           Function=function, StartX=self._x_range[0], EndX=self._x_range[1],
-                           FitType='Sequential', CreateOutput=True)
+        PlotPeakByLogValue(Input=input_params,
+                           OutputWorkspace=self._output_msd_ws,
+                           Function=function,
+                           StartX=self._x_range[0],
+                           EndX=self._x_range[1],
+                           FitType='Sequential',
+                           CreateOutput=True)
 
         DeleteWorkspace(self._output_msd_ws + '_NormalisedCovarianceMatrices')
         DeleteWorkspace(self._output_msd_ws + '_Parameters')
-        RenameWorkspace(self._output_msd_ws, OutputWorkspace=self._output_param_ws)
+        RenameWorkspace(self._output_msd_ws,
+                        OutputWorkspace=self._output_param_ws)
 
         params_table = mtd[self._output_param_ws]
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -209,10 +209,11 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             logger.notice('Vertical axis is in run number')
             unit = ('Run No', 'last 3 digits')
 
-        q_ws_axis = mtd[self._q_workspace].getAxis(1)
+        # Create a new vertical axis for the Q and Q**2 workspaces
+        q_ws_axis = NumericAxis.create(len(input_workspace_names))
         q_ws_axis.setUnit("Label").setLabel(unit[0], unit[1])
 
-        q2_ws_axis = mtd[self._q2_workspace].getAxis(1)
+        q2_ws_axis = NumericAxis.create(len(input_workspace_names))
         q2_ws_axis.setUnit("Label").setLabel(unit[0], unit[1])
 
         # Set the vertical axis values
@@ -223,6 +224,10 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             else:
                 q_ws_axis.setValue(idx, float(run_numbers[idx][-3:]))
                 q2_ws_axis.setValue(idx, float(run_numbers[idx][-3:]))
+
+        # Add the new vertical axis to each workspace
+        mtd[self._q_workspace].replaceAxis(1, q_ws_axis)
+        mtd[self._q2_workspace].replaceAxis(1, q2_ws_axis)
 
         # Process the ELF workspace
         if self._elf_workspace != '':


### PR DESCRIPTION
Fixes #12838.

Test using this script (data is in system test data):

```
red = Load(Filename='irs26176_graphite002_red.nxs')
sqw = SofQWPolygon(InputWorkspace=red,
                   QAxisBinning='0.4,0.1,1.8',
                   EMode='Indirect',
                   EFixed=1.845)

params_red = PlotPeakByLogValue(Input='red,i0;red,i1',
                                Function='name=LinearBackground;name=Lorentzian')

params_sqw = PlotPeakByLogValue(Input='sqw,i0;sqw,i1',
                                Function='name=LinearBackground;name=Lorentzian')
```

Notice that first column in parameter tables match the vertical axis in matrix data view (at least for the two fitted spectra), notice that vertical axis of `red` is points (spectrum numbers) and `sqw` is bin edges.
Compare this to the behaviour on the current master.

Release notes updates [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_Framework_Changes&diff=24302&oldid=24300).
