### PR TITLE
Keep errors after fit in BaselineModelling step

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
@@ -84,6 +84,9 @@ namespace CustomInterfaces
     void setCorrectedData(MatrixWorkspace_const_sptr data);
     void setFittedFunction(IFunction_const_sptr function);
 
+    // Set errors in the ws after the fit
+    void setErrorsAfterFit(MatrixWorkspace_sptr data);
+
     /// Disables points which shouldn't be used for fitting
     static void disableUnwantedPoints(MatrixWorkspace_sptr ws, const std::vector<Section>& sections);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -44,6 +44,7 @@ namespace CustomInterfaces
     m_parameterTable = fit->getProperty("OutputParameters");
 
     enableDisabledPoints(fitOutput,m_data);
+    setErrorsAfterFit(fitOutput);
 
     setCorrectedData(fitOutput);
     setFittedFunction(funcToFit);
@@ -107,6 +108,15 @@ namespace CustomInterfaces
     // Unwanted points were disabled by setting their errors to very high values.
     // We recover here the original errors stored in sourceWs
     destWs->dataE(0) = sourceWs->readE(0);
+  }
+
+  /**
+   * Set errors in Diff spectrum after a fit
+   * @param data :: [input/output] Workspace containing spectrum to set errors to
+   */
+  void ALCBaselineModellingModel::setErrorsAfterFit (MatrixWorkspace_sptr data) {
+
+    data->dataE(2)=data->readE(0);
   }
 
   MatrixWorkspace_sptr ALCBaselineModellingModel::exportWorkspace()

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -93,8 +93,8 @@ public:
     if (fittedFunc)
     {
       TS_ASSERT_EQUALS(fittedFunc->name(), "FlatBackground");
-      TS_ASSERT_DELTA(fittedFunc->getParameter("A0"), 2.35714, 1E-5);
-      TS_ASSERT_DELTA(fittedFunc->getError(0),0.53452,1E-5);
+      TS_ASSERT_DELTA(fittedFunc->getParameter("A0"), 2.13979, 1E-5);
+      TS_ASSERT_DELTA(fittedFunc->getError(0),0.66709,1E-5);
     }
 
     MatrixWorkspace_const_sptr corrected = m_model->correctedData();
@@ -105,10 +105,10 @@ public:
       TS_ASSERT_EQUALS(corrected->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(corrected->blocksize(), 9);
 
-      TS_ASSERT_DELTA(corrected->readY(0)[0], 97.64285, 1E-5);
-      TS_ASSERT_DELTA(corrected->readY(0)[2], -0.35714, 1E-5);
-      TS_ASSERT_DELTA(corrected->readY(0)[5], 0.64285, 1E-5);
-      TS_ASSERT_DELTA(corrected->readY(0)[8], 97.64285, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[0], 97.86021, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[2], -0.13979, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[5], 0.86021, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[8], 97.86021, 1E-5);
 
       TS_ASSERT_EQUALS (corrected->readE(0), data->readE(0));
     }
@@ -124,12 +124,11 @@ public:
 
       // Check table entries
       TS_ASSERT_EQUALS(parameters->String(0,0), "A0");
-      TS_ASSERT_DELTA (parameters->Double(0,1), 2.35714, 1E-5);
-      TS_ASSERT_DELTA (parameters->Double(0,2), 0.53452, 1E-5);
+      TS_ASSERT_DELTA (parameters->Double(0,1), 2.13978, 1E-5);
+      TS_ASSERT_DELTA (parameters->Double(0,2), 0.66709, 1E-5);
       TS_ASSERT_EQUALS(parameters->String(1,0), "Cost function value");
-      TS_ASSERT_DELTA (parameters->Double(1,1), 0.60044, 1E-5);
+      TS_ASSERT_DELTA (parameters->Double(1,1), 0.46627, 1E-5);
       TS_ASSERT_EQUALS(parameters->Double(1,2), 0);
-
     }
 
     TS_ASSERT_EQUALS(m_model->sections(), sections);

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -109,6 +109,8 @@ public:
       TS_ASSERT_DELTA(corrected->readY(0)[2], -0.35714, 1E-5);
       TS_ASSERT_DELTA(corrected->readY(0)[5], 0.64285, 1E-5);
       TS_ASSERT_DELTA(corrected->readY(0)[8], 97.64285, 1E-5);
