### PR TITLE
Harmonize EventFiltering

### DIFF
--- a/Code/Mantid/Framework/Algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/Algorithms/CMakeLists.txt
@@ -246,6 +246,9 @@ set ( SRC_FILES
 	src/SumSpectra.cpp
 	src/TOFSANSResolution.cpp
 	src/TOFSANSResolutionByPixel.cpp
+	src/TimeAtSampleStrategyDirect.cpp
+	src/TimeAtSampleStrategyElastic.cpp
+	src/TimeAtSampleStrategyIndirect.cpp
 	src/Transpose.cpp
 	src/UnGroupWorkspace.cpp
 	src/UnaryOperation.cpp
@@ -510,6 +513,10 @@ set ( INC_FILES
 	inc/MantidAlgorithms/SumSpectra.h
 	inc/MantidAlgorithms/TOFSANSResolution.h
 	inc/MantidAlgorithms/TOFSANSResolutionByPixel.h
+	inc/MantidAlgorithms/TimeAtSampleStrategy.h
+	inc/MantidAlgorithms/TimeAtSampleStrategyDirect.h
+	inc/MantidAlgorithms/TimeAtSampleStrategyElastic.h
+	inc/MantidAlgorithms/TimeAtSampleStrategyIndirect.h
 	inc/MantidAlgorithms/Transpose.h
 	inc/MantidAlgorithms/UnGroupWorkspace.h
 	inc/MantidAlgorithms/UnaryOperation.h
@@ -761,6 +768,9 @@ set ( TEST_FILES
 	SumRowColumnTest.h
 	SumSpectraTest.h
 	TOFSANSResolutionByPixelTest.h
+	TimeAtSampleStrategyDirectTest.h
+	TimeAtSampleStrategyElasticTest.h
+	TimeAtSampleStrategyIndirectTest.h
 	TransposeTest.h
 	UnGroupWorkspaceTest.h
 	UnaryOperationTest.h

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/FilterEvents.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/FilterEvents.h
@@ -14,6 +14,8 @@
 namespace Mantid {
 namespace Algorithms {
 
+class TimeAtSampleStrategy;
+
 /** FilterEvents : Filter Events in EventWorkspace to multiple EventsWorkspace
   by Splitters
 
@@ -92,15 +94,15 @@ private:
   void setupDetectorTOFCalibration();
 
   /// Set up detector calibration parameters for elastic scattering instrument
-  void setupElasticTOFCorrection(API::MatrixWorkspace_sptr corrws);
+  TimeAtSampleStrategy* setupElasticTOFCorrection() const;
 
   /// Set up detector calibration parmaeters for direct inelastic scattering
   /// instrument
-  void setupDirectTOFCorrection(API::MatrixWorkspace_sptr corrws);
+  TimeAtSampleStrategy* setupDirectTOFCorrection() const;
 
   /// Set up detector calibration parameters for indirect inelastic scattering
   /// instrument
-  void setupIndirectTOFCorrection(API::MatrixWorkspace_sptr corrws);
+  TimeAtSampleStrategy* setupIndirectTOFCorrection() const;
 
   /// Set up detector calibration parameters from customized values
   void setupCustomizedTOFCorrection();

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/RebinByTimeAtSample.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/RebinByTimeAtSample.h
@@ -5,15 +5,7 @@
 #include "MantidAlgorithms/RebinByTimeBase.h"
 
 namespace Mantid {
-namespace Kernel{
-   // Forward declarations
-   class V3D;
-}
-namespace Geometry{
-   // Forward declarations
-   class IComponent;
-   class IDetector;
-}
+
 namespace Algorithms {
 
 /** RebinByTimeAtSample : Rebins an event workspace to a histogram workspace
@@ -49,12 +41,6 @@ public:
   virtual int version() const;
   virtual const std::string category() const;
   virtual const std::string summary() const;
-
-  static double calculateTOFRatio(const Mantid::Geometry::IDetector& detector,
-                                  const Mantid::Geometry::IComponent& source,
-                                  const Mantid::Geometry::IComponent& sample,
-                                  const double& L1s,
-                                  const Mantid::Kernel::V3D& beamDir);
 
 private:
   void doHistogramming(Mantid::API::IEventWorkspace_sptr inWS,

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/RebinByTimeAtSample.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/RebinByTimeAtSample.h
@@ -5,6 +5,15 @@
 #include "MantidAlgorithms/RebinByTimeBase.h"
 
 namespace Mantid {
+namespace Kernel{
+   // Forward declarations
+   class V3D;
+}
+namespace Geometry{
+   // Forward declarations
+   class IComponent;
+   class IDetector;
+}
 namespace Algorithms {
 
 /** RebinByTimeAtSample : Rebins an event workspace to a histogram workspace
@@ -40,6 +49,12 @@ public:
   virtual int version() const;
   virtual const std::string category() const;
   virtual const std::string summary() const;
+
+  static double calculateTOFRatio(const Mantid::Geometry::IDetector& detector,
+                                  const Mantid::Geometry::IComponent& source,
+                                  const Mantid::Geometry::IComponent& sample,
+                                  const double& L1s,
+                                  const Mantid::Kernel::V3D& beamDir);
 
 private:
   void doHistogramming(Mantid::API::IEventWorkspace_sptr inWS,

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategy.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategy.h
@@ -6,14 +6,15 @@
 namespace Mantid {
 namespace Algorithms {
 
-struct Correction{
-  Correction(double tOffset, double tFactor) : offset(tOffset), factor(tFactor){
-  }
+struct Correction {
+  Correction(double tOffset, double tFactor)
+      : offset(tOffset), factor(tFactor) {}
   double offset;
   double factor;
 };
 
-/** TimeAtSampleStrategy : Strategy (technique dependent) for determining Time At Sample
+/** TimeAtSampleStrategy : Strategy (technique dependent) for determining Time
+  At Sample
 
   SampleT = PulseT + [TOF to sample]
 
@@ -40,10 +41,9 @@ struct Correction{
 */
 class DLLExport TimeAtSampleStrategy {
 public:
-  virtual Correction calculate(const size_t& workspace_index) const = 0;
+  virtual Correction calculate(const size_t &workspace_index) const = 0;
   virtual ~TimeAtSampleStrategy(){};
 };
-
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategy.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategy.h
@@ -1,0 +1,53 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGY_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGY_H_
+
+#include "MantidKernel/System.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+struct Correction{
+  Correction(double tOffset, double tFactor) : offset(tOffset), factor(tFactor){
+  }
+  double offset;
+  double factor;
+};
+
+/** TimeAtSampleStrategy : Strategy (technique dependent) for determining Time At Sample
+
+  SampleT = PulseT + [TOF to sample]
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport TimeAtSampleStrategy {
+public:
+  virtual Correction calculate(const size_t& workspace_index) const = 0;
+  virtual ~TimeAtSampleStrategy()=0;
+};
+
+TimeAtSampleStrategy::~TimeAtSampleStrategy(){
+}
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGY_H_ */

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategy.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategy.h
@@ -41,11 +41,9 @@ struct Correction{
 class DLLExport TimeAtSampleStrategy {
 public:
   virtual Correction calculate(const size_t& workspace_index) const = 0;
-  virtual ~TimeAtSampleStrategy()=0;
+  virtual ~TimeAtSampleStrategy(){};
 };
 
-TimeAtSampleStrategy::~TimeAtSampleStrategy(){
-}
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyDirect.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyDirect.h
@@ -1,0 +1,41 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECT_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECT_H_
+
+#include "MantidKernel/System.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** TimeAtSampleStrategyDirect : TODO: DESCRIPTION
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport TimeAtSampleStrategyDirect {
+public:
+  TimeAtSampleStrategyDirect();
+  virtual ~TimeAtSampleStrategyDirect();
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECT_H_ */

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyDirect.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyDirect.h
@@ -2,11 +2,18 @@
 #define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECT_H_
 
 #include "MantidKernel/System.h"
+#include "MantidAlgorithms/TimeAtSampleStrategy.h"
+#include <boost/shared_ptr.hpp>
 
 namespace Mantid {
-namespace Algorithms {
 
-/** TimeAtSampleStrategyDirect : TODO: DESCRIPTION
+namespace API {
+class MatrixWorkspace;
+}
+
+namespace Algorithms {
+/** TimeAtSampleStrategyDirect : Determine the Time at Sample corrections for a
+  Direct Geometry instrument
 
   Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
@@ -29,10 +36,15 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport TimeAtSampleStrategyDirect {
+class DLLExport TimeAtSampleStrategyDirect : public TimeAtSampleStrategy {
 public:
-  TimeAtSampleStrategyDirect();
+  TimeAtSampleStrategyDirect(boost::shared_ptr<const Mantid::API::MatrixWorkspace> ws, double ei);
   virtual ~TimeAtSampleStrategyDirect();
+  Correction calculate(const size_t &workspace_index) const;
+
+private:
+  /// Cached L1, Ei dependent const shift
+  double m_constShift;
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyElastic.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyElastic.h
@@ -7,8 +7,8 @@
 
 namespace Mantid {
 
-namespace API{
-  class MatrixWorkspace;
+namespace API {
+class MatrixWorkspace;
 }
 namespace Algorithms {
 
@@ -35,11 +35,14 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport TimeAtSampleStrategyElastic : public Mantid::Algorithms::TimeAtSampleStrategy {
+class DLLExport TimeAtSampleStrategyElastic
+    : public Mantid::Algorithms::TimeAtSampleStrategy {
 public:
-  TimeAtSampleStrategyElastic(boost::shared_ptr<const Mantid::API::MatrixWorkspace> ws);
+  TimeAtSampleStrategyElastic(
+      boost::shared_ptr<const Mantid::API::MatrixWorkspace> ws);
   virtual ~TimeAtSampleStrategyElastic();
   virtual Correction calculate(const size_t &workspace_index) const;
+
 private:
   boost::shared_ptr<const Mantid::API::MatrixWorkspace> m_ws;
 };

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyElastic.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyElastic.h
@@ -1,0 +1,50 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYELASTIC_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYELASTIC_H_
+
+#include "MantidKernel/System.h"
+#include "MantidAlgorithms/TimeAtSampleStrategy.h"
+#include <boost/shared_ptr.hpp>
+
+namespace Mantid {
+
+namespace API{
+  class MatrixWorkspace;
+}
+namespace Algorithms {
+
+/** TimeAtSampleStrategyElastic : Time at sample stragegy for elastic scattering
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport TimeAtSampleStrategyElastic : public Mantid::Algorithms::TimeAtSampleStrategy {
+public:
+  TimeAtSampleStrategyElastic(boost::shared_ptr<const Mantid::API::MatrixWorkspace> ws);
+  virtual ~TimeAtSampleStrategyElastic();
+  virtual Correction calculate(const size_t &workspace_index) const;
+private:
+  boost::shared_ptr<const Mantid::API::MatrixWorkspace> m_ws;
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYELASTIC_H_ */

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyIndirect.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyIndirect.h
@@ -2,11 +2,18 @@
 #define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECT_H_
 
 #include "MantidKernel/System.h"
+#include "MantidAlgorithms/TimeAtSampleStrategy.h"
+#include <boost/shared_ptr.hpp>
 
 namespace Mantid {
+
+namespace API {
+class MatrixWorkspace;
+}
+
 namespace Algorithms {
 
-/** TimeAtSampleStrategyIndirect : TODO: DESCRIPTION
+/** TimeAtSampleStrategyIndirect : Determine Time At Sample for an indirect instrument setup.
 
   Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
@@ -29,10 +36,14 @@ namespace Algorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport TimeAtSampleStrategyIndirect {
+class DLLExport TimeAtSampleStrategyIndirect : public TimeAtSampleStrategy {
 public:
-  TimeAtSampleStrategyIndirect();
+  TimeAtSampleStrategyIndirect(boost::shared_ptr<const Mantid::API::MatrixWorkspace> ws);
   virtual ~TimeAtSampleStrategyIndirect();
+  virtual Correction calculate(const size_t &workspace_index) const;
+private:
+  /// Workspace to operate on
+  boost::shared_ptr<const Mantid::API::MatrixWorkspace> m_ws;
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyIndirect.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/TimeAtSampleStrategyIndirect.h
@@ -1,0 +1,41 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECT_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECT_H_
+
+#include "MantidKernel/System.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** TimeAtSampleStrategyIndirect : TODO: DESCRIPTION
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport TimeAtSampleStrategyIndirect {
+public:
+  TimeAtSampleStrategyIndirect();
+  virtual ~TimeAtSampleStrategyIndirect();
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECT_H_ */

--- a/Code/Mantid/Framework/Algorithms/src/RebinByTimeAtSample.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/RebinByTimeAtSample.cpp
@@ -1,10 +1,9 @@
 #include "MantidAlgorithms/RebinByTimeAtSample.h"
-
+#include "MantidAlgorithms/TimeAtSampleStrategyElastic.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidKernel/VectorHelper.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/V3D.h"
-#include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include <boost/make_shared.hpp>
 #include <algorithm>
 #include <cmath>
@@ -49,30 +48,6 @@ const std::string RebinByTimeAtSample::name() const {
 }
 
 /**
- * For detectors (not monitor detectors). neutrons interact with the sample first. so the ratio we want to
- * calculate is L1 / (L1 + L2) in order to calculate a TatSample for a neturon based on it's recorded TOF at the detector.
- *
- * For monitors. The L2 scattering distance is of no consequence. The ratio we want to calculate is L1m / L1s where L1m
- * is the L1 for the monitor, and L1s is the L1 for the sample.
- *
- *
- * @param detector : Detector
- * @param source : Source
- * @param L1s : L1 distance Source - Sample
- * @return Calculated ratio
- */
-double RebinByTimeAtSample::calculateTOFRatio(const Geometry::IDetector& detector, const Geometry::IComponent& source, const Geometry::IComponent& sample,
-                         const double& L1s, const V3D& beamDir){
-    if(detector.isMonitor()){
-       double L1m = beamDir.scalar_prod(source.getPos() - detector.getPos());
-       return std::abs(L1s / L1m);
-    } else {
-       const double L2 = sample.getPos().distance(detector.getPos());
-       return L1s / (L1s + L2);
-    }
-}
-
-/**
  * Do histogramming of the data to create the output workspace.
  * @param inWS : input workspace
  * @param outputWS : output workspace
@@ -88,19 +63,17 @@ void RebinByTimeAtSample::doHistogramming(IEventWorkspace_sptr inWS,
   const int histnumber = static_cast<int>(inWS->getNumberHistograms());
 
   const double tofOffset = 0;
-  auto instrument = inWS->getInstrument();
-  auto source = instrument->getSource();
-  auto sample = instrument->getSample();
-  const double L1s = source->getDistance(*sample);
-  auto refFrame = instrument->getReferenceFrame();
-  const V3D& beamDir = refFrame->vecPointingAlongBeam();
+
+  TimeAtSampleStrategyElastic strategy(inWS);
 
   // Go through all the histograms and set the data
   PARALLEL_FOR2(inWS, outputWS)
   for (int i = 0; i < histnumber; ++i) {
     PARALLEL_START_INTERUPT_REGION
 
-    const double tofFactor = calculateTOFRatio(*inWS->getDetector(i), *source, *sample, L1s, beamDir);
+    Correction correction = strategy.calculate(i);
+
+    const double tofFactor = correction.factor;
 
     const IEventList *el = inWS->getEventListPtr(i);
     MantidVec y_data, e_data;

--- a/Code/Mantid/Framework/Algorithms/src/ReflectometryWorkflowBase.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ReflectometryWorkflowBase.cpp
@@ -373,7 +373,7 @@ ReflectometryWorkflowBase::toLamMonitor(const MatrixWorkspace_sptr &toConvert,
   cropWorkspaceAlg->execute();
   monitorWS = cropWorkspaceAlg->getProperty("OutputWorkspace");
 
-  //If min&max are both 0, we won't do the flat background normalization.
+  // If min&max are both 0, we won't do the flat background normalization.
   if (backgroundMinMax.get<0>() == 0 && backgroundMinMax.get<1>() == 0)
     return monitorWS;
 
@@ -405,8 +405,7 @@ ReflectometryWorkflowBase::toLamDetector(const std::string &processingCommands,
                                          const MatrixWorkspace_sptr &toConvert,
                                          const MinMax &wavelengthMinMax,
                                          const double &wavelengthStep) {
-  // Process the input workspace according to the processingCommands to get a
-  // detector workspace
+
   auto convertUnitsAlg = this->createChildAlgorithm("ConvertUnits");
   convertUnitsAlg->initialize();
   convertUnitsAlg->setProperty("InputWorkspace", toConvert);
@@ -415,6 +414,9 @@ ReflectometryWorkflowBase::toLamDetector(const std::string &processingCommands,
   convertUnitsAlg->execute();
   MatrixWorkspace_sptr detectorWS =
       convertUnitsAlg->getProperty("OutputWorkspace");
+
+  // Process the input workspace according to the processingCommands to get a
+  // detector workspace
 
   auto performIndexAlg = this->createChildAlgorithm("GroupDetectors");
   performIndexAlg->initialize();

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyDirect.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyDirect.cpp
@@ -1,4 +1,18 @@
 #include "MantidAlgorithms/TimeAtSampleStrategyDirect.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidKernel/Logger.h"
+#include "MantidKernel/PhysicalConstants.h"
+#include "MantidKernel/Property.h"
+#include "MantidKernel/V3D.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include <cmath>
+
+using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
+using namespace Mantid::API;
 
 namespace Mantid {
 namespace Algorithms {
@@ -6,12 +20,35 @@ namespace Algorithms {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-TimeAtSampleStrategyDirect::TimeAtSampleStrategyDirect() {}
+TimeAtSampleStrategyDirect::TimeAtSampleStrategyDirect(
+    MatrixWorkspace_const_sptr ws, double ei)
+    :  m_constShift(0) {
+
+  // Get L1
+  V3D samplepos = ws->getInstrument()->getSample()->getPos();
+  V3D sourcepos = ws->getInstrument()->getSource()->getPos();
+  double l1 = samplepos.distance(sourcepos);
+
+  // Calculate constant (to all spectra) shift
+  m_constShift = l1 / std::sqrt(ei * 2. * PhysicalConstants::meV /
+                                PhysicalConstants::NeutronMass);
+}
 
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */
 TimeAtSampleStrategyDirect::~TimeAtSampleStrategyDirect() {}
+
+/**
+ * @brief Calculate corrections to get a Time at Sample for a DG instrument.
+ * @return Correction struct
+ */
+Correction Mantid::Algorithms::TimeAtSampleStrategyDirect::calculate(
+    const size_t&) const {
+
+  // Correction is L1 and Ei dependent only. Detector positions are not required.
+  return Correction(0, m_constShift);
+}
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyDirect.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyDirect.cpp
@@ -1,0 +1,17 @@
+#include "MantidAlgorithms/TimeAtSampleStrategyDirect.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+TimeAtSampleStrategyDirect::TimeAtSampleStrategyDirect() {}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+TimeAtSampleStrategyDirect::~TimeAtSampleStrategyDirect() {}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyElastic.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyElastic.cpp
@@ -50,6 +50,11 @@ TimeAtSampleStrategyElastic::TimeAtSampleStrategyElastic(Mantid::API::MatrixWork
  */
 TimeAtSampleStrategyElastic::~TimeAtSampleStrategyElastic() {}
 
+/**
+ * @brief Calculate correction
+ * @param workspace_index
+ * @return Correction
+ */
 Correction TimeAtSampleStrategyElastic::calculate(const size_t &workspace_index) const
 {
     auto instrument = m_ws->getInstrument();

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyElastic.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyElastic.cpp
@@ -12,10 +12,13 @@ using namespace Mantid::API;
 
 namespace {
 /**
- * For detectors (not monitor detectors). neutrons interact with the sample first. so the ratio we want to
- * calculate is L1 / (L1 + L2) in order to calculate a TatSample for a neturon based on it's recorded TOF at the detector.
+ * For detectors (not monitor detectors). neutrons interact with the sample
+ *first. so the ratio we want to
+ * calculate is L1 / (L1 + L2) in order to calculate a TatSample for a neturon
+ *based on it's recorded TOF at the detector.
  *
- * For monitors. The L2 scattering distance is of no consequence. The ratio we want to calculate is L1m / L1s where L1m
+ * For monitors. The L2 scattering distance is of no consequence. The ratio we
+ *want to calculate is L1m / L1s where L1m
  * is the L1 for the monitor, and L1s is the L1 for the sample.
  *
  *
@@ -24,18 +27,18 @@ namespace {
  * @param L1s : L1 distance Source - Sample
  * @return Calculated ratio
  */
-double calculateTOFRatio(const IDetector& detector, const IComponent& source, const IComponent& sample,
-                         const double& L1s, const V3D& beamDir){
-    if(detector.isMonitor()){
-       double L1m = beamDir.scalar_prod(source.getPos() - detector.getPos());
-       return std::abs(L1s / L1m);
-    } else {
-       const double L2 = sample.getPos().distance(detector.getPos());
-       return L1s / (L1s + L2);
-    }
+double calculateTOFRatio(const IDetector &detector, const IComponent &source,
+                         const IComponent &sample, const double &L1s,
+                         const V3D &beamDir) {
+  if (detector.isMonitor()) {
+    double L1m = beamDir.scalar_prod(source.getPos() - detector.getPos());
+    return std::abs(L1s / L1m);
+  } else {
+    const double L2 = sample.getPos().distance(detector.getPos());
+    return L1s / (L1s + L2);
+  }
 }
 }
-
 
 namespace Mantid {
 namespace Algorithms {
@@ -43,7 +46,9 @@ namespace Algorithms {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-TimeAtSampleStrategyElastic::TimeAtSampleStrategyElastic(Mantid::API::MatrixWorkspace_const_sptr ws) : m_ws(ws) {}
+TimeAtSampleStrategyElastic::TimeAtSampleStrategyElastic(
+    Mantid::API::MatrixWorkspace_const_sptr ws)
+    : m_ws(ws) {}
 
 //----------------------------------------------------------------------------------------------
 /** Destructor
@@ -55,16 +60,17 @@ TimeAtSampleStrategyElastic::~TimeAtSampleStrategyElastic() {}
  * @param workspace_index
  * @return Correction
  */
-Correction TimeAtSampleStrategyElastic::calculate(const size_t &workspace_index) const
-{
-    auto instrument = m_ws->getInstrument();
-    auto source = instrument->getSource();
-    auto sample = instrument->getSample();
-    const double L1s = source->getDistance(*sample);
-    auto refFrame = instrument->getReferenceFrame();
-    const V3D& beamDir = refFrame->vecPointingAlongBeam();
-    const double factor = calculateTOFRatio(*m_ws->getDetector(workspace_index),*source, *sample, L1s, beamDir);
-    return Correction(0, factor);
+Correction
+TimeAtSampleStrategyElastic::calculate(const size_t &workspace_index) const {
+  auto instrument = m_ws->getInstrument();
+  auto source = instrument->getSource();
+  auto sample = instrument->getSample();
+  const double L1s = source->getDistance(*sample);
+  auto refFrame = instrument->getReferenceFrame();
+  const V3D &beamDir = refFrame->vecPointingAlongBeam();
+  const double factor = calculateTOFRatio(*m_ws->getDetector(workspace_index),
+                                          *source, *sample, L1s, beamDir);
+  return Correction(0, factor);
 }
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyElastic.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyElastic.cpp
@@ -1,0 +1,66 @@
+#include "MantidAlgorithms/TimeAtSampleStrategyElastic.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidKernel/V3D.h"
+#include "MantidAPI/MatrixWorkspace.h"
+
+using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
+using namespace Mantid::API;
+
+namespace {
+/**
+ * For detectors (not monitor detectors). neutrons interact with the sample first. so the ratio we want to
+ * calculate is L1 / (L1 + L2) in order to calculate a TatSample for a neturon based on it's recorded TOF at the detector.
+ *
+ * For monitors. The L2 scattering distance is of no consequence. The ratio we want to calculate is L1m / L1s where L1m
+ * is the L1 for the monitor, and L1s is the L1 for the sample.
+ *
+ *
+ * @param detector : Detector
+ * @param source : Source
+ * @param L1s : L1 distance Source - Sample
+ * @return Calculated ratio
+ */
+double calculateTOFRatio(const IDetector& detector, const IComponent& source, const IComponent& sample,
+                         const double& L1s, const V3D& beamDir){
+    if(detector.isMonitor()){
+       double L1m = beamDir.scalar_prod(source.getPos() - detector.getPos());
+       return std::abs(L1s / L1m);
+    } else {
+       const double L2 = sample.getPos().distance(detector.getPos());
+       return L1s / (L1s + L2);
+    }
+}
+}
+
+
+namespace Mantid {
+namespace Algorithms {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+TimeAtSampleStrategyElastic::TimeAtSampleStrategyElastic(Mantid::API::MatrixWorkspace_const_sptr ws) : m_ws(ws) {}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+TimeAtSampleStrategyElastic::~TimeAtSampleStrategyElastic() {}
+
+Correction TimeAtSampleStrategyElastic::calculate(const size_t &workspace_index) const
+{
+    auto instrument = m_ws->getInstrument();
+    auto source = instrument->getSource();
+    auto sample = instrument->getSample();
+    const double L1s = source->getDistance(*sample);
+    auto refFrame = instrument->getReferenceFrame();
+    const V3D& beamDir = refFrame->vecPointingAlongBeam();
+    const double factor = calculateTOFRatio(*m_ws->getDetector(workspace_index),*source, *sample, L1s, beamDir);
+    return Correction(0, factor);
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyIndirect.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyIndirect.cpp
@@ -1,0 +1,17 @@
+#include "MantidAlgorithms/TimeAtSampleStrategyIndirect.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+TimeAtSampleStrategyIndirect::TimeAtSampleStrategyIndirect() {}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+TimeAtSampleStrategyIndirect::~TimeAtSampleStrategyIndirect() {}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyIndirect.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/TimeAtSampleStrategyIndirect.cpp
@@ -1,17 +1,83 @@
 #include "MantidAlgorithms/TimeAtSampleStrategyIndirect.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidGeometry/Instrument/ParameterMap.h"
+#include "MantidKernel/Logger.h"
+#include "MantidKernel/PhysicalConstants.h"
+#include "MantidKernel/V3D.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include <cmath>
+#include <boost/shared_ptr.hpp>
+#include <sstream>
+
+using namespace Mantid::Kernel;
+using namespace Mantid::Geometry;
+using namespace Mantid::API;
 
 namespace Mantid {
+
+namespace API {
+class MatrixWorkspace;
+}
+
 namespace Algorithms {
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-TimeAtSampleStrategyIndirect::TimeAtSampleStrategyIndirect() {}
+TimeAtSampleStrategyIndirect::TimeAtSampleStrategyIndirect(
+    MatrixWorkspace_const_sptr ws)
+    : m_ws(ws) {}
 
 //----------------------------------------------------------------------------------------------
 /** Destructor
  */
 TimeAtSampleStrategyIndirect::~TimeAtSampleStrategyIndirect() {}
+
+Correction
+TimeAtSampleStrategyIndirect::calculate(const size_t &workspace_index) const {
+
+  // A constant among all spectra
+  double twomev_d_mass =
+      2. * PhysicalConstants::meV / PhysicalConstants::NeutronMass;
+  V3D samplepos = m_ws->getInstrument()->getSample()->getPos();
+
+  // Get the parameter map
+  const ParameterMap &pmap = m_ws->constInstrumentParameters();
+
+  double shift;
+  IDetector_const_sptr det = m_ws->getDetector(workspace_index);
+  if (!det->isMonitor()) {
+    // Get E_fix
+    double efix = 0.;
+    try {
+      Parameter_sptr par = pmap.getRecursive(det.get(), "Efixed");
+      if (par) {
+        efix = par->value<double>();
+      }
+    } catch (std::runtime_error &) {
+      // Throws if a DetectorGroup, use single provided value
+      std::stringstream errmsg;
+      errmsg << "Inelastic instrument detector " << det->getID()
+             << " of spectrum " << workspace_index << " does not have EFixed ";
+      throw std::runtime_error(errmsg.str());
+    }
+
+    // Get L2
+    double l2 = det->getPos().distance(samplepos);
+
+    // Calculate shift
+    shift = -1. * l2 / sqrt(efix * twomev_d_mass);
+
+  } else {
+    std::stringstream errormsg;
+    errormsg << "Workspace index " << workspace_index << " is a monitor. ";
+    throw std::invalid_argument(errormsg.str());
+  }
+  return Correction(1.0, shift);
+}
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/test/CreateTransmissionWorkspaceTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/CreateTransmissionWorkspaceTest.h
@@ -178,12 +178,12 @@ public:
     alg->setProperty("WavelengthMin", 1.0);
     alg->setProperty("WavelengthMax", 15.0);
     alg->setProperty("WavelengthStep", 0.05);
-    alg->setProperty("I0MonitorIndex", 0);
+    alg->setProperty("I0MonitorIndex", 1);
     alg->setProperty("MonitorBackgroundWavelengthMin", 14.0);
     alg->setProperty("MonitorBackgroundWavelengthMax", 15.0);
     alg->setProperty("MonitorIntegrationWavelengthMin", 4.0);
     alg->setProperty("MonitorIntegrationWavelengthMax", 10.0);
-    alg->setPropertyValue("ProcessingInstructions", "1");
+    alg->setPropertyValue("ProcessingInstructions", "0");
     alg->setPropertyValue("OutputWorkspace", "demo_ws");
     alg->execute();
 

--- a/Code/Mantid/Framework/Algorithms/test/RebinByTimeAtSampleTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/RebinByTimeAtSampleTest.h
@@ -268,51 +268,6 @@ public:
 
   }
 
-  void test_L2_detector(){
-      using namespace Mantid::Geometry;
-
-      Component sample;
-      sample.setPos(V3D(0,0,0));
-
-      Component source;
-      source.setPos(-10,0,0);
-
-      const V3D beamDir(1,0,0); // Along x
-
-      Detector detector("det",1,  NULL);
-      detector.setPos(1, 1, 0);
-      detector.markAsMonitor(false);
-
-      const double L1 = source.getPos().distance(sample.getPos());
-      const double ratio = RebinByTimeAtSample::calculateTOFRatio(detector, source, sample, L1,
-                                             beamDir);
-
-      TSM_ASSERT_EQUALS("L1 / (L1 + L2)", L1 / (L1 + sample.getPos().distance(detector.getPos())), ratio);
-  }
-
-  void test_L2_monitor(){
-      using namespace Mantid::Geometry;
-
-      Component sample;
-      sample.setPos(V3D(0,0,0));
-
-      Component source;
-      source.setPos(-10,0,0);
-
-      const V3D beamDir(1,0,0); // Along x
-
-      Detector monitor("monitor",1,  NULL);
-      monitor.setPos(1, 1, 0);
-      monitor.markAsMonitor(true);
-
-      const double L1 = source.getPos().distance(sample.getPos());
-
-      const double ratio = RebinByTimeAtSample::calculateTOFRatio(monitor, source, sample, L1,
-                                             beamDir);
-
-      TSM_ASSERT_EQUALS("L1/L1m", std::abs(L1/beamDir.scalar_prod(source.getPos() - monitor.getPos())), ratio);
-  }
-
 };
 
 //=====================================================================================

--- a/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyDirectTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyDirectTest.h
@@ -1,0 +1,27 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECTTEST_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECTTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/TimeAtSampleStrategyDirect.h"
+
+using Mantid::Algorithms::TimeAtSampleStrategyDirect;
+
+class TimeAtSampleStrategyDirectTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static TimeAtSampleStrategyDirectTest *createSuite() { return new TimeAtSampleStrategyDirectTest(); }
+  static void destroySuite( TimeAtSampleStrategyDirectTest *suite ) { delete suite; }
+
+
+  void test_Something()
+  {
+    TSM_ASSERT( "You forgot to write a test!", 0);
+  }
+
+
+};
+
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYDIRECTTEST_H_ */

--- a/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyElasticTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyElasticTest.h
@@ -1,0 +1,83 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYELASTICTEST_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYELASTICTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/TimeAtSampleStrategy.h"
+#include "MantidAlgorithms/TimeAtSampleStrategyElastic.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/IDetector.h"
+#include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidKernel/V3D.h"
+#include "MantidAPI/MatrixWorkspace.h"
+
+using namespace Mantid::Algorithms;
+using namespace Mantid::Geometry;
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+
+class TimeAtSampleStrategyElasticTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static TimeAtSampleStrategyElasticTest *createSuite() { return new TimeAtSampleStrategyElasticTest(); }
+  static void destroySuite( TimeAtSampleStrategyElasticTest *suite ) { delete suite; }
+
+  void test_L2_detector(){
+
+      auto ws = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+
+      auto instrument = ws->getInstrument();
+
+      auto sample =instrument->getSample();
+
+      auto source = instrument->getSource();
+
+      const size_t detectorIndex = 0; // detector workspace index.
+      auto detector = ws->getDetector(detectorIndex);
+
+      const double L1 = source->getPos().distance(sample->getPos());
+
+      TimeAtSampleStrategyElastic strategy(ws);
+      Correction correction = strategy.calculate(detectorIndex);
+
+      const double ratio = correction.factor;
+
+      TSM_ASSERT_EQUALS("L1 / (L1 + L2)", L1 / (L1 + sample->getPos().distance(detector->getPos())), ratio);
+  }
+
+
+  void test_L2_monitor(){
+
+      auto ws = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+
+      auto instrument = ws->getInstrument();
+
+      auto sample =instrument->getSample();
+
+      auto source = instrument->getSource();
+
+      const V3D& beamDir = instrument->getReferenceFrame()->vecPointingAlongBeam();
+
+      const size_t monitorIndex = 1; // monitor workspace index.
+      auto monitor = ws->getDetector(monitorIndex);
+
+      const double L1 = source->getPos().distance(sample->getPos());
+
+      TimeAtSampleStrategyElastic strategy(ws);
+      Correction correction = strategy.calculate(monitorIndex);
+
+      const double ratio = correction.factor;
+
+      TSM_ASSERT_EQUALS("L1/L1m", std::abs(L1/beamDir.scalar_prod(source->getPos() - monitor->getPos())), ratio);
+  }
+
+
+
+
+};
+
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYELASTICTEST_H_ */

--- a/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyIndirectTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyIndirectTest.h
@@ -2,8 +2,9 @@
 #define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECTTEST_H_
 
 #include <cxxtest/TestSuite.h>
-
 #include "MantidAlgorithms/TimeAtSampleStrategyIndirect.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
 
 using Mantid::Algorithms::TimeAtSampleStrategyIndirect;
 
@@ -15,9 +16,11 @@ public:
   static void destroySuite( TimeAtSampleStrategyIndirectTest *suite ) { delete suite; }
 
 
-  void test_Something()
+  void test_break_on_monitors()
   {
-    TSM_ASSERT( "You forgot to write a test!", 0);
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();// workspace has monitors
+    TimeAtSampleStrategyIndirect strategy(ws);
+    TS_ASSERT_THROWS(strategy.calculate(1 /*monitor index*/), std::invalid_argument&);
   }
 
 

--- a/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyIndirectTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/TimeAtSampleStrategyIndirectTest.h
@@ -1,0 +1,27 @@
+#ifndef MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECTTEST_H_
+#define MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECTTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/TimeAtSampleStrategyIndirect.h"
+
+using Mantid::Algorithms::TimeAtSampleStrategyIndirect;
+
+class TimeAtSampleStrategyIndirectTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static TimeAtSampleStrategyIndirectTest *createSuite() { return new TimeAtSampleStrategyIndirectTest(); }
+  static void destroySuite( TimeAtSampleStrategyIndirectTest *suite ) { delete suite; }
+
+
+  void test_Something()
+  {
+    TSM_ASSERT( "You forgot to write a test!", 0);
+  }
+
+
+};
+
+
+#endif /* MANTID_ALGORITHMS_TIMEATSAMPLESTRATEGYINDIRECTTEST_H_ */

--- a/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
@@ -88,7 +88,9 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
   }
 
   // Add axes that reference the data
+  size_t size= m_axes.size();
   m_axes.resize(2);
+  size = m_axes.size();
   m_axes[0] = new API::RefAxis(XLength, this);
   m_axes[1] = new API::SpectraAxis(this);
 }

--- a/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
@@ -88,9 +88,7 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
   }
 
   // Add axes that reference the data
-  size_t size= m_axes.size();
   m_axes.resize(2);
-  size = m_axes.size();
   m_axes[0] = new API::RefAxis(XLength, this);
   m_axes[1] = new API::SpectraAxis(this);
 }

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -518,12 +518,8 @@ create2DWorkspaceWithReflectometryInstrument(double startX) {
   workspace->setYUnit("Counts");
 
   workspace->setInstrument(instrument);
-  //workspace->getSpectrum(0)->clearDetectorIDs();
-  //workspace->getSpectrum(1)->clearDetectorIDs();
   workspace->getSpectrum(0)->setDetectorID(det->getID());
   workspace->getSpectrum(1)->setDetectorID(monitor->getID());
-  //workspace->getSpectrum(0)->addDetectorID(det->getID());
-  //workspace->getSpectrum(1)->addDetectorID(monitor->getID());
   return workspace;
 }
 

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -498,7 +498,7 @@ create2DWorkspaceWithReflectometryInstrument(double startX) {
   instrument->markAsMonitor(monitor);
 
   ObjComponent *sample = new ObjComponent("some-surface-holder");
-  source->setPos(V3D(15, 0, 0));
+  sample->setPos(V3D(15, 0, 0));
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
@@ -518,10 +518,12 @@ create2DWorkspaceWithReflectometryInstrument(double startX) {
   workspace->setYUnit("Counts");
 
   workspace->setInstrument(instrument);
-  workspace->getSpectrum(0)->clearDetectorIDs();
-  workspace->getSpectrum(1)->clearDetectorIDs();
-  workspace->getSpectrum(0)->addDetectorID(det->getID());
-  workspace->getSpectrum(1)->addDetectorID(monitor->getID());
+  //workspace->getSpectrum(0)->clearDetectorIDs();
+  //workspace->getSpectrum(1)->clearDetectorIDs();
+  workspace->getSpectrum(0)->setDetectorID(det->getID());
+  workspace->getSpectrum(1)->setDetectorID(monitor->getID());
+  //workspace->getSpectrum(0)->addDetectorID(det->getID());
+  //workspace->getSpectrum(1)->addDetectorID(monitor->getID());
   return workspace;
 }
 

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -518,7 +518,8 @@ create2DWorkspaceWithReflectometryInstrument(double startX) {
   workspace->setYUnit("Counts");
 
   workspace->setInstrument(instrument);
-
+  workspace->getSpectrum(0)->clearDetectorIDs();
+  workspace->getSpectrum(1)->clearDetectorIDs();
   workspace->getSpectrum(0)->addDetectorID(det->getID());
   workspace->getSpectrum(1)->addDetectorID(monitor->getID());
   return workspace;


### PR DESCRIPTION
Two objectives here as part of #13035
- Enable elastic event filtering on Monitors as the issue describes
- Harmonize the code for event filtering. Calculations which are the same for this have been implemented in `EventFilter` and `RebinByTimeAtSample` algorithms.

**Tester**

More unit tests have been added over this functionality. But it would be beneficial to execute  a real event filtering (Fast Log) case and check that things are working out OK.
