### PR TITLE
DateAndTime performance

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/DateAndTime.cpp
+++ b/Code/Mantid/Framework/Kernel/src/DateAndTime.cpp
@@ -12,19 +12,19 @@ namespace {
 Logger g_log("DateAndTime");
 
 /// Max allowed nanoseconds in the time; 2^62-1
-int64_t MAX_NANOSECONDS = 4611686018427387903LL;
+const int64_t MAX_NANOSECONDS = 4611686018427387903LL;
 
 /// Max allowed seconds in the time
-int64_t MAX_SECONDS = 4611686017LL;
+const int64_t MAX_SECONDS = 4611686017LL;
 
 /// Min allowed nanoseconds in the time; -2^62+1
-int64_t MIN_NANOSECONDS = -4611686018427387903LL;
+const int64_t MIN_NANOSECONDS = -4611686018427387903LL;
 
 /// Min allowed seconds in the time
-int64_t MIN_SECONDS = -4611686017LL;
+const int64_t MIN_SECONDS = -4611686017LL;
 
 /// Number of nanoseconds in one second
-int64_t NANO_PER_SEC = 1000000000LL;
+const int64_t NANO_PER_SEC = 1000000000LL;
 }
 
 namespace DateAndTimeHelpers {
@@ -202,12 +202,14 @@ DateAndTime::DateAndTime(const int64_t seconds, const int64_t nanoseconds) {
  * @param nanoseconds :: nanoseconds to add to the number of seconds
  */
 DateAndTime::DateAndTime(const int32_t seconds, const int32_t nanoseconds) {
-  if (seconds >= MAX_SECONDS)
+  const int64_t seconds_64bit = static_cast<int64_t>(seconds);
+
+  if (seconds_64bit >= MAX_SECONDS)
     _nanoseconds = MAX_NANOSECONDS;
-  else if (seconds <= MIN_SECONDS)
+  else if (seconds_64bit <= MIN_SECONDS)
     _nanoseconds = MIN_NANOSECONDS;
   else
-    _nanoseconds = static_cast<int64_t>(seconds) * NANO_PER_SEC +
+    _nanoseconds = seconds_64bit * NANO_PER_SEC +
                    static_cast<int64_t>(nanoseconds);
 }
 


### PR DESCRIPTION
There is a correlation between #12859 being merged and [performance degradation in LoadMuonNexus2TestPerformance](http://builds.mantidproject.org/view/Tests/job/performance_tests_master/Master_branch_performance_tests/DataHandlingTest.LoadMuonNexus2TestPerformance.testDefaultLoad.htm). My solution is to just decorate everything as constant that can be. Unfortunately, I'm suspicious that the actual cause is [here](https://github.com/mantidproject/mantid/pull/12859/files#diff-e3f88ee18aa139a6818be90a9ef7ccbbL207) which can't really have anything done about it (need to convert everything to 64bit before doing the math). On my system this change improved the performance of the test by about 2%.

**To test:** Try running the offending test before and after merging the branch and see if there is a difference.
