### PR TITLE
Fix PlotAsymmetryByLogValue

### DIFF
--- a/Code/Mantid/MantidQt/CustomDialogs/inc/MantidQtCustomDialogs/PlotAsymmetryByLogValueDialog.ui
+++ b/Code/Mantid/MantidQt/CustomDialogs/inc/MantidQtCustomDialogs/PlotAsymmetryByLogValueDialog.ui
@@ -308,53 +308,6 @@
           </layout>
         </widget>
       </item>
-      <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_13">
-          <property name="spacing">
-            <number>6</number>
-          </property>
-          <item>
-            <widget class="QPushButton" name="btnHelp">
-              <property name="maximumSize">
-                <size>
-                  <width>31</width>
-                  <height>26</height>
-                </size>
-              </property>
-              <property name="text">
-                <string>?</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <spacer name="horizontalSpacer">
-              <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-                <size>
-                  <width>40</width>
-                  <height>20</height>
-                </size>
-              </property>
-            </spacer>
-          </item>
-          <item>
-            <widget class="QPushButton" name="btnOK">
-              <property name="text">
-                <string>OK</string>
-              </property>
-            </widget>
-          </item>
-          <item>
-            <widget class="QPushButton" name="btnCancel">
-              <property name="text">
-                <string>Cancel</string>
-              </property>
-            </widget>
-          </item>
-        </layout>
-      </item>
     </layout>
   </widget>
   <tabstops>

--- a/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
@@ -89,9 +89,6 @@ void PlotAsymmetryByLogValueDialog::initLayout()
   connect(m_uiForm.dtcFileBrowseButton, SIGNAL(clicked()), browseButtonMapper, SLOT(map()));
 
   connect( m_uiForm.firstRunBox, SIGNAL(textChanged(const QString&)), this, SLOT(fillLogBox(const QString&)) );
-  connect( m_uiForm.btnOK,SIGNAL(clicked()),this,SLOT(accept()));
-  connect( m_uiForm.btnCancel,SIGNAL(clicked()),this,SLOT(reject()));
-  connect( m_uiForm.btnHelp,SIGNAL(clicked()),this,SLOT(helpClicked()));
 
   connect( m_uiForm.dtcType, SIGNAL(currentIndexChanged(int)), this, SLOT(showHideDeadTimeFileWidget(int)));
 

--- a/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
@@ -103,6 +103,9 @@ void PlotAsymmetryByLogValueDialog::initLayout()
 
   // So user can enter a custom value
   m_uiForm.logBox->setEditable(true);
+
+  // Create and add the OK/Cancel/Help. buttons
+  m_uiForm.verticalLayout->addLayout(this->createDefaultButtonLayout());
 }
 
 /**


### PR DESCRIPTION
Fixes #12972

For some reason PlotAsymmetryByLogValue stopped working when #12910 was merged (see issue description).

Tester:
- Check that you can reproduce the bug
- Check that PlotAsymmetryByLogValue works regardless of the status of the "Keep open" checkbox. You can find user examples in the algorithm's documentation.
-  Review code changes. I have removed the custom "OK", "Cancel" and "?" buttons and replaced them with the generic ones defined in the AlgorithmDialog class.

Release notes are unchanged as this bug was introduced in this release.
