### PR TITLE
Fix jenkins mpi build

### DIFF
--- a/Code/Mantid/Framework/CMakeLists.txt
+++ b/Code/Mantid/Framework/CMakeLists.txt
@@ -58,6 +58,7 @@ if ( ${CMAKE_PROJECT_NAME} MATCHES "MantidFramework" AND ${CMAKE_SYSTEM_NAME} MA
   endif ( MPI_BUILD )
 endif ()
 
+find_package ( OpenGL REQUIRED )
 find_package ( GSL REQUIRED )
 
 ###########################################################################

--- a/Code/Mantid/Framework/CMakeLists.txt
+++ b/Code/Mantid/Framework/CMakeLists.txt
@@ -58,6 +58,8 @@ if ( ${CMAKE_PROJECT_NAME} MATCHES "MantidFramework" AND ${CMAKE_SYSTEM_NAME} MA
   endif ( MPI_BUILD )
 endif ()
 
+find_package ( GSL REQUIRED )
+
 ###########################################################################
 # Now add the packages one-by-one, building up the dependencies as we go
 ###########################################################################

--- a/Code/Mantid/Framework/CMakeLists.txt
+++ b/Code/Mantid/Framework/CMakeLists.txt
@@ -55,11 +55,10 @@ if ( ${CMAKE_PROJECT_NAME} MATCHES "MantidFramework" AND ${CMAKE_SYSTEM_NAME} MA
   if ( MPI_BUILD )
   include ( MPISetup )
         set ( MANTIDLIBS  ${MANTIDLIBS} ${Boost_LIBRARIES} ${MPI_CXX_LIBRARIES} )
+        find_package ( OpenGL REQUIRED )
+        find_package ( GSL REQUIRED )
   endif ( MPI_BUILD )
 endif ()
-
-find_package ( OpenGL REQUIRED )
-find_package ( GSL REQUIRED )
 
 ###########################################################################
 # Now add the packages one-by-one, building up the dependencies as we go


### PR DESCRIPTION
As the MPI build points to the CMakeLists file in the Framework directory it can't find GSL or OpenGL as they are found at the top level.

This just affects the MPI build.
