### PR TITLE
Move JumpFit from Bayes to IDA

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayes.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayes.h
@@ -11,91 +11,85 @@
 #include <Poco/NObserver.h>
 #include "MantidKernel/ConfigService.h"
 
-namespace MantidQt
-{
-  namespace CustomInterfaces
-  {
-    /** 
-    This class defines the Indirect Bayes interface. It handles the creation of the interface window and 
-		handles the interaction between the child tabs on the window.
+namespace MantidQt {
+namespace CustomInterfaces {
+/**
+This class defines the Indirect Bayes interface. It handles the creation of the
+interface window and handles the interaction between the child tabs on the
+window.
 
-    @author Samuel Jackson, STFC
+@author Samuel Jackson, STFC
 
-    Copyright &copy; 2010 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+Copyright &copy; 2010 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
 
-    This file is part of Mantid.
+This file is part of Mantid.
 
-    Mantid is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
 
-    Mantid is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    File change history is stored at: <https://github.com/mantidproject/mantid>
-    Code Documentation is available at: <http://doxygen.mantidproject.org>    
-    */
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
 
-    class DLLExport IndirectBayes : public MantidQt::API::UserSubWindow
-    {
-      Q_OBJECT
+class DLLExport IndirectBayes : public MantidQt::API::UserSubWindow {
+  Q_OBJECT
 
-		public: //public constants and enums
+public: // public constants and enums
+  /// Enumeration for the index of each tab
+  enum TabChoice { RES_NORM, QUASI, STRETCH };
 
-      /// Enumeration for the index of each tab
-			enum TabChoice
-			{
-				RES_NORM,
-				QUASI,
-				STRETCH,
-				JUMP_FIT
-			};
+public: // public constructor, destructor and functions
+  /// Default Constructor
+  IndirectBayes(QWidget *parent = 0);
+  /// Destructor
+  ~IndirectBayes();
+  /// Interface name
+  static std::string name() { return "Bayes"; }
+  // This interface's categories.
+  static QString categoryInfo() { return "Indirect"; }
+  virtual void initLayout();
 
-    public: // public constructor, destructor and functions
-      /// Default Constructor
-      IndirectBayes(QWidget *parent = 0);
-      ///Destructor
-      ~IndirectBayes();
-      /// Interface name
-      static std::string name() { return "Bayes"; }
-      // This interface's categories.
-      static QString categoryInfo() { return "Indirect"; }
-      virtual void initLayout();
+private slots:
+  // Run the appropriate action depending based on the selected tab
 
-    private slots:
-      // Run the appropriate action depending based on the selected tab
+  /// Slot for clicking on the run button
+  void runClicked();
+  /// Slot for clicking on the hlep button
+  void helpClicked();
+  /// Slot for clicking on the manage directories button
+  void manageUserDirectories();
+  /// Slot showing a message box to the user
+  void showMessageBox(const QString &message);
 
-      /// Slot for clicking on the run button
-      void runClicked();
-      /// Slot for clicking on the hlep button
-      void helpClicked();
-      /// Slot for clicking on the manage directories button
-      void manageUserDirectories();
-      /// Slot showing a message box to the user
-      void showMessageBox(const QString& message);
+private:
+  /// Called upon a close event.
+  virtual void closeEvent(QCloseEvent *);
+  /// handle POCO event
+  void
+  handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
+  /// Load default interface settings for each tab
+  void loadSettings();
 
-		private:
-      /// Called upon a close event.
-      virtual void closeEvent(QCloseEvent*);
-      /// handle POCO event
-      void handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
-      /// Load default interface settings for each tab
-      void loadSettings();
-
-      /// Map of tabs indexed by position on the window
-			std::map<unsigned int, IndirectBayesTab*> m_bayesTabs;
-      /// Change Observer for ConfigService (monitors user directories)
-      Poco::NObserver<IndirectBayes, Mantid::Kernel::ConfigValChangeNotification> m_changeObserver;
-      ///Main interface window
-      Ui::IndirectBayes m_uiForm;
-    };
-  }
+  /// Map of tabs indexed by position on the window
+  std::map<unsigned int, IndirectBayesTab *> m_bayesTabs;
+  /// Change Observer for ConfigService (monitors user directories)
+  Poco::NObserver<IndirectBayes, Mantid::Kernel::ConfigValChangeNotification>
+      m_changeObserver;
+  /// Main interface window
+  Ui::IndirectBayes m_uiForm;
+};
+}
 }
 
 #endif

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayes.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayes.ui
@@ -35,11 +35,6 @@
        <string>Stretch</string>
       </attribute>
      </widget>
-     <widget class="QWidget" name="JumpFit">
-      <attribute name="title">
-       <string>JumpFit</string>
-      </attribute>
-     </widget>
     </widget>
    </item>
    <item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayesTab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayesTab.h
@@ -20,95 +20,84 @@
 
 // Suppress a warning coming out of code that isn't ours
 #if defined(__INTEL_COMPILER)
-  #pragma warning disable 1125
+#pragma warning disable 1125
 #elif defined(__GNUC__)
-  #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6 )
-    #pragma GCC diagnostic push
-  #endif
-  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic push
+#endif
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
 #include "DoubleEditorFactory.h"
 #if defined(__INTEL_COMPILER)
-  #pragma warning enable 1125
+#pragma warning enable 1125
 #elif defined(__GNUC__)
-  #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6 )
-    #pragma GCC diagnostic pop
-  #endif
+#if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
-		/**
-			This class defines a abstract base class for the different tabs of the Indirect Bayes interface.
-			Any joint functionality shared between each of the tabs should be implemented here as well as defining
-			shared member functions.
+namespace MantidQt {
+namespace CustomInterfaces {
+/**
+This class defines a abstract base class for the different tabs of the Indirect
+Bayes interface.
+Any joint functionality shared between each of the tabs should be implemented
+here as well as defining shared member functions.
 
-			@author Samuel Jackson, STFC
+@author Samuel Jackson, STFC
 
-			Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
 
-			This file is part of Mantid.
+This file is part of Mantid.
 
-			Mantid is free software; you can redistribute it and/or modify
-			it under the terms of the GNU General Public License as published by
-			the Free Software Foundation; either version 3 of the License, or
-			(at your option) any later version.
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
 
-			Mantid is distributed in the hope that it will be useful,
-			but WITHOUT ANY WARRANTY; without even the implied warranty of
-			MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-			GNU General Public License for more details.
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-			You should have received a copy of the GNU General Public License
-			along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-			File change history is stored at: <https://github.com/mantidproject/mantid>
-			Code Documentation is available at: <http://doxygen.mantidproject.org>
-		*/
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
 
-		/// precision of double properties in bayes tabs
-		static const unsigned int NUM_DECIMALS = 6;
-		/// precision for integer properties in bayes tabs
-		static const unsigned int INT_DECIMALS = 0;
+/// precision of double properties in bayes tabs
+static const unsigned int NUM_DECIMALS = 6;
+/// precision for integer properties in bayes tabs
+static const unsigned int INT_DECIMALS = 0;
 
