### PR TITLE
Rename DensityOfStates algorithm

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDesnityOfStates.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDesnityOfStates.py
@@ -9,7 +9,7 @@ import os.path
 import math
 
 #pylint: disable=too-many-instance-attributes
-class DensityOfStates(PythonAlgorithm):
+class SimulatedDensityOfStates(PythonAlgorithm):
 
     _float_regex = None
     _temperature = None
@@ -807,6 +807,6 @@ class DensityOfStates(PythonAlgorithm):
 
 try:
     import scipy.constants
-    AlgorithmFactory.subscribe(DensityOfStates)
+    AlgorithmFactory.subscribe(SimulatedDensityOfStates)
 except ImportError:
-    logger.debug('Failed to subscribe algorithm DensityOfStates; The python package scipy may be missing.')
+    logger.debug('Failed to subscribe algorithm SimulatedDensityOfStates; The python package scipy may be missing.')

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -16,7 +16,6 @@ set ( TEST_PY_FILES
   CylinderPaalmanPingsCorrectionTest.py
   CylinderPaalmanPingsCorrection2Test.py
   DakotaChiSquaredTest.py
-  DensityOfStatesTest.py
   DSFinterpTest.py
   EnggCalibrateFullTest.py
   EnggCalibrateTest.py
@@ -54,6 +53,7 @@ set ( TEST_PY_FILES
   SANSWideAngleCorrectionTest.py
   SavePlot1DTest.py
   SaveVulcanGSSTest.py
+  SimulatedDensityOfStatesTest.py
   SortByQVectorsTest.py
   SofQWMomentsTest.py
   SortDetectorsTest.py

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/SimulatedDensityOfStatesTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/SimulatedDensityOfStatesTest.py
@@ -1,6 +1,6 @@
 import unittest
 from mantid import logger
-from mantid.simpleapi import DensityOfStates, CheckWorkspacesMatch, Scale, CreateEmptyTableWorkspace
+from mantid.simpleapi import SimulatedDensityOfStates, CheckWorkspacesMatch, Scale, CreateEmptyTableWorkspace
 
 
 def scipy_not_available():
@@ -9,7 +9,7 @@ def scipy_not_available():
         import scipy
         return False
     except:
-        logger.warning("Skipping DensityOfStatesTest because scipy is unavailable.")
+        logger.warning("Skipping SimulatedDensityOfStatesTest because scipy is unavailable.")
         return True
 
 
@@ -28,44 +28,44 @@ def skip_if(skipping_criteria):
 
 
 @skip_if(scipy_not_available)
-class DensityOfStatesTest(unittest.TestCase):
+class SimulatedDensityOfStatesTest(unittest.TestCase):
 
     def setUp(self):
         self._file_name = 'squaricn.phonon'
 
     def test_phonon_load(self):
-        ws = DensityOfStates(File=self._file_name)
+        ws = SimulatedDensityOfStates(File=self._file_name)
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_castep_load(self):
-        ws = DensityOfStates(File='squaricn.castep')
+        ws = SimulatedDensityOfStates(File='squaricn.castep')
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_raman_active(self):
         spec_type = 'Raman_Active'
-        ws = DensityOfStates(File=self._file_name, SpectrumType=spec_type)
+        ws = SimulatedDensityOfStates(File=self._file_name, SpectrumType=spec_type)
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_ir_active(self):
         spec_type = 'IR_Active'
-        ws = DensityOfStates(File=self._file_name, SpectrumType=spec_type)
+        ws = SimulatedDensityOfStates(File=self._file_name, SpectrumType=spec_type)
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_lorentzian_function(self):
-        ws = DensityOfStates(File=self._file_name, Function='Lorentzian')
+        ws = SimulatedDensityOfStates(File=self._file_name, Function='Lorentzian')
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_peak_width(self):
-        ws = DensityOfStates(File=self._file_name, PeakWidth=0.3)
+        ws = SimulatedDensityOfStates(File=self._file_name, PeakWidth=0.3)
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_temperature(self):
-        ws = DensityOfStates(File=self._file_name, Temperature=50)
+        ws = SimulatedDensityOfStates(File=self._file_name, Temperature=50)
         self.assertEquals(ws.getNumberHistograms(), 1)
 
     def test_scale(self):
-        ws = DensityOfStates(File=self._file_name, Scale=10)
-        ref = DensityOfStates(File=self._file_name)
+        ws = SimulatedDensityOfStates(File=self._file_name, Scale=10)
+        ref = SimulatedDensityOfStates(File=self._file_name)
         ref = Scale(ref, Factor=10)
 
         self.assertEqual(CheckWorkspacesMatch(ws, ref), 'Success!')
@@ -73,8 +73,8 @@ class DensityOfStatesTest(unittest.TestCase):
     def test_bin_width(self):
         import math
 
-        ref = DensityOfStates(File=self._file_name)
-        ws = DensityOfStates(File=self._file_name, BinWidth=2)
+        ref = SimulatedDensityOfStates(File=self._file_name)
+        ws = SimulatedDensityOfStates(File=self._file_name, BinWidth=2)
 
         size = ws.blocksize()
         ref_size = ref.blocksize()
@@ -84,7 +84,7 @@ class DensityOfStatesTest(unittest.TestCase):
     def test_zero_threshold(self):
         import numpy as np
 
-        ws = DensityOfStates(File=self._file_name, ZeroThreshold=20)
+        ws = SimulatedDensityOfStates(File=self._file_name, ZeroThreshold=20)
 
         x = ws.readX(0)
         y = ws.readY(0)
@@ -95,7 +95,7 @@ class DensityOfStatesTest(unittest.TestCase):
     def test_partial(self):
         spec_type = 'DOS'
 
-        ws = DensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O')
+        ws = SimulatedDensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O')
 
         workspaces = ws.getNames()
         self.assertEquals(len(workspaces), 3)
@@ -104,15 +104,15 @@ class DensityOfStatesTest(unittest.TestCase):
         spec_type = 'DOS'
         tolerance = 1e-10
 
-        summed = DensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O', SumContributions=True)
-        total = DensityOfStates(File=self._file_name,  SpectrumType=spec_type)
+        summed = SimulatedDensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O', SumContributions=True)
+        total = SimulatedDensityOfStates(File=self._file_name,  SpectrumType=spec_type)
 
         self.assertEquals(CheckWorkspacesMatch(summed, total, tolerance), 'Success!')
 
     def test_partial_cross_section_scale(self):
         spec_type = 'DOS'
 
-        ws = DensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O', ScaleByCrossSection='Incoherent')
+        ws = SimulatedDensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O', ScaleByCrossSection='Incoherent')
 
         workspaces = ws.getNames()
         self.assertEquals(len(workspaces), 3)
@@ -121,13 +121,13 @@ class DensityOfStatesTest(unittest.TestCase):
         spec_type = 'DOS'
         tolerance = 1e-10
 
-        summed = DensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O', SumContributions=True, ScaleByCrossSection='Incoherent')
-        total = DensityOfStates(File=self._file_name,  SpectrumType=spec_type, ScaleByCrossSection='Incoherent')
+        summed = SimulatedDensityOfStates(File=self._file_name, SpectrumType=spec_type, Ions='H,C,O', SumContributions=True, ScaleByCrossSection='Incoherent')
+        total = SimulatedDensityOfStates(File=self._file_name,  SpectrumType=spec_type, ScaleByCrossSection='Incoherent')
 
         self.assertEquals(CheckWorkspacesMatch(summed, total, tolerance), 'Success!')
 
     def test_ion_table(self):
-        ws = DensityOfStates(File=self._file_name, SpectrumType='IonTable')
+        ws = SimulatedDensityOfStates(File=self._file_name, SpectrumType='IonTable')
 
         # Build the expected output
         expected = CreateEmptyTableWorkspace()
@@ -143,7 +143,7 @@ class DensityOfStatesTest(unittest.TestCase):
         """
         Creating an ion table from a castep file is not possible and should fail validation.
         """
-        self.assertRaises(RuntimeError, DensityOfStates,
+        self.assertRaises(RuntimeError, SimulatedDensityOfStates,
                           File=self._file_name, SpectrumType='IonTable')
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.h
@@ -4,39 +4,35 @@
 #include "ui_DensityOfStates.h"
 #include "MantidQtCustomInterfaces/Indirect/IndirectSimulationTab.h"
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  class DLLExport DensityOfStates : public IndirectSimulationTab
-  {
-    Q_OBJECT
+namespace MantidQt {
+namespace CustomInterfaces {
+class DLLExport DensityOfStates : public IndirectSimulationTab {
+  Q_OBJECT
 
-    public:
-      DensityOfStates(QWidget * parent = 0);
+public:
+  DensityOfStates(QWidget *parent = 0);
 
-      QString help() { return "DensityOfStates"; };
+  QString help() { return "DensityOfStates"; };
 
-      void setup();
-      bool validate();
-      void run();
+  void setup();
+  bool validate();
+  void run();
 
-      /// Load default settings into the interface
-      void loadSettings(const QSettings& settings);
+  /// Load default settings into the interface
+  void loadSettings(const QSettings &settings);
 
-      private slots:
-        void dosAlgoComplete(bool error);
-      void handleFileChange();
-      void ionLoadComplete(bool error);
+private slots:
+  void dosAlgoComplete(bool error);
+  void handleFileChange();
+  void ionLoadComplete(bool error);
 
-    private:
-      /// The ui form
-      Ui::DensityOfStates m_uiForm;
-      /// Name of output workspace
-      QString m_outputWsName;
-
-  };
+private:
+  /// The ui form
+  Ui::DensityOfStates m_uiForm;
+  /// Name of output workspace
+  QString m_outputWsName;
+};
 } // namespace CustomInterfaces
 } // namespace MantidQt
 
-#endif //MANTIDQTCUSTOMINTERFACES_DENSITYOFSTATES_H_
+#endif // MANTIDQTCUSTOMINTERFACES_DENSITYOFSTATES_H_

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/DensityOfStates.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/DensityOfStates.cpp
@@ -11,250 +11,231 @@
 using namespace Mantid::API;
 using MantidQt::API::BatchAlgorithmRunner;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("DensityOfStates");
+namespace {
+Mantid::Kernel::Logger g_log("DensityOfStates");
 }
 
+namespace MantidQt {
+namespace CustomInterfaces {
+DensityOfStates::DensityOfStates(QWidget *parent)
+    : IndirectSimulationTab(parent) {
+  m_uiForm.setupUi(parent);
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  DensityOfStates::DensityOfStates(QWidget * parent) :
-    IndirectSimulationTab(parent)
-  {
-    m_uiForm.setupUi(parent);
+  connect(m_uiForm.mwInputFile, SIGNAL(filesFound()), this,
+          SLOT(handleFileChange()));
 
-    connect(m_uiForm.mwInputFile, SIGNAL(filesFound()), this, SLOT(handleFileChange()));
+  m_uiForm.lwIons->setSelectionMode(QAbstractItemView::MultiSelection);
+}
 
-    m_uiForm.lwIons->setSelectionMode(QAbstractItemView::MultiSelection);
-  }
+void DensityOfStates::setup() {}
 
+/**
+ * Validate the form to check the program can be run.
+ *
+ * @return Whether the form was valid
+ */
+bool DensityOfStates::validate() {
+  UserInputValidator uiv;
 
-  void DensityOfStates::setup()
-  {
-  }
+  // Ensure there are ions selected when using DensityOfStates sectrum with
+  // .phonon file
+  QString filename = m_uiForm.mwInputFile->getFirstFilename();
+  QFileInfo fileInfo(filename);
+  bool canDoPartialDoS = fileInfo.suffix() == "phonon";
 
+  QString specType = m_uiForm.cbSpectrumType->currentText();
+  auto items = m_uiForm.lwIons->selectedItems();
 
-  /**
-   * Validate the form to check the program can be run.
-   *
-   * @return Whether the form was valid
-   */
-  bool DensityOfStates::validate()
-  {
-    UserInputValidator uiv;
+  if (specType == "DensityOfStates" && canDoPartialDoS && items.size() < 1)
+    uiv.addErrorMessage("Must select at least one ion for DensityOfStates.");
 
-    // Ensure there are ions selected when using DensityOfStates sectrum with .phonon file
-    QString filename = m_uiForm.mwInputFile->getFirstFilename();
-    QFileInfo fileInfo(filename);
-    bool canDoPartialDoS = fileInfo.suffix() == "phonon";
+  // Give error message when there are errors
+  if (!uiv.isAllInputValid())
+    emit showMessageBox(uiv.generateErrorMessage());
 
-    QString specType = m_uiForm.cbSpectrumType->currentText();
+  return uiv.isAllInputValid();
+}
+
+/**
+ * Configures and executes the LoadSassena algorithm.
+ */
+void DensityOfStates::run() {
+  // Get the SimulatedDensityOfStates algorithm
+  IAlgorithm_sptr dosAlgo =
+      AlgorithmManager::Instance().create("SimulatedDensityOfStates");
+
+  QString filename = m_uiForm.mwInputFile->getFirstFilename();
+  QFileInfo inputFileInfo(filename);
+  QString specType = m_uiForm.cbSpectrumType->currentText();
+
+  m_outputWsName = inputFileInfo.baseName() + "_" + specType;
+
+  // Set common properties
+  dosAlgo->setProperty("File", filename.toStdString());
+  dosAlgo->setProperty("OutputWorkspace", m_outputWsName.toStdString());
+
+  QString peakShape = m_uiForm.cbPeakShape->currentText();
+  dosAlgo->setProperty("Function", peakShape.toStdString());
+
+  double peakWidth = m_uiForm.spPeakWidth->value();
+  dosAlgo->setProperty("PeakWidth", peakWidth);
+
+  double binWidth = m_uiForm.spBinWidth->value();
+  dosAlgo->setProperty("BinWidth", binWidth);
+
+  double zeroThreshold = m_uiForm.spZeroThreshold->value();
+  dosAlgo->setProperty("ZeroThreshold", zeroThreshold);
+
+  bool scale = m_uiForm.ckScale->isChecked();
+  double scaleFactor = m_uiForm.spScale->value();
+  if (scale)
+    dosAlgo->setProperty("Scale", scaleFactor);
+
+  // Set spectrum type specific properties
+  if (specType == "DensityOfStates") {
+    dosAlgo->setProperty("SpectrumType", "DOS");
+
+    bool crossSectionScale = m_uiForm.ckCrossSectionScale->isChecked();
+    QString crossSectionScaleType = m_uiForm.cbCrossSectionScale->currentText();
+    if (crossSectionScale)
+      dosAlgo->setProperty("ScaleByCrossSection",
+                           crossSectionScaleType.toStdString());
+
+    bool sumContributions = m_uiForm.ckSumContributions->isChecked();
+    dosAlgo->setProperty("SumContributions", sumContributions);
+
+    std::vector<std::string> selectedIons;
     auto items = m_uiForm.lwIons->selectedItems();
+    for (auto it = items.begin(); it != items.end(); ++it)
+      selectedIons.push_back((*it)->text().toStdString());
+    dosAlgo->setProperty("Ions", selectedIons);
+  } else if (specType == "IR") {
+    dosAlgo->setProperty("SpectrumType", "IR_Active");
+  } else if (specType == "Raman") {
+    dosAlgo->setProperty("SpectrumType", "Raman_Active");
 
-    if(specType == "DensityOfStates" && canDoPartialDoS && items.size() < 1)
-      uiv.addErrorMessage("Must select at least one ion for DensityOfStates.");
-
-    // Give error message when there are errors
-    if(!uiv.isAllInputValid())
-      emit showMessageBox(uiv.generateErrorMessage());
-
-    return uiv.isAllInputValid();
+    double temperature = m_uiForm.spTemperature->value();
+    dosAlgo->setProperty("Temperature", temperature);
   }
 
+  m_batchAlgoRunner->addAlgorithm(dosAlgo);
 
-  /**
-   * Configures and executes the LoadSassena algorithm.
-   */
-  void DensityOfStates::run()
-  {
-    // Get the SimulatedDensityOfStates algorithm
-    IAlgorithm_sptr dosAlgo = AlgorithmManager::Instance().create("SimulatedDensityOfStates");
+  // Setup save algorithm if needed
+  if (m_uiForm.ckSave->isChecked()) {
+    BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
+    saveProps["InputWorkspace"] = m_outputWsName.toStdString();
 
-    QString filename = m_uiForm.mwInputFile->getFirstFilename();
-    QFileInfo inputFileInfo(filename);
-    QString specType = m_uiForm.cbSpectrumType->currentText();
+    QString filename = m_outputWsName + ".nxs";
 
-    m_outputWsName = inputFileInfo.baseName() + "_" + specType;
+    IAlgorithm_sptr saveAlgo =
+        AlgorithmManager::Instance().create("SaveNexusProcessed");
+    saveAlgo->setProperty("Filename", filename.toStdString());
 
-    // Set common properties
-    dosAlgo->setProperty("File", filename.toStdString());
-    dosAlgo->setProperty("OutputWorkspace", m_outputWsName.toStdString());
+    m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+  }
 
-    QString peakShape = m_uiForm.cbPeakShape->currentText();
-    dosAlgo->setProperty("Function", peakShape.toStdString());
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(dosAlgoComplete(bool)));
+  m_batchAlgoRunner->executeBatchAsync();
+}
 
-    double peakWidth = m_uiForm.spPeakWidth->value();
-    dosAlgo->setProperty("PeakWidth", peakWidth);
+/**
+ * Handles completion of the SimulatedDensityOfStates algorithm.
+ *
+ * @param error If the algorithm failed
+ */
+void DensityOfStates::dosAlgoComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(dosAlgoComplete(bool)));
 
-    double binWidth = m_uiForm.spBinWidth->value();
-    dosAlgo->setProperty("BinWidth", binWidth);
+  if (error)
+    return;
 
-    double zeroThreshold = m_uiForm.spZeroThreshold->value();
-    dosAlgo->setProperty("ZeroThreshold", zeroThreshold);
+  // Handle spectra plotting
+  if (m_uiForm.ckPlot->isChecked())
+    plotSpectrum(m_outputWsName);
+}
 
-    bool scale = m_uiForm.ckScale->isChecked();
-    double scaleFactor = m_uiForm.spScale->value();
-    if(scale)
-      dosAlgo->setProperty("Scale", scaleFactor);
+/**
+ * Handles a new file being selected by the browser.
+ */
+void DensityOfStates::handleFileChange() {
+  QString filename = m_uiForm.mwInputFile->getFirstFilename();
 
-    // Set spectrum type specific properties
-    if(specType == "DensityOfStates")
-    {
-      dosAlgo->setProperty("SpectrumType", "DOS");
+  // Check if we have a .phonon file
+  QFileInfo fileInfo(filename);
+  bool canDoPartialDoS = fileInfo.suffix() == "phonon";
 
-      bool crossSectionScale = m_uiForm.ckCrossSectionScale->isChecked();
-      QString crossSectionScaleType = m_uiForm.cbCrossSectionScale->currentText();
-      if(crossSectionScale)
-        dosAlgo->setProperty("ScaleByCrossSection", crossSectionScaleType.toStdString());
+  // Need a .phonon file for ion contributions
+  if (canDoPartialDoS) {
+    // Load the ion table to populate the list of ions
+    IAlgorithm_sptr ionTableAlgo =
+        AlgorithmManager::Instance().create("SimulatedDensityOfStates");
+    ionTableAlgo->initialize();
+    ionTableAlgo->setProperty("File", filename.toStdString());
+    ionTableAlgo->setProperty("SpectrumType", "IonTable");
+    ionTableAlgo->setProperty("OutputWorkspace", "__dos_ions");
 
-      bool sumContributions = m_uiForm.ckSumContributions->isChecked();
-      dosAlgo->setProperty("SumContributions", sumContributions);
+    m_batchAlgoRunner->addAlgorithm(ionTableAlgo);
 
-      std::vector<std::string> selectedIons;
-      auto items = m_uiForm.lwIons->selectedItems();
-      for(auto it = items.begin(); it != items.end(); ++it)
-        selectedIons.push_back((*it)->text().toStdString());
-      dosAlgo->setProperty("Ions", selectedIons);
-    }
-    else if(specType == "IR")
-    {
-      dosAlgo->setProperty("SpectrumType", "IR_Active");
-    }
-    else if(specType == "Raman")
-    {
-      dosAlgo->setProperty("SpectrumType", "Raman_Active");
-
-      double temperature = m_uiForm.spTemperature->value();
-      dosAlgo->setProperty("Temperature", temperature);
-    }
-
-    m_batchAlgoRunner->addAlgorithm(dosAlgo);
-
-    // Setup save algorithm if needed
-    if(m_uiForm.ckSave->isChecked())
-    {
-      BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
-      saveProps["InputWorkspace"] = m_outputWsName.toStdString();
-
-      QString filename = m_outputWsName + ".nxs";
-
-      IAlgorithm_sptr saveAlgo = AlgorithmManager::Instance().create("SaveNexusProcessed");
-      saveAlgo->setProperty("Filename", filename.toStdString());
-
-      m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
-    }
-
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(dosAlgoComplete(bool)));
+    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+            SLOT(ionLoadComplete(bool)));
     m_batchAlgoRunner->executeBatchAsync();
-  }
-
-
-  /**
-   * Handles completion of the SimulatedDensityOfStates algorithm.
-   *
-   * @param error If the algorithm failed
-   */
-  void DensityOfStates::dosAlgoComplete(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(dosAlgoComplete(bool)));
-
-    if(error)
-      return;
-
-    // Handle spectra plotting
-    if(m_uiForm.ckPlot->isChecked())
-      plotSpectrum(m_outputWsName);
-  }
-
-
-  /**
-   * Handles a new file being selected by the browser.
-   */
-  void DensityOfStates::handleFileChange()
-  {
-    QString filename = m_uiForm.mwInputFile->getFirstFilename();
-
-    // Check if we have a .phonon file
-    QFileInfo fileInfo(filename);
-    bool canDoPartialDoS = fileInfo.suffix() == "phonon";
-
-    // Need a .phonon file for ion contributions
-    if(canDoPartialDoS)
-    {
-      // Load the ion table to populate the list of ions
-      IAlgorithm_sptr ionTableAlgo = AlgorithmManager::Instance().create("SimulatedDensityOfStates");
-      ionTableAlgo->initialize();
-      ionTableAlgo->setProperty("File", filename.toStdString());
-      ionTableAlgo->setProperty("SpectrumType", "IonTable");
-      ionTableAlgo->setProperty("OutputWorkspace", "__dos_ions");
-
-      m_batchAlgoRunner->addAlgorithm(ionTableAlgo);
-
-      connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(ionLoadComplete(bool)));
-      m_batchAlgoRunner->executeBatchAsync();
-    }
-    else
-    {
-      m_uiForm.lwIons->clear();
-      m_uiForm.ckSumContributions->setChecked(false);
-      m_uiForm.ckCrossSectionScale->setChecked(false);
-    }
-
-    // Enable partial DOS related optons when they can be used
-    m_uiForm.lwIons->setEnabled(canDoPartialDoS);
-    m_uiForm.pbSelectAllIons->setEnabled(canDoPartialDoS);
-    m_uiForm.pbDeselectAllIons->setEnabled(canDoPartialDoS);
-    m_uiForm.ckSumContributions->setEnabled(canDoPartialDoS);
-    m_uiForm.ckCrossSectionScale->setEnabled(canDoPartialDoS);
-  }
-
-
-  /**
-   * Handles the algorithm loading the list of ions in a file
-   * being completed.
-   *
-   * @param error If the algorithm failed
-   */
-  void DensityOfStates::ionLoadComplete(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(ionLoadComplete(bool)));
-
-    if(error)
-      g_log.error("Could not get a list of ions from .phonon file");
-
-    // Get the list of ions from algorithm
-    ITableWorkspace_sptr ionTable = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("__dos_ions");
-    Column_sptr ionColumn = ionTable->getColumn("Ion");
-    size_t numIons = ionColumn->size();
-
-    // Remove old ions
+  } else {
     m_uiForm.lwIons->clear();
-
-    // Add ions to list
-    for(size_t ion = 0; ion < numIons; ion++)
-    {
-      const std::string ionName = ionColumn->cell<std::string>(ion);
-      m_uiForm.lwIons->addItem(QString::fromStdString(ionName));
-    }
-
-    // Select all ions by default
-    m_uiForm.lwIons->selectAll();
+    m_uiForm.ckSumContributions->setChecked(false);
+    m_uiForm.ckCrossSectionScale->setChecked(false);
   }
 
