### PR TITLE
Fix bug in ALC

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -172,26 +172,34 @@ namespace CustomInterfaces
 
   MatrixWorkspace_const_sptr ALCBaselineModellingModel::data() const
   {
-    IAlgorithm_sptr extract = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
-    extract->setChild(true);
-    extract->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
-    extract->setProperty("WorkspaceIndex", 0);
-    extract->setProperty("OutputWorkspace", "__NotUsed__");
-    extract->execute();
-    MatrixWorkspace_const_sptr result = extract->getProperty("OutputWorkspace");
-    return result;
+    if (m_data) {
+      IAlgorithm_sptr extract = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
+      extract->setChild(true);
+      extract->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
+      extract->setProperty("WorkspaceIndex", 0);
+      extract->setProperty("OutputWorkspace", "__NotUsed__");
+      extract->execute();
+      MatrixWorkspace_const_sptr result = extract->getProperty("OutputWorkspace");
+      return result;
+    } else {
+      return MatrixWorkspace_const_sptr();
+    }
   }
 
   MatrixWorkspace_const_sptr ALCBaselineModellingModel::correctedData() const
   {
-    IAlgorithm_sptr extract = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
-    extract->setChild(true);
-    extract->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
-    extract->setProperty("WorkspaceIndex", 2);
-    extract->setProperty("OutputWorkspace", "__NotUsed__");
-    extract->execute();
-    MatrixWorkspace_const_sptr result = extract->getProperty("OutputWorkspace");
-    return result;
+    if (m_data && (m_data->getNumberHistograms()==3) ) {
+      IAlgorithm_sptr extract = AlgorithmManager::Instance().create("ExtractSingleSpectrum");
+      extract->setChild(true);
+      extract->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
+      extract->setProperty("WorkspaceIndex", 2);
+      extract->setProperty("OutputWorkspace", "__NotUsed__");
+      extract->execute();
+      MatrixWorkspace_const_sptr result = extract->getProperty("OutputWorkspace");
+      return result;
+    } else {
+      return MatrixWorkspace_const_sptr();
+    }
   }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -145,6 +145,16 @@ public:
     TS_ASSERT_THROWS_NOTHING(m_model->exportModel());
   }
 
+  void test_noData()
+  {
+    // Set an empty workspace
+    MatrixWorkspace_const_sptr data = MatrixWorkspace_const_sptr();
+    m_model->setData(data);
+
+    TS_ASSERT_THROWS_NOTHING(m_model->data());
+    TS_ASSERT_THROWS_NOTHING(m_model->correctedData());
+  }
+
 };
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -147,7 +147,7 @@ public:
 
   void test_noData()
   {
-    // Set an empty workspace
+    // Set a null shared pointer
     MatrixWorkspace_const_sptr data = MatrixWorkspace_const_sptr();
     m_model->setData(data);
 


### PR DESCRIPTION
Fixes #12852 

For tester: code review. To check that the bug has been fixed open the ALC interface, load "MUSR00015189.nxs" as "First" and "MUSR00015191.nxs" as "Last". Go to "BaselineModelling", hit "PeakFitting", you should get an error message saying that you must fit a baseline first.
