### PR TITLE
Cannot save the output of SplineInterpolation

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/src/SplineInterpolation.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/SplineInterpolation.cpp
@@ -154,7 +154,7 @@ SplineInterpolation::setupOutputWorkspace(API::MatrixWorkspace_sptr mws,
       WorkspaceFactory::Instance().create(mws, numSpec);
 
   // Use the vertical axis form the workspace to interpolate on the output WS
-  Axis *vAxis = iws->getAxis(1)->clone(NULL);
+  Axis *vAxis = iws->getAxis(1)->clone(mws.get());
   outputWorkspace->replaceAxis(1, vAxis);
 
   return outputWorkspace;


### PR DESCRIPTION
Fixes #12850.

Run the script in the original issue and see that it works.

No release notes updates as this bug was introduced this release.
