### PR TITLE
Corrections to LoadDNSLegacy

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -91,61 +91,66 @@ class LoadDNSLegacy(PythonAlgorithm):
         run.addProperty('run_title', fname, True)
 
         # rotate the detector bank to the proper position
-        api.RotateInstrumentComponent(outws,
-                                      "bank0", X=0, Y=1, Z=0, Angle=metadata.deterota)
+        api.RotateInstrumentComponent(outws, "bank0", X=0, Y=1, Z=0, Angle=metadata.deterota)
         # add sample log Ei and wavelength
-        api.AddSampleLog(outws,
-                         'Ei', LogText=str(metadata.incident_energy),
-                         LogType='Number')
-        api.AddSampleLog(outws,
-                         'wavelength', LogText=str(metadata.wavelength),
-                         LogType='Number')
+        api.AddSampleLog(outws, LogName='Ei', LogText=str(metadata.incident_energy),
+                         LogType='Number', LogUnit='meV')
+        api.AddSampleLog(outws, LogName='wavelength', LogText=str(metadata.wavelength),
+                         LogType='Number', LogUnit='Angstrom')
         # add other sample logs
-        api.AddSampleLog(outws, 'deterota',
-                         LogText=str(metadata.deterota), LogType='Number')
+        api.AddSampleLog(outws, LogName='deterota', LogText=str(metadata.deterota),
+                         LogType='Number', LogUnit='Degrees')
         api.AddSampleLog(outws, 'mon_sum',
                          LogText=str(float(metadata.monitor_counts)), LogType='Number')
-        api.AddSampleLog(outws, 'duration',
-                         LogText=str(metadata.duration), LogType='Number')
-        api.AddSampleLog(outws, 'huber',
-                         LogText=str(metadata.huber), LogType='Number')
-        api.AddSampleLog(outws, 'T1',
-                         LogText=str(metadata.t1), LogType='Number')
-        api.AddSampleLog(outws, 'T2',
-                         LogText=str(metadata.t2), LogType='Number')
-        api.AddSampleLog(outws, 'Tsp',
-                         LogText=str(metadata.tsp), LogType='Number')
+        api.AddSampleLog(outws, LogName='duration', LogText=str(metadata.duration),
+                         LogType='Number', LogUnit='Seconds')
+        api.AddSampleLog(outws, LogName='huber', LogText=str(metadata.huber),
+                         LogType='Number', LogUnit='Degrees')
+        api.AddSampleLog(outws, LogName='omega', LogText=str(metadata.huber - metadata.deterota),
+                         LogType='Number', LogUnit='Degrees')
+        api.AddSampleLog(outws, LogName='T1', LogText=str(metadata.t1),
+                         LogType='Number', LogUnit='K')
+        api.AddSampleLog(outws, LogName='T2', LogText=str(metadata.t2),
+                         LogType='Number', LogUnit='K')
+        api.AddSampleLog(outws, LogName='Tsp', LogText=str(metadata.tsp),
+                         LogType='Number', LogUnit='K')
         # flipper
-        api.AddSampleLog(outws, 'flipper_precession',
-                         LogText=str(metadata.flipper_precession_current), LogType='Number')
-        api.AddSampleLog(outws, 'flipper_z_compensation',
-                         LogText=str(metadata.flipper_z_compensation_current), LogType='Number')
-        flipper_status = 0.0    # flipper OFF
+        api.AddSampleLog(outws, LogName='flipper_precession',
+                         LogText=str(metadata.flipper_precession_current),
+                         LogType='Number', LogUnit='A')
+        api.AddSampleLog(outws, LogName='flipper_z_compensation',
+                         LogText=str(metadata.flipper_z_compensation_current),
+                         LogType='Number', LogUnit='A')
+        flipper_status = 'OFF'    # flipper OFF
         if abs(metadata.flipper_precession_current) > sys.float_info.epsilon:
-            flipper_status = 1.0    # flipper ON
-        api.AddSampleLog(outws, 'flipper',
-                         LogText=str(flipper_status), LogType='Number')
+            flipper_status = 'ON'    # flipper ON
+        api.AddSampleLog(outws, LogName='flipper',
+                         LogText=flipper_status, LogType='String')
         # coil currents
