### PR TITLE
Skip steps and re-use results

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h
@@ -57,6 +57,9 @@ namespace CustomInterfaces
     /// Set the data we should fit baseline for
     void setData(MatrixWorkspace_const_sptr data);
 
+    /// Set the corrected data resulting from fit
+    void setCorrectedData(MatrixWorkspace_const_sptr data);
+
     /// Export data + baseline + corrected data as a single workspace
     MatrixWorkspace_sptr exportWorkspace();
 
@@ -81,7 +84,6 @@ namespace CustomInterfaces
     std::vector<Section> m_sections;
 
     // Setters for convenience
-    void setCorrectedData(MatrixWorkspace_const_sptr data);
     void setFittedFunction(IFunction_const_sptr function);
 
     /// Disables points which shouldn't be used for fitting

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
@@ -50,6 +50,9 @@ namespace CustomInterfaces
     /// @return Loaded data as MatrixWorkspace_sptr
     MatrixWorkspace_sptr exportWorkspace();
 
+    /// Sets some data
+    void setData (MatrixWorkspace_const_sptr data);
+
   private slots:
     /// Load new data and update the view accordingly
     void load();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
@@ -5,13 +5,6 @@
 
 #include "MantidQtCustomInterfaces/DllConfig.h"
 
-#include "MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h"
-#include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h"
-#include "MantidQtCustomInterfaces/Muon/ALCPeakFittingPresenter.h"
-
-#include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h"
-#include "MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h"
-
 #include "MantidQtAPI/UserSubWindow.h"
 
 #include "ui_ALCInterface.h"
