### PR TITLE
Add WorkspaceGroup forward declaration header (and use it)

### DIFF
--- a/Code/Mantid/Framework/API/CMakeLists.txt
+++ b/Code/Mantid/Framework/API/CMakeLists.txt
@@ -292,6 +292,7 @@ set ( INC_FILES
 	inc/MantidAPI/Workspace_fwd.h
 	inc/MantidAPI/WorkspaceFactory.h
 	inc/MantidAPI/WorkspaceGroup.h
+	inc/MantidAPI/WorkspaceGroup_fwd.h
 	inc/MantidAPI/WorkspaceHistory.h
 	inc/MantidAPI/WorkspaceOpOverloads.h
 	inc/MantidAPI/WorkspaceProperty.h

--- a/Code/Mantid/Framework/API/inc/MantidAPI/MultiPeriodGroupWorker.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MultiPeriodGroupWorker.h
@@ -2,7 +2,7 @@
 #define MANTID_API_MULTIPERIODGROUPWORKER_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAPI/Algorithm.h"
 #include <string>
 #include <vector>
@@ -46,7 +46,7 @@ namespace API {
 class DLLExport MultiPeriodGroupWorker {
 public:
   /// Convenience typdef for workspace names.
-  typedef std::vector<boost::shared_ptr<Mantid::API::WorkspaceGroup>>
+  typedef std::vector<WorkspaceGroup_sptr>
       VecWSGroupType;
   /// Constructor
   MultiPeriodGroupWorker();

--- a/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -5,6 +5,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAPI/AnalysisDataService.h"
 
 #include <Poco/NObserver.h>
@@ -144,11 +145,6 @@ private:
   friend class AnalysisDataServiceImpl;
   friend class Algorithm;
 };
-
-/// Shared pointer to a workspace group class
-typedef boost::shared_ptr<WorkspaceGroup> WorkspaceGroup_sptr;
-/// Shared pointer to a workspace group class (const version)
-typedef boost::shared_ptr<const WorkspaceGroup> WorkspaceGroup_const_sptr;
 
 } // namespace API
 } // namespace Mantid

