### PR TITLE
Allow Detector ID Lists for ExtractSpectra algorithm

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
@@ -68,8 +68,8 @@ private:
   bool m_histogram;
   /// Flag indicating whether XMin and/or XMax has been set
   bool m_croppingInX;
-  /// The list of spectra to extract.
-  std::vector<size_t> m_spectrumList;
+  /// The list of workspaces to extract.
+  std::vector<size_t> m_workspaceIndexList;
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ExtractSpectra.h
@@ -69,7 +69,7 @@ private:
   /// Flag indicating whether XMin and/or XMax has been set
   bool m_croppingInX;
   /// The list of spectra to extract.
-  std::vector<specid_t> m_spectrumList;
+  std::vector<size_t> m_spectrumList;
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/RemoveMaskedSpectra.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/RemoveMaskedSpectra.h
@@ -43,7 +43,7 @@ public:
 private:
   void init();
   void exec();
-  void makeIndexList(std::vector<specid_t> &indices,
+  void makeIndexList(std::vector<size_t> &indices,
                      const API::MatrixWorkspace *maskedWorkspace);
 };
 

--- a/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -87,8 +87,8 @@ void ExtractSpectra::init() {
       "The index number of the last entry in the Workspace to be loaded\n"
       "(default: last entry in the Workspace)");
   declareProperty(
-      new ArrayProperty<specid_t>("SpectrumList"),
-      "A comma-separated list of individual spectra to read.  Only used if\n"
+      new ArrayProperty<size_t>("WorkspaceIndexList"),
+      "A comma-separated list of individual workspace indices to read.  Only used if\n"
       "explicitly set.");
 }
 
