### PR TITLE
EnginX: use InputWorkspace property instead of Filename in all algorithms

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -15,11 +15,12 @@ class EnginXCalibrateFull(PythonAlgorithm):
         return "Calibrates every pixel position by performing single peak fitting."
 
     def PyInit(self):
-        self.declareProperty(FileProperty("Filename", "", FileAction.Load),\
-    		"Calibration run to use")
+        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input),
+                             "Workspace with the calibration run to use.")
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Output),\
-    		"A table with the detector IDs and calibrated detector positions in V3P format.")
+                             "A table with the detector IDs and calibrated detector positions in V3D format "
+                             "(3D vector with x, y, z values).")
 
         self.declareProperty(FloatArrayProperty("ExpectedPeaks", ""),\
     		"A list of dSpacing values where peaks are expected.")
@@ -43,7 +44,7 @@ class EnginXCalibrateFull(PythonAlgorithm):
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")
 
-        ws = self._loadCalibrationRun()
+        ws = self.getProperty('InputWorkspace').value
 
         ws = self._prepareWsForFitting(ws)
 
@@ -66,14 +67,6 @@ class EnginXCalibrateFull(PythonAlgorithm):
             prog.report()
 
         self.setProperty("DetectorPositions", positionTable)
-
-    def _loadCalibrationRun(self):
-        """ Loads specified calibration run
-    	"""
-        alg = self.createChildAlgorithm('Load')
-        alg.setProperty('Filename', self.getProperty('Filename').value)
-        alg.execute()
-        return alg.getProperty('OutputWorkspace').value
 
     def _prepareWsForFitting(self, ws):
         """ Rebins the workspace and converts it to distribution

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFocus.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXFocus.py
@@ -13,8 +13,8 @@ class EnginXFocus(PythonAlgorithm):
         return "Focuses a run."
 
     def PyInit(self):
-        self.declareProperty(FileProperty("Filename", "", FileAction.Load),\
-    		"Run to focus")
+        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input),
+                             "Workspace with the run to focus.")
 
         self.declareProperty("Bank", 1, "Which bank to focus")
 
@@ -28,10 +28,8 @@ class EnginXFocus(PythonAlgorithm):
 
 
     def PyExec(self):
-    	# Load the run file
-        self.log().information("Loading input file: %s" % self.getProperty("Filename").value)
-        ws = self._loadRun()
-        self.log().information("Input file loaded")
+        # Get the run workspace
+        ws = self.getProperty('InputWorkspace').value
 
     	# Leave the data for the bank we are interested in only
         ws = self._cropData(ws)
@@ -53,14 +51,6 @@ class EnginXFocus(PythonAlgorithm):
         self._convertToDistr(ws)
 
         self.setProperty("OutputWorkspace", ws)
-
-    def _loadRun(self):
-        """ Loads the specified run
-    	"""
-        alg = self.createChildAlgorithm('Load')
-        alg.setProperty('Filename', self.getProperty("Filename").value)
-        alg.execute()
-        return alg.getProperty('OutputWorkspace').value
 
     def _applyCalibration(self, ws):
         """ Refines the detector positions using the result of calibration (if one is specified)
@@ -125,5 +115,6 @@ class EnginXFocus(PythonAlgorithm):
         alg.setProperty('InputWorkspace', ws)
         alg.execute()
         return alg.getProperty('OutputWorkspace').value
+
 
 AlgorithmFactory.subscribe(EnginXFocus)

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -4,6 +4,22 @@ from mantid.api import *
 
 class EnginXCalibrateFullTest(unittest.TestCase):
 
