### PR TITLE
Sum monitors to allow GetEI work for poor monitor signal.

### DIFF
--- a/Code/Mantid/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -281,7 +281,7 @@ class ISISLoadFilesLET(stresstesting.MantidStressTest):
         self.assertEqual(ws.getNumberHistograms(),40960)
         self.assertTrue(isinstance(mon_ws,Workspace))
         #
-        self.assertEqual(mon_ws.getNumberHistograms(),9)
+        self.assertEqual(mon_ws.getNumberHistograms(),27)
 
 
         self.valid = True

--- a/Code/Mantid/instrument/LET_Parameters_dr2to12.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr2to12.xml
@@ -98,37 +98,51 @@
 <value val="False"/>
 </parameter>
 
-
-<!-- First spectra number (monitor number) to use when measuring incident energy
-    Should be spectra with well defined energy peak -->
-<parameter name="ei-mon1-spec"  type="int">
+<!-- -->
+<parameter name="ei-mon1-spec"  type="string">
   <value val="90118"/>
+  <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak  or monitor's spectra. 
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
 </parameter>
-<!-- Second spectra number (monitor number) to use when measuring incident energy
-     Should be spectra with well defined energy peak -->
-<parameter name="ei-mon2-spec"  type="int">
-  <value val="13698"/>
+<!-- -->
+<parameter name="ei-mon2-spec"  type="string">
+  <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
+  <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
 </parameter>
-
+<!-- -->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
+  <description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectra lists
+  for each of two monitors, used in GetEi calculations"/>
 </parameter>
- 
-<!--if you use some detectors as monitors and work in event mode, one needs to specify the comma separated list of these detectors here 
-    to copy detectors spectra to monitors spectra collected in histogram mode. If no such monitors are used "None" 
-    (with brackets) has to be specified as the value. This is also necessary in Histogram mode if you want to use detectors as monitors and 
-    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)
--->
+
+<!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
-  <value val="13698"/>
+  <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
+  <description is="If you use some detectors as monitors and work in event mode,
+    one needs to specify the comma separated list of these detectors here
+    to copy detectors spectra to monitors spectra collected in histogram mode.
+    If no such monitors are used, 'None' (text string) has to be specified as the value.
+    This is also necessary in Histogram mode if you want to use some detectors as monitors and 
+    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)"/>
 </parameter>
 
-
-<!-- List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
-     These detectors locations are used to identify TOF range, contributing into each energy range 
-     in multirep mode  -->
+<!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
     <value val="1,128"/>
+    <description is="List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
+    These detectors locations are used to identify TOF range, contributing into each energy range 
+     in multirep mode"/>
 </parameter>
 
 

--- a/Code/Mantid/instrument/LET_Parameters_dr2to12.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr2to12.xml
@@ -84,7 +84,7 @@
 </parameter>
 
 <!-- Relative energy range (wrt. to the incident energy) in which monitor 2 signal is present and the integration to 
-     caluclate monitor-2 current occurs   -->
+     calculate monitor-2 current occurs   -->
 <parameter name="mon2_norm_energy_range" type = "string">
     <value val="0.8,1.2"/>
 </parameter>
@@ -92,7 +92,7 @@
 <!-- Usually one wants to avoid loading monitors together with data except in special cases. One of this cases is 
      MARI which monitors numbers are in the beginning of the spectra. If one loads them separately, 
      spectra numbers change and ISIS hard masks (msk) prepared for workspace with monitors become invalid. 
-     This parameter is actual until Mantid Masking change
+     This parameter is actual until Mantid Masking change.
   -->
 <parameter name="load_monitors_with_workspace"  type="bool">
 <value val="False"/>
@@ -103,10 +103,10 @@
   <value val="90118"/>
   <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
-     Should be spectra with well defined energy peak  or monitor's spectra. 
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
@@ -114,35 +114,35 @@
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
 </parameter>
 <!-- -->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
-  <description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
-  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectra lists
-  for each of two monitors, used in GetEi calculations"/>
+  <description is="List of spectra, used to calculate incident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectrum or
+  spectra lists for each of two monitors, used in GetEi calculations"/>
 </parameter>
 
 <!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
   <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
   <description is="If you use some detectors as monitors and work in event mode,
-    one needs to specify the comma separated list of these detectors here
+    one needs to specify the comma separated list of these detectors as the value of this property
     to copy detectors spectra to monitors spectra collected in histogram mode.
-    If no such monitors are used, 'None' (text string) has to be specified as the value.
+    If no such monitors are used, None (or text string 'None' in IDF) has to be specified as the value.
     This is also necessary in Histogram mode if you want to use some detectors as monitors and 
-    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)"/>
+    load_monitors_with_workspace is set to False necessary if monitors are measured with different time channels"/>
 </parameter>
 
 <!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
     <value val="1,128"/>
-    <description is="List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
-    These detectors locations are used to identify TOF range, contributing into each energy range 
-     in multirep mode"/>
+    <description is="List of two spectra corresponding to the detectors which are closest and furthest from the sample.
+    These detectors locations are used to identify TOF range, contributing into each energy range
+    in multirep mode"/>
 </parameter>
 
 
@@ -428,6 +428,7 @@
        fix_ei=fixei;
        sum_runs=sum;
        wb_integr_range=detector_van_range;
+       motor_log_names = motor_name;       
        van_mass=vanadium-mass;
        check_background = background;
        mon1_norm_spec=norm-mon1-spec;

--- a/Code/Mantid/instrument/LET_Parameters_dr2to12.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr2to12.xml
@@ -341,7 +341,7 @@
 </parameter>
 <!-- Vanaduim mass used in absolute units normalization and is usually instrument specific (changes rarely) -->
 <parameter name="vanadium-mass">
-  <value val="20.79"/>
+  <value val="8.47"/>
 </parameter>
 <!-- if this value set to true, modo-vanadium run is not analyzed and masks obtained for arbitrary units are used for mono-vanadium -->
 <parameter name="use_sam_msk_on_monovan" type = "bool">

--- a/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
@@ -110,7 +110,7 @@
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
-  <value val="13698,13696,13697,13699"/>
+  <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
@@ -128,7 +128,7 @@
 
 <!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
-  <value val="13698,13696,13697,13699"/>
+  <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
   <description is="If you use some detectors as monitors and work in event mode,
     one needs to specify the comma separated list of these detectors here
     to copy detectors spectra to monitors spectra collected in histogram mode.

--- a/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
@@ -84,7 +84,7 @@
 </parameter>
 
 <!-- Relative energy range (wrt. to the incident energy) in which monitor 2 signal is present and the integration to 
-     caluclate monitor-2 current occurs   -->
+     calculate monitor-2 current occurs   -->
 <parameter name="mon2_norm_energy_range" type = "string">
     <value val="0.8,1.2"/>
 </parameter>
@@ -92,7 +92,7 @@
 <!-- Usually one wants to avoid loading monitors together with data except in special cases. One of this cases is 
      MARI which monitors numbers are in the beginning of the spectra. If one loads them separately, 
      spectra numbers change and ISIS hard masks (msk) prepared for workspace with monitors become invalid. 
-     This parameter is actual until Mantid Masking change
+     This parameter is actual until Mantid Masking change.
   -->
 <parameter name="load_monitors_with_workspace"  type="bool">
 <value val="False"/>
@@ -103,10 +103,10 @@
   <value val="73734"/>
   <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
-     Should be spectra with well defined energy peak  or monitor's spectra. 
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
@@ -114,34 +114,34 @@
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
 </parameter>
 <!-- -->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
-  <description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
-  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectra lists
-  for each of two monitors, used in GetEi calculations"/>
+  <description is="List of spectra, used to calculate incident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectrum or
+  spectra lists for each of two monitors, used in GetEi calculations"/>
 </parameter>
 
 <!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
   <value val="5506"/>
   <description is="If you use some detectors as monitors and work in event mode,
