### PR TITLE
LoadVesuvio does not load the PAR file when in single foil mode

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -120,6 +120,7 @@ class LoadVesuvio(PythonAlgorithm):
                              doc="The name of the output workspace.")
 
 #----------------------------------------------------------------------------------------
+
     def PyExec(self):
         self._load_inst_parameters()
         self._retrieve_input()
@@ -216,6 +217,10 @@ class LoadVesuvio(PythonAlgorithm):
             np.sqrt(dataE, dataE)
             foil_out.setX(ws_index, x_values)
 
+        ip_file = self.getPropertyValue(INST_PAR_PROP)
+        if len(ip_file) > 0:
+            self._load_ip_file(ip_file)
+
         if self._sumspectra:
             self._sum_all_spectra()
 
@@ -282,6 +287,7 @@ class LoadVesuvio(PythonAlgorithm):
         ms.DeleteWorkspace(__empty_vesuvio_ws,EnableLogging=_LOGGING_)
 
 #----------------------------------------------------------------------------------------
+
     def _retrieve_input(self):
         self._diff_opt = self.getProperty(MODE_PROP).value
 
@@ -325,6 +331,7 @@ class LoadVesuvio(PythonAlgorithm):
         self.delta_tmon = (mon_raw_t[1:] - mon_raw_t[:-1])
 
 #----------------------------------------------------------------------------------------
+
     def _load_and_sum_runs(self, spectra):
         """Load the input set of runs & sum them if there
         is more than one.
@@ -381,6 +388,7 @@ class LoadVesuvio(PythonAlgorithm):
             runs = [run_str]
 
         return runs
+
 #----------------------------------------------------------------------------------------
 
     def _set_spectra_type(self, spectrum_no):
@@ -405,8 +413,8 @@ class LoadVesuvio(PythonAlgorithm):
             self._period_sum2_start, self._period_sum2_end = self._forw_period_sum2
             self._foil_out_norm_start, self._foil_out_norm_end = self._forw_foil_out_norm
 
-
 #----------------------------------------------------------------------------------------
+
     def _integrate_periods(self):
         """
             Calculates 2 arrays of sums, 1 per period, of the Y values from
@@ -498,6 +506,7 @@ class LoadVesuvio(PythonAlgorithm):
                             foil_thick_periods, mon_thick_periods)
 
 #----------------------------------------------------------------------------------------
+
     def _get_foil_periods(self):
         """
         Return the period numbers (starting from 1) that contribute to the
@@ -530,6 +539,7 @@ class LoadVesuvio(PythonAlgorithm):
         return foil_out_periods, foil_thin_periods, foil_thick_periods
 
 #----------------------------------------------------------------------------------------
+
     #pylint: disable=too-many-arguments
     def _sum_foils(self, foil_ws, mon_ws, sum_index, foil_periods, mon_periods=None):
         """
@@ -568,6 +578,7 @@ class LoadVesuvio(PythonAlgorithm):
         outY /= self.delta_tmon
 
 #----------------------------------------------------------------------------------------
+
     def _normalise_by_monitor(self):
         """
             Normalises by the monitor counts between mon_norm_start & mon_norm_end
@@ -595,6 +606,8 @@ class LoadVesuvio(PythonAlgorithm):
         if self._nperiods != 2:
             monitor_normalization(self.foil_thick, self.mon_thick)
 
+#----------------------------------------------------------------------------------------
+
     def _normalise_to_foil_out(self):
         """
             Normalises the thin/thick foil counts to the
@@ -621,6 +634,7 @@ class LoadVesuvio(PythonAlgorithm):
         normalise_to_out(self.foil_thin, "thin")
         if self._nperiods != 2:
             normalise_to_out(self.foil_thick, "thick")
+
 #----------------------------------------------------------------------------------------
 
     def _calculate_diffs(self):
@@ -639,6 +653,7 @@ class LoadVesuvio(PythonAlgorithm):
             raise RuntimeError("Unknown difference type requested: %d" % self._diff_opt)
 
         self.foil_out.setX(wsindex, self.pt_times)
+
 #----------------------------------------------------------------------------------------
 
     def _calculate_thin_difference(self, ws_index):
@@ -662,6 +677,7 @@ class LoadVesuvio(PythonAlgorithm):
         np.sqrt((eout**2 + ethin**2), eout) # The second argument makes it happen in place
 
 #----------------------------------------------------------------------------------------
+
     def _calculate_double_difference(self, ws_index):
         """
             Calculates the difference between the foil out, thin & thick foils
@@ -684,6 +700,7 @@ class LoadVesuvio(PythonAlgorithm):
         np.sqrt((one_min_beta*eout)**2 + ethin**2 + (self._beta**2)*ethick**2, eout)
 
 #----------------------------------------------------------------------------------------
+
     def _calculate_thick_difference(self, ws_index):
         """
             Calculates the difference between the foil out & thick foils
@@ -700,6 +717,7 @@ class LoadVesuvio(PythonAlgorithm):
         np.sqrt((eout**2 + ethick**2), eout) # The second argument makes it happen in place
 
 #----------------------------------------------------------------------------------------
