### PR TITLE
Allow PreviewPlot to toggle errors per curve

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.ui
@@ -121,8 +121,10 @@
        <property name="showLegend" stdset="0">
         <bool>true</bool>
        </property>
-       <property name="showErrorBars" stdset="0">
-        <bool>true</bool>
+       <property name="curveErrorBars" stdset="0">
+        <stringlist>
+         <string>Sample</string>
+        </stringlist>
        </property>
       </widget>
      </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/MSDFit.ui
@@ -58,8 +58,10 @@
          <property name="showLegend" stdset="0">
           <bool>true</bool>
          </property>
-         <property name="showErrorBars" stdset="0">
-          <bool>true</bool>
+         <property name="curveErrorBars" stdset="0">
+          <stringlist>
+           <string>Sample</string>
+          </stringlist>
          </property>
          <property name="canvasColour" stdset="0">
           <color>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -330,6 +330,7 @@ void JumpFit::handleSampleInputReady(const QString &filename) {
  * @param ws :: The workspace to search
  */
 void JumpFit::findAllWidths(Mantid::API::MatrixWorkspace_const_sptr ws) {
+  m_uiForm.cbWidth->blockSignals(true);
   m_uiForm.cbWidth->clear();
   m_spectraList.clear();
 
@@ -368,6 +369,7 @@ void JumpFit::findAllWidths(Mantid::API::MatrixWorkspace_const_sptr ws) {
       }
     }
   }
