### PR TITLE
Parameter correction file reader function 

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadIDFFromNexus.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadIDFFromNexus.h
@@ -69,6 +69,10 @@ public:
   /// Get the parameter correction file, if it exists else return ""
   std::string getParameterCorrectionFile( const std::string& instName ) ;
 
+  /// Read parameter correction file, return applicabel parameter file and whether to append
+  void readParameterCorrectionFile( const std::string& correction_file, const std::string& date, 
+    std::string parameter_file, bool append  );
+
   /// Load the parameters from Nexus file if possible, else from parameter file, into workspace
   void LoadParameters( ::NeXus::File *nxfile, const API::MatrixWorkspace_sptr localWorkspace );
 

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadIDFFromNexus.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadIDFFromNexus.h
@@ -71,7 +71,7 @@ public:
 
   /// Read parameter correction file, return applicabel parameter file and whether to append
   void readParameterCorrectionFile( const std::string& correction_file, const std::string& date, 
-    std::string parameter_file, bool append  );
+    std::string& parameter_file, bool& append  );
 
   /// Load the parameters from Nexus file if possible, else from parameter file, into workspace
   void LoadParameters( ::NeXus::File *nxfile, const API::MatrixWorkspace_sptr localWorkspace );

--- a/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -87,6 +87,9 @@ void LoadIDFFromNexus::exec() {
   std::string correctionParameterFile = "";
   bool append = false;
   if( parameterCorrectionFile != "") {
+    // Read parameter correction file 
+    // to find out which parameter file to use 
+    // and whether it is appended to default parameters.
     readParameterCorrectionFile( parameterCorrectionFile, "2015-07-23 12:00:00", correctionParameterFile, append );
   }
   g_log.notice() << "Result of readParameterCorrectionFile: " << correctionParameterFile << " " << append << "\n";

--- a/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -167,11 +167,9 @@ void LoadIDFFromNexus::readParameterCorrectionFile( const std::string& correctio
 
   // Examine the XML structure obtained by parsing
   Poco::AutoPtr<NodeList> correctionNodeList = pRootElem->getElementsByTagName("correction");
-  g_log.notice() << "Number of corrections elements in correction file root = " << correctionNodeList->length() << "\n";
   for( unsigned long i=0; i < correctionNodeList->length(); ++i ){
     // For each correction element
     Element* corr = (Element *)correctionNodeList->item(i);
-    g_log.notice() << corr->getAttribute("valid-from") << " " <<corr->getAttribute("valid-to") << " " << corr->getAttribute("file") << "\n";
     DateAndTime start(corr->getAttribute("valid-from"));
     DateAndTime end(corr->getAttribute("valid-to"));
     if ( start <= externalDate && externalDate <= end ){

--- a/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -84,8 +84,8 @@ void LoadIDFFromNexus::exec() {
   g_log.notice() << "Parameter correction file: " << parameterCorrectionFile << "\n";
 
   // Read parameter correction file, if found
-  std::string correctionParameterFile;
-  bool append;
+  std::string correctionParameterFile = "";
+  bool append = false;
   if( parameterCorrectionFile != "") {
     readParameterCorrectionFile( parameterCorrectionFile, "2015-07-23 12:00:00", correctionParameterFile, append );
   }

--- a/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -84,8 +84,8 @@ void LoadIDFFromNexus::exec() {
   g_log.notice() << "Parameter correction file: " << parameterCorrectionFile << "\n";
 
   // Read parameter correction file, if found
-  std::string correctionParameterFile = "";
-  bool append = false;
+  std::string correctionParameterFile;
+  bool append;
   if( parameterCorrectionFile != "") {
     readParameterCorrectionFile( parameterCorrectionFile, "2015-07-23 12:00:00", correctionParameterFile, append );
   }
@@ -127,7 +127,7 @@ void LoadIDFFromNexus::exec() {
   /* Reads the parameter correction file and if a correction is needed output the parameterfile needed 
   *  and whether it is to be appended.
   * @param correction_file :: path nsame of correction file as returned by getParameterCorrectionFile()
-  * @param date :: IS8601 date string applicable
+  * @param date :: IS8601 date string applicable: Must be full timestamp (timezone optional)
   * @param parameter_file :: output parameter file to use or "" if none
   * @param append :: output whether the parameters from parameter_file should be appended.
   *


### PR DESCRIPTION
This fixes issue #13162 .

To test review the code and check the unit test is adequate.

You may generate a test parameter correction file of format:

```
<EmbeddedParameterCorrections name='XXX'>
   <correction  valid-from='2015-06-26 00:00:00'  valid-to='2015-07-21 23:59:59' file='test1.xml' append='false'/>
   <correction  valid-from='2015-07-22 00:00:00'  valid-to='2015-07-31 11:59:59' file='test2.xml' append='true'/>
</EmbeddedParameterCorrections>
```

and put it into the 'embedded_instrument_corrections' subfolder of the instrument folder, check that the correct parameter correction file 
is logged in the results. Code it actually use the correction file will be added in a later ticket.
