### PR TITLE
Fix OSIRIS vanadium to loading OSIRIS

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDiffractionReduction.ui
@@ -177,6 +177,9 @@
              <property name="multipleFiles" stdset="0">
               <bool>true</bool>
              </property>
+             <property name="instrumentOverride" stdset="0">
+              <string>OSIRIS</string>
+             </property>
             </widget>
            </item>
           </layout>


### PR DESCRIPTION
Fixes #13009.

To test:
- Set log level to Debug
- Set default instrument to something other than OSIRIS
- Open Indirect > Diffraction
- Set instrument to OSIRIS, diffonly
- Enter `10153` in vanadium file
- See that an OSIRIS file is loaded

This bug came in this release so no release notes updates.
