### PR TITLE
EnginXCalibrateFull: extend bank calibration output table, write it to file, apply calibration on workspace

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -17,7 +17,7 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
     def PyInit(self):
         self.declareProperty(MatrixWorkspaceProperty("Workspace", "", Direction.InOut),
-                             "Workspace with the calibration run to use. The calibration will applied on it.")
+                             "Workspace with the calibration run to use. The calibration will be applied on it.")
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Output),\
                              "A table with the detector IDs and calibrated detector positions and additional "

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -19,16 +19,16 @@ class EnginXCalibrateFull(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty("Workspace", "", Direction.InOut),
                              "Workspace with the calibration run to use. The calibration will be applied on it.")
 
-        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Output),\
+        self.declareProperty(ITableWorkspaceProperty("OutDetPosTable", "", Direction.Output),\
                              "A table with the detector IDs and calibrated detector positions and additional "
                              "calibration information. The table includes: the old positions in V3D format "
                              "(3D vector with x, y, z values), the new positions in V3D, the new positions "
                              "in spherical coordinates, the change in L2, and the DIFC and ZERO parameters.")
 
-        self.declareProperty(FileProperty("OutputDetectorPositionsFilename", "", FileAction.OptionalSave, [".csv"]),
+        self.declareProperty(FileProperty("OutDetPosFilename", "", FileAction.OptionalSave, [".csv"]),
                              "Name of the file to save the pre-/post-calibrated detector positions - this "
                              "saves the same information that is provided in the output table workspace "
-                             "(DetectorPositions).")
+                             "(OutDetPosTable).")
 
         self.declareProperty(FloatArrayProperty("ExpectedPeaks", ""),\
     		"A list of dSpacing values where peaks are expected.")
@@ -57,9 +57,9 @@ class EnginXCalibrateFull(PythonAlgorithm):
         posTbl = self._calculateCalibPositionsTbl(rebinWS, bank, expectedPeaksD)
 
         # Produce 2 results: 'output table' and 'apply calibration' + (optional) calibration file
-        self.setProperty("DetectorPositions", posTbl)
+        self.setProperty("OutDetPosTable", posTbl)
         self._applyCalibrationTable(inWS, posTbl)
