### PR TITLE
Adding sourcelinks to fit functions

### DIFF
--- a/Code/Mantid/docs/source/fitfunctions/Abragam.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Abragam.rst
@@ -18,3 +18,5 @@ Abragam fitting function for use by Muon scientists defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/BSpline.rst
+++ b/Code/Mantid/docs/source/fitfunctions/BSpline.rst
@@ -26,3 +26,5 @@ the type double. Likewise, the attribute names have the form 'xi'.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/BackToBackExponential.rst
+++ b/Code/Mantid/docs/source/fitfunctions/BackToBackExponential.rst
@@ -52,3 +52,5 @@ peak:
    HRPD instrument.
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/BivariateNormal.rst
+++ b/Code/Mantid/docs/source/fitfunctions/BivariateNormal.rst
@@ -63,3 +63,5 @@ The values for out in function1D are, for each pixel, the difference of
 V(see formula) and dataY(0).
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Chebyshev.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Chebyshev.rst
@@ -40,3 +40,5 @@ the expansion (fitting) interval.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ChudleyElliot.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ChudleyElliot.rst
@@ -20,3 +20,5 @@ motions of molecules. The Chudley-Elliot Jump diffusion model (1961) has the for
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/CompositeFunction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/CompositeFunction.rst
@@ -70,3 +70,5 @@ inner one in brackets:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Convolution.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Convolution.rst
@@ -43,3 +43,7 @@ Note that the box function is defined on interval [-5, 5]:
 .. properties::
 
 .. categories::
+
+.. sourcelink::
+   :h: Framework/CurveFitting/inc/MantidCurveFitting/Convolution.h
+   :cpp: Framework/CurveFitting/src/Convolution.cpp

