### PR TITLE
Speed up loading FITS images with option to have one spectrum per row

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceModel.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceModel.cpp
@@ -571,8 +571,10 @@ TomographyIfaceModel::loadFITSImage(const std::string &path) {
   auto alg = Algorithm::fromString("LoadFITS");
   alg->initialize();
   alg->setPropertyValue("Filename", path);
-  std::string wsName = "__fits_ws_imat_tomography_gui";
+  std::string wsName = "__fits_ws_tomography_gui";
   alg->setProperty("OutputWorkspace", wsName);
+  // this is way faster when loading into a MatrixWorkspace
+  alg->setProperty("LoadAsRectImg", true);
   try {
     alg->execute();
   } catch (std::exception &e) {

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/TomographyIfacePresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/TomographyIfacePresenterTest.h
@@ -80,8 +80,7 @@ public:
     pres.notify(ITomographyIfacePresenter::SetupResourcesAndTools);
 
     // needs one tool at a very minimum
-    EXPECT_CALL(mockView, currentReconTool()).Times(1).WillOnce(
-        Return(g_ccpi));
+    EXPECT_CALL(mockView, currentReconTool()).Times(1).WillOnce(Return(g_ccpi));
     // and basic tools settings
     EXPECT_CALL(mockView, reconToolsSettings()).Times(0);
 
@@ -156,10 +155,13 @@ public:
         mockView,
         showImage(testing::Matcher<const Mantid::API::MatrixWorkspace_sptr &>(
             testing::_))).Times(1);
+    EXPECT_CALL(mockView,
+                showImage(testing::Matcher<const std::string &>(testing::_)))
+        .Times(0);
+
     // No errors, no warnings
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
-    // EXPECT_CALL(pres, notify(testing::_)).Times(1);
 
     pres.notify(ITomographyIfacePresenter::ViewImg);
   }


### PR DESCRIPTION
Fixes #13130

**To test**:
- The GUI's unit test checks this. It should pass.
- Code review.
- If you want to check it manually to see that the images display
  correctly, you can open Custom Interfaces -> Diffraction ->
  Tomographic Reconstruction, and then open for example one of the fits
  files included in the unit test data: `FITS_small_01.fits` or
  `FITS_small_02.fits`.

This is a small update before bigger additions. It changes the way images are loaded into MatrixWorkspaces in this GUI with the LoadAsRectImg option. This way it is much faster as it doesn't create a huge amount of Spectrum objects. The speed up is by a factor of ~10. Functionality is not changed when loading images in other formats.