+  // Enable partial DOS related optons when they can be used
+  m_uiForm.lwIons->setEnabled(canDoPartialDoS);
+  m_uiForm.pbSelectAllIons->setEnabled(canDoPartialDoS);
+  m_uiForm.pbDeselectAllIons->setEnabled(canDoPartialDoS);
+  m_uiForm.ckSumContributions->setEnabled(canDoPartialDoS);
+  m_uiForm.ckCrossSectionScale->setEnabled(canDoPartialDoS);
+}
 
-  /**
-   * Set the data selectors to use the default save directory
-   * when browsing for input files.
-   *
-   * @param settings :: The settings to loading into the interface
-   */
-  void DensityOfStates::loadSettings(const QSettings& settings)
-  {
-    m_uiForm.mwInputFile->readSettings(settings.group());
+/**
+ * Handles the algorithm loading the list of ions in a file
+ * being completed.
+ *
+ * @param error If the algorithm failed
+ */
+void DensityOfStates::ionLoadComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(ionLoadComplete(bool)));
+
+  if (error)
+    g_log.error("Could not get a list of ions from .phonon file");
+
+  // Get the list of ions from algorithm
+  ITableWorkspace_sptr ionTable =
+      AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("__dos_ions");
+  Column_sptr ionColumn = ionTable->getColumn("Ion");
+  size_t numIons = ionColumn->size();
+
+  // Remove old ions
+  m_uiForm.lwIons->clear();
+
+  // Add ions to list
+  for (size_t ion = 0; ion < numIons; ion++) {
+    const std::string ionName = ionColumn->cell<std::string>(ion);
+    m_uiForm.lwIons->addItem(QString::fromStdString(ionName));
   }