-        self._outputDetPosFile(self.getPropertyValue('OutputDetectorPositionsFilename'), posTbl)
+        self._outputDetPosFile(self.getPropertyValue('OutDetPosFilename'), posTbl)
 
     def _prepareWsForFitting(self, ws):
         """

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -17,7 +17,7 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
     def PyInit(self):
         self.declareProperty(MatrixWorkspaceProperty("Workspace", "", Direction.InOut),
-                             "Workspace with the calibration run to use.")
+                             "Workspace with the calibration run to use. The calibration will applied on it.")
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Output),\
                              "A table with the detector IDs and calibrated detector positions and additional "

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -2,6 +2,7 @@
 from mantid.kernel import *
 from mantid.api import *
 import math
+import EnginXUtils
 
 class EnginXCalibrateFull(PythonAlgorithm):
 
@@ -15,12 +16,19 @@ class EnginXCalibrateFull(PythonAlgorithm):
         return "Calibrates every pixel position by performing single peak fitting."
 
     def PyInit(self):
-        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input),
+        self.declareProperty(MatrixWorkspaceProperty("Workspace", "", Direction.InOut),
                              "Workspace with the calibration run to use.")
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "", Direction.Output),\
-                             "A table with the detector IDs and calibrated detector positions in V3D format "
-                             "(3D vector with x, y, z values).")
+                             "A table with the detector IDs and calibrated detector positions and additional "
+                             "calibration information. The table includes: the old positions in V3D format "
+                             "(3D vector with x, y, z values), the new positions in V3D, the new positions "
+                             "in spherical coordinates, the change in L2, and the DIFC and ZERO parameters.")
+
+        self.declareProperty(FileProperty("OutputDetectorPositionsFilename", "", FileAction.OptionalSave, [".csv"]),
+                             "Name of the file to save the pre-/post-calibrated detector positions - this "
+                             "saves the same information that is provided in the output table workspace "
+                             "(DetectorPositions).")
 
         self.declareProperty(FloatArrayProperty("ExpectedPeaks", ""),\
     		"A list of dSpacing values where peaks are expected.")
@@ -35,8 +43,6 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
     def PyExec(self):
 
-        import EnginXUtils
-
         # Get peaks in dSpacing from file, and check we have what we need, before doing anything
         expectedPeaksD = EnginXUtils.readInExpectedPeaks(self.getPropertyValue("ExpectedPeaksFromFile"),
                                                          self.getProperty('ExpectedPeaks').value)
@@ -44,33 +50,21 @@ class EnginXCalibrateFull(PythonAlgorithm):
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")
 
-        ws = self.getProperty('InputWorkspace').value
+        inWS = self.getProperty('Workspace').value
+        bank = self.getProperty('Bank').value
 
-        ws = self._prepareWsForFitting(ws)
+        rebinWS = self._prepareWsForFitting(inWS)
+        posTbl = self._calculateCalibPositionsTbl(rebinWS, bank, expectedPeaksD)
 
-        positionTable = self._createPositionsTable()
-
-        indices = EnginXUtils.getWsIndicesForBank(self.getProperty('Bank').value, ws)
-
-        prog = Progress(self, 0, 1, len(indices))
-
-        for i in indices:
-
-            _, difc = self._fitPeaks(ws, i, expectedPeaksD)
-
-            det = ws.getDetector(i)
-
-            newPos = self._getCalibratedDetPos(difc, det, ws)
-
-            positionTable.addRow([det.getID(), newPos])
-
-            prog.report()
-
-        self.setProperty("DetectorPositions", positionTable)
+        # Produce 2 results: 'output table' and 'apply calibration' + (optional) calibration file
+        self.setProperty("DetectorPositions", posTbl)
+        ws = self._applyCalibrationTable(inWS, posTbl)
+        self._outputDetPosFile(self.getPropertyValue('OutputDetectorPositionsFilename'), posTbl)
 
     def _prepareWsForFitting(self, ws):
-        """ Rebins the workspace and converts it to distribution
-    	"""
+        """
+        Rebins the workspace and converts it to distribution
+        """
         rebinAlg = self.createChildAlgorithm('Rebin')
         rebinAlg.setProperty('InputWorkspace', ws)
         rebinAlg.setProperty('Params', '-0.0005') # The value is borrowed from OG routines
@@ -84,24 +78,50 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
         return result
 
-    def _createPositionsTable(self):
-        """ Creates an empty table for storing detector positions
-    	"""
-        alg = self.createChildAlgorithm('CreateEmptyTableWorkspace')
-        alg.execute()
-        table = alg.getProperty('OutputWorkspace').value
+    def _calculateCalibPositionsTbl(self, ws, bank, expectedPeaksD):
+        """
+        Makes a table of calibrated positions (and additional parameters). It goes through
+        the detectors of the workspace and calculates the difc and zero parameters by fitting
+        peaks, then calculates the coordinates and adds them in the returned table.
 
-        table.addColumn('int', 'Detector ID')
-        table.addColumn('V3D', 'Detector Position')
+        @param ws :: input workspace with an instrument definition
+        @param bank :: instrument bank to calibrate
+        @param expectedPeaksD :: expected peaks in d-spacing
 
