### PR TITLE
Performance tests for algorithm Fit

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/test/FitTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/FitTest.h
@@ -141,13 +141,12 @@ public:
   void test_peaks_fit() {
     API::MatrixWorkspace_sptr ws = generatePeaksCurveWorkspace();
 
-    return;
     Fit fit;
     fit.setChild(true);
     fit.initialize();
 
-    fit.setProperty("Function",
-                    "name=BackToBackExponential");
+    // example X0, S values after a good fit are 10079.0, 404.5
+    fit.setProperty("Function", "name=BackToBackExponential, X0=8500, S=800");
     fit.setProperty("InputWorkspace", ws);
     // fit.setProperty("MaxIterations", 99);
     fit.setProperty("CreateOutput", true);
@@ -169,7 +168,7 @@ public:
       // the delta/difference includes a bit of tolerance for random variations
       // of the generated/sample data
       TSM_ASSERT_DELTA("The difference between data and fit too big", y[i], 0.0,
-                       0.1);
+                       1);
     }
   }
 

--- a/Code/Mantid/Framework/CurveFitting/test/FitTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/FitTest.h
@@ -147,8 +147,7 @@ public:
     fit.initialize();
 
     fit.setProperty("Function",
-                    "name=BackToBackExponential"); //, I=8000, A=1, B=1.2,
-    // X0=10000, S=150");
+                    "name=BackToBackExponential");
     fit.setProperty("InputWorkspace", ws);
     // fit.setProperty("MaxIterations", 99);
     fit.setProperty("CreateOutput", true);
@@ -157,9 +156,6 @@ public:
 
     TS_ASSERT(fit.existsProperty("OutputParameters"));
     TS_ASSERT(fit.existsProperty("OutputWorkspace"));
-    // TS_ASSERT_EQUALS(fit.getPropertyValue("SomeOutput"), "MinimizerOutput");
-    // TS_ASSERT(
-    //    API::AnalysisDataService::Instance().doesExist("MinimizerOutput"));
 
     API::MatrixWorkspace_sptr outWS = fit.getProperty("OutputWorkspace");
     TS_ASSERT(outWS);

--- a/Code/Mantid/Framework/CurveFitting/test/FitTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/FitTest.h
@@ -4,133 +4,283 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidTestHelpers/FakeObjects.h"
 
-#include "MantidCurveFitting/Fit.h"
-
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/IFuncMinimizer.h"
 #include "MantidAPI/FuncMinimizerFactory.h"
+#include "MantidCurveFitting/Fit.h"
 
 using namespace Mantid;
 using namespace Mantid::CurveFitting;
 using namespace Mantid::API;
 