-        api.AddSampleLog(outws, 'C_a',
-                         LogText=str(metadata.a_coil_current), LogType='Number')
-        api.AddSampleLog(outws, 'C_b',
-                         LogText=str(metadata.b_coil_current), LogType='Number')
-        api.AddSampleLog(outws, 'C_c',
-                         LogText=str(metadata.c_coil_current), LogType='Number')
-        api.AddSampleLog(outws, 'C_z',
-                         LogText=str(metadata.z_coil_current), LogType='Number')
+        api.AddSampleLog(outws, LogName='C_a', LogText=str(metadata.a_coil_current),
+                         LogType='Number', LogUnit='A')
+        api.AddSampleLog(outws, LogName='C_b', LogText=str(metadata.b_coil_current),
+                         LogType='Number', LogUnit='A')
+        api.AddSampleLog(outws, LogName='C_c', LogText=str(metadata.c_coil_current),
+                         LogType='Number', LogUnit='A')
+        api.AddSampleLog(outws, LogName='C_z', LogText=str(metadata.z_coil_current),
+                         LogType='Number', LogUnit='A')
         # type of polarisation
         api.AddSampleLog(outws, 'polarisation',
                          LogText=pol, LogType='String')
         # slits
-        api.AddSampleLog(outws, 'slit_i_upper_blade_position',
-                         LogText=str(metadata.slit_i_upper_blade_position), LogType='String')
-        api.AddSampleLog(outws, 'slit_i_lower_blade_position',
-                         LogText=str(metadata.slit_i_lower_blade_position), LogType='String')
-        api.AddSampleLog(outws, 'slit_i_left_blade_position',
-                         LogText=str(metadata.slit_i_left_blade_position), LogType='String')
+        api.AddSampleLog(outws, LogName='slit_i_upper_blade_position',
+                         LogText=str(metadata.slit_i_upper_blade_position),
+                         LogType='Number', LogUnit='mm')
+        api.AddSampleLog(outws, LogName='slit_i_lower_blade_position',
+                         LogText=str(metadata.slit_i_lower_blade_position),
+                         LogType='Number', LogUnit='mm')
+        api.AddSampleLog(outws, LogName='slit_i_left_blade_position',
+                         LogText=str(metadata.slit_i_left_blade_position),
+                         LogType='Number', LogUnit='mm')
         api.AddSampleLog(outws, 'slit_i_right_blade_position',
-                         LogText=str(metadata.slit_i_right_blade_position), LogType='String')
+                         LogText=str(metadata.slit_i_right_blade_position),
+                         LogType='Number', LogUnit='mm')
 
         self.setProperty("OutputWorkspace", outws)
         self.log().debug('LoadDNSLegacy: data are loaded to the workspace ' + outws_name)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -64,7 +64,6 @@ class LoadDNSLegacy(PythonAlgorithm):
             message = "File " + filename + " does not contain any data!"
             self.log().error(message)
             raise RuntimeError(message)
-            return
 
         # load run information
         metadata = DNSdata()
@@ -74,7 +73,6 @@ class LoadDNSLegacy(PythonAlgorithm):
             message = "Error of loading of file " + filename + ": " + err
             self.log().error(message)
             raise RuntimeError(message)
-            return
 
         ndet = 24
         # this needed to be able to use ConvertToMD

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -44,10 +44,10 @@ class LoadDNSLegacy(PythonAlgorithm):
                              doc="Name of the workspace to store the experimental data.")
         self.declareProperty("Polarisation", "0",
                              StringListValidator(POLARISATIONS),
-                             doc="Type of polarisation. Valid values: %s" % str(POLARISATIONS))
+                             doc="Type of polarisation.")
         self.declareProperty("Normalization", "duration",
                              StringListValidator(NORMALIZATIONS),
-                             doc="Type of data for normalization. Valid values: %s" % str(NORMALIZATIONS))
+                             doc="Type of data for normalization.")
         return
 
     def PyExec(self):

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/dnsdata.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/dnsdata.py
@@ -69,6 +69,10 @@ class DNSdata(object):
             unparsed = fhandler.read()
             blocks = unparsed.split(splitsymbol)
 
+            # check whether the file is complete
+            if len(blocks) < 9:
+                raise RuntimeError("The file %s is not complete!" % filename)
+
             # parse each block
             # parse block 0 (header)
             res = parse_header(blocks[0])
@@ -79,7 +83,7 @@ class DNSdata(object):
                 self.sample_name = res['sample']
                 self.userid = res['userid']
             except:
-                raise ValueError("The file %s does not contain valid DNS data format." % filename)
+                raise RuntimeError("The file %s does not contain valid DNS data format." % filename)
             # parse block 1 (general information)
             b1splitted = [s.strip() for s in blocks[1].split('#')]
             b1rest = [el for el in b1splitted]

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
@@ -38,7 +38,7 @@ class LoadDNSLegacyTest(unittest.TestCase):
         """
         creates an incomplete data file
         """
-        with open (filename, "w") as f:
+        with open(filename, "w") as f:
             f.write("# DNS Data userid=sa,exp=961,file=988,sample=run2")
             f.write("#--------------------------------------------------------------------------")
             f.write("# 9")

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
@@ -27,7 +27,7 @@ class LoadDNSLegacyTest(unittest.TestCase):
         self.assertEqual(8332872, run.getProperty('mon_sum').value)
         self.assertEqual('y', run.getProperty('polarisation').value)
         # check whether detector bank is rotated
