### PR TITLE
refactor icon state changing code for Sliceviewer

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/SelectWorkspacesDialog.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/SelectWorkspacesDialog.h
@@ -48,7 +48,7 @@ class EXPORT_OPT_MANTIDQT_MANTIDWIDGETS SelectWorkspacesDialog : public QDialog
 
 public:
   ///return value of the Custom button
-  static const int CustomButton = 45654;
+  static const int CustomButton = 45654;  //do not use this number direct, just refer to this static constant
   
   /// Constructor
   SelectWorkspacesDialog (QWidget* parent = NULL, const std::string& typeFilter = "", const std::string& customButtonLabel = "");

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -209,6 +209,10 @@ protected:
 private:
   void loadSettings();
   void saveSettings();
+  void setIconFromString(QAction* action, const std::string& iconName,
+    QIcon::Mode mode, QIcon::State state);
+  void setIconFromString(QWidget* btn, const std::string& iconName,
+    QIcon::Mode mode, QIcon::State state);
   void initMenus();
   void initZoomer();
 

--- a/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/Code/Mantid/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -10,7 +10,6 @@
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/VMD.h"
-#include "MantidQtAPI/MantidColorMap.h"
 #include "MantidQtAPI/MdSettings.h"
 #include "MantidQtMantidWidgets/SafeQwtPlot.h"
 #include "MantidQtAPI/SyncedCheckboxes.h"
@@ -19,16 +18,10 @@
 #include "MantidQtSliceViewer/ZoomablePeaksView.h"
 #include "MantidQtAPI/QwtRasterDataMD.h"
 #include "ui_SliceViewer.h"
-#include <QtCore/QtCore>
-#include <QtGui/qdialog.h>
-#include <QtGui/QWidget>
 #include <qwt_color_map.h>
 #include <qwt_plot_spectrogram.h>
 #include <qwt_plot.h>
-#include <qwt_raster_data.h>
-#include <qwt_scale_widget.h>
 #include <vector>
-#include "MantidAPI/Algorithm.h"
 #include "MantidQtAPI/AlgorithmRunner.h"
 #include <boost/shared_ptr.hpp>
 
@@ -211,7 +204,7 @@ private:
   void saveSettings();
   void setIconFromString(QAction* action, const std::string& iconName,
     QIcon::Mode mode, QIcon::State state);
-  void setIconFromString(QWidget* btn, const std::string& iconName,
+  void setIconFromString(QAbstractButton* btn, const std::string& iconName,
     QIcon::Mode mode, QIcon::State state);
   void initMenus();
   void initZoomer();

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -231,8 +231,35 @@ void SliceViewer::saveSettings() {
                       static_cast<int>(this->getNormalization()));
   settings.endGroup();
 }
-
 //------------------------------------------------------------------------------