@@ -22,6 +15,14 @@ namespace MantidQt
 {
 namespace CustomInterfaces
 {
+
+  class ALCDataLoadingPresenter;
+
+  class ALCBaselineModellingPresenter;
+  class ALCBaselineModellingModel;
+
+  class ALCPeakFittingPresenter;
+  class ALCPeakFittingModel;
 
   /** ALCInterface : Custom interface for Avoided Level Crossing analysis
     

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
@@ -65,6 +65,7 @@ namespace CustomInterfaces
     void switchStep(int newStepIndex);
 
     void exportResults();
+    void importResults();
 
   private:
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.ui
@@ -83,14 +83,21 @@
      </item>
      <item row="0" column="0">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
+        <item>
         <widget class="QPushButton" name="previousStep">
          <property name="text">
           <string>%PREV%</string>
          </property>
         </widget>
        </item>
-       <item>
+        <item>
+          <widget class="QPushButton" name="importResults">
+            <property name="text">
+              <string>Import results...</string>
+            </property>
+          </widget>
+        </item>
+        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -196,11 +196,17 @@ namespace CustomInterfaces
    }
 
    void ALCDataLoadingPresenter::setData(MatrixWorkspace_const_sptr data) {
-     // Set the data
-     m_loadedData = data;
-     // Plot the data
-     m_view->setDataCurve(*(ALCHelper::curveDataFromWs(m_loadedData, 0)),
-                           ALCHelper::curveErrorsFromWs(m_loadedData, 0));
+
+     if (data) {
+       // Set the data
+       m_loadedData = data;
+       // Plot the data
+       m_view->setDataCurve(*(ALCHelper::curveDataFromWs(m_loadedData, 0)),
+         ALCHelper::curveErrorsFromWs(m_loadedData, 0));
+
+     } else {
+       std::invalid_argument("Cannot load an empty workspace");
+     }
    }
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -195,5 +195,12 @@ namespace CustomInterfaces
     }
    }
 
+   void ALCDataLoadingPresenter::setData(MatrixWorkspace_const_sptr data) {
+     // Set the data
+     m_loadedData = data;
+     // Plot the data
+     m_view->setDataCurve(*(ALCHelper::curveDataFromWs(m_loadedData, 0)),
+                           ALCHelper::curveErrorsFromWs(m_loadedData, 0));
+   }
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -238,7 +238,7 @@ namespace CustomInterfaces
     } else if (currentStep == 2) {
       // PeakFitting step
 
-      std::string wsFit = groupName + "_Peaks_FitResults";
+      std::string wsData = groupName + "_Peaks_Workspace";
 
       if (AnalysisDataService::Instance().doesExist(wsData)) {
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -39,6 +39,7 @@ namespace CustomInterfaces
     connect(m_ui.nextStep, SIGNAL(clicked()), SLOT(nextStep()));
     connect(m_ui.previousStep, SIGNAL(clicked()), SLOT(previousStep()));
     connect(m_ui.exportResults, SIGNAL(clicked()), SLOT(exportResults()));
+    connect(m_ui.importResults, SIGNAL(clicked()), SLOT(importResults()));
 
     auto dataLoadingView = new ALCDataLoadingView(m_ui.dataLoadingView);
     m_dataLoading = new ALCDataLoadingPresenter(dataLoadingView);
@@ -181,6 +182,36 @@ namespace CustomInterfaces
     } else {
       // Nothing to export, show error message
       QMessageBox::critical(this, "Error", "Nothing to export");
+    }
+  }
+
+  void ALCInterface::importResults() {
+
+    bool ok;
+    QString label = QInputDialog::getText(this, "Results label", "Label to assign to the results: ",
+      QLineEdit::Normal, "ALCResults", &ok);
+
+    if (!ok) // Cancelled
+    {
+      return;
+    }
+
+    std::string groupName = label.toStdString();
+
+    int currentStep = m_ui.stepView->currentIndex();
+
+    if (currentStep == 0) {
+      // DataLoading step
+
+    } else if (currentStep == 1) {
+      // BaselineModelling step
+
+    } else if (currentStep == 2) {
+      // PeakFitting step
+
+    } else {
+      // Exception: we can never get here
+      throw std::runtime_error("Fatal error in ALC interface");
     }
   }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -233,7 +233,9 @@ namespace CustomInterfaces
         ITableWorkspace_sptr sectionsWs =
             AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsSections);
 
-        // Do something with the retrieved workspaces
+        // Set the retrieved workspace
+        m_baselineModellingModel->setData(dataWs);
+        m_baselineModellingModel->setCorrectedData(dataWs);
 
       } else {
         // Error message

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -203,15 +203,17 @@ namespace CustomInterfaces
 
       if(AnalysisDataService::Instance().doesExist(wsData)) {
 
-        MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
+        MatrixWorkspace_sptr ws =
+            AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
 
         // Set the retrieved data
         m_dataLoading->setData(ws);
 
       } else {
         // Error message
-        QMessageBox::critical(
-            this, "Error", "Workspace *_Loaded_Data was not found");
+        QMessageBox::critical(this, "Error",
+                              "Workspace " + QString::fromStdString(wsData) +
+                                  " was not found");
       }
 
 
@@ -231,8 +233,9 @@ namespace CustomInterfaces
 
       } else {
         // Error message
-        QMessageBox::critical(
-            this, "Error", "Some of the *_Baseline_* workspaces were not found");
+        QMessageBox::critical(this, "Error",
+                              "Workspace " + QString::fromStdString(wsData) +
+                                  " was not found");
       }
 
     } else if (currentStep == 2) {
@@ -250,8 +253,9 @@ namespace CustomInterfaces
 
       } else {
         // Error message
-        QMessageBox::critical(
-            this, "Error", "Some of the *_Peaks_* workspaces were not found");
+        QMessageBox::critical(this, "Error",
+                              "Workspace " + QString::fromStdString(wsData) +
+                                  " was not found");
       }
 
     } else {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -154,16 +154,20 @@ namespace CustomInterfaces
     results["Peaks_FitResults"] = m_peakFittingModel->exportFittedPeaks();
 
     // Check if any of the above is not empty
+    bool nothingToExport = true;
     for (auto it=results.begin(); it!=results.end(); ++it) {
     
       if ( it->second ) {
-        AnalysisDataService::Instance().addOrReplace(groupName, boost::make_shared<WorkspaceGroup>());
+        nothingToExport = false;
         break;
       }
     }
 
     // There is something to export
-    if (AnalysisDataService::Instance().doesExist(groupName)) {
+    if (!nothingToExport) {
+
+      // Add output group to the ADS
+      AnalysisDataService::Instance().addOrReplace(groupName, boost::make_shared<WorkspaceGroup>());
 
       for(auto it = results.begin(); it != results.end(); ++it)
       {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -257,7 +257,8 @@ namespace CustomInterfaces
         ITableWorkspace_sptr fit =
             AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsFit);
 
-        // Do something with the retrieved workspaces
+        // Set the retrieved data
+        m_peakFittingModel->setData(data);
 
       } else {
         // Error message

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -4,6 +4,10 @@
 #include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h"
 #include "MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h"
 
+#include "MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h"
+#include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingPresenter.h"
+#include "MantidQtCustomInterfaces/Muon/ALCPeakFittingPresenter.h"
+
 #include "MantidQtCustomInterfaces/Muon/ALCBaselineModellingModel.h"
 #include "MantidQtCustomInterfaces/Muon/ALCPeakFittingModel.h"
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -205,7 +205,8 @@ namespace CustomInterfaces
 
         MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
 
-        // Do something with the retrieved workspace
+        // Set the retrieved data
+        m_dataLoading->setData(ws);
 
       } else {
         // Error message

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -71,22 +71,12 @@ namespace CustomInterfaces
       {
         m_baselineModellingModel->setData(m_dataLoading->loadedData());
       }
-      else
-      {
-        QMessageBox::critical(this, "Error", "Please load some data first");
-        return;
-      }
     }
     if (nextWidget == m_ui.peakFittingView)
     {
       if (m_baselineModellingModel->correctedData())
       {
         m_peakFittingModel->setData(m_baselineModellingModel->correctedData());
-      }
-      else
-      {
-        QMessageBox::critical(this, "Error", "Please fit a baseline first");
-        return;
       }
     }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -219,19 +219,11 @@ namespace CustomInterfaces
       // BaselineModelling step
 
       std::string wsData = groupName + "_Baseline_Workspace";
-      std::string wsModel = groupName + "_Baseline_Model";
-      std::string wsSections = groupName + "_Baseline_Sections";
 
-      if (AnalysisDataService::Instance().doesExist(wsData) &&
-          AnalysisDataService::Instance().doesExist(wsModel) &&
-          AnalysisDataService::Instance().doesExist(wsSections)) {
+      if (AnalysisDataService::Instance().doesExist(wsData)) {
 
         MatrixWorkspace_sptr dataWs =
             AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
-        ITableWorkspace_sptr modelWs =
-            AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsModel);
-        ITableWorkspace_sptr sectionsWs =
-            AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsSections);
 
         // Set the retrieved workspace
         m_baselineModellingModel->setData(dataWs);
@@ -247,15 +239,11 @@ namespace CustomInterfaces
       // PeakFitting step
 
       std::string wsFit = groupName + "_Peaks_FitResults";
-      std::string wsData = groupName + "_Peaks_Workspace";
 
-      if (AnalysisDataService::Instance().doesExist(wsData) &&
-          AnalysisDataService::Instance().doesExist(wsFit)) {
+      if (AnalysisDataService::Instance().doesExist(wsData)) {
 
         MatrixWorkspace_sptr data =
             AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
-        ITableWorkspace_sptr fit =
-            AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsFit);
 
         // Set the retrieved data
         m_peakFittingModel->setData(data);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -265,10 +265,10 @@ namespace CustomInterfaces
             AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
 
         // Check that ws contains one spectrum only
-        if (data->getNumberHistograms() != 1) {
+        if (data->getNumberHistograms() < 3) {
           QMessageBox::critical(this, "Error",
                                 "Workspace " + QString::fromStdString(wsData) +
-                                    " must contain one spectrum only");
+                                    " must contain at least three spectra");
           return;
         }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -188,16 +188,75 @@ namespace CustomInterfaces
 
     std::string groupName = label.toStdString();
 
+    using namespace Mantid::API;
+
     int currentStep = m_ui.stepView->currentIndex();
 
     if (currentStep == 0) {
       // DataLoading step
 
+      std::string wsData = groupName + "_Loaded_Data";
+
+      if(AnalysisDataService::Instance().doesExist(wsData)) {
+
+        MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
+
+        // Do something with the retrieved workspace
+
+      } else {
+        // Error message
+        QMessageBox::critical(
+            this, "Error", "Workspace *_Loaded_Data was not found");
+      }
+
+
     } else if (currentStep == 1) {
       // BaselineModelling step
 
+      std::string wsData = groupName + "_Baseline_Workspace";
+      std::string wsModel = groupName + "_Baseline_Model";
+      std::string wsSections = groupName + "_Baseline_Sections";
+
+      if (AnalysisDataService::Instance().doesExist(wsData) &&
+          AnalysisDataService::Instance().doesExist(wsModel) &&
+          AnalysisDataService::Instance().doesExist(wsSections)) {
+
+        MatrixWorkspace_sptr dataWs =
+            AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
+        ITableWorkspace_sptr modelWs =
+            AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsModel);
+        ITableWorkspace_sptr sectionsWs =
+            AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsSections);
+
+        // Do something with the retrieved workspaces
+
+      } else {
+        // Error message
+        QMessageBox::critical(
+            this, "Error", "Some of the *_Baseline_* workspaces were not found");
+      }
+
     } else if (currentStep == 2) {
       // PeakFitting step
+
+      std::string wsFit = groupName + "_Peaks_FitResults";
+      std::string wsData = groupName + "_Peaks_Workspace";
+
+      if (AnalysisDataService::Instance().doesExist(wsData) &&
+          AnalysisDataService::Instance().doesExist(wsFit)) {
+
+        MatrixWorkspace_sptr data =
+            AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
+        ITableWorkspace_sptr fit =
+            AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(wsFit);
+
+        // Do something with the retrieved workspaces
+
+      } else {
+        // Error message
+        QMessageBox::critical(
+            this, "Error", "Some of the *_Peaks_* workspaces were not found");
+      }
 
     } else {
       // Exception: we can never get here

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -206,6 +206,14 @@ namespace CustomInterfaces
         MatrixWorkspace_sptr ws =
             AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
 
+        // Check that ws contains one spectrum only
+        if (ws->getNumberHistograms() != 1) {
+          QMessageBox::critical(this, "Error",
+                                "Workspace " + QString::fromStdString(wsData) +
+                                    " must contain one spectrum only");
+          return;
+        }
+
         // Set the retrieved data
         m_dataLoading->setData(ws);
 
@@ -227,6 +235,14 @@ namespace CustomInterfaces
         MatrixWorkspace_sptr dataWs =
             AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
 
+        // Check that ws contains three spectra
+        if (dataWs->getNumberHistograms() != 3) {
+          QMessageBox::critical(this, "Error",
+                                "Workspace " + QString::fromStdString(wsData) +
+                                    " must contain three spectra");
+          return;
+        }
+
         // Set the retrieved workspace
         m_baselineModellingModel->setData(dataWs);
         m_baselineModellingModel->setCorrectedData(dataWs);
@@ -247,6 +263,14 @@ namespace CustomInterfaces
 
         MatrixWorkspace_sptr data =
             AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsData);
+
+        // Check that ws contains one spectrum only
+        if (data->getNumberHistograms() != 1) {
+          QMessageBox::critical(this, "Error",
+                                "Workspace " + QString::fromStdString(wsData) +
+                                    " must contain one spectrum only");
+          return;
+        }
 
         // Set the retrieved data
         m_peakFittingModel->setData(data);

--- a/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
+++ b/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
@@ -98,7 +98,8 @@ Import Results
 ~~~~~~~~~~~~~~
 
 The 'Import results...' button allows the user to load previously analysed data, ideally saved using
-'Export results...'. When clicked, this button searches for a workspace corresponding to the
+'Export results...'. When clicked, it propmts the user to enter a label for the workspace group from which
+data will be imported, which is defaulted to 'ALCResults'. The interface then searches for a workspace corresponding to the
 interface's step from which it was called. This means that if the user is currently in the
 DataLoading step, the interface will search for a workspace named <Label>_Loaded_Data. If
 it is used from the BaselineModelling step, the workspace named <Label>_Baseline_Workspace

--- a/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
+++ b/Code/Mantid/docs/source/interfaces/Muon_ALC.rst
@@ -60,6 +60,55 @@ necessary to determine a baseline, perform a baseline subtraction and then
 fit the peaks. The Muon ALC interface integrates this sequence of
 operations hiding the complexity of the underlying algorithms.
 
+Global Options
+--------------
+
+Gloabl options are options visible and accesible from any step in the
+interface. Currently, there are two buttons that can be used at any point during the analysis.
+
+Export Results
+~~~~~~~~~~~~~~
+
+The 'Export results...' button allows the user to export intermediate results at any step. When clicked,
+it propmts the user to enter a label for the workspace group that will gather the ALC results. This
+label is defaulted to 'ALCResults'. In the DataLoading step, data are exported in a workspace named
+<Label>_Loaded_Data, which contains a single spectrum. In the BaselineModelling step, data and model
+are exported in a set of three workspaces: a workspace named <Label>_Baseline_Workspace, which contains
+three spectra corresponding to the original data, model and corrected data respectively, a TableWorkspace
+named <Label>_Baseline_Model with information on the fitting parameters, and a second TableWorkspace
+named <Label>_Baseline_Sections containing information on the sections used to fit the baseline. When
+exporting results in the PeakFitting steps, two workspaces will be created: a <Label>_Peaks_Workspace,
+that contains at least three spectra: the corrected data (i.e., the data after the baseline model
+subtraction), fitting function and difference curve. If more than one peak was fitted, individual peaks
+will be stored in subsequent spectra. The <Label>_Peaks_FitResults TableWorkspace provides information
+about the fitting parameters and errors.
+
+Note that the 'Export results...' button exports as much information as possible, which means that all
+the data stored in the interface will be exported when clicked, regardless of the current step. For
+example, if the user starts a new analysis and the button is used in the 'DataLoading' step, only the
+<Label>_Loaded_Data workspace will be created in the ADS. However, if the user proceeds with the analysis
+and clicks 'Export results...' at the 'BaselineModelling' step, the interface will export not only the
+<Label>_Baseline_* workspaces but also the <Label>_Loaded_Data workspace. In the same way, if the user
+has completed the peak fitting analysis and uses the button in the PeakFitting step, not only the
+<Label>_Peaks_* workspaces will be created, but also the <Label>_Baseline_* and the <Label>_Loaded_Data
+workspaces. Also, note that if 'Export results...' is used at a specific step but results from a previous
+analysis exist in a subsequent stage of the analysis, the latter will be exported as well.
+
+Import Results
+~~~~~~~~~~~~~~
+
+The 'Import results...' button allows the user to load previously analysed data, ideally saved using
+'Export results...'. When clicked, this button searches for a workspace corresponding to the
+interface's step from which it was called. This means that if the user is currently in the
+DataLoading step, the interface will search for a workspace named <Label>_Loaded_Data. If
+it is used from the BaselineModelling step, the workspace named <Label>_Baseline_Workspace
+will be loaded. Finally, if PeakFitting is the current step in the analysis, the workspace
+<Label>_Peaks_Workspaces will be imported. Note that using the 'Import results...' button
+at a specific step does not produce the loading of data corresponding to previous or subsequent
+steps. In addition, data at subsequent steps will not be cleared. For instance, if some data
+were analysed in the PeakFitting step and you went back to BaselineModelling to import a new
+set of runs, previous peaks would be kept in PeakFitting. Note that at this stage of development
+'Import results...' does not load fitting results or fitting sections.
 
 Data Loading
 ------------


### PR DESCRIPTION
Fixes #10346 

Currently, the ALC interface guides the user through a set of three steps to complete an ALC analysis. Scientists reported that they would like the interface to allow them to skip certain steps so that they are able to re-use previous results. For instance, if they have saved the corrected data during a previous session, they don't want to go through loading and baseline fitting again, but rather jump directly to the peak fitting. This can be achieved by adding an 'Import results...' button that loads data from workspaces stored in the ADS.

**Tester:**
1. Review the documentation, specially the "Export results..." and "Import results..." sections. Please, let me know if there is anything unclear. The documentation should help you understand how the new "Import results..." button works.
2.  Open the ALC interface. Check that you can skip the DataLoading and BaselineModelling step and go to PeakFitting without loading any data.
3.  Hit 'Import results...', check that, as the ADS is empty,  nothing is loaded and an error message appears.

You may find useful the following script that creates sample workspaces for testing:

```
import numpy as np
# Gaussian mean and sigma + constant background
mu, sig, bg = 0, 0.5, 4.5

x = [] # x values
g = [] # Gaussian signal
g0 = [] # Gaussian + Noise + Background
g1 = [] # Background
g2 = [] # Gaussian + Noise
e = [] # errors

for i in np.arange(-3,3,0.1):
       # x
       x.append(i)
       # Gaussian distribution
       s = np.exp(-np.power(i - mu, 2.) / (2 * np.power(sig, 2.)))
       # Gaussian signal
       g.append(s)
       # A bit of noise
       r = np.random.normal(0, 0.01)
       # Gaussian + Noise + Background
       g0.append(s+r+bg)
       # Background
       g1.append(bg)
       # Gaussian + noise
       g2.append(s+r)
       # Errors
       e.append(0.1*np.sqrt(np.absolute(s)))

# Create workspaces that can be loaded into the ALC interface
# Original data, will be loaded in the DataLoading step
ALCResults_Loaded_Data = CreateWorkspace(DataX=x,DataY=g0,DataE=e)
# Corrected data, will be loaded in the BaselineModelling step
ALCResults_Baseline_Workspace = CreateWorkspace(DataX=x+x+x,DataY=g0+g1+g2,DataE=e+e+e,NSpec=3)
# Peak data, will be loaded in the PeakFitting step
ALCResults_Peaks_Workspace = CreateWorkspace(DataX=x+x+x,DataY=g2+g+[a-b for a, b in zip(g2,g)],DataE=e+e+e, NSpec=3)
# Group the workspaces
ALCResults = GroupWorkspaces("ALCResults_Loaded_Data,ALCResults_Baseline_Workspace,ALCResults_Peaks_Workspace")
```
1. Check that you can import ALCResults at any step
2. Try to import a wrong workspace. For instance, a workspace with three spectra in the DataLoading step, a ws containing only one spectra in the BaselineModelling step, or a ws containing two spectra in the PeakFitting step.
3. Try to break the interface

**Release notes:** http://www.mantidproject.org/index.php?title=Release_Notes_3_5_MuonAnalysis&diff=24320&oldid=24318
