### PR TITLE
Change format of printing lattice parameters

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/FindUBUsingIndexedPeaks.cpp
+++ b/Code/Mantid/Framework/Crystal/src/FindUBUsingIndexedPeaks.cpp
@@ -106,32 +106,12 @@ void FindUBUsingIndexedPeaks::exec() {
 
     OrientedLattice o_lattice;
     o_lattice.setUB(UB);
-    double calc_a = o_lattice.a();
-    double calc_b = o_lattice.b();
-    double calc_c = o_lattice.c();
-    double calc_alpha = o_lattice.alpha();
-    double calc_beta = o_lattice.beta();
-    double calc_gamma = o_lattice.gamma();
-    // Show the modified lattice parameters
-    sprintf(
-        logInfo,
-        std::string("Lattice Parameters: %8.3f %8.3f %8.3f %8.3f %8.3f %8.3f")
-            .c_str(),
-        calc_a, calc_b, calc_c, calc_alpha, calc_beta, calc_gamma);
-    g_log.notice(std::string(logInfo));
-    g_log.notice() << std::fixed << std::setprecision(3) << std::setw(9);
 
-    g_log.notice() << "Parameter Errors   :" << std::fixed
-                   << std::setprecision(3) << std::setw(9) << sigabc[0]
-                   << std::fixed << std::setprecision(3) << std::setw(9)
-                   << sigabc[1] << std::fixed << std::setprecision(3)
-                   << std::setw(9) << sigabc[2] << std::fixed
-                   << std::setprecision(3) << std::setw(9) << sigabc[3]
-                   << std::fixed << std::setprecision(3) << std::setw(9)
-                   << sigabc[4] << std::fixed << std::setprecision(3)
-                   << std::setw(9) << sigabc[5] << std::endl;
     o_lattice.setError(sigabc[0], sigabc[1], sigabc[2], sigabc[3], sigabc[4],
                        sigabc[5]);
+
+    // Show the modified lattice parameters
+    g_log.notice() << o_lattice << "\n";
     ws->mutableSample().setOrientedLattice(&o_lattice);
   }
 }