-        det = ws.getDetector(1)
+        det = ws.getDetector(0)
         self.assertAlmostEqual(8.54, ws.detectorSignedTwoTheta(det)*180/pi)
         run_algorithm("DeleteWorkspace", Workspace=outputWorkspaceName)
         return

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
@@ -2,6 +2,8 @@ import unittest
 from testhelpers import run_algorithm
 from mantid.api import AnalysisDataService
 from math import pi
+import os
+from mantid.simpleapi import LoadDNSLegacy
 
 
 class LoadDNSLegacyTest(unittest.TestCase):
@@ -31,6 +33,27 @@ class LoadDNSLegacyTest(unittest.TestCase):
         self.assertAlmostEqual(8.54, ws.detectorSignedTwoTheta(det)*180/pi)
         run_algorithm("DeleteWorkspace", Workspace=outputWorkspaceName)
         return
+
+    def _createIncompleteFile(self, filename):
+        """
+        creates an incomplete data file
+        """
+        with open (filename, "w") as f:
+            f.write("# DNS Data userid=sa,exp=961,file=988,sample=run2")
+            f.write("#--------------------------------------------------------------------------")
+            f.write("# 9")
+            f.write("# User: Some User")
+            f.close()
+        return
+
+    def test_LoadInvalidData(self):
+        outputWorkspaceName = "LoadDNSLegacyTest_Test2"
+        filename = "dns-incomplete.d_dat"
+        self._createIncompleteFile(filename)
+        self.assertRaises(RuntimeError, LoadDNSLegacy,  Filename=filename,
+                          OutputWorkspace=outputWorkspaceName, Polarisation='y')
+        os.remove(filename)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Code/Mantid/docs/source/algorithms/LoadDNSLegacy-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/LoadDNSLegacy-v1.rst
@@ -9,10 +9,17 @@
 Description
 -----------
 
-Loads a DNS legacy .d_dat data file into a :ref:`Workspace2D <Workspace2D>` with
-the given name. 
+.. warning::
 
-The loader rotates the detector bank in the position given in the data file.
+   This algorithm is being developed for a specific instrument. It might get changed or even 
+   removed without a notification, should instrument scientists decide to do so.
+
+This algorithm loads a DNS legacy data file into a :ref:`Workspace2D <Workspace2D>`. Two workspaces will be created: 
+
+-  raw data workspace with the given name. 
+-  workspace with normalization data (monitor counts or experiment duration by user's choice). The normalization workspace is named same as the data workspace, but has suffix "_NORM". 
+
+The loader rotates the detector bank in the position given in the data file. No operations on the neutron counts are performed. Sample logs are dublicated for both, data and normalization workspaces.
 
 This algorithm only supports DNS instrument in its configuration before major upgrade. 
 
@@ -27,10 +34,9 @@ Usage
    datafile = 'dn134011vana.d_dat'
 
    # Load dataset
-   ws = LoadDNSLegacy(datafile, Polarisation='x')
+   ws = LoadDNSLegacy(datafile, Polarisation='x', Normalization='monitor')
 
-   print "This workspace has", ws.getNumDims(), "dimensions and has", \
-        ws.getNumberHistograms(), "histograms."
+   print "This workspace has", ws.getNumDims(), "dimensions and has", ws.getNumberHistograms(), "histograms."
 
 Output:
 

--- a/Code/Mantid/instrument/DNS_Definition_PAonly.xml
+++ b/Code/Mantid/instrument/DNS_Definition_PAonly.xml
@@ -22,13 +22,14 @@
   </component>
   <type name="moderator" is="Source"></type>
   <!-- monitor -->
-  <component type="monitor" idlist="monitor">
+  <!--<component type="monitor" idlist="monitor">
     <location z="-0.229" />
   </component>
   <type name="monitor" is="monitor"></type>
   <idlist idname="monitor">
     <id val="-1"/>
   </idlist>
+  -->
   <!-- Sample position -->
   <component type="sample-position">
     <location y="0.0" x="0.0" z="0.0" />


### PR DESCRIPTION
Changes to DNS IDF:
1. monitor has bin commented out, otherwise 2theta was not calculated correctly by getTwoTheta and ConvertToMD algorithms.

Some small corrections to the LoadDNSLegacy algorithm, it's unittest and documentation:
1. structure of the created workspace has been changed (2 'X' columns were needed to apply ConvertToMD and other Mantid algorithms to this workspace)
2. Units have been added to the sample logs.
3. Corrected handling of the incomplete data files.
4. Now loader creates additional workspace with normalization data (monitor or duration by user's choice).

Labels: Component:Diffraction

Thank you for review.
