### PR TITLE
 Add missing dependencies for ipython notebook.

### DIFF
--- a/Code/Mantid/MantidPlot/make_package.rb.in
+++ b/Code/Mantid/MantidPlot/make_package.rb.in
@@ -204,12 +204,12 @@ end
 #Copy over python libraries not included with OSX. 
 #currently missing epics
 path = "/Library/Python/2.7/site-packages"
-directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports","certifi","tornado","markupsafe","jinja2","psutil"]
+directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports","certifi","tornado","markupsafe","jinja2","psutil","jsonschema","functools32","ptyprocess"]
 directories.each do |directory|
   addPythonLibrary("#{path}/#{directory}")
 end
 
-files = ["gnureadline.so","readline.py","pyparsing.py"]
+files = ["gnureadline.so","readline.py","pyparsing.py","mistune.py","mistune.so"]
 files.each do |file|
   copyFile("#{path}/#{file}")
 end


### PR DESCRIPTION
This fixes #12871.

IPython notebook was failing because of missing dependencies. After upgrading IPython notebook, it looks like new dependencies have been added. According to pip, the full list is 
- gnureadline
- tornado>=3.1
- pyzmq>=2.1.11
- jinja2 
- certifi
- backports.ssl-match-hostname
- markupsafe

The file `make_package.rb.in` has been updated to copy over those dependencies. 

testing:
1. Download Mantid app bundle from the build server or build your own from source.
2. Run IPython notebook according to the [instructions](http://www.mantidproject.org/Using_IPython_Notebook). 
4. Verify that one can use Mantid from the IPython notebook. The following script should not produce errors. You may also need to set your MANTIDPATH (`export MANTIDPATH=/Applications/MantidPlot.app/Contents/MacOS`)

```
import sys
import os
sys.path.append(os.environ['MANTIDPATH'])
from mantid.simpleapi import *
```
