### PR TITLE
Engin-X: more flexible bank interpretation

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrate.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrate.py
@@ -3,7 +3,7 @@ from mantid.kernel import *
 from mantid.api import *
 
 class EnginXCalibrate(PythonAlgorithm):
-    INDICES_PROP_NAME = 'DetectorIndices'
+    INDICES_PROP_NAME = 'SpectrumNumbers'
 
     def category(self):
         return "Diffraction\\Engineering;PythonAlgorithms"
@@ -27,18 +27,22 @@ class EnginXCalibrate(PythonAlgorithm):
                              "find expected peaks. This takes precedence over 'ExpectedPeaks' if both "
                              "options are given.")
 
-        self.declareProperty("Bank", '', direction=Direction.Input,
+        import EnginXUtils
+        self.declareProperty("Bank", '', StringListValidator(EnginXUtils.ENGINX_BANKS),
+                             direction=Direction.Input,
                              doc = "Which bank to calibrate. It can be specified as 1 or 2, or "
-                             "equivalently, North or South. See also " + self.INDICES_PROP_NAME)
+                             "equivalently, North or South. See also " + self.INDICES_PROP_NAME + " "
+                             "for a more flexible alternative to select specific detectors")
+
+        self.declareProperty(self.INDICES_PROP_NAME, '', direction=Direction.Input,
+                             doc = 'Sets the spectrum numbers for the detectors '
+                             'that should be considered in the calibration (all others will be '
+                             'ignored). This options cannot be used together with Bank, as they overlap. '
+                             'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "",\
                 Direction.Input, PropertyMode.Optional),\
     		"Calibrated detector positions. If not specified, default ones are used.")
-
-        self.declareProperty(self.INDICES_PROP_NAME, '', direction=Direction.Input,
-                             doc = 'Sets the workspace indices for the detectors '
-                             'that should be considered in the calibration (all others will be '
-                             'ignored). This options cannot be used together with Bank, as they overlap.')
 
         self.declareProperty('OutputParametersTableName', '', direction=Direction.Input,
                              doc = 'Name for a table workspace with the calibration parameters calculated '

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -26,7 +26,6 @@ class EnginXCalibrateFull(PythonAlgorithm):
                              "(3D vector with x, y, z values), the new positions in V3D, the new positions "
                              "in spherical coordinates, the change in L2, and the DIFC and ZERO parameters.")
 
-        import EnginXUtils
         self.declareProperty("Bank", '', StringListValidator(EnginXUtils.ENGINX_BANKS),
                              direction=Direction.Input,
                              doc = "Which bank to calibrate: It can be specified as 1 or 2, or "

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnginXCalibrateFull.py
@@ -5,7 +5,7 @@ import math
 import EnginXUtils
 
 class EnginXCalibrateFull(PythonAlgorithm):
-    INDICES_PROP_NAME = 'DetectorIndices'
+    INDICES_PROP_NAME = 'SpectrumNumbers'
 
     def category(self):
         return "Diffraction\\Engineering;PythonAlgorithms"
@@ -20,20 +20,24 @@ class EnginXCalibrateFull(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty("Workspace", "", Direction.InOut),
                              "Workspace with the calibration run to use. The calibration will be applied on it.")
 
-        self.declareProperty("Bank", '', direction=Direction.Input,
-                             doc = "Which bank to calibrate. It can be specified as 1 or 2, or "
-                             "equivalently,North or South. See also " + self.INDICES_PROP_NAME)
-
-        self.declareProperty(self.INDICES_PROP_NAME, '', direction=Direction.Input,
-                             doc = 'Sets the workspace indices for the detectors '
-                             'that should be considered in the calibration (all others will be '
-                             'ignored). This options cannot be used together with Bank, as they overlap.')
-
         self.declareProperty(ITableWorkspaceProperty("OutDetPosTable", "", Direction.Output),\
                              "A table with the detector IDs and calibrated detector positions and additional "
                              "calibration information. The table includes: the old positions in V3D format "
                              "(3D vector with x, y, z values), the new positions in V3D, the new positions "
                              "in spherical coordinates, the change in L2, and the DIFC and ZERO parameters.")
+
+        import EnginXUtils
+        self.declareProperty("Bank", '', StringListValidator(EnginXUtils.ENGINX_BANKS),
+                             direction=Direction.Input,
+                             doc = "Which bank to calibrate: It can be specified as 1 or 2, or "
+                             "equivalently,North or South. See also " + self.INDICES_PROP_NAME + " "
+                             "for a more flexible alternative to select specific detectors")
+
+        self.declareProperty(self.INDICES_PROP_NAME, '', direction=Direction.Input,
+                             doc = 'Sets the spectrum numbers for the detectors '
+                             'that should be considered in the calibration (all others will be '
+                             'ignored). This options cannot be used together with Bank, as they overlap. '
+                             'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
 
         self.declareProperty(FileProperty("OutDetPosFilename", "", FileAction.OptionalSave, [".csv"]),
                              "Name of the file to save the pre-/post-calibrated detector positions - this "

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateFullTest.py
@@ -23,27 +23,33 @@ class EnginXCalibrateFullTest(unittest.TestCase):
         # No Filename property (required)
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          Input='foo', Bank=1)
+                          Input='foo', Bank='1')
 
         # Wrong workspace name
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          Input='this_ws_is_not_there.not', Bank=2)
+                          Input='this_ws_is_not_there.not', Bank='2')
 
         # mispelled ExpectedPeaks
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
+                          InputWorkspace=self.__class__._data_ws, Bank='2', Peaks='2')
 
         # mispelled OutDetPosFilename
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull, OutDetPosFile='any.csv',
-                          InputWorkspace=self.__class__._data_ws, Bank=2, Peaks='2')
+                          InputWorkspace=self.__class__._data_ws, Bank='2', Peaks='2')
 
         # all fine, except missing DetectorPositions (output)
         self.assertRaises(RuntimeError,
                           EnginXCalibrateFull,
-                          InputWorkspace=self.__class__._data_ws, Bank=2)
+                          InputWorkspace=self.__class__._data_ws, Bank='2')
+
+        # all fine, except Bank should be a string
+        self.assertRaises(RuntimeError,
+                          EnginXCalibrateFull,
+                          InputWorkspace=self.__class__._data_ws, DetectorPositions=[0.6, 0.9],
+                          Bank=2)
 
     def test_wrong_fit_fails_gracefully(self):
         """

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXCalibrateTest.py
@@ -24,28 +24,28 @@ class EnginXCalibrateTest(unittest.TestCase):
         # No InputWorkspace property (required)
         self.assertRaises(RuntimeError,
                           EnginXCalibrate,
-                          File='foo', Bank=1)
+                          File='foo', Bank='1')
 
         # Wrong (mispelled) InputWorkspace property
         self.assertRaises(RuntimeError,
                           EnginXCalibrate,
-                          InputWorkpace='anything_goes', Bank=2)
+                          InputWorkpace='anything_goes', Bank='2')
 
         # mispelled ExpectedPeaks
         tbl = CreateEmptyTableWorkspace(OutputWorkspace='test_table')
         self.assertRaises(RuntimeError,
                           EnginXCalibrate,
-                          Inputworkspace=self.__class__._data_ws, DetectorPositions=tbl, Bank=2, Peaks='2')
+                          Inputworkspace=self.__class__._data_ws, DetectorPositions=tbl, Bank='2', Peaks='2')
 
         # mispelled DetectorPositions
         self.assertRaises(RuntimeError,
                           EnginXCalibrate,
-                          InputWorkspace=self.__class__._data_ws, Detectors=tbl, Bank=2, Peaks='2')
+                          InputWorkspace=self.__class__._data_ws, Detectors=tbl, Bank='2', Peaks='2')
 
         # There's no output workspace
         self.assertRaises(RuntimeError,
                           EnginXCalibrate,
-                          InputWorkspace=self.__class__._data_ws, Bank=1)
+                          InputWorkspace=self.__class__._data_ws, Bank='1')
 
 
     def test_fails_gracefully(self):
@@ -57,7 +57,7 @@ class EnginXCalibrateTest(unittest.TestCase):
         # and finally raise after a 'some peaks not found' error
         self.assertRaises(RuntimeError,
                           EnginXCalibrate,
-                          InputWorkspace=self.__class__._data_ws, ExpectedPeaks=[0.2, 0.4], Bank=2)
+                          InputWorkspace=self.__class__._data_ws, ExpectedPeaks=[0.2, 0.4], Bank='2')
 
     def test_runs_ok(self):
         """
