### PR TITLE
AsymmetryCalc documentation

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/AsymmetryCalc.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/AsymmetryCalc.cpp
@@ -91,7 +91,7 @@ void AsymmetryCalc::exec() {
     // If some spectra were not found, can't continue
     if (specIDs.size() != indices.size())
       throw std::invalid_argument(
-          "Some of the spectra specified do not exist in a workspace");
+          "Could not find two spectra in the input workspace");
 
     forward = static_cast<int>(indices[0]);
     backward = static_cast<int>(indices[1]);

--- a/Code/Mantid/docs/source/algorithms/AsymmetryCalc-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/AsymmetryCalc-v1.rst
@@ -10,7 +10,11 @@ Description
 -----------
 
 This algorithm is used to calculate the asymmetry for a Muon workspace.
-The asymmetry is given by:
+It first groups the input workspace according to the spectra numbers
+provided as *ForwardSpectra* and *BackwardSpectra*. If these properties
+are not supplied, the algorithm assumes that the first spectrum in the
+workspace is the forward group and the second one is the backward
+group. It then calculates the asymmetry as:
 
 .. math:: Asymmetry = \frac{F-\alpha B}{F+\alpha B}
 

--- a/Code/Mantid/docs/source/algorithms/AsymmetryCalc-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/AsymmetryCalc-v1.rst
@@ -26,11 +26,6 @@ the errors in :math:`F-\alpha B` and :math:`F+\alpha B`.
 The output workspace contains one set of data for the time of flight:
 the asymmetry and the asymmetry errors.
 
-.. note::
-   This algorithm does not perform any grouping. The grouping must be
-   done using :ref:`algm-MuonGroupDetectors` or *AutoGroup* option
-   of :ref:`algm-LoadMuonNexus`.
-
 .. [1] See :ref:`algm-AlphaCalc`
 
 Usage


### PR DESCRIPTION
Fixes #13187 

For tester:

This PR is very easy to test, basically, make sure you agree with me that the documentation was incorrect, and that AsymmetryCalc groups spectra when `ForwardSpectra` and `BackwardSpectra` are supplied.
