### PR TITLE
PoldiFitPeaks2D should be able to output integrated intensities

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PoldiDataAnalysis.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PoldiDataAnalysis.py
@@ -81,6 +81,10 @@ class PoldiDataAnalysis(PythonAlgorithm):
                              doc=('If this is activated, plot the sum of residuals and calculated spectrum together '
                                   'with the theoretical spectrum and the residuals.'))
 
+        self.declareProperty("OutputIntegratedIntensities", False, direction=Direction.Input,
+                             doc=("If this option is checked the peak intensities of the 2D-fit will be integrated, "
+                                  "otherwise they will be the maximum intensity."))
+
         self.declareProperty('OutputRawFitParameters', False, direction=Direction.Input,
                              doc=('Activating this option produces an output workspace which contains the raw '
                                   'fit parameters.'))
@@ -97,6 +101,7 @@ class PoldiDataAnalysis(PythonAlgorithm):
         self.profileFunction = self.getProperty("ProfileFunction").value
         self.useGlobalParameters = self.getProperty("TieProfileParameters").value
         self.maximumRelativeFwhm = self.getProperty("MaximumRelativeFwhm").value
+        self.outputIntegratedIntensities = self.getProperty("OutputIntegratedIntensities").value
 
         self.globalParameters = ''
         if self.useGlobalParameters:
@@ -233,6 +238,7 @@ class PoldiDataAnalysis(PythonAlgorithm):
                         OutputWorkspace=spectrum2DName,
                         Calculated1DSpectrum=spectrum1DName,
                         RefinedPoldiPeakWorkspace=refinedPeaksName,
+                        OutputIntegratedIntensities=self.outputIntegratedIntensities,
                         RefinedCellParameters=refinedCellName,
                         RawFitParameters=rawFitParametersWorkspaceName)
 

