### PR TITLE
FindPeaks: logs about fit parameters, notice level  -> debug level

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/FindPeaks.cpp
@@ -375,7 +375,7 @@ FindPeaks::findPeaksGivenStartingPoints(const std::vector<double> &peakcentres,
           break;
         }
       }
-      g_log.notice()
+      g_log.debug()
           << "Finding peaks from giving starting point, with interval i_min = "
           << i_min << " i_max = " << i_max << std::endl;
       practical_x_max = vecX[i_max];
@@ -1472,11 +1472,11 @@ void FindPeaks::addInfoRow(const size_t spectrum,
 
     t << a0 << a1 << a2;
 
-    g_log.notice() << "Peak parameters found: cen=" << peakcentre
-                   << " fwhm=" << fwhm << " height=" << height << " a0=" << a0
-                   << " a1=" << a1 << " a2=" << a2;
+    g_log.debug() << "Peak parameters found: cen=" << peakcentre
+                  << " fwhm=" << fwhm << " height=" << height << " a0=" << a0
+                  << " a1=" << a1 << " a2=" << a2;
   }
-  g_log.notice() << " chsq=" << mincost << "\n";
+  g_log.debug() << " chsq=" << mincost << "\n";
   // Minimum cost function value
   t << mincost;
 


### PR DESCRIPTION
Fixes #12807.

This simply changes the log level of a couple of log messages from FindPeaks that were initially added as too high level logs because of other issues which are now fixed (#12686).

**To test**:
- simple code review
- green light from the build servers.

This doesn't change functionality and absolutely does not need to go in the release notes.

@peterfpeterson : you might want to check  or just be aware of this. I think that this should be fine as we planned some days ago, but feel free to revert or change as you need for FindPeaks development. After this I think that the verbosity level of FindPeaks is reasonable.
