### PR TITLE
Fix WorkspaceSingleValue to have dimensions = axes = 0.

### DIFF
--- a/Code/Mantid/Framework/API/src/MDGeometry.cpp
+++ b/Code/Mantid/Framework/API/src/MDGeometry.cpp
@@ -101,10 +101,6 @@ MDGeometry::~MDGeometry() {
  */
 void MDGeometry::initGeometry(
     std::vector<Mantid::Geometry::IMDDimension_sptr> &dimensions) {
-  if (dimensions.size() == 0)
-    throw std::invalid_argument(
-        "MDGeometry::initGeometry() 0 valid dimensions were given!");
-
   // Copy the dimensions array
   m_dimensions = dimensions;
   // Make sure the basis vectors are big enough

--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/WorkspaceSingleValue.h
@@ -66,6 +66,9 @@ public:
                          MantidVec &Y, MantidVec &E,
                          bool skipError = false) const;
 
+  /// Returns the number of dimensions, 0 in this case.
+  virtual size_t getNumDims() const;
+
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
   WorkspaceSingleValue(const WorkspaceSingleValue &other);

--- a/Code/Mantid/Framework/DataObjects/src/WorkspaceSingleValue.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/WorkspaceSingleValue.cpp
@@ -65,6 +65,9 @@ void WorkspaceSingleValue::generateHistogram(const std::size_t index,
       "generateHistogram() not implemented for WorkspaceSingleValue.");
 }
 
+/// Our parent MatrixWorkspace has hardcoded 2, but we need 0.
+size_t WorkspaceSingleValue::getNumDims() const { return 0; }
+
 } // namespace DataObjects
 } // namespace Mantid
 

--- a/Code/Mantid/Framework/DataObjects/test/WorkspaceSingleValueTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/WorkspaceSingleValueTest.h
@@ -52,5 +52,11 @@ public:
     TS_ASSERT_EQUALS(v1,ws.dataE(0));
   }
 
+  void testgetNumDims()
+  {
+    WorkspaceSingleValue ws;
+    TS_ASSERT_EQUALS(0, ws.getNumDims());
+  }
+
 };
 #endif /*TESTWORKSPACESINGLEVALUE_*/


### PR DESCRIPTION
Fixes #12974 

Previously `getNumDims()` returned 2 (by default from `MatrixWorkspace`), but `axes()` returned 0. This is wrong and makes trouble in copy constructors. `getNumDims()` is now overridden to return 0 as well.
