### PR TITLE
Fix bug in FunctionBrowser

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
@@ -1650,6 +1650,38 @@ void FunctionBrowser::removeFunction()
   if (!isFunction(prop)) return;
   removeProperty(prop);
   updateFunctionIndices();
+
+  // After removing a function we could end up with
+  // a CompositeFunction with only one function
+  // In this case, the function should be kept but
+  // the composite function should be removed
+  auto props = m_browser->properties();
+  if (!props.isEmpty()) {
+    // The function browser is not empty
+
+    // Check if the current function in the browser is a
+    // composite function
+    auto topProp = props[0];
+    auto fun = Mantid::API::FunctionFactory::Instance().createFunction(topProp->propertyName().toStdString());
+    auto cf = boost::dynamic_pointer_cast<Mantid::API::CompositeFunction>(fun);
+    if (cf) {
+      // If it is a composite function
+      // check that there are more than one function
+      // which means more than two subproperties
+      size_t nFunctions = props[0]->subProperties().size() -1;
+
+      if ( nFunctions == 1 ) {
+        // If only one function remains, remove the composite function:
+        // Temporary copy the remaining function
+        auto func =  getFunction(m_browser->properties()[0]->subProperties()[1]);
+        // Remove the composite function
+        m_browser->removeProperty(topProp);
+        // Add the temporary stored function
+        setFunction(func);
+      }
+    }
+  }
+
   emit functionStructureChanged();
 }
 

--- a/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
@@ -1662,18 +1662,19 @@ void FunctionBrowser::removeFunction()
     // Check if the current function in the browser is a
     // composite function
     auto topProp = props[0];
-    auto fun = Mantid::API::FunctionFactory::Instance().createFunction(topProp->propertyName().toStdString());
+    auto fun = Mantid::API::FunctionFactory::Instance().createFunction(
+        topProp->propertyName().toStdString());
     auto cf = boost::dynamic_pointer_cast<Mantid::API::CompositeFunction>(fun);
     if (cf) {
       // If it is a composite function
       // check that there are more than one function
       // which means more than two subproperties
-      size_t nFunctions = props[0]->subProperties().size() -1;
+      size_t nFunctions = props[0]->subProperties().size() - 1;
 
-      if ( nFunctions == 1 ) {
+      if (nFunctions == 1) {
         // If only one function remains, remove the composite function:
         // Temporary copy the remaining function
-        auto func =  getFunction(m_browser->properties()[0]->subProperties()[1]);
+        auto func = getFunction(m_browser->properties()[0]->subProperties()[1]);
         // Remove the composite function
         m_browser->removeProperty(topProp);
         // Add the temporary stored function


### PR DESCRIPTION
Fixes #12618 

See #12618 for a description of the problem. This was affecting both ALC and MDF interfaces.

Tester: make sure you can reproduce the issue, understand the problem and agree with the fix. Test the fix:
- Open ALC, select "MUSR00015189.nxs" as "First" and "MUSR00015191.nxs" as "Last", hit "Load" and go to "BaselineModelling". Add a function (right-click on blank region "Function"). Add another function and see that a CompositeFunction is created and now both functions appear as sub-properties in the browser. Remove one of them, the CompositeFunction should be removed but the other function should be kept.
- Try to break Mantid by using more than two functions, removing some of them, fit the data, remove/add functions after the fitting, etc.
- Try the same with the Multi Dataset Fitting interface: load some data and play with different functions. Add more, remove some. Check that the function browser works as expected.
