### PR TITLE
Add load log option to Indirect Diffraction

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -14,6 +14,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
     _chopped_data = None
     _output_ws = None
     _data_files = None
+    _load_logs = None
     _instrument_name = None
     _mode = None
     _spectra_range = None
@@ -37,6 +38,9 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         self.declareProperty(name='SumFiles', defaultValue=False,
                              doc='Enabled to sum spectra from each input file.')
+
+        self.declareProperty(name='LoadLogFiles', defaultValue=True,
+                             doc='Load log files when loading runs')
 
         self.declareProperty(name='Instrument', defaultValue='IRIS',
                              validator=StringListValidator(['IRIS', 'OSIRIS', 'TOSCA', 'VESUVIO']),
@@ -107,6 +111,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                                                               self._spectra_range[0],
                                                               self._spectra_range[1],
                                                               self._sum_files,
+                                                              self._load_logs,
                                                               load_opts=load_opts)
 
         for c_ws_name in self._workspace_names:
@@ -181,6 +186,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         self._output_ws = self.getPropertyValue('OutputWorkspace')
         self._data_files = self.getProperty('InputFiles').value
+        self._load_logs = self.getProperty('LoadLogFiles').value
         self._instrument_name = self.getPropertyValue('Instrument')
         self._mode = self.getPropertyValue('Mode')
         self._spectra_range = self.getProperty('SpectraRange').value

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReduction.py
@@ -152,6 +152,7 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
     _vans = None
     _samMap = None
     _vanMap = None
+    _load_logs = None
 
     def category(self):
         return 'Diffraction;PythonAlgorithms'
@@ -172,6 +173,8 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty('OutputWorkspace', '', Direction.Output),
                              doc="Name to give the output workspace. If no name is provided, "+\
                                  "one will be generated based on the run numbers.")
+        self.declareProperty(name='LoadLogFiles', defaultValue=True,
+                             doc='Load log files when loading runs')
 
         self._cal = None
         self._outputWsName = None
@@ -183,6 +186,7 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
         # Set OSIRIS as default instrument.
         config["default.instrument"] = 'OSIRIS'
 
+        self._load_logs = self.getProperty('LoadLogFiles').value
         self._cal = self.getProperty("CalFile").value
         self._outputWsName = self.getPropertyValue("OutputWorkspace")
 
@@ -201,7 +205,11 @@ class OSIRISDiffractionReduction(PythonAlgorithm):
 
         # Load all sample and vanadium files, and add the resulting workspaces to the DRangeToWsMaps.
         for fileName in self._sams + self._vans:
-            Load(Filename=fileName, OutputWorkspace=fileName, SpectrumMin=3, SpectrumMax=962)
+            Load(Filename=fileName,
+                 OutputWorkspace=fileName,
+                 SpectrumMin=3,
+                 SpectrumMax=962,
+                 LoadLogFiles=self._load_logs)
         for sam in self._sams:
             self._samMap.addWs(sam)
         for van in self._vans:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
@@ -88,6 +88,16 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QCheckBox" name="ckLoadLogs">
+           <property name="text">
+            <string>Load Log Files</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>
@@ -443,6 +453,24 @@
    <header>MantidQtMantidWidgets/IndirectInstrumentConfig.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>iicInstrumentConfiguration</tabstop>
+  <tabstop>dem_ckSumFiles</tabstop>
+  <tabstop>ckLoadLogs</tabstop>
+  <tabstop>set_leSpecMin</tabstop>
+  <tabstop>set_leSpecMax</tabstop>
+  <tabstop>leRebinStart</tabstop>
+  <tabstop>leRebinWidth</tabstop>
+  <tabstop>leRebinEnd</tabstop>
+  <tabstop>ckIndividualGrouping</tabstop>
+  <tabstop>cbPlotType</tabstop>
+  <tabstop>ckGSS</tabstop>
+  <tabstop>ckNexus</tabstop>
+  <tabstop>ckAscii</tabstop>
+  <tabstop>pbHelp</tabstop>
+  <tabstop>pbRun</tabstop>
+  <tabstop>pbManageDirs</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDiffractionReduction.cpp
@@ -280,6 +280,7 @@ void IndirectDiffractionReduction::runGenericReduction(QString instName, QString
   msgDiffReduction->setProperty("Instrument", instName.toStdString());
   msgDiffReduction->setProperty("Mode", mode.toStdString());
   msgDiffReduction->setProperty("SumFiles", m_uiForm.dem_ckSumFiles->isChecked());
+  msgDiffReduction->setProperty("LoadLogFiles", m_uiForm.ckLoadLogs->isChecked());
   msgDiffReduction->setProperty("InputFiles", m_uiForm.dem_rawFiles->getFilenames().join(",").toStdString());
   msgDiffReduction->setProperty("SpectraRange", detRange);
   msgDiffReduction->setProperty("RebinParam", rebin.toStdString());
@@ -329,6 +330,7 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction()
   osirisDiffReduction->setProperty("Sample", m_uiForm.dem_rawFiles->getFilenames().join(",").toStdString());
   osirisDiffReduction->setProperty("Vanadium", m_uiForm.dem_vanadiumFile->getFilenames().join(",").toStdString());
   osirisDiffReduction->setProperty("CalFile", m_uiForm.dem_calFile->getFirstFilename().toStdString());
+  osirisDiffReduction->setProperty("LoadLogFiles", m_uiForm.ckLoadLogs->isChecked());
   osirisDiffReduction->setProperty("OutputWorkspace", drangeWsName.toStdString());
   m_batchAlgoRunner->addAlgorithm(osirisDiffReduction);
 

--- a/Code/Mantid/scripts/Inelastic/IndirectReductionCommon.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectReductionCommon.py
@@ -303,7 +303,8 @@ def unwrap_monitor(workspace_name):
         try:
             FFTSmooth(InputWorkspace=monitor_workspace_name,
                       OutputWorkspace=monitor_workspace_name,
-                      WorkspaceIndex=0)
+                      WorkspaceIndex=0,
+                      IgnoreXBins=True)
         except ValueError:
             raise ValueError('Uneven bin widths are not supported.')
 


### PR DESCRIPTION
Fixes #12953.

To test:
- Open Indirect > Diffraction
- Instrument: OSIRIS, diffonly
- Load run file: `OSIRIS00114160.raw` (from ISIS data archive)
- Run with and without load log option, notice the difference in sample logs of results
- Do the same in diffspec mode

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24322&oldid=24321).