-    one needs to specify the comma separated list of these detectors here
+    one needs to specify the comma separated list of these detectors as the values of this property
     to copy detectors spectra to monitors spectra collected in histogram mode.
-    If no such monitors are used, 'None' (text string) has to be specified as the value.
+    If no such monitors are used, None (or text string 'None' in IDF) has to be specified as the value.
     This is also necessary in Histogram mode if you want to use some detectors as monitors and 
-    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)"/>
+    load_monitors_with_workspace is set to False necessary if monitors are measured with different time channels"/>
 </parameter>
 
 <!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
     <value val="12416,21761"/>
-    <description is="List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
-     These detectors locations are used to identify TOF range, contributing into each energy range 
+    <description is="List of two spectra corresponding to the detectors which are closest and furthest from the sample.
+    These detectors locations are used to identify TOF range, contributing into each energy range
      in multirep mode"/>
 </parameter>
 

--- a/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
@@ -99,17 +99,34 @@
 </parameter>
 
 
-<!-- First spectra number (monitor number) to use when measuring incident energy
-    Should be spectra with well defined energy peak -->
-<parameter name="ei-mon1-spec"  type="int">
+<!-- First spectra number (monitor number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak 
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector.
+-->
+<parameter name="ei-mon1-spec"  type="string">
   <value val="73734"/>
 </parameter>
-<!-- Second spectra number (monitor number) to use when measuring incident energy
-     Should be spectra with well defined energy peak -->
-<parameter name="ei-mon2-spec"  type="int">
+<!-- Second spectra number (monitor number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak.
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector.
+-->
+<parameter name="ei-mon2-spec"  type="string">
   <value val="5506"/>
 </parameter>
 
+<!--
+  description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
+  
+  It is complex property, dependent on two other properties, ei-mon1-spec and ei-mon2-spec, which define spectra lists 
+  for each of two monitors, used in GetEi calculations
+
+-->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
 </parameter>

--- a/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
@@ -341,7 +341,7 @@
 </parameter>
 <!-- Vanaduim mass used in absolute units normalization and is usually instrument specific (changes rarely) -->
 <parameter name="vanadium-mass">
-  <value val="8.47"/>
+  <value val="20.79"/>
 </parameter>
 <!-- if this value set to true, modo-vanadium run is not analyzed and masks obtained for arbitrary units are used for mono-vanadium -->
 <parameter name="use_sam_msk_on_monovan" type = "bool">

--- a/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
@@ -98,54 +98,51 @@
 <value val="False"/>
 </parameter>
 
-
-<!-- First spectra number (monitor number) to use when measuring incident energy,
-     or comma separated list of such numbers.
-     Should be spectra with well defined energy peak 
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
-     It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector.
--->
+<!-- -->
 <parameter name="ei-mon1-spec"  type="string">
   <value val="73734"/>
-</parameter>
-<!-- Second spectra number (monitor number) to use when measuring incident energy,
+  <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
-     Should be spectra with well defined energy peak.
+     Should be spectra with well defined energy peak  or monitor's spectra. 
      If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector.
--->
-<parameter name="ei-mon2-spec"  type="string">
-  <value val="5506"/>
+     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
 </parameter>
-
-<!--
-  description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
-  
-  It is complex property, dependent on two other properties, ei-mon1-spec and ei-mon2-spec, which define spectra lists 
-  for each of two monitors, used in GetEi calculations
-
--->
+<!-- -->
+<parameter name="ei-mon2-spec"  type="string">
+  <value val="13698,13696,13697,13699"/>
+  <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+</parameter>
+<!-- -->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
+  <description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectra lists
+  for each of two monitors, used in GetEi calculations"/>
 </parameter>
- 
-<!--if you use some detectors as monitors and work in event mode, one needs to specify the comma separated list of these detectors here 
-    to copy detectors spectra to monitors spectra collected in histogram mode. If no such monitors are used "None" 
-    (with brackets) has to be specified as the value. This is also necessary in Histogram mode if you want to use detectors as monitors and 
-    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)
--->
+
+<!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
-  <value val="5506"/>
+  <value val="13698,13696,13697,13699"/>
+  <description is="If you use some detectors as monitors and work in event mode,
+    one needs to specify the comma separated list of these detectors here
+    to copy detectors spectra to monitors spectra collected in histogram mode.
+    If no such monitors are used, 'None' (text string) has to be specified as the value.
+    This is also necessary in Histogram mode if you want to use some detectors as monitors and 
+    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)"/>
 </parameter>
 
-
-<!-- List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
-     These detectors locations are used to identify TOF range, contributing into each energy range 
-     in multirep mode  -->
+<!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
     <value val="12416,21761"/>
+    <description is="List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
+     These detectors locations are used to identify TOF range, contributing into each energy range 
+     in multirep mode"/>
 </parameter>
 
 
@@ -344,7 +341,7 @@
 </parameter>
 <!-- Vanaduim mass used in absolute units normalization and is usually instrument specific (changes rarely) -->
 <parameter name="vanadium-mass">
-  <value val="20.79"/>
+  <value val="8.47"/>
 </parameter>
 <!-- if this value set to true, modo-vanadium run is not analyzed and masks obtained for arbitrary units are used for mono-vanadium -->
 <parameter name="use_sam_msk_on_monovan" type = "bool">

--- a/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
+++ b/Code/Mantid/instrument/LET_Parameters_dr3to11.xml
@@ -110,7 +110,7 @@
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
-  <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
+  <value val="5506"/>
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
@@ -128,7 +128,7 @@
 
 <!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
-  <value val="13696,13693,13694,13695,13697,13698,13699,13948,13949,13950,13951,13952,13953,13954,13955,14207,14208,14209,14210"/>
+  <value val="5506"/>
   <description is="If you use some detectors as monitors and work in event mode,
     one needs to specify the comma separated list of these detectors here
     to copy detectors spectra to monitors spectra collected in histogram mode.

--- a/Code/Mantid/instrument/MERLIN_Parameters_after2013_4.xml
+++ b/Code/Mantid/instrument/MERLIN_Parameters_after2013_4.xml
@@ -107,7 +107,7 @@
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
-  <value val="61638,61639,61640,61641"/>
+  <value val="69638,69639,69640,69641"/>
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.

--- a/Code/Mantid/instrument/MERLIN_Parameters_after2013_4.xml
+++ b/Code/Mantid/instrument/MERLIN_Parameters_after2013_4.xml
@@ -20,7 +20,7 @@
    <value val="one2one_125.map"/>
 </parameter>
 
-<!-- Prefered extension of the data files obtained from DAE, e.g. what to prefer if two 
+<!-- Preferred extension of the data files obtained from DAE, e.g. what to prefer if two 
      files with the same name and different extension are found
  -->
 <parameter name="data_file_ext" type="string">
@@ -81,7 +81,7 @@
     <value val="69634"/>
 </parameter>
 <!-- Relative energy range (wrt. to the incident energy) in which monitor 2 signal is present and the integration to 
-     caluclate monitor-2 current occurs   -->
+     calculate monitor-2 current occurs   -->
 <parameter name="mon2_norm_energy_range" type = "string">
     <value val="0.8,1.2"/>
 </parameter>
@@ -89,7 +89,7 @@
 <!-- Usually one wants to avoid loading monitors together with data except in special cases. One of this cases is 
      MARI which monitors numbers are in the beginning of the spectra. If one loads them separately, 
      spectra numbers change and ISIS hard masks (msk) prepared for workspace with monitors become invalid. 
