### PR TITLE
Fixes #12924 Separate functions to load Embedded IDF and load Embedded Parameters

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -121,6 +121,8 @@ public:
   virtual void loadExperimentInfoNexus(const std::string& nxFilename, ::NeXus::File *file, std::string &parameterStr);
   /// Load the instrument from an open NeXus file.
   virtual void loadInstrumentInfoNexus(const std::string& nxFilename, ::NeXus::File *file, std::string &parameterStr);
+  /// Load instrument parameters from an open Nexus file in Instument group if found there
+  virtual void loadInstrumentParametersNexus ( ::NeXus::File *file, std::string &parameterStr);
 
   /// Load the sample and log info from an open NeXus file.
   virtual void loadSampleAndLogInfoNexus(::NeXus::File *file);

--- a/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
+++ b/Code/Mantid/Framework/API/src/ExperimentInfo.cpp
@@ -973,14 +973,9 @@ void ExperimentInfo::loadInstrumentInfoNexus(const std::string& nxFilename,
     g_log.debug(std::string("Unable to load instrument_xml: ") + ex.what());
   }
 
-  try {
-    file->openGroup("instrument_parameter_map", "NXnote");
-    file->readData("data", parameterStr);
-    file->closeGroup();
-  } catch (NeXus::Exception &ex) {
-    g_log.debug(std::string("Unable to load instrument_parameter_map: ") + ex.what());
-    g_log.information("Parameter map entry missing from NeXus file. Continuing without it.");
-  }
+  // load parameters if found
+  loadInstrumentParametersNexus( file, parameterStr );
+
   // Close the instrument group
   file->closeGroup();
 
@@ -1040,6 +1035,27 @@ std::string ExperimentInfo::loadInstrumentXML(const std::string &filename) {
     g_log.debug() << e.what() << std::endl;
     throw;
   }
+}
+
+//--------------------------------------------------------------------------------------------
+/** Load the instrument parameters from an open NeXus file if found there.
+ * @param file :: open NeXus file in its Instrument group
+ * @param[out] parameterStr :: special string for all the parameters.
+ *             Feed that to ExperimentInfo::readParameterMap() after the
+ * instrument is done.
+ */
+void ExperimentInfo::loadInstrumentParametersNexus( ::NeXus::File *file, 
+                                                    std::string &parameterStr) {
+  try 
+  {
+    file->openGroup("instrument_parameter_map", "NXnote");
+    file->readData("data", parameterStr);
+    file->closeGroup();
+  } catch (NeXus::Exception &ex) {
+    g_log.debug(std::string("Unable to load instrument_parameter_map: ") + ex.what());
+    g_log.information("Parameter map entry missing from NeXus file. Continuing without it.");
+  }
+
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Code/Mantid/Framework/API/test/ExperimentInfoTest.h
+++ b/Code/Mantid/Framework/API/test/ExperimentInfoTest.h
@@ -698,7 +698,7 @@ public:
     std::string path = FileFinder::Instance().getFullPath(testFile);
 
    
-    // Get nexus file for this and move it to ISIS Nexus group 'raw_data_1'
+    // Get nexus file for this. 
     ::NeXus::File nxFile(path, NXACC_READ);
 
     // Load the Nexus IDF info
@@ -706,6 +706,30 @@ public:
     TS_ASSERT_THROWS_NOTHING(ei.loadInstrumentInfoNexus( testFile, &nxFile, params));
     Instrument_const_sptr inst = ei.getInstrument();
     TS_ASSERT_EQUALS( inst->getName(), "LOQ" );  // Check instrument name
+    TS_ASSERT_EQUALS( params.size() , 613 );     // Check size of parameter string
+
+  }
+
+  void test_nexus_parameters()
+  {
+     ExperimentInfo ei;
+
+    // We get an instrument group from a test file in the form that would occur in an ISIS Nexus file
+    // with an embedded instrument definition and parameters
+
+    // Create the root Nexus class
+    std::string testFile = "LOQinstrument.h5";
+    std::string path = FileFinder::Instance().getFullPath(testFile);
+
+   
+    // Get nexus file for this.
+    ::NeXus::File nxFile(path, NXACC_READ);
+    // Open instrument group
+    nxFile.openGroup("instrument", "NXinstrument");
+
+    // Load the Nexus IDF info
+    std::string params;
+    TS_ASSERT_THROWS_NOTHING(ei.loadInstrumentParametersNexus(&nxFile, params));
     TS_ASSERT_EQUALS( params.size() , 613 );     // Check size of parameter string
 
   }


### PR DESCRIPTION
This change in the core is a step in ticket #12255 . To test, ensure code is reviewed by a senior developer and that it is a good implementation of step 2 of the work plan of issue 12255 in the context of the other steps.

(1) Unit test ExperminentInfo.loadInstrumentInfoNexus (http://trac.mantidproject.org/mantid/ticket/11719). #12557 

(2) Make separate functions to Load embedded IDF and Load embedded parameters (currently both done together by ExperminentInfo.loadInstrumentInfoNexus). 

(3) Make one function to Load embedded parameters or if not found load parameter file. This is currently done separately in ExperminentInfo.loadInstrumentInfoNexus and LoadIDFFromNexus.

(4) Function or code to search for and find the XML file that has the corrections to parameters in it, henceforth referred to as the correction file. This must not take a long time if no such file exists.

(5) Function or Algorithm to read the correction file and output a filename & append flag as required.

(6) Code that makes use of the products of the previous steps to implement the ticket in each loader that may make use on an embedded IDF (may be one step per loader).