-		class DLLExport IndirectBayesTab : public IndirectTab
-		{
-			Q_OBJECT
+class DLLExport IndirectBayesTab : public IndirectTab {
+  Q_OBJECT
 
-		public:
-			IndirectBayesTab(QWidget * parent = 0);
-			~IndirectBayesTab();
+public:
+  IndirectBayesTab(QWidget *parent = 0);
+  ~IndirectBayesTab();
 
-			/// Base methods implemented in derived classes
-			virtual void loadSettings(const QSettings& settings) = 0;
+  /// Base methods implemented in derived classes
+  virtual void loadSettings(const QSettings &settings) = 0;
 
-		signals:
-			/// Send signal to parent window to show a message box to user
-			void showMessageBox(const QString& message);
+signals:
+  /// Send signal to parent window to show a message box to user
+  void showMessageBox(const QString &message);
 
-    protected slots:
-			/// Slot to update the guides when the range properties change
-			virtual void updateProperties(QtProperty* prop, double val) = 0;
+protected slots:
+  /// Slot to update the guides when the range properties change
+  virtual void updateProperties(QtProperty *prop, double val) = 0;
 
-		protected:
-			/// Function to run a string as python code
-			void runPythonScript(const QString& pyInput);
-			/// Function to read an instrument's resolution from the IPF using a string
-    	bool getInstrumentResolution(const QString& filename, QPair<double, double> & res);
-			/// Function to read an instrument's resolution from the IPF using a workspace pointer
-			bool getInstrumentResolution(Mantid::API::MatrixWorkspace_const_sptr ws, QPair<double, double> & res);
-			/// Function to set the position of the lower guide on the plot
-	    void updateLowerGuide(MantidQt::MantidWidgets::RangeSelector* rs, QtProperty* lower, QtProperty* upper, double value);
-			/// Function to set the position of the upper guide on the plot
-	    void updateUpperGuide(MantidQt::MantidWidgets::RangeSelector* rs, QtProperty* lower, QtProperty* upper, double value);
-
-			/// Tree of the properties
-			QtTreePropertyBrowser* m_propTree;
-
-		};
-	} // namespace CustomInterfaces
+protected:
+  /// Function to run a string as python code
+  void runPythonScript(const QString &pyInput);
+  /// Tree of the properties
+  QtTreePropertyBrowser *m_propTree;
+};
+} // namespace CustomInterfaces
 } // namespace Mantid
 
 #endif

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDataAnalysis.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDataAnalysis.h
@@ -15,90 +15,82 @@ class DoubleEditorFactory;
 class QtCheckBoxFactory;
 class QtStringPropertyManager;
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-namespace IDA
-{
-  // The assumption is made elsewhere that the ordering of these enums matches the ordering of the
-  // tabs as they appear in the interface itself.
-  enum IDATabChoice
-  {
-    ELWIN,
-    MSD_FIT,
-    IQT,
-    IQT_FIT,
-    CONV_FIT
-  };
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+// The assumption is made elsewhere that the ordering of these enums matches the
+// ordering of the
+// tabs as they appear in the interface itself.
+enum IDATabChoice { ELWIN, MSD_FIT, IQT, IQT_FIT, CONV_FIT, JUMP_FIT };
 
-  // Number of decimal places in property browsers.
-  static const unsigned int NUM_DECIMALS = 6;
+// Number of decimal places in property browsers.
+static const unsigned int NUM_DECIMALS = 6;
 
-  // Forward Declaration
-  class IndirectDataAnalysisTab;
+// Forward Declaration
+class IndirectDataAnalysisTab;
 
-  /**
-   * The IndirectDataAnalysis class is the main class that handles the interface and controls
-   * its tabs.
-   *
-   * Is a friend to the IndirectDataAnalysisTab class.
-   */
-  class IndirectDataAnalysis : public MantidQt::API::UserSubWindow
-  {
-    Q_OBJECT
+/**
+ * The IndirectDataAnalysis class is the main class that handles the interface
+ *and controls
+ * its tabs.
+ *
+ * Is a friend to the IndirectDataAnalysisTab class.
+ */
+class IndirectDataAnalysis : public MantidQt::API::UserSubWindow {
+  Q_OBJECT
 
-    /// Allow IndirectDataAnalysisTab to have access.
-    friend class IndirectDataAnalysisTab;
+  /// Allow IndirectDataAnalysisTab to have access.
+  friend class IndirectDataAnalysisTab;
 
-  public:
-    /// The name of the interface as registered into the factory
-    static std::string name() { return "Data Analysis"; }
-    // This interface's categories.
-    static QString categoryInfo() { return "Indirect"; }
-    /// Default Constructor
-    IndirectDataAnalysis(QWidget *parent = 0);
+public:
+  /// The name of the interface as registered into the factory
+  static std::string name() { return "Data Analysis"; }
+  // This interface's categories.
+  static QString categoryInfo() { return "Indirect"; }
+  /// Default Constructor
+  IndirectDataAnalysis(QWidget *parent = 0);
 
-  private:
-    /// Initialize the layout
-    virtual void initLayout();
-    /// Initialize Python-dependent sections
-    virtual void initLocalPython();
-    /// Load the settings of the interface (and child tabs).
-    void loadSettings();
+private:
+  /// Initialize the layout
+  virtual void initLayout();
+  /// Initialize Python-dependent sections
+  virtual void initLocalPython();
+  /// Load the settings of the interface (and child tabs).
+  void loadSettings();
 
-    /// Called upon a close event.
-    virtual void closeEvent(QCloseEvent*);
-    /// handle POCO event
-    void handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
+  /// Called upon a close event.
+  virtual void closeEvent(QCloseEvent *);
+  /// handle POCO event
+  void
+  handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
 
-  private slots:
-    /// Called when the user clicks the Py button
-    void exportTabPython();
-    /// Called when the Run button is pressed.  Runs current tab.
-    void run();
-    /// Opens a directory dialog.
-    void openDirectoryDialog();
-    /// Opens the Mantid Wiki web page of the current tab.
-    void help();
-    /// Slot showing a message box to the user
-    void showMessageBox(const QString& message);
+private slots:
+  /// Called when the user clicks the Py button
+  void exportTabPython();
+  /// Called when the Run button is pressed.  Runs current tab.
+  void run();
+  /// Opens a directory dialog.
+  void openDirectoryDialog();
+  /// Opens the Mantid Wiki web page of the current tab.
+  void help();
+  /// Slot showing a message box to the user
+  void showMessageBox(const QString &message);
 
-  private:
-    /// UI form containing all Qt elements.
-    Ui::IndirectDataAnalysis m_uiForm;
-    /// Integer validator
-    QIntValidator* m_valInt;
-    /// Double validator
-    QDoubleValidator* m_valDbl;
+private:
+  /// UI form containing all Qt elements.
+  Ui::IndirectDataAnalysis m_uiForm;
+  /// Integer validator
+  QIntValidator *m_valInt;
+  /// Double validator
+  QDoubleValidator *m_valDbl;
 
-    /// Change Observer for ConfigService (monitors user directories)
-    Poco::NObserver<IndirectDataAnalysis, Mantid::Kernel::ConfigValChangeNotification> m_changeObserver;
+  /// Change Observer for ConfigService (monitors user directories)
+  Poco::NObserver<IndirectDataAnalysis,
+                  Mantid::Kernel::ConfigValChangeNotification> m_changeObserver;
 
-    /// Map of unsigned int (TabChoice enum values) to tabs.
-    std::map<unsigned int, IndirectDataAnalysisTab*> m_tabs;
-
-  };
+  /// Map of unsigned int (TabChoice enum values) to tabs.
+  std::map<unsigned int, IndirectDataAnalysisTab *> m_tabs;
+};
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDataAnalysis.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDataAnalysis.ui
@@ -51,6 +51,11 @@
         <string>ConvFit</string>
        </attribute>
       </widget>
+       <widget class="QWidget" name="tabJumpFit">
+        <attribute name="title">
+         <string>JumpFit</string>
+        </attribute>
+       </widget>
      </widget>
     </item>
     <item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectTab.h
@@ -22,173 +22,184 @@
 
 // Suppress a warning coming out of code that isn't ours
 #if defined(__INTEL_COMPILER)
-  #pragma warning disable 1125
+#pragma warning disable 1125
 #elif defined(__GNUC__)
-  #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6 )
-    #pragma GCC diagnostic push
-  #endif
-  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic push
+#endif
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
 #include "DoubleEditorFactory.h"
 #if defined(__INTEL_COMPILER)
-  #pragma warning enable 1125
+#pragma warning enable 1125
 #elif defined(__GNUC__)
-  #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6 )
-    #pragma GCC diagnostic pop
-  #endif
+#if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  /** IndirectTab
+namespace MantidQt {
+namespace CustomInterfaces {
+/** IndirectTab
 
-    Provided common functionality of all indirect interface tabs.
+  Provided common functionality of all indirect interface tabs.
 
-    @author Dan Nixon
-    @date 08/10/2014
+  @author Dan Nixon
+  @date 08/10/2014
 
-    Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+  Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
 
-    This file is part of Mantid.
+  This file is part of Mantid.
 
-    Mantid is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
 
-    Mantid is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    File change history is stored at: <https://github.com/mantidproject/mantid>
-    Code Documentation is available at: <http://doxygen.mantidproject.org>
-  */
-  class DLLExport IndirectTab : public QObject
-  {
-    Q_OBJECT
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport IndirectTab : public QObject {
+  Q_OBJECT
 
-  public:
-    IndirectTab(QObject* parent = 0);
-    virtual ~IndirectTab();
+public:
+  IndirectTab(QObject *parent = 0);
+  virtual ~IndirectTab();
 
-  public slots:
-    void runTab();
-    void setupTab();
-    bool validateTab();
-    void exportPythonScript();
+public slots:
+  void runTab();
+  void setupTab();
+  bool validateTab();
+  void exportPythonScript();
 
-  protected slots:
-    /// Slot to handle when an algorithm finishes running
-    virtual void algorithmFinished(bool error);
+protected slots:
+  /// Slot to handle when an algorithm finishes running
+  virtual void algorithmFinished(bool error);
 
-  protected:
-    /// Run the load algorithm with the given file name, output name and spectrum range
-    bool loadFile(const QString& filename, const QString& outputName, const int specMin = -1, const int specMax = -1);
+protected:
+  /// Run the load algorithm with the given file name, output name and spectrum
+  /// range
+  bool loadFile(const QString &filename, const QString &outputName,
+                const int specMin = -1, const int specMax = -1);
 
-    /// Add a SaveNexusProcessed step to the batch queue
-    void addSaveWorkspaceToQueue(const QString & wsName, const QString & filename = "");
+  /// Add a SaveNexusProcessed step to the batch queue
+  void addSaveWorkspaceToQueue(const QString &wsName,
+                               const QString &filename = "");
 
-    /// Gets the workspace suffix of a workspace name
-    QString getWorkspaceSuffix(const QString & wsName);
-    /// Gets the base name of a workspace
-    QString getWorkspaceBasename(const QString & wsName);
+  /// Gets the workspace suffix of a workspace name
+  QString getWorkspaceSuffix(const QString &wsName);
+  /// Gets the base name of a workspace
+  QString getWorkspaceBasename(const QString &wsName);
 
-    /// Plot a spectrum plot with a given spectrum index
-    void plotSpectrum(const QStringList & workspaceNames, int specIndex = 0);
-    /// Plot a spectrum plot of a given workspace
-    void plotSpectrum(const QString & workspaceName, int specIndex = 0);
+  /// Plot a spectrum plot with a given spectrum index
+  void plotSpectrum(const QStringList &workspaceNames, int specIndex = 0);
+  /// Plot a spectrum plot of a given workspace
+  void plotSpectrum(const QString &workspaceName, int specIndex = 0);
 
-    /// Plot a spectrum plot with a given spectra range
-    void plotSpectrum(const QStringList & workspaceNames, int specStart, int specEnd);
-    /// Plot a spectrum plot with a given spectra range of a given workspace
-    void plotSpectrum(const QString & workspaceName, int specStart, int specEnd);
+  /// Plot a spectrum plot with a given spectra range
+  void plotSpectrum(const QStringList &workspaceNames, int specStart,
+                    int specEnd);
+  /// Plot a spectrum plot with a given spectra range of a given workspace
+  void plotSpectrum(const QString &workspaceName, int specStart, int specEnd);
 
-    /// Plot a time bin plot given a list of workspace names
-    void plotTimeBin(const QStringList & workspaceNames, int specIndex = 0);
-    /// Plot a time bin plot of a given workspace
-    void plotTimeBin(const QString & workspaceName, int specIndex = 0);
+  /// Plot a time bin plot given a list of workspace names
+  void plotTimeBin(const QStringList &workspaceNames, int specIndex = 0);
+  /// Plot a time bin plot of a given workspace
+  void plotTimeBin(const QString &workspaceName, int specIndex = 0);
 
-    /// Plot a contour plot of a given workspace
-    void plot2D(const QString & workspaceName);
+  /// Plot a contour plot of a given workspace
+  void plot2D(const QString &workspaceName);
 
-    /// Function to set the range limits of the plot
-    void setPlotPropertyRange(MantidQt::MantidWidgets::RangeSelector * rs,
-                              QtProperty* min, QtProperty* max,
-                              const QPair<double, double> & bounds);
-    /// Function to set the range selector on the mini plot
-    void setRangeSelector(MantidQt::MantidWidgets::RangeSelector * rs,
-                          QtProperty* lower, QtProperty* upper,
-                          const QPair<double, double> & bounds);
+  /// Function to set the range limits of the plot
+  void setPlotPropertyRange(MantidQt::MantidWidgets::RangeSelector *rs,
+                            QtProperty *min, QtProperty *max,
+                            const QPair<double, double> &bounds);
+  /// Function to set the range selector on the mini plot
+  void setRangeSelector(MantidQt::MantidWidgets::RangeSelector *rs,
+                        QtProperty *lower, QtProperty *upper,
+                        const QPair<double, double> &bounds);
 
-    /// Function to get energy mode from a workspace
-    std::string getEMode(Mantid::API::MatrixWorkspace_sptr ws);
+  /// Function to get energy mode from a workspace
+  std::string getEMode(Mantid::API::MatrixWorkspace_sptr ws);
 
-    /// Function to get eFixed from a workspace
-    double getEFixed(Mantid::API::MatrixWorkspace_sptr ws);
+  /// Function to get eFixed from a workspace
+  double getEFixed(Mantid::API::MatrixWorkspace_sptr ws);
 
-    /// Function to run an algorithm on a seperate thread
-    void runAlgorithm(const Mantid::API::IAlgorithm_sptr algorithm);
+  /// Function to read an instrument's resolution from the IPF using a string
+  bool getResolutionRangeFromWs(const QString &filename,
+                                QPair<double, double> &res);
 
-    QString runPythonCode(QString vode, bool no_output = false);
+  /// Function to read an instrument's resolution from the IPF using a workspace
+  /// pointer
+  bool getResolutionRangeFromWs(Mantid::API::MatrixWorkspace_const_sptr ws,
+                                QPair<double, double> &res);
 
-    /// Parent QWidget (if applicable)
-    QWidget *m_parentWidget;
+  /// Function to run an algorithm on a seperate thread
+  void runAlgorithm(const Mantid::API::IAlgorithm_sptr algorithm);
 
-    /// Tree of the properties
-    std::map<QString, QtTreePropertyBrowser *> m_propTrees;
+  QString runPythonCode(QString vode, bool no_output = false);
 
-    /// Internal list of the properties
-    QMap<QString, QtProperty*> m_properties;
+  /// Parent QWidget (if applicable)
+  QWidget *m_parentWidget;
 
-    /// Double manager to create properties
-    QtDoublePropertyManager* m_dblManager;
-    /// Boolean manager to create properties
-    QtBoolPropertyManager* m_blnManager;
-    /// Group manager to create properties
-    QtGroupPropertyManager* m_grpManager;
+  /// Tree of the properties
+  std::map<QString, QtTreePropertyBrowser *> m_propTrees;
 
-    /// Double editor facotry for the properties browser
-    DoubleEditorFactory* m_dblEdFac;
+  /// Internal list of the properties
+  QMap<QString, QtProperty *> m_properties;
 
-    /// Algorithm runner object to execute chains algorithms on a seperate thread from the GUI
-    MantidQt::API::BatchAlgorithmRunner *m_batchAlgoRunner;
+  /// Double manager to create properties
+  QtDoublePropertyManager *m_dblManager;
+  /// Boolean manager to create properties
+  QtBoolPropertyManager *m_blnManager;
+  /// Group manager to create properties
+  QtGroupPropertyManager *m_grpManager;
 
-    /// Use a Python runner for when we need the output of a script
-    MantidQt::API::PythonRunner m_pythonRunner;
+  /// Double editor facotry for the properties browser
+  DoubleEditorFactory *m_dblEdFac;
 
-    /// Validator for int inputs
-    QIntValidator *m_valInt;
-    /// Validator for double inputs
-    QDoubleValidator *m_valDbl;
-    /// Validator for positive double inputs
-    QDoubleValidator *m_valPosDbl;
+  /// Algorithm runner object to execute chains algorithms on a seperate thread
+  /// from the GUI
+  MantidQt::API::BatchAlgorithmRunner *m_batchAlgoRunner;
 
-  signals:
-    /// Send signal to parent window to show a message box to user
-    void showMessageBox(const QString& message);
-    /// Run a python script
-    void runAsPythonScript(const QString & code, bool noOutput = false);
+  /// Use a Python runner for when we need the output of a script
+  MantidQt::API::PythonRunner m_pythonRunner;
 
-  protected:
-    /// Overidden by child class.
-    virtual void setup() = 0;
-    /// Overidden by child class.
-    virtual void run() = 0;
-    /// Overidden by child class.
-    virtual bool validate() = 0;
+  /// Validator for int inputs
+  QIntValidator *m_valInt;
+  /// Validator for double inputs
+  QDoubleValidator *m_valDbl;
+  /// Validator for positive double inputs
+  QDoubleValidator *m_valPosDbl;
 
-    Mantid::Kernel::DateAndTime m_tabStartTime;
-    Mantid::Kernel::DateAndTime m_tabEndTime;
-    std::string m_pythonExportWsName;
+signals:
+  /// Send signal to parent window to show a message box to user
+  void showMessageBox(const QString &message);
+  /// Run a python script
+  void runAsPythonScript(const QString &code, bool noOutput = false);
 
-  };
+protected:
+  /// Overidden by child class.
+  virtual void setup() = 0;
+  /// Overidden by child class.
+  virtual void run() = 0;
+  /// Overidden by child class.
+  virtual bool validate() = 0;
+
+  Mantid::Kernel::DateAndTime m_tabStartTime;
+  Mantid::Kernel::DateAndTime m_tabEndTime;
+  std::string m_pythonExportWsName;
+};
 } // namespace CustomInterfaces
 } // namespace Mantid
 
-#endif  /* MANTID_CUSTOMINTERFACES_INDIRECTTAB_H_ */
+#endif /* MANTID_CUSTOMINTERFACES_INDIRECTTAB_H_ */

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -2,17 +2,18 @@
 #define MANTIDQTCUSTOMINTERFACES_JUMPFIT_H_
 
 #include "ui_JumpFit.h"
-#include "IndirectBayesTab.h"
+#include "IndirectDataAnalysisTab.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
-class DLLExport JumpFit : public IndirectBayesTab {
+namespace IDA {
+class DLLExport JumpFit : public IndirectDataAnalysisTab {
   Q_OBJECT
 
 public:
   JumpFit(QWidget *parent = 0);
 
-  // Inherited methods from IndirectBayesTab
+  // Inherited methods from IndirectDataAnalysisTab
   void setup();
   bool validate();
   void run();
@@ -50,8 +51,11 @@ private:
   // Map of axis labels to spectrum number
   std::map<std::string, int> m_spectraList;
 
+  QtTreePropertyBrowser* m_jfTree;
+
   Mantid::API::IAlgorithm_sptr m_fitAlg;
 };
+} // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectBayes.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectBayes.cpp
@@ -1,7 +1,6 @@
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtAPI/ManageUserDirectories.h"
 #include "MantidQtCustomInterfaces/Indirect/IndirectBayes.h"
-#include "MantidQtCustomInterfaces/Indirect/JumpFit.h"
 #include "MantidQtCustomInterfaces/Indirect/Quasi.h"
 #include "MantidQtCustomInterfaces/Indirect/ResNorm.h"
 #include "MantidQtCustomInterfaces/Indirect/Stretch.h"
@@ -9,56 +8,56 @@
 #include <QDesktopServices>
 #include <QUrl>
 
-//Add this class to the list of specialised dialogs in this namespace
-namespace MantidQt
-{
-  namespace CustomInterfaces
-  {
-    DECLARE_SUBWINDOW(IndirectBayes)
-  }
+// Add this class to the list of specialised dialogs in this namespace
+namespace MantidQt {
+namespace CustomInterfaces {
+DECLARE_SUBWINDOW(IndirectBayes)
+}
 }
 
 using namespace MantidQt::CustomInterfaces;
 
-IndirectBayes::IndirectBayes(QWidget *parent) : UserSubWindow(parent),
-	m_changeObserver(*this, &IndirectBayes::handleDirectoryChange)
-{
-	m_uiForm.setupUi(this);
+IndirectBayes::IndirectBayes(QWidget *parent)
+    : UserSubWindow(parent),
+      m_changeObserver(*this, &IndirectBayes::handleDirectoryChange) {
+  m_uiForm.setupUi(this);
 
   // Connect Poco Notification Observer
   Mantid::Kernel::ConfigService::Instance().addObserver(m_changeObserver);
 
-	//insert each tab into the interface on creation
-	m_bayesTabs.insert(std::make_pair(RES_NORM, new ResNorm(m_uiForm.indirectBayesTabs->widget(RES_NORM))));
-	m_bayesTabs.insert(std::make_pair(QUASI, new Quasi(m_uiForm.indirectBayesTabs->widget(QUASI))));
-	m_bayesTabs.insert(std::make_pair(STRETCH, new Stretch(m_uiForm.indirectBayesTabs->widget(STRETCH))));
-	m_bayesTabs.insert(std::make_pair(JUMP_FIT, new JumpFit(m_uiForm.indirectBayesTabs->widget(JUMP_FIT))));
+  // insert each tab into the interface on creation
+  m_bayesTabs.insert(std::make_pair(
+      RES_NORM, new ResNorm(m_uiForm.indirectBayesTabs->widget(RES_NORM))));
+  m_bayesTabs.insert(std::make_pair(
+      QUASI, new Quasi(m_uiForm.indirectBayesTabs->widget(QUASI))));
+  m_bayesTabs.insert(std::make_pair(
+      STRETCH, new Stretch(m_uiForm.indirectBayesTabs->widget(STRETCH))));
 
-	//Connect each tab to the actions available in this GUI
-	std::map<unsigned int, IndirectBayesTab*>::iterator iter;
-	for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter)
-	{
-		connect(iter->second, SIGNAL(runAsPythonScript(const QString&, bool)), this, SIGNAL(runAsPythonScript(const QString&, bool)));
-		connect(iter->second, SIGNAL(showMessageBox(const QString&)), this, SLOT(showMessageBox(const QString&)));
-	}
+  // Connect each tab to the actions available in this GUI
+  std::map<unsigned int, IndirectBayesTab *>::iterator iter;
+  for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter) {
+    connect(iter->second, SIGNAL(runAsPythonScript(const QString &, bool)),
+            this, SIGNAL(runAsPythonScript(const QString &, bool)));
+    connect(iter->second, SIGNAL(showMessageBox(const QString &)), this,
+            SLOT(showMessageBox(const QString &)));
+  }
 
-	loadSettings();
+  loadSettings();
 
-	//Connect statements for the buttons shared between all tabs on the Indirect Bayes interface
-	connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
-	connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(helpClicked()));
-	connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(manageUserDirectories()));
+  // Connect statements for the buttons shared between all tabs on the Indirect
+  // Bayes interface
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
+  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(helpClicked()));
+  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
+          SLOT(manageUserDirectories()));
 }
 
-void IndirectBayes::initLayout()
-{
-}
+void IndirectBayes::initLayout() {}
 
 /**
  * @param :: the detected close event
  */
