### PR TITLE
Engg: write instrument parameters file for GSAS

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -66,7 +66,7 @@ class EnggCalibrateFull(PythonAlgorithm):
 
         # Get peaks in dSpacing from file, and check we have what we need, before doing anything
         expectedPeaksD = EnggUtils.readInExpectedPeaks(self.getPropertyValue("ExpectedPeaksFromFile"),
-                                                         self.getProperty('ExpectedPeaks').value)
+                                                       self.getProperty('ExpectedPeaks').value)
 
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")
@@ -143,7 +143,7 @@ class EnggCalibrateFull(PythonAlgorithm):
             oldPos = det.getPos()
 
             posTbl.addRow([det.getID(), oldPos, newPos, newL2, det2Theta, detPhi, newL2-oldL2,
-                                  difc, zero])
+                           difc, zero])
             prog.report()
 
         return posTbl

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -56,7 +56,7 @@ class EnggFitPeaks(PythonAlgorithm):
 
         # Get peaks in dSpacing from file
         expectedPeaksD = EnggUtils.readInExpectedPeaks(self.getPropertyValue("ExpectedPeaksFromFile"),
-                                                         self.getProperty('ExpectedPeaks').value)
+                                                       self.getProperty('ExpectedPeaks').value)
 
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")
@@ -88,8 +88,8 @@ class EnggFitPeaks(PythonAlgorithm):
     def _getDefaultPeaks(self):
         """ Gets default peaks for Engg algorithm. Values from CeO2 """
         defaultPeaks = [3.1243, 2.7057, 1.9132, 1.6316, 1.5621, 1.3529, 1.2415,
-                       1.2100, 1.1046, 1.0414, 0.9566, 0.9147, 0.9019, 0.8556,
-                       0.8252, 0.8158, 0.7811]
+                        1.2100, 1.1046, 1.0414, 0.9566, 0.9147, 0.9019, 0.8556,
+                        0.8252, 0.8158, 0.7811]
 
         return defaultPeaks
 

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -31,8 +31,8 @@ class EnginXFocusWithVanadiumCorrection(stresstesting.MantidStressTest):
         self._precalc_van_ws = LoadNexus(Filename='ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs',
                                          OutputWorkspace='ENGIN-X_vanadium_curves_test_ws')
         self._precalc_van_integ_tbl = LoadNexus(Filename=
-                                               'ENGINX_precalculated_vanadium_run000236516_integration.nxs',
-                                               OutputWorkspace='ENGIN-X_vanadium_integ_test_ws')
+                                                'ENGINX_precalculated_vanadium_run000236516_integration.nxs',
+                                                OutputWorkspace='ENGIN-X_vanadium_integ_test_ws')
 
         self.van_bank_curves_name = 'enginx_van_bank_curves'
         self.van_bank_curves_pre_integ_name = 'enginx_van_bank_curves_with_precalc_integ'

--- a/Code/Mantid/docs/source/algorithms/EnggCalibrate-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnggCalibrate-v1.rst
@@ -36,6 +36,12 @@ output properties as well. If a name is given in
 OutputParametersTableName the algorithm also produces a table
 workspace with that name, containing the two output parameters.
 
+The script EnggUtils included with Mantid can produce a GSAS
+parameters file for the ENGIN-X instrument, given the DIFC and ZERO
+parameters for the instrument banks as produced by EnggCalibrate. This
+can be done with the write_ENGINX_GSAS_iparam_file() function as shown
+in the usage example below.
+
 See the algorithm :ref:`algm-EnggFocus` for details on the Vanadium
 corrections.
 
@@ -57,16 +63,29 @@ Usage
    van_ws_name = 'test_vanadium'
    Load('ENGINX00213855.nxs', OutputWorkspace=ws_name)
    Load('ENGINX00193749.nxs', OutputWorkspace=van_ws_name)
-   Difc, Zero = EnggCalibrate(InputWorkspace=ws_name,
-                              VanadiumWorkspace= van_ws_name,
-                              ExpectedPeaks=[1.097, 2.1], Bank='1',
-                              OutputParametersTableName=out_tbl_name)
+   Difc1, Zero1 = EnggCalibrate(InputWorkspace=ws_name,
+                                VanadiumWorkspace= van_ws_name,
+                                ExpectedPeaks=[1.097, 2.1], Bank='1',
+                                OutputParametersTableName=out_tbl_name)
 
