### PR TITLE
Fix bug in PlotAsymmetryByLogValue

### DIFF
--- a/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/PlotAsymmetryByLogValueDialog.cpp
@@ -150,9 +150,7 @@ void PlotAsymmetryByLogValueDialog::fillLogBox(const QString&)
   {
     alg->setPropertyValue("Filename",nexusFileName.toStdString());
     alg->setPropertyValue("OutputWorkspace","PlotAsymmetryByLogValueDialog_tmp");
-    alg->setPropertyValue("DeadTimeTable", ""); // Don't need it for now
-    alg->setPropertyValue("SpectrumMin","0");
-    alg->setPropertyValue("SpectrumMax","0");
+    alg->setPropertyValue("SpectrumList","1"); // Need to load at least one spectrum
     alg->execute();
     if (alg->isExecuted())
     {


### PR DESCRIPTION
Fixes #12969

Tester:
- Execute PlotAsymmetryByLogValue, select a muon nexus file as "First run" (for instance MUSR00015189.nxs)
- Check that the list of Log values is automatically populated when the first run is selected. 

Release notes: http://www.mantidproject.org/index.php?title=Release_Notes_3_5_MuonAnalysis&diff=24335&oldid=24325
