### PR TITLE
Fix fipped mask in SANS

### DIFF
--- a/Code/Mantid/scripts/SANS/ISISCommandInterface.py
+++ b/Code/Mantid/scripts/SANS/ISISCommandInterface.py
@@ -985,8 +985,9 @@ def DisplayMask(mask_worksp=None):
             Integration(InputWorkspace=mask_worksp,OutputWorkspace= counts_data)
 
         else:
-            instrument.load_empty(mask_worksp)
-            instrument.set_up_for_run('emptyInstrument')
+            msg = 'Cannot display the mask without a sample workspace'
+            _printMessage(msg, log = True, no_console=False)
+            return
 
     ReductionSingleton().mask.display(mask_worksp, ReductionSingleton(), counts_data)
     if counts_data:

--- a/Code/Mantid/scripts/SANS/SANSUtility.py
+++ b/Code/Mantid/scripts/SANS/SANSUtility.py
@@ -147,15 +147,6 @@ def spectrumBlock(base, ylow, xlow, ydim, xdim, det_dimension, orientation):
             for x in range(0, xdim):
                 std_i = start_spec + x + (y*det_dimension)
                 output += str(max_spec - (std_i - base)) + ','
-    elif orientation == Orientation.HorizontalFlipped:
-        start_spec = base + ylow*det_dimension + xlow
-        for y in range(0,ydim):
-            max_row = base + (y+1)*det_dimension - 1
-            min_row = base + (y)*det_dimension
-            for x in range(0,xdim):
-                std_i = start_spec + x + (y*det_dimension)
-                diff_s = std_i - min_row
-                output += str(max_row - diff_s) + ','
 
     return output.rstrip(",")
 
@@ -868,8 +859,6 @@ class Orientation(object):
     Horizontal = 1
     Vertical = 2
     Rotated = 3
-    # This is for the empty instrument
-    HorizontalFlipped = 4
 
 # A small class holds the run number with the workspace name, because the run number is not contained in the workspace at the moment
 @deprecated

--- a/Code/Mantid/scripts/SANS/isis_instrument.py
+++ b/Code/Mantid/scripts/SANS/isis_instrument.py
@@ -364,14 +364,6 @@ class DetectorBank(object):
                 for x in range(0, xdim):
                     std_i = start_spec + x + (y*det_dimension)
                     output += str(max_spec - (std_i - base)) + ','
-        elif self._orientation == 'HorizontalFlipped':
-            for y in range(ylow,ylow+ydim):
-                max_row = base + (y+1)*det_dimension - 1
-                min_row = base + (y)*det_dimension
-                for x in range(xlow,xlow+xdim):
-                    std_i = base + x + (y*det_dimension)
-                    diff_s = std_i - min_row
-                    output += str(max_row - diff_s) + ','
 
         return output.rstrip(",")
 
@@ -379,8 +371,7 @@ class DetectorBank(object):
     _ORIENTED = {
         'Horizontal' : None,        #most runs have the detectors in this state
         'Vertical' : None,
-        'Rotated' : None,
-        'HorizontalFlipped' : None} # This is for the empty instrument
+        'Rotated' : None}
 
     def set_orien(self, orien):
         """

--- a/Code/Mantid/scripts/SANS/isis_instrument.py
+++ b/Code/Mantid/scripts/SANS/isis_instrument.py
@@ -224,8 +224,9 @@ class DetectorBank(object):
         # hold rescale and shift object _RescaleAndShift
         self.rescaleAndShift = self._RescaleAndShift()
 
-        #in the empty instrument detectors are laid out as below on loading a run the orientation becomes run dependent
-        self._orientation = 'HorizontalFlipped'
+        # The orientation is set by default to Horizontal (Note this used to be HorizontalFlipped,
+        # probably as part of some hack for specific run numbers of SANS2D)
+        self._orientation = 'Horizontal'
 
     def disable_y_and_rot_corrs(self):
         """
@@ -866,11 +867,7 @@ class SANS2D(ISISInstrument):
             #this is the default case
             first.set_first_spec_num(9)
             first.set_orien('Horizontal')
-            # empty instrument number spectra differently.
-            if base_runno == 'emptyInstrument':
-                second.set_orien('HorizontalFlipped')
-            else:
-                second.set_orien('Horizontal')
+            second.set_orien('Horizontal')
 
         #as spectrum numbers of the first detector have changed we'll move those in the second too
         second.place_after(first)


### PR DESCRIPTION
Fixes #12893 

**For testing**

Please find the User files and test data on the Olympic server: \olympic\Babylon5\Scratch\Anton\12893\Sandbox

You need to set the search path within Mantid to the directory which contains the User file, etc. There are two user files:
- USER_LOQ_151D_Xpress_6mm_NO_MASK   : Without a mask
- USER_LOQ_151D_Xpress_6mm_EXPECTED_MASK  : With a mask

The sample file is LOQ92053.nxs
1. Open the SANS GUI
2. Load the User file USER_LOQ_151D_Xpress_6mm_NO_MASK
3. Load the sample data set
4. Go to the  Mask tab and press "Display Mask"
   - Confirm that you see an area with bad pixels. We want to mask this area
5. Load teh User file USER_LOQ_151D_Xpress_6mm_EXPECTED_MASK
6. Go to the  Mask tab and press "Display Mask"
   - Confirm that the previoulsy bad are is masked. Before this fix the mask as not placed on top of the bad area
7. For completeness sake, load the sample data set again. 
8. Go to the  Mask tab and press "Display Mask"
   - Confirm that the previoulsy bad are is masked.
