### PR TITLE
Get PredictPeaks working again for WISH PeaksWorkspace

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/PredictPeaks.cpp
+++ b/Code/Mantid/Framework/Crystal/src/PredictPeaks.cpp
@@ -170,7 +170,7 @@ void PredictPeaks::exec() {
       boost::dynamic_pointer_cast<IMDEventWorkspace>(inBareWS);
   std::vector<Matrix<double>> gonioVec;
   m_gonio = Matrix<double>(3, 3, true);
-  Mantid::Kernel::DblMatrix gonioLast = Matrix<double>(3, 3, true);
+  Mantid::Kernel::DblMatrix gonioLast = Matrix<double>(3, 3, false);
   if (matrixWS) {
     inWS = matrixWS;
     // Retrieve the goniometer rotation matrix


### PR DESCRIPTION
Fixes #12955. No need to include in release notes.  Modified to include goniometer matrix that is identiy matrix.  Input data and script was in issue, but need to set NumberOfPeaks to 0 in CreatePeaksWorkspace for this script to work correctly.

``` python
Load(Filename='WISH00031189.raw', OutputWorkspace='31189', LoadLogFiles=False)
SetUB('31189', a=4.6100000000000003, b=4.6100000000000003, c=7.4100000000000001, alpha=90, beta=90, gamma=90)
CropWorkspace(InputWorkspace='31189', OutputWorkspace='31189', XMin=6000, XMax=99900)
ConvertUnits(InputWorkspace='31189', OutputWorkspace='31189', Target='dSpacing')
NormaliseByCurrent(InputWorkspace='31189', OutputWorkspace='31189')
CreatePeaksWorkspace(InstrumentWorkspace='31189', OutputWorkspace='SingleCrystalPeakTable',NumberOfPeaks=0)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='31189', TOF=3.0015735641227379, DetectorID=1109226, Height=118.5858587591939, BinCount=2.6428435324016362)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='31189', TOF=2.52166007461057, DetectorID=8415179, Height=714.30173279789074, BinCount=2.8280529375421142)
mtd['SingleCrystalPeakTable'].getPeak(0).setHKL(1,1,1)
mtd['SingleCrystalPeakTable'].getPeak(1).setHKL(0,0,-3)
CalculateUMatrix(PeaksWorkspace='SingleCrystalPeakTable', a=4.6100000000000003, b=4.6100000000000003, c=7.4100000000000001, alpha=90, beta=90, gamma=90)
PredictPeaks(InputWorkspace='SingleCrystalPeakTable', WavelengthMin=0.5, WavelengthMax=10, MinDSpacing=0.80000000000000004, MaxDSpacing=12, OutputWorkspace='31189_predicted')
```
