### PR TITLE
Fix two small bugs in FindPyQt cmake.

### DIFF
--- a/Code/Mantid/Build/CMake/FindPyQt.py
+++ b/Code/Mantid/Build/CMake/FindPyQt.py
@@ -12,9 +12,9 @@ def get_default_sip_dir():
     # default case where installation paths have not been changed in PyQt's
     # configuration process.
     if sys.platform == 'win32':
-        pyqt_sip_dir = os.path.join(sys.platform, 'sip', 'PyQt4')
+        pyqt_sip_dir = os.path.join(sys.prefix, 'sip', 'PyQt4')
     else:
-        pyqt_sip_dir = os.path.join(sys.platform, 'share', 'sip', 'PyQt4')
+        pyqt_sip_dir = os.path.join(sys.prefix, 'share', 'sip', 'PyQt4')
     return pyqt_sip_dir
 
 def get_qt4_tag(sip_flags):

--- a/Code/Mantid/Build/CMake/FindPyQt4.cmake
+++ b/Code/Mantid/Build/CMake/FindPyQt4.cmake
@@ -45,7 +45,7 @@ ELSE(EXISTS PYQT4_VERSION)
     SET(PYQT4_VERSION_TAG "${CMAKE_MATCH_1}" CACHE STRING "The Qt4 version tag used by PyQt4's .sip files")
 
     STRING(REGEX MATCH ".*\npyqt_sip_dir:([^\n]+).*$" _dummy ${pyqt_config})
-    SET(PYQT4_SIP_DIR "${CMAKE_MATCH_1}" CACHE FILEPATH "The base directory where PyQt4's .sip files are installed")
+    SET(PYQT4_SIP_DIR "${CMAKE_MATCH_1}" CACHE PATH "The base directory where PyQt4's .sip files are installed")
 
     STRING(REGEX MATCH ".*\npyqt_sip_flags:([^\n]+).*$" _dummy ${pyqt_config})
     SET(PYQT4_SIP_FLAGS "${CMAKE_MATCH_1}" CACHE STRING "The SIP flags used to build PyQt4")


### PR DESCRIPTION
This doesn't currently affect any of out targeted OS's, only ones that don't build with the now deprecated with PyQt.pyqtconfig (like Arch Linux :smiley:).

Sources https://projects.kde.org/projects/kde/kdelibs/repository/revisions/8b1abe25dcf243cd2cdf23dff7272aca921292ae and
https://projects.kde.org/projects/kde/kdelibs/repository/revisions/37f31f9ce39569a1096e5a04b6679a91e6ae18fe

No release notes needed.