+  m_uiForm.cbWidth->blockSignals(false);
 }
 
 /**

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
@@ -22,180 +22,183 @@
 #include <qwt_plot_panner.h>
 #include <qwt_plot_zoomer.h>
 
+namespace MantidQt {
+namespace MantidWidgets {
+/**
+A widget to display several workspaces on a plot on a custom interface.
 
-namespace MantidQt
-{
-namespace MantidWidgets
-{
-  /**
-  A widget to display several workspaces on a plot on a custom interface.
+Gives option to use pan and zoom options to navigate plot.
 
-  Gives option to use pan and zoom options to navigate plot.
+@author Dan Nixon
 
-  @author Dan Nixon
+Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
 
-  Copyright &copy; 2011 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+This file is part of Mantid.
 
-  This file is part of Mantid.
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
 
-  Mantid is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 3 of the License, or
-  (at your option) any later version.
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-  Mantid is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
 
-  File change history is stored at: <https://github.com/mantidproject/mantid>
-  Code Documentation is available at: <http://doxygen.mantidproject.org>
-  */
+class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS PreviewPlot : public API::MantidWidget {
+  Q_OBJECT
 
-  class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS PreviewPlot : public API::MantidWidget
-  {
-    Q_OBJECT
+  Q_PROPERTY(QColor canvasColour READ canvasColour WRITE setCanvasColour)
+  Q_PROPERTY(bool showLegend READ legendIsShown WRITE showLegend)
+  Q_PROPERTY(QStringList curveErrorBars READ getShownErrorBars WRITE
+                 setDefaultShownErrorBars)
 
-    Q_PROPERTY(QColor canvasColour READ canvasColour WRITE setCanvasColour)
-    Q_PROPERTY(bool showLegend READ legendIsShown WRITE showLegend)
-    Q_PROPERTY(QStringList curveErrorBars READ getShownErrorBars WRITE setDefaultShownErrorBars)
+public:
+  PreviewPlot(QWidget *parent = NULL, bool init = true);
+  virtual ~PreviewPlot();
 
-  public:
-    PreviewPlot(QWidget *parent = NULL, bool init = true);
-    virtual ~PreviewPlot();
+  QColor canvasColour();
+  void setCanvasColour(const QColor &colour);
 
-    QColor canvasColour();
-    void setCanvasColour(const QColor & colour);
+  bool legendIsShown();
+  QStringList getShownErrorBars();
 
-    bool legendIsShown();
-    QStringList getShownErrorBars();
+  void setAxisRange(QPair<double, double> range, int axisID = QwtPlot::xBottom);
 
-    void setAxisRange(QPair<double, double> range, int axisID = QwtPlot::xBottom);
+  QPair<double, double>
+  getCurveRange(const Mantid::API::MatrixWorkspace_sptr ws);
+  QPair<double, double> getCurveRange(const QString &curveName);
 
-    QPair<double, double> getCurveRange(const Mantid::API::MatrixWorkspace_sptr ws);
-    QPair<double, double> getCurveRange(const QString & curveName);
+  void addSpectrum(const QString &curveName,
+                   const Mantid::API::MatrixWorkspace_sptr ws,
+                   const size_t specIndex = 0,
+                   const QColor &curveColour = QColor());
+  void addSpectrum(const QString &curveName, const QString &wsName,
+                   const size_t specIndex = 0,
+                   const QColor &curveColour = QColor());
 
-    void addSpectrum(const QString & curveName, const Mantid::API::MatrixWorkspace_sptr ws, const size_t specIndex = 0, const QColor & curveColour = QColor());
-    void addSpectrum(const QString & curveName, const QString & wsName, const size_t specIndex = 0, const QColor & curveColour = QColor());
+  void removeSpectrum(const Mantid::API::MatrixWorkspace_sptr ws);
+  void removeSpectrum(const QString &curveName);
 
-    void removeSpectrum(const Mantid::API::MatrixWorkspace_sptr ws);
-    void removeSpectrum(const QString & curveName);
+  bool hasCurve(const QString &curveName);
 
-    bool hasCurve(const QString & curveName);
+  RangeSelector *
+  addRangeSelector(const QString &rsName,
+                   RangeSelector::SelectType type = RangeSelector::XMINMAX);
+  RangeSelector *getRangeSelector(const QString &rsName);
+  void removeRangeSelector(const QString &rsName, bool del);
 
-    RangeSelector * addRangeSelector(const QString & rsName,
-                                     RangeSelector::SelectType type = RangeSelector::XMINMAX);
-    RangeSelector * getRangeSelector(const QString & rsName);
-    void removeRangeSelector(const QString & rsName, bool del);
+  bool hasRangeSelector(const QString &rsName);
 
-    bool hasRangeSelector(const QString & rsName);
+  QString getAxisType(int axisID);
 
-    QString getAxisType(int axisID);
+signals:
+  /// Signals that the plot should be refreshed
+  void needToReplot();
+  void needToHardReplot();
+  /// Signals that the axis scale has been changed
+  void axisScaleChanged();
 
-  signals:
-    /// Signals that the plot should be refreshed
-    void needToReplot();
-    void needToHardReplot();
-    /// Signals that the axis scale has been changed
-    void axisScaleChanged();
+public slots:
+  void showLegend(bool show);
+  void setDefaultShownErrorBars(const QStringList &curveNames);
+  void togglePanTool(bool enabled);
+  void toggleZoomTool(bool enabled);
+  void resetView();
+  void resizeX();
+  void clear();
+  void replot();
+  void hardReplot();
 
-  public slots:
-    void showLegend(bool show);
-    void setDefaultShownErrorBars(const QStringList & curveNames);
-    void togglePanTool(bool enabled);
-    void toggleZoomTool(bool enabled);
-    void resetView();
-    void resizeX();
-    void clear();
-    void replot();
-    void hardReplot();
+private:
+  /// Holds information about a plot curve
+  struct PlotCurveConfiguration {
+    Mantid::API::MatrixWorkspace_sptr ws;
+    QwtPlotCurve *curve;
+    MantidQt::MantidWidgets::ErrorCurve *errorCurve;
+    QAction *showErrorsAction;
+    QLabel *label;
+    QColor colour;
+    size_t wsIndex;
 
-  private:
-    /// Holds information about a plot curve
-    struct PlotCurveConfiguration
-    {
-      Mantid::API::MatrixWorkspace_sptr ws;
-      QwtPlotCurve *curve;
-      MantidQt::MantidWidgets::ErrorCurve *errorCurve;
-      QAction *showErrorsAction;
-      QLabel *label;
-      QColor colour;
-      size_t wsIndex;
-
-      PlotCurveConfiguration():
-        curve(NULL),
-        errorCurve(NULL),
-        showErrorsAction(NULL),
-        label(NULL),
-        colour(),
-        wsIndex(0)
-      {}
-    };
-
-    void handleRemoveEvent(Mantid::API::WorkspacePreDeleteNotification_ptr pNf);
-    void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
-
-    void addCurve(PlotCurveConfiguration& curveConfig, Mantid::API::MatrixWorkspace_sptr ws, const size_t specIndex, const QColor & curveColour);
-    void removeCurve(QwtPlotItem *curve);
-
-    QList<QAction *> addOptionsToMenus(QString menuName, QActionGroup *group, QStringList items, QString defaultItem);
-
-    QStringList getCurvesForWorkspace(const Mantid::API::MatrixWorkspace_sptr ws);
-
-  private slots:
-    void showContextMenu(QPoint position);
-    void handleViewToolSelect();
-    void handleAxisTypeSelect();
-
-  private:
-    Ui::PreviewPlot m_uiForm;
-
-    /// Range selector widget for mini plot
-    QMap<QString, MantidQt::MantidWidgets::RangeSelector *> m_rangeSelectors;
-    /// Cache of range selector visibility
-    QMap<QString, bool> m_rsVisibility;
-
-    /// Poco Observers for ADS Notifications
-    Poco::NObserver<PreviewPlot, Mantid::API::WorkspacePreDeleteNotification> m_removeObserver;
-    Poco::NObserver<PreviewPlot, Mantid::API::WorkspaceAfterReplaceNotification> m_replaceObserver;
-
-    /// If the widget was initialised
-    bool m_init;
-
-    friend class RangeSelector;
-
-    /// Map of curve key to plot info
-    QMap<QString, PlotCurveConfiguration> m_curves;
-
-    /// Plot manipulation tools
-    QwtPlotMagnifier *m_magnifyTool;
-    QwtPlotPanner *m_panTool;
-    QwtPlotZoomer *m_zoomTool;
-
-    /// Context menu items
-    QMenu *m_contextMenu;
-    QActionGroup *m_plotToolGroup;
-    QActionGroup *m_xAxisTypeGroup;
-    QActionGroup *m_yAxisTypeGroup;
-
-    /// Menu action for showing/hiding plot legend
-    QAction *m_showLegendAction;
-
-    /// Menu group for error bar show/hide
-    QAction *m_showErrorsMenuAction;
-    QMenu *m_showErrorsMenu;
-
-    /// Cache of error bar options
-    // Persists error bar options when curves of same name are removed and
-    // readded
-    QMap<QString, bool> m_errorBarOptionCache;
-
+    PlotCurveConfiguration()
+        : curve(NULL), errorCurve(NULL), showErrorsAction(NULL), label(NULL),
+          colour(), wsIndex(0) {}
   };
 
+  void handleRemoveEvent(Mantid::API::WorkspacePreDeleteNotification_ptr pNf);
+  void
+  handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
+
+  void addCurve(PlotCurveConfiguration &curveConfig,
+                Mantid::API::MatrixWorkspace_sptr ws, const size_t specIndex,
+                const QColor &curveColour);
+  void removeCurve(QwtPlotItem *curve);
+
+  QList<QAction *> addOptionsToMenus(QString menuName, QActionGroup *group,
+                                     QStringList items, QString defaultItem);
+
+  QStringList getCurvesForWorkspace(const Mantid::API::MatrixWorkspace_sptr ws);
+
+private slots:
+  void showContextMenu(QPoint position);
+  void handleViewToolSelect();
+  void handleAxisTypeSelect();
+
+private:
+  Ui::PreviewPlot m_uiForm;
+
+  /// Range selector widget for mini plot
+  QMap<QString, MantidQt::MantidWidgets::RangeSelector *> m_rangeSelectors;
+  /// Cache of range selector visibility
+  QMap<QString, bool> m_rsVisibility;
+
+  /// Poco Observers for ADS Notifications
+  Poco::NObserver<PreviewPlot, Mantid::API::WorkspacePreDeleteNotification>
+      m_removeObserver;
+  Poco::NObserver<PreviewPlot, Mantid::API::WorkspaceAfterReplaceNotification>
+      m_replaceObserver;
+
+  /// If the widget was initialised
+  bool m_init;
+
+  friend class RangeSelector;
+
+  /// Map of curve key to plot info
+  QMap<QString, PlotCurveConfiguration> m_curves;
+
+  /// Plot manipulation tools
+  QwtPlotMagnifier *m_magnifyTool;
+  QwtPlotPanner *m_panTool;
+  QwtPlotZoomer *m_zoomTool;
+
+  /// Context menu items
+  QMenu *m_contextMenu;
+  QActionGroup *m_plotToolGroup;
+  QActionGroup *m_xAxisTypeGroup;
+  QActionGroup *m_yAxisTypeGroup;
+
+  /// Menu action for showing/hiding plot legend
+  QAction *m_showLegendAction;
+
+  /// Menu group for error bar show/hide
+  QAction *m_showErrorsMenuAction;
+  QMenu *m_showErrorsMenu;
+
+  /// Cache of error bar options
+  // Persists error bar options when curves of same name are removed and
+  // readded
+  QMap<QString, bool> m_errorBarOptionCache;
+};
 }
 }
 
