### PR TITLE
 Fixed behavior of VectorHelper::convertToBinBoundary for two special cases

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/VectorHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/VectorHelper.cpp
@@ -376,9 +376,14 @@ void convertToBinCentre(const std::vector<double> &bin_edges,
 void convertToBinBoundary(const std::vector<double> &bin_centers,
                           std::vector<double> &bin_edges) {
   const std::vector<double>::size_type n = bin_centers.size();
-  if (bin_edges.size() != (n + 1)) {
-    bin_edges.resize(n + 1);
+
+  // Special case empty input: output is also empty
+  if (n == 0) {
+    bin_edges.resize(0);
+    return;
   }
+
+  bin_edges.resize(n + 1);
 
   for (size_t i = 0; i < n - 1; ++i) {
     bin_edges[i + 1] = 0.5 * (bin_centers[i] + bin_centers[i + 1]);

--- a/Code/Mantid/Framework/Kernel/src/VectorHelper.cpp
+++ b/Code/Mantid/Framework/Kernel/src/VectorHelper.cpp
@@ -366,7 +366,9 @@ void convertToBinCentre(const std::vector<double> &bin_edges,
  * that the first and last bin centers are in the center of the
  * first and last bins, respectively. For a particular set of
  * bin centers, this may not be correct, but it is the best that
- * can be done, lacking any other information.
+ * can be done, lacking any other information. For an empty input vector, an
+ * empty output is returned. For an input vector of size 1, i.e., a single bin,
+ * there is no information about a proper bin size, so it is set to 1.0.
  *
  * @param bin_centers :: A vector of values specifying bin centers.
  * @param bin_edges   :: An output vector of values specifying bin
@@ -384,6 +386,14 @@ void convertToBinBoundary(const std::vector<double> &bin_centers,
   }
 
   bin_edges.resize(n + 1);
+
+  // Special case input of size one: we have no means of guessing the bin size,
+  // set it to 1.
+  if (n == 1) {
+    bin_edges[0] = bin_centers[0] - 0.5;
+    bin_edges[1] = bin_centers[0] + 0.5;
+    return;
+  }
 
   for (size_t i = 0; i < n - 1; ++i) {
     bin_edges[i + 1] = 0.5 * (bin_centers[i] + bin_centers[i + 1]);

--- a/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
+++ b/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
@@ -111,6 +111,14 @@ public:
     TS_ASSERT_EQUALS(axis, expectedAxis);
   }
 
+  void test_ConvertToBinBoundary_EmptyInputVector() {
+    std::vector<double> bin_centers;
+    std::vector<double> bin_edges;
+    VectorHelper::convertToBinBoundary(bin_centers, bin_edges);
+
+    TS_ASSERT_EQUALS(bin_edges.size(), 0);
+  }
+
   void test_ConvertToBinBoundary_Size2InputVector() {
     std::vector<double> bin_centers = {0.5, 1.5};
     std::vector<double> bin_edges;

--- a/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
+++ b/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
@@ -120,7 +120,7 @@ public:
   }
 
   void test_ConvertToBinBoundary_Size1InputVector() {
-    std::vector<double> bin_centers = {0.4};
+    std::vector<double> bin_centers = boost::assign::list_of(0.4);
     std::vector<double> bin_edges;
     VectorHelper::convertToBinBoundary(bin_centers, bin_edges);
 
@@ -131,7 +131,7 @@ public:
   }
 
   void test_ConvertToBinBoundary_Size2InputVector() {
-    std::vector<double> bin_centers = {0.5, 1.5};
+    std::vector<double> bin_centers = boost::assign::list_of(0.5)(1.5);
     std::vector<double> bin_edges;
 
     VectorHelper::convertToBinBoundary(bin_centers, bin_edges);

--- a/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
+++ b/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
@@ -119,6 +119,17 @@ public:
     TS_ASSERT_EQUALS(bin_edges.size(), 0);
   }
 
+  void test_ConvertToBinBoundary_Size1InputVector() {
+    std::vector<double> bin_centers = {0.4};
+    std::vector<double> bin_edges;
+    VectorHelper::convertToBinBoundary(bin_centers, bin_edges);
+
+    TS_ASSERT_EQUALS(bin_edges.size(), 2);
+    // In lack of a better guess for the bin width it is set to 1.0.
+    TS_ASSERT_DELTA(bin_edges[0], -0.1, 1e-12);
+    TS_ASSERT_DELTA(bin_edges[1], 0.9, 1e-12);
+  }
+
   void test_ConvertToBinBoundary_Size2InputVector() {
     std::vector<double> bin_centers = {0.5, 1.5};
     std::vector<double> bin_edges;

--- a/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
+++ b/Code/Mantid/Framework/Kernel/test/VectorHelperTest.h
@@ -111,6 +111,18 @@ public:
     TS_ASSERT_EQUALS(axis, expectedAxis);
   }
 
+  void test_ConvertToBinBoundary_Size2InputVector() {
+    std::vector<double> bin_centers = {0.5, 1.5};
+    std::vector<double> bin_edges;
+
+    VectorHelper::convertToBinBoundary(bin_centers, bin_edges);
+
+    TS_ASSERT_EQUALS(bin_edges.size(), 3);
+    TS_ASSERT_DELTA(bin_edges[0], 0.0, 1e-12);
+    TS_ASSERT_DELTA(bin_edges[1], 1.0, 1e-12);
+    TS_ASSERT_DELTA(bin_edges[2], 2.0, 1e-12);
+  }
+
   // TODO: More tests of other methods
 
   void test_splitStringIntoVector()


### PR DESCRIPTION
Fixes #12897

I noticed these issues when looking at #4600. Changes are as follows:
- For input vector of size 0 an empty output vector is returned. Previously this caused a segfault.
- For input vector of size 1 the bin width is set to 1.0 (in lack of a better option). Previously the behavior was probably random, due to use of uninitialized values.
- Removed 'if' around output vector resize, since this is identical to what std::vector would do internally.

Previously there were no tests for this, this branch adds tests to VectorHelperTest that test the two special cases and one non-special case.
