### PR TITLE
Better documentation for sample transmission calculator

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/CalculateSampleTransmission.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/CalculateSampleTransmission.py
@@ -23,14 +23,16 @@ class CalculateSampleTransmission(PythonAlgorithm):
 
 
     def PyInit(self):
-        self.declareProperty(name='WavelengthRange', defaultValue='', validator=StringMandatoryValidator(),
+        self.declareProperty(name='WavelengthRange', defaultValue='',
+                             validator=StringMandatoryValidator(),
                              doc='Wavelength range to calculate transmission for.')
 
-        self.declareProperty(name='ChemicalFormula', defaultValue='', validator=StringMandatoryValidator(),
+        self.declareProperty(name='ChemicalFormula', defaultValue='',
+                             validator=StringMandatoryValidator(),
                              doc='Sample chemical formula')
 
         self.declareProperty(name='NumberDensity', defaultValue=0.1,
-                             doc='Number denisty (atoms/Angstrom^3). Default=0.1')
+                             doc='Number denisty per atom (atoms/Angstrom^3). Default=0.1')
 
         self.declareProperty(name='Thickness', defaultValue=0.1,
                              doc='Sample thickness (cm). Default=0.1')

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SampleTransmission.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SampleTransmission.ui
@@ -184,7 +184,7 @@
        <item row="1" column="1">
         <widget class="QDoubleSpinBox" name="spNumberDensity">
          <property name="suffix">
-          <string> Å^3</string>
+          <string notr="true"> atoms/Å³</string>
          </property>
          <property name="decimals">
           <number>5</number>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SampleTransmission.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SampleTransmission.ui
@@ -82,6 +82,9 @@
            </item>
            <item>
             <widget class="QDoubleSpinBox" name="spSingleLow">
+             <property name="decimals">
+              <number>3</number>
+             </property>
              <property name="minimum">
               <double>-99.989999999999995</double>
              </property>
@@ -99,6 +102,9 @@
            </item>
            <item>
             <widget class="QDoubleSpinBox" name="spSingleWidth">
+             <property name="decimals">
+              <number>3</number>
+             </property>
              <property name="minimum">
               <double>-99.989999999999995</double>
              </property>
@@ -116,6 +122,9 @@
            </item>
            <item>
             <widget class="QDoubleSpinBox" name="spSingleHigh">
+             <property name="decimals">
+              <number>3</number>
+             </property>
              <property name="minimum">
               <double>-99.989999999999995</double>
              </property>
@@ -177,6 +186,9 @@
          <property name="suffix">
           <string> Å^3</string>
          </property>
+         <property name="decimals">
+          <number>5</number>
+         </property>
          <property name="singleStep">
           <double>0.100000000000000</double>
          </property>
@@ -189,6 +201,9 @@
         <widget class="QDoubleSpinBox" name="spThickness">
          <property name="suffix">
           <string> cm</string>
+         </property>
+         <property name="decimals">
+          <number>5</number>
          </property>
          <property name="singleStep">
           <double>0.100000000000000</double>

--- a/Code/Mantid/docs/source/algorithms/CalculateSampleTransmission-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CalculateSampleTransmission-v1.rst
@@ -26,7 +26,8 @@ Usage
 
 .. testcode:: ExCalculateSampleTransmissionSimple
 
-    ws = CalculateSampleTransmission(WavelengthRange='2.0, 0.1, 10.0', ChemicalFormula='H2-O')
+    ws = CalculateSampleTransmission(WavelengthRange='2.0, 0.1, 10.0',
+                                     ChemicalFormula='H2-O')
 
     print 'Transmission: %f, %f, %f ...' % tuple(ws.readY(0)[:3])
     print 'Scattering: %f, %f, %f ...' % tuple(ws.readY(1)[:3])
@@ -44,8 +45,10 @@ Output:
 
 .. testcode:: ExCalculateSampleTransmissionParams
 
-    ws = CalculateSampleTransmission(WavelengthRange='2.0, 0.1, 10.0', ChemicalFormula='H2-O',
-                                    NumberDensity=0.2, Thickness=0.58)
+    ws = CalculateSampleTransmission(WavelengthRange='2.0, 0.1, 10.0',
+                                     ChemicalFormula='H2-O',
+                                     NumberDensity=0.2,
+                                     Thickness=0.58)
 
     print 'Transmission: %f, %f, %f ...' % tuple(ws.readY(0)[:3])
     print 'Scattering: %f, %f, %f ...' % tuple(ws.readY(1)[:3])

--- a/Code/Mantid/docs/source/interfaces/SampleTransmissionCalculator.rst
+++ b/Code/Mantid/docs/source/interfaces/SampleTransmissionCalculator.rst
@@ -43,7 +43,8 @@ Sample Details
 
 The sample details required are the chemical formula which is to be given in the
 format expected by the :ref:`SetSampleMaterial <algm-SetSampleMaterial>`
-algorithm, number density in :math:`\mathrm{\AA{}}^3` and thickness in :math:`cm`.
+algorithm, number density per atom in :math:`atoms/\mathrm{\AA{}}^3` and
+thickness in :math:`cm`.
 
 Output
 ~~~~~~


### PR DESCRIPTION
Fixes #13153.

To test: review the documentation changes.
Also see that spin boxes have more precision than before.

Not a big enough change to be in the release notes.
