### PR TITLE
Fix broken Qt connection in VSI

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -239,7 +239,7 @@ void MdViewerWidget::setupUiAndConnections()
   QObject::connect(this->ui.resetViewsStateToAllData,
                    SIGNAL(released()),
                    this,
-                   SLOT(onResetViewToAll()));
+                   SLOT(onResetViewsStateToAllData()));
 
   // Setup rotation point button
   QObject::connect(this->ui.resetCenterToPointButton,


### PR DESCRIPTION
Fixes #12873 

**To test** 

This is only a on-line fix, but still it is worth to verify that there is no console output message warning about a broken Qt link when loading data into the VSI.