-void IndirectBayes::closeEvent(QCloseEvent*)
-{
+void IndirectBayes::closeEvent(QCloseEvent *) {
   Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
 }
 
@@ -67,71 +66,69 @@ void IndirectBayes::closeEvent(QCloseEvent*)
  *
  * @param pNf :: notification
  */
-void IndirectBayes::handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf)
-{
+void IndirectBayes::handleDirectoryChange(
+    Mantid::Kernel::ConfigValChangeNotification_ptr pNf) {
   std::string key = pNf->key();
 
-  if ( key == "defaultsave.directory" )
+  if (key == "defaultsave.directory")
     loadSettings();
 }
 
 /**
  * Load the setting for each tab on the interface.
  *
- * This includes setting the default browsing directory to be the default save directory.
+ * This includes setting the default browsing directory to be the default save
+ *directory.
  */
-void IndirectBayes::loadSettings()
-{
+void IndirectBayes::loadSettings() {
   QSettings settings;
   QString settingsGroup = "CustomInterfaces/IndirectAnalysis/";
-  QString saveDir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"));
+  QString saveDir = QString::fromStdString(
+      Mantid::Kernel::ConfigService::Instance().getString(
+          "defaultsave.directory"));
 
   settings.beginGroup(settingsGroup + "ProcessedFiles");
   settings.setValue("last_directory", saveDir);
 
-	std::map<unsigned int, IndirectBayesTab*>::iterator iter;
-	for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter)
-	{
-  	iter->second->loadSettings(settings);
+  std::map<unsigned int, IndirectBayesTab *>::iterator iter;
+  for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter) {
+    iter->second->loadSettings(settings);
   }
 
   settings.endGroup();
 }
 
-
 /**
  * Slot to run the underlying algorithm code based on the currently selected
  * tab.
- * 
+ *
  * This method checks the tabs validate method is passing before calling
  * the run method.
  */
-void IndirectBayes::runClicked()
-{
-	int tabIndex = m_uiForm.indirectBayesTabs->currentIndex();
+void IndirectBayes::runClicked() {
+  int tabIndex = m_uiForm.indirectBayesTabs->currentIndex();
 
-	if(m_bayesTabs[tabIndex]->validateTab())
-	{
-		m_bayesTabs[tabIndex]->runTab();
-	}
+  if (m_bayesTabs[tabIndex]->validateTab()) {
+    m_bayesTabs[tabIndex]->runTab();
+  }
 }
 
 /**
  * Slot to open a new browser window and navigate to the help page
  * on the wiki for the currently selected tab.
  */
-void IndirectBayes::helpClicked()
-{
-  MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Indirect_Bayes"));
+void IndirectBayes::helpClicked() {
+  MantidQt::API::HelpWindow::showCustomInterface(NULL,
+                                                 QString("Indirect_Bayes"));
 }
 
 /**
  * Slot to show the manage user dicrectories dialog when the user clicks
  * the button on the interface.
  */
-void IndirectBayes::manageUserDirectories()
-{
-  MantidQt::API::ManageUserDirectories *ad = new MantidQt::API::ManageUserDirectories(this);
+void IndirectBayes::manageUserDirectories() {
+  MantidQt::API::ManageUserDirectories *ad =
+      new MantidQt::API::ManageUserDirectories(this);
   ad->show();
   ad->setFocus();
 }
@@ -139,14 +136,11 @@ void IndirectBayes::manageUserDirectories()
 /**
  * Slot to wrap the protected showInformationBox method defined
  * in UserSubWindow and provide access to composed tabs.
- * 
+ *
  * @param message :: The message to display in the message box
  */
-void IndirectBayes::showMessageBox(const QString& message)
-{
+void IndirectBayes::showMessageBox(const QString &message) {
   showInformationBox(message);
 }
 
-IndirectBayes::~IndirectBayes()
-{
-}
+IndirectBayes::~IndirectBayes() {}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectBayesTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectBayesTab.cpp
@@ -6,115 +6,35 @@
 
 using MantidQt::MantidWidgets::RangeSelector;
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
+namespace MantidQt {
+namespace CustomInterfaces {
 
-    //----------------------------------------------------------------------------------------------
-    /** Constructor
-     */
-    IndirectBayesTab::IndirectBayesTab(QWidget * parent) : IndirectTab(parent),
-      m_propTree(new QtTreePropertyBrowser())
-    {
-      m_propTree->setFactoryForManager(m_dblManager, m_dblEdFac);
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectBayesTab::IndirectBayesTab(QWidget *parent)
+    : IndirectTab(parent), m_propTree(new QtTreePropertyBrowser()) {
+  m_propTree->setFactoryForManager(m_dblManager, m_dblEdFac);
 
-      // Connect double maneger signals
-      connect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(updateProperties(QtProperty*, double)));
-    }
+  // Connect double maneger signals
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(updateProperties(QtProperty *, double)));
+}
 
-    //----------------------------------------------------------------------------------------------
-    /** Destructor
-     */
-    IndirectBayesTab::~IndirectBayesTab()
-    {
-    }
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+IndirectBayesTab::~IndirectBayesTab() {}
 
-    /**
-     * Emits a signal to run a python script using the method in the parent
-     * UserSubWindow
-     *
-     * @param pyInput :: A string of python code to execute
-     */
-    void IndirectBayesTab::runPythonScript(const QString& pyInput)
-    {
-      emit runAsPythonScript(pyInput, true);
-    }
+/**
+ * Emits a signal to run a python script using the method in the parent
+ * UserSubWindow
+ *
+ * @param pyInput :: A string of python code to execute
+ */
+void IndirectBayesTab::runPythonScript(const QString &pyInput) {
+  emit runAsPythonScript(pyInput, true);
+}
 
-    /**
-     * Checks the workspace's intrument for a resolution parameter to use as
-     * a default for the energy range on the mini plot
-     *
-     * @param workspace :: Name of the workspace to use
-     * @param res :: The retrieved values for the resolution parameter (if one was found)
-     */
-    bool IndirectBayesTab::getInstrumentResolution(const QString& workspace, QPair<double, double> & res)
-    {
-      auto ws = Mantid::API::AnalysisDataService::Instance().retrieveWS<const Mantid::API::MatrixWorkspace>(workspace.toStdString());
-      return getInstrumentResolution(ws, res);
-    }
-
-    /**
-     * Checks the workspace's intrument for a resolution parameter to use as
-     * a default for the energy range on the mini plot
-     *
-     * @param ws :: Pointer to the workspace to use
-     * @param res :: The retrieved values for the resolution parameter (if one was found)
-     */
-    bool IndirectBayesTab::getInstrumentResolution(Mantid::API::MatrixWorkspace_const_sptr ws, QPair<double, double> & res)
-    {
-      auto inst = ws->getInstrument();
-      auto analyser = inst->getStringParameter("analyser");
-
-      if(analyser.size() > 0)
-      {
-        auto comp = inst->getComponentByName(analyser[0]);
-        auto params = comp->getNumberParameter("resolution", true);
-
-        //set the default instrument resolution
-        if(params.size() > 0)
-        {
-          res = qMakePair(-params[0], params[0]);
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    /**
-     * Set the position of the lower guide on the mini plot
-     *
-     * @param rs :: Range selector to update
-     * @param lower :: The lower guide property in the property browser
-     * @param upper :: The upper guide property in the property browser
-     * @param value :: The value of the lower guide
-     */
-    void IndirectBayesTab::updateLowerGuide(RangeSelector* rs, QtProperty* lower, QtProperty* upper, double value)
-    {
-      // Check if the user is setting the max less than the min
-      if(value > m_dblManager->value(upper))
-        m_dblManager->setValue(lower, m_dblManager->value(upper));
-      else
-        rs->setMinimum(value);
-    }
-
-    /**
-     * Set the position of the upper guide on the mini plot
-     *
-     * @param rs :: Range selector to update
-     * @param lower :: The lower guide property in the property browser
-     * @param upper :: The upper guide property in the property browser
-     * @param value :: The value of the upper guide
-     */
-    void IndirectBayesTab::updateUpperGuide(RangeSelector* rs, QtProperty* lower, QtProperty* upper, double value)
-    {
-      // Check if the user is setting the min greater than the max
-      if(value < m_dblManager->value(lower))
-        m_dblManager->setValue(upper, m_dblManager->value(lower));
-      else
-        rs->setMaximum(value);
-    }
-
-  }
+}
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
@@ -3,12 +3,6 @@
 //----------------------
 #include "MantidQtCustomInterfaces/Indirect/IndirectCorrections.h"
 
-// IndirectDataAnalysisTab subclasses:
-#include "MantidQtCustomInterfaces/Indirect/Elwin.h"
-#include "MantidQtCustomInterfaces/Indirect/MSDFit.h"
-#include "MantidQtCustomInterfaces/Indirect/Iqt.h"
-#include "MantidQtCustomInterfaces/Indirect/IqtFit.h"
-#include "MantidQtCustomInterfaces/Indirect/ConvFit.h"
 #include "MantidQtCustomInterfaces/Indirect/CalcCorr.h"
 #include "MantidQtCustomInterfaces/Indirect/ApplyCorr.h"
 #include "MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h"

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataAnalysis.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectDataAnalysis.cpp
@@ -3,15 +3,12 @@
 //----------------------
 #include "MantidQtCustomInterfaces/Indirect/IndirectDataAnalysis.h"
 
-// IndirectDataAnalysisTab subclasses:
 #include "MantidQtCustomInterfaces/Indirect/Elwin.h"
 #include "MantidQtCustomInterfaces/Indirect/MSDFit.h"
 #include "MantidQtCustomInterfaces/Indirect/Iqt.h"
 #include "MantidQtCustomInterfaces/Indirect/IqtFit.h"
+#include "MantidQtCustomInterfaces/Indirect/JumpFit.h"
 #include "MantidQtCustomInterfaces/Indirect/ConvFit.h"
-#include "MantidQtCustomInterfaces/Indirect/CalcCorr.h"
-#include "MantidQtCustomInterfaces/Indirect/ApplyCorr.h"
-#include "MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h"
 
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtAPI/ManageUserDirectories.h"
@@ -21,156 +18,157 @@
 #include <QDesktopServices>
 #include <QUrl>
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-namespace IDA
-{
-  // Add this class to the list of specialised dialogs in this namespace
-  DECLARE_SUBWINDOW(IndirectDataAnalysis)
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+// Add this class to the list of specialised dialogs in this namespace
+DECLARE_SUBWINDOW(IndirectDataAnalysis)
 
-  /**
-   * Constructor.
-   *
-   * @param parent :: the parent QWidget.
-   */
-  IndirectDataAnalysis::IndirectDataAnalysis(QWidget *parent) :
-    UserSubWindow(parent),
-    m_valInt(NULL), m_valDbl(NULL),
-    m_changeObserver(*this, &IndirectDataAnalysis::handleDirectoryChange)
-  {
-    m_uiForm.setupUi(this);
+/**
+ * Constructor.
+ *
+ * @param parent :: the parent QWidget.
+ */
+IndirectDataAnalysis::IndirectDataAnalysis(QWidget *parent)
+    : UserSubWindow(parent), m_valInt(NULL), m_valDbl(NULL),
+      m_changeObserver(*this, &IndirectDataAnalysis::handleDirectoryChange) {
+  m_uiForm.setupUi(this);
 
-    // Allows us to get a handle on a tab using an enum, for example "m_tabs[ELWIN]".
-    // All tabs MUST appear here to be shown in interface.
-    // We make the assumption that each map key corresponds to the order in which the tabs appear.
-    m_tabs.insert(std::make_pair(ELWIN,      new Elwin(m_uiForm.twIDATabs->widget(ELWIN))));
-    m_tabs.insert(std::make_pair(MSD_FIT,    new MSDFit(m_uiForm.twIDATabs->widget(MSD_FIT))));
-    m_tabs.insert(std::make_pair(IQT,        new Iqt(m_uiForm.twIDATabs->widget(IQT))));
-    m_tabs.insert(std::make_pair(IQT_FIT,    new IqtFit(m_uiForm.twIDATabs->widget(IQT_FIT))));
-    m_tabs.insert(std::make_pair(CONV_FIT,   new ConvFit(m_uiForm.twIDATabs->widget(CONV_FIT))));
-  }
+  // Allows us to get a handle on a tab using an enum, for example
+  // "m_tabs[ELWIN]".
+  // All tabs MUST appear here to be shown in interface.
+  // We make the assumption that each map key corresponds to the order in which
+  // the tabs appear.
+  m_tabs.insert(
+      std::make_pair(ELWIN, new Elwin(m_uiForm.twIDATabs->widget(ELWIN))));
+  m_tabs.insert(
+      std::make_pair(MSD_FIT, new MSDFit(m_uiForm.twIDATabs->widget(MSD_FIT))));
+  m_tabs.insert(std::make_pair(IQT, new Iqt(m_uiForm.twIDATabs->widget(IQT))));
+  m_tabs.insert(
+      std::make_pair(IQT_FIT, new IqtFit(m_uiForm.twIDATabs->widget(IQT_FIT))));
+  m_tabs.insert(std::make_pair(
+      CONV_FIT, new ConvFit(m_uiForm.twIDATabs->widget(CONV_FIT))));
+  m_tabs.insert(std::make_pair(
+      JUMP_FIT, new JumpFit(m_uiForm.twIDATabs->widget(JUMP_FIT))));
+}
 
-  /**
-   * @param :: the detected close event
-   */
-  void IndirectDataAnalysis::closeEvent(QCloseEvent*)
-  {
-    Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
-  }
+/**
+ * @param :: the detected close event
+ */
+void IndirectDataAnalysis::closeEvent(QCloseEvent *) {
+  Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
+}
 
-  /**
-   * Handles a change in directory.
-   *
-   * @param pNf :: notification
-   */
-  void IndirectDataAnalysis::handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf)
-  {
-    std::string key = pNf->key();
+/**
+ * Handles a change in directory.
+ *
+ * @param pNf :: notification
+ */
+void IndirectDataAnalysis::handleDirectoryChange(
+    Mantid::Kernel::ConfigValChangeNotification_ptr pNf) {
+  std::string key = pNf->key();
 
-    if ( key == "defaultsave.directory" )
-      loadSettings();
-  }
-
-  /**
-   * Initialised the layout of the interface.  MUST be called.
-   */
-  void IndirectDataAnalysis::initLayout()
-  {
-    // Connect Poco Notification Observer
-    Mantid::Kernel::ConfigService::Instance().addObserver(m_changeObserver);
-
-    // Set up all tabs
-    for(auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab)
-    {
-      tab->second->setupTab();
-      connect(tab->second, SIGNAL(runAsPythonScript(const QString&, bool)), this, SIGNAL(runAsPythonScript(const QString&, bool)));
-      connect(tab->second, SIGNAL(showMessageBox(const QString&)), this, SLOT(showMessageBox(const QString&)));
-    }
-
-    connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));
-    connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-    connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
-    connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(openDirectoryDialog()));
-  }
-
-  /**
-   * Allow Python to be called locally.
-   */
-  void IndirectDataAnalysis::initLocalPython()
-  {
-    QString pyInput = "from mantid.simpleapi import *";
-    QString pyOutput = runPythonCode(pyInput).trimmed();
+  if (key == "defaultsave.directory")
     loadSettings();
+}
+
+/**
+ * Initialised the layout of the interface.  MUST be called.
+ */
+void IndirectDataAnalysis::initLayout() {
+  // Connect Poco Notification Observer
+  Mantid::Kernel::ConfigService::Instance().addObserver(m_changeObserver);
+
+  // Set up all tabs
+  for (auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab) {
+    tab->second->setupTab();
+    connect(tab->second, SIGNAL(runAsPythonScript(const QString &, bool)), this,
+            SIGNAL(runAsPythonScript(const QString &, bool)));
+    connect(tab->second, SIGNAL(showMessageBox(const QString &)), this,
+            SLOT(showMessageBox(const QString &)));
   }
 
-  /**
-   * Load the settings saved for this interface.
-   */
-  void IndirectDataAnalysis::loadSettings()
-  {
-    QSettings settings;
-    QString settingsGroup = "CustomInterfaces/IndirectAnalysis/";
-    QString saveDir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"));
+  connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
+          SLOT(exportTabPython()));
+  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
+  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
+          SLOT(openDirectoryDialog()));
+}
 
-    settings.beginGroup(settingsGroup + "ProcessedFiles");
-    settings.setValue("last_directory", saveDir);
+/**
+ * Allow Python to be called locally.
+ */
+void IndirectDataAnalysis::initLocalPython() {
+  QString pyInput = "from mantid.simpleapi import *";
+  QString pyOutput = runPythonCode(pyInput).trimmed();
+  loadSettings();
+}
 
-    // Load each tab's settings.
-    auto tab = m_tabs.begin();
-    for( ; tab != m_tabs.end(); ++tab )
-      tab->second->loadTabSettings(settings);
+/**
+ * Load the settings saved for this interface.
+ */
+void IndirectDataAnalysis::loadSettings() {
+  QSettings settings;
+  QString settingsGroup = "CustomInterfaces/IndirectAnalysis/";
+  QString saveDir = QString::fromStdString(
+      Mantid::Kernel::ConfigService::Instance().getString(
+          "defaultsave.directory"));
 
-    settings.endGroup();
-  }
+  settings.beginGroup(settingsGroup + "ProcessedFiles");
+  settings.setValue("last_directory", saveDir);
 
-  /**
-   * Private slot, called when the Run button is pressed.  Runs current tab.
-   */
-  void IndirectDataAnalysis::run()
-  {
-    const unsigned int currentTab = m_uiForm.twIDATabs->currentIndex();
-    m_tabs[currentTab]->runTab();
-  }
+  // Load each tab's settings.
+  auto tab = m_tabs.begin();
+  for (; tab != m_tabs.end(); ++tab)
+    tab->second->loadTabSettings(settings);
 
-  /**
-   * Opens a directory dialog.
-   */
-  void IndirectDataAnalysis::openDirectoryDialog()
-  {
-    MantidQt::API::ManageUserDirectories *ad = new MantidQt::API::ManageUserDirectories(this);
-    ad->show();
-    ad->setFocus();
-  }
+  settings.endGroup();
+}
 
-  /**
-   * Opens the Mantid Wiki web page of the current tab.
-   */
-  void IndirectDataAnalysis::help()
-  {
-    MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Indirect_DataAnalysis"));
-  }
+/**
+ * Private slot, called when the Run button is pressed.  Runs current tab.
+ */
+void IndirectDataAnalysis::run() {
+  const unsigned int currentTab = m_uiForm.twIDATabs->currentIndex();
+  m_tabs[currentTab]->runTab();
+}
 
-  /**
-   * Handles exporting a Python script for the current tab.
-   */
-  void IndirectDataAnalysis::exportTabPython()
-  {
-    unsigned int currentTab = m_uiForm.twIDATabs->currentIndex();
-    m_tabs[currentTab]->exportPythonScript();
-  }
+/**
+ * Opens a directory dialog.
+ */
+void IndirectDataAnalysis::openDirectoryDialog() {
+  MantidQt::API::ManageUserDirectories *ad =
+      new MantidQt::API::ManageUserDirectories(this);
+  ad->show();
+  ad->setFocus();
+}
 
-  /**
-   * Slot to wrap the protected showInformationBox method defined
-   * in UserSubWindow and provide access to composed tabs.
-   *
-   * @param message The message to display in the message box
-   */
-  void IndirectDataAnalysis::showMessageBox(const QString& message)
-  {
-    showInformationBox(message);
-  }
+/**
+ * Opens the Mantid Wiki web page of the current tab.
+ */
+void IndirectDataAnalysis::help() {
+  MantidQt::API::HelpWindow::showCustomInterface(
+      NULL, QString("Indirect_DataAnalysis"));
+}
+
+/**
+ * Handles exporting a Python script for the current tab.
+ */
+void IndirectDataAnalysis::exportTabPython() {
+  unsigned int currentTab = m_uiForm.twIDATabs->currentIndex();
+  m_tabs[currentTab]->exportPythonScript();
+}
+
+/**
+ * Slot to wrap the protected showInformationBox method defined
+ * in UserSubWindow and provide access to composed tabs.
+ *
+ * @param message The message to display in the message box
+ */
+void IndirectDataAnalysis::showMessageBox(const QString &message) {
+  showInformationBox(message);
+}
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectTab.cpp
@@ -13,506 +13,519 @@ using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 using namespace MantidQt::MantidWidgets;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("IndirectTab");
+namespace {
+Mantid::Kernel::Logger g_log("IndirectTab");
 }
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  //----------------------------------------------------------------------------------------------
-  /** Constructor
-   */
-  IndirectTab::IndirectTab(QObject* parent) : QObject(parent),
-      m_properties(),
-      m_dblManager(new QtDoublePropertyManager()), m_blnManager(new QtBoolPropertyManager()), m_grpManager(new QtGroupPropertyManager()),
-      m_dblEdFac(new DoubleEditorFactory()),
-      m_pythonRunner(),
-      m_tabStartTime(DateAndTime::getCurrentTime()), m_tabEndTime(DateAndTime::maximum())
-  {
-    m_parentWidget = dynamic_cast<QWidget *>(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectTab::IndirectTab(QObject *parent)
+    : QObject(parent), m_properties(),
+      m_dblManager(new QtDoublePropertyManager()),
+      m_blnManager(new QtBoolPropertyManager()),
+      m_grpManager(new QtGroupPropertyManager()),
+      m_dblEdFac(new DoubleEditorFactory()), m_pythonRunner(),
+      m_tabStartTime(DateAndTime::getCurrentTime()),
+      m_tabEndTime(DateAndTime::maximum()) {
+  m_parentWidget = dynamic_cast<QWidget *>(parent);
 
-    m_batchAlgoRunner = new MantidQt::API::BatchAlgorithmRunner(m_parentWidget);
-    m_valInt = new QIntValidator(m_parentWidget);
-    m_valDbl = new QDoubleValidator(m_parentWidget);
-    m_valPosDbl = new QDoubleValidator(m_parentWidget);
+  m_batchAlgoRunner = new MantidQt::API::BatchAlgorithmRunner(m_parentWidget);
+  m_valInt = new QIntValidator(m_parentWidget);
+  m_valDbl = new QDoubleValidator(m_parentWidget);
+  m_valPosDbl = new QDoubleValidator(m_parentWidget);
 
-    const double tolerance = 0.00001;
-    m_valPosDbl->setBottom(tolerance);
+  const double tolerance = 0.00001;
+  m_valPosDbl->setBottom(tolerance);
 
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmFinished(bool)));
-    connect(&m_pythonRunner, SIGNAL(runAsPythonScript(const QString&, bool)), this, SIGNAL(runAsPythonScript(const QString&, bool)));
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(algorithmFinished(bool)));
+  connect(&m_pythonRunner, SIGNAL(runAsPythonScript(const QString &, bool)),
+          this, SIGNAL(runAsPythonScript(const QString &, bool)));
+}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+IndirectTab::~IndirectTab() {}
+
+void IndirectTab::runTab() {
+  if (validate()) {
+    m_tabStartTime = DateAndTime::getCurrentTime();
+    run();
+  } else {
+    g_log.warning("Failed to validate indirect tab input!");
+  }
+}
+
+void IndirectTab::setupTab() { setup(); }
+
+bool IndirectTab::validateTab() { return validate(); }
+
+/**
+ * Handles generating a Python script for the algorithms run on the current tab.
+ */
+void IndirectTab::exportPythonScript() {
+  g_log.information() << "Python export for workspace: " << m_pythonExportWsName
+                      << ", between " << m_tabStartTime << " and "
+                      << m_tabEndTime << std::endl;
+
+  // Take the search times to be a second either side of the actual times, just
+  // in case
+  DateAndTime startSearchTime = m_tabStartTime - 1.0;
+  DateAndTime endSearchTime = m_tabEndTime + 1.0;
+
+  // Don't let the user change the time range
+  QStringList enabled;
+  enabled << "Filename"
+          << "InputWorkspace"
+          << "UnrollAll"
+          << "SpecifyAlgorithmVersions";
+
+  // Give some indication to the user that they will have to specify the
+  // workspace
+  if (m_pythonExportWsName.empty())
+    g_log.warning("This tab has not specified a result workspace name.");
+
+  // Set default properties
+  QHash<QString, QString> props;
+  props["Filename"] = "IndirectInterfacePythonExport.py";
+  props["InputWorkspace"] = QString::fromStdString(m_pythonExportWsName);
+  props["SpecifyAlgorithmVersions"] = "Specify All";
+  props["UnrollAll"] = "1";
+  props["StartTimestamp"] =
+      QString::fromStdString(startSearchTime.toISO8601String());
+  props["EndTimestamp"] =
+      QString::fromStdString(endSearchTime.toISO8601String());
+
+  // Create an algorithm dialog for the script export algorithm
+  MantidQt::API::InterfaceManager interfaceManager;
+  MantidQt::API::AlgorithmDialog *dlg = interfaceManager.createDialogFromName(
+      "GeneratePythonScript", -1, NULL, false, props, "", enabled);
+
+  // Show the dialog
+  dlg->show();
+  dlg->raise();
+  dlg->activateWindow();
+}
+
+/**
+ * Run the load algorithm with the supplied filename and spectrum range
+ *
+ * @param filename :: The name of the file to load
+ * @param outputName :: The name of the output workspace
+ * @param specMin :: Lower spectra bound
+ * @param specMax :: Upper spectra bound
+ * @return If the algorithm was successful
+ */
+bool IndirectTab::loadFile(const QString &filename, const QString &outputName,
+                           const int specMin, const int specMax) {
+  Algorithm_sptr load =
+      AlgorithmManager::Instance().createUnmanaged("Load", -1);
+  load->initialize();
+
+  load->setProperty("Filename", filename.toStdString());
+  load->setProperty("OutputWorkspace", outputName.toStdString());
+
+  if (specMin != -1)
+    load->setPropertyValue("SpectrumMin",
+                           boost::lexical_cast<std::string>(specMin));
+
+  if (specMax != -1)
+    load->setPropertyValue("SpectrumMax",
+                           boost::lexical_cast<std::string>(specMax));
+
+  load->execute();
+
+  // If reloading fails we're out of options
+  return load->isExecuted();
+}
+
+/**
+ * Configures the SaveNexusProcessed algorithm to save a workspace in the
+ *default
+ * save directory and adds the algorithm to the batch queue.
+ *
+ * This uses the plotSpectrum function from the Python API.
+ *
+ * @param wsName Name of workspace to save
+ * @param filename Name of file to save as (including extension)
+ */
+void IndirectTab::addSaveWorkspaceToQueue(const QString &wsName,
+                                          const QString &filename) {
+  // Setup the input workspace property
+  API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
+  saveProps["InputWorkspace"] = wsName.toStdString();
+
+  // Setup the algorithm
+  IAlgorithm_sptr saveAlgo =
+      AlgorithmManager::Instance().create("SaveNexusProcessed");
+  saveAlgo->initialize();
+
+  if (filename.isEmpty())
+    saveAlgo->setProperty("Filename", wsName.toStdString() + ".nxs");
+  else
+    saveAlgo->setProperty("Filename", filename.toStdString());
+
+  // Add the save algorithm to the batch
+  m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+}
+
+/**
+ * Gets the suffix of a workspace (i.e. part after last underscore (red, sqw)).
+ *
+ * @param wsName Name of workspace
+ * @return Suffix, or empty string if no underscore
+ */
+QString IndirectTab::getWorkspaceSuffix(const QString &wsName) {
+  int lastUnderscoreIndex = wsName.lastIndexOf("_");
+  if (lastUnderscoreIndex == -1)
+    return QString();
+
+  return wsName.right(lastUnderscoreIndex);
+}
+
+/**
+ * Returns the basename of a workspace (i.e. the part before the last
+ *underscore)
+ *
+ * e.g. basename of irs26176_graphite002_red is irs26176_graphite002
+ *
+ * @param wsName Name of workspace
+ * @return Base name, or wsName if no underscore
+ */
+QString IndirectTab::getWorkspaceBasename(const QString &wsName) {
+  int lastUnderscoreIndex = wsName.lastIndexOf("_");
+  if (lastUnderscoreIndex == -1)
+    return QString(wsName);
+
+  return wsName.left(lastUnderscoreIndex);
+}
+
+/**
+ * Creates a spectrum plot of one or more workspaces at a given spectrum
+ * index.
+ *
+ * This uses the plotSpectrum function from the Python API.
+ *
+ * @param workspaceNames List of names of workspaces to plot
+ * @param specIndex Index of spectrum from each workspace to plot
+ */
+void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
+                               int specIndex) {
+  if (workspaceNames.isEmpty())
+    return;
+
+  QString pyInput = "from mantidplot import plotSpectrum\n";
+
+  pyInput += "plotSpectrum(['";
+  pyInput += workspaceNames.join("','");
+  pyInput += "'], ";
+  pyInput += QString::number(specIndex);
+  pyInput += ")\n";
+
+  m_pythonRunner.runPythonCode(pyInput);
+}
+
+/**
+ * Creates a spectrum plot of a single workspace at a given spectrum
+ * index.
+ *
+ * @param workspaceName Names of workspace to plot
+ * @param specIndex Index of spectrum to plot
+ */
+void IndirectTab::plotSpectrum(const QString &workspaceName, int specIndex) {
+  if (workspaceName.isEmpty())
+    return;
+
+  QStringList workspaceNames;
+  workspaceNames << workspaceName;
+  plotSpectrum(workspaceNames, specIndex);
+}
+
+/**
+ * Creates a spectrum plot of one or more workspaces with the range of
+ * spectra [specStart, specEnd)
+ *
+ * This uses the plotSpectrum function from the Python API.
+ *
+ * @param workspaceNames List of names of workspaces to plot
+ * @param specStart Range start index
+ * @param specEnd Range end index
+ */
+void IndirectTab::plotSpectrum(const QStringList &workspaceNames, int specStart,
+                               int specEnd) {
+  if (workspaceNames.isEmpty())
+    return;
+
+  QString pyInput = "from mantidplot import plotSpectrum\n";
+
+  pyInput += "plotSpectrum(['";
+  pyInput += workspaceNames.join("','");
+  pyInput += "'], range(";
+  pyInput += QString::number(specStart);
+  pyInput += ",";
+  pyInput += QString::number(specEnd + 1);
+  pyInput += "))\n";
+
+  m_pythonRunner.runPythonCode(pyInput);
+}
+
+/**
+ * Creates a spectrum plot of a single workspace with the range of
+ * spectra [specStart, specEnd)
+ *
+ * This uses the plotSpectrum function from the Python API.
+ *
+ * @param workspaceName Names of workspace to plot
+ * @param specStart Range start index
+ * @param specEnd Range end index
+ */
+void IndirectTab::plotSpectrum(const QString &workspaceName, int specStart,
+                               int specEnd) {
+  if (workspaceName.isEmpty())
+    return;
+
+  QStringList workspaceNames;
+  workspaceNames << workspaceName;
+  plotSpectrum(workspaceNames, specStart, specEnd);
+}
+
+/**
+ * Plots a contour (2D) plot of a given workspace.
+ *
+ * This uses the plot2D function from the Python API.
+ *
+ * @param workspaceName Name of workspace to plot
+ */
+void IndirectTab::plot2D(const QString &workspaceName) {
+  if (workspaceName.isEmpty())
+    return;
+
+  QString pyInput = "from mantidplot import plot2D\n";
+
+  pyInput += "plot2D('";
+  pyInput += workspaceName;
+  pyInput += "')\n";
+
+  m_pythonRunner.runPythonCode(pyInput);
+}
+
+/**
+ * Creates a time bin plot of one or more workspaces at a given spectrum
+ * index.
+ *
+ * This uses the plotTimeBin function from the Python API.
+ *
+ * @param workspaceNames List of names of workspaces to plot
+ * @param specIndex Index of spectrum from each workspace to plot
+ */
+void IndirectTab::plotTimeBin(const QStringList &workspaceNames,
+                              int specIndex) {
+  if (workspaceNames.isEmpty())
+    return;
+
+  QString pyInput = "from mantidplot import plotTimeBin\n";
+
+  pyInput += "plotTimeBin(['";
+  pyInput += workspaceNames.join("','");
+  pyInput += "'], ";
+  pyInput += QString::number(specIndex);
+  pyInput += ")\n";
+
+  m_pythonRunner.runPythonCode(pyInput);
+}
+
+/**
+ * Creates a time bin plot of a single workspace at a given spectrum
+ * index.
+ *
+ * @param workspaceName Names of workspace to plot
+ * @param specIndex Index of spectrum to plot
+ */
+void IndirectTab::plotTimeBin(const QString &workspaceName, int specIndex) {
+  if (workspaceName.isEmpty())
+    return;
+
+  QStringList workspaceNames;
+  workspaceNames << workspaceName;
+  plotTimeBin(workspaceNames, specIndex);
+}
+
+/**
+ * Sets the edge bounds of plot to prevent the user inputting invalid values
+ * Also sets limits for range selector movement
+ *
+ * @param rs :: Pointer to the RangeSelector
+ * @param min :: The lower bound property in the property browser
+ * @param max :: The upper bound property in the property browser
+ * @param bounds :: The upper and lower bounds to be set
+ */
+void IndirectTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min,
+                                       QtProperty *max,
+                                       const QPair<double, double> &bounds) {
+  m_dblManager->setMinimum(min, bounds.first);
+  m_dblManager->setMaximum(min, bounds.second);
+  m_dblManager->setMinimum(max, bounds.first);
+  m_dblManager->setMaximum(max, bounds.second);
+  rs->setRange(bounds.first, bounds.second);
+}
+
+/**
+ * Set the position of the range selectors on the mini plot
+ *
+ * @param rs :: Pointer to the RangeSelector
+ * @param lower :: The lower bound property in the property browser
+ * @param upper :: The upper bound property in the property browser
+ * @param bounds :: The upper and lower bounds to be set
+ */
+void IndirectTab::setRangeSelector(RangeSelector *rs, QtProperty *lower,
+                                   QtProperty *upper,
+                                   const QPair<double, double> &bounds) {
+  m_dblManager->setValue(lower, bounds.first);
+  m_dblManager->setValue(upper, bounds.second);
+  rs->setMinimum(bounds.first);
+  rs->setMaximum(bounds.second);
+}
+
+/**
+ * Gets the energy mode from a workspace based on the X unit.
+ *
+ * Units of dSpacing typically denote diffraction, hence Elastic.
+ * All other units default to spectroscopy, therefore Indirect.
+ *
+ * @param ws Pointer to the workspace
+ * @return Energy mode
+ */
+std::string IndirectTab::getEMode(Mantid::API::MatrixWorkspace_sptr ws) {
+  Mantid::Kernel::Unit_sptr xUnit = ws->getAxis(0)->unit();
+  std::string xUnitName = xUnit->caption();
+
+  g_log.debug() << "X unit name is: " << xUnitName << std::endl;
+
+  if (boost::algorithm::find_first(xUnitName, "d-Spacing"))
+    return "Elastic";
+
+  return "Indirect";
+}
+
+/**
+ * Gets the eFixed value from the workspace using the instrument parameters.
+ *
+ * @param ws Pointer to the workspace
+ * @return eFixed value
+ */
+double IndirectTab::getEFixed(Mantid::API::MatrixWorkspace_sptr ws) {
+  Mantid::Geometry::Instrument_const_sptr inst = ws->getInstrument();
+  if (!inst)
+    throw std::runtime_error("No instrument on workspace");
+
+  // Try to get the parameter form the base instrument
+  if (inst->hasParameter("Efixed"))
+    return inst->getNumberParameter("Efixed")[0];
+
+  // Try to get it form the analyser component
+  if (inst->hasParameter("analyser")) {
+    std::string analyserName = inst->getStringParameter("analyser")[0];
+    auto analyserComp = inst->getComponentByName(analyserName);
+
+    if (analyserComp && analyserComp->hasParameter("Efixed"))
+      return analyserComp->getNumberParameter("Efixed")[0];
   }
 
-
-  //----------------------------------------------------------------------------------------------
-  /** Destructor
-   */
-  IndirectTab::~IndirectTab()
-  {
-  }
-
-
-  void IndirectTab::runTab()
-  {
-    if(validate())
-    {
-      m_tabStartTime = DateAndTime::getCurrentTime();
-      run();
-    }
-    else
-    {
-      g_log.warning("Failed to validate indirect tab input!");
-    }
-  }
-
-
-  void IndirectTab::setupTab()
-  {
-    setup();
-  }
-
-
-  bool IndirectTab::validateTab()
-  {
-    return validate();
-  }
-
-
-  /**
-   * Handles generating a Python script for the algorithms run on the current tab.
-   */
-  void IndirectTab::exportPythonScript()
-  {
-    g_log.information() << "Python export for workspace: " << m_pythonExportWsName <<
-      ", between " << m_tabStartTime << " and " << m_tabEndTime << std::endl;
-
-    // Take the search times to be a second either side of the actual times, just in case
-    DateAndTime startSearchTime = m_tabStartTime - 1.0;
-    DateAndTime endSearchTime = m_tabEndTime + 1.0;
-
-    // Don't let the user change the time range
-    QStringList enabled;
-    enabled << "Filename" << "InputWorkspace" << "UnrollAll" << "SpecifyAlgorithmVersions";
-
-    // Give some indication to the user that they will have to specify the workspace
-    if(m_pythonExportWsName.empty())
-      g_log.warning("This tab has not specified a result workspace name.");
-
-    // Set default properties
-    QHash<QString, QString> props;
-    props["Filename"] = "IndirectInterfacePythonExport.py";
-    props["InputWorkspace"] = QString::fromStdString(m_pythonExportWsName);
-    props["SpecifyAlgorithmVersions"] = "Specify All";
-    props["UnrollAll"] = "1";
-    props["StartTimestamp"] = QString::fromStdString(startSearchTime.toISO8601String());
-    props["EndTimestamp"] = QString::fromStdString(endSearchTime.toISO8601String());
-
-    // Create an algorithm dialog for the script export algorithm
-    MantidQt::API::InterfaceManager interfaceManager;
-    MantidQt::API::AlgorithmDialog *dlg = interfaceManager.createDialogFromName("GeneratePythonScript", -1,
-        NULL, false, props, "", enabled);
-
-    // Show the dialog
-    dlg->show();
-    dlg->raise();
-    dlg->activateWindow();
-  }
-
-
-  /**
-   * Run the load algorithm with the supplied filename and spectrum range
-   *
-   * @param filename :: The name of the file to load
-   * @param outputName :: The name of the output workspace
-   * @param specMin :: Lower spectra bound
-   * @param specMax :: Upper spectra bound
-   * @return If the algorithm was successful
-   */
-  bool IndirectTab::loadFile(const QString& filename, const QString& outputName,
-      const int specMin, const int specMax)
-  {
-    Algorithm_sptr load = AlgorithmManager::Instance().createUnmanaged("Load", -1);
-    load->initialize();
-
-    load->setProperty("Filename", filename.toStdString());
-    load->setProperty("OutputWorkspace", outputName.toStdString());
-
-    if(specMin != -1)
-      load->setPropertyValue("SpectrumMin", boost::lexical_cast<std::string>(specMin));
-
-    if(specMax != -1)
-      load->setPropertyValue("SpectrumMax", boost::lexical_cast<std::string>(specMax));
-
-    load->execute();
-
-    // If reloading fails we're out of options
-    return load->isExecuted();
-  }
-
-
-  /**
-   * Configures the SaveNexusProcessed algorithm to save a workspace in the default
-   * save directory and adds the algorithm to the batch queue.
-   *
-   * This uses the plotSpectrum function from the Python API.
-   *
-   * @param wsName Name of workspace to save
-   * @param filename Name of file to save as (including extension)
-   */
-  void IndirectTab::addSaveWorkspaceToQueue(const QString & wsName, const QString & filename)
-  {
-    // Setup the input workspace property
-    API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
-    saveProps["InputWorkspace"] = wsName.toStdString();
-
-    // Setup the algorithm
-    IAlgorithm_sptr saveAlgo = AlgorithmManager::Instance().create("SaveNexusProcessed");
-    saveAlgo->initialize();
-
-    if(filename.isEmpty())
-      saveAlgo->setProperty("Filename", wsName.toStdString() + ".nxs");
-    else
-      saveAlgo->setProperty("Filename", filename.toStdString());
-
-    // Add the save algorithm to the batch
-    m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
-  }
-
-
-  /**
-   * Gets the suffix of a workspace (i.e. part after last underscore (red, sqw)).
-   *
-   * @param wsName Name of workspace
-   * @return Suffix, or empty string if no underscore
-   */
-  QString IndirectTab:: getWorkspaceSuffix(const QString & wsName)
-  {
-    int lastUnderscoreIndex = wsName.lastIndexOf("_");
-    if(lastUnderscoreIndex == -1)
-      return QString();
-
-    return wsName.right(lastUnderscoreIndex);
-  }
-
-
-  /**
-   * Returns the basename of a workspace (i.e. the part before the last underscore)
-   *
-   * e.g. basename of irs26176_graphite002_red is irs26176_graphite002
-   *
-   * @param wsName Name of workspace
-   * @return Base name, or wsName if no underscore
-   */
-  QString IndirectTab:: getWorkspaceBasename(const QString & wsName)
-  {
-    int lastUnderscoreIndex = wsName.lastIndexOf("_");
-    if(lastUnderscoreIndex == -1)
-      return QString(wsName);
-
-    return wsName.left(lastUnderscoreIndex);
-  }
-
-
-  /**
-   * Creates a spectrum plot of one or more workspaces at a given spectrum
-   * index.
-   *
-   * This uses the plotSpectrum function from the Python API.
-   *
-   * @param workspaceNames List of names of workspaces to plot
-   * @param specIndex Index of spectrum from each workspace to plot
-   */
-  void IndirectTab::plotSpectrum(const QStringList & workspaceNames, int specIndex)
-  {
-    if (workspaceNames.isEmpty())
-      return;
-
-    QString pyInput = "from mantidplot import plotSpectrum\n";
-
-    pyInput += "plotSpectrum(['";
-    pyInput += workspaceNames.join("','");
-    pyInput += "'], ";
-    pyInput += QString::number(specIndex);
-    pyInput += ")\n";
-
-    m_pythonRunner.runPythonCode(pyInput);
-  }
-
-
-  /**
-   * Creates a spectrum plot of a single workspace at a given spectrum
-   * index.
-   *
-   * @param workspaceName Names of workspace to plot
-   * @param specIndex Index of spectrum to plot
-   */
-  void IndirectTab::plotSpectrum(const QString & workspaceName, int specIndex)
-  {
-    if (workspaceName.isEmpty())
-      return;
-
-    QStringList workspaceNames;
-    workspaceNames << workspaceName;
-    plotSpectrum(workspaceNames, specIndex);
-  }
-
-
-  /**
-   * Creates a spectrum plot of one or more workspaces with the range of
-   * spectra [specStart, specEnd)
-   *
-   * This uses the plotSpectrum function from the Python API.
-   *
-   * @param workspaceNames List of names of workspaces to plot
-   * @param specStart Range start index
-   * @param specEnd Range end index
-   */
-  void IndirectTab::plotSpectrum(const QStringList & workspaceNames, int specStart, int specEnd)
-  {
-    if (workspaceNames.isEmpty())
-      return;
-
-    QString pyInput = "from mantidplot import plotSpectrum\n";
-
-    pyInput += "plotSpectrum(['";
-    pyInput += workspaceNames.join("','");
-    pyInput += "'], range(";
-    pyInput += QString::number(specStart);
-    pyInput += ",";
-    pyInput += QString::number(specEnd + 1);
-    pyInput += "))\n";
-
-    m_pythonRunner.runPythonCode(pyInput);
-  }
-
-
-  /**
-   * Creates a spectrum plot of a single workspace with the range of
-   * spectra [specStart, specEnd)
-   *
-   * This uses the plotSpectrum function from the Python API.
-   *
-   * @param workspaceName Names of workspace to plot
-   * @param specStart Range start index
-   * @param specEnd Range end index
-   */
-  void IndirectTab::plotSpectrum(const QString & workspaceName, int specStart, int specEnd)
-  {
-    if (workspaceName.isEmpty())
-      return;
-
-    QStringList workspaceNames;
-    workspaceNames << workspaceName;
-    plotSpectrum(workspaceNames, specStart, specEnd);
-  }
-
-
-  /**
-   * Plots a contour (2D) plot of a given workspace.
-   *
-   * This uses the plot2D function from the Python API.
-   *
-   * @param workspaceName Name of workspace to plot
-   */
-  void IndirectTab::plot2D(const QString & workspaceName)
-  {
-    if (workspaceName.isEmpty())
-      return;
-
-    QString pyInput = "from mantidplot import plot2D\n";
-
-    pyInput += "plot2D('";
-    pyInput += workspaceName;
-    pyInput += "')\n";
-
-    m_pythonRunner.runPythonCode(pyInput);
-  }
-
-
-  /**
-   * Creates a time bin plot of one or more workspaces at a given spectrum
-   * index.
-   *
-   * This uses the plotTimeBin function from the Python API.
-   *
-   * @param workspaceNames List of names of workspaces to plot
-   * @param specIndex Index of spectrum from each workspace to plot
-   */
-  void IndirectTab::plotTimeBin(const QStringList & workspaceNames, int specIndex)
-  {
-    if (workspaceNames.isEmpty())
-      return;
-
-    QString pyInput = "from mantidplot import plotTimeBin\n";
-
-    pyInput += "plotTimeBin(['";
-    pyInput += workspaceNames.join("','");
-    pyInput += "'], ";
-    pyInput += QString::number(specIndex);
-    pyInput += ")\n";
-
-    m_pythonRunner.runPythonCode(pyInput);
-  }
-
-
-  /**
-   * Creates a time bin plot of a single workspace at a given spectrum
-   * index.
-   *
-   * @param workspaceName Names of workspace to plot
-   * @param specIndex Index of spectrum to plot
-   */
-  void IndirectTab::plotTimeBin(const QString & workspaceName, int specIndex)
-  {
-    if (workspaceName.isEmpty())
-      return;
-
-    QStringList workspaceNames;
-    workspaceNames << workspaceName;
-    plotTimeBin(workspaceNames, specIndex);
-  }
-
-
-  /**
-   * Sets the edge bounds of plot to prevent the user inputting invalid values
-   * Also sets limits for range selector movement
-   *
-   * @param rs :: Pointer to the RangeSelector
-   * @param min :: The lower bound property in the property browser
-   * @param max :: The upper bound property in the property browser
-   * @param bounds :: The upper and lower bounds to be set
-   */
-  void IndirectTab::setPlotPropertyRange(RangeSelector * rs, QtProperty* min, QtProperty* max,
-      const QPair<double, double> & bounds)
-  {
-    m_dblManager->setMinimum(min, bounds.first);
-    m_dblManager->setMaximum(min, bounds.second);
-    m_dblManager->setMinimum(max, bounds.first);
-    m_dblManager->setMaximum(max, bounds.second);
-    rs->setRange(bounds.first, bounds.second);
-  }
-
-
-  /**
-   * Set the position of the range selectors on the mini plot
-   *
-   * @param rs :: Pointer to the RangeSelector
-   * @param lower :: The lower bound property in the property browser
-   * @param upper :: The upper bound property in the property browser
-   * @param bounds :: The upper and lower bounds to be set
-   */
-  void IndirectTab::setRangeSelector(RangeSelector * rs, QtProperty* lower, QtProperty* upper,
-      const QPair<double, double> & bounds)
-  {
-    m_dblManager->setValue(lower, bounds.first);
-    m_dblManager->setValue(upper, bounds.second);
-    rs->setMinimum(bounds.first);
-    rs->setMaximum(bounds.second);
-  }
-
-
-  /**
-   * Gets the energy mode from a workspace based on the X unit.
-   *
-   * Units of dSpacing typically denote diffraction, hence Elastic.
-   * All other units default to spectroscopy, therefore Indirect.
-   *
-   * @param ws Pointer to the workspace
-   * @return Energy mode
-   */
-  std::string IndirectTab::getEMode(Mantid::API::MatrixWorkspace_sptr ws)
-  {
-    Mantid::Kernel::Unit_sptr xUnit = ws->getAxis(0)->unit();
-    std::string xUnitName = xUnit->caption();
-
-    g_log.debug() << "X unit name is: " << xUnitName << std::endl;
-
-    if(boost::algorithm::find_first(xUnitName, "d-Spacing"))
-      return "Elastic";
-
-    return "Indirect";
-  }
-
-
-  /**
-   * Gets the eFixed value from the workspace using the instrument parameters.
-   *
-   * @param ws Pointer to the workspace
-   * @return eFixed value
-   */
-  double IndirectTab::getEFixed(Mantid::API::MatrixWorkspace_sptr ws)
-  {
-    Mantid::Geometry::Instrument_const_sptr inst = ws->getInstrument();
-    if(!inst)
-      throw std::runtime_error("No instrument on workspace");
-
-    // Try to get the parameter form the base instrument
-    if(inst->hasParameter("Efixed"))
-      return inst->getNumberParameter("Efixed")[0];
-
-    // Try to get it form the analyser component
-    if(inst->hasParameter("analyser"))
-    {
-      std::string analyserName = inst->getStringParameter("analyser")[0];
-      auto analyserComp = inst->getComponentByName(analyserName);
-
-      if(analyserComp && analyserComp->hasParameter("Efixed"))
-        return analyserComp->getNumberParameter("Efixed")[0];
-    }
-
-    throw std::runtime_error("Instrument has no efixed parameter");
-  }
-
-
-  /**
-   * Runs an algorithm async
-   *
-   * @param algorithm :: The algorithm to be run
-   */
-  void IndirectTab::runAlgorithm(const Mantid::API::IAlgorithm_sptr algorithm)
-  {
-    algorithm->setRethrows(true);
-
-    // There should never really be unexecuted algorithms in the queue, but it is worth warning in case of possible weirdness
-    size_t batchQueueLength = m_batchAlgoRunner->queueLength();
-    if(batchQueueLength > 0)
-      g_log.warning() << "Batch queue already contains " << batchQueueLength << " algorithms!" << std::endl;
-
-    m_batchAlgoRunner->addAlgorithm(algorithm);
-    m_batchAlgoRunner->executeBatchAsync();
-  }
-
-
-  /**
-   * Handles getting the results of an algorithm running async
-   *
-   * @param error :: True if execution failed, false otherwise
-   */
-  void IndirectTab::algorithmFinished(bool error)
-  {
-    m_tabEndTime = DateAndTime::getCurrentTime();
-
-    if(error)
-    {
-      emit showMessageBox("Error running algorithm. \nSee results log for details.");
+  throw std::runtime_error("Instrument has no efixed parameter");
+}
+
+/**
+ * Checks the workspace's intrument for a resolution parameter to use as
+ * a default for the energy range on the mini plot
+ *
+ * @param workspace :: Name of the workspace to use
+ * @param res :: The retrieved values for the resolution parameter (if one was
+ *found)
+ */
+bool IndirectTab::getResolutionRangeFromWs(const QString &workspace,
+                                           QPair<double, double> &res) {
+  auto ws = Mantid::API::AnalysisDataService::Instance()
+                .retrieveWS<const Mantid::API::MatrixWorkspace>(
+                    workspace.toStdString());
+  return getResolutionRangeFromWs(ws, res);
+}
+
+/**
+ * Checks the workspace's intrument for a resolution parameter to use as
+ * a default for the energy range on the mini plot
+ *
+ * @param ws :: Pointer to the workspace to use
+ * @param res :: The retrieved values for the resolution parameter (if one was
+ *found)
+ */
+bool IndirectTab::getResolutionRangeFromWs(
+    Mantid::API::MatrixWorkspace_const_sptr ws, QPair<double, double> &res) {
+  auto inst = ws->getInstrument();
+  auto analyser = inst->getStringParameter("analyser");
+
+  if (analyser.size() > 0) {
+    auto comp = inst->getComponentByName(analyser[0]);
+    if (comp) {
+      auto params = comp->getNumberParameter("resolution", true);
+
+      // set the default instrument resolution
+      if (params.size() > 0) {
+        res = qMakePair(-params[0], params[0]);
+        return true;
+      }
     }
   }
 
+  return false;
+}
 
-  /**
-   * Run Python code and return anything printed to stdout.
-   *
-   * @param code Python code the execute
-   * @param no_output Enable to ignore any output
-   * @returns What was printed to stdout
-   */
-  QString IndirectTab::runPythonCode(QString code, bool no_output)
-  {
-    return m_pythonRunner.runPythonCode(code, no_output);
+/**
+ * Runs an algorithm async
+ *
+ * @param algorithm :: The algorithm to be run
+ */
+void IndirectTab::runAlgorithm(const Mantid::API::IAlgorithm_sptr algorithm) {
+  algorithm->setRethrows(true);
+
+  // There should never really be unexecuted algorithms in the queue, but it is
+  // worth warning in case of possible weirdness
+  size_t batchQueueLength = m_batchAlgoRunner->queueLength();
+  if (batchQueueLength > 0)
+    g_log.warning() << "Batch queue already contains " << batchQueueLength
+                    << " algorithms!" << std::endl;
+
+  m_batchAlgoRunner->addAlgorithm(algorithm);
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Handles getting the results of an algorithm running async
+ *
+ * @param error :: True if execution failed, false otherwise
+ */
+void IndirectTab::algorithmFinished(bool error) {
+  m_tabEndTime = DateAndTime::getCurrentTime();
+
+  if (error) {
+    emit showMessageBox(
+        "Error running algorithm. \nSee results log for details.");
   }
+}
+
+/**
+ * Run Python code and return anything printed to stdout.
+ *
+ * @param code Python code the execute
+ * @param no_output Enable to ignore any output
+ * @returns What was printed to stdout
+ */
+QString IndirectTab::runPythonCode(QString code, bool no_output) {
+  return m_pythonRunner.runPythonCode(code, no_output);
+}
 
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -4,354 +4,351 @@
 
 using namespace Mantid::API;
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
-		Quasi::Quasi(QWidget * parent) :
-			IndirectBayesTab(parent),
-      m_previewSpec(0)
-		{
-			m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+Quasi::Quasi(QWidget *parent) : IndirectBayesTab(parent), m_previewSpec(0) {
+  m_uiForm.setupUi(parent);
 
-      // Create range selector
-      auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("QuasiERange");
-      connect(eRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minValueChanged(double)));
-      connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxValueChanged(double)));
+  // Create range selector
+  auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("QuasiERange");
+  connect(eRangeSelector, SIGNAL(minValueChanged(double)), this,
+          SLOT(minValueChanged(double)));
+  connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this,
+          SLOT(maxValueChanged(double)));
 
-			// Add the properties browser to the UI form
-			m_uiForm.treeSpace->addWidget(m_propTree);
+  // Add the properties browser to the UI form
+  m_uiForm.treeSpace->addWidget(m_propTree);
 
-			m_properties["EMin"] = m_dblManager->addProperty("EMin");
-			m_properties["EMax"] = m_dblManager->addProperty("EMax");
-			m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
-			m_properties["ResBinning"] = m_dblManager->addProperty("Resolution Binning");
+  m_properties["EMin"] = m_dblManager->addProperty("EMin");
+  m_properties["EMax"] = m_dblManager->addProperty("EMax");
+  m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
+  m_properties["ResBinning"] = m_dblManager->addProperty("Resolution Binning");
 
-			m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
-			m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
-			m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
-			m_dblManager->setDecimals(m_properties["ResBinning"], INT_DECIMALS);
+  m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
+  m_dblManager->setDecimals(m_properties["ResBinning"], INT_DECIMALS);
 
-			m_propTree->addProperty(m_properties["EMin"]);
-			m_propTree->addProperty(m_properties["EMax"]);
-			m_propTree->addProperty(m_properties["SampleBinning"]);
-			m_propTree->addProperty(m_properties["ResBinning"]);
+  m_propTree->addProperty(m_properties["EMin"]);
+  m_propTree->addProperty(m_properties["EMax"]);
+  m_propTree->addProperty(m_properties["SampleBinning"]);
+  m_propTree->addProperty(m_properties["ResBinning"]);
 
-			//Set default values
-			m_dblManager->setValue(m_properties["SampleBinning"], 1);
-			m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
-			m_dblManager->setValue(m_properties["ResBinning"], 1);
-			m_dblManager->setMinimum(m_properties["ResBinning"], 1);
+  // Set default values
+  m_dblManager->setValue(m_properties["SampleBinning"], 1);
+  m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
+  m_dblManager->setValue(m_properties["ResBinning"], 1);
+  m_dblManager->setMinimum(m_properties["ResBinning"], 1);
 
-			//Connect optional form elements with enabling checkboxes
-			connect(m_uiForm.chkFixWidth, SIGNAL(toggled(bool)), m_uiForm.mwFixWidthDat, SLOT(setEnabled(bool)));
-			connect(m_uiForm.chkUseResNorm, SIGNAL(toggled(bool)), m_uiForm.dsResNorm, SLOT(setEnabled(bool)));
+  // Connect optional form elements with enabling checkboxes
+  connect(m_uiForm.chkFixWidth, SIGNAL(toggled(bool)), m_uiForm.mwFixWidthDat,
+          SLOT(setEnabled(bool)));
+  connect(m_uiForm.chkUseResNorm, SIGNAL(toggled(bool)), m_uiForm.dsResNorm,
+          SLOT(setEnabled(bool)));
 
-			//Connect the data selector for the sample to the mini plot
-			connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString&)), this, SLOT(handleSampleInputReady(const QString&)));
+  // Connect the data selector for the sample to the mini plot
+  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
+          SLOT(handleSampleInputReady(const QString &)));
 