+
+  // Select all ions by default
+  m_uiForm.lwIons->selectAll();
+}
+
+/**
+ * Set the data selectors to use the default save directory
+ * when browsing for input files.
+ *
+ * @param settings :: The settings to loading into the interface
+ */
+void DensityOfStates::loadSettings(const QSettings &settings) {
+  m_uiForm.mwInputFile->readSettings(settings.group());
+}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/DensityOfStates.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/DensityOfStates.cpp
@@ -70,8 +70,8 @@ namespace CustomInterfaces
    */
   void DensityOfStates::run()
   {
-    // Get the DensityOfStates algorithm
-    IAlgorithm_sptr dosAlgo = AlgorithmManager::Instance().create("DensityOfStates");
+    // Get the SimulatedDensityOfStates algorithm
+    IAlgorithm_sptr dosAlgo = AlgorithmManager::Instance().create("SimulatedDensityOfStates");
 
     QString filename = m_uiForm.mwInputFile->getFirstFilename();
     QFileInfo inputFileInfo(filename);
@@ -153,7 +153,7 @@ namespace CustomInterfaces
 
 
   /**
-   * Handles completion of the DensityOfStates algorithm.
+   * Handles completion of the SimulatedDensityOfStates algorithm.
    *
    * @param error If the algorithm failed
    */
@@ -185,7 +185,7 @@ namespace CustomInterfaces
     if(canDoPartialDoS)
     {
       // Load the ion table to populate the list of ions
-      IAlgorithm_sptr ionTableAlgo = AlgorithmManager::Instance().create("DensityOfStates");
+      IAlgorithm_sptr ionTableAlgo = AlgorithmManager::Instance().create("SimulatedDensityOfStates");
       ionTableAlgo->initialize();
       ionTableAlgo->setProperty("File", filename.toStdString());
       ionTableAlgo->setProperty("SpectrumType", "IonTable");

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/DOSTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/DOSTest.py
@@ -4,6 +4,8 @@ from mantid.kernel import *
 from mantid.api import *
 from mantid.simpleapi import *
 
+#------------------------------------------------------------------------------------
+
 class DOSPhononTest(stresstesting.MantidStressTest):
 
     def runTest(self):
@@ -11,7 +13,8 @@ class DOSPhononTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -25,7 +28,9 @@ class DOSPhononCrossSectionScaleTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSCrossSectionScaleTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name, ScaleByCrossSection='Incoherent', OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 ScaleByCrossSection='Incoherent',
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -39,7 +44,8 @@ class DOSCastepTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name,OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -54,7 +60,9 @@ class DOSRamanActiveTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSRamanTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 SpectrumType=spec_type,
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         self.tolerance = 1e-3
@@ -70,7 +78,9 @@ class DOSIRActiveTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSIRTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 SpectrumType=spec_type,
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -85,7 +95,10 @@ class DOSPartialTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSPartialTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 SpectrumType=spec_type,
+                                 Ions="H,C,O",
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -107,7 +120,11 @@ class DOSPartialSummedContributionsTest(stresstesting.MantidStressTest):
         self.ref_result = 'II.DOSTest.nxs'
         self.tolerance = 1e-10
 
-        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", SumContributions=True, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 SpectrumType=spec_type,
+                                 Ions="H,C,O",
+                                 SumContributions=True,
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -122,8 +139,11 @@ class DOSPartialCrossSectionScaleTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSPartialCrossSectionScaleTest.nxs'
 
-        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", ScaleByCrossSection='Incoherent',
-                        OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 SpectrumType=spec_type,
+                                 Ions="H,C,O",
+                                 ScaleByCrossSection='Incoherent',
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -145,8 +165,12 @@ class DOSPartialSummedContributionsCrossSectionScaleTest(stresstesting.MantidStr
         self.ref_result = 'II.DOSCrossSectionScaleTest.nxs'
         self.tolerance = 1e-10
 
-        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", SumContributions=True,
-                        ScaleByCrossSection='Incoherent', OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,
+                                 SpectrumType=spec_type,
+                                 Ions="H,C,O",
+                                 SumContributions=True,
+                                 ScaleByCrossSection='Incoherent',
+                                 OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/DOSTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/DOSTest.py
@@ -11,7 +11,7 @@ class DOSPhononTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSTest.nxs'
 
-        DensityOfStates(File=file_name, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name, OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -25,7 +25,7 @@ class DOSPhononCrossSectionScaleTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSCrossSectionScaleTest.nxs'
 
-        DensityOfStates(File=file_name, ScaleByCrossSection='Incoherent', OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name, ScaleByCrossSection='Incoherent', OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -39,7 +39,7 @@ class DOSCastepTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSTest.nxs'
 
-        DensityOfStates(File=file_name,OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name,OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -54,7 +54,7 @@ class DOSRamanActiveTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSRamanTest.nxs'
 
-        DensityOfStates(File=file_name, SpectrumType=spec_type, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         self.tolerance = 1e-3
@@ -70,7 +70,7 @@ class DOSIRActiveTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSIRTest.nxs'
 
-        DensityOfStates(File=file_name, SpectrumType=spec_type, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -85,7 +85,7 @@ class DOSPartialTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSPartialTest.nxs'
 
-        DensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -107,7 +107,7 @@ class DOSPartialSummedContributionsTest(stresstesting.MantidStressTest):
         self.ref_result = 'II.DOSTest.nxs'
         self.tolerance = 1e-10
 
-        DensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", SumContributions=True, OutputWorkspace=self.ouput_ws_name)
+        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", SumContributions=True, OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
         return self.ouput_ws_name, self.ref_result
@@ -122,7 +122,7 @@ class DOSPartialCrossSectionScaleTest(stresstesting.MantidStressTest):
         self.ouput_ws_name = 'squaricn'
         self.ref_result = 'II.DOSPartialCrossSectionScaleTest.nxs'
 
-        DensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", ScaleByCrossSection='Incoherent',
+        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", ScaleByCrossSection='Incoherent',
                         OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):
@@ -145,7 +145,7 @@ class DOSPartialSummedContributionsCrossSectionScaleTest(stresstesting.MantidStr
         self.ref_result = 'II.DOSCrossSectionScaleTest.nxs'
         self.tolerance = 1e-10
 
-        DensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", SumContributions=True,
+        SimulatedDensityOfStates(File=file_name, SpectrumType=spec_type, Ions="H,C,O", SumContributions=True,
                         ScaleByCrossSection='Incoherent', OutputWorkspace=self.ouput_ws_name)
 
     def validate(self):

--- a/Code/Mantid/docs/source/algorithms/DensityOfStates-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DensityOfStates-v1.rst
@@ -18,6 +18,8 @@ a table workspace containing each ion that is present in a .phonon file.
 Usage
 -----
 
+.. include:: ../usagedata-note.txt
+
 **Example - loading data from phonon & castep files:**
 
 .. testcode:: ExDensityOfStatesSimple

--- a/Code/Mantid/docs/source/algorithms/DensityOfStates-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DensityOfStates-v1.rst
@@ -22,32 +22,32 @@ Usage
 
 **Example - loading data from phonon & castep files:**
 
-.. testcode:: ExDensityOfStatesSimple
+.. testcode:: ExSimulatedDensityOfStatesSimple
 
     # Loading the same data from a castep and phonon file
-    phonon_ws = DensityOfStates(File='squaricn.phonon')
-    castep_ws = DensityOfStates(File='squaricn.castep')
+    phonon_ws = SimulatedDensityOfStates(File='squaricn.phonon')
+    castep_ws = SimulatedDensityOfStates(File='squaricn.castep')
 
     print CheckWorkspacesMatch(phonon_ws, castep_ws)
 
 Output:
 
-.. testoutput:: ExDensityOfStatesSimple
+.. testoutput:: ExSimulatedDensityOfStatesSimple
 
     Success!
 
 **Example - loading partial contributions of ions:**
 
-.. testcode:: ExDensityOfStatesPartial
+.. testcode:: ExSimulatedDensityOfStatesPartial
 
-    squaricn = DensityOfStates(File='squaricn.phonon', Ions=['H', 'C', 'O'])
+    squaricn = SimulatedDensityOfStates(File='squaricn.phonon', Ions=['H', 'C', 'O'])
 
     for name in squaricn.getNames():
       print name
 
 Output:
 
-.. testoutput:: ExDensityOfStatesPartial
+.. testoutput:: ExSimulatedDensityOfStatesPartial
 
     squaricn_H
     squaricn_C
@@ -55,30 +55,30 @@ Output:
 
 **Example - loading summed partial contributions of ions:**
 
-.. testcode:: ExDensityOfStatesPartialSummed
+.. testcode:: ExSimulatedDensityOfStatesPartialSummed
 
-    sum_ws = DensityOfStates(File='squaricn.phonon', Ions=['H', 'C', 'O'], SumContributions=True)
-    total_ws = DensityOfStates(File='squaricn.phonon')
+    sum_ws = SimulatedDensityOfStates(File='squaricn.phonon', Ions=['H', 'C', 'O'], SumContributions=True)
+    total_ws = SimulatedDensityOfStates(File='squaricn.phonon')
 
     print CheckWorkspacesMatch(total_ws, sum_ws, Tolerance=1e-12)
 
 Output:
 
-.. testoutput:: ExDensityOfStatesPartialSummed
+.. testoutput:: ExSimulatedDensityOfStatesPartialSummed
 
     Success!
 
 **Example - Getting the list of ions in a phonon file:**
 
-.. testcode:: ExDensityOfStatesIonTable
+.. testcode:: ExSimulatedDensityOfStatesIonTable
 
-    ion_ws = DensityOfStates(File='squaricn.phonon', SpectrumType='IonTable')
+    ion_ws = SimulatedDensityOfStates(File='squaricn.phonon', SpectrumType='IonTable')
     for i in range (0, ion_ws.rowCount()):
         print ion_ws.row(i)['Ion']
 
 Output:
 
-.. testoutput:: ExDensityOfStatesIonTable
+.. testoutput:: ExSimulatedDensityOfStatesIonTable
 
     H
     C

--- a/Code/Mantid/docs/source/interfaces/Indirect_Simulation.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_Simulation.rst
@@ -100,7 +100,7 @@ DensityOfStates
   :widget: dos
 
 The DensityOfStates interface is used to load CASTEP simulations using the
-:ref:`DensityOfStates <algm-DensityOfStates>` algorithm. It supports loading
+:ref:`SimulatedDensityOfStates <algm-SimulatedDensityOfStates>` algorithm. It supports loading
 full and partial densities of states, raman and IR spectroscopy.
 
 Options


### PR DESCRIPTION
Fixes #13177.

To test:
- See that the algorithm is now called SimulatedDesnityOfStates
- Load a `.phonon` file in the Indirect > Simulation > DensityOfStates UI

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24462&oldid=24459).
