### PR TITLE
Quasielastic fit functions with conv fit

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -78,7 +78,7 @@ private:
 
 
 
-  QStringList getFunctionParameters(const QString &);
+  QStringList getFunctionParameters(QString);
 
 
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -49,7 +49,7 @@ private:
   boost::shared_ptr<Mantid::API::CompositeFunction>
   createFunction(bool tieCentres = false);
   double getInstrumentResolution(std::string workspaceName);
-  QtProperty *createFitType(const QString &); 
+  QtProperty *createFitType(const QString &);
 
   void createTemperatureCorrection(Mantid::API::CompositeFunction_sptr product);
   void populateFunction(Mantid::API::IFunction_sptr func,
@@ -58,6 +58,7 @@ private:
   QString fitTypeString() const;
   QString backgroundString() const;
   QString minimizerString(QString outputName) const;
+  QStringList getFunctionParameters(QString);
 
   Ui::ConvFit m_uiForm;
   QtStringPropertyManager *m_stringManager;
@@ -68,12 +69,7 @@ private:
   bool m_confitResFileType;
   Mantid::API::IAlgorithm_sptr m_singleFitAlg;
   QString m_singleFitOutputName;
-
-
-
-  QStringList getFunctionParameters(QString);
-  Mantid::API::IAlgorithm_sptr m_fitAlg;
-
+  QStringList m_fitStrings;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -45,6 +45,7 @@ private slots:
   void singleFitComplete(bool error);
   void fitFunctionSelected(const QString &);
 
+
 private:
   boost::shared_ptr<Mantid::API::CompositeFunction>
   createFunction(bool tieCentres = false);
@@ -59,6 +60,7 @@ private:
   QString backgroundString() const;
   QString minimizerString(QString outputName) const;
   QStringList getFunctionParameters(QString);
+  void updatePlotOptions();
 
   Ui::ConvFit m_uiForm;
   QtStringPropertyManager *m_stringManager;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -49,14 +49,7 @@ private:
   boost::shared_ptr<Mantid::API::CompositeFunction>
   createFunction(bool tieCentres = false);
   double getInstrumentResolution(std::string workspaceName);
-  QtProperty *createLorentzian(const QString &);
-  QtProperty *createDiffSphere(const QString &);
-  QtProperty *createDiffRotDiscreteCircle(const QString &);
-  QtProperty *createElasticDiffSphere(const QString &);
-  QtProperty *createElasticDiffRotDiscreteCircle(const QString &);
-  QtProperty *createInelasticDiffSphere(const QString &);
-  QtProperty *createInelasticDiffRotDiscreteCircle(const QString &);
-  QtProperty *createStretchedExpFT(const QString &);
+  QtProperty *createLorentzian(const QString &); 
   void createTemperatureCorrection(Mantid::API::CompositeFunction_sptr product);
   void populateFunction(Mantid::API::IFunction_sptr func,
                         Mantid::API::IFunction_sptr comp, QtProperty *group,
@@ -80,6 +73,8 @@ private:
   QStringList getFunctionParameters(QString);
   Mantid::API::IAlgorithm_sptr m_fitAlg;
 
+
+  void removeTreeParams();
 
 };
 } // namespace IDA

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -6,72 +6,70 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/CompositeFunction.h"
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-namespace IDA
-{
-  class DLLExport ConvFit : public IndirectDataAnalysisTab
-  {
-    Q_OBJECT
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+class DLLExport ConvFit : public IndirectDataAnalysisTab {
+  Q_OBJECT
 
-  public:
-    ConvFit(QWidget * parent = 0);
+public:
+  ConvFit(QWidget *parent = 0);
 
-  private:
-    virtual void setup();
-    virtual void run();
-    virtual bool validate();
-    virtual void loadSettings(const QSettings & settings);
+private:
+  virtual void setup();
+  virtual void run();
+  virtual bool validate();
+  virtual void loadSettings(const QSettings &settings);
 
-  private slots:
-    void typeSelection(int index);
-    void bgTypeSelection(int index);
-    void newDataLoaded(const QString wsName);
-    void extendResolutionWorkspace();
-    void updatePlot();
-    void plotGuess();
-    void singleFit();
-    void specMinChanged(int value);
-    void specMaxChanged(int value);
-    void minChanged(double);
-    void maxChanged(double);
-    void backgLevel(double);
-    void updateRS(QtProperty*, double);
-    void checkBoxUpdate(QtProperty*, bool);
-    void hwhmChanged(double);
-    void hwhmUpdateRS(double);
-    void fitContextMenu(const QPoint &);
-    void fixItem();
-    void unFixItem();
-    void showTieCheckbox(QString);
-    void updatePlotOptions();
-    void singleFitComplete(bool error);
+private slots:
+  void typeSelection(int index);
+  void bgTypeSelection(int index);
+  void newDataLoaded(const QString wsName);
+  void extendResolutionWorkspace();
+  void updatePlot();
+  void plotGuess();
+  void singleFit();
+  void specMinChanged(int value);
+  void specMaxChanged(int value);
+  void minChanged(double);
+  void maxChanged(double);
+  void backgLevel(double);
+  void updateRS(QtProperty *, double);
+  void checkBoxUpdate(QtProperty *, bool);
+  void hwhmChanged(double);
+  void hwhmUpdateRS(double);
+  void fitContextMenu(const QPoint &);
+  void fixItem();
+  void unFixItem();
+  void showTieCheckbox(QString);
+  void updatePlotOptions();
+  void singleFitComplete(bool error);
 
-  private:
-    boost::shared_ptr<Mantid::API::CompositeFunction> createFunction(bool tieCentres=false);
-    double getInstrumentResolution(std::string workspaceName);
-    QtProperty* createLorentzian(const QString &);
-    QtProperty* createDiffSphere(const QString &);
-    QtProperty* createDiffRotDiscreteCircle(const QString &);
-    void createTemperatureCorrection(Mantid::API::CompositeFunction_sptr product);
-    void populateFunction(Mantid::API::IFunction_sptr func, Mantid::API::IFunction_sptr comp, QtProperty* group, const std::string & pref, bool tie);
-    QString fitTypeString() const;
-    QString backgroundString() const;
-    QString minimizerString(QString outputName) const;
+private:
+  boost::shared_ptr<Mantid::API::CompositeFunction>
+  createFunction(bool tieCentres = false);
+  double getInstrumentResolution(std::string workspaceName);
+  QtProperty *createLorentzian(const QString &);
+  QtProperty *createDiffSphere(const QString &);
+  QtProperty *createDiffRotDiscreteCircle(const QString &);
+  void createTemperatureCorrection(Mantid::API::CompositeFunction_sptr product);
+  void populateFunction(Mantid::API::IFunction_sptr func,
+                        Mantid::API::IFunction_sptr comp, QtProperty *group,
+                        const std::string &pref, bool tie);
+  QString fitTypeString() const;
+  QString backgroundString() const;
+  QString minimizerString(QString outputName) const;
 
-    Ui::ConvFit m_uiForm;
-    QtStringPropertyManager* m_stringManager;
-    QtTreePropertyBrowser* m_cfTree;
-    QMap<QtProperty*, QtProperty*> m_fixedProps;
-    Mantid::API::MatrixWorkspace_sptr m_cfInputWS;
-    QString m_cfInputWSName;
-    bool m_confitResFileType;
-    Mantid::API::IAlgorithm_sptr m_singleFitAlg;
-    QString m_singleFitOutputName;
-
-  };
+  Ui::ConvFit m_uiForm;
+  QtStringPropertyManager *m_stringManager;
+  QtTreePropertyBrowser *m_cfTree;
+  QMap<QtProperty *, QtProperty *> m_fixedProps;
+  Mantid::API::MatrixWorkspace_sptr m_cfInputWS;
+  QString m_cfInputWSName;
+  bool m_confitResFileType;
+  Mantid::API::IAlgorithm_sptr m_singleFitAlg;
+  QString m_singleFitOutputName;
+};
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -52,6 +52,11 @@ private:
   QtProperty *createLorentzian(const QString &);
   QtProperty *createDiffSphere(const QString &);
   QtProperty *createDiffRotDiscreteCircle(const QString &);
+  QtProperty *createElasticDiffSphere(const QString &);
+  QtProperty *createElasticDiffRotDiscreteCircle(const QString &);
+  QtProperty *createInelasticDiffSphere(const QString &);
+  QtProperty *createInelasticDiffRotDiscreteCircle(const QString &);
+  QtProperty *createStretchedExpFT(const QString &);
   void createTemperatureCorrection(Mantid::API::CompositeFunction_sptr product);
   void populateFunction(Mantid::API::IFunction_sptr func,
                         Mantid::API::IFunction_sptr comp, QtProperty *group,

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -42,7 +42,6 @@ private slots:
   void fixItem();
   void unFixItem();
   void showTieCheckbox(QString);
-  void updatePlotOptions();
   void singleFitComplete(bool error);
   void fitFunctionSelected(const QString &);
 
@@ -79,6 +78,7 @@ private:
 
 
   QStringList getFunctionParameters(QString);
+  Mantid::API::IAlgorithm_sptr m_fitAlg;
 
 
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -49,7 +49,8 @@ private:
   boost::shared_ptr<Mantid::API::CompositeFunction>
   createFunction(bool tieCentres = false);
   double getInstrumentResolution(std::string workspaceName);
-  QtProperty *createLorentzian(const QString &); 
+  QtProperty *createFitType(const QString &); 
+
   void createTemperatureCorrection(Mantid::API::CompositeFunction_sptr product);
   void populateFunction(Mantid::API::IFunction_sptr func,
                         Mantid::API::IFunction_sptr comp, QtProperty *group,

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -44,6 +44,7 @@ private slots:
   void showTieCheckbox(QString);
   void updatePlotOptions();
   void singleFitComplete(bool error);
+  void fitFunctionSelected(const QString &);
 
 private:
   boost::shared_ptr<Mantid::API::CompositeFunction>
@@ -74,6 +75,12 @@ private:
   bool m_confitResFileType;
   Mantid::API::IAlgorithm_sptr m_singleFitAlg;
   QString m_singleFitOutputName;
+
+
+
+  QStringList getFunctionParameters(const QString &);
+
+
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -74,9 +74,6 @@ private:
   QStringList getFunctionParameters(QString);
   Mantid::API::IAlgorithm_sptr m_fitAlg;
 
-
-  void removeTreeParams();
-
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
@@ -143,12 +143,12 @@
              </item>
              <item>
               <property name="text">
-               <string>DiffSphere</string>
+               <string>InelasticDiffSphere</string>
               </property>
              </item>
              <item>
               <property name="text">
-               <string>DiffRotDiscreteCircle</string>
+               <string>InelasticDiffRotDiscreteCircle</string>
               </property>
              </item>
              <item>
@@ -161,16 +161,6 @@
                 <string>ElasticDiffRotDiscreteCircle</string>
               </property>
              </item>
-              <item>
-                <property name="text">
-                  <string>InelasticDiffSphere</string>
-                </property>
-              </item>
-              <item>
-                <property name="text">
-                  <string>InelasticDiffRotDiscreteCircle</string>
-                </property>
-              </item>
               <item>
                 <property name="text">
                   <string>StretchedExpFT</string>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
@@ -143,37 +143,37 @@
              </item>
              <item>
               <property name="text">
-               <string>Diffusion Sphere</string>
+               <string>DiffSphere</string>
               </property>
              </item>
              <item>
               <property name="text">
-               <string>Diffusion Circle</string>
+               <string>DiffRotDiscreteCircle</string>
               </property>
              </item>
              <item>
               <property name="text">
-                <string>Elastic Diffusion Sphere</string>
+                <string>ElasticDiffSphere</string>
               </property>
              </item>
              <item>
               <property name="text">
-                <string>Elastic Diffusion Circle</string>
+                <string>ElasticDiffRotDiscreteCircle</string>
               </property>
              </item>
               <item>
                 <property name="text">
-                  <string>Inelastic Diffusion Sphere</string>
+                  <string>InelasticDiffSphere</string>
                 </property>
               </item>
               <item>
                 <property name="text">
-                  <string>Inelastic Diffusion Circle</string>
+                  <string>InelasticDiffRotDiscreteCircle</string>
                 </property>
               </item>
               <item>
                 <property name="text">
-                  <string>Strecthced Exponential Fit</string>
+                  <string>StretchedExpFT</string>
                 </property>
               </item>
             </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
@@ -151,6 +151,31 @@
                <string>Diffusion Circle</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+                <string>Elastic Diffusion Sphere</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+                <string>Elastic Diffusion Circle</string>
+              </property>
+             </item>
+              <item>
+                <property name="text">
+                  <string>Inelastic Diffusion Sphere</string>
+                </property>
+              </item>
+              <item>
+                <property name="text">
+                  <string>Inelastic Diffusion Circle</string>
+                </property>
+              </item>
+              <item>
+                <property name="text">
+                  <string>Strecthced Exponential Fit</string>
+                </property>
+              </item>
             </widget>
            </item>
           </layout>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1353,12 +1353,15 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
  * @param functionName Name of new fit function
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
+  //remove previous parameters from tree
   m_cfTree->removeProperty(m_properties["FitFunction1"]);
   m_cfTree->removeProperty(m_properties["FitFunction2"]);
-  int fitFunctionIndex = m_uiForm.cbFitType->currentIndex();
+
   // Add new parameter elements
+  int fitFunctionIndex = m_uiForm.cbFitType->currentIndex();
   QStringList parameters = getFunctionParameters(functionName);
 
+  //Two Loremtzians Fit
   if (fitFunctionIndex == 2) {
     m_properties["FitFunction1"] = m_grpManager->addProperty("Lorentzian 1");
     m_cfTree->addProperty(m_properties["FitFunction1"]);
@@ -1372,6 +1375,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   QString propName;
   // No fit function parameters required for Zero
   if (parameters[0].compare("Zero") != 0) {
+	//Two Lorentzians Fit
     if (fitFunctionIndex == 2) {
       int count = 0;
       propName = "Lorentzian 1";
@@ -1381,7 +1385,13 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         }
         QString name = propName + "." + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
-        m_dblManager->setValue(m_properties[name], 0.0);
+
+        if (QString(*it).compare("FWHM") == 0) {
+          m_dblManager->setValue(m_properties[name], 0.0175);
+        } else {
+          m_dblManager->setValue(m_properties[name], 0.0);
+        }
+
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
         if (count < 3) {
           m_properties["FitFunction1"]->addSubProperty(m_properties[name]);
@@ -1399,7 +1409,13 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
       for (auto it = parameters.begin(); it != parameters.end(); ++it) {
         QString name = propName + "." + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
-        m_dblManager->setValue(m_properties[name], 0.0);
+
+        if (QString(*it).compare("FWHM") == 0) {
+          m_dblManager->setValue(m_properties[name], 0.0175);
+        } else {
+          m_dblManager->setValue(m_properties[name], 0.0);
+        }
+
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
         m_properties["FitFunction1"]->addSubProperty(m_properties[name]);
       }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -456,8 +456,7 @@ std::string createParName(size_t index, size_t subIndex,
  *					+- Temperature Correction(yes/no)
  *				+- ProductFunction
  *					|
- *					+-
- *InelasticDiffRotDiscreteCircle(yes/no)
+ *					+- InelasticDiffRotDiscreteCircle(yes/no)
  *					+- Temperature Correction(yes/no)
  *
  * @param tieCentres :: whether to tie centres of the two lorentzians.
@@ -1112,15 +1111,13 @@ void ConvFit::singleFitComplete(bool error) {
     pref += "f" + QString::number(subIndex) + ".";
   }
 
-  if (m_uiForm.cbFitType->currentIndex() == 1) {
+  if (fitTypeIndex == 1 || fitTypeIndex == 2) {
     functionName = "Lorentzian 1";
   }
 
-  for (auto it = params.begin(); it != params.end(); ++it) {
+  for (auto it = params.begin(); it != params.end() - 3; ++it) {
     QString functionParam = functionName + "." + *it;
-    std::string fp = functionParam.toStdString();
     QString paramValue = pref + *it;
-    std::string pv = paramValue.toStdString();
     m_dblManager->setValue(m_properties[functionParam], parameters[paramValue]);
   }
   funcIndex++;
@@ -1132,7 +1129,7 @@ void ConvFit::singleFitComplete(bool error) {
 
     functionName = "Lorentzian 2";
 
-    for (auto it = params.begin(); it != params.end(); ++it) {
+    for (auto it = params.begin() + 3; it != params.end(); ++it) {
       QString functionParam = functionName + "." + *it;
       QString paramValue = pref + *it;
       m_dblManager->setValue(m_properties[functionParam],
@@ -1181,7 +1178,6 @@ void ConvFit::hwhmChanged(double val) {
   auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
   hwhmRangeSelector->blockSignals(true);
   m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], hwhm * 2);
-  m_dblManager->setValue(m_properties["Lorentzian 2.FWHM"], hwhm * 2);
   hwhmRangeSelector->blockSignals(false);
 }
 
@@ -1378,8 +1374,11 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   if (parameters[0].compare("Zero") != 0) {
     if (fitFunctionIndex == 2) {
       int count = 0;
-      propName = "Lorentzian 2";
+      propName = "Lorentzian 1";
       for (auto it = parameters.begin(); it != parameters.end(); ++it) {
+        if (count == 3) {
+          propName = "Lorentzian 2";
+        }
         QString name = propName + "." + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
         m_dblManager->setValue(m_properties[name], 0.0);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -456,7 +456,8 @@ std::string createParName(size_t index, size_t subIndex,
  *					+- Temperature Correction(yes/no)
  *				+- ProductFunction
  *					|
- *					+- InelasticDiffRotDiscreteCircle(yes/no)
+ *					+-
+ *InelasticDiffRotDiscreteCircle(yes/no)
  *					+- Temperature Correction(yes/no)
  *
  * @param tieCentres :: whether to tie centres of the two lorentzians.
@@ -1114,15 +1115,15 @@ void ConvFit::singleFitComplete(bool error) {
     functionName = "Lorentzian 1";
   }
 
-  for (auto it = params.begin(); it != params.end() - 3; ++it) {
-    QString functionParam = functionName + "." + *it;
-    QString paramValue = pref + *it;
-    m_dblManager->setValue(m_properties[functionParam], parameters[paramValue]);
-  }
-  funcIndex++;
   if (fitTypeIndex == 2) {
-    // Two Lorentz
-    QString pref = prefBase;
+    for (auto it = params.begin(); it != params.end() - 3; ++it) {
+      QString functionParam = functionName + "." + *it;
+      QString paramValue = pref + *it;
+      m_dblManager->setValue(m_properties[functionParam],
+                             parameters[paramValue]);
+    }
+
+    pref = prefBase;
     pref += "f" + QString::number(funcIndex) + ".f" +
             QString::number(subIndex) + ".";
 
@@ -1134,7 +1135,17 @@ void ConvFit::singleFitComplete(bool error) {
       m_dblManager->setValue(m_properties[functionParam],
                              parameters[paramValue]);
     }
+
+  } else {
+    for (auto it = params.begin(); it != params.end(); ++it) {
+      QString functionParam = functionName + "." + *it;
+      QString paramValue = pref + *it;
+      m_dblManager->setValue(m_properties[functionParam],
+                             parameters[paramValue]);
+    }
   }
+  funcIndex++;
+
   m_pythonExportWsName = "";
 }
 
@@ -1352,7 +1363,7 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
  * @param functionName Name of new fit function
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
-  //remove previous parameters from tree
+  // remove previous parameters from tree
   m_cfTree->removeProperty(m_properties["FitFunction1"]);
   m_cfTree->removeProperty(m_properties["FitFunction2"]);
 
@@ -1360,7 +1371,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   int fitFunctionIndex = m_uiForm.cbFitType->currentIndex();
   QStringList parameters = getFunctionParameters(functionName);
 
-  //Two Loremtzians Fit
+  // Two Loremtzians Fit
   if (fitFunctionIndex == 2) {
     m_properties["FitFunction1"] = m_grpManager->addProperty("Lorentzian 1");
     m_cfTree->addProperty(m_properties["FitFunction1"]);
@@ -1374,7 +1385,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   QString propName;
   // No fit function parameters required for Zero
   if (parameters[0].compare("Zero") != 0) {
-	//Two Lorentzians Fit
+    // Two Lorentzians Fit
     if (fitFunctionIndex == 2) {
       int count = 0;
       propName = "Lorentzian 1";

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -412,8 +412,7 @@ std::string createParName(size_t index, size_t subIndex,
 
 /**
  * Creates a function to carry out the fitting in the "ConvFit" tab.  The
- *function consists
- * of various sub functions, with the following structure:
+ * function consists of various sub functions, with the following structure:
  *
  * Composite
  *  |
@@ -785,12 +784,12 @@ QtProperty *ConvFit::createDiffRotDiscreteCircle(const QString &name) {
 }
 
 /**
- * Populates the properties of a function with required values
- * @param func The function tobe populated
- * @param comp The composite function
+ * Populates the properties of a function with given values
+ * @param func The function currently being added to the composite
+ * @param comp A composite function of the previously called functions
  * @param group The QtProperty representing the fit type
  * @param pref The index of the functions eg. (f0.f1)
- * @param tie 
+ * @param tie Bool to state if parameters are to be tied together
  */
 void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp,
                                QtProperty *group, const std::string &pref,

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -703,7 +703,6 @@ QtProperty *ConvFit::createFitType(const QString &propName) {
 
   for (auto it = params.begin(); it != params.end(); ++it) {
     QString paramName = propName + "." + *it;
-    std::string test = paramName.toStdString();
     m_properties[paramName] = m_dblManager->addProperty(*it);
     m_dblManager->setDecimals(m_properties[paramName], NUM_DECIMALS);
     if (QString(*it).compare("FWHM") == 0) {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1459,7 +1459,6 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
 
 /**
  * Populates the plot combobox
- * @param params The values to append to the list of plot Types
  */
 void ConvFit::updatePlotOptions() {
   m_uiForm.cbPlotType->clear();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -196,109 +196,100 @@ void ConvFit::setup() {
   showTieCheckbox(m_uiForm.cbFitType->currentText());
 
   // Fitting function
-  /*m_properties["FitFunction"] = m_grpManager->addProperty("Fitting Parameters");
+  /*m_properties["FitFunction"] = m_grpManager->addProperty("Fitting
+  Parameters");
   m_cfTree->addProperty(m_properties["FitFunction"]);*/
 
   // Update fit parameters in browser when function is selected
-  connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(QString)),
-          this, SLOT(fitFunctionSelected(const QString &)));
+  connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(QString)), this,
+          SLOT(fitFunctionSelected(const QString &)));
   fitFunctionSelected(m_uiForm.cbFitType->currentText());
-
 }
 
 /**
  * Converts data into a python script which prodcues the output workspace
  */
-//void ConvFit::run() {
-  /*if (m_cfInputWS == NULL) {
-    g_log.error("No workspace loaded");
-    return;
-  }
+// void ConvFit::run() {
+/*if (m_cfInputWS == NULL) {
+  g_log.error("No workspace loaded");
+  return;
+}
 
-  QString fitType = fitTypeString();
-  QString bgType = backgroundString();
+QString fitType = fitTypeString();
+QString bgType = backgroundString();
 
-  if (fitType == "") {
-    g_log.error("No fit type defined");
-  }
+if (fitType == "") {
+  g_log.error("No fit type defined");
+}
 
-  bool useTies = m_uiForm.ckTieCentres->isChecked();
-  QString ties = (useTies ? "True" : "False");
+bool useTies = m_uiForm.ckTieCentres->isChecked();
+QString ties = (useTies ? "True" : "False");
 
-  CompositeFunction_sptr func = createFunction(useTies);
-  std::string function = std::string(func->asString());
-  QString stX = m_properties["StartX"]->valueText();
-  QString enX = m_properties["EndX"]->valueText();
-  QString specMin = m_uiForm.spSpectraMin->text();
-  QString specMax = m_uiForm.spSpectraMax->text();
-  int maxIterations =
-      static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
+CompositeFunction_sptr func = createFunction(useTies);
+std::string function = std::string(func->asString());
+QString stX = m_properties["StartX"]->valueText();
+QString enX = m_properties["EndX"]->valueText();
+QString specMin = m_uiForm.spSpectraMin->text();
+QString specMax = m_uiForm.spSpectraMax->text();
+int maxIterations =
+    static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
 
-  QString pyInput = "from IndirectDataAnalysis import confitSeq\n"
-                    "input = '" +
-                    m_cfInputWSName + "'\n"
-                                      "func = r'" +
-                    QString::fromStdString(function) + "'\n"
-                                                       "startx = " +
-                    stX + "\n"
-                          "endx = " +
-                    enX + "\n"
-                          "plot = '" +
-                    m_uiForm.cbPlotType->currentText() + "'\n"
-                                                         "ties = " +
-                    ties + "\n"
-                           "specMin = " +
-                    specMin + "\n"
-                              "specMax = " +
-                    specMax + "\n"
-                              "max_iterations = " +
-                    QString::number(maxIterations) + "\n"
-                                                     "minimizer = '" +
-                    minimizerString("$outputname_$wsindex") + "'\n"
-                                                              "save = " +
-                    (m_uiForm.ckSave->isChecked() ? "True\n" : "False\n");
+QString pyInput = "from IndirectDataAnalysis import confitSeq\n"
+                  "input = '" +
+                  m_cfInputWSName + "'\n"
+                                    "func = r'" +
+                  QString::fromStdString(function) + "'\n"
+                                                     "startx = " +
+                  stX + "\n"
+                        "endx = " +
+                  enX + "\n"
+                        "plot = '" +
+                  m_uiForm.cbPlotType->currentText() + "'\n"
+                                                       "ties = " +
+                  ties + "\n"
+                         "specMin = " +
+                  specMin + "\n"
+                            "specMax = " +
+                  specMax + "\n"
+                            "max_iterations = " +
+                  QString::number(maxIterations) + "\n"
+                                                   "minimizer = '" +
+                  minimizerString("$outputname_$wsindex") + "'\n"
+                                                            "save = " +
+                  (m_uiForm.ckSave->isChecked() ? "True\n" : "False\n");
 
-  if (m_blnManager->value(m_properties["Convolve"]))
-    pyInput += "convolve = True\n";
-  else
-    pyInput += "convolve = False\n";
+if (m_blnManager->value(m_properties["Convolve"]))
+  pyInput += "convolve = True\n";
+else
+  pyInput += "convolve = False\n";
 
-  QString temperature = m_uiForm.leTempCorrection->text();
-  bool useTempCorrection =
-      (!temperature.isEmpty() && m_uiForm.ckTempCorrection->isChecked());
-  if (useTempCorrection) {
-    pyInput += "temp=" + temperature + "\n";
-  } else {
-    pyInput += "temp=None\n";
-  }
+QString temperature = m_uiForm.leTempCorrection->text();
+bool useTempCorrection =
+    (!temperature.isEmpty() && m_uiForm.ckTempCorrection->isChecked());
+if (useTempCorrection) {
+  pyInput += "temp=" + temperature + "\n";
+} else {
+  pyInput += "temp=None\n";
+}
 
-  pyInput += "bg = '" + bgType + "'\n"
-                                 "ftype = '" +
-             fitType +
-             "'\n"
-             "rws = confitSeq(input, func, startx, endx, ftype, bg, temp, "
-             "specMin, specMax, convolve, max_iterations=max_iterations, "
-             "minimizer=minimizer, Plot=plot, Save=save)\n"
-             "AddSampleLog(Workspace=rws, LogName='res_workspace', LogText='" +
-             m_uiForm.dsResInput->getCurrentDataName() + "')\n"
-                                                         "print rws\n";
+pyInput += "bg = '" + bgType + "'\n"
+                               "ftype = '" +
+           fitType +
+           "'\n"
+           "rws = confitSeq(input, func, startx, endx, ftype, bg, temp, "
+           "specMin, specMax, convolve, max_iterations=max_iterations, "
+           "minimizer=minimizer, Plot=plot, Save=save)\n"
+           "AddSampleLog(Workspace=rws, LogName='res_workspace', LogText='" +
+           m_uiForm.dsResInput->getCurrentDataName() + "')\n"
+                                                       "print rws\n";
 
-  QString pyOutput = runPythonCode(pyInput);
+QString pyOutput = runPythonCode(pyInput);
 
-  // Set the result workspace for Python script export
-  m_pythonExportWsName = pyOutput.toStdString();
+// Set the result workspace for Python script export
+m_pythonExportWsName = pyOutput.toStdString();
 
-  updatePlot();*/
+updatePlot();*/
 //}
-
-
-
-
-
-
-
-
-
 
 /**
  * Runs algorithm.
@@ -312,11 +303,11 @@ void ConvFit::run() {
 
   // Fit function to use
   QString functionName = m_uiForm.cbFitType->currentText();
-  if(functionName.compare("One Lorentzian") == 0){
-	functionName = "Lorentzian";
+  if (functionName.compare("One Lorentzian") == 0) {
+    functionName = "Lorentzian";
   }
-  if(functionName.compare("Two Lorentzian") == 0){
-   //Implement two peak lorentxian behaviour
+  if (functionName.compare("Two Lorentzian") == 0) {
+    // Implement two peak lorentxian behaviour
   }
   QString functionString = "name=" + functionName;
 
@@ -349,31 +340,18 @@ void ConvFit::run() {
   m_fitAlg->setProperty("CreateOutput", true);
   m_fitAlg->setProperty("Output", outputName.toStdString());
 
-
-  //Debugging
+  // Debugging
   std::string fs = functionString.toStdString();
   std::string smple = sample.toStdString();
   double sx = m_dblManager->value(m_properties["StartX"]);
   double ex = m_dblManager->value(m_properties["EndX"]);
   std::string on = outputName.toStdString();
 
-
   m_batchAlgoRunner->addAlgorithm(m_fitAlg);
   m_batchAlgoRunner->executeBatchAsync();
 
   updatePlot();
 }
-
-
-
-
-
-
-
-
-
-
-
 
 /**
  * Validates the user's inputs in the ConvFit tab.
@@ -529,25 +507,30 @@ std::string createParName(size_t index, size_t subIndex,
  *							|
  *							+-- Lorentzian 1
  *(yes/no)
- *							+-- Temperature Correction
+ *							+-- Temperature
+ *Correction
  *(yes/no)
  *					+-- ProductFunction
  *							|
  *							+-- Lorentzian 2
  *(yes/no)
- *							+-- Temperature Correction
+ *							+-- Temperature
+ *Correction
  *(yes/no)
  *					+-- ProductFunction
  *							|
  *							+-- InelasticDiffSphere
  *(yes/no)
- *							+-- Temperature Correction
+ *							+-- Temperature
+ *Correction
  *(yes/no)
  *					+-- ProductFunction
  *							|
- *							+-- InelasticDiffRotDiscreteCircle
+ *							+--
+ *InelasticDiffRotDiscreteCircle
  *(yes/no)
- *							+-- Temperature Correction
+ *							+-- Temperature
+ *Correction
  *(yes/no)
  *
  * @param tieCentres :: whether to tie centres of the two lorentzians.
@@ -1052,7 +1035,6 @@ QString ConvFit::minimizerString(QString outputName) const {
 void ConvFit::typeSelection(int index) {
   m_uiForm.ckPlotGuess->setEnabled(index < 3);
   m_properties["UseDeltaFunc"]->setEnabled(index < 3);
-
 }
 
 /**
@@ -1561,13 +1543,6 @@ void ConvFit::showTieCheckbox(QString fitType) {
   m_uiForm.ckTieCentres->setVisible(fitType == "Two Lorentzians");
 }
 
-
-
-
-
-
-
-
 /**
  * Gets a list of parameters for a given fit function.
  *
@@ -1608,7 +1583,7 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
  * @param functionName Name of new fit function
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
-  //remove old parameter elements 
+  // remove old parameter elements
   for (auto it = m_properties.begin(); it != m_properties.end();) {
     if (it.key().startsWith("parameter_")) {
       delete it.value();
@@ -1618,9 +1593,8 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
     }
   }
 
-    m_cfTree->removeProperty(m_properties["FitFunction1"]);
-    m_cfTree->removeProperty(m_properties["FitFunction2"]);
-
+  m_cfTree->removeProperty(m_properties["FitFunction1"]);
+  m_cfTree->removeProperty(m_properties["FitFunction2"]);
 
   // Add new parameter elements
   QStringList parameters = getFunctionParameters(functionName);
@@ -1633,7 +1607,6 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
     m_properties["FitFunction1"] = m_grpManager->addProperty(functionName);
     m_cfTree->addProperty(m_properties["FitFunction1"]);
   }
-
 
   if (parameters[0].compare("Zero") != 0) {
     if (functionName.compare("Two Lorentzians") == 0) {
@@ -1659,8 +1632,6 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
       }
     }
   }
-
-
 }
 
 } // namespace IDA

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1401,6 +1401,9 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         } else {
           m_dblManager->setValue(m_properties[name], 0.0);
         }
+		if (QString(*it).compare("Amplitude") == 0 || QString(*it).compare("Intensity") == 0){
+		  m_dblManager->setValue(m_properties[name], 1.0);
+		}
 
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
         if (count < 3) {
@@ -1425,6 +1428,9 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         } else {
           m_dblManager->setValue(m_properties[name], 0.0);
         }
+		if (QString(*it).compare("Amplitude") == 0 || QString(*it).compare("Intensity") == 0){
+		  m_dblManager->setValue(m_properties[name], 1.0);
+		}
 
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
         m_properties["FitFunction1"]->addSubProperty(m_properties[name]);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -109,23 +109,6 @@ void ConvFit::setup() {
   m_properties["DeltaFunction"]->addSubProperty(m_properties["UseDeltaFunc"]);
   m_cfTree->addProperty(m_properties["DeltaFunction"]);
 
-  // Fit functions
-  m_properties["Lorentzian1"] = createLorentzian("Lorentzian 1");
-  m_properties["Lorentzian2"] = createLorentzian("Lorentzian 2");
-  m_properties["DiffSphere"] = createDiffSphere("Diffusion Sphere");
-  m_properties["DiffRotDiscreteCircle"] =
-      createDiffRotDiscreteCircle("Diffusion Circle");
-  m_properties["ElasticDiffSphere"] =
-      createElasticDiffSphere("Elastic Diffusion Sphere");
-  m_properties["ElasticDiffRotDiscreteCircle"] =
-      createElasticDiffRotDiscreteCircle("Elastic Diffusion Circle");
-  m_properties["InelasticDiffSphere"] =
-      createInelasticDiffSphere("Inelastic Diffusion Sphere");
-  m_properties["InelasticDiffRotDiscreteCircle"] =
-      createInelasticDiffRotDiscreteCircle("Inelastic Diffusion Circle");
-  m_properties["StretchedExpFT"] =
-      createStretchedExpFT("Strecthced Exponential Fit");
-
   m_uiForm.leTempCorrection->setValidator(new QDoubleValidator(m_parentWidget));
 
   // Connections
@@ -195,11 +178,6 @@ void ConvFit::setup() {
           SLOT(showTieCheckbox(QString)));
   showTieCheckbox(m_uiForm.cbFitType->currentText());
 
-  // Fitting function
-  /*m_properties["FitFunction"] = m_grpManager->addProperty("Fitting
-  Parameters");
-  m_cfTree->addProperty(m_properties["FitFunction"]);*/
-
   // Update fit parameters in browser when function is selected
   connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(QString)), this,
           SLOT(fitFunctionSelected(const QString &)));
@@ -209,8 +187,8 @@ void ConvFit::setup() {
 /**
  * Converts data into a python script which prodcues the output workspace
  */
-// void ConvFit::run() {
-/*if (m_cfInputWS == NULL) {
+ void ConvFit::run() {
+if (m_cfInputWS == NULL) {
   g_log.error("No workspace loaded");
   return;
 }
@@ -288,8 +266,10 @@ QString pyOutput = runPythonCode(pyInput);
 // Set the result workspace for Python script export
 m_pythonExportWsName = pyOutput.toStdString();
 
-updatePlot();*/
-//}
+updatePlot();
+}
+
+
 
 /**
  * Runs algorithm.
@@ -297,7 +277,7 @@ updatePlot();*/
  * @param plot Enable/disable plotting
  * @param save Enable/disable saving
  */
-void ConvFit::run() {
+/*void ConvFit::run() {
   if (m_batchAlgoRunner->queueLength() > 0)
     return;
 
@@ -307,7 +287,7 @@ void ConvFit::run() {
     functionName = "Lorentzian";
   }
   if (functionName.compare("Two Lorentzian") == 0) {
-    // Implement two peak lorentxian behaviour
+    // Implement two peak lorentzian behaviour
   }
   QString functionString = "name=" + functionName;
 
@@ -340,18 +320,19 @@ void ConvFit::run() {
   m_fitAlg->setProperty("CreateOutput", true);
   m_fitAlg->setProperty("Output", outputName.toStdString());
 
-  // Debugging
+  // Debugging -----------TO BE REMOVED
   std::string fs = functionString.toStdString();
   std::string smple = sample.toStdString();
   double sx = m_dblManager->value(m_properties["StartX"]);
   double ex = m_dblManager->value(m_properties["EndX"]);
   std::string on = outputName.toStdString();
+  std::string funcString = functionString.toStdString();
 
   m_batchAlgoRunner->addAlgorithm(m_fitAlg);
   m_batchAlgoRunner->executeBatchAsync();
 
   updatePlot();
-}
+}*/
 
 /**
  * Validates the user's inputs in the ConvFit tab.
@@ -820,89 +801,6 @@ QtProperty *ConvFit::createLorentzian(const QString &name) {
   lorentzGroup->addSubProperty(m_properties[name + ".FWHM"]);
 
   return lorentzGroup;
-}
-
-/**
- * Creates a DiffSphere
- * @param name The name of the DiffSphere
- * @return The QTProperty that represents the DiffSphere
- */
-QtProperty *ConvFit::createDiffSphere(const QString &name) {
-  QtProperty *diffSphereGroup = m_grpManager->addProperty(name);
-
-  m_properties[name + ".Intensity"] = m_dblManager->addProperty("Intensity");
-  m_properties[name + ".Radius"] = m_dblManager->addProperty("Radius");
-  m_properties[name + ".Diffusion"] = m_dblManager->addProperty("Diffusion");
-  m_properties[name + ".Shift"] = m_dblManager->addProperty("Shift");
-
-  m_dblManager->setDecimals(m_properties[name + ".Intensity"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties[name + ".Radius"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties[name + ".Diffusion"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties[name + ".Shift"], NUM_DECIMALS);
-
-  diffSphereGroup->addSubProperty(m_properties[name + ".Intensity"]);
-  diffSphereGroup->addSubProperty(m_properties[name + ".Radius"]);
-  diffSphereGroup->addSubProperty(m_properties[name + ".Diffusion"]);
-  diffSphereGroup->addSubProperty(m_properties[name + ".Shift"]);
-
-  return diffSphereGroup;
-}
-
-/**
- * Creates a DiffRotDiscreteCircle
- * @param name The name of the DiffRotDiscreteCircle
- * @return The QTProperty that represents the DiffRotDiscreteCircle
- */
-QtProperty *ConvFit::createDiffRotDiscreteCircle(const QString &name) {
-  QtProperty *diffRotDiscreteCircleGroup = m_grpManager->addProperty(name);
-
-  m_properties[name + ".N"] = m_dblManager->addProperty("N");
-  m_dblManager->setValue(m_properties[name + ".N"], 3.0);
-
-  m_properties[name + ".Intensity"] = m_dblManager->addProperty("Intensity");
-  m_properties[name + ".Radius"] = m_dblManager->addProperty("Radius");
-  m_properties[name + ".Decay"] = m_dblManager->addProperty("Decay");
-  m_properties[name + ".Shift"] = m_dblManager->addProperty("Shift");
-
-  m_dblManager->setDecimals(m_properties[name + ".N"], 0);
-  m_dblManager->setDecimals(m_properties[name + ".Intensity"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties[name + ".Radius"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties[name + ".Decay"], NUM_DECIMALS);
-  m_dblManager->setDecimals(m_properties[name + ".Shift"], NUM_DECIMALS);
-
-  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".N"]);
-  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Intensity"]);
-  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Radius"]);
-  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Decay"]);
-  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Shift"]);
-
-  return diffRotDiscreteCircleGroup;
-}
-
-QtProperty *ConvFit::createElasticDiffSphere(const QString &name) {
-  QtProperty *elasticDiffSphereGroup = m_grpManager->addProperty(name);
-  return elasticDiffSphereGroup;
-}
-
-QtProperty *ConvFit::createElasticDiffRotDiscreteCircle(const QString &name) {
-  QtProperty *elasticDiffRotDiscreteCircleGroup =
-      m_grpManager->addProperty(name);
-  return elasticDiffRotDiscreteCircleGroup;
-}
-
-QtProperty *ConvFit::createInelasticDiffSphere(const QString &name) {
-  QtProperty *elasticDiffSphereGroup = m_grpManager->addProperty(name);
-  return elasticDiffSphereGroup;
-}
-
-QtProperty *ConvFit::createInelasticDiffRotDiscreteCircle(const QString &name) {
-  QtProperty *inelasticDiffSphereGroup = m_grpManager->addProperty(name);
-  return inelasticDiffSphereGroup;
-}
-
-QtProperty *ConvFit::createStretchedExpFT(const QString &name) {
-  QtProperty *stretchedExpFTGroup = m_grpManager->addProperty(name);
-  return stretchedExpFTGroup;
 }
 
 /**
@@ -1522,6 +1420,9 @@ void ConvFit::fixItem() {
   item->parent()->property()->removeSubProperty(prop);
 }
 
+/**
+ * 
+ */
 void ConvFit::unFixItem() {
   QtBrowserItem *item = m_cfTree->currentItem();
 
@@ -1539,9 +1440,11 @@ void ConvFit::unFixItem() {
   delete prop;
 }
 
+
 void ConvFit::showTieCheckbox(QString fitType) {
   m_uiForm.ckTieCentres->setVisible(fitType == "Two Lorentzians");
 }
+
 
 /**
  * Gets a list of parameters for a given fit function.
@@ -1577,24 +1480,13 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
   return parameters;
 }
 
+
 /**
  * Handles a new fit function being selected.
- *
  * @param functionName Name of new fit function
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
-  // remove old parameter elements
-  for (auto it = m_properties.begin(); it != m_properties.end();) {
-    if (it.key().startsWith("parameter_")) {
-      delete it.value();
-      it = m_properties.erase(it);
-    } else {
-      ++it;
-    }
-  }
-
-  m_cfTree->removeProperty(m_properties["FitFunction1"]);
-  m_cfTree->removeProperty(m_properties["FitFunction2"]);
+  removeTreeParams();
 
   // Add new parameter elements
   QStringList parameters = getFunctionParameters(functionName);
@@ -1608,6 +1500,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
     m_cfTree->addProperty(m_properties["FitFunction1"]);
   }
 
+  //No fit function parameters required for Zero
   if (parameters[0].compare("Zero") != 0) {
     if (functionName.compare("Two Lorentzians") == 0) {
       int count = 0;
@@ -1615,6 +1508,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         QString name = "parameter_" + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
         m_dblManager->setValue(m_properties[name], 0.0);
+		m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
         if (count < 3) {
           m_properties["FitFunction1"]->addSubProperty(m_properties[name]);
         } else {
@@ -1622,16 +1516,32 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         }
         count++;
       }
-
     } else {
       for (auto it = parameters.begin(); it != parameters.end(); ++it) {
         QString name = "parameter_" + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
         m_dblManager->setValue(m_properties[name], 0.0);
-        m_properties["FitFunction1"]->addSubProperty(m_properties[name]);
+		m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
+        m_properties["FitFunction1"]->addSubProperty(m_properties[name]);		
       }
     }
   }
+}
+
+/**
+ * Removes fit function related parameters from the cfTree 
+ */ 
+void ConvFit::removeTreeParams() {
+  for (auto it = m_properties.begin(); it != m_properties.end();) {
+    if (it.key().startsWith("parameter_")) {
+      delete it.value();
+      it = m_properties.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  m_cfTree->removeProperty(m_properties["FitFunction1"]);
+  m_cfTree->removeProperty(m_properties["FitFunction2"]);
 }
 
 } // namespace IDA

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1213,6 +1213,7 @@ void ConvFit::hwhmChanged(double val) {
   auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
   hwhmRangeSelector->blockSignals(true);
   m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], hwhm * 2);
+  m_dblManager->setValue(m_properties["Lorentzian 2.FWHM"], hwhm * 2);
   hwhmRangeSelector->blockSignals(false);
 }
 
@@ -1390,7 +1391,8 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
  * @param functionName Name of new fit function
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
-  removeTreeParams();
+  m_cfTree->removeProperty(m_properties["FitFunction1"]);
+  m_cfTree->removeProperty(m_properties["FitFunction2"]);
   int fitFunctionIndex = m_uiForm.cbFitType->currentIndex();
   // Add new parameter elements
   QStringList parameters = getFunctionParameters(functionName);
@@ -1405,12 +1407,14 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
     m_cfTree->addProperty(m_properties["FitFunction1"]);
   }
 
+  QString propName;
   // No fit function parameters required for Zero
   if (parameters[0].compare("Zero") != 0) {
     if (fitFunctionIndex == 2) {
       int count = 0;
+	  propName = "Lorentzian 2";
       for (auto it = parameters.begin(); it != parameters.end(); ++it) {
-        QString name = "parameter_" + *it;
+        QString name = propName + "." + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
         m_dblManager->setValue(m_properties[name], 0.0);
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
@@ -1422,8 +1426,13 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         count++;
       }
     } else {
+	  if(fitFunctionIndex == 1){
+		propName = "Lorentzian 1";
+	  }else{
+		propName = functionName;
+	  }
       for (auto it = parameters.begin(); it != parameters.end(); ++it) {
-        QString name = "parameter_" + *it;
+        QString name = propName + "." + *it;
         m_properties[name] = m_dblManager->addProperty(*it);
         m_dblManager->setValue(m_properties[name], 0.0);
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
@@ -1433,21 +1442,6 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   }
 }
 
-/**
- * Removes fit function related parameters from the cfTree
- */
-void ConvFit::removeTreeParams() {
-  for (auto it = m_properties.begin(); it != m_properties.end();) {
-    if (it.key().startsWith("parameter_")) {
-      delete it.value();
-      it = m_properties.erase(it);
-    } else {
-      ++it;
-    }
-  }
-  m_cfTree->removeProperty(m_properties["FitFunction1"]);
-  m_cfTree->removeProperty(m_properties["FitFunction2"]);
-}
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -514,8 +514,6 @@ CompositeFunction_sptr ConvFit::createFunction(bool tieCentres) {
 
   bool useDeltaFunc = m_blnManager->value(m_properties["UseDeltaFunc"]);
 
-  size_t subIndex = 0;
-
   if (useDeltaFunc) {
     func = FunctionFactory::Instance().createFunction("DeltaFunction");
     index = model->addFunction(func);
@@ -542,12 +540,14 @@ CompositeFunction_sptr ConvFit::createFunction(bool tieCentres) {
 
   int fitTypeIndex = m_uiForm.cbFitType->currentIndex();
   if (fitTypeIndex > 0) {
+    size_t subIndex = 0;
     auto product = boost::dynamic_pointer_cast<CompositeFunction>(
         FunctionFactory::Instance().createFunction("ProductFunction"));
 
     if (useTempCorrection) {
       createTemperatureCorrection(product);
     }
+
     // Add 1st Lorentzian
 
     // if temperature not included then product is lorentzian * 1

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1368,6 +1368,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   // remove previous parameters from tree
   m_cfTree->removeProperty(m_properties["FitFunction1"]);
   m_cfTree->removeProperty(m_properties["FitFunction2"]);
+  m_uiForm.ckTieCentres->setChecked(false);
 
   // Add new parameter elements
   int fitFunctionIndex = m_uiForm.cbFitType->currentIndex();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -871,7 +871,7 @@ void ConvFit::updatePlot() {
     return;
   }
 
-  const bool plotGuess = m_uiForm.ckPlotGuess->isChecked();
+  bool plotGuess = m_uiForm.ckPlotGuess->isChecked();
   m_uiForm.ckPlotGuess->setChecked(false);
 
   int specNo = m_uiForm.spPlotSpectrum->text().toInt();
@@ -921,6 +921,10 @@ void ConvFit::plotGuess() {
   if (!(m_uiForm.dsSampleInput->isValid() && m_uiForm.dsResInput->isValid() &&
         m_uiForm.ckPlotGuess->isChecked()))
     return;
+
+  if(m_uiForm.cbFitType->currentIndex() > 2){
+	return;
+  }
 
   bool tieCentres = (m_uiForm.cbFitType->currentIndex() > 1);
   CompositeFunction_sptr function = createFunction(tieCentres);
@@ -1368,7 +1372,10 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   // remove previous parameters from tree
   m_cfTree->removeProperty(m_properties["FitFunction1"]);
   m_cfTree->removeProperty(m_properties["FitFunction2"]);
+  
+  m_uiForm.ckPlotGuess->setChecked(false);
   m_uiForm.ckTieCentres->setChecked(false);
+  
 
   // Add new parameter elements
   int fitFunctionIndex = m_uiForm.cbFitType->currentIndex();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1,11 +1,12 @@
 #include "MantidQtCustomInterfaces/Indirect/ConvFit.h"
 
 #include "MantidQtCustomInterfaces/UserInputValidator.h"
+
 #include "MantidQtMantidWidgets/RangeSelector.h"
 
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/FunctionDomain1D.h"
+#include "MantidAPI/FunctionFactory.h"
 
 #include <QDoubleValidator>
 #include <QFileInfo>
@@ -16,1458 +17,1494 @@
 
 using namespace Mantid::API;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("ConvFit");
+namespace {
+Mantid::Kernel::Logger g_log("ConvFit");
 }
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-namespace IDA
-{
-  ConvFit::ConvFit(QWidget * parent) :
-    IndirectDataAnalysisTab(parent),
-    m_stringManager(NULL), m_cfTree(NULL),
-    m_fixedProps(),
-    m_cfInputWS(), m_cfInputWSName(),
-    m_confitResFileType()
-  {
-    m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+ConvFit::ConvFit(QWidget *parent)
+    : IndirectDataAnalysisTab(parent), m_stringManager(NULL), m_cfTree(NULL),
+      m_fixedProps(), m_cfInputWS(), m_cfInputWSName(), m_confitResFileType() {
+  m_uiForm.setupUi(parent);
+}
+
+void ConvFit::setup() {
+  // Create Property Managers
+  m_stringManager = new QtStringPropertyManager();
+
+  // Create TreeProperty Widget
+  m_cfTree = new QtTreePropertyBrowser();
+  m_uiForm.properties->addWidget(m_cfTree);
+
+  // add factories to managers
+  m_cfTree->setFactoryForManager(m_blnManager, m_blnEdFac);
+  m_cfTree->setFactoryForManager(m_dblManager, m_dblEdFac);
+
+  // Create Range Selectors
+  auto fitRangeSelector = m_uiForm.ppPlot->addRangeSelector("ConvFitRange");
+  auto backRangeSelector = m_uiForm.ppPlot->addRangeSelector(
+      "ConvFitBackRange", MantidWidgets::RangeSelector::YSINGLE);
+  auto hwhmRangeSelector = m_uiForm.ppPlot->addRangeSelector("ConvFitHWHM");
+  backRangeSelector->setColour(Qt::darkGreen);
+  backRangeSelector->setRange(0.0, 1.0);
+  hwhmRangeSelector->setColour(Qt::red);
+
+  // Populate Property Widget
+
+  // Option to convolve members
+  m_properties["Convolve"] = m_blnManager->addProperty("Convolve");
+  m_cfTree->addProperty(m_properties["Convolve"]);
+  m_blnManager->setValue(m_properties["Convolve"], true);
+
+  // Max iterations option
+  m_properties["MaxIterations"] = m_dblManager->addProperty("Max Iterations");
+  m_dblManager->setDecimals(m_properties["MaxIterations"], 0);
+  m_dblManager->setValue(m_properties["MaxIterations"], 500);
+  m_cfTree->addProperty(m_properties["MaxIterations"]);
+
+  // Fitting range
+  m_properties["FitRange"] = m_grpManager->addProperty("Fitting Range");
+  m_properties["StartX"] = m_dblManager->addProperty("StartX");
+  m_dblManager->setDecimals(m_properties["StartX"], NUM_DECIMALS);
+  m_properties["EndX"] = m_dblManager->addProperty("EndX");
+  m_dblManager->setDecimals(m_properties["EndX"], NUM_DECIMALS);
+  m_properties["FitRange"]->addSubProperty(m_properties["StartX"]);
+  m_properties["FitRange"]->addSubProperty(m_properties["EndX"]);
+  m_cfTree->addProperty(m_properties["FitRange"]);
+
+  // FABADA
+  m_properties["FABADA"] = m_grpManager->addProperty("Bayesian");
+  m_properties["UseFABADA"] = m_blnManager->addProperty("Use FABADA");
+  m_properties["FABADA"]->addSubProperty(m_properties["UseFABADA"]);
+  m_properties["OutputFABADAChain"] = m_blnManager->addProperty("Output Chain");
+  m_properties["FABADAChainLength"] = m_dblManager->addProperty("Chain Length");
+  m_dblManager->setDecimals(m_properties["FABADAChainLength"], 0);
+  m_dblManager->setValue(m_properties["FABADAChainLength"], 10000);
+  m_properties["FABADAConvergenceCriteria"] =
+      m_dblManager->addProperty("Convergence Criteria");
+  m_dblManager->setValue(m_properties["FABADAConvergenceCriteria"], 0.1);
+  m_properties["FABADAJumpAcceptanceRate"] =
+      m_dblManager->addProperty("Acceptance Rate");
+  m_dblManager->setValue(m_properties["FABADAJumpAcceptanceRate"], 0.25);
+  m_cfTree->addProperty(m_properties["FABADA"]);
+
+  // Background type
+  m_properties["LinearBackground"] = m_grpManager->addProperty("Background");
+  m_properties["BGA0"] = m_dblManager->addProperty("A0");
+  m_dblManager->setDecimals(m_properties["BGA0"], NUM_DECIMALS);
+  m_properties["BGA1"] = m_dblManager->addProperty("A1");
+  m_dblManager->setDecimals(m_properties["BGA1"], NUM_DECIMALS);
+  m_properties["LinearBackground"]->addSubProperty(m_properties["BGA0"]);
+  m_properties["LinearBackground"]->addSubProperty(m_properties["BGA1"]);
+  m_cfTree->addProperty(m_properties["LinearBackground"]);
+
+  // Delta Function
+  m_properties["DeltaFunction"] = m_grpManager->addProperty("Delta Function");
+  m_properties["UseDeltaFunc"] = m_blnManager->addProperty("Use");
+  m_properties["DeltaHeight"] = m_dblManager->addProperty("Height");
+  m_dblManager->setDecimals(m_properties["DeltaHeight"], NUM_DECIMALS);
+  m_properties["DeltaFunction"]->addSubProperty(m_properties["UseDeltaFunc"]);
+  m_cfTree->addProperty(m_properties["DeltaFunction"]);
+
+  // Fit functions
+  m_properties["Lorentzian1"] = createLorentzian("Lorentzian 1");
+  m_properties["Lorentzian2"] = createLorentzian("Lorentzian 2");
+  m_properties["DiffSphere"] = createDiffSphere("Diffusion Sphere");
+  m_properties["DiffRotDiscreteCircle"] =
+      createDiffRotDiscreteCircle("Diffusion Circle");
+
+  m_uiForm.leTempCorrection->setValidator(new QDoubleValidator(m_parentWidget));
+
+  // Connections
+  connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this,
+          SLOT(minChanged(double)));
+  connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this,
+          SLOT(maxChanged(double)));
+  connect(backRangeSelector, SIGNAL(minValueChanged(double)), this,
+          SLOT(backgLevel(double)));
+  connect(hwhmRangeSelector, SIGNAL(minValueChanged(double)), this,
+          SLOT(hwhmChanged(double)));
+  connect(hwhmRangeSelector, SIGNAL(maxValueChanged(double)), this,
+          SLOT(hwhmChanged(double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(updateRS(QtProperty *, double)));
+  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
+          SLOT(checkBoxUpdate(QtProperty *, bool)));
+  connect(m_uiForm.ckTempCorrection, SIGNAL(toggled(bool)),
+          m_uiForm.leTempCorrection, SLOT(setEnabled(bool)));
+
+  // Update guess curve when certain things happen
+  connect(m_dblManager, SIGNAL(propertyChanged(QtProperty *)), this,
+          SLOT(plotGuess()));
+  connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(plotGuess()));
+  connect(m_uiForm.ckPlotGuess, SIGNAL(stateChanged(int)), this,
+          SLOT(plotGuess()));
+
+  // Have FWHM Range linked to Fit Start/End Range
+  connect(fitRangeSelector, SIGNAL(rangeChanged(double, double)),
+          hwhmRangeSelector, SLOT(setRange(double, double)));
+  hwhmRangeSelector->setRange(-1.0, 1.0);
+  hwhmUpdateRS(0.02);
+
+  typeSelection(m_uiForm.cbFitType->currentIndex());
+  bgTypeSelection(m_uiForm.cbBackground->currentIndex());
+
+  // Replot input automatically when file / spec no changes
+  connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this,
+          SLOT(updatePlot()));
+  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
+          SLOT(newDataLoaded(const QString &)));
+
+  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
+          SLOT(extendResolutionWorkspace()));
+  connect(m_uiForm.dsResInput, SIGNAL(dataReady(const QString &)), this,
+          SLOT(extendResolutionWorkspace()));
+
+  connect(m_uiForm.spSpectraMin, SIGNAL(valueChanged(int)), this,
+          SLOT(specMinChanged(int)));
+  connect(m_uiForm.spSpectraMax, SIGNAL(valueChanged(int)), this,
+          SLOT(specMaxChanged(int)));
+
+  connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(typeSelection(int)));
+  connect(m_uiForm.cbBackground, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(bgTypeSelection(int)));
+  connect(m_uiForm.pbSingleFit, SIGNAL(clicked()), this, SLOT(singleFit()));
+
+  // Context menu
+  m_cfTree->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(m_cfTree, SIGNAL(customContextMenuRequested(const QPoint &)), this,
+          SLOT(fitContextMenu(const QPoint &)));
+
+  // Tie
+  connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(QString)),
+          SLOT(showTieCheckbox(QString)));
+  showTieCheckbox(m_uiForm.cbFitType->currentText());
+
+  updatePlotOptions();
+}
+
+/**
+ * Converts data into a python script which prodcues the output workspace
+ */
+void ConvFit::run() {
+  if (m_cfInputWS == NULL) {
+    g_log.error("No workspace loaded");
+    return;
   }
 
+  QString fitType = fitTypeString();
+  QString bgType = backgroundString();
 
-  void ConvFit::setup()
-  {
-    // Create Property Managers
-    m_stringManager = new QtStringPropertyManager();
-
-    // Create TreeProperty Widget
-    m_cfTree = new QtTreePropertyBrowser();
-    m_uiForm.properties->addWidget(m_cfTree);
-
-    // add factories to managers
-    m_cfTree->setFactoryForManager(m_blnManager, m_blnEdFac);
-    m_cfTree->setFactoryForManager(m_dblManager, m_dblEdFac);
-
-    // Create Range Selectors
-    auto fitRangeSelector = m_uiForm.ppPlot->addRangeSelector("ConvFitRange");
-    auto backRangeSelector = m_uiForm.ppPlot->addRangeSelector("ConvFitBackRange",
-                                                               MantidWidgets::RangeSelector::YSINGLE);
-    auto hwhmRangeSelector = m_uiForm.ppPlot->addRangeSelector("ConvFitHWHM");
-    backRangeSelector->setColour(Qt::darkGreen);
-    backRangeSelector->setRange(0.0, 1.0);
-    hwhmRangeSelector->setColour(Qt::red);
-
-    // Populate Property Widget
-
-    // Option to convolve members
-    m_properties["Convolve"] = m_blnManager->addProperty("Convolve");
-    m_cfTree->addProperty(m_properties["Convolve"]);
-    m_blnManager->setValue(m_properties["Convolve"], true);
-
-    // Max iterations option
-    m_properties["MaxIterations"] = m_dblManager->addProperty("Max Iterations");
-    m_dblManager->setDecimals(m_properties["MaxIterations"], 0);
-    m_dblManager->setValue(m_properties["MaxIterations"], 500);
-    m_cfTree->addProperty(m_properties["MaxIterations"]);
-
-    // Fitting range
-    m_properties["FitRange"] = m_grpManager->addProperty("Fitting Range");
-    m_properties["StartX"] = m_dblManager->addProperty("StartX");
-    m_dblManager->setDecimals(m_properties["StartX"], NUM_DECIMALS);
-    m_properties["EndX"] = m_dblManager->addProperty("EndX");
-    m_dblManager->setDecimals(m_properties["EndX"], NUM_DECIMALS);
-    m_properties["FitRange"]->addSubProperty(m_properties["StartX"]);
-    m_properties["FitRange"]->addSubProperty(m_properties["EndX"]);
-    m_cfTree->addProperty(m_properties["FitRange"]);
-
-    // FABADA
-    m_properties["FABADA"] = m_grpManager->addProperty("Bayesian");
-    m_properties["UseFABADA"] = m_blnManager->addProperty("Use FABADA");
-    m_properties["FABADA"]->addSubProperty(m_properties["UseFABADA"]);
-    m_properties["OutputFABADAChain"] = m_blnManager->addProperty("Output Chain");
-    m_properties["FABADAChainLength"] = m_dblManager->addProperty("Chain Length");
-    m_dblManager->setDecimals(m_properties["FABADAChainLength"], 0);
-    m_dblManager->setValue(m_properties["FABADAChainLength"], 10000);
-    m_properties["FABADAConvergenceCriteria"] = m_dblManager->addProperty("Convergence Criteria");
-    m_dblManager->setValue(m_properties["FABADAConvergenceCriteria"], 0.1);
-    m_properties["FABADAJumpAcceptanceRate"] = m_dblManager->addProperty("Acceptance Rate");
-    m_dblManager->setValue(m_properties["FABADAJumpAcceptanceRate"], 0.25);
-    m_cfTree->addProperty(m_properties["FABADA"]);
-
-    // Background type
-    m_properties["LinearBackground"] = m_grpManager->addProperty("Background");
-    m_properties["BGA0"] = m_dblManager->addProperty("A0");
-    m_dblManager->setDecimals(m_properties["BGA0"], NUM_DECIMALS);
-    m_properties["BGA1"] = m_dblManager->addProperty("A1");
-    m_dblManager->setDecimals(m_properties["BGA1"], NUM_DECIMALS);
-    m_properties["LinearBackground"]->addSubProperty(m_properties["BGA0"]);
-    m_properties["LinearBackground"]->addSubProperty(m_properties["BGA1"]);
-    m_cfTree->addProperty(m_properties["LinearBackground"]);
-
-    // Delta Function
-    m_properties["DeltaFunction"] = m_grpManager->addProperty("Delta Function");
-    m_properties["UseDeltaFunc"] = m_blnManager->addProperty("Use");
-    m_properties["DeltaHeight"] = m_dblManager->addProperty("Height");
-    m_dblManager->setDecimals(m_properties["DeltaHeight"], NUM_DECIMALS);
-    m_properties["DeltaFunction"]->addSubProperty(m_properties["UseDeltaFunc"]);
-    m_cfTree->addProperty(m_properties["DeltaFunction"]);
-
-    // Fit functions
-    m_properties["Lorentzian1"] = createLorentzian("Lorentzian 1");
-    m_properties["Lorentzian2"] = createLorentzian("Lorentzian 2");
-    m_properties["DiffSphere"] = createDiffSphere("Diffusion Sphere");
-    m_properties["DiffRotDiscreteCircle"] = createDiffRotDiscreteCircle("Diffusion Circle");
-
-    m_uiForm.leTempCorrection->setValidator(new QDoubleValidator(m_parentWidget));
-
-    // Connections
-    connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));
-    connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxChanged(double)));
-    connect(backRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(backgLevel(double)));
-    connect(hwhmRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(hwhmChanged(double)));
-    connect(hwhmRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(hwhmChanged(double)));
-    connect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(updateRS(QtProperty*, double)));
-    connect(m_blnManager, SIGNAL(valueChanged(QtProperty*, bool)), this, SLOT(checkBoxUpdate(QtProperty*, bool)));
-    connect(m_uiForm.ckTempCorrection, SIGNAL(toggled(bool)), m_uiForm.leTempCorrection, SLOT(setEnabled(bool)));
-
-    // Update guess curve when certain things happen
-    connect(m_dblManager, SIGNAL(propertyChanged(QtProperty*)), this, SLOT(plotGuess()));
-    connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(int)), this, SLOT(plotGuess()));
-    connect(m_uiForm.ckPlotGuess, SIGNAL(stateChanged(int)), this, SLOT(plotGuess()));
-
-    // Have FWHM Range linked to Fit Start/End Range
-    connect(fitRangeSelector, SIGNAL(rangeChanged(double, double)),
-            hwhmRangeSelector, SLOT(setRange(double, double)));
-    hwhmRangeSelector->setRange(-1.0, 1.0);
-    hwhmUpdateRS(0.02);
-
-    typeSelection(m_uiForm.cbFitType->currentIndex());
-    bgTypeSelection(m_uiForm.cbBackground->currentIndex());
-
-    // Replot input automatically when file / spec no changes
-    connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(updatePlot()));
-    connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString&)), this, SLOT(newDataLoaded(const QString&)));
-
-    connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString&)), this, SLOT(extendResolutionWorkspace()));
-    connect(m_uiForm.dsResInput, SIGNAL(dataReady(const QString&)), this, SLOT(extendResolutionWorkspace()));
-
-    connect(m_uiForm.spSpectraMin, SIGNAL(valueChanged(int)), this, SLOT(specMinChanged(int)));
-    connect(m_uiForm.spSpectraMax, SIGNAL(valueChanged(int)), this, SLOT(specMaxChanged(int)));
-
-    connect(m_uiForm.cbFitType, SIGNAL(currentIndexChanged(int)), this, SLOT(typeSelection(int)));
-    connect(m_uiForm.cbBackground, SIGNAL(currentIndexChanged(int)), this, SLOT(bgTypeSelection(int)));
-    connect(m_uiForm.pbSingleFit, SIGNAL(clicked()), this, SLOT(singleFit()));
-
-    // Context menu
-    m_cfTree->setContextMenuPolicy(Qt::CustomContextMenu);
-    connect(m_cfTree, SIGNAL(customContextMenuRequested(const QPoint &)), this, SLOT(fitContextMenu(const QPoint &)));
-
-    // Tie
-    connect(m_uiForm.cbFitType,SIGNAL(currentIndexChanged(QString)),SLOT(showTieCheckbox(QString)));
-    showTieCheckbox( m_uiForm.cbFitType->currentText() );
-
-    updatePlotOptions();
+  if (fitType == "") {
+    g_log.error("No fit type defined");
   }
 
+  bool useTies = m_uiForm.ckTieCentres->isChecked();
+  QString ties = (useTies ? "True" : "False");
 
-  void ConvFit::run()
-  {
-    if ( m_cfInputWS == NULL )
-    {
-      g_log.error("No workspace loaded");
-      return;
-    }
+  CompositeFunction_sptr func = createFunction(useTies);
+  std::string function = std::string(func->asString());
+  QString stX = m_properties["StartX"]->valueText();
+  QString enX = m_properties["EndX"]->valueText();
+  QString specMin = m_uiForm.spSpectraMin->text();
+  QString specMax = m_uiForm.spSpectraMax->text();
+  int maxIterations =
+      static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
 
-    QString fitType = fitTypeString();
-    QString bgType = backgroundString();
+  QString pyInput = "from IndirectDataAnalysis import confitSeq\n"
+                    "input = '" +
+                    m_cfInputWSName + "'\n"
+                                      "func = r'" +
+                    QString::fromStdString(function) + "'\n"
+                                                       "startx = " +
+                    stX + "\n"
+                          "endx = " +
+                    enX + "\n"
+                          "plot = '" +
+                    m_uiForm.cbPlotType->currentText() + "'\n"
+                                                         "ties = " +
+                    ties + "\n"
+                           "specMin = " +
+                    specMin + "\n"
+                              "specMax = " +
+                    specMax + "\n"
+                              "max_iterations = " +
+                    QString::number(maxIterations) + "\n"
+                                                     "minimizer = '" +
+                    minimizerString("$outputname_$wsindex") + "'\n"
+                                                              "save = " +
+                    (m_uiForm.ckSave->isChecked() ? "True\n" : "False\n");
 
-    if(fitType == "")
-    {
-      g_log.error("No fit type defined");
-    }
+  if (m_blnManager->value(m_properties["Convolve"]))
+    pyInput += "convolve = True\n";
+  else
+    pyInput += "convolve = False\n";
 
-    bool useTies = m_uiForm.ckTieCentres->isChecked();
-    QString ties = (useTies ? "True" : "False");
-
-    CompositeFunction_sptr func = createFunction(useTies);
-    std::string function = std::string(func->asString());
-    QString stX = m_properties["StartX"]->valueText();
-    QString enX = m_properties["EndX"]->valueText();
-    QString specMin = m_uiForm.spSpectraMin->text();
-    QString specMax = m_uiForm.spSpectraMax->text();
-    int maxIterations = static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
-
-    QString pyInput =
-      "from IndirectDataAnalysis import confitSeq\n"
-      "input = '" + m_cfInputWSName + "'\n"
-      "func = r'" + QString::fromStdString(function) + "'\n"
-      "startx = " + stX + "\n"
-      "endx = " + enX + "\n"
-      "plot = '" + m_uiForm.cbPlotType->currentText() + "'\n"
-      "ties = " + ties + "\n"
-      "specMin = " + specMin + "\n"
-      "specMax = " + specMax + "\n"
-      "max_iterations = " + QString::number(maxIterations) + "\n"
-      "minimizer = '" + minimizerString("$outputname_$wsindex") + "'\n"
-      "save = " + (m_uiForm.ckSave->isChecked() ? "True\n" : "False\n");
-
-    if ( m_blnManager->value(m_properties["Convolve"]) ) pyInput += "convolve = True\n";
-    else pyInput += "convolve = False\n";
-
-    QString temperature = m_uiForm.leTempCorrection->text();
-    bool useTempCorrection = (!temperature.isEmpty() && m_uiForm.ckTempCorrection->isChecked());
-    if ( useTempCorrection )
-    {
-      pyInput += "temp=" + temperature + "\n";
-    }
-    else
-    {
-      pyInput += "temp=None\n";
-    }
-
-    pyInput +=
-      "bg = '" + bgType + "'\n"
-      "ftype = '" + fitType + "'\n"
-      "rws = confitSeq(input, func, startx, endx, ftype, bg, temp, specMin, specMax, convolve, max_iterations=max_iterations, minimizer=minimizer, Plot=plot, Save=save)\n"
-      "AddSampleLog(Workspace=rws, LogName='res_workspace', LogText='" + m_uiForm.dsResInput->getCurrentDataName() + "')\n"
-      "print rws\n";
-
-    QString pyOutput = runPythonCode(pyInput);
-
-    // Set the result workspace for Python script export
-    m_pythonExportWsName = pyOutput.toStdString();
-
-    updatePlot();
+  QString temperature = m_uiForm.leTempCorrection->text();
+  bool useTempCorrection =
+      (!temperature.isEmpty() && m_uiForm.ckTempCorrection->isChecked());
+  if (useTempCorrection) {
+    pyInput += "temp=" + temperature + "\n";
+  } else {
+    pyInput += "temp=None\n";
   }
 
+  pyInput += "bg = '" + bgType + "'\n"
+                                 "ftype = '" +
+             fitType +
+             "'\n"
+             "rws = confitSeq(input, func, startx, endx, ftype, bg, temp, "
+             "specMin, specMax, convolve, max_iterations=max_iterations, "
+             "minimizer=minimizer, Plot=plot, Save=save)\n"
+             "AddSampleLog(Workspace=rws, LogName='res_workspace', LogText='" +
+             m_uiForm.dsResInput->getCurrentDataName() + "')\n"
+                                                         "print rws\n";
 
-  /**
-   * Validates the user's inputs in the ConvFit tab.
-   */
-  bool ConvFit::validate()
-  {
-    UserInputValidator uiv;
+  QString pyOutput = runPythonCode(pyInput);
 
-    uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSampleInput);
-    uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResInput);
+  // Set the result workspace for Python script export
+  m_pythonExportWsName = pyOutput.toStdString();
 
-    auto range = std::make_pair(m_dblManager->value(m_properties["StartX"]), m_dblManager->value(m_properties["EndX"]));
-    uiv.checkValidRange("Fitting Range", range);
+  updatePlot();
+}
 
-    // Enforce the rule that at least one fit is needed; either a delta function, one or two lorentzian functions,
-    // or both.  (The resolution function must be convolved with a model.)
-    if ( m_uiForm.cbFitType->currentIndex() == 0 && ! m_blnManager->value(m_properties["UseDeltaFunc"]) )
-      uiv.addErrorMessage("No fit function has been selected.");
+/**
+ * Validates the user's inputs in the ConvFit tab.
+ * @return If the validation was successful
+ */
+bool ConvFit::validate() {
+  UserInputValidator uiv;
 
-    QString error = uiv.generateErrorMessage();
-    showMessageBox(error);
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSampleInput);
+  uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResInput);
 
-    return error.isEmpty();
-  }
+  auto range = std::make_pair(m_dblManager->value(m_properties["StartX"]),
+                              m_dblManager->value(m_properties["EndX"]));
+  uiv.checkValidRange("Fitting Range", range);
 
-  void ConvFit::loadSettings(const QSettings & settings)
-  {
-    m_uiForm.dsSampleInput->readSettings(settings.group());
-    m_uiForm.dsResInput->readSettings(settings.group());
-  }
+  // Enforce the rule that at least one fit is needed; either a delta function,
+  // one or two lorentzian functions,
+  // or both.  (The resolution function must be convolved with a model.)
+  if (m_uiForm.cbFitType->currentIndex() == 0 &&
+      !m_blnManager->value(m_properties["UseDeltaFunc"]))
+    uiv.addErrorMessage("No fit function has been selected.");
 
-  /**
-   * Called when new data has been loaded by the data selector.
-   *
-   * Configures ranges for spin boxes before raw plot is done.
-   *
-   * @param wsName Name of new workspace loaded
-   */
-  void ConvFit::newDataLoaded(const QString wsName)
-  {
-    m_cfInputWSName = wsName;
-    m_cfInputWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(m_cfInputWSName.toStdString());
+  QString error = uiv.generateErrorMessage();
+  showMessageBox(error);
 
-    int maxSpecIndex = static_cast<int>(m_cfInputWS->getNumberHistograms()) - 1;
+  return error.isEmpty();
+}
 
-    m_uiForm.spPlotSpectrum->setMaximum(maxSpecIndex);
-    m_uiForm.spPlotSpectrum->setMinimum(0);
-    m_uiForm.spPlotSpectrum->setValue(0);
+/**
+ * Reads in settings files
+ * @param settings The name of the QSettings object to retrieve data from
+ */
+void ConvFit::loadSettings(const QSettings &settings) {
+  m_uiForm.dsSampleInput->readSettings(settings.group());
+  m_uiForm.dsResInput->readSettings(settings.group());
+}
 
-    m_uiForm.spSpectraMin->setMaximum(maxSpecIndex);
-    m_uiForm.spSpectraMin->setMinimum(0);
+/**
+ * Called when new data has been loaded by the data selector.
+ *
+ * Configures ranges for spin boxes before raw plot is done.
+ *
+ * @param wsName Name of new workspace loaded
+ */
+void ConvFit::newDataLoaded(const QString wsName) {
+  m_cfInputWSName = wsName;
+  m_cfInputWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      m_cfInputWSName.toStdString());
 
-    m_uiForm.spSpectraMax->setMaximum(maxSpecIndex);
-    m_uiForm.spSpectraMax->setMinimum(0);
-    m_uiForm.spSpectraMax->setValue(maxSpecIndex);
+  int maxSpecIndex = static_cast<int>(m_cfInputWS->getNumberHistograms()) - 1;
 
-    updatePlot();
-  }
+  m_uiForm.spPlotSpectrum->setMaximum(maxSpecIndex);
+  m_uiForm.spPlotSpectrum->setMinimum(0);
+  m_uiForm.spPlotSpectrum->setValue(0);
 
+  m_uiForm.spSpectraMin->setMaximum(maxSpecIndex);
+  m_uiForm.spSpectraMin->setMinimum(0);
 
-  /**
-   * Create a resolution workspace with the same number of histograms as in the sample.
-   *
-   * Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as they need
-   * to have the WorkspaceIndex attribute set.
-   */
-  void ConvFit::extendResolutionWorkspace()
-  {
-    if(m_cfInputWS && m_uiForm.dsResInput->isValid())
-    {
-      const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
+  m_uiForm.spSpectraMax->setMaximum(maxSpecIndex);
+  m_uiForm.spSpectraMax->setMinimum(0);
+  m_uiForm.spSpectraMax->setValue(maxSpecIndex);
 
-      API::BatchAlgorithmRunner::AlgorithmRuntimeProps appendProps;
-      appendProps["InputWorkspace1"] = "__ConvFit_Resolution";
+  updatePlot();
+}
 
-      size_t numHist = m_cfInputWS->getNumberHistograms();
-      for(size_t i = 0; i < numHist; i++)
-      {
-        IAlgorithm_sptr appendAlg = AlgorithmManager::Instance().create("AppendSpectra");
-        appendAlg->initialize();
-        appendAlg->setProperty("InputWorkspace2", resWsName.toStdString());
-        appendAlg->setProperty("OutputWorkspace", "__ConvFit_Resolution");
+/**
+ * Create a resolution workspace with the same number of histograms as in the
+ * sample.
+ *
+ * Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as
+ * they need
+ * to have the WorkspaceIndex attribute set.
+ */
+void ConvFit::extendResolutionWorkspace() {
+  if (m_cfInputWS && m_uiForm.dsResInput->isValid()) {
+    const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
 
-        if(i == 0)
-        {
-          appendAlg->setProperty("InputWorkspace1", resWsName.toStdString());
-          m_batchAlgoRunner->addAlgorithm(appendAlg);
-        }
-        else
-        {
-          m_batchAlgoRunner->addAlgorithm(appendAlg, appendProps);
-        }
+    API::BatchAlgorithmRunner::AlgorithmRuntimeProps appendProps;
+    appendProps["InputWorkspace1"] = "__ConvFit_Resolution";
+
+    size_t numHist = m_cfInputWS->getNumberHistograms();
+    for (size_t i = 0; i < numHist; i++) {
+      IAlgorithm_sptr appendAlg =
+          AlgorithmManager::Instance().create("AppendSpectra");
+      appendAlg->initialize();
+      appendAlg->setProperty("InputWorkspace2", resWsName.toStdString());
+      appendAlg->setProperty("OutputWorkspace", "__ConvFit_Resolution");
+
+      if (i == 0) {
+        appendAlg->setProperty("InputWorkspace1", resWsName.toStdString());
+        m_batchAlgoRunner->addAlgorithm(appendAlg);
+      } else {
+        m_batchAlgoRunner->addAlgorithm(appendAlg, appendProps);
       }
+    }
 
-      m_batchAlgoRunner->executeBatchAsync();
+    m_batchAlgoRunner->executeBatchAsync();
+  }
+}
+
+namespace {
+////////////////////////////
+// Anon Helper functions. //
+////////////////////////////
+
+/**
+ * Takes an index and a name, and constructs a single level parameter name
+ * for use with function ties, etc.
+ *
+ * @param index :: the index of the function in the first level.
+ * @param name  :: the name of the parameter inside the function.
+ *
+ * @returns the constructed function parameter name.
+ */
+std::string createParName(size_t index, const std::string &name = "") {
+  std::stringstream prefix;
+  prefix << "f" << index << "." << name;
+  return prefix.str();
+}
+
+/**
+ * Takes an index, a sub index and a name, and constructs a double level
+ * (nested) parameter name for use with function ties, etc.
+ *
+ * @param index    :: the index of the function in the first level.
+ * @param subIndex :: the index of the function in the second level.
+ * @param name     :: the name of the parameter inside the function.
+ *
+ * @returns the constructed function parameter name.
+ */
+std::string createParName(size_t index, size_t subIndex,
+                          const std::string &name = "") {
+  std::stringstream prefix;
+  prefix << "f" << index << ".f" << subIndex << "." << name;
+  return prefix.str();
+}
+}
+
+/**
+ * Creates a function to carry out the fitting in the "ConvFit" tab.  The
+ *function consists
+ * of various sub functions, with the following structure:
+ *
+ * Composite
+ *  |
+ *  +-- LinearBackground
+ *  +-- Convolution
+ *      |
+ *      +-- Resolution
+ *      +-- Model (AT LEAST one delta function or one/two lorentzians.)
+ *          |
+ *          +-- DeltaFunction (yes/no)
+ *					+-- ProductFunction
+ *							|
+ *							+-- Lorentzian 1 (yes/no)
+ *							+-- Temperature Correction (yes/no)
+ *					+-- ProductFunction
+ *							|
+ *							+-- Lorentzian 2 (yes/no)
+ *							+-- Temperature Correction (yes/no)
+ *					+-- ProductFunction
+ *							|
+ *							+-- InelasticDiffSphere (yes/no)
+ *							+-- Temperature Correction (yes/no)
+ *					+-- ProductFunction
+ *							|
+ *							+-- InelasticDiffRotDiscreteCircle (yes/no)
+ *							+-- Temperature Correction (yes/no)
+ *
+ * @param tieCentres :: whether to tie centres of the two lorentzians.
+ *
+ * @returns the composite fitting function.
+ */
+CompositeFunction_sptr ConvFit::createFunction(bool tieCentres) {
+  auto conv = boost::dynamic_pointer_cast<CompositeFunction>(
+      FunctionFactory::Instance().createFunction("Convolution"));
+  CompositeFunction_sptr comp(new CompositeFunction);
+
+  IFunction_sptr func;
+  size_t index = 0;
+
+  // -------------------------------------
+  // --- Composite / Linear Background ---
+  // -------------------------------------
+  func = FunctionFactory::Instance().createFunction("LinearBackground");
+  comp->addFunction(func);
+
+  const int bgType =
+      m_uiForm.cbBackground
+          ->currentIndex(); // 0 = Fixed Flat, 1 = Fit Flat, 2 = Fit all
+
+  if (bgType == 0 || !m_properties["BGA0"]->subProperties().isEmpty()) {
+    comp->tie("f0.A0", m_properties["BGA0"]->valueText().toStdString());
+  } else {
+    func->setParameter("A0", m_properties["BGA0"]->valueText().toDouble());
+  }
+
+  if (bgType != 2) {
+    comp->tie("f0.A1", "0.0");
+  } else {
+    if (!m_properties["BGA1"]->subProperties().isEmpty()) {
+      comp->tie("f0.A1", m_properties["BGA1"]->valueText().toStdString());
+    } else {
+      func->setParameter("A1", m_properties["BGA1"]->valueText().toDouble());
     }
   }
 
+  // --------------------------------------------
+  // --- Composite / Convolution / Resolution ---
+  // --------------------------------------------
+  func = FunctionFactory::Instance().createFunction("Resolution");
+  conv->addFunction(func);
 
-  namespace
-  {
-    ////////////////////////////
-    // Anon Helper functions. //
-    ////////////////////////////
+  // add resolution file
+  IFunction::Attribute attr("__ConvFit_Resolution");
+  func->setAttribute("Workspace", attr);
 
-    /**
-     * Takes an index and a name, and constructs a single level parameter name
-     * for use with function ties, etc.
-     *
-     * @param index :: the index of the function in the first level.
-     * @param name  :: the name of the parameter inside the function.
-     *
-     * @returns the constructed function parameter name.
-     */
-    std::string createParName(size_t index, const std::string & name = "")
-    {
-      std::stringstream prefix;
-      prefix << "f" << index << "." << name;
-      return prefix.str();
-    }
+  // --------------------------------------------------------
+  // --- Composite / Convolution / Model / Delta Function ---
+  // --------------------------------------------------------
+  CompositeFunction_sptr model(new CompositeFunction);
 
+  bool useDeltaFunc = m_blnManager->value(m_properties["UseDeltaFunc"]);
 
-    /**
-     * Takes an index, a sub index and a name, and constructs a double level
-     * (nested) parameter name for use with function ties, etc.
-     *
-     * @param index    :: the index of the function in the first level.
-     * @param subIndex :: the index of the function in the second level.
-     * @param name     :: the name of the parameter inside the function.
-     *
-     * @returns the constructed function parameter name.
-     */
-    std::string createParName(size_t index, size_t subIndex, const std::string & name = "")
-    {
-      std::stringstream prefix;
-      prefix << "f" << index << ".f" << subIndex << "." << name;
-      return prefix.str();
-    }
+  size_t subIndex = 0;
+
+  if (useDeltaFunc) {
+    func = FunctionFactory::Instance().createFunction("DeltaFunction");
+    index = model->addFunction(func);
+    std::string parName = createParName(index);
+    populateFunction(func, model, m_properties["DeltaFunction"], parName,
+                     false);
   }
 
+  // ------------------------------------------------------------
+  // --- Composite / Convolution / Model / Temperature Factor ---
+  // ------------------------------------------------------------
 
-  /**
-   * Creates a function to carry out the fitting in the "ConvFit" tab.  The function consists
-   * of various sub functions, with the following structure:
-   *
-   * Composite
-   *  |
-   *  +-- LinearBackground
-   *  +-- Convolution
-   *      |
-   *      +-- Resolution
-   *      +-- Model (AT LEAST one delta function or one/two lorentzians.)
-   *          |
-   *          +-- DeltaFunction (yes/no)
-   *					+-- ProductFunction
-   *							|
-   *							+-- Lorentzian 1 (yes/no)
-   *							+-- Temperature Correction (yes/no)
-   *					+-- ProductFunction
-   *							|
-   *							+-- Lorentzian 2 (yes/no)
-   *							+-- Temperature Correction (yes/no)
-   *					+-- ProductFunction
-   *							|
-   *							+-- InelasticDiffSphere (yes/no)
-   *							+-- Temperature Correction (yes/no)
-   *					+-- ProductFunction
-   *							|
-   *							+-- InelasticDiffRotDiscreteCircle (yes/no)
-   *							+-- Temperature Correction (yes/no)
-   *
-   * @param tieCentres :: whether to tie centres of the two lorentzians.
-   *
-   * @returns the composite fitting function.
-   */
-  CompositeFunction_sptr ConvFit::createFunction(bool tieCentres)
-  {
-    auto conv = boost::dynamic_pointer_cast<CompositeFunction>(FunctionFactory::Instance().createFunction("Convolution"));
-    CompositeFunction_sptr comp( new CompositeFunction );
+  // create temperature correction function to multiply with the lorentzians
+  IFunction_sptr tempFunc;
+  QString temperature = m_uiForm.leTempCorrection->text();
+  bool useTempCorrection =
+      (!temperature.isEmpty() && m_uiForm.ckTempCorrection->isChecked());
 
-    IFunction_sptr func;
-    size_t index = 0;
+  // -----------------------------------------------------
+  // --- Composite / Convolution / Model / Lorentzians ---
+  // -----------------------------------------------------
+  std::string prefix1;
+  std::string prefix2;
 
-    // -------------------------------------
-    // --- Composite / Linear Background ---
-    // -------------------------------------
-    func = FunctionFactory::Instance().createFunction("LinearBackground");
-    comp->addFunction(func);
+  int fitTypeIndex = m_uiForm.cbFitType->currentIndex();
 
-    const int bgType = m_uiForm.cbBackground->currentIndex(); // 0 = Fixed Flat, 1 = Fit Flat, 2 = Fit all
+  // Add 1st Lorentzian
+  if (fitTypeIndex == 1 || fitTypeIndex == 2) {
+    // if temperature not included then product is lorentzian * 1
+    // create product function for temp * lorentzian
+    auto product = boost::dynamic_pointer_cast<CompositeFunction>(
+        FunctionFactory::Instance().createFunction("ProductFunction"));
 
-    if ( bgType == 0 || ! m_properties["BGA0"]->subProperties().isEmpty() )
-    {
-      comp->tie("f0.A0", m_properties["BGA0"]->valueText().toStdString() );
-    }
-    else
-    {
-      func->setParameter("A0", m_properties["BGA0"]->valueText().toDouble());
+    if (useTempCorrection) {
+      createTemperatureCorrection(product);
     }
 
-    if ( bgType != 2 )
-    {
-      comp->tie("f0.A1", "0.0");
-    }
-    else
-    {
-      if ( ! m_properties["BGA1"]->subProperties().isEmpty() )
-      {
-        comp->tie("f0.A1", m_properties["BGA1"]->valueText().toStdString() );
-      }
-      else { func->setParameter("A1", m_properties["BGA1"]->valueText().toDouble()); }
-    }
+    func = FunctionFactory::Instance().createFunction("Lorentzian");
+    subIndex = product->addFunction(func);
+    index = model->addFunction(product);
+    prefix1 = createParName(index, subIndex);
 
-    // --------------------------------------------
-    // --- Composite / Convolution / Resolution ---
-    // --------------------------------------------
-    func = FunctionFactory::Instance().createFunction("Resolution");
-    conv->addFunction(func);
-
-    //add resolution file
-    IFunction::Attribute attr("__ConvFit_Resolution");
-    func->setAttribute("Workspace", attr);
-
-    // --------------------------------------------------------
-    // --- Composite / Convolution / Model / Delta Function ---
-    // --------------------------------------------------------
-    CompositeFunction_sptr model( new CompositeFunction );
-
-    bool useDeltaFunc = m_blnManager->value(m_properties["UseDeltaFunc"]);
-
-    size_t subIndex = 0;
-
-    if ( useDeltaFunc )
-    {
-      func = FunctionFactory::Instance().createFunction("DeltaFunction");
-      index = model->addFunction(func);
-      std::string parName = createParName(index);
-      populateFunction(func, model, m_properties["DeltaFunction"], parName, false);
-    }
-
-    // ------------------------------------------------------------
-    // --- Composite / Convolution / Model / Temperature Factor ---
-    // ------------------------------------------------------------
-
-    //create temperature correction function to multiply with the lorentzians
-    IFunction_sptr tempFunc;
-    QString temperature = m_uiForm.leTempCorrection->text();
-    bool useTempCorrection = (!temperature.isEmpty() && m_uiForm.ckTempCorrection->isChecked());
-
-    // -----------------------------------------------------
-    // --- Composite / Convolution / Model / Lorentzians ---
-    // -----------------------------------------------------
-    std::string prefix1;
-    std::string prefix2;
-
-    int fitTypeIndex = m_uiForm.cbFitType->currentIndex();
-
-    // Add 1st Lorentzian
-    if(fitTypeIndex == 1 || fitTypeIndex == 2)
-    {
-      //if temperature not included then product is lorentzian * 1
-      //create product function for temp * lorentzian
-      auto product = boost::dynamic_pointer_cast<CompositeFunction>(FunctionFactory::Instance().createFunction("ProductFunction"));
-
-      if(useTempCorrection)
-      {
-        createTemperatureCorrection(product);
-      }
-
-      func = FunctionFactory::Instance().createFunction("Lorentzian");
-      subIndex = product->addFunction(func);
-      index = model->addFunction(product);
-      prefix1 = createParName(index, subIndex);
-
-      populateFunction(func, model, m_properties["Lorentzian1"], prefix1, false);
-    }
-
-    // Add 2nd Lorentzian
-    if(fitTypeIndex == 2)
-    {
-      //if temperature not included then product is lorentzian * 1
-      //create product function for temp * lorentzian
-      auto product = boost::dynamic_pointer_cast<CompositeFunction>(FunctionFactory::Instance().createFunction("ProductFunction"));
-
-      if(useTempCorrection)
-      {
-        createTemperatureCorrection(product);
-      }
-
-      func = FunctionFactory::Instance().createFunction("Lorentzian");
-      subIndex = product->addFunction(func);
-      index = model->addFunction(product);
-      prefix2 = createParName(index, subIndex);
-
-      populateFunction(func, model, m_properties["Lorentzian2"], prefix2, false);
-    }
-
-    // -------------------------------------------------------------
-    // --- Composite / Convolution / Model / InelasticDiffSphere ---
-    // -------------------------------------------------------------
-    if(fitTypeIndex == 3)
-    {
-      auto product = boost::dynamic_pointer_cast<CompositeFunction>(FunctionFactory::Instance().createFunction("ProductFunction"));
-
-      if(useTempCorrection)
-      {
-        createTemperatureCorrection(product);
-      }
-
-      func = FunctionFactory::Instance().createFunction("InelasticDiffSphere");
-      subIndex = product->addFunction(func);
-      index = model->addFunction(product);
-      prefix2 = createParName(index, subIndex);
-
-      populateFunction(func, model, m_properties["DiffSphere"], prefix2, false);
-    }
-
-    // ------------------------------------------------------------------------
-    // --- Composite / Convolution / Model / InelasticDiffRotDiscreteCircle ---
-    // ------------------------------------------------------------------------
-    if(fitTypeIndex == 4)
-    {
-      auto product = boost::dynamic_pointer_cast<CompositeFunction>(FunctionFactory::Instance().createFunction("ProductFunction"));
-
-      if(useTempCorrection)
-      {
-        createTemperatureCorrection(product);
-      }
-
-      func = FunctionFactory::Instance().createFunction("InelasticDiffRotDiscreteCircle");
-      subIndex = product->addFunction(func);
-      index = model->addFunction(product);
-      prefix2 = createParName(index, subIndex);
-
-      populateFunction(func, model, m_properties["DiffRotDiscreteCircle"], prefix2, false);
-    }
-
-    conv->addFunction(model);
-    comp->addFunction(conv);
-
-    // Tie PeakCentres together
-    if ( tieCentres )
-    {
-      std::string tieL = prefix1 + "PeakCentre";
-      std::string tieR = prefix2 + "PeakCentre";
-      model->tie(tieL, tieR);
-    }
-
-    comp->applyTies();
-    return comp;
+    populateFunction(func, model, m_properties["Lorentzian1"], prefix1, false);
   }
 
+  // Add 2nd Lorentzian
+  if (fitTypeIndex == 2) {
+    // if temperature not included then product is lorentzian * 1
+    // create product function for temp * lorentzian
+    auto product = boost::dynamic_pointer_cast<CompositeFunction>(
+        FunctionFactory::Instance().createFunction("ProductFunction"));
 
-  void ConvFit::createTemperatureCorrection(CompositeFunction_sptr product)
-  {
-    //create temperature correction function to multiply with the lorentzians
-    IFunction_sptr tempFunc;
-    QString temperature = m_uiForm.leTempCorrection->text();
+    if (useTempCorrection) {
+      createTemperatureCorrection(product);
+    }
 
-    //create user function for the exponential correction
-    // (x*temp) / 1-exp(-(x*temp))
-    tempFunc = FunctionFactory::Instance().createFunction("UserFunction");
-    //11.606 is the conversion factor from meV to K
-    std::string formula = "((x*11.606)/Temp) / (1 - exp(-((x*11.606)/Temp)))";
-    IFunction::Attribute att(formula);
-    tempFunc->setAttribute("Formula", att);
-    tempFunc->setParameter("Temp", temperature.toDouble());
+    func = FunctionFactory::Instance().createFunction("Lorentzian");
+    subIndex = product->addFunction(func);
+    index = model->addFunction(product);
+    prefix2 = createParName(index, subIndex);
 
-    product->addFunction(tempFunc);
-    product->tie("f0.Temp", temperature.toStdString());
-    product->applyTies();
+    populateFunction(func, model, m_properties["Lorentzian2"], prefix2, false);
   }
 
+  // -------------------------------------------------------------
+  // --- Composite / Convolution / Model / InelasticDiffSphere ---
+  // -------------------------------------------------------------
+  if (fitTypeIndex == 3) {
+    auto product = boost::dynamic_pointer_cast<CompositeFunction>(
+        FunctionFactory::Instance().createFunction("ProductFunction"));
 
-  double ConvFit::getInstrumentResolution(std::string workspaceName)
-  {
-    using namespace Mantid::API;
+    if (useTempCorrection) {
+      createTemperatureCorrection(product);
+    }
 
-    double resolution = 0.0;
-    try
-    {
-      Mantid::Geometry::Instrument_const_sptr inst =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName)->getInstrument();
-      std::vector<std::string> analysers = inst->getStringParameter("analyser");
-      if(analysers.empty())
-      {
-        g_log.warning("Could not load instrument resolution from parameter file");
+    func = FunctionFactory::Instance().createFunction("InelasticDiffSphere");
+    subIndex = product->addFunction(func);
+    index = model->addFunction(product);
+    prefix2 = createParName(index, subIndex);
+
+    populateFunction(func, model, m_properties["DiffSphere"], prefix2, false);
+  }
+
+  // ------------------------------------------------------------------------
+  // --- Composite / Convolution / Model / InelasticDiffRotDiscreteCircle ---
+  // ------------------------------------------------------------------------
+  if (fitTypeIndex == 4) {
+    auto product = boost::dynamic_pointer_cast<CompositeFunction>(
+        FunctionFactory::Instance().createFunction("ProductFunction"));
+
+    if (useTempCorrection) {
+      createTemperatureCorrection(product);
+    }
+
+    func = FunctionFactory::Instance().createFunction(
+        "InelasticDiffRotDiscreteCircle");
+    subIndex = product->addFunction(func);
+    index = model->addFunction(product);
+    prefix2 = createParName(index, subIndex);
+
+    populateFunction(func, model, m_properties["DiffRotDiscreteCircle"],
+                     prefix2, false);
+  }
+
+  conv->addFunction(model);
+  comp->addFunction(conv);
+
+  // Tie PeakCentres together
+  if (tieCentres) {
+    std::string tieL = prefix1 + "PeakCentre";
+    std::string tieR = prefix2 + "PeakCentre";
+    model->tie(tieL, tieR);
+  }
+
+  comp->applyTies();
+  return comp;
+}
+
+/**
+ * Creates the correction for the temperature
+ */
+void ConvFit::createTemperatureCorrection(CompositeFunction_sptr product) {
+  // create temperature correction function to multiply with the lorentzians
+  IFunction_sptr tempFunc;
+  QString temperature = m_uiForm.leTempCorrection->text();
+
+  // create user function for the exponential correction
+  // (x*temp) / 1-exp(-(x*temp))
+  tempFunc = FunctionFactory::Instance().createFunction("UserFunction");
+  // 11.606 is the conversion factor from meV to K
+  std::string formula = "((x*11.606)/Temp) / (1 - exp(-((x*11.606)/Temp)))";
+  IFunction::Attribute att(formula);
+  tempFunc->setAttribute("Formula", att);
+  tempFunc->setParameter("Temp", temperature.toDouble());
+
+  product->addFunction(tempFunc);
+  product->tie("f0.Temp", temperature.toStdString());
+  product->applyTies();
+}
+
+/**
+ * Obtains the instrument resolution from the provided workspace
+ * @param workspaceName The name of the workspaces which holds the instrument resolution
+ * @return The resolution of the instrument. returns 0 if no resolution data could be found
+ */
+double ConvFit::getInstrumentResolution(std::string workspaceName) {
+  using namespace Mantid::API;
+
+  double resolution = 0.0;
+  try {
+    Mantid::Geometry::Instrument_const_sptr inst =
+        AnalysisDataService::Instance()
+            .retrieveWS<MatrixWorkspace>(workspaceName)
+            ->getInstrument();
+    std::vector<std::string> analysers = inst->getStringParameter("analyser");
+    if (analysers.empty()) {
+      g_log.warning("Could not load instrument resolution from parameter file");
+      return 0.0;
+    }
+
+    std::string analyser = analysers[0];
+    std::string idfDirectory =
+        Mantid::Kernel::ConfigService::Instance().getString(
+            "instrumentDefinition.directory");
+
+    // If the analyser component is not already in the data file then load it
+    // from the parameter file
+    if (inst->getComponentByName(analyser)
+            ->getNumberParameter("resolution")
+            .size() == 0) {
+      std::string reflection = inst->getStringParameter("reflection")[0];
+
+      IAlgorithm_sptr loadParamFile =
+          AlgorithmManager::Instance().create("LoadParameterFile");
+      loadParamFile->initialize();
+      loadParamFile->setProperty("Workspace", workspaceName);
+      loadParamFile->setProperty(
+          "Filename", idfDirectory + inst->getName() + "_" + analyser + "_" +
+                          reflection + "_Parameters.xml");
+      loadParamFile->execute();
+
+      if (!loadParamFile->isExecuted()) {
+        g_log.warning("Could not load parameter file, ensure instrument "
+                      "directory is in data search paths.");
         return 0.0;
       }
 
-      std::string analyser = analysers[0];
-      std::string idfDirectory = Mantid::Kernel::ConfigService::Instance().getString("instrumentDefinition.directory");
-
-      // If the analyser component is not already in the data file the laod it from the parameter file
-      if(inst->getComponentByName(analyser)->getNumberParameter("resolution").size() == 0)
-      {
-        std::string reflection = inst->getStringParameter("reflection")[0];
-
-        IAlgorithm_sptr loadParamFile = AlgorithmManager::Instance().create("LoadParameterFile");
-        loadParamFile->initialize();
-        loadParamFile->setProperty("Workspace", workspaceName);
-        loadParamFile->setProperty("Filename", idfDirectory + inst->getName() + "_"+analyser + "_" + reflection + "_Parameters.xml");
-        loadParamFile->execute();
-
-        if(!loadParamFile->isExecuted())
-        {
-          g_log.warning("Could not load parameter file, ensure instrument directory is in data search paths.");
-          return 0.0;
-        }
-
-        inst = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName)->getInstrument();
-      }
-
-      resolution = inst->getComponentByName(analyser)->getNumberParameter("resolution")[0];
-    }
-    catch(Mantid::Kernel::Exception::NotFoundError &e)
-    {
-      UNUSED_ARG(e);
-
-      g_log.warning("Could not load instrument resolution from parameter file");
-      resolution = 0.0;
+      inst = AnalysisDataService::Instance()
+                 .retrieveWS<MatrixWorkspace>(workspaceName)
+                 ->getInstrument();
     }
 
-    return resolution;
+    resolution =
+        inst->getComponentByName(analyser)->getNumberParameter("resolution")[0];
+  } catch (Mantid::Kernel::Exception::NotFoundError &e) {
+    UNUSED_ARG(e);
+
+    g_log.warning("Could not load instrument resolution from parameter file");
+    resolution = 0.0;
   }
 
+  return resolution;
+}
 
-  QtProperty* ConvFit::createLorentzian(const QString & name)
-  {
-    QtProperty* lorentzGroup = m_grpManager->addProperty(name);
+/**
+ * Creates a Lorentz peak 
+ * @param name The name of the Lorentz peak (1 or 2)
+ * @return The QTProperty that represents the lorentz peak
+ */
+QtProperty *ConvFit::createLorentzian(const QString &name) {
+  QtProperty *lorentzGroup = m_grpManager->addProperty(name);
 
-    m_properties[name+".Amplitude"] = m_dblManager->addProperty("Amplitude");
-    // m_dblManager->setRange(m_properties[name+".Amplitude"], 0.0, 1.0); // 0 < Amplitude < 1
-    m_properties[name+".PeakCentre"] = m_dblManager->addProperty("PeakCentre");
-    m_properties[name+".FWHM"] = m_dblManager->addProperty("FWHM");
+  m_properties[name + ".Amplitude"] = m_dblManager->addProperty("Amplitude");
+  // m_dblManager->setRange(m_properties[name+".Amplitude"], 0.0, 1.0); // 0 < Amplitude < 1
+  m_properties[name + ".PeakCentre"] = m_dblManager->addProperty("PeakCentre");
+  m_properties[name + ".FWHM"] = m_dblManager->addProperty("FWHM");
 
-    m_dblManager->setDecimals(m_properties[name+".Amplitude"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".PeakCentre"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".FWHM"], NUM_DECIMALS);
-    m_dblManager->setValue(m_properties[name+".FWHM"], 0.02);
+  m_dblManager->setDecimals(m_properties[name + ".Amplitude"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".PeakCentre"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".FWHM"], NUM_DECIMALS);
+  m_dblManager->setValue(m_properties[name + ".FWHM"], 0.02);
 
-    lorentzGroup->addSubProperty(m_properties[name+".Amplitude"]);
-    lorentzGroup->addSubProperty(m_properties[name+".PeakCentre"]);
-    lorentzGroup->addSubProperty(m_properties[name+".FWHM"]);
+  lorentzGroup->addSubProperty(m_properties[name + ".Amplitude"]);
+  lorentzGroup->addSubProperty(m_properties[name + ".PeakCentre"]);
+  lorentzGroup->addSubProperty(m_properties[name + ".FWHM"]);
 
-    return lorentzGroup;
-  }
+  return lorentzGroup;
+}
 
+/**
+ * Creates a DiffSphere
+ * @param name The name of the DiffSphere
+ * @return The QTProperty that represents the DiffSphere
+ */
+QtProperty *ConvFit::createDiffSphere(const QString &name) {
+  QtProperty *diffSphereGroup = m_grpManager->addProperty(name);
 
-  QtProperty* ConvFit::createDiffSphere(const QString & name)
-  {
-    QtProperty* diffSphereGroup = m_grpManager->addProperty(name);
+  m_properties[name + ".Intensity"] = m_dblManager->addProperty("Intensity");
+  m_properties[name + ".Radius"] = m_dblManager->addProperty("Radius");
+  m_properties[name + ".Diffusion"] = m_dblManager->addProperty("Diffusion");
+  m_properties[name + ".Shift"] = m_dblManager->addProperty("Shift");
 
-    m_properties[name+".Intensity"] = m_dblManager->addProperty("Intensity");
-    m_properties[name+".Radius"] = m_dblManager->addProperty("Radius");
-    m_properties[name+".Diffusion"] = m_dblManager->addProperty("Diffusion");
-    m_properties[name+".Shift"] = m_dblManager->addProperty("Shift");
+  m_dblManager->setDecimals(m_properties[name + ".Intensity"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".Radius"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".Diffusion"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".Shift"], NUM_DECIMALS);
 
-    m_dblManager->setDecimals(m_properties[name+".Intensity"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".Radius"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".Diffusion"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".Shift"], NUM_DECIMALS);
+  diffSphereGroup->addSubProperty(m_properties[name + ".Intensity"]);
+  diffSphereGroup->addSubProperty(m_properties[name + ".Radius"]);
+  diffSphereGroup->addSubProperty(m_properties[name + ".Diffusion"]);
+  diffSphereGroup->addSubProperty(m_properties[name + ".Shift"]);
 
-    diffSphereGroup->addSubProperty(m_properties[name+".Intensity"]);
-    diffSphereGroup->addSubProperty(m_properties[name+".Radius"]);
-    diffSphereGroup->addSubProperty(m_properties[name+".Diffusion"]);
-    diffSphereGroup->addSubProperty(m_properties[name+".Shift"]);
+  return diffSphereGroup;
+}
 
-    return diffSphereGroup;
-  }
+/**
+ * Creates a DiffRotDiscreteCircle 
+ * @param name The name of the DiffRotDiscreteCircle
+ * @return The QTProperty that represents the DiffRotDiscreteCircle
+ */
+QtProperty *ConvFit::createDiffRotDiscreteCircle(const QString &name) {
+  QtProperty *diffRotDiscreteCircleGroup = m_grpManager->addProperty(name);
 
+  m_properties[name + ".N"] = m_dblManager->addProperty("N");
+  m_dblManager->setValue(m_properties[name + ".N"], 3.0);
 
-  QtProperty* ConvFit::createDiffRotDiscreteCircle(const QString & name)
-  {
-    QtProperty* diffRotDiscreteCircleGroup = m_grpManager->addProperty(name);
+  m_properties[name + ".Intensity"] = m_dblManager->addProperty("Intensity");
+  m_properties[name + ".Radius"] = m_dblManager->addProperty("Radius");
+  m_properties[name + ".Decay"] = m_dblManager->addProperty("Decay");
+  m_properties[name + ".Shift"] = m_dblManager->addProperty("Shift");
 
-    m_properties[name+".N"] = m_dblManager->addProperty("N");
-    m_dblManager->setValue(m_properties[name+".N"], 3.0);
+  m_dblManager->setDecimals(m_properties[name + ".N"], 0);
+  m_dblManager->setDecimals(m_properties[name + ".Intensity"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".Radius"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".Decay"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties[name + ".Shift"], NUM_DECIMALS);
 
-    m_properties[name+".Intensity"] = m_dblManager->addProperty("Intensity");
-    m_properties[name+".Radius"] = m_dblManager->addProperty("Radius");
-    m_properties[name+".Decay"] = m_dblManager->addProperty("Decay");
-    m_properties[name+".Shift"] = m_dblManager->addProperty("Shift");
+  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".N"]);
+  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Intensity"]);
+  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Radius"]);
+  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Decay"]);
+  diffRotDiscreteCircleGroup->addSubProperty(m_properties[name + ".Shift"]);
 
-    m_dblManager->setDecimals(m_properties[name+".N"], 0);
-    m_dblManager->setDecimals(m_properties[name+".Intensity"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".Radius"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".Decay"], NUM_DECIMALS);
-    m_dblManager->setDecimals(m_properties[name+".Shift"], NUM_DECIMALS);
+  return diffRotDiscreteCircleGroup;
+}
 
-    diffRotDiscreteCircleGroup->addSubProperty(m_properties[name+".N"]);
-    diffRotDiscreteCircleGroup->addSubProperty(m_properties[name+".Intensity"]);
-    diffRotDiscreteCircleGroup->addSubProperty(m_properties[name+".Radius"]);
-    diffRotDiscreteCircleGroup->addSubProperty(m_properties[name+".Decay"]);
-    diffRotDiscreteCircleGroup->addSubProperty(m_properties[name+".Shift"]);
+/**
+ * Populates the properties of a function with required values
+ * @param func The function tobe populated
+ * @param comp The composite function
+ * @param group The QtProperty representing the fit type
+ * @param pref The index of the functions eg. (f0.f1)
+ * @param tie 
+ */
+void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp,
+                               QtProperty *group, const std::string &pref,
+                               bool tie) {
+  // Get subproperties of group and apply them as parameters on the function object
+  QList<QtProperty *> props = group->subProperties();
 
-    return diffRotDiscreteCircleGroup;
-  }
-
-
-  void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp, QtProperty* group, const std::string & pref, bool tie)
-  {
-    // Get subproperties of group and apply them as parameters on the function object
-    QList<QtProperty*> props = group->subProperties();
-
-    for ( int i = 0; i < props.size(); i++ )
-    {
-      if ( tie || ! props[i]->subProperties().isEmpty() )
-      {
-        std::string name = pref + props[i]->propertyName().toStdString();
-        std::string value = props[i]->valueText().toStdString();
-        comp->tie(name, value);
-      }
-      else
-      {
-        std::string propName = props[i]->propertyName().toStdString();
-        double propValue = props[i]->valueText().toDouble();
-        if(propValue)
-        {
-          if(func->hasAttribute(propName))
-            func->setAttributeValue(propName, propValue);
-          else
-            func->setParameter(propName, propValue);
-        }
+  for (int i = 0; i < props.size(); i++) {
+    if (tie || !props[i]->subProperties().isEmpty()) {
+      std::string name = pref + props[i]->propertyName().toStdString();
+      std::string value = props[i]->valueText().toStdString();
+      comp->tie(name, value);
+    } else {
+      std::string propName = props[i]->propertyName().toStdString();
+      double propValue = props[i]->valueText().toDouble();
+      if (propValue) {
+        if (func->hasAttribute(propName))
+          func->setAttributeValue(propName, propValue);
+        else
+          func->setParameter(propName, propValue);
       }
     }
   }
+}
 
+/**
+ * Generate a string to describe the fit type selected by the user.
+ * Used when naming the resultant workspaces.
+ *
+ * Assertions used to guard against any future changes that dont take
+ * workspace naming into account.
+ *
+ * @returns the generated QString.
+ */
+QString ConvFit::fitTypeString() const {
+  QString fitType("");
 
-  /**
-   * Generate a string to describe the fit type selected by the user.
-   * Used when naming the resultant workspaces.
-   *
-   * Assertions used to guard against any future changes that dont take
-   * workspace naming into account.
-   *
-   * @returns the generated QString.
-   */
-  QString ConvFit::fitTypeString() const
-  {
-    QString fitType("");
+  if (m_blnManager->value(m_properties["UseDeltaFunc"]))
+    fitType += "Delta";
 
-    if( m_blnManager->value(m_properties["UseDeltaFunc"]) )
-      fitType += "Delta";
-
-    switch ( m_uiForm.cbFitType->currentIndex() )
-    {
-      case 0:
-        break;
-      case 1:
-        fitType += "1L"; break;
-      case 2:
-        fitType += "2L"; break;
-      case 3:
-        fitType += "DS"; break;
-      case 4:
-        fitType += "DC"; break;
-    }
-
-    return fitType;
+  switch (m_uiForm.cbFitType->currentIndex()) {
+  case 0:
+    break;
+  case 1:
+    fitType += "1L";
+    break;
+  case 2:
+    fitType += "2L";
+    break;
+  case 3:
+    fitType += "DS";
+    break;
+  case 4:
+    fitType += "DC";
+    break;
   }
 
+  return fitType;
+}
 
-  /**
-   * Generate a string to describe the background selected by the user.
-   * Used when naming the resultant workspaces.
-   *
-   * Assertions used to guard against any future changes that dont take
-   * workspace naming into account.
-   *
-   * @returns the generated QString.
-   */
-  QString ConvFit::backgroundString() const
-  {
-    switch ( m_uiForm.cbBackground->currentIndex() )
-    {
-      case 0:
-        return "FixF_s";
-      case 1:
-        return "FitF_s";
-      case 2:
-        return "FitL_s";
-      default:
-        return "";
-    }
+/**
+ * Generate a string to describe the background selected by the user.
+ * Used when naming the resultant workspaces.
+ *
+ * Assertions used to guard against any future changes that dont take
+ * workspace naming into account.
+ *
+ * @returns the generated QString.
+ */
+QString ConvFit::backgroundString() const {
+  switch (m_uiForm.cbBackground->currentIndex()) {
+  case 0:
+    return "FixF_s";
+  case 1:
+    return "FitF_s";
+  case 2:
+    return "FitL_s";
+  default:
+    return "";
+  }
+}
+
+/**
+ * Generates a string that defines the fitting minimizer based on the user
+ * options.
+ *
+ * @return Minimizer as a string
+ */
+QString ConvFit::minimizerString(QString outputName) const {
+  QString minimizer = "Levenberg-Marquardt";
+
+  if (m_blnManager->value(m_properties["UseFABADA"])) {
+    minimizer = "FABADA";
+
+    int chainLength = static_cast<int>(
+        m_dblManager->value(m_properties["FABADAChainLength"]));
+    minimizer += ",ChainLength=" + QString::number(chainLength);
+
+    double convergenceCriteria =
+        m_dblManager->value(m_properties["FABADAConvergenceCriteria"]);
+    minimizer += ",ConvergenceCriteria=" + QString::number(convergenceCriteria);
+
+    double jumpAcceptanceRate =
+        m_dblManager->value(m_properties["FABADAJumpAcceptanceRate"]);
+    minimizer += ",JumpAcceptanceRate=" + QString::number(jumpAcceptanceRate);
+
+    minimizer += ",PDF=" + outputName + "_PDF";
+
+    if (m_blnManager->value(m_properties["OutputFABADAChain"]))
+      minimizer += ",Chains=" + outputName + "_Chain";
   }
 
+  return minimizer;
+}
 
-  /**
-   * Generates a string that defines the fitting minimizer based on the user
-   * options.
-   *
-   * @return Minimizer as a string
-   */
-  QString ConvFit::minimizerString(QString outputName) const
-  {
-    QString minimizer = "Levenberg-Marquardt";
+/**
+ * Changes property tree appearance based on Fit Type
+ * @param index A reference to the Fit Type (0-4)
+ */
+void ConvFit::typeSelection(int index) {
+  m_cfTree->removeProperty(m_properties["Lorentzian1"]);
+  m_cfTree->removeProperty(m_properties["Lorentzian2"]);
+  m_cfTree->removeProperty(m_properties["DiffSphere"]);
+  m_cfTree->removeProperty(m_properties["DiffRotDiscreteCircle"]);
 
-    if(m_blnManager->value(m_properties["UseFABADA"]))
-    {
-      minimizer = "FABADA";
+  auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
 
-      int chainLength = static_cast<int>(m_dblManager->value(m_properties["FABADAChainLength"]));
-      minimizer += ",ChainLength=" + QString::number(chainLength);
-
-      double convergenceCriteria = m_dblManager->value(m_properties["FABADAConvergenceCriteria"]);
-      minimizer += ",ConvergenceCriteria=" + QString::number(convergenceCriteria);
-
-      double jumpAcceptanceRate = m_dblManager->value(m_properties["FABADAJumpAcceptanceRate"]);
-      minimizer += ",JumpAcceptanceRate=" + QString::number(jumpAcceptanceRate);
-
-      minimizer += ",PDF=" + outputName + "_PDF";
-
-      if(m_blnManager->value(m_properties["OutputFABADAChain"]))
-        minimizer += ",Chains=" + outputName + "_Chain";
-    }
-
-    return minimizer;
-  }
-
-
-  void ConvFit::typeSelection(int index)
-  {
-    m_cfTree->removeProperty(m_properties["Lorentzian1"]);
-    m_cfTree->removeProperty(m_properties["Lorentzian2"]);
-    m_cfTree->removeProperty(m_properties["DiffSphere"]);
-    m_cfTree->removeProperty(m_properties["DiffRotDiscreteCircle"]);
-
-    auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
-
-    switch ( index )
-    {
-      case 0:
-        hwhmRangeSelector->setVisible(false);
-        break;
-      case 1:
-        m_cfTree->addProperty(m_properties["Lorentzian1"]);
-        hwhmRangeSelector->setVisible(true);
-        break;
-      case 2:
-        m_cfTree->addProperty(m_properties["Lorentzian1"]);
-        m_cfTree->addProperty(m_properties["Lorentzian2"]);
-        hwhmRangeSelector->setVisible(true);
-        break;
-      case 3:
-        m_cfTree->addProperty(m_properties["DiffSphere"]);
-        hwhmRangeSelector->setVisible(false);
-        m_uiForm.ckPlotGuess->setChecked(false);
-        m_blnManager->setValue(m_properties["UseDeltaFunc"], false);
-        break;
-      case 4:
-        m_cfTree->addProperty(m_properties["DiffRotDiscreteCircle"]);
-        hwhmRangeSelector->setVisible(false);
-        m_uiForm.ckPlotGuess->setChecked(false);
-        m_blnManager->setValue(m_properties["UseDeltaFunc"], false);
-        break;
-    }
-
-    // Disable Plot Guess and Use Delta Function for DiffSphere and DiffRotDiscreteCircle
-    m_uiForm.ckPlotGuess->setEnabled(index < 3);
-    m_properties["UseDeltaFunc"]->setEnabled(index < 3);
-
-    updatePlotOptions();
-  }
-
-
-  void ConvFit::bgTypeSelection(int index)
-  {
-    if ( index == 2 )
-    {
-      m_properties["LinearBackground"]->addSubProperty(m_properties["BGA1"]);
-    }
-    else
-    {
-      m_properties["LinearBackground"]->removeSubProperty(m_properties["BGA1"]);
-    }
-  }
-
-
-  void ConvFit::updatePlot()
-  {
-    using Mantid::Kernel::Exception::NotFoundError;
-
-    if(!m_cfInputWS)
-    {
-      g_log.error("No workspace loaded, cannot create preview plot.");
-      return;
-    }
-
-    const bool plotGuess = m_uiForm.ckPlotGuess->isChecked();
+  switch (index) {
+  case 0:
+    hwhmRangeSelector->setVisible(false);
+    break;
+  case 1:
+    m_cfTree->addProperty(m_properties["Lorentzian1"]);
+    hwhmRangeSelector->setVisible(true);
+    break;
+  case 2:
+    m_cfTree->addProperty(m_properties["Lorentzian1"]);
+    m_cfTree->addProperty(m_properties["Lorentzian2"]);
+    hwhmRangeSelector->setVisible(true);
+    break;
+  case 3:
+    m_cfTree->addProperty(m_properties["DiffSphere"]);
+    hwhmRangeSelector->setVisible(false);
     m_uiForm.ckPlotGuess->setChecked(false);
-
-    int specNo = m_uiForm.spPlotSpectrum->text().toInt();
-
-    m_uiForm.ppPlot->clear();
-    m_uiForm.ppPlot->addSpectrum("Sample", m_cfInputWS, specNo);
-
-    try
-    {
-      const QPair<double, double> curveRange = m_uiForm.ppPlot->getCurveRange("Sample");
-      const std::pair<double, double> range(curveRange.first, curveRange.second);
-      m_uiForm.ppPlot->getRangeSelector("ConvFitRange")->setRange(range.first, range.second);
-      m_uiForm.ckPlotGuess->setChecked(plotGuess);
-    }
-    catch(std::invalid_argument & exc)
-    {
-      showMessageBox(exc.what());
-    }
-
-    // Default FWHM to resolution of instrument
-    double resolution = getInstrumentResolution(m_cfInputWSName.toStdString());
-    if(resolution > 0)
-    {
-      m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], resolution);
-      m_dblManager->setValue(m_properties["Lorentzian 2.FWHM"], resolution);
-    }
-
-    // If there is a result plot then plot it
-    if(AnalysisDataService::Instance().doesExist(m_pythonExportWsName))
-    {
-      WorkspaceGroup_sptr outputGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(m_pythonExportWsName);
-      if(specNo >= static_cast<int>(outputGroup->size()))
-        return;
-      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputGroup->getItem(specNo));
-      if(ws)
-        m_uiForm.ppPlot->addSpectrum("Fit", ws, 1, Qt::red);
-    }
+    m_blnManager->setValue(m_properties["UseDeltaFunc"], false);
+    break;
+  case 4:
+    m_cfTree->addProperty(m_properties["DiffRotDiscreteCircle"]);
+    hwhmRangeSelector->setVisible(false);
+    m_uiForm.ckPlotGuess->setChecked(false);
+    m_blnManager->setValue(m_properties["UseDeltaFunc"], false);
+    break;
   }
 
+  // Disable Plot Guess and Use Delta Function for DiffSphere and
+  // DiffRotDiscreteCircle
+  m_uiForm.ckPlotGuess->setEnabled(index < 3);
+  m_properties["UseDeltaFunc"]->setEnabled(index < 3);
 
-  void ConvFit::plotGuess()
-  {
-    m_uiForm.ppPlot->removeSpectrum("Guess");
+  updatePlotOptions();
+}
 
-    // Do nothing if there is not a sample and resolution
-    if(!(m_uiForm.dsSampleInput->isValid() && m_uiForm.dsResInput->isValid()
-          && m_uiForm.ckPlotGuess->isChecked()))
-      return;
+/**
+ * Add/Remove sub property 'BGA1' from background based on Background type
+ * @param index A reference to the Background type
+ */ 
+void ConvFit::bgTypeSelection(int index) {
+  if (index == 2) {
+    m_properties["LinearBackground"]->addSubProperty(m_properties["BGA1"]);
+  } else {
+    m_properties["LinearBackground"]->removeSubProperty(m_properties["BGA1"]);
+  }
+}
 
-    bool tieCentres = (m_uiForm.cbFitType->currentIndex() > 1);
-    CompositeFunction_sptr function = createFunction(tieCentres);
+/**
+ * Updates the plot in the gui window
+ */ 
+void ConvFit::updatePlot() {
+  using Mantid::Kernel::Exception::NotFoundError;
 
-    if ( m_cfInputWS == NULL )
-    {
-      updatePlot();
-    }
-
-    const size_t binIndexLow = m_cfInputWS->binIndexOf(m_dblManager->value(m_properties["StartX"]));
-    const size_t binIndexHigh = m_cfInputWS->binIndexOf(m_dblManager->value(m_properties["EndX"]));
-    const size_t nData = binIndexHigh - binIndexLow;
-
-    std::vector<double> inputXData(nData);
-    const Mantid::MantidVec& XValues = m_cfInputWS->readX(0);
-    const bool isHistogram = m_cfInputWS->isHistogramData();
-
-    for ( size_t i = 0; i < nData; i++ )
-    {
-      if ( isHistogram )
-      {
-        inputXData[i] = 0.5 * ( XValues[binIndexLow+i] + XValues[binIndexLow+i+1] );
-      }
-      else
-      {
-        inputXData[i] = XValues[binIndexLow+i];
-      }
-    }
-
-    FunctionDomain1DVector domain(inputXData);
-    FunctionValues outputData(domain);
-    function->function(domain, outputData);
-
-    QVector<double> dataX, dataY;
-
-    for ( size_t i = 0; i < nData; i++ )
-    {
-      dataX.append(inputXData[i]);
-      dataY.append(outputData.getCalculated(i));
-    }
-
-    IAlgorithm_sptr createWsAlg = AlgorithmManager::Instance().create("CreateWorkspace");
-    createWsAlg->initialize();
-    createWsAlg->setChild(true);
-    createWsAlg->setLogging(false);
-    createWsAlg->setProperty("OutputWorkspace", "__GuessAnon");
-    createWsAlg->setProperty("NSpec", 1);
-    createWsAlg->setProperty("DataX", dataX.toStdVector());
-    createWsAlg->setProperty("DataY", dataY.toStdVector());
-    createWsAlg->execute();
-    MatrixWorkspace_sptr guessWs = createWsAlg->getProperty("OutputWorkspace");
-
-    m_uiForm.ppPlot->addSpectrum("Guess", guessWs, 0, Qt::green);
+  if (!m_cfInputWS) {
+    g_log.error("No workspace loaded, cannot create preview plot.");
+    return;
   }
 
+  const bool plotGuess = m_uiForm.ckPlotGuess->isChecked();
+  m_uiForm.ckPlotGuess->setChecked(false);
 
-  void ConvFit::singleFit()
-  {
-    if(!validate())
+  int specNo = m_uiForm.spPlotSpectrum->text().toInt();
+
+  m_uiForm.ppPlot->clear();
+  m_uiForm.ppPlot->addSpectrum("Sample", m_cfInputWS, specNo);
+
+  try {
+    const QPair<double, double> curveRange =
+        m_uiForm.ppPlot->getCurveRange("Sample");
+    const std::pair<double, double> range(curveRange.first, curveRange.second);
+    m_uiForm.ppPlot->getRangeSelector("ConvFitRange")
+        ->setRange(range.first, range.second);
+    m_uiForm.ckPlotGuess->setChecked(plotGuess);
+  } catch (std::invalid_argument &exc) {
+    showMessageBox(exc.what());
+  }
+
+  // Default FWHM to resolution of instrument
+  double resolution = getInstrumentResolution(m_cfInputWSName.toStdString());
+  if (resolution > 0) {
+    m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], resolution);
+    m_dblManager->setValue(m_properties["Lorentzian 2.FWHM"], resolution);
+  }
+
+  // If there is a result plot then plot it
+  if (AnalysisDataService::Instance().doesExist(m_pythonExportWsName)) {
+    WorkspaceGroup_sptr outputGroup =
+        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+            m_pythonExportWsName);
+    if (specNo >= static_cast<int>(outputGroup->size()))
       return;
+    MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        outputGroup->getItem(specNo));
+    if (ws)
+      m_uiForm.ppPlot->addSpectrum("Fit", ws, 1, Qt::red);
+  }
+}
 
+/**
+ * Updates the guess for the plot
+ */
+void ConvFit::plotGuess() {
+  m_uiForm.ppPlot->removeSpectrum("Guess");
+
+  // Do nothing if there is not a sample and resolution
+  if (!(m_uiForm.dsSampleInput->isValid() && m_uiForm.dsResInput->isValid() &&
+        m_uiForm.ckPlotGuess->isChecked()))
+    return;
+
+  bool tieCentres = (m_uiForm.cbFitType->currentIndex() > 1);
+  CompositeFunction_sptr function = createFunction(tieCentres);
+
+  if (m_cfInputWS == NULL) {
     updatePlot();
-
-    m_uiForm.ckPlotGuess->setChecked(false);
-
-    CompositeFunction_sptr function = createFunction(m_uiForm.ckTieCentres->isChecked());
-
-    // get output name
-    QString fitType = fitTypeString();
-    QString bgType = backgroundString();
-
-    if(fitType == "")
-    {
-      g_log.error("No fit type defined!");
-    }
-
-    m_singleFitOutputName = runPythonCode(QString("from IndirectCommon import getWSprefix\nprint getWSprefix('") + m_cfInputWSName + QString("')\n")).trimmed();
-    m_singleFitOutputName += QString("conv_") + fitType + bgType + m_uiForm.spPlotSpectrum->text();
-    int maxIterations = static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
-
-    m_singleFitAlg = AlgorithmManager::Instance().create("Fit");
-    m_singleFitAlg->initialize();
-    m_singleFitAlg->setPropertyValue("Function", function->asString());
-    m_singleFitAlg->setPropertyValue("InputWorkspace", m_cfInputWSName.toStdString());
-    m_singleFitAlg->setProperty<int>("WorkspaceIndex", m_uiForm.spPlotSpectrum->text().toInt());
-    m_singleFitAlg->setProperty<double>("StartX", m_dblManager->value(m_properties["StartX"]));
-    m_singleFitAlg->setProperty<double>("EndX", m_dblManager->value(m_properties["EndX"]));
-    m_singleFitAlg->setProperty("Output", m_singleFitOutputName.toStdString());
-    m_singleFitAlg->setProperty("CreateOutput", true);
-    m_singleFitAlg->setProperty("OutputCompositeMembers", true);
-    m_singleFitAlg->setProperty("ConvolveMembers", true);
-    m_singleFitAlg->setProperty("MaxIterations", maxIterations);
-    m_singleFitAlg->setProperty("Minimizer", minimizerString(m_singleFitOutputName).toStdString());
-
-    m_batchAlgoRunner->addAlgorithm(m_singleFitAlg);
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)),
-            this, SLOT(singleFitComplete(bool)));
-    m_batchAlgoRunner->executeBatchAsync();
   }
 
+  const size_t binIndexLow =
+      m_cfInputWS->binIndexOf(m_dblManager->value(m_properties["StartX"]));
+  const size_t binIndexHigh =
+      m_cfInputWS->binIndexOf(m_dblManager->value(m_properties["EndX"]));
+  const size_t nData = binIndexHigh - binIndexLow;
 
-  /**
-   * Handle completion of the fit algorithm for single fit.
-   *
-   * @param error If the fit algorithm failed
-   */
-  void ConvFit::singleFitComplete(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)),
-               this, SLOT(singleFitComplete(bool)));
+  std::vector<double> inputXData(nData);
+  const Mantid::MantidVec &XValues = m_cfInputWS->readX(0);
+  const bool isHistogram = m_cfInputWS->isHistogramData();
 
-    if(error)
-    {
-      showMessageBox("Fit algorithm failed.");
-      return;
-    }
-
-    // Plot the line on the mini plot
-    m_uiForm.ppPlot->removeSpectrum("Guess");
-    m_uiForm.ppPlot->addSpectrum("Fit", m_singleFitOutputName+"_Workspace", 1, Qt::red);
-
-    IFunction_sptr outputFunc = m_singleFitAlg->getProperty("Function");
-
-    // Get params.
-    QMap<QString,double> parameters;
-    std::vector<std::string> parNames = outputFunc->getParameterNames();
-    std::vector<double> parVals;
-
-    for( size_t i = 0; i < parNames.size(); ++i )
-      parVals.push_back(outputFunc->getParameter(parNames[i]));
-
-    for ( size_t i = 0; i < parNames.size(); ++i )
-      parameters[QString(parNames[i].c_str())] = parVals[i];
-
-    // Populate Tree widget with values
-    // Background should always be f0
-    m_dblManager->setValue(m_properties["BGA0"], parameters["f0.A0"]);
-    m_dblManager->setValue(m_properties["BGA1"], parameters["f0.A1"]);
-
-    int fitTypeIndex = m_uiForm.cbFitType->currentIndex();
-
-    int funcIndex = 0;
-    int subIndex = 0;
-
-    //check if we're using a temperature correction
-    if (m_uiForm.ckTempCorrection->isChecked() &&
-        !m_uiForm.leTempCorrection->text().isEmpty())
-    {
-      subIndex++;
-    }
-
-    bool usingDeltaFunc = m_blnManager->value(m_properties["UseDeltaFunc"]);
-
-    // If using a delta function with any fit type or using two Lorentzians
-    bool usingCompositeFunc = ((usingDeltaFunc && fitTypeIndex > 0) || fitTypeIndex == 2);
-
-    QString prefBase = "f1.f1.";
-
-    if ( usingDeltaFunc )
-    {
-      QString key = prefBase;
-      if (usingCompositeFunc)
-      {
-        key += "f0.";
-      }
-
-      key += "Height";
-
-      m_dblManager->setValue(m_properties["DeltaHeight"], parameters[key]);
-      funcIndex++;
-    }
-
-    if ( fitTypeIndex == 1 || fitTypeIndex == 2 )
-    {
-      // One Lorentz
-      QString pref = prefBase;
-
-      if ( usingCompositeFunc )
-      {
-        pref += "f" + QString::number(funcIndex) + ".f" + QString::number(subIndex) + ".";
-      }
-      else
-      {
-        pref += "f" + QString::number(subIndex) + ".";
-      }
-
-      m_dblManager->setValue(m_properties["Lorentzian 1.Amplitude"], parameters[pref+"Amplitude"]);
-      m_dblManager->setValue(m_properties["Lorentzian 1.PeakCentre"], parameters[pref+"PeakCentre"]);
-      m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], parameters[pref+"FWHM"]);
-      funcIndex++;
-    }
-
-    if ( fitTypeIndex == 2 )
-    {
-      // Two Lorentz
-      QString pref = prefBase;
-      pref += "f" + QString::number(funcIndex) + ".f" + QString::number(subIndex) + ".";
-
-      m_dblManager->setValue(m_properties["Lorentzian 2.Amplitude"], parameters[pref+"Amplitude"]);
-      m_dblManager->setValue(m_properties["Lorentzian 2.PeakCentre"], parameters[pref+"PeakCentre"]);
-      m_dblManager->setValue(m_properties["Lorentzian 2.FWHM"], parameters[pref+"FWHM"]);
-    }
-
-    if ( fitTypeIndex == 3 )
-    {
-      // DiffSphere
-      QString pref = prefBase;
-
-      if ( usingCompositeFunc )
-      {
-        pref += "f" + QString::number(funcIndex) + ".f" + QString::number(subIndex) + ".";
-      }
-      else
-      {
-        pref += "f" + QString::number(subIndex) + ".";
-      }
-
-      m_dblManager->setValue(m_properties["Diffusion Sphere.Intensity"], parameters[pref+"Intensity"]);
-      m_dblManager->setValue(m_properties["Diffusion Sphere.Radius"], parameters[pref+"Radius"]);
-      m_dblManager->setValue(m_properties["Diffusion Sphere.Diffusion"], parameters[pref+"Diffusion"]);
-      m_dblManager->setValue(m_properties["Diffusion Sphere.Shift"], parameters[pref+"Shift"]);
-    }
-
-    if ( fitTypeIndex == 4 )
-    {
-      // DiffSphere
-      QString pref = prefBase;
-
-      if ( usingCompositeFunc )
-      {
-        pref += "f" + QString::number(funcIndex) + ".f" + QString::number(subIndex) + ".";
-      }
-      else
-      {
-        pref += "f" + QString::number(subIndex) + ".";
-      }
-
-      m_dblManager->setValue(m_properties["Diffusion Circle.Intensity"], parameters[pref+"Intensity"]);
-      m_dblManager->setValue(m_properties["Diffusion Circle.Radius"], parameters[pref+"Radius"]);
-      m_dblManager->setValue(m_properties["Diffusion Circle.Decay"], parameters[pref+"Decay"]);
-      m_dblManager->setValue(m_properties["Diffusion Circle.Shift"], parameters[pref+"Shift"]);
-    }
-
-    m_pythonExportWsName = "";
-  }
-
-
-  /**
-   * Handles the user entering a new minimum spectrum index.
-   *
-   * Prevents the user entering an overlapping spectra range.
-   *
-   * @param value Minimum spectrum index
-   */
-  void ConvFit::specMinChanged(int value)
-  {
-    m_uiForm.spSpectraMax->setMinimum(value);
-  }
-
-
-  /**
-   * Handles the user entering a new maximum spectrum index.
-   *
-   * Prevents the user entering an overlapping spectra range.
-   *
-   * @param value Maximum spectrum index
-   */
-  void ConvFit::specMaxChanged(int value)
-  {
-    m_uiForm.spSpectraMin->setMaximum(value);
-  }
-
-
-  void ConvFit::minChanged(double val)
-  {
-    m_dblManager->setValue(m_properties["StartX"], val);
-  }
-
-
-  void ConvFit::maxChanged(double val)
-  {
-    m_dblManager->setValue(m_properties["EndX"], val);
-  }
-
-
-  void ConvFit::hwhmChanged(double val)
-  {
-    const double peakCentre = m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
-    // Always want FWHM to display as positive.
-    const double hwhm = std::fabs(val-peakCentre);
-    // Update the property
-    auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
-    hwhmRangeSelector->blockSignals(true);
-    m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], hwhm*2);
-    hwhmRangeSelector->blockSignals(false);
-  }
-
-
-  void ConvFit::backgLevel(double val)
-  {
-    m_dblManager->setValue(m_properties["BGA0"], val);
-  }
-
-
-  void ConvFit::updateRS(QtProperty* prop, double val)
-  {
-    auto fitRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitRange");
-    auto backRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitBackRange");
-
-    if ( prop == m_properties["StartX"] ) { fitRangeSelector->setMinimum(val); }
-    else if ( prop == m_properties["EndX"] ) { fitRangeSelector->setMaximum(val); }
-    else if ( prop == m_properties["BGA0"] ) { backRangeSelector->setMinimum(val); }
-    else if ( prop == m_properties["Lorentzian 1.FWHM"] ) { hwhmUpdateRS(val); }
-    else if ( prop == m_properties["Lorentzian 1.PeakCentre"] )
-    {
-      hwhmUpdateRS(m_dblManager->value(m_properties["Lorentzian 1.FWHM"]));
+  for (size_t i = 0; i < nData; i++) {
+    if (isHistogram) {
+      inputXData[i] =
+          0.5 * (XValues[binIndexLow + i] + XValues[binIndexLow + i + 1]);
+    } else {
+      inputXData[i] = XValues[binIndexLow + i];
     }
   }
 
+  FunctionDomain1DVector domain(inputXData);
+  FunctionValues outputData(domain);
+  function->function(domain, outputData);
 
-  void ConvFit::hwhmUpdateRS(double val)
-  {
-    const double peakCentre = m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
-    auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
-    hwhmRangeSelector->setMinimum(peakCentre-val/2);
-    hwhmRangeSelector->setMaximum(peakCentre+val/2);
+  QVector<double> dataX, dataY;
+
+  for (size_t i = 0; i < nData; i++) {
+    dataX.append(inputXData[i]);
+    dataY.append(outputData.getCalculated(i));
   }
 
+  IAlgorithm_sptr createWsAlg =
+      AlgorithmManager::Instance().create("CreateWorkspace");
+  createWsAlg->initialize();
+  createWsAlg->setChild(true);
+  createWsAlg->setLogging(false);
+  createWsAlg->setProperty("OutputWorkspace", "__GuessAnon");
+  createWsAlg->setProperty("NSpec", 1);
+  createWsAlg->setProperty("DataX", dataX.toStdVector());
+  createWsAlg->setProperty("DataY", dataY.toStdVector());
+  createWsAlg->execute();
+  MatrixWorkspace_sptr guessWs = createWsAlg->getProperty("OutputWorkspace");
 
-  void ConvFit::checkBoxUpdate(QtProperty* prop, bool checked)
-  {
-    UNUSED_ARG(checked);
+  m_uiForm.ppPlot->addSpectrum("Guess", guessWs, 0, Qt::green);
+}
 
-    if(prop == m_properties["UseDeltaFunc"])
-      updatePlotOptions();
-    else if(prop == m_properties["UseFABADA"])
-    {
-      if(checked)
-      {
-        // FABADA needs a much higher iteration limit
-        m_dblManager->setValue(m_properties["MaxIterations"], 20000);
+/**
+ * Fits a single spectrum to the plot
+ */
+void ConvFit::singleFit() {
+  if (!validate())
+    return;
 
-        m_properties["FABADA"]->addSubProperty(m_properties["OutputFABADAChain"]);
-        m_properties["FABADA"]->addSubProperty(m_properties["FABADAChainLength"]);
-        m_properties["FABADA"]->addSubProperty(m_properties["FABADAConvergenceCriteria"]);
-        m_properties["FABADA"]->addSubProperty(m_properties["FABADAJumpAcceptanceRate"]);
-      }
-      else
-      {
-        m_dblManager->setValue(m_properties["MaxIterations"], 500);
+  updatePlot();
 
-        m_properties["FABADA"]->removeSubProperty(m_properties["OutputFABADAChain"]);
-        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAChainLength"]);
-        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAConvergenceCriteria"]);
-        m_properties["FABADA"]->removeSubProperty(m_properties["FABADAJumpAcceptanceRate"]);
-      }
-    }
+  m_uiForm.ckPlotGuess->setChecked(false);
+
+  CompositeFunction_sptr function =
+      createFunction(m_uiForm.ckTieCentres->isChecked());
+
+  // get output name
+  QString fitType = fitTypeString();
+  QString bgType = backgroundString();
+
+  if (fitType == "") {
+    g_log.error("No fit type defined!");
   }
 
+  m_singleFitOutputName =
+      runPythonCode(
+          QString(
+              "from IndirectCommon import getWSprefix\nprint getWSprefix('") +
+          m_cfInputWSName + QString("')\n"))
+          .trimmed();
+  m_singleFitOutputName +=
+      QString("conv_") + fitType + bgType + m_uiForm.spPlotSpectrum->text();
+  int maxIterations =
+      static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
 
-  void ConvFit::fitContextMenu(const QPoint &)
-  {
-    QtBrowserItem* item(NULL);
+  m_singleFitAlg = AlgorithmManager::Instance().create("Fit");
+  m_singleFitAlg->initialize();
+  m_singleFitAlg->setPropertyValue("Function", function->asString());
+  m_singleFitAlg->setPropertyValue("InputWorkspace",
+                                   m_cfInputWSName.toStdString());
+  m_singleFitAlg->setProperty<int>("WorkspaceIndex",
+                                   m_uiForm.spPlotSpectrum->text().toInt());
+  m_singleFitAlg->setProperty<double>(
+      "StartX", m_dblManager->value(m_properties["StartX"]));
+  m_singleFitAlg->setProperty<double>(
+      "EndX", m_dblManager->value(m_properties["EndX"]));
+  m_singleFitAlg->setProperty("Output", m_singleFitOutputName.toStdString());
+  m_singleFitAlg->setProperty("CreateOutput", true);
+  m_singleFitAlg->setProperty("OutputCompositeMembers", true);
+  m_singleFitAlg->setProperty("ConvolveMembers", true);
+  m_singleFitAlg->setProperty("MaxIterations", maxIterations);
+  m_singleFitAlg->setProperty(
+      "Minimizer", minimizerString(m_singleFitOutputName).toStdString());
 
-    item = m_cfTree->currentItem();
+  m_batchAlgoRunner->addAlgorithm(m_singleFitAlg);
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(singleFitComplete(bool)));
+  m_batchAlgoRunner->executeBatchAsync();
+}
 
-    if ( ! item )
-      return;
+/**
+ * Handle completion of the fit algorithm for single fit.
+ *
+ * @param error If the fit algorithm failed
+ */
+void ConvFit::singleFitComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(singleFitComplete(bool)));
 
-    // is it a fit property ?
-    QtProperty* prop = item->property();
-
-    if ( prop == m_properties["StartX"] || prop == m_properties["EndX"] )
-      return;
-
-    // is it already fixed?
-    bool fixed = prop->propertyManager() != m_dblManager;
-
-    if ( fixed && prop->propertyManager() != m_stringManager )
-      return;
-
-    // Create the menu
-    QMenu* menu = new QMenu("ConvFit", m_cfTree);
-    QAction* action;
-
-    if ( ! fixed )
-    {
-      action = new QAction("Fix", m_parentWidget);
-      connect(action, SIGNAL(triggered()), this, SLOT(fixItem()));
-    }
-    else
-    {
-      action = new QAction("Remove Fix", m_parentWidget);
-      connect(action, SIGNAL(triggered()), this, SLOT(unFixItem()));
-    }
-
-    menu->addAction(action);
-
-    // Show the menu
-    menu->popup(QCursor::pos());
+  if (error) {
+    showMessageBox("Fit algorithm failed.");
+    return;
   }
 
+  // Plot the line on the mini plot
+  m_uiForm.ppPlot->removeSpectrum("Guess");
+  m_uiForm.ppPlot->addSpectrum("Fit", m_singleFitOutputName + "_Workspace", 1,
+                               Qt::red);
 
-  void ConvFit::fixItem()
-  {
-    QtBrowserItem* item = m_cfTree->currentItem();
+  IFunction_sptr outputFunc = m_singleFitAlg->getProperty("Function");
 
-    // Determine what the property is.
-    QtProperty* prop = item->property();
-    QtProperty* fixedProp = m_stringManager->addProperty( prop->propertyName() );
-    QtProperty* fprlbl = m_stringManager->addProperty("Fixed");
-    fixedProp->addSubProperty(fprlbl);
-    m_stringManager->setValue(fixedProp, prop->valueText());
+  // Get params.
+  QMap<QString, double> parameters;
+  std::vector<std::string> parNames = outputFunc->getParameterNames();
+  std::vector<double> parVals;
 
-    item->parent()->property()->addSubProperty(fixedProp);
+  for (size_t i = 0; i < parNames.size(); ++i)
+    parVals.push_back(outputFunc->getParameter(parNames[i]));
 
-    m_fixedProps[fixedProp] = prop;
+  for (size_t i = 0; i < parNames.size(); ++i)
+    parameters[QString(parNames[i].c_str())] = parVals[i];
 
-    item->parent()->property()->removeSubProperty(prop);
+  // Populate Tree widget with values
+  // Background should always be f0
+  m_dblManager->setValue(m_properties["BGA0"], parameters["f0.A0"]);
+  m_dblManager->setValue(m_properties["BGA1"], parameters["f0.A1"]);
+
+  int fitTypeIndex = m_uiForm.cbFitType->currentIndex();
+
+  int funcIndex = 0;
+  int subIndex = 0;
+
+  // check if we're using a temperature correction
+  if (m_uiForm.ckTempCorrection->isChecked() &&
+      !m_uiForm.leTempCorrection->text().isEmpty()) {
+    subIndex++;
   }
 
+  bool usingDeltaFunc = m_blnManager->value(m_properties["UseDeltaFunc"]);
 
-  void ConvFit::unFixItem()
-  {
-    QtBrowserItem* item = m_cfTree->currentItem();
+  // If using a delta function with any fit type or using two Lorentzians
+  bool usingCompositeFunc =
+      ((usingDeltaFunc && fitTypeIndex > 0) || fitTypeIndex == 2);
 
-    QtProperty* prop = item->property();
-    if ( prop->subProperties().empty() )
-    {
-      item = item->parent();
-      prop = item->property();
-    }
+  QString prefBase = "f1.f1.";
 
-    item->parent()->property()->addSubProperty(m_fixedProps[prop]);
-    item->parent()->property()->removeSubProperty(prop);
-    m_fixedProps.remove(prop);
-    QtProperty* proplbl = prop->subProperties()[0];
-    delete proplbl;
-    delete prop;
-  }
-
-
-  void ConvFit::showTieCheckbox(QString fitType)
-  {
-    m_uiForm.ckTieCentres->setVisible( fitType == "Two Lorentzians" );
-  }
-
-
-  void ConvFit::updatePlotOptions()
-  {
-    m_uiForm.cbPlotType->clear();
-
-    bool deltaFunction = m_blnManager->value(m_properties["UseDeltaFunc"]);
-
-    QStringList plotOptions;
-    plotOptions << "None";
-
-    if(deltaFunction)
-      plotOptions << "Height";
-
-    switch(m_uiForm.cbFitType->currentIndex())
-    {
-      // Lorentzians
-      case 1:
-      case 2:
-        plotOptions << "Amplitude" << "FWHM";
-        if(deltaFunction)
-          plotOptions << "EISF";
-        break;
-
-      // DiffSphere
-      case 3:
-        plotOptions << "Intensity" << "Radius" << "Diffusion" << "Shift";
-        break;
-
-      // DiffRotDiscreteCircle
-      case 4:
-        plotOptions << "Intensity" << "Radius" << "Decay" << "Shift";
-        break;
-
-      default:
-        break;
+  if (usingDeltaFunc) {
+    QString key = prefBase;
+    if (usingCompositeFunc) {
+      key += "f0.";
     }
 
-    plotOptions << "All";
-    m_uiForm.cbPlotType->addItems(plotOptions);
+    key += "Height";
+
+    m_dblManager->setValue(m_properties["DeltaHeight"], parameters[key]);
+    funcIndex++;
   }
+
+  if (fitTypeIndex == 1 || fitTypeIndex == 2) {
+    // One Lorentz
+    QString pref = prefBase;
+
+    if (usingCompositeFunc) {
+      pref += "f" + QString::number(funcIndex) + ".f" +
+              QString::number(subIndex) + ".";
+    } else {
+      pref += "f" + QString::number(subIndex) + ".";
+    }
+
+    m_dblManager->setValue(m_properties["Lorentzian 1.Amplitude"],
+                           parameters[pref + "Amplitude"]);
+    m_dblManager->setValue(m_properties["Lorentzian 1.PeakCentre"],
+                           parameters[pref + "PeakCentre"]);
+    m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"],
+                           parameters[pref + "FWHM"]);
+    funcIndex++;
+  }
+
+  if (fitTypeIndex == 2) {
+    // Two Lorentz
+    QString pref = prefBase;
+    pref += "f" + QString::number(funcIndex) + ".f" +
+            QString::number(subIndex) + ".";
+
+    m_dblManager->setValue(m_properties["Lorentzian 2.Amplitude"],
+                           parameters[pref + "Amplitude"]);
+    m_dblManager->setValue(m_properties["Lorentzian 2.PeakCentre"],
+                           parameters[pref + "PeakCentre"]);
+    m_dblManager->setValue(m_properties["Lorentzian 2.FWHM"],
+                           parameters[pref + "FWHM"]);
+  }
+
+  if (fitTypeIndex == 3) {
+    // DiffSphere
+    QString pref = prefBase;
+
+    if (usingCompositeFunc) {
+      pref += "f" + QString::number(funcIndex) + ".f" +
+              QString::number(subIndex) + ".";
+    } else {
+      pref += "f" + QString::number(subIndex) + ".";
+    }
+
+    m_dblManager->setValue(m_properties["Diffusion Sphere.Intensity"],
+                           parameters[pref + "Intensity"]);
+    m_dblManager->setValue(m_properties["Diffusion Sphere.Radius"],
+                           parameters[pref + "Radius"]);
+    m_dblManager->setValue(m_properties["Diffusion Sphere.Diffusion"],
+                           parameters[pref + "Diffusion"]);
+    m_dblManager->setValue(m_properties["Diffusion Sphere.Shift"],
+                           parameters[pref + "Shift"]);
+  }
+
+  if (fitTypeIndex == 4) {
+    // DiffSphere
+    QString pref = prefBase;
+
+    if (usingCompositeFunc) {
+      pref += "f" + QString::number(funcIndex) + ".f" +
+              QString::number(subIndex) + ".";
+    } else {
+      pref += "f" + QString::number(subIndex) + ".";
+    }
+
+    m_dblManager->setValue(m_properties["Diffusion Circle.Intensity"],
+                           parameters[pref + "Intensity"]);
+    m_dblManager->setValue(m_properties["Diffusion Circle.Radius"],
+                           parameters[pref + "Radius"]);
+    m_dblManager->setValue(m_properties["Diffusion Circle.Decay"],
+                           parameters[pref + "Decay"]);
+    m_dblManager->setValue(m_properties["Diffusion Circle.Shift"],
+                           parameters[pref + "Shift"]);
+  }
+
+  m_pythonExportWsName = "";
+}
+
+/**
+ * Handles the user entering a new minimum spectrum index.
+ *
+ * Prevents the user entering an overlapping spectra range.
+ *
+ * @param value Minimum spectrum index
+ */
+void ConvFit::specMinChanged(int value) {
+  m_uiForm.spSpectraMax->setMinimum(value);
+}
+
+/**
+ * Handles the user entering a new maximum spectrum index.
+ *
+ * Prevents the user entering an overlapping spectra range.
+ *
+ * @param value Maximum spectrum index
+ */
+void ConvFit::specMaxChanged(int value) {
+  m_uiForm.spSpectraMin->setMaximum(value);
+}
+
+void ConvFit::minChanged(double val) {
+  m_dblManager->setValue(m_properties["StartX"], val);
+}
+
+void ConvFit::maxChanged(double val) {
+  m_dblManager->setValue(m_properties["EndX"], val);
+}
+
+void ConvFit::hwhmChanged(double val) {
+  const double peakCentre =
+      m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
+  // Always want FWHM to display as positive.
+  const double hwhm = std::fabs(val - peakCentre);
+  // Update the property
+  auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
+  hwhmRangeSelector->blockSignals(true);
+  m_dblManager->setValue(m_properties["Lorentzian 1.FWHM"], hwhm * 2);
+  hwhmRangeSelector->blockSignals(false);
+}
+
+void ConvFit::backgLevel(double val) {
+  m_dblManager->setValue(m_properties["BGA0"], val);
+}
+
+void ConvFit::updateRS(QtProperty *prop, double val) {
+  auto fitRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitRange");
+  auto backRangeSelector =
+      m_uiForm.ppPlot->getRangeSelector("ConvFitBackRange");
+
+  if (prop == m_properties["StartX"]) {
+    fitRangeSelector->setMinimum(val);
+  } else if (prop == m_properties["EndX"]) {
+    fitRangeSelector->setMaximum(val);
+  } else if (prop == m_properties["BGA0"]) {
+    backRangeSelector->setMinimum(val);
+  } else if (prop == m_properties["Lorentzian 1.FWHM"]) {
+    hwhmUpdateRS(val);
+  } else if (prop == m_properties["Lorentzian 1.PeakCentre"]) {
+    hwhmUpdateRS(m_dblManager->value(m_properties["Lorentzian 1.FWHM"]));
+  }
+}
+
+void ConvFit::hwhmUpdateRS(double val) {
+  const double peakCentre =
+      m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
+  auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
+  hwhmRangeSelector->setMinimum(peakCentre - val / 2);
+  hwhmRangeSelector->setMaximum(peakCentre + val / 2);
+}
+
+void ConvFit::checkBoxUpdate(QtProperty *prop, bool checked) {
+  UNUSED_ARG(checked);
+
+  if (prop == m_properties["UseDeltaFunc"])
+    updatePlotOptions();
+  else if (prop == m_properties["UseFABADA"]) {
+    if (checked) {
+      // FABADA needs a much higher iteration limit
+      m_dblManager->setValue(m_properties["MaxIterations"], 20000);
+
+      m_properties["FABADA"]->addSubProperty(m_properties["OutputFABADAChain"]);
+      m_properties["FABADA"]->addSubProperty(m_properties["FABADAChainLength"]);
+      m_properties["FABADA"]->addSubProperty(
+          m_properties["FABADAConvergenceCriteria"]);
+      m_properties["FABADA"]->addSubProperty(
+          m_properties["FABADAJumpAcceptanceRate"]);
+    } else {
+      m_dblManager->setValue(m_properties["MaxIterations"], 500);
+
+      m_properties["FABADA"]->removeSubProperty(
+          m_properties["OutputFABADAChain"]);
+      m_properties["FABADA"]->removeSubProperty(
+          m_properties["FABADAChainLength"]);
+      m_properties["FABADA"]->removeSubProperty(
+          m_properties["FABADAConvergenceCriteria"]);
+      m_properties["FABADA"]->removeSubProperty(
+          m_properties["FABADAJumpAcceptanceRate"]);
+    }
+  }
+}
+
+void ConvFit::fitContextMenu(const QPoint &) {
+  QtBrowserItem *item(NULL);
+
+  item = m_cfTree->currentItem();
+
+  if (!item)
+    return;
+
+  // is it a fit property ?
+  QtProperty *prop = item->property();
+  if (prop == m_properties["StartX"] || prop == m_properties["EndX"])
+    return;
+
+  // is it already fixed?
+  bool fixed = prop->propertyManager() != m_dblManager;
+  if (fixed && prop->propertyManager() != m_stringManager)
+    return;
+
+  // Create the menu
+  QMenu *menu = new QMenu("ConvFit", m_cfTree);
+  QAction *action;
+
+  if (!fixed) {
+    action = new QAction("Fix", m_parentWidget);
+    connect(action, SIGNAL(triggered()), this, SLOT(fixItem()));
+  } else {
+    action = new QAction("Remove Fix", m_parentWidget);
+    connect(action, SIGNAL(triggered()), this, SLOT(unFixItem()));
+  }
+
+  menu->addAction(action);
+
+  // Show the menu
+  menu->popup(QCursor::pos());
+}
+
+void ConvFit::fixItem() {
+  QtBrowserItem *item = m_cfTree->currentItem();
+
+  // Determine what the property is.
+  QtProperty *prop = item->property();
+  QtProperty *fixedProp = m_stringManager->addProperty(prop->propertyName());
+  QtProperty *fprlbl = m_stringManager->addProperty("Fixed");
+  fixedProp->addSubProperty(fprlbl);
+  m_stringManager->setValue(fixedProp, prop->valueText());
+
+  item->parent()->property()->addSubProperty(fixedProp);
+
+  m_fixedProps[fixedProp] = prop;
+
+  item->parent()->property()->removeSubProperty(prop);
+}
+
+void ConvFit::unFixItem() {
+  QtBrowserItem *item = m_cfTree->currentItem();
+
+  QtProperty *prop = item->property();
+  if (prop->subProperties().empty()) {
+    item = item->parent();
+    prop = item->property();
+  }
+
+  item->parent()->property()->addSubProperty(m_fixedProps[prop]);
+  item->parent()->property()->removeSubProperty(prop);
+  m_fixedProps.remove(prop);
+  QtProperty *proplbl = prop->subProperties()[0];
+  delete proplbl;
+  delete prop;
+}
+
+void ConvFit::showTieCheckbox(QString fitType) {
+  m_uiForm.ckTieCentres->setVisible(fitType == "Two Lorentzians");
+}
+
+void ConvFit::updatePlotOptions() {
+  m_uiForm.cbPlotType->clear();
+
+  bool deltaFunction = m_blnManager->value(m_properties["UseDeltaFunc"]);
+
+  QStringList plotOptions;
+  plotOptions << "None";
+
+  if (deltaFunction)
+    plotOptions << "Height";
+
+  switch (m_uiForm.cbFitType->currentIndex()) {
+  // Lorentzians
+  case 1:
+  case 2:
+    plotOptions << "Amplitude"
+                << "FWHM";
+    if (deltaFunction)
+      plotOptions << "EISF";
+    break;
+
+  // DiffSphere
+  case 3:
+    plotOptions << "Intensity"
+                << "Radius"
+                << "Diffusion"
+                << "Shift";
+    break;
+
+  // DiffRotDiscreteCircle
+  case 4:
+    plotOptions << "Intensity"
+                << "Radius"
+                << "Decay"
+                << "Shift";
+    break;
+
+  default:
+    break;
+  }
+
+  plotOptions << "All";
+  m_uiForm.cbPlotType->addItems(plotOptions);
+}
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -115,6 +115,16 @@ void ConvFit::setup() {
   m_properties["DiffSphere"] = createDiffSphere("Diffusion Sphere");
   m_properties["DiffRotDiscreteCircle"] =
       createDiffRotDiscreteCircle("Diffusion Circle");
+  m_properties["ElasticDiffSphere"] =
+      createElasticDiffSphere("Elastic Diffusion Sphere");
+  m_properties["ElasticDiffRotDiscreteCircle"] =
+      createElasticDiffRotDiscreteCircle("Elastic Diffusion Circle");
+  m_properties["InelasticDiffSphere"] =
+      createInelasticDiffSphere("Inelastic Diffusion Sphere");
+  m_properties["InelasticDiffRotDiscreteCircle"] =
+      createInelasticDiffRotDiscreteCircle("Inelastic Diffusion Circle");
+  m_properties["StretchedExpFT"] =
+      createStretchedExpFT("Strecthced Exponential Fit");
 
   m_uiForm.leTempCorrection->setValidator(new QDoubleValidator(m_parentWidget));
 
@@ -425,20 +435,28 @@ std::string createParName(size_t index, size_t subIndex,
  *          +-- DeltaFunction (yes/no)
  *					+-- ProductFunction
  *							|
- *							+-- Lorentzian 1 (yes/no)
- *							+-- Temperature Correction (yes/no)
+ *							+-- Lorentzian 1
+ *(yes/no)
+ *							+-- Temperature Correction
+ *(yes/no)
  *					+-- ProductFunction
  *							|
- *							+-- Lorentzian 2 (yes/no)
- *							+-- Temperature Correction (yes/no)
+ *							+-- Lorentzian 2
+ *(yes/no)
+ *							+-- Temperature Correction
+ *(yes/no)
  *					+-- ProductFunction
  *							|
- *							+-- InelasticDiffSphere (yes/no)
- *							+-- Temperature Correction (yes/no)
+ *							+-- InelasticDiffSphere
+ *(yes/no)
+ *							+-- Temperature Correction
+ *(yes/no)
  *					+-- ProductFunction
  *							|
- *							+-- InelasticDiffRotDiscreteCircle (yes/no)
- *							+-- Temperature Correction (yes/no)
+ *							+-- InelasticDiffRotDiscreteCircle
+ *(yes/no)
+ *							+-- Temperature Correction
+ *(yes/no)
  *
  * @param tieCentres :: whether to tie centres of the two lorentzians.
  *
@@ -639,8 +657,10 @@ void ConvFit::createTemperatureCorrection(CompositeFunction_sptr product) {
 
 /**
  * Obtains the instrument resolution from the provided workspace
- * @param workspaceName The name of the workspaces which holds the instrument resolution
- * @return The resolution of the instrument. returns 0 if no resolution data could be found
+ * @param workspaceName The name of the workspaces which holds the instrument
+ * resolution
+ * @return The resolution of the instrument. returns 0 if no resolution data
+ * could be found
  */
 double ConvFit::getInstrumentResolution(std::string workspaceName) {
   using namespace Mantid::API;
@@ -702,7 +722,7 @@ double ConvFit::getInstrumentResolution(std::string workspaceName) {
 }
 
 /**
- * Creates a Lorentz peak 
+ * Creates a Lorentz peak
  * @param name The name of the Lorentz peak (1 or 2)
  * @return The QTProperty that represents the lorentz peak
  */
@@ -710,7 +730,8 @@ QtProperty *ConvFit::createLorentzian(const QString &name) {
   QtProperty *lorentzGroup = m_grpManager->addProperty(name);
 
   m_properties[name + ".Amplitude"] = m_dblManager->addProperty("Amplitude");
-  // m_dblManager->setRange(m_properties[name+".Amplitude"], 0.0, 1.0); // 0 < Amplitude < 1
+  // m_dblManager->setRange(m_properties[name+".Amplitude"], 0.0, 1.0); // 0 <
+  // Amplitude < 1
   m_properties[name + ".PeakCentre"] = m_dblManager->addProperty("PeakCentre");
   m_properties[name + ".FWHM"] = m_dblManager->addProperty("FWHM");
 
@@ -753,7 +774,7 @@ QtProperty *ConvFit::createDiffSphere(const QString &name) {
 }
 
 /**
- * Creates a DiffRotDiscreteCircle 
+ * Creates a DiffRotDiscreteCircle
  * @param name The name of the DiffRotDiscreteCircle
  * @return The QTProperty that represents the DiffRotDiscreteCircle
  */
@@ -783,6 +804,32 @@ QtProperty *ConvFit::createDiffRotDiscreteCircle(const QString &name) {
   return diffRotDiscreteCircleGroup;
 }
 
+QtProperty *ConvFit::createElasticDiffSphere(const QString &name) {
+  QtProperty *elasticDiffSphereGroup = m_grpManager->addProperty(name);
+  return elasticDiffSphereGroup;
+}
+
+QtProperty *ConvFit::createElasticDiffRotDiscreteCircle(const QString &name) {
+  QtProperty *elasticDiffRotDiscreteCircleGroup =
+      m_grpManager->addProperty(name);
+  return elasticDiffRotDiscreteCircleGroup;
+}
+
+QtProperty *ConvFit::createInelasticDiffSphere(const QString &name) {
+  QtProperty *elasticDiffSphereGroup = m_grpManager->addProperty(name);
+  return elasticDiffSphereGroup;
+}
+
+QtProperty *ConvFit::createInelasticDiffRotDiscreteCircle(const QString &name) {
+  QtProperty *inelasticDiffSphereGroup = m_grpManager->addProperty(name);
+  return inelasticDiffSphereGroup;
+}
+
+QtProperty *ConvFit::createStretchedExpFT(const QString &name) {
+  QtProperty *stretchedExpFTGroup = m_grpManager->addProperty(name);
+  return stretchedExpFTGroup;
+}
+
 /**
  * Populates the properties of a function with given values
  * @param func The function currently being added to the composite
@@ -794,7 +841,8 @@ QtProperty *ConvFit::createDiffRotDiscreteCircle(const QString &name) {
 void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp,
                                QtProperty *group, const std::string &pref,
                                bool tie) {
-  // Get subproperties of group and apply them as parameters on the function object
+  // Get subproperties of group and apply them as parameters on the function
+  // object
   QList<QtProperty *> props = group->subProperties();
 
   for (int i = 0; i < props.size(); i++) {
@@ -955,7 +1003,7 @@ void ConvFit::typeSelection(int index) {
 /**
  * Add/Remove sub property 'BGA1' from background based on Background type
  * @param index A reference to the Background type
- */ 
+ */
 void ConvFit::bgTypeSelection(int index) {
   if (index == 2) {
     m_properties["LinearBackground"]->addSubProperty(m_properties["BGA1"]);
@@ -966,7 +1014,7 @@ void ConvFit::bgTypeSelection(int index) {
 
 /**
  * Updates the plot in the gui window
- */ 
+ */
 void ConvFit::updatePlot() {
   using Mantid::Kernel::Exception::NotFoundError;
 

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -355,19 +355,33 @@ and *Use Delta Function* options in the interface.
 
       - :ref:`ProductFunction <func-ProductFunction>`
 
-        - :ref:`DiffSphere <func-DiffSphere>`
+        - :ref:`InelasticDiffSphere <func-DiffSphere>`
 
         - Temperature Correction
 
       - :ref:`ProductFunction <func-ProductFunction>`
 
-        - :ref:`DiffRotDiscreteCircle <func-DiffRotDiscreteCircle>`
+        - :ref:`InelasticDiffRotDiscreteCircle <func-DiffRotDiscreteCircle>`
 
         - Temperature Correction
+		
+	  - :ref:`ProductFunction <func-ProductFunction>`
 
-Note that it is the Inelastic variants of :ref:`DiffSphere <func-DiffSphere>`
-and :ref:`DiffRotDiscreteCircle <func-DiffRotDiscreteCircle>` that are used in
-this interface.
+        - :ref:`ElasticDiffSphere <func-DiffSphere>`
+
+        - Temperature Correction
+		
+	  - :ref:`ProductFunction <func-ProductFunction>`
+
+        - :ref:`ElasticDiffRotDiscreteCircle <func-DiffRotDiscreteCircle>`
+
+        - Temperature Correction
+		
+	  - :ref:`ProductFunction <func-ProductFunction>`
+
+        - :ref:`StetchedExpFT <func-StretchedExpFT>`
+
+        - Temperature Correction
 
 The Temperature Correction is a :ref:`UserFunction <func-UserFunction>` with the
 formula :math:`((x * 11.606) / T) / (1 - exp(-((x * 11.606) / T)))` where

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataAnalysis.rst
@@ -341,45 +341,45 @@ and *Use Delta Function* options in the interface.
 
       - DeltaFunction
 
-      - :ref:`ProductFunction <func-ProductFunction>`
+      - :ref:`ProductFunction <func-ProductFunction>` (One Lorentzian)
 
         - :ref:`Lorentzian <func-Lorentzian>`
 
         - Temperature Correction
 
-      - :ref:`ProductFunction <func-ProductFunction>`
+      - :ref:`ProductFunction <func-ProductFunction>` (Two Lorentzians)
 
         - :ref:`Lorentzian <func-Lorentzian>`
 
         - Temperature Correction
 
-      - :ref:`ProductFunction <func-ProductFunction>`
+      - :ref:`ProductFunction <func-ProductFunction>` (InelasticDiffSphere)
 
-        - :ref:`InelasticDiffSphere <func-DiffSphere>`
-
-        - Temperature Correction
-
-      - :ref:`ProductFunction <func-ProductFunction>`
-
-        - :ref:`InelasticDiffRotDiscreteCircle <func-DiffRotDiscreteCircle>`
+        - :ref:`Inelastic Diff Sphere <func-DiffSphere>`
 
         - Temperature Correction
-		
-	  - :ref:`ProductFunction <func-ProductFunction>`
 
-        - :ref:`ElasticDiffSphere <func-DiffSphere>`
+      - :ref:`ProductFunction <func-ProductFunction>` (InelasticDiffRotDiscreteCircle)
+
+        - :ref:`Inelastic Diff Rot Discrete Circle <func-DiffRotDiscreteCircle>` 
 
         - Temperature Correction
 		
-	  - :ref:`ProductFunction <func-ProductFunction>`
+      - :ref:`ProductFunction <func-ProductFunction>` (ElasticDiffSphere)
 
-        - :ref:`ElasticDiffRotDiscreteCircle <func-DiffRotDiscreteCircle>`
+        - :ref:`Elastic Diff Sphere <func-DiffSphere>`
 
         - Temperature Correction
 		
-	  - :ref:`ProductFunction <func-ProductFunction>`
+      - :ref:`ProductFunction <func-ProductFunction>` (ElasticDiffRotDiscreteCircle)
 
-        - :ref:`StetchedExpFT <func-StretchedExpFT>`
+        - :ref:`Elastic Diff Rot Discrete Circle <func-DiffRotDiscreteCircle>`
+
+        - Temperature Correction
+		
+      - :ref:`ProductFunction <func-ProductFunction>` (StretchedExpFT)
+
+        - :ref:`StretchedExpFT <func-StretchedExpFT>`
 
         - Temperature Correction
 

--- a/Code/Mantid/scripts/Inelastic/IndirectDataAnalysis.py
+++ b/Code/Mantid/scripts/Inelastic/IndirectDataAnalysis.py
@@ -81,7 +81,7 @@ def confitSeq(inputWS, func, startX, endX, ftype, bgd,
                     for i in xrange(specMin, specMax+1)]
 
     fit_args = dict()
-    if 'DS' in ftype or 'DC' in ftype:
+    if 'DS' in ftype or 'DC' in ftype or 'SFT' in ftype:
         fit_args['PassWSIndexToFunction'] = True
 
     PlotPeakByLogValue(Input=';'.join(input_params),
@@ -107,6 +107,8 @@ def confitSeq(inputWS, func, startX, endX, ftype, bgd,
         parameter_names = ['Height', 'Intensity', 'Radius', 'Diffusion', 'Shift']
     elif 'DC' in ftype:
         parameter_names = ['Height', 'Intensity', 'Radius', 'Decay', 'Shift']
+    elif 'SFT' in ftype:
+        parameter_names = ['height', 'tau', 'beta']
     else:
         parameter_names = ['Height', 'Amplitude', 'FWHM', 'EISF']
 


### PR DESCRIPTION
Fixes #12669 

The ConvFit tab in indirect data analysis now allows for QuasiElastic functions to be used.
The code has also been changed from the previous hard coded approach to have a far better coverage for generalised code.
# To test:
- Open the Convfit tab (from the menu select: Interfaces>Indirect>Data Analysis then click the ConvFit tab)
- Run any of the newly added QuasiElastic functions (selected in the FitType dropdown menu)
  - Load sample relevant data
  - Adjust parameters via the property tree
  - Click run
- Check the output is as expected 

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24523&oldid=24462).