-     This parameter is actual until Mantid Masking change
+     This parameter is actual until Mantid Masking change.
   -->
 <parameter name="load_monitors_with_workspace"  type="bool">
 <value val="False"/>
@@ -100,10 +100,10 @@
   <value val="69634,69635,69636,69637"/>
   <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
-     Should be spectra with well defined energy peak  or monitor's spectra. 
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
 </parameter>
 <!-- -->
 <parameter name="ei-mon2-spec"  type="string">
@@ -111,34 +111,34 @@
   <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
      or comma separated list of such numbers.
      Should be spectra with well defined energy peak or monitor's spectra.
-     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
      It is important to have the detectors for these spectra to be located at the same distance from the source,
-     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
 </parameter>
 <!-- -->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
-  <description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
-  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectra lists
-  for each of two monitors, used in GetEi calculations"/>
+  <description is="List of spectra, used to calculate incident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectrum or
+  spectra lists for each of two monitors, used in GetEi calculations"/>
 </parameter>
 
 <!-- -->
 <parameter name="spectra_to_monitors_list"  type="string">
   <value val="None"/>
   <description is="If you use some detectors as monitors and work in event mode,
-    one needs to specify the comma separated list of these detectors here
+    one needs to specify the comma separated list of these detectors as the value of this property
     to copy detectors spectra to monitors spectra collected in histogram mode.
-    If no such monitors are used, 'None' (text string) has to be specified as the value.
+    If no such monitors are used, None (or text string 'None' in IDF) has to be specified as the value.
     This is also necessary in Histogram mode if you want to use some detectors as monitors and 
-    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)"/>
+    load_monitors_with_workspace is set to False necessary if monitors are measured with different time channels"/>
 </parameter>
 
 <!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
     <value val="382,68353"/>
-    <description is="List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
-     These detectors locations are used to identify TOF range, contributing into each energy range 
+    <description is="List of two spectra corresponding to the detectors which are closest and furthest from the sample.
+    These detectors locations are used to identify TOF range, contributing into each energy range
      in multirep mode"/>
 </parameter>
 
@@ -175,7 +175,6 @@
 <parameter name="wb_integr_range"   type="string">
     <value val="wb-integr-min:wb-integr-max"/>
 </parameter>
-
 
 
 <!-- integration range for background tests  (in TOF) - composite property 
@@ -346,7 +345,7 @@
   <value val="False"/>
 </parameter>
 
-<!-- if this value is provided (nont None) it is string reperesentation of the number used instead of calculating mono-vanadium based normalization factor 
+<!-- if this value is provided (not None) it is string reperesentation of the number used instead of calculating mono-vanadium based normalization factor 
    one does not need to provide mono-vanadium run if this value is provided as it will be used instead
   -->
 <parameter name="mono_correction_factor" type="string">
@@ -371,7 +370,7 @@
 </parameter>
 
 <!-- If one wants to sum runs. By default no, as in addition to the key word one has to provide list of input run-numbers
-     but presence of this key here allows to propagate this key word for to the reducer   -->  
+     but presence of this key here allows to propagate this key-word to the reducer   -->
 <parameter name="sum_runs"  type="bool">
    <value val="False"/>
 </parameter>
@@ -394,6 +393,7 @@
 <parameter name="run_diagnostics" type="bool">
     <value val="True"/>
 </parameter>
+
 
 <!-- If this parameter is set to true, dgreduce will try to load mask from the mask file
      correspondent to the run if finds it and uses this mask as hard mask only (does not run diagnostics). 
@@ -454,7 +454,7 @@
        bleed_maxrate = diag_bleed_maxrate;
        bleed_pixels  = diag_bleed_pixels;
        deltaE_mode =  deltaE-mode;
-       ei-mon1-spec=ei_mon1_spec;       
+       ei-mon1-spec=ei_mon1_spec;
        ei-mon2-spec = test_ei2_mon_spectra=ei_mon2_spec;
        ei_mon_spectra=test_mon_spectra_composite"
     />

--- a/Code/Mantid/instrument/MERLIN_Parameters_after2013_4.xml
+++ b/Code/Mantid/instrument/MERLIN_Parameters_after2013_4.xml
@@ -95,35 +95,51 @@
 <value val="False"/>
 </parameter>
 
-
-<!-- First spectra number (monitor number) to use when measuring incident energy
-    Should be spectra with well defined energy peak -->
-<parameter name="ei-mon1-spec"  type="int">
-  <value val="69634"/>
+<!-- -->
+<parameter name="ei-mon1-spec"  type="string">
+  <value val="69634,69635,69636,69637"/>
+  <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak  or monitor's spectra. 
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
 </parameter>
-<!-- Second spectra number (monitor number) to use when measuring incident energy
-     Should be spectra with well defined energy peak -->
-<parameter name="ei-mon2-spec"  type="int">
-  <value val="69638"/>
+<!-- -->
+<parameter name="ei-mon2-spec"  type="string">
+  <value val="61638,61639,61640,61641"/>
+  <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectra will be sum of the spectra numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spetra's detector."/>
 </parameter>
+<!-- -->
 <parameter name="ei_mon_spectra"  type="string">
   <value val="ei-mon1-spec:ei-mon2-spec"/>
-</parameter>
-  
-<!--if you use some detectors as monitors and work in event mode, one needs to specify the comma separated list of these detectors here 
-    to copy detectors spectra to monitors spectra collected in histogram mode. If no such monitors are used "None" 
-    (with brackets) has to be specified as the value. This is also necessary in Histogram mode if you want to use detectors as monitors and 
-    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)
--->
-<parameter name="spectra_to_monitors_list"  type="string">
-    <value val="None"/>
+  <description is="List of spectra, used to calculate insident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectra lists
+  for each of two monitors, used in GetEi calculations"/>
 </parameter>
 
-<!-- List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
-     These detectors locations are used to identify TOF range, contributing into each energy range 
-     in multirep mode  -->
+<!-- -->
+<parameter name="spectra_to_monitors_list"  type="string">
+  <value val="None"/>
+  <description is="If you use some detectors as monitors and work in event mode,
+    one needs to specify the comma separated list of these detectors here
+    to copy detectors spectra to monitors spectra collected in histogram mode.
+    If no such monitors are used, 'None' (text string) has to be specified as the value.
+    This is also necessary in Histogram mode if you want to use some detectors as monitors and 
+    load_monitors_with_workspace is set to False (or monitors are measured with different time channels)"/>
+</parameter>
+
+<!-- -->
 <parameter name="multirep_tof_specta_list"  type="string">
     <value val="382,68353"/>
+    <description is="List of two spectra corresponding to the detectors which are closest and furtherest from the sample.
+     These detectors locations are used to identify TOF range, contributing into each energy range 
+     in multirep mode"/>
 </parameter>
 
 

--- a/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -674,10 +674,10 @@ class DirectEnergyConversion(object):
     def sum_monitors_spectra(self,monitor_ws,ei_mon_spectra):
         """Sum monitors spectra for all spectra, specified in the spectra list(s)
            and create monitor workspace containing only the spectra summed and organized
-           according to ei_mon_spectea tuple.
+           according to ei_mon_spectra tuple.
 
-           Returns tuple of two spectra, containing in the new monitor workspace and
-           pointer to the new workspace itself
+           Returns tuple of two spectra numbers, containing in the
+           new summed monitors workspace and pointer to the new workspace itself.
         """
         spectra_list1=ei_mon_spectra[0]
         spectra_list2=ei_mon_spectra[1]

--- a/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -1052,15 +1052,16 @@ class DirectEnergyConversion(object):
                 src_name = None
                 mon1_peak = 0
             else:
-                mon_1_spec_ID = ei_mon_spectra[1]
+                mon_1_spec_ID = ei_mon_spectra[0]
                 if isinstance(mon_1_spec_ID,collections.Iterable):
                     fix_ei = True # This could be a HACK
                     mon_1_spec_ID = mon_1_spec_ID[0]
