### PR TITLE
Changing live data server for HYSPEC

### DIFF
--- a/Code/Mantid/instrument/Facilities.xml
+++ b/Code/Mantid/instrument/Facilities.xml
@@ -422,7 +422,7 @@
   <instrument name="HYSPEC" shortname="HYS" beamline="14B">
     <technique>Neutron Spectroscopy</technique>
     <technique>TOF Direct Geometry Spectroscopy</technique>
-    <livedata address="hyspec-sms1.sns.gov:31415" />
+    <livedata address="bl14b-daq1.sns.gov:31415" />
   </instrument>
 
   <instrument name="VISION" shortname="VIS" beamline="16B">


### PR DESCRIPTION
An excerpt of an email from Jim Kohl:

```
Fyi, I am switching the "Production" SMS for HYSPEC from the old host:

   hyspec-sms1.sns.gov

over to the new DAS 2.0 host setup on:

   bl14b-daq1.sns.gov

I have updated the config files and will shut down the "old" SMS service,
and restart the "new" one on DAQ1.
```