-#endif //MANTIDQTMANTIDWIDGETS_PREVIEWPLOT_H_
+#endif // MANTIDQTMANTIDWIDGETS_PREVIEWPLOT_H_

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/PreviewPlot.h
@@ -61,7 +61,7 @@ namespace MantidWidgets
 
     Q_PROPERTY(QColor canvasColour READ canvasColour WRITE setCanvasColour)
     Q_PROPERTY(bool showLegend READ legendIsShown WRITE showLegend)
-    Q_PROPERTY(bool showErrorBars READ errorBarsAreShown WRITE showErrorBars)
+    Q_PROPERTY(QStringList curveErrorBars READ getShownErrorBars WRITE setDefaultShownErrorBars)
 
   public:
     PreviewPlot(QWidget *parent = NULL, bool init = true);
@@ -71,7 +71,7 @@ namespace MantidWidgets
     void setCanvasColour(const QColor & colour);
 
     bool legendIsShown();
-    bool errorBarsAreShown();
+    QStringList getShownErrorBars();
 
     void setAxisRange(QPair<double, double> range, int axisID = QwtPlot::xBottom);
 
@@ -104,7 +104,7 @@ namespace MantidWidgets
 
   public slots:
     void showLegend(bool show);
-    void showErrorBars(bool show);
+    void setDefaultShownErrorBars(const QStringList & curveNames);
     void togglePanTool(bool enabled);
     void toggleZoomTool(bool enabled);
     void resetView();
@@ -120,12 +120,19 @@ namespace MantidWidgets
       Mantid::API::MatrixWorkspace_sptr ws;
       QwtPlotCurve *curve;
       MantidQt::MantidWidgets::ErrorCurve *errorCurve;
+      QAction *showErrorsAction;
       QLabel *label;
       QColor colour;
       size_t wsIndex;
 
       PlotCurveConfiguration():
-        curve(NULL), label(NULL), colour(), wsIndex(0) {}
+        curve(NULL),
+        errorCurve(NULL),
+        showErrorsAction(NULL),
+        label(NULL),
+        colour(),
+        wsIndex(0)
+      {}
     };
 
     void handleRemoveEvent(Mantid::API::WorkspacePreDeleteNotification_ptr pNf);
@@ -177,8 +184,14 @@ namespace MantidWidgets
     /// Menu action for showing/hiding plot legend
     QAction *m_showLegendAction;
 
-    /// Menu action for showing/hiding error bars
-    QAction *m_showErrorsAction;
+    /// Menu group for error bar show/hide
+    QAction *m_showErrorsMenuAction;
+    QMenu *m_showErrorsMenu;
+
+    /// Cache of error bar options
+    // Persists error bar options when curves of same name are removed and
+    // readded
+    QMap<QString, bool> m_errorBarOptionCache;
 
   };
 

--- a/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
@@ -24,40 +24,33 @@
 using namespace MantidQt::MantidWidgets;
 using namespace Mantid::API;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("PreviewPlot");
-  bool isNegative(double v) { return v <= 0.0; }
+namespace {
+Mantid::Kernel::Logger g_log("PreviewPlot");
+bool isNegative(double v) { return v <= 0.0; }
 }
 
-
-PreviewPlot::PreviewPlot(QWidget *parent, bool init) : API::MantidWidget(parent),
-  m_removeObserver(*this, &PreviewPlot::handleRemoveEvent),
-  m_replaceObserver(*this, &PreviewPlot::handleReplaceEvent),
-  m_init(init),
-  m_curves(),
-  m_magnifyTool(NULL),
-  m_panTool(NULL),
-  m_zoomTool(NULL),
-  m_contextMenu(new QMenu(this)),
-  m_showLegendAction(NULL),
-  m_showErrorsMenuAction(NULL),
-  m_showErrorsMenu(NULL),
-  m_errorBarOptionCache()
-{
+PreviewPlot::PreviewPlot(QWidget *parent, bool init)
+    : API::MantidWidget(parent),
+      m_removeObserver(*this, &PreviewPlot::handleRemoveEvent),
+      m_replaceObserver(*this, &PreviewPlot::handleReplaceEvent), m_init(init),
+      m_curves(), m_magnifyTool(NULL), m_panTool(NULL), m_zoomTool(NULL),
+      m_contextMenu(new QMenu(this)), m_showLegendAction(NULL),
+      m_showErrorsMenuAction(NULL), m_showErrorsMenu(NULL),
+      m_errorBarOptionCache() {
   m_uiForm.setupUi(this);
   m_uiForm.loLegend->addStretch();
 
-  if(init)
-  {
-    AnalysisDataServiceImpl& ads = AnalysisDataService::Instance();
+  if (init) {
+    AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
     ads.notificationCenter.addObserver(m_removeObserver);
     ads.notificationCenter.addObserver(m_replaceObserver);
   }
 
   // Setup plot manipulation tools
-  m_zoomTool = new QwtPlotZoomer(QwtPlot::xBottom, QwtPlot::yLeft,
-      QwtPicker::DragSelection | QwtPicker::CornerToCorner, QwtPicker::AlwaysOff, m_uiForm.plot->canvas());
+  m_zoomTool =
+      new QwtPlotZoomer(QwtPlot::xBottom, QwtPlot::yLeft,
+                        QwtPicker::DragSelection | QwtPicker::CornerToCorner,
+                        QwtPicker::AlwaysOff, m_uiForm.plot->canvas());
   m_zoomTool->setEnabled(false);
 
   m_panTool = new QwtPlotPanner(m_uiForm.plot->canvas());
@@ -69,16 +62,20 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init) : API::MantidWidget(parent)
 
   // Handle showing the context menu
   m_uiForm.plot->setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showContextMenu(QPoint)));
+  connect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this,
+          SLOT(showContextMenu(QPoint)));
 
   // Create the plot tool list for context menu
   m_plotToolGroup = new QActionGroup(m_contextMenu);
   m_plotToolGroup->setExclusive(true);
 
   QStringList plotTools;
-  plotTools << "None" << "Pan" << "Zoom";
-  QList<QAction *> plotToolActions = addOptionsToMenus("Plot Tools", m_plotToolGroup, plotTools, "None");
-  for(auto it = plotToolActions.begin(); it != plotToolActions.end(); ++it)
+  plotTools << "None"
+            << "Pan"
+            << "Zoom";
+  QList<QAction *> plotToolActions =
+      addOptionsToMenus("Plot Tools", m_plotToolGroup, plotTools, "None");
+  for (auto it = plotToolActions.begin(); it != plotToolActions.end(); ++it)
     connect(*it, SIGNAL(triggered()), this, SLOT(handleViewToolSelect()));
 
   // Create the reset plot view option
@@ -93,9 +90,12 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init) : API::MantidWidget(parent)
   m_xAxisTypeGroup->setExclusive(true);
 
   QStringList xAxisTypes;
