### PR TITLE
Added link to the opt out dialog

### DIFF
--- a/Code/Mantid/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -122,7 +122,8 @@ void FirstTimeSetup::allowUsageDataStateChanged(int checkedState)
   {
     QMessageBox msgBox(this);
     msgBox.setWindowTitle("Mantid: Report Usage Data ");
-    msgBox.setText("Are you sure you want to disable reporting usage data?");
+    msgBox.setTextFormat(Qt::RichText);   //this is what makes the links clickable
+    msgBox.setText("Are you sure you want to disable reporting <a href='http://reports.mantidproject.org'>usage data</a>?");
     msgBox.setInformativeText("All usage data is anonymous and untraceable.\n"
       "We use the usage data to inform the future development of Mantid.\n"
       "If you click \"Yes\" aspects you need risk being deprecated in "


### PR DESCRIPTION
fixes #11827

Link to the reporting data is now included on the opt out dialog box for usage data.

Too minor for the release notes. No comment added.
### To test (something other than windows)
1. Start Mantidplot
2. Help->first time
3. uncheck report usage data (check it first if you need to).
4. in the dialog that appears you should have a clickable link on usage data.
