### PR TITLE
BinaryOperateMasks POWGEN bug

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/BinaryOperateMasks.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/BinaryOperateMasks.cpp
@@ -64,14 +64,13 @@ void BinaryOperateMasks::exec() {
   std::string op = getProperty("OperationType");
 
   // 2. Output
-  Mantid::DataObjects::MaskWorkspace_sptr outputws =
+  DataObjects::MaskWorkspace_sptr outputws =
       getProperty("OutputWorkspace");
 
   if (outputws != inputws1) {
     // if the input and output are not the same, then create a new workspace for
     // the output.
-    outputws = boost::dynamic_pointer_cast<DataObjects::MaskWorkspace>(
-        API::WorkspaceFactory::Instance().create(inputws1));
+    outputws = boost::make_shared<DataObjects::MaskWorkspace>(inputws1->getInstrument());
     outputws->copyFrom(inputws1);
   }
 


### PR DESCRIPTION
By using constructing the `MaskWorkspace` differently, the visual artifacts are gone. I think the original bug was just in the representation rather than just the data. This does not need to be in the release notes.

**To test:** There is a script and a file file below to use to see that things are indeed working. Look at the various `MaskWorkspace`s to see that things look how you expect.

``` python
LoadCalFile(InstrumentName="POWGEN",
            CalFilename="/SNS/PG3/IPTS-2767/shared/2015_1_11A_CAL/PG3_AGES_d22504_2015_02_25.cal",
            MakeGroupingWorkspace=False, MakeOffsetsWorkspace=False,
            MakeMaskWorkspace=True, WorkspaceName="PG3")
LoadMask(Instrument="POWGEN", InputFile="/location/of/powgen_mask.xml",
         OutputWorkspace="PG3_xml")
BinaryOperateMasks(InputWorkspace1="PG3_mask", OperationType="NOT",
                   OutputWorkspace="NOT")
BinaryOperateMasks(InputWorkspace1="PG3_mask", InputWorkspace2="PG3_xml",
                   OperationType="AND", OutputWorkspace="AND")
BinaryOperateMasks(InputWorkspace1="PG3_mask", InputWorkspace2="PG3_xml",
                   OperationType="OR", OutputWorkspace="OR")
BinaryOperateMasks(InputWorkspace1="PG3_mask", InputWorkspace2="PG3_xml",
                   OperationType="XOR", OutputWorkspace="XOR")
```

filename: powgen_mask.xml

``` xml
<?xml version="1.0" encoding="UTF-8" ?>
<detector-masking>
 <group>
   <component>Group3</component>
 </group>
</detector-masking>
```
