### PR TITLE
Fix PreviewPlot showing multiple error bar options for same curve

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/PreviewPlot.cpp
@@ -511,6 +511,9 @@ void PreviewPlot::clear() {
     removeCurve(it.value().curve);
     removeCurve(it.value().errorCurve);
     m_uiForm.loLegend->removeWidget(it.value().label);
+    m_errorBarOptionCache[it.key()] = it.value().showErrorsAction->isChecked();
+    m_showErrorsMenu->removeAction(it.value().showErrorsAction);
+    delete it.value().showErrorsAction;
     delete it.value().label;
   }
 


### PR DESCRIPTION
Fixes #12909.

No release notes updates as this bug was added this release.