-      // Connect the progrm selector to its handler
-			connect(m_uiForm.cbProgram, SIGNAL(currentIndexChanged(int)), this, SLOT(handleProgramChange(int)));
+  // Connect the progrm selector to its handler
+  connect(m_uiForm.cbProgram, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(handleProgramChange(int)));
 
-      // Connect preview spectrum spinner to handler
-      connect(m_uiForm.spPreviewSpectrum, SIGNAL(valueChanged(int)), this, SLOT(previewSpecChanged(int)));
-		}
+  // Connect preview spectrum spinner to handler
+  connect(m_uiForm.spPreviewSpectrum, SIGNAL(valueChanged(int)), this,
+          SLOT(previewSpecChanged(int)));
+}
 
-		/**
-		 * Set the data selectors to use the default save directory
-		 * when browsing for input files.
-		 *
-     * @param settings :: The current settings
-		 */
-		void Quasi::loadSettings(const QSettings& settings)
-		{
-			m_uiForm.dsSample->readSettings(settings.group());
-			m_uiForm.dsResolution->readSettings(settings.group());
-			m_uiForm.dsResNorm->readSettings(settings.group());
-			m_uiForm.mwFixWidthDat->readSettings(settings.group());
-		}
+/**
+ * Set the data selectors to use the default save directory
+ * when browsing for input files.
+ *
+* @param settings :: The current settings
+ */
+void Quasi::loadSettings(const QSettings &settings) {
+  m_uiForm.dsSample->readSettings(settings.group());
+  m_uiForm.dsResolution->readSettings(settings.group());
+  m_uiForm.dsResNorm->readSettings(settings.group());
+  m_uiForm.mwFixWidthDat->readSettings(settings.group());
+}
 
