### PR TITLE
Refs #12439. pass PathToExecutable to ParaView.

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/VatesParaViewApplication.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/VatesParaViewApplication.cpp
@@ -55,7 +55,7 @@ namespace Mantid
 
         // Provide ParaView's application core with a path to the running executable
         int argc = 1;
-        std::string exePath = configSvc.getDirectoryOfExecutable();
+        std::string exePath = configSvc.getPathToExecutable();
         std::vector<char> argvConversion(exePath.begin(), exePath.end());
         argvConversion.push_back('\0');
         char *argv[] = {&argvConversion[0]};


### PR DESCRIPTION
This fixes #12439.

When opening the VSI in OS X, the following pop up notification appears:

```
Generic Warning: In /Users/builder/src/ParaView-v4.3.1-source/ParaViewCore/ClientServerCore/Core/vtkProcessModuleInitializePython.py, line 254
Non-app bundle in install directory not supported
```

Passing the path to the executable instead of the directory of the executable allows ParaView to find the directory "Contents" and therefore eliminates this warning.

This pull request shouldn't be in the release notes because there should be no visible change to the end user. We previously patched ParaView to comment out this warning.