-namespace
-{
-    class TestMinimizer : public API::IFuncMinimizer
-    {
-    public:
-      /// Constructor setting a value for the relative error acceptance (default=0.01)
-      TestMinimizer()
-      {
-          declareProperty(new API::WorkspaceProperty<API::MatrixWorkspace>("SomeOutput","abc",Kernel::Direction::Output),
-              "Name of the output Workspace holding some output.");
+namespace {
+class TestMinimizer : public API::IFuncMinimizer {
+public:
+  /// Constructor setting a value for the relative error acceptance
+  /// (default=0.01)
+  TestMinimizer() {
+    declareProperty(new API::WorkspaceProperty<API::MatrixWorkspace>(
+                        "SomeOutput", "abc", Kernel::Direction::Output),
+                    "Name of the output Workspace holding some output.");
+  }
+
+  /// Overloading base class methods.
+  std::string name() const { return "TestMinimizer"; }
+  /// Do one iteration.
+  bool iterate(size_t iter) {
+    m_data[iter] = iter;
+
+    if (iter >= m_data.size() - 1) {
+      API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create(
+          "Workspace2D", 1, m_data.size(), m_data.size());
+      auto &Y = ws->dataY(0);
+      for (size_t i = 0; i < Y.size(); ++i) {
+        Y[i] = static_cast<double>(m_data[i]);
       }
+      setProperty("SomeOutput", ws);
+      return false;
+    }
+    return true;
+  }
 
-      /// Overloading base class methods.
-      std::string name()const{return "TestMinimizer";}
-      /// Do one iteration.
-      bool iterate(size_t iter)
-      {
-          m_data[iter] = iter;
+  /// Return current value of the cost function
+  double costFunctionVal() { return 0.0; }
+  /// Initialize minimizer.
+  virtual void initialize(API::ICostFunction_sptr, size_t maxIterations = 0) {
+    m_data.resize(maxIterations);
+  }
 
-          if ( iter >= m_data.size() - 1 )
-          {
-              API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D",1,m_data.size(),m_data.size());
-              auto & Y = ws->dataY(0);
-              for(size_t i = 0; i < Y.size(); ++i)
-              {
-                Y[i] = static_cast<double>(m_data[i]);
-              }
-              setProperty("SomeOutput",ws);
-              return false;
-          }
-          return true;
-      }
+private:
+  std::vector<size_t> m_data;
+};
 
-      /// Return current value of the cost function
-      double costFunctionVal() {return 0.0;}
-      /// Initialize minimizer.
-      virtual void initialize(API::ICostFunction_sptr, size_t maxIterations = 0)
-      {
-            m_data.resize(maxIterations);
-      }
-
-    private:
-      std::vector<size_t> m_data;
-    };
-
-    DECLARE_FUNCMINIMIZER(TestMinimizer,TestMinimizer)
+DECLARE_FUNCMINIMIZER(TestMinimizer, TestMinimizer)
 }
 
-class FitTest : public CxxTest::TestSuite
-{
+class FitTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
   static FitTest *createSuite() { return new FitTest(); }
-  static void destroySuite( FitTest *suite ) { delete suite; }
-  
-  FitTest()
-  {
+  static void destroySuite(FitTest *suite) { delete suite; }
+
+  FitTest() {
     // need to have DataObjects loaded
     FrameworkManager::Instance();
   }
 
-
   // Test that Fit copies minimizer's output properties to Fit
   // Test that minimizer's iterate(iter) method is called maxIteration times
   //  and iter passed to iterate() has values within 0 <= iter < maxIterations
-  void test_minimizer_output()
-  {
-      API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D",1,1,1);
-      Fit fit;
-      fit.initialize();
+  void test_minimizer_output() {
+    API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+    Fit fit;
+    fit.initialize();
 
-      fit.setProperty("Function","name=LinearBackground");
-      fit.setProperty("InputWorkspace",ws);
-      fit.setProperty("MaxIterations",99);
-      fit.setProperty("Minimizer","TestMinimizer,SomeOutput=MinimizerOutput");
-      fit.setProperty("CreateOutput",true);
+    fit.setProperty("Function", "name=LinearBackground");
+    fit.setProperty("InputWorkspace", ws);
+    fit.setProperty("MaxIterations", 99);
+    fit.setProperty("Minimizer", "TestMinimizer,SomeOutput=MinimizerOutput");
+    fit.setProperty("CreateOutput", true);
 
-      fit.execute();
-      TS_ASSERT( fit.existsProperty("SomeOutput") );
-      TS_ASSERT_EQUALS( fit.getPropertyValue("SomeOutput"), "MinimizerOutput");
-      TS_ASSERT( API::AnalysisDataService::Instance().doesExist("MinimizerOutput") );
+    fit.execute();
+    TS_ASSERT(fit.existsProperty("SomeOutput"));
+    TS_ASSERT_EQUALS(fit.getPropertyValue("SomeOutput"), "MinimizerOutput");
+    TS_ASSERT(
+        API::AnalysisDataService::Instance().doesExist("MinimizerOutput"));
 
-      API::MatrixWorkspace_sptr outWS = API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("MinimizerOutput");
-      TS_ASSERT( outWS );
-      auto &y = outWS->readY(0);
-      TS_ASSERT_EQUALS( y.size(), 99 );
-      for(size_t iter = 0; iter < 99; ++iter)
-      {
-          TS_ASSERT_EQUALS( y[iter], static_cast<double>(iter) );
-      }
+    API::MatrixWorkspace_sptr outWS =
+        API::AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            "MinimizerOutput");
+    TS_ASSERT(outWS);
+    auto &y = outWS->readY(0);
+    TS_ASSERT_EQUALS(y.size(), 99);
+    for (size_t iter = 0; iter < 99; ++iter) {
+      TS_ASSERT_EQUALS(y[iter], static_cast<double>(iter));
+    }
 
-      API::AnalysisDataService::Instance().clear();
+    API::AnalysisDataService::Instance().clear();
   }
 
-  // Test that minimizer's output is'n passed to Fit if no other output is created.
+  // Test that minimizer's output is'n passed to Fit if no other output is
+  // created.
   // Other output are: fitting parameters table, calculated values.
-  // To create output either CreateOutput must be set to true or Output be set to non-empty string
-  void test_minimizer_output_not_passed_to_Fit()
-  {
-      API::MatrixWorkspace_sptr ws = API::WorkspaceFactory::Instance().create("Workspace2D",1,1,1);
-      Fit fit;
-      fit.initialize();
+  // To create output either CreateOutput must be set to true or Output be set
+  // to non-empty string
+  void test_minimizer_output_not_passed_to_Fit() {
+    API::MatrixWorkspace_sptr ws =
+        API::WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1);
+    Fit fit;
+    fit.initialize();
 
-      fit.setProperty("Function","name=LinearBackground");
-      fit.setProperty("InputWorkspace",ws);
-      fit.setProperty("MaxIterations",99);
-      fit.setProperty("Minimizer","TestMinimizer,SomeOutput=MinimizerOutput");
+    fit.setProperty("Function", "name=LinearBackground");
+    fit.setProperty("InputWorkspace", ws);
+    fit.setProperty("MaxIterations", 99);
+    fit.setProperty("Minimizer", "TestMinimizer,SomeOutput=MinimizerOutput");
 
-      fit.execute();
-      TS_ASSERT( !fit.existsProperty("SomeOutput") );
-      TS_ASSERT( !API::AnalysisDataService::Instance().doesExist("MinimizerOutput") );
+    fit.execute();
+    TS_ASSERT(!fit.existsProperty("SomeOutput"));
+    TS_ASSERT(
+        !API::AnalysisDataService::Instance().doesExist("MinimizerOutput"));
+  }
+};
 
+class FitTestPerformance : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static FitTestPerformance *createSuite() { return new FitTestPerformance(); }
+  static void destroySuite(FitTestPerformance *suite) { delete suite; }
+
+  // Equivalent Python script. Fit a back-to-back exponential:
+  // Fit(InputWorkspace=pws, Function='name=BackToBackExponential')
+  void test_peaks_fit() {
+    API::MatrixWorkspace_sptr ws = generatePeaksCurveWorkspace();
+
+    return;
+    Fit fit;
+    fit.setChild(true);
+    fit.initialize();
+
+    fit.setProperty("Function",
+                    "name=BackToBackExponential"); //, I=8000, A=1, B=1.2,
+    // X0=10000, S=150");
+    fit.setProperty("InputWorkspace", ws);
+    // fit.setProperty("MaxIterations", 99);
+    fit.setProperty("CreateOutput", true);
+
+    fit.execute();
+
+    TS_ASSERT(fit.existsProperty("OutputParameters"));
+    TS_ASSERT(fit.existsProperty("OutputWorkspace"));
+    // TS_ASSERT_EQUALS(fit.getPropertyValue("SomeOutput"), "MinimizerOutput");
+    // TS_ASSERT(
+    //    API::AnalysisDataService::Instance().doesExist("MinimizerOutput"));
+
+    API::MatrixWorkspace_sptr outWS = fit.getProperty("OutputWorkspace");
+    TS_ASSERT(outWS);
+
+    TS_ASSERT_EQUALS(3, outWS->getNumberHistograms());
+
+    // takes the third histogram (difference between data and fit)
+    auto &y = outWS->readY(2);
+    TS_ASSERT_EQUALS(y.size(), 1000);
+    for (size_t i = 0; i < y.size(); ++i) {
+      // the delta/difference includes a bit of tolerance for random variations
+      // of the generated/sample data
+      TSM_ASSERT_DELTA("The difference between data and fit too big", y[i], 0.0,
+                       0.1);
+    }
   }
 
+  // Equivalent Python script. Fit with a BSpline function:
+  // Fit(InputWorkspace=ws, Function='name=BSpline, Order=40')
+  void test_smooth_curve_fit() {
+    API::MatrixWorkspace_sptr ws = generateSmoothCurveWorkspace();
+
+    Fit fit;
+    fit.setChild(true);
+    fit.initialize();
+
+    // From a quick test, order 30 => ~2.5s; order 40 => ~6s; order 50 =>
+    // ~14s
+    fit.setProperty("Function", "name=BSpline, Order=40, StartX=0, EndX=10");
+    fit.setProperty("InputWorkspace", ws);
+    fit.setProperty("CreateOutput", true);
+    fit.execute();
+
+    TS_ASSERT(fit.existsProperty("OutputParameters"));
+    TS_ASSERT(fit.existsProperty("OutputWorkspace"));
+
+    API::MatrixWorkspace_sptr outWS = fit.getProperty("OutputWorkspace");
+    TS_ASSERT(outWS);
+
+    TS_ASSERT_EQUALS(3, outWS->getNumberHistograms());
+
+    // takes the third histogram (difference between data and fit)
+    auto &y = outWS->readY(2);
+    TS_ASSERT_EQUALS(y.size(), 1000);
+    for (size_t i = 0; i < y.size(); ++i) {
+      // the difference includes a bit of tolerance for random variations of the
+      // generated/sample data
+      TSM_ASSERT_DELTA("The difference between data and fit is too big", y[i],
+                       0.0, 0.7);
+    }
+  }
+
+private:
+  // Equivalent python script. Create data with a peak and a bit of noise:
+  // pws = CreateSampleWorkspace(Function="User Defined",
+  // UserDefinedFunction="name=BackToBackExponential, I=15000, A=1, B=1.2,
+  // X0=10000, S=400", NumBanks=1, BankPixelWidth=1, Random=True)
+  API::MatrixWorkspace_sptr generatePeaksCurveWorkspace() {
+    Mantid::API::IAlgorithm_sptr sampleAlg =
+        Mantid::API::AlgorithmManager::Instance().create(
+            "CreateSampleWorkspace");
+    sampleAlg->initialize();
+    sampleAlg->setChild(true);
+    sampleAlg->setProperty("Function", "User Defined");
+    sampleAlg->setProperty(
+        "UserDefinedFunction",
+        "name=BackToBackExponential, I=15000, A=1, B=1.2, X0=10000, S=400");
+    sampleAlg->setProperty("NumBanks", 1);
+    sampleAlg->setProperty("BankPixelWidth", 1);
+    sampleAlg->setProperty("XMin", 0.0);
+    sampleAlg->setProperty("XMax", 100.0);
+    sampleAlg->setProperty("BinWidth", 0.1);
+    sampleAlg->setProperty("Random", true);
+    sampleAlg->setPropertyValue("OutputWorkspace", "sample_peak_curve_ws");
+
+    sampleAlg->execute();
+
+    TS_ASSERT(sampleAlg->isExecuted());
+    TS_ASSERT(sampleAlg->existsProperty("OutputWorkspace"));
+
+    API::MatrixWorkspace_sptr ws = sampleAlg->getProperty("OutputWorkspace");
+    TS_ASSERT(ws);
+
+    return ws;
+  }
+
+  // Equivalent python script. Create smooth-ish data curve:
+  // ws = CreateSampleWorkspace(Function="User Defined",
+  // UserDefinedFunction="name=LinearBackground, A0=0.4, A1=0.4; name=Gaussian,
+  // PeakCentre=1.3, Height=7, Sigma=1.7; name=Gaussian, PeakCentre=5,
+  // Height=10, Sigma=0.7; name=Gaussian, PeakCentre=8, Height=9, Sigma=1.8",
+  // NumBanks=1, BankPixelWidth=1, XMin=0, XMax=10, BinWidth=0.01, Random=True)
+  API::MatrixWorkspace_sptr generateSmoothCurveWorkspace() {
+    Mantid::API::IAlgorithm_sptr sampleAlg =
+        Mantid::API::AlgorithmManager::Instance().create(
+            "CreateSampleWorkspace");
+    sampleAlg->initialize();
+    sampleAlg->setChild(true);
+    sampleAlg->setProperty("Function", "User Defined");
+    sampleAlg->setProperty(
+        "UserDefinedFunction",
+        "name=LinearBackground, A0=0.4, A1=0.4; name=Gaussian, PeakCentre=1.3, "
+        "Height=7, Sigma=1.7; name=Gaussian, PeakCentre=5, Height=10, "
+        "Sigma=0.7; name=Gaussian, PeakCentre=8, Height=9, Sigma=1.8");
+    sampleAlg->setProperty("NumBanks", 1);
+    sampleAlg->setProperty("BankPixelWidth", 1);
+    sampleAlg->setProperty("XMin", 0.0);
+    sampleAlg->setProperty("XMax", 10.0);
+    sampleAlg->setProperty("BinWidth", 0.01);
+    sampleAlg->setProperty("Random", true);
+    sampleAlg->setPropertyValue("OutputWorkspace", "sample_smooth_curve_ws");
+
+    sampleAlg->execute();
+
+    TS_ASSERT(sampleAlg->isExecuted());
+    TS_ASSERT(sampleAlg->existsProperty("OutputWorkspace"));
+    API::MatrixWorkspace_sptr ws = sampleAlg->getProperty("OutputWorkspace");
+
+    TS_ASSERT(ws);
+    return ws;
+  }
 };
 
 #endif /*CURVEFITTING_FITMWTEST_H_*/


### PR DESCRIPTION
Fixes #13174.

This adds a performance test with a couple of test cases that should serve as an starting point and example for further tests. The test cases check:
- a simple peak fit 
-  a smooth curve fit with a spline with 40 knots.
  ![fit_simple_peak](https://cloud.githubusercontent.com/assets/5257172/8912155/c30303b0-3488-11e5-926a-749d0009ab2a.png)

![fit_smooth_curve](https://cloud.githubusercontent.com/assets/5257172/8911459/92de42de-3484-11e5-95a9-791fa64577f4.png)

The test runs in approximately <7s.

**To test**:
- Code review
- To run this performance test alone you can use `ctest -R CurveFittingTest_FitTestPerformance` or `ctest -V -R FitTestPerformance` for short.

Notes:
- I added the performance test together with the unit test of fit in the FitTest CxxTest file, as this seems to be the common practice. I think we actually don't have many test cases for Fit in place.
- I left the test with constraints out for now.

No need for a release note about this.