-  xAxisTypes << "Linear" << "Logarithmic" << "Squared";
-  QList<QAction *> xAxisTypeActions = addOptionsToMenus("X Axis", m_xAxisTypeGroup, xAxisTypes, "Linear");
-  for(auto it = xAxisTypeActions.begin(); it != xAxisTypeActions.end(); ++it)
+  xAxisTypes << "Linear"
+             << "Logarithmic"
+             << "Squared";
+  QList<QAction *> xAxisTypeActions =
+      addOptionsToMenus("X Axis", m_xAxisTypeGroup, xAxisTypes, "Linear");
+  for (auto it = xAxisTypeActions.begin(); it != xAxisTypeActions.end(); ++it)
     connect(*it, SIGNAL(triggered()), this, SLOT(handleAxisTypeSelect()));
 
   // Create the X axis type list for context menu
@@ -103,9 +103,11 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init) : API::MantidWidget(parent)
   m_yAxisTypeGroup->setExclusive(true);
 
   QStringList yAxisTypes;
-  yAxisTypes << "Linear" << "Logarithmic";
-  QList<QAction *> yAxisTypeActions = addOptionsToMenus("Y Axis", m_yAxisTypeGroup, yAxisTypes, "Linear");
-  for(auto it = yAxisTypeActions.begin(); it != yAxisTypeActions.end(); ++it)
+  yAxisTypes << "Linear"
+             << "Logarithmic";
+  QList<QAction *> yAxisTypeActions =
+      addOptionsToMenus("Y Axis", m_yAxisTypeGroup, yAxisTypes, "Linear");
+  for (auto it = yAxisTypeActions.begin(); it != yAxisTypeActions.end(); ++it)
     connect(*it, SIGNAL(triggered()), this, SLOT(handleAxisTypeSelect()));
 
   m_contextMenu->addSeparator();
@@ -113,7 +115,8 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init) : API::MantidWidget(parent)
   // Create the show legend option
   m_showLegendAction = new QAction("Show Legend", m_contextMenu);
   m_showLegendAction->setCheckable(true);
-  connect(m_showLegendAction, SIGNAL(toggled(bool)), this, SLOT(showLegend(bool)));
+  connect(m_showLegendAction, SIGNAL(toggled(bool)), this,
+          SLOT(showLegend(bool)));
   m_contextMenu->addAction(m_showLegendAction);
 
   // Create the show errors option
@@ -126,73 +129,58 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init) : API::MantidWidget(parent)
   connect(this, SIGNAL(needToHardReplot()), this, SLOT(hardReplot()));
 }
 
-
 /**
  * Destructor
  *
  * Removes observers on the ADS.
  */
