### PR TITLE
Adding python-matplotlib to dev packages.

### DIFF
--- a/Code/Mantid/Build/dev-packages/deb/mantid-developer/README
+++ b/Code/Mantid/Build/dev-packages/deb/mantid-developer/README
@@ -2,5 +2,5 @@ This directory contains the structure required to build the simple mantid-develo
 
 To build the package:
    * Switch to the directory containing this file
-   * Run "dpkg --build mantid-developer-1.2.4"
-   * A file called mantid-developer-1.2.4.deb will appear in the current directory.
+   * Run "dpkg --build mantid-developer-1.2.5"
+   * A file called mantid-developer-1.2.5.deb will appear in the current directory.

--- a/Code/Mantid/Build/dev-packages/deb/mantid-developer/mantid-developer-1.2.5/DEBIAN/control
+++ b/Code/Mantid/Build/dev-packages/deb/mantid-developer/mantid-developer-1.2.5/DEBIAN/control
@@ -1,0 +1,13 @@
+Package: mantid-developer
+Version: 1.2.5
+Section: main
+Priority: optional
+Architecture: all
+Depends: g++, git, clang, cmake-qt-gui(>=2.8.12), qt4-qmake, qt4-dev-tools, libqt4-dbg, libpoco-dev(>=1.4.2), libboost-all-dev, libboost-dbg, libnexus0-dev, libgoogle-perftools-dev, libqwt5-qt4-dev, libqwtplot3d-qt4-dev, python-qt4-dev, libgsl0-dev, liboce-visualization-dev, libmuparser-dev, python-numpy, libssl-dev, libqscintilla2-dev, texlive,texlive-latex-extra, dvipng, libhdf4-dev, doxygen, python-sphinx, python-scipy, ipython-qtconsole (>=1.2.0), libhdf5-dev, libhdf4-dev, libpococrypto11-dbg, libpocodata11-dbg, libpocofoundation11-dbg, libpocomysql11-dbg, libpoconet11-dbg, libpoconetssl11-dbg, libpocoodbc11-dbg, libpocosqlite11-dbg, libpocoutil11-dbg, libpocoxml11-dbg, libpocozip11-dbg, python-qt4-dbg, qt4-default, ninja-build, libjsoncpp-dev, python-dateutil, python-sphinx-bootstrap-theme, graphviz, python-matplotlib
+Installed-Size: 0
+Maintainer: Mantid Project <mantid-help@mantidproject.org>
+Description: Installs all packages required for a Mantid developer
+ A metapackage which requires all the dependencies and tools that are 
+ required for Mantid development. It works for Ubuntu version 14.04, 14.10
+ Some packages (poco) must be newer than those in the Ubuntu repository. Please 
+ follow instructions at http://www.mantidproject.org/Mantid_Prerequisites#Repositories

--- a/Code/Mantid/Build/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/Code/Mantid/Build/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -1,5 +1,5 @@
 Name:           mantid-developer
-Version:        1.10
+Version:        1.11
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -31,6 +31,7 @@ Requires: PyQt4-devel
 Requires: python-devel
 Requires: python-ipython >= 1.1
 %{?el6:Conflicts: python-ipython >= 2.0}
+Requires: python-matplotlib
 Requires: python-pip
 Requires: python-sphinx
 Requires: qscintilla-devel


### PR DESCRIPTION
This fixes #12982.

`python-matplotlib` is missing from the rpm and deb development packages. This adds it as a required package and increments the version number.

testing: code review should be sufficient.
