### PR TITLE
Fix BinMd normalization in SliceViewer

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/MDGeometry.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MDGeometry.h
@@ -80,6 +80,7 @@ public:
   Mantid::Kernel::VMD &getBasisVector(size_t index);
   const Mantid::Kernel::VMD &getBasisVector(size_t index) const;
   void setBasisVector(size_t index, const Mantid::Kernel::VMD &vec);
+  bool allBasisNormalized() const;
 
   // --------------------------------------------------------------------------------------------
   bool hasOriginalWorkspace(size_t index = 0) const;

--- a/Code/Mantid/Framework/API/src/MDGeometry.cpp
+++ b/Code/Mantid/Framework/API/src/MDGeometry.cpp
@@ -279,6 +279,17 @@ void MDGeometry::setBasisVector(size_t index, const Mantid::Kernel::VMD &vec) {
   m_basisVectors[index] = vec;
 }
 
+bool MDGeometry::allBasisNormalized() const {
+  bool allNormalized = true;
+  for (auto it = m_basisVectors.begin(); it != m_basisVectors.end(); ++it) {
+      if (it->length() != 1.0) {
+        allNormalized = false;
+        break;
+      }
+  }
+  return allNormalized;
+}
+
 //---------------------------------------------------------------------------------------------------
 /// @return true if the geometry is defined relative to another workspace.
 /// @param index :: index into the vector of original workspaces

--- a/Code/Mantid/Framework/API/src/MDGeometry.cpp
+++ b/Code/Mantid/Framework/API/src/MDGeometry.cpp
@@ -279,6 +279,9 @@ void MDGeometry::setBasisVector(size_t index, const Mantid::Kernel::VMD &vec) {
   m_basisVectors[index] = vec;
 }
 
+/**
+ * @return True ONLY if ALL the basis vectors have been normalized.
+ */
 bool MDGeometry::allBasisNormalized() const {
   bool allNormalized = true;
   for (auto it = m_basisVectors.begin(); it != m_basisVectors.end(); ++it) {

--- a/Code/Mantid/Framework/API/test/MDGeometryTest.h
+++ b/Code/Mantid/Framework/API/test/MDGeometryTest.h
@@ -256,6 +256,29 @@ public:
     TSM_ASSERT_EQUALS("Wrong number of transforms to original reported.", 2, g.getNumberTransformsToOriginal());
   }
 
+  void test_all_normalized(){
+      MDGeometry geometry;
+      std::vector<IMDDimension_sptr> dims;
+      IMDDimension_sptr dim1(new MDHistoDimension("Qx", "Qx", "Ang", -1, +1, 10));
+      IMDDimension_sptr dim2(new MDHistoDimension("Qy", "Qy", "Ang", -1, +1, 20));
+      dims.push_back(dim1);
+      dims.push_back(dim2);
+      geometry.initGeometry(dims);
+
+      //  Both basis vectors are not normalized
+      geometry.setBasisVector(0, VMD(2.0, 0.0));
+      geometry.setBasisVector(1, VMD(0.0, 4.0));
+      TSM_ASSERT("All Not all basis vectors are normalized", !geometry.allBasisNormalized());
+
+      //  First basis vector is now normalized. The other is not.
+      geometry.setBasisVector(1, VMD(0.0, 1.0));
+      TSM_ASSERT("Not all basis vectors are normalized", !geometry.allBasisNormalized());
+
+      // We overwrite the zeroth basis vector to be normalized. Now both are normalized
+      geometry.setBasisVector(0, VMD(1.0, 0.0));
+      TSM_ASSERT("All basis vectors are normalized", geometry.allBasisNormalized());
+  }
+
 
 };
 

--- a/Code/Mantid/Framework/MDAlgorithms/test/BinMDTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/BinMDTest.h
@@ -2,6 +2,7 @@
 #define MANTID_MDEVENTS_BINTOMDHISTOWORKSPACETEST_H_
 
 #include "MantidAPI/IMDEventWorkspace.h"
+#include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/ImplicitFunctionBuilder.h"
 #include "MantidAPI/ImplicitFunctionFactory.h"
@@ -1005,6 +1006,36 @@ public:
       TSM_ASSERT_THROWS("Cannot allow BinMD on a pure MDHistoWorkspace. Should throw.", alg.execute(), std::runtime_error&);
   }
 