-    void Quasi::setup()
-    {
+void Quasi::setup() {}
+
+/**
+ * Validate the form to check the program can be run
+ *
+ * @return :: Whether the form was valid
+ */
+bool Quasi::validate() {
+  UserInputValidator uiv;
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+  uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
+
+  // check that the ResNorm file is valid if we are using it
+  if (m_uiForm.chkUseResNorm->isChecked()) {
+    uiv.checkDataSelectorIsValid("ResNorm", m_uiForm.dsResNorm);
+  }
+
+  // check fixed width file exists
+  if (m_uiForm.chkFixWidth->isChecked() && !m_uiForm.mwFixWidthDat->isValid()) {
+    uiv.checkMWRunFilesIsValid("Width", m_uiForm.mwFixWidthDat);
+  }
+
+  QString errors = uiv.generateErrorMessage();
+  if (!errors.isEmpty()) {
+    emit showMessageBox(errors);
+    return false;
+  }
+
+  QString program = m_uiForm.cbProgram->currentText();
+  if (program == "Stretched Exponential") {
+    QString resName = m_uiForm.dsResolution->getCurrentDataName();
+    if (!resName.endsWith("_res")) {
+      emit showMessageBox("Stretched Exponential program can only be used with "
+                          "a resolution file.");
+      return false;
     }
+  }
 
-		/**
-		 * Validate the form to check the program can be run
-		 *
-		 * @return :: Whether the form was valid
-		 */
-		bool Quasi::validate()
-		{
-			UserInputValidator uiv;
-			uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
-			uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
+  return true;
+}
 
-			//check that the ResNorm file is valid if we are using it
-			if(m_uiForm.chkUseResNorm->isChecked())
-			{
-				uiv.checkDataSelectorIsValid("ResNorm", m_uiForm.dsResNorm);
-			}
+/**
+ * Collect the settings on the GUI and build a python
+ * script that runs Quasi
+ */
+void Quasi::run() {
+  // Using 1/0 instead of True/False for compatibility with underlying Fortran
+  // code
+  // in some places
+  QString save("False");
+  QString elasticPeak("False");
+  QString sequence("False");
 
-			//check fixed width file exists
-			if(m_uiForm.chkFixWidth->isChecked() &&
-					 !m_uiForm.mwFixWidthDat->isValid())
-			{
-				uiv.checkMWRunFilesIsValid("Width", m_uiForm.mwFixWidthDat);
-			}
+  QString fixedWidth("False");
+  QString fixedWidthFile("");
 
-			QString errors = uiv.generateErrorMessage();
-			if (!errors.isEmpty())
-			{
-				emit showMessageBox(errors);
-				return false;
-			}
+  QString useResNorm("False");
+  QString resNormFile("");
 
-			QString program = m_uiForm.cbProgram->currentText();
-      if(program == "Stretched Exponential")
-      {
-			  QString resName = m_uiForm.dsResolution->getCurrentDataName();
-        if(!resName.endsWith("_res"))
-        {
-          emit showMessageBox("Stretched Exponential program can only be used with a resolution file.");
-          return false;
-        }
-      }
+  QString pyInput = "from IndirectBayes import QLRun\n";
 
-			return true;
-		}
+  QString sampleName = m_uiForm.dsSample->getCurrentDataName();
+  QString resName = m_uiForm.dsResolution->getCurrentDataName();
 
-		/**
-		 * Collect the settings on the GUI and build a python
-		 * script that runs Quasi
-		 */
-		void Quasi::run()
-		{
-			// Using 1/0 instead of True/False for compatibility with underlying Fortran code
-			// in some places
-			QString save("False");
-			QString elasticPeak("False");
-			QString sequence("False");
+  QString program = m_uiForm.cbProgram->currentText();
 
-			QString fixedWidth("False");
-			QString fixedWidthFile("");
+  if (program == "Lorentzians") {
+    program = "QL";
+  } else {
+    program = "QSe";
+  }
 
-			QString useResNorm("False");
-			QString resNormFile("");
+  // Collect input from fit options section
+  QString background = m_uiForm.cbBackground->currentText();
 
-			QString pyInput =
-				"from IndirectBayes import QLRun\n";
+  if (m_uiForm.chkElasticPeak->isChecked()) {
+    elasticPeak = "True";
+  }
+  if (m_uiForm.chkSequentialFit->isChecked()) {
+    sequence = "True";
+  }
 
-			QString sampleName = m_uiForm.dsSample->getCurrentDataName();
-			QString resName = m_uiForm.dsResolution->getCurrentDataName();
+  if (m_uiForm.chkFixWidth->isChecked()) {
+    fixedWidth = "True";
+    fixedWidthFile = m_uiForm.mwFixWidthDat->getFirstFilename();
+  }
 
-			QString program = m_uiForm.cbProgram->currentText();
+  if (m_uiForm.chkUseResNorm->isChecked()) {
+    useResNorm = "True";
+    resNormFile = m_uiForm.dsResNorm->getCurrentDataName();
+  }
 
-			if(program == "Lorentzians")
-			{
-				program = "QL";
-			}
-			else
-			{
-				program = "QSe";
-			}
+  QString fitOps = "[" + elasticPeak + ", '" + background + "', " + fixedWidth +
+                   ", " + useResNorm + "]";
 
-			// Collect input from fit options section
-			QString background = m_uiForm.cbBackground->currentText();
+  // Collect input from the properties browser
+  QString eMin = m_properties["EMin"]->valueText();
+  QString eMax = m_properties["EMax"]->valueText();
+  QString eRange = "[" + eMin + "," + eMax + "]";
 
-			if(m_uiForm.chkElasticPeak->isChecked()) { elasticPeak = "True"; }
-			if(m_uiForm.chkSequentialFit->isChecked()) { sequence = "True"; }
+  QString sampleBins = m_properties["SampleBinning"]->valueText();
+  QString resBins = m_properties["ResBinning"]->valueText();
+  QString nBins = "[" + sampleBins + "," + resBins + "]";
 
-			if(m_uiForm.chkFixWidth->isChecked())
-			{
-				fixedWidth = "True";
-				fixedWidthFile = m_uiForm.mwFixWidthDat->getFirstFilename();
-			}
+  // Output options
+  if (m_uiForm.chkSave->isChecked()) {
+    save = "True";
+  }
+  QString plot = m_uiForm.cbPlot->currentText();
 
-			if(m_uiForm.chkUseResNorm->isChecked())
-			{
-				useResNorm = "True";
-				resNormFile = m_uiForm.dsResNorm->getCurrentDataName();
-			}
+  pyInput += "QLRun('" + program + "','" + sampleName + "','" + resName +
+             "','" + resNormFile + "'," + eRange + ","
+                                                   " " +
+             nBins + "," + fitOps + ",'" + fixedWidthFile + "'," + sequence +
+             ", "
+             " Save=" +
+             save + ", Plot='" + plot + "')\n";
 
-			QString fitOps = "[" + elasticPeak + ", '" + background + "', " + fixedWidth + ", " + useResNorm + "]";
+  runPythonScript(pyInput);
 
-			// Collect input from the properties browser
-			QString eMin = m_properties["EMin"]->valueText();
-			QString eMax = m_properties["EMax"]->valueText();
-			QString eRange = "[" + eMin + "," + eMax + "]";
+  updateMiniPlot();
+}
 
-			QString sampleBins = m_properties["SampleBinning"]->valueText();
-			QString resBins = m_properties["ResBinning"]->valueText();
-			QString nBins = "[" + sampleBins + "," + resBins + "]";
+/**
+ * Updates the data and fit curves on the mini plot.
+ */
+void Quasi::updateMiniPlot() {
+  // Update sample plot
+  if (!m_uiForm.dsSample->isValid())
+    return;
 
-			// Output options
-			if(m_uiForm.chkSave->isChecked()) { save = "True"; }
-			QString plot = m_uiForm.cbPlot->currentText();
+  m_uiForm.ppPlot->clear();
 
-			pyInput += "QLRun('"+program+"','"+sampleName+"','"+resName+"','"+resNormFile+"',"+eRange+","
-										" "+nBins+","+fitOps+",'"+fixedWidthFile+"',"+sequence+", "
-										" Save="+save+", Plot='"+plot+"')\n";
+  QString sampleName = m_uiForm.dsSample->getCurrentDataName();
+  m_uiForm.ppPlot->addSpectrum("Sample", sampleName, m_previewSpec);
 
-			runPythonScript(pyInput);
+  // Update fit plot
+  QString program = m_uiForm.cbProgram->currentText();
+  if (program == "Lorentzians")
+    program = "QL";
+  else
+    program = "QSe";
 
-      updateMiniPlot();
-		}
+  QString resName = m_uiForm.dsResolution->getCurrentDataName();
 
-    /**
-     * Updates the data and fit curves on the mini plot.
-     */
-    void Quasi::updateMiniPlot()
-    {
-      // Update sample plot
-      if(!m_uiForm.dsSample->isValid())
-        return;
+  // Should be either "red", "sqw" or "res"
+  QString resType = resName.right(3);
 
-	  m_uiForm.ppPlot->clear();
+  // Get the correct workspace name based on the type of resolution file
+  if (program == "QL") {
+    if (resType == "res")
+      program += "r";
+    else
+      program += "d";
+  }
 
-      QString sampleName = m_uiForm.dsSample->getCurrentDataName();
-	  m_uiForm.ppPlot->addSpectrum("Sample", sampleName, m_previewSpec);
+  QString outWsName = sampleName.left(sampleName.size() - 3) + program +
+                      "_Workspace_" + QString::number(m_previewSpec);
+  if (!AnalysisDataService::Instance().doesExist(outWsName.toStdString()))
+    return;
 
-      // Update fit plot
-			QString program = m_uiForm.cbProgram->currentText();
-			if(program == "Lorentzians")
-				program = "QL";
-			else
-				program = "QSe";
+  MatrixWorkspace_sptr outputWorkspace =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+          outWsName.toStdString());
 
-			QString resName = m_uiForm.dsResolution->getCurrentDataName();
+  TextAxis *axis = dynamic_cast<TextAxis *>(outputWorkspace->getAxis(1));
 
-      // Should be either "red", "sqw" or "res"
-      QString resType = resName.right(3);
+  for (size_t histIndex = 0; histIndex < outputWorkspace->getNumberHistograms();
+       histIndex++) {
+    QString specName = QString::fromStdString(axis->label(histIndex));
+    QColor curveColour;
 
-      // Get the correct workspace name based on the type of resolution file
-      if(program == "QL")
-      {
-        if(resType == "res")
-          program += "r";
-        else
-          program += "d";
-      }
+    if (specName.contains("fit.1"))
+      curveColour = Qt::red;
+    else if (specName.contains("fit.2"))
+      curveColour = Qt::magenta;
 
-      QString outWsName = sampleName.left(sampleName.size() - 3) + program + "_Workspace_" + QString::number(m_previewSpec);
-      if(!AnalysisDataService::Instance().doesExist(outWsName.toStdString()))
-        return;
+    else if (specName.contains("diff.1"))
+      curveColour = Qt::green;
+    else if (specName.contains("diff.2"))
+      curveColour = Qt::cyan;
 
-      MatrixWorkspace_sptr outputWorkspace = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWsName.toStdString());
+    else
+      continue;
 
-      TextAxis* axis = dynamic_cast<TextAxis*>(outputWorkspace->getAxis(1));
+    m_uiForm.ppPlot->addSpectrum(specName, outputWorkspace, histIndex,
+                                 curveColour);
+  }
+}
 
