### PR TITLE
Revert logging changes to FindPeaksMD

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -161,11 +161,6 @@ void FindPeaksMD::readExperimentInfo(const ExperimentInfo_sptr &ei,
                                      const IMDWorkspace_sptr &ws) {
   // Instrument associated with workspace
   inst = ei->getInstrument();
-  if (inst)
-    g_log.information() << "Instrument has " << inst->getNumberDetectors() << " detectors.\n";
-  else
-    g_log.warning("Instrument is not defined.");
-
   // Find the run number
   m_runNumber = ei->getRunNumber();
 
@@ -180,19 +175,14 @@ void FindPeaksMD::readExperimentInfo(const ExperimentInfo_sptr &ei,
   } else if (dim0 == "Q_sample_x")
     dimType = QSAMPLE;
   else
-  {
-    std::stringstream errss;
-    errss << "Unexpected dimensions: need either Q_lab_x or Q_sample_x."
-             << "Input MDEventWorkspace has dimenion name as " << dim0;
-    throw std::runtime_error(errss.str());
-  }
+    throw std::runtime_error(
+        "Unexpected dimensions: need either Q_lab_x or Q_sample_x.");
 
   // Find the goniometer rotation matrix
   m_goniometer =
       Mantid::Kernel::Matrix<double>(3, 3, true); // Default IDENTITY matrix
   try {
     m_goniometer = ei->mutableRun().getGoniometerMatrix();
-    g_log.debug() << "Goniometer matrix: " << m_goniometer.str() << "\n";
   } catch (std::exception &e) {
     g_log.warning() << "Error finding goniometer matrix. It will not be set in "
                        "the peaks found." << std::endl;
@@ -224,13 +214,11 @@ FindPeaksMD::createPeak(const Mantid::Kernel::V3D &Q, const double binCount) {
   boost::shared_ptr<DataObjects::Peak> p;
   if (dimType == QLAB) {
     // Build using the Q-lab-frame constructor
-    g_log.debug("Add peak as Q-lab.");
     p = boost::shared_ptr<DataObjects::Peak>(new Peak(inst, Q));
     // Save gonio matrix for later
     p->setGoniometerMatrix(m_goniometer);
   } else if (dimType == QSAMPLE) {
     // Build using the Q-sample-frame constructor
-    g_log.debug("Add peak as Q-sample.");
     p = boost::shared_ptr<DataObjects::Peak>(new Peak(inst, Q, m_goniometer));
   }
 
@@ -274,12 +262,9 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     throw std::runtime_error(
         "No instrument was found in the MDEventWorkspace. Cannot find peaks.");
 
-  g_log.debug() << "Number of experiment info = " << ws->getNumExperimentInfo() << "\n";
   for (uint16_t iexp = 0; iexp < ws->getNumExperimentInfo(); iexp++) {
     ExperimentInfo_sptr ei = ws->getExperimentInfo(iexp);
     this->readExperimentInfo(ei, boost::dynamic_pointer_cast<IMDWorkspace>(ws));
-    g_log.information() << iexp << "-th Experiment Info of run number = "
-                        << ei->getRunNumber() << "\n";
     // Copy the instrument, sample, run to the peaks workspace.
     peakWS->copyExperimentInfoFrom(ei.get());
 
@@ -291,8 +276,7 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         (thresholdDensity == std::numeric_limits<double>::infinity()) ||
         (thresholdDensity == -std::numeric_limits<double>::infinity())) {
       g_log.warning() << "Infinite or NaN overall density found. Your input data "
-                         "may be invalid. Using a 0 threshold instead. "
-                      << "Original normalized signal = " << ws->getBox()->getSignalNormalized()
+                         "may be invalid. Using a 0 threshold instead."
                       << std::endl;
       thresholdDensity = 0;
     }
@@ -307,7 +291,6 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     // Get all the MDboxes
     progress(0.10, "Getting Boxes");
     ws->getBox()->getBoxes(boxes, 1000, true);
-    g_log.information() << "Number of boxes (IMDNode) = " << boxes.size() << "\n";
 
     // This pair is the <density, ptr to the box>
     typedef std::pair<double, API::IMDNode *> dens_box;
@@ -322,32 +305,11 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     auto it1_end = boxes.end();
     for (; it1 != it1_end; it1++) {
       auto box = *it1;
-#if 0
-      box->calcVolume();
-      double density_orig = box->getSignalNormalized() * m_densityScaleFactor;
-      size_t numCols;
-      std::vector<coord_t> coordTable;
-      box->getEventsData(coordTable, numCols);
-      g_log.warning() << "[VZExp] Number of events = " << coordTable.size() << ", "
-                      << "Number of column = " << numCols << "\n";
-      g_log.notice() << "[DB] density comparison: " << density_orig << " vs. "
-                     << density <<"\n";
-#endif
       double density = box->getSignalNormalized() * m_densityScaleFactor;
-
       // Skip any boxes with too small a signal density.
       if (density > thresholdDensity)
-      {
         sortedBoxes.insert(dens_box(density, box));
-        g_log.information() << "Add sorted box with density = " << density << "\n";
-      }
-      else
-      {
-        g_log.information() << "Box is rejected b/c density (" << density << ") is not larger than threshold ("
-                            << thresholdDensity << ":)\n";
-      }
     }
-
 
     // --------------- Find Peak Boxes -----------------------------
     // List of chosen possible peak boxes.
@@ -376,7 +338,6 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
 
       // Compare to all boxes already picked.
       bool badBox = false;
-      g_log.debug() << "peakBoxes.size = " << peakBoxes.size() << "\n";
       for (typename std::vector<boxPtr>::iterator it3 = peakBoxes.begin();
            it3 != peakBoxes.end(); it3++) {
 
@@ -399,7 +360,7 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
           badBox = true;
           break;
         }
-      } // END OF COMPARING
+      }
 
       // The box was not rejected for another reason.
       if (!badBox) {
@@ -410,10 +371,10 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         }
 
         peakBoxes.push_back(box);
-        g_log.information() << "Found box at ";
+        g_log.debug() << "Found box at ";
         for (size_t d = 0; d < nd; d++)
-          g_log.information() << (d > 0 ? "," : "") << boxCenter[d];
-        g_log.information() << "; Density = " << density << std::endl;
+          g_log.debug() << (d > 0 ? "," : "") << boxCenter[d];
+        g_log.debug() << "; Density = " << density << std::endl;
         // Report progres for each box found.
         prog->report("Finding Peaks");
       }