+
+      TS_ASSERT_EQUALS (corrected->readE(0), data->readE(0));
     }
 
     ITableWorkspace_sptr parameters = m_model->parameterTable();

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -67,7 +67,7 @@ public:
 
   void test_fit()
   {
-    std::vector<double> e = boost::assign::list_of(10)(1)(1.41)(10)(10)(1.73)(2)(2.5)(10);
+    std::vector<double> e = boost::assign::list_of(10.0)(1.0)(1.41)(10.0)(10.0)(1.73)(2.0)(2.5)(10.0);
     std::vector<double> y = boost::assign::list_of(100)(1)(2)(100)(100)(3)(4)(5)(100);
     std::vector<double> x = boost::assign::list_of(1)(2)(3)(4)(5)(6)(7)(8)(9);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingModelTest.h
@@ -67,10 +67,12 @@ public:
 
   void test_fit()
   {
+    std::vector<double> e = boost::assign::list_of(10)(1)(1.41)(10)(10)(1.73)(2)(2.5)(10);
     std::vector<double> y = boost::assign::list_of(100)(1)(2)(100)(100)(3)(4)(5)(100);
     std::vector<double> x = boost::assign::list_of(1)(2)(3)(4)(5)(6)(7)(8)(9);
 
     MatrixWorkspace_sptr data = WorkspaceFactory::Instance().create("Workspace2D", 1, y.size(), y.size());
+    data->dataE(0) = e;
     data->dataY(0) = y;
     data->dataX(0) = x;
 
@@ -91,8 +93,8 @@ public:
     if (fittedFunc)
     {
       TS_ASSERT_EQUALS(fittedFunc->name(), "FlatBackground");
-      TS_ASSERT_DELTA(fittedFunc->getParameter("A0"), 3, 1E-8);
-      TS_ASSERT_DELTA(fittedFunc->getError(0),0.447214,1E-6);
+      TS_ASSERT_DELTA(fittedFunc->getParameter("A0"), 2.35714, 1E-5);
+      TS_ASSERT_DELTA(fittedFunc->getError(0),0.53452,1E-5);
     }
 
     MatrixWorkspace_const_sptr corrected = m_model->correctedData();
@@ -103,10 +105,10 @@ public:
       TS_ASSERT_EQUALS(corrected->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(corrected->blocksize(), 9);
 
-      TS_ASSERT_DELTA(corrected->readY(0)[0], 97, 1E-8);
-      TS_ASSERT_DELTA(corrected->readY(0)[2], -1, 1E-8);
-      TS_ASSERT_DELTA(corrected->readY(0)[5], 0.0, 1E-8);
-      TS_ASSERT_DELTA(corrected->readY(0)[8], 97, 1E-8);
+      TS_ASSERT_DELTA(corrected->readY(0)[0], 97.64285, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[2], -0.35714, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[5], 0.64285, 1E-5);
+      TS_ASSERT_DELTA(corrected->readY(0)[8], 97.64285, 1E-5);
     }
 
     ITableWorkspace_sptr parameters = m_model->parameterTable();
@@ -120,11 +122,12 @@ public:
 
       // Check table entries
       TS_ASSERT_EQUALS(parameters->String(0,0), "A0");
-      TS_ASSERT_EQUALS(parameters->Double(0,1), 3);
-      TS_ASSERT_DELTA (parameters->Double(0,2), 0.447214,1E-6);
+      TS_ASSERT_DELTA (parameters->Double(0,1), 2.35714, 1E-5);
+      TS_ASSERT_DELTA (parameters->Double(0,2), 0.53452, 1E-5);
       TS_ASSERT_EQUALS(parameters->String(1,0), "Cost function value");
-      TS_ASSERT_DELTA (parameters->Double(1,1), 1.250000,1E-6);
+      TS_ASSERT_DELTA (parameters->Double(1,1), 0.60044, 1E-5);
       TS_ASSERT_EQUALS(parameters->Double(1,2), 0);
+
     }
 
     TS_ASSERT_EQUALS(m_model->sections(), sections);


### PR DESCRIPTION
Fixes #12907 

In the BaselineModelling step the user fits a baseline model than then subtracts from the original data. The new data corresponds to the `Diff` spectrum resulting from the `Fit` algorithm in Mantid, which has no errors. In the specific case of the ALC interface, errors should be kept, which means copying the original errors to the `Diff` spectrum (the third spectrum in the output ws).

Tester: I think code review should be enough, as I have added a unit test to check that errors in the corrected data match the errors in the original ws. However, you can also test this manually by loading some runs (for instance "MUSR00015189.nxs" to "MUSR00015193.nxs"), fitting a baseline (a FlatBackground should be enough) and checking that data in the "PeakFitting" step have errors.

Release notes have been updated: http://www.mantidproject.org/index.php?title=Release_Notes_3_5_MuonAnalysis&diff=24318&oldid=24301
