### PR TITLE
update on error messages when ticking combinations of options for LoadMD

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -363,8 +363,10 @@ void LoadMD::doLoad(typename MDEventWorkspace<MDE, nd>::sptr ws) {
   bool fileBackEnd = getProperty("FileBackEnd");
 
   if (fileBackEnd && m_BoxStructureAndMethadata)
-    throw std::invalid_argument("Both BoxStructureOnly and fileBackEnd were "
-                                "set to TRUE: this is not possible.");
+    throw std::invalid_argument("Combination of BoxStructureOnly or "
+                                "MetaDataOnly were set to TRUE with "
+                                "fileBackEnd "
+                                ": this is not possible.");
 
   CPUTimer tim;
   Progress *prog = new Progress(this, 0.0, 1.0, 100);


### PR DESCRIPTION
fixes #12442 

When either BoxStructureOnly or MetaDataOnly is selected with fileBackEnd option, it will display a more appropriate error message 
