### PR TITLE
Adding symbolic links to startup scripts to /usr/bin

### DIFF
--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
@@ -17,17 +17,17 @@ if [ -f $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot ]; then
     fi
 fi
 
-# Create symbolic links in worlds path
-if [ ! -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
-    ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
-fi
-if [ ! -L /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@ ]; then
-    ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidpython /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@
-fi
-
 # Environment updates if required
 if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
     # Link profiles to /etc/profile.d
     ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.sh /etc/profile.d/mantid.sh
     ln -s $RPM_INSTALL_PREFIX0/@ETC_DIR@/mantid.csh /etc/profile.d/mantid.csh
+else
+    # Create symbolic links in worlds path
+    if [ ! -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
+        ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
+    fi
+    if [ ! -L /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@ ]; then
+        ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidpython /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@
+    fi
 fi

--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_post_install.sh.in
@@ -17,6 +17,14 @@ if [ -f $RPM_INSTALL_PREFIX0/@BIN_DIR@/MantidPlot ]; then
     fi
 fi
 
+# Create symbolic links in worlds path
+if [ ! -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
+    ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/launch_mantidplot.sh /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
+fi
+if [ ! -L /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@ ]; then
+    ln -s $RPM_INSTALL_PREFIX0/@BIN_DIR@/mantidpython /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@
+fi
+
 # Environment updates if required
 if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
     # Link profiles to /etc/profile.d

--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_uninstall.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_uninstall.sh.in
@@ -3,4 +3,10 @@
 # RPM pre-uninstall script
 #
 
-# Nothing needs to be done
+if [ -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
+    rm /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
+fi
+
+if [ -L /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@ ]; then
+    rm /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@
+fi

--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_uninstall.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_uninstall.sh.in
@@ -2,11 +2,14 @@
 #
 # RPM pre-uninstall script
 #
+ENVVARS_ON_INSTALL=@ENVVARS_ON_INSTALL_INT@
 
-if [ -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
-    rm /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
-fi
+if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
+    if [ -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
+        rm /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
+    fi
 
-if [ -L /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@ ]; then
-    rm /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@
+    if [ -L /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@ ]; then
+        rm /usr/bin/mantidpython@CPACK_PACKAGE_SUFFIX@
+    fi
 fi

--- a/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_uninstall.sh.in
+++ b/Code/Mantid/Build/CMake/Packaging/rpm/scripts/rpm_pre_uninstall.sh.in
@@ -4,7 +4,7 @@
 #
 ENVVARS_ON_INSTALL=@ENVVARS_ON_INSTALL_INT@
 
-if [ ${ENVVARS_ON_INSTALL} -eq 1 ]; then
+if [ ${ENVVARS_ON_INSTALL} -eq 0 ]; then
     if [ -L /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@ ]; then
         rm /usr/bin/mantidplot@CPACK_PACKAGE_SUFFIX@
     fi


### PR DESCRIPTION
The real way to test this is to install the rpm and look for links in `/usr/bin`. A code review and re-running `cmake` with and without a `CPACK_PACKAGE_SUFFIX` set should work too.

This does not need to be mentioned in the release notes.
