### PR TITLE
Implementation of clone() for all Workspaces

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
@@ -72,7 +72,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
-  virtual IEventWorkspace *doClone() const override = 0;
+  virtual IEventWorkspace *doClone() const = 0;
 
 };
 }

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
@@ -65,7 +65,7 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  IEventWorkspace(const IEventWorkspace &other);
+  IEventWorkspace(const IEventWorkspace &other) : MatrixWorkspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   IEventWorkspace &operator=(const IEventWorkspace &other);
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IEventWorkspace.h
@@ -38,6 +38,12 @@ namespace API {
 class MANTID_API_DLL IEventWorkspace : public MatrixWorkspace {
 public:
   IEventWorkspace() : MatrixWorkspace() {}
+
+  /// Returns a clone of the workspace
+  std::unique_ptr<IEventWorkspace> clone() const {
+    return std::unique_ptr<IEventWorkspace>(doClone());
+  }
+
   /// Return the workspace typeID
   virtual const std::string id() const { return "IEventWorkspace"; }
   virtual std::size_t getNumberEvents() const = 0;
@@ -64,6 +70,10 @@ protected:
   IEventWorkspace &operator=(const IEventWorkspace &other);
 
   virtual const std::string toString() const;
+
+private:
+  virtual IEventWorkspace *doClone() const override = 0;
+
 };
 }
 }

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
@@ -97,7 +97,7 @@ protected:
   bool m_fileNeedsUpdating;
 
 private:
-  virtual IMDEventWorkspace *doClone() const override = 0;
+  virtual IMDEventWorkspace *doClone() const = 0;
 };
 
 } // namespace MDEvents

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
@@ -34,6 +34,11 @@ public:
   IMDEventWorkspace();
   virtual ~IMDEventWorkspace() {}
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<IMDEventWorkspace> clone() const {
+    return std::unique_ptr<IMDEventWorkspace>(doClone());
+  }
+
   /// Perform initialization after dimensions (and others) have been set.
   virtual void initialize() = 0;
 
@@ -90,6 +95,9 @@ protected:
   /// Marker set to true when a file-backed workspace needs its back-end file
   /// updated (by calling SaveMD(UpdateFileBackEnd=1) )
   bool m_fileNeedsUpdating;
+
+private:
+  virtual IMDEventWorkspace *doClone() const override = 0;
 };
 
 } // namespace MDEvents

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
@@ -106,7 +106,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
-  virtual IMDHistoWorkspace *doClone() const override = 0;
+  virtual IMDHistoWorkspace *doClone() const = 0;
 };
 
 } // namespace API

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
@@ -41,6 +41,11 @@ public:
   IMDHistoWorkspace();
   virtual ~IMDHistoWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<IMDHistoWorkspace> clone() const {
+    return std::unique_ptr<IMDHistoWorkspace>(doClone());
+  }
+
   /// See the MDHistoWorkspace definition for descriptions of these
   virtual coord_t getInverseVolume() const = 0;
   virtual signal_t *getSignalArray() const = 0;
@@ -91,8 +96,6 @@ public:
   virtual void setCoordinateSystem(
       const Kernel::SpecialCoordinateSystem coordinateSystem) = 0;
 
-  virtual boost::shared_ptr<IMDHistoWorkspace> clone() const = 0;
-
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
@@ -101,6 +104,9 @@ protected:
   IMDHistoWorkspace &operator=(const IMDHistoWorkspace &other);
 
   virtual const std::string toString() const;
+
+private:
+  virtual IMDHistoWorkspace *doClone() const override = 0;
 };
 
 } // namespace API

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -72,6 +72,11 @@ public:
   IMDWorkspace();
   virtual ~IMDWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<IMDWorkspace> clone() const {
+    return std::unique_ptr<IMDWorkspace>(doClone());
+  }
+
   /// Get the number of points associated with the workspace.
   /// For MDEvenWorkspace it is the number of events contributing into the
   /// workspace
@@ -139,6 +144,9 @@ protected:
   IMDWorkspace &operator=(const IMDWorkspace &other);
 
   virtual const std::string toString() const;
+
+private:
+  virtual IMDWorkspace *doClone() const override = 0;
 };
 
 /// Shared pointer to the IMDWorkspace base class

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -146,7 +146,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
-  virtual IMDWorkspace *doClone() const override = 0;
+  virtual IMDWorkspace *doClone() const = 0;
 };
 
 /// Shared pointer to the IMDWorkspace base class

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IMaskWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IMaskWorkspace.h
@@ -52,7 +52,7 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  IMaskWorkspace(const IMaskWorkspace &other);
+  IMaskWorkspace(const IMaskWorkspace &other) { (void)other; }
   /// Protected copy assignment operator. Assignment not implemented.
   IMaskWorkspace &operator=(const IMaskWorkspace &other);
 };

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -161,7 +161,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
-  virtual IPeaksWorkspace *doClone() const override = 0;
+  virtual IPeaksWorkspace *doClone() const = 0;
 };
 
 }

--- a/Code/Mantid/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -54,6 +54,11 @@ public:
   /// Destructor
   virtual ~IPeaksWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<IPeaksWorkspace> clone() const {
+    return std::unique_ptr<IPeaksWorkspace>(doClone());
+  }
+
   //---------------------------------------------------------------------------------------------
   /** @return the number of peaks
    */
@@ -154,6 +159,9 @@ protected:
   IPeaksWorkspace &operator=(const IPeaksWorkspace &other);
 
   virtual const std::string toString() const;
+
+private:
+  virtual IPeaksWorkspace *doClone() const override = 0;
 };
 
 }

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
@@ -46,6 +46,11 @@ public:
    */
   virtual ~ISplittersWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<ISplittersWorkspace> clone() const {
+    return std::unique_ptr<ISplittersWorkspace>(doClone());
+  }
+
   /*
    * Add a time splitter to table workspace
    */
@@ -69,9 +74,13 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  ISplittersWorkspace(const ISplittersWorkspace &other);
+  ISplittersWorkspace(const ISplittersWorkspace &other)
+      : ITableWorkspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   ISplittersWorkspace &operator=(const ISplittersWorkspace &other);
+
+private:
+  virtual ISplittersWorkspace *doClone() const = 0;
 };
 
 /// Typedef for a shared pointer to \c TableWorkspace

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
@@ -2,7 +2,6 @@
 #define MANTID_API_ISPLITTERSWORKSPACE_H_
 
 #include "MantidAPI/DllConfig.h"
-#include "MantidAPI/ITableWorkspace.h"
 #include "MantidKernel/TimeSplitter.h"
 
 namespace Mantid {
@@ -34,12 +33,12 @@ namespace API {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_API_DLL ISplittersWorkspace : virtual public API::ITableWorkspace {
+class MANTID_API_DLL ISplittersWorkspace {
 public:
   /*
    * Constructor
    */
-  ISplittersWorkspace() : API::ITableWorkspace() {}
+  ISplittersWorkspace() {}
 
   /*
    * Destructor
@@ -74,8 +73,7 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  ISplittersWorkspace(const ISplittersWorkspace &other)
-      : ITableWorkspace(other) {}
+  ISplittersWorkspace(const ISplittersWorkspace &other) { UNUSED_ARG(other) }
   /// Protected copy assignment operator. Assignment not implemented.
   ISplittersWorkspace &operator=(const ISplittersWorkspace &other);
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISplittersWorkspace.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_API_ISPLITTERSWORKSPACE_H_
 #define MANTID_API_ISPLITTERSWORKSPACE_H_
 
-#include "MantidKernel/System.h"
+#include "MantidAPI/DllConfig.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidKernel/TimeSplitter.h"
 
@@ -34,7 +34,7 @@ namespace API {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport ISplittersWorkspace : virtual public API::ITableWorkspace {
+class MANTID_API_DLL ISplittersWorkspace : virtual public API::ITableWorkspace {
 public:
   /*
    * Constructor

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
@@ -123,6 +123,11 @@ public:
   /// Virtual destructor.
   virtual ~ITableWorkspace() {}
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<ITableWorkspace> clone() const {
+    return std::unique_ptr<ITableWorkspace>(doClone());
+  }
+
   /// Return the workspace typeID
   virtual const std::string id() const { return "ITableWorkspace"; }
   virtual const std::string toString() const;
@@ -143,9 +148,6 @@ public:
 
   /// Removes a column.
   virtual void removeColumn(const std::string &name) = 0;
-
-  /// Clones the table workspace
-  virtual ITableWorkspace *clone() const = 0;
 
   /// Number of columns in the workspace.
   virtual size_t columnCount() const = 0;
@@ -329,6 +331,9 @@ protected:
          @param index :: Index of the element to be removed.
    */
   void removeFromColumn(Column *c, size_t index) { c->remove(index); }
+
+private:
+  virtual ITableWorkspace *doClone() const override = 0;
 };
 
 // =====================================================================================

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ITableWorkspace.h
@@ -333,7 +333,7 @@ protected:
   void removeFromColumn(Column *c, size_t index) { c->remove(index); }
 
 private:
-  virtual ITableWorkspace *doClone() const override = 0;
+  virtual ITableWorkspace *doClone() const = 0;
 };
 
 // =====================================================================================

--- a/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -82,6 +82,11 @@ public:
   /// Delete
   virtual ~MatrixWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<MatrixWorkspace> clone() const {
+    return std::unique_ptr<MatrixWorkspace>(doClone());
+  }
+
   using IMDWorkspace::toString;
   /// String description of state
   const std::string toString() const;
@@ -446,6 +451,8 @@ protected:
   std::vector<Axis *> m_axes;
 
 private:
+  virtual MatrixWorkspace *doClone() const override = 0;
+
   /// Create an MantidImage instance.
   MantidImage_sptr
   getImage(const MantidVec &(MatrixWorkspace::*read)(std::size_t const) const,

--- a/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -451,7 +451,7 @@ protected:
   std::vector<Axis *> m_axes;
 
 private:
-  virtual MatrixWorkspace *doClone() const override = 0;
+  virtual MatrixWorkspace *doClone() const = 0;
 
   /// Create an MantidImage instance.
   MantidImage_sptr

--- a/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/Workspace.h
@@ -56,6 +56,29 @@ public:
   Workspace();
   virtual ~Workspace();
 
+  /** Returns a clone (copy) of the workspace with covariant return type in all
+   * derived classes.
+   *
+   * Note that this public function is *not* virtual. This has two reasons:
+   * - We want to enforce covariant return types. If this public clone() method
+   *   was virtual some derived class might fail to reimplement it. Since there
+   *   are several levels of inheritance in the Workspace inheritance tree we
+   *   cannot just use a pure virtual method in the base class. Thus, we use
+   *   this non-virtual interface method which calls the private and virtual
+   *   doClone() method. Since it is private, failing to reimplement it will
+   *   cause a compiler error as a reminder. Note that this mechanism does not
+   *   always work if a derived class does not implement clone(): if doClone()
+   *   in a parent is implemented then calling clone on a base class will return
+   *   a clone of the parent defining doClone, not the actual instance. This is
+   *   more a problem of the inheritance structure, i.e., whether or not all
+   *   non-leaf classes are pure virtual and declare doClone()=0.
+   * - Covariant return types are in conflict with smart pointers, but if
+   *   clone() is not virtual this is a non-issue.
+   */
+  std::unique_ptr<Workspace> clone() const {
+    return std::unique_ptr<Workspace>(doClone());
+  }
+
   // DataItem interface
   /// Name
   virtual const std::string name() const { return this->getName(); }
@@ -100,6 +123,9 @@ private:
   std::string m_name;
   /// The history of the workspace, algorithm and environment
   WorkspaceHistory m_history;
+
+  /// Virtual clone method. Not implemented to force implementation in childs.
+  virtual Workspace *doClone() const = 0;
 
   friend class AnalysisDataServiceImpl;
 };

--- a/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -117,7 +117,7 @@ protected:
   const WorkspaceGroup &operator=(const WorkspaceGroup &);
 
 private:
-  virtual WorkspaceGroup *doClone() const override {
+  virtual WorkspaceGroup *doClone() const {
     throw std::runtime_error("Cloning of WorkspaceGroup is not implemented.");
   }
   /// ADS removes a member of this group using this method. It doesn't send

--- a/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -117,6 +117,9 @@ protected:
   const WorkspaceGroup &operator=(const WorkspaceGroup &);
 
 private:
+  virtual WorkspaceGroup *doClone() const override {
+    throw std::runtime_error("Cloning of WorkspaceGroup is not implemented.");
+  }
   /// ADS removes a member of this group using this method. It doesn't send
   /// notifications in contrast to remove(name).
   void removeByADS(const std::string &name);

--- a/Code/Mantid/Framework/API/src/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/API/src/MatrixWorkspace.cpp
@@ -43,6 +43,27 @@ MatrixWorkspace::MatrixWorkspace(
           (nnFactory == NULL) ? new NearestNeighboursFactory : nnFactory),
       m_nearestNeighbours() {}
 
+MatrixWorkspace::MatrixWorkspace(const MatrixWorkspace &other)
+    : IMDWorkspace(other), ExperimentInfo(other) {
+  m_axes.resize(other.m_axes.size());
+  for (size_t i = 0; i < m_axes.size(); ++i)
+    m_axes[i] = other.m_axes[i]->clone(this);
+
+  m_isInitialized = other.m_isInitialized;
+  m_YUnit = other.m_YUnit;
+  m_YUnitLabel = other.m_YUnitLabel;
+  m_isDistribution = other.m_isDistribution;
+  m_isCommonBinsFlagSet = other.m_isCommonBinsFlagSet;
+  m_isCommonBinsFlag = other.m_isCommonBinsFlag;
+  m_masks = other.m_masks;
+  m_indexCalculator = other.m_indexCalculator;
+  // I think it is necessary to create our own copy of the factory, since we do
+  // not know who owns the factory in other and how its lifetime is controlled.
+  m_nearestNeighboursFactory.reset(new NearestNeighboursFactory);
+  // TODO: Do we need to init m_nearestNeighbours?
+  // TODO: Do we need to init m_monitorWorkspace?
+}
+
 /// Destructor
 // RJT, 3/10/07: The Analysis Data Service needs to be able to delete
 // workspaces, so I moved this from protected to public.

--- a/Code/Mantid/Framework/API/src/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/API/src/MatrixWorkspace.cpp
@@ -60,8 +60,15 @@ MatrixWorkspace::MatrixWorkspace(const MatrixWorkspace &other)
   // I think it is necessary to create our own copy of the factory, since we do
   // not know who owns the factory in other and how its lifetime is controlled.
   m_nearestNeighboursFactory.reset(new NearestNeighboursFactory);
-  // TODO: Do we need to init m_nearestNeighbours?
+  // m_nearestNeighbours seem to be built automatically when needed, so we do
+  // not copy here.
+
   // TODO: Do we need to init m_monitorWorkspace?
+
+  // This call causes copying of m_parmap (ParameterMap). The constructor of
+  // ExperimentInfo just kept a shared_ptr to the same map as in other, which
+  // is not enough as soon as the maps in one of the workspaces it edited.
+  instrumentParameters();
 }
 
 /// Destructor

--- a/Code/Mantid/Framework/API/src/WorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/API/src/WorkspaceProperty.cpp
@@ -21,8 +21,6 @@ template MANTID_API_DLL class Mantid::API::WorkspaceProperty<
     Mantid::API::MatrixWorkspace>;
 template MANTID_API_DLL class Mantid::API::WorkspaceProperty<
     Mantid::API::ITableWorkspace>;
-template MANTID_API_DLL class Mantid::API::WorkspaceProperty<
-    Mantid::API::ISplittersWorkspace>;
 ///@endcond TEMPLATE
 } // namespace API
 } // namespace Mantid

