### PR TITLE
disables users from deleting all graphs at once

### DIFF
--- a/Code/Mantid/MantidPlot/src/CurvesDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/CurvesDialog.cpp
@@ -451,19 +451,24 @@ bool CurvesDialog::addCurve(const QString& name)
   return false;
 }
 
+
+/**Remove curves function
+*
+*/
 void CurvesDialog::removeCurves()
 {
   int count = contents->count();
+  QList<QListWidgetItem *> lst = contents->selectedItems();
+  
   //disables user from deleting last graph from the graph
-  if(count == 1) {
+  if(count == 1 || count == lst.size()) {
   QMessageBox::information( 
     this, 
     tr("Error - Cannot Delete "), 
     tr("There should be at least one graph plotted in the graph contents ") );
 	return; 
   }
-
-  QList<QListWidgetItem *> lst = contents->selectedItems();
+  
   for (int i = 0; i < lst.size(); ++i){
     QListWidgetItem *it = lst.at(i);
     QString s = it->text();

--- a/Code/Mantid/MantidPlot/src/CurvesDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/CurvesDialog.cpp
@@ -462,9 +462,9 @@ void CurvesDialog::removeCurves()
   
   //disables user from deleting last graph from the graph
   if(count == 1 || count == lst.size()) {
-  QMessageBox::information( 
+  QMessageBox::warning( 
     this, 
-    tr("Error - Cannot Delete "), 
+    tr("Cannot Delete"), 
     tr("There should be at least one graph plotted in the graph contents ") );
 	return; 
   }


### PR DESCRIPTION
Fixes #13221

To test: 
- Create a plot of few curves
- Right click, and in add/remove select all the curves on the right hand side to delete
- It should display:

`Error - Cannot Delete`
`There should be at least one graph plotted in the graph contents
`