+                #-----------
                 mon_2_spec_ID = ei_mon_spectra[1]
                 if isinstance(mon_2_spec_ID,collections.Iterable):
                     fix_ei = True # This could be a HACK
-                    mon_2_spec_ID = mon_2_spec_ID[0]
-
+                    mon_2_spec_ID = mon_2_spec_ID[1]
+                #-----------
 
                 # Calculate the incident energy and TOF when the particles access Monitor1
                 try:

--- a/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -669,6 +669,24 @@ class DirectEnergyConversion(object):
         return mono_s
 
 #-------------------------------------------------------------------------------
+    def sum_monitors_spectra(self,monitor_ws,ei_mon_spectra):
+        """Sum monitors spectra for all spectra, specified in the spectra list(s)
+        """
+        spectra_list1=ei_mon_spectra[0]
+        spectra_list2=ei_mon_spectra[1]
+        if isinstance(spectra_list1,list):
+            spectra1 = self._process_spectra_list(monitor_ws,spectra_list1)
+        else:
+            spectra1 = spectra_list1
+        if isinstance(spectra_list2,list):
+            spectra2 = self._process_spectra_list(monitor_ws,spectra_list2)
+        else:
+            spectra2 = spectra_list2
+        return (spectra1,spectra2)
+
+    def _process_spectra_list(self,workspace,spectra_list):
+        """Method sums the specified spectra in the workspace"""
+#-------------------------------------------------------------------------------
     def get_ei(self, data_run, ei_guess):
         """ Calculate incident energy of neutrons and the time of the of the
             peak in the monitor spectrum
@@ -691,6 +709,9 @@ class DirectEnergyConversion(object):
                  format(data_ws.name(),data_ws.getRunNumber()))
         separate_monitors = data_run.is_monws_separate()
         data_run.set_action_suffix('_shifted')
+        # sum monitor spectra if this is requested
+        if RunDescriptor.ei_mon_spectra.need_to_sum_monitors():
+            ei_mon_spectra = self.sum_monitors_spectra(monitor_ws,ei_mon_spectra)
 
 
         # Calculate the incident energy

--- a/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -507,7 +507,8 @@ class DirectEnergyConversion(object):
                 else:
                     if results_name != out_ws_name:
                         RenameWorkspace(InputWorkspace=results_name,OutputWorkspace=out_ws_name)
-                        result = mtd[out_ws_name]
+                        results_name = out_ws_name
+                        result = mtd[results_name]
                     else:
                         result = deltaE_ws_sample
             else: # delete workspace if no output is requested

--- a/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/DirectEnergyConversion.py
@@ -682,7 +682,7 @@ class DirectEnergyConversion(object):
         spectra_list1=ei_mon_spectra[0]
         spectra_list2=ei_mon_spectra[1]
         if not isinstance(spectra_list1,list):
-           spectra_list1 = [spectra_list1]
+            spectra_list1 = [spectra_list1]
         spec_num1 = self._process_spectra_list(monitor_ws,spectra_list1,'spectr_ws1')
 
         if not isinstance(spectra_list2,list):
@@ -696,8 +696,9 @@ class DirectEnergyConversion(object):
         if 'spectr_ws2' in mtd:
             DeleteWorkspace('spectr_ws2')
         monitor_ws = mtd[monitor_ws_name]
-        # Weird operation. It looks like the spectra numbers obtained from 
-        # Append operation depend on instrument. Looks like a bug in AppendSpectra
+        # Weird operation. It looks like the spectra numbers obtained from
+        # AppendSpectra operation depend on instrument.
+        # Looks like a bug in AppendSpectra
         spec_num1 = monitor_ws.getSpectrum(0).getSpectrumNo()
         spec_num2 = monitor_ws.getSpectrum(1).getSpectrumNo()
 
@@ -840,11 +841,11 @@ class DirectEnergyConversion(object):
                 method,old_ws_name = self._normalize_to_monitor2(run,old_ws_name, range_offset,external_monitors_ws)
                 break
             if case('current'):
-                out_ws=NormaliseByCurrent(InputWorkspace=old_ws_name,OutputWorkspace=old_ws_name)
+                NormaliseByCurrent(InputWorkspace=old_ws_name,OutputWorkspace=old_ws_name)
                 # NormalizationFactor log has been added by the algorithm themselves.
                 break
             if case(): # default
-                raise RuntimeError("""Normalization method {0} not found. 
+                raise RuntimeError("""Normalization method {0} not found.
                                    It must be one of monitor-1, monitor-2, current, or None""".\
                                    format(method))
         #endCase
@@ -881,7 +882,7 @@ class DirectEnergyConversion(object):
                    .format(ws.name(),run.run_number()))
 
 
-        range = self.norm_mon_integration_range
+        int_range = self.norm_mon_integration_range
         if self._debug_mode:
             kwargs = {'NormFactorWS':'NormMon1_WS' + data_ws.getName()}
         else:
@@ -891,12 +892,12 @@ class DirectEnergyConversion(object):
         if separate_monitors:
             kwargs['MonitorWorkspace'] = mon_ws
             kwargs['MonitorWorkspaceIndex'] = int(mon_ws.getIndexFromSpectrumNumber(int(mon_spect)))
-            range_min = float(range[0])
-            range_max = float(range[1])
+            range_min = float(int_range[0])
+            range_max = float(int_range[1])
         else:
             kwargs['MonitorSpectrum'] = int(mon_spect) # shame TODO: change c++ algorithm, which need float monitor ID
-            range_min = float(range[0] + range_offset)
-            range_max = float(range[1] + range_offset)
+            range_min = float(int_range[0] + range_offset)
+            range_max = float(int_range[1] + range_offset)
         kwargs['NormFactorWS'] = 'Monitor1_norm_ws'
 
         # Normalize to monitor 1
@@ -948,9 +949,9 @@ class DirectEnergyConversion(object):
 
         #Find TOF range, correspondent to incident energy monitor peak
         if self._mon2_norm_time_range: # range has been found during ei-calculations
-            range = self._mon2_norm_time_range
-            range_min = range[0] + range_offset
-            range_max = range[1] + range_offset
+            norm_range = self._mon2_norm_time_range
+            range_min = norm_range[0] + range_offset
+            range_max = norm_range[1] + range_offset
             self._mon2_norm_time_range = None
         else:
             mon_ws_name = mon_ws.name() #monitor's workspace and detector's workspace are e
@@ -1539,14 +1540,13 @@ class DirectEnergyConversion(object):
 # -------------------------------------------------------------------------------------------
 #         This actually does the conversion for the mono-sample and
 #         mono-vanadium runs
-#
 # -------------------------------------------------------------------------------------------
     def _do_mono_SNS(self, data_ws, result_name, ei_guess,\
                  white_run=None, map_file=None, spectra_masks=None, Tzero=None):
-        # does not work -- retrieve from repo and fix
+        # does not work -- retrieve from repo and fix if this functionality is needed.
         raise NotImplementedError("Non currently implemented. Retrieve from repository"
                                   " if necessary and fix")
-        return
+        #return
 #-------------------------------------------------------------------------------
     def _do_mono_ISIS(self, data_run, ei_guess,\
                  white_run=None, map_file=None, spectra_masks=None, Tzero=None):
@@ -1783,7 +1783,7 @@ def get_failed_spectra_list_from_masks(masked_wksp,prop_man):
     if masked_wksp is None:
         return (failed_spectra,0)
     try:
-        name = masked_wksp.name()
+        masked_wksp.name()
     except Exeption as ex:
         prop_man.log("***WARNING: cached mask workspace invalidated. Incorrect masking reported")
         return (failed_spectra,0)