@@ -65,7 +65,7 @@ class EnginXCalibrateTest(unittest.TestCase):
         """
 
         difc, zero = EnginXCalibrate(InputWorkspace=self.__class__._data_ws,
-                                     ExpectedPeaks=[1.6, 1.1, 1.8], Bank=2)
+                                     ExpectedPeaks=[1.6, 1.1, 1.8], Bank='2')
 
         self.check_3peaks_values(difc, zero)
 
@@ -79,7 +79,7 @@ class EnginXCalibrateTest(unittest.TestCase):
         difc, zero = EnginXCalibrate(InputWorkspace=self.__class__._data_ws,
                                      ExpectedPeaks=[-4, 40, 323], # nonsense, but FromFile should prevail
                                      ExpectedPeaksFromFile=filename,
-                                     Bank=2)
+                                     Bank='2')
 
         self.check_3peaks_values(difc, zero)
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -57,13 +57,13 @@ class EnginXFocusTest(unittest.TestCase):
         self.assertRaises(RuntimeError,
                           EnginXFocus,
                           InputWorkspace=self.__class__._data_ws, Bank='2', DetectorPositions=tbl,
-                          DetectorIndices='0-10', OutputWorkspace='nop')
+                          SpectrumNumbers='1-10', OutputWorkspace='nop')
 
         # workspace index too big. This starts as a ValueError but the managers is raising a RuntimeError
         self.assertRaises(RuntimeError,
                           EnginXFocus,
                           InputWorkspace=self.__class__._data_ws, DetectorPositions=tbl,
-                          DetectorIndices='999999999999999', OutputWorkspace='nop')
+                          SpectrumNumbers='999999999999999', OutputWorkspace='nop')
 
     def _check_output_ok(self, ws, ws_name='', y_dim_max=1, yvalues=None):
         """