+/** set an icon given the control and a string.
+* @param btn the widget to give the new icon
+* @param iconName the path of the new icon
+* @param mode the mode of the icon
+* @param state on or off state of the icon
+*/
+void SliceViewer::setIconFromString(QWidget* btn, const std::string& iconName,
+    QIcon::Mode mode = QIcon::Mode::Normal, QIcon::State state = QIcon::State::Off)
+{
+  QIcon icon;
+  icon.addFile(QString::fromStdString(iconName), QSize(), mode,state);
+  btn->setIcon(icon.pixmap());
+}
+/** set an icon given the control and a string.
+* @param action the menu action to give the new icon
+* @param iconName the path of the new icon
+* @param mode the mode of the icon
+* @param state on or off state of the icon
+*/
+void SliceViewer::setIconFromString(QAction* action,const std::string& iconName,
+    QIcon::Mode mode = QIcon::Mode::Normal, QIcon::State state= QIcon::State::Off)
+{
+  QIcon icon;
+  icon.addFile(QString::fromStdString(iconName), QSize(), mode,state);
+  action->setIcon(icon);
+}
+
+  //------------------------------------------------------------------------------
 /** Create the menus */
 void SliceViewer::initMenus() {
   // ---------------------- Build the menu bar -------------------------
@@ -277,10 +304,7 @@ void SliceViewer::initMenus() {
   action = new QAction(QPixmap(), "&Reset Zoom", this);
   connect(action, SIGNAL(triggered()), this, SLOT(resetZoom()));
   {
-    QIcon icon;
-    icon.addFile(QString::fromStdString(g_iconViewFull), QSize(), QIcon::Normal,
-                 QIcon::Off);
-    action->setIcon(icon);
+    setIconFromString(action,g_iconViewFull);
   }
   m_menuView->addAction(action);
 
@@ -383,20 +407,14 @@ void SliceViewer::initMenus() {
   connect(action, SIGNAL(triggered()), this, SLOT(setColorScaleAutoSlice()));
   action->setIconVisibleInMenu(true);
   {
-    QIcon icon;
-    icon.addFile(QString::fromStdString(g_iconZoomPlus), QSize(), QIcon::Normal,
-                 QIcon::Off);
-    action->setIcon(icon);
+    setIconFromString(action,g_iconZoomPlus);
   }
   m_menuColorOptions->addAction(action);
 
   action = new QAction(QPixmap(), "&Full range", this);
   connect(action, SIGNAL(triggered()), this, SLOT(setColorScaleAutoFull()));
   {
-    QIcon icon;
-    icon.addFile(QString::fromStdString(g_iconZoomMinus), QSize(),
-                 QIcon::Normal, QIcon::Off);
-    action->setIcon(icon);
+    setIconFromString(action,g_iconZoomMinus);
   }
   m_menuColorOptions->addAction(action);
 
@@ -922,11 +940,8 @@ void SliceViewer::refreshRebin() { this->rebinParamsChanged(); }
 void SliceViewer::LineMode_toggled(bool checked) {
   m_lineOverlay->setShown(checked);
 
-  QIcon icon;
   if (checked) {
-    icon.addFile(QString::fromStdString(g_iconCutOn), QSize(), QIcon::Normal,
-                 QIcon::On);
-    ui.btnDoLine->setIcon(icon);
+    setIconFromString(ui.btnDoLine,g_iconCutOn,QIcon::Mode::Normal,QIcon::State::On);
     QString text;
     if (m_lineOverlay->getCreationMode())
       text = "Click and drag to draw an cut line.\n"
@@ -938,9 +953,7 @@ void SliceViewer::LineMode_toggled(bool checked) {
   if (!checked) {
     // clear the old line
     clearLine();
-    icon.addFile(QString::fromStdString(g_iconCut), QSize(), QIcon::Normal,
-                 QIcon::Off);
-    ui.btnDoLine->setIcon(icon);
+    setIconFromString(ui.btnDoLine,g_iconCut);
   }
   emit showLineViewer(checked);
 }
@@ -966,8 +979,6 @@ void SliceViewer::clearLine() {
 //------------------------------------------------------------------------------
 /// Slot called when the snap to grid is checked
 void SliceViewer::SnapToGrid_toggled(bool checked) {
-
-  QIcon icon;
   if (checked) {
     SnapToGridDialog *dlg = new SnapToGridDialog(this);
     dlg->setSnap(m_lineOverlay->getSnapX(), m_lineOverlay->getSnapY());
@@ -975,21 +986,17 @@ void SliceViewer::SnapToGrid_toggled(bool checked) {
       m_lineOverlay->setSnapEnabled(true);
       m_lineOverlay->setSnapX(dlg->getSnapX());
       m_lineOverlay->setSnapY(dlg->getSnapY());
-      icon.addFile(QString::fromStdString(g_iconGridOn), QSize(), QIcon::Normal,
-                   QIcon::On);
+      setIconFromString(ui.btnSnapToGrid,g_iconGridOn, QIcon::Normal, QIcon::On);
     } else {
       // Uncheck - the user clicked cancel
       ui.btnSnapToGrid->setChecked(false);
       m_lineOverlay->setSnapEnabled(false);
-      icon.addFile(QString::fromStdString(g_iconGrid), QSize(), QIcon::Normal,
-                   QIcon::Off);
+      setIconFromString(ui.btnSnapToGrid,g_iconGrid, QIcon::Normal, QIcon::Off);
     }
   } else {
     m_lineOverlay->setSnapEnabled(false);
-    icon.addFile(QString::fromStdString(g_iconGrid), QSize(), QIcon::Normal,
-                 QIcon::Off);
+    setIconFromString(ui.btnSnapToGrid,g_iconGrid, QIcon::Normal, QIcon::Off);
   }
-  ui.btnSnapToGrid->setIcon(icon);
 }
 
 //------------------------------------------------------------------------------
@@ -1003,11 +1010,8 @@ void SliceViewer::RebinMode_toggled(bool checked) {
   m_actionRefreshRebin->setEnabled(checked);
   m_rebinMode = checked;
 
-  QIcon icon;
   if (!m_rebinMode) {
-    icon.addFile(QString::fromStdString(g_iconRebin), QSize(), QIcon::Normal,
-                 QIcon::Off);
-    ui.btnRebinMode->setIcon(icon);
+    setIconFromString(ui.btnRebinMode,g_iconRebin, QIcon::Normal, QIcon::Off);
     // uncheck auto-rebin
     ui.btnAutoRebin->setChecked(false);
     // Remove the overlay WS
@@ -1015,9 +1019,7 @@ void SliceViewer::RebinMode_toggled(bool checked) {
     this->m_data->setOverlayWorkspace(m_overlayWS);
     this->updateDisplay();
   } else {
-    icon.addFile(QString::fromStdString(g_iconRebinOn), QSize(), QIcon::Normal,
-                 QIcon::On);
-    ui.btnRebinMode->setIcon(icon);
+    setIconFromString(ui.btnRebinMode,g_iconRebinOn, QIcon::Normal, QIcon::On);
     // Start the rebin
     this->rebinParamsChanged();
   }
@@ -2140,10 +2142,7 @@ void SliceViewer::disablePeakOverlays() {
   emit showPeaksViewer(false);
   m_menuPeaks->setEnabled(false);
 
-  QIcon icon;
-  icon.addFile(QString::fromStdString(g_iconPeakList), QSize(), QIcon::Normal,
-               QIcon::Off);
-  ui.btnPeakOverlay->setIcon(icon);
+  setIconFromString(ui.btnPeakOverlay,g_iconPeakList, QIcon::Normal, QIcon::Off);
   ui.btnPeakOverlay->setChecked(false);
 }
 
@@ -2219,11 +2218,8 @@ SliceViewer::setPeaksWorkspaces(const QStringList &list) {
   updatePeakOverlaySliderWidget();
   emit showPeaksViewer(true);
   m_menuPeaks->setEnabled(true);
-
-  QIcon icon;
-  icon.addFile(QString::fromStdString(g_iconPeakList), QSize(), QIcon::Normal,
-               QIcon::Off);
-  ui.btnPeakOverlay->setIcon(icon);
+  
+  setIconFromString(ui.btnPeakOverlay,g_iconPeakList, QIcon::Normal, QIcon::Off);
   ui.btnPeakOverlay->setChecked(true);
   return m_proxyPeaksPresenter.get();
 }
@@ -2249,17 +2245,11 @@ void SliceViewer::peakOverlay_clicked() {
   if (ret == MantidQt::MantidWidgets::SelectWorkspacesDialog::CustomButton) {
     disablePeakOverlays();
   }
-  QIcon icon;
   if (m_peaksPresenter->size() > 0) {
-    icon.addFile(QString::fromStdString(g_iconPeakListOn), QSize(),
-                 QIcon::Normal, QIcon::On);
-    ui.btnPeakOverlay->setIcon(icon);
+    setIconFromString(ui.btnPeakOverlay,g_iconPeakListOn, QIcon::Normal, QIcon::On);
     ui.btnPeakOverlay->setChecked(true);
   } else {
-
-    icon.addFile(QString::fromStdString(g_iconPeakList), QSize(), QIcon::Normal,
-                 QIcon::Off);
-    ui.btnPeakOverlay->setIcon(icon);
+    setIconFromString(ui.btnPeakOverlay,g_iconPeakList, QIcon::Normal, QIcon::Off);
     ui.btnPeakOverlay->setChecked(false);
   }
 }

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -14,7 +14,6 @@
 #include "MantidGeometry/Crystal/PeakTransformQSample.h"
 #include "MantidGeometry/Crystal/PeakTransformQLab.h"
 #include "MantidAPI/IPeaksWorkspace.h"
-#include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
@@ -37,12 +36,10 @@
 #include "MantidQtSliceViewer/ProxyCompositePeaksPresenter.h"
 #include "MantidQtSliceViewer/PeakOverlayMultiCrossFactory.h"
 #include "MantidQtSliceViewer/PeakOverlayMultiSphereFactory.h"
-#include "MantidQtSliceViewer/FirstExperimentInfoQuery.h"
 #include "MantidQtSliceViewer/PeakBoundingBox.h"
 #include "MantidQtSliceViewer/PeaksViewerOverlayDialog.h"
 #include "MantidQtSliceViewer/PeakOverlayViewFactorySelector.h"
 #include "MantidQtMantidWidgets/SelectWorkspacesDialog.h"
-#include "MantidQtMantidWidgets/InputController.h"
 
 #include <qwt_plot_panner.h>
 #include <Poco/AutoPtr.h>
@@ -238,12 +235,12 @@ void SliceViewer::saveSettings() {
 * @param mode the mode of the icon
 * @param state on or off state of the icon
 */
-void SliceViewer::setIconFromString(QWidget* btn, const std::string& iconName,
+void SliceViewer::setIconFromString(QAbstractButton* btn, const std::string& iconName,
     QIcon::Mode mode = QIcon::Mode::Normal, QIcon::State state = QIcon::State::Off)
 {
   QIcon icon;
   icon.addFile(QString::fromStdString(iconName), QSize(), mode,state);
-  btn->setIcon(icon.pixmap());
+  btn->setIcon(icon);
 }
 /** set an icon given the control and a string.
 * @param action the menu action to give the new icon
@@ -303,9 +300,7 @@ void SliceViewer::initMenus() {
   m_menuView = new QMenu("&View", this);
   action = new QAction(QPixmap(), "&Reset Zoom", this);
   connect(action, SIGNAL(triggered()), this, SLOT(resetZoom()));
-  {
-    setIconFromString(action,g_iconViewFull);
-  }
+  setIconFromString(action,g_iconViewFull);
   m_menuView->addAction(action);
 
   action = new QAction(QPixmap(), "&Set X/Y View Size", this);
@@ -941,7 +936,7 @@ void SliceViewer::LineMode_toggled(bool checked) {
   m_lineOverlay->setShown(checked);
 
   if (checked) {
-    setIconFromString(ui.btnDoLine,g_iconCutOn,QIcon::Mode::Normal,QIcon::State::On);
+    setIconFromString(ui.btnDoLine,g_iconCutOn,QIcon::Mode::Normal,QIcon::State::Off);
     QString text;
     if (m_lineOverlay->getCreationMode())
       text = "Click and drag to draw an cut line.\n"
@@ -953,7 +948,7 @@ void SliceViewer::LineMode_toggled(bool checked) {
   if (!checked) {
     // clear the old line
     clearLine();
-    setIconFromString(ui.btnDoLine,g_iconCut);
+    setIconFromString(ui.btnDoLine,g_iconCut,QIcon::Mode::Normal,QIcon::State::On);
   }
   emit showLineViewer(checked);
 }


### PR DESCRIPTION
Refactoring of hastily added icon code in the sliceviewer.

fixes #12324

No change to functionality just slightly neater code. So no release notes change
### To Test
1. Start the sliceviewer
2. use the buttons above the view.
3. they should react the same way as before!, so icons changing with tick marks, toggling etc
4. it is worth having a unchanged mantid (last release or nightly build) side by side for comparison.