+    _data_ws = None
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up dependencies for one or more of the tests below.
+        """
+        cls._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean up tasks complementary to setUp, like removing workspaces
+        """
+        DeleteWorkspace(cls._data_ws)
+
     def test_issues_with_properties(self):
         """
         Handle in/out property errors appropriately.
@@ -12,22 +28,22 @@ class EnginXCalibrateFullTest(unittest.TestCase):
         # No Filename property (required)
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          File='foo', Bank=1)
+                          Input='foo', Bank=1)
 
-        # Wrong filename
+        # Wrong workspace name
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          File='bar_file_is_not_there.not', Bank=2)
+                          Input='this_ws_is_not_there.not', Bank=2)
 
         # mispelled ExpectedPeaks
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          Filename='ENGINX00228061.nxs', Bank=2, Peaks='2')
+                          InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
 
         # all fine, except missing DetectorPositions (output)
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          Filename='ENGINX00228061.nxs', Bank=2)
+                          InputWorkspace=self.__class__._data_ws, Bank=2)
 
     def test_wrong_fit_fails_gracefully(self):
         """
@@ -38,7 +54,7 @@ class EnginXCalibrateFullTest(unittest.TestCase):
         # warnings and finally raise after a 'some peaks not found' error
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          Filename="ENGINX00228061.nxs", ExpectedPeaks=[0.01], Bank=1,
+                          InputWorkspace=self.__class__._data_ws, ExpectedPeaks=[0.01], Bank=1,
                           DetectorPositions='out_det_positions_table')
 
 
@@ -54,7 +70,7 @@ class EnginXCalibrateFullTest(unittest.TestCase):
         det_peaks_tbl = CreateEmptyTableWorkspace()
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          Filename="ENGINX00228061.nxs", Bank=2,
+                          InputWorkspace=self.__class__._data_ws, Bank=2,
                           ExpectedPeaks='0.915, 1.257, 1.688',
                           DetectorPositions=tbl_name)
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -6,19 +6,14 @@ class EnginXCalibrateFullTest(unittest.TestCase):
 
     _data_ws = None
 
-    @classmethod
-    def setUpClass(cls):
+    # Note not using @classmethod setUpClass / tearDownClass because that's not supported in the old
+    # unittest of rhel6. setUpClass would do LoadNexus(...) and then tearDownClass DeleteWorkspace(...)
+    def setUp(self):
         """
         Set up dependencies for one or more of the tests below.
         """
-        cls._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Clean up tasks complementary to setUp, like removing workspaces
-        """
-        DeleteWorkspace(cls._data_ws)
+        if not self.__class__._data_ws:
+            self.__class__._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
 
     def test_issues_with_properties(self):
         """

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
@@ -6,19 +6,14 @@ class EnginXCalibrateTest(unittest.TestCase):
 
     _data_ws = None
 
-    @classmethod
-    def setUpClass(cls):
+    # Note not using @classmethod setUpClass / tearDownClass because that's not supported in the old
+    # unittest of rhel6
+    def setUp(self):
         """
         Set up dependencies for one or more of the tests below.
         """
-        cls._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Clean up tasks complementary to setUp, like removing workspaces
-        """
-        DeleteWorkspace(cls._data_ws)
+        if not self.__class__._data_ws:
+            self.__class__._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
 
     def test_issues_with_properties(self):
         """

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -4,32 +4,53 @@ from mantid.api import *
 
 class EnginXFocusTest(unittest.TestCase):
 
+    _data_ws = None
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Set up dependencies for one or more of the tests below.
+        """
+        cls._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
+
+    @classmethod
+    def tearDownClass(cls):
+        """
+        Clean up tasks complementary to setUp, like removing workspaces
+        """
+        DeleteWorkspace(cls._data_ws)
+
     def test_wrong_properties(self):
         """
         Tests proper error handling when passing wrong properties or not passing
         required ones.
         """
 
-        # No Filename property
+        # No InputWorkspace property
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          File='foo', Bank=1, OutputWorkspace='nop')
+                          Bank=1, OutputWorkspace='nop')
 
-        # Wrong filename
+        # Mispelled InputWorkspace prop
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          File='foo_is_not_there', Bank=1, OutputWorkspace='nop')
+                          InputWrkspace='anything_goes', Bank=1, OutputWorkspace='nop')
+
+        # Wrong InputWorkspace name
+        self.assertRaises(ValueError,
+                          EnginXFocus,
+                          InputWorkspace='foo_is_not_there', Bank=1, OutputWorkspace='nop')
 
         # mispelled bank
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          Filename='ENGINX00228061.nxs', bnk='2', OutputWorkspace='nop')
+                          InputWorkspace=self.__class__._data_ws, bnk='2', OutputWorkspace='nop')
 
         # mispelled DetectorsPosition
         tbl = CreateEmptyTableWorkspace()
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          Filename='ENGINX00228061.nxs', Detectors=tbl, OutputWorkspace='nop')
+                          InputWorkspace=self.__class__._data_ws, Detectors=tbl, OutputWorkspace='nop')
 
 
     def _check_output_ok(self, ws, ws_name='', y_dim_max=1, yvalues=None):
@@ -72,7 +93,7 @@ class EnginXFocusTest(unittest.TestCase):
         """
 
         out_name = 'out'
