### PR TITLE
Cleanup of Workspace copy constructors and assignment operators.

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
@@ -37,7 +37,7 @@ namespace API {
 */
 class MANTID_API_DLL IEventWorkspace : public MatrixWorkspace {
 public:
-  IEventWorkspace() {}
+  IEventWorkspace() : MatrixWorkspace() {}
   /// Return the workspace typeID
   virtual const std::string id() const { return "IEventWorkspace"; }
   virtual std::size_t getNumberEvents() const = 0;

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
@@ -37,6 +37,7 @@ namespace API {
 */
 class MANTID_API_DLL IEventWorkspace : public MatrixWorkspace {
 public:
+  IEventWorkspace() {}
   /// Return the workspace typeID
   virtual const std::string id() const { return "IEventWorkspace"; }
   virtual std::size_t getNumberEvents() const = 0;
@@ -57,6 +58,11 @@ public:
   virtual void clearMRU() const = 0;
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  IEventWorkspace(const IEventWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  IEventWorkspace &operator=(const IEventWorkspace &other);
+
   virtual const std::string toString() const;
 };
 }

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
@@ -32,7 +32,6 @@ class MANTID_API_DLL IMDEventWorkspace : public API::IMDWorkspace,
                                          public API::MultipleExperimentInfos {
 public:
   IMDEventWorkspace();
-  IMDEventWorkspace(const IMDEventWorkspace &other);
   virtual ~IMDEventWorkspace() {}
 
   /// Perform initialization after dimensions (and others) have been set.
@@ -82,6 +81,11 @@ public:
       const Mantid::Kernel::SpecialCoordinateSystem coordinateSystem) = 0;
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  IMDEventWorkspace(const IMDEventWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  IMDEventWorkspace &operator=(const IMDEventWorkspace &other);
+
   virtual const std::string toString() const;
   /// Marker set to true when a file-backed workspace needs its back-end file
   /// updated (by calling SaveMD(UpdateFileBackEnd=1) )

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
@@ -39,7 +39,6 @@ class DLLExport IMDHistoWorkspace : public IMDWorkspace,
                                     public MultipleExperimentInfos {
 public:
   IMDHistoWorkspace();
-  IMDHistoWorkspace(const IMDHistoWorkspace &other);
   virtual ~IMDHistoWorkspace();
 
   /// See the MDHistoWorkspace definition for descriptions of these
@@ -96,6 +95,11 @@ public:
 
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  IMDHistoWorkspace(const IMDHistoWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  IMDHistoWorkspace &operator=(const IMDHistoWorkspace &other);
+
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -133,8 +133,11 @@ public:
   virtual MDNormalization displayNormalization() const;
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
   IMDWorkspace(const IMDWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
   IMDWorkspace &operator=(const IMDWorkspace &other);
+
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -70,7 +70,6 @@ enum MDNormalization {
 class MANTID_API_DLL IMDWorkspace : public Workspace, public API::MDGeometry {
 public:
   IMDWorkspace();
-  IMDWorkspace(const IMDWorkspace &other);
   virtual ~IMDWorkspace();
 
   /// Get the number of points associated with the workspace.
@@ -134,6 +133,7 @@ public:
   virtual MDNormalization displayNormalization() const;
 
 protected:
+  IMDWorkspace(const IMDWorkspace &other);
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -133,8 +133,8 @@ public:
   virtual MDNormalization displayNormalization() const;
 
 protected:
-  IMDWorkspace(const IMDWorkspace &other) = default;
-  IMDWorkspace &operator=(const IMDWorkspace &other) = default;
+  IMDWorkspace(const IMDWorkspace &other);
+  IMDWorkspace &operator=(const IMDWorkspace &other);
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -134,6 +134,7 @@ public:
 
 protected:
   IMDWorkspace(const IMDWorkspace &other) = default;
+  IMDWorkspace &operator=(const IMDWorkspace &other) = default;
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -133,7 +133,7 @@ public:
   virtual MDNormalization displayNormalization() const;
 
 protected:
-  IMDWorkspace(const IMDWorkspace &other);
+  IMDWorkspace(const IMDWorkspace &other) = default;
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMaskWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMaskWorkspace.h
@@ -35,6 +35,7 @@ namespace API {
 */
 class DLLExport IMaskWorkspace {
 public:
+  IMaskWorkspace() {}
   /// Return the workspace typeID
   virtual const std::string id() const { return "IMaskWorkspace"; }
   /// Total number of masked pixels
@@ -48,6 +49,12 @@ public:
   /// Set / remove masks of all detectors in a set
   virtual void setMasked(const std::set<detid_t> &detectorIDs,
                          const bool mask = true) = 0;
+
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  IMaskWorkspace(const IMaskWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  IMaskWorkspace &operator=(const IMaskWorkspace &other);
 };
 
 /// shared pointer to the matrix workspace base class

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -51,10 +51,6 @@ public:
   /// Ctor
   IPeaksWorkspace() : ITableWorkspace(), ExperimentInfo() {}
 
-  /// Copy constructor
-  IPeaksWorkspace(const IPeaksWorkspace &other)
-      : ITableWorkspace(other), ExperimentInfo(other) {}
-
   /// Destructor
   virtual ~IPeaksWorkspace();
 
@@ -151,6 +147,12 @@ public:
   virtual int peakInfoNumber(Kernel::V3D qLabFrame, bool labCoords) const = 0;
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  IPeaksWorkspace(const IPeaksWorkspace &other)
+      : ITableWorkspace(other), ExperimentInfo(other) {}
+  /// Protected copy assignment operator. Assignment not implemented.
+  IPeaksWorkspace &operator=(const IPeaksWorkspace &other);
+
   virtual const std::string toString() const;
 };
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
@@ -66,6 +66,12 @@ public:
    * Remove one entry of a splitter
    */
   virtual bool removeSplitter(size_t splitterindex) = 0;
+
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  ISplittersWorkspace(const ISplittersWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  ISplittersWorkspace &operator=(const ISplittersWorkspace &other);
 };
 
 /// Typedef for a shared pointer to \c TableWorkspace

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
@@ -306,6 +306,11 @@ public:
   void modified();
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  ITableWorkspace(const ITableWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  ITableWorkspace &operator=(const ITableWorkspace &other);
+
   /**  Resize a column.
          @param c :: Pointer to the column
          @param size :: New column size

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
@@ -307,7 +307,7 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  ITableWorkspace(const ITableWorkspace &other);
+  ITableWorkspace(const ITableWorkspace &other) : Workspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   ITableWorkspace &operator=(const ITableWorkspace &other);
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -426,6 +426,11 @@ public:
   //=====================================================================================
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  MatrixWorkspace(const MatrixWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  MatrixWorkspace &operator=(const MatrixWorkspace &other);
+
   MatrixWorkspace(Mantid::Geometry::INearestNeighboursFactory *factory = NULL);
 
   /// Initialises the workspace. Sets the size and lengths of the arrays. Must
@@ -441,10 +446,6 @@ protected:
   std::vector<Axis *> m_axes;
 
 private:
-  /// Private copy constructor. NO COPY ALLOWED
-  MatrixWorkspace(const MatrixWorkspace &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  MatrixWorkspace &operator=(const MatrixWorkspace &);
   /// Create an MantidImage instance.
   MantidImage_sptr
   getImage(const MantidVec &(MatrixWorkspace::*read)(std::size_t const) const,

--- a/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
@@ -54,7 +54,6 @@ class AnalysisDataServiceImpl;
 class MANTID_API_DLL Workspace : public Kernel::DataItem {
 public:
   Workspace();
-  Workspace(const Workspace &other);
   virtual ~Workspace();
 
   // DataItem interface
@@ -83,6 +82,9 @@ public:
   WorkspaceHistory &history() { return m_history; }
   /// Returns a reference to the WorkspaceHistory const
   const WorkspaceHistory &getHistory() const { return m_history; }
+
+protected:
+  Workspace(const Workspace &other);
 
 private:
   void setName(const std::string &);

--- a/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
@@ -84,7 +84,9 @@ public:
   const WorkspaceHistory &getHistory() const { return m_history; }
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
   Workspace(const Workspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
   Workspace &operator=(const Workspace &other);
 
 private:

--- a/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
@@ -84,8 +84,8 @@ public:
   const WorkspaceHistory &getHistory() const { return m_history; }
 
 protected:
-  Workspace(const Workspace &other) = default;
-  Workspace &operator=(const Workspace &other) = default;
+  Workspace(const Workspace &other);
+  Workspace &operator=(const Workspace &other);
 
 private:
   void setName(const std::string &);

--- a/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
@@ -84,7 +84,7 @@ public:
   const WorkspaceHistory &getHistory() const { return m_history; }
 
 protected:
-  Workspace(const Workspace &other);
+  Workspace(const Workspace &other) = default;
 
 private:
   void setName(const std::string &);

--- a/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
@@ -85,6 +85,7 @@ public:
 
 protected:
   Workspace(const Workspace &other) = default;
+  Workspace &operator=(const Workspace &other) = default;
 
 private:
   void setName(const std::string &);

--- a/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -110,11 +110,13 @@ public:
 
   //@}
 
-private:
-  /// Private, unimplemented copy constructor
+protected:
+  /// Protected, unimplemented copy constructor
   WorkspaceGroup(const WorkspaceGroup &ref);
-  /// Private, unimplemented copy assignment operator
+  /// Protected, unimplemented copy assignment operator
   const WorkspaceGroup &operator=(const WorkspaceGroup &);
+
+private:
   /// ADS removes a member of this group using this method. It doesn't send
   /// notifications in contrast to remove(name).
   void removeByADS(const std::string &name);

--- a/Code/Mantid/Framework/API/src/IMDWorkspace.cpp
+++ b/Code/Mantid/Framework/API/src/IMDWorkspace.cpp
@@ -13,6 +13,11 @@ namespace API {
 /** Default constructor */
 IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {}
 
+//-----------------------------------------------------------------------------------------------
+/** Copy constructor */
+IMDWorkspace::IMDWorkspace(const IMDWorkspace &other)
+    : Workspace(other), Mantid::API::MDGeometry(other) {}
+
 /// Destructor
 IMDWorkspace::~IMDWorkspace() {}
 

--- a/Code/Mantid/Framework/API/src/IMDWorkspace.cpp
+++ b/Code/Mantid/Framework/API/src/IMDWorkspace.cpp
@@ -13,11 +13,6 @@ namespace API {
 /** Default constructor */
 IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {}
 
-//-----------------------------------------------------------------------------------------------
-/** Copy constructor */
-IMDWorkspace::IMDWorkspace(const IMDWorkspace &other)
-    : Workspace(other), Mantid::API::MDGeometry(other) {}
-
 /// Destructor
 IMDWorkspace::~IMDWorkspace() {}
 

--- a/Code/Mantid/Framework/API/src/Workspace.cpp
+++ b/Code/Mantid/Framework/API/src/Workspace.cpp
@@ -11,13 +11,6 @@ namespace API {
 Workspace::Workspace()
     : DataItem(), m_title(), m_comment(), m_name(), m_history() {}
 
-/** Copy constructor
- * @param other :: workspace to copy
- */
-Workspace::Workspace(const Workspace &other)
-    : DataItem(other), m_title(other.m_title), m_comment(other.m_comment),
-      m_name(other.m_name), m_history(other.m_history) {}
-
 /// Workspace destructor
 Workspace::~Workspace() {}
 

--- a/Code/Mantid/Framework/API/src/Workspace.cpp
+++ b/Code/Mantid/Framework/API/src/Workspace.cpp
@@ -11,6 +11,13 @@ namespace API {
 Workspace::Workspace()
     : DataItem(), m_title(), m_comment(), m_name(), m_history() {}
 
+/** Copy constructor
+ * @param other :: workspace to copy
+ */
+Workspace::Workspace(const Workspace &other)
+    : DataItem(other), m_title(other.m_title), m_comment(other.m_comment),
+      m_name(other.m_name), m_history(other.m_history) {}
+
 /// Workspace destructor
 Workspace::~Workspace() {}
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -189,12 +189,13 @@ public:
                                     const double maxX,
                                     const bool entireRange) const;
 
-private:
-  /// NO COPY ALLOWED
-  EventWorkspace(const EventWorkspace &);
-  /// NO ASSIGNMENT ALLOWED
-  EventWorkspace &operator=(const EventWorkspace &);
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  EventWorkspace(const EventWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  EventWorkspace &operator=(const EventWorkspace &other);
 
+private:
   /** A vector that holds the event list for each spectrum; the key is
    * the workspace index, which is not necessarily the pixelid.
    */

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -34,11 +34,11 @@ public:
   void makeDetectorIDToGroupVector(std::vector<int> &detIDToGroup,
                                    int64_t &ngroups) const;
 
-private:
-  /// Private copy constructor. NO COPY ALLOWED
-  GroupingWorkspace(const GroupingWorkspace &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  GroupingWorkspace &operator=(const GroupingWorkspace &);
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  GroupingWorkspace(const GroupingWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  GroupingWorkspace &operator=(const GroupingWorkspace &other);
 };
 
 /// shared pointer to the GroupingWorkspace class

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -168,7 +168,7 @@ public:
 
 protected:
   /// Protected copy assignment operator. Assignment not implemented.
-  MDEventWorkspace &operator=(const MDEventWorkspace<MDE, nd> &other);
+  MDEventWorkspace<MDE, nd> &operator=(const MDEventWorkspace<MDE, nd> &other);
 
   /** MDBox containing all of the events in the workspace. */
   MDBoxBase<MDE, nd> *data;

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -168,7 +168,15 @@ public:
 
 protected:
   /// Protected copy assignment operator. Assignment not implemented.
-  MDEventWorkspace<MDE, nd> &operator=(const MDEventWorkspace<MDE, nd> &other);
+  /// Windows Visual Studio 2012 has trouble with declaration without definition
+  /// so we provide one that throws an error. This seems template related.
+  /// TODO: clean this up.
+  MDEventWorkspace<MDE, nd> &operator=(const MDEventWorkspace<MDE, nd> &other) {
+    throw std::runtime_error("MDEventWorkspace::operator= not implemented.");
+    // this codepath should never be reached, prevent unused parameter warning:
+    setTitle(other.getTitle());
+    return *this;
+  }
 
   /** MDBox containing all of the events in the workspace. */
   MDBoxBase<MDE, nd> *data;

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -40,6 +40,7 @@ public:
   typedef MDE MDEventType;
 
   MDEventWorkspace();
+  // TODO once we have a polymorphic clone this should be made protected
   MDEventWorkspace(const MDEventWorkspace<MDE, nd> &other);
   virtual ~MDEventWorkspace();
 
@@ -166,6 +167,9 @@ public:
   virtual Mantid::API::MDNormalization displayNormalization() const;
 
 protected:
+  /// Protected copy assignment operator. Assignment not implemented.
+  MDEventWorkspace &operator=(const MDEventWorkspace<MDE, nd> &other);
+
   /** MDBox containing all of the events in the workspace. */
   MDBoxBase<MDE, nd> *data;
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -47,6 +47,7 @@ public:
   MDHistoWorkspace(
       std::vector<Mantid::Geometry::IMDDimension_sptr> &dimensions);
 
+  // TODO once we have a polymorphic clone this should be made protected
   MDHistoWorkspace(const MDHistoWorkspace &other);
 
   virtual ~MDHistoWorkspace();
@@ -427,6 +428,9 @@ private:
   Kernel::SpecialCoordinateSystem m_coordSystem;
 
 protected:
+  /// Protected copy assignment operator. Assignment not implemented.
+  MDHistoWorkspace &operator=(const MDHistoWorkspace &other);
+
   /// Linear array of masks for each bin
   bool *m_masks;
 };

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
@@ -36,16 +36,16 @@ public:
   virtual void copyFrom(boost::shared_ptr<const SpecialWorkspace2D> sourcews);
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  MaskWorkspace(const MaskWorkspace &other);
+
+  /// Protected copy assignment operator. Assignment not implemented.
+  MaskWorkspace &operator=(const MaskWorkspace &other);
+
   /// Return human-readable string
   virtual const std::string toString() const;
 
 private:
-  /// Private copy constructor. NO COPY ALLOWED
-  MaskWorkspace(const MaskWorkspace &);
-
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  MaskWorkspace &operator=(const MaskWorkspace &);
-
   /// Clear original incorrect mask
   void clearMask();
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MementoTableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MementoTableWorkspace.h
@@ -40,6 +40,12 @@ public:
   MementoTableWorkspace(int nRows = 0);
   ~MementoTableWorkspace();
 
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  MementoTableWorkspace(const MementoTableWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  MementoTableWorkspace &operator=(const MementoTableWorkspace &other);
+
 private:
   static bool expectedColumn(Mantid::API::Column_const_sptr expected,
                              Mantid::API::Column_const_sptr candidate);

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/OffsetsWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/OffsetsWorkspace.h
@@ -26,11 +26,11 @@ public:
   @return Standard string name  */
   virtual const std::string id() const { return "OffsetsWorkspace"; }
 
-private:
-  /// Private copy constructor. NO COPY ALLOWED
-  OffsetsWorkspace(const OffsetsWorkspace &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  OffsetsWorkspace &operator=(const OffsetsWorkspace &);
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  OffsetsWorkspace(const OffsetsWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  OffsetsWorkspace &operator=(const OffsetsWorkspace &other);
 };
 
 /// shared pointer to the OffsetsWorkspace class

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -67,8 +67,6 @@ public:
 
   PeaksWorkspace();
 
-  PeaksWorkspace(const PeaksWorkspace &other);
-
   PeaksWorkspace *clone() const;
 
   /** Get access to shared pointer containing workspace porperties. This
@@ -180,6 +178,12 @@ public:
   // --- Nexus Methods ---
   // Save to Nexus
   void saveNexus(::NeXus::File *file) const;
+
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  PeaksWorkspace(const PeaksWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  PeaksWorkspace &operator=(const PeaksWorkspace &other);
 
 private:
   /// Initialize the table structure

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
@@ -64,18 +64,17 @@ public:
   void setF(const std::size_t index, const MantidVecPtr &F);
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  RebinnedOutput(const RebinnedOutput &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  RebinnedOutput &operator=(const RebinnedOutput &other);
+
   /// Called by initialize() in MatrixWorkspace
   virtual void init(const std::size_t &NVectors, const std::size_t &XLength,
                     const std::size_t &YLength);
 
   /// A vector that holds the 1D vectors for the fractional area.
   std::vector<MantidVec> fracArea;
-
-private:
-  /// Private copy constructor. NO COPY ALLOWED
-  RebinnedOutput(const RebinnedOutput &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  RebinnedOutput &operator=(const RebinnedOutput &);
 };
 
 /// shared pointer to the RebinnedOutput class

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
@@ -52,14 +52,14 @@ public:
   virtual void copyFrom(boost::shared_ptr<const SpecialWorkspace2D> sourcews);
 
 private:
-  /// Private copy constructor. NO COPY ALLOWED
-  SpecialWorkspace2D(const SpecialWorkspace2D &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  SpecialWorkspace2D &operator=(const SpecialWorkspace2D &);
-
   bool isCompatible(boost::shared_ptr<const SpecialWorkspace2D> ws);
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  SpecialWorkspace2D(const SpecialWorkspace2D &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  SpecialWorkspace2D &operator=(const SpecialWorkspace2D &other);
+
   virtual void init(const size_t &NVectors, const size_t &XLength,
                     const size_t &YLength);
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
@@ -57,6 +57,12 @@ public:
   size_t getNumberSplitters() const;
 
   bool removeSplitter(size_t);
+
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  SplittersWorkspace(const SplittersWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  SplittersWorkspace &operator=(const SplittersWorkspace &other);
 };
 
 typedef boost::shared_ptr<SplittersWorkspace> SplittersWorkspace_sptr;

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
@@ -287,6 +287,12 @@ public:
   /// Sort this table. @see ITableWorkspace::sort
   void sort(std::vector<std::pair<std::string, bool>> &criteria);
 
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  TableWorkspace(const TableWorkspace &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  TableWorkspace &operator=(const TableWorkspace &other);
+
 private:
   /// template method to find a given value in a table.
   template <typename Type>
@@ -398,11 +404,6 @@ private:
   /// shared pointer to the logManager, responsible for the workspace
   /// properties.
   API::LogManager_sptr m_LogManager;
-
-  // not asignable, not copy constructable, clonable
-  /// Copy constructor
-  TableWorkspace(const TableWorkspace &other);
-  TableWorkspace &operator=(const TableWorkspace &rhs);
 };
 
 /// Typedef for a shared pointer to \c TableWorkspace

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -90,6 +90,11 @@ public:
                      bool parallelExecution = true);
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  Workspace2D(const Workspace2D &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  Workspace2D &operator=(const Workspace2D &other);
+
   /// Called by initialize()
   virtual void init(const std::size_t &NVectors, const std::size_t &XLength,
                     const std::size_t &YLength);
@@ -104,11 +109,6 @@ protected:
   std::vector<Mantid::API::ISpectrum *> data;
 
 private:
-  /// Private copy constructor. NO COPY ALLOWED
-  Workspace2D(const Workspace2D &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  Workspace2D &operator=(const Workspace2D &);
-
   virtual std::size_t getHistogramNumberHelper() const;
 };
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -66,12 +66,13 @@ public:
                          MantidVec &Y, MantidVec &E,
                          bool skipError = false) const;
 
-private:
-  /// Private copy constructor. NO COPY ALLOWED
-  WorkspaceSingleValue(const WorkspaceSingleValue &);
-  /// Private copy assignment operator. NO ASSIGNMENT ALLOWED
-  WorkspaceSingleValue &operator=(const WorkspaceSingleValue &);
+protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  WorkspaceSingleValue(const WorkspaceSingleValue &other);
+  /// Protected copy assignment operator. Assignment not implemented.
+  WorkspaceSingleValue &operator=(const WorkspaceSingleValue &other);
 
+private:
   // allocates space in a new workspace - does nothing in this case
   virtual void init(const std::size_t &NVectors, const std::size_t &XLength,
                     const std::size_t &YLength);

--- a/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -73,10 +73,16 @@ public:
     checkPW(*pw);
   }
 
+  class TestablePeaksWorkspace : public PeaksWorkspace {
+  public:
+    TestablePeaksWorkspace(const PeaksWorkspace &other)
+        : PeaksWorkspace(other) {}
+  };
+
   void test_copyConstructor()
   {
     auto pw = buildPW();
-    auto pw2 = PeaksWorkspace_sptr(new PeaksWorkspace(*pw));
+    auto pw2 = PeaksWorkspace_sptr(new TestablePeaksWorkspace(*pw));
     checkPW(*pw2);
   }
 


### PR DESCRIPTION
Fixes #12917 

None of the changes should change the behavior of existing code. Some compiler-generated copy constructors or assignment operators should now be disabled as they should. Both are now in general `protected` instead of `private`. The reason is the upcoming implementation of `Workspace::clone()`, which will need access to copy constructors of base classes.

Testing:
None of the tests should be affected. The only change in test code is the addition of a wrapper class such that a test that tests a previously `public` (now `protected`) copy constructor works.
