### PR TITLE
Scripting window remembers open files

### DIFF
--- a/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.cpp
+++ b/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.cpp
@@ -37,32 +37,27 @@
 /**
  * Constructor
  */
-MultiTabScriptInterpreter::MultiTabScriptInterpreter(ScriptingEnv *env, QWidget *parent)
-  : QTabWidget(parent), Scripted(env), m_last_dir(""),
-    m_cursor_pos(), m_reportProgress(false), m_recentScriptList(), m_nullScript(new NullScriptFileInterpreter),
-    m_current(m_nullScript), m_globalZoomLevel(0), m_showWhitespace(false),
-    m_replaceTabs(true), m_tabWhitespaceCount(4), m_fontFamily(), m_codeFolding(false)
-{
-  connect(this, SIGNAL(currentChanged(int)), this, SLOT(tabSelectionChanged(int)));
+MultiTabScriptInterpreter::MultiTabScriptInterpreter(ScriptingEnv *env,
+                                                     QWidget *parent)
+    : QTabWidget(parent), Scripted(env), m_last_dir(""), m_cursor_pos(),
+      m_reportProgress(false), m_recentScriptList(),
+      m_nullScript(new NullScriptFileInterpreter), m_current(m_nullScript),
+      m_globalZoomLevel(0), m_showWhitespace(false), m_replaceTabs(true),
+      m_tabWhitespaceCount(4), m_fontFamily(), m_codeFolding(false) {
+  connect(this, SIGNAL(currentChanged(int)), this,
+          SLOT(tabSelectionChanged(int)));
 }
 
 /**
  * Destructor
  */
-MultiTabScriptInterpreter::~MultiTabScriptInterpreter()
-{
-  delete m_nullScript;
-}
+MultiTabScriptInterpreter::~MultiTabScriptInterpreter() { delete m_nullScript; }
 
 /// @return Interpreter at given index
-ScriptFileInterpreter * MultiTabScriptInterpreter::interpreterAt(int index)
-{
-  if(count() > 0)
-  {
-    return qobject_cast<ScriptFileInterpreter*>(widget(index));
-  }
-  else
-  {
+ScriptFileInterpreter *MultiTabScriptInterpreter::interpreterAt(int index) {
+  if (count() > 0) {
+    return qobject_cast<ScriptFileInterpreter *>(widget(index));
+  } else {
     return m_nullScript;
   }
 }
@@ -70,11 +65,10 @@ ScriptFileInterpreter * MultiTabScriptInterpreter::interpreterAt(int index)
 /**
  * Is a script running in the environment
  */
-bool MultiTabScriptInterpreter::isExecuting()
-{
-  for(int i = 0; i < count(); ++i)
-  {
-    if(interpreterAt(i)->isExecuting()) return true;
+bool MultiTabScriptInterpreter::isExecuting() {
+  for (int i = 0; i < count(); ++i) {
+    if (interpreterAt(i)->isExecuting())
+      return true;
   }
   return false;
 }
@@ -84,12 +78,13 @@ bool MultiTabScriptInterpreter::isExecuting()
 //-------------------------------------------
 /**
  * Create a new tab such that it is the specified index within the tab range.
- * @param index :: The index to give the new tab. If this is invalid the tab is simply appended
+ * @param index :: The index to give the new tab. If this is invalid the tab is
+ * simply appended
  * @param filename :: An optional filename
  */
-void MultiTabScriptInterpreter::newTab(int index, const QString & filename)
-{
-  ScriptFileInterpreter *scriptRunner = new ScriptFileInterpreter(this,"ScriptWindow");
+void MultiTabScriptInterpreter::newTab(int index, const QString &filename) {
+  ScriptFileInterpreter *scriptRunner =
+      new ScriptFileInterpreter(this, "ScriptWindow");
   scriptRunner->setup(*scriptingEnv(), filename);
   scriptRunner->toggleProgressReporting(m_reportProgress);
   scriptRunner->toggleCodeFolding(m_codeFolding);
@@ -97,17 +92,21 @@ void MultiTabScriptInterpreter::newTab(int index, const QString & filename)
   scriptRunner->setTabWhitespaceCount(m_tabWhitespaceCount);
   scriptRunner->toggleReplaceTabs(m_replaceTabs);
   scriptRunner->setFont(m_fontFamily);
-  connect(scriptRunner, SIGNAL(editorModificationChanged(bool)),
-          this, SLOT(currentEditorModified(bool)));
+  connect(scriptRunner, SIGNAL(editorModificationChanged(bool)), this,
+          SLOT(currentEditorModified(bool)));
   index = insertTab(index, scriptRunner, "");
   setCurrentIndex(index);
   setTabTitle(scriptRunner, filename); // Make sure the tooltip is set
   scriptRunner->setFocus();
   scriptRunner->editor()->zoomIn(globalZoomLevel());
-  connect(scriptRunner->editor(), SIGNAL(textZoomedIn()), this, SLOT(zoomInAllButCurrent()));
-  connect(scriptRunner->editor(), SIGNAL(textZoomedIn()), this, SLOT(trackZoomIn()));
-  connect(scriptRunner->editor(), SIGNAL(textZoomedOut()), this, SLOT(zoomOutAllButCurrent()));
-  connect(scriptRunner->editor(), SIGNAL(textZoomedOut()), this, SLOT(trackZoomOut()));
+  connect(scriptRunner->editor(), SIGNAL(textZoomedIn()), this,
+          SLOT(zoomInAllButCurrent()));
+  connect(scriptRunner->editor(), SIGNAL(textZoomedIn()), this,
+          SLOT(trackZoomIn()));
+  connect(scriptRunner->editor(), SIGNAL(textZoomedOut()), this,
+          SLOT(zoomOutAllButCurrent()));
+  connect(scriptRunner->editor(), SIGNAL(textZoomedOut()), this,
+          SLOT(trackZoomOut()));
 
   emit newTabCreated(index);
   emit tabCountChanged(count());
@@ -117,8 +116,7 @@ void MultiTabScriptInterpreter::newTab(int index, const QString & filename)
  * Open a file in the current tab
  * @param filename :: An optional file name
  */
-void MultiTabScriptInterpreter::openInCurrentTab(const QString & filename)
-{
+void MultiTabScriptInterpreter::openInCurrentTab(const QString &filename) {
   open(false, filename);
 }
 
@@ -126,8 +124,7 @@ void MultiTabScriptInterpreter::openInCurrentTab(const QString & filename)
  * Open a file in a new tab
  * @param filename :: An optional file name
  */
-void MultiTabScriptInterpreter::openInNewTab(const QString & filename)
-{
+void MultiTabScriptInterpreter::openInNewTab(const QString &filename) {
   open(true, filename);
 }
 
@@ -135,58 +132,43 @@ void MultiTabScriptInterpreter::openInNewTab(const QString & filename)
  * open the selected script from the File->Recent Scripts  in a new tab
  * @param index :: The index of the selected script
  */
-void MultiTabScriptInterpreter::openRecentScript(int index)
-{
-  if(index < m_recentScriptList.count())
-  {
+void MultiTabScriptInterpreter::openRecentScript(int index) {
+  if (index < m_recentScriptList.count()) {
     QString filename = m_recentScriptList[index];
     openInNewTab(filename);
   }
 }
 
 /// Save current file
-void MultiTabScriptInterpreter::saveToCurrentFile()
-{
-  try
-  {
+void MultiTabScriptInterpreter::saveToCurrentFile() {
+  try {
     m_current->saveToCurrentFile();
     setTabTitle(m_current, m_current->filename());
-  }
-  catch(ScriptEditor::SaveCancelledException&) {}
-  catch(std::runtime_error& exc)
-  {
+  } catch (ScriptEditor::SaveCancelledException &) {
+  } catch (std::runtime_error &exc) {
     QMessageBox::critical(this, tr("MantidPlot"), tr(exc.what()));
   }
 }
 
 /// Save to new file
-void MultiTabScriptInterpreter::saveAs()
-{
-  try
-  {
+void MultiTabScriptInterpreter::saveAs() {
+  try {
     m_current->saveAs();
     setTabTitle(m_current, m_current->filename());
-  }
-  catch(ScriptEditor::SaveCancelledException&) {}
-  catch(std::runtime_error& exc)
-  {
+  } catch (ScriptEditor::SaveCancelledException &) {
+  } catch (std::runtime_error &exc) {
     QMessageBox::critical(this, tr("MantidPlot"), tr(exc.what()));
   }
 }
 
 /// Print the current script
-void MultiTabScriptInterpreter::print()
-{
-  m_current->printScript();
-}
+void MultiTabScriptInterpreter::print() { m_current->printScript(); }
 
 /**
  * Close current tab
  */
-int MultiTabScriptInterpreter::closeCurrentTab()
-{
-  if( count() > 0 )
-  {
+int MultiTabScriptInterpreter::closeCurrentTab() {
+  if (count() > 0) {
     int index = currentIndex();
     closeTabAtIndex(index);
     return index;
@@ -194,104 +176,98 @@ int MultiTabScriptInterpreter::closeCurrentTab()
   return -1;
 }
 
-
 /**
  * Close all tabs
  */
-void MultiTabScriptInterpreter::closeAllTabs()
-{
+void MultiTabScriptInterpreter::closeAllTabs() {
   int index_end = count() - 1;
   setCurrentIndex(index_end);
-  for( int index = index_end; index >= 0; --index )
-  {
-    //This closes the tab at the end.
+  for (int index = index_end; index >= 0; --index) {
+    // This closes the tab at the end.
     closeTabAtIndex(index);
   }
   m_current = m_nullScript;
 }
 
 /**
- *  This method is useful for saving the currently opened script files to project file 
+ *  This method is useful for saving the currently opened script files to
+ * project file
 */
-QString MultiTabScriptInterpreter::saveToString()
-{
+QString MultiTabScriptInterpreter::saveToString() {
   int nscripts = 0;
   QString fileNames;
-  fileNames="<scriptwindow>\n";
-  fileNames+="ScriptNames\t";
+  fileNames = "<scriptwindow>\n";
+  fileNames += "ScriptNames\t";
   int ntabs = count();
-  //get the number of tabs and append  the script file name for each tab
-  //to a string
-  for( int index = 0; index < ntabs; ++index )
-  {
+  // get the number of tabs and append  the script file name for each tab
+  // to a string
+  for (int index = 0; index < ntabs; ++index) {
     ScriptFileInterpreter *interpreter = interpreterAt(index);
     QString s = interpreter->filename();
-    if(!s.isEmpty())
-    {
-      fileNames+=s;
-      fileNames+="\t";
+    if (!s.isEmpty()) {
+      fileNames += s;
+      fileNames += "\t";
       nscripts++;
     }
   }
-  fileNames+="\n</scriptwindow>\n";
+  fileNames += "\n</scriptwindow>\n";
   return (nscripts > 0) ? fileNames : "";
 }
 
+/**
+ * Creates a returns a QStringList of filenames associated with the currently
+ * opened tabs
+ * @return A QStringList of all the filenames associated with each tab
+ */
+QStringList MultiTabScriptInterpreter::fileNamesToQStringList() {
+  int nscripts = 0;
+  QStringList fileNames;
+  int ntabs = count();
+  // get the number of tabs and append  the script file name for each tab
+  // to a QStringList
+  for (int index = 0; index < ntabs; ++index) {
+    ScriptFileInterpreter *interpreter = interpreterAt(index);
+    QString s = interpreter->filename();
+    if (!s.isEmpty()) {
+      fileNames.append(s);
+      nscripts++;
+    }
+  }
+  QStringList empty;
+  return (nscripts > 0) ? fileNames : empty;
+}
 
 /**
  * Show the find/replace dialog
  */
-void MultiTabScriptInterpreter::showFindReplaceDialog()
-{
+void MultiTabScriptInterpreter::showFindReplaceDialog() {
   m_current->showFindReplaceDialog();
 }
 
 /// undo
-void MultiTabScriptInterpreter::undo()
-{
-  m_current->undo();
-}
+void MultiTabScriptInterpreter::undo() { m_current->undo(); }
 /// redo
-void MultiTabScriptInterpreter::redo()
-{
-  m_current->redo();
-}
+void MultiTabScriptInterpreter::redo() { m_current->redo(); }
 
 /// cut current
-void MultiTabScriptInterpreter::cut()
-{
-  m_current->cut();
-}
+void MultiTabScriptInterpreter::cut() { m_current->cut(); }
 
 /// copy method
-void MultiTabScriptInterpreter::copy()
-{
-  m_current->copy();
-}
-  ///paste method
-void MultiTabScriptInterpreter::paste()
-{
-  m_current->paste();
-}
+void MultiTabScriptInterpreter::copy() { m_current->copy(); }
+/// paste method
+void MultiTabScriptInterpreter::paste() { m_current->paste(); }
 
-///comment method
-void MultiTabScriptInterpreter::comment()
-{
-  m_current->comment();
-}
+/// comment method
+void MultiTabScriptInterpreter::comment() { m_current->comment(); }
 
-///uncomment method
-void MultiTabScriptInterpreter::uncomment()
-{
-  m_current->uncomment();
-}
+/// uncomment method
+void MultiTabScriptInterpreter::uncomment() { m_current->uncomment(); }
 
 /**
  * Execute the highlighted code from the current tab
  * *@param mode :: The mode used to execute
  */
-void MultiTabScriptInterpreter::executeAll(const Script::ExecutionMode mode)
-{
+void MultiTabScriptInterpreter::executeAll(const Script::ExecutionMode mode) {
   m_current->executeAll(mode);
 }
 
@@ -299,43 +275,33 @@ void MultiTabScriptInterpreter::executeAll(const Script::ExecutionMode mode)
  * given execution mode
  * @param mode :: The mode used to execute
  */
-void MultiTabScriptInterpreter::executeSelection(const Script::ExecutionMode mode)
-{
+void MultiTabScriptInterpreter::executeSelection(
+    const Script::ExecutionMode mode) {
   m_current->executeSelection(mode);
 }
 
 /**
  * Evaluate
  */
-void MultiTabScriptInterpreter::evaluate()
-{
+void MultiTabScriptInterpreter::evaluate() {
   QMessageBox::information(this, "MantidPlot", "Evaluate is not implemented.");
 }
 
 /**
  */
-void MultiTabScriptInterpreter::clearScriptVariables()
-{
+void MultiTabScriptInterpreter::clearScriptVariables() {
   m_current->clearVariables();
 }
 
 /// Tracks the global zoom level
-void MultiTabScriptInterpreter::trackZoomIn()
-{
-  ++m_globalZoomLevel;
-}
+void MultiTabScriptInterpreter::trackZoomIn() { ++m_globalZoomLevel; }
 
 /// Tracks the global zoom level
-void MultiTabScriptInterpreter::trackZoomOut()
-{
-  --m_globalZoomLevel;
-}
+void MultiTabScriptInterpreter::trackZoomOut() { --m_globalZoomLevel; }
 
 /// Increase font size on all tabs
-void MultiTabScriptInterpreter::zoomIn()
-{
-  for(int index = 0; index < count(); ++index)
-  {
+void MultiTabScriptInterpreter::zoomIn() {
+  for (int index = 0; index < count(); ++index) {
     interpreterAt(index)->editor()->zoomIn();
   }
 }
@@ -343,20 +309,17 @@ void MultiTabScriptInterpreter::zoomIn()
 /**
  * @param skipIndex The tab that should be skipped
  */
-void MultiTabScriptInterpreter::zoomInAllButCurrent()
-{
+void MultiTabScriptInterpreter::zoomInAllButCurrent() {
   int skipIndex = this->currentIndex();
-  for(int i = 0; i < count(); ++i)
-  {
-    if(i != skipIndex) interpreterAt(i)->editor()->zoomIn();
+  for (int i = 0; i < count(); ++i) {
+    if (i != skipIndex)
+      interpreterAt(i)->editor()->zoomIn();
   }
 }
 
 /// Decrease font size on all tabs
-void MultiTabScriptInterpreter::zoomOut()
-{
-  for(int i = 0; i < count(); ++i)
-  {
+void MultiTabScriptInterpreter::zoomOut() {
+  for (int i = 0; i < count(); ++i) {
     interpreterAt(i)->editor()->zoomOut();
   }
 }
@@ -364,39 +327,32 @@ void MultiTabScriptInterpreter::zoomOut()
 /**
  * @param skipIndex The tab that should be skipped
  */
-void MultiTabScriptInterpreter::zoomOutAllButCurrent()
-{
+void MultiTabScriptInterpreter::zoomOutAllButCurrent() {
   int skipIndex = this->currentIndex();
-  for(int i = 0; i < count(); ++i)
-  {
-    if(i != skipIndex) interpreterAt(i)->editor()->zoomOut();
+  for (int i = 0; i < count(); ++i) {
+    if (i != skipIndex)
+      interpreterAt(i)->editor()->zoomOut();
   }
 }
 
 /**
  * Resets to zoom on all tabs to default
  */
-void MultiTabScriptInterpreter::resetZoom()
-{
+void MultiTabScriptInterpreter::resetZoom() {
   m_globalZoomLevel = 0;
-  for(int i = 0; i < count(); ++i)
-  {
+  for (int i = 0; i < count(); ++i) {
     interpreterAt(i)->editor()->zoomTo(m_globalZoomLevel);
   }
-
 }
-
 
 /**
  * Toggle the progress arrow on/off
  * @param state :: The state of the option
  */
-void MultiTabScriptInterpreter::toggleProgressReporting(bool state)
-{
+void MultiTabScriptInterpreter::toggleProgressReporting(bool state) {
   m_reportProgress = state;
   int index_end = count() - 1;
-  for( int index = index_end; index >= 0; --index )
-  {
+  for (int index = index_end; index >= 0; --index) {
     interpreterAt(index)->toggleProgressReporting(state);
   }
 }
@@ -405,12 +361,10 @@ void MultiTabScriptInterpreter::toggleProgressReporting(bool state)
  * Toggle code folding on/off
  * @param state :: The state of the option
  */
-void MultiTabScriptInterpreter::toggleCodeFolding(bool state)
-{
+void MultiTabScriptInterpreter::toggleCodeFolding(bool state) {
   m_codeFolding = state;
   int index_end = count() - 1;
-  for( int index = index_end; index >= 0; --index )
-  {
+  for (int index = index_end; index >= 0; --index) {
     interpreterAt(index)->toggleCodeFolding(state);
   }
 }
@@ -418,12 +372,10 @@ void MultiTabScriptInterpreter::toggleCodeFolding(bool state)
  * Toggle the whitespace arrow on/off
  * @param state :: The state of the option
  */
-void MultiTabScriptInterpreter::toggleWhitespace(bool state)
-{
+void MultiTabScriptInterpreter::toggleWhitespace(bool state) {
   m_showWhitespace = state;
   int index_end = count() - 1;
-  for( int index = index_end; index >= 0; --index )
-  {
+  for (int index = index_end; index >= 0; --index) {
     interpreterAt(index)->toggleWhitespace(state);
   }
 }
@@ -431,83 +383,77 @@ void MultiTabScriptInterpreter::toggleWhitespace(bool state)
 /**
  * Show configuration dialogue for tab whitespace
  */
-void MultiTabScriptInterpreter::openConfigTabs()
-{
+void MultiTabScriptInterpreter::openConfigTabs() {
   // Create dialogue
-  QDialog configTabs(this,"Configure Tab Whitespace",false,Qt::Dialog);
-  QBoxLayout *layoutTabDialogue = new QBoxLayout(QBoxLayout::Direction::TopToBottom);
+  QDialog configTabs(this, "Configure Tab Whitespace", false, Qt::Dialog);
+  QBoxLayout *layoutTabDialogue =
+      new QBoxLayout(QBoxLayout::Direction::TopToBottom);
   configTabs.setLayout(layoutTabDialogue);
 
   // Toggle replace tab with spaces
   QCheckBox *chkbxReplaceTabs = new QCheckBox("Replace tabs with spaces?");
   chkbxReplaceTabs->setChecked(m_replaceTabs);
-  connect(chkbxReplaceTabs, SIGNAL(toggled(bool)), this, SLOT(toggleReplaceTabs(bool)));
+  connect(chkbxReplaceTabs, SIGNAL(toggled(bool)), this,
+          SLOT(toggleReplaceTabs(bool)));
   layoutTabDialogue->addWidget(chkbxReplaceTabs);
 
   // Count spaces per tab
   QFrame *frameSpacesPerTab = new QFrame();
-  QBoxLayout *layoutSpacesPerTab = new QBoxLayout(QBoxLayout::Direction::LeftToRight);
+  QBoxLayout *layoutSpacesPerTab =
+      new QBoxLayout(QBoxLayout::Direction::LeftToRight);
   frameSpacesPerTab->setLayout(layoutSpacesPerTab);
   layoutTabDialogue->addWidget(frameSpacesPerTab);
 
-  QLabel *labelSpaceCount = new QLabel("Number of spaces per tab"); 
+  QLabel *labelSpaceCount = new QLabel("Number of spaces per tab");
   layoutSpacesPerTab->addWidget(labelSpaceCount);
 
-  QSpinBox *spinnerSpaceCount = new QSpinBox(); 
-  spinnerSpaceCount->setRange(0,20);
+  QSpinBox *spinnerSpaceCount = new QSpinBox();
+  spinnerSpaceCount->setRange(0, 20);
   spinnerSpaceCount->setValue(m_tabWhitespaceCount);
-  connect (spinnerSpaceCount,SIGNAL(valueChanged(int)),this,SLOT(changeWhitespaceCount(int)));
+  connect(spinnerSpaceCount, SIGNAL(valueChanged(int)), this,
+          SLOT(changeWhitespaceCount(int)));
   layoutSpacesPerTab->addWidget(spinnerSpaceCount);
 
-  configTabs.exec(); 
+  configTabs.exec();
 }
 
 /**
  * Toggle tabs being replaced with whitespace
  * @param state :: The state of the option
  */
-void MultiTabScriptInterpreter::toggleReplaceTabs(bool state)
-{
+void MultiTabScriptInterpreter::toggleReplaceTabs(bool state) {
   m_replaceTabs = state;
-  
+
   int index_end = count() - 1;
-  for( int index = index_end; index >= 0; --index )
-  {
+  for (int index = index_end; index >= 0; --index) {
     interpreterAt(index)->toggleReplaceTabs(state);
   }
 }
 
 /// Change number of characters used for a tab
-void MultiTabScriptInterpreter::changeWhitespaceCount(int value)
-{
+void MultiTabScriptInterpreter::changeWhitespaceCount(int value) {
   m_tabWhitespaceCount = value;
 
   int index_end = count() - 1;
-  for( int index = index_end; index >= 0; --index )
-  {
+  for (int index = index_end; index >= 0; --index) {
     interpreterAt(index)->setTabWhitespaceCount(value);
   }
 }
 
 /// Convert tabs in selection to spaces
-void MultiTabScriptInterpreter::tabsToSpaces()
-{
-  m_current->tabsToSpaces();
-}
+void MultiTabScriptInterpreter::tabsToSpaces() { m_current->tabsToSpaces(); }
 
 /// Convert spaces in selection to tabs
-void MultiTabScriptInterpreter::spacesToTabs()
-{
-  m_current->spacesToTabs();
-}
+void MultiTabScriptInterpreter::spacesToTabs() { m_current->spacesToTabs(); }
 
 /// Show select font dialog
-void MultiTabScriptInterpreter::showSelectFont()
-{
+void MultiTabScriptInterpreter::showSelectFont() {
   // Would prefer to use QFontDialog but only interested in font family
-  
-  QDialog *selectFont = new QDialog(this,"Configure Tab Whitespace",false,Qt::Dialog);
-  QBoxLayout *layoutFontDialogue = new QBoxLayout(QBoxLayout::Direction::TopToBottom);
+
+  QDialog *selectFont =
+      new QDialog(this, "Configure Tab Whitespace", false, Qt::Dialog);
+  QBoxLayout *layoutFontDialogue =
+      new QBoxLayout(QBoxLayout::Direction::TopToBottom);
   selectFont->setLayout(layoutFontDialogue);
 
   // Get available fonts
@@ -515,37 +461,38 @@ void MultiTabScriptInterpreter::showSelectFont()
   QFontDatabase database;
   fontList->addItems(database.families());
   layoutFontDialogue->addWidget(fontList);
-  
+
   // Select saved choice. If not available, use current font
-  QString fontToUse = m_current->font().family(); // Not actually the font used by default by the lexer
-  
-  if(database.families().contains(m_fontFamily))
+  QString fontToUse =
+      m_current->font()
+          .family(); // Not actually the font used by default by the lexer
+
+  if (database.families().contains(m_fontFamily))
     fontToUse = m_fontFamily;
 
-  QListWidgetItem *item = fontList->findItems(fontToUse,Qt::MatchExactly)[0];
-  fontList->setItemSelected(item, true);  
+  QListWidgetItem *item = fontList->findItems(fontToUse, Qt::MatchExactly)[0];
+  fontList->setItemSelected(item, true);
   fontList->scrollToItem(item, QAbstractItemView::PositionAtTop);
 
   QFrame *frameButtons = new QFrame();
-  QBoxLayout *layoutButtons = new QBoxLayout(QBoxLayout::Direction::LeftToRight);
+  QBoxLayout *layoutButtons =
+      new QBoxLayout(QBoxLayout::Direction::LeftToRight);
   frameButtons->setLayout(layoutButtons);
   layoutFontDialogue->addWidget(frameButtons);
-  
+
   QPushButton *cancelButton = new QPushButton("Cancel");
   layoutButtons->addWidget(cancelButton);
-  connect (cancelButton,SIGNAL(clicked()), selectFont, SLOT(reject()));
+  connect(cancelButton, SIGNAL(clicked()), selectFont, SLOT(reject()));
 
   QPushButton *acceptButton = new QPushButton("Set Font");
   layoutButtons->addWidget(acceptButton);
-  connect (acceptButton,SIGNAL(clicked()), selectFont, SLOT(accept()));
+  connect(acceptButton, SIGNAL(clicked()), selectFont, SLOT(accept()));
 
-  if(selectFont->exec() == QDialog::Accepted)
-  {
+  if (selectFont->exec() == QDialog::Accepted) {
     m_fontFamily = fontList->selectedItems()[0]->text();
 
     int index_end = count() - 1;
-    for( int index = index_end; index >= 0; --index )
-    {
+    for (int index = index_end; index >= 0; --index) {
       interpreterAt(index)->setFont(m_fontFamily);
     }
   }
@@ -556,11 +503,11 @@ void MultiTabScriptInterpreter::showSelectFont()
 //--------------------------------------------
 
 /**
- * Close clicked tab. Qt cannot give the position where an action is clicked so this just gets 
+ * Close clicked tab. Qt cannot give the position where an action is clicked so
+ * this just gets
  * the current cursor position and calls the closeAtPosition function
  */
-void MultiTabScriptInterpreter::closeClickedTab()
-{
+void MultiTabScriptInterpreter::closeClickedTab() {
   closeTabAtPosition(m_cursor_pos);
 }
 
@@ -568,17 +515,13 @@ void MultiTabScriptInterpreter::closeClickedTab()
  * Mark the current tab as changed. True means that the editor has
  * modifications
  */
-void MultiTabScriptInterpreter::currentEditorModified(bool state)
-{
+void MultiTabScriptInterpreter::currentEditorModified(bool state) {
   static const QString modifiedLabel("*");
   const int index = currentIndex();
   QString tabLabel = tabText(index);
-  if(state)
-  {
+  if (state) {
     tabLabel += modifiedLabel;
-  }
-  else
-  {
+  } else {
     tabLabel.chop(modifiedLabel.length());
   }
   setTabText(index, tabLabel);
@@ -588,21 +531,19 @@ void MultiTabScriptInterpreter::currentEditorModified(bool state)
  * The current selection has changed
  * @param index The index of the new selection
  */
-void MultiTabScriptInterpreter::tabSelectionChanged(int index)
-{
+void MultiTabScriptInterpreter::tabSelectionChanged(int index) {
   m_current->disconnect(SIGNAL(executionStarted()));
   m_current->disconnect(SIGNAL(executionStopped()));
-  if( count() > 0 )
-  {
+  if (count() > 0) {
     m_current = interpreterAt(index);
-    connect(m_current, SIGNAL(executionStarted()), this, SLOT(sendScriptExecutingSignal()));
-    connect(m_current, SIGNAL(executionStopped()), this, SLOT(sendScriptStoppedSignal()));
+    connect(m_current, SIGNAL(executionStarted()), this,
+            SLOT(sendScriptExecutingSignal()));
+    connect(m_current, SIGNAL(executionStopped()), this,
+            SLOT(sendScriptStoppedSignal()));
     emit executionStateChanged(m_current->isExecuting());
     setFocusProxy(m_current);
     m_current->setFocus();
-  }
-  else
-  {
+  } else {
     m_current = m_nullScript;
   }
 }
@@ -610,16 +551,14 @@ void MultiTabScriptInterpreter::tabSelectionChanged(int index)
 /**
  * Emits the executionStateChanged(true) signal
  */
-void MultiTabScriptInterpreter::sendScriptExecutingSignal()
-{
+void MultiTabScriptInterpreter::sendScriptExecutingSignal() {
   emit executionStateChanged(true);
 }
 
 /**
  * Emits the executionStateChanged(false) signal
  */
-void MultiTabScriptInterpreter::sendScriptStoppedSignal()
-{
+void MultiTabScriptInterpreter::sendScriptStoppedSignal() {
   emit executionStateChanged(false);
 }
 
@@ -630,17 +569,14 @@ void MultiTabScriptInterpreter::sendScriptStoppedSignal()
 /**
  * A context menu event for the tab widget itself
  * @param event :: The context menu event
- */  
-void MultiTabScriptInterpreter::contextMenuEvent(QContextMenuEvent *event)
-{
+ */
+void MultiTabScriptInterpreter::contextMenuEvent(QContextMenuEvent *event) {
   QMenu context(this);
 
-  m_cursor_pos = event->pos(); //in widget coordinates
-  
-  if( count() > 0 )
-  {
-    if( tabBar()->tabAt(m_cursor_pos) >= 0 )
-    {
+  m_cursor_pos = event->pos(); // in widget coordinates
+
+  if (count() > 0) {
+    if (tabBar()->tabAt(m_cursor_pos) >= 0) {
       QAction *close = new QAction(tr("&Close Tab"), this);
       connect(close, SIGNAL(triggered()), this, SLOT(closeClickedTab()));
       context.addAction(close);
@@ -657,19 +593,17 @@ void MultiTabScriptInterpreter::contextMenuEvent(QContextMenuEvent *event)
   connect(newtab, SIGNAL(triggered()), this, SLOT(newTab()));
   context.addAction(newtab);
 
-
   context.exec(QCursor::pos());
 }
 
 /**
- * A custom event handler, which in this case monitors for ScriptChangeEvent signals
+ * A custom event handler, which in this case monitors for ScriptChangeEvent
+ * signals
  * @param event :: The custome event
  */
-void MultiTabScriptInterpreter::customEvent(QEvent *event)
-{
-  if( !isExecuting() && event->type() == SCRIPTING_CHANGE_EVENT )
-  {
-    ScriptingChangeEvent *sce = static_cast<ScriptingChangeEvent*>(event);
+void MultiTabScriptInterpreter::customEvent(QEvent *event) {
+  if (!isExecuting() && event->type() == SCRIPTING_CHANGE_EVENT) {
+    ScriptingChangeEvent *sce = static_cast<ScriptingChangeEvent *>(event);
     // This handles reference counting of the scripting environment
     Scripted::scriptingChangeEvent(sce);
   }
@@ -680,37 +614,32 @@ void MultiTabScriptInterpreter::customEvent(QEvent *event)
  * @param newtab :: If true, a new tab will be created
  * @param filename :: An optional file name
  */
-void MultiTabScriptInterpreter::open(bool newtab, const QString & filename)
-{
+void MultiTabScriptInterpreter::open(bool newtab, const QString &filename) {
   QString fileToOpen = filename;
-  if( fileToOpen.isEmpty() )
-  {
+  if (fileToOpen.isEmpty()) {
     QString filter = scriptingEnv()->fileFilter();
     filter += tr("Text") + " (*.txt *.TXT);;";
-    filter += tr("All Files")+" (*)";
-    fileToOpen = QFileDialog::getOpenFileName(this, tr("MantidPlot - Open a script from a file"),
-        m_last_dir, filter);
-    if( fileToOpen.isEmpty() )
-    {
+    filter += tr("All Files") + " (*)";
+    fileToOpen = QFileDialog::getOpenFileName(
+        this, tr("MantidPlot - Open a script from a file"), m_last_dir, filter);
+    if (fileToOpen.isEmpty()) {
       return;
     }
-  }
-  else
-  {
+  } else {
     QFileInfo details(fileToOpen);
     fileToOpen = details.absoluteFilePath();
   }
 
-  //Save last directory
+  // Save last directory
   m_last_dir = QFileInfo(fileToOpen).absolutePath();
 
   int index(-1);
-  if( !newtab ) index = closeCurrentTab();
+  if (!newtab)
+    index = closeCurrentTab();
   newTab(index, fileToOpen);
 
-  //update the recent scripts menu 
+  // update the recent scripts menu
   updateRecentScriptList(fileToOpen);
-
 }
 
 /**
@@ -718,8 +647,8 @@ void MultiTabScriptInterpreter::open(bool newtab, const QString & filename)
  * @param widget A pointer to the widget on the tab
  * @param filename The filename on the tab
  */
-void MultiTabScriptInterpreter::setTabTitle(QWidget *widget, const QString & filename)
-{
+void MultiTabScriptInterpreter::setTabTitle(QWidget *widget,
+                                            const QString &filename) {
   setTabLabel(widget, createTabTitle(filename));
   setTabToolTip(widget, filename);
 }
@@ -730,15 +659,12 @@ void MultiTabScriptInterpreter::setTabTitle(QWidget *widget, const QString & fil
  * @param filename The filename of the script.
  * @return A string to use as the tab title
  */
-QString MultiTabScriptInterpreter::createTabTitle(const QString & filename) const
-{
+QString
+MultiTabScriptInterpreter::createTabTitle(const QString &filename) const {
   QString title;
-  if( filename.isEmpty() )
-  {
+  if (filename.isEmpty()) {
     title = "New script";
-  }
-  else
-  {
+  } else {
     title = QFileInfo(filename).fileName();
   }
   return title;
@@ -747,9 +673,8 @@ QString MultiTabScriptInterpreter::createTabTitle(const QString & filename) cons
 /**
  * Close a given tab
  * @param index :: The tab index
- */ 
-void MultiTabScriptInterpreter::closeTabAtIndex(int index)
-{
+ */
+void MultiTabScriptInterpreter::closeTabAtIndex(int index) {
   ScriptFileInterpreter *interpreter = interpreterAt(index);
   interpreter->prepareToClose();
   emit tabClosing(index);
@@ -757,48 +682,44 @@ void MultiTabScriptInterpreter::closeTabAtIndex(int index)
   emit tabClosed(index);
   const int nTabs = count();
   emit tabCountChanged(nTabs);
-  if(nTabs == 0) emit lastTabClosed();
+  if (nTabs == 0)
+    emit lastTabClosed();
 }
-
 
 /**
  * Close a tab at a given position
  * @param pos :: The tab at the given position
- */ 
-void MultiTabScriptInterpreter::closeTabAtPosition(const QPoint & pos)
-{
+ */
+void MultiTabScriptInterpreter::closeTabAtPosition(const QPoint &pos) {
   int index = tabBar()->tabAt(pos);
-  //Index is checked in closeTab
+  // Index is checked in closeTab
   closeTabAtIndex(index);
 }
 
-/** 
+/**
  * Keeps the recent script list up to date
  */
-void MultiTabScriptInterpreter::updateRecentScriptList(const QString & filename)
-{
+void MultiTabScriptInterpreter::updateRecentScriptList(
+    const QString &filename) {
   m_recentScriptList.remove(filename);
   m_recentScriptList.push_front(filename);
-  if( m_recentScriptList.count() > MaxRecentScripts )
-  {
+  if (m_recentScriptList.count() > MaxRecentScripts) {
     m_recentScriptList.pop_back();
   }
 }
 
-/** 
+/**
 * This method returns the recent scripts list
 * @returns a list containing the name of the recent scripts.
 */
-QStringList MultiTabScriptInterpreter::recentScripts() 
-{
+QStringList MultiTabScriptInterpreter::recentScripts() {
   return m_recentScriptList;
 }
 
-/** 
+/**
  * sets the recent scripts list
  * @param rslist :: list containing the name of the recent scripts.
  */
-void MultiTabScriptInterpreter::setRecentScripts(const QStringList& rslist)
-{
+void MultiTabScriptInterpreter::setRecentScripts(const QStringList &rslist) {
   m_recentScriptList = rslist;
 }

--- a/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.h
+++ b/Code/Mantid/MantidPlot/src/MultiTabScriptInterpreter.h
@@ -26,15 +26,16 @@ class QStringList;
 
 class ScriptingWindow;
 
-/** 
+/**
     This class manages ScriptEditor objects and displays them in a series
     of tabs. It is also the single point of entry for executing scripts
     with in the current ScriptingEnv
-    
+
     @author Martyn Gigg, Tessella Support Services plc
     @date 19/08/2009
 
-    Copyright &copy; 2009 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+    Copyright &copy; 2009 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+   National Laboratory & European Spallation Source
 
     This file is part of Mantid.
 
@@ -52,22 +53,21 @@ class ScriptingWindow;
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     File change history is stored at: <https://github.com/mantidproject/mantid>
-    Code Documentation is available at: <http://doxygen.mantidproject.org>    
+    Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MultiTabScriptInterpreter : public QTabWidget, Scripted
-{
+class MultiTabScriptInterpreter : public QTabWidget, Scripted {
   Q_OBJECT
 
 public:
   /// Constructor
   MultiTabScriptInterpreter(ScriptingEnv *env, QWidget *parent);
-  ///Destructor
+  /// Destructor
   ~MultiTabScriptInterpreter();
 
   /// Current interpreter
-  ScriptFileInterpreter * currentInterpreter();
+  ScriptFileInterpreter *currentInterpreter();
   /// Interpreter at given index
-  ScriptFileInterpreter * interpreterAt(int index);
+  ScriptFileInterpreter *interpreterAt(int index);
 
   /// Is a script running in the environment
   bool isExecuting();
@@ -75,15 +75,17 @@ public:
   /// Returns the global zoom level
   int globalZoomLevel() const { return m_globalZoomLevel; }
 
- /// this method appends the file names of scripts
- ///in different tabs to a string and returns 
+  /// this method appends the file names of scripts
+  /// in different tabs to a string and returns
   QString saveToString();
-  ///this method returns a list containing  recent scripts
+  /// Saves Filenames associated with each tab to a QStringList
+  QStringList fileNamesToQStringList();
+  /// this method returns a list containing  recent scripts
   QStringList recentScripts();
   /// update the Recent Scripts menu items
-  void updateRecentScriptList(const QString & filename);
-  ///set the recent script list
-  void setRecentScripts(const QStringList & scriptList);
+  void updateRecentScriptList(const QString &filename);
+  /// set the recent script list
+  void setRecentScripts(const QStringList &scriptList);
 
 signals:
   /// Signal that a tab has been created
@@ -104,12 +106,13 @@ signals:
   void executionStateChanged(bool state);
 
 public slots:
-  /// Create a new tab for script editing with the text within the file imported and insert it at the index
-  void newTab(int index = -1, const QString & filename = "");
+  /// Create a new tab for script editing with the text within the file imported
+  /// and insert it at the index
+  void newTab(int index = -1, const QString &filename = "");
   /// Open a file in the current tab
-  void openInCurrentTab(const QString & filename = QString());
+  void openInCurrentTab(const QString &filename = QString());
   /// Open a file in a new tab
-  void openInNewTab(const QString & filename = QString());
+  void openInNewTab(const QString &filename = QString());
   /// open recent scripts
   void openRecentScript(int index);
   /// Save current file
@@ -147,7 +150,7 @@ public slots:
   //@{
   /// Execute all using the given mode
   void executeAll(const Script::ExecutionMode mode);
-  ///Execute selection using the given mode
+  /// Execute selection using the given mode
   void executeSelection(const Script::ExecutionMode mode);
   /// Evaluate
   void evaluate();
@@ -202,24 +205,26 @@ private:
   void contextMenuEvent(QContextMenuEvent *event);
   /// A custom defined event handler
   void customEvent(QEvent *event);
-  ///Open a script
-  void open(bool newtab, const QString & filename = QString());
+  /// Open a script
+  void open(bool newtab, const QString &filename = QString());
   /// Sets the tab title & tooltip from the filename
-  void setTabTitle(QWidget *widget, const QString & filename);
+  void setTabTitle(QWidget *widget, const QString &filename);
   /// Returns the tab title for the given filename
-  QString createTabTitle(const QString & filename) const;
-  ///Close a tab with a given index
+  QString createTabTitle(const QString &filename) const;
+  /// Close a tab with a given index
   void closeTabAtIndex(int index);
-  ///Close a tab at a given position
-  void closeTabAtPosition(const QPoint & pos);
+  /// Close a tab at a given position
+  void closeTabAtPosition(const QPoint &pos);
 
- private:
+private:
   friend class ScriptingWindow;
 
   /// The last directory visited with a file dialog
   QString m_last_dir;
-  // The cursor position within the tab bar when the right-mouse button was last clicked
-  // I need this to ensure that the position of a call to tabBar()->tabAt() is accurate
+  // The cursor position within the tab bar when the right-mouse button was last
+  // clicked
+  // I need this to ensure that the position of a call to tabBar()->tabAt() is
+  // accurate
   // as Qt doesn't provide an action signal parameterised on a position
   QPoint m_cursor_pos;
   /// Current progress report state

--- a/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
@@ -123,18 +123,8 @@ void ScriptingWindow::readSettings() {
   m_manager->m_replaceTabs = settings.value("ReplaceTabs", true).toBool();
   m_manager->m_tabWhitespaceCount =
       settings.value("TabWhitespaceCount", 4).toInt();
-  m_manager->m_fontFamily = settings.value("ScriptFontFamily", "").toString();
-  
-  const QStringList filesToOpen =
-      settings.value("/PreviousFiles", "").toStringList();
-  const int totalFiles = filesToOpen.size();
-  if (totalFiles == 0) {
-    m_manager->newTab();
-  } else {
-    for (int i = 0; i < totalFiles; i++) {
-      m_manager->newTab(i, filesToOpen[i]);
-    }
-  }
+  m_manager->m_fontFamily = settings.value("ScriptFontFamily", "").toString();      
+  openPreviousTabs(settings.value("/PreviousFiles", "").toStringList());
 
   settings.endGroup();
 }
@@ -753,4 +743,15 @@ QStringList ScriptingWindow::extractPyFiles(const QList<QUrl> &urlList) const {
     }
   }
   return filenames;
+}
+
+void ScriptingWindow::openPreviousTabs(const QStringList &tabsToOpen) {
+  const int totalFiles = tabsToOpen.size();
+  if (totalFiles == 0) {
+    m_manager->newTab();
+  } else {
+    for (int i = 0; i < totalFiles; i++) {
+      m_manager->newTab(i, tabsToOpen[i]);
+    }
+  }
 }

--- a/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
@@ -64,15 +64,6 @@ ScriptingWindow::ScriptingWindow(ScriptingEnv *env, bool capturePrint,
 
   setWindowIcon(QIcon(":/MantidPlot_Icon_32offset.png"));
   setWindowTitle("MantidPlot: " + env->languageName() + " Window");
-
-  const int total = m_manager->recentScripts().count();
-  if (total == 0) {
-    m_manager->newTab();
-  } else {
-    for (int i = 0; i < total; i++) {
-      m_manager->openRecentScript(i);
-    }
-  }
 }
 
 /**
@@ -102,7 +93,6 @@ void ScriptingWindow::saveSettings() {
   settings.setValue("/TabWhitespaceCount", m_manager->m_tabWhitespaceCount);
   settings.setValue("/ScriptFontFamily", m_manager->m_fontFamily);
   settings.setValue("/CodeFolding", m_toggleFolding->isChecked());
-
   settings.endGroup();
 }
 
@@ -133,7 +123,6 @@ void ScriptingWindow::readSettings() {
   m_manager->m_tabWhitespaceCount =
       settings.value("TabWhitespaceCount", 4).toInt();
   m_manager->m_fontFamily = settings.value("ScriptFontFamily", "").toString();
-
   settings.endGroup();
 }
 

--- a/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
@@ -16,7 +16,7 @@
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtMantidWidgets/ScriptEditor.h"
 
-//Qt
+// Qt
 #include <QTextEdit>
 #include <QMenuBar>
 #include <QMenu>
@@ -32,10 +32,9 @@
 #include <QList>
 #include <QUrl>
 
-namespace
-{
-  /// static logger
-  Mantid::Kernel::Logger g_log("ScriptingWindow");
+namespace {
+/// static logger
+Mantid::Kernel::Logger g_log("ScriptingWindow");
 }
 
 //-------------------------------------------
@@ -47,9 +46,9 @@ namespace
  * @param parent :: The parent widget
  * @param flags :: Window flags passed to the base class
  */
-ScriptingWindow::ScriptingWindow(ScriptingEnv *env, bool capturePrint, QWidget *parent, Qt::WindowFlags flags) :
-  QMainWindow(parent, flags), m_acceptClose(false)
-{
+ScriptingWindow::ScriptingWindow(ScriptingEnv *env, bool capturePrint,
+                                 QWidget *parent, Qt::WindowFlags flags)
+    : QMainWindow(parent, flags), m_acceptClose(false) {
   Q_UNUSED(capturePrint);
   setObjectName("MantidScriptWindow");
   setAcceptDrops(true);
@@ -66,39 +65,38 @@ ScriptingWindow::ScriptingWindow(ScriptingEnv *env, bool capturePrint, QWidget *
   setWindowIcon(QIcon(":/MantidPlot_Icon_32offset.png"));
   setWindowTitle("MantidPlot: " + env->languageName() + " Window");
 
-  // Start with a single script
-  m_manager->newTab();
+  const int total = m_manager->recentScripts().count();
+  if (total == 0) {
+    m_manager->newTab();
+  } else {
+    for (int i = 0; i < total; i++) {
+      m_manager->openRecentScript(i);
+    }
+  }
 }
 
 /**
  * Destructor
  */
-ScriptingWindow::~ScriptingWindow()
-{
-  delete m_manager;
-}
+ScriptingWindow::~ScriptingWindow() { delete m_manager; }
 
 /**
  * Is a script executing
  * @returns A flag indicating the current state
  */
-bool ScriptingWindow::isExecuting() const
-{
-  return m_manager->isExecuting();
-}
+bool ScriptingWindow::isExecuting() const { return m_manager->isExecuting(); }
 
 /**
  * Save the settings on the window
  */
-void ScriptingWindow::saveSettings()
-{
+void ScriptingWindow::saveSettings() {
   QSettings settings;
   settings.beginGroup("/ScriptWindow");
   settings.setValue("/AlwaysOnTop", m_alwaysOnTop->isChecked());
   settings.setValue("/ProgressArrow", m_toggleProgress->isChecked());
   settings.setValue("/LastDirectoryVisited", m_manager->m_last_dir);
-  settings.setValue("/RecentScripts",m_manager->recentScripts());
-  settings.setValue("/ZoomLevel",m_manager->globalZoomLevel());
+  settings.setValue("/RecentScripts", m_manager->recentScripts());
+  settings.setValue("/ZoomLevel", m_manager->globalZoomLevel());
   settings.setValue("/ShowWhitespace", m_toggleWhitespace->isChecked());
   settings.setValue("/ReplaceTabs", m_manager->m_replaceTabs);
   settings.setValue("/TabWhitespaceCount", m_manager->m_tabWhitespaceCount);
@@ -111,44 +109,45 @@ void ScriptingWindow::saveSettings()
 /**
  * Read the settings on the window
  */
-void ScriptingWindow::readSettings()
-{
+void ScriptingWindow::readSettings() {
   QSettings settings;
   settings.beginGroup("/ScriptWindow");
   QString lastdir = settings.value("LastDirectoryVisited", "").toString();
-  // If nothing, set the last directory to the Mantid scripts directory (if present)
-  if( lastdir.isEmpty() )
-  {
-    lastdir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("pythonscripts.directory"));
+  // If nothing, set the last directory to the Mantid scripts directory (if
+  // present)
+  if (lastdir.isEmpty()) {
+    lastdir = QString::fromStdString(
+        Mantid::Kernel::ConfigService::Instance().getString(
+            "pythonscripts.directory"));
   }
   m_manager->m_last_dir = lastdir;
   m_toggleProgress->setChecked(settings.value("ProgressArrow", true).toBool());
   m_manager->setRecentScripts(settings.value("/RecentScripts").toStringList());
-  m_manager->m_globalZoomLevel = settings.value("ZoomLevel",0).toInt();
+  m_manager->m_globalZoomLevel = settings.value("ZoomLevel", 0).toInt();
   m_toggleFolding->setChecked(settings.value("CodeFolding", false).toBool());
-  m_toggleWhitespace->setChecked(settings.value("ShowWhitespace", false).toBool());
+  m_toggleWhitespace->setChecked(
+      settings.value("ShowWhitespace", false).toBool());
 
   m_manager->m_showWhitespace = m_toggleWhitespace->isChecked();
-  m_manager->m_replaceTabs = settings.value("ReplaceTabs", true ).toBool();
-  m_manager->m_tabWhitespaceCount = settings.value("TabWhitespaceCount", 4).toInt();
-  m_manager->m_fontFamily = settings.value("ScriptFontFamily","").toString();
+  m_manager->m_replaceTabs = settings.value("ReplaceTabs", true).toBool();
+  m_manager->m_tabWhitespaceCount =
+      settings.value("TabWhitespaceCount", 4).toInt();
+  m_manager->m_fontFamily = settings.value("ScriptFontFamily", "").toString();
 
   settings.endGroup();
-
 }
 
 /**
  * Override the closeEvent
  * @param event :: A pointer to the event object
  */
-void ScriptingWindow::closeEvent(QCloseEvent *event)
-{
+void ScriptingWindow::closeEvent(QCloseEvent *event) {
   // We ideally don't want a close button but are force by some window managers.
-  // Therefore if someone clicks close and MantidPlot is not quitting then we will just hide
-  if( !m_acceptClose )
-  {
+  // Therefore if someone clicks close and MantidPlot is not quitting then we
+  // will just hide
+  if (!m_acceptClose) {
     emit hideMe();
-    //this->hide();
+    // this->hide();
     return;
   }
 
@@ -162,23 +161,21 @@ void ScriptingWindow::closeEvent(QCloseEvent *event)
  * Override the showEvent function
  * @param event :: A pointer to the event object
  */
-void ScriptingWindow::showEvent(QShowEvent *event)
-{
-  if( m_manager->count() == 0 )
-  {
+void ScriptingWindow::showEvent(QShowEvent *event) {
+  if (m_manager->count() == 0) {
     m_manager->newTab();
   }
   event->accept();
 }
 
 /**
- * Open a script directly. This is here for backwards compatability with the old ScriptWindow
+ * Open a script directly. This is here for backwards compatability with the old
+ * ScriptWindow
  * class
  * @param filename :: The file name
  * @param newtab :: Do we want a new tab
  */
-void ScriptingWindow::open(const QString & filename, bool newtab)
-{
+void ScriptingWindow::open(const QString &filename, bool newtab) {
   m_manager->open(newtab, filename);
 }
 
@@ -187,8 +184,7 @@ void ScriptingWindow::open(const QString & filename, bool newtab)
  * running a script loaded with open
  * @param mode :: The execution type
  * */
-void ScriptingWindow::executeCurrentTab(const Script::ExecutionMode mode)
-{
+void ScriptingWindow::executeCurrentTab(const Script::ExecutionMode mode) {
   m_manager->executeAll(mode);
 }
 
@@ -196,16 +192,14 @@ void ScriptingWindow::executeCurrentTab(const Script::ExecutionMode mode)
 // Private slot member functions
 //-------------------------------------------
 /// Populate file menu
-void ScriptingWindow::populateFileMenu()
-{
+void ScriptingWindow::populateFileMenu() {
   m_fileMenu->clear();
   const bool scriptsOpen(m_manager->count() > 0);
 
   m_fileMenu->addAction(m_newTab);
   m_fileMenu->addAction(m_openInNewTab);
 
-  if(scriptsOpen)
-  {
+  if (scriptsOpen) {
     m_fileMenu->addAction(m_openInCurTab);
     m_fileMenu->insertSeparator();
     m_fileMenu->addAction(m_save);
@@ -217,28 +211,24 @@ void ScriptingWindow::populateFileMenu()
   m_fileMenu->addMenu(m_recentScripts);
   m_recentScripts->setEnabled(m_manager->recentScripts().count() > 0);
 
-  if(scriptsOpen)
-  {
+  if (scriptsOpen) {
     m_fileMenu->insertSeparator();
     m_fileMenu->addAction(m_closeTab);
   }
 }
 
 /// Ensure the list is up to date
-void ScriptingWindow::populateRecentScriptsMenu()
-{
+void ScriptingWindow::populateRecentScriptsMenu() {
   m_recentScripts->clear();
   QStringList recentScripts = m_manager->recentScripts();
   QStringListIterator iter(recentScripts);
-  while(iter.hasNext())
-  {
+  while (iter.hasNext()) {
     m_recentScripts->addAction(iter.next());
   }
 }
 
 /// Populate edit menu
-void ScriptingWindow::populateEditMenu()
-{
+void ScriptingWindow::populateEditMenu() {
   m_editMenu->clear();
   m_editMenu->addAction(m_undo);
   m_editMenu->addAction(m_redo);
@@ -259,8 +249,7 @@ void ScriptingWindow::populateEditMenu()
 }
 
 /// Populate execute menu
-void ScriptingWindow::populateExecMenu()
-{
+void ScriptingWindow::populateExecMenu() {
   m_runMenu->clear();
   m_runMenu->addAction(m_execSelect);
   m_runMenu->addAction(m_execAll);
@@ -278,16 +267,14 @@ void ScriptingWindow::populateExecMenu()
 }
 
 /// Populate window menu
-void ScriptingWindow::populateWindowMenu()
-{
+void ScriptingWindow::populateWindowMenu() {
   m_windowMenu->clear();
   const bool scriptsOpen(m_manager->count() > 0);
 
   m_windowMenu->addAction(m_alwaysOnTop);
   m_windowMenu->addAction(m_hide);
 
-  if(scriptsOpen)
-  {
+  if (scriptsOpen) {
     m_windowMenu->insertSeparator();
     m_windowMenu->addAction(m_zoomIn);
     m_windowMenu->addAction(m_zoomOut);
@@ -305,8 +292,7 @@ void ScriptingWindow::populateWindowMenu()
 }
 
 /// Populate help menu
-void ScriptingWindow::populateHelpMenu()
-{
+void ScriptingWindow::populateHelpMenu() {
   m_helpMenu->clear();
   m_helpMenu->addAction(m_showHelp);
   m_helpMenu->addAction(m_showPythonHelp);
@@ -314,16 +300,15 @@ void ScriptingWindow::populateHelpMenu()
 
 /**
  */
-void ScriptingWindow::updateWindowFlags()
-{
+void ScriptingWindow::updateWindowFlags() {
   Qt::WindowFlags flags = Qt::Window;
-  if( m_alwaysOnTop->isChecked() )
-  {
+  if (m_alwaysOnTop->isChecked()) {
     flags |= Qt::WindowStaysOnTopHint;
   }
   setWindowFlags(flags);
-  //This is necessary due to the setWindowFlags function reparenting the window and causing is
-  //to hide itself
+  // This is necessary due to the setWindowFlags function reparenting the window
+  // and causing is
+  // to hide itself
   show();
 }
 
@@ -332,8 +317,7 @@ void ScriptingWindow::updateWindowFlags()
  *  the number of tabs changes
  *  @param ntabs :: The number of tabs now open
  */
-void ScriptingWindow::setMenuStates(int ntabs)
-{
+void ScriptingWindow::setMenuStates(int ntabs) {
   const bool tabsOpen(ntabs > 0);
   m_editMenu->setEnabled(tabsOpen);
   m_runMenu->setEnabled(tabsOpen);
@@ -343,8 +327,7 @@ void ScriptingWindow::setMenuStates(int ntabs)
  * Set the state of the execution actions/menu depending on the flag
  * @param state :: If the true the items are enabled, otherwise the are disabled
  */
-void ScriptingWindow::setEditActionsDisabled(bool state)
-{
+void ScriptingWindow::setEditActionsDisabled(bool state) {
   m_editMenu->setDisabled(state);
 }
 
@@ -352,8 +335,7 @@ void ScriptingWindow::setEditActionsDisabled(bool state)
  * Set the state of the execution actions/menu depending on the flag
  * @param state :: If the true the items are enabled, otherwise the are disabled
  */
-void ScriptingWindow::setExecutionActionsDisabled(bool state)
-{
+void ScriptingWindow::setExecutionActionsDisabled(bool state) {
   m_execSelect->setDisabled(state);
   m_execAll->setDisabled(state);
   m_execModeMenu->setDisabled(state);
@@ -364,9 +346,8 @@ void ScriptingWindow::setExecutionActionsDisabled(bool state)
  * Maps the QAction to an index in the recent scripts list
  * @param item A pointer to the action that triggered the slot
  */
-void ScriptingWindow::openRecentScript(QAction* item)
-{
-  const QList<QAction*> actions = m_recentScripts->actions();
+void ScriptingWindow::openRecentScript(QAction *item) {
+  const QList<QAction *> actions = m_recentScripts->actions();
   const int index = actions.indexOf(item);
   assert(index >= 0);
   m_manager->openRecentScript(index);
@@ -375,58 +356,52 @@ void ScriptingWindow::openRecentScript(QAction* item)
 /**
  * Ask the manager to execute all code based on the currently selected mode
  */
-void ScriptingWindow::executeAll()
-{
+void ScriptingWindow::executeAll() {
   m_manager->executeAll(this->getExecutionMode());
 }
 
 /**
- * Ask the manager to execute the current selection based on the currently selected mode
+ * Ask the manager to execute the current selection based on the currently
+ * selected mode
  */
-void ScriptingWindow::executeSelection()
-{
+void ScriptingWindow::executeSelection() {
   m_manager->executeSelection(this->getExecutionMode());
 }
 
 /**
  */
-void ScriptingWindow::clearScriptVariables()
-{
+void ScriptingWindow::clearScriptVariables() {
   m_manager->clearScriptVariables();
 }
 
 /**
  * Opens the Qt help windows for the scripting window.
  */
-void ScriptingWindow::showHelp()
-{
-  MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("ScriptingWindow"));
+void ScriptingWindow::showHelp() {
+  MantidQt::API::HelpWindow::showCustomInterface(NULL,
+                                                 QString("ScriptingWindow"));
 }
-
 
 /**
  * Opens the Qt help windows for the Python API.
  */
-void ScriptingWindow::showPythonHelp()
-{
-  MantidQt::API::HelpWindow::showPage(NULL, QString("qthelp://org.mantidproject/doc/api/python/index.html"));
+void ScriptingWindow::showPythonHelp() {
+  MantidQt::API::HelpWindow::showPage(
+      NULL, QString("qthelp://org.mantidproject/doc/api/python/index.html"));
 }
 
 /**
  * calls MultiTabScriptInterpreter saveToString and
  *  saves the currently opened script file names to a string
  */
-QString ScriptingWindow::saveToString()
-{
-  return m_manager->saveToString();
-}
+QString ScriptingWindow::saveToString() { return m_manager->saveToString(); }
 
 /**
  * Saves scripts file names to a string
- * @param value If true a future close event will be accepted otherwise it will be ignored
+ * @param value If true a future close event will be accepted otherwise it will
+ * be ignored
  */
-void ScriptingWindow::acceptCloseEvent(const bool value)
-{
+void ScriptingWindow::acceptCloseEvent(const bool value) {
   m_acceptClose = value;
 }
 
@@ -437,33 +412,37 @@ void ScriptingWindow::acceptCloseEvent(const bool value)
 /**
  * Initialise the menus
  */
-void ScriptingWindow::initMenus()
-{
+void ScriptingWindow::initMenus() {
   initActions();
 
   m_fileMenu = menuBar()->addMenu(tr("&File"));
 #ifdef SCRIPTING_DIALOG
   m_scripting_lang = new QAction(tr("Scripting &language"), this);
-  connect(m_scripting_lang, SIGNAL(triggered()), this, SIGNAL(chooseScriptingLanguage()));
+  connect(m_scripting_lang, SIGNAL(triggered()), this,
+          SIGNAL(chooseScriptingLanguage()));
 #endif
   connect(m_fileMenu, SIGNAL(aboutToShow()), this, SLOT(populateFileMenu()));
 
   m_editMenu = menuBar()->addMenu(tr("&Edit"));
   connect(m_editMenu, SIGNAL(aboutToShow()), this, SLOT(populateEditMenu()));
-  connect(m_manager, SIGNAL(executionStateChanged(bool)), this, SLOT(setEditActionsDisabled(bool)));
+  connect(m_manager, SIGNAL(executionStateChanged(bool)), this,
+          SLOT(setEditActionsDisabled(bool)));
 
   m_runMenu = menuBar()->addMenu(tr("E&xecute"));
   connect(m_runMenu, SIGNAL(aboutToShow()), this, SLOT(populateExecMenu()));
-  connect(m_manager, SIGNAL(executionStateChanged(bool)), this, SLOT(setExecutionActionsDisabled(bool)));
+  connect(m_manager, SIGNAL(executionStateChanged(bool)), this,
+          SLOT(setExecutionActionsDisabled(bool)));
   m_execModeMenu = new QMenu("Mode", this);
 
   m_windowMenu = menuBar()->addMenu(tr("&Window"));
-  connect(m_windowMenu, SIGNAL(aboutToShow()), this, SLOT(populateWindowMenu()));
+  connect(m_windowMenu, SIGNAL(aboutToShow()), this,
+          SLOT(populateWindowMenu()));
 
   m_helpMenu = menuBar()->addMenu(tr("&Help"));
   connect(m_windowMenu, SIGNAL(aboutToShow()), this, SLOT(populateHelpMenu()));
 
-  connect(m_manager, SIGNAL(tabCountChanged(int)), this, SLOT(setMenuStates(int)));
+  connect(m_manager, SIGNAL(tabCountChanged(int)), this,
+          SLOT(setMenuStates(int)));
 
   // The menu items must be populated for the shortcuts to work
   populateFileMenu();
@@ -471,19 +450,22 @@ void ScriptingWindow::initMenus()
   populateExecMenu();
   populateWindowMenu();
   populateHelpMenu();
-  connect(m_manager, SIGNAL(tabCountChanged(int)), this, SLOT(populateFileMenu()));
-  connect(m_manager, SIGNAL(tabCountChanged(int)), this, SLOT(populateEditMenu()));
-  connect(m_manager, SIGNAL(tabCountChanged(int)), this, SLOT(populateExecMenu()));
-  connect(m_manager, SIGNAL(tabCountChanged(int)), this, SLOT(populateWindowMenu()));
-  connect(m_manager, SIGNAL(tabCountChanged(int)), this, SLOT(populateHelpMenu()));
+  connect(m_manager, SIGNAL(tabCountChanged(int)), this,
+          SLOT(populateFileMenu()));
+  connect(m_manager, SIGNAL(tabCountChanged(int)), this,
+          SLOT(populateEditMenu()));
+  connect(m_manager, SIGNAL(tabCountChanged(int)), this,
+          SLOT(populateExecMenu()));
+  connect(m_manager, SIGNAL(tabCountChanged(int)), this,
+          SLOT(populateWindowMenu()));
+  connect(m_manager, SIGNAL(tabCountChanged(int)), this,
+          SLOT(populateHelpMenu()));
 }
-
 
 /**
  *  Create all actions
  */
-void ScriptingWindow::initActions()
-{
+void ScriptingWindow::initActions() {
   initFileMenuActions();
   initEditMenuActions();
   initExecMenuActions();
@@ -494,14 +476,14 @@ void ScriptingWindow::initActions()
 /**
  * Create the file actions
  */
-void ScriptingWindow::initFileMenuActions()
-{
+void ScriptingWindow::initFileMenuActions() {
   m_newTab = new QAction(tr("&New Tab"), this);
   connect(m_newTab, SIGNAL(triggered()), m_manager, SLOT(newTab()));
   m_newTab->setShortcut(tr("Ctrl+N"));
 
   m_openInCurTab = new QAction(tr("&Open"), this);
-  connect(m_openInCurTab, SIGNAL(triggered()), m_manager, SLOT(openInCurrentTab()));
+  connect(m_openInCurTab, SIGNAL(triggered()), m_manager,
+          SLOT(openInCurrentTab()));
   m_openInCurTab->setShortcut(tr("Ctrl+O"));
 
   m_openInNewTab = new QAction(tr("&Open in New Tab"), this);
@@ -524,23 +506,26 @@ void ScriptingWindow::initFileMenuActions()
   connect(m_closeTab, SIGNAL(triggered()), m_manager, SLOT(closeCurrentTab()));
   m_closeTab->setShortcut(tr("Ctrl+W"));
 
-  m_recentScripts = new QMenu(tr("&Recent Scripts"),this);
-  connect(m_recentScripts, SIGNAL(aboutToShow()), this, SLOT(populateRecentScriptsMenu()));
-  connect(m_recentScripts, SIGNAL(triggered(QAction*)), this, SLOT(openRecentScript(QAction*)));
+  m_recentScripts = new QMenu(tr("&Recent Scripts"), this);
+  connect(m_recentScripts, SIGNAL(aboutToShow()), this,
+          SLOT(populateRecentScriptsMenu()));
+  connect(m_recentScripts, SIGNAL(triggered(QAction *)), this,
+          SLOT(openRecentScript(QAction *)));
 }
 
 /**
  * Create the edit menu action*/
-void ScriptingWindow::initEditMenuActions()
-{
+void ScriptingWindow::initEditMenuActions() {
   m_undo = new QAction(tr("&Undo"), this);
   connect(m_undo, SIGNAL(triggered()), m_manager, SLOT(undo()));
-  connect(m_manager, SIGNAL(undoAvailable(bool)), m_undo, SLOT(setEnabled(bool)));
+  connect(m_manager, SIGNAL(undoAvailable(bool)), m_undo,
+          SLOT(setEnabled(bool)));
   m_undo->setShortcut(QKeySequence::Undo);
 
   m_redo = new QAction(tr("&Redo"), this);
   connect(m_redo, SIGNAL(triggered()), m_manager, SLOT(redo()));
-  connect(m_manager, SIGNAL(redoAvailable(bool)), m_redo, SLOT(setEnabled(bool)));
+  connect(m_manager, SIGNAL(redoAvailable(bool)), m_redo,
+          SLOT(setEnabled(bool)));
   m_redo->setShortcut(QKeySequence::Redo);
 
   m_cut = new QAction(tr("C&ut"), this);
@@ -575,12 +560,10 @@ void ScriptingWindow::initEditMenuActions()
   m_find->setShortcut(QKeySequence::Find);
 }
 
-
 /**
  * Create the execute menu actions
  */
-void ScriptingWindow::initExecMenuActions()
-{
+void ScriptingWindow::initExecMenuActions() {
   m_execSelect = new QAction(tr("E&xecute Selection"), this);
   connect(m_execSelect, SIGNAL(triggered()), this, SLOT(executeSelection()));
 
@@ -591,12 +574,15 @@ void ScriptingWindow::initExecMenuActions()
   m_execAll = new QAction(tr("Execute &All"), this);
   connect(m_execAll, SIGNAL(triggered()), this, SLOT(executeAll()));
   shortcuts.clear();
-  shortcuts << Qt::CTRL + Qt::SHIFT + Qt::Key_Return << Qt::CTRL + Qt::SHIFT + Qt::Key_Enter;
+  shortcuts << Qt::CTRL + Qt::SHIFT + Qt::Key_Return
+            << Qt::CTRL + Qt::SHIFT + Qt::Key_Enter;
   m_execAll->setShortcuts(shortcuts);
 
   m_clearScriptVars = new QAction(tr("&Clear Variables"), this);
-  connect(m_clearScriptVars, SIGNAL(triggered()), this, SLOT(clearScriptVariables()));
-  m_clearScriptVars->setToolTip("Clear all variable definitions in this script");
+  connect(m_clearScriptVars, SIGNAL(triggered()), this,
+          SLOT(clearScriptVariables()));
+  m_clearScriptVars->setToolTip(
+      "Clear all variable definitions in this script");
 
   m_execParallel = new QAction("Asynchronous", this);
   m_execParallel->setCheckable(true);
@@ -612,11 +598,11 @@ void ScriptingWindow::initExecMenuActions()
 /**
  * Create the window menu actions
  */
-void ScriptingWindow::initWindowMenuActions()
-{
+void ScriptingWindow::initWindowMenuActions() {
   m_alwaysOnTop = new QAction(tr("Always on &Top"), this);
   m_alwaysOnTop->setCheckable(true);
-  connect(m_alwaysOnTop, SIGNAL(toggled(bool)), this, SLOT(updateWindowFlags()));
+  connect(m_alwaysOnTop, SIGNAL(toggled(bool)), this,
+          SLOT(updateWindowFlags()));
 
   m_hide = new QAction(tr("&Hide"), this);
 #ifdef __APPLE__
@@ -624,15 +610,18 @@ void ScriptingWindow::initWindowMenuActions()
 #else
   m_hide->setShortcut(tr("F3"));
 #endif
-  // Note that we channel the hide through the parent so that we can save the geometry state
+  // Note that we channel the hide through the parent so that we can save the
+  // geometry state
   connect(m_hide, SIGNAL(triggered()), this, SIGNAL(hideMe()));
 
   m_zoomIn = new QAction(("&Increase font size"), this);
-  // Setting two shortcuts makes it work for both the plus on the keypad and one above an =
-  // Despite the Qt docs advertising the use of QKeySequence::ZoomIn as the solution to this,
+  // Setting two shortcuts makes it work for both the plus on the keypad and one
+  // above an =
+  // Despite the Qt docs advertising the use of QKeySequence::ZoomIn as the
+  // solution to this,
   // it doesn't seem to work for me
-  m_zoomIn->setShortcut(Qt::SHIFT+Qt::CTRL+Qt::Key_Equal);
-  m_zoomIn->setShortcut(Qt::CTRL+Qt::Key_Plus);
+  m_zoomIn->setShortcut(Qt::SHIFT + Qt::CTRL + Qt::Key_Equal);
+  m_zoomIn->setShortcut(Qt::CTRL + Qt::Key_Plus);
   connect(m_zoomIn, SIGNAL(triggered()), m_manager, SLOT(zoomIn()));
   connect(m_zoomIn, SIGNAL(triggered()), m_manager, SLOT(trackZoomIn()));
 
@@ -651,28 +640,31 @@ void ScriptingWindow::initWindowMenuActions()
   // Toggle the progress arrow
   m_toggleProgress = new QAction(tr("&Progress Reporting"), this);
   m_toggleProgress->setCheckable(true);
-  connect(m_toggleProgress, SIGNAL(toggled(bool)), m_manager, SLOT(toggleProgressReporting(bool)));
+  connect(m_toggleProgress, SIGNAL(toggled(bool)), m_manager,
+          SLOT(toggleProgressReporting(bool)));
 
   // Toggle code folding
   m_toggleFolding = new QAction(tr("Code &Folding"), this);
   m_toggleFolding->setCheckable(true);
-  connect(m_toggleFolding, SIGNAL(toggled(bool)), m_manager, SLOT(toggleCodeFolding(bool)));
+  connect(m_toggleFolding, SIGNAL(toggled(bool)), m_manager,
+          SLOT(toggleCodeFolding(bool)));
 
   // Toggle the whitespace arrow
   m_toggleWhitespace = new QAction(tr("&Show Whitespace"), this);
   m_toggleWhitespace->setCheckable(true);
-  connect(m_toggleWhitespace, SIGNAL(toggled(bool)), m_manager, SLOT(toggleWhitespace(bool)));
+  connect(m_toggleWhitespace, SIGNAL(toggled(bool)), m_manager,
+          SLOT(toggleWhitespace(bool)));
 
   // Open Config Tabs dialog
   m_openConfigTabs = new QAction(tr("Configure Tabs"), this);
-  connect(m_openConfigTabs, SIGNAL(triggered()), m_manager, SLOT(openConfigTabs()));
+  connect(m_openConfigTabs, SIGNAL(triggered()), m_manager,
+          SLOT(openConfigTabs()));
 }
 
 /**
  * Create the help menu actions
  */
-void ScriptingWindow::initHelpMenuActions()
-{
+void ScriptingWindow::initHelpMenuActions() {
   // Show Qt help window
   m_showHelp = new QAction(tr("Scripting Window Help"), this);
   connect(m_showHelp, SIGNAL(triggered()), this, SLOT(showHelp()));
@@ -685,37 +677,33 @@ void ScriptingWindow::initHelpMenuActions()
 /**
  * Returns the current execution mode set in the menu
  */
-Script::ExecutionMode ScriptingWindow::getExecutionMode() const
-{
-  if(m_execParallel->isChecked()) return Script::Asynchronous;
-  else return Script::Serialised;
+Script::ExecutionMode ScriptingWindow::getExecutionMode() const {
+  if (m_execParallel->isChecked())
+    return Script::Asynchronous;
+  else
+    return Script::Serialised;
 }
 
 /**
  * Accept a custom event and in this case test if it is a ScriptingChangeEvent
  * @param event :: The custom event
  */
-void ScriptingWindow::customEvent(QEvent *event)
-{
-  if( !m_manager->isExecuting() && event->type() == SCRIPTING_CHANGE_EVENT )
-  {
-    ScriptingChangeEvent *sce = static_cast<ScriptingChangeEvent*>(event);
-    setWindowTitle("MantidPlot: " + sce->scriptingEnv()->languageName() + " Window");
+void ScriptingWindow::customEvent(QEvent *event) {
+  if (!m_manager->isExecuting() && event->type() == SCRIPTING_CHANGE_EVENT) {
+    ScriptingChangeEvent *sce = static_cast<ScriptingChangeEvent *>(event);
+    setWindowTitle("MantidPlot: " + sce->scriptingEnv()->languageName() +
+                   " Window");
   }
 }
-
 
 /**
  * Accept a drag move event and selects whether to accept the action
  * @param de :: The drag move event
  */
-void ScriptingWindow::dragMoveEvent(QDragMoveEvent *de)
-{
+void ScriptingWindow::dragMoveEvent(QDragMoveEvent *de) {
   const QMimeData *mimeData = de->mimeData();
-  if (mimeData->hasUrls())
-  {
-    if (extractPyFiles(mimeData->urls()).size() > 0)
-    {
+  if (mimeData->hasUrls()) {
+    if (extractPyFiles(mimeData->urls()).size() > 0) {
       de->accept();
     }
   }
@@ -725,13 +713,10 @@ void ScriptingWindow::dragMoveEvent(QDragMoveEvent *de)
  * Accept a drag enter event and selects whether to accept the action
  * @param de :: The drag enter event
  */
-void ScriptingWindow::dragEnterEvent(QDragEnterEvent *de)
-{
+void ScriptingWindow::dragEnterEvent(QDragEnterEvent *de) {
   const QMimeData *mimeData = de->mimeData();
-  if (mimeData->hasUrls())
-  {
-    if (extractPyFiles(mimeData->urls()).size() > 0)
-    {
+  if (mimeData->hasUrls()) {
+    if (extractPyFiles(mimeData->urls()).size() > 0) {
       de->acceptProposedAction();
     }
   }
@@ -741,33 +726,26 @@ void ScriptingWindow::dragEnterEvent(QDragEnterEvent *de)
  * Accept a drag drop event and process the data appropriately
  * @param de :: The drag drop event
  */
-void ScriptingWindow::dropEvent(QDropEvent *de)
-{
+void ScriptingWindow::dropEvent(QDropEvent *de) {
   const QMimeData *mimeData = de->mimeData();
-  if (mimeData->hasUrls())
-  {
+  if (mimeData->hasUrls()) {
     QStringList filenames = extractPyFiles(mimeData->urls());
     de->acceptProposedAction();
 
-    for (int i = 0; i < filenames.size(); ++i)
-    {
+    for (int i = 0; i < filenames.size(); ++i) {
       m_manager->openInNewTab(filenames[i]);
     }
   }
 }
 
-QStringList ScriptingWindow::extractPyFiles(const QList<QUrl>& urlList) const
-{
+QStringList ScriptingWindow::extractPyFiles(const QList<QUrl> &urlList) const {
   QStringList filenames;
-  for (int i = 0; i < urlList.size(); ++i)
-  {
+  for (int i = 0; i < urlList.size(); ++i) {
     QString fName = urlList[i].toLocalFile();
-    if (fName.size()>0)
-    {
+    if (fName.size() > 0) {
       QFileInfo fi(fName);
 
-      if (fi.suffix().upper()=="PY")
-      {
+      if (fi.suffix().upper() == "PY") {
         filenames.append(fName);
       }
     }

--- a/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptingWindow.cpp
@@ -93,6 +93,7 @@ void ScriptingWindow::saveSettings() {
   settings.setValue("/TabWhitespaceCount", m_manager->m_tabWhitespaceCount);
   settings.setValue("/ScriptFontFamily", m_manager->m_fontFamily);
   settings.setValue("/CodeFolding", m_toggleFolding->isChecked());
+  settings.setValue("/PreviousFiles", m_manager->fileNamesToQStringList());
   settings.endGroup();
 }
 
@@ -123,6 +124,18 @@ void ScriptingWindow::readSettings() {
   m_manager->m_tabWhitespaceCount =
       settings.value("TabWhitespaceCount", 4).toInt();
   m_manager->m_fontFamily = settings.value("ScriptFontFamily", "").toString();
+  
+  const QStringList filesToOpen =
+      settings.value("/PreviousFiles", "").toStringList();
+  const int totalFiles = filesToOpen.size();
+  if (totalFiles == 0) {
+    m_manager->newTab();
+  } else {
+    for (int i = 0; i < totalFiles; i++) {
+      m_manager->newTab(i, filesToOpen[i]);
+    }
+  }
+
   settings.endGroup();
 }
 

--- a/Code/Mantid/MantidPlot/src/ScriptingWindow.h
+++ b/Code/Mantid/MantidPlot/src/ScriptingWindow.h
@@ -21,19 +21,18 @@ class QCloseEvent;
 class QShowEvent;
 class QHideEvent;
 
-
 /** @class ScriptingWindow
     This class displays a seperate window for editing and executing scripts
 */
-class ScriptingWindow : public QMainWindow
-{
-  ///Qt macro
+class ScriptingWindow : public QMainWindow {
+  /// Qt macro
   Q_OBJECT
 
 public:
-  ///Constructor
-  ScriptingWindow(ScriptingEnv *env,bool capturePrint = true,QWidget *parent = 0, Qt::WindowFlags flags = 0);
-  ///Destructor
+  /// Constructor
+  ScriptingWindow(ScriptingEnv *env, bool capturePrint = true,
+                  QWidget *parent = 0, Qt::WindowFlags flags = 0);
+  /// Destructor
   ~ScriptingWindow();
   /// Override the closeEvent
   void closeEvent(QCloseEvent *event);
@@ -41,19 +40,20 @@ public:
   void showEvent(QShowEvent *event);
   /// Is a script running?
   bool isExecuting() const;
-  ///Save the current state of the script window for next time
+  /// Save the current state of the script window for next time
   void saveSettings();
   /// Read settings from store
   void readSettings();
   /// Open a script in a new tab. Primarily useful for automatically
   /// opening a script
-  void open(const QString & filename, bool newtab = true);
-  /// Executes whatever is in the current tab. Primarily useful for automatically
+  void open(const QString &filename, bool newtab = true);
+  /// Executes whatever is in the current tab. Primarily useful for
+  /// automatically
   /// running a script loaded with open
   void executeCurrentTab(const Script::ExecutionMode mode);
-  ///saves scripts file names to a string
+  /// saves scripts file names to a string
   QString saveToString();
-  ///Set whether to accept/reject close events
+  /// Set whether to accept/reject close events
   void acceptCloseEvent(const bool value);
 
 signals:
@@ -94,11 +94,11 @@ private slots:
 
   /// Finds the script corresponding to the action and
   /// asks the manager to open it
-  void openRecentScript(QAction*);
+  void openRecentScript(QAction *);
 
   /// Execute all using the current mode option
   void executeAll();
-  ///Execute selection using the current mode option
+  /// Execute selection using the current mode option
   void executeSelection();
   /// Clear out any previous variable definitions in the current script
   void clearScriptVariables();
@@ -124,15 +124,17 @@ private:
   void initWindowMenuActions();
   /// Create the help menu actions
   void initHelpMenuActions();
+  /// Opens tabs based on QStringList
+  void openPreviousTabs(const QStringList &tabsToOpen);
 
   /// Returns the current execution mode
   Script::ExecutionMode getExecutionMode() const;
 
   /// Accept a custom defined event
-  void customEvent(QEvent * event);
+  void customEvent(QEvent *event);
 
   /// Extract py files from urllist
-  QStringList extractPyFiles(const QList<QUrl>& urlList) const;
+  QStringList extractPyFiles(const QList<QUrl> &urlList) const;
 
 private:
   /// The script editors' manager
@@ -141,14 +143,14 @@ private:
   /// File menu
   QMenu *m_fileMenu;
   /// File menu actions
-  QAction *m_newTab, *m_openInCurTab, *m_openInNewTab,
-    *m_save, *m_saveAs, *m_print, *m_closeTab;
+  QAction *m_newTab, *m_openInCurTab, *m_openInNewTab, *m_save, *m_saveAs,
+      *m_print, *m_closeTab;
   QMenu *m_recentScripts;
   /// Edit menu
   QMenu *m_editMenu;
   /// Edit menu actions
   QAction *m_undo, *m_redo, *m_cut, *m_copy, *m_paste, *m_comment, *m_uncomment,
-    *m_tabsToSpaces, *m_spacesToTabs, *m_find;
+      *m_tabsToSpaces, *m_spacesToTabs, *m_find;
   /// Run menu
   QMenu *m_runMenu;
   /// Execute menu actions
@@ -163,8 +165,8 @@ private:
   QMenu *m_windowMenu;
   /// Window actions
   QAction *m_alwaysOnTop, *m_hide, *m_zoomIn, *m_zoomOut, *m_resetZoom,
-    *m_toggleProgress, *m_toggleFolding, *m_toggleWhitespace,
-    *m_openConfigTabs, *m_selectFont;
+      *m_toggleProgress, *m_toggleFolding, *m_toggleWhitespace,
+      *m_openConfigTabs, *m_selectFont;
   /// Help menu
   QMenu *m_helpMenu;
   /// Help actions
@@ -173,7 +175,6 @@ private:
   QAction *m_scripting_lang;
   /// Flag to define whether we should accept a close event
   bool m_acceptClose;
-
 };
 
-#endif //SCRIPTINGWINDOW_H_
+#endif // SCRIPTINGWINDOW_H_


### PR DESCRIPTION
Fixes #13082 

Scripting window will now remember the previously opened scripts and reload them after the application is restarted.
# To test:
# Test open tabs
- Start Mantid Plot
- Open the Scripting window (F3 or "View > Script Window")
- Open any couple of python scripts
- Close Mantid Plot
- Start Mantid Plot again
- Open the Scripting window
  - The previous opened scripts should be in the window already
# Test empty window
- Start Mantid Plot
- Opening the Scripting window (F3 or "View > Script Window")
- Close all the tabs in the Scripting window (right click on a tab and select "Close all")
  - The Scripting window should now be blank (no open tabs)
- Close Mantid Plot
- Start Mantid Plot again
- Open the Scripting window
- The Scripting window should contain a blank tab labelled "New script"
