### PR TITLE
Allow individual log level control for each channel

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/src/Fit.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/Fit.cpp
@@ -181,11 +181,6 @@ void Fit::execConcrete() {
     }
     prog.report();
     m_function->iterationFinished();
-    if (g_log.is(Kernel::Logger::Priority::PRIO_INFORMATION)) {
-      g_log.debug() << "Iteration " << iter
-                    << ", cost function = " << minimizer->costFunctionVal()
-                    << "\n";
-    }
     ++iter;
   }
   g_log.debug() << "Number of minimizer iterations=" << iter << "\n";

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -20,6 +20,7 @@
 //----------------------------------------------------------------------
 /// @cond Exclude from doxygen documentation
 namespace Poco {
+class Channel;
 namespace Util {
 class PropertyFileConfiguration;
 class SystemConfiguration;
@@ -223,6 +224,14 @@ public:
   /// Set the default facility
   void setFacility(const std::string &facilityName);
 
+  
+  ///Sets the log level priority for the File log channel
+  void setFileLogLevel(int logLevel);
+  ///Sets the log level priority for the Console log channel
+  void setConsoleLogLevel(int logLevel);
+  ///Sets the log level priority for the selected Filter log channel
+  void setFilterChannelLogLevel(const std::string& filterChannelName, int logLevel);
+
   /// Look for an instrument
   const InstrumentInfo &
   getInstrument(const std::string &instrumentName = "") const;
@@ -262,7 +271,7 @@ private:
   void loadConfig(const std::string &filename, const bool append = false);
   /// Read a file and place its contents into the given string
   bool readFile(const std::string &filename, std::string &contents) const;
-  /// Provies a string of a default configuration
+  /// Provides a string of a default configuration
   std::string defaultConfig() const;
   /// Writes out a fresh user properties file
   void createUserPropertiesFile() const;

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/FilterChannel.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/FilterChannel.h
@@ -59,8 +59,10 @@ public:
 
   /// Returns the channel pointer.
   Channel *getChannel() { return _channel; }
-
-  /// Attaches a channel, which may not be null.
+  
+  /// set the priority cutoff by integer.
+  const FilterChannel &setPriority(const int &priority);
+  /// Set the priority cutoff by string.
   const FilterChannel &setPriority(const std::string &priority);
 
   /// Returns the integer representation of the priority

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ListValidator.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ListValidator.h
@@ -9,6 +9,7 @@
 #include <boost/lexical_cast.hpp>
 #endif
 #include <vector>
+#include <set>
 #include <map>
 
 namespace Mantid {

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/Logger.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/Logger.h
@@ -9,7 +9,7 @@
 #include <Poco/Message.h>
 
 #include <iosfwd>
-#include <set>
+
 #include <string>
 
 //----------------------------------------------------------------------
@@ -71,6 +71,8 @@ public:
   // Our logger's priority types are the same as POCO's Message's types.
   typedef Poco::Message::Priority Priority;
 
+  static const std::string* PriorityNames;
+
   /// Constructor giving the logger name
   Logger(const std::string &name);
   /// Destructor
@@ -103,6 +105,12 @@ public:
   std::ostream &information();
   /// Logs at debug level
   std::ostream &debug();
+
+  /// Log a message at a given priority
+  void log(const std::string &message, Logger::Priority priority);
+
+  /// gets the correct log stream for a priority
+  std::ostream &getLogStream(Logger::Priority priority);
 
   /// Logs the given message at debug level, followed by the data in buffer.
   void dump(const std::string &msg, const void *buffer, std::size_t length);
@@ -146,10 +154,6 @@ private:
   /// Disable assignment
   Logger &operator=(const Logger &);
 
-  /// Log a message at a given priority
-  void log(const std::string &message, Logger::Priority priority);
-  /// gets the correct log stream for a priority
-  std::ostream &getLogStream(Logger::Priority priority);
   /// Return a log stream set with the given priority
   Priority applyLevelOffset(Priority proposedLevel);
 

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -4,7 +4,6 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/MantidVersion.h"
-#include "MantidKernel/ParaViewVersion.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/FilterChannel.h"
@@ -29,6 +28,10 @@
 #ifdef _WIN32
 #pragma warning(disable : 4250)
 #endif
+#include <Poco/Logger.h>
+#include <Poco/Channel.h>
+#include <Poco/SplitterChannel.h>
+#include <Poco/LoggingRegistry.h>
 #include <Poco/PipeStream.h>
 #include <Poco/StreamCopier.h>
 
@@ -995,7 +998,7 @@ void ConfigServiceImpl::getKeysRecursive(const std::string &root,
   }
 }
 
-/**
+  /**
  * Recursively gets a list of all config options.
  *
  * This function is needed as Boost Python does not like calling function with
@@ -1946,6 +1949,59 @@ Kernel::ProxyInfo &ConfigServiceImpl::getProxy(const std::string &url) {
   }
   return m_proxyInfo;
 }
+
+/** Sets the log level priority for the File log channel
+* @logLevel the integer value of the log level to set, 1=Critical, 7=Debug
+*/
+void ConfigServiceImpl::setFileLogLevel(int logLevel)
+{
+  setFilterChannelLogLevel("fileFilterChannel",logLevel);
+}
+/** Sets the log level priority for the Console log channel
+* @logLevel the integer value of the log level to set, 1=Critical, 7=Debug
+*/
+void ConfigServiceImpl::setConsoleLogLevel(int logLevel)
+{
+  setFilterChannelLogLevel("consoleFilterChannel",logLevel);
+}
+
+
+/** Sets the Log level for a filter channel
+* @filterChannelName the channel name of the filter channel to change
+* @logLevel the integer value of the log level to set, 1=Critical, 7=Debug
+* @throws std::invalid_argument if the channel name is incorrect or it is not a filterChannel
+*/
+void ConfigServiceImpl::setFilterChannelLogLevel(const std::string& filterChannelName, int logLevel)
+{
+  Poco::Channel* channel = NULL;
+  try
+  {
+    channel = Poco::LoggingRegistry::defaultRegistry().channelForName(filterChannelName);
+  }
+  catch(Poco::NotFoundException&)
+  {
+    throw std::invalid_argument(filterChannelName + " not found in the Logging Registry");
+  }
+
+  auto *filterChannel = dynamic_cast<Poco::FilterChannel*>(channel);
+  if (filterChannel)
+  {
+    filterChannel->setPriority(logLevel);      
+    //set root level if required
+    int rootLevel = Poco::Logger::root().getLevel();
+    if (rootLevel < logLevel)
+    {
+        Mantid::Kernel::Logger::setLevelForAll(logLevel);
+    }
+    g_log.log(filterChannelName + " log channel set to " + Logger::PriorityNames[logLevel] + " priority",static_cast<Logger::Priority>(logLevel));
+  }
+  else
+  {
+    throw std::invalid_argument(filterChannelName + " was not a filter channel");
+  }
+}
+
+
 
 /// \cond TEMPLATE
 template DLLExport int ConfigServiceImpl::getValue(const std::string &,

--- a/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
+++ b/Code/Mantid/Framework/Kernel/src/ConfigService.cpp
@@ -1951,14 +1951,14 @@ Kernel::ProxyInfo &ConfigServiceImpl::getProxy(const std::string &url) {
 }
 
 /** Sets the log level priority for the File log channel
-* @logLevel the integer value of the log level to set, 1=Critical, 7=Debug
+* @param logLevel the integer value of the log level to set, 1=Critical, 7=Debug
 */
 void ConfigServiceImpl::setFileLogLevel(int logLevel)
 {
   setFilterChannelLogLevel("fileFilterChannel",logLevel);
 }
 /** Sets the log level priority for the Console log channel
-* @logLevel the integer value of the log level to set, 1=Critical, 7=Debug
+* @param logLevel the integer value of the log level to set, 1=Critical, 7=Debug
 */
 void ConfigServiceImpl::setConsoleLogLevel(int logLevel)
 {
@@ -1967,8 +1967,8 @@ void ConfigServiceImpl::setConsoleLogLevel(int logLevel)
 
 
 /** Sets the Log level for a filter channel
-* @filterChannelName the channel name of the filter channel to change
-* @logLevel the integer value of the log level to set, 1=Critical, 7=Debug
+* @param filterChannelName the channel name of the filter channel to change
+* @param logLevel the integer value of the log level to set, 1=Critical, 7=Debug
 * @throws std::invalid_argument if the channel name is incorrect or it is not a filterChannel
 */
 void ConfigServiceImpl::setFilterChannelLogLevel(const std::string& filterChannelName, int logLevel)

--- a/Code/Mantid/Framework/Kernel/src/FilterChannel.cpp
+++ b/Code/Mantid/Framework/Kernel/src/FilterChannel.cpp
@@ -50,6 +50,12 @@ void FilterChannel::close() {
   }
 }
 
+const FilterChannel &FilterChannel::setPriority(const int &priority) {
+  _priority = priority;
+  
+  return *this;
+}
+
 const FilterChannel &FilterChannel::setPriority(const std::string &priority) {
   // take a local copy of the input
   std::string workPriority = priority;

--- a/Code/Mantid/Framework/Kernel/src/Logger.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Logger.cpp
@@ -24,6 +24,19 @@ namespace {
 Poco::NullOutputStream NULL_STREAM;
 }
 
+static const std::string PriorityNames_data[] = {
+    "PRIO_FATAL",
+    "PRIO_CRITICAL",
+    "PRIO_ERROR",
+    "PRIO_WARNING",
+    "PRIO_NOTICE",
+    "PRIO_INFORMATION",
+    "PRIO_DEBUG",
+    "PRIO_TRACE"
+};
+const std::string* Logger::PriorityNames = PriorityNames_data;
+
+
 /** Constructor
  * @param name :: The class name invoking this logger
  */

--- a/Code/Mantid/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ConfigServiceTest.h
@@ -102,6 +102,16 @@ public:
     TS_ASSERT_THROWS_NOTHING(log1.debug("a debug string with offset 999 should be trace"));
   }
 
+  void testLogLevelFiltering()
+  {
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setConsoleLogLevel(4));
+    TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().setFileLogLevel(4));
+    TSM_ASSERT_THROWS("A false channel name for setFilterChannelLogLevel did not throw",
+      ConfigService::Instance().setFilterChannelLogLevel("AnIncorrectChannelName",4),std::invalid_argument);
+    TSM_ASSERT_THROWS("A correct channel name, but not a filterChannel for setFilterChannelLogLevel did not throw",
+      ConfigService::Instance().setFilterChannelLogLevel("consoleChannel",4),std::invalid_argument);
+  }
+
   void testDefaultFacility()
   {
     TS_ASSERT_THROWS_NOTHING(ConfigService::Instance().getFacility() );

--- a/Code/Mantid/Framework/Kernel/test/FilterChannelTest.h
+++ b/Code/Mantid/Framework/Kernel/test/FilterChannelTest.h
@@ -19,15 +19,11 @@ using Mantid::TestChannel;
 
 class FilterChannelTest : public CxxTest::TestSuite
 {
-public: 
-
+public:
   void testContructor()
   {
-    TS_ASSERT_THROWS_NOTHING
-      (
-	Poco::FilterChannel a;
-	)
-      }
+    TS_ASSERT_THROWS_NOTHING(Poco::FilterChannel a;)
+  }
 
   void testContructorDefaults()
   {
@@ -127,7 +123,24 @@ public:
     a.log(msg);
     TS_ASSERT_EQUALS(tChannel->list().size(),1);
   }
-
+  void testSimpleLogMessagesByPriority()
+  {
+    //initialise the channel
+    boost::shared_ptr<TestChannel> tChannel(new TestChannel);
+    Poco::FilterChannel a;
+    a.addChannel(tChannel.get());
+    Poco::Message msg;
+    a.setPriority(Poco::Message::Priority::PRIO_INFORMATION);
+    msg.setPriority(Poco::Message::Priority::PRIO_NOTICE);
+    a.log(msg);
+    TSM_ASSERT_EQUALS("Message of greater priority failed to get through",tChannel->list().size(),1);
+    msg.setPriority(Poco::Message::Priority::PRIO_INFORMATION);
+    a.log(msg);
+    TSM_ASSERT_EQUALS("Message of equal priority failed to get through",tChannel->list().size(),2);
+    msg.setPriority(Poco::Message::Priority::PRIO_DEBUG);
+    a.log(msg);
+    TSM_ASSERT_EQUALS("Message of lesser priority managed to get through",tChannel->list().size(),2);
+  }
   void testLogMessagesByPriority()
   {
     //initialise the channel
@@ -163,7 +176,7 @@ public:
         msg.setPriority(static_cast<Poco::Message::Priority>(msgPriority));
 
         size_t previousMessageCount = tChannel->list().size();
-	a.log(msg);
+	      a.log(msg);
         size_t addedMessageCount = tChannel->list().size() - previousMessageCount;
 
         if ((channelPriority >= msgPriority)&&(addedMessageCount==1))

--- a/Code/Mantid/Framework/Properties/Mantid.properties.template
+++ b/Code/Mantid/Framework/Properties/Mantid.properties.template
@@ -146,7 +146,7 @@ graph1d.autodistribution = On
 
 # logging configuration
 # root level message filter (This sets a minimal level possible for any channel)
-logging.loggers.root.level = notice
+logging.loggers.root.level = information
 
 # splitting the messages to many logging channels
 logging.loggers.root.channel.class = SplitterChannel
@@ -158,10 +158,10 @@ logging.channels.consoleFilterChannel.class= FilterChannel
 logging.channels.consoleFilterChannel.channel= consoleChannel
 logging.channels.consoleFilterChannel.level= notice
 
-# specific filter for the file channel raising the level to notice (drop to debug for debugging)
+# specific filter for the file channel raising the level to information (drop to debug for debugging)
 logging.channels.fileFilterChannel.class= FilterChannel
 logging.channels.fileFilterChannel.channel= fileChannel
-logging.channels.fileFilterChannel.level= notice
+logging.channels.fileFilterChannel.level= information
 
 # output to the console - primarily for console based apps
 logging.channels.consoleChannel.class = ConsoleChannel

--- a/Code/Mantid/Framework/Properties/Mantid.properties.template
+++ b/Code/Mantid/Framework/Properties/Mantid.properties.template
@@ -145,19 +145,28 @@ graph1d.autodistribution = On
 #AlgorithmChaining.SwitchedOn = 1
 
 # logging configuration
-# root level message filter (drop to debug for more messages)
+# root level message filter (This sets a minimal level possible for any channel)
 logging.loggers.root.level = notice
+
 # splitting the messages to many logging channels
 logging.loggers.root.channel.class = SplitterChannel
-logging.loggers.root.channel.channel1 = consoleChannel
+logging.loggers.root.channel.channel1 = consoleFilterChannel
 logging.loggers.root.channel.channel2 = fileFilterChannel
-# output to the console - primarily for console based apps
-logging.channels.consoleChannel.class = ConsoleChannel
-logging.channels.consoleChannel.formatter = f1
+
+# specific filter for the console channel raising the level to notice (drop to debug for debugging)
+logging.channels.consoleFilterChannel.class= FilterChannel
+logging.channels.consoleFilterChannel.channel= consoleChannel
+logging.channels.consoleFilterChannel.level= notice
+
 # specific filter for the file channel raising the level to notice (drop to debug for debugging)
 logging.channels.fileFilterChannel.class= FilterChannel
 logging.channels.fileFilterChannel.channel= fileChannel
 logging.channels.fileFilterChannel.level= notice
+
+# output to the console - primarily for console based apps
+logging.channels.consoleChannel.class = ConsoleChannel
+logging.channels.consoleChannel.formatter = f1
+
 # output to a file (For error capturing and debugging)
 logging.channels.fileChannel.class = @FILECHANNEL@
 logging.channels.fileChannel.path =
@@ -165,10 +174,10 @@ logging.channels.fileChannel.rotation = 1 M
 logging.channels.fileChannel.purgeCount = 9
 logging.channels.fileChannel.formatter.class = PatternFormatter
 logging.channels.fileChannel.formatter.pattern = %Y-%m-%d %H:%M:%S,%i [%I] %p %s - %t
+logging.channels.fileChannel.formatter.times = local
 logging.formatters.f1.class = PatternFormatter
 logging.formatters.f1.pattern = @CONSOLEPATTERN@
 logging.formatters.f1.times = local
-logging.channels.fileChannel.formatter.times = local
 
 workspace.sendto.SansView.arguments=[file]
 workspace.sendto.SansView.saveusing=SaveCanSAS1D

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -123,6 +123,12 @@ void export_ConfigService() {
            "Saves the keys that have changed from their default to the given "
            "filename")
 
+      .def("setFileLogLevel", &ConfigServiceImpl::setFileLogLevel,
+          "Sets the log level priority for the File log channel, logLevel 1 = Critical, 7 = Debug")
+
+      .def("setConsoleLogLevel", &ConfigServiceImpl::setConsoleLogLevel,
+          "Sets the log level priority for the Console log channel, logLevel 1 = Critical, 7 = Debug")
+
       .def("keys", &ConfigServiceImpl::keys)
 
       // Treat this as a dictionary

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -124,10 +124,10 @@ void export_ConfigService() {
            "filename")
 
       .def("setFileLogLevel", &ConfigServiceImpl::setFileLogLevel,
-          "Sets the log level priority for the File log channel, logLevel 1 = Critical, 7 = Debug")
+          "Sets the log level priority for the File log channel, logLevel 1 = Fatal, 6 = information, 7 = Debug")
 
       .def("setConsoleLogLevel", &ConfigServiceImpl::setConsoleLogLevel,
-          "Sets the log level priority for the Console log channel, logLevel 1 = Critical, 7 = Debug")
+          "Sets the log level priority for the Console log channel, logLevel 1 = Fatal, 6 = information, 7 = Debug")
 
       .def("keys", &ConfigServiceImpl::keys)
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import testhelpers
 
 from mantid.kernel import (ConfigService, ConfigServiceImpl, config,
                            std_vector_str, FacilityInfo, InstrumentInfo)
@@ -89,8 +90,11 @@ class ConfigServiceTest(unittest.TestCase):
         self.assertTrue('tmp' in paths[0])
         self.assertTrue('tmp_2' in paths[1])
         self._clean_up_test_areas()
-
-
+            
+    def test_setting_log_channel_levels(self):
+        testhelpers.assertRaisesNothing(self, config.setFileLogLevel, 4)
+        testhelpers.assertRaisesNothing(self, config.setConsoleLogLevel, 4)
+    
     def _setup_test_areas(self):
         """Create a new data search path string
         """

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MessageDisplay.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/MessageDisplay.h
@@ -5,6 +5,7 @@
 // Includes
 //----------------------------------
 #include "WidgetDllOption.h"
+#include "MantidKernel/FilterChannel.h"
 #include "MantidQtAPI/Message.h"
 #include "MantidQtAPI/QtSignalChannel.h"
 
@@ -120,6 +121,8 @@ namespace MantidQt
       LogLevelControl m_logLevelControl;
       /// A reference to the log channel
       API::QtSignalChannel *m_logChannel;
+      /// A reference to the log channel
+      Poco::FilterChannel *m_filterChannel;
       /// The actual widget holding the text
       QPlainTextEdit * m_textDisplay;
       /// Map priority to text formatting

--- a/Code/Mantid/docs/source/concepts/PropertiesFile.rst
+++ b/Code/Mantid/docs/source/concepts/PropertiesFile.rst
@@ -102,32 +102,38 @@ that it closely emulates. There are several comments in the properties file itse
 the configuration we provide by default.  However there are some obvious areas that you may want 
 to alter and those properties are detailed below.
 
-+----------------------------------------+---------------------------------------------------+-----------------------+
-|Property                                |Description                                        |Example value          |
-+========================================+===================================================+=======================+
-|logging.loggers.root.level              |Defines the lowest level of messages to be output  |debug, informtion,     |
-|                                        |by the system, and will override lower settings in |notice, warning,       |
-|                                        |filterChannels. The default is information, but    |error, critical        |
-|                                        |this can be lowered to debug for more detailed     |or fatal               |
-|                                        |feedback.                                          |                       |
-|                                        |                                                   |                       |
-+----------------------------------------+---------------------------------------------------+-----------------------+
-|logging.channels.fileFilterChannel.level|The lowest level messages to output to the log     |debug, informtion,     |
-|                                        |file. The default is warning, but this can be      |notice, warning,       |
-|                                        |lowered to debug for more detailed feedback. The   |error, critical        |
-|                                        |higher level of this and logging.loggers.root.level|or fatal               |
-|                                        |will apply.                                        |                       |
-+----------------------------------------+---------------------------------------------------+-----------------------+
-|logging.channels.fileChannel.path       | The Path to the log file.                         |../logs/mantid.log     |
-+----------------------------------------+---------------------------------------------------+-----------------------+
++-------------------------------------------+---------------------------------------------------+-----------------------+
+|Property                                   |Description                                        |Example value          |
++===========================================+===================================================+=======================+
+|logging.loggers.root.level                 |Defines the lowest level of messages to be output  |debug, information,    |
+|                                           |by the system, and will override lower settings in |notice, warning,       |
+|                                           |filterChannels. The default is information, but    |error, critical        |
+|                                           |this can be lowered to debug for more detailed     |or fatal               |
+|                                           |feedback.                                          |                       |
+|                                           |                                                   |                       |
++-------------------------------------------+---------------------------------------------------+-----------------------+
+|logging.channels.fileFilterChannel.level   |The lowest level messages to output to the log     |debug, information,    |
+|                                           |file. The default is warning, but this can be      |notice, warning,       |
+|                                           |lowered to debug for more detailed feedback. The   |error, critical        |
+|                                           |higher level of this and logging.loggers.root.level|or fatal               |
+|                                           |will apply.                                        |                       |
++-------------------------------------------+---------------------------------------------------+-----------------------+
+|logging.channels.consoleFilterChannel.level|The lowest level messages to output to the console.|debug, information,    |
+|                                           | The default is warning, but this can be           |notice, warning,       |
+|                                           |lowered to debug for more detailed feedback. The   |error, critical        |
+|                                           |higher level of this and logging.loggers.root.level|or fatal               |
+|                                           |will apply.                                        |                       |
++-------------------------------------------+---------------------------------------------------+-----------------------+
+|logging.channels.fileChannel.path          | The Path to the log file.                         |../logs/mantid.log     |
++-------------------------------------------+---------------------------------------------------+-----------------------+
 The logging priority levels for the file logging and console logging can also be adjusted in python using the commands:
 
 .. testcode:: LoggingConfigExample
 
   #Set the console to log at debug level on above (7=debug)
   ConfigService.setConsoleLogLevel(7)
-  #Set the file to only log at critical level (1=critical)
-  ConfigService.setConsoleLogLevel(7)
+  #Set the file to only log at critical level (2=critical)
+  ConfigService.setConsoleLogLevel(2)
   
 .. testoutput:: AddSampleLogExample 
 

--- a/Code/Mantid/docs/source/concepts/PropertiesFile.rst
+++ b/Code/Mantid/docs/source/concepts/PropertiesFile.rst
@@ -96,15 +96,21 @@ Directory Properties
 Logging Properties
 ******************
 
-The details of configuring the logging functionality within Mantid will not be explained here. For those who want more details look into the POCO logging classes and the Log4J logging module that it closely emulates. There are several comments in the properties file itself that explain the configuration we provide by default.However there are some obvious areas that you may want to alter and those properties are detailed below.
+The details of configuring the logging functionality within Mantid will not be explained here. 
+For those who want more details look into the POCO logging classes and the Log4J logging module 
+that it closely emulates. There are several comments in the properties file itself that explain 
+the configuration we provide by default.  However there are some obvious areas that you may want 
+to alter and those properties are detailed below.
 
 +----------------------------------------+---------------------------------------------------+-----------------------+
 |Property                                |Description                                        |Example value          |
 +========================================+===================================================+=======================+
 |logging.loggers.root.level              |Defines the lowest level of messages to be output  |debug, informtion,     |
-|                                        |by the system. The default is information, but this|notice, warning,       |
-|                                        |can be lowered to debug for more detailed feedback.|error, critical        |
-|                                        |                                                   |or fatal               |
+|                                        |by the system, and will override lower settings in |notice, warning,       |
+|                                        |filterChannels. The default is information, but    |error, critical        |
+|                                        |this can be lowered to debug for more detailed     |or fatal               |
+|                                        |feedback.                                          |                       |
+|                                        |                                                   |                       |
 +----------------------------------------+---------------------------------------------------+-----------------------+
 |logging.channels.fileFilterChannel.level|The lowest level messages to output to the log     |debug, informtion,     |
 |                                        |file. The default is warning, but this can be      |notice, warning,       |
@@ -114,6 +120,18 @@ The details of configuring the logging functionality within Mantid will not be e
 +----------------------------------------+---------------------------------------------------+-----------------------+
 |logging.channels.fileChannel.path       | The Path to the log file.                         |../logs/mantid.log     |
 +----------------------------------------+---------------------------------------------------+-----------------------+
+The logging priority levels for the file logging and console logging can also be adjusted in python using the commands:
+
+.. testcode:: LoggingConfigExample
+
+  #Set the console to log at debug level on above (7=debug)
+  ConfigService.setConsoleLogLevel(7)
+  #Set the file to only log at critical level (1=critical)
+  ConfigService.setConsoleLogLevel(7)
+  
+.. testoutput:: AddSampleLogExample 
+
+
 
 MantidPlot Properties
 *********************


### PR DESCRIPTION
fixes #12703

Extends the logging to allow individual control of logging per output channel.
- console
- file
- GUI message display

The GUI message display is controlled by the right click action as before, but there are now two python commands to control the other log channels.  They can also be altered by using the config file if you want to make a longer term change.

``` python

   #Set the console to log at debug level on above (7=debug)
  ConfigService.setConsoleLogLevel(7)
  #Set the file to only log at critical level (1=critical)
  ConfigService.setConsoleLogLevel(7)
```
### To test
1. start up python
2. load the log file
3. look at the console output
4. change the log settings using the right click on the log output in the GUI, and the python commands above and check they respond ok.
5. changes to the GUI log level will be remembered on startup, but not the others.

Documentation has been updated, but this is too internal to mention in the release notes.