-        out = EnginXFocus(Filename='ENGINX00228061.nxs', Bank=1, OutputWorkspace=out_name)
+        out = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank=1, OutputWorkspace=out_name)
 
         yvals = [0.0037582279159681957, 0.00751645583194, 0.0231963801368, 0.0720786940576,
                  0.0615909620868, 0.00987979301753]
@@ -85,7 +106,7 @@ class EnginXFocusTest(unittest.TestCase):
         """
 
         out_name = 'out_bank2'
-        out_bank2 = EnginXFocus(Filename="ENGINX00228061.nxs", Bank=2,
+        out_bank2 = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank=2,
                                 OutputWorkspace=out_name)
 
         yvals = [0, 0.0112746837479, 0.0394536605073, 0.0362013481777,

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -6,19 +6,14 @@ class EnginXFocusTest(unittest.TestCase):
 
     _data_ws = None
 
-    @classmethod
-    def setUpClass(cls):
+    # Note not using @classmethod setUpClass / tearDownClass because that's not supported in the old
+    # unittest of rhel6
+    def setUp(self):
         """
         Set up dependencies for one or more of the tests below.
         """
-        cls._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
-
-    @classmethod
-    def tearDownClass(cls):
-        """
-        Clean up tasks complementary to setUp, like removing workspaces
-        """
-        DeleteWorkspace(cls._data_ws)
+        if not self.__class__._data_ws:
+            self.__class__._data_ws = LoadNexus("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
 
     def test_wrong_properties(self):
         """

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
@@ -10,11 +10,13 @@ class EnginXCalibrateTest(stresstesting.MantidStressTest):
         self.zero = -1
 
     def runTest(self):
