### PR TITLE
Allow alg dialogs to stay open

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Algorithm.h
@@ -229,6 +229,7 @@ public:
   bool isRecordingHistoryForChild() { return m_recordHistoryForChild; };
   void setAlwaysStoreInADS(const bool doStore);
   void setRethrows(const bool rethrow);
+  IAlgorithm_sptr clone() const;
 
   /** @name Asynchronous Execution */
   Poco::ActiveResult<bool> executeAsync();

--- a/Code/Mantid/Framework/API/inc/MantidAPI/AlgorithmProxy.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/AlgorithmProxy.h
@@ -66,7 +66,7 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 class MANTID_API_DLL AlgorithmProxy : public IAlgorithm,
                                       public Kernel::PropertyManagerOwner {
 public:
-  AlgorithmProxy(Algorithm_sptr alg);
+  AlgorithmProxy(const Algorithm_sptr& alg);
   virtual ~AlgorithmProxy();
 
   /// The name of the algorithm
@@ -151,12 +151,10 @@ public:
   //@}
 
 private:
-  /// Private Copy constructor: NO COPY ALLOWED
-  AlgorithmProxy(const AlgorithmProxy &);
   /// Private assignment operator: NO ASSIGNMENT ALLOWED
   AlgorithmProxy &operator=(const AlgorithmProxy &);
 
-  void createConcreteAlg(bool initOnly = false);
+  void createConcreteAlg(bool initOnly = false, bool forceRecreation = false);
   void stopped();
   void addObservers();
   void dropWorkspaceReferences();

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IAlgorithm.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IAlgorithm.h
@@ -15,12 +15,18 @@ template <class T> class ActiveResult;
 namespace Mantid {
 namespace API {
 
+//forward declaration for typedef
+class IAlgorithm;
+
 /** As we have multiple interfaces to the same logical algorithm (Algorithm &
  * AlgorithmProxy)
  *  we need a way of uniquely identifying managed algorithms. It can be
  * AlgorithmID.
  */
 typedef void *AlgorithmID;
+
+typedef boost::shared_ptr<IAlgorithm> IAlgorithm_sptr;
+typedef boost::shared_ptr<const IAlgorithm> IAlgorithm_const_sptr;
 
 /**
  IAlgorithm is the interface implemented by the Algorithm base class.
@@ -57,7 +63,7 @@ class MANTID_API_DLL IAlgorithm : virtual public Kernel::IPropertyManager {
 public:
   /// Virtual destructor (always needed for abstract classes)
   virtual ~IAlgorithm() {}
-
+  
   /// function to return a name of the algorithm, must be overridden in all
   /// algorithms
   virtual const std::string name() const = 0;
@@ -177,8 +183,7 @@ public:
   virtual std::string toString() const = 0;
 };
 
-typedef boost::shared_ptr<IAlgorithm> IAlgorithm_sptr;
-typedef boost::shared_ptr<const IAlgorithm> IAlgorithm_const_sptr;
+
 
 } // namespace API
 } // namespace Mantid

--- a/Code/Mantid/Framework/API/src/Algorithm.cpp
+++ b/Code/Mantid/Framework/API/src/Algorithm.cpp
@@ -10,7 +10,7 @@
 #include "MantidAPI/MemoryManager.h"
 #include "MantidAPI/IWorkspaceProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidAPI/MemoryManager.h"
+//#include "MantidAPI/MemoryManager.h"
 
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/DateAndTime.h"
@@ -18,8 +18,8 @@
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Timer.h"
 
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/algorithm/string/split.hpp>
+//#include <boost/algorithm/string/trim.hpp>
+//#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/regex.hpp>
 #include <boost/weak_ptr.hpp>
 

--- a/Code/Mantid/Framework/API/test/AlgorithmProxyTest.h
+++ b/Code/Mantid/Framework/API/test/AlgorithmProxyTest.h
@@ -215,6 +215,7 @@ public:
       TS_ASSERT_EQUALS("InputWorkspace", alg->workspaceMethodInputProperty());
     }
 
+
 };
 
 #endif /*ALGORITHMPROXYTEST_H_*/

--- a/Code/Mantid/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
@@ -130,11 +130,15 @@ void AlgorithmMonitor::showDialog()
 
 //-----------------------------------------------------------------------------
 /** Cancel the given algorithm's execution */
-void AlgorithmMonitor::cancel(Mantid::API::AlgorithmID id)
+void AlgorithmMonitor::cancel(Mantid::API::AlgorithmID id, QPushButton* cancelBtn = NULL)
 {
-  IAlgorithm_sptr a = Mantid::API::AlgorithmManager::Instance().getAlgorithm(id);
-  if (!a.get()) return;
-  a->cancel();
+  if ((cancelBtn) && (cancelBtn->text() == "Cancel"))
+  {
+    cancelBtn->setText("Cancelling");
+    IAlgorithm_sptr a = Mantid::API::AlgorithmManager::Instance().getAlgorithm(id);
+    if (!a.get()) return;
+    a->cancel();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -229,7 +233,7 @@ void MonitorDlg::update()
       algItem->addChild(new QTreeWidgetItem(lstr));
     }
 
-    connect(cancelButton,SIGNAL(clicked(Mantid::API::AlgorithmID)),m_algMonitor,SLOT(cancel(Mantid::API::AlgorithmID)));
+    connect(cancelButton,SIGNAL(clicked(Mantid::API::AlgorithmID, QPushButton*)),m_algMonitor,SLOT(cancel(Mantid::API::AlgorithmID, QPushButton*)));
   }
   m_algMonitor->unlock();
 }

--- a/Code/Mantid/MantidPlot/src/Mantid/AlgorithmMonitor.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/AlgorithmMonitor.h
@@ -65,7 +65,7 @@ protected:
 public slots:
   void update();
   void showDialog();
-  void cancel(Mantid::API::AlgorithmID);
+  void cancel(Mantid::API::AlgorithmID, QPushButton*);
   void cancelAll();
 
 private:
@@ -108,9 +108,9 @@ public:
     connect(this,SIGNAL(clicked()),this,SLOT(sendClicked()));
   }
 private slots:
-  void sendClicked(){emit clicked(m_alg);}
+  void sendClicked(){emit clicked(m_alg, this);}
 signals:
-  void clicked(Mantid::API::AlgorithmID );
+  void clicked(Mantid::API::AlgorithmID, QPushButton*);
 private:
   Mantid::API::AlgorithmID m_alg;
 };

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/AlgorithmDialog.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/AlgorithmDialog.h
@@ -91,7 +91,7 @@ class InterfaceManager;
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>    
 */
