### PR TITLE
DiffCalFile bugfixes

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -245,8 +245,9 @@ void LoadDiffCal::makeMaskWorkspace(const std::vector<int32_t> &detids, const st
     for (size_t i=0; i<numDet; ++i) {
         bool shouldUse = (use[i] > 0);
         detid_t detid = static_cast<detid_t>(detids[i]);
-        wksp->setMasked(detid, shouldUse);
-        wksp->setValue(detid, (shouldUse ? 1. : 0.));
+        // in maskworkspace 0=use, 1=dontuse
+        wksp->setMasked(detid, !shouldUse);
+        wksp->setValue(detid, (shouldUse ? 0. : 1.));
         progress.report();
     }
 

--- a/Code/Mantid/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -183,24 +183,35 @@ void SaveDiffCal::writeIntFieldFromTable(H5::Group &group,
   writeArray(group, name, std::vector<int32_t>(data));
 }
 
+// TODO should flip for mask
 void SaveDiffCal::writeIntFieldFromSVWS(
     H5::Group &group, const std::string &name,
     DataObjects::SpecialWorkspace2D_const_sptr ws) {
   auto detidCol = m_calibrationWS->getColumn("detid");
   std::vector<detid_t> detids;
   detidCol->numeric_fill(detids);
+  bool isMask = bool(boost::dynamic_pointer_cast<const MaskWorkspace>(ws));
 
   // output array defaults to all one (one group, use the pixel)
-  const int32_t DEFAULT_VALUE = 1;
+  const int32_t DEFAULT_VALUE = (isMask ? 0 : 1);
   std::vector<int32_t> values(detids.size(), DEFAULT_VALUE);
 
   size_t numSpectra = ws->size();
+  int32_t value;
   for (size_t i = 0; i < numSpectra; ++i) {
     auto spectrum = ws->getSpectrum(i);
     auto ids = spectrum->getDetectorIDs();
     auto found = m_detidToIndex.find(*(ids.begin()));
     if (found != m_detidToIndex.end()) {
-      values[found->second] = static_cast<int32_t>(ws->getValue(found->first));
+      value = static_cast<int32_t>(ws->getValue(found->first));
+      // in maskworkspace 0=use, 1=dontuse
+      if (isMask) {
+        if (value == 0)
+          value = 1;
+        else
+          value = 0;
+      }
+      values[found->second] = value;
     }
   }
 


### PR DESCRIPTION
Fixing meaning of mask versus use. By definition, `bool(mask) = !bool(use)`. This is really just a code review and doesn't need to be in the release notes.

Please note that mask/delete data has a value of one, where keeping the data has a value of zero.