-      for(size_t histIndex = 0; histIndex < outputWorkspace->getNumberHistograms(); histIndex++)
-      {
-        QString specName = QString::fromStdString(axis->label(histIndex));
-        QColor curveColour;
+/**
+ * Plots the loaded file to the miniplot and sets the guides
+ * and the range
+ *
+ * @param filename :: The name of the workspace to plot
+ */
+void Quasi::handleSampleInputReady(const QString &filename) {
+  MatrixWorkspace_sptr inWs =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+          filename.toStdString());
+  int numHist = static_cast<int>(inWs->getNumberHistograms()) - 1;
+  m_uiForm.spPreviewSpectrum->setMaximum(numHist);
+  updateMiniPlot();
 
-        if(specName.contains("fit.1"))
-          curveColour = Qt::red;
-        else if(specName.contains("fit.2"))
-          curveColour = Qt::magenta;
+  QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
+  auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("QuasiERange");
 
-        else if(specName.contains("diff.1"))
-          curveColour = Qt::green;
-        else if(specName.contains("diff.2"))
-          curveColour = Qt::cyan;
+  setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                   range);
+  setPlotPropertyRange(eRangeSelector, m_properties["EMin"],
+                       m_properties["EMax"], range);
+}
 
-        else
-          continue;
+/**
+ * Updates the property manager when the lower guide is moved on the mini plot
+ *
+ * @param min :: The new value of the lower guide
+ */
+void Quasi::minValueChanged(double min) {
+  m_dblManager->setValue(m_properties["EMin"], min);
+}
 