-        positions = EnginXCalibrateFull(Filename = 'ENGINX00193749.nxs',
+        calib_ws = Load(Filename = 'ENGINX00193749.nxs')
+
+        positions = EnginXCalibrateFull(InputWorkspace = calib_ws,
                                       Bank = 1,
                                       ExpectedPeaks = '1.3529, 1.6316, 1.9132')
 
-        (self.difc, self.zero) = EnginXCalibrate(Filename = 'ENGINX00193749.nxs',
+        (self.difc, self.zero) = EnginXCalibrate(InputWorkspace = calib_ws,
                                                Bank = 1,
                                                ExpectedPeaks = '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
                                                DetectorPositions = positions)

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrate-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrate-v1.rst
@@ -18,10 +18,12 @@ Description
 Utilises :ref:`algm-EnginXFocus` which performs a TOF to dSpacing
 conversion using calibrated pixel positions, focuses the values in
 dSpacing and then converts them back to TOF.
-Then calls :ref:`algm-EnginXFitPeaks` which through a sequence of peak
-fits determines a linear relationship between dSpacing and measured
-TOF values in terms of DIFC and ZERO values and provides the these
-parameters to the Calibrate algorithm.
+
+Then this algorithm calls :ref:`algm-EnginXFitPeaks` (as a child
+algorithm) which through a sequence of peak fits determines a linear
+relationship between dSpacing and measured TOF values in terms of DIFC
+and ZERO values and provides the these parameters to the Calibrate
+algorithm.
 
 This algorithm provides an indirect calibration of the sample
 position, that is, a calibration returned in terms of Difc and Zero
@@ -45,7 +47,9 @@ Usage
 .. testcode:: ExampleCalib
 
    out_tbl_name = 'out_params'
-   Difc, Zero = EnginXCalibrate(Filename="ENGINX00213855.nxs",
+   ws_name = 'test'
+   Load('ENGINX00213855.nxs', OutputWorkspace=ws_name)
+   Difc, Zero = EnginXCalibrate(InputWorkspace=ws_name,
                                 ExpectedPeaks=[1.097, 2.1], Bank=1,
                                 OutputParametersTableName=out_tbl_name)
 
@@ -58,6 +62,7 @@ Usage
 .. testcleanup:: ExampleCalib
 
    DeleteWorkspace(out_tbl_name)
+   DeleteWorkspace(ws_name)
 
 Output:
 

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
@@ -39,18 +39,24 @@ Usage
 
 **Example - Calculate Difc and Zero:**
 
-.. testcode:: Ex
+.. testcode:: ExCalFull
 
-   table = EnginXCalibrateFull(Filename="ENGINX00213855focussed.nxs",
-                                     ExpectedPeaks=[1.097, 2.1], Bank=1)
+   ws_name = 'ws_focussed'
+   Load('ENGINX00213855focussed.nxs', OutputWorkspace=ws_name)
+   table = EnginXCalibrateFull(InputWorkspace=ws_name,
+                               ExpectedPeaks=[1.097, 2.1], Bank=1)
 
    pos =  table.column(1)[0]
    print "Det ID:", table.column(0)[0]
    print "Calibrated position: (%.3f,%.3f,%.3f)" % (pos.getX(),pos.getY(),pos.getZ())
 
+.. testcleanup:: ExCalFull
+
+   DeleteWorkspace(ws_name)
+
 Output:
 
-.. testoutput:: Ex
+.. testoutput:: ExCalFull
 
    Det ID: 100001
    Calibrated position: (1.506,0.000,0.002)

--- a/Code/Mantid/docs/source/algorithms/EnginXFocus-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXFocus-v1.rst
@@ -14,10 +14,10 @@ Description
    This algorithm is being developed for a specific instrument. It might get changed or even 
    removed without a notification, should instrument scientists decide to do so.
 
-Performs a TOF to dSpacing conversion using calibrated pixel
-positions, focuses the values in dSpacing and then converts them back
-to TOF. The output workspace produced by this algorithm has one
-spectrum.
+Performs a Time-of-flight (TOF) to dSpacing conversion using
+calibrated pixel positions, focuses the values in dSpacing (summing
+them up into a single spectrum) and then converts them back to
+TOF. The output workspace produced by this algorithm has one spectrum.
 
 Usage
 -----
@@ -26,11 +26,12 @@ Usage
 
 **Example - Simple focussing of and EnginX data file:**
 
-.. testcode:: ExSimple
+.. testcode:: ExSimpleFocussing
 
    # Run the algorithm
-   ws = EnginXFocus(Filename="ENGINX00213855.nxs",
-   			   		Bank=1)
+   ws_name = 'data_ws'
+   Load('ENGINX00213855.nxs', OutputWorkspace=ws_name)
+   ws = EnginXFocus(InputWorkspace=ws_name, Bank=1)
 
    # Should have one spectrum only
    print "No. of spectra:", ws.getNumberHistograms()
@@ -40,9 +41,13 @@ Usage
    for bin in [3169, 6037, 7124]:
      print fmt.format(ws.readX(0)[bin], ws.readY(0)[bin])
 
+.. testcleanup:: ExSimpleFocussing
+
+   DeleteWorkspace(ws_name)
+
 Output:
 
-.. testoutput:: ExSimple
+.. testoutput:: ExSimpleFocussing
 
    No. of spectra: 1
    For TOF of 20165.642 intensity is 7.436


### PR DESCRIPTION
This fixes #12926.

**To test**:
- If tests pass, we are safe. They also go a bit faster, as files are loaded only once.
- Code review.
