### PR TITLE
Adapt unit tests for classes used to set values in PredictFractionalPeaks

### DIFF
--- a/Code/Mantid/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Code/Mantid/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -37,29 +37,13 @@ void PredictFractionalPeaks::init() {
       new WorkspaceProperty<IPeaksWorkspace>("FracPeaks", "",
                                              Direction::Output),
       "Workspace of Peaks with peaks with fractional h,k, and/or l values");
-
-  std::vector<double> hOffsetDefault(3);
-  hOffsetDefault[0] = -0.5;
-  hOffsetDefault[1] = 0.0;
-  hOffsetDefault[2] = 0.5;
-
-
   declareProperty(
-	  new Kernel::ArrayProperty<double>(string("HOffset"), "-0.5,0.0,0.5"),
+      new Kernel::ArrayProperty<double>(string("HOffset"), "-0.5,0.0,0.5"),
       "Offset in the h direction");
-
-  //const std::vector<double> kOffsetDefault(1, 0);
-  //std::vector<double>(1, 0)
+  declareProperty(new Kernel::ArrayProperty<double>(string("KOffset"), "0"),
+                  "Offset in the h direction");
   declareProperty(
-      new Kernel::ArrayProperty<double>(string("KOffset"), "0"),
-      "Offset in the h direction");
-
-  std::vector<double> lOffsetDefault(3);
-  lOffsetDefault[0] = -0.5;
-  lOffsetDefault[1] = 0.5;
-
-  declareProperty(
-	  new Kernel::ArrayProperty<double>(string("LOffset"), "-0.5,0.5"),
+      new Kernel::ArrayProperty<double>(string("LOffset"), "-0.5,0.5"),
       "Offset in the h direction");
 
   declareProperty("IncludeAllPeaksInRange", false,

--- a/Code/Mantid/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Code/Mantid/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -45,13 +45,13 @@ void PredictFractionalPeaks::init() {
 
 
   declareProperty(
-	  new Kernel::ArrayProperty<double>(string("HOffset"), hOffsetDefault),
+	  new Kernel::ArrayProperty<double>(string("HOffset"), "-0.5,0.0,0.5"),
       "Offset in the h direction");
 
   //const std::vector<double> kOffsetDefault(1, 0);
   //std::vector<double>(1, 0)
   declareProperty(
-      new Kernel::ArrayProperty<double>(string("KOffset"), std::vector<double>(1, 0)),
+      new Kernel::ArrayProperty<double>(string("KOffset"), "0"),
       "Offset in the h direction");
 
   std::vector<double> lOffsetDefault(3);
@@ -59,7 +59,7 @@ void PredictFractionalPeaks::init() {
   lOffsetDefault[1] = 0.5;
 
   declareProperty(
-	  new Kernel::ArrayProperty<double>(string("LOffset"), lOffsetDefault),
+	  new Kernel::ArrayProperty<double>(string("LOffset"), "-0.5,0.5"),
       "Offset in the h direction");
 
   declareProperty("IncludeAllPeaksInRange", false,

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -6,6 +6,7 @@
 //----------------------------------------------------------------------
 #include "PropertyWithValue.h"
 
+
 namespace Mantid {
 namespace Kernel {
 /** Support for a property that holds an array of values.
@@ -60,6 +61,7 @@ public:
    *  @param validator :: The validator to use for this property, if required
    *  @param direction :: The direction (Input/Output/InOut) of this property
    */
+
   ArrayProperty(const std::string &name, IValidator_sptr validator,
                 const unsigned int direction = Direction::Input)
       : PropertyWithValue<std::vector<T>>(name, std::vector<T>(), validator,
@@ -77,11 +79,11 @@ public:
       : PropertyWithValue<std::vector<T>>(name, std::vector<T>(),
                                           IValidator_sptr(new NullValidator),
                                           direction) {}
-  /** Constructor from which you can set the property's values through a string
-   * 
-   * The constructor of the base class is called with an empty vector for the default values
-   * The values are set directly from the string. Since the default values are never initialized, isDefault
-   * will return false for any non-empty string input.
+
+  /** Constructor from which you can set the property's values through a string:
+   *
+   * Inherits from the constructor of PropertyWithValue specifically made to handle a list
+   * of numeric values in a string format so that initial value is set correctly.
    * 
    *  @param name ::      The name to assign to the property
    *  @param values ::    A comma-separated string containing the values to
@@ -94,13 +96,8 @@ public:
   ArrayProperty(const std::string &name, const std::string &values,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input)
-      : PropertyWithValue<std::vector<T>>(name, std::vector<T>(), validator,
-                                          direction) {
-    std::string result = this->setValue(values);
-    if (!result.empty()) {
-      throw std::invalid_argument(
-          "Invalid values string passed to constructor: " + result);
-    }
+      : PropertyWithValue<std::vector<T>>(name,std::vector<T>(),values, validator,
+                                          direction){
   }
 
   /// Copy constructor

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -6,7 +6,6 @@
 //----------------------------------------------------------------------
 #include "PropertyWithValue.h"
 
-
 namespace Mantid {
 namespace Kernel {
 /** Support for a property that holds an array of values.
@@ -82,9 +81,11 @@ public:
 
   /** Constructor from which you can set the property's values through a string:
    *
-   * Inherits from the constructor of PropertyWithValue specifically made to handle a list
-   * of numeric values in a string format so that initial value is set correctly.
-   * 
+   * Inherits from the constructor of PropertyWithValue specifically made to
+   * handle a list
+   * of numeric values in a string format so that initial value is set
+   * correctly.
+   *
    *  @param name ::      The name to assign to the property
    *  @param values ::    A comma-separated string containing the values to
    * store in the property
@@ -96,9 +97,8 @@ public:
   ArrayProperty(const std::string &name, const std::string &values,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input)
-      : PropertyWithValue<std::vector<T>>(name,std::vector<T>(),values, validator,
-                                          direction){
-  }
+      : PropertyWithValue<std::vector<T>>(name, std::vector<T>(), values,
+                                          validator, direction) {}
 
   /// Copy constructor
   ArrayProperty(const ArrayProperty &right)

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -187,11 +187,10 @@ void toValue(const std::string &strvalue, std::vector<std::vector<T>> &value,
  * given to it from strvalue parameter, Using toValue method.
  (See constructor used specifically for vector assignments)
  */
-template <typename T>
-T extractToValueVector(const std::string &strvalue){
-    T valueVec;
-    toValue(strvalue, valueVec);
-    return valueVec;
+template <typename T> T extractToValueVector(const std::string &strvalue) {
+  T valueVec;
+  toValue(strvalue, valueVec);
+  return valueVec;
 }
 
 /// Macro for the vector<int> specializations
@@ -289,25 +288,26 @@ public:
         m_validator(boost::make_shared<NullValidator>()) {}
 
   /*
-    Constructor to handle vector value assignments to m_initialValue 
+    Constructor to handle vector value assignments to m_initialValue
     so they can be remembered when the algorithm dialog is reloaded.
   */
- /**Constructor
-   *  @param name :: The name to assign to the property.
-   *  @param defaultValue :: A vector of numerical type, empty to comply with other definitions.
-   *  @param defaultValueStr :: The numerical values you wish to assign to the property
-   *  @param validator :: The validator to use for this property
-   *  @param direction :: Whether this is a Direction::Input, Direction::Output
-   * or Direction::InOut (Input & Output) property
-   */
+  /**Constructor
+    *  @param name :: The name to assign to the property.
+    *  @param defaultValue :: A vector of numerical type, empty to comply with
+   * other definitions.
+    *  @param defaultValueStr :: The numerical values you wish to assign to the
+   * property
+    *  @param validator :: The validator to use for this property
+    *  @param direction :: Whether this is a Direction::Input, Direction::Output
+    * or Direction::InOut (Input & Output) property
+    */
   PropertyWithValue(const std::string &name, const TYPE &defaultValue,
                     const std::string defaultValueStr,
-                    IValidator_sptr validator,
-                    const unsigned int direction)
-                    : Property(name, typeid(TYPE), direction), m_value(extractToValueVector<TYPE>(defaultValueStr)),
-                    m_initialValue(extractToValueVector<TYPE>(defaultValueStr)), m_validator(validator){
-  }
-
+                    IValidator_sptr validator, const unsigned int direction)
+      : Property(name, typeid(TYPE), direction),
+        m_value(extractToValueVector<TYPE>(defaultValueStr)),
+        m_initialValue(extractToValueVector<TYPE>(defaultValueStr)),
+        m_validator(validator) {}
 
   /**Copy constructor
   *  Note the default value of the copied object is the initial value of
@@ -505,7 +505,7 @@ protected:
   /// The value of the property
   TYPE m_value;
   /// the property's default value which is also its initial value
-  //const TYPE m_initialValue;
+  // const TYPE m_initialValue;
   TYPE m_initialValue;
 
 private:

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -307,7 +307,9 @@ public:
       : Property(name, typeid(TYPE), direction),
         m_value(extractToValueVector<TYPE>(defaultValueStr)),
         m_initialValue(extractToValueVector<TYPE>(defaultValueStr)),
-        m_validator(validator) {}
+        m_validator(validator) {
+            UNUSED_ARG(defaultValue);
+  }
 
   /**Copy constructor
   *  Note the default value of the copied object is the initial value of

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -183,6 +183,17 @@ void toValue(const std::string &strvalue, std::vector<std::vector<T>> &value,
   }
 }
 
+/*Used specifically to retrieve a vector of type T populated with values
+ * given to it from strvalue parameter, Using toValue method.
+ (See constructor used specifically for vector assignments)
+ */
+template <typename T>
+T extractToValueVector(const std::string &strvalue){
+    T valueVec;
+    toValue(strvalue, valueVec);
+    return valueVec;
+}
+
 /// Macro for the vector<int> specializations
 #define PROPERTYWITHVALUE_TOVALUE(type)                                        \
   template <>                                                                  \
@@ -276,6 +287,27 @@ public:
       : Property(name, typeid(TYPE), direction), m_value(defaultValue),
         m_initialValue(defaultValue),
         m_validator(boost::make_shared<NullValidator>()) {}
+
+  /*
+    Constructor to handle vector value assignments to m_initialValue 
+    so they can be remembered when the algorithm dialog is reloaded.
+  */
+ /**Constructor
+   *  @param name :: The name to assign to the property.
+   *  @param defaultValue :: A vector of numerical type, empty to comply with other definitions.
+   *  @param defaultValueStr :: The numerical values you wish to assign to the property
+   *  @param validator :: The validator to use for this property
+   *  @param direction :: Whether this is a Direction::Input, Direction::Output
+   * or Direction::InOut (Input & Output) property
+   */
+  PropertyWithValue(const std::string &name, const TYPE &defaultValue,
+                    const std::string defaultValueStr,
+                    IValidator_sptr validator,
+                    const unsigned int direction)
+                    : Property(name, typeid(TYPE), direction), m_value(extractToValueVector<TYPE>(defaultValueStr)),
+                    m_initialValue(extractToValueVector<TYPE>(defaultValueStr)), m_validator(validator){
+  }
+
 
   /**Copy constructor
   *  Note the default value of the copied object is the initial value of
@@ -473,7 +505,8 @@ protected:
   /// The value of the property
   TYPE m_value;
   /// the property's default value which is also its initial value
-  const TYPE m_initialValue;
+  //const TYPE m_initialValue;
+  TYPE m_initialValue;
 
 private:
   /**

--- a/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
@@ -130,12 +130,11 @@ public:
     TS_ASSERT_EQUALS( d2.operator()()[2], 0.15 )
     //Now we change the values that are set in the indices of d2
     //by using a string
-    ArrayProperty<double> tempd("d", "0.3,0.1,-0.2");
-    d2 = tempd;
-    TS_ASSERT_EQUALS(d2, tempd)
+    d2.setValue("0.3,0.1,-0.2");
     TS_ASSERT_EQUALS( d2.operator()()[0], 0.3 )
     TS_ASSERT_EQUALS( d2.operator()()[1], 0.1)
     TS_ASSERT_EQUALS( d2.operator()()[2], -0.2 )
+	TS_ASSERT(! d2.isDefault());
 
     ArrayProperty<std::string> s("d","a,b,c");
     TS_ASSERT( ! s.operator()()[0].compare("a") )

--- a/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
@@ -81,10 +81,13 @@ public:
 
   void testConstructorByString()
   {
-	  ArrayProperty<int> i("i","1,2,3");
-	  TS_ASSERT_EQUALS( i.operator()()[0], 1 )
-    TS_ASSERT_EQUALS( i.operator()()[1], 2 )
-    TS_ASSERT_EQUALS( i.operator()()[2], 3 )
+     const std::string &i_stringValue = "1,2,3";
+    ArrayProperty<int> i("i",i_stringValue);
+    TS_ASSERT_EQUALS( i.operator()()[0], 1 );
+    TS_ASSERT_EQUALS( i.operator()()[1], 2 );
+    TS_ASSERT_EQUALS( i.operator()()[2], 3 );
+    TS_ASSERT_EQUALS(i.getDefault(), i_stringValue);
+    TS_ASSERT(i.isDefault());
 
     ArrayProperty<int> i2("i", "-1-1");
     TS_ASSERT_EQUALS( i2.operator()()[0], -1);
@@ -134,16 +137,17 @@ public:
     TS_ASSERT_EQUALS( d2.operator()()[0], 0.3 )
     TS_ASSERT_EQUALS( d2.operator()()[1], 0.1)
     TS_ASSERT_EQUALS( d2.operator()()[2], -0.2 )
-	TS_ASSERT(! d2.isDefault());
+    TS_ASSERT_EQUALS(d2.value(), "0.3,0.1,-0.2");
+	TS_ASSERT(!d2.isDefault());
 
     ArrayProperty<std::string> s("d","a,b,c");
     TS_ASSERT( ! s.operator()()[0].compare("a") )
     TS_ASSERT( ! s.operator()()[1].compare("b") )
     TS_ASSERT( ! s.operator()()[2].compare("c") )
 
-    TS_ASSERT_THROWS( ArrayProperty<int> ii("ii","aa,bb"), std::invalid_argument )
-    TS_ASSERT_THROWS( ArrayProperty<int> ii("ii","5.5,6.6"), std::invalid_argument )
-    TS_ASSERT_THROWS( ArrayProperty<double> dd("dd","aa,bb"), std::invalid_argument )
+    TS_ASSERT_THROWS( ArrayProperty<int> ii("ii","aa,bb"), std::bad_cast )
+    TS_ASSERT_THROWS( ArrayProperty<int> ii("ii","5.5,6.6"), std::bad_cast )
+    TS_ASSERT_THROWS( ArrayProperty<double> dd("dd","aa,bb"), std::bad_cast )
   }
 	
   void testCopyConstructor()

--- a/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
@@ -124,6 +124,19 @@ public:
     TS_ASSERT_EQUALS( d.operator()()[1], 8.88 )
     TS_ASSERT_EQUALS( d.operator()()[2], 9.99 )
 
+    ArrayProperty<double> d2("d","-0.15,0.0,0.15");
+    TS_ASSERT_EQUALS( d2.operator()()[0], -0.15 )
+    TS_ASSERT_EQUALS( d2.operator()()[1], 0.0 )
+    TS_ASSERT_EQUALS( d2.operator()()[2], 0.15 )
+    //Now we change the values that are set in the indices of d2
+    //by using a string
+    ArrayProperty<double> tempd("d", "0.3,0.1,-0.2");
+    d2 = tempd;
+    TS_ASSERT_EQUALS(d2, tempd)
+    TS_ASSERT_EQUALS( d2.operator()()[0], 0.3 )
+    TS_ASSERT_EQUALS( d2.operator()()[1], 0.1)
+    TS_ASSERT_EQUALS( d2.operator()()[2], -0.2 )
+
     ArrayProperty<std::string> s("d","a,b,c");
     TS_ASSERT( ! s.operator()()[0].compare("a") )
     TS_ASSERT( ! s.operator()()[1].compare("b") )

--- a/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Code/Mantid/Framework/Kernel/test/ArrayPropertyTest.h
@@ -7,295 +7,292 @@
 
 using namespace Mantid::Kernel;
 
-class ArrayPropertyTest : public CxxTest::TestSuite
-{
+class ArrayPropertyTest : public CxxTest::TestSuite {
 public:
-  void setUp()
-  {
+  void setUp() {
     iProp = new ArrayProperty<int>("intProp");
     dProp = new ArrayProperty<double>("doubleProp");
-    sProp = new ArrayProperty<std::string>("stringProp");    
+    sProp = new ArrayProperty<std::string>("stringProp");
   }
-  
-  void tearDown()
-  {
+
+  void tearDown() {
     delete iProp;
     delete dProp;
     delete sProp;
   }
-  
-  void testConstructor()
-  {
-    TS_ASSERT( ! iProp->name().compare("intProp") )
-    TS_ASSERT( ! iProp->documentation().compare("") )
-    TS_ASSERT( typeid( std::vector<int> ) == *iProp->type_info()  )
-    TS_ASSERT( iProp->isDefault() )
-    TS_ASSERT( iProp->operator()().empty() )
-    
-    TS_ASSERT( ! dProp->name().compare("doubleProp") )
-    TS_ASSERT( ! dProp->documentation().compare("") )
-    TS_ASSERT( typeid( std::vector<double> ) == *dProp->type_info()  )
-    TS_ASSERT( dProp->isDefault() )
-    TS_ASSERT( dProp->operator()().empty() )
-    
-    TS_ASSERT( ! sProp->name().compare("stringProp") )
-    TS_ASSERT( ! sProp->documentation().compare("") )
-    TS_ASSERT( typeid( std::vector<std::string> ) == *sProp->type_info()  )
-    TS_ASSERT( sProp->isDefault() )
-    TS_ASSERT( sProp->operator()().empty() )
-    
-    std::vector<int> i(5,2);
-    ArrayProperty<int> ip("ip",i);
-    TS_ASSERT_EQUALS( ip.operator()().size(), 5 )
-    TS_ASSERT_EQUALS( ip.operator()()[3], 2 )
 
-    std::vector<double> d(4,6.66);
-    ArrayProperty<double> dp("dp",d);
-    TS_ASSERT_EQUALS( dp.operator()().size(), 4 )
-    TS_ASSERT_EQUALS( dp.operator()()[1], 6.66 )
+  void testConstructor() {
+    TS_ASSERT(!iProp->name().compare("intProp"))
+    TS_ASSERT(!iProp->documentation().compare(""))
+    TS_ASSERT(typeid(std::vector<int>) == *iProp->type_info())
+    TS_ASSERT(iProp->isDefault())
+    TS_ASSERT(iProp->operator()().empty())
 
-    std::vector<std::string> s(3,"yyy");
-    ArrayProperty<std::string> sp("sp",s);
-    TS_ASSERT_EQUALS( sp.operator()().size(), 3 )
-    TS_ASSERT( ! sp.operator()()[2].compare("yyy") )
+    TS_ASSERT(!dProp->name().compare("doubleProp"))
+    TS_ASSERT(!dProp->documentation().compare(""))
+    TS_ASSERT(typeid(std::vector<double>) == *dProp->type_info())
+    TS_ASSERT(dProp->isDefault())
+    TS_ASSERT(dProp->operator()().empty())
+
+    TS_ASSERT(!sProp->name().compare("stringProp"))
+    TS_ASSERT(!sProp->documentation().compare(""))
+    TS_ASSERT(typeid(std::vector<std::string>) == *sProp->type_info())
+    TS_ASSERT(sProp->isDefault())
+    TS_ASSERT(sProp->operator()().empty())
+
+    std::vector<int> i(5, 2);
+    ArrayProperty<int> ip("ip", i);
+    TS_ASSERT_EQUALS(ip.operator()().size(), 5)
+    TS_ASSERT_EQUALS(ip.operator()()[3], 2)
+
+    std::vector<double> d(4, 6.66);
+    ArrayProperty<double> dp("dp", d);
+    TS_ASSERT_EQUALS(dp.operator()().size(), 4)
+    TS_ASSERT_EQUALS(dp.operator()()[1], 6.66)
+
+    std::vector<std::string> s(3, "yyy");
+    ArrayProperty<std::string> sp("sp", s);
+    TS_ASSERT_EQUALS(sp.operator()().size(), 3)
+    TS_ASSERT(!sp.operator()()[2].compare("yyy"))
   }
 
-  void testSize()
-  {
+  void testSize() {
     TS_ASSERT_EQUALS(0, iProp->size());
     TS_ASSERT_EQUALS(0, dProp->size());
     TS_ASSERT_EQUALS(0, sProp->size());
 
     // Make something bigger and test that.
-    Property* a = new ArrayProperty<int>("int_property", "1, 2, 3");
+    Property *a = new ArrayProperty<int>("int_property", "1, 2, 3");
     TS_ASSERT_EQUALS(3, a->size());
     delete a;
 
     // Test vector of vector.
-    std::vector<std::vector<int> > input;
-    input.push_back(std::vector<int>(10)); // Make it 10 elements long, but should only be the size of the parent vector that is counted.
-    Property* b = new ArrayProperty<std::vector<int> >("vec_property", input);
+    std::vector<std::vector<int>> input;
+    input.push_back(std::vector<int>(10)); // Make it 10 elements long, but
+                                           // should only be the size of the
+                                           // parent vector that is counted.
+    Property *b = new ArrayProperty<std::vector<int>>("vec_property", input);
     TS_ASSERT_EQUALS(1, b->size());
     delete b;
   }
 
-  void testConstructorByString()
-  {
-     const std::string &i_stringValue = "1,2,3";
-    ArrayProperty<int> i("i",i_stringValue);
-    TS_ASSERT_EQUALS( i.operator()()[0], 1 );
-    TS_ASSERT_EQUALS( i.operator()()[1], 2 );
-    TS_ASSERT_EQUALS( i.operator()()[2], 3 );
+  void testConstructorByString() {
+    const std::string &i_stringValue = "1,2,3";
+    ArrayProperty<int> i("i", i_stringValue);
+    TS_ASSERT_EQUALS(i.operator()()[0], 1);
+    TS_ASSERT_EQUALS(i.operator()()[1], 2);
+    TS_ASSERT_EQUALS(i.operator()()[2], 3);
     TS_ASSERT_EQUALS(i.getDefault(), i_stringValue);
     TS_ASSERT(i.isDefault());
 
     ArrayProperty<int> i2("i", "-1-1");
-    TS_ASSERT_EQUALS( i2.operator()()[0], -1);
-    TS_ASSERT_EQUALS( i2.operator()()[1], 0);
-    TS_ASSERT_EQUALS( i2.operator()()[2], 1);
+    TS_ASSERT_EQUALS(i2.operator()()[0], -1);
+    TS_ASSERT_EQUALS(i2.operator()()[1], 0);
+    TS_ASSERT_EQUALS(i2.operator()()[2], 1);
 
     ArrayProperty<int> i4("i", "-1:1");
-    TS_ASSERT_EQUALS( i4.operator()()[0], -1);
-    TS_ASSERT_EQUALS( i4.operator()()[1], 0);
-    TS_ASSERT_EQUALS( i4.operator()()[2], 1);
+    TS_ASSERT_EQUALS(i4.operator()()[0], -1);
+    TS_ASSERT_EQUALS(i4.operator()()[1], 0);
+    TS_ASSERT_EQUALS(i4.operator()()[2], 1);
 
     ArrayProperty<int> i5("i", "-3--1");
-    TS_ASSERT_EQUALS( i5.operator()()[0], -3);
-    TS_ASSERT_EQUALS( i5.operator()()[1], -2);
-    TS_ASSERT_EQUALS( i5.operator()()[2], -1);
+    TS_ASSERT_EQUALS(i5.operator()()[0], -3);
+    TS_ASSERT_EQUALS(i5.operator()()[1], -2);
+    TS_ASSERT_EQUALS(i5.operator()()[2], -1);
 
     ArrayProperty<int> i7("i", "-3:-1");
-    TS_ASSERT_EQUALS( i7.operator()()[0], -3);
-    TS_ASSERT_EQUALS( i7.operator()()[1], -2);
-    TS_ASSERT_EQUALS( i7.operator()()[2], -1);
+    TS_ASSERT_EQUALS(i7.operator()()[0], -3);
+    TS_ASSERT_EQUALS(i7.operator()()[1], -2);
+    TS_ASSERT_EQUALS(i7.operator()()[2], -1);
 
     ArrayProperty<unsigned int> i3("i", "0:2,5");
-    TS_ASSERT_EQUALS( i3.operator()()[0], 0);
-    TS_ASSERT_EQUALS( i3.operator()()[1], 1);
-    TS_ASSERT_EQUALS( i3.operator()()[2], 2);
-    TS_ASSERT_EQUALS( i3.operator()()[3], 5);
+    TS_ASSERT_EQUALS(i3.operator()()[0], 0);
+    TS_ASSERT_EQUALS(i3.operator()()[1], 1);
+    TS_ASSERT_EQUALS(i3.operator()()[2], 2);
+    TS_ASSERT_EQUALS(i3.operator()()[3], 5);
 
     ArrayProperty<unsigned int> i6("i", "5,0-2,5");
-    TS_ASSERT_EQUALS( i6.operator()()[0], 5);
-    TS_ASSERT_EQUALS( i6.operator()()[1], 0);
-    TS_ASSERT_EQUALS( i6.operator()()[2], 1);
-    TS_ASSERT_EQUALS( i6.operator()()[3], 2);
-    TS_ASSERT_EQUALS( i6.operator()()[4], 5);
+    TS_ASSERT_EQUALS(i6.operator()()[0], 5);
+    TS_ASSERT_EQUALS(i6.operator()()[1], 0);
+    TS_ASSERT_EQUALS(i6.operator()()[2], 1);
+    TS_ASSERT_EQUALS(i6.operator()()[3], 2);
+    TS_ASSERT_EQUALS(i6.operator()()[4], 5);
 
-    ArrayProperty<double> d("d","7.77,8.88,9.99");
-    TS_ASSERT_EQUALS( d.operator()()[0], 7.77 )
-    TS_ASSERT_EQUALS( d.operator()()[1], 8.88 )
-    TS_ASSERT_EQUALS( d.operator()()[2], 9.99 )
+    ArrayProperty<double> d("d", "7.77,8.88,9.99");
+    TS_ASSERT_EQUALS(d.operator()()[0], 7.77)
+    TS_ASSERT_EQUALS(d.operator()()[1], 8.88)
+    TS_ASSERT_EQUALS(d.operator()()[2], 9.99)
 
-    ArrayProperty<double> d2("d","-0.15,0.0,0.15");
-    TS_ASSERT_EQUALS( d2.operator()()[0], -0.15 )
-    TS_ASSERT_EQUALS( d2.operator()()[1], 0.0 )
-    TS_ASSERT_EQUALS( d2.operator()()[2], 0.15 )
-    //Now we change the values that are set in the indices of d2
-    //by using a string
+    ArrayProperty<double> d2("d", "-0.15,0.0,0.15");
+    TS_ASSERT_EQUALS(d2.operator()()[0], -0.15)
+    TS_ASSERT_EQUALS(d2.operator()()[1], 0.0)
+    TS_ASSERT_EQUALS(d2.operator()()[2], 0.15)
+    // Now we change the values that are set in the indices of d2
+    // by using a string
     d2.setValue("0.3,0.1,-0.2");
-    TS_ASSERT_EQUALS( d2.operator()()[0], 0.3 )
-    TS_ASSERT_EQUALS( d2.operator()()[1], 0.1)
-    TS_ASSERT_EQUALS( d2.operator()()[2], -0.2 )
+    TS_ASSERT_EQUALS(d2.operator()()[0], 0.3)
+    TS_ASSERT_EQUALS(d2.operator()()[1], 0.1)
+    TS_ASSERT_EQUALS(d2.operator()()[2], -0.2)
     TS_ASSERT_EQUALS(d2.value(), "0.3,0.1,-0.2");
-	TS_ASSERT(!d2.isDefault());
+    TS_ASSERT(!d2.isDefault());
 
-    ArrayProperty<std::string> s("d","a,b,c");
-    TS_ASSERT( ! s.operator()()[0].compare("a") )
-    TS_ASSERT( ! s.operator()()[1].compare("b") )
-    TS_ASSERT( ! s.operator()()[2].compare("c") )
+    ArrayProperty<std::string> s("d", "a,b,c");
+    TS_ASSERT(!s.operator()()[0].compare("a"))
+    TS_ASSERT(!s.operator()()[1].compare("b"))
+    TS_ASSERT(!s.operator()()[2].compare("c"))
 
-    TS_ASSERT_THROWS( ArrayProperty<int> ii("ii","aa,bb"), std::bad_cast )
-    TS_ASSERT_THROWS( ArrayProperty<int> ii("ii","5.5,6.6"), std::bad_cast )
-    TS_ASSERT_THROWS( ArrayProperty<double> dd("dd","aa,bb"), std::bad_cast )
+    TS_ASSERT_THROWS(ArrayProperty<int> ii("ii", "aa,bb"), std::bad_cast)
+    TS_ASSERT_THROWS(ArrayProperty<int> ii("ii", "5.5,6.6"), std::bad_cast)
+    TS_ASSERT_THROWS(ArrayProperty<double> dd("dd", "aa,bb"), std::bad_cast)
   }
-	
-  void testCopyConstructor()
-  {
+
+  void testCopyConstructor() {
     ArrayProperty<int> i = *iProp;
-    TS_ASSERT( ! i.name().compare("intProp") )
-    TS_ASSERT( ! i.documentation().compare("") )
-    TS_ASSERT( typeid( std::vector<int> ) == *i.type_info()  )
-    TS_ASSERT( i.isDefault() )
-    TS_ASSERT( i.operator()().empty() )
-	    
+    TS_ASSERT(!i.name().compare("intProp"))
+    TS_ASSERT(!i.documentation().compare(""))
+    TS_ASSERT(typeid(std::vector<int>) == *i.type_info())
+    TS_ASSERT(i.isDefault())
+    TS_ASSERT(i.operator()().empty())
+
     ArrayProperty<double> d = *dProp;
-    TS_ASSERT( ! d.name().compare("doubleProp") )
-    TS_ASSERT( ! d.documentation().compare("") )
-    TS_ASSERT( typeid( std::vector<double> ) == *d.type_info()  )
-    TS_ASSERT( d.isDefault() )
-    TS_ASSERT( d.operator()().empty() )
-	    
+    TS_ASSERT(!d.name().compare("doubleProp"))
+    TS_ASSERT(!d.documentation().compare(""))
+    TS_ASSERT(typeid(std::vector<double>) == *d.type_info())
+    TS_ASSERT(d.isDefault())
+    TS_ASSERT(d.operator()().empty())
+
     ArrayProperty<std::string> s = *sProp;
-    TS_ASSERT( ! s.name().compare("stringProp") )
-    TS_ASSERT( ! s.documentation().compare("") )
-    TS_ASSERT( typeid( std::vector<std::string> ) == *s.type_info()  )
-    TS_ASSERT( s.isDefault() )
-    TS_ASSERT( s.operator()().empty() )
+    TS_ASSERT(!s.name().compare("stringProp"))
+    TS_ASSERT(!s.documentation().compare(""))
+    TS_ASSERT(typeid(std::vector<std::string>) == *s.type_info())
+    TS_ASSERT(s.isDefault())
+    TS_ASSERT(s.operator()().empty())
   }
 
-  void testValue()
-  {
-    std::vector<int> i(3,3);
-    ArrayProperty<int> ip("ip",i);
-    TS_ASSERT( ! ip.value().compare("3,3,3") )
+  void testValue() {
+    std::vector<int> i(3, 3);
+    ArrayProperty<int> ip("ip", i);
+    TS_ASSERT(!ip.value().compare("3,3,3"))
 
-    std::vector<double> d(4,1.23);
-    ArrayProperty<double> dp("dp",d);
-    TS_ASSERT( ! dp.value().compare("1.23,1.23,1.23,1.23") )
-  
-    std::vector<std::string> s(2,"yyy");
-    ArrayProperty<std::string> sp("sp",s);
-    TS_ASSERT( ! sp.value().compare("yyy,yyy") )
+    std::vector<double> d(4, 1.23);
+    ArrayProperty<double> dp("dp", d);
+    TS_ASSERT(!dp.value().compare("1.23,1.23,1.23,1.23"))
+
+    std::vector<std::string> s(2, "yyy");
+    ArrayProperty<std::string> sp("sp", s);
+    TS_ASSERT(!sp.value().compare("yyy,yyy"))
   }
 
-  void testSetValueAndIsDefault()
-  {
-    std::string couldnt = "Could not set property ", cant = ". Can not convert \"";
+  void testSetValueAndIsDefault() {
+    std::string couldnt = "Could not set property ",
+                cant = ". Can not convert \"";
 
-    TS_ASSERT_EQUALS( iProp->setValue("1.1,2,2"),
-      couldnt + iProp->name() + cant + "1.1,2,2\" to " + iProp->type() )
-    TS_ASSERT( iProp->operator()().empty() )
-    TS_ASSERT( iProp->isDefault() )
-    TS_ASSERT_EQUALS( iProp->setValue("aaa,bbb"), 
-      couldnt + iProp->name() + cant + "aaa,bbb\" to " + iProp->type() )
-    TS_ASSERT( iProp->operator()().empty() )
-    TS_ASSERT( iProp->isDefault() )
-    TS_ASSERT_EQUALS( iProp->setValue("1,2,3,4"), "" )
-    TS_ASSERT_EQUALS( iProp->operator()().size(), 4 )
-    for ( std::size_t i=0; i < 4; ++i )
-    {
-      TS_ASSERT_EQUALS( iProp->operator()()[i], i+1 )
+    TS_ASSERT_EQUALS(iProp->setValue("1.1,2,2"), couldnt + iProp->name() +
+                                                     cant + "1.1,2,2\" to " +
+                                                     iProp->type())
+    TS_ASSERT(iProp->operator()().empty())
+    TS_ASSERT(iProp->isDefault())
+    TS_ASSERT_EQUALS(iProp->setValue("aaa,bbb"), couldnt + iProp->name() +
+                                                     cant + "aaa,bbb\" to " +
+                                                     iProp->type())
+    TS_ASSERT(iProp->operator()().empty())
+    TS_ASSERT(iProp->isDefault())
+    TS_ASSERT_EQUALS(iProp->setValue("1,2,3,4"), "")
+    TS_ASSERT_EQUALS(iProp->operator()().size(), 4)
+    for (std::size_t i = 0; i < 4; ++i) {
+      TS_ASSERT_EQUALS(iProp->operator()()[i], i + 1)
     }
-    TS_ASSERT( !iProp->isDefault() )
-    TS_ASSERT_EQUALS( iProp->setValue(""), "" )
-    TS_ASSERT( iProp->operator()().empty() )
-    TS_ASSERT( iProp->isDefault() )
-    
-    TS_ASSERT_EQUALS( dProp->setValue("aaa,bbb"),
-      couldnt + dProp->name() + cant + "aaa,bbb\" to " + dProp->type() )
-    TS_ASSERT( dProp->operator()().empty() )
-    TS_ASSERT( dProp->isDefault() )
-    TS_ASSERT_EQUALS( dProp->setValue("1,2"), "" )
-    TS_ASSERT_EQUALS( dProp->operator()()[1], 2 )
-    TS_ASSERT( !dProp->isDefault() )
-    TS_ASSERT_EQUALS( dProp->setValue("1.11,2.22,3.33,4.44"), "" )
-    TS_ASSERT_EQUALS( dProp->operator()()[0], 1.11 )
-    TS_ASSERT( !dProp->isDefault() )
-    TS_ASSERT_EQUALS( dProp->setValue(""), "" )
-    TS_ASSERT( dProp->operator()().empty() )
-    TS_ASSERT( dProp->isDefault() )
-    
-    TS_ASSERT_EQUALS( sProp->setValue("This,is,a,test"), "" )
-    TS_ASSERT_EQUALS( sProp->operator()()[2], "a" )
-    TS_ASSERT( !sProp->isDefault() )
-    TS_ASSERT_EQUALS( sProp->setValue(""), "" )
-    TS_ASSERT( sProp->operator()().empty() )
-    TS_ASSERT( sProp->isDefault() )    
+    TS_ASSERT(!iProp->isDefault())
+    TS_ASSERT_EQUALS(iProp->setValue(""), "")
+    TS_ASSERT(iProp->operator()().empty())
+    TS_ASSERT(iProp->isDefault())
+
+    TS_ASSERT_EQUALS(dProp->setValue("aaa,bbb"), couldnt + dProp->name() +
+                                                     cant + "aaa,bbb\" to " +
+                                                     dProp->type())
+    TS_ASSERT(dProp->operator()().empty())
+    TS_ASSERT(dProp->isDefault())
+    TS_ASSERT_EQUALS(dProp->setValue("1,2"), "")
+    TS_ASSERT_EQUALS(dProp->operator()()[1], 2)
+    TS_ASSERT(!dProp->isDefault())
+    TS_ASSERT_EQUALS(dProp->setValue("1.11,2.22,3.33,4.44"), "")
+    TS_ASSERT_EQUALS(dProp->operator()()[0], 1.11)
+    TS_ASSERT(!dProp->isDefault())
+    TS_ASSERT_EQUALS(dProp->setValue(""), "")
+    TS_ASSERT(dProp->operator()().empty())
+    TS_ASSERT(dProp->isDefault())
+
+    TS_ASSERT_EQUALS(sProp->setValue("This,is,a,test"), "")
+    TS_ASSERT_EQUALS(sProp->operator()()[2], "a")
+    TS_ASSERT(!sProp->isDefault())
+    TS_ASSERT_EQUALS(sProp->setValue(""), "")
+    TS_ASSERT(sProp->operator()().empty())
+    TS_ASSERT(sProp->isDefault())
   }
 
-  void testAssignmentOperator()
-  {
+  void testAssignmentOperator() {
     ArrayProperty<int> i("i");
-    TS_ASSERT( i.isDefault() )
-    std::vector<int> ii(3,4);
-    TS_ASSERT_EQUALS( i = ii, ii )
-    TS_ASSERT_EQUALS( i.operator()()[1], 4 )
-    TS_ASSERT( !i.isDefault() )
+    TS_ASSERT(i.isDefault())
+    std::vector<int> ii(3, 4);
+    TS_ASSERT_EQUALS(i = ii, ii)
+    TS_ASSERT_EQUALS(i.operator()()[1], 4)
+    TS_ASSERT(!i.isDefault())
 
     ArrayProperty<double> d("d");
-    TS_ASSERT( d.isDefault() )
-    std::vector<double> dd(5,9.99);
-    TS_ASSERT_EQUALS( d = dd, dd )
-    TS_ASSERT_EQUALS( d.operator()()[3], 9.99 )
-    TS_ASSERT( !d.isDefault() )
+    TS_ASSERT(d.isDefault())
+    std::vector<double> dd(5, 9.99);
+    TS_ASSERT_EQUALS(d = dd, dd)
+    TS_ASSERT_EQUALS(d.operator()()[3], 9.99)
+    TS_ASSERT(!d.isDefault())
 
     ArrayProperty<std::string> s("s");
-    TS_ASSERT( s.isDefault() )
-    std::vector<std::string> ss(2,"zzz");
-    TS_ASSERT_EQUALS( s = ss, ss )
-    TS_ASSERT_EQUALS( s.operator()()[0], "zzz" )
-    TS_ASSERT( !s.isDefault() )
+    TS_ASSERT(s.isDefault())
+    std::vector<std::string> ss(2, "zzz");
+    TS_ASSERT_EQUALS(s = ss, ss)
+    TS_ASSERT_EQUALS(s.operator()()[0], "zzz")
+    TS_ASSERT(!s.isDefault())
   }
-  
-  void testOperatorBrackets()
-  {
-    TS_ASSERT( iProp->operator()().empty() )
-    TS_ASSERT( dProp->operator()().empty() )
-    TS_ASSERT( sProp->operator()().empty() )    
+
+  void testOperatorBrackets() {
+    TS_ASSERT(iProp->operator()().empty())
+    TS_ASSERT(dProp->operator()().empty())
+    TS_ASSERT(sProp->operator()().empty())
   }
-  
-  void testOperatorNothing()
-  {
+
+  void testOperatorNothing() {
     std::vector<int> i = *iProp;
-    TS_ASSERT( i.empty() )
-    
-    std::vector<double> d(3,8.8);
+    TS_ASSERT(i.empty())
+
+    std::vector<double> d(3, 8.8);
     *dProp = d;
     std::vector<double> dd = *dProp;
-    for(std::size_t i = 0; i<3; ++i)
-    {
-      TS_ASSERT_EQUALS( dProp->operator()()[i], 8.8 )
+    for (std::size_t i = 0; i < 3; ++i) {
+      TS_ASSERT_EQUALS(dProp->operator()()[i], 8.8)
     }
-    
+
     std::vector<std::string> s = *sProp;
-    TS_ASSERT( s.empty() )
+    TS_ASSERT(s.empty())
   }
-  
-  void testCasting()
-  {
-    TS_ASSERT_DIFFERS( dynamic_cast<PropertyWithValue<std::vector<int> >*>(iProp), 
-                            static_cast<PropertyWithValue<std::vector<int> >*>(0) )
-    TS_ASSERT_DIFFERS( dynamic_cast<PropertyWithValue<std::vector<double> >*>(dProp), 
-                            static_cast<PropertyWithValue<std::vector<double> >*>(0) )
-    TS_ASSERT_DIFFERS( dynamic_cast<PropertyWithValue<std::vector<std::string> >*>(sProp), 
-                            static_cast<PropertyWithValue<std::vector<std::string> >*>(0) )
-    
-    TS_ASSERT_DIFFERS( dynamic_cast<Property*>(iProp), static_cast<Property*>(0) )
-    TS_ASSERT_DIFFERS( dynamic_cast<Property*>(dProp), static_cast<Property*>(0) )
-    TS_ASSERT_DIFFERS( dynamic_cast<Property*>(sProp), static_cast<Property*>(0) )
+
+  void testCasting() {
+    TS_ASSERT_DIFFERS(
+        dynamic_cast<PropertyWithValue<std::vector<int>> *>(iProp),
+        static_cast<PropertyWithValue<std::vector<int>> *>(0))
+    TS_ASSERT_DIFFERS(
+        dynamic_cast<PropertyWithValue<std::vector<double>> *>(dProp),
+        static_cast<PropertyWithValue<std::vector<double>> *>(0))
+    TS_ASSERT_DIFFERS(
+        dynamic_cast<PropertyWithValue<std::vector<std::string>> *>(sProp),
+        static_cast<PropertyWithValue<std::vector<std::string>> *>(0))
+
+    TS_ASSERT_DIFFERS(dynamic_cast<Property *>(iProp),
+                      static_cast<Property *>(0))
+    TS_ASSERT_DIFFERS(dynamic_cast<Property *>(dProp),
+                      static_cast<Property *>(0))
+    TS_ASSERT_DIFFERS(dynamic_cast<Property *>(sProp),
+                      static_cast<Property *>(0))
   }
-  
+
 private:
   ArrayProperty<int> *iProp;
   ArrayProperty<double> *dProp;


### PR DESCRIPTION
Fixes #13119 
The test added should replicate the conditions under which PredictFractionalPeaks fails to remember the values the user has entered
following from #13119. Tests run fine and pass which makes me think ArrayProperty was not the problem.

PropertyWithValue now has a new constructor which will set the initial value of the dialog to a vector populated by a string of comma separated numeric values. Tests for ArrayProperty have been updated accordingly and pass.
