### PR TITLE
Make binning options workspace denpdent in isis sans gui add tabs

### DIFF
--- a/Code/Mantid/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Code/Mantid/Framework/API/src/FileLoaderRegistry.cpp
@@ -151,9 +151,11 @@ bool FileLoaderRegistryImpl::canLoad(const std::string &algorithmName,
   std::multimap<std::string, int> names;
   names.insert(std::make_pair(algorithmName, -1));
   IAlgorithm_sptr loader;
-  if (nexus && NexusDescriptor::isHDF(filename)) {
-    loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(
-        filename, names, m_log);
+  if (nexus) {
+    if( NexusDescriptor::isHDF(filename)) {
+      loader = searchForLoader<NexusDescriptor, IFileLoader<NexusDescriptor>>(
+          filename, names, m_log);
+    }
   } else {
     loader = searchForLoader<FileDescriptor, IFileLoader<FileDescriptor>>(
         filename, names, m_log);

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -79,6 +79,7 @@ set ( SRC_FILES
   src/ReflSearchModel.cpp
   src/SampleTransmission.cpp
   src/SANSAddFiles.cpp
+  src/SANSConstants.cpp
   src/SANSDiagnostics.cpp
   src/SANSEventSlicing.cpp
   src/SANSPlotSpecial.cpp
@@ -186,6 +187,7 @@ set ( INC_FILES
   inc/MantidQtCustomInterfaces/QtReflOptionsDialog.h
   inc/MantidQtCustomInterfaces/SampleTransmission.h
   inc/MantidQtCustomInterfaces/SANSAddFiles.h
+  inc/MantidQtCustomInterfaces/SANSConstants.h
   inc/MantidQtCustomInterfaces/SANSDiagnostics.h
   inc/MantidQtCustomInterfaces/SANSEventSlicing.h
   inc/MantidQtCustomInterfaces/SANSPlotSpecial.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSAddFiles.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSAddFiles.h
@@ -2,6 +2,7 @@
 #define MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_
 
 #include "ui_SANSRunWindow.h"
+#include "MantidQtCustomInterfaces/SANSConstants.h"
 #include "MantidQtAPI/UserSubWindow.h"
 #include "MantidKernel/ConfigService.h"
 #include <Poco/NObserver.h>
@@ -55,6 +56,8 @@ private:
   void setInputEnabled(bool enabled);
   /// Create Python string list
   QString createPythonStringList(QString inputString);
+  /// SANS constants
+  SANSConstants m_constants;
 
   void initLayout();
   void setToolTips();
@@ -85,6 +88,12 @@ private slots:
   void onCurrentIndexChangedForHistogramChoice(int index);
   /// reacts to changes of the overlay check box
   void onStateChangedForOverlayCheckBox(int);
+  /// checks if a file corresponds to a histogram worksapce
+  bool isEventWorkspace(QString file_name);
+  /// checks if the files which are to be added are all based on event workspaces
+  bool existNonEventFiles();
+  /// sets the binning options
+  void setBinningOptions(bool enable);
 };
 
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSConstants.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSConstants.h
@@ -1,0 +1,24 @@
+#ifndef MANTIDQTCUSTOMINTERFACES_SANSCONSTANTS_H_
+#define MANTIDQTCUSTOMINTERFACES_SANSCONSTANTS_H_
+
+#include <QString>
+
+namespace MantidQt
+{
+namespace CustomInterfaces
+{
+
+class SANSConstants
+{
+public:
+  SANSConstants();
+  ~SANSConstants();
+  QString getPythonSuccessKeyword();
+  QString getPythonEmptyKeyword();
+  QString getPythonTrueKeyword();
+};
+
+}
+}
+
+#endif  //MANTIDQTCUSTOMINTERFACES_SANSADDFILES_H_

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -370,10 +370,6 @@ private:
   QAction *m_batch_clear;
   //Time/Pixel mask string
   QString m_maskScript;
-  /// Success keyword
-  static const QString m_pythonSuccessKeyword;
-  /// Keyword for empty return value in python
-  static const QString m_pythonEmptyKeyword;
   /// Stores the URL of each tab's help page.
   QMap<Tab, QString> m_helpPageUrls;
   /// SANS constants

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.h
@@ -10,6 +10,7 @@
 #include "MantidQtMantidWidgets/SaveWorkspaces.h"
 #include "MantidQtCustomInterfaces/SANSDiagnostics.h"
 #include "MantidQtCustomInterfaces/SANSPlotSpecial.h"
+#include "MantidQtCustomInterfaces/SANSConstants.h"
 
 #include <QHash>
 #include <QSettings>
@@ -360,7 +361,9 @@ private:
   static const QString m_pythonEmptyKeyword;
   /// Stores the URL of each tab's help page.
   QMap<Tab, QString> m_helpPageUrls;
-  
+  /// SANS constants
+  SANSConstants m_constants;
+
   void initAnalysDetTab();
   void makeValidator(QLabel * const newValid, QWidget * control, QWidget * tab, const QString & errorMsg);
   void upDateDataDir();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
@@ -3952,7 +3952,7 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item row="9" column="2">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="histogram_binning_label">
           <property name="text">
            <string>Histogram binning (when adding event data):</string>
           </property>
@@ -3997,7 +3997,7 @@ p, li { white-space: pre-wrap; }
         <item row="12" column="2">
          <layout class="QHBoxLayout" name="horizontalLayout_24">
           <item>
-           <widget class="QLabel" name="labelBinning">
+           <widget class="QLabel" name="binning_label">
             <property name="minimumSize">
              <size>
               <width>70</width>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSConstants.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSConstants.cpp
@@ -1,0 +1,40 @@
+#include "MantidQtCustomInterfaces/SANSConstants.h"
+
+
+namespace MantidQt
+{
+namespace CustomInterfaces
+{
+SANSConstants::SANSConstants() {}
+
+SANSConstants::~SANSConstants() {}
+
+/**
+ * Defines the python keyword for a succssful operation
+ * @returns the keyword for success
+ */
+QString SANSConstants::getPythonSuccessKeyword() {
+  const static QString pythonSuccessKeyword = "pythonExecutionWasSuccessful";
+  return pythonSuccessKeyword;
+}
+
+/**
+ * Defines the python keyword for an empty object , ie None
+ * @returns the python keyword for an empty object
+ */
+QString SANSConstants::getPythonEmptyKeyword() {
+  const static QString pythonSuccessKeyword = "None";
+  return pythonSuccessKeyword;
+}
+
+/**
+ * Defines the python keyword for true , ie True
+ * @returns the python true keyword
+ */
+QString SANSConstants::getPythonTrueKeyword() {
+  const static QString pythonSuccessKeyword = "True";
+  return pythonSuccessKeyword;
+}
+
+}
+}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -4010,7 +4010,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionRadiusRequest("\nprint i.GetTransmissionRadiusInMM()");
   QString resultTransmissionRadius(runPythonCode(transmissionRadiusRequest, false));
   resultTransmissionRadius = resultTransmissionRadius.simplified();
-  if (resultTransmissionRadius != m_pythonEmptyKeyword) {
+  if (resultTransmissionRadius != m_constants.getPythonEmptyKeyword()) {
       this->m_uiForm.trans_radius_line_edit->setText(resultTransmissionRadius);
       this->m_uiForm.trans_radius_check_box->setChecked(true);
       setBeamStopLogic(TransSettings::RADIUS, true);
@@ -4020,7 +4020,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionROIRequest("\nprint i.GetTransmissionROI()");
   QString resultTransmissionROI(runPythonCode(transmissionROIRequest, false));
   resultTransmissionROI = resultTransmissionROI.simplified();
-  if (resultTransmissionROI != m_pythonEmptyKeyword) {
+  if (resultTransmissionROI != m_constants.getPythonEmptyKeyword()) {
       resultTransmissionROI = runPythonCode("\nprint i.ConvertFromPythonStringList(to_convert=" + resultTransmissionROI+ ")", false);
       this->m_uiForm.trans_roi_files_line_edit->setText(resultTransmissionROI);
       this->m_uiForm.trans_roi_files_checkbox->setChecked(true);
@@ -4032,7 +4032,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionMaskRequest("\nprint i.GetTransmissionMask()");
   QString resultTransmissionMask(runPythonCode(transmissionMaskRequest, false));
   resultTransmissionMask = resultTransmissionMask.simplified();
-  if (resultTransmissionMask != m_pythonEmptyKeyword) {
+  if (resultTransmissionMask != m_constants.getPythonEmptyKeyword()) {
     resultTransmissionMask = runPythonCode("\nprint i.ConvertFromPythonStringList(to_convert=" + resultTransmissionMask+ ")", false);
     this->m_uiForm.trans_masking_line_edit->setText(resultTransmissionMask);
   }
@@ -4041,7 +4041,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionMonitorSpectrumShiftRequest("\nprint i.GetTransmissionMonitorSpectrumShift()");
   QString resultTransmissionMonitorSpectrumShift(runPythonCode(transmissionMonitorSpectrumShiftRequest, false));
   resultTransmissionMonitorSpectrumShift = resultTransmissionMonitorSpectrumShift.simplified();
-  if (resultTransmissionMonitorSpectrumShift != m_pythonEmptyKeyword) {
+  if (resultTransmissionMonitorSpectrumShift != m_constants.getPythonEmptyKeyword()) {
     this->m_uiForm.trans_M3M4_line_edit->setText(resultTransmissionMonitorSpectrumShift);
   }
 
@@ -4050,7 +4050,7 @@ void SANSRunWindow::setTransmissionSettingsFromUserFile() {
   QString transmissionMonitorSpectrumRequest("\nprint i.GetTransmissionMonitorSpectrum()");
   QString resultTransmissionMonitorSpectrum(runPythonCode(transmissionMonitorSpectrumRequest, false));
   resultTransmissionMonitorSpectrum = resultTransmissionMonitorSpectrum.simplified();
-  if (resultTransmissionMonitorSpectrum != m_pythonEmptyKeyword) {
+  if (resultTransmissionMonitorSpectrum != m_constants.getPythonEmptyKeyword()) {
     if (resultTransmissionMonitorSpectrum == "3") {
       this->m_uiForm.trans_M3_check_box->setChecked(true);
       setM3M4Logic(TransSettings::M3, true);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -149,11 +149,7 @@ namespace
   }
 }
 
-//----------------------------------------------
-// Static key strings
-//----------------------------------------------
-const QString SANSRunWindow::m_pythonSuccessKeyword  = "pythonExecutionWasSuccessful";
-const QString SANSRunWindow::m_pythonEmptyKeyword = "None";
+
 //----------------------------------------------
 // Public member functions
 //----------------------------------------------
@@ -3020,7 +3016,7 @@ void SANSRunWindow::handleInstrumentChange()
   int ind = m_uiForm.detbank_sel->findText(detect);
   // We set the detector selection only if nothing is set yet.
   // Previously, we didn't handle merged and both at this point
-  if (detectorSelection == m_pythonEmptyKeyword || detectorSelection.isEmpty()) {
+  if (detectorSelection == m_constants.getPythonEmptyKeyword() || detectorSelection.isEmpty()) {
     if( ind != -1 ) {
       m_uiForm.detbank_sel->setCurrentIndex(ind);
     }
@@ -3881,11 +3877,11 @@ void SANSRunWindow::createZeroErrorFreeClone(QString& originalWorkspaceName, QSt
     QString pythonCode("print i.CreateZeroErrorFreeClonedWorkspace(input_workspace_name='");
     pythonCode += originalWorkspaceName + "',";
     pythonCode += " output_workspace_name='" + clonedWorkspaceName + "')\n";
-    pythonCode += "print '" + m_pythonSuccessKeyword + "'\n";
+    pythonCode += "print '" + m_constants.getPythonSuccessKeyword() + "'\n";
     QString result(runPythonCode(pythonCode, false));
     result = result.simplified();
-    if (result != m_pythonSuccessKeyword) {
-      result.replace(m_pythonSuccessKeyword, "");
+    if (result != m_constants.getPythonSuccessKeyword()) {
+      result.replace(m_constants.getPythonSuccessKeyword(), "");
       g_log.warning("Error creating a zerror error free cloned workspace. Will save original workspace. More info: " + result.toStdString());
     }
   }
@@ -3900,11 +3896,11 @@ void SANSRunWindow::deleteZeroErrorFreeClone(QString& clonedWorkspaceName) {
     // Run the python script which destroys the cloned workspace
     QString pythonCode("print i.DeleteZeroErrorFreeClonedWorkspace(input_workspace_name='");
     pythonCode += clonedWorkspaceName + "')\n";
-    pythonCode += "print '" + m_pythonSuccessKeyword + "'\n";
+    pythonCode += "print '" + m_constants.getPythonSuccessKeyword() + "'\n";
     QString result(runPythonCode(pythonCode, false));
     result = result.simplified();
-    if (result != m_pythonSuccessKeyword) {
-      result.replace(m_pythonSuccessKeyword, "");
+    if (result != m_constants.getPythonSuccessKeyword()) {
+      result.replace(m_constants.getPythonSuccessKeyword(), "");
       g_log.warning("Error deleting a zerror error free cloned workspace. More info: " + result.toStdString());
     }
   }
@@ -3917,12 +3913,12 @@ void SANSRunWindow::deleteZeroErrorFreeClone(QString& clonedWorkspaceName) {
 bool SANSRunWindow::isValidWsForRemovingZeroErrors(QString& wsName) {
     QString pythonCode("\nprint i.IsValidWsForRemovingZeroErrors(input_workspace_name='");
     pythonCode += wsName + "')";
-    pythonCode += "\nprint '" + m_pythonSuccessKeyword + "'";
+    pythonCode += "\nprint '" + m_constants.getPythonSuccessKeyword() + "'";
     QString result(runPythonCode(pythonCode, false));
     result = result.simplified();
     bool isValid = true;
-    if (result != m_pythonSuccessKeyword) {
-      result.replace(m_pythonSuccessKeyword, "");
+    if (result != m_constants.getPythonSuccessKeyword()) {
+      result.replace(m_constants.getPythonSuccessKeyword(), "");
       g_log.warning("Not a valid workspace for zero error replacement. Will save original workspace. More info: " + result.toStdString());
       isValid = false;
     }

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
@@ -49,7 +49,7 @@ class SANS2DMinimalBatchReduction(stresstesting.MantidStressTest):
         fit_settings = batch.BatchReduce(BATCHFILE,'.nxs', combineDet='rear')
 
     def validate(self):
-
+        self.disableChecking.append('Instrument')
         return "trans_test_rear","SANSReductionGUI.nxs"
 
 
@@ -206,6 +206,7 @@ class SANS2DGUIBatchReduction(SANS2DMinimalBatchReduction):
     def validate(self):
         self.tolerance_is_reller = True
         self.tolerance = 1.0e-2
+        self.disableChecking.append('Instrument')
         return "trans_test_rear","SANSReductionGUI.nxs"
 
 class SANS2DGUIReduction(SANS2DGUIBatchReduction):

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANSLoadersTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANSLoadersTest.py
@@ -241,6 +241,7 @@ class LoadAddedEventDataSampleTestStressTest(stresstesting.MantidStressTest):
         os.remove(os.path.join(config['defaultsave.directory'],'SANS2D00022023-add.nxs'))
 
     def validate(self):
+        self.disableChecking.append('Instrument')
         return self._success
 
 

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
@@ -4,6 +4,14 @@ from mantid.simpleapi import *
 from SANSUtility import can_load_as_event_workspace
 import os
 
+# WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- START
+CAN_IMPORT_NXS_TEST = True
+try:
+    import nxs
+except ImportError:
+    CAN_IMPORT_NXS_TEST = False
+# WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- STOP
+
 def create_file_name(base_name):
     temp_save_dir = config['defaultsave.directory']
     if temp_save_dir == '':
@@ -30,21 +38,24 @@ class SANSProcessedEventWorkspaceInFile(stresstesting.MantidStressTest):
         self._success = False
 
     def runTest(self):
-        # Arrange
-        base_name = "processed_event"
-        filename = create_file_name(base_name)
-        ws = CreateSampleWorkspace("Event")
-        SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
-        # Act
-        can_load = can_load_as_event_workspace(filename)
-        # Assert
-        if can_load:
-            self._success = True
+        if CAN_IMPORT_NXS_TEST:
+            # Arrange
+            base_name = "processed_event"
+            filename = create_file_name(base_name)
+            ws = CreateSampleWorkspace("Event")
+            SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
+            # Act
+            can_load = can_load_as_event_workspace(filename)
+            # Assert
+            if can_load:
+                self._success = True
+            else:
+                self._success = False
+            # Clean up
+            remove_temporary_file(filename)
+            clean_up_workspaces()
         else:
-            self._success = False
-        # Clean up
-        remove_temporary_file(filename)
-        clean_up_workspaces()
+            self._success = True
 
     def validate(self):
         return self._success
@@ -60,21 +71,24 @@ class SANSProcessedHistoWorkspaceInFile(stresstesting.MantidStressTest):
         self._success = False
 
     def runTest(self):
-        # Arrange
-        base_name = "processed_histo"
-        filename = create_file_name(base_name)
-        ws = CreateSampleWorkspace()
-        SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
-        # Act
-        can_load = can_load_as_event_workspace(filename)
-        # Assert
-        if not can_load:
-            self._success = True
+        if CAN_IMPORT_NXS_TEST:
+            # Arrange
+            base_name = "processed_histo"
+            filename = create_file_name(base_name)
+            ws = CreateSampleWorkspace()
+            SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
+            # Act
+            can_load = can_load_as_event_workspace(filename)
+            # Assert
+            if not can_load:
+                self._success = True
+            else:
+                self._success = False
+            # Clean up
+            remove_temporary_file(filename)
+            clean_up_workspaces()
         else:
-            self._success = False
-        # Clean up
-        remove_temporary_file(filename)
-        clean_up_workspaces()
+            self._success = True
 
     def validate(self):
         return self._success

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
@@ -1,0 +1,72 @@
+#pylint: disable=no-init
+import stresstesting
+from mantid.simpleapi import *
+from SANSUtility import can_load_as_event_workspace
+import os
+
+def create_file_name(base_name):
+    temp_save_dir = config['defaultsave.directory']
+    if (temp_save_dir == ''):
+        temp_save_dir = os.getcwd()
+    filename = os.path.join(temp_save_dir, base_name + '.nxs')
+    return filename
+
+def remove_temporary_file(filename):
+    if os.path.exists(filename):
+        os.remove(filename)
+
+def clean_up_workspaces():
+    for element in mtd.getObjectNames():
+        if element in mtd:
+            DeleteWorkspace(element)
+
+class SANSProcessedEventWorkspaceInFile(stresstesting.MantidStressTest):
+    '''
+    Check if a processed nexus file is correctly detected to contain
+    an event workspace.
+    '''
+    def runTest(self):
+        # Arrange
+        base_name = "processed_event"
+        filename = create_file_name(base_name)
+        ws = CreateSampleWorkspace("Event")
+        SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
+        # Act
+        can_load = can_load_as_event_workspace(filename)
+        # Assert
+        if can_load:
+            self.success = True
+        else:
+            self.success = False
+        # Clean up
+        remove_temporary_file(filename)
+        clean_up_workspaces()
+
+    def validate(self):
+        return self.success
+
+
+class SANSProcessedHistoWorkspaceInFile(stresstesting.MantidStressTest):
+    '''
+    Check if a processed nexus file is correctly detected to contain
+    a histo workspace.
+    '''
+    def runTest(self):
+        # Arrange
+        base_name = "processed_histo"
+        filename = create_file_name(base_name)
+        ws = CreateSampleWorkspace()
+        SaveNexusProcessed(InputWorkspace=ws, Filename = filename)
+        # Act
+        can_load = can_load_as_event_workspace(filename)
+        # Assert
+        if not can_load:
+            self.success = True
+        else:
+            self.success = False
+        # Clean up
+        remove_temporary_file(filename)
+        clean_up_workspaces()
+
+    def validate(self):
+        return self.success

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
@@ -7,7 +7,7 @@ import os
 # WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- START
 CAN_IMPORT_NXS_TEST = True
 try:
-    import nxs
+    import nxs # pylint: disable=unused-import
 except ImportError:
     CAN_IMPORT_NXS_TEST = False
 # WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- STOP

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
@@ -39,15 +39,15 @@ class SANSProcessedEventWorkspaceInFile(stresstesting.MantidStressTest):
         can_load = can_load_as_event_workspace(filename)
         # Assert
         if can_load:
-            self.success = True
+            self._success = True
         else:
-            self.success = False
+            self._success = False
         # Clean up
         remove_temporary_file(filename)
         clean_up_workspaces()
 
     def validate(self):
-        return self.success
+        return self._success
 
 
 class SANSProcessedHistoWorkspaceInFile(stresstesting.MantidStressTest):
@@ -69,12 +69,12 @@ class SANSProcessedHistoWorkspaceInFile(stresstesting.MantidStressTest):
         can_load = can_load_as_event_workspace(filename)
         # Assert
         if not can_load:
-            self.success = True
+            self._success = True
         else:
-            self.success = False
+            self._success = False
         # Clean up
         remove_temporary_file(filename)
         clean_up_workspaces()
 
     def validate(self):
-        return self.success
+        return self._success

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/SANSWorkspaceTypeTest.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init
+#pylint: disable=invalid-name,no-init
 import stresstesting
 from mantid.simpleapi import *
 from SANSUtility import can_load_as_event_workspace
@@ -6,7 +6,7 @@ import os
 
 def create_file_name(base_name):
     temp_save_dir = config['defaultsave.directory']
-    if (temp_save_dir == ''):
+    if temp_save_dir == '':
         temp_save_dir = os.getcwd()
     filename = os.path.join(temp_save_dir, base_name + '.nxs')
     return filename
@@ -25,6 +25,10 @@ class SANSProcessedEventWorkspaceInFile(stresstesting.MantidStressTest):
     Check if a processed nexus file is correctly detected to contain
     an event workspace.
     '''
+    def __init__(self):
+        stresstesting.MantidStressTest.__init__(self)
+        self._success = False
+
     def runTest(self):
         # Arrange
         base_name = "processed_event"
@@ -51,6 +55,10 @@ class SANSProcessedHistoWorkspaceInFile(stresstesting.MantidStressTest):
     Check if a processed nexus file is correctly detected to contain
     a histo workspace.
     '''
+    def __init__(self):
+        stresstesting.MantidStressTest.__init__(self)
+        self._success = False
+
     def runTest(self):
         # Arrange
         base_name = "processed_histo"

--- a/Code/Mantid/scripts/CMakeLists.txt
+++ b/Code/Mantid/scripts/CMakeLists.txt
@@ -32,7 +32,6 @@ set ( TEST_PY_FILES
       test/SANSCommandInterfaceTest.py
       test/SANSUtilityTest.py
       test/SANSIsisInstrumentTest.py
-      test/SANSCommandInterfaceTest.py
       test/SANSReductionStepsUserFileTest.py
       test/SettingsTest.py
       test/ReductionSettingsTest.py

--- a/Code/Mantid/scripts/CMakeLists.txt
+++ b/Code/Mantid/scripts/CMakeLists.txt
@@ -29,6 +29,7 @@ set ( TEST_PY_FILES
       test/RunDescriptorTest.py
       test/SansIsisGuiSettings.py
       test/SANSBatchModeTest.py
+      test/SANSCommandInterfaceTest.py
       test/SANSUtilityTest.py
       test/SANSIsisInstrumentTest.py
       test/SANSReductionStepsUserFileTest.py

--- a/Code/Mantid/scripts/SANS/ISISCommandInterface.py
+++ b/Code/Mantid/scripts/SANS/ISISCommandInterface.py
@@ -13,7 +13,7 @@ import isis_reducer
 from centre_finder import CentreFinder as CentreFinder
 #import SANSReduction
 from mantid.simpleapi import *
-from mantid.api import WorkspaceGroup
+from mantid.api import WorkspaceGroup, FileLoaderRegistry
 import copy
 from SANSadd2 import *
 import SANSUtility as su
@@ -1197,6 +1197,18 @@ def IsValidWsForRemovingZeroErrors(input_workspace_name):
         return message
     else:
         return ""
+
+
+def check_if_event_workspace(file_name):
+    '''
+    Checks if a file is associated with an event workspace. It tests if
+    the workspace can be loaded.
+    @param file_name: The file name to test
+    @returns true if the workspace is an event workspace otherwise false
+    '''
+    result = FileLoaderRegistry.canLoad("LoadEventNexus", file_name)
+    print result
+    return result
 
 ################################################################################
 # Input check functions

--- a/Code/Mantid/scripts/SANS/ISISCommandInterface.py
+++ b/Code/Mantid/scripts/SANS/ISISCommandInterface.py
@@ -1206,9 +1206,7 @@ def check_if_event_workspace(file_name):
     @param file_name: The file name to test
     @returns true if the workspace is an event workspace otherwise false
     '''
-
-
-    result = FileLoaderRegistry.canLoad("LoadEventNexus", file_name)
+    result = su.can_load_as_event_workspace(filename = file_name)
     print result
     return result
 

--- a/Code/Mantid/scripts/SANS/ISISCommandInterface.py
+++ b/Code/Mantid/scripts/SANS/ISISCommandInterface.py
@@ -13,7 +13,7 @@ import isis_reducer
 from centre_finder import CentreFinder as CentreFinder
 #import SANSReduction
 from mantid.simpleapi import *
-from mantid.api import WorkspaceGroup, FileLoaderRegistry
+from mantid.api import WorkspaceGroup
 import copy
 from SANSadd2 import *
 import SANSUtility as su
@@ -1206,6 +1206,8 @@ def check_if_event_workspace(file_name):
     @param file_name: The file name to test
     @returns true if the workspace is an event workspace otherwise false
     '''
+
+
     result = FileLoaderRegistry.canLoad("LoadEventNexus", file_name)
     print result
     return result

--- a/Code/Mantid/scripts/SANS/SANSUtility.py
+++ b/Code/Mantid/scripts/SANS/SANSUtility.py
@@ -1024,6 +1024,7 @@ def can_load_as_event_workspace(filename):
     is_event_workspace = FileLoaderRegistry.canLoad("LoadEventNexus", filename)
 
     if is_event_workspace == False:
+        # pylint: disable=bare-except
         try:
             # We only check the first entry in the root
             # and check for event_eventworkspace in the next level
@@ -1032,7 +1033,7 @@ def can_load_as_event_workspace(filename):
             nxs_file.opengroup(rootKeys[0])
             nxs_file.opengroup('event_workspace')
             is_event_workspace = True
-        except ValueError, NexusError:
+        except:
             pass
         finally:
             nxs_file.close()

--- a/Code/Mantid/scripts/SANS/SANSUtility.py
+++ b/Code/Mantid/scripts/SANS/SANSUtility.py
@@ -1026,20 +1026,22 @@ def can_load_as_event_workspace(filename):
     # Check if it can be loaded with LoadEventNexus
     is_event_workspace = FileLoaderRegistry.canLoad("LoadEventNexus", filename)
 
-    if is_event_workspace == False:
-        # pylint: disable=bare-except
-        try:
-            # We only check the first entry in the root
-            # and check for event_eventworkspace in the next level
-            nxs_file =nxs.open(filename, 'r')
-            rootKeys =  nxs_file.getentries().keys()
-            nxs_file.opengroup(rootKeys[0])
-            nxs_file.opengroup('event_workspace')
-            is_event_workspace = True
-        except:
-            pass
-        finally:
-            nxs_file.close()
+    # Ubuntu does not provide NEXUS for python currently, need to hedge for that
+    if CAN_IMPORT_NXS:
+        if is_event_workspace == False:
+            # pylint: disable=bare-except
+            try:
+                # We only check the first entry in the root
+                # and check for event_eventworkspace in the next level
+                nxs_file =nxs.open(filename, 'r')
+                rootKeys =  nxs_file.getentries().keys()
+                nxs_file.opengroup(rootKeys[0])
+                nxs_file.opengroup('event_workspace')
+                is_event_workspace = True
+            except:
+                pass
+            finally:
+                nxs_file.close()
 
     return is_event_workspace
 

--- a/Code/Mantid/scripts/SANS/SANSUtility.py
+++ b/Code/Mantid/scripts/SANS/SANSUtility.py
@@ -12,18 +12,21 @@ import math
 import os
 import re
 import types
-import nxs
 
 sanslog = Logger("SANS")
-
 ADDED_EVENT_DATA_TAG = '_added_event_data'
-
 REG_DATA_NAME = '-add' + ADDED_EVENT_DATA_TAG + '[_1-9]*$'
 REG_DATA_MONITORS_NAME = '-add_monitors' + ADDED_EVENT_DATA_TAG + '[_1-9]*$'
-
 ZERO_ERROR_DEFAULT = 1e6
-
 INCIDENT_MONITOR_TAG = '_incident_monitor'
+
+# WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- START
+CAN_IMPORT_NXS = True
+try:
+    import nxs
+except ImportError:
+    CAN_IMPORT_NXS = False
+# WORKAROUND FOR IMPORT ISSUE IN UBUNTU --- STOP
 
 def deprecated(obj):
     """

--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -141,7 +141,7 @@ class LoadRun(object):
         """
         if self._period != self.UNSET_PERIOD:
             workspace = self._get_workspace_name(self._period)
-            if not can_load_as_event_workspace(self.data_file):
+            if not can_load_as_event_workspace(self._data_file):
                 extra_options['EntryNumber'] = self._period
         else:
             workspace = self._get_workspace_name()

--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -17,13 +17,14 @@ from mantid.kernel import Logger
 sanslog = Logger("SANS")
 
 from mantid.simpleapi import *
-from mantid.api import WorkspaceGroup, Workspace, IEventWorkspace, FileLoaderRegistry
+from mantid.api import WorkspaceGroup, Workspace, IEventWorkspace
 from SANSUtility import (GetInstrumentDetails, MaskByBinRange,
                          isEventWorkspace, getFilePathFromWorkspace,
                          getWorkspaceReference, slice2histogram, getFileAndName,
                          mask_detectors_with_masking_ws, check_child_ws_for_name_and_type_for_added_eventdata, extract_spectra,
                          extract_child_ws_for_added_eventdata, load_monitors_for_multiperiod_event_data,
-                          MaskWithCylinder, get_masked_det_ids, get_masked_det_ids_from_mask_file, INCIDENT_MONITOR_TAG)
+                          MaskWithCylinder, get_masked_det_ids, get_masked_det_ids_from_mask_file, INCIDENT_MONITOR_TAG,
+                          can_load_as_event_workspace)
 import isis_instrument
 import isis_reducer
 from reducer_singleton import ReductionStep
@@ -140,7 +141,7 @@ class LoadRun(object):
         """
         if self._period != self.UNSET_PERIOD:
             workspace = self._get_workspace_name(self._period)
-            if not FileLoaderRegistry.canLoad("LoadEventNexus", self._data_file):
+            if not can_load_as_event_workspace(self.data_file):
                 extra_options['EntryNumber'] = self._period
         else:
             workspace = self._get_workspace_name()

--- a/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
+++ b/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
@@ -5,8 +5,8 @@ import ISISCommandInterface as command_iface
 from reducer_singleton import ReductionSingleton
 import isis_reduction_steps as reduction_steps
 from mantid.simpleapi import *
-
-
+from mantid.kernel import DateAndTime
+import random
 
 class SANSCommandInterfaceGetAndSetTransmissionSettings(unittest.TestCase):
     def test_that_gets_transmission_monitor(self):
@@ -199,15 +199,26 @@ class TestEventWorkspaceCheck(unittest.TestCase):
         temp_save_dir = config['defaultsave.directory']
         if (temp_save_dir == ''):
             temp_save_dir = os.getcwd()
-        return os.path.join(temp_save_dir, names + '.nxs')
+        return os.path.join(temp_save_dir, name + '.nxs')
+
+    def addSampleLogEntry(self, log_name, ws, start_time, extra_time_shift):
+        number_of_times = 10
+        for i in range(0, number_of_times):
+
+            val = random.randrange(0, 10, 1)
+            date = DateAndTime(start_time)
+            date +=  int(i*1e9)
+            date += int(extra_time_shift*1e9)
+            AddTimeSeriesLog(ws, Name=log_name, Time=date.__str__().strip(), Value=val)
 
     def _clean_up(self, file_name):
         if os.path.exists(file_name):
             os.remove(file_name)
 
-    def test_that_event_workspace_is_detected(self):
+    def test_that_histogram_workspace_is_detected(self):
         # Arrange
         ws = CreateSampleWorkspace()
+        self.addSampleLogEntry('proton_charge', ws, "2010-01-01T00:00:00", 0.0)
         file_name = self._create_file_name('dummy')
         SaveNexus(Filename= file_name, InputWorkspace=ws)
         # Act
@@ -216,19 +227,5 @@ class TestEventWorkspaceCheck(unittest.TestCase):
         # Clean Up
         self._clean_up(file_name)
 
-    def test_that_histogram_workspace_is_detected(self):
-        # Arrange
-        ws = CreateSampleWorkspace('Event')
-        file_name = self._create_file_name('dummy')
-        SaveNexus(Filename= file_name, InputWorkspace=ws)
-        # Act
-        result = command_iface.check_if_event_workspace(file_name)
-        self.assertTrue(result)
-        # Clean Up
-        self._clean_up(file_name)
-       
-        
-        
-        
 if __name__ == "__main__":
     unittest.main()

--- a/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
+++ b/Code/Mantid/scripts/test/SANSCommandInterfaceTest.py
@@ -1,0 +1,40 @@
+import unittest
+import re
+# Need to import mantid before we import SANSUtility
+import mantid
+from mantid.simpleapi import *
+import ISISCommandInterface as ci
+
+
+class TestEventWorkspaceCheck(unittest.TestCase):
+    def _create_file_name(self, name):
+        temp_save_dir = config['defaultsave.directory']
+        if (temp_save_dir == ''):
+            temp_save_dir = os.getcwd()
+        return os.path.join(temp_save_dir, names + '.nxs')
+
+    def _clean_up(self, file_name):
+        if os.path.exists(file_name):
+            os.remove(file_name)
+
+    def test_that_event_workspace_is_detected(self):
+        # Arrange
+        ws = CreateSampleWorkspace()
+        file_name = self._create_file_name('dummy')
+        SaveNexus(Filename= file_name, InputWorkspace=ws)
+        # Act
+        result = ci.check_if_event_workspace(file_name)
+        self.assertFalse(result)
+        # Clean Up
+        self._clean_up(file_name)
+
+    def test_that_histogram_workspace_is_detected(self):
+        # Arrange
+        ws = CreateSampleWorkspace('Event')
+        file_name = self._create_file_name('dummy')
+        SaveNexus(Filename= file_name, InputWorkspace=ws)
+        # Act
+        result = ci.check_if_event_workspace(file_name)
+        self.assertTrue(result)
+        # Clean Up
+        self._clean_up(file_name)


### PR DESCRIPTION
Fixes #13179 

**Context**

We want to make the options on the Add Tabs section of the ISIS SANS GUI depend on the type of workspace which is being added. 
In this context it was requested that we document the funcitonality in the WIKI pages.
### For testing

Please find the relevant test files here: \olympic\Babylon5\Scratch\Anton\Testing\1321_Make_binning_options_workspace_dependent

The folder also contains a Windows installer
Run through the test instructions twice once with each data set

Data Set 1  == Processed Nexus files:
- EventData1  ==> ED1 
- EventData2  ==> ED2
- HistogramData1 ==> HD1
- HistogramData2 ==>HD2

Data Set 2  == "Raw" Nexus files:
- SANS2D00028793  ==> ED1 
- SANS2D00028797  ==> ED2
- SANS2D00028804  ==> HD1
- SANS2D00028784 ==>HD2

Before starting:
- Open the ISIS SANS GUI
- Set the path to the sample data
- Set the instrument to SANS2DTUBES
- Load the user file: USER_SANS2D_143ZC_2p4_4m_M4_Knowles_12mm.txt
- Close the ISIS SANS GUI. Next time it starts everything should be set.

**Test that options are available only for event type data**
1. Open the ISIS SANS GUI
2. Go to the Add Tabs
   - Confirm that the options reegarding Binning are available (we don't have any files selected so we should show what there is available).
3. Load ED1
   - Confirm that the options are still enabled
4. Load ED2
   - Confirm that the options are still enabled 
5. Remove the ED1 file
   - Confirm that the options are still enabled 
6. Add the  HD1 file
   - Confirm that the options are **disabled**
7. Remove the HD1 file
   - Confirm that the options are again enabled
8. Remove all
   - Confirm that the options are all enabled
9. Add ED1 and ED2, then press sum
   - Confirm that there is no error

**Test that the WIKI documentation appears complete**

Check that there is a documentation regarding:
- How to set the output directory
- How to select files to add
- How to add files
- How to set the options for adding event files
