### PR TITLE
Updates to indirect reduction for VESUVIO

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -107,12 +107,12 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
             load_opts['Mode'] = 'FoilOut'
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
-                                                              self._ipf_filename,
-                                                              self._spectra_range[0],
-                                                              self._spectra_range[1],
-                                                              self._sum_files,
-                                                              self._load_logs,
-                                                              load_opts=load_opts)
+                                                               ipf_filename=self._ipf_filename,
+                                                               spec_min=self._spectra_range[0],
+                                                               spec_max=self._spectra_range[1],
+                                                               sum_files=self._sum_files,
+                                                               load_logs=self._load_logs,
+                                                               load_opts=load_opts)
 
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -92,8 +92,8 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         self._setup()
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,
-                                                               spec_max=self._spectra_range[0],
-                                                               spec_min=self._spectra_range[1],
+                                                               spec_min=self._spectra_range[0],
+                                                               spec_max=self._spectra_range[1],
                                                                sum_files=self._sum_files,
                                                                load_logs=self._load_logs)
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -91,11 +91,11 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         self._setup()
         self._workspace_names, self._chopped_data = load_files(self._data_files,
-                                                              self._ipf_filename,
-                                                              self._spectra_range[0],
-                                                              self._spectra_range[1],
-                                                              self._sum_files,
-                                                              self._load_logs)
+                                                               ipf_filename=self._ipf_filename,
+                                                               spec_max=self._spectra_range[0],
+                                                               spec_min=self._spectra_range[1],
+                                                               sum_files=self._sum_files,
+                                                               load_logs=self._load_logs)
 
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)

--- a/Code/Mantid/scripts/Inelastic/IndirectReductionCommon.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectReductionCommon.py
@@ -7,7 +7,7 @@ import numpy as np
 
 #-------------------------------------------------------------------------------
 
-def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, load_logs=True, load_opts=None):
+def load_files(data_files, spec_min, spec_max, ipf_filename='', sum_files=False, load_logs=True, load_opts=None):
     """
     Loads a set of files and extracts just the spectra we care about (i.e. detector range and monitor).
 
@@ -48,8 +48,9 @@ def load_files(data_files, ipf_filename, spec_min, spec_max, sum_files=False, lo
                  **load_opts)
 
         # Load the instrument parameters
-        LoadParameterFile(Workspace=ws_name,
-                          Filename=ipf_filename)
+        if ipf_filename != '':
+            LoadParameterFile(Workspace=ws_name,
+                              Filename=ipf_filename)
 
         # Add the workspace to the list of workspaces
         workspace_names.append(ws_name)


### PR DESCRIPTION
Fixes #13058.

This changes very little, just make sure the tests still pass and the changes look sensible.

If you want then do an energy transfer reduction with IRIS 26176 and make sure LoadParameterFile is in the history of ISISIndirectEnergyTransfer.

No release notes updates needed.
