### PR TITLE
Fix BinMD for non-orthogonal axes

### DIFF
--- a/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/CoordTransformAffine.h
+++ b/Code/Mantid/Framework/DataObjects/inc/MantidDataObjects/CoordTransformAffine.h
@@ -43,6 +43,10 @@ public:
                        const std::vector<Mantid::Kernel::VMD> &axes,
                        const Mantid::Kernel::VMD &scaling);
 
+  void buildNonOrthogonal(const Mantid::Kernel::VMD &origin,
+                       const std::vector<Mantid::Kernel::VMD> &axes,
+                       const Mantid::Kernel::VMD &scaling);
+
   virtual void apply(const coord_t *inputVector, coord_t *outVector) const;
 
   static CoordTransformAffine *combineTransformations(CoordTransform *first,

--- a/Code/Mantid/Framework/DataObjects/src/CoordTransformAffine.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/CoordTransformAffine.cpp
@@ -226,31 +226,30 @@ void CoordTransformAffine::buildNonOrthogonal(
 
   // Start with identity
   m_affineMatrix.identityMatrix();
-  Mantid::Kernel::Matrix<coord_t> A(outD,inD);
+  //A matrix is columns of basis vectors
+  Mantid::Kernel::Matrix<coord_t> A(inD,outD);
   for(size_t i = 0; i < outD; i++){
       for(size_t j = 0; j < inD; j++){
-          A[i][j]=axes[i][j];
+          A[j][i]=axes[i][j];
       }
   }
-
   Mantid::Kernel::Matrix<coord_t> AT=A;
   AT.Transpose();
-  Mantid::Kernel::Matrix<coord_t> AAT=A*AT;
-  AAT.Invert();
-  Mantid::Kernel::Matrix<coord_t> Ainv=AT*AAT;
-  Mantid::Kernel::Matrix<coord_t> offset(1,inD);
+  Mantid::Kernel::Matrix<coord_t> ATA=AT*A;
+  ATA.Invert();
+  Mantid::Kernel::Matrix<coord_t> Ainv=ATA*AT;
+  Mantid::Kernel::Matrix<coord_t> offset(inD,1);
   for(size_t j = 0; j < inD; j++){
-      offset[0][j]=origin[j];
+      offset[j][0]=origin[j];
   }
-  Mantid::Kernel::Matrix<coord_t> outoffset=offset*Ainv;
+  Mantid::Kernel::Matrix<coord_t> outoffset=Ainv*offset;
 
   for(size_t i = 0; i < outD; i++){
       for(size_t j = 0; j < inD; j++){
           m_affineMatrix[i][j]=Ainv[i][j]*scaling[i];
       }
-      m_affineMatrix[i][inD]=-outoffset[0][i]*scaling[i];
+      m_affineMatrix[i][inD]=-outoffset[i][0]*scaling[i];
   }
-
   // Copy into the raw matrix (for speed)
   copyRawMatrix();
 }

--- a/Code/Mantid/Framework/Kernel/src/Matrix.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Matrix.cpp
@@ -965,6 +965,13 @@ T Matrix<T>::Invert()
   if (nx != ny && nx < 1)
     return 0;
 
+  if(nx==1)
+  {
+      T det=V[0][0];
+      if(V[0][0]!=static_cast<T>(0.))
+          V[0][0]=static_cast<T>(1.)/V[0][0];
+      return det;
+  }
   int *indx = new int[nx]; // Set in lubcmp
 
   double *col = new double[nx];

--- a/Code/Mantid/Framework/Kernel/test/MatrixTest.h
+++ b/Code/Mantid/Framework/Kernel/test/MatrixTest.h
@@ -55,6 +55,10 @@ public:
     A[2][2]=-7.0;
 
     TS_ASSERT_DELTA(A.Invert(),105.0,1e-5);
+    Matrix<double> B(1,1);
+    B[0][0]=2.;
+    TS_ASSERT_DELTA(B.Invert(),2,1e-5);
+    TS_ASSERT_DELTA(B[0][0],0.5,1e-5);
   }
 
   void testIdent()

--- a/Code/Mantid/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/SlicingAlgorithm.cpp
@@ -394,15 +394,19 @@ void SlicingAlgorithm::createGeneralTransform() {
   DataObjects::CoordTransformAffine *ct =
       new DataObjects::CoordTransformAffine(inD, m_outD);
   // Note: the scaling makes the coordinate correspond to a bin index
-  ct->buildOrthogonal(m_inputMinPoint, this->m_bases,
-                      VMD(this->m_binningScaling));
+  //ct->buildOrthogonal(m_inputMinPoint, this->m_bases,
+  //                    VMD(this->m_binningScaling));
+  ct->buildNonOrthogonal(m_inputMinPoint, this->m_bases,
+                          VMD(this->m_binningScaling)/VMD(m_transformScaling));
   this->m_transform = ct;
 
   // Transformation original->binned
   DataObjects::CoordTransformAffine *ctFrom =
       new DataObjects::CoordTransformAffine(inD, m_outD);
-  ctFrom->buildOrthogonal(m_translation, this->m_bases,
-                          VMD(m_transformScaling));
+  //ctFrom->buildOrthogonal(m_translation, this->m_bases,
+  //                        VMD(m_transformScaling));
+  ctFrom->buildNonOrthogonal(m_translation, this->m_bases,
+                             VMD(m_transformScaling)/VMD(m_transformScaling));
   m_transformFromOriginal = ctFrom;
 
   // Validate


### PR DESCRIPTION
Fixes #13247. Slicing algorithms can now use non-orthogonal axes