@@ -124,7 +124,7 @@ class EnginXFocusTest(unittest.TestCase):
         Same as above but with detector (workspace) indices equivalent to bank 1
         """
         out_idx_name = 'out_idx'
-        out_idx = EnginXFocus(InputWorkspace=self.__class__._data_ws, DetectorIndices='0-1199',
+        out_idx = EnginXFocus(InputWorkspace=self.__class__._data_ws, SpectrumNumbers='1-1200',
                               OutputWorkspace=out_idx_name)
         self._check_output_ok(ws=out_idx, ws_name=out_idx_name, y_dim_max=1,
                               yvalues=self._expected_yvals_bank1)
@@ -135,7 +135,7 @@ class EnginXFocusTest(unittest.TestCase):
         """
         out_idx_name = 'out_idx'
         out_idx = EnginXFocus(InputWorkspace=self.__class__._data_ws,
-                              DetectorIndices='0-100, 101-500, 400-1199',
+                              SpectrumNumbers='1-100, 101-500, 400-1200',
                               OutputWorkspace=out_idx_name)
         self._check_output_ok(ws=out_idx, ws_name=out_idx_name, y_dim_max=1,
                               yvalues=self._expected_yvals_bank1)

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -109,6 +109,16 @@ class EnginXFocusTest(unittest.TestCase):
 
         self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
 