--- a/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup_fwd.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup_fwd.h
@@ -1,0 +1,43 @@
+#ifndef MANTID_API_WORKSPACEGROUP_FWD_H_
+#define MANTID_API_WORKSPACEGROUP_FWD_H_
+
+#include <boost/shared_ptr.hpp>
+
+namespace Mantid {
+namespace API {
+/**
+  This file provides forward declarations for Mantid::API::WorkspaceGroup
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>.
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+/// forward declare of Mantid::API::WorkspaceGroup
+class WorkspaceGroup;
+/// shared pointer to Mantid::API::WorkspaceGroup
+typedef boost::shared_ptr<WorkspaceGroup> WorkspaceGroup_sptr;
+/// shared pointer to Mantid::API::WorkspaceGroup, pointer to const version
+typedef boost::shared_ptr<const WorkspaceGroup> WorkspaceGroup_const_sptr;
+
+} // namespace API
+} // namespace Mantid
+
+#endif // MANTID_API_WORKSPACEGROUP_FWD_H_

--- a/Code/Mantid/Framework/API/src/WorkspaceOpOverloads.cpp
+++ b/Code/Mantid/Framework/API/src/WorkspaceOpOverloads.cpp
@@ -12,7 +12,7 @@
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/IMDHistoWorkspace.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 
 #include <numeric>
 

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -7,7 +7,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/Workspace_fwd.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/System.h"

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/GroupWorkspaces.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/GroupWorkspaces.h
@@ -7,9 +7,11 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidAPI/WorkspaceProperty.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
+
 namespace Mantid {
 namespace Algorithms {
+
 /** Takes   workspaces as input and groups the workspaces.
 
 Required Properties:

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadMcStas.h
@@ -5,7 +5,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IFileLoader.h"
 
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadNexus.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadNexus.h
@@ -8,7 +8,7 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidKernel/Property.h"
 #include <climits>
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 
 namespace Mantid {
 namespace DataHandling {

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSassena.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadSassena.h
@@ -5,7 +5,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/IFileLoader.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include <hdf5.h>
 

--- a/Code/Mantid/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMcStas.cpp
@@ -1,21 +1,21 @@
-#include "MantidDataHandling/LoadMcStas.h"
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FileProperty.h"
+#include "MantidAPI/IEventWorkspace.h"
+#include "MantidAPI/InstrumentDataService.h"
+#include "MantidAPI/NumericAxis.h"
+#include "MantidAPI/RegisterFileLoader.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidAPI/IEventWorkspace.h"
 #include "MantidKernel/Unit.h"
-#include <nexus/NeXusFile.hpp>
-#include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/UnitFactory.h"
+#include "MantidDataHandling/LoadEventNexus.h"
+#include "MantidDataHandling/LoadMcStas.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
-#include "MantidAPI/InstrumentDataService.h"
-#include "MantidDataHandling/LoadEventNexus.h"
-#include "MantidKernel/UnitFactory.h"
-#include "MantidAPI/RegisterFileLoader.h"
 
-#include "MantidAPI/NumericAxis.h"
-#include <nexus/NeXusException.hpp>
 #include <boost/algorithm/string.hpp>
+#include <nexus/NeXusException.hpp>
+#include <nexus/NeXusFile.hpp>
 
 namespace Mantid {
 namespace DataHandling {

--- a/Code/Mantid/Framework/DataHandling/src/LoadRaw3.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRaw3.cpp
@@ -4,7 +4,7 @@
 #include "MantidDataHandling/LoadRaw3.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidAPI/MemoryManager.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidKernel/UnitFactory.h"

--- a/Code/Mantid/Framework/DataHandling/src/LoadRawBin0.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRawBin0.cpp
@@ -4,7 +4,7 @@
 #include "MantidDataHandling/LoadRawBin0.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidAPI/MemoryManager.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/ArrayProperty.h"

--- a/Code/Mantid/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -5,7 +5,6 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidAPI/MemoryManager.h"
 #include "MantidAPI/SpectrumDetectorMapping.h"
-#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/ArrayProperty.h"

--- a/Code/Mantid/Framework/DataHandling/test/FilterEventsByLogValuePreNexusTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/FilterEventsByLogValuePreNexusTest.h
@@ -6,7 +6,6 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Workspace.h"
-#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidDataHandling/LoadInstrument.h"
 #include "MantidDataObjects/EventWorkspace.h"

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/BinaryOperations.cpp
@@ -5,7 +5,7 @@
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidPythonInterface/kernel/Policies/AsType.h"
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceGroupProperty.cpp
@@ -1,5 +1,5 @@
 #include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 
 void export_WorkspaceGroupProperty() {
   using Mantid::API::WorkspaceGroup;

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -22,7 +22,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/WorkspaceFactory.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidGeometry/Instrument/Detector.h"
 
 namespace Mantid {

--- a/Code/Mantid/MantidPlot/src/Mantid/MantidDock.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/MantidDock.h
@@ -7,7 +7,6 @@
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidAPI/WorkspaceGroup.h"
 
 #include "MantidQtMantidWidgets/AlgorithmSelectorWidget.h"
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/TomoReconstruction/TomoReconstruction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/TomoReconstruction/TomoReconstruction.h
@@ -5,7 +5,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/TableRow.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidQtAPI/UserSubWindow.h"
 #include "MantidQtCustomInterfaces/TomoReconstruction/TomoToolConfigDialog.h"
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/MSDFit.cpp
@@ -1,5 +1,5 @@
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidQtCustomInterfaces/Indirect/MSDFit.h"
 #include "MantidQtCustomInterfaces/UserInputValidator.h"
 #include "MantidQtMantidWidgets/RangeSelector.h"


### PR DESCRIPTION
Fixes #12848.
Added `WorkspaceGroup_fwd.h` and also tried to use it wherever possible, or deleted actually unused includes of `MantidAPI/WorkspaceGroup.h`.

**Tester**:
- Tests should be happy about these changes.
- Code review.

Nothing to say about this in the release notes.