-        m_uiForm.ppPlot->addSpectrum(specName, outputWorkspace, histIndex, curveColour);
-      }
-    }
+/**
+ * Updates the property manager when the upper guide is moved on the mini plot
+ *
+ * @param max :: The new value of the upper guide
+ */
+void Quasi::maxValueChanged(double max) {
+  m_dblManager->setValue(m_properties["EMax"], max);
+}
 
-		/**
-		 * Plots the loaded file to the miniplot and sets the guides
-		 * and the range
-		 *
-		 * @param filename :: The name of the workspace to plot
-		 */
-		void Quasi::handleSampleInputReady(const QString& filename)
-		{
-      MatrixWorkspace_sptr inWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(filename.toStdString());
-      int numHist = static_cast<int>(inWs->getNumberHistograms()) - 1;
-      m_uiForm.spPreviewSpectrum->setMaximum(numHist);
-      updateMiniPlot();
+/**
+ * Handles when properties in the property manager are updated.
+ *
+ * @param prop :: The property being updated
+ * @param val :: The new value for the property
+ */
+void Quasi::updateProperties(QtProperty *prop, double val) {
+  UNUSED_ARG(val);
 
-			QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
-      auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("QuasiERange");
+  auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("QuasiERange");
 
-			setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
-			setPlotPropertyRange(eRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
-		}
+  if (prop == m_properties["EMin"] || prop == m_properties["EMax"]) {
+    auto bounds = qMakePair(m_dblManager->value(m_properties["EMin"]),
+                            m_dblManager->value(m_properties["EMax"]));
+    setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                     bounds);
+  }
+}
 
-		/**
-		 * Updates the property manager when the lower guide is moved on the mini plot
-		 *
-		 * @param min :: The new value of the lower guide
-		 */
-		void Quasi::minValueChanged(double min)
-    {
-      m_dblManager->setValue(m_properties["EMin"], min);
-    }
+/**
+ * Handles when the slected item in the program combobox
+ * is changed
+ *
+ * @param index :: The current index of the combobox
+ */
+void Quasi::handleProgramChange(int index) {
+  int numberOptions = m_uiForm.cbPlot->count();
+  switch (index) {
+  case 0:
+    m_uiForm.cbPlot->setItemText(numberOptions - 1, "Prob");
+    break;
+  case 1:
+    m_uiForm.cbPlot->setItemText(numberOptions - 1, "Beta");
+    break;
+  }
+}
 
-		/**
-		 * Updates the property manager when the upper guide is moved on the mini plot
-		 *
-		 * @param max :: The new value of the upper guide
-		 */
-    void Quasi::maxValueChanged(double max)
-    {
-			m_dblManager->setValue(m_properties["EMax"], max);
-    }
+/**
+ * Handles setting a new preview spectrum on the preview plot.
+ *
+ * @param value Spectrum index
+ */
+void Quasi::previewSpecChanged(int value) {
+  m_previewSpec = value;
+  updateMiniPlot();
+}
 
-		/**
-		 * Handles when properties in the property manager are updated.
-		 *
-		 * @param prop :: The property being updated
-		 * @param val :: The new value for the property
-		 */
-    void Quasi::updateProperties(QtProperty* prop, double val)
-    {
-      auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("QuasiERange");
-
-    	if(prop == m_properties["EMin"])
-    	{
-    		updateLowerGuide(eRangeSelector, m_properties["EMin"], m_properties["EMax"], val);
-    	}
-    	else if (prop == m_properties["EMax"])
-    	{
-				updateUpperGuide(eRangeSelector, m_properties["EMin"], m_properties["EMax"], val);
-    	}
-    }
-
-		/**
-		 * Handles when the slected item in the program combobox
-		 * is changed
-		 *
-		 * @param index :: The current index of the combobox
-		 */
-    void Quasi::handleProgramChange(int index)
-    {
-    	int numberOptions = m_uiForm.cbPlot->count();
-    	switch(index)
-    	{
-    		case 0:
-    			m_uiForm.cbPlot->setItemText(numberOptions-1, "Prob");
-    			break;
-    		case 1:
-    			m_uiForm.cbPlot->setItemText(numberOptions-1, "Beta");
-    			break;
-    	}
-    }
-
-    /**
-     * Handles setting a new preview spectrum on the preview plot.
-     *
-     * @param value Spectrum index
-     */
-    void Quasi::previewSpecChanged(int value)
-    {
-      m_previewSpec = value;
-      updateMiniPlot();
-    }
-
-	} // namespace CustomInterfaces
+} // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -159,7 +159,7 @@ void ResNorm::handleVanadiumInputReady(const QString &filename) {
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("ResNormERange");
 
   // Use the values from the instrument parameter file if we can
