### PR TITLE
Fix MantidPlot Pyplot savefig

### DIFF
--- a/Code/Mantid/MantidPlot/pymantidplot/proxies.py
+++ b/Code/Mantid/MantidPlot/pymantidplot/proxies.py
@@ -279,7 +279,7 @@ class Layer(QtProxyObject):
     # The only purpose of listing them here is that these will be returned by this class' __dir()__, and
     #    shown interactively, while the ones not listed and/or overloaded here may not be shown in ipython, etc.
     additional_methods = ['logLogAxes', 'logXLinY', 'logXLinY',
-                          'removeLegend', 'saveImage', 'setAxisScale', 'setCurveLineColor', 'setCurveLineStyle',
+                          'removeLegend', 'export', 'setAxisScale', 'setCurveLineColor', 'setCurveLineStyle',
                           'setCurveLineWidth', 'setCurveSymbol', 'setScale', 'setTitle', 'setXTitle', 'setYTitle']
 
     def __init__(self, toproxy):

--- a/Code/Mantid/MantidPlot/pymantidplot/pyplot.py
+++ b/Code/Mantid/MantidPlot/pymantidplot/pyplot.py
@@ -686,8 +686,8 @@ class Figure():
         """
         if not name:
             raise ValueError("Error: you need to specify a non-empty file name")
-        l = _graph.activeLayer()
-        l.saveImage(name);
+        l = self._graph.activeLayer()
+        l.export(name);
 
     @classmethod
     def fig_seq(cls):
@@ -1561,4 +1561,4 @@ def savefig(name):
     if not name:
         raise ValueError("Error: you need to specify a non-empty file name")
     l = __last_fig()._graph.activeLayer()
-    l.saveImage(name);
+    l.export(name);

--- a/Code/Mantid/MantidPlot/test/MantidPlotPyplotGeneralTest.py
+++ b/Code/Mantid/MantidPlot/test/MantidPlotPyplotGeneralTest.py
@@ -225,5 +225,16 @@ class MantidPlotPyplotGeneralTest(unittest.TestCase):
         except:
             print "Failed, as it should"
 
+    def test_savefig(self):
+        # save a minimal figure just to check that the file is written
+        import os
+
+        plot([0, 0.5, 0.1])
+
+        tmp_figname = 'pyplot_tmp_fig_test.png'
+        savefig(tmp_figname)
+        self.assertTrue(os.path.exists(tmp_figname))
+        os.remove(tmp_figname)
+
 # Run the unit tests
 mantidplottests.runTests(MantidPlotPyplotGeneralTest)

--- a/Code/Mantid/MantidPlot/test/MantidPlotPyplotGeneralTest.py
+++ b/Code/Mantid/MantidPlot/test/MantidPlotPyplotGeneralTest.py
@@ -82,6 +82,12 @@ class MantidPlotPyplotGeneralTest(unittest.TestCase):
             self.assertTrue(isinstance(lines[i].figure()._graph, proxies.Graph))
 
     def close_win(self, lines):
+        """
+        Close a plot window. Use this on your test windows to prevent very likely
+        segfaults at the end of the tests.
+
+        @param lines :: lines object as returned by the plot function
+        """
         if len(lines) > 0:
             self.close_win_by_graph(lines[0]._graph)        
 
@@ -229,10 +235,11 @@ class MantidPlotPyplotGeneralTest(unittest.TestCase):
         # save a minimal figure just to check that the file is written
         import os
 
-        plot([0, 0.5, 0.1])
-
+        lines = plot([0, 0.5, 0.1])
         tmp_figname = 'pyplot_tmp_fig_test.png'
         savefig(tmp_figname)
+        self.close_win(lines)
+
         self.assertTrue(os.path.exists(tmp_figname))
         os.remove(tmp_figname)
 


### PR DESCRIPTION
Fixes #13066.

**To test**:
- tests should pass
- Check that it works for you with an example like in the issue description or these ones:

```
plot([0,0.5, 0.1])
savefig('simple.png')
```

```
lines=plot([0.1, 0.3])
lines[0].figure().savefig('figure.png')
```

These files should be written and the images should look like the plots that you get in MantidPlot. Before this branch it would just fail because the code was using a wrong method name.

I added a test case for this, as it is very user visible. Apparently this had been wrong for a while and it wasn't caught during testing, or might have been introduced in the middle of the tests, as I also fixed anothe issue in Figure.savefig().

The bugfix release note is here: http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_UI_Changes&diff=24409&oldid=24392