--- a/Code/Mantid/Framework/Crystal/src/FindUBUsingLatticeParameters.cpp
+++ b/Code/Mantid/Framework/Crystal/src/FindUBUsingLatticeParameters.cpp
@@ -139,25 +139,10 @@ void FindUBUsingLatticeParameters::exec() {
     double calc_beta = o_lattice.beta();
     double calc_gamma = o_lattice.gamma();
     // Show the modified lattice parameters
-    sprintf(
-        logInfo,
-        std::string("Lattice Parameters: %8.3f %8.3f %8.3f %8.3f %8.3f %8.3f")
-            .c_str(),
-        calc_a, calc_b, calc_c, calc_alpha, calc_beta, calc_gamma);
-    g_log.notice(std::string(logInfo));
+    g_log.notice() << o_lattice << "\n";
 
-    g_log.notice() << "Parameter Errors  :" << std::fixed
-                   << std::setprecision(3) << std::setw(9) << sigabc[0]
-                   << std::fixed << std::setprecision(3) << std::setw(9)
-                   << sigabc[1] << std::fixed << std::setprecision(3)
-                   << std::setw(9) << sigabc[2] << std::fixed
-                   << std::setprecision(3) << std::setw(9) << sigabc[3]
-                   << std::fixed << std::setprecision(3) << std::setw(9)
-                   << sigabc[4] << std::fixed << std::setprecision(3)
-                   << std::setw(9) << sigabc[5] << std::endl;
-
-    sprintf(logInfo, std::string("Lattice Parameters (Refined - Input): %8.3f "
-                                 "%8.3f %8.3f %8.3f %8.3f %8.3f").c_str(),
+    sprintf(logInfo, std::string("Lattice Parameters (Refined - Input): %11.6f "
+                                 "%11.6f %11.6f %11.6f %11.6f %11.6f").c_str(),
             calc_a - a, calc_b - b, calc_c - c, calc_alpha - alpha,
             calc_beta - beta, calc_gamma - gamma);
     g_log.notice(std::string(logInfo));

--- a/Code/Mantid/Framework/Crystal/src/FindUBUsingMinMaxD.cpp
+++ b/Code/Mantid/Framework/Crystal/src/FindUBUsingMinMaxD.cpp
@@ -135,29 +135,9 @@ void FindUBUsingMinMaxD::exec() {
     o_lattice.setError(sigabc[0], sigabc[1], sigabc[2], sigabc[3], sigabc[4],
                        sigabc[5]);
 
-    double calc_a = o_lattice.a();
-    double calc_b = o_lattice.b();
-    double calc_c = o_lattice.c();
-    double calc_alpha = o_lattice.alpha();
-    double calc_beta = o_lattice.beta();
-    double calc_gamma = o_lattice.gamma();
     // Show the modified lattice parameters
-    sprintf(
-        logInfo,
-        std::string("Lattice Parameters: %8.3f %8.3f %8.3f %8.3f %8.3f %8.3f")
-            .c_str(),
-        calc_a, calc_b, calc_c, calc_alpha, calc_beta, calc_gamma);
-    g_log.notice(std::string(logInfo));
+    g_log.notice() << o_lattice << "\n";
 
-    g_log.notice() << "Parameter Errors  :" << std::fixed
-                   << std::setprecision(3) << std::setw(9) << sigabc[0]
-                   << std::fixed << std::setprecision(3) << std::setw(9)
-                   << sigabc[1] << std::fixed << std::setprecision(3)
-                   << std::setw(9) << sigabc[2] << std::fixed
-                   << std::setprecision(3) << std::setw(9) << sigabc[3]
-                   << std::fixed << std::setprecision(3) << std::setw(9)
-                   << sigabc[4] << std::fixed << std::setprecision(3)
-                   << std::setw(9) << sigabc[5] << std::endl;
     ws->mutableSample().setOrientedLattice(&o_lattice);
   }
 }

--- a/Code/Mantid/Framework/Geometry/src/Crystal/UnitCell.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Crystal/UnitCell.cpp
@@ -569,26 +569,26 @@ void UnitCell::recalculateFromGstar(const DblMatrix &NewGstar) {
 
 std::ostream &operator<<(std::ostream &out, const UnitCell &unitCell) {
   // always show the lattice constants
-  out << "Lattice Parameters:" << std::fixed << std::setprecision(3)
-      << std::setw(9) << unitCell.a() << std::fixed << std::setprecision(3)
-      << std::setw(9) << unitCell.b() << std::fixed << std::setprecision(3)
-      << std::setw(9) << unitCell.c() << std::fixed << std::setprecision(3)
-      << std::setw(9) << unitCell.alpha() << std::fixed << std::setprecision(3)
-      << std::setw(9) << unitCell.beta() << std::fixed << std::setprecision(3)
-      << std::setw(9) << unitCell.gamma();
+  out << "Lattice Parameters:" << std::fixed << std::setprecision(6)
+      << std::setw(12) << unitCell.a() << std::fixed << std::setprecision(6)
+      << std::setw(12) << unitCell.b() << std::fixed << std::setprecision(6)
+      << std::setw(12) << unitCell.c() << std::fixed << std::setprecision(6)
+      << std::setw(12) << unitCell.alpha() << std::fixed << std::setprecision(6)
+      << std::setw(12) << unitCell.beta() << std::fixed << std::setprecision(6)
+      << std::setw(12) << unitCell.gamma();
 
   // write out the uncertainty if there is a positive one somewhere
   if ((unitCell.errora() > 0) || (unitCell.errorb() > 0) ||
       (unitCell.errorc() > 0) || (unitCell.erroralpha() > 0) ||
       (unitCell.errorbeta() > 0) || (unitCell.errorgamma() > 0))
-    out << "\nParameter Errors  :" << std::fixed << std::setprecision(3)
-        << std::setw(9) << unitCell.errora() << std::fixed
-        << std::setprecision(3) << std::setw(9) << unitCell.errorb()
-        << std::fixed << std::setprecision(3) << std::setw(9)
-        << unitCell.errorc() << std::fixed << std::setprecision(3)
-        << std::setw(9) << unitCell.erroralpha() << std::fixed
-        << std::setprecision(3) << std::setw(9) << unitCell.errorbeta()
-        << std::fixed << std::setprecision(3) << std::setw(9)
+    out << "\nParameter Errors  :" << std::fixed << std::setprecision(6)
+        << std::setw(12) << unitCell.errora() << std::fixed
+        << std::setprecision(6) << std::setw(12) << unitCell.errorb()
+        << std::fixed << std::setprecision(6) << std::setw(12)
+        << unitCell.errorc() << std::fixed << std::setprecision(6)
+        << std::setw(12) << unitCell.erroralpha() << std::fixed
+        << std::setprecision(6) << std::setw(12) << unitCell.errorbeta()
+        << std::fixed << std::setprecision(6) << std::setw(12)
         << unitCell.errorgamma();
 
   return out;

--- a/Code/Mantid/Framework/Geometry/test/UnitCellTest.h
+++ b/Code/Mantid/Framework/Geometry/test/UnitCellTest.h
@@ -133,7 +133,7 @@ public:
       std::stringstream msg;
       msg << cell;
       TS_ASSERT_EQUALS(msg.str(),
-                       "Lattice Parameters:    2.000    3.000    4.000   80.000   90.000  100.000");
+                       "Lattice Parameters:    2.000000    3.000000    4.000000   80.000000   90.000000  100.000000");
     }
 
     // w/ uncertainties
@@ -142,7 +142,7 @@ public:
       std::stringstream msg;
       msg << cell;
       TS_ASSERT_EQUALS(msg.str(),
-                       "Lattice Parameters:    2.000    3.000    4.000   80.000   90.000  100.000\nParameter Errors  :    1.000    2.000    3.000    4.000    5.000    6.000");
+                       "Lattice Parameters:    2.000000    3.000000    4.000000   80.000000   90.000000  100.000000\nParameter Errors  :    1.000000    2.000000    3.000000    4.000000    5.000000    6.000000");
     }
   }
 


### PR DESCRIPTION
Fixes #12866.  No need to put in release notes.  Change format of lattice errors so they are not 0.000 when truncated.

``` python
Load(Filename='scolecite295K_Monoclinic_C.integrate',OutputWorkspace='scolecite295K_Monoclinic_C')
FindUBUsingIndexedPeaks(PeaksWorkspace='scolecite295K_Monoclinic_C', Tolerance=0.12)
OptimizeLatticeForCellType(PeaksWorkspace='scolecite295K_Monoclinic_C', CellType='Monoclinic ( b unique )', Tolerance=0.20000000000000001, OutputDirectory='.')
```