-   print "Difc: %.2f" % (Difc)
-   print "Zero: %.2f" % (Zero)
+   Difc2, Zero2 = EnggCalibrate(InputWorkspace=ws_name,
+                                VanadiumWorkspace= van_ws_name,
+                                ExpectedPeaks=[1.097, 2.1], Bank='2')
+
+   # You can produce an instrument parameters (iparam) file for GSAS.
+   # Note that this is very specific to ENGIN-X
+   GSAS_iparm_fname = 'ENGIN_X_bank1'
+   import EnggUtils
+   EnggUtils.write_ENGINX_GSAS_iparam_file(GSAS_iparm_fname, [Difc1, Difc2], [Zero1, Zero2])
+
+   print "Difc1: %.2f" % (Difc1)
+   print "Zero1: %.2f" % (Zero1)
    tbl = mtd[out_tbl_name]
    print "The output table has %d row(s)" % tbl.rowCount()
-   print "Parameters from the table, Difc: %.2f, Zero: %.2f" % (tbl.cell(0,0), tbl.cell(0,1))
+   print "Parameters from the table, Difc1: %.2f, Zero1: %.2f" % (tbl.cell(0,0), tbl.cell(0,1))
+   import os
+   print "Output GSAS iparam file was written?", os.path.exists(GSAS_iparm_fname)
+   print "Size of the GSAS iparam file in bytes:", os.path.getsize(GSAS_iparm_fname)
 
 .. testcleanup:: ExampleCalib
 
@@ -74,11 +93,15 @@ Usage
    DeleteWorkspace(ws_name)
    DeleteWorkspace(van_ws_name)
 
+   os.remove(GSAS_iparm_fname)
+
 Output:
 
 .. testoutput:: ExampleCalib
 
-   Difc: 18404.35
-   Zero: -8.77
+   Difc1: 18404.35
+   Zero1: -8.77
    The output table has 1 row(s)
-   Parameters from the table, Difc: 18404.35, Zero: -8.77
+   Parameters from the table, Difc1: 18404.35, Zero1: -8.77
+   Output GSAS iparam file was written? True
+   Size of the GSAS iparam file in bytes: 2870

--- a/Code/Mantid/docs/source/algorithms/EnggCalibrate-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/EnggCalibrate-v1.rst
@@ -85,7 +85,7 @@ Usage
    print "Parameters from the table, Difc1: %.2f, Zero1: %.2f" % (tbl.cell(0,0), tbl.cell(0,1))
    import os
    print "Output GSAS iparam file was written?", os.path.exists(GSAS_iparm_fname)
-   print "Size of the GSAS iparam file in bytes:", os.path.getsize(GSAS_iparm_fname)
+   print "Number of lines of the GSAS iparam file:", sum(1 for line in open(GSAS_iparm_fname))
 
 .. testcleanup:: ExampleCalib
 
@@ -104,4 +104,4 @@ Output:
    The output table has 1 row(s)
    Parameters from the table, Difc1: 18404.35, Zero1: -8.77
    Output GSAS iparam file was written? True
-   Size of the GSAS iparam file in bytes: 2870
+   Number of lines of the GSAS iparam file: 35

--- a/Code/Mantid/scripts/Engineering/EnggUtils.py
+++ b/Code/Mantid/scripts/Engineering/EnggUtils.py
@@ -1,8 +1,9 @@
 #pylint: disable=invalid-name
-import os
-
+#pylint: disable=too-many-arguments
+# R0913: Too many arguments - strictly for write_GSAS_iparam_file()
 from mantid.api import *
 import mantid.simpleapi as sapi
+
 # numpy needed only for Vanadium calculations, at the moment
 import numpy as np
 