-        return table
+        @return table that with the detector positions, with one row per detector
+
+        """
+        posTbl = self._createPositionsTable()
+
+        indices = EnginXUtils.getWsIndicesForBank(bank, ws)
+
+        prog = Progress(self, start=0, end=1, nreports=len(indices))
+
+        for i in indices:
+
+            zero, difc = self._fitPeaks(ws, i, expectedPeaksD)
+
+            det = ws.getDetector(i)
+            newPos, newL2 = self._getCalibratedDetPos(difc, det, ws)
+
+            # get old (pre-calibration) detector coordinates
+            oldL2 = det.getDistance(ws.getInstrument().getSample())
+            det2Theta = ws.detectorTwoTheta(det)
+            detPhi = det.getPhi()
+            oldPos = det.getPos()
+
+            posTbl.addRow([det.getID(), oldPos, newPos, newL2, det2Theta, detPhi, newL2-oldL2,
+                                  difc, zero])
+            prog.report()
+
+        return posTbl
 
     def _fitPeaks(self, ws, wsIndex, expectedPeaksD):
         """
         Fits expected peaks to the spectrum, and returns calibrated zero and difc values.
 
         @param wsIndex workspace index of the spectrum to fit
-        @param  expectedPeaksD :: expected peaks for the fitting, in d-spacing units
+        @param expectedPeaksD :: expected peaks for the fitting, in d-spacing units
 
         @returns a pair of parameters: difc and zero
     	"""
@@ -115,6 +135,57 @@ class EnginXCalibrateFull(PythonAlgorithm):
         zero = alg.getProperty('Zero').value
 
         return (zero, difc)
+
+    def _createPositionsTable(self):
+        """
+        Helper method to create an empty table for storing detector positions
+
+        @return table with the expected output columns
+        """
+        alg = self.createChildAlgorithm('CreateEmptyTableWorkspace')
+        alg.execute()
+        table = alg.getProperty('OutputWorkspace').value
+
+        # Note: the colums 'Detector ID' and 'Detector Position' must have those
+        # exact names (expected by child alg. ApplyCalibration in EnginXFocus)
+        table.addColumn('int', 'Detector ID')
+        table.addColumn('V3D', 'Old Detector Position')
+        table.addColumn('V3D', 'Detector Position')
+        table.addColumn('float', 'L2')
+        table.addColumn('float', '2 \\theta')
+        table.addColumn('float', '\\phi')
+        table.addColumn('float', '\\delta L2 (calibrated - old)')
+        table.addColumn('float', 'difc')
+        table.addColumn('float', 'zero')
+
+        return table
+
+    def _outputDetPosFile(self, filename, tbl):
+        """
+        Writes a text (csv) file with the detector positions information that also goes into the
+        output DetectorPostions table workspace.
+
+        @param filename :: name of the file to write. If it is empty nothing is saved/written.
+        @param tbl :: detector positions table workspace
+        """
+        if not filename:
+            return
+
+        if 9 > tbl.columnCount():
+            return
+
+        self.log().information("Saving detector positions in file: %s" % filename)
+        with open(filename, "w") as f:
+            f.write('# detector ID, old position (x), old position (y), old position (z), '
+                    'calibrated position (x), calibrated position (y), calibrated position (z), '
+                    'calib. L2, calib. 2\\theta, calib. \\phi, delta L2 (calibrated - old), difc, zero\n')
+            for r in range(0, tbl.rowCount()):
+                f.write("%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s\n" %
+                        (tbl.cell(r,0),
+                         tbl.cell(r,1).getX(), tbl.cell(r,1).getY(), tbl.cell(r,1).getZ(),
+                         tbl.cell(r,2).getX(), tbl.cell(r,2).getY(), tbl.cell(r,2).getZ(),
+                         tbl.cell(r,3), tbl.cell(r,4), tbl.cell(r,5),
+                         tbl.cell(r,6), tbl.cell(r,7), tbl.cell(r,8)))
 
     def _getCalibratedDetPos(self, newDifc, det, ws):
         """
@@ -131,7 +202,23 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
         newPos = self._V3DFromSpherical(newL2, detTwoTheta, detPhi)
 
