### PR TITLE
Copy paste error in LoadDiffCal

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -125,7 +125,7 @@ std::vector<NumT> readArrayCoerce(DataSet &dataset, const DataType &desiredDataT
         std::vector<float> temp(dataSpace.getSelectNpoints());
         dataset.read(&temp[0], dataType, dataSpace);
         for( auto it = temp.begin(); it != temp.end(); ++it)
-          result.push_back(static_cast<int32_t>(*it));
+          result.push_back(static_cast<NumT>(*it));
     } else {
         throw DataTypeIException();
     }


### PR DESCRIPTION
Don't truncate floats when coercing to double.

This does not need to be in the release notes.

**To test:** Just review the code and see that it is fine.