--- a/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -867,7 +867,11 @@ class EiMonSpectra(prop_helpers.ComplexProperty):
     #
     def _process_monitors_spectra(self,mon_range):
         """A method to process any form of monitor spectra list
-           representation"""
+           representation
+        Called on get rather then on set operation as monitor lists
+        can be set separately through ei-mon1-spec or 'ei-mon2-spec
+        properties and these properties are currently standard properties
+        """
 
         if isinstance(mon_range,str):
             mon_val = mon_range.split(',')
@@ -883,9 +887,8 @@ class EiMonSpectra(prop_helpers.ComplexProperty):
             rez_spectra = int(mon_range)
         return rez_spectra
 
-        return (mon_range,False)
     def validate(self,instance, owner):
-        """"""
+        """ """
         return (True,0,'')
 
 #-----------------------------------------------------------------------------------------

--- a/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -785,8 +785,108 @@ class MonovanIntegrationRange(prop_helpers.ComplexProperty):
         if range[0] < -100 * ei or range[0] > 100 * ei:
             return (False,1,'monovan integration is suspiciously wide: [{0}:{1}]. This may be incorrect'.format(range[0],range[1]))
         return (True,0,'')
-
 #end MonovanIntegrationRange
+
+class EiMonSpectra(prop_helpers.ComplexProperty):
+    """Property defines list of spectra, used to calculate incident energy.
+       it defines two monitor spectra for GetEi algorithm to work
+       or two spectra lists to sum and obtain two combined spectra
+       for GetEi algorithm to work.
+    """
+    def __init__(self):
+        """ Ei mon spectra is defined as function of two other complex properties"""
+        prop_helpers.ComplexProperty.__init__(self,['ei-mon1-spec','ei-mon2-spec'])
+
+    def __get__(self,instance,owner):
+        if instance is None:
+            return self
+
+        if isinstance(instance,dict):
+            tDict = instance
+        else:
+            tDict = instance.__dict__
+
+        mon_range = prop_helpers.ComplexProperty.__get__(self,tDict)
+
+        # Return monitors range, converted into the standard form.
+        # namely tuple of two monitors or monitors list
+        monitors = [0,0]
+        for index,mon_val in enumerate(mon_range):
+            monitors[index]=self._process_monitors_spectra(mon_val)
+        return (monitors[0],monitors[1])
+
+
+        return monitors
+
+    def __set__(self,instance,value):
+        if value is None: # Do nothing
+            return
+
+        if isinstance(instance,dict):
+            dDict = instance
+        else:
+            tDict = instance.__dict__
+
+        if isinstance(value,str):
+            val =  value.translate(None,'[]').strip()
+            if val.find(':')>-1:
+                val = val.split(':')
+            else:
+                val = val.split(',')
+        else:
+            val = value
+        #end if
+        if len(val) != 2:
+            raise KeyError("ei_mon_spectra may be either tuple defining two spectra "\
+                "lists or string, which can be transformed to such lists. Got {0}"
+                .format(value))
+
+        # Handle self-assignment. Otherwise suppose that the values are meaningful
+        if val[0] == 'ei-mon1-spec':
+            val[0] = tDict['ei-mon1-spec']
+        if val[1] == 'ei-mon2-spec':
+            val[1] = tDict['ei-mon2-spec']
+        #
+        prop_helpers.ComplexProperty.__set__(self,tDict,val)
+
+    def need_to_sum_monitors(self,instance):
+        """Returns True if some monitors are defined as range of spectra to sum
+           False -- if all monitors are related to one spectra each.
+        """
+        tDict = instance.__dict__
+        mon_range = prop_helpers.ComplexProperty.__get__(self,tDict)
+        # Return monitors range, converted into the standard form.
+        need_to_sum =False
+        for index,mon_val in enumerate(mon_range):
+            mon_list = self._process_monitors_spectra(mon_val)
+            if isinstance(mon_list,list):
+                need_to_sum  = True
+                break
+        return need_to_sum
+
+    #
+    def _process_monitors_spectra(self,mon_range):
+        """A method to process any form of monitor spectra list
+           representation"""
+
+        if isinstance(mon_range,str):
+            mon_val = mon_range.split(',')
+        else:
+            mon_val = mon_range
+        if isinstance(mon_val,list) or isinstance(mon_val,tuple):
+            rez_spectra=[]
+            for mon in mon_val:
+                rez_spectra.append(int(mon))
+            if len(rez_spectra) == 1:
+                rez_spectra = rez_spectra[0]
+        else:
+            rez_spectra = int(mon_range)
+        return rez_spectra
+
+        return (mon_range,False)
+    def validate(self,instance, owner):
+        """"""
+        return (True,0,'')
 
 #-----------------------------------------------------------------------------------------
 class SpectraToMonitorsList(PropDescriptor):
@@ -1232,6 +1332,7 @@ class RotationAngle(PropDescriptor):
     def dependencies(self):
         return ['motor_log_names','motor_offset']
 #end RotationAngle
+
 
 #-----------------------------------------------------------------------------------------
 # END Descriptors for PropertyManager itself

--- a/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -789,8 +789,8 @@ class MonovanIntegrationRange(prop_helpers.ComplexProperty):
 
 class EiMonSpectra(prop_helpers.ComplexProperty):
     """Property defines list of spectra, used to calculate incident energy.