--- a/Code/Mantid/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Code/Mantid/Framework/API/test/AnalysisDataServiceTest.h
@@ -18,7 +18,7 @@ namespace
     virtual size_t getMemorySize() const { return 1; }
 
   private:
-    virtual MockWorkspace *doClone() const override {
+    virtual MockWorkspace *doClone() const {
       throw std::runtime_error("Cloning of MockWorkspace is not implemented.");
     }
   };

--- a/Code/Mantid/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Code/Mantid/Framework/API/test/AnalysisDataServiceTest.h
@@ -16,6 +16,11 @@ namespace
     virtual const std::string id() const { return "MockWorkspace"; }
     virtual const std::string toString() const { return ""; }
     virtual size_t getMemorySize() const { return 1; }
+
+  private:
+    virtual MockWorkspace *doClone() const override {
+      throw std::runtime_error("Cloning of MockWorkspace is not implemented.");
+    }
   };
   typedef boost::shared_ptr<MockWorkspace> MockWorkspace_sptr;
 }

--- a/Code/Mantid/Framework/API/test/CompositeFunctionTest.h
+++ b/Code/Mantid/Framework/API/test/CompositeFunctionTest.h
@@ -79,7 +79,7 @@ public:
   void clearFileBacked(bool ){};
   ITableWorkspace_sptr makeBoxTable(size_t /* start*/, size_t /*num*/){return ITableWorkspace_sptr();}
 private:
-  virtual CompositeFunctionTest_MocMatrixWorkspace *doClone() const override {
+  virtual CompositeFunctionTest_MocMatrixWorkspace *doClone() const {
     throw std::runtime_error("Cloning of "
                              "CompositeFunctionTest_MocMatrixWorkspace is not "
                              "implemented.");

--- a/Code/Mantid/Framework/API/test/CompositeFunctionTest.h
+++ b/Code/Mantid/Framework/API/test/CompositeFunctionTest.h
@@ -79,6 +79,11 @@ public:
   void clearFileBacked(bool ){};
   ITableWorkspace_sptr makeBoxTable(size_t /* start*/, size_t /*num*/){return ITableWorkspace_sptr();}
 private:
+  virtual CompositeFunctionTest_MocMatrixWorkspace *doClone() const override {
+    throw std::runtime_error("Cloning of "
+                             "CompositeFunctionTest_MocMatrixWorkspace is not "
+                             "implemented.");
+  }
   std::vector<CompositeFunctionTest_MocSpectrum> m_spectra;
   size_t m_blocksize;
 };

--- a/Code/Mantid/Framework/API/test/ScopedWorkspaceTest.h
+++ b/Code/Mantid/Framework/API/test/ScopedWorkspaceTest.h
@@ -17,6 +17,11 @@ class MockWorkspace : public Workspace
   virtual const std::string id() const { return "MockWorkspace"; }
   virtual const std::string toString() const { return ""; }
   virtual size_t getMemorySize() const { return 1; }
+
+private:
+  virtual MockWorkspace *doClone() const override {
+    throw std::runtime_error("Cloning of MockWorkspace is not implemented.");
+  }
 };
 typedef boost::shared_ptr<MockWorkspace> MockWorkspace_sptr;
 

--- a/Code/Mantid/Framework/API/test/ScopedWorkspaceTest.h
+++ b/Code/Mantid/Framework/API/test/ScopedWorkspaceTest.h
@@ -19,7 +19,7 @@ class MockWorkspace : public Workspace
   virtual size_t getMemorySize() const { return 1; }
 
 private:
-  virtual MockWorkspace *doClone() const override {
+  virtual MockWorkspace *doClone() const {
     throw std::runtime_error("Cloning of MockWorkspace is not implemented.");
   }
 };

--- a/Code/Mantid/Framework/API/test/WorkspaceGroupTest.h
+++ b/Code/Mantid/Framework/API/test/WorkspaceGroupTest.h
@@ -60,6 +60,11 @@ private:
     MOCK_CONST_METHOD0(threadSafe, bool());
     MOCK_CONST_METHOD0(toString, const std::string());
     MOCK_CONST_METHOD0(getMemorySize, size_t());
+
+  private:
+    virtual MockWorkspace *doClone() const override {
+      throw std::runtime_error("Cloning of MockWorkspace is not implemented.");
+    }
   };
 
   /// Make a simple group

--- a/Code/Mantid/Framework/API/test/WorkspaceGroupTest.h
+++ b/Code/Mantid/Framework/API/test/WorkspaceGroupTest.h
@@ -62,7 +62,7 @@ private:
     MOCK_CONST_METHOD0(getMemorySize, size_t());
 
   private:
-    virtual MockWorkspace *doClone() const override {
+    virtual MockWorkspace *doClone() const {
       throw std::runtime_error("Cloning of MockWorkspace is not implemented.");
     }
   };

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/GenerateEventsFilter.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/GenerateEventsFilter.h
@@ -6,7 +6,6 @@
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidDataObjects/SplittersWorkspace.h"
-#include "MantidAPI/ISplittersWorkspace.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 
 namespace Mantid {
@@ -174,7 +173,7 @@ private:
   DataObjects::EventWorkspace_const_sptr m_dataWS;
 
   /// SplitterWorkspace
-  API::ISplittersWorkspace_sptr m_splitWS;
+  DataObjects::SplittersWorkspace_sptr m_splitWS;
   /// Matrix workspace containing splitters
   API::MatrixWorkspace_sptr m_filterWS;
 

--- a/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -38,10 +38,7 @@ void CloneWorkspace::exec() {
   TableWorkspace_const_sptr tableWS =
       boost::dynamic_pointer_cast<const TableWorkspace>(inputWorkspace);
 
-  if (inputEvent) {
-    Workspace_sptr outputWS(inputWorkspace->clone().release());
-    setProperty("OutputWorkspace", outputWS);
-  } else if (inputMatrix) {
+  if (inputEvent || inputMatrix) {
     Workspace_sptr outputWS(inputWorkspace->clone().release());
     setProperty("OutputWorkspace", outputWS);
   } else if (inputMD) {

--- a/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -56,35 +56,8 @@ void CloneWorkspace::exec() {
     setProperty("OutputWorkspace",
                 boost::dynamic_pointer_cast<Workspace>(outputWS));
   } else if (inputMatrix) {
-    // Create the output workspace. This will copy many aspects fron the input
-    // one.
-    MatrixWorkspace_sptr outputWorkspace =
-        WorkspaceFactory::Instance().create(inputMatrix);
-
-    // ...but not the data, so do that here.
-
-    const int64_t numHists =
-        static_cast<int64_t>(inputMatrix->getNumberHistograms());
-    Progress prog(this, 0.0, 1.0, numHists);
-
-    PARALLEL_FOR2(inputMatrix, outputWorkspace)
-    for (int64_t i = 0; i < int64_t(numHists); ++i) {
-      PARALLEL_START_INTERUPT_REGION
-
-      outputWorkspace->setX(i, inputMatrix->refX(i));
-      outputWorkspace->dataY(i) = inputMatrix->readY(i);
-      outputWorkspace->dataE(i) = inputMatrix->readE(i);
-      // Be sure to not break sharing between Dx vectors by assigning pointers
-      outputWorkspace->getSpectrum(i)
-          ->setDx(inputMatrix->getSpectrum(i)->ptrDx());
-
-      prog.report();
-
-      PARALLEL_END_INTERUPT_REGION
-    }
-    PARALLEL_CHECK_INTERUPT_REGION
-    setProperty("OutputWorkspace",
-                boost::dynamic_pointer_cast<Workspace>(outputWorkspace));
+    Workspace_sptr outputWS(inputWorkspace->clone().release());
+    setProperty("OutputWorkspace", outputWS);
   } else if (inputMD) {
     // Call the CloneMDWorkspace algo to handle MDEventWorkspace
     IAlgorithm_sptr alg =

--- a/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -96,14 +96,10 @@ void CloneWorkspace::exec() {
     IMDWorkspace_sptr outputWS = alg->getProperty("OutputWorkspace");
     setProperty("OutputWorkspace",
                 boost::dynamic_pointer_cast<Workspace>(outputWS));
-  } else if (inputPeaks) {
-    PeaksWorkspace_sptr outputWS(inputPeaks->clone().release());
-    setProperty("OutputWorkspace",
-                boost::dynamic_pointer_cast<Workspace>(outputWS));
-  } else if (tableWS) {
-    TableWorkspace_sptr outputWS(tableWS->clone().release());
-    setProperty("OutputWorkspace",
-                boost::dynamic_pointer_cast<Workspace>(outputWS));
+  } else if (inputPeaks || tableWS) {
+    // Workspace::clone() is polymorphic, we can use the same for all types
+    Workspace_sptr outputWS(inputWorkspace->clone().release());
+    setProperty("OutputWorkspace", outputWS);
   } else
     throw std::runtime_error("Expected a MatrixWorkspace, PeaksWorkspace, "
                              "MDEventWorkspace, or a MDHistoWorkspace. Cannot "

--- a/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -97,11 +97,11 @@ void CloneWorkspace::exec() {
     setProperty("OutputWorkspace",
                 boost::dynamic_pointer_cast<Workspace>(outputWS));
   } else if (inputPeaks) {
-    PeaksWorkspace_sptr outputWS(inputPeaks->clone());
+    PeaksWorkspace_sptr outputWS(inputPeaks->clone().release());
     setProperty("OutputWorkspace",
                 boost::dynamic_pointer_cast<Workspace>(outputWS));
   } else if (tableWS) {
-    TableWorkspace_sptr outputWS(tableWS->clone());
+    TableWorkspace_sptr outputWS(tableWS->clone().release());
     setProperty("OutputWorkspace",
                 boost::dynamic_pointer_cast<Workspace>(outputWS));
   } else

--- a/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -29,16 +29,13 @@ void CloneWorkspace::exec() {
   Workspace_sptr inputWorkspace = getProperty("InputWorkspace");
   MatrixWorkspace_const_sptr inputMatrix =
       boost::dynamic_pointer_cast<const MatrixWorkspace>(inputWorkspace);
-  EventWorkspace_const_sptr inputEvent =
-      boost::dynamic_pointer_cast<const EventWorkspace>(inputWorkspace);
   IMDWorkspace_sptr inputMD =
       boost::dynamic_pointer_cast<IMDWorkspace>(inputWorkspace);
-  PeaksWorkspace_const_sptr inputPeaks =
-      boost::dynamic_pointer_cast<const PeaksWorkspace>(inputWorkspace);
-  TableWorkspace_const_sptr tableWS =
-      boost::dynamic_pointer_cast<const TableWorkspace>(inputWorkspace);
+  ITableWorkspace_const_sptr iTableWS =
+      boost::dynamic_pointer_cast<const ITableWorkspace>(inputWorkspace);
 
-  if (inputEvent || inputMatrix) {
+  if (inputMatrix || iTableWS) {
+    // Workspace::clone() is polymorphic, we can use the same for all types
     Workspace_sptr outputWS(inputWorkspace->clone().release());
     setProperty("OutputWorkspace", outputWS);
   } else if (inputMD) {
@@ -52,10 +49,6 @@ void CloneWorkspace::exec() {
     IMDWorkspace_sptr outputWS = alg->getProperty("OutputWorkspace");
     setProperty("OutputWorkspace",
                 boost::dynamic_pointer_cast<Workspace>(outputWS));
-  } else if (inputPeaks || tableWS) {
-    // Workspace::clone() is polymorphic, we can use the same for all types
-    Workspace_sptr outputWS(inputWorkspace->clone().release());
-    setProperty("OutputWorkspace", outputWS);
   } else
     throw std::runtime_error("Expected a MatrixWorkspace, PeaksWorkspace, "
                              "MDEventWorkspace, or a MDHistoWorkspace. Cannot "

--- a/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -39,22 +39,8 @@ void CloneWorkspace::exec() {
       boost::dynamic_pointer_cast<const TableWorkspace>(inputWorkspace);
 
   if (inputEvent) {
-    // Handle an EventWorkspace as the input.
-    // Make a brand new EventWorkspace
-    EventWorkspace_sptr outputWS = boost::dynamic_pointer_cast<EventWorkspace>(
-        API::WorkspaceFactory::Instance().create(
-            "EventWorkspace", inputEvent->getNumberHistograms(), 2, 1));
-
-    // Copy geometry over.
-    API::WorkspaceFactory::Instance().initializeFromParent(inputEvent, outputWS,
-                                                           false);
-
-    // You need to copy over the data as well.
-    outputWS->copyDataFrom((*inputEvent));
-
-    // Cast to the matrixOutputWS and save it
-    setProperty("OutputWorkspace",
-                boost::dynamic_pointer_cast<Workspace>(outputWS));
+    Workspace_sptr outputWS(inputWorkspace->clone().release());
+    setProperty("OutputWorkspace", outputWS);
   } else if (inputMatrix) {
     Workspace_sptr outputWS(inputWorkspace->clone().release());
     setProperty("OutputWorkspace", outputWS);

--- a/Code/Mantid/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -93,7 +93,7 @@ namespace
     {}
 
   private:
-    virtual MockIEventWorkspace *doClone() const override {
+    virtual MockIEventWorkspace *doClone() const {
       throw std::runtime_error(
           "Cloning of MockIEventWorkspace is not implemented.");
     }

--- a/Code/Mantid/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -91,6 +91,12 @@ namespace
     MOCK_CONST_METHOD0(getSpecialCoordinateSystem, Mantid::Kernel::SpecialCoordinateSystem());
     virtual ~MockIEventWorkspace()
     {}
+
+  private:
+    virtual MockIEventWorkspace *doClone() const override {
+      throw std::runtime_error(
+          "Cloning of MockIEventWorkspace is not implemented.");
+    }
   };}
 //=====================================================================================
 // Functional Tests

--- a/Code/Mantid/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Code/Mantid/Framework/Crystal/src/CentroidPeaks.cpp
@@ -72,7 +72,7 @@ void CentroidPeaks::integrate() {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutPeaksWorkspace");
   if (peakWS != inPeakWS)
-    peakWS = inPeakWS->clone();
+    peakWS.reset(inPeakWS->clone().release());
 
   /// Radius to use around peaks
   int PeakRadius = getProperty("PeakRadius");
@@ -208,7 +208,7 @@ void CentroidPeaks::integrateEvent() {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutPeaksWorkspace");
   if (peakWS != inPeakWS)
-    peakWS = inPeakWS->clone();
+    peakWS.reset(inPeakWS->clone().release());
 
   /// Radius to use around peaks
   int PeakRadius = getProperty("PeakRadius");

--- a/Code/Mantid/Framework/Crystal/src/CombinePeaksWorkspaces.cpp
+++ b/Code/Mantid/Framework/Crystal/src/CombinePeaksWorkspaces.cpp
@@ -79,7 +79,7 @@ void CombinePeaksWorkspaces::exec() {
   }
 
   // Copy the first workspace to our output workspace
-  PeaksWorkspace_sptr output(LHSWorkspace->clone());
+  PeaksWorkspace_sptr output(LHSWorkspace->clone().release());
   // Get hold of the peaks in the second workspace
   auto &rhsPeaks = RHSWorkspace->getPeaks();
 

--- a/Code/Mantid/Framework/Crystal/src/ConnectedComponentLabeling.cpp
+++ b/Code/Mantid/Framework/Crystal/src/ConnectedComponentLabeling.cpp
@@ -61,7 +61,7 @@ size_t calculateMaxClusters(IMDHistoWorkspace const *const ws,
  */
 boost::shared_ptr<Mantid::API::IMDHistoWorkspace>
 cloneInputWorkspace(IMDHistoWorkspace_sptr &inWS) {
-  IMDHistoWorkspace_sptr outWS = inWS->clone();
+  IMDHistoWorkspace_sptr outWS(inWS->clone().release());
 
   // Initialize to zero.
   PARALLEL_FOR_NO_WSP_CHECK()

--- a/Code/Mantid/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
+++ b/Code/Mantid/Framework/Crystal/src/DiffPeaksWorkspaces.cpp
@@ -72,7 +72,7 @@ void DiffPeaksWorkspaces::exec() {
   }
 
   // Copy the first workspace to our output workspace
-  PeaksWorkspace_sptr output(LHSWorkspace->clone());
+  PeaksWorkspace_sptr output(LHSWorkspace->clone().release());
   // Get hold of the peaks in the second workspace
   auto &rhsPeaks = RHSWorkspace->getPeaks();
   // Get hold of the peaks in the first workspace as we'll need to examine them

--- a/Code/Mantid/Framework/Crystal/src/IntegratePeaksHybrid.cpp
+++ b/Code/Mantid/Framework/Crystal/src/IntegratePeaksHybrid.cpp
@@ -164,8 +164,7 @@ void IntegratePeaksHybrid::exec() {
   const double peakOuterRadius = getProperty("BackgroundOuterRadius");
   const double halfPeakOuterRadius = peakOuterRadius / 2;
   if (peakWS != inPeakWS) {
-    peakWS = IPeaksWorkspace_sptr(
-        dynamic_cast<IPeaksWorkspace *>(inPeakWS->clone()));
+    peakWS = IPeaksWorkspace_sptr(inPeakWS->clone().release());
   }
 
   {

--- a/Code/Mantid/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Code/Mantid/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -120,8 +120,7 @@ void IntegratePeaksUsingClusters::exec() {
   IPeaksWorkspace_sptr inPeakWS = getProperty("PeaksWorkspace");
   IPeaksWorkspace_sptr peakWS = getProperty("OutputWorkspace");
   if (peakWS != inPeakWS) {
-    peakWS = IPeaksWorkspace_sptr(
-        dynamic_cast<IPeaksWorkspace *>(inPeakWS->clone()));
+    peakWS = IPeaksWorkspace_sptr(inPeakWS->clone().release());
   }
 
   {

--- a/Code/Mantid/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
+++ b/Code/Mantid/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
@@ -151,7 +151,7 @@ void OptimizeCrystalPlacement::exec() {
   PeaksWorkspace_sptr OutPeaks = getProperty("ModifiedPeaksWorkspace");
 
   if (Peaks != OutPeaks) {
-    boost::shared_ptr<PeaksWorkspace> X(Peaks->clone());
+    boost::shared_ptr<PeaksWorkspace> X(Peaks->clone().release());
     OutPeaks = X;
   }
 

--- a/Code/Mantid/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Code/Mantid/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -122,8 +122,7 @@ void OptimizeLatticeForCellType::exec() {
   }
   // finally do the optimization
   for (size_t i_run = 0; i_run < runWS.size(); i_run++) {
-    DataObjects::PeaksWorkspace_sptr peakWS(new PeaksWorkspace());
-    peakWS = runWS[i_run]->clone();
+    DataObjects::PeaksWorkspace_sptr peakWS(runWS[i_run]->clone().release());
     AnalysisDataService::Instance().addOrReplace("_peaks", peakWS);
     const DblMatrix UB = peakWS->sample().getOrientedLattice().getUB();
     std::vector<double> lat(6);

--- a/Code/Mantid/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Code/Mantid/Framework/Crystal/src/PeakIntegration.cpp
@@ -73,7 +73,7 @@ void PeakIntegration::exec() {
   /// Output peaks workspace, create if needed
   PeaksWorkspace_sptr peaksW = getProperty("OutPeaksWorkspace");
   if (peaksW != inPeaksW)
-    peaksW = inPeaksW->clone();
+    peaksW.reset(inPeaksW->clone().release());
 
   double qspan = 0.12;
   m_IC = getProperty("IkedaCarpenterTOF");

--- a/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SaveHKL.cpp
@@ -109,7 +109,7 @@ void SaveHKL::exec() {
   // HKL will be overwritten by equivalent HKL but never seen by user
   PeaksWorkspace_sptr peaksW = getProperty("OutputWorkspace");
   if (peaksW != ws)
-    peaksW = ws->clone();
+    peaksW.reset(ws->clone().release());
   double scaleFactor = getProperty("ScalePeaks");
   double dMin = getProperty("MinDSpacing");
   double wlMin = getProperty("MinWavelength");

--- a/Code/Mantid/Framework/Crystal/src/SortHKL.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SortHKL.cpp
@@ -68,7 +68,7 @@ void SortHKL::exec() {
   // HKL will be overwritten by equivalent HKL but never seen by user
   PeaksWorkspace_sptr peaksW = getProperty("OutputWorkspace");
   if (peaksW != InPeaksW)
-    peaksW = InPeaksW->clone();
+    peaksW.reset(InPeaksW->clone().release());
 
   // Init or append to a table workspace
   bool append = getProperty("Append");

--- a/Code/Mantid/Framework/Crystal/src/SortPeaksWorkspace.cpp
+++ b/Code/Mantid/Framework/Crystal/src/SortPeaksWorkspace.cpp
@@ -90,7 +90,7 @@ void SortPeaksWorkspace::exec() {
     inputWS->getColumn(columnToSortBy);
 
     if (inputWS != outputWS) {
-      outputWS = boost::shared_ptr<PeaksWorkspace>(inputWS->clone());
+      outputWS = boost::shared_ptr<PeaksWorkspace>(inputWS->clone().release());
     }
 
     // Perform the sorting.

--- a/Code/Mantid/Framework/Crystal/src/TOFExtinction.cpp
+++ b/Code/Mantid/Framework/Crystal/src/TOFExtinction.cpp
@@ -77,7 +77,7 @@ void TOFExtinction::exec() {
   /// Output peaks workspace, create if needed
   PeaksWorkspace_sptr peaksW = getProperty("OutputWorkspace");
   if (peaksW != inPeaksW)
-    peaksW = inPeaksW->clone();
+    peaksW.reset(inPeaksW->clone().release());
 
   const Kernel::Material *m_sampleMaterial =
       &(inPeaksW->sample().getMaterial());

--- a/Code/Mantid/Framework/Crystal/test/IndexSXPeaksTest.h
+++ b/Code/Mantid/Framework/Crystal/test/IndexSXPeaksTest.h
@@ -60,7 +60,7 @@ public:
   {
     
     //Take a copy of the original peaks workspace.
-    PeaksWorkspace_sptr local = m_masterPeaks->clone();
+    PeaksWorkspace_sptr local(m_masterPeaks->clone().release());
     //Clear the copies hkl values with some invalid values so that we'll know if we fail.
     for(int i = 0; i < nPixels; i++)
     {
@@ -115,7 +115,7 @@ public:
 
   void test_colinearPeaksThrows()
   {
-    PeaksWorkspace_sptr temp = m_masterPeaks->clone();
+    PeaksWorkspace_sptr temp(m_masterPeaks->clone().release());
 
     for(int i = 0; i < m_masterPeaks->getNumberPeaks(); i++)
     {

--- a/Code/Mantid/Framework/DataHandling/src/SortTableWorkspace.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SortTableWorkspace.cpp
@@ -87,7 +87,7 @@ void SortTableWorkspace::exec() {
     crt->second = (*asc) != 0;
   }
 
-  API::ITableWorkspace_sptr outputWS(ws->clone());
+  API::ITableWorkspace_sptr outputWS(ws->clone().release());
   outputWS->sort(criteria);
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -47,6 +47,11 @@ public:
   // Destructor
   virtual ~EventWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<EventWorkspace> clone() const {
+    return std::unique_ptr<EventWorkspace>(doClone());
+  }
+
   // Initialize the pixels
   void init(const std::size_t &, const std::size_t &, const std::size_t &);
 
@@ -196,6 +201,10 @@ protected:
   EventWorkspace &operator=(const EventWorkspace &other);
 
 private:
+  virtual EventWorkspace *doClone() const override {
+    throw std::runtime_error("Cloning of EventWorkspace is not implemented.");
+  }
+
   /** A vector that holds the event list for each spectrum; the key is
    * the workspace index, which is not necessarily the pixelid.
    */

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -201,7 +201,7 @@ protected:
   EventWorkspace &operator=(const EventWorkspace &other);
 
 private:
-  virtual EventWorkspace *doClone() const override {
+  virtual EventWorkspace *doClone() const {
     throw std::runtime_error("Cloning of EventWorkspace is not implemented.");
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -201,9 +201,7 @@ protected:
   EventWorkspace &operator=(const EventWorkspace &other);
 
 private:
-  virtual EventWorkspace *doClone() const {
-    throw std::runtime_error("Cloning of EventWorkspace is not implemented.");
-  }
+  virtual EventWorkspace *doClone() const { return new EventWorkspace(*this); }
 
   /** A vector that holds the event list for each spectrum; the key is
    * the workspace index, which is not necessarily the pixelid.

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -25,6 +25,11 @@ public:
   GroupingWorkspace(size_t numvectors);
   ~GroupingWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<GroupingWorkspace> clone() const {
+    return std::unique_ptr<GroupingWorkspace>(doClone());
+  }
+
   /** Gets the name of the workspace type
   @return Standard string name  */
   virtual const std::string id() const { return "GroupingWorkspace"; }
@@ -36,9 +41,15 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  GroupingWorkspace(const GroupingWorkspace &other);
+  GroupingWorkspace(const GroupingWorkspace &other)
+      : SpecialWorkspace2D(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   GroupingWorkspace &operator=(const GroupingWorkspace &other);
+
+private:
+  virtual GroupingWorkspace *doClone() const {
+    return new GroupingWorkspace(*this);
+  }
 };
 
 /// shared pointer to the GroupingWorkspace class

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -190,7 +190,7 @@ protected:
   API::BoxController_sptr m_BoxController;
   // boost::shared_ptr<BoxCtrlChangesList > m_BoxController;
 private:
-  virtual MDEventWorkspace *doClone() const override {
+  virtual MDEventWorkspace *doClone() const {
     throw std::runtime_error("Cloning of MDEventWorkspace is not implemented.");
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -44,6 +44,11 @@ public:
   MDEventWorkspace(const MDEventWorkspace<MDE, nd> &other);
   virtual ~MDEventWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<MDEventWorkspace> clone() const {
+    return std::unique_ptr<MDEventWorkspace>(doClone());
+  }
+
   /// Perform initialization after dimensions (and others) have been set.
   virtual void initialize();
 
@@ -185,6 +190,10 @@ protected:
   API::BoxController_sptr m_BoxController;
   // boost::shared_ptr<BoxCtrlChangesList > m_BoxController;
 private:
+  virtual MDEventWorkspace *doClone() const override {
+    throw std::runtime_error("Cloning of MDEventWorkspace is not implemented.");
+  }
+
   Kernel::SpecialCoordinateSystem m_coordSystem;
 };
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -40,8 +40,6 @@ public:
   typedef MDE MDEventType;
 
   MDEventWorkspace();
-  // TODO once we have a polymorphic clone this should be made protected
-  MDEventWorkspace(const MDEventWorkspace<MDE, nd> &other);
   virtual ~MDEventWorkspace();
 
   /// Returns a clone of the workspace
@@ -172,6 +170,8 @@ public:
   virtual Mantid::API::MDNormalization displayNormalization() const;
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  MDEventWorkspace(const MDEventWorkspace<MDE, nd> &other);
   /// Protected copy assignment operator. Assignment not implemented.
   /// Windows Visual Studio 2012 has trouble with declaration without definition
   /// so we provide one that throws an error. This seems template related.
@@ -191,7 +191,7 @@ protected:
   // boost::shared_ptr<BoxCtrlChangesList > m_BoxController;
 private:
   virtual MDEventWorkspace *doClone() const {
-    throw std::runtime_error("Cloning of MDEventWorkspace is not implemented.");
+    return new MDEventWorkspace(*this);
   }
 
   Kernel::SpecialCoordinateSystem m_coordSystem;

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -47,9 +47,6 @@ public:
   MDHistoWorkspace(
       std::vector<Mantid::Geometry::IMDDimension_sptr> &dimensions);
 
-  // TODO once we have a polymorphic clone this should be made protected
-  MDHistoWorkspace(const MDHistoWorkspace &other);
-
   virtual ~MDHistoWorkspace();
 
   /// Returns a clone of the workspace
@@ -434,6 +431,8 @@ private:
   Kernel::SpecialCoordinateSystem m_coordSystem;
 
 protected:
+  /// Protected copy constructor. May be used by childs for cloning.
+  MDHistoWorkspace(const MDHistoWorkspace &other);
   /// Protected copy assignment operator. Assignment not implemented.
   MDHistoWorkspace &operator=(const MDHistoWorkspace &other);
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -52,6 +52,11 @@ public:
 
   virtual ~MDHistoWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<MDHistoWorkspace> clone() const {
+    return std::unique_ptr<MDHistoWorkspace>(doClone());
+  }
+
   void init(std::vector<Mantid::Geometry::MDHistoDimension_sptr> &dimensions);
   void init(std::vector<Mantid::Geometry::IMDDimension_sptr> &dimensions);
 
@@ -379,13 +384,14 @@ public:
   /// Get the size of an element in the HistoWorkspace.
   static size_t sizeOfElement();
 
-  /// Virutal constructor.
-  boost::shared_ptr<IMDHistoWorkspace> clone() const;
-
   /// Preferred visual normalization method.
   virtual Mantid::API::MDNormalization displayNormalization() const;
 
 private:
+  virtual MDHistoWorkspace *doClone() const override {
+    return new MDHistoWorkspace(*this);
+  }
+
   void initVertexesArray();
 
   /// Number of dimensions in this workspace

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -388,7 +388,7 @@ public:
   virtual Mantid::API::MDNormalization displayNormalization() const;
 
 private:
-  virtual MDHistoWorkspace *doClone() const override {
+  virtual MDHistoWorkspace *doClone() const {
     return new MDHistoWorkspace(*this);
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MaskWorkspace.h
@@ -20,6 +20,11 @@ public:
   MaskWorkspace(const API::MatrixWorkspace_const_sptr parent);
   ~MaskWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<MaskWorkspace> clone() const {
+    return std::unique_ptr<MaskWorkspace>(doClone());
+  }
+
   bool isMasked(const detid_t detectorID) const;
   bool isMasked(const std::set<detid_t> &detectorIDs) const;
   bool isMaskedIndex(const std::size_t wkspIndex) const;
@@ -46,6 +51,8 @@ protected:
   virtual const std::string toString() const;
 
 private:
+  virtual MaskWorkspace *doClone() const { return new MaskWorkspace(*this); }
+
   /// Clear original incorrect mask
   void clearMask();
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MementoTableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MementoTableWorkspace.h
@@ -48,7 +48,7 @@ public:
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
   MementoTableWorkspace(const MementoTableWorkspace &other)
-      : ITableWorkspace(other), TableWorkspace(other) {}
+      : TableWorkspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   MementoTableWorkspace &operator=(const MementoTableWorkspace &other);
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MementoTableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/MementoTableWorkspace.h
@@ -40,13 +40,23 @@ public:
   MementoTableWorkspace(int nRows = 0);
   ~MementoTableWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<MementoTableWorkspace> clone() const {
+    return std::unique_ptr<MementoTableWorkspace>(doClone());
+  }
+
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  MementoTableWorkspace(const MementoTableWorkspace &other);
+  MementoTableWorkspace(const MementoTableWorkspace &other)
+      : ITableWorkspace(other), TableWorkspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   MementoTableWorkspace &operator=(const MementoTableWorkspace &other);
 
 private:
+  virtual MementoTableWorkspace *doClone() const {
+    return new MementoTableWorkspace(*this);
+  }
+
   static bool expectedColumn(Mantid::API::Column_const_sptr expected,
                              Mantid::API::Column_const_sptr candidate);
 };

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/OffsetsWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/OffsetsWorkspace.h
@@ -22,15 +22,25 @@ public:
   OffsetsWorkspace(Geometry::Instrument_const_sptr inst);
   ~OffsetsWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<OffsetsWorkspace> clone() const {
+    return std::unique_ptr<OffsetsWorkspace>(doClone());
+  }
+
   /** Gets the name of the workspace type
   @return Standard string name  */
   virtual const std::string id() const { return "OffsetsWorkspace"; }
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  OffsetsWorkspace(const OffsetsWorkspace &other);
+  OffsetsWorkspace(const OffsetsWorkspace &other) : SpecialWorkspace2D(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   OffsetsWorkspace &operator=(const OffsetsWorkspace &other);
+
+private:
+  virtual OffsetsWorkspace *doClone() const {
+    return new OffsetsWorkspace(*this);
+  }
 };
 
 /// shared pointer to the OffsetsWorkspace class

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -187,7 +187,7 @@ protected:
   PeaksWorkspace &operator=(const PeaksWorkspace &other);
 
 private:
-  virtual PeaksWorkspace *doClone() const override {
+  virtual PeaksWorkspace *doClone() const {
     return new PeaksWorkspace(*this);
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -67,8 +67,6 @@ public:
 
   PeaksWorkspace();
 
-  PeaksWorkspace *clone() const;
-
   /** Get access to shared pointer containing workspace porperties. This
    function is there to provide common interface of iTableWorkspace
     * Despite it is non-constant method, one should be very carefull using it to
@@ -90,7 +88,10 @@ public:
 
   virtual ~PeaksWorkspace();
 
-  boost::shared_ptr<PeaksWorkspace> clone();
+  /// Returns a clone of the workspace
+  std::unique_ptr<PeaksWorkspace> clone() const {
+    return std::unique_ptr<PeaksWorkspace>(doClone());
+  }
 
   void appendFile(std::string filename, Geometry::Instrument_sptr inst);
 
@@ -186,6 +187,10 @@ protected:
   PeaksWorkspace &operator=(const PeaksWorkspace &other);
 
 private:
+  virtual PeaksWorkspace *doClone() const override {
+    return new PeaksWorkspace(*this);
+  }
+
   /// Initialize the table structure
   void initColumns();
   /// Adds a new PeakColumn of the given type

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
@@ -45,6 +45,11 @@ public:
   /// Class destructor.
   virtual ~RebinnedOutput();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<RebinnedOutput> clone() const {
+    return std::unique_ptr<RebinnedOutput>(doClone());
+  }
+
   /// Get the workspace ID.
   virtual const std::string id() const;
 
@@ -75,6 +80,9 @@ protected:
 
   /// A vector that holds the 1D vectors for the fractional area.
   std::vector<MantidVec> fracArea;
+
+private:
+  virtual RebinnedOutput *doClone() const { return new RebinnedOutput(*this); }
 };
 
 /// shared pointer to the RebinnedOutput class

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
@@ -31,6 +31,11 @@ public:
   SpecialWorkspace2D(API::MatrixWorkspace_const_sptr parent);
   ~SpecialWorkspace2D();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<SpecialWorkspace2D> clone() const {
+    return std::unique_ptr<SpecialWorkspace2D>(doClone());
+  }
+
   /** Gets the name of the workspace type
   @return Standard string name  */
   virtual const std::string id() const { return "SpecialWorkspace2D"; }
@@ -52,6 +57,9 @@ public:
   virtual void copyFrom(boost::shared_ptr<const SpecialWorkspace2D> sourcews);
 
 private:
+  virtual SpecialWorkspace2D *doClone() const {
+    return new SpecialWorkspace2D(*this);
+  }
   bool isCompatible(boost::shared_ptr<const SpecialWorkspace2D> ws);
 
 protected:

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
@@ -50,6 +50,11 @@ public:
   SplittersWorkspace();
   virtual ~SplittersWorkspace();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<SplittersWorkspace> clone() const {
+    return std::unique_ptr<SplittersWorkspace>(doClone());
+  }
+
   void addSplitter(Kernel::SplittingInterval splitter);
 
   Kernel::SplittingInterval getSplitter(size_t index);
@@ -60,9 +65,15 @@ public:
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
-  SplittersWorkspace(const SplittersWorkspace &other);
+  SplittersWorkspace(const SplittersWorkspace &other)
+      : ITableWorkspace(other), TableWorkspace(other), ISplittersWorkspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   SplittersWorkspace &operator=(const SplittersWorkspace &other);
+
+private:
+  virtual SplittersWorkspace *doClone() const {
+    return new SplittersWorkspace(*this);
+  }
 };
 
 typedef boost::shared_ptr<SplittersWorkspace> SplittersWorkspace_sptr;

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/SplittersWorkspace.h
@@ -44,8 +44,8 @@ namespace DataObjects {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport SplittersWorkspace : virtual public DataObjects::TableWorkspace,
-                                     virtual public API::ISplittersWorkspace {
+class DLLExport SplittersWorkspace : public DataObjects::TableWorkspace,
+                                     public API::ISplittersWorkspace {
 public:
   SplittersWorkspace();
   virtual ~SplittersWorkspace();
@@ -66,7 +66,7 @@ public:
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
   SplittersWorkspace(const SplittersWorkspace &other)
-      : ITableWorkspace(other), TableWorkspace(other), ISplittersWorkspace(other) {}
+      : TableWorkspace(other), ISplittersWorkspace(other) {}
   /// Protected copy assignment operator. Assignment not implemented.
   SplittersWorkspace &operator=(const SplittersWorkspace &other);
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
@@ -296,7 +296,7 @@ protected:
   TableWorkspace &operator=(const TableWorkspace &other);
 
 private:
-  virtual TableWorkspace *doClone() const override {
+  virtual TableWorkspace *doClone() const {
     return new TableWorkspace(*this);
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
@@ -77,7 +77,7 @@ namespace DataObjects {
 */
 
 class MANTID_DATAOBJECTS_DLL TableWorkspace
-    : virtual public API::ITableWorkspace {
+    : public API::ITableWorkspace {
 public:
   /// Constructor.
   TableWorkspace(size_t nrows = 0);

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/TableWorkspace.h
@@ -83,6 +83,10 @@ public:
   TableWorkspace(size_t nrows = 0);
   /// Virtual destructor.
   virtual ~TableWorkspace();
+  /// Returns a clone of the workspace
+  std::unique_ptr<TableWorkspace> clone() const {
+    return std::unique_ptr<TableWorkspace>(doClone());
+  }
   /// Return the workspace typeID
   virtual const std::string id() const { return "TableWorkspace"; }
   /// Get the footprint in memory in KB.
@@ -213,8 +217,6 @@ public:
   size_t insertRow(size_t index);
   /// Delets a row if it exists.
   void removeRow(size_t index);
-  /// Clone table workspace instance.
-  TableWorkspace *clone() const;
 
   /** This method finds the row and column index of an integer cell value in a
    * table workspace
@@ -294,6 +296,10 @@ protected:
   TableWorkspace &operator=(const TableWorkspace &other);
 
 private:
+  virtual TableWorkspace *doClone() const override {
+    return new TableWorkspace(*this);
+  }
+
   /// template method to find a given value in a table.
   template <typename Type>
   void findValue(const Type value, size_t &row, const size_t &colIndex) {

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -114,9 +114,7 @@ protected:
   std::vector<Mantid::API::ISpectrum *> data;
 
 private:
-  virtual Workspace2D *doClone() const {
-    throw std::runtime_error("Cloning of Workspace2D is not implemented.");
-  }
+  virtual Workspace2D *doClone() const { return new Workspace2D(*this); }
 
   virtual std::size_t getHistogramNumberHelper() const;
 };

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -52,6 +52,11 @@ public:
   Workspace2D();
   virtual ~Workspace2D();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<Workspace2D> clone() const {
+    return std::unique_ptr<Workspace2D>(doClone());
+  }
+
   /// Returns the histogram number
   std::size_t getNumberHistograms() const;
 
@@ -109,6 +114,10 @@ protected:
   std::vector<Mantid::API::ISpectrum *> data;
 
 private:
+  virtual Workspace2D *doClone() const override {
+    throw std::runtime_error("Cloning of Workspace2D is not implemented.");
+  }
+
   virtual std::size_t getHistogramNumberHelper() const;
 };
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/Workspace2D.h
@@ -114,7 +114,7 @@ protected:
   std::vector<Mantid::API::ISpectrum *> data;
 
 private:
-  virtual Workspace2D *doClone() const override {
+  virtual Workspace2D *doClone() const {
     throw std::runtime_error("Cloning of Workspace2D is not implemented.");
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -82,7 +82,7 @@ protected:
 
 private:
   virtual WorkspaceSingleValue *doClone() const {
-    throw std::runtime_error("Cloning of WorkspaceSingleValue is not implemented.");
+    return new WorkspaceSingleValue(*this);
   }
 
   // allocates space in a new workspace - does nothing in this case

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -81,7 +81,7 @@ protected:
   WorkspaceSingleValue &operator=(const WorkspaceSingleValue &other);
 
 private:
-  virtual WorkspaceSingleValue *doClone() const override {
+  virtual WorkspaceSingleValue *doClone() const {
     throw std::runtime_error("Cloning of WorkspaceSingleValue is not implemented.");
   }
 

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -45,6 +45,11 @@ public:
 
   virtual ~WorkspaceSingleValue();
 
+  /// Returns a clone of the workspace
+  std::unique_ptr<WorkspaceSingleValue> clone() const {
+    return std::unique_ptr<WorkspaceSingleValue>(doClone());
+  }
+
   /// Returns the number of single indexable items in the workspace
   virtual std::size_t size() const { return 1; }
 
@@ -76,6 +81,10 @@ protected:
   WorkspaceSingleValue &operator=(const WorkspaceSingleValue &other);
 
 private:
+  virtual WorkspaceSingleValue *doClone() const override {
+    throw std::runtime_error("Cloning of WorkspaceSingleValue is not implemented.");
+  }
+
   // allocates space in a new workspace - does nothing in this case
   virtual void init(const std::size_t &NVectors, const std::size_t &XLength,
                     const std::size_t &YLength);

--- a/Code/Mantid/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/EventWorkspace.cpp
@@ -39,6 +39,11 @@ EventWorkspace::EventWorkspace() : data(), m_noVectors(),
   mru(new EventWorkspaceMRU) {
 }
 
+EventWorkspace::EventWorkspace(const EventWorkspace &other)
+    : IEventWorkspace(other), mru(new EventWorkspaceMRU) {
+    copyDataFrom(other);
+}
+
 EventWorkspace::~EventWorkspace() {
   delete mru;
 

--- a/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -1217,14 +1217,6 @@ size_t MDHistoWorkspace::sizeOfElement() {
 }
 
 /**
- * Clone the workspace.
- * @return Deep copy of existing workspace.
- */
-boost::shared_ptr<IMDHistoWorkspace> MDHistoWorkspace::clone() const {
-  return boost::shared_ptr<IMDHistoWorkspace>(new MDHistoWorkspace(*this));
-}
-
-/**
 Preferred normalization to use for visual purposes.
 */
 MDNormalization MDHistoWorkspace::displayNormalization() const {

--- a/Code/Mantid/Framework/DataObjects/src/MaskWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MaskWorkspace.cpp
@@ -32,6 +32,9 @@ const double ERROR_VALUE = 0.;
  */
 MaskWorkspace::MaskWorkspace() {}
 
+MaskWorkspace::MaskWorkspace(const MaskWorkspace &other)
+    : SpecialWorkspace2D(other), IMaskWorkspace(other) {}
+
 /**
  * Constructor - with a given dimension.
  * @param[in] numvectors Number of vectors/histograms for this workspace.

--- a/Code/Mantid/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -50,16 +50,6 @@ PeaksWorkspace::PeaksWorkspace()
 }
 
 //---------------------------------------------------------------------------------------------
-/** Virtual constructor. Clone method to duplicate the peaks workspace.
- *
- * @return PeaksWorkspace object
- */
-PeaksWorkspace *PeaksWorkspace::clone() const {
-  // Deep copy via copy construtor.
-  return new PeaksWorkspace(*this);
-}
-
-//---------------------------------------------------------------------------------------------
 /** Copy constructor
  *
  * @param other :: other PeaksWorkspace to copy from
@@ -69,16 +59,6 @@ PeaksWorkspace::PeaksWorkspace(const PeaksWorkspace &other)
     : IPeaksWorkspace(other), peaks(other.peaks), columns(), columnNames(),
       m_coordSystem(other.m_coordSystem) {
   initColumns();
-}
-
-//---------------------------------------------------------------------------------------------
-/** Clone a shared pointer
- *
- * @return copy of the peaksworkspace
- */
-boost::shared_ptr<PeaksWorkspace> PeaksWorkspace::clone() {
-  // Copy construct and return
-  return boost::shared_ptr<PeaksWorkspace>(new PeaksWorkspace(*this));
 }
 
 //=====================================================================================

--- a/Code/Mantid/Framework/DataObjects/src/RebinnedOutput.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/RebinnedOutput.cpp
@@ -16,6 +16,9 @@ DECLARE_WORKSPACE(RebinnedOutput)
 
 RebinnedOutput::RebinnedOutput() : Workspace2D() {}
 
+RebinnedOutput::RebinnedOutput(const RebinnedOutput &other)
+    : Workspace2D(other), fracArea(other.fracArea) {}
+
 RebinnedOutput::~RebinnedOutput() {}
 
 /**

--- a/Code/Mantid/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -72,6 +72,9 @@ SpecialWorkspace2D::SpecialWorkspace2D(API::MatrixWorkspace_const_sptr parent) {
   }
 }
 
+SpecialWorkspace2D::SpecialWorkspace2D(const SpecialWorkspace2D &other)
+    : Workspace2D(other), detID_to_WI(other.detID_to_WI) {}
+
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */

--- a/Code/Mantid/Framework/DataObjects/src/TableWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/TableWorkspace.cpp
@@ -31,6 +31,19 @@ TableWorkspace::TableWorkspace(size_t nrows)
   setRowCount(nrows);
 }
 
+TableWorkspace::TableWorkspace(const TableWorkspace &other)
+    : ITableWorkspace(), m_rowCount(0), m_LogManager(new API::LogManager) {
+  setRowCount(other.m_rowCount);
+
+  column_const_it it = other.m_columns.begin();
+  while (it != other.m_columns.end()) {
+    addColumn(boost::shared_ptr<API::Column>((*it)->clone()));
+    it++;
+  }
+  // copy logs/properties.
+  m_LogManager = boost::make_shared<API::LogManager>(*(other.m_LogManager));
+}
+
 /// Destructor
 TableWorkspace::~TableWorkspace() {}
 
@@ -195,15 +208,7 @@ bool TableWorkspace::addColumn(boost::shared_ptr<API::Column> column) {
 }
 
 TableWorkspace *TableWorkspace::clone() const {
-  TableWorkspace *copy = new TableWorkspace(this->m_rowCount);
-  column_const_it it = m_columns.begin();
-  while (it != m_columns.end()) {
-    copy->addColumn(boost::shared_ptr<API::Column>((*it)->clone()));
-    it++;
-  }
-  // copy logs/properties.
-  copy->m_LogManager = boost::make_shared<API::LogManager>(*this->m_LogManager);
-  return copy;
+  return new TableWorkspace(*this);
 }
 
 /**

--- a/Code/Mantid/Framework/DataObjects/src/TableWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/TableWorkspace.cpp
@@ -207,10 +207,6 @@ bool TableWorkspace::addColumn(boost::shared_ptr<API::Column> column) {
   return true;
 }
 
-TableWorkspace *TableWorkspace::clone() const {
-  return new TableWorkspace(*this);
-}
-
 /**
  * Sort.
  * @param criteria : a vector with a list of pairs: column name, bool;

--- a/Code/Mantid/Framework/DataObjects/src/TableWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/TableWorkspace.cpp
@@ -32,7 +32,7 @@ TableWorkspace::TableWorkspace(size_t nrows)
 }
 
 TableWorkspace::TableWorkspace(const TableWorkspace &other)
-    : ITableWorkspace(), m_rowCount(0), m_LogManager(new API::LogManager) {
+    : ITableWorkspace(other), m_rowCount(0), m_LogManager(new API::LogManager) {
   setRowCount(other.m_rowCount);
 
   column_const_it it = other.m_columns.begin();

--- a/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
@@ -19,6 +19,19 @@ DECLARE_WORKSPACE(Workspace2D)
 /// Constructor
 Workspace2D::Workspace2D(): m_noVectors(0) {}
 
+Workspace2D::Workspace2D(const Workspace2D &other)
+    : MatrixWorkspace(other), m_noVectors(other.m_noVectors),
+      m_monitorList(other.m_monitorList) {
+  data.resize(m_noVectors);
+
+  for (size_t i = 0; i < m_noVectors; ++i) {
+    // Careful: data holds pointers to ISpectrum, but they point to Histogram1D.
+    // There are copy constructors, but we would need a clone() function that is
+    // aware of the polymorphism. Use cast + copy constructor for now.
+    data[i] = new Histogram1D(*static_cast<Histogram1D *>(other.data[i]));
+  }
+}
+
 /// Destructor
 Workspace2D::~Workspace2D() {
 // Clear out the memory

--- a/Code/Mantid/Framework/DataObjects/src/WorkspaceSingleValue.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/WorkspaceSingleValue.cpp
@@ -21,6 +21,11 @@ WorkspaceSingleValue::WorkspaceSingleValue(double value, double error)
   isDistribution(true);
 }
 
+WorkspaceSingleValue::WorkspaceSingleValue(const WorkspaceSingleValue &other)
+    : MatrixWorkspace(other), data(other.data) {
+  isDistribution(true);
+}
+
 /// Destructor
 WorkspaceSingleValue::~WorkspaceSingleValue() {}
 

--- a/Code/Mantid/Framework/DataObjects/test/GroupingWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/GroupingWorkspaceTest.h
@@ -60,6 +60,39 @@ public:
     TS_ASSERT_EQUALS( map[45], 5 );
   }
 
+  void testClone() {
+    // As test_constructor_from_Instrument(), set on ws, get on clone.
+    // Fake instrument with 5*9 pixels with ID starting at 1
+    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
+
+    GroupingWorkspace_sptr ws(new GroupingWorkspace(inst));
+    auto cloned = ws->clone();
+
+    TS_ASSERT_EQUALS( cloned->getNumberHistograms(), 45);
+    TS_ASSERT_EQUALS( cloned->blocksize(), 1);
+    TS_ASSERT_EQUALS( cloned->getInstrument()->getName(), "basic"); // Name of the test instrument
+    std::set<detid_t> dets = cloned->getSpectrum(0)->getDetectorIDs();
+    TS_ASSERT_EQUALS(dets.size(), 1);
+
+    // Set the group numbers
+    for (int group=0; group<5; group++)
+      for (int i=0; i<9; i++)
+        ws->dataY(group*9+i)[0] = double(group+1);
+    cloned = ws->clone();
+
+    // Get the map
+    std::map<detid_t,int> map;
+    int64_t ngroups;
+    cloned->makeDetectorIDToGroupMap(map, ngroups);
+
+    TS_ASSERT_EQUALS(ngroups, 5);
+
+    TS_ASSERT_EQUALS( map[1], 1 );
+    TS_ASSERT_EQUALS( map[9], 1 );
+    TS_ASSERT_EQUALS( map[10], 2 );
+    TS_ASSERT_EQUALS( map[45], 5 );
+  }
+
 
 };
 

--- a/Code/Mantid/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -87,6 +87,12 @@ public:
     delete ew3;
   }
 
+  class TestableMDEventWorkspace : public MDEventWorkspace<MDLeanEvent<3>, 3> {
+  public:
+    TestableMDEventWorkspace(const MDEventWorkspace<MDLeanEvent<3>, 3> &other)
+        : MDEventWorkspace<MDLeanEvent<3>, 3>(other) {}
+  };
+
   void test_copy_constructor()
   {
     MDEventWorkspace<MDLeanEvent<3>, 3> ew3;
@@ -105,7 +111,7 @@ public:
     ExperimentInfo_sptr ei(new ExperimentInfo);
     TS_ASSERT_EQUALS( ew3.addExperimentInfo(ei), 0);
 
-    MDEventWorkspace<MDLeanEvent<3>, 3> copy(ew3);
+    TestableMDEventWorkspace copy(ew3);
     TS_ASSERT_EQUALS( copy.getNumDims(), 3);
     TS_ASSERT_EQUALS( copy.getDimension(0)->getName(), "x");
     TS_ASSERT_EQUALS( copy.getNumExperimentInfo(), 1);

--- a/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -207,6 +207,11 @@ public:
     TS_ASSERT_DELTA( data[5], 2.3456, 1e-5);
   }
 
+  class TestableMDHistoWorkspace : public MDHistoWorkspace {
+  public:
+    TestableMDHistoWorkspace(const MDHistoWorkspace &other)
+        : MDHistoWorkspace(other) {}
+  };
 
   //--------------------------------------------------------------------------------------
   void test_copy_constructor()
@@ -215,7 +220,7 @@ public:
     a->addExperimentInfo( ExperimentInfo_sptr(new ExperimentInfo()) );
     for (size_t i=0; i<a->getNPoints(); i++)
       a->setNumEventsAt(i, 123.);
-    MDHistoWorkspace_sptr b( new MDHistoWorkspace(*a));
+    MDHistoWorkspace_sptr b( new TestableMDHistoWorkspace(*a));
     TS_ASSERT_EQUALS( b->getNumDims(), a->getNumDims() );
     TS_ASSERT_EQUALS( b->getNPoints(), a->getNPoints() );
     TS_ASSERT_EQUALS( b->getNumExperimentInfo(), a->getNumExperimentInfo() );

--- a/Code/Mantid/Framework/DataObjects/test/MaskWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MaskWorkspaceTest.h
@@ -46,6 +46,41 @@ public:
         TS_ASSERT(maskWS.isMasked(0));
     }
 
+    void testClone() {
+        // As test_mask_accessors(), set on ws, get on clone.
+        int pixels = 10;
+        int maskpixels = 25;
+
+        Mantid::Geometry::Instrument_sptr inst =
+                ComponentCreationHelper::createTestInstrumentRectangular2(1,pixels);
+        inst->setName("MaskWorkspaceTest_Instrument");
+
+        Mantid::DataObjects::MaskWorkspace maskWS(inst, false);
+        for (int i = 0; i < maskpixels; i++)
+          maskWS.setMasked(i); // mask the pixel
+
+        auto cloned = maskWS.clone();
+        TS_ASSERT_EQUALS(cloned->getNumberHistograms(), pixels*pixels);
+        TS_ASSERT_EQUALS(cloned->getNumberMasked(), maskpixels);
+        TS_ASSERT(cloned->isMasked(0));
+        TS_ASSERT_EQUALS(cloned->isMasked(maskpixels), false); // one past the masked ones
+
+        // unmask a pixel and check it
+        maskWS.setMasked(0, false);
+        cloned = maskWS.clone();
+        TS_ASSERT_EQUALS(cloned->isMasked(0), false);
+
+        // check of a group of pixels
+        std::set<Mantid::detid_t> detIds;
+        detIds.insert(0); // isn't masked
+        TS_ASSERT_EQUALS(cloned->isMasked(detIds), false);
+        detIds.insert(1); // is masked
+        TS_ASSERT_EQUALS(cloned->isMasked(detIds), false);
+        detIds.erase(0);
+        detIds.insert(2);
+        TS_ASSERT_EQUALS(cloned->isMasked(detIds), true);
+    }
+
     void test_mask_accessors()
     {
         int pixels = 10;

--- a/Code/Mantid/Framework/DataObjects/test/MementoTableWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/MementoTableWorkspaceTest.h
@@ -29,6 +29,40 @@ public:
     TSM_ASSERT_EQUALS("Wrong number of columns constructed", 11, pWs->columnCount());
   }
 
+  void testClone()
+  {
+    MementoTableWorkspace tw(1);
+
+    tw.getColumn(0)->cell<std::string>(0) = "a";
+    tw.getColumn(1)->cell<std::string>(0) = "b";
+    tw.getColumn(2)->cell<int>(0) = 421;
+    tw.getColumn(3)->cell<std::string>(0) = "c";
+    tw.getColumn(4)->cell<double>(0) = 1.1;
+    tw.getColumn(5)->cell<double>(0) = 2.1;
+    tw.getColumn(6)->cell<double>(0) = 3.1;
+    tw.getColumn(7)->cell<double>(0) = 4.1;
+    tw.getColumn(8)->cell<double>(0) = 5.1;
+    tw.getColumn(9)->cell<double>(0) = 6.1;
+    tw.getColumn(10)->cell<std::string>(0) = "d";
+
+    auto cloned = tw.clone();
+
+    // Check clone is same as original.
+    TS_ASSERT_EQUALS(tw.columnCount(), cloned->columnCount());
+    TS_ASSERT_EQUALS(tw.rowCount(), cloned->rowCount());
+    TS_ASSERT_EQUALS("a", cloned->getColumn(0)->cell<std::string>(0));
+    TS_ASSERT_EQUALS("b", cloned->getColumn(1)->cell<std::string>(0));
+    TS_ASSERT_EQUALS(421, cloned->getColumn(2)->cell<int>(0));
+    TS_ASSERT_EQUALS("c", cloned->getColumn(3)->cell<std::string>(0));
+    TS_ASSERT_EQUALS(1.1, cloned->getColumn(4)->cell<double>(0));
+    TS_ASSERT_EQUALS(2.1, cloned->getColumn(5)->cell<double>(0));
+    TS_ASSERT_EQUALS(3.1, cloned->getColumn(6)->cell<double>(0));
+    TS_ASSERT_EQUALS(4.1, cloned->getColumn(7)->cell<double>(0));
+    TS_ASSERT_EQUALS(5.1, cloned->getColumn(8)->cell<double>(0));
+    TS_ASSERT_EQUALS(6.1, cloned->getColumn(9)->cell<double>(0));
+    TS_ASSERT_EQUALS("d", cloned->getColumn(10)->cell<std::string>(0));
+  }
+
   void testCompareWithWrongNColumns()
   {
     //Create a table workspace with too few columns.

--- a/Code/Mantid/Framework/DataObjects/test/OffsetsWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/OffsetsWorkspaceTest.h
@@ -8,6 +8,7 @@
 #include <iomanip>
 
 #include "MantidDataObjects/OffsetsWorkspace.h"
+#include "MantidTestHelpers/ComponentCreationHelper.h"
 
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
@@ -20,7 +21,12 @@ public:
   {
   }
 
+  void testClone() {
+    auto inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
 
+    OffsetsWorkspace ws(inst);
+    TS_ASSERT_THROWS_NOTHING(ws.clone());
+  }
 };
 
 

--- a/Code/Mantid/Framework/DataObjects/test/RebinnedOutputTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/RebinnedOutputTest.h
@@ -31,6 +31,21 @@ public:
     ws = WorkspaceCreationHelper::CreateRebinnedOutputWorkspace();
   }
 
+  void testClone() {
+    RebinnedOutput_sptr cloned(ws->clone().release());
+
+    // Swap ws with cloned pointer, such that we can reuse existing tests.
+    ws.swap(cloned);
+
+    // Run all other tests on ws.
+    testId();
+    testRepresentation();
+    testSetF();
+
+    // Undo swap, to avoid possible interferences.
+    ws.swap(cloned);
+  }
+
   void testId()
   {
     TS_ASSERT_EQUALS( ws->id(), "RebinnedOutput" );

--- a/Code/Mantid/Framework/DataObjects/test/SpecialWorkspace2DTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/SpecialWorkspace2DTest.h
@@ -32,6 +32,32 @@ public:
     TS_ASSERT_EQUALS( ws->blocksize(), 1);
   }
 
+  void testClone() {
+    // As test_setValue_getValue, set on ws, get on clone.
+    Instrument_sptr inst =
+        ComponentCreationHelper::createTestInstrumentCylindrical(5);
+    SpecialWorkspace2D_sptr ws(new SpecialWorkspace2D(inst));
+
+    auto cloned = ws->clone();
+    TS_ASSERT_DIFFERS(cloned->getValue(1), 12.3);
+    TS_ASSERT_THROWS_NOTHING(ws->setValue(1, 12.3));
+    cloned = ws->clone();
+    TS_ASSERT_DELTA(cloned->getValue(1), 12.3, 1e-6);
+    TS_ASSERT_THROWS_ANYTHING(ws->setValue(46, 789));
+    TS_ASSERT_THROWS_ANYTHING(ws->setValue(-1, 789));
+    cloned = ws->clone();
+    TS_ASSERT_THROWS_ANYTHING(cloned->getValue(47));
+    TS_ASSERT_THROWS_ANYTHING(cloned->getValue(-34));
+    TS_ASSERT_EQUALS(cloned->getValue(47, 5.0), 5.0);
+    TS_ASSERT_EQUALS(cloned->getValue(147, -12.0), -12.0);
+
+    // Some extra tests: 1. clone ws, 2. set on ws, 3. clone should differ.
+    cloned = ws->clone();
+    TS_ASSERT_DELTA(cloned->getValue(1), 12.3, 1e-6);
+    TS_ASSERT_THROWS_NOTHING(ws->setValue(1, 1.1));
+    TS_ASSERT_DIFFERS(cloned->getValue(1), 1.1);
+  }
+
   void test_constructor_from_Instrument()
   {
     // Fake instrument with 5*9 pixels with ID starting at 1

--- a/Code/Mantid/Framework/DataObjects/test/SplittersWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/SplittersWorkspaceTest.h
@@ -23,6 +23,26 @@ public:
   static void destroySuite( SplittersWorkspaceTest *suite ) { delete suite; }
 
 
+  void testClone()
+  {
+    SplittersWorkspace splitterws;
+
+    Kernel::SplittingInterval s1(Kernel::DateAndTime(10000), Kernel::DateAndTime(15000), 1);
+    Kernel::SplittingInterval s2(Kernel::DateAndTime(20000), Kernel::DateAndTime(30000), 3);
+    Kernel::SplittingInterval s3(Kernel::DateAndTime(40000), Kernel::DateAndTime(50000), 2);
+
+    splitterws.addSplitter(s1);
+    splitterws.addSplitter(s2);
+    splitterws.addSplitter(s3);
+
+    auto cloned = splitterws.clone();
+
+    // Check clone is same as original.
+    TS_ASSERT_EQUALS(splitterws.columnCount(), cloned->columnCount());
+    TS_ASSERT_EQUALS(splitterws.rowCount(), cloned->rowCount());
+    TS_ASSERT_EQUALS(splitterws.getNumberSplitters(), 3);
+  }
+
   void test_Add()
   {
     DataObjects::SplittersWorkspace splitterws;

--- a/Code/Mantid/Framework/DataObjects/test/TableWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/TableWorkspaceTest.h
@@ -311,7 +311,7 @@ public:
     tw.getColumn(1)->cell<std::string>(0) = "b";
     tw.getColumn(2)->cell<std::string>(0) = "c";
 
-    boost::scoped_ptr<TableWorkspace> cloned(tw.clone());
+    boost::scoped_ptr<TableWorkspace> cloned(tw.clone().release());
 
     //Check clone is same as original.
     TS_ASSERT_EQUALS(tw.columnCount(), cloned->columnCount());

--- a/Code/Mantid/Framework/DataObjects/test/Workspace2DTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/Workspace2DTest.h
@@ -56,6 +56,20 @@ public:
     return retVal;
   }
 
+  void testClone() {
+    Workspace2D_sptr cloned(ws->clone().release());
+
+    // Swap ws with cloned pointer, such that we can reuse existing tests.
+    ws.swap(cloned);
+
+    // Run all other (non-destructive) tests on ws.
+    testInit();
+    testId();
+    testDataDx();
+
+    // Undo swap, to avoid possible interferences.
+    ws.swap(cloned);
+  }
 
   void testInit()
   {

--- a/Code/Mantid/Framework/DataObjects/test/WorkspaceSingleValueTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/WorkspaceSingleValueTest.h
@@ -29,6 +29,16 @@ public:
     TS_ASSERT_DELTA(2,ws.dataE(0)[0],1e-6);
   }
 
+  void testClone()
+  {
+    WorkspaceSingleValue ws(2.0, 0.1);
+    auto cloned = ws.clone();
+
+    TS_ASSERT_EQUALS(ws.dataX(0)[0], cloned->dataX(0)[0]);
+    TS_ASSERT_EQUALS(ws.dataY(0)[0], cloned->dataY(0)[0]);
+    TS_ASSERT_EQUALS(ws.dataE(0)[0], cloned->dataE(0)[0]);
+  }
+
   void testsetgetXvector()
   {
     WorkspaceSingleValue ws;

--- a/Code/Mantid/Framework/MDAlgorithms/src/CentroidPeaksMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CentroidPeaksMD.cpp
@@ -84,7 +84,7 @@ void CentroidPeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS = inPeakWS->clone();
+    peakWS.reset(inPeakWS->clone().release());
 
   std::string CoordinatesToUseStr = getPropertyValue("CoordinatesToUse");
   int CoordinatesToUse = ws->getSpecialCoordinateSystem();

--- a/Code/Mantid/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CentroidPeaksMD2.cpp
@@ -81,7 +81,7 @@ void CentroidPeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS = inPeakWS->clone();
+    peakWS.reset(inPeakWS->clone().release());
 
   int CoordinatesToUse = ws->getSpecialCoordinateSystem();
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/CloneMDWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CloneMDWorkspace.cpp
@@ -108,10 +108,8 @@ CloneMDWorkspace::doClone(const typename MDEventWorkspace<MDE, nd>::sptr ws) {
                       boost::dynamic_pointer_cast<IMDWorkspace>(outWS));
   } else {
     // Perform the clone in memory.
-    boost::shared_ptr<MDEventWorkspace<MDE, nd>> outWS(
-        new MDEventWorkspace<MDE, nd>(*ws));
-    this->setProperty("OutputWorkspace",
-                      boost::dynamic_pointer_cast<IMDWorkspace>(outWS));
+    IMDWorkspace_sptr outWS(ws->clone().release());
+    setProperty("OutputWorkspace", outWS);
   }
 }
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/CloneMDWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/CloneMDWorkspace.cpp
@@ -128,11 +128,10 @@ void CloneMDWorkspace::exec() {
   if (inWS) {
     CALL_MDEVENT_FUNCTION(this->doClone, inWS);
   } else if (inHistoWS) {
-    // Clone using the copy constructor
-    MDHistoWorkspace_sptr outWS(new MDHistoWorkspace(*inHistoWS));
+    // Polymorphic clone().
+    IMDWorkspace_sptr outWS(inHistoWS->clone().release());
     // And set to the output. Easy.
-    this->setProperty("OutputWorkspace",
-                      boost::dynamic_pointer_cast<IMDWorkspace>(outWS));
+    this->setProperty("OutputWorkspace", outWS);
   } else {
     // Call CloneWorkspace as a fall-back?
     throw std::runtime_error("CloneMDWorkspace can only clone a "

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -306,7 +306,7 @@ void IntegrateEllipsoids::exec() {
   Mantid::DataObjects::PeaksWorkspace_sptr peak_ws =
       getProperty("OutputWorkspace");
   if (peak_ws != in_peak_ws) {
-    peak_ws = in_peak_ws->clone();
+    peak_ws.reset(in_peak_ws->clone().release());
   }
   double radius = getProperty("RegionRadius");
   int numSigmas = getProperty("NumSigmas");

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -245,7 +245,8 @@ void IntegrateMDHistoWorkspace::exec() {
   if (emptyCount == pbins.size()) {
     // No work to do.
     g_log.information(this->name() + " Direct clone of input.");
-    this->setProperty("OutputWorkspace", inWS->clone());
+    this->setProperty("OutputWorkspace", boost::shared_ptr<IMDHistoWorkspace>(
+                                             inWS->clone().release()));
   } else {
 
     /* Create the output workspace in the right shape. This allows us to iterate

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
@@ -164,7 +164,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS = inPeakWS->clone();
+    peakWS.reset(inPeakWS->clone().release());
 
   /// Value of the CoordinatesToUse property.
   std::string CoordinatesToUseStr = getPropertyValue("CoordinatesToUse");

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -171,7 +171,7 @@ void IntegratePeaksMD2::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   Mantid::DataObjects::PeaksWorkspace_sptr peakWS =
       getProperty("OutputWorkspace");
   if (peakWS != inPeakWS)
-    peakWS = inPeakWS->clone();
+    peakWS.reset(inPeakWS->clone().release());
   // This only fails in the unit tests which say that MaskBTP is not registered
   try {
     runMaskDetectors(inPeakWS, "Tube", "edges");

--- a/Code/Mantid/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -245,7 +245,7 @@ MDHistoWorkspace_sptr MDNormDirectSC::binInputWS() {
  */
 void MDNormDirectSC::createNormalizationWS(const MDHistoWorkspace &dataWS) {
   // Copy the MDHisto workspace, and change signals and errors to 0.
-  m_normWS = boost::make_shared<MDHistoWorkspace>(dataWS);
+  m_normWS.reset(dataWS.clone().release());
   m_normWS->setTo(0., 0., 0.);
 }
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -218,7 +218,7 @@ MDHistoWorkspace_sptr MDNormSCD::binInputWS() {
  */
 void MDNormSCD::createNormalizationWS(const MDHistoWorkspace &dataWS) {
   // Copy the MDHisto workspace, and change signals and errors to 0.
-  m_normWS = boost::make_shared<MDHistoWorkspace>(dataWS);
+  m_normWS.reset(dataWS.clone().release());
   m_normWS->setTo(0., 0., 0.);
 }
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -117,7 +117,7 @@ SmoothMD::hatSmooth(IMDHistoWorkspace_const_sptr toSmooth,
   uint64_t nPoints = toSmooth->getNPoints();
   Progress progress(this, 0, 1, size_t(double(nPoints) * 1.1));
   // Create the output workspace.
-  IMDHistoWorkspace_sptr outWS = toSmooth->clone();
+  IMDHistoWorkspace_sptr outWS(toSmooth->clone().release());
   progress.reportIncrement(
       size_t(double(nPoints) * 0.1)); // Report ~10% progress
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -33,7 +33,6 @@ set ( EXPORT_FILES
   src/Exports/ITableWorkspace.cpp
   src/Exports/ITableWorkspaceProperty.cpp
   src/Exports/ISplittersWorkspace.cpp
-  src/Exports/ISplittersWorkspaceProperty.cpp
   src/Exports/MDGeometry.cpp
   src/Exports/IMDWorkspace.cpp
   src/Exports/IMDWorkspaceProperty.cpp

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspace.cpp
@@ -4,12 +4,11 @@
 #include <boost/python/return_internal_reference.hpp>
 
 using Mantid::API::ISplittersWorkspace;
-using Mantid::API::ITableWorkspace;
 using namespace Mantid::PythonInterface::Registry;
 using namespace boost::python;
 
 void export_ISplittersWorkspace() {
-  class_<ISplittersWorkspace, bases<ITableWorkspace>, boost::noncopyable>(
+  class_<ISplittersWorkspace, boost::noncopyable>(
          "ISplittersWorkspace", no_init)
       .def("getNumberSplitters", &ISplittersWorkspace::getNumberSplitters,
            "Returns the number of splitters within the workspace")

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspaceProperty.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISplittersWorkspaceProperty.cpp
@@ -1,8 +1,0 @@
-#include "MantidPythonInterface/api/WorkspacePropertyExporter.h"
-#include "MantidAPI/ISplittersWorkspace.h"
-
-void export_ISplittersWorkspaceProperty() {
-  using Mantid::API::ISplittersWorkspace;
-  using Mantid::PythonInterface::WorkspacePropertyExporter;
-  WorkspacePropertyExporter<ISplittersWorkspace>::define("ISplittersWorkspaceProperty");
-}

--- a/Code/Mantid/Framework/SINQ/test/PoldiPeakCollectionTest.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiPeakCollectionTest.h
@@ -161,7 +161,7 @@ public:
 
         TS_ASSERT_EQUALS(collection.intensityType(), PoldiPeakCollection::Maximum);
 
-        TableWorkspace_sptr newDummy(m_dummyData->clone());
+        TableWorkspace_sptr newDummy(m_dummyData->clone().release());
         newDummy->logs()->addProperty<std::string>("IntensityType", "Integral");
 
         PoldiPeakCollection otherCollection(newDummy);
@@ -170,7 +170,7 @@ public:
 
     void testIntensityTypeRecoveryConversion()
     {
-        TableWorkspace_sptr newDummy(m_dummyData->clone());
+        TableWorkspace_sptr newDummy(m_dummyData->clone().release());
         newDummy->logs()->addProperty<std::string>("IntensityType", "Integral");
 
         PoldiPeakCollection collection(newDummy);
@@ -218,7 +218,7 @@ public:
 
     void testUnitCellFromLogs()
     {
-        TableWorkspace_sptr newDummy(m_dummyData->clone());
+        TableWorkspace_sptr newDummy(m_dummyData->clone().release());
 
         UnitCell cell(1, 2, 3, 90, 91, 92);
         newDummy->logs()->addProperty<std::string>("UnitCell", unitCellToStr(cell));
@@ -241,7 +241,7 @@ public:
 
     void testGetPointGroupStringFromLog()
     {
-        TableWorkspace_sptr newDummy(m_dummyData->clone());
+        TableWorkspace_sptr newDummy(m_dummyData->clone().release());
         newDummy->logs()->addProperty<std::string>("PointGroup", "SomeString");
 
         TestablePoldiPeakCollection peaks;

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -132,6 +132,9 @@ public:
   }
 
 private:
+  virtual WorkspaceTester *doClone() const override {
+    throw std::runtime_error("Cloning of WorkspaceTester is not implemented.");
+  }
   std::vector<SpectrumTester> vec;
   size_t spec;
 };
@@ -230,6 +233,12 @@ public:
 
   void find(V3D, size_t&, const size_t&) {
     throw std::runtime_error("find not implemented");
+  }
+
+private:
+  virtual TableWorkspaceTester *doClone() const override {
+    throw std::runtime_error(
+        "Cloning of TableWorkspaceTester is not implemented.");
   }
 };
 

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -132,7 +132,7 @@ public:
   }
 
 private:
-  virtual WorkspaceTester *doClone() const override {
+  virtual WorkspaceTester *doClone() const {
     throw std::runtime_error("Cloning of WorkspaceTester is not implemented.");
   }
   std::vector<SpectrumTester> vec;
@@ -236,7 +236,7 @@ public:
   }
 
 private:
-  virtual TableWorkspaceTester *doClone() const override {
+  virtual TableWorkspaceTester *doClone() const {
     throw std::runtime_error(
         "Cloning of TableWorkspaceTester is not implemented.");
   }

--- a/Code/Mantid/MantidQt/API/test/SignalRangeTest.h
+++ b/Code/Mantid/MantidQt/API/test/SignalRangeTest.h
@@ -35,6 +35,11 @@ private:
     MOCK_METHOD1(setMDMasking, void(Mantid::Geometry::MDImplicitFunction*));
     MOCK_METHOD0(clearMDMasking, void());
     MOCK_CONST_METHOD0(getSpecialCoordinateSystem, Mantid::Kernel::SpecialCoordinateSystem());
+  private:
+    virtual MockMDWorkspace *doClone() const override {
+      throw std::runtime_error(
+          "Cloning of MockMDWorkspace is not implemented.");
+    }
   };
 
   class MockMDIterator : public Mantid::API::IMDIterator

--- a/Code/Mantid/MantidQt/API/test/SignalRangeTest.h
+++ b/Code/Mantid/MantidQt/API/test/SignalRangeTest.h
@@ -36,7 +36,7 @@ private:
     MOCK_METHOD0(clearMDMasking, void());
     MOCK_CONST_METHOD0(getSpecialCoordinateSystem, Mantid::Kernel::SpecialCoordinateSystem());
   private:
-    virtual MockMDWorkspace *doClone() const override {
+    virtual MockMDWorkspace *doClone() const {
       throw std::runtime_error(
           "Cloning of MockMDWorkspace is not implemented.");
     }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -1044,7 +1044,9 @@ namespace MantidQt
     {
       if(!m_wsName.empty())
       {
-        AnalysisDataService::Instance().addOrReplace(m_wsName,boost::shared_ptr<ITableWorkspace>(m_ws->clone()));
+        AnalysisDataService::Instance().addOrReplace(
+            m_wsName,
+            boost::shared_ptr<ITableWorkspace>(m_ws->clone().release()));
         m_tableDirty = false;
       }
       else
@@ -1107,7 +1109,8 @@ namespace MantidQt
       ITableWorkspace_sptr origTable = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(toOpen);
 
       //We create a clone of the table for live editing. The original is not updated unless we explicitly save.
-      ITableWorkspace_sptr newTable = boost::shared_ptr<ITableWorkspace>(origTable->clone());
+      ITableWorkspace_sptr newTable =
+          boost::shared_ptr<ITableWorkspace>(origTable->clone().release());
       try
       {
         validateModel(newTable);

--- a/Code/Mantid/Vates/VatesAPI/test/MockObjects.h
+++ b/Code/Mantid/Vates/VatesAPI/test/MockObjects.h
@@ -111,6 +111,12 @@ public:
   }
 
   virtual ~MockIMDWorkspace() {}
+
+private:
+  virtual MockIMDWorkspace *doClone() const {
+    throw std::runtime_error(
+        "Cloning of MockIMDWorkspace is not implemented.");
+  }
 };
 
 


### PR DESCRIPTION
Closes #12687.

Implements `Workspace::clone()` with covariant return type in all sub-classes. Note that there is one remaining issue when cloning a file-backed MDEventWorkspace, see #12994.

The copy implementation by `CloneWorkspace` was generally replaced by the new `clone()` method. Therefore the tests of `CloneWorkspace` test the changes in these commits. Furthermore a few tests of the `clone()` method itself were added, but the actual coverage is probably by far not complete.
