### PR TITLE
13119 predict fraction peaks dialog forgets previous settings

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Code/Mantid/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -38,16 +38,28 @@ void PredictFractionalPeaks::init() {
                                              Direction::Output),
       "Workspace of Peaks with peaks with fractional h,k, and/or l values");
 
-  declareProperty(
-      new Kernel::ArrayProperty<double>(string("HOffset"), string("-.5,0, .5")),
-      "Offset in the h direction");
+  std::vector<double> hOffsetDefault(3);
+  hOffsetDefault[0] = -0.5;
+  hOffsetDefault[1] = 0.0;
+  hOffsetDefault[2] = 0.5;
+
 
   declareProperty(
-      new Kernel::ArrayProperty<double>(string("KOffset"), string("0")),
+	  new Kernel::ArrayProperty<double>(string("HOffset"), hOffsetDefault),
       "Offset in the h direction");
 
+  //const std::vector<double> kOffsetDefault(1, 0);
+  //std::vector<double>(1, 0)
   declareProperty(
-      new Kernel::ArrayProperty<double>(string("LOffset"), string("-.5,.5")),
+      new Kernel::ArrayProperty<double>(string("KOffset"), std::vector<double>(1, 0)),
+      "Offset in the h direction");
+
+  std::vector<double> lOffsetDefault(3);
+  lOffsetDefault[0] = -0.5;
+  lOffsetDefault[1] = 0.5;
+
+  declareProperty(
+	  new Kernel::ArrayProperty<double>(string("LOffset"), lOffsetDefault),
       "Offset in the h direction");
 
   declareProperty("IncludeAllPeaksInRange", false,

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -86,6 +86,10 @@ public:
    *  @throw std::invalid_argument if the string passed is not compatible with
    * the array type
    */
+
+  //The constructor of the base class is called with an empty vector
+  //resulting in the most current previous values not being remembered
+  //correctly. Use this constructor with caution.
   ArrayProperty(const std::string &name, const std::string &values,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input)

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -78,6 +78,11 @@ public:
                                           IValidator_sptr(new NullValidator),
                                           direction) {}
   /** Constructor from which you can set the property's values through a string
+   * 
+   * The constructor of the base class is called with an empty vector for the default values
+   * The values are set directly from the string. Since the default values are never initialized, isDefault
+   * will return false for any non-empty string input.
+   * 
    *  @param name ::      The name to assign to the property
    *  @param values ::    A comma-separated string containing the values to
    * store in the property
@@ -86,10 +91,6 @@ public:
    *  @throw std::invalid_argument if the string passed is not compatible with
    * the array type
    */
-
-  //The constructor of the base class is called with an empty vector
-  //resulting in the most current previous values not being remembered
-  //correctly. Use this constructor with caution.
   ArrayProperty(const std::string &name, const std::string &values,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input)


### PR DESCRIPTION
Problem with retrieving most current previous values when executing the algorithm.

ArrayProperty was using the wrong constructor from PropertyWithValue which used a list of values as a string. Fixed by using a vector of doubles containing the relevant values and then calling the appropriate constructor.

Fixes #13119 