-PreviewPlot::~PreviewPlot()
-{
-  if(m_init)
-  {
-    AnalysisDataService::Instance().notificationCenter.removeObserver(m_removeObserver);
-    AnalysisDataService::Instance().notificationCenter.removeObserver(m_replaceObserver);
+PreviewPlot::~PreviewPlot() {
+  if (m_init) {
+    AnalysisDataService::Instance().notificationCenter.removeObserver(
+        m_removeObserver);
+    AnalysisDataService::Instance().notificationCenter.removeObserver(
+        m_replaceObserver);
   }
 }
-
 
 /**
  * Gets the background colour of the plot window.
  *
  * @return Plot canvas colour
  */
-QColor PreviewPlot::canvasColour()
-{
-  return m_uiForm.plot->canvasBackground();
-}
-
+QColor PreviewPlot::canvasColour() { return m_uiForm.plot->canvasBackground(); }
 
 /**
  * Sets the background colour of the plot window.
  *
  * @param colour Plot canvas colour
  */
-void PreviewPlot::setCanvasColour(const QColor & colour)
-{
+void PreviewPlot::setCanvasColour(const QColor &colour) {
   m_uiForm.plot->setCanvasBackground(QBrush(colour));
 }
-
 
 /**
  * Checks to see if the plot legend is visible.
  *
  * @returns True if the legend is shown
  */
-bool PreviewPlot::legendIsShown()
-{
-  return m_showLegendAction->isChecked();
-}
-
+bool PreviewPlot::legendIsShown() { return m_showLegendAction->isChecked(); }
 
 /**
  * Gets a list of curves that have their error bars shown.
  *
  * @return List of curve names with error bars shown
  */
-QStringList PreviewPlot::getShownErrorBars()
-{
+QStringList PreviewPlot::getShownErrorBars() {
   QStringList curvesWithErrors;
 
-  for(auto it = m_curves.begin(); it != m_curves.end(); ++it)
-  {
-    if(it.value().showErrorsAction->isChecked())
+  for (auto it = m_curves.begin(); it != m_curves.end(); ++it) {
+    if (it.value().showErrorsAction->isChecked())
       curvesWithErrors << it.key();
   }
 
   return curvesWithErrors;
 }
-
 
 /**
  * Sets the range of the given axis scale to a given range.
@@ -200,45 +188,41 @@ QStringList PreviewPlot::getShownErrorBars()
  * @param range Pair of values for range
  * @param axisID ID of axis
  */
-void PreviewPlot::setAxisRange(QPair<double, double> range, int axisID)
-{
-  if(range.first > range.second)
+void PreviewPlot::setAxisRange(QPair<double, double> range, int axisID) {
+  if (range.first > range.second)
     throw std::runtime_error("Supplied range is invalid.");
 
   m_uiForm.plot->setAxisScale(axisID, range.first, range.second);
   emit needToReplot();
 }
 
-
 /**
  * Gets the X range of a curve given a pointer to the workspace.
  *
  * @param ws Pointer to workspace
  */
-QPair<double, double> PreviewPlot::getCurveRange(const Mantid::API::MatrixWorkspace_sptr ws)
-{
+QPair<double, double>
+PreviewPlot::getCurveRange(const Mantid::API::MatrixWorkspace_sptr ws) {
   QStringList curveNames = getCurvesForWorkspace(ws);
 
-  if(curveNames.size() == 0)
+  if (curveNames.size() == 0)
     throw std::runtime_error("Curve for workspace not found.");
 
   return getCurveRange(curveNames[0]);
 }
-
 
 /**
  * Gets the X range of a curve given its name.
  *
  * @param curveName Name of curve
  */
-QPair<double, double> PreviewPlot::getCurveRange(const QString & curveName)
-{
-  if(!m_curves.contains(curveName))
+QPair<double, double> PreviewPlot::getCurveRange(const QString &curveName) {
+  if (!m_curves.contains(curveName))
     throw std::runtime_error("Curve not on preview plot.");
 
   size_t numPoints = m_curves[curveName].curve->data().size();
 
-  if(numPoints < 2)
+  if (numPoints < 2)
     return qMakePair(0.0, 0.0);
 
   double low = m_curves[curveName].curve->data().x(0);
@@ -246,7 +230,6 @@ QPair<double, double> PreviewPlot::getCurveRange(const QString & curveName)
 
   return qMakePair(low, high);
 }
-
 
 /**
  * Adds a workspace to the preview plot given a pointer to it.
@@ -256,19 +239,23 @@ QPair<double, double> PreviewPlot::getCurveRange(const QString & curveName)
  * @param specIndex Spectrum index to plot
  * @param curveColour Colour of curve to plot
  */
-void PreviewPlot::addSpectrum(const QString & curveName, const MatrixWorkspace_sptr ws,
-    const size_t specIndex, const QColor & curveColour)
-{
+void PreviewPlot::addSpectrum(const QString &curveName,
+                              const MatrixWorkspace_sptr ws,
+                              const size_t specIndex,
+                              const QColor &curveColour) {
   // Remove the existing curve if it exists
-  if(m_curves.contains(curveName))
+  if (m_curves.contains(curveName))
     removeSpectrum(curveName);
 
   // Add the error bar option
-  m_curves[curveName].showErrorsAction = new QAction(curveName, m_showErrorsMenuAction);
+  m_curves[curveName].showErrorsAction =
+      new QAction(curveName, m_showErrorsMenuAction);
   m_curves[curveName].showErrorsAction->setCheckable(true);
-  if(m_errorBarOptionCache.contains(curveName))
-    m_curves[curveName].showErrorsAction->setChecked(m_errorBarOptionCache[curveName]);
-  connect(m_curves[curveName].showErrorsAction, SIGNAL(toggled(bool)), this, SIGNAL(needToHardReplot()));
+  if (m_errorBarOptionCache.contains(curveName))
+    m_curves[curveName].showErrorsAction->setChecked(
+        m_errorBarOptionCache[curveName]);
+  connect(m_curves[curveName].showErrorsAction, SIGNAL(toggled(bool)), this,
+          SIGNAL(needToHardReplot()));
   m_showErrorsMenu->addAction(m_curves[curveName].showErrorsAction);
 
   // Create the curve
@@ -292,7 +279,6 @@ void PreviewPlot::addSpectrum(const QString & curveName, const MatrixWorkspace_s
   emit needToReplot();
 }
 
-
 /**
  * Adds a workspace to the preview plot given its name.
  *
@@ -301,50 +287,49 @@ void PreviewPlot::addSpectrum(const QString & curveName, const MatrixWorkspace_s
  * @param specIndex Spectrum index to plot
  * @param curveColour Colour of curve to plot
  */
-void PreviewPlot::addSpectrum(const QString & curveName, const QString & wsName,
-        const size_t specIndex, const QColor & curveColour)
-{
+void PreviewPlot::addSpectrum(const QString &curveName, const QString &wsName,
+                              const size_t specIndex,
+                              const QColor &curveColour) {
   // Try to get a pointer from the name
   std::string wsNameStr = wsName.toStdString();
-  auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName.toStdString());
+  auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      wsName.toStdString());
 
-  if(!ws)
-    throw std::runtime_error(wsNameStr + " is not a MatrixWorkspace, not supported by PreviewPlot.");
+  if (!ws)
+    throw std::runtime_error(
+        wsNameStr + " is not a MatrixWorkspace, not supported by PreviewPlot.");
 
   addSpectrum(curveName, ws, specIndex, curveColour);
 }
 
-
 /**
  * Removes spectra from a given workspace from the plot given a pointer to it.
  *
- * If multiple curves are plotted form the same workspace then all will be removed.
+ * If multiple curves are plotted form the same workspace then all will be
+ * removed.
  *
  * @param ws Pointer to workspace
  */
-void PreviewPlot::removeSpectrum(const MatrixWorkspace_sptr ws)
-{
+void PreviewPlot::removeSpectrum(const MatrixWorkspace_sptr ws) {
   QStringList curveNames = getCurvesForWorkspace(ws);
 
-  for(auto it = curveNames.begin(); it != curveNames.end(); ++it)
+  for (auto it = curveNames.begin(); it != curveNames.end(); ++it)
     removeSpectrum(*it);
 }
-
 
 /**
  * Removes spectra from a given workspace from the plot given its name.
  *
  * @param curveName Name of curve
  */
-void PreviewPlot::removeSpectrum(const QString & curveName)
-{
+void PreviewPlot::removeSpectrum(const QString &curveName) {
   // Remove the curve object and legend label
-  if(m_curves.contains(curveName))
-  {
+  if (m_curves.contains(curveName)) {
     removeCurve(m_curves[curveName].curve);
     removeCurve(m_curves[curveName].errorCurve);
     m_uiForm.loLegend->removeWidget(m_curves[curveName].label);
-    m_errorBarOptionCache[curveName] = m_curves[curveName].showErrorsAction->isChecked();
+    m_errorBarOptionCache[curveName] =
+        m_curves[curveName].showErrorsAction->isChecked();
     m_showErrorsMenu->removeAction(m_curves[curveName].showErrorsAction);
     delete m_curves[curveName].showErrorsAction;
     delete m_curves[curveName].label;
@@ -354,12 +339,11 @@ void PreviewPlot::removeSpectrum(const QString & curveName)
   auto it = m_curves.find(curveName);
 
   // Remove the curve from the map
-  if(it != m_curves.end())
+  if (it != m_curves.end())
     m_curves.erase(it);
 
   emit needToReplot();
 }
-
 
 /**
  * Checks to see if a given curve name is present on the plot.
@@ -367,11 +351,9 @@ void PreviewPlot::removeSpectrum(const QString & curveName)
  * @param curveName Curve name
  * @return True if curve is on plot
  */
-bool PreviewPlot::hasCurve(const QString & curveName)
-{
+bool PreviewPlot::hasCurve(const QString &curveName) {
   return m_curves.contains(curveName);
 }
-
 
 /**
  * Creates a RangeSelector, adds it to the plot and stores it.
@@ -380,18 +362,17 @@ bool PreviewPlot::hasCurve(const QString & curveName)
  * @param type Type of range selector to add
  * @return RangeSelector object
  */
-RangeSelector * PreviewPlot::addRangeSelector(const QString & rsName,
-                                              RangeSelector::SelectType type)
-{
-  if(hasRangeSelector(rsName))
+RangeSelector *PreviewPlot::addRangeSelector(const QString &rsName,
+                                             RangeSelector::SelectType type) {
+  if (hasRangeSelector(rsName))
     throw std::runtime_error("RangeSelector already exists on PreviewPlot");
 
-  m_rangeSelectors[rsName] = new MantidWidgets::RangeSelector(m_uiForm.plot, type);
+  m_rangeSelectors[rsName] =
+      new MantidWidgets::RangeSelector(m_uiForm.plot, type);
   m_rsVisibility[rsName] = m_rangeSelectors[rsName]->isVisible();
 
   return m_rangeSelectors[rsName];
 }
-
 
 /**
  * Gets a RangeSelector.
@@ -399,14 +380,12 @@ RangeSelector * PreviewPlot::addRangeSelector(const QString & rsName,
  * @param rsName Name of range selector
  * @return RangeSelector object
  */
-RangeSelector * PreviewPlot::getRangeSelector(const QString & rsName)
-{
-  if(!hasRangeSelector(rsName))
+RangeSelector *PreviewPlot::getRangeSelector(const QString &rsName) {
+  if (!hasRangeSelector(rsName))
     throw std::runtime_error("RangeSelector not found on PreviewPlot");
 
   return m_rangeSelectors[rsName];
 }
-
 
 /**
  * Removes a RangeSelector from the plot.
@@ -414,17 +393,15 @@ RangeSelector * PreviewPlot::getRangeSelector(const QString & rsName)
  * @param rsName Name of range selector
  * @param del If the object should be deleted
  */
-void PreviewPlot::removeRangeSelector(const QString & rsName, bool del = true)
-{
-  if(!hasRangeSelector(rsName))
+void PreviewPlot::removeRangeSelector(const QString &rsName, bool del = true) {
+  if (!hasRangeSelector(rsName))
     return;
 
-  if(del)
+  if (del)
     delete m_rangeSelectors[rsName];
 
   m_rangeSelectors.remove(rsName);
 }
-
 
 /**
  * Checks to see if a range selector with a given name is on the plot.
@@ -432,25 +409,21 @@ void PreviewPlot::removeRangeSelector(const QString & rsName, bool del = true)
  * @param rsName Name of range selector
  * @return True if the plot has a range selector with the given name
  */
-bool PreviewPlot::hasRangeSelector(const QString & rsName)
-{
+bool PreviewPlot::hasRangeSelector(const QString &rsName) {
   return m_rangeSelectors.contains(rsName);
 }
-
 
 /**
  * Shows or hides the plot legend.
  *
  * @param show If the legend should be shown
  */
-void PreviewPlot::showLegend(bool show)
-{
+void PreviewPlot::showLegend(bool show) {
   m_showLegendAction->setChecked(show);
 
-  for(auto it = m_curves.begin(); it != m_curves.end(); ++it)
+  for (auto it = m_curves.begin(); it != m_curves.end(); ++it)
     it.value().label->setVisible(show);
 }
-
 
 /**
  * Show error bars for the given curves and set a marker that if any curves
@@ -458,57 +431,49 @@ void PreviewPlot::showLegend(bool show)
  *
  * @param curveNames List of curve names to show error bars of
  */
-void PreviewPlot::setDefaultShownErrorBars(const QStringList & curveNames)
-{
-  for(auto it = curveNames.begin(); it != curveNames.end(); ++it)
-  {
+void PreviewPlot::setDefaultShownErrorBars(const QStringList &curveNames) {
+  for (auto it = curveNames.begin(); it != curveNames.end(); ++it) {
     m_errorBarOptionCache[*it] = true;
 
-    if(m_curves.contains(*it))
+    if (m_curves.contains(*it))
       m_curves[*it].showErrorsAction->setChecked(true);
   }
 
   emit needToHardReplot();
 }
 
-
 /**
  * Toggles the pan plot tool.
  *
  * @param enabled If the tool should be enabled
  */
-void PreviewPlot::togglePanTool(bool enabled)
-{
+void PreviewPlot::togglePanTool(bool enabled) {
   // First disbale the zoom tool
-  if(enabled && m_zoomTool->isEnabled())
+  if (enabled && m_zoomTool->isEnabled())
     m_zoomTool->setEnabled(false);
 
   m_panTool->setEnabled(enabled);
   m_magnifyTool->setEnabled(enabled);
 }
 
-
 /**
  * Toggles the zoom plot tool.
  *
  * @param enabled If the tool should be enabled
  */
-void PreviewPlot::toggleZoomTool(bool enabled)
-{
+void PreviewPlot::toggleZoomTool(bool enabled) {
   // First disbale the pan tool
-  if(enabled && m_panTool->isEnabled())
+  if (enabled && m_panTool->isEnabled())
     m_panTool->setEnabled(false);
 
   m_zoomTool->setEnabled(enabled);
   m_magnifyTool->setEnabled(enabled);
 }
 
-
 /**
  * Resets the view to a sensible default.
  */
-void PreviewPlot::resetView()
-{
+void PreviewPlot::resetView() {
   // Auto scale the axis
   m_uiForm.plot->setAxisAutoScale(QwtPlot::xBottom);
   m_uiForm.plot->setAxisAutoScale(QwtPlot::yLeft);
@@ -517,38 +482,32 @@ void PreviewPlot::resetView()
   m_zoomTool->setZoomBase(true);
 }
 
-
 /**
  * Resizes the X axis scale range to exactly fir the curves currently
  * plotted on it.
  */
-void PreviewPlot::resizeX()
-{
+void PreviewPlot::resizeX() {
   double low = DBL_MAX;
   double high = DBL_MIN;
 
-  for(auto it = m_curves.begin(); it != m_curves.end(); ++it)
-  {
+  for (auto it = m_curves.begin(); it != m_curves.end(); ++it) {
     auto range = getCurveRange(it.key());
 
-    if(range.first < low)
+    if (range.first < low)
       low = range.first;
 
-    if(range.second > high)
+    if (range.second > high)
       high = range.second;
   }
 
   setAxisRange(qMakePair(low, high), QwtPlot::xBottom);
 }
 
-
 /**
  * Removes all curves from the plot.
  */
-void PreviewPlot::clear()
-{
-  for(auto it = m_curves.begin(); it != m_curves.end(); ++it)
-  {
+void PreviewPlot::clear() {
+  for (auto it = m_curves.begin(); it != m_curves.end(); ++it) {
     removeCurve(it.value().curve);
     removeCurve(it.value().errorCurve);
     m_uiForm.loLegend->removeWidget(it.value().label);
@@ -560,33 +519,26 @@ void PreviewPlot::clear()
   emit needToReplot();
 }
 
-
 /**
  * Replots the curves shown on the plot.
  */
-void PreviewPlot::replot()
-{
-  m_uiForm.plot->replot();
-}
-
+void PreviewPlot::replot() { m_uiForm.plot->replot(); }
 
 /**
  * Removes all curves and re-adds them.
  */
-void PreviewPlot::hardReplot()
-{
+void PreviewPlot::hardReplot() {
   QStringList keys = m_curves.keys();
 
-  for(auto it = keys.begin(); it != keys.end(); ++it)
-  {
+  for (auto it = keys.begin(); it != keys.end(); ++it) {
     removeCurve(m_curves[*it].curve);
     removeCurve(m_curves[*it].errorCurve);
-    addCurve(m_curves[*it], m_curves[*it].ws, m_curves[*it].wsIndex, m_curves[*it].colour);
+    addCurve(m_curves[*it], m_curves[*it].ws, m_curves[*it].wsIndex,
+             m_curves[*it].colour);
   }
 
   emit needToReplot();
 }
-
 
 /**
  * Handle a workspace being deleted from ADS.
@@ -595,12 +547,12 @@ void PreviewPlot::hardReplot()
  *
  * @param pNf Poco notification
  */
-void PreviewPlot::handleRemoveEvent(WorkspacePreDeleteNotification_ptr pNf)
-{
-  MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(pNf->object());
+void PreviewPlot::handleRemoveEvent(WorkspacePreDeleteNotification_ptr pNf) {
+  MatrixWorkspace_sptr ws =
+      boost::dynamic_pointer_cast<MatrixWorkspace>(pNf->object());
 
   // Ignore non matrix worksapces
-  if(!ws)
+  if (!ws)
     return;
 
   // Remove the workspace
@@ -609,7 +561,6 @@ void PreviewPlot::handleRemoveEvent(WorkspacePreDeleteNotification_ptr pNf)
   emit needToReplot();
 }
 
-
 /**
  * Handle a workspace being modified in ADS.
  *
@@ -617,18 +568,18 @@ void PreviewPlot::handleRemoveEvent(WorkspacePreDeleteNotification_ptr pNf)
  *
  * @param pNf Poco notification
  */
-void PreviewPlot::handleReplaceEvent(WorkspaceAfterReplaceNotification_ptr pNf)
-{
-  MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(pNf->object());
+void
+PreviewPlot::handleReplaceEvent(WorkspaceAfterReplaceNotification_ptr pNf) {
+  MatrixWorkspace_sptr ws =
+      boost::dynamic_pointer_cast<MatrixWorkspace>(pNf->object());
 
   // Ignore non matrix worksapces
-  if(!ws)
+  if (!ws)
     return;
 
-  if(getCurvesForWorkspace(ws).size() > 0)
+  if (getCurvesForWorkspace(ws).size() > 0)
     emit needToHardReplot();
 }
-
 
 /**
  * Creates a new curve and adds it to the plot.
@@ -638,21 +589,23 @@ void PreviewPlot::handleReplaceEvent(WorkspaceAfterReplaceNotification_ptr pNf)
  * @param specIndex Index of histogram to plot
  * @param curveColour Colour of curve
  */
-void PreviewPlot::addCurve(PlotCurveConfiguration& curveConfig,
-    MatrixWorkspace_sptr ws, const size_t specIndex, const QColor & curveColour)
-{
+void PreviewPlot::addCurve(PlotCurveConfiguration &curveConfig,
+                           MatrixWorkspace_sptr ws, const size_t specIndex,
+                           const QColor &curveColour) {
   // Check the spectrum index is in range
-  if(specIndex >= ws->getNumberHistograms())
+  if (specIndex >= ws->getNumberHistograms())
     throw std::runtime_error("Workspace index is out of range, cannot plot.");
 
   // Check the X axis is large enough
-  if(ws->readX(0).size() < 2)
-    throw std::runtime_error("X axis is too small to generate a histogram plot.");
+  if (ws->readX(0).size() < 2)
+    throw std::runtime_error(
+        "X axis is too small to generate a histogram plot.");
 
   // Convert X axis to squared if needed
-  if(getAxisType(QwtPlot::xBottom) == "Squared")
-  {
-    Mantid::API::IAlgorithm_sptr convertXAlg = Mantid::API::AlgorithmManager::Instance().create("ConvertAxisByFormula");
+  if (getAxisType(QwtPlot::xBottom) == "Squared") {
+    Mantid::API::IAlgorithm_sptr convertXAlg =
+        Mantid::API::AlgorithmManager::Instance().create(
+            "ConvertAxisByFormula");
     convertXAlg->initialize();
     convertXAlg->setChild(true);
     convertXAlg->setLogging(false);
@@ -668,11 +621,11 @@ void PreviewPlot::addCurve(PlotCurveConfiguration& curveConfig,
 
   // If using log scale need to remove all negative Y values
   bool logYScale = getAxisType(QwtPlot::yLeft) == "Logarithmic";
-  if(logYScale)
-  {
+  if (logYScale) {
     // Remove negative data in order to search for minimum positive value
     std::vector<double> validData(wsDataY.size());
-    auto it = std::remove_copy_if(wsDataY.begin(), wsDataY.end(), validData.begin(), isNegative);
+    auto it = std::remove_copy_if(wsDataY.begin(), wsDataY.end(),
+                                  validData.begin(), isNegative);
     validData.resize(std::distance(validData.begin(), it));
 
     // Get minimum positive value
@@ -694,26 +647,22 @@ void PreviewPlot::addCurve(PlotCurveConfiguration& curveConfig,
   curveConfig.curve->attach(m_uiForm.plot);
 
   // Create error bars if needed
-  if(curveConfig.showErrorsAction->isChecked())
-  {
-    curveConfig.errorCurve = new ErrorCurve(curveConfig.curve, ws->readE(specIndex));
+  if (curveConfig.showErrorsAction->isChecked()) {
+    curveConfig.errorCurve =
+        new ErrorCurve(curveConfig.curve, ws->readE(specIndex));
     curveConfig.errorCurve->attach(m_uiForm.plot);
-  }
-  else
-  {
+  } else {
     curveConfig.errorCurve = NULL;
   }
 }
-
 
 /**
  * Removes a curve from the plot.
  *
  * @param curve Curve to remove
  */
-void PreviewPlot::removeCurve(QwtPlotItem * curve)
-{
-  if(!curve)
+void PreviewPlot::removeCurve(QwtPlotItem *curve) {
+  if (!curve)
     return;
 
   // Take it off the plot
@@ -724,9 +673,9 @@ void PreviewPlot::removeCurve(QwtPlotItem * curve)
   curve = NULL;
 }
 
-
 /**
- * Helper function for adding a set of items to an exclusive menu on the context menu.
+ * Helper function for adding a set of items to an exclusive menu on the context
+ *menu.
  *
  * @param menuName Name of sub menu
  * @param group Pointer to ActionGroup
@@ -734,12 +683,13 @@ void PreviewPlot::removeCurve(QwtPlotItem * curve)
  * @param defaultItem Default item name
  * @return List of Actions added
  */
-QList<QAction *> PreviewPlot::addOptionsToMenus(QString menuName, QActionGroup *group, QStringList items, QString defaultItem)
-{
+QList<QAction *> PreviewPlot::addOptionsToMenus(QString menuName,
+                                                QActionGroup *group,
+                                                QStringList items,
+                                                QString defaultItem) {
   QMenu *menu = new QMenu(m_contextMenu);
 
-  for(auto it = items.begin(); it != items.end(); ++it)
-  {
+  for (auto it = items.begin(); it != items.end(); ++it) {
     QAction *action = new QAction(*it, menu);
     action->setCheckable(true);
 
@@ -758,31 +708,28 @@ QList<QAction *> PreviewPlot::addOptionsToMenus(QString menuName, QActionGroup *
   return group->actions();
 }
 
-
 /**
  * Returns the type of axis scale specified for a given axis.
  *
  * @param axisID ID of axis
  * @return Axis type as string
  */
-QString PreviewPlot::getAxisType(int axisID)
-{
+QString PreviewPlot::getAxisType(int axisID) {
   QString axisType("Linear");
-  QAction * selectedAxisType = NULL;
+  QAction *selectedAxisType = NULL;
 
-  if(axisID == QwtPlot::xBottom)
+  if (axisID == QwtPlot::xBottom)
     selectedAxisType = m_xAxisTypeGroup->checkedAction();
   else if (axisID == QwtPlot::yLeft)
     selectedAxisType = m_yAxisTypeGroup->checkedAction();
   else
     return QString();
 
-  if(selectedAxisType)
+  if (selectedAxisType)
     axisType = selectedAxisType->text();
 
   return axisType;
 }
-
 
 /**
  * Gets a list of curve names that are plotted form the given workspace.
@@ -790,63 +737,50 @@ QString PreviewPlot::getAxisType(int axisID)
  * @param ws Pointer to workspace
  * @return List of curve names
  */
-QStringList PreviewPlot::getCurvesForWorkspace(const MatrixWorkspace_sptr ws)
-{
+QStringList PreviewPlot::getCurvesForWorkspace(const MatrixWorkspace_sptr ws) {
   QStringList curveNames;
 
-  for(auto it = m_curves.begin(); it != m_curves.end(); ++it)
-  {
-    if(it.value().ws == ws)
+  for (auto it = m_curves.begin(); it != m_curves.end(); ++it) {
+    if (it.value().ws == ws)
       curveNames << it.key();
   }
 
   return curveNames;
 }
 
-
 /**
  * Handles displaying the context menu when a user right clicks on the plot.
  *
  * @param position Position at which to show menu
  */
-void PreviewPlot::showContextMenu(QPoint position)
-{
+void PreviewPlot::showContextMenu(QPoint position) {
   // Show the context menu
   m_contextMenu->popup(m_uiForm.plot->mapToGlobal(position));
 }
 
-
 /**
  * Handles the view tool being selected from the context menu.
  */
-void PreviewPlot::handleViewToolSelect()
-{
+void PreviewPlot::handleViewToolSelect() {
   QAction *selectedPlotType = m_plotToolGroup->checkedAction();
-  if(!selectedPlotType)
+  if (!selectedPlotType)
     return;
 
   QString selectedTool = selectedPlotType->text();
-  if(selectedTool == "None")
-  {
+  if (selectedTool == "None") {
     togglePanTool(false);
     toggleZoomTool(false);
-  }
-  else if(selectedTool == "Pan")
-  {
+  } else if (selectedTool == "Pan") {
     togglePanTool(true);
-  }
-  else if(selectedTool == "Zoom")
-  {
+  } else if (selectedTool == "Zoom") {
     toggleZoomTool(true);
   }
 }
 
-
 /**
  * Handles a change in the plot axis type.
  */
-void PreviewPlot::handleAxisTypeSelect()
-{
+void PreviewPlot::handleAxisTypeSelect() {
   // Determine the type of engine to use for each axis
   QString xAxisType = getAxisType(QwtPlot::xBottom);
   QString yAxisType = getAxisType(QwtPlot::yLeft);
@@ -855,56 +789,43 @@ void PreviewPlot::handleAxisTypeSelect()
   QwtScaleEngine *yEngine = NULL;
 
   // Get the X axis engine
-  if(xAxisType == "Linear")
-  {
+  if (xAxisType == "Linear") {
     xEngine = new QwtLinearScaleEngine();
-  }
-  else if(xAxisType == "Logarithmic")
-  {
+  } else if (xAxisType == "Logarithmic") {
     xEngine = new QwtLog10ScaleEngine();
-  }
-  else if(xAxisType == "Squared")
-  {
+  } else if (xAxisType == "Squared") {
     xEngine = new QwtLinearScaleEngine();
   }
 
   // Get the Y axis engine
-  if(yAxisType == "Linear")
-  {
+  if (yAxisType == "Linear") {
     yEngine = new QwtLinearScaleEngine();
-  }
-  else if(yAxisType == "Logarithmic")
-  {
+  } else if (yAxisType == "Logarithmic") {
     yEngine = new QwtLog10ScaleEngine();
   }
 
   // Set the axis scale engines
-  if(xEngine)
+  if (xEngine)
     m_uiForm.plot->setAxisScaleEngine(QwtPlot::xBottom, xEngine);
 
-  if(yEngine)
+  if (yEngine)
     m_uiForm.plot->setAxisScaleEngine(QwtPlot::yLeft, yEngine);
 
   emit axisScaleChanged();
 
   // Hide range selectors on X axis when X axis scale is X^2
   bool xIsSquared = xAxisType == "Squared";
-  for(auto it = m_rangeSelectors.begin(); it != m_rangeSelectors.end(); ++it)
-  {
+  for (auto it = m_rangeSelectors.begin(); it != m_rangeSelectors.end(); ++it) {
     QString rsName = it.key();
-    RangeSelector * rs = it.value();
+    RangeSelector *rs = it.value();
     RangeSelector::SelectType type = rs->getType();
 
-    if(type == RangeSelector:: XMINMAX || type == RangeSelector::XSINGLE)
-    {
+    if (type == RangeSelector::XMINMAX || type == RangeSelector::XSINGLE) {
       // When setting to invisible save the last visibility setting
-      if(xIsSquared)
-      {
+      if (xIsSquared) {
         m_rsVisibility[rsName] = rs->isVisible();
         rs->setVisible(false);
-      }
-      else
-      {
+      } else {
         rs->setVisible(m_rsVisibility[rsName]);
       }
     }


### PR DESCRIPTION
Fixes #12877.

To test:
- Open Indirect > Data Analysis > MSDFit
- Open `Babylon5/Public/DanNixon/data/osi92762_graphite002_elwin_eq2.nxs`
- See that Sample curve has errors
- Run
- See that Fit does not have errors
- Toggle error bars via context menu
- See that when errors are added to Fit, they are still there after the algorithm is run again

No release notes updates as this is covered in the mention of last changes to PreviewPlot.