-  if (getInstrumentResolution(filename, res)) {
+  if (getResolutionRangeFromWs(filename, res)) {
     // ResNorm resolution should be +/- 10 * the IPF resolution
     res.first = res.first * 10;
     res.second = res.second * 10;
@@ -210,14 +210,15 @@ void ResNorm::maxValueChanged(double max) {
  * @param val :: The new value for the property
  */
 void ResNorm::updateProperties(QtProperty *prop, double val) {
+  UNUSED_ARG(val);
+
   auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("ResNormERange");
 
-  if (prop == m_properties["EMin"]) {
-    updateLowerGuide(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
-                     val);
-  } else if (prop == m_properties["EMax"]) {
-    updateUpperGuide(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
-                     val);
+  if (prop == m_properties["EMin"] || prop == m_properties["EMax"]) {
+    auto bounds = qMakePair(m_dblManager->value(m_properties["EMin"]),
+                            m_dblManager->value(m_properties["EMax"]));
+    setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                     bounds);
   }
 }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/Stretch.cpp
@@ -1,202 +1,200 @@
 #include "MantidQtCustomInterfaces/Indirect/Stretch.h"
 #include "MantidQtCustomInterfaces/UserInputValidator.h"
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("Stretch");
+namespace {
+Mantid::Kernel::Logger g_log("Stretch");
 }
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
-		Stretch::Stretch(QWidget * parent) :
-			IndirectBayesTab(parent)
-		{
-			m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+Stretch::Stretch(QWidget *parent) : IndirectBayesTab(parent) {
+  m_uiForm.setupUi(parent);
 
+  // Create range selector
+  auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("StretchERange");
+  connect(eRangeSelector, SIGNAL(minValueChanged(double)), this,
+          SLOT(minValueChanged(double)));
+  connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this,
+          SLOT(maxValueChanged(double)));
 
-      // Create range selector
-      auto eRangeSelector = m_uiForm.ppPlot->addRangeSelector("StretchERange");
-      connect(eRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minValueChanged(double)));
-      connect(eRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxValueChanged(double)));
+  // Add the properties browser to the ui form
+  m_uiForm.treeSpace->addWidget(m_propTree);
 
-			// Add the properties browser to the ui form
-			m_uiForm.treeSpace->addWidget(m_propTree);
+  m_properties["EMin"] = m_dblManager->addProperty("EMin");
+  m_properties["EMax"] = m_dblManager->addProperty("EMax");
+  m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
+  m_properties["Sigma"] = m_dblManager->addProperty("Sigma");
+  m_properties["Beta"] = m_dblManager->addProperty("Beta");
 
-			m_properties["EMin"] = m_dblManager->addProperty("EMin");
-			m_properties["EMax"] = m_dblManager->addProperty("EMax");
-			m_properties["SampleBinning"] = m_dblManager->addProperty("Sample Binning");
-			m_properties["Sigma"] = m_dblManager->addProperty("Sigma");
-			m_properties["Beta"] = m_dblManager->addProperty("Beta");
+  m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
+  m_dblManager->setDecimals(m_properties["Sigma"], INT_DECIMALS);
+  m_dblManager->setDecimals(m_properties["Beta"], INT_DECIMALS);
 
-			m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
-			m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
-			m_dblManager->setDecimals(m_properties["SampleBinning"], INT_DECIMALS);
-			m_dblManager->setDecimals(m_properties["Sigma"], INT_DECIMALS);
-			m_dblManager->setDecimals(m_properties["Beta"], INT_DECIMALS);
+  m_propTree->addProperty(m_properties["EMin"]);
+  m_propTree->addProperty(m_properties["EMax"]);
+  m_propTree->addProperty(m_properties["SampleBinning"]);
+  m_propTree->addProperty(m_properties["Sigma"]);
+  m_propTree->addProperty(m_properties["Beta"]);
 
-			m_propTree->addProperty(m_properties["EMin"]);
-			m_propTree->addProperty(m_properties["EMax"]);
-			m_propTree->addProperty(m_properties["SampleBinning"]);
-			m_propTree->addProperty(m_properties["Sigma"]);
-			m_propTree->addProperty(m_properties["Beta"]);
+  // default values
+  m_dblManager->setValue(m_properties["Sigma"], 50);
+  m_dblManager->setMinimum(m_properties["Sigma"], 1);
+  m_dblManager->setMaximum(m_properties["Sigma"], 200);
+  m_dblManager->setValue(m_properties["Beta"], 50);
+  m_dblManager->setMinimum(m_properties["Beta"], 1);
+  m_dblManager->setMaximum(m_properties["Beta"], 200);
+  m_dblManager->setValue(m_properties["SampleBinning"], 1);
+  m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
 
-			//default values
-			m_dblManager->setValue(m_properties["Sigma"], 50);
-			m_dblManager->setMinimum(m_properties["Sigma"], 1);
-			m_dblManager->setMaximum(m_properties["Sigma"], 200);
-			m_dblManager->setValue(m_properties["Beta"], 50);
-			m_dblManager->setMinimum(m_properties["Beta"], 1);
-			m_dblManager->setMaximum(m_properties["Beta"], 200);
-			m_dblManager->setValue(m_properties["SampleBinning"], 1);
-			m_dblManager->setMinimum(m_properties["SampleBinning"], 1);
+  // Connect the data selector for the sample to the mini plot
+  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
+          SLOT(handleSampleInputReady(const QString &)));
+  connect(m_uiForm.chkSequentialFit, SIGNAL(toggled(bool)), m_uiForm.cbPlot,
+          SLOT(setEnabled(bool)));
+}
 
-			//Connect the data selector for the sample to the mini plot
-			connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString&)), this, SLOT(handleSampleInputReady(const QString&)));
-			connect(m_uiForm.chkSequentialFit, SIGNAL(toggled(bool)), m_uiForm.cbPlot, SLOT(setEnabled(bool)));
-		}
+void Stretch::setup() {}
 
-    void Stretch::setup()
-    {
-    }
+/**
+ * Validate the form to check the program can be run
+ *
+ * @return :: Whether the form was valid
+ */
+bool Stretch::validate() {
+  UserInputValidator uiv;
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+  uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
-		/**
-		 * Validate the form to check the program can be run
-		 *
-		 * @return :: Whether the form was valid
-		 */
-		bool Stretch::validate()
-		{
-			UserInputValidator uiv;
-			uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
-			uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
+  QString errors = uiv.generateErrorMessage();
+  if (!errors.isEmpty()) {
+    emit showMessageBox(errors);
+    return false;
+  }
 
-			QString errors = uiv.generateErrorMessage();
-			if (!errors.isEmpty())
-			{
-				emit showMessageBox(errors);
-				return false;
-			}
+  return true;
+}
 
-			return true;
-		}
+/**
+ * Collect the settings on the GUI and build a python
+ * script that runs Stretch
+ */
+void Stretch::run() {
+  using namespace Mantid::API;
 
-		/**
-		 * Collect the settings on the GUI and build a python
-		 * script that runs Stretch
-		 */
-		void Stretch::run()
-		{
-      using namespace Mantid::API;
+  QString save("False");
 
-			QString save("False");
+  QString elasticPeak("False");
+  QString sequence("False");
 
-			QString elasticPeak("False");
-			QString sequence("False");
+  QString pyInput = "from IndirectBayes import QuestRun\n";
 
-			QString pyInput =
-				"from IndirectBayes import QuestRun\n";
+  QString sampleName = m_uiForm.dsSample->getCurrentDataName();
+  QString resName = m_uiForm.dsResolution->getCurrentDataName();
 
-			QString sampleName = m_uiForm.dsSample->getCurrentDataName();
-			QString resName = m_uiForm.dsResolution->getCurrentDataName();
+  // Collect input from options section
+  QString background = m_uiForm.cbBackground->currentText();
 
-			// Collect input from options section
-			QString background = m_uiForm.cbBackground->currentText();
+  if (m_uiForm.chkElasticPeak->isChecked()) {
+    elasticPeak = "True";
+  }
+  if (m_uiForm.chkSequentialFit->isChecked()) {
+    sequence = "True";
+  }
 
-			if(m_uiForm.chkElasticPeak->isChecked()) { elasticPeak = "True"; }
-			if(m_uiForm.chkSequentialFit->isChecked()) { sequence = "True"; }
+  QString fitOps = "[" + elasticPeak + ", '" + background + "', False, False]";
 
-			QString fitOps = "[" + elasticPeak + ", '" + background + "', False, False]";
+  // Collect input from the properties browser
+  QString eMin = m_properties["EMin"]->valueText();
+  QString eMax = m_properties["EMax"]->valueText();
+  QString eRange = "[" + eMin + "," + eMax + "]";
 
-			//Collect input from the properties browser
-			QString eMin = m_properties["EMin"]->valueText();
-			QString eMax = m_properties["EMax"]->valueText();
-			QString eRange = "[" + eMin + "," + eMax + "]";
+  QString beta = m_properties["Beta"]->valueText();
+  QString sigma = m_properties["Sigma"]->valueText();
+  QString betaSig = "[" + beta + ", " + sigma + "]";
 
-			QString beta = m_properties["Beta"]->valueText();
-			QString sigma = m_properties["Sigma"]->valueText();
-			QString betaSig = "[" + beta + ", " + sigma + "]";
+  QString nBins = m_properties["SampleBinning"]->valueText();
+  nBins = "[" + nBins + ", 1]";
 
-			QString nBins = m_properties["SampleBinning"]->valueText();
-			nBins = "[" + nBins + ", 1]";
+  // Output options
+  if (m_uiForm.chkSave->isChecked()) {
+    save = "True";
+  }
+  QString plot = m_uiForm.cbPlot->currentText();
 
-			//Output options
-			if(m_uiForm.chkSave->isChecked()) { save = "True"; }
-			QString plot = m_uiForm.cbPlot->currentText();
+  pyInput += "QuestRun('" + sampleName + "','" + resName + "'," + betaSig +
+             "," + eRange + "," + nBins + "," + fitOps + "," + sequence +
+             ","
+             " Save=" +
+             save + ", Plot='" + plot + "')\n";
 
-			pyInput += "QuestRun('"+sampleName+"','"+resName+"',"+betaSig+","+eRange+","+nBins+","+fitOps+","+sequence+","
-										" Save="+save+", Plot='"+plot+"')\n";
+  runPythonScript(pyInput);
+}
 
-			runPythonScript(pyInput);
-		}
+/**
+ * Set the data selectors to use the default save directory
+ * when browsing for input files.
+ *
+* @param settings :: The current settings
+ */
+void Stretch::loadSettings(const QSettings &settings) {
+  m_uiForm.dsSample->readSettings(settings.group());
+  m_uiForm.dsResolution->readSettings(settings.group());
+}
 
-		/**
-		 * Set the data selectors to use the default save directory
-		 * when browsing for input files.
-		 *
-     * @param settings :: The current settings
-		 */
-		void Stretch::loadSettings(const QSettings& settings)
-		{
-			m_uiForm.dsSample->readSettings(settings.group());
-			m_uiForm.dsResolution->readSettings(settings.group());
-		}
+/**
+ * Plots the loaded file to the miniplot and sets the guides
+ * and the range
+ *
+ * @param filename :: The name of the workspace to plot
+ */
+void Stretch::handleSampleInputReady(const QString &filename) {
+  m_uiForm.ppPlot->addSpectrum("Sample", filename, 0);
+  QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
+  auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("StretchERange");
+  setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                   range);
+  setPlotPropertyRange(eRangeSelector, m_properties["EMin"],
+                       m_properties["EMax"], range);
+}
 
-		/**
-		 * Plots the loaded file to the miniplot and sets the guides
-		 * and the range
-		 *
-		 * @param filename :: The name of the workspace to plot
-		 */
-		void Stretch::handleSampleInputReady(const QString& filename)
-		{
-			m_uiForm.ppPlot->addSpectrum("Sample", filename, 0);
-			QPair<double, double> range = m_uiForm.ppPlot->getCurveRange("Sample");
-      auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("StretchERange");
-			setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
-			setPlotPropertyRange(eRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
-		}
+/**
+ * Updates the property manager when the lower guide is moved on the mini plot
+ *
+ * @param min :: The new value of the lower guide
+ */
+void Stretch::minValueChanged(double min) {
+  m_dblManager->setValue(m_properties["EMin"], min);
+}
 
-		/**
-		 * Updates the property manager when the lower guide is moved on the mini plot
-		 *
-		 * @param min :: The new value of the lower guide
-		 */
-		void Stretch::minValueChanged(double min)
-    {
-      m_dblManager->setValue(m_properties["EMin"], min);
-    }
+/**
+ * Updates the property manager when the upper guide is moved on the mini plot
+ *
+ * @param max :: The new value of the upper guide
+ */
+void Stretch::maxValueChanged(double max) {
+  m_dblManager->setValue(m_properties["EMax"], max);
+}
 
-		/**
-		 * Updates the property manager when the upper guide is moved on the mini plot
-		 *
-		 * @param max :: The new value of the upper guide
-		 */
-    void Stretch::maxValueChanged(double max)
-    {
-			m_dblManager->setValue(m_properties["EMax"], max);
-    }
+/**
+ * Handles when properties in the property manager are updated.
+ *
+ * @param prop :: The property being updated
+ * @param val :: The new value for the property
+ */
+void Stretch::updateProperties(QtProperty *prop, double val) {
+  UNUSED_ARG(val);
 
-		/**
-		 * Handles when properties in the property manager are updated.
-		 *
-		 * @param prop :: The property being updated
-		 * @param val :: The new value for the property
-		 */
-    void Stretch::updateProperties(QtProperty* prop, double val)
-    {
-      auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("StretchERange");
+  auto eRangeSelector = m_uiForm.ppPlot->getRangeSelector("StretchERange");
 
-    	if(prop == m_properties["EMin"])
-    	{
-    		updateLowerGuide(eRangeSelector, m_properties["EMin"], m_properties["EMax"], val);
-    	}
-    	else if (prop == m_properties["EMax"])
-    	{
-				updateUpperGuide(eRangeSelector, m_properties["EMin"], m_properties["EMax"], val);
-    	}
-    }
+  if (prop == m_properties["EMin"] || prop == m_properties["EMax"]) {
+    auto bounds = qMakePair(m_dblManager->value(m_properties["EMin"]),
+                            m_dblManager->value(m_properties["EMax"]));
+    setRangeSelector(eRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                     bounds);
+  }
+}
 
-	} // namespace CustomInterfaces
+} // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/docs/source/interfaces/Indirect_Bayes.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_Bayes.rst
@@ -188,40 +188,4 @@ Plot Result
 Save Result
   Saves the result in the default save directory.
 
-JumpFit
--------
-
-.. interface:: Bayes
-  :widget: JumpFit
-
-One of the models used to interpret diffusion is that of jump diffusion in which
-it is assumed that an atom remains at a given site for a time :math:`\tau`; and
-then moves rapidly, that is, in a time negligible compared to :math:`\tau`;
-hence ‘jump’.
-
-Options
-~~~~~~~
-
-Sample
-  A sample workspace created with either ConvFit or Quasi.
-
-Fit Funcion
-  Selects the model to be used for fitting.
-
-Width
-  Spectrum in the sample workspace to fit.
-
-QMin & QMax
-  The Q range to perform fitting within.
-
-Fitting Parameters
-  Provides the option to change the defautl fitting parameters passed to the
-  chosen function.
-
-Plot Result
-  Plots the result workspaces.
-
-Save Result
-  Saves the result in the default save directory.
-
 .. categories:: Interfaces Indirect

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -523,4 +523,40 @@ References:
 1. J S Higgins, R E Ghosh, W S Howells & G Allen, `JCS Faraday II 73 40 (1977) <http://dx.doi.org/10.1039/F29777300040>`_
 2. J S Higgins, G Allen, R E Ghosh, W S Howells & B Farnoux, `Chem Phys Lett 49 197 (1977) <http://dx.doi.org/10.1016/0009-2614(77)80569-1>`_
 
+JumpFit
+-------
+
+.. interface:: Data Analysis
+  :widget: tabJumpFit
+
+One of the models used to interpret diffusion is that of jump diffusion in which
+it is assumed that an atom remains at a given site for a time :math:`\tau`; and
+then moves rapidly, that is, in a time negligible compared to :math:`\tau`;
+hence ‘jump’.
+
+Options
+~~~~~~~
+
+Sample
+  A sample workspace created with either ConvFit or Quasi.
+
+Fit Funcion
+  Selects the model to be used for fitting.
+
+Width
+  Spectrum in the sample workspace to fit.
+
+QMin & QMax
+  The Q range to perform fitting within.
+
+Fitting Parameters
+  Provides the option to change the defautl fitting parameters passed to the
+  chosen function.
+
+Plot Result
+  Plots the result workspaces.
+
+Save Result
+  Saves the result in the default save directory.
+
 .. categories:: Interfaces Indirect


### PR DESCRIPTION
Fixes #12985.

To test:
- Open Indirect > Data Analysis > JumpFit
- Load a file (`babylon5/Public/DanNixon/data/cf_Result.nxs`)
- See that the range selectors work as expected

A lot of the interface code has poor indentation formatting so may as well just run clang-format to fix it.

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24432&oldid=24419).