-       it defines two monitor spectra for GetEi algorithm to work
-       or two spectra lists to sum and obtain two combined spectra
+       It defines two monitor spectra for GetEi algorithm to work
+       or two spectra lists to sum and obtain workspace with two combined spectra
        for GetEi algorithm to work.
     """
     def __init__(self):

--- a/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -11,6 +11,7 @@ import numpy as np
 
 import Direct.ReductionHelpers as prop_helpers
 import Direct.CommonFunctions as common
+from collections import Iterable
 
 #-----------------------------------------------------------------------------------------
 # Descriptors, providing overloads for complex properties in NonIDF_Properties
@@ -187,10 +188,12 @@ class IncidentEnergy(PropDescriptor):
         if isinstance(inc_en,list):
             for ind,en in enumerate(inc_en):
                 if en <= 0:
-                    return (False,2,"Incident energy have to be positive number or list of positive numbers.\n" + "For input argument {0} got negative energy {1}".format(ind,en))
+                    return (False,2,"Incident energy have to be positive number or list of positive numbers.\n"
+                            "For input argument {0} got negative energy {1}".format(ind,en))
         else:
             if inc_en <= 0:
-                return (False,2,"Incident energy have to be positive number or list of positive numbers.\n" + "Got single negative incident energy {0} ".format(inc_en))
+                return (False,2,"Incident energy have to be positive number or list of positive numbers.\n"
+                        "Got single negative incident energy {0} ".format(inc_en))
         return (True,0,'')
 # end IncidentEnergy
 #-----------------------------------------------------------------------------------------
@@ -445,13 +448,14 @@ class mon2NormalizationEnergyRange(PropDescriptor):
 
     def validate(self,instance,owner=None):
         """ function verifies if the energy range is consistent with incident energies """
-        range = self._relative_range
-        if len(range) != 2:
-            return(False,2,'mon2_normalization_energy_range can be initialized by list of two values only. Got {0} values'.format(len(range)))
+        en_range = self._relative_range
+        if len(en_range) != 2:
+            return(False,2,'mon2_normalization_energy_range can be initialized by list of two values only.'
+                  ' Got {0} values'.format(len(range)))
 
         result = (True,0,'')
 
-        val1 = float(range[0])
+        val1 = float(en_range[0])
         if val1 < 0.1 or val1 > 0.9:
             message = "Lower mon2_norm_energy_range describes lower limit of energy to integrate neutron signal after the chopper.\n"\
                       "The limit is defined as (this value)*incident_energy. Are you sure you want to set this_value to {0}?\n".format(val1)
@@ -461,7 +465,7 @@ class mon2NormalizationEnergyRange(PropDescriptor):
                 result = (False,1,message)
 
 
-        val2 = float(range[1])
+        val2 = float(en_range[1])
         if val2 < 1.1 or val2 > 1.9:
             message = "Upper mon2_norm_energy_range describes upper limit of energy to integrate neutron signal after the chopper.\n"\
                      "The limit is defined as (this value)*incident_energy. Are you sure you want to set this_value to {0}?\n".format(val2)
@@ -660,7 +664,7 @@ class HardMaskOnly(prop_helpers.ComplexProperty):
     def __init__(self):
         prop_helpers.ComplexProperty.__init__(self,['use_hard_mask_only','run_diagnostics'])
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -726,7 +730,7 @@ class MonovanIntegrationRange(prop_helpers.ComplexProperty):
             self._rel_range = True
             prop_helpers.ComplexProperty.__init__(self,['monovan_lo_frac','monovan_hi_frac'])
 
-    def __get__(self,instance,owner):
+    def __get__(self,instance,owner=None):
 
         if instance is None:
             return self
@@ -742,8 +746,8 @@ class MonovanIntegrationRange(prop_helpers.ComplexProperty):
             if ei is None:
                 raise AttributeError('Attempted to obtain relative to ei monovan integration range, but incident energy has not been set')
             rel_range = prop_helpers.ComplexProperty.__get__(self,tDict)
-            range = [rel_range[0] * ei,rel_range[1] * ei]
-            return range
+            the_range = [rel_range[0] * ei,rel_range[1] * ei]
+            return the_range
         else: # absolute range
             return prop_helpers.ComplexProperty.__get__(self,tDict)
 
@@ -778,12 +782,13 @@ class MonovanIntegrationRange(prop_helpers.ComplexProperty):
         if instance.monovan_run is None:
             return (True,0,'')
 
-        range = sepf.__get__(instance,owner)
+        the_range = sepf.__get__(instance,owner)
         ei = instance.incident_energy
-        if range[0] >= range[1]:
-            return (False,2,'monovan integration range limits = [{0}:{1}] are wrong'.format(range[0],range[1]))
-        if range[0] < -100 * ei or range[0] > 100 * ei:
-            return (False,1,'monovan integration is suspiciously wide: [{0}:{1}]. This may be incorrect'.format(range[0],range[1]))
+        if the_range[0] >= the_range[1]:
+            return (False,2,'monovan integration range limits = [{0}:{1}] are wrong'.format(the_range[0],the_range[1]))
+        if the_range[0] < -100 * ei or the_range[0] > 100 * ei:
+            return (False,1,'monovan integration is suspiciously wide: [{0}:{1}]. This may be incorrect'\
+                            .format(the_range[0],the_range[1]))
         return (True,0,'')
 #end MonovanIntegrationRange
 
@@ -797,7 +802,7 @@ class EiMonSpectra(prop_helpers.ComplexProperty):
         """ Ei mon spectra is defined as function of two other complex properties"""
         prop_helpers.ComplexProperty.__init__(self,['ei-mon1-spec','ei-mon2-spec'])
 
-    def __get__(self,instance,owner):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -815,8 +820,6 @@ class EiMonSpectra(prop_helpers.ComplexProperty):
             monitors[index]=self._process_monitors_spectra(mon_val)
         return (monitors[0],monitors[1])
 
-
-        return monitors
 
     def __set__(self,instance,value):
         if value is None: # Do nothing
@@ -857,9 +860,9 @@ class EiMonSpectra(prop_helpers.ComplexProperty):
         mon_range = prop_helpers.ComplexProperty.__get__(self,tDict)
         # Return monitors range, converted into the standard form.
         need_to_sum =False
-        for index,mon_val in enumerate(mon_range):
+        for mon_val in mon_range:
             mon_list = self._process_monitors_spectra(mon_val)
-            if isinstance(mon_list,list):
+            if isinstance(mon_list,Iterable):
                 need_to_sum  = True
                 break
         return need_to_sum
@@ -887,9 +890,9 @@ class EiMonSpectra(prop_helpers.ComplexProperty):
             rez_spectra = int(mon_range)
         return rez_spectra
 
-    def validate(self,instance, owner):
-        """ """
-        return (True,0,'')
+#    def validate(self,instance, owner):
+#        """ """
+#        return (True,0,'')
 
 #-----------------------------------------------------------------------------------------
 class SpectraToMonitorsList(PropDescriptor):
@@ -906,7 +909,7 @@ class SpectraToMonitorsList(PropDescriptor):
         self._spectra_to_monitors_list = None
 
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
         return self._spectra_to_monitors_list
@@ -956,7 +959,7 @@ class SaveFormat(PropDescriptor):
     def __init__(self):
         self._save_format = set()
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -1018,7 +1021,7 @@ class DiagSpectra(PropDescriptor):
     def __init__(self):
         self._diag_spectra = None
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -1059,7 +1062,7 @@ class BackbgroundTestRange(PropDescriptor):
     def __init__(self):
         self._background_test_range = None
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -1080,15 +1083,15 @@ class BackbgroundTestRange(PropDescriptor):
 
     def validate(self,instance, owner=None):
         """ validate background test range """
-        range = self.__get__(instance,owner)
-        if range is None:
+        test_range = self.__get__(instance,owner)
+        if test_range is None:
             return (True,0,'')
-        if range[0] >= range[1]:
-            return (False,2,' Background test range: [{0}:{1}] is incorrect '.format(range[0],range[1]))
-        if range[0] < 0:
-            return (False,2,' Background test range is TOF range, so it can not be negative={0}'.format(range[0]))
-        if range[1] > 20000:
-            return (False,1,' Background test range is TOF range, its max value looks suspiciously big={0}'.format(range[1]))
+        if test_range[0] >= test_range[1]:
+            return (False,2,' Background test range: [{0}:{1}] is incorrect '.format(test_range[0],test_range[1]))
+        if test_range[0] < 0:
+            return (False,2,' Background test range is TOF range, so it can not be negative={0}'.format(test_range[0]))
+        if test_range[1] > 20000:
+            return (False,1,' Background test range is TOF range, its max value looks suspiciously big={0}'.format(test_range[1]))
         return (True,0,'')
 #end BackbgroundTestRange
 
@@ -1103,7 +1106,7 @@ class MultirepTOFSpectraList(PropDescriptor):
     def __init__(self):
         self._spectra_list = None
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -1147,7 +1150,7 @@ class MonoCorrectionFactor(PropDescriptor):
         self.cashed_values = {}
         self._mono_run_prop = monovan_run_prop
 
-    def __get__(self,instance,type):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 
@@ -1212,7 +1215,7 @@ class MotorLogName(PropDescriptor):
     def __init__(self):
         self._log_names = []
 
-    def __get__(self,instance,type):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
         return self._log_names
@@ -1236,7 +1239,7 @@ class MotorOffset(PropDescriptor):
     """
     def __init__(self):
         self._offset = None
-    def __get__(self,instance,type):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
         return self._offset
@@ -1272,7 +1275,7 @@ class RotationAngle(PropDescriptor):
         self._log_ws_name = None
 
     #
-    def __get__(self,instance,type):
+    def __get__(self,instance,owner=None):
         if instance is None:
             return self
 

--- a/Code/Mantid/scripts/Inelastic/Direct/PropertyManager.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/PropertyManager.py
@@ -1,7 +1,7 @@
 #pylint: disable=invalid-name
 from Direct.NonIDF_Properties import *
 
-from collections import OrderedDict
+from collections import OrderedDict,Iterable
 
 
 class PropertyManager(NonIDF_Properties):
