### PR TITLE
Set the y axis label for transmission ratios in SANS

### DIFF
--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -1214,6 +1214,9 @@ class TransmissionCalc(ReductionStep):
 
     DEFAULT_FIT = 'LOGARITHMIC'
 
+    # The y unit label for transmission data
+    YUNITLABEL_TRANSMISSION_RATIO = "Transmission"
+
     def __init__(self, loader=None):
         super(TransmissionCalc, self).__init__()
         #set these variables to None, which means they haven't been set and defaults will be set further down
@@ -1453,6 +1456,14 @@ class TransmissionCalc(ReductionStep):
                               TransmissionMonitor=post_sample,
                               RebinParams=reducer.to_wavelen.get_rebin(),
                               OutputUnfittedData=True, **options) # options FitMethod, PolynomialOrder if present
+
+        # Set the y axis label correctly for the transmission ratio data
+        fitted_trans_ws = mtd[fittedtransws]
+        unfitted_trans_ws = mtd[unfittedtransws]
+        if fitted_trans_ws:
+            fitted_trans_ws.setYUnitLabel(self.YUNITLABEL_TRANSMISSION_RATIO)
+        if unfitted_trans_ws:
+            unfitted_trans_ws.setYUnitLabel(self.YUNITLABEL_TRANSMISSION_RATIO)
 
         # Remove temporaries
         files2delete = [trans_tmp_out]

--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -1395,7 +1395,8 @@ class TransmissionCalc(ReductionStep):
         trans_raw, direct_raw = self._get_run_wksps(reducer)
 
         if not trans_raw:
-            raise RuntimeError('Attempting transmission correction with no specified transmission %s file' % self.CAN_SAMPLE_SUFFIXES[reducer.is_can()])
+            raise RuntimeError('Attempting transmission correction with no specified transmission %s file'
+                               % self.CAN_SAMPLE_SUFFIXES[reducer.is_can()])
         if not direct_raw:
             raise RuntimeError('Attempting transmission correction with no direct file')
 
@@ -1790,10 +1791,32 @@ class ConvertToQISIS(ReductionStep):
 
         try:
             if self._Q_alg == 'Q1D':
-                Q1D(DetBankWorkspace=workspace,OutputWorkspace= workspace, OutputBinning=self.binning, WavelengthAdj=wave_adj, PixelAdj=pixel_adj, AccountForGravity=self._use_gravity, RadiusCut=self.r_cut*1000.0, WaveCut=self.w_cut, OutputParts=self.outputParts, WavePixelAdj = wavepixeladj, ExtraLength=self._grav_extra_length)
+                Q1D(DetBankWorkspace=workspace,
+                    OutputWorkspace= workspace,
+                    OutputBinning=self.binning,
+                    WavelengthAdj=wave_adj,
+                    PixelAdj=pixel_adj,
+                    AccountForGravity=self._use_gravity,
+                    RadiusCut=self.r_cut*1000.0,
+                    WaveCut=self.w_cut,
+                    OutputParts=self.outputParts,
+                    WavePixelAdj = wavepixeladj,
+                    ExtraLength=self._grav_extra_length)
             elif self._Q_alg == 'Qxy':
-                Qxy(InputWorkspace=workspace,OutputWorkspace= workspace,MaxQxy= reducer.QXY2,DeltaQ= reducer.DQXY, WavelengthAdj=wave_adj, PixelAdj=pixel_adj, AccountForGravity=self._use_gravity, RadiusCut=self.r_cut*1000.0, WaveCut=self.w_cut, OutputParts=self.outputParts, ExtraLength=self._grav_extra_length)
-                ReplaceSpecialValues(InputWorkspace=workspace,OutputWorkspace= workspace, NaNValue="0", InfinityValue="0")
+                Qxy(InputWorkspace=workspace,
+                    OutputWorkspace= workspace,
+                    MaxQxy= reducer.QXY2,
+                    DeltaQ= reducer.DQXY,
+                    WavelengthAdj=wave_adj,
+                    PixelAdj=pixel_adj,
+                    AccountForGravity=self._use_gravity,
+                    RadiusCut=self.r_cut*1000.0,
+                    WaveCut=self.w_cut,
+                    OutputParts=self.outputParts,
+                    ExtraLength=self._grav_extra_length)
+                ReplaceSpecialValues(InputWorkspace=workspace,
+                                     OutputWorkspace= workspace,
+                                     NaNValue="0", InfinityValue="0")
             else:
                 raise NotImplementedError('The type of Q reduction has not been set, e.g. 1D or 2D')
         except:


### PR DESCRIPTION
Fixes #12326 

**For Testing**

You will need the files in this folder:

The sample files you need to handle are: \olympic\Babylon5\Scratch\Anton\Testing\12326
User file: UserFile.txt
Scattering Sample: SANS2D00023785-add.nxs
Transmission Sample: SANS2D00023775.nxs
Direct Sample: SANS2D00023774.nxs
1. Open the Interfaces >SANS > ISIS SANS
2. On the first tab set Instrument to SANS2DTUBES
3. In "Manage Directories" set the input to the location which contains all the sample files. Set an output directory as well.
4. Load the User file (towards the top of the tab)
5. Provide the paths for the "Scattering Sample", "Transmission Sample" and "Direct Sample" files. The rest you can leave blank
6. Press "Load Data"
7. Once the files are loaded, press "1D Reduce"
8. In MantidDock you should see the files 23775_trans_sample_1.75_16.6 and  23775_trans_sample_1.75_16.6_unfitted
9. Plot 23775_trans_sample_1.75_16.6
   - Confirm that the Y axis label shows "Transmission"
10. Do the same for 23775_trans_sample_1.75_16.6_unfitted