+    def test_runs_ok_south(self):
+        """
+        Same as before but with Bank='South' - equivalent to Bank='1'
+        """
+
+        out_name = 'out'
+        out = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank='North', OutputWorkspace=out_name)
+
+        self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
+
     def test_runs_ok_indices(self):
         """
         Same as above but with detector (workspace) indices equivalent to bank 1

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnginXFocusTest.py
@@ -6,6 +6,12 @@ class EnginXFocusTest(unittest.TestCase):
 
     _data_ws = None
 
+    _expected_yvals_bank1  = [0.0037582279159681957, 0.00751645583194, 0.0231963801368,
+                              0.0720786940576, 0.0615909620868, 0.00987979301753]
+
+    _expected_yvals_bank2 = [0, 0.0112746837479, 0.0394536605073, 0.0362013481777,
+                    0.0728500403862, 0.000870882282987]
+
     # Note not using @classmethod setUpClass / tearDownClass because that's not supported in the old
     # unittest of rhel6
     def setUp(self):
@@ -24,17 +30,17 @@ class EnginXFocusTest(unittest.TestCase):
         # No InputWorkspace property
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          Bank=1, OutputWorkspace='nop')
+                          Bank='1', OutputWorkspace='nop')
 
         # Mispelled InputWorkspace prop
         self.assertRaises(RuntimeError,
                           EnginXFocus,
-                          InputWrkspace='anything_goes', Bank=1, OutputWorkspace='nop')
+                          InputWrkspace='anything_goes', Bank='1', OutputWorkspace='nop')
 
         # Wrong InputWorkspace name
         self.assertRaises(ValueError,
                           EnginXFocus,
-                          InputWorkspace='foo_is_not_there', Bank=1, OutputWorkspace='nop')
+                          InputWorkspace='foo_is_not_there', Bank='1', OutputWorkspace='nop')
 
         # mispelled bank
         self.assertRaises(RuntimeError,
@@ -47,6 +53,17 @@ class EnginXFocusTest(unittest.TestCase):
                           EnginXFocus,
                           InputWorkspace=self.__class__._data_ws, Detectors=tbl, OutputWorkspace='nop')
 
+        # bank and indices list clsh. This starts as a ValueError but the managers is raising a RuntimeError
+        self.assertRaises(RuntimeError,
+                          EnginXFocus,
+                          InputWorkspace=self.__class__._data_ws, Bank='2', DetectorPositions=tbl,
+                          DetectorIndices='0-10', OutputWorkspace='nop')
+
+        # workspace index too big. This starts as a ValueError but the managers is raising a RuntimeError
+        self.assertRaises(RuntimeError,
+                          EnginXFocus,
+                          InputWorkspace=self.__class__._data_ws, DetectorPositions=tbl,
+                          DetectorIndices='999999999999999', OutputWorkspace='nop')
 
     def _check_output_ok(self, ws, ws_name='', y_dim_max=1, yvalues=None):
         """
@@ -88,12 +105,30 @@ class EnginXFocusTest(unittest.TestCase):
         """
 
         out_name = 'out'
-        out = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank=1, OutputWorkspace=out_name)
+        out = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank='1', OutputWorkspace=out_name)
 
-        yvals = [0.0037582279159681957, 0.00751645583194, 0.0231963801368, 0.0720786940576,
-                 0.0615909620868, 0.00987979301753]
-        self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=yvals)
+        self._check_output_ok(ws=out, ws_name=out_name, y_dim_max=1, yvalues=self._expected_yvals_bank1)
 
+    def test_runs_ok_indices(self):
+        """
+        Same as above but with detector (workspace) indices equivalent to bank 1
+        """
+        out_idx_name = 'out_idx'
+        out_idx = EnginXFocus(InputWorkspace=self.__class__._data_ws, DetectorIndices='0-1199',
+                              OutputWorkspace=out_idx_name)
+        self._check_output_ok(ws=out_idx, ws_name=out_idx_name, y_dim_max=1,
+                              yvalues=self._expected_yvals_bank1)
+
+    def test_runs_ok_indices_split3(self):
+        """
+        Same as above but with detector (workspace) indices equivalent to bank 1
+        """
+        out_idx_name = 'out_idx'
+        out_idx = EnginXFocus(InputWorkspace=self.__class__._data_ws,
+                              DetectorIndices='0-100, 101-500, 400-1199',
+                              OutputWorkspace=out_idx_name)
+        self._check_output_ok(ws=out_idx, ws_name=out_idx_name, y_dim_max=1,
+                              yvalues=self._expected_yvals_bank1)
 
     def test_runs_ok_bank2(self):
         """
