### PR TITLE
IDR load log file option

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -107,7 +107,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                                                               self._spectra_range[0],
                                                               self._spectra_range[1],
                                                               self._sum_files,
-                                                              load_opts)
+                                                              load_opts=load_opts)
 
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -27,7 +27,11 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         self.declareProperty(StringArrayProperty(name='InputFiles'),
                              doc='Comma separated list of input files')
 
-        self.declareProperty(name='SumFiles', defaultValue=False, doc='Toggle input file summing or sequential processing')
+        self.declareProperty(name='SumFiles', defaultValue=False,
+                             doc='Toggle input file summing or sequential processing')
+
+        self.declareProperty(name='LoadLogFiles', defaultValue=True,
+                             doc='Load log files when loading runs')
 
         self.declareProperty(WorkspaceProperty('CalibrationWorkspace', '', direction=Direction.Input, optional=PropertyMode.Optional),
                              doc='Workspace contining calibration data')
@@ -90,7 +94,8 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                                                               self._ipf_filename,
                                                               self._spectra_range[0],
                                                               self._spectra_range[1],
-                                                              self._sum_files)
+                                                              self._sum_files,
+                                                              self._load_logs)
 
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)
@@ -273,6 +278,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         # Get properties
         self._data_files = self.getProperty('InputFiles').value
         self._sum_files = self.getProperty('SumFiles').value
+        self._load_logs = self.getProperty('LoadLogFiles').value
         self._calibration_ws = _str_or_none(self.getPropertyValue('CalibrationWorkspace'))
 
         self._instrument_name = self.getPropertyValue('Instrument')

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
@@ -36,7 +36,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCalibrationFile" native="true">
         <property name="enabled">
          <bool>false</bool>
@@ -61,7 +61,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QCheckBox" name="ckUseCalib">
         <property name="toolTip">
          <string>Use calibration file to adjust for detector efficiency.</string>
@@ -83,6 +83,16 @@
          <string>Run Files</string>
         </property>
         <property name="multipleFiles" stdset="0">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="ckLoadLogFiles">
+        <property name="text">
+         <string>Load Log Files</string>
+        </property>
+        <property name="checked">
          <bool>true</bool>
         </property>
        </widget>
@@ -949,6 +959,41 @@
    <header>MantidQtMantidWidgets/MWRunFiles.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>ckSumFiles</tabstop>
+  <tabstop>cbLoadLogFiles</tabstop>
+  <tabstop>ckUseCalib</tabstop>
+  <tabstop>spPlotTimeSpecMin</tabstop>
+  <tabstop>spPlotTimeSpecMax</tabstop>
+  <tabstop>pbPlotTime</tabstop>
+  <tabstop>ckBackgroundRemoval</tabstop>
+  <tabstop>spBackgroundStart</tabstop>
+  <tabstop>spBackgroundEnd</tabstop>
+  <tabstop>ckDetailedBalance</tabstop>
+  <tabstop>ckScaleMultiplier</tabstop>
+  <tabstop>spDetailedBalance</tabstop>
+  <tabstop>spScaleMultiplier</tabstop>
+  <tabstop>leEfixed</tabstop>
+  <tabstop>spSpectraMin</tabstop>
+  <tabstop>spSpectraMax</tabstop>
+  <tabstop>cbGroupingOptions</tabstop>
+  <tabstop>ckDoNotRebin</tabstop>
+  <tabstop>cbRebinType</tabstop>
+  <tabstop>spRebinLow</tabstop>
+  <tabstop>spRebinWidth</tabstop>
+  <tabstop>spRebinHigh</tabstop>
+  <tabstop>leRebinString</tabstop>
+  <tabstop>spNumberGroups</tabstop>
+  <tabstop>ckSaveSPE</tabstop>
+  <tabstop>ckSaveNexus</tabstop>
+  <tabstop>ckSaveNXSPE</tabstop>
+  <tabstop>ckSaveASCII</tabstop>
+  <tabstop>ckSaveAclimax</tabstop>
+  <tabstop>ckSaveDaveGrp</tabstop>
+  <tabstop>cbPlotType</tabstop>
+  <tabstop>ckFold</tabstop>
+  <tabstop>ckCm1Units</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -118,6 +118,7 @@ namespace CustomInterfaces
     reductionAlg->setProperty("InputFiles", files.toStdString());
 
     reductionAlg->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
+    reductionAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
 
     if(m_uiForm.ckUseCalib->isChecked())
     {

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
@@ -76,7 +76,7 @@ Sum Files
   If selected the data from each raw file will be summed and from then on
   treated as a single run.
 
-Load Logs
+Load Log Files
   If selected the sample logs will be laoded from each of the run files.
 
 Grouping

--- a/Code/Mantid/scripts/Inelastic/IndirectReductionCommon.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectReductionCommon.py
@@ -7,7 +7,7 @@ import numpy as np
 
 #-------------------------------------------------------------------------------
 
-def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files, load_opts=None):
+def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, load_logs=True, load_opts=None):
     """
     Loads a set of files and extracts just the spectra we care about (i.e. detector range and monitor).
 
@@ -15,7 +15,8 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files, load_opt
     @param ipf_filename FIle path/name for the instrument parameter file to load
     @param spec_min Minimum spectra ID to load
     @param spec_max Maximum spectra ID to load
-    @param sum Sum loaded files
+    @param sum_files Sum loaded files
+    @param load_logs Load log files when loading runs
     @param load_opts Additional options to be passed to load algorithm
 
     @return List of loaded workspace names and flag indicating chopped data
@@ -43,6 +44,7 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files, load_opt
         else:
             Load(Filename=filename,
                  OutputWorkspace=ws_name,
+                 LoadLogFiles=load_logs,
                  **load_opts)
 
         # Load the instrument parameters


### PR DESCRIPTION
Fixes #12889.

To test:
- Open Indirect > Data Reduction > ISIS Energy Transfer
- Set instrument to IRIS, graphite, 002
- Run number: 26176
- Run
- Compare the sample logs to that of a reduction with the Load Log Files option disabled and see that some logs are not loaded.

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24309&oldid=24299).
