### PR TITLE
Fix axes of scaled data sets

### DIFF
--- a/Code/Mantid/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
@@ -1,4 +1,5 @@
 #include "MantidVatesAPI/vtkDataSetToScaledDataSet.h"
+#include "MantidKernel/Logger.h"
 
 #include <vtkFieldData.h>
 #include <vtkFloatArray.h>
@@ -6,160 +7,119 @@
 #include <vtkPoints.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
+#include <vtkSmartPointer.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPVChangeOfBasisHelper.h>
 
 #include <stdexcept>
 
-namespace Mantid
-{
-namespace VATES
-{
-  /**
-   * Standard constructor for object.
-   * @param input : The dataset to scale
-   * @param output : The resulting scaled dataset
-   */
-  vtkDataSetToScaledDataSet::vtkDataSetToScaledDataSet(vtkUnstructuredGrid *input,
-                                                       vtkUnstructuredGrid *output) :
-    m_inputData(input),
-    m_outputData(output),
-    m_xScaling(1.0),
-    m_yScaling(1.0),
-    m_zScaling(1.0),
-    m_isInitialised(false)
-  {
-    if (NULL == m_inputData)
-    {
-      throw std::runtime_error("Cannot construct vtkDataSetToScaledDataSet with NULL input vtkUnstructuredGrid");
-    }
-    if (NULL == m_outputData)
-    {
-      throw std::runtime_error("Cannot construct vtkDataSetToScaledDataSet with NULL output vtkUnstructuredGrid");
-    }
-  }
-    
-  vtkDataSetToScaledDataSet::~vtkDataSetToScaledDataSet()
-  {
-  }
-  
-  /**
-   * Set the scaling factors for the data, once run, the object is now
-   * initialised.
-   * @param xScale : Scale factor for the x direction
-   * @param yScale : Scale factor for the y direction
-   * @param zScale : Scale factor for the z direction
-   */
-  void vtkDataSetToScaledDataSet::initialize(double xScale, double yScale, double zScale)
-  {
-    m_xScaling = xScale;
-    m_yScaling = yScale;
-    m_zScaling = zScale;
-    m_isInitialised = true;
-  }
 
-  /**
-   * Process the input data. First, scale a copy of the points and apply
-   * that to the output data. Next, update the metadata for range information.
-   */
-  void vtkDataSetToScaledDataSet::execute()
-  {
-    if (!m_isInitialised)
-    {
-      throw std::runtime_error("vtkDataSetToScaledDataSet needs initialize run before executing");
-    }
+namespace {
+Mantid::Kernel::Logger g_log("vtkDataSetTOScaledDataSet");
+}
 
-    vtkPoints *points = m_inputData->GetPoints();
+namespace Mantid {
+namespace VATES {
+/**
+ * Standard constructor for object.
+ * @param input : The dataset to scale
+ * @param output : The resulting scaled dataset
+ */
+vtkDataSetToScaledDataSet::vtkDataSetToScaledDataSet(
+    vtkUnstructuredGrid *input, vtkUnstructuredGrid *output)
+    : m_inputData(input), m_outputData(output), m_xScaling(1.0),
+      m_yScaling(1.0), m_zScaling(1.0), m_isInitialised(false) {
+  if (NULL == m_inputData) {
+    throw std::runtime_error("Cannot construct vtkDataSetToScaledDataSet with "
+                             "NULL input vtkUnstructuredGrid");
+  }
+  if (NULL == m_outputData) {
+    throw std::runtime_error("Cannot construct vtkDataSetToScaledDataSet with "
+                             "NULL output vtkUnstructuredGrid");
+  }
+}
 
-    double *point;
-    vtkPoints* newPoints = vtkPoints::New();
-    newPoints->Allocate(points->GetNumberOfPoints());
-    for(int i = 0; i < points->GetNumberOfPoints(); i++)
-    {
-      point = points->GetPoint(i);
-      point[0] *= m_xScaling;
-      point[1] *= m_yScaling;
-      point[2] *= m_zScaling;
-      newPoints->InsertNextPoint(point);
-    }
-    //Shallow copy the input.
-    m_outputData->ShallowCopy(m_inputData);
-    //Give the output dataset the scaled set of points.
-    m_outputData->SetPoints(newPoints);
-    this->updateMetaData();
+vtkDataSetToScaledDataSet::~vtkDataSetToScaledDataSet() {}
+
+/**
+ * Set the scaling factors for the data, once run, the object is now
+ * initialised.
+ * @param xScale : Scale factor for the x direction
+ * @param yScale : Scale factor for the y direction
+ * @param zScale : Scale factor for the z direction
+ */
+void vtkDataSetToScaledDataSet::initialize(double xScale, double yScale,
+                                           double zScale) {
+  m_xScaling = xScale;
+  m_yScaling = yScale;
+  m_zScaling = zScale;
+  m_isInitialised = true;
+}
+
+/**
+ * Process the input data. First, scale a copy of the points and apply
+ * that to the output data. Next, update the metadata for range information.
+ */
+void vtkDataSetToScaledDataSet::execute() {
+  if (!m_isInitialised) {
+    throw std::runtime_error(
+        "vtkDataSetToScaledDataSet needs initialize run before executing");
   }
 
-  /**
-   * In order for the axis range and labels to not come out scaled,
-   * this function set metadata that ParaView will read to override
-   * the scaling to return the original presentation.
-   */
-  void vtkDataSetToScaledDataSet::updateMetaData()
-  {
-    // Grab original bounding box so we can recall original extents
-    double bb[6];
-    m_inputData->GetBounds(bb);
+  vtkPoints *points = m_inputData->GetPoints();
 
-    vtkFieldData *fieldData = m_outputData->GetFieldData();
-
-    // Set that the label range is actively being managed
-    vtkNew<vtkUnsignedCharArray> activeLabelRange;
-    activeLabelRange->SetNumberOfComponents(1);
-    activeLabelRange->SetNumberOfTuples(3);
-    activeLabelRange->SetName("LabelRangeActiveFlag");
-    fieldData->AddArray(activeLabelRange.GetPointer());
-    activeLabelRange->SetValue(0, 1);
-    activeLabelRange->SetValue(1, 1);
-    activeLabelRange->SetValue(2, 1);
-
-    // Set the original axis extents from the bounding box
-    vtkNew<vtkFloatArray> uLabelRange;
-    uLabelRange->SetNumberOfComponents(2);
-    uLabelRange->SetNumberOfTuples(1);
-    uLabelRange->SetName("LabelRangeForX");
-    double labelRangeX[2] = {bb[0], bb[1]};
-    uLabelRange->SetTuple(0, labelRangeX);
-    fieldData->AddArray(uLabelRange.GetPointer());
-
-    vtkNew<vtkFloatArray> vLabelRange;
-    vLabelRange->SetNumberOfComponents(2);
-    vLabelRange->SetNumberOfTuples(1);
-    vLabelRange->SetName("LabelRangeForY");
-    double labelRangeY[2] = {bb[2], bb[3]};
-    vLabelRange->SetTuple(0, labelRangeY);
-    fieldData->AddArray(vLabelRange.GetPointer());
-
-    vtkNew<vtkFloatArray> wLabelRange;
-    wLabelRange->SetNumberOfComponents(2);
-    wLabelRange->SetNumberOfTuples(1);
-    wLabelRange->SetName("LabelRangeForZ");
-    double labelRangeZ[2] = {bb[4], bb[5]};
-    wLabelRange->SetTuple(0, labelRangeZ);
-    fieldData->AddArray(wLabelRange.GetPointer());
-
-    // Set the linear transform for each axis based on scaling factor
-    vtkNew<vtkFloatArray> uLinearTransform;
-    uLinearTransform->SetNumberOfComponents(2);
-    uLinearTransform->SetNumberOfTuples(1);
-    uLinearTransform->SetName("LinearTransformForX");
-    double transformX[2] = {1.0 / m_xScaling, 0.0};
-    uLinearTransform->SetTuple(0, transformX);
-    fieldData->AddArray(uLinearTransform.GetPointer());
-
-    vtkNew<vtkFloatArray> vLinearTransform;
-    vLinearTransform->SetNumberOfComponents(2);
-    vLinearTransform->SetNumberOfTuples(1);
-    vLinearTransform->SetName("LinearTransformForY");
-    double transformY[2] = {1.0 / m_yScaling, 0.0};
-    vLinearTransform->SetTuple(0, transformY);
-    fieldData->AddArray(vLinearTransform.GetPointer());
-
-    vtkNew<vtkFloatArray> wLinearTransform;
-    wLinearTransform->SetNumberOfComponents(2);
-    wLinearTransform->SetNumberOfTuples(1);
-    wLinearTransform->SetName("LinearTransformForZ");
-    double transformZ[2] = {1.0 / m_zScaling, 0.0};
-    wLinearTransform->SetTuple(0, transformZ);
-    fieldData->AddArray(wLinearTransform.GetPointer());
+  double *point;
+  vtkPoints *newPoints = vtkPoints::New();
+  newPoints->Allocate(points->GetNumberOfPoints());
+  for (int i = 0; i < points->GetNumberOfPoints(); i++) {
+    point = points->GetPoint(i);
+    point[0] *= m_xScaling;
+    point[1] *= m_yScaling;
+    point[2] *= m_zScaling;
+    newPoints->InsertNextPoint(point);
   }
+  // Shallow copy the input.
+  m_outputData->ShallowCopy(m_inputData);
+  // Give the output dataset the scaled set of points.
+  m_outputData->SetPoints(newPoints);
+  this->updateMetaData();
+}
+
+/**
+ * In order for the axis range and labels to not come out scaled,
+ * this function set metadata that ParaView will read to override
+ * the scaling to return the original presentation.
+ * See
+ * http://www.paraview.org/ParaQ/Doc/Nightly/html/classvtkCubeAxesRepresentation.html
+ * and
+ * http://www.paraview.org/ParaView/Doc/Nightly/www/cxx-doc/classvtkPVChangeOfBasisHelper.html
+ * for a better understanding.
+ */
+void vtkDataSetToScaledDataSet::updateMetaData() {
+  // We need to put the scaling on the diagonal elements of the ChangeOfBasis
+  // (COB) Matrix.
+  vtkSmartPointer<vtkMatrix4x4> cobMatrix =
+      vtkSmartPointer<vtkMatrix4x4>::New();
+  cobMatrix->Identity();
+  cobMatrix->Element[0][0] *= m_xScaling;
+  cobMatrix->Element[1][1] *= m_yScaling;
+  cobMatrix->Element[2][2] *= m_zScaling;
+
+  if (!vtkPVChangeOfBasisHelper::AddChangeOfBasisMatrixToFieldData(m_outputData,
+                                                                   cobMatrix)) {
+    g_log.warning("The Change-of-Basis-Matrix could not be added to the field "
+                  "data of the scaled data set.\n");
+  }
+
+  // We also need to update the bounding box for the COB Matrix
+  double boundingBox[6];
+  m_inputData->GetBounds(boundingBox);
+  if (!vtkPVChangeOfBasisHelper::AddBoundingBoxInBasis(m_outputData,
+                                                       boundingBox)) {
+    g_log.warning("The bounding box could not be added to the field data of "
+                  "the scaled data set.\n");
+  }
+}
 
 } // namespace VATES
 } // namespace Mantid

--- a/Code/Mantid/Vates/VatesAPI/test/vtkDataSetToScaledDataSetTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/vtkDataSetToScaledDataSetTest.h
@@ -17,102 +17,83 @@
 #include <vtkDataSet.h>
 #include <vtkFieldData.h>
 #include <vtkFloatArray.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPVChangeOfBasisHelper.h>
+#include <vtkSmartPointer.h>
 #include <vtkUnsignedCharArray.h>
 #include <vtkUnstructuredGrid.h>
 
 using namespace Mantid::DataObjects;
 using namespace Mantid::VATES;
 
-class vtkDataSetToScaledDataSetTest : public CxxTest::TestSuite
-{
+class vtkDataSetToScaledDataSetTest : public CxxTest::TestSuite {
 private:
-  vtkUnstructuredGrid *makeDataSet()
-  {
+  vtkUnstructuredGrid *makeDataSet() {
     FakeProgressAction progressUpdate;
-    MDEventWorkspace3Lean::sptr ws = MDEventsTestHelper::makeMDEW<3>(8,
-                                                                     -10.0,
-                                                                     10.0,
-                                                                     1);
+    MDEventWorkspace3Lean::sptr ws =
+        MDEventsTestHelper::makeMDEW<3>(8, -10.0, 10.0, 1);
     vtkMDHexFactory factory(ThresholdRange_scptr(new NoThresholdRange),
                             VolumeNormalization);
     factory.initialize(ws);
     return vtkUnstructuredGrid::SafeDownCast(factory.create(progressUpdate));
   }
 
-  float *getRangeComp(vtkDataSet *ds, std::string fieldname)
-  {
-    vtkDataArray *arr = ds->GetFieldData()->GetArray(fieldname.c_str());
-    vtkFloatArray *farr = vtkFloatArray::SafeDownCast(arr);
-    static float vals[2];
-    farr->GetTupleValue(0, vals);
-    return vals;
-  }
+  vtkUnstructuredGrid *makeDataSetWithJsonMetadata() {
+    vtkUnstructuredGrid *data = makeDataSet();
 
-  unsigned char *getRangeActiveComp(vtkDataSet *ds, int index)
-  {
-    vtkDataArray *arr = ds->GetFieldData()->GetArray("LabelRangeActiveFlag");
-    vtkUnsignedCharArray *uarr = vtkUnsignedCharArray::SafeDownCast(arr);
-    static unsigned char vals[1];
-    uarr->GetTupleValue(index, vals);
-    return vals;
-  }
+    MetadataJsonManager manager;
+    std::string instrument = "OSIRIS";
+    manager.setInstrument(instrument);
+    std::string jsonString = manager.getSerializedJson();
 
-  vtkUnstructuredGrid  *makeDataSetWithJsonMetadata()
-  {
-     vtkUnstructuredGrid* data = makeDataSet();
-     
-      MetadataJsonManager manager;
-      std::string instrument = "OSIRIS";
-      manager.setInstrument(instrument);
-      std::string jsonString = manager.getSerializedJson();
-      
-      MetadataToFieldData convert;
-      VatesConfigurations config;
-      vtkFieldData* fieldData = data->GetFieldData();
-      convert(fieldData, jsonString, config.getMetadataIdJson().c_str());
+    MetadataToFieldData convert;
+    VatesConfigurations config;
+    vtkFieldData *fieldData = data->GetFieldData();
+    convert(fieldData, jsonString, config.getMetadataIdJson().c_str());
 
-      data->SetFieldData(fieldData);
+    data->SetFieldData(fieldData);
 
-      return data;
+    return data;
   }
 
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static vtkDataSetToScaledDataSetTest *createSuite() { return new vtkDataSetToScaledDataSetTest(); }
-  static void destroySuite( vtkDataSetToScaledDataSetTest *suite ) { delete suite; }
+  static vtkDataSetToScaledDataSetTest *createSuite() {
+    return new vtkDataSetToScaledDataSetTest();
+  }
+  static void destroySuite(vtkDataSetToScaledDataSetTest *suite) {
+    delete suite;
+  }
 
-  void testThrowIfInputNull()
-  {
+  void testThrowIfInputNull() {
     vtkUnstructuredGrid *in = NULL;
     vtkUnstructuredGrid *out = vtkUnstructuredGrid::New();
     TS_ASSERT_THROWS(vtkDataSetToScaledDataSet scaler(in, out),
                      std::runtime_error);
   }
 
-  void testThrowIfOutputNull()
-  {
+  void testThrowIfOutputNull() {
     vtkUnstructuredGrid *in = vtkUnstructuredGrid::New();
     vtkUnstructuredGrid *out = NULL;
     TS_ASSERT_THROWS(vtkDataSetToScaledDataSet scaler(in, out),
                      std::runtime_error);
   }
 
-  void testExecThrowIfNoInit()
-  {
+  void testExecThrowIfNoInit() {
     vtkUnstructuredGrid *in = vtkUnstructuredGrid::New();
     vtkUnstructuredGrid *out = vtkUnstructuredGrid::New();
     vtkDataSetToScaledDataSet scaler(in, out);
     TS_ASSERT_THROWS(scaler.execute(), std::runtime_error);
   }
 
-  void testExecution()
-  {
+  void testExecution() {
     vtkUnstructuredGrid *in = makeDataSet();
     vtkUnstructuredGrid *out = vtkUnstructuredGrid::New();
     vtkDataSetToScaledDataSet scaler(in, out);
     scaler.initialize(0.1, 0.5, 0.2);
     TS_ASSERT_THROWS_NOTHING(scaler.execute());
+
     // Check bounds are scaled
     double *bb = out->GetBounds();
     TS_ASSERT_EQUALS(-1.0, bb[0]);
@@ -121,40 +102,46 @@ public:
     TS_ASSERT_EQUALS(5.0, bb[3]);
     TS_ASSERT_EQUALS(-2.0, bb[4]);
     TS_ASSERT_EQUALS(2.0, bb[5]);
-    // Check that the range metadata is set
-    float *rangeX = getRangeComp(out, "LabelRangeForX");
-    TS_ASSERT_EQUALS(-10.0, rangeX[0]);
-    TS_ASSERT_EQUALS(10.0, rangeX[1]);
-    float *rangeY = getRangeComp(out, "LabelRangeForY");
-    TS_ASSERT_EQUALS(-10.0, rangeY[0]);
-    TS_ASSERT_EQUALS(10.0, rangeY[1]);
-    float *rangeZ = getRangeComp(out, "LabelRangeForZ");
-    TS_ASSERT_EQUALS(-10.0, rangeZ[0]);
-    TS_ASSERT_EQUALS(10.0, rangeZ[1]);
-    // Check that the scaling transform metadata is set
-    float *transformX = getRangeComp(out, "LinearTransformForX");
-    TS_ASSERT_EQUALS(1.0/0.1, transformX[0]);
-    TS_ASSERT_EQUALS(0.0, transformX[1]);
-    float *transformY = getRangeComp(out, "LinearTransformForY");
-    TS_ASSERT_EQUALS(1.0/0.5, transformY[0]);
-    TS_ASSERT_EQUALS(0.0, transformY[1]);
-    float *transformZ = getRangeComp(out, "LinearTransformForZ");
-    TS_ASSERT_EQUALS(1.0/0.2, transformZ[0]);
-    TS_ASSERT_EQUALS(0.0, transformZ[1]);
-    // Check the active label range flags are set
-    unsigned char *activeX = getRangeActiveComp(out, 0);
-    TS_ASSERT_EQUALS(1, activeX[0]);
-    unsigned char *activeY = getRangeActiveComp(out, 1);
-    TS_ASSERT_EQUALS(1, activeY[0]);
-    unsigned char *activeZ = getRangeActiveComp(out, 2);
-    TS_ASSERT_EQUALS(1, activeZ[0]);
+
+    // Check that the Change-Of-Basis-Matrix is correct
+    vtkSmartPointer<vtkMatrix4x4> cobMatrix =
+        vtkPVChangeOfBasisHelper::GetChangeOfBasisMatrix(out);
+    TS_ASSERT_EQUALS(0.1, cobMatrix->Element[0][0])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[0][1])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[0][2])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[0][3])
+
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[1][0])
+    TS_ASSERT_EQUALS(0.5, cobMatrix->Element[1][1])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[1][2])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[1][3])
+
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[2][0])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[2][1])
+    TS_ASSERT_EQUALS(0.2, cobMatrix->Element[2][2])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[2][3])
+
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[3][0])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[3][1])
+    TS_ASSERT_EQUALS(0.0, cobMatrix->Element[3][2])
+    TS_ASSERT_EQUALS(1.0, cobMatrix->Element[3][3])
+
+    // Check the bounding box element for axes
+    double bounds[6] = {0, 0, 0, 0, 0, 0};
+    vtkPVChangeOfBasisHelper::GetBoundingBoxInBasis(out, bounds);
+
+    TS_ASSERT_EQUALS(-10.0, bounds[0]);
+    TS_ASSERT_EQUALS(10.0, bounds[1]);
+    TS_ASSERT_EQUALS(-10.0, bounds[2]);
+    TS_ASSERT_EQUALS(10.0, bounds[3]);
+    TS_ASSERT_EQUALS(-10.0, bounds[4]);
+    TS_ASSERT_EQUALS(10.0, bounds[5]);
 
     in->Delete();
     out->Delete();
   }
 
-  void testJsonMetadataExtractionFromScaledDataSet()
-  {
+  void testJsonMetadataExtractionFromScaledDataSet() {
     // Arrange
     vtkUnstructuredGrid *in = makeDataSetWithJsonMetadata();
     vtkUnstructuredGrid *out = vtkUnstructuredGrid::New();
@@ -164,14 +151,14 @@ public:
     scaler.initialize(0.1, 0.5, 0.2);
     TS_ASSERT_THROWS_NOTHING(scaler.execute());
 
-    vtkFieldData* fieldData = out->GetFieldData();
+    vtkFieldData *fieldData = out->GetFieldData();
     MetadataJsonManager manager;
     VatesConfigurations config;
     FieldDataToMetadata convert;
 
     std::string jsonString = convert(fieldData, config.getMetadataIdJson());
     manager.readInSerializedJson(jsonString);
-    
+
     // Assert
     TS_ASSERT("OSIRIS" == manager.getInstrument());
 
@@ -179,6 +166,5 @@ public:
     out->Delete();
   }
 };
-
 
 #endif /* MANTID_VATESAPI_VTKDATASETTOSCALEDDATASETTEST_H_ */


### PR DESCRIPTION
Fixes #12916 

**For testing**
1. Load a sample data set into the VSI 
2. Go to the Standard View mode
3. Enable the "Show Axis" checkbox and make a note of the extents
4. Press the scale filter; set the x-scale to 2; press apply
5. Enable the "Show Axis" checkbox
   - Confirm that the extent in the x-direction has not changed
6. Change the scales in the other on-the-fly
   - Confirm that the extents do not change