@@ -308,9 +308,18 @@ class PropertyManager(NonIDF_Properties):
                 break
             if case(): # default, could also just omit condition or 'if True'
                 pass
-
-        used_mon.add(self.ei_mon1_spec)
-        used_mon.add(self.ei_mon2_spec)
+        #
+        def add_ei_monitors(used_mon,ei_mon_list):
+            if isinstance(ei_mon_list,Iterable) :
+                for mon_sp in ei_mon_list:
+                    used_mon.add(mon_sp )
+            else:
+                used_mon.add(ei_mon_list)
+            return used_mon
+        #
+        ei_monitors = self.ei_mon_spectra
+        used_mon = add_ei_monitors(used_mon,ei_monitors[0])
+        used_mon = add_ei_monitors(used_mon,ei_monitors[1])
 
         return used_mon
     #

--- a/Code/Mantid/scripts/Inelastic/Direct/PropertyManager.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/PropertyManager.py
@@ -243,6 +243,8 @@ class PropertyManager(NonIDF_Properties):
     #
     mono_correction_factor = MonoCorrectionFactor(NonIDF_Properties.incident_energy,
                                                   NonIDF_Properties.monovan_run)
+    # list of spectra number used to identify ei
+    ei_mon_spectra = EiMonSpectra()
     # property responsible for summing runs
     sum_runs = SumRuns(NonIDF_Properties.sample_run)
     # properties responsible for rotation angle
@@ -418,6 +420,10 @@ class PropertyManager(NonIDF_Properties):
                 #end
                 if new_val != cur_val:
                     changed_descriptors.add(key)
+                    changed_throug_main = True
+                else: # property may be changed through descriptors
+                    changed_throug_main  = False
+
                 # dependencies removed either properties are equal or not
                 try:
                     dependencies = getattr(PropertyManager,key).dependencies()
@@ -426,7 +432,8 @@ class PropertyManager(NonIDF_Properties):
 
                 for dep_name in dependencies:
                     if dep_name in sorted_param:
-                        del sorted_param[dep_name]
+                        if changed_throug_main or (sorted_param[dep_name] == getattr(self,dep_name)):
+                            del sorted_param[dep_name]
             else: # remove property from old changes list not to reapply it again?
                 pass
         #end loop

--- a/Code/Mantid/scripts/Inelastic/Direct/ReductionWrapper.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ReductionWrapper.py
@@ -419,6 +419,7 @@ class ReductionWrapper(object):
         self.reducer.prop_man.sum_runs = True
 
         timeToWait = self._wait_for_file
+        self._wait_for_file = 0
         if timeToWait > 0:
             run_files = PropertyManager.sample_run.get_run_list()
             num_files_to_sum = len(PropertyManager.sample_run)
@@ -432,6 +433,9 @@ class ReductionWrapper(object):
                 while n_found > 0:
                     last_found = found[-1]
                     self.reducer.prop_man.sample_run = last_found # request to reduce all up to last found
+                    # Note that here we run convert to energy instead of user (may be) reloaded reduction!
+                    # This would cause problem for user-defined reduction, which pre-process rather than
+                    # post-process resulting workspace
                     ws = self.reducer.convert_to_energy()
                  # reset search to whole file list again
                     self.reducer.prop_man.sample_run = run_files[num_files_to_sum - 1]
@@ -449,10 +453,10 @@ class ReductionWrapper(object):
             if n_found > 0:
             # cash sum can be dropped now if it has not been done before
                 self.reducer.prop_man.cashe_sum_ws = False
-                ws = self.reducer.convert_to_energy()
+                ws = self.reduce()
         else:
-            ws = self.reducer.convert_to_energy()
-
+            ws = self.reduce()
+        self._wait_for_file = timeToWait
         return ws
     #
     def run_reduction(self):

--- a/Code/Mantid/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/RunDescriptor.py
@@ -4,6 +4,7 @@
 from mantid.simpleapi import *
 from Direct.PropertiesDescriptors import *
 import re
