### PR TITLE
Fix X label after FFT transformation

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/FFT.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/FFT.cpp
@@ -154,7 +154,12 @@ void FFT::exec() {
         lblUnit->setLabel("Frequency", "MHz");
       } else if (inputUnit->caption() == "Frequency" && inputUnit->label() == "MHz") {
         lblUnit->setLabel("Time", Units::Symbol::Microsecond);
+      } else if (inputUnit->caption() == "d-Spacing" && inputUnit->label() == "Angstrom") {
+        lblUnit->setLabel("q", Units::Symbol::InverseAngstrom);
+      } else if (inputUnit->caption() == "q" && inputUnit->label() == "Angstrom^-1") {
+        lblUnit->setLabel("d-Spacing", Units::Symbol::Angstrom);
       }
+
       outWS->getAxis(0)->unit() = lblUnit;
     }
   }

--- a/Code/Mantid/Framework/Algorithms/src/FFT.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/FFT.cpp
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/FFT.h"
 #include "MantidKernel/UnitFactory.h"
+#include "MantidKernel/UnitLabelTypes.h"
 #include "MantidAPI/TextAxis.h"
 
 #include <boost/shared_array.hpp>
@@ -145,6 +146,14 @@ void FFT::exec() {
           inputUnit->label() == "meV") {
         lblUnit->setLabel("Time", "ns");
         df /= 2.418e2;
+      } else if (inputUnit->caption() == "Time" && inputUnit->label() == "s") {
+        lblUnit->setLabel("Frequency", "Hz");
+      } else if (inputUnit->caption() == "Frequency" && inputUnit->label() == "Hz") {
+        lblUnit->setLabel("Time", "s");
+      } else if (inputUnit->caption() == "Time" && inputUnit->label() == "microsecond") {
+        lblUnit->setLabel("Frequency", "MHz");
+      } else if (inputUnit->caption() == "Frequency" && inputUnit->label() == "MHz") {
+        lblUnit->setLabel("Time", Units::Symbol::Microsecond);
       }
       outWS->getAxis(0)->unit() = lblUnit;
     }

--- a/Code/Mantid/Framework/Algorithms/src/FFT.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/FFT.cpp
@@ -127,25 +127,28 @@ void FFT::exec() {
   MatrixWorkspace_sptr outWS =
       WorkspaceFactory::Instance().create(inWS, nOut, xSize, ySize);
 
-  bool isEnergyMeV = false;
-  if (inWS->getAxis(0)->unit() &&
-      (inWS->getAxis(0)->unit()->caption() == "Energy" ||
-       inWS->getAxis(0)->unit()->caption() == "Energy transfer") &&
-      inWS->getAxis(0)->unit()->label() == "meV") {
+  double df = 1.0 / (dx * ySize);
+
+  // Output label
+  outWS->getAxis(0)->unit() = UnitFactory::Instance().create("Label");
+
+  auto inputUnit = inWS->getAxis(0)->unit();
+  if (inputUnit) {
+
     boost::shared_ptr<Kernel::Units::Label> lblUnit =
         boost::dynamic_pointer_cast<Kernel::Units::Label>(
             UnitFactory::Instance().create("Label"));
     if (lblUnit) {
-      lblUnit->setLabel("Time", "ns");
+
+      if ((inputUnit->caption() == "Energy" ||
+           inputUnit->caption() == "Energy transfer") &&
+          inputUnit->label() == "meV") {
+        lblUnit->setLabel("Time", "ns");
+        df /= 2.418e2;
+      }
       outWS->getAxis(0)->unit() = lblUnit;
     }
-    isEnergyMeV = true;
-  } else
-    outWS->getAxis(0)->unit() = UnitFactory::Instance().create("Label");
-
-  double df = 1.0 / (dx * ySize);
-  if (isEnergyMeV)
-    df /= 2.418e2;
+  }
 
   // centerShift == true means that the zero on the x axis is assumed to be in
   // the data centre


### PR DESCRIPTION
Fixes #13056 

Tester: Review the code changes. Try executing FFT on different datasets and check that units in the output workspace are as expected:
- Load 'MUSR00015189.nxs', run FFT, check that the X axis label reads 'Frecuency (MHz)' in the output ws. Apply FFT again on the output ws and see that you recover 'Time (\mu s)'
- Load 'PG3_733_focussed.nxs'. Apply FFT and check that output units are 'q (A^-1)'. Run FFT on the output ws and check that 'd-Spacing (A)' is recovered.
- Load 'GEM38370_Focussed_Legacy.nxs' and do the same check.

Note that I've only added the cases mentioned by James Lord. Other conversions can be included in the future if needed.

Release notes: http://www.mantidproject.org/index.php?title=Release_Notes_3_5_MuonAnalysis&diff=24415&oldid=24335 
Note that I've included this fix under MuonAnalysis category, as it was requested by Muon scientes, although it should probably go in Framework.
