### PR TITLE
Fix SystemTests / EnginXCalibrateFullThenCalibrateTest on some platforms

### DIFF
--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -2,7 +2,7 @@
 import stresstesting
 from mantid.simpleapi import *
 
-def relErrLessDelta(val, ref, epsilon):
+def rel_err_less_delta(val, ref, epsilon):
     """
     Checks that a value 'val' does not defer from a reference value 'ref' by 'epsilon'
     or more. This method compares the relative error. An epsilon of 0.1 means a relative
@@ -103,12 +103,12 @@ class EnginXFocusWithVanadiumCorrection(stresstesting.MantidStressTest):
 
         delta = 1e-5
         for i in range(0, len(simul)):
-            self.assertTrue(relErrLessDelta(simul[i], precalc_curve_simul[i], delta),
+            self.assertTrue(rel_err_less_delta(simul[i], precalc_curve_simul[i], delta),
                             "Relative difference bigger than acceptable error (%f) when comparing bin %d "
                             "against bank curves previously fitted. got: %f where I expect: %f"%
                             (delta, i, simul[i], precalc_curve_simul[i]))
 
-            self.assertTrue(relErrLessDelta(simul[i], precalc_curve_simul[i], delta),
+            self.assertTrue(rel_err_less_delta(simul[i], precalc_curve_simul[i], delta),
                             "Relative difference bigger than acceptable error (%f) when comparing bin %d "
                             "against bank curves previously fitted (and also using pre-calculated integration "
                             "values). got: %f where I expect: %f"%
@@ -121,7 +121,7 @@ class EnginXFocusWithVanadiumCorrection(stresstesting.MantidStressTest):
         focussed_sp = out_ws.readY(0)
         focussed_sp_precalc = out_precalc_ws.readY(0)
         for i in range(0, out_ws.blocksize()):
-            self.assertTrue(relErrLessDelta(simul[i], precalc_curve_simul[i], delta),
+            self.assertTrue(rel_err_less_delta(simul[i], precalc_curve_simul[i], delta),
                             "Relative difference bigger than accepted delta (%f) when comparing bin %d "
                             "of the focussed spectrum against the focussed spectrum obtained using bank curves "
                             "and spectra integration values pre-calculated. got: %f where I expect: %f"%
@@ -183,37 +183,42 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
         self.assertEquals(self.posTable.cell(88, 0), 100089)   # det ID
         self.assertEquals(self.posTable.cell(200, 0), 101081)  # det ID
 
-        # this will be used as a comparison delta of 'delta' %
+        # this will be used as a comparison delta in relative terms (percentage)
         exdelta = 1e-5
-        # Note that the reference values are given with 12 digits more for reference than
-        # for assert-comparison purposes (comparisons are not that picky, by far)
-        self.assertTrue(relErrLessDelta(self.posTable.cell(100, 3), 1.49010562897, exdelta))
-        #self.assertDelta(self.posTable.cell(100, 3), 1.49010562897, delta)
-        self.assertTrue(relErrLessDelta(self.posTable.cell(400, 4), 1.65264105797, exdelta))
-        self.assertTrue(relErrLessDelta(self.posTable.cell(200, 5), 0.296705961227, exdelta))
-        self.assertTrue(relErrLessDelta(self.posTable.cell(610, 7), 18585.1738281, exdelta))
-        self.assertTrue(relErrLessDelta(self.posTable.cell(1199, 8), -1.56501817703, exdelta))
-
-        # === check difc, zero parameters for GSAS produced by EnggCalibrate
         # Mac fitting tests produce differences for some reason.
         import sys
-        if sys.platform == "darwin":
+        if "darwin" == sys.platform:
             delta_darwin = 5e-3
             exdelta = delta_darwin
+        if "win32" == sys.platform:
+            delta_win7 =  5e-4 # this is needed especially for the zero parameter (error >=1e-4)
+            exdelta = delta_win7
+
+        # Note that the reference values are given with 12 digits more for reference than
+        # for assert-comparison purposes (comparisons are not that picky, by far)
+        self.assertTrue(rel_err_less_delta(self.posTable.cell(100, 3), 1.49010562897, exdelta))
+        #self.assertDelta(self.posTable.cell(100, 3), 1.49010562897, delta)
+        self.assertTrue(rel_err_less_delta(self.posTable.cell(400, 4), 1.65264105797, exdelta))
+        self.assertTrue(rel_err_less_delta(self.posTable.cell(200, 5), 0.296705961227, exdelta))
+        self.assertTrue(rel_err_less_delta(self.posTable.cell(610, 7), 18585.1738281, exdelta))
+        self.assertTrue(rel_err_less_delta(self.posTable.cell(1199, 8), -1.56501817703, exdelta))
+
+        # === check difc, zero parameters for GSAS produced by EnggCalibrate
 
         # Bank 1
-        self.assertTrue(relErrLessDelta(self.difc, 18405.0526862, exdelta),
+        self.assertTrue(rel_err_less_delta(self.difc, 18405.0526862, exdelta),
                         "difc parameter for bank 1 is not what was expected, got: %f" % self.difc)
-        self.assertTrue(relErrLessDelta(self.zero, -0.835864, exdelta),
+        self.assertTrue(rel_err_less_delta(self.zero, -0.835864, exdelta),
                         "zero parameter for bank 1 is not what was expected, got: %f" % self.zero)
 
         # Bank 2
-        self.assertTrue(relErrLessDelta(self.difc_b2, 18392.7375314, exdelta),
+        self.assertTrue(rel_err_less_delta(self.difc_b2, 18392.7375314, exdelta),
                         "difc parameter for bank 2 is not what was expected, got: %f" % self.difc_b2)
-        self.assertTrue(relErrLessDelta(self.zero_b2, -11.341251, exdelta),
+        self.assertTrue(rel_err_less_delta(self.zero_b2, -11.341251, exdelta),
                         "zero parameter for bank 2 is not what was expected, got: %f" % self.zero_b2)
 
     def cleanup(self):
         mtd.remove('long_calib_ws')
         mtd.remove('van_ws')
         mtd.remove('positions')
+        mtd.remove('calib_ws')


### PR DESCRIPTION
master_systemtests failed last night because of this test.

This a quick fix that increases the comparison tolerance to different platform specific levels for 'win7' and 'darwin', as these were failing in different steps of the test because of the platform dependent results from various fits. It seems that different windows machines / configurations can also produce slightly different results!

**To test**:
- This seems to be fine on linux and windows. Tests should pass (but system tests only run on Ubuntu)
- I couldn't test this on osx, but the tolerance has been increased so that it would be enough for what the osx build machine reported for master last night. If you have access to an osx build machine you could quickly check that 
  `runSystemTests.py  -m bin/MantidPlot  -R Engg` is happy now.

Note this also fixes a pylint warning by changing the name of a function `relErrLessDelta` => `rel_err_less_delta`.