@@ -177,7 +177,7 @@ void ExtractSpectra::execHistogram() {
         ->copyInfoFrom(*m_inputWorkspace->getSpectrum(i));
 
     if (!m_commonBoundaries)
-      this->cropRagged(outputWorkspace, i, j);
+      this->cropRagged(outputWorkspace, static_cast<int>(i), j);
 
     // Propagate bin masking if there is any
     if (m_inputWorkspace->hasMaskedBins(i)) {
@@ -376,7 +376,7 @@ void ExtractSpectra::checkProperties() {
   if (!m_commonBoundaries)
     m_maxX = static_cast<int>(m_inputWorkspace->readX(0).size());
 
-  m_spectrumList = getProperty("SpectrumList");
+  m_spectrumList = getProperty("WorkspaceIndexList");
 
   if (m_spectrumList.empty()) {
     int minSpec = getProperty("StartWorkspaceIndex");
@@ -402,7 +402,7 @@ void ExtractSpectra::checkProperties() {
                               "to EndWorkspaceIndex");
     }
     m_spectrumList.reserve(maxSpec - minSpec + 1);
-    for (specid_t i = minSpec; i <= maxSpec; ++i) {
+    for (size_t i = minSpec; i <= maxSpec; ++i) {
       m_spectrumList.push_back(i);
     }
   }

--- a/Code/Mantid/Framework/Algorithms/src/RemoveMaskedSpectra.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/RemoveMaskedSpectra.cpp
@@ -77,7 +77,7 @@ void RemoveMaskedSpectra::exec() {
   }
 
   // Find indices of the unmasked spectra.
-  std::vector<specid_t> indices;
+  std::vector<size_t> indices;
   makeIndexList(indices, maskedWorkspace.get());
 
   auto extract = createChildAlgorithm("ExtractSpectra", 0, 1);
@@ -85,7 +85,7 @@ void RemoveMaskedSpectra::exec() {
   extract->setRethrows(true);
 
   extract->setProperty("InputWorkspace", inputWorkspace);
-  extract->setProperty("SpectrumList", indices);
+  extract->setProperty("WorkspaceIndexList", indices);
 
   extract->execute();
 
@@ -98,12 +98,12 @@ void RemoveMaskedSpectra::exec() {
 /// @param indices :: A reference to a vector to fill with the indices.
 /// @param maskedWorkspace :: A workspace with masking information.
 void RemoveMaskedSpectra::makeIndexList(
-    std::vector<specid_t> &indices, const API::MatrixWorkspace *maskedWorkspace) {
+    std::vector<size_t> &indices, const API::MatrixWorkspace *maskedWorkspace) {
   auto mask = dynamic_cast<const DataObjects::MaskWorkspace *>(maskedWorkspace);
   if (mask) {
     for (size_t i = 0; i < mask->getNumberHistograms(); ++i) {
       if (mask->readY(i)[0] == 0.0) {
-        indices.push_back(static_cast<specid_t>(i));
+        indices.push_back(static_cast<size_t>(i));
       }
     }
   } else {
@@ -115,7 +115,7 @@ void RemoveMaskedSpectra::makeIndexList(
         continue;
       }
       if (!det->isMasked()) {
-        indices.push_back(static_cast<specid_t>(i));
+        indices.push_back(static_cast<size_t>(i));
       }
     }
   }

--- a/Code/Mantid/Framework/Algorithms/test/ExtractSpectraTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ExtractSpectraTest.h
@@ -84,37 +84,37 @@ public:
   void test_spectrum_list()
   {
     Parameters params;
-    params.setSpectrumList();
+    params.setWorkspaceIndexList();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     TS_ASSERT_EQUALS(ws->blocksize(), nBins);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void test_index_and_spectrum_list()
   {
     Parameters params;
-    params.setSpectrumList().setIndexRange();
+    params.setWorkspaceIndexList().setIndexRange();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     TS_ASSERT_EQUALS(ws->blocksize(), nBins);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void test_x_range_and_spectrum_list()
   {
     Parameters params;
-    params.setSpectrumList().setXRange();
+    params.setWorkspaceIndexList().setXRange();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     params.testXRange(*ws);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void test_invalid_x_range()
@@ -169,37 +169,37 @@ public:
   void test_spectrum_list_event()
   {
     Parameters params("event");
-    params.setSpectrumList();
+    params.setWorkspaceIndexList();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     TS_ASSERT_EQUALS(ws->blocksize(), nBins);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void test_index_and_spectrum_list_event()
   {
     Parameters params("event");
-    params.setSpectrumList().setIndexRange();
+    params.setWorkspaceIndexList().setIndexRange();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     TS_ASSERT_EQUALS(ws->blocksize(), nBins);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void test_x_range_and_spectrum_list_event()
   {
     Parameters params("event");
-    params.setSpectrumList().setXRange();
+    params.setWorkspaceIndexList().setXRange();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     params.testXRange(*ws);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void test_invalid_x_range_event()
@@ -256,13 +256,13 @@ public:
   void test_spectrum_list_ragged()
   {
     Parameters params("histo-ragged");
-    params.setSpectrumList();
+    params.setWorkspaceIndexList();
 
     auto ws = runAlgorithm(params);
     if (!ws) return;
 
     TS_ASSERT_EQUALS(ws->blocksize(), nBins);
-    params.testSpectrumList(*ws);
+    params.testWorkspaceIndexList(*ws);
   }
 
   void xtest_invalid_x_range_ragged()
@@ -336,14 +336,14 @@ private:
   {
     Parameters(const std::string& workspaceType = "histo")
         : XMin(EMPTY_DBL()), XMax(EMPTY_DBL()), StartWorkspaceIndex(0),
-        EndWorkspaceIndex(EMPTY_INT()), SpectrumList(), wsType(workspaceType)
+        EndWorkspaceIndex(EMPTY_INT()), WorkspaceIndexList(), wsType(workspaceType)
     {
     }
     double XMin;
     double XMax;
     int StartWorkspaceIndex;
     int EndWorkspaceIndex;
-    std::vector<int> SpectrumList;
+    std::vector<size_t> WorkspaceIndexList;
     std::string wsType;
 
     // ---- x range ----
@@ -418,15 +418,15 @@ private:
     }
 
     // ---- spectrum list ----
-    Parameters& setSpectrumList()
+    Parameters& setWorkspaceIndexList()
     {
-      SpectrumList.resize(3);
-      SpectrumList[0] = 0;
-      SpectrumList[1] = 2;
-      SpectrumList[2] = 4;
+      WorkspaceIndexList.resize(3);
+      WorkspaceIndexList[0] = 0;
+      WorkspaceIndexList[1] = 2;
+      WorkspaceIndexList[2] = 4;
       return *this;
     }
-    void testSpectrumList(const MatrixWorkspace& ws) const
+    void testWorkspaceIndexList(const MatrixWorkspace& ws) const
     {
       TS_ASSERT_EQUALS(ws.getNumberHistograms(), 3);
       if (wsType == "histo")
@@ -486,9 +486,9 @@ private:
     {
       TS_ASSERT_THROWS_NOTHING( alg.setProperty("EndWorkspaceIndex", params.EndWorkspaceIndex) );
     }
-    if (!params.SpectrumList.empty())
+    if (!params.WorkspaceIndexList.empty())
     {
-      TS_ASSERT_THROWS_NOTHING( alg.setProperty("SpectrumList", params.SpectrumList) );
+      TS_ASSERT_THROWS_NOTHING( alg.setProperty("WorkspaceIndexList", params.WorkspaceIndexList) );
     }
 
     TS_ASSERT_THROWS_NOTHING( alg.execute(); );

--- a/Code/Mantid/Framework/Algorithms/test/ExtractSpectraTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ExtractSpectraTest.h
@@ -139,6 +139,55 @@ public:
     }
   }
 
+  void test_detector_list()
+  {
+    Parameters params("histo-detector");
+    params.setDetectorList();
+
+    auto ws = runAlgorithm(params);
+    if (!ws) return;
+
+    TS_ASSERT_EQUALS(ws->blocksize(), nBins);
+    params.testDetectorList(*ws);
+  }
+
+  void test_index_and_detector_list()
+  {
+    Parameters params("histo-detector");
+    params.setDetectorList().setIndexRange();
+
+    auto ws = runAlgorithm(params);
+    if (!ws) return;
+
+    TS_ASSERT_EQUALS(ws->blocksize(), nBins);
+    params.testDetectorList(*ws);
+  }
+
+  void test_x_range_and_detector_list()
+  {
+    Parameters params("histo-detector");
+    params.setDetectorList().setXRange();
+
+    auto ws = runAlgorithm(params);
+    if (!ws) return;
+
+    params.testXRange(*ws);
+    params.testDetectorList(*ws);
+  }
+
+  void test_spectrum_list_and_detector_list()
+  {
+    Parameters params("histo-detector");
+    params.setWorkspaceIndexList().setDetectorList();
+
+    auto ws = runAlgorithm(params);
+    if (!ws) return;
+
+    TS_ASSERT_EQUALS(ws->blocksize(), nBins);
+    params.testDetectorList(*ws);
+  }
+
+
 
   // ---- test event ----
 
@@ -357,10 +406,7 @@ private:
     for( size_t i = 0; i < ws->getNumberHistograms(); ++i )
     {
       // Create a detector for each spectra
-      Mantid::Geometry::Detector * det = new Mantid::Geometry::Detector("pixel", static_cast<detid_t>(i), inst.get());
-      inst->add(det);
-      inst->markAsDetector(det);
-      ws->getSpectrum(i)->addDetectorID(static_cast<detid_t>(i));
+      ws->getSpectrum(i)->setDetectorID(static_cast<detid_t>(i));
     }
     return ws;
   }

--- a/Code/Mantid/docs/source/algorithms/ExtractSpectra-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExtractSpectra-v1.rst
@@ -28,7 +28,7 @@ Usage
     print 'Input workspace has %s spectra' % ws.getNumberHistograms()
 
     # Extract spectra 1,3 and 5 and crop the x-vector to interval 200 <= x <= 1300
-    cropped = ExtractSpectra(ws,200,1300,SpectrumList=[1,3,5])
+    cropped = ExtractSpectra(ws,200,1300,WorkspaceIndexList=[1,3,5])
     print 'Output workspace has %s bins' % cropped.blocksize()
     print 'Output workspace has %s spectra' % cropped.getNumberHistograms()
 


### PR DESCRIPTION
Implements #12843

**Context**

We want to extend the input options for the ExtractSpectra algorithm. In particular, we want to be able to pass a detector ID list to the algorithm

**For testing**

Plese code review

There are several unit tests in place for the added feature, but it is worth to run [this script](https://gist.github.com/picatess/cc5ad7c9d0b0de487b88) and ensure that it shows the desired behaviour.