@@ -44,7 +45,7 @@ def readInExpectedPeaks(filename, expectedGiven):
             if [] == expectedGiven:
                 raise ValueError("Could not read any peaks from the file given in 'ExpectedPeaksFromFile: '" +
                                  filename + "', and no expected peaks were given in the property "
-                                     "'ExpectedPeaks' either. Cannot continue without a list of expected peaks.")
+                                 "'ExpectedPeaks' either. Cannot continue without a list of expected peaks.")
             expectedPeaksD = sorted(expectedGiven)
 
         else:
@@ -82,13 +83,13 @@ def getWsIndicesFromInProperties(ws, bank, detIndices):
         indices = getWsIndicesForBank(ws, bank)
         if not indices:
             raise RuntimeError("Unable to find a meaningful list of workspace indices for the "
-                                "bank passed: %s. Please check the inputs." % bank)
+                               "bank passed: %s. Please check the inputs." % bank)
         return indices
     elif detIndices:
         indices = parseSpectrumIndices(ws, detIndices)
         if not indices:
             raise RuntimeError("Unable to find a meaningful list of workspace indices for the "
-                                "range(s) of detectors passed: %s. Please check the inputs." % detIndices)
+                               "range(s) of detectors passed: %s. Please check the inputs." % detIndices)
         return indices
     else:
         raise ValueError("You have not given any value for the properties 'Bank' and 'DetectorIndices' "
@@ -147,6 +148,7 @@ def getDetIDsForBank(bank):
 
     @returns list of detector IDs corresponding to the specified Engg bank number
     """
+    import os
     groupingFilePath = os.path.join(sapi.config.getInstrumentDirectory(),
                                     'Grouping', 'ENGINX_Grouping.xml')
 

--- a/Code/Mantid/scripts/Engineering/EnggUtils.py
+++ b/Code/Mantid/scripts/Engineering/EnggUtils.py
@@ -262,13 +262,14 @@ def sumSpectra(parent, ws):
 
     return alg.getProperty('OutputWorkspace').value
 
-def write_GSAS_iparam_file(output_file, difc, zero, ceria_run=241391,
-                           vanadium_run=236516, template_file=None):
+def write_ENGINX_GSAS_iparam_file(output_file, difc, zero, ceria_run=241391,
+                                  vanadium_run=236516, template_file=None):
     """
-    Produces and writes an instrument parameter file for GSAS (in the
-    GSAS iparam format, as partially described in the GSAS manual). It
-    simply uses a template (found in template_path) where some values
-    are replaced with the values (difc, zero) passed to this function.
+    Produces and writes an ENGIN-X instrument parameter file for GSAS
+    (in the GSAS iparam format, as partially described in the GSAS
+    manual). It simply uses a template (found in template_path) where
+    some values are replaced with the values (difc, zero) passed to
+    this function.
 
     Possible extensions for the file are .par (used here as default),
     .prm, .ipar, etc.

--- a/Code/Mantid/scripts/Engineering/template_ENGINX_241391_236516_North_and_South_banks.par
+++ b/Code/Mantid/scripts/Engineering/template_ENGINX_241391_236516_North_and_South_banks.par
@@ -1,0 +1,35 @@
+ID    ENGIN-X CALIBRATION WITH CeO2 and V-Nb                                    
+INS   BANK     2                                                                
+INS   HTYPE   PNTR                                                              
+INS     NAME  North_bank and South_bank                                         
+INS     NDET 1200    5  240    1                                                
+INS     TYPE    1                                                               
+INS   TOFLIM     10.00     80.00    0.0004                                      
+INS   MONITR 2402   16.0000   43.0000                                           
+INS   DEADTI 0.00                                                               
+INS    OGPK1   0.183305E+05  -0.387262E+02                                      
+INS    OGPK2   0.839000E+00   0.700000E+00   0.320000E+02   0.149000E+01        
+INS    OGPK3  -0.686285E+01   0.220000E+01   0.108719E+01                       
+INS    CALIB   241391   236516 ceo2                                             
+INS    INCBM  ob+mon_236516_North_and_South_banks.his                           
+INS   FCSTBL  det_pars_93875_93874_North_and_South_banks.hdf                     
+INS  1I ITYP    0    1.0000   80.0000         0                                 
+INS  1BNKPAR     1.502    89.341     0.720     0.000     0.000    0    0        
+INS  1 ICONS  18306.98      2.99     14.44                                      
+INS  1PRCF1     3   21   0.00050                                                
+INS  1PRCF11   0.274872E+00   0.179289E-01   0.379667E-01   0.388241E+03        
+INS  1PRCF12   0.768656E+02   0.432991E+02   0.000000E+00   0.514723E+01        
+INS  1PRCF13   0.000000E+00   0.000000E+00   0.000000E+00   0.000000E+00        
+INS  1PRCF14   0.000000E+00   0.000000E+00   0.000000E+00   0.000000E+00        
+INS  1PRCF15   0.000000E+00   0.000000E+00   0.000000E+00   0.000000E+00        
+INS  1PRCF16   0.000000E+00                                                     
+INS  2I ITYP    0    1.0000   80.0000         0                                 
+INS  2BNKPAR     1.479   -90.157    -0.216     0.000     0.000    0    0        
+INS  2 ICONS  18497.75    -29.68    -26.50                                      
+INS  2PRCF1     3   21   0.00050                                                
+INS  2PRCF11   0.804794E+00   0.336823E-02   0.460981E+00   0.000000E+00        
+INS  2PRCF12   0.107075E+04   0.432991E+02   0.000000E+00   0.652544E+01        
+INS  2PRCF13   0.000000E+00   0.000000E+00   0.000000E+00   0.000000E+00        
+INS  2PRCF14   0.000000E+00   0.000000E+00   0.000000E+00   0.000000E+00        
+INS  2PRCF15   0.000000E+00   0.000000E+00   0.000000E+00   0.000000E+00        
+INS  2PRCF16   0.000000E+00                                                     

--- a/Code/Mantid/scripts/Engineering/template_ENGINX_241391_236516_North_and_South_banks.par
+++ b/Code/Mantid/scripts/Engineering/template_ENGINX_241391_236516_North_and_South_banks.par
@@ -12,7 +12,7 @@ INS    OGPK2   0.839000E+00   0.700000E+00   0.320000E+02   0.149000E+01
 INS    OGPK3  -0.686285E+01   0.220000E+01   0.108719E+01                       
 INS    CALIB   241391   236516 ceo2                                             
 INS    INCBM  ob+mon_236516_North_and_South_banks.his                           
-INS   FCSTBL  det_pars_93875_93874_North_and_South_banks.hdf                     
+INS   FCSTBL  det_pars_93875_93874_North_and_South_banks.hdf                    
 INS  1I ITYP    0    1.0000   80.0000         0                                 
 INS  1BNKPAR     1.502    89.341     0.720     0.000     0.000    0    0        
 INS  1 ICONS  18306.98      2.99     14.44                                      


### PR DESCRIPTION
Fixes #12611.

This adds a function that generates an 'iparam' file for GSAS. It takes a list of difc (bank1 and bank2) and the corresponding list of zero values, and puts them in a template GSAS instrument file. It also fills in the ceria and vanadium run numbers which go in a 'CALIB' line.

As this is an internal and temporary solution, I think it is better not to expose it as an algorithm. I've included it in the EnggUtil script. The template file is also distributed in the same Engineering/ directory as the EnggUtils script.

**To test**:
- Code review
- The doc test of EnggCalibrate now has a small test for this
- You can try it with commands like:

```
import EnggUtils
EnggUtils.write_ENGINX_GSAS_iparam_file('/home/user/ENGINX_bla.par', [18500, 18499], [0.5, 20])
```

It should produce a GSAS instrument file, with fixed 80 character length lines, using the values passed.

You can also test that it is able to use different template files with for example:

```
import EnggUtils
fname= '/home/user/ENGINX_bla.par'
EnggUtils.write_ENGINX_GSAS_iparam_file(fname, [18500, 18499], [0.5, 20])
EnggUtils.write_ENGINX_GSAS_iparam_file(fname, [18500, 18499], [0.5, 20], template_file=fname)
```

which re-uses the file generated in the first write as template of the second write.

These GSAS files can only be truly validated in GSAS when we are able to generate the .his files (next steps) but as it stands now the files written by this function should be valid or very close to valid.
