### PR TITLE
Fix canLoad method in FileLoaderRegistry

### DIFF
--- a/Code/Mantid/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Code/Mantid/Framework/API/src/FileLoaderRegistry.cpp
@@ -151,9 +151,11 @@ bool FileLoaderRegistryImpl::canLoad(const std::string &algorithmName,
   std::multimap<std::string, int> names;
   names.insert(std::make_pair(algorithmName, -1));
   IAlgorithm_sptr loader;
-  if (nexus && NexusDescriptor::isHDF(filename)) {
-    loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(
-        filename, names, m_log);
+  if (nexus) {
+    if (NexusDescriptor::isHDF(filename)) {
+      loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(
+          filename, names, m_log);
+    }
   } else {
     loader = searchForLoader<FileDescriptor, IFileLoader<FileDescriptor>>(
         filename, names, m_log);


### PR DESCRIPTION
Fixes #13199 

Please find the test files here \olympic\Babylon5\Scratch\Anton\Testing\13179

Run the following 

``` python
file_path_raw = 'YOURPATH/LOQ99630.RAW'
file_path_nxs_histo= 'YOURPATH/SANS2D00028784.nxs'
file_path_nxs_event= 'YOURPATH/SANS2D00028793.nxs'

print FileLoaderRegistry.canLoad("LoadEventNexus", file_path_raw)
print FileLoaderRegistry.canLoad("LoadEventNexus", file_path_nxs_histo)
print FileLoaderRegistry.canLoad("LoadEventNexus", file_path_nxs_event)
```

Confirm that output is 

``` python
False
False
True
```
