### PR TITLE
Exposing empty parameter constants to python

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/src/Exports/Property.cpp
@@ -1,3 +1,4 @@
+#include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Property.h"
 #include "MantidKernel/IPropertySettings.h"
 #include "MantidPythonInterface/kernel/StlExportDefinitions.h"
@@ -78,5 +79,9 @@ void export_Property() {
       .add_property("settings",
                     make_function(&Property::getSettings,
                                   return_value_policy<return_by_value>()),
-                    "Return the object managing this property's settings");
+                    "Return the object managing this property's settings")
+
+      .add_static_property("EMPTY_DBL", &Mantid::EMPTY_DBL)
+      .add_static_property("EMPTY_INT", &Mantid::EMPTY_INT)
+      .add_static_property("EMPTY_LONG", &Mantid::EMPTY_LONG);
 }


### PR DESCRIPTION
**To test:**

``` python
import mantid
print mantid.kernel.Property.EMPTY_DOUBLE
```

The [change in release notes](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_Framework_Changes&diff=24449&oldid=24448).
