### PR TITLE
Fix confusion between 'Output' and 'CreateOutput' in the documentation of `Fit`

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/src/Fit.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/Fit.cpp
@@ -32,7 +32,7 @@ void Fit::initConcrete() {
                          "the fitting function.");
   declareProperty("Constraints", "", Kernel::Direction::Input);
   getPointerToProperty("Constraints")->setDocumentation("List of constraints");
-  auto mustBePositive = boost::shared_ptr<Kernel::BoundedValidator<int> >(
+  auto mustBePositive = boost::shared_ptr<Kernel::BoundedValidator<int>>(
       new Kernel::BoundedValidator<int>());
   mustBePositive->setLower(0);
   declareProperty(
@@ -79,8 +79,12 @@ void Fit::initConcrete() {
       "CreateOutput", false,
       "Set to true to create output workspaces with the results of the fit"
       "(default is false).");
-  declareProperty("Output", "", "A base name for the output workspaces (if not "
-                                "given default names will be created).");
+  declareProperty(
+      "Output", "",
+      "A base name for the output workspaces (if not "
+      "given default names will be created). The "
+      "default is to use the name of the original data workspace as prefix "
+      "followed by suffixes _Workspace, _Parameters, etc.");
   declareProperty("CalcErrors", false,
                   "Set to true to calcuate errors when output isn't created "
                   "(default is false).");
@@ -281,8 +285,10 @@ void Fit::execConcrete() {
           row << 100.0;
         else {
           if (!covar.gsl()) {
-            throw std::runtime_error("There was an error while allocating the (GSL) covariance matrix "
-                                     "which is needed to produce fitting error results.");
+            throw std::runtime_error(
+                "There was an error while allocating the (GSL) covariance "
+                "matrix "
+                "which is needed to produce fitting error results.");
           }
           row << 100.0 * covar.get(ia, ja) /
                      sqrt(covar.get(ia, ia) * covar.get(ja, ja));

--- a/Code/Mantid/docs/source/algorithms/Fit-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/Fit-v1.rst
@@ -181,17 +181,20 @@ the fit. Zero error values are not allowed and are replaced with ones.
 Output
 ######
 
-Two output properties are added if the property 'Output' is set:
+Two output properties are added if the property 'CreateOutput' is set:
 
 1. OutputParameters
 2. OutputWorkspace (only if OutputParametersOnly is not set)
 
 These two properties are not shown in the table of properties above,
 as they are declared dynamically, but they can be retrieved after
-executing the algorithm (as long as the property 'Output' was
+executing the algorithm (as long as the property 'CreateOutput' was
 used). These two output properties provide workspaces which are also
 added in the Analysis Data Service (ADS) with names defined by
-appending a suffix to the string given as value of 'Output'.
+appending a suffix to the name of the original data workspace. You can
+replace the name of the workspace with a different name if you give a
+value to the property 'Output' which redefines the base name of the
+output workspaces.
 
 OutputParameters is is a `TableWorkspace
 <http://www.mantidproject.org/TableWorkspace>`_ with the fitted


### PR DESCRIPTION
In #13083 the output properties of Fit were documented in more detail, but a couple of confusing sentences were introduced (I mixed up the names of variables in the code with names of properties). This fixes the issue.

**To test**: the only changes are in documentation, check that they make sense.