--- a/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -398,17 +398,17 @@ PoldiFitPeaks2D::getPeakFromPeakFunction(IPeakFunction_sptr profileFunction,
   errorAlg->execute();
 
   double centre = profileFunction->centre();
-  double height = profileFunction->height();
+  double integratedIntensity = profileFunction->intensity();
   double fwhmValue = profileFunction->fwhm();
 
   ITableWorkspace_sptr errorTable = errorAlg->getProperty("OutputWorkspace");
 
   double centreError = errorTable->cell<double>(0, 2);
-  double heightError = errorTable->cell<double>(1, 2);
+  double integratedIntensityError = errorTable->cell<double>(3, 2);
   double fwhmError = errorTable->cell<double>(2, 2);
 
   UncertainValue d(centre, centreError);
-  UncertainValue intensity(height, heightError);
+  UncertainValue intensity(integratedIntensity, integratedIntensityError);
   UncertainValue fwhm(fwhmValue, fwhmError);
 
   // Create peak with extracted parameters and supplied hkl

--- a/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Code/Mantid/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -398,18 +398,27 @@ PoldiFitPeaks2D::getPeakFromPeakFunction(IPeakFunction_sptr profileFunction,
   errorAlg->execute();
 
   double centre = profileFunction->centre();
-  double integratedIntensity = profileFunction->intensity();
   double fwhmValue = profileFunction->fwhm();
 
   ITableWorkspace_sptr errorTable = errorAlg->getProperty("OutputWorkspace");
-
   double centreError = errorTable->cell<double>(0, 2);
-  double integratedIntensityError = errorTable->cell<double>(3, 2);
   double fwhmError = errorTable->cell<double>(2, 2);
 
   UncertainValue d(centre, centreError);
-  UncertainValue intensity(integratedIntensity, integratedIntensityError);
   UncertainValue fwhm(fwhmValue, fwhmError);
+
+  UncertainValue intensity;
+
+  bool useIntegratedIntensities = getProperty("OutputIntegratedIntensities");
+  if (useIntegratedIntensities) {
+    double integratedIntensity = profileFunction->intensity();
+    double integratedIntensityError = errorTable->cell<double>(3, 2);
+    intensity = UncertainValue(integratedIntensity, integratedIntensityError);
+  } else {
+    double height = profileFunction->height();
+    double heightError = errorTable->cell<double>(1, 2);
+    intensity = UncertainValue(height, heightError);
+  }
 
   // Create peak with extracted parameters and supplied hkl
   PoldiPeak_sptr peak =
@@ -1214,6 +1223,11 @@ void PoldiFitPeaks2D::init() {
   declareProperty(new WorkspaceProperty<Workspace>("RefinedPoldiPeakWorkspace",
                                                    "", Direction::Output),
                   "Table workspace with fitted peaks.");
+
+  declareProperty("OutputIntegratedIntensities", false,
+                  "If this option is checked, the peaks in the algorithm's "
+                  "output will have integrated intensities instead of the "
+                  "maximum.");
 
   declareProperty(new WorkspaceProperty<Workspace>(
       "RefinedCellParameters", "", Direction::Output, PropertyMode::Optional));

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIFitPeaks2DTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIFitPeaks2DTest.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-init,invalid-name,too-many-locals
+# pylint: disable=no-init,invalid-name,too-many-locals,too-few-public-methods
 import stresstesting
 from mantid.simpleapi import *
 import numpy as np
@@ -112,6 +112,15 @@ class POLDIFitPeaks2DPawleyTest(stresstesting.MantidStressTest):
         self.assertLessThan(np.abs(cell_a_err), 5.0e-5)
         self.assertLessThan(np.abs(cell_a - 5.4311946) / cell_a_err, 1.5)
 
+        DeleteWorkspace(si_refs)
+        DeleteWorkspace(indexed)
+        DeleteWorkspace(peaks)
+        DeleteWorkspace(si)
+        DeleteWorkspace(fit2d)
+        DeleteWorkspace(fit1d)
+        DeleteWorkspace(fit_plots)
+        DeleteWorkspace(peaks_ref_2d)
+
 
 class POLDIFitPeaks2DIntegratedIntensities(stresstesting.MantidStressTest):
     def runTest(self):
@@ -142,3 +151,9 @@ class POLDIFitPeaks2DIntegratedIntensities(stresstesting.MantidStressTest):
 
             # The numerical peak integration is done with a precision of 1e-10
             self.assertDelta(integratedGaussian, rowIntegrated['Intensity'], 1e-10)
+
+        DeleteWorkspace(fit2d)
+        DeleteWorkspace(fit1d)
+        DeleteWorkspace(si)
+        DeleteWorkspace(peaks)
+        DeleteWorkspace(fit_plots)

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIFitPeaks2DTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/POLDIFitPeaks2DTest.py
@@ -1,7 +1,8 @@
-#pylint: disable=no-init,invalid-name,too-many-locals
+# pylint: disable=no-init,invalid-name,too-many-locals
 import stresstesting
 from mantid.simpleapi import *
 import numpy as np
+
 
 class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
     """The system test currently checks that the calculation of 2D spectra
@@ -18,7 +19,7 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
 
     def loadAndPrepareData(self, filenames):
         for dataFile in filenames:
-            LoadSINQFile(Instrument='POLDI',Filename=dataFile + ".hdf",OutputWorkspace=dataFile)
+            LoadSINQFile(Instrument='POLDI', Filename=dataFile + ".hdf", OutputWorkspace=dataFile)
             LoadInstrument(Workspace=dataFile, InstrumentName="POLDI", RewriteSpectraMap=True)
             PoldiTruncateData(InputWorkspace=dataFile, OutputWorkspace=dataFile)
 
@@ -28,19 +29,21 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
 
     def loadReferenceSpectrum(self, filenames):
         for dataFile in filenames:
-            Load(Filename="%s_2d_reference_Spectrum.nxs" % (dataFile), OutputWorkspace="%s_2d_reference_Spectrum" % (dataFile))
+            Load(Filename="%s_2d_reference_Spectrum.nxs" % (dataFile),
+                 OutputWorkspace="%s_2d_reference_Spectrum" % (dataFile))
             LoadInstrument(Workspace="%s_2d_reference_Spectrum" % (dataFile), InstrumentName="POLDI")
-            Load(Filename="%s_1d_reference_Spectrum.nxs" % (dataFile), OutputWorkspace="%s_1d_reference_Spectrum" % (dataFile))
+            Load(Filename="%s_1d_reference_Spectrum.nxs" % (dataFile),
+                 OutputWorkspace="%s_1d_reference_Spectrum" % (dataFile))
 
     def runCalculateSpectrum2D(self, filenames):
         for dataFile in filenames:
             PoldiFitPeaks2D(InputWorkspace="%s_2d_reference_Spectrum" % (dataFile),
-                               PoldiPeakWorkspace="%s_reference_Peaks" % (dataFile),
-                               FitConstantBackground=False, FitLinearBackground=False,
-                               RefinedPoldiPeakWorkspace="%s_refined_Peaks" % (dataFile),
-                               OutputWorkspace="%s_2d_calculated_Spectrum" % (dataFile),
-                               Calculated1DSpectrum="%s_1d_calculated_Spectrum" % (dataFile),
-                               MaximumIterations=100)
+                            PoldiPeakWorkspace="%s_reference_Peaks" % (dataFile),
+                            FitConstantBackground=False, FitLinearBackground=False,
+                            RefinedPoldiPeakWorkspace="%s_refined_Peaks" % (dataFile),
+                            OutputWorkspace="%s_2d_calculated_Spectrum" % (dataFile),
+                            Calculated1DSpectrum="%s_1d_calculated_Spectrum" % (dataFile),
+                            MaximumIterations=100)
 
     def analyseResults(self, filenames):
         for dataFile in filenames:
@@ -66,7 +69,6 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
 
                     self.assertLessThan(np.fabs(value - reference), error)
 
-
             spectra1D = ["%s_1d_%s_Spectrum"]
 
             for wsName in spectra1D:
@@ -85,8 +87,8 @@ class POLDIFitPeaks2DTest(stresstesting.MantidStressTest):
                 self.assertTrue(np.all(xDataCalc == xDataRef))
                 self.assertLessThan(maxDifference, 0.07)
 
-class POLDIFitPeaks2DPawleyTest(stresstesting.MantidStressTest):
 
+class POLDIFitPeaks2DPawleyTest(stresstesting.MantidStressTest):
     def runTest(self):
         si = PoldiLoadRuns(2013, 6903, 6904, 2)
         corr = PoldiAutoCorrelation('si_data_6904')
@@ -110,3 +112,33 @@ class POLDIFitPeaks2DPawleyTest(stresstesting.MantidStressTest):
         self.assertLessThan(np.abs(cell_a_err), 5.0e-5)
         self.assertLessThan(np.abs(cell_a - 5.4311946) / cell_a_err, 1.5)
 
+
+class POLDIFitPeaks2DIntegratedIntensities(stresstesting.MantidStressTest):
+    def runTest(self):
+        si = PoldiLoadRuns(2013, 6903, 6904, 2)
+        corr = PoldiAutoCorrelation('si_data_6904')
+        peaks = PoldiPeakSearch(corr, MaximumPeakNumber=8)
+        peaks_ref, fit_plots = PoldiFitPeaks1D(corr, PoldiPeakTable='peaks')
+
+        # Run the same analysis twice, once with integrated and once with maximum intensities
+        # Since a Gaussian is used, the integration can be checked numerically.
+        fit2d, fit1d, peaks_ref_2d = PoldiFitPeaks2D('si_data_6904', peaks_ref,
+                                                           OutputIntegratedIntensities=False,
+                                                           MaximumIterations=100)
+
+        fit2d, fit1d, peaks_ref_2d_integrated = PoldiFitPeaks2D('si_data_6904', peaks_ref,
+                                                                      OutputIntegratedIntensities=True,
+                                                                      MaximumIterations=100)
+
+        self.assertEquals(peaks_ref_2d.rowCount(), peaks_ref_2d_integrated.rowCount())
+
+        for i in range(peaks_ref_2d.rowCount()):
+            rowHeight = peaks_ref_2d.row(i)
+
+            sigmaGaussian = (rowHeight['FWHM (rel.)'] * rowHeight['d']) / (2.0 * np.sqrt(2.0 * np.log(2.0)))
+            integratedGaussian = rowHeight['Intensity'] * np.sqrt(np.pi * 2.0) * sigmaGaussian
+
+            rowIntegrated = peaks_ref_2d_integrated.row(i)
+
+            # The numerical peak integration is done with a precision of 1e-10
+            self.assertDelta(integratedGaussian, rowIntegrated['Intensity'], 1e-10)

--- a/Code/Mantid/docs/source/algorithms/PoldiFitPeaks2D-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiFitPeaks2D-v1.rst
@@ -21,7 +21,7 @@ Alternatively, if the peaks have been indexed using a different method, the log 
 
 PoldiFitPeaks2D can also be used to calculate a theoretical 2D pattern from a set of peaks by limiting the iterations to 0.
 
-In addition to performing the 2D-fit, a theoretical 1D-diffractogram of the fit-function is calculated as well, which can be used in conjunction with :ref:`algm-PoldiAnalyseResiduals` to assess the quality of a fit. The output peak table contains integrated intensities.
+In addition to performing the 2D-fit, a theoretical 1D-diffractogram of the fit-function is calculated as well, which can be used in conjunction with :ref:`algm-PoldiAnalyseResiduals` to assess the quality of a fit. Depending on the value of the `OutputIntegratedIntensity`-option, the output peaks intensities are either integrated or describe the maximum.
 
 Usage
 -----

--- a/Code/Mantid/docs/source/algorithms/PoldiFitPeaks2D-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PoldiFitPeaks2D-v1.rst
@@ -21,7 +21,7 @@ Alternatively, if the peaks have been indexed using a different method, the log 
 
 PoldiFitPeaks2D can also be used to calculate a theoretical 2D pattern from a set of peaks by limiting the iterations to 0.
 
-In addition to performing the 2D-fit, a theoretical 1D-diffractogram of the fit-function is calculated as well, which can be used in conjunction with :ref:`algm-PoldiAnalyseResiduals` to assess the quality of a fit.
+In addition to performing the 2D-fit, a theoretical 1D-diffractogram of the fit-function is calculated as well, which can be used in conjunction with :ref:`algm-PoldiAnalyseResiduals` to assess the quality of a fit. The output peak table contains integrated intensities.
 
 Usage
 -----


### PR DESCRIPTION
This fixes #12833.

I decided to make the output of integrated intensities optional. If the option is not selected, the old behavior is preserved. The option has been added to `PoldiDataAnalysis` as well.

**Testing information**
Correctness of the values is checked by a new system test. For manual testing you could run the usage example from `PoldiDataAnalysis`, once with the `OutputIntegratedIntensities`-option checked and once without. The numerical values should be lower for the integrated intensities option.
