### PR TITLE
Fix det merge command

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -356,7 +356,8 @@ private:
   QString m_maskScript;
   // Success keyword
   static const QString m_pythonSuccessKeyword;
-
+  /// Keyword for empty return value in python
+  static const QString m_pythonEmptyKeyword;
   /// Stores the URL of each tab's help page.
   QMap<Tab, QString> m_helpPageUrls;
   

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -153,7 +153,7 @@ namespace
 // Static key strings
 //----------------------------------------------
 const QString SANSRunWindow::m_pythonSuccessKeyword  = "pythonExecutionWasSuccessful";
-
+const QString SANSRunWindow::m_pythonEmptyKeyword = "None";
 //----------------------------------------------
 // Public member functions
 //----------------------------------------------
@@ -3019,9 +3019,12 @@ void SANSRunWindow::handleInstrumentChange()
   QString detectorSelection = runReduceScriptFunction(
     "print i.ReductionSingleton().instrument.det_selection").trimmed();
   int ind = m_uiForm.detbank_sel->findText(detect);
-  if( ind != -1 )
-  {
-    m_uiForm.detbank_sel->setCurrentIndex(ind);
+  // We set the detector selection only if nothing is set yet.
+  // Previously, we didn't handle merged and both at this point
+  if (detectorSelection == m_pythonEmptyKeyword || detectorSelection.isEmpty()) {
+    if( ind != -1 ) {
+      m_uiForm.detbank_sel->setCurrentIndex(ind);
+    }
   }
 
   m_uiForm.beam_rmin->setText("60");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -983,6 +983,7 @@ bool SANSRunWindow::loadUserFile()
   ////Detector bank: support REAR, FRONT, HAB, BOTH, MERGED, MERGE options
   QString detName = runReduceScriptFunction(
     "print i.ReductionSingleton().instrument.det_selection").trimmed();
+
   if (detName == "REAR" || detName == "MAIN"){
      m_uiForm.detbank_sel->setCurrentIndex(0);
   }else if (detName == "FRONT" || detName == "HAB"){
@@ -3015,7 +3016,9 @@ void SANSRunWindow::handleInstrumentChange()
   fillDetectNames(m_uiForm.detbank_sel);
   QString detect = runReduceScriptFunction(
     "print i.ReductionSingleton().instrument.cur_detector().name()");
-  int ind = m_uiForm.detbank_sel->findText(detect);  
+  QString detectorSelection = runReduceScriptFunction(
+    "print i.ReductionSingleton().instrument.det_selection").trimmed();
+  int ind = m_uiForm.detbank_sel->findText(detect);
   if( ind != -1 )
   {
     m_uiForm.detbank_sel->setCurrentIndex(ind);

--- a/Code/Mantid/scripts/SANS/isis_instrument.py
+++ b/Code/Mantid/scripts/SANS/isis_instrument.py
@@ -596,13 +596,11 @@ class ISISInstrument(BaseInstrument):
         if self.other_detector().isAlias(detName) :
             self.lowAngDetSet = not self.lowAngDetSet
             return True
-        else:
-            #there are only two detectors, they must have selected the current one so no change is need
-            if self.cur_detector().isAlias(detName):
-                return True
-            else:
-                sanslog.notice("setDetector: Detector not found")
-                sanslog.notice("setDetector: Detector set to " + self.cur_detector().name() + ' in ' + self.name())
+        elif self.cur_detector().isAlias(detName):
+            return True
+        #else:
+        #   sanslog.notice("setDetector: Detector not found")
+        #   sanslog.notice("setDetector: Detector set to " + self.cur_detector().name() + ' in ' + self.name())
 
     def setDefaultDetector(self):
         self.lowAngDetSet = True

--- a/Code/Mantid/scripts/SANS/isis_instrument.py
+++ b/Code/Mantid/scripts/SANS/isis_instrument.py
@@ -598,9 +598,6 @@ class ISISInstrument(BaseInstrument):
             return True
         elif self.cur_detector().isAlias(detName):
             return True
-        #else:
-        #   sanslog.notice("setDetector: Detector not found")
-        #   sanslog.notice("setDetector: Detector set to " + self.cur_detector().name() + ' in ' + self.name())
 
     def setDefaultDetector(self):
         self.lowAngDetSet = True

--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -2089,9 +2089,15 @@ class UserFile(ReductionStep):
                 self._readDetectorCorrections(upper_line[8:], reducer)
             elif det_specif.startswith('RESCALE') or det_specif.startswith('SHIFT'):
                 self._readFrontRescaleShiftSetup(det_specif, reducer)
-            else:
-                # for /DET/FRONT and /DET/REAR commands
+            elif (det_specif.startswith('FRONT') or
+                 det_specif.startswith('REAR') or
+                 det_specif.startswith('BOTH') or
+                 det_specif.startswith('MERGED') or
+                 det_specif.startswith('MERGED')):
+                # for /DET/FRONT, /DET/REAR, /DET/BOTH, /DET/MERGE and /DET/MERGED commands
                 reducer.instrument.setDetector(det_specif)
+            else:
+                _issueWarning('Incorrectly formatted DET line, %s, line ignored' % upper_line)
 
         # There are two entries for Gravity: 1. ON/OFF (TRUE/FALSE)
         #                                    2. LEXTRA=xx.xx

--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -2089,12 +2089,11 @@ class UserFile(ReductionStep):
                 self._readDetectorCorrections(upper_line[8:], reducer)
             elif det_specif.startswith('RESCALE') or det_specif.startswith('SHIFT'):
                 self._readFrontRescaleShiftSetup(det_specif, reducer)
-            elif (det_specif.startswith('FRONT') or
-                 det_specif.startswith('REAR') or
-                 det_specif.startswith('BOTH') or
-                 det_specif.startswith('MERGED') or
-                 det_specif.startswith('MERGED')):
+            elif any(it == det_specif.strip() for it in ['FRONT','REAR','BOTH','MERGE','MERGED']):
                 # for /DET/FRONT, /DET/REAR, /DET/BOTH, /DET/MERGE and /DET/MERGED commands
+                det_specif = det_specif.strip()
+                if det_specif == 'MERGE':
+                    det_specif = 'MERGED'
                 reducer.instrument.setDetector(det_specif)
             else:
                 _issueWarning('Incorrectly formatted DET line, %s, line ignored' % upper_line)


### PR DESCRIPTION
Fixes #10888 

**Context**

The commands MERGE(D) and BOTH were not being picked up from the User file and displayed on the screen when initially loading the SANS GUI. The reasons for this are documeneted in the original issue.

We make sure that the User file setting for DET is being displayed correctly
### For Testing

You can find the sample files here:  \olympic\Babylon5\Scratch\Anton\Testing\10888
You need to set the directory path to the location of the sample files.

**DET/REAR**
1. Open the SANSGUI load the user file REAR.txt
2. Close and reopen the SANSGUI.
   - Confirm on the Reduction Settings tab that REAR is selected as the detector bank

**DET/FRONT**
1. Open the SANSGUI load the user file FRONT.txt
2. Close and reopen the SANSGUI.
   - Confirm on the Reduction Settings tab that FRONT is selected as the detector bank

**DET/MERGE**
1. Open the SANSGUI load the user file MERGE.txt
2. Close and reopen the SANSGUI.
   - Confirm on the Reduction Settings tab that MERGED is selected as the detector bank

**DET/MERGED**
1. Open the SANSGUI load the user file MERGED.txt
2. Close and reopen the SANSGUI.
   - Confirm on the Reduction Settings tab that MERGED is selected as the detector bank

**DET/BOTH**
1. Open the SANSGUI load the user file BOTH.txt
2. Close and reopen the SANSGUI.
   - Confirm on the Reduction Settings tab that BOTH is selected as the detector bank

**invalid DET/xxxx**
1. Open the SANSGUI load the user file INVALID.txt
2. Close and reopen the SANSGUI.
   - Confirm that a warning message is displayed and that the detector defaults back to REAR
