### PR TITLE
Cannot delete plot legend with fit tool

### DIFF
--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -8393,7 +8393,7 @@ void ApplicationWindow::clearSelection()
     if (!g)
       return;
 
-    if (g->activeTool())
+    if (g->activeTool() && !dynamic_cast<PeakPickerTool*>(g->activeTool()))
     {
       auto rst = dynamic_cast<RangeSelectorTool*>(g->activeTool());
       auto lbt = dynamic_cast<LabelTool*>(g->activeTool());
@@ -8450,19 +8450,19 @@ void ApplicationWindow::copySelection()
     if (!g)
       return;
 
-    if (g->activeTool()){
+    if (g->activeTool())
+    {
       if (g->activeTool()->rtti() == PlotToolInterface::Rtti_RangeSelector)
       {
         RangeSelectorTool* rst = dynamic_cast<RangeSelectorTool*>(g->activeTool());
         if(rst)
           rst->copySelection();
       }
-    } else if (g->markerSelected()){
-      copyMarker();
-    } else
-    {
-      copyActiveLayer();
     }
+    else if (g->markerSelected())
+      copyMarker();
+    else
+      copyActiveLayer();
 
     plot->copyAllLayers();
   }
@@ -8498,11 +8498,14 @@ void ApplicationWindow::cutSelection()
     if (!g)
       return;
 
-    if (g->activeTool()){
+    if (g->activeTool())
+    {
       auto rst = dynamic_cast<RangeSelectorTool*>(g->activeTool());
       if (rst)
         rst->cutSelection();
-    } else {
+    }
+    else
+    {
       copyMarker();
       g->removeMarker();
     }
@@ -9607,8 +9610,12 @@ void ApplicationWindow::showMarkerPopupMenu()
     markerMenu.insertSeparator();
   }
 
-  markerMenu.insertItem(getQPixmap("cut_xpm"),tr("&Cut"),this, SLOT(cutSelection()));
-  markerMenu.insertItem(getQPixmap("copy_xpm"), tr("&Copy"),this, SLOT(copySelection()));
+  if (!(g->activeTool() && dynamic_cast<PeakPickerTool*>(g->activeTool())))
+  {
+    markerMenu.insertItem(getQPixmap("cut_xpm"),tr("&Cut"),this, SLOT(cutSelection()));
+    markerMenu.insertItem(getQPixmap("copy_xpm"), tr("&Copy"),this, SLOT(copySelection()));
+  }
+
   markerMenu.insertItem(getQPixmap("erase_xpm"), tr("&Delete"),this, SLOT(clearSelection()));
   markerMenu.insertSeparator();
   if (g->arrowMarkerSelected())


### PR DESCRIPTION
Fixes #12262.

To test:
- Do steps in original ticket
- See that you only have the delete option for markers when using the peak selection tool (since this has a custom context menu it made little sense to allow cutting and copying)

Release notes updates [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_UI_Changes&diff=24430&oldid=24409).