--- a/Code/Mantid/docs/source/fitfunctions/CubicSpline.rst
+++ b/Code/Mantid/docs/source/fitfunctions/CubicSpline.rst
@@ -26,3 +26,5 @@ the type double. Likewise, the attribute names have the form 'xi'.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/DiffRotDiscreteCircle.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DiffRotDiscreteCircle.rst
@@ -80,3 +80,5 @@ Then:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/DiffSphere.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DiffSphere.rst
@@ -52,3 +52,5 @@ attibute is empty.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/DynamicKuboToyabe.rst
@@ -32,3 +32,5 @@ small values will lead to long calculation times, while large values will produc
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/EndErfc.rst
+++ b/Code/Mantid/docs/source/fitfunctions/EndErfc.rst
@@ -18,3 +18,5 @@ The function is A*erfc((B-x)/C) + D for positive A and the same minus 2A for neg
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ExpDecay.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ExpDecay.rst
@@ -18,3 +18,5 @@ Exponential decay function is defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ExpDecayMuon.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ExpDecayMuon.rst
@@ -18,3 +18,5 @@ Exponential decay for use by Muon scientists defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ExpDecayOsc.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ExpDecayOsc.rst
@@ -20,3 +20,5 @@ Oscillation exponential decay function is defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/FickDiffusion.rst
+++ b/Code/Mantid/docs/source/fitfunctions/FickDiffusion.rst
@@ -20,3 +20,5 @@ motions of molecules. Fick's law for diffusion has the form:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/FlatBackground.rst
+++ b/Code/Mantid/docs/source/fitfunctions/FlatBackground.rst
@@ -18,3 +18,5 @@ A Flat background function is defined as:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/GausDecay.rst
+++ b/Code/Mantid/docs/source/fitfunctions/GausDecay.rst
@@ -18,3 +18,5 @@ Gaussian decay for use by Muon scientists defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/GausOsc.rst
+++ b/Code/Mantid/docs/source/fitfunctions/GausOsc.rst
@@ -18,3 +18,5 @@ Oscillating Gaussian decay for use by Muon scientists defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Gaussian.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Gaussian.rst
@@ -34,3 +34,5 @@ a TOF peak:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Guinier.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Guinier.rst
@@ -22,3 +22,5 @@ where:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/GuinierPorod.rst
+++ b/Code/Mantid/docs/source/fitfunctions/GuinierPorod.rst
@@ -17,3 +17,5 @@ The Guinier-Porod model is defined in Hammouda, J. Appl. Cryst. (2010) 43, 716-7
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/HallRoss.rst
+++ b/Code/Mantid/docs/source/fitfunctions/HallRoss.rst
@@ -20,3 +20,5 @@ motions of molecules. The Hall-Ross Jump diffusion model has the form:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/IkedaCarpenterPV.rst
+++ b/Code/Mantid/docs/source/fitfunctions/IkedaCarpenterPV.rst
@@ -74,3 +74,5 @@ peak:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/LatticeErrors.rst
+++ b/Code/Mantid/docs/source/fitfunctions/LatticeErrors.rst
@@ -14,3 +14,5 @@ Description
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/LatticeFunction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/LatticeFunction.rst
@@ -79,3 +79,5 @@ well the peak positions calculated from the fitted parameters match the observed
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/LinearBackground.rst
+++ b/Code/Mantid/docs/source/fitfunctions/LinearBackground.rst
@@ -21,3 +21,5 @@ be renamed to Linear in the not too distance future.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/LogNormal.rst
+++ b/Code/Mantid/docs/source/fitfunctions/LogNormal.rst
@@ -18,3 +18,5 @@ The LogNormal fit function is defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Lorentz.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Lorentz.rst
@@ -23,3 +23,5 @@ where:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Lorentzian.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Lorentzian.rst
@@ -35,3 +35,5 @@ a TOF peak:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/MuonFInteraction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/MuonFInteraction.rst
@@ -35,3 +35,5 @@ and
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/NeutronBk2BkExpConvPVoigt.rst
+++ b/Code/Mantid/docs/source/fitfunctions/NeutronBk2BkExpConvPVoigt.rst
@@ -191,3 +191,5 @@ where
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/PawleyFunction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/PawleyFunction.rst
@@ -18,3 +18,5 @@ Since the function requires special setup (assignment of HKLs, selection of crys
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/PeakHKLErrors.rst
+++ b/Code/Mantid/docs/source/fitfunctions/PeakHKLErrors.rst
@@ -56,3 +56,5 @@ offsets from an integer using the current parameter values.
    be tied to zero.
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Porod.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Porod.rst
@@ -22,3 +22,5 @@ where:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ProductFunction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ProductFunction.rst
@@ -20,3 +20,5 @@ a ProductFunction can be a composite function itself.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ProductLinearExp.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ProductLinearExp.rst
@@ -25,3 +25,5 @@ detector efficiency calibration.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ProductQuadraticExp.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ProductQuadraticExp.rst
@@ -25,3 +25,5 @@ detector efficiency calibration. Also see
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/PseudoVoigt.rst
+++ b/Code/Mantid/docs/source/fitfunctions/PseudoVoigt.rst
@@ -27,3 +27,5 @@ The figure below shows data together with a fitted Pseudo-Voigt function, as wel
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/Quadratic.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Quadratic.rst
@@ -24,3 +24,7 @@ where
 .. properties::
 
 .. categories::
+
+.. sourcelink::
+    :h: Framework/CurveFitting/inc/MantidCurveFitting/Quadratic.h
+    :cpp: Framework/CurveFitting/src/Quadratic.cpp

--- a/Code/Mantid/docs/source/fitfunctions/SCDPanelErrors.rst
+++ b/Code/Mantid/docs/source/fitfunctions/SCDPanelErrors.rst
@@ -94,3 +94,5 @@ follows:
 The order of rotations correspond to the order used in all of Mantid.
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/StaticKuboToyabe.rst
+++ b/Code/Mantid/docs/source/fitfunctions/StaticKuboToyabe.rst
@@ -19,3 +19,5 @@ by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/StaticKuboToyabeTimesExpDecay.rst
+++ b/Code/Mantid/docs/source/fitfunctions/StaticKuboToyabeTimesExpDecay.rst
@@ -20,3 +20,5 @@ Fitting function for use by Muon scientists defined by:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/StaticKuboToyabeTimesGausDecay.rst
+++ b/Code/Mantid/docs/source/fitfunctions/StaticKuboToyabeTimesGausDecay.rst
@@ -20,3 +20,5 @@ Fitting function for use by Muon scientists defined by:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/StretchExp.rst
+++ b/Code/Mantid/docs/source/fitfunctions/StretchExp.rst
@@ -18,3 +18,5 @@ The Stretched exponential fit function is defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/StretchExpMuon.rst
+++ b/Code/Mantid/docs/source/fitfunctions/StretchExpMuon.rst
@@ -18,3 +18,5 @@ The Stretched exponential fit function is defined by
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/StretchedExpFT.rst
+++ b/Code/Mantid/docs/source/fitfunctions/StretchedExpFT.rst
@@ -21,3 +21,5 @@ tau is expressed in nano-seconds.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/TabulatedFunction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/TabulatedFunction.rst
@@ -60,3 +60,5 @@ Output:
     Number of spectra in fitWorkspace is: 3
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/TeixeiraWater.rst
+++ b/Code/Mantid/docs/source/fitfunctions/TeixeiraWater.rst
@@ -20,3 +20,5 @@ motions of molecules. The this model (1961) has the form:
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/ThermalNeutronBk2BkExpConvPVoigt.rst
+++ b/Code/Mantid/docs/source/fitfunctions/ThermalNeutronBk2BkExpConvPVoigt.rst
@@ -177,3 +177,5 @@ where
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/source/fitfunctions/UserFunction.rst
+++ b/Code/Mantid/docs/source/fitfunctions/UserFunction.rst
@@ -23,3 +23,7 @@ go first in UserFunction definition.
 .. properties::
 
 .. categories::
+
+.. sourcelink::
+    :h: Framework/CurveFitting/inc/MantidCurveFitting/UserFunction.h
+    :cpp: Framework/CurveFitting/src/UserFunction.cpp

--- a/Code/Mantid/docs/source/fitfunctions/Voigt.rst
+++ b/Code/Mantid/docs/source/fitfunctions/Voigt.rst
@@ -41,3 +41,5 @@ to generate good approximation to the true function.
 .. properties::
 
 .. categories::
+
+.. sourcelink::

--- a/Code/Mantid/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/Code/Mantid/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -58,7 +58,7 @@ class SourceLinkDirective(AlgorithmBaseDirective):
         if file_name is None:
             #build a sensible default
             file_name = self.algorithm_name()
-            if (self.algorithm_version() != 1):
+            if (self.algorithm_version() != 1) and (self.algorithm_version() is not None):
                 file_name += str(self.algorithm_version())
                 
         


### PR DESCRIPTION
Add sourelinks to fit function documentation pages

fixes #13016
Release note added - http://www.mantidproject.org/ReleaseNotes_3_5_UI_Changes#Documentation
### To test
1. Check the builds passed ok, especially the docs one, check the output from that one for any lines including "SourceLink"
2. Check a couple of fit function and the links created, they should link to the exact code, specific to the commit
3. Check a python based fit function pages and the links created, they should link to the exact code, specific to the commit. (Example: ChudleyElliot)