-        return newPos
+        return (newPos, newL2)
+
+    def _applyCalibrationTable(self, ws, detPos):
+        """
+        Refines the detector positions using the result of calibration (if one is specified)
+
+        @param ws :: workspace to calibrate which should be consistent with the detPos table passed
+
+        @param detPos :: detector positions table to apply the calibration. It must have columns
+        'Detector ID' and 'Detector Position'
+        """
+        self.log().notice("Applying calibration on the input workspace")
+        alg = self.createChildAlgorithm('ApplyCalibration')
+        alg.setProperty('Workspace', ws)
+        alg.setProperty('PositionTable', detPos)
+        alg.execute()
+        return ws
 
     def _V3DFromSpherical(self, R, polar, azimuth):
         """

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -58,7 +58,7 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
         # Produce 2 results: 'output table' and 'apply calibration' + (optional) calibration file
         self.setProperty("DetectorPositions", posTbl)
-        ws = self._applyCalibrationTable(inWS, posTbl)
+        self._applyCalibrationTable(inWS, posTbl)
         self._outputDetPosFile(self.getPropertyValue('OutputDetectorPositionsFilename'), posTbl)
 
     def _prepareWsForFitting(self, ws):
@@ -206,9 +206,12 @@ class EnginXCalibrateFull(PythonAlgorithm):
 
     def _applyCalibrationTable(self, ws, detPos):
         """
-        Refines the detector positions using the result of calibration (if one is specified)
+        Corrects the detector positions using the result of calibration (if one is specified).
+        The parameters of the instrument definition of the workspace are updated in place using the
+        geometry parameters given in the input table.
 
-        @param ws :: workspace to calibrate which should be consistent with the detPos table passed
+        @param ws :: workspace to calibrate which should be consistent with the detector positions
+        table passed
 
         @param detPos :: detector positions table to apply the calibration. It must have columns
         'Detector ID' and 'Detector Position'
@@ -218,7 +221,6 @@ class EnginXCalibrateFull(PythonAlgorithm):
         alg.setProperty('Workspace', ws)
         alg.setProperty('PositionTable', detPos)
         alg.execute()