+import collections
 
 class RunList(object):
     """Helper class to maintain list of runs used in RunDescriptor for summing
@@ -831,8 +832,16 @@ class RunDescriptor(PropDescriptor):
                 mon_ws = self.copy_spectrum2monitors(data_ws,mon_ws,specID)
 
         if monitors_ID:
-            if isinstance(monitors_ID,list):
-                mon_list = monitors_ID
+            def flatten_list(targ_list,source):
+                if isinstance(source, collections.Iterable):
+                    for item in source:
+                        targ_list = flatten_list(targ_list,item)
+                else:
+                    targ_list.append(source)
+                return targ_list
+            if isinstance(monitors_ID, collections.Iterable):
+                mon_list = []
+                mon_list = flatten_list(mon_list,monitors_ID)
             else:
                 mon_list = [monitors_ID]
         else:
@@ -846,7 +855,7 @@ class RunDescriptor(PropDescriptor):
                     monws_name = mon_ws.name()
                 except:
                     monws_name = 'None'
-                RunDescriptor._logger('*** Monitor workspace {0} does not have monitor with ID {1}. Monitor workspace set to None'.\
+                RunDescriptor._logger('*** Monitor workspace {0} does not have spectra with ID {1}. Monitor workspace set to None'.\
                                           format(monws_name,monID),'warning')
                 mon_ws = None
                 break

--- a/Code/Mantid/scripts/Inelastic/Direct/dgreduce.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/dgreduce.py
@@ -30,7 +30,7 @@ def setup(instname=None,reload=False):
         instname = config['default.instrument']
 
 
-    if not Reducer is None :
+    if not (Reducer is None or Reducer.prop_man is None):
         old_name=Reducer.prop_man.instr_name
         if  old_name.upper()[0:3] == instname.upper()[0:3] :
             if not reload :

--- a/Code/Mantid/scripts/test/DirectEnergyConversionTest.py
+++ b/Code/Mantid/scripts/test/DirectEnergyConversionTest.py
@@ -569,8 +569,8 @@ class DirectEnergyConversionTest(unittest.TestCase):
                                 X=mon2_pos.getX(),Y=mon2_pos.getY(), Z=mon2_pos.getZ(),
                                  RelativePosition=False)
         ConvertUnits(InputWorkspace=monitor_ws, OutputWorkspace='monitor_ws', Target='TOF')
-        # Rebin to "formally" make common bin boundaries as it is not considered as such now 
-        #(Is is a bug?) 
+        # Rebin to "formally" make common bin boundaries as it is not considered as such
+        #any more after converting units (Is this a bug?)
         xx = monitor_ws.readX(0)
         x_min = min(xx[0],xx[-1])
         x_max= max(xx[0],xx[-1])
@@ -579,8 +579,8 @@ class DirectEnergyConversionTest(unittest.TestCase):
         monitor_ws = mtd['monitor_ws']
         #
         # keep this workspace for second test below -- clone and give
-        # special name for RunDescriptor to recognize as monitor workspace for 
-        # fake data workspace we will provide
+        # special name for RunDescriptor to recognize as monitor workspace for
+        # fake data workspace we will provide.
         _TMPmonitor_ws_monitors = CloneWorkspace(monitor_ws)
 
         # Estimate energy from two monitors
@@ -601,7 +601,7 @@ class DirectEnergyConversionTest(unittest.TestCase):
         ei_mon_spectra  = tReducer.prop_man.ei_mon_spectra
         ei_mon_spectra,monitor_ws  = tReducer.sum_monitors_spectra(monitor_ws,ei_mon_spectra)
         #
-        # Check GetEi with summed monitors run separately
+        # Check GetEi with summed monitors. Try to run separately.
         ei1,mon1_peak,mon1_index,tzero = \
             GetEi(InputWorkspace=monitor_ws, Monitor1Spec=1,Monitor2Spec=6,
                   EnergyEstimate=62.2,FixEi=False)

--- a/Code/Mantid/scripts/test/DirectPropertyManagerTest.py
+++ b/Code/Mantid/scripts/test/DirectPropertyManagerTest.py
@@ -192,7 +192,8 @@ class DirectPropertyManagerTest(unittest.TestCase):
 
         self.assertTrue("ei_mon_spectra" in prop_changed,"changing test_mon_spectra_composite should change ei_mon_spectra")
 
-       ## weird way to prohibit this assignment
+        ## weird way to prohibit this assignment
+        # But it works and I was not able to find any other way!
         try:
             propman.ei_mon_spectra[1] = 100
             Success=True
@@ -202,7 +203,7 @@ class DirectPropertyManagerTest(unittest.TestCase):
         self.assertEqual(10000,propman.ei_mon_spectra[0])
         self.assertEqual(2000,propman.ei_mon_spectra[1])
 
-
+        # This works as should
         propman.ei_mon_spectra = (100,200)
         self.assertEqual(100,propman.ei_mon_spectra[0])
         self.assertEqual(200,propman.ei_mon_spectra[1])

--- a/Code/Mantid/scripts/test/DirectPropertyManagerTest.py
+++ b/Code/Mantid/scripts/test/DirectPropertyManagerTest.py
@@ -153,7 +153,7 @@ class DirectPropertyManagerTest(unittest.TestCase):
         self.assertAlmostEqual(range[0],1000.,7," Default integration min range on MARI should be as described in MARI_Parameters.xml file")
         self.assertAlmostEqual(range[1],2000.,7," Default integration max range on MAPS should be as described in MARI_Parameters.xml file")
 
-        self.assertEqual(propman.ei_mon_spectra,[2,3]," Default ei monitors on MARI should be as described in MARI_Parameters.xml file")
+        self.assertEqual(propman.ei_mon_spectra,(2,3)," Default ei monitors on MARI should be as described in MARI_Parameters.xml file")
 
 
         propman.norm_mon_integration_range = [50,1050]
@@ -162,7 +162,7 @@ class DirectPropertyManagerTest(unittest.TestCase):
         self.assertAlmostEqual(range[1],1050.,7)
         propman.ei_mon1_spec = 10
         mon_spectra = propman.ei_mon_spectra
-        self.assertEqual(mon_spectra,[10,3])
+        self.assertEqual(mon_spectra,(10,3))
         self.assertEqual(propman.ei_mon1_spec,10)
 
 
@@ -176,7 +176,7 @@ class DirectPropertyManagerTest(unittest.TestCase):
     def test_set_non_default_complex_value_synonims(self):
         propman = PropertyManager("MAP")
         propman.test_ei2_mon_spectra = 10000
-        self.assertEqual(propman.ei_mon_spectra,[41474,10000])
+        self.assertEqual(propman.ei_mon_spectra,(41474,10000))
 
         prop_changed = propman.getChangedProperties()
         self.assertEqual(len(prop_changed),1)
@@ -185,20 +185,25 @@ class DirectPropertyManagerTest(unittest.TestCase):
 
 
         propman.test_mon_spectra_composite = [10000,2000]
-        self.assertEqual(propman.ei_mon_spectra,[10000,2000])
+        self.assertEqual(propman.ei_mon_spectra,(10000,2000))
 
         prop_changed = propman.getChangedProperties()
         self.assertEqual(len(prop_changed),2)
 
         self.assertTrue("ei_mon_spectra" in prop_changed,"changing test_mon_spectra_composite should change ei_mon_spectra")
 
-    ## HOW TO MAKE IT WORK?  it fails silently
-        propman.ei_mon_spectra[1] = 100
+       ## weird way to prohibit this assignment
+        try:
+            propman.ei_mon_spectra[1] = 100
+            Success=True
+        except TypeError:
+            Success=False
+        self.assertFalse(Success)
         self.assertEqual(10000,propman.ei_mon_spectra[0])
         self.assertEqual(2000,propman.ei_mon_spectra[1])
 
 
-        propman.ei_mon_spectra = [100,200]
+        propman.ei_mon_spectra = (100,200)
         self.assertEqual(100,propman.ei_mon_spectra[0])
         self.assertEqual(200,propman.ei_mon_spectra[1])
 
@@ -524,10 +529,10 @@ class DirectPropertyManagerTest(unittest.TestCase):
 
         ws = mtd['ws']
         changed_prop = propman.update_defaults_from_instrument(ws.getInstrument(),False)
-        self.assertFalse('ei-mon1-spec' in changed_prop)
+        self.assertTrue('ei-mon1-spec' in changed_prop)
         self.assertEqual(propman.ei_mon1_spec,65542)
 
-        self.assertTrue('ei_mon_spectra' in changed_prop)
+        self.assertFalse('ei_mon_spectra' in changed_prop)
         ei_spec = propman.ei_mon_spectra
         self.assertEqual(ei_spec[0],65542)
         self.assertEqual(ei_spec[1],5506)
@@ -1104,6 +1109,52 @@ class DirectPropertyManagerTest(unittest.TestCase):
        self.assertEqual(propman.save_file_name,'RUN2000atEi20.0meV_One2One')
        # clean up
        PropertyManager.save_file_name.set_custom_print(None)
+
+    def test_ei_mon_spectra(self):
+        propman = self.prop_man
+        # test default property assignment
+        setattr(propman,'ei-mon1-spec',101)
+        setattr(propman,'ei-mon2-spec',2020)
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],101)
+        self.assertEqual(spectra[1],2020)
+
+        propman.ei_mon_spectra = "ei-mon1-spec:ei-mon2-spec"
+
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],101)
+        self.assertEqual(spectra[1],2020)
+
+        setattr(propman,'ei-mon1-spec',[101,102,103])
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],[101,102,103])
+        self.assertEqual(spectra[1],2020)
+        self.assertTrue(PropertyManager.ei_mon_spectra.need_to_sum_monitors(propman))
+
+        propman.ei_mon_spectra=(1,[3,4,5])
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],1)
+        self.assertEqual(spectra[1],[3,4,5])
+        self.assertTrue(PropertyManager.ei_mon_spectra.need_to_sum_monitors(propman))
+
+        propman.ei_mon_spectra="3,4,5:1,2"
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],[3,4,5])
+        self.assertEqual(spectra[1],[1,2])
+        self.assertTrue(PropertyManager.ei_mon_spectra.need_to_sum_monitors(propman))
+
+        propman.ei_mon_spectra="3:10"
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],3)
+        self.assertEqual(spectra[1],10)
+        self.assertFalse(PropertyManager.ei_mon_spectra.need_to_sum_monitors(propman))
+
+        propman.ei_mon_spectra="[4:11]"
+        spectra = propman.ei_mon_spectra
+        self.assertEqual(spectra[0],4)
+        self.assertEqual(spectra[1],11)
+        self.assertFalse(PropertyManager.ei_mon_spectra.need_to_sum_monitors(propman))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This fixes #12818 
The changes address advanced user request for Direct inelastic reduction. The conditions where the change is important is not easy to reproduce so testing is suggested by code review only. 

I would summarize changes as follows: Reduction properties have changed in a way that user may provide not one but list of spectra, used to identify incident energy. If list of spectra is provided, the spectra summed to one, finally used in identifying energy. It is user responsibility to provide correct spectra numbers to get meaningful physical results. 

Unit tests are written to test the changes in the code and IDF-s for instruments,  where it is important (LET and MERLIN),are modified accordingly.  

I have deployed changed code on analysis computers and it works to user satisfaction so, I think tester can be sure that changes are working and code review should not be too complex. 

A couple of minor bugfixes which are not worth a separate ticket are squeezed into the code changes too.

I put release notes into the issue itself. 