@@ -101,13 +136,22 @@ class EnginXFocusTest(unittest.TestCase):
         """
 
         out_name = 'out_bank2'
-        out_bank2 = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank=2,
+        out_bank2 = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank='2',
                                 OutputWorkspace=out_name)
 
-        yvals = [0, 0.0112746837479, 0.0394536605073, 0.0362013481777,
-                 0.0728500403862, 0.000870882282987]
         self._check_output_ok(ws=out_bank2, ws_name=out_name, y_dim_max=1201,
-                              yvalues=yvals)
+                              yvalues=self._expected_yvals_bank2)
+
+    def test_runs_ok_bank_south(self):
+        """
+        As before but using the Bank='South' alias. Should produce the same results.
+        """
+        out_name = 'out_bank_south'
+        out_bank_south = EnginXFocus(InputWorkspace=self.__class__._data_ws, Bank='South',
+                                OutputWorkspace=out_name)
+
+        self._check_output_ok(ws=out_bank_south, ws_name=out_name, y_dim_max=1201,
+                              yvalues=self._expected_yvals_bank2)
 
 
 

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
@@ -13,11 +13,11 @@ class EnginXCalibrateTest(stresstesting.MantidStressTest):
         calib_ws = Load(Filename = 'ENGINX00193749.nxs')
 
         positions = EnginXCalibrateFull(Workspace = calib_ws,
-                                        Bank = 1,
+                                        Bank = '1',
                                         ExpectedPeaks = '1.3529, 1.6316, 1.9132')
 
         (self.difc, self.zero) = EnginXCalibrate(InputWorkspace = calib_ws,
-                                                 Bank = 1,
+                                                 Bank = '1',
                                                  ExpectedPeaks = '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
                                                  DetectorPositions = positions)
 

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnginXCalibrateTest.py
@@ -13,13 +13,13 @@ class EnginXCalibrateTest(stresstesting.MantidStressTest):
         calib_ws = Load(Filename = 'ENGINX00193749.nxs')
 
         positions = EnginXCalibrateFull(Workspace = calib_ws,
-                                      Bank = 1,
-                                      ExpectedPeaks = '1.3529, 1.6316, 1.9132')
+                                        Bank = 1,
+                                        ExpectedPeaks = '1.3529, 1.6316, 1.9132')
 
         (self.difc, self.zero) = EnginXCalibrate(InputWorkspace = calib_ws,
-                                               Bank = 1,
-                                               ExpectedPeaks = '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
-                                               DetectorPositions = positions)
+                                                 Bank = 1,
+                                                 ExpectedPeaks = '2.7057,1.9132,1.6316,1.5621,1.3528,0.9566',
+                                                 DetectorPositions = positions)
 
     def validate(self):
         import sys

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrate-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrate-v1.rst
@@ -50,7 +50,7 @@ Usage
    ws_name = 'test'
    Load('ENGINX00213855.nxs', OutputWorkspace=ws_name)
    Difc, Zero = EnginXCalibrate(InputWorkspace=ws_name,
-                                ExpectedPeaks=[1.097, 2.1], Bank=1,
+                                ExpectedPeaks=[1.097, 2.1], Bank='1',
                                 OutputParametersTableName=out_tbl_name)
 
    print "Difc: %.2f" % (Difc)

--- a/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXCalibrateFull-v1.rst
@@ -74,7 +74,7 @@ Usage
    Load('ENGINX00213855focussed.nxs', OutputWorkspace=ws_name)
 
    posTable = EnginXCalibrateFull(Workspace=ws_name,
-                                  ExpectedPeaks=[1.097, 2.1], Bank=1)
+                                  ExpectedPeaks=[1.097, 2.1], Bank='1')
 
    detID = posTable.column(0)[0]
    calPos =  posTable.column(2)[0]
@@ -106,7 +106,7 @@ Output:
    pos_filename = 'detectors_pos.csv'
    Load('ENGINX00213855focussed.nxs', OutputWorkspace=ws_name)
    posTable = EnginXCalibrateFull(Workspace=ws_name,
-                                  ExpectedPeaks=[1.097, 2.1], Bank=1,
+                                  ExpectedPeaks=[1.097, 2.1], Bank='1',
                                   OutDetPosFilename=pos_filename)
 
    detID = posTable.column(0)[0]

--- a/Code/Mantid/docs/source/algorithms/EnginXFocus-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnginXFocus-v1.rst
@@ -31,7 +31,7 @@ Usage
    # Run the algorithm
    ws_name = 'data_ws'
    Load('ENGINX00213855.nxs', OutputWorkspace=ws_name)
-   ws = EnginXFocus(InputWorkspace=ws_name, Bank=1)
+   ws = EnginXFocus(InputWorkspace=ws_name, Bank='1')
 
    # Should have one spectrum only
    print "No. of spectra:", ws.getNumberHistograms()

--- a/Code/Mantid/scripts/Engineering/EnginXUtils.py
+++ b/Code/Mantid/scripts/Engineering/EnginXUtils.py
@@ -4,46 +4,6 @@ import os
 from mantid.api import *
 import mantid.simpleapi as sapi
 
-def getDetIDsForBank(bank):
-    """ Returns detector IDs corresponding to the specified EnginX bank number
-    """
-    groupingFilePath = os.path.join(sapi.config.getInstrumentDirectory(),
-                                    'Grouping', 'ENGINX_Grouping.xml')
-
-    alg = AlgorithmManager.create('LoadDetectorsGroupingFile')
-    alg.setProperty('InputFile', groupingFilePath)
-    alg.setProperty('OutputWorkspace', '__EnginXGrouping')
-    alg.execute()
-
-    grouping = mtd['__EnginXGrouping']
-
-    detIDs = set()
-
-    for i in range(grouping.getNumberHistograms()):
-        if grouping.readY(i)[0] == bank:
-            detIDs.add(grouping.getDetector(i).getID())
-
-    sapi.DeleteWorkspace(grouping)
-
-    if len(detIDs) == 0:
-        raise Exception('Unknown bank')
-
-    return detIDs
-
-def getWsIndicesForBank(bank, ws):
-    """ Get a list of workspace indices which correspond to the specified bank
-    """
-    detIDs = getDetIDsForBank(bank)
-
-    def isIndexInBank(index):
-        try:
-            det = ws.getDetector(index)
-            return det.getID() in detIDs
-        except RuntimeError:
-            return False
-
-    return [i for i in range(0, ws.getNumberHistograms()) if isIndexInBank(i)]
-
 def readInExpectedPeaks(filename, expectedGiven):
     """
     Reads in expected peaks from the .csv file if requested. Otherwise fall back to the list of