+  void test_normalization(){
+
+   FrameworkManager::Instance().exec("CreateMDWorkspace", 16,
+       "Dimensions", "2",
+       "Extents", "-10,10,-10,10",
+       "Names", "x,y",
+       "Units", "m,m",
+       "SplitInto", "4",
+       "SplitThreshold", "100",
+       "MaxRecursionDepth", "20",
+       "OutputWorkspace", "mdew");
+
+  FrameworkManager::Instance().exec("BinMD", 20,
+      "InputWorkspace", "mdew",
+      "OutputWorkspace", "binned",
+      "AxisAligned", "0",
+      "BasisVector0", "tx, m, 2.0, 0.0",
+      "BasisVector1", "ty, m, 0.0, 2.0",
+      "NormalizeBasisVectors", "1",
+      "ForceOrthogonal", "0",
+      "Translation", "-2, -2",
+      "OutputExtents", "-4,6, -4,6", /* The extents are in the scaled OUTPUT dimensions */
+      "OutputBins", "10,10");
+
+  auto binned = AnalysisDataService::Instance().retrieveWS<IMDHistoWorkspace>("binned");
+  TSM_ASSERT("All basis vectors should have been normalized", binned->allBasisNormalized());
+
+
+  }
+
 };
 
 
@@ -1071,6 +1102,7 @@ public:
     for (size_t i=0; i<1; i++)
       do_test("2.0,8.0, 1", true);
   }
+
 
 
 };

--- a/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/LineViewer.cpp
@@ -472,6 +472,11 @@ LineViewer::applyMDWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   alg->setPropertyValue("OutputWorkspace", m_integratedWSName);
   alg->setProperty("AxisAligned", false);
 
+  // If we are rebinning from an existing MDHistoWorkspace, and that workspace has been created with basis vectors normalized, then we reapply that setting here.
+  if(boost::dynamic_pointer_cast<IMDHistoWorkspace>(m_ws)){
+      alg->setProperty("NormalizeBasisVectors", m_ws->allBasisNormalized());
+  }
+
   std::vector<int> OutputBins;
   std::vector<double> OutputExtents;
 

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -8,6 +8,7 @@
 #include <boost/math/special_functions/fpclassify.hpp>
 
 #include "MantidAPI/CoordTransform.h"
+#include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/IMDIterator.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Crystal/PeakTransformHKL.h"
@@ -1985,6 +1986,11 @@ void SliceViewer::rebinParamsChanged() {
   alg->setProperty("InputWorkspace", m_ws);
   alg->setProperty("AxisAligned", false);
 
+  // If we are rebinning from an existing MDHistoWorkspace, and that workspace has been created with basis vectors normalized, then we reapply that setting here.
+  if(boost::dynamic_pointer_cast<IMDHistoWorkspace>(m_ws)){
+      alg->setProperty("NormalizeBasisVectors", m_ws->allBasisNormalized());
+  }
+
   std::vector<double> OutputExtents;
   std::vector<int> OutputBins;
 
@@ -2032,7 +2038,6 @@ void SliceViewer::rebinParamsChanged() {
   alg->setProperty("OutputExtents", OutputExtents);
   alg->setProperty("OutputBins", OutputBins);
   alg->setPropertyValue("Translation", "");
-  alg->setProperty("NormalizeBasisVectors", true);
   alg->setProperty("ForceOrthogonal", false);
   alg->setProperty("Parallel", true);
   alg->setPropertyValue("OutputWorkspace", m_overlayWSName);


### PR DESCRIPTION
Fixes #12939 

**Tester**

1) Run this:

``` python
normalizeBasisVectors = True

mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
FakeMDEventData(InputWorkspace=mdws, PeakParams='100000,-5,-5,0,1')
FakeMDEventData(InputWorkspace=mdws, PeakParams='100000,-5,5,0,1')
FakeMDEventData(InputWorkspace=mdws, PeakParams='100000,5,5,0,1')
FakeMDEventData(InputWorkspace=mdws, PeakParams='100000,5,-5,0,1')
binned = BinMD(mdws, NormalizeBasisVectors=normalizeBasisVectors, AxisAligned=False, BasisVector0='a,units,1,0,0',BasisVector1='b,units,0,2,0',BasisVector2='c,units,0,0,2'
    ,OutputExtents='-5,5,-5,5,-5,5', OutputBins='10,10,10')
plotSlice(binned)
```

2) Then in the SliceViewer, when it opens, click the rebin button. Then inspect the history for the freshly created 'binned_rebinned' workspace. You should see that the normalization (**NormalizeBasisVectors** property setting of _BinMD_)is the same as used for the input 'binned' workspace. 
3) Exit the rebin mode and create a line cut over some area of the plot. Look at the history for 'binned_line'. Again you should see the normalization is the same as for the input workspace.
4) Repeat 1-3 again, this time changing the normalization flag to True.
