### PR TITLE
Detect event workspace in add tab and react to it

### DIFF
--- a/Code/Mantid/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Code/Mantid/Framework/API/src/FileLoaderRegistry.cpp
@@ -151,9 +151,11 @@ bool FileLoaderRegistryImpl::canLoad(const std::string &algorithmName,
   std::multimap<std::string, int> names;
   names.insert(std::make_pair(algorithmName, -1));
   IAlgorithm_sptr loader;
-  if (nexus && NexusDescriptor::isHDF(filename)) {
-    loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(
-        filename, names, m_log);
+  if (nexus) {
+    if( NexusDescriptor::isHDF(filename)) {
+      loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(
+          filename, names, m_log);
+    }
   } else {
     loader = searchForLoader<FileDescriptor, IFileLoader<FileDescriptor>>(
         filename, names, m_log);

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -79,6 +79,7 @@ set ( SRC_FILES
   src/ReflSearchModel.cpp
   src/SampleTransmission.cpp
   src/SANSAddFiles.cpp
+  src/SANSConstants.cpp
   src/SANSDiagnostics.cpp
   src/SANSEventSlicing.cpp
   src/SANSPlotSpecial.cpp
@@ -186,6 +187,7 @@ set ( INC_FILES
   inc/MantidQtCustomInterfaces/QtReflOptionsDialog.h
   inc/MantidQtCustomInterfaces/SampleTransmission.h
   inc/MantidQtCustomInterfaces/SANSAddFiles.h
+  inc/MantidQtCustomInterfaces/SANSConstants.h
   inc/MantidQtCustomInterfaces/SANSDiagnostics.h
   inc/MantidQtCustomInterfaces/SANSEventSlicing.h
   inc/MantidQtCustomInterfaces/SANSPlotSpecial.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSAddFiles.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSAddFiles.h
@@ -2,6 +2,7 @@
 #define MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_
 
 #include "ui_SANSRunWindow.h"
+#include "MantidQtCustomInterfaces/SANSConstants.h"
 #include "MantidQtAPI/UserSubWindow.h"
 #include "MantidKernel/ConfigService.h"
 #include <Poco/NObserver.h>
@@ -55,6 +56,8 @@ private:
   void setInputEnabled(bool enabled);
   /// Create Python string list
   QString createPythonStringList(QString inputString);
+  /// SANS constants
+  SANSConstants m_constants;
 
   void initLayout();
   void setToolTips();
@@ -85,6 +88,12 @@ private slots:
   void onCurrentIndexChangedForHistogramChoice(int index);
   /// reacts to changes of the overlay check box
   void onStateChangedForOverlayCheckBox(int);
+  /// checks if a file corresponds to a histogram worksapce
+  bool isEventWorkspace(QString file_name);
+  /// checks if the files which are to be added are all based on event workspaces
+  bool existNonEventFiles();
+  /// sets the binning options
+  void setBinningOptions(bool enable);
 };
 
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSConstants.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSConstants.h
@@ -1,0 +1,24 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_SANSCONSTANTS_H_
+#define MANTIDQTCUSTOMINTERFACES_SANSCONSTANTS_H_
+
+#include <QString>
+
+namespace MantidQt
+{
+namespace CustomInterfaces
+{
+
+class SANSConstants
+{
+public:
+  SANSConstants();
+  ~SANSConstants();
+  QString getPythonSuccessKeyword();
+  QString getPythonEmptyKeyword();
+  QString getPythonTrueKeyword();
+};
+
+}
+}
+
+#endif  //MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -370,10 +370,6 @@ private:
   QAction *m_batch_clear;
   //Time/Pixel mask string
   QString m_maskScript;
-  /// Success keyword
-  static const QString m_pythonSuccessKeyword;
-  /// Keyword for empty return value in python
-  static const QString m_pythonEmptyKeyword;
   /// Stores the URL of each tab's help page.
   QMap<Tab, QString> m_helpPageUrls;
   /// SANS constants

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -10,6 +10,7 @@
 #include "MantidQtMantidWidgets/SaveWorkspaces.h"
 #include "MantidQtCustomInterfaces/SANSDiagnostics.h"
 #include "MantidQtCustomInterfaces/SANSPlotSpecial.h"
+#include "MantidQtCustomInterfaces/SANSConstants.h"
 
 #include <QHash>
 #include <QSettings>
@@ -360,7 +361,9 @@ private:
   static const QString m_pythonEmptyKeyword;
   /// Stores the URL of each tab's help page.
   QMap<Tab, QString> m_helpPageUrls;
-  
+  /// SANS constants
+  SANSConstants m_constants;
+
   void initAnalysDetTab();
   void makeValidator(QLabel * const newValid, QWidget * control, QWidget * tab, const QString & errorMsg);
   void upDateDataDir();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
@@ -3952,7 +3952,7 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item row="9" column="2">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="histogram_binning_label">
           <property name="text">
            <string>Histogram binning (when adding event data):</string>
           </property>
@@ -3997,7 +3997,7 @@ p, li { white-space: pre-wrap; }
         <item row="12" column="2">
          <layout class="QHBoxLayout" name="horizontalLayout_24">
           <item>
-           <widget class="QLabel" name="labelBinning">
+           <widget class="QLabel" name="binning_label">
             <property name="minimumSize">
              <size>
               <width>70</width>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSConstants.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSConstants.cpp
@@ -1,0 +1,40 @@
+#include "MantidQtCustomInterfaces/SANSConstants.h"
+
+
+namespace MantidQt
+{
+namespace CustomInterfaces
+{
+SANSConstants::SANSConstants() {}
+
+SANSConstants::~SANSConstants() {}
+
+/**
+ * Defines the python keyword for a succssful operation
+ * @returns the keyword for success
+ */
+QString SANSConstants::getPythonSuccessKeyword() {
+  const static QString pythonSuccessKeyword = "pythonExecutionWasSuccessful";
+  return pythonSuccessKeyword;
+}
+
+/**
+ * Defines the python keyword for an empty object , ie None
+ * @returns the python keyword for an empty object
+ */
+QString SANSConstants::getPythonEmptyKeyword() {
+  const static QString pythonSuccessKeyword = "None";
+  return pythonSuccessKeyword;
+}
+
+/**
+ * Defines the python keyword for true , ie True
+ * @returns the python true keyword
+ */
+QString SANSConstants::getPythonTrueKeyword() {
+  const static QString pythonSuccessKeyword = "True";
+  return pythonSuccessKeyword;
+}
+
+}
+}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4010,7 +4010,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionRadiusRequest("\nprint i.GetTransmissionRadiusInMM()");
   QString resultTransmissionRadius(runPythonCode(transmissionRadiusRequest, false));
   resultTransmissionRadius = resultTransmissionRadius.simplified();
-  if (resultTransmissionRadius != m_pythonEmptyKeyword) {
+  if (resultTransmissionRadius != m_constants.getPythonEmptyKeyword()) {
       this->m_uiForm.trans_radius_line_edit->setText(resultTransmissionRadius);
       this->m_uiForm.trans_radius_check_box->setChecked(true);
       setBeamStopLogic(TransSettings::RADIUS, true);
@@ -4020,7 +4020,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionROIRequest("\nprint i.GetTransmissionROI()");
   QString resultTransmissionROI(runPythonCode(transmissionROIRequest, false));
   resultTransmissionROI = resultTransmissionROI.simplified();
-  if (resultTransmissionROI != m_pythonEmptyKeyword) {
+  if (resultTransmissionROI != m_constants.getPythonEmptyKeyword()) {
       resultTransmissionROI = runPythonCode("\nprint i.ConvertFromPythonStringList(to_convert=" + resultTransmissionROI+ ")", false);
       this->m_uiForm.trans_roi_files_line_edit->setText(resultTransmissionROI);
       this->m_uiForm.trans_roi_files_checkbox->setChecked(true);
@@ -4032,7 +4032,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionMaskRequest("\nprint i.GetTransmissionMask()");
   QString resultTransmissionMask(runPythonCode(transmissionMaskRequest, false));
   resultTransmissionMask = resultTransmissionMask.simplified();
-  if (resultTransmissionMask != m_pythonEmptyKeyword) {
+  if (resultTransmissionMask != m_constants.getPythonEmptyKeyword()) {
     resultTransmissionMask = runPythonCode("\nprint i.ConvertFromPythonStringList(to_convert=" + resultTransmissionMask+ ")", false);
     this->m_uiForm.trans_masking_line_edit->setText(resultTransmissionMask);
   }
@@ -4041,7 +4041,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionMonitorSpectrumShiftRequest("\nprint i.GetTransmissionMonitorSpectrumShift()");
   QString resultTransmissionMonitorSpectrumShift(runPythonCode(transmissionMonitorSpectrumShiftRequest, false));
   resultTransmissionMonitorSpectrumShift = resultTransmissionMonitorSpectrumShift.simplified();
-  if (resultTransmissionMonitorSpectrumShift != m_pythonEmptyKeyword) {
+  if (resultTransmissionMonitorSpectrumShift != m_constants.getPythonEmptyKeyword()) {
     this->m_uiForm.trans_M3M4_line_edit->setText(resultTransmissionMonitorSpectrumShift);
   }
 
@@ -4050,7 +4050,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionMonitorSpectrumRequest("\nprint i.GetTransmissionMonitorSpectrum()");
   QString resultTransmissionMonitorSpectrum(runPythonCode(transmissionMonitorSpectrumRequest, false));
   resultTransmissionMonitorSpectrum = resultTransmissionMonitorSpectrum.simplified();
-  if (resultTransmissionMonitorSpectrum != m_pythonEmptyKeyword) {
+  if (resultTransmissionMonitorSpectrum != m_constants.getPythonEmptyKeyword()) {
     if (resultTransmissionMonitorSpectrum == "3") {
       this->m_uiForm.trans_M3_check_box->setChecked(true);
       setM3M4Logic(TransSettings::M3, true);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -149,11 +149,7 @@ namespace
   }
 }
 
-//----------------------------------------------
-// Static key strings
-//----------------------------------------------
-const QString SANSRunWindow::m_pythonSuccessKeyword  = "pythonExecutionWasSuccessful";
-const QString SANSRunWindow::m_pythonEmptyKeyword = "None";
+
 //----------------------------------------------
 // Public member functions
 //----------------------------------------------
@@ -3020,7 +3016,7 @@ void SANSRunWindow::handleInstrumentChange()
   int ind = m_uiForm.detbank_sel->findText(detect);
   // We set the detector selection only if nothing is set yet.
   // Previously, we didn't handle merged and both at this point
-  if (detectorSelection == m_pythonEmptyKeyword || detectorSelection.isEmpty()) {
+  if (detectorSelection == m_constants.getPythonEmptyKeyword() || detectorSelection.isEmpty()) {
     if( ind != -1 ) {
       m_uiForm.detbank_sel->setCurrentIndex(ind);
     }
@@ -3881,11 +3877,11 @@ void SANSRunWindow::createZeroErrorFreeClone(QString& originalWorkspaceName, QSt
     QString pythonCode("print i.CreateZeroErrorFreeClonedWorkspace(input_workspace_name='");
     pythonCode += originalWorkspaceName + "',";
     pythonCode += " output_workspace_name='" + clonedWorkspaceName + "')\n";
-    pythonCode += "print '" + m_pythonSuccessKeyword + "'\n";
+    pythonCode += "print '" + m_constants.getPythonSuccessKeyword() + "'\n";
     QString result(runPythonCode(pythonCode, false));
     result = result.simplified();
-    if (result != m_pythonSuccessKeyword) {
-      result.replace(m_pythonSuccessKeyword, "");
+    if (result != m_constants.getPythonSuccessKeyword()) {
+      result.replace(m_constants.getPythonSuccessKeyword(), "");
       g_log.warning("Error creating a zerror error free cloned workspace. Will save original workspace. More info: " + result.toStdString());
     }
   }
@@ -3900,11 +3896,11 @@ void SANSRunWindow::deleteZeroErrorFreeClone(QString& clonedWorkspaceName) {
     // Run the python script which destroys the cloned workspace
     QString pythonCode("print i.DeleteZeroErrorFreeClonedWorkspace(input_workspace_name='");
     pythonCode += clonedWorkspaceName + "')\n";
-    pythonCode += "print '" + m_pythonSuccessKeyword + "'\n";
+    pythonCode += "print '" + m_constants.getPythonSuccessKeyword() + "'\n";
     QString result(runPythonCode(pythonCode, false));
     result = result.simplified();
-    if (result != m_pythonSuccessKeyword) {
-      result.replace(m_pythonSuccessKeyword, "");
+    if (result != m_constants.getPythonSuccessKeyword()) {
+      result.replace(m_constants.getPythonSuccessKeyword(), "");
       g_log.warning("Error deleting a zerror error free cloned workspace. More info: " + result.toStdString());
     }
   }
@@ -3917,12 +3913,12 @@ void SANSRunWindow::deleteZeroErrorFreeClone(QString& clonedWorkspaceName) {
 bool SANSRunWindow::isValidWsForRemovingZeroErrors(QString& wsName) {
     QString pythonCode("\nprint i.IsValidWsForRemovingZeroErrors(input_workspace_name='");
     pythonCode += wsName + "')";
-    pythonCode += "\nprint '" + m_pythonSuccessKeyword + "'";
+    pythonCode += "\nprint '" + m_constants.getPythonSuccessKeyword() + "'";
     QString result(runPythonCode(pythonCode, false));
     result = result.simplified();
     bool isValid = true;
-    if (result != m_pythonSuccessKeyword) {
-      result.replace(m_pythonSuccessKeyword, "");
+    if (result != m_constants.getPythonSuccessKeyword()) {
+      result.replace(m_constants.getPythonSuccessKeyword(), "");
       g_log.warning("Not a valid workspace for zero error replacement. Will save original workspace. More info: " + result.toStdString());
       isValid = false;
     }

--- a/Code/Mantid/scripts/CMakeLists.txt
+++ b/Code/Mantid/scripts/CMakeLists.txt
@@ -32,7 +32,6 @@ set ( TEST_PY_FILES
       test/SANSCommandInterfaceTest.py
       test/SANSUtilityTest.py
       test/SANSIsisInstrumentTest.py
-      test/SANSCommandInterfaceTest.py
       test/SANSReductionStepsUserFileTest.py
       test/SettingsTest.py
       test/ReductionSettingsTest.py

--- a/Code/Mantid/scripts/CMakeLists.txt
+++ b/Code/Mantid/scripts/CMakeLists.txt
@@ -29,6 +29,7 @@ set ( TEST_PY_FILES
       test/RunDescriptorTest.py
       test/SansIsisGuiSettings.py
       test/SANSBatchModeTest.py
+      test/SANSCommandInterfaceTest.py
       test/SANSUtilityTest.py
       test/SANSIsisInstrumentTest.py
       test/SANSReductionStepsUserFileTest.py

--- a/Code/Mantid/scripts/SANS/ISISCommandInterface.py
+++ b/Code/Mantid/scripts/SANS/ISISCommandInterface.py
@@ -13,7 +13,7 @@ import isis_reducer
 from centre_finder import CentreFinder as CentreFinder
 #import SANSReduction
 from mantid.simpleapi import *
-from mantid.api import WorkspaceGroup
+from mantid.api import WorkspaceGroup, FileLoaderRegistry
 import copy
 from SANSadd2 import *
 import SANSUtility as su
@@ -1197,6 +1197,18 @@ def IsValidWsForRemovingZeroErrors(input_workspace_name):
         return message
     else:
         return ""
+
+
+def check_if_event_workspace(file_name):
+    '''
+    Checks if a file is associated with an event workspace. It tests if
+    the workspace can be loaded.
+    @param file_name: The file name to test
+    @returns true if the workspace is an event workspace otherwise false
+    '''
+    result = FileLoaderRegistry.canLoad("LoadEventNexus", file_name)
+    print result
+    return result
 
 ################################################################################
 # Input check functions

--- a/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
+++ b/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
@@ -5,8 +5,8 @@ import ISISCommandInterface as command_iface
 from reducer_singleton import ReductionSingleton
 import isis_reduction_steps as reduction_steps
 from mantid.simpleapi import *
-
-
+from mantid.kernel import DateAndTime
+import random
 
 class SANSCommandInterfaceGetAndSetTransmissionSettings(unittest.TestCase):
     def test_that_gets_transmission_monitor(self):
@@ -199,15 +199,26 @@ class TestEventWorkspaceCheck(unittest.TestCase):
         temp_save_dir = config['defaultsave.directory']
         if (temp_save_dir == ''):
             temp_save_dir = os.getcwd()
-        return os.path.join(temp_save_dir, names + '.nxs')
+        return os.path.join(temp_save_dir, name + '.nxs')
+
+    def addSampleLogEntry(self, log_name, ws, start_time, extra_time_shift):
+        number_of_times = 10
+        for i in range(0, number_of_times):
+
+            val = random.randrange(0, 10, 1)
+            date = DateAndTime(start_time)
+            date +=  int(i*1e9)
+            date += int(extra_time_shift*1e9)
+            AddTimeSeriesLog(ws, Name=log_name, Time=date.__str__().strip(), Value=val)
 
     def _clean_up(self, file_name):
         if os.path.exists(file_name):
             os.remove(file_name)
 
-    def test_that_event_workspace_is_detected(self):
+    def test_that_histogram_workspace_is_detected(self):
         # Arrange
         ws = CreateSampleWorkspace()
+        self.addSampleLogEntry('proton_charge', ws, "2010-01-01T00:00:00", 0.0)
         file_name = self._create_file_name('dummy')
         SaveNexus(Filename= file_name, InputWorkspace=ws)
         # Act
@@ -216,19 +227,5 @@ class TestEventWorkspaceCheck(unittest.TestCase):
         # Clean Up
         self._clean_up(file_name)
 
-    def test_that_histogram_workspace_is_detected(self):
-        # Arrange
-        ws = CreateSampleWorkspace('Event')
-        file_name = self._create_file_name('dummy')
-        SaveNexus(Filename= file_name, InputWorkspace=ws)
-        # Act
-        result = command_iface.check_if_event_workspace(file_name)
-        self.assertTrue(result)
-        # Clean Up
-        self._clean_up(file_name)
-       
-        
-        
-        
 if __name__ == "__main__":
     unittest.main()

--- a/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
+++ b/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
@@ -1,0 +1,40 @@
+import unittest
+import re
+# Need to import mantid before we import SANSUtility
+import mantid
+from mantid.simpleapi import *
+import ISISCommandInterface as ci
+
+
+class TestEventWorkspaceCheck(unittest.TestCase):
+    def _create_file_name(self, name):
+        temp_save_dir = config['defaultsave.directory']
+        if (temp_save_dir == ''):
+            temp_save_dir = os.getcwd()
+        return os.path.join(temp_save_dir, names + '.nxs')
+
+    def _clean_up(self, file_name):
+        if os.path.exists(file_name):
+            os.remove(file_name)
+
+    def test_that_event_workspace_is_detected(self):
+        # Arrange
+        ws = CreateSampleWorkspace()
+        file_name = self._create_file_name('dummy')
+        SaveNexus(Filename= file_name, InputWorkspace=ws)
+        # Act
+        result = ci.check_if_event_workspace(file_name)
+        self.assertFalse(result)
+        # Clean Up
+        self._clean_up(file_name)
+
+    def test_that_histogram_workspace_is_detected(self):
+        # Arrange
+        ws = CreateSampleWorkspace('Event')
+        file_name = self._create_file_name('dummy')
+        SaveNexus(Filename= file_name, InputWorkspace=ws)
+        # Act
+        result = ci.check_if_event_workspace(file_name)
+        self.assertTrue(result)
+        # Clean Up
+        self._clean_up(file_name)


### PR DESCRIPTION
Fixes #13179
### For Testing

Please find the sample files here: \olympic\Babylon5\Scratch\Anton\Testing\13179
- LOQ99630.RAW 
- SANS2D00028793.nxs (event file)
- SANS2D00028784.nxs (histo file)
1. Open the ISIS SANS GUI 
2. Go to the Add Tabs page
   - Confirm that the options for event data are enabled
3. Add LOQ99630.RAW
   - Confirm that the options for event data are disabled
4. Remove LOQ99630.RAW
   - Confirm that the options for event data are enabled
5. Load LOQ99630.RAW