@@ -92,12 +52,121 @@ def readInExpectedPeaks(filename, expectedGiven):
 
     return expectedPeaksD
 
+def getWsIndicesFromInProperties(ws, bank, detIndices):
+    """
+    Get the detector indices that the user requests, either through the input property 'Bank' or
+    'DetectorIndices'
+
+    @param workspace :: input workspace (with instrument)
+    @param bank :: value passed in the input property 'Bank' to an EnginX algorithm
+    @param detIndices :: value passed in the 'Det
+
+    @returns list of workspace indices that can be used in mantid algorithms such as CropWorkspace.
+    """
+    indices = None
+    if bank and detIndices:
+        raise ValueError("It is not possible to use at the same time the input properties 'Bank' and "
+                         "'DetectorIndices', as they overlap. Please use either of them. Got Bank: '%s', "
+                         "and DetectorIndices: '%s'"%(bank, detIndices))
+    elif bank:
+        bankAliases = {'North': '1', 'South': '2'}
+        bank = bankAliases.get(bank, bank)
+        indices = getWsIndicesForBank(ws, bank)
+        if not indices:
+            return RuntimeError("Unable to find a meaningful list of workspace indices for the "
+                                "bank passed: %s. Please check the inputs." % bank)
+        return indices
+    elif detIndices:
+        indices = parseWsIndices(ws, detIndices)
+        if not indices:
+            return RuntimeError("Unable to find a meaningful list of workspace indices for the "
+                                "range(s) of detectors passed: %s. Please check the inputs." % detIndices)
+        return indices
+    else:
+        raise ValueError("You have not given any value for the properties 'Bank' and 'DetectorIndices' "
+                         "One of them is required")
+
+
+def parseWsIndices(ws, detIndices):
+    """
+    Get a usable list of indices from a user list that can look like: '8-10, 20-40, 100-110'
+    For that example this method will produce: [8,9,10,20, 21,... , 110]
+
+    @param workspace :: input workspace (with instrument)
+    @param detIndices :: range of indices (or list of ranges) as given to an algorithm
+
+    @return list of indices ready to be used in mantid algorithms such as CropWorkspace
+    """
+    segments = [ s.split("-") for s in detIndices.split(",") ]
+    indices = [ idx for s in segments for idx in range(int(s[0]), int(s[-1])+1) ]
+    # remove duplicates and sort
+    indices = list(set(indices))
+    indices.sort()
+    if indices[-1] >= ws.getNumberHistograms():
+        raise ValueError("A workspace index bigger than the number of histograms available in the "
+                         "workspace '" + ws.getName() +"'has been given. Please check the list of indices.")
+    return indices
+
+def getWsIndicesForBank(ws, bank):
+    """
+    Finds the workspace indices of all the pixels/detectors/spectra corresponding to a bank.
+
+    ws :: workspace with instrument definition
+    bank :: bank number as it appears in the instrument definition
+
+    @returns :: list of workspace indices for the bank
+    """
+    detIDs = getDetIDsForBank(bank)
+
+    def isIndexInBank(index):
+        try:
+            det = ws.getDetector(index)
+            return det.getID() in detIDs
+        except RuntimeError:
+            return False
+
+    return [i for i in range(0, ws.getNumberHistograms()) if isIndexInBank(i)]
+
+def getDetIDsForBank(bank):
+    """
+    Find the detector IDs for an instrument bank.
+
+    @param bank :: name/number as a string
+
+    @returns list of detector IDs corresponding to the specified EnginX bank number
+    """
+    groupingFilePath = os.path.join(sapi.config.getInstrumentDirectory(),
+                                    'Grouping', 'ENGINX_Grouping.xml')
+
+    alg = AlgorithmManager.create('LoadDetectorsGroupingFile')
+    alg.setProperty('InputFile', groupingFilePath)
+    alg.setProperty('OutputWorkspace', '__EnginXGrouping')
+    alg.execute()
+
+    grouping = mtd['__EnginXGrouping']
+
+    detIDs = set()
+
+    for i in range(grouping.getNumberHistograms()):
+        if grouping.readY(i)[0] == int(bank):
+            detIDs.add(grouping.getDetector(i).getID())
+
+    sapi.DeleteWorkspace(grouping)
+
+    if len(detIDs) == 0:
+        raise ValueError('Could not find any detector for this bank: ' + bank +
+                         '. This looks like an unknown bank')
+
+    return detIDs
+
 def  generateOutputParTable(name, difc, zero):
     """
     Produces a table workspace with the two fitted calibration parameters
 
     @param name :: the name to use for the table workspace that is created here
-        """
+    @param difc :: difc calibration parameter
+    @param zero :: zero calibration parameter
+    """
     tbl = sapi.CreateEmptyTableWorkspace(OutputWorkspace=name)
     tbl.addColumn('double', 'difc')
     tbl.addColumn('double', 'zero')

--- a/Code/Mantid/scripts/Engineering/EnginXUtils.py
+++ b/Code/Mantid/scripts/Engineering/EnginXUtils.py
@@ -106,7 +106,7 @@ def parseWsIndices(ws, detIndices):
     if indices[-1] >= maxIdx:
         raise ValueError("A workspace index equal or bigger than the number of histograms available in the "
                          "workspace '" + ws.getName() +"' (" + str(ws.getNumberHistograms()) +
-                         ")has been given. Please check the list of indices.")
+                         ") has been given. Please check the list of indices.")
     return indices
 
 def getWsIndicesForBank(ws, bank):

--- a/Code/Mantid/scripts/Engineering/EnginXUtils.py
+++ b/Code/Mantid/scripts/Engineering/EnginXUtils.py
@@ -73,13 +73,13 @@ def getWsIndicesFromInProperties(ws, bank, detIndices):
         bank = bankAliases.get(bank, bank)
         indices = getWsIndicesForBank(ws, bank)
         if not indices:
-            return RuntimeError("Unable to find a meaningful list of workspace indices for the "
+            raise RuntimeError("Unable to find a meaningful list of workspace indices for the "
                                 "bank passed: %s. Please check the inputs." % bank)
         return indices
     elif detIndices:
         indices = parseWsIndices(ws, detIndices)
         if not indices:
-            return RuntimeError("Unable to find a meaningful list of workspace indices for the "
+            raise RuntimeError("Unable to find a meaningful list of workspace indices for the "
                                 "range(s) of detectors passed: %s. Please check the inputs." % detIndices)
         return indices
     else:
@@ -102,9 +102,11 @@ def parseWsIndices(ws, detIndices):
     # remove duplicates and sort
     indices = list(set(indices))
     indices.sort()
-    if indices[-1] >= ws.getNumberHistograms():
-        raise ValueError("A workspace index bigger than the number of histograms available in the "
-                         "workspace '" + ws.getName() +"'has been given. Please check the list of indices.")
+    maxIdx = ws.getNumberHistograms()
+    if indices[-1] >= maxIdx:
+        raise ValueError("A workspace index equal or bigger than the number of histograms available in the "
+                         "workspace '" + ws.getName() +"' (" + str(ws.getNumberHistograms()) +
+                         ")has been given. Please check the list of indices.")
     return indices
 
 def getWsIndicesForBank(ws, bank):


### PR DESCRIPTION
Fixes #11808.

This adds aliases `North` and `South` for the input property `Bank`, and a new input property `DetectorIndices` that can be used instead of `Bank` to have full control over what detectors are used for calibration.

**To test:**
- Tests should go well
- Code review and maybe some manual checks (see below)

With this you can do Bank='1' as before, but also DetectorIndices='0-1199' or DetectorIndices='0-99, 1000-1100, 10000-10100'. This new option could be called DetectorIndices or WorkspaceIndices (to avoid confusion with the detector IDs), as they are actually the workspace indices as it stands now. This is something we'll need to check with instrument scientists, as the detector IDs that we have in the ENGIN-X IDF are a bit non-intuitive and the last day Saurabh was not very sure about this. 

Because the new 'North' and 'South' aliases for banks 1 and 2, the property Bank is now of string type. And also, Bank doesn't have a default value now, as you can use either Bank or DetectorIndices.

For validation I've included a few unit test cases where the results when using Bank='1' and Bank='2' are compared with the results when using the equivalent North/South alias and ranges of indices.
You can also run manually some commands like in the tests, like:

```
ws=Load("ENGINX00228061.nxs", OutputWorkspace='ENGIN-X_test_ws')
# all 4 are equivalent:
EnginXFocus(InputWorkspace=ws, Bank='1', OutputWorkspace='out_1')
EnginXFocus(InputWorkspace=ws, Bank='North', OutputWorkspace='out_north')
EnginXFocus(InputWorkspace=ws, DetectorIndices='0-1199', OutputWorkspace='out_indices1')
EnginXFocus(InputWorkspace=ws, DetectorIndices='0-100, 101-500, 400-1199', OutputWorkspace='out_indices3')

# you can compare all these like:
CheckWorkspacesMatch('out_1', 'out_north')
CheckWorkspacesMatch('out_1', 'out_indices1')
# etc.

# note the too big index, should produce an error message:
EnginXFocus(InputWorkspace=ws, DetectorIndices='50000-100000', OutputWorkspace='out_nope')

```

Small note: the approach taken here to add the bank aliases (North, South) is specific to ENGIN-X. We could chat one day about having aliases for banks more in general in Mantid. Not sure if there's general demand for that. One practical problem for this is that it seems that the widespread practice is to put bank names in comments.
