### PR TITLE
Fix crash in ALC

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingPresenter.cpp
@@ -84,16 +84,22 @@ namespace CustomInterfaces
    */
   void ALCBaselineModellingPresenter::addSection()
   {
-    double xMin = m_model->data()->getXMin();
-    double xMax = m_model->data()->getXMax();
+    if (MatrixWorkspace_const_sptr data = m_model->data()) {
+      double xMin = data->getXMin();
+      double xMax = data->getXMax();
 
-    int noOfSections = m_view->noOfSectionRows();
+      int noOfSections = m_view->noOfSectionRows();
 
-    m_view->setNoOfSectionRows(noOfSections + 1);
+      m_view->setNoOfSectionRows(noOfSections + 1);
 
-    m_view->setSectionRow(noOfSections, std::make_pair(QString::number(xMin), QString::number(xMax)));
+      m_view->setSectionRow(
+          noOfSections,
+          std::make_pair(QString::number(xMin), QString::number(xMax)));
 
-    m_view->addSectionSelector(noOfSections, std::make_pair(xMin, xMax));
+      m_view->addSectionSelector(noOfSections, std::make_pair(xMin, xMax));
+    } else {
+      m_view->displayError("Please load some data first");
+    }
   }
 
   /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCBaselineModellingPresenterTest.h
@@ -221,6 +221,18 @@ public:
     m_view->requestAddSection();
   }
 
+  void test_addSection_toEmptyWS()
+  {
+    ON_CALL(*m_model, data()).WillByDefault(Return(MatrixWorkspace_const_sptr()));
+
+    EXPECT_CALL(*m_view, noOfSectionRows()).Times(0);
+    EXPECT_CALL(*m_view, setSectionRow(_,_)).Times(0);
+    EXPECT_CALL(*m_view, addSectionSelector(_,_)).Times(0);
+    EXPECT_CALL(*m_view, displayError(_)).Times(1);
+
+    m_view->requestAddSection();
+  }
+
   void test_removeSection()
   {
     ON_CALL(*m_view, noOfSectionRows()).WillByDefault(Return(3));


### PR DESCRIPTION
Fixes #13098

To test:
- Open Muon > ALC
- Go to 'BaselineModelling'
- Right click on 'Sections' blank region, add a section.
- See that an error message is shown
- Review new unit test 

Release notes: no changes in the release notes, as this bug was introduced in this release.