-        return ws
 
     def _V3DFromSpherical(self, R, polar, azimuth):
         """

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -35,6 +35,11 @@ class EnginXCalibrateFullTest(unittest.TestCase):
                           EnginXCalibrateFull,
                           InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
 
+        # mispelled OutputDetectorPositionsFilename
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull, OutputDetectorPositionsFile='any.csv',
+                          InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
+
         # all fine, except missing DetectorPositions (output)
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -35,9 +35,9 @@ class EnginXCalibrateFullTest(unittest.TestCase):
                           EnginXCalibrateFull,
                           InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
 
-        # mispelled OutputDetectorPositionsFilename
+        # mispelled OutDetPosFilename
         self.assertRaises(RuntimeError,
-                          EnginXCalibrateFull, OutputDetectorPositionsFile='any.csv',
+                          EnginXCalibrateFull, OutDetPosFile='any.csv',
                           InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
 
         # all fine, except missing DetectorPositions (output)

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
@@ -12,7 +12,7 @@ class EnginXCalibrateTest(stresstesting.MantidStressTest):
     def runTest(self):
         calib_ws = Load(Filename = 'ENGINX00193749.nxs')
 
-        positions = EnginXCalibrateFull(InputWorkspace = calib_ws,
+        positions = EnginXCalibrateFull(Workspace = calib_ws,
                                       Bank = 1,
                                       ExpectedPeaks = '1.3529, 1.6316, 1.9132')
 

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
@@ -21,33 +21,43 @@ bank's detector indices, (using :ref:`algm-EnginXFitPeaks` as a child
 algorithm) and using the resulting difc values to calibrate the
 detector positions.
 
-This algorithm produces a table with calibration information that can
-be inspected and used in other algorithms. The algorithm also applies
-that calibration on the input workspace. After running this algorithm
-the resulting calibration can be checked by inspecting the output
-table values and/or visualizing the input workspace instrument in the
-instrument viewer.
+This algorithm produces a table with calibration information,
+including calibrated or corrected positions and parameters. This
+calibration information that can be inspected and can also be used in
+other algorithms. The algorithm also applies the calibration on the
+input workspace. After running this algorithm the resulting
+calibration can be checked by visualizing the input workspace
+instrument in the instrument viewer and/or inspecting the output table
+values.
 
-This algorithm produces a table with calibration information
-(calibrated or corrected positions and parameters). The calibrated
-detector positions are calculated as follows:
+The output table has one row per detector where each row gives the
+original position before calibration (as a V3D point, x-y-z values),
+the new calibrated position (as V3D) and the calibrated spherical
+co-ordinates (L2, :math:`2 \theta`, :math:`\phi`). It also gives the
+variation in the L2 position, and the 'difc' and 'zero' calibration
+parameters.
+
+The result of the calibration (the output table given in
+DetectorPositions) is accepted by both :ref:`algm-EnginXCalibrate` and
+:ref:`algm-EnginXFocus` which use the columns 'Detector ID' and
+'Detector Position' of the table to correct the detector positions
+before focussing. The DetectorPositions output table can also be used
+to apply the calibration calculated by this algorithm on any other
+workspace by using the algorithm :ref:`algm-AppplyCalibration`.
+
+In the output table the calibrated positions for every detector are
+found by calculating the *L2* values from the *difc* values as
+follows:
 
 .. math:: L2 = \left(\frac{Difc} { 252.816 * 2 * sin \left(\frac{2\theta} {2.0}\right)}\right) - 50
 
-The output table gives, for every detector, the original position
-before calibration (as a V3D point, x-y-z values), the new calibrated
-position (as V3D), the calibrated spherical co-ordinates (L2, :math:`2
-\theta`, :math:`\phi`). It also gives the variation in the L2
-position, and the 'difc' and 'zero' calibration parameters.
+where the *difc* values are obtained from the fitting of expected
+peaks. See the algorithm :ref:`algm-EnginXFitPeaks` for details on how
+*difc* and other calibration parameters are calculated.
 
-The result of the calibration (the DetectorPositions output table) is
-accepted by both :ref:`algm-EnginXCalibrate` and
-:ref:`algm-EnginXFocus` which use the columns 'Detector ID' and
-'Detector Position' of the table to correct the detector positions
-before focussing.
-
-Expects the *long* calibration run, which provides a decent pattern
-for every pixel.
+This algorithm expects as input/output workspace the *long*
+calibration run, which provides a decent pattern for every detector or
+pixel.
 
 .. categories::
 

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
@@ -38,10 +38,10 @@ variation in the L2 position, and the 'difc' and 'zero' calibration
 parameters.
 
 The result of the calibration (the output table given in
-DetectorPositions) is accepted by both :ref:`algm-EnginXCalibrate` and
+OutDetPosTable) is accepted by both :ref:`algm-EnginXCalibrate` and
 :ref:`algm-EnginXFocus` which use the columns 'Detector ID' and
 'Detector Position' of the table to correct the detector positions
-before focussing. The DetectorPositions output table can also be used
+before focussing. The OutDetPosTable output table can also be used
 to apply the calibration calculated by this algorithm on any other
 workspace by using the algorithm :ref:`algm-AppplyCalibration`.
 
@@ -107,7 +107,7 @@ Output:
    Load('ENGINX00213855focussed.nxs', OutputWorkspace=ws_name)
    posTable = EnginXCalibrateFull(Workspace=ws_name,
                                   ExpectedPeaks=[1.097, 2.1], Bank=1,
-                                  OutputDetectorPositionsFilename=pos_filename)
+                                  OutDetPosFilename=pos_filename)
 
    detID = posTable.column(0)[0]
    pos =  posTable.column(2)[0]

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
@@ -15,20 +15,39 @@ Description
    removed without a notification, should instrument scientists decide to do so.
 
 
-Allows to correct for tiny variations in pixel parameters. It does this by fitting the peak for each of the the selected bank's indices, (using :ref:`algm-EnginXFitPeaks` ) and using the resulting difc value to calibrate the detector position. The calibrated detector position is produced as shown below: 
+Allows to calibrate or correct for variations in detector position
+parameters. It does this by fitting the peaks for each of the selected
+bank's detector indices, (using :ref:`algm-EnginXFitPeaks` as a child
+algorithm) and using the resulting difc values to calibrate the
+detector positions.
 
+This algorithm produces a table with calibration information that can
+be inspected and used in other algorithms. The algorithm also applies
+that calibration on the input workspace. After running this algorithm
+the resulting calibration can be checked by inspecting the output
+table values and/or visualizing the input workspace instrument in the
+instrument viewer.
 
+This algorithm produces a table with calibration information
+(calibrated or corrected positions and parameters). The calibrated
+detector positions are calculated as follows:
 
 .. math:: L2 = \left(\frac{Difc} { 252.816 * 2 * sin \left(\frac{2\theta} {2.0}\right)}\right) - 50
 
+The output table gives, for every detector, the original position
+before calibration (as a V3D point, x-y-z values), the new calibrated
+position (as V3D), the calibrated spherical co-ordinates (L2, :math:`2
+\theta`, :math:`\phi`). It also gives the variation in the L2
+position, and the 'difc' and 'zero' calibration parameters.
 
+The result of the calibration (the DetectorPositions output table) is
+accepted by both :ref:`algm-EnginXCalibrate` and
+:ref:`algm-EnginXFocus` which use the columns 'Detector ID' and
+'Detector Position' of the table to correct the detector positions
+before focussing.
 
-The cartesian2d vector is then returned for the given spherical co ordinates (L2, 2theta and phi).
-
-The result of the calibration is accepted by both :ref:`algm-EnginXCalibrate` and 
-:ref:`algm-EnginXFocus` to correct the detector positions before focussing.
-
-Expects the *long* calibration run, which provides a decent pattern for every pixel.
+Expects the *long* calibration run, which provides a decent pattern
+for every pixel.
 
 .. categories::
 
@@ -37,18 +56,23 @@ Usage
 
 .. include:: ../usagedata-note.txt
 
-**Example - Calculate Difc and Zero:**
+**Example - Calculate corrected positions, and difc and zero:**
 
 .. testcode:: ExCalFull
 
    ws_name = 'ws_focussed'
    Load('ENGINX00213855focussed.nxs', OutputWorkspace=ws_name)
-   table = EnginXCalibrateFull(InputWorkspace=ws_name,
-                               ExpectedPeaks=[1.097, 2.1], Bank=1)
 
-   pos =  table.column(1)[0]
-   print "Det ID:", table.column(0)[0]
-   print "Calibrated position: (%.3f,%.3f,%.3f)" % (pos.getX(),pos.getY(),pos.getZ())
+   posTable = EnginXCalibrateFull(Workspace=ws_name,
+                                  ExpectedPeaks=[1.097, 2.1], Bank=1)
+
+   detID = posTable.column(0)[0]
+   calPos =  posTable.column(2)[0]
+   print "Det ID:", detID
+   print "Calibrated position: (%.3f,%.3f,%.3f)" % (calPos.getX(), calPos.getY(), calPos.getZ())
+   ws = mtd[ws_name]
+   posInWSInst = ws.getInstrument().getDetector(detID).getPos()
+   print "Is the detector position calibrated now in the original workspace instrument?", (calPos == posInWSInst)
 
 .. testcleanup:: ExCalFull
 
@@ -60,3 +84,49 @@ Output:
 
    Det ID: 100001
    Calibrated position: (1.506,0.000,0.002)
+   Is the detector position calibrated now in the original workspace instrument? True
+
+**Example - Calculate corrected positions, saving in a file:**
+
+.. testcode:: ExCalFullWithOutputFile
+
+   import os, csv
+
+   ws_name = 'ws_focussed'
+   pos_filename = 'detectors_pos.csv'
+   Load('ENGINX00213855focussed.nxs', OutputWorkspace=ws_name)
+   posTable = EnginXCalibrateFull(Workspace=ws_name,
+                                  ExpectedPeaks=[1.097, 2.1], Bank=1,
+                                  OutputDetectorPositionsFilename=pos_filename)
+
+   detID = posTable.column(0)[0]
+   pos =  posTable.column(2)[0]
+   print "Det ID:", detID
+   print "Calibrated position: (%.3f,%.3f,%.3f)" % (pos.getX(),pos.getY(),pos.getZ())
+   print "Was the file created?", os.path.exists(pos_filename)
+   with open(pos_filename) as csvf:
+      reader = csv.reader(csvf, dialect='excel')
+      reader.next()
+      calibOK = True
+      for i,row in enumerate(reader):
+         calPos = posTable.column(2)[i]
+         calibOK = calibOK and (abs(float(row[4]) - calPos.getX()) < 1e-6) and\
+                   (abs(float(row[5]) - calPos.getY()) < 1e-6) and\
+                   (abs(float(row[6]) - calPos.getZ()) < 1e-6)
+         if not calibOK: break
+   print "Does the calibration file have the expected values?", calibOK
+
+.. testcleanup:: ExCalFullWithOutputFile
+
+   DeleteWorkspace(ws_name)
+   import os
+   os.remove(pos_filename)
+
+Output:
+
+.. testoutput:: ExCalFullWithOutputFile
+
+   Det ID: 100001
+   Calibrated position: (1.506,0.000,0.002)
+   Was the file created? True
+   Does the calibration file have the expected values? True


### PR DESCRIPTION
This fixes #12609.
This also fixes #12700.

**To test**:
- unit/doc/system tests
- code review
- manual checks to see that this is consistent (explained below).

The unit and doc test example files are not very nice to test this as they're not full workspaces. You can see how this would work in practice using the file from the system test (it can take a while):

```
ws = Load(Filename = 'ENGINX00193749.nxs')
# not saving file
# positions = EnginXCalibrateFull(Workspace=ws, Bank=1, ExpectedPeaks = '1.3529, 1.6316, 1.9132')
# saving file
positions = EnginXCalibrateFull(Workspace=ws, Bank=1, ExpectedPeaks = '1.3529, 1.6316, 1.9132', OutputDetectorPositionsFilename='det_pos.csv')
```

This saves a plain text csv file with all the information that EnginX scientists usually like to inspect. EnginXCalibrteFull also applies the calibration on the workspace (property renamed: `InputWorkspace` => `Workspace`).

If you open the instrument viewer, after calibration it should be very visible that the detectors of one bank have been scattered. Probably this is not a very reliable calibration! And if you then run `EnginXCalibrateFull` on the other bank you should see both scattered:

```
positions_bank2 = EnginXCalibrateFull(InputWorkspace=ws, Bank=2, ExpectedPeaks = '1.3529, 1.6316, 1.9132', OutputDetectorPositionsFilename='det_pos2.csv')
```

Also, if you open the output csv file  in notepad/excel, etc. it should look fine. An open question is how many digits should we use / do EnginX scientists need?

@Anders-Markvardsen: I've expanded the documentation a bit but I'd say that in general the EnginX algorithms documentation needs more improvements. Please see if it reads well/acceptable for now.

So this is now saving the simple text / csv file that scientists like to have in principle. Having this option doesn't do any harm, but I'd tend to say that we shouldn't use this format if possible for the more automated/GUI code. So I'd create another issue to add other format(s) (nexus processed, or parameters xml, or the new calibration nexus, etc.), that would be used from the GUI, and maybe complemented with a button that would produce/show a mantid table with all the old/new positions in x-y-z and spherical coordinates.
