### PR TITLE
Bank number in PeaksWorkspace for CORELLI

### DIFF
--- a/Code/Mantid/Framework/DataObjects/src/Peak.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/Peak.cpp
@@ -287,6 +287,12 @@ void Peak::setDetectorID(int id) {
     return;
   // Use the grand-parent whenever possible
   m_bankName = parent->getName();
+  // For CORELLI, one level above sixteenpack
+  if(m_bankName.compare("sixteenpack") == 0){
+    parent = parent->getParent();
+    m_bankName = parent->getName();
+  }
+
 
   // Special for rectangular detectors: find the row and column.
   RectangularDetector_const_sptr retDet =


### PR DESCRIPTION
Fixes #12884 by putting bank number in Peak object.  No need to put in release notes.  To test, look for bank numbers in PeaksWorkspace table:

```
Load(Filename='CORELLI_11061.nxs.h5', OutputWorkspace='CORELLI_11061.nxs')
LoadInstrument(Workspace='CORELLI_11061.nxs', Filename='/home/vel/workspace/CORELLI_Definition_new.xml', MonitorList='-1,-2,-3')
ConvertToMD(InputWorkspace='CORELLI_11061.nxs', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_lab', OutputWorkspace='md', MinValues='-30,-30,-30', MaxValues='30,30,30', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=11)
FindPeaksMD(InputWorkspace='md', OutputWorkspace='peaks')
```