@@ -422,7 +383,6 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
     prog->resetNumSteps(numBoxesFound, 0.95, 1.0);
 
     // --- Convert the "boxes" to peaks ----
-    g_log.information() << "Convert " << peakBoxes.size() << " from peak box to peaks." << "\n";
     for (typename std::vector<boxPtr>::iterator it3 = peakBoxes.begin();
          it3 != peakBoxes.end(); it3++) {
       // The center of the box = Q in the lab frame
@@ -434,6 +394,13 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       const coord_t *boxCenter = box->getCentroid();
   #endif
 
+        if (false) {
+          // FIXME - Test for compiling
+          coord_t *boxcentre2;
+          int thisrunindex = ei->getRunNumber();
+          box->calculateCentroid(boxcentre2, thisrunindex);
+        }
+
       // Q of the centroid of the box
       V3D Q(boxCenter[0], boxCenter[1], boxCenter[2]);
 
@@ -444,26 +411,25 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
         binCount = static_cast<double>(box->getNPoints());
 
       try {
-        g_log.information() << "About to create peak Q = " << Q.toString() << ", "
-                            << "Bin Count (NPoints) = " << binCount << "\n";
         auto p = this->createPeak(Q, binCount);
-        if (m_addDetectors)
-          addDetectors(*p, *dynamic_cast<MDBoxBase<MDE, nd> *>(box));
-
-        g_log.information() << "Peak's detector ID = " << p->getDetectorID() << "\n";
-        if (p->getDetectorID() != -1)
-          peakWS->addPeak(*p);
+        if (m_addDetectors) {
+          auto mdBox = dynamic_cast<MDBoxBase<MDE, nd> *>(box);
+          if (!mdBox) {
+            throw std::runtime_error("Failed to cast box to MDBoxBase");
+          }
+          addDetectors(*p, *mdBox);
+        }
+        if (p->getDetectorID() != -1) peakWS->addPeak(*p);
       } catch (std::exception &e) {
-        g_log.warning() << "Error creating peak at " << Q << " because of '"
-                        << e.what() << "'. Peak will be skipped." << std::endl;
+        g_log.notice() << "Error creating peak at " << Q << " because of '"
+                       << e.what() << "'. Peak will be skipped." << std::endl;
       }
 
       // Report progress for each box found.
       prog->report("Adding Peaks");
 
     } // for each box found
