### PR TITLE
SetScriptOutputDisplay allows copying with ctrl+c

### DIFF
--- a/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
@@ -48,7 +48,7 @@ void ScriptOutputDisplay::mouseMoveEvent(QMouseEvent * e)
     this->setReadOnly(true);
     QTextEdit::mouseMoveEvent(e);
     this->setReadOnly(false);
-  };
+  }
 
 /**
  * Is there anything here

--- a/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
@@ -8,9 +8,6 @@
 #include <QFileDialog>
 #include <QPrinter>
 #include <QPrintDialog>
-#include <QMessageBox>
-#include <QTextStream>
-#include <QApplication>
 
 /**
  * Constructor
@@ -21,7 +18,14 @@
 ScriptOutputDisplay::ScriptOutputDisplay(QWidget * parent) :
   QTextEdit(parent), m_copy(NULL), m_clear(NULL), m_save(NULL)
 {
-  setReadOnly(true);
+  //the control is readonly, but if you set it read only then ctrl+c for copying does not work
+  //this approach allows ctrl+c and disables user editing through the use of the KeyPress handler
+  //and disabling drag and drop
+  //also the mouseMoveEventHandler prevents dragging out of the control affecting the text.
+  setReadOnly(false);
+  this->setAcceptDrops(false);
+  
+
   setLineWrapMode(QTextEdit::WidgetWidth);
   setLineWrapColumnOrWidth(105);
   setAutoFormatting(QTextEdit::AutoNone);
@@ -34,6 +38,17 @@ ScriptOutputDisplay::ScriptOutputDisplay(QWidget * parent) :
 
   initActions();
 }
+
+/** Mouse move event handler - overridden to prevent dragging out of the control affecting the text
+ * it does this by temporarily setting the control to read only while the base event handler operates
+ * @param e the mouse move event
+ */
+void ScriptOutputDisplay::mouseMoveEvent(QMouseEvent * e)
+  {
+    this->setReadOnly(true);
+    QTextEdit::mouseMoveEvent(e);
+    this->setReadOnly(false);
+  };
 
 /**
  * Is there anything here
@@ -50,6 +65,22 @@ bool ScriptOutputDisplay::isEmpty() const
 void ScriptOutputDisplay::populateEditMenu(QMenu &editMenu)
 {
   editMenu.addAction(m_clear);
+}
+
+
+
+/** 
+ * Capture key presses. 
+ * @param event A pointer to the QKeyPressEvent object
+ */
+void ScriptOutputDisplay::keyPressEvent(QKeyEvent* event)
+{
+  if ((event->key() == Qt::Key_C) && (event->modifiers() == Qt::KeyboardModifier::ControlModifier))
+  {
+    this->copy();
+  }
+  //accept all key presses to prevent keyboard interaction
+  event->accept();
 }
 
 /**

--- a/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.h
+++ b/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.h
@@ -20,6 +20,10 @@ public:
 
   /// Add actions applicable to an edit menu
   void populateEditMenu(QMenu &editMenu);
+  ///Capture key presses
+  virtual void keyPressEvent(QKeyEvent* event);
+  //squash dragging ability
+  void mouseMoveEvent(QMouseEvent * e);
 
 public slots:
   /// Print the text within the window


### PR DESCRIPTION
This is because if you set it read only then ctrl+c for copying does not work
this approach allows ctrl+c and disables user editing through the use of the KeyPress handler
and disabling drag and drop
also the mouseMoveEventHandler prevents dragging out of the control affecting the text.

fixes #5895
### To Test
1. start up mantidplot
2. Open the script window
3. Run something 

``` python
print "hi there"
print  "mantid is cool"
print "ctrl+c works now!"
```
1. select some text in the output display and copy it to clipboard using ctrl+c, paste it somewhere to check it worked.
2. do the same with the copy right click menu
3. check that you cannot alter what is in the output display window. suggested methods are:
   1. typing
   2. pasting ctrl + v
   3. cutting ctrl +x
   4. dragging text into the window
   5. dragging text out of the window
   6. dragging text around in the window
   7. anything else you can think of
