### PR TITLE
Make SaveNexusProcessed error message read less severe

### DIFF
--- a/Code/Mantid/Framework/Geometry/src/Instrument.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument.cpp
@@ -1062,9 +1062,8 @@ void Instrument::saveNexus(::NeXus::File *file,
   const std::string& xmlText = getXmlText();
   if (xmlText.empty())
     g_log.warning() << "Saving Instrument with no XML data. Mantid might NOT be"
-                    << " able to re-open the resulting Nexus file. This should"
-                    << " never happen. Please notify the Mantid development"
-                    << " team." << std::endl;
+                    << " able to re-open the resulting Nexus file."
+                    << std::endl;
   file->writeData("data", xmlText);
   file->writeData("type", "text/xml"); // mimetype
   file->writeData("description", "XML contents of the instrument IDF file.");

--- a/Code/Mantid/Framework/Geometry/src/Instrument.cpp
+++ b/Code/Mantid/Framework/Geometry/src/Instrument.cpp
@@ -1059,11 +1059,12 @@ void Instrument::saveNexus(::NeXus::File *file,
 
   // XML contents of instrument, as a NX note
   file->makeGroup("instrument_xml", "NXnote", true);
-  const std::string& xmlText = getXmlText();
+  const std::string &xmlText = getXmlText();
   if (xmlText.empty())
-    g_log.warning() << "Saving Instrument with no XML data. Mantid might NOT be"
-                    << " able to re-open the resulting Nexus file."
-                    << std::endl;
+    g_log.warning() << "Saving Instrument with no XML data. If this was "
+                       "instrument data you may not be able to load this data "
+                       "back into Mantid, for fitted/analysed data this "
+                       "warning can be ignored." << std::endl;
   file->writeData("data", xmlText);
   file->writeData("type", "text/xml"); // mimetype
   file->writeData("description", "XML contents of the instrument IDF file.");


### PR DESCRIPTION
This is a perfectly normal situation to be in.

Code review should be enough, but if not:
- Fit something
- Save the result with `SaveNexusProcessed`