+
     def _load_ip_file(self, ip_file):
         """
             If provided, load the instrument parameter file into the result
@@ -755,6 +773,7 @@ class LoadVesuvio(PythonAlgorithm):
         self.foil_out = ws_out
 
 #----------------------------------------------------------------------------------------
+
     def _get_header_format(self, ip_filename):
         """
             Returns the header format to be used for the given
@@ -774,6 +793,7 @@ class LoadVesuvio(PythonAlgorithm):
                              "variants. ncols=%d" % (len(columns)))
 
 #----------------------------------------------------------------------------------------
+
     def _store_results(self):
         """
            Sets the values of the output workspace properties
@@ -818,6 +838,8 @@ class SpectraToFoilPeriodMap(object):
             raise RuntimeError("Unsupported number of periods given: " + str(nperiods) +
                                ". Supported number of periods=2,3,6,9")
 
+#----------------------------------------------------------------------------------------
+
     def reorder(self, arr):
         """
            Orders the given array by increasing value. At the same time
@@ -833,6 +855,8 @@ class SpectraToFoilPeriodMap(object):
             self._one_to_one[index+1] = int(val)
         return arr
 
+#----------------------------------------------------------------------------------------
+
     def get_foilout_periods(self, spectrum_no):
         """Returns a list of the foil-out periods for the given
         spectrum number. Note that these start from 1 not zero
@@ -841,6 +865,8 @@ class SpectraToFoilPeriodMap(object):
         """
         return self.get_foil_periods(spectrum_no, state=0)
 
+#----------------------------------------------------------------------------------------
+
     def get_foilin_periods(self, spectrum_no):
         """Returns a list of the foil-out periods for the given
         spectrum number. Note that these start from 1 not zero
@@ -848,6 +874,8 @@ class SpectraToFoilPeriodMap(object):
             @returns A list of period numbers for foil out state
         """
         return self.get_foil_periods(spectrum_no, state=1)
+
+#----------------------------------------------------------------------------------------
 
     def get_foil_periods(self, spectrum_no, state):
         """Returns a list of the periods for the given
@@ -871,6 +899,8 @@ class SpectraToFoilPeriodMap(object):
             foil_periods = [1,3,5] if foil_out else [2,4,6]
         return foil_periods
 
+#----------------------------------------------------------------------------------------
+
     def get_indices(self, spectrum_no, foil_state_numbers):
         """
         Returns a tuple of indices that can be used to access the Workspace within
@@ -884,6 +914,8 @@ class SpectraToFoilPeriodMap(object):
         for state in foil_state_numbers:
             indices.append(self.get_index(spectrum_no, state))
         return tuple(indices)
+
+#----------------------------------------------------------------------------------------
 
     def get_index(self, spectrum_no, foil_state_no):
         """Returns an index that can be used to access the Workspace within
@@ -912,10 +944,14 @@ class SpectraToFoilPeriodMap(object):
         foil_period_no = foil_periods[foil_state_no]
         return foil_period_no - 1 # Minus 1 to get to WorkspaceGroup index
 
+#----------------------------------------------------------------------------------------
+
     def _validate_foil_number(self, foil_number):
         if foil_number < 1 or foil_number > 9:
             raise ValueError("Invalid foil state given, expected a number between "
                              "1 and 9. number=%d" % foil_number)
+
+#----------------------------------------------------------------------------------------
 
     def _validate_spectrum_number(self, spectrum_no):
         if spectrum_no < 1 or spectrum_no > 198:

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -102,8 +102,18 @@ class VesuvioTests(unittest.TestCase):
         self.assertAlmostEqual(37594.0, evs_raw.readY(0)[1], places=DIFF_PLACES)
         self.assertAlmostEqual(193.89172236070317, evs_raw.readE(0)[1], places=DIFF_PLACES)
 
-    def test_using_ip_file_adjusts_instrument_and_attaches_parameters(self):
-        self._run_load("14188", "3", "SingleDifference","IP0005.dat")
+    def test_using_ip_file_adjusts_instrument_and_attaches_parameters_difference_mode(self):
+        self._run_load("14188", "3", "SingleDifference", "IP0005.dat")
+
+        # Check some data
+        evs_raw = mtd[self.ws_name]
+        det0 = evs_raw.getDetector(0)
+        param = det0.getNumberParameter("t0")
+        self.assertEqual(1, len(param))
+        self.assertAlmostEqual(-0.4157, param[0],places=4)
+
+    def test_using_ip_file_adjusts_instrument_and_attaches_parameters_foil_mode(self):
+        self._run_load("14188", "3", "FoilOut", "IP0005.dat")
 
         # Check some data
         evs_raw = mtd[self.ws_name]


### PR DESCRIPTION
Fixes #13062.

To test:
- Review new test case
- Run the script attached and look at the detector table (compare this to the same script on master or remove the InstrumentParFile option)

```
evs = LoadVesuvio(Filename='15039',
                  SpectrumList='3-198',
                  InstrumentParFile='IP0005.dat')
```

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24402&oldid=24401).