-  } // ENDFOR (number of experiment info)
-
+  }
   g_log.notice() << "Number of peaks found: " << peakWS->getNumberPeaks()
                  << std::endl;
 
@@ -606,7 +572,7 @@ void FindPeaksMD::findPeaksHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) 
   }
   g_log.notice() << "Number of peaks found: " << peakWS->getNumberPeaks()
                  << std::endl;
-} // Histogram
+}
 
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.

--- a/Code/Mantid/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -394,13 +394,6 @@ void FindPeaksMD::findPeaks(typename MDEventWorkspace<MDE, nd>::sptr ws) {
       const coord_t *boxCenter = box->getCentroid();
   #endif
 
-        if (false) {
-          // FIXME - Test for compiling
-          coord_t *boxcentre2;
-          int thisrunindex = ei->getRunNumber();
-          box->calculateCentroid(boxcentre2, thisrunindex);
-        }
-
       // Q of the centroid of the box
       V3D Q(boxCenter[0], boxCenter[1], boxCenter[2]);
 

--- a/Code/Mantid/Framework/MDAlgorithms/test/FindPeaksMDTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/FindPeaksMDTest.h
@@ -16,46 +16,50 @@ using namespace Mantid::DataObjects;
 using Mantid::Geometry::Instrument_sptr;
 using Mantid::Kernel::PropertyWithValue;
 
+//-------------------------------------------------------------------------------
+/** Create the (blank) MDEW */
+static void createMDEW()
+{
+  // ---- Start with empty MDEW ----
+  FrameworkManager::Instance().exec("CreateMDWorkspace", 18, "Dimensions", "3", "EventType", "MDEvent",
+      "Extents", "-10,10,-10,10,-10,10", "Names", "Q_lab_x,Q_lab_y,Q_lab_z", "Units", "-,-,-",
+      "SplitInto", "5", "SplitThreshold", "20", "MaxRecursionDepth", "15", "OutputWorkspace", "MDEWS");
+
+  // Give it an instrument
+  Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentRectangular2(1, 100, 0.05);
+  IMDEventWorkspace_sptr ws;
+  TS_ASSERT_THROWS_NOTHING(
+      ws = AnalysisDataService::Instance().retrieveWS<IMDEventWorkspace>("MDEWS"));
+  ExperimentInfo_sptr ei(new ExperimentInfo());
+  ei->setInstrument(inst);
+  // Give it a run number
+  ei->mutableRun().addProperty(new PropertyWithValue<std::string>("run_number", "12345"), true);
+  ws->addExperimentInfo(ei);
+}
+
+//-------------------------------------------------------------------------------
+/** Add a fake peak */
+static void addPeak(size_t num, double x, double y, double z, double radius)
+{
+  std::ostringstream mess;
+  mess << num / 2 << ", " << x << ", " << y << ", " << z << ", " << radius;
+  FrameworkManager::Instance().exec("FakeMDEventData", 4, "InputWorkspace", "MDEWS", "PeakParams",
+      mess.str().c_str());
+
+  // Add a center with more events (half radius, half the total), to create a "peak"
+  std::ostringstream mess2;
+  mess2 << num / 2 << ", " << x << ", " << y << ", " << z << ", " << radius / 2;
+  FrameworkManager::Instance().exec("FakeMDEventData", 4, "InputWorkspace", "MDEWS", "PeakParams",
+      mess2.str().c_str());
+}
+
+
+//=====================================================================================
+// Functional Tests
+//=====================================================================================
 class FindPeaksMDTest: public CxxTest::TestSuite
 {
 public:
-
-  //-------------------------------------------------------------------------------
-  /** Create the (blank) MDEW */
-  static void createMDEW()
-  {
-    // ---- Start with empty MDEW ----
-    FrameworkManager::Instance().exec("CreateMDWorkspace", 18, "Dimensions", "3", "EventType", "MDEvent",
-        "Extents", "-10,10,-10,10,-10,10", "Names", "Q_lab_x,Q_lab_y,Q_lab_z", "Units", "-,-,-",
-        "SplitInto", "5", "SplitThreshold", "20", "MaxRecursionDepth", "15", "OutputWorkspace", "MDEWS");
-
-    // Give it an instrument
-    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentRectangular2(1, 100, 0.05);
-    IMDEventWorkspace_sptr ws;
-    TS_ASSERT_THROWS_NOTHING(
-        ws = AnalysisDataService::Instance().retrieveWS<IMDEventWorkspace>("MDEWS"));
-    ExperimentInfo_sptr ei(new ExperimentInfo());
-    ei->setInstrument(inst);
-    // Give it a run number
-    ei->mutableRun().addProperty(new PropertyWithValue<std::string>("run_number", "12345"), true);
-    ws->addExperimentInfo(ei);
-  }
-
-  //-------------------------------------------------------------------------------
-  /** Add a fake peak */
-  static void addPeak(size_t num, double x, double y, double z, double radius)
-  {
-    std::ostringstream mess;
-    mess << num / 2 << ", " << x << ", " << y << ", " << z << ", " << radius;
-    FrameworkManager::Instance().exec("FakeMDEventData", 4, "InputWorkspace", "MDEWS", "PeakParams",
-        mess.str().c_str());
-
-    // Add a center with more events (half radius, half the total), to create a "peak"
-    std::ostringstream mess2;
-    mess2 << num / 2 << ", " << x << ", " << y << ", " << z << ", " << radius / 2;
-    FrameworkManager::Instance().exec("FakeMDEventData", 4, "InputWorkspace", "MDEWS", "PeakParams",
-        mess2.str().c_str());
-  }
 
   void test_Init()
   {
@@ -204,6 +208,68 @@ public:
   void test_exec_histo_withMaxPeaks()
   {
     do_test(true, 1, 1, false, true /*histo conversion*/);
+  }
+
+};
+
+//=====================================================================================
+// Performance Tests
+//=====================================================================================
+class FindPeaksMDTestPerformance: public CxxTest::TestSuite
+{
+
+private:
+
+  // Input data
+  
+
+
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static FindPeaksMDTestPerformance *createSuite()
+  {
+    return new FindPeaksMDTestPerformance();
+  }
+  static void destroySuite(FindPeaksMDTestPerformance *suite)
+  {
+    delete suite;
+  }
+  FindPeaksMDTestPerformance()
+  {
+    FrameworkManager::Instance();
+
+    // Make the fake data
+    createMDEW();
+
+    for(double x = -5; x <= 5; x+=1.0){
+    for(double y = -2; y <= 2; y+=1.0){
+    for(double z = -2; z <= 2; z+=1.0){
+      addPeak(100, x, y, z, 0.01);
+    }
+    }
+    }
+
+  }
+
+  void test_performance(){
+  // Name of the output workspace.
+    std::string outWSName("peaksFound");
+
+    FindPeaksMD alg; 
+    alg.initialize();
+
+    alg.setPropertyValue("InputWorkspace", "MDEWS");
+    alg.setPropertyValue("OutputWorkspace", outWSName);
+    alg.setPropertyValue("DensityThresholdFactor", "2.0");
+    alg.setPropertyValue("PeakDistanceThreshold", "0.7");
+    alg.setProperty("MaxPeaks", int64_t(300));
+
+    alg.execute();
+
+    // Retrieve the workspace from data service.
+    PeaksWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>(outWSName);
+    TS_ASSERT(ws);
   }
 
 };


### PR DESCRIPTION
Fixes issue #12967. 

**Tester** : You should now find that the FindPeaksMD step marked in [here](https://github.com/mantidproject/mantid/blob/master/Code/Mantid/scripts/Vates/SXD_NaCl.py) runs in < 1 second. On both my mac and my windows box, this was failing to complete.