-class EXPORT_OPT_MANTIDQT_API AlgorithmDialog : public QDialog
+class EXPORT_OPT_MANTIDQT_API AlgorithmDialog : public QDialog, Mantid::API::AlgorithmObserver
 {
   
   Q_OBJECT
@@ -102,6 +102,12 @@ public:
   AlgorithmDialog(QWidget* parent = 0);
   /// Destructor
   virtual ~AlgorithmDialog();
+
+  /// Set if the keep open option is shown.
+  void setShowKeepOpen(const bool showOption);
+
+  /// Set if the keep open option is shown.
+  bool isShowKeepOpen() const;
 
   /// Create the layout of the widget. Can only be called once.
   void initializeLayout();
@@ -196,9 +202,10 @@ protected:
   void fillLineEdit(const QString & propName, QLineEdit* field);
 
   /// Create a row layout of buttons with specified text
-  QHBoxLayout *createDefaultButtonLayout(const QString & helpText = QString("?"),
+  QLayout *createDefaultButtonLayout(const QString & helpText = QString("?"),
                      const QString & loadText = QString("Run"), 
-                     const QString & cancelText = QString("Cancel"));
+                     const QString & cancelText = QString("Cancel"), 
+                     const QString & keepOpenText = QString("Keep Open"));
 
   /// Create a help button for this algorithm
   QPushButton* createHelpButton(const QString & helpText = QString("?")) const;
@@ -210,6 +217,10 @@ protected:
   /// Retrieve a text value for a property from a widget
   QString getValue(QWidget *widget);
 
+signals:
+  /// Emitted when alg completes and dialog is staying open
+  void algCompletedSignal();
+
 protected slots:
   
   /// A default slot that can be used for an OK button.
@@ -217,6 +228,13 @@ protected slots:
 
   /// Help button clicked;
   virtual void helpClicked();
+
+  /// Keep open checkbox clicked;
+  virtual void keepOpenChanged(int state);
+
+  
+  /// Keep the running algorithm has completed
+  virtual void algorithmCompleted();
 
   /// Executes the algorithm in a separate thread
   virtual void executeAlgorithmAsync();
@@ -235,6 +253,10 @@ protected:
   QString getPreviousValue(const QString& propName);
   /// Set a value based on any old input that we have
   void setPreviousValue(QWidget *widget, const QString & property);
+  /// Handle completion of algorithm started while staying open
+  virtual void finishHandle(const Mantid::API::IAlgorithm *alg);
+  /// Handle completion of algorithm started while staying open
+  virtual void errorHandle(const Mantid::API::IAlgorithm *alg, const std::string &what);
 
 /// The following methods were made public for testing in GenericDialogDemo.cpp
 public:
@@ -280,7 +302,9 @@ protected:
   /// A list of property names that the user has requested to be disabled (overrides those in enabled)
   QStringList m_disabled;
   /// The message string to be displayed at the top of the widget; if it exists.
-  QString m_strMessage;
+  QString m_strMessage;  
+  /// Whether to keep the dialog box open after alg execution
+  bool m_keepOpen;
   /// Is the message string empty or not
   bool m_msgAvailable;
 
@@ -306,6 +330,11 @@ protected:
 
   /// A map to keep track of replace workspace button presses
   QHash<QPushButton*, int> m_wsbtn_tracker;
+
+  //the keep open checkbox control
+  QCheckBox* m_keepOpenCheckBox;
+
+  QPushButton* m_okButton;
 
   /// A list of AlgorithmObservers to add to the algorithm prior to execution
   std::vector<Mantid::API::AlgorithmObserver *> m_observers;

--- a/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
+++ b/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
@@ -1,10 +1,8 @@
 //----------------------------------
 // Includes
 //----------------------------------
-#include "MantidAPI/FileProperty.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IWorkspaceProperty.h"
-#include "MantidAPI/MultipleFileProperty.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/Logger.h"
 
@@ -13,25 +11,18 @@
 #include "MantidQtAPI/MantidWidget.h"
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtAPI/FilePropertyWidget.h"
-#include "MantidQtAPI/PropertyWidgetFactory.h"
 
 #include <QIcon>
 #include <QLabel>
 #include <QMessageBox>
-#include <QFileDialog>
-#include <QFileInfo>
 #include <QLineEdit>
 #include <QComboBox>
 #include <QCheckBox>
 #include <QPushButton>
-#include <QDesktopServices>
-#include <QUrl>
 #include <QHBoxLayout>
-#include <QSignalMapper>
 #include <QCheckBox>
 #include <QtGui>
 
-#include <Poco/AbstractObserver.h>
 #include <Poco/ActiveResult.h>
 
 using namespace MantidQt::API;
@@ -52,8 +43,10 @@ namespace
 AlgorithmDialog::AlgorithmDialog(QWidget* parent) :
   QDialog(parent), m_algorithm(), m_algName(""), m_algProperties(),
   m_propertyValueMap(), m_tied_properties(), m_forScript(false), m_python_arguments(),
-  m_enabled(), m_disabled(), m_strMessage(""), m_msgAvailable(false), m_isInitialized(false), m_autoParseOnInit(true),
-  m_validators(), m_noValidation(), m_inputws_opts(), m_outputws_fields(), m_wsbtn_tracker()
+  m_enabled(), m_disabled(), m_strMessage(""), m_keepOpen(false), 
+  m_msgAvailable(false), m_isInitialized(false),   m_autoParseOnInit(true),  m_validators(), 
+  m_noValidation(), m_inputws_opts(), m_outputws_fields(), m_wsbtn_tracker(), 
+  m_keepOpenCheckBox(NULL), m_okButton(NULL)
 {
 }
 
@@ -62,6 +55,38 @@ AlgorithmDialog::AlgorithmDialog(QWidget* parent) :
  */
 AlgorithmDialog::~AlgorithmDialog()
 {
+  m_observers.clear();
+  this->stopObserving(m_algorithm);
+}
+
+/**
+ * Set if the keep open option is shown.
+ * This must be set after calling initializeLayout.
+ * @param showOption false to hide the control, otherwise true
+ */
+void AlgorithmDialog::setShowKeepOpen(const bool showOption) {
+  if (m_keepOpenCheckBox)
+  {    
+    //if hidden then turn it off
+    if (!showOption)
+    {
+      m_keepOpenCheckBox->setCheckState(Qt::CheckState::Unchecked);
+    }
+    m_keepOpenCheckBox->setVisible(showOption);
+  }
+}
+/**
+ * Is the keep open option going to be shown?
+ * @returns true if it will be shown
+ */
+bool AlgorithmDialog::isShowKeepOpen() const
+{
+  bool retval = true;
+  if (m_keepOpenCheckBox)
+  {
+    retval = m_keepOpenCheckBox->isVisible();
+  }
+  return retval;
 }
 
 /**
@@ -103,6 +128,8 @@ void AlgorithmDialog::initializeLayout()
 
   executeOnAccept(true);
 
+  connect(this, SIGNAL(algCompletedSignal()), this, SLOT(algorithmCompleted()));
+    
   m_isInitialized = true;
 }
 
@@ -221,7 +248,7 @@ QString AlgorithmDialog::getInputValue(const QString& propName) const
     if( prop ) return QString::fromStdString(prop->getDefault());
     else return "";
   }
-  else return value;
+
   return value;
 }
 
@@ -675,22 +702,34 @@ void AlgorithmDialog::fillLineEdit(const QString & propName, QLineEdit* textFiel
 
 //-------------------------------------------------------------------------------------------------
 /** Layout the buttons and others in the generic dialog */
-QHBoxLayout *
+QLayout *
 AlgorithmDialog::createDefaultButtonLayout(const QString & helpText,
                        const QString & loadText,
-                       const QString & cancelText)
+                       const QString & cancelText,
+                       const QString & keepOpenText)
 {
-  QPushButton *okButton = new QPushButton(loadText);
-  connect(okButton, SIGNAL(clicked()), this, SLOT(accept()));
-  okButton->setDefault(true);
+  m_okButton = new QPushButton(loadText);
+  connect(m_okButton, SIGNAL(clicked()), this, SLOT(accept()));
+  m_okButton->setDefault(true);
 
   QPushButton *exitButton = new QPushButton(cancelText);
   connect(exitButton, SIGNAL(clicked()), this, SLOT(close()));
+  
 
   QHBoxLayout *buttonRowLayout = new QHBoxLayout;
   buttonRowLayout->addWidget(createHelpButton(helpText));
   buttonRowLayout->addStretch();
-  buttonRowLayout->addWidget(okButton);
+  
+  m_keepOpenCheckBox = new QCheckBox(keepOpenText);
+  m_keepOpenCheckBox->setLayoutDirection(Qt::LayoutDirection::RightToLeft);
+  connect(m_keepOpenCheckBox, SIGNAL(stateChanged(int)), this, SLOT(keepOpenChanged(int)));
+  buttonRowLayout->addWidget(m_keepOpenCheckBox);
+  if (keepOpenText.isEmpty())
+  {
+    setShowKeepOpen(false);
+  }
+
+  buttonRowLayout->addWidget(m_okButton);
   buttonRowLayout->addWidget(exitButton);
 
   return buttonRowLayout;
@@ -738,7 +777,12 @@ void AlgorithmDialog::accept()
   {
     //Store input for next time
     saveInput();
-    QDialog::accept();
+    if (!this->m_keepOpen) {
+      QDialog::accept();
+    }
+    else {
+       executeAlgorithmAsync();
+    }
   }
   else
   {
@@ -765,23 +809,38 @@ void AlgorithmDialog::helpClicked()
 }
 
 //-------------------------------------------------------------------------------------------------
+
+/**
+ * A slot to handle the keep open button click
+ */
+void AlgorithmDialog::keepOpenChanged(int state)
+{
+  m_keepOpen = (state == QCheckBox::On);
+}
+
+
+//-------------------------------------------------------------------------------------------------
 /**
  * Execute the underlying algorithm
  */
 void AlgorithmDialog::executeAlgorithmAsync()
 {
+  Mantid::API::IAlgorithm_sptr algToExec = m_algorithm;
   try
   {
-    // Add AlgorithmObservers to the algorithm
+    // Add any custom AlgorithmObservers to the algorithm
     for(auto it = m_observers.begin(); it != m_observers.end(); ++it)
-      (*it)->observeAll(m_algorithm);
+      (*it)->observeAll(algToExec);
 
-    m_algorithm->executeAsync();
-    m_observers.clear();
+    this->observeFinish(algToExec);
+    this->observeError(algToExec);
+
+    algToExec->executeAsync();
+    m_okButton->setEnabled(false);
   }
   catch (Poco::NoThreadAvailableException &)
   {
-    g_log.error() << "No thread was available to run the " << m_algorithm->name() << " algorithm in the background." << std::endl;
+    g_log.error() << "No thread was available to run the " << algToExec->name() << " algorithm in the background." << std::endl;
   }
 }
 
@@ -1069,4 +1128,40 @@ void AlgorithmDialog::setPreviousValue(QWidget* widget, const QString& propName)
 void AlgorithmDialog::addAlgorithmObserver(Mantid::API::AlgorithmObserver *observer)
 {
   m_observers.push_back(observer);
+  //turn off the keep open option - it would only confuse things if someone is watching
+  setShowKeepOpen(false);
+}
+
+/**Handle completion of algorithm started while staying open.
+ * emits another signal to marshal the call to the main ui thread
+ *
+ * @param alg Completed algorithm (unused)
+ */
+void AlgorithmDialog::finishHandle(const IAlgorithm *alg)
+{
+  UNUSED_ARG(alg);
+  emit algCompletedSignal();
+}
+
+/**Handle error signal of algorithm started while staying open.
+ * emits another signal to marshal the call to the main ui thread
+ *
+ * @param alg Completed algorithm (unused)
+ * @param what the error message (unused)
+ */
+void AlgorithmDialog::errorHandle(const IAlgorithm *alg, const std::string &what)
+{
+  UNUSED_ARG(alg);
+  UNUSED_ARG(what);
+  emit algCompletedSignal();
+}
+
+
+/**Handle completion of algorithm started while staying open.
+ * reenables the OK button when the algorithms finishes.
+ *
+ */
+void AlgorithmDialog::algorithmCompleted()
+{
+  if (m_okButton) m_okButton->setEnabled(true);
 }

--- a/Code/Mantid/MantidQt/API/src/GenericDialog.cpp
+++ b/Code/Mantid/MantidQt/API/src/GenericDialog.cpp
@@ -163,7 +163,12 @@ void GenericDialog::accept()
   {
     //Store input for next time
     saveInput();
-    QDialog::accept();
+    if (!this->m_keepOpen) {
+      QDialog::accept();
+    }
+    else {
+       executeAlgorithmAsync();
+    }
   }
   else
   {

--- a/Code/Mantid/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/StartLiveDataDialog.cpp
@@ -197,7 +197,7 @@ void StartLiveDataDialog::initLayout()
   connect(ui.cmbInstrument,SIGNAL(currentIndexChanged(const QString&)),this,SLOT(initListenerPropLayout(const QString&)));
   connect(ui.cmbInstrument,SIGNAL(currentIndexChanged(const QString&)),this,SLOT(updateUiElements(const QString&)));
 
-  QHBoxLayout * buttonLayout = this->createDefaultButtonLayout();
+  QLayout * buttonLayout = this->createDefaultButtonLayout();
   ui.mainLayout->addLayout(buttonLayout);
 }
 


### PR DESCRIPTION
Add an option to allow alg dialogs to stay open

Fixes #12835 

TODO Release Notes!!
### To Test
1. Start up Mantid plot, try loading some files with and without the Keep open checkbox ticked.
2. Run another alg that will error with keep open ticked (?Plus with two different size ws)
3. Check you cannot spam the ok button
4. check that runing alg dialogs from python is still ok
5. check that running dialogs that wait for the alg dialog to return do not offer the keep open option (e.g. right click on a ws select sample material, then click set sample material, chemical formula V).
