### PR TITLE
Allow the efixed option in ISIS Energy Transfer to actually set the efixed

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name,attribute-defined-outside-init,too-many-instance-attributes,too-many-branches,no-init,deprecated-module
+#pylint: disable=invalid-name,too-many-instance-attributes,too-many-branches,no-init,deprecated-module
 from mantid.kernel import *
 from mantid.api import *
 from mantid.simpleapi import *
@@ -13,6 +13,32 @@ _elems_or_none = lambda l: l if len(l) != 0 else None
 
 
 class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
+
+    _chopped_data = None
+    _data_files = None
+    _load_logs = None
+    _calibration_ws = None
+    _instrument_name = None
+    _analyser = None
+    _reflection = None
+    _efixed = None
+    _spectra_range = None
+    _background_range = None
+    _rebin_string = None
+    _detailed_balance = None
+    _scale_factor = None
+    _fold_multiple_frames = None
+    _grouping_method = None
+    _grouping_ws = None
+    _grouping_map_file = None
+    _output_x_units = None
+    _plot_type = None
+    _save_formats = None
+    _output_ws = None
+    _sum_files = None
+    _ipf_filename = None
+    _workspace_names = None
+
 
     def category(self):
         return 'Workflow\\Inelastic;PythonAlgorithms;Inelastic'
@@ -39,22 +65,31 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                              doc='Workspace contining calibration data')
 
         # Instrument configuration properties
-        self.declareProperty(name='Instrument', defaultValue='', doc='Instrument used during run.',
-                             validator=StringListValidator(['IRIS', 'OSIRIS', 'TOSCA', 'TFXA']))
-        self.declareProperty(name='Analyser', defaultValue='', doc='Analyser bank used during run.',
-                             validator=StringListValidator(['graphite', 'mica', 'fmica']))
-        self.declareProperty(name='Reflection', defaultValue='', doc='Reflection number for instrument setup during run.',
-                             validator=StringListValidator(['002', '004', '006']))
+        self.declareProperty(name='Instrument', defaultValue='',
+                             validator=StringListValidator(['IRIS', 'OSIRIS', 'TOSCA', 'TFXA']),
+                             doc='Instrument used during run.')
+        self.declareProperty(name='Analyser', defaultValue='',
+                             validator=StringListValidator(['graphite', 'mica', 'fmica']),
+                             doc='Analyser bank used during run.')
+        self.declareProperty(name='Reflection', defaultValue='',
+                             validator=StringListValidator(['002', '004', '006']),
+                             doc='Reflection number for instrument setup during run.')
+
+        self.declareProperty(name='Efixed', defaultValue=Property.EMPTY_DBL,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Overrides the default Efixed value for the analyser/reflection selection.')
 
         self.declareProperty(IntArrayProperty(name='SpectraRange', values=[0, 1],
                                               validator=IntArrayMandatoryValidator()),
                              doc='Comma separated range of spectra number to use.')
         self.declareProperty(FloatArrayProperty(name='BackgroundRange'),
                              doc='Range of background to subtact from raw data in time of flight.')
-        self.declareProperty(name='RebinString', defaultValue='', doc='Rebin string parameters.')
+        self.declareProperty(name='RebinString', defaultValue='',
+                             doc='Rebin string parameters.')
         self.declareProperty(name='DetailedBalance', defaultValue=Property.EMPTY_DBL,
                              doc='')
-        self.declareProperty(name='ScaleFactor', defaultValue=1.0, doc='Factor by which to scale result.')
+        self.declareProperty(name='ScaleFactor', defaultValue=1.0,
+                             doc='Factor by which to scale result.')
         self.declareProperty(name='FoldMultipleFrames', defaultValue=True,
                              doc='Folds multiple framed data sets into a single workspace.')
 
@@ -66,15 +101,20 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                                                direction=Direction.Input,
                                                optional=PropertyMode.Optional),
                              doc='Workspace containing spectra grouping.')
-        self.declareProperty(FileProperty('MapFile', '', action=FileAction.OptionalLoad, extensions=['.map']),
+        self.declareProperty(FileProperty('MapFile', '',
+                                          action=FileAction.OptionalLoad,
+                                          extensions=['.map']),
                              doc='Workspace containing spectra grouping.')
 
         # Output properties
-        self.declareProperty(name='UnitX', defaultValue='DeltaE', doc='X axis units for the result workspace.',
-                             validator=StringListValidator(['DeltaE', 'DeltaE_inWavenumber']))
-        self.declareProperty(StringArrayProperty(name='SaveFormats'), doc='Comma seperated list of save formats')
-        self.declareProperty(name='Plot', defaultValue='None', doc='Type of plot to output after reduction.',
-                             validator=StringListValidator(['None', 'Spectra', 'Contour', 'Both']))
+        self.declareProperty(name='UnitX', defaultValue='DeltaE',
+                             validator=StringListValidator(['DeltaE', 'DeltaE_inWavenumber']),
+                             doc='X axis units for the result workspace.')
+        self.declareProperty(StringArrayProperty(name='SaveFormats'),
+                             doc='Comma seperated list of save formats')
+        self.declareProperty(name='Plot', defaultValue='None',
+                             validator=StringListValidator(['None', 'Spectra', 'Contour', 'Both']),
+                             doc='Type of plot to output after reduction.')
 
         self.declareProperty(WorkspaceGroupProperty('OutputWorkspace', '',
                                                     direction=Direction.Output),
@@ -99,11 +139,11 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         self._setup()
         self._workspace_names, self._chopped_data = load_files(self._data_files,
-                                                              self._ipf_filename,
-                                                              self._spectra_range[0],
-                                                              self._spectra_range[1],
-                                                              self._sum_files,
-                                                              self._load_logs)
+                                                               self._ipf_filename,
+                                                               self._spectra_range[0],
+                                                               self._spectra_range[1],
+                                                               self._sum_files,
+                                                               self._load_logs)
 
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)
@@ -122,6 +162,14 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
             # Process workspaces
             for ws_name in workspaces:
+                # Set Efixed if given to algorithm
+                if self._efixed != Property.EMPTY_DBL:
+                    SetInstrumentParameter(Workspace=ws_name,
+                                           ComponentName=self._analyser,
+                                           ParameterName='Efixed',
+                                           ParameterType='Number',
+                                           Value=str(self._efixed))
+
                 monitor_ws_name = ws_name + '_mon'
 
                 # Process monitor
@@ -283,6 +331,10 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                 issues['SaveFormats'] = '%s is not a valid save format' % format_name
                 break
 
+        efixed = self.getProperty('Efixed').value
+        if efixed != Property.EMPTY_DBL and instrument_name not in ['IRIS', 'OSIRIS']:
+            issues['Efixed'] = 'Can only override Efixed on IRIS and OSIRIS'
+
         return issues
 
 
@@ -300,6 +352,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         self._instrument_name = self.getPropertyValue('Instrument')
         self._analyser = self.getPropertyValue('Analyser')
         self._reflection = self.getPropertyValue('Reflection')
+        self._efixed = self.getProperty('Efixed').value
 
         self._spectra_range = self.getProperty('SpectraRange').value
         self._background_range = _elems_or_none(self.getProperty('BackgroundRange').value)

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectEnergyTransferTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectEnergyTransferTest.py
@@ -175,5 +175,46 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                           GroupingMethod='Workspace')
 
 
+    def test_reduction_with_manual_efixed(self):
+        """
+        Sanity test to ensure a reduction with a manual Efixed value completes.
+        """
+
+        wks = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'],
+                                         Instrument='IRIS',
+                                         Analyser='graphite',
+                                         Reflection='002',
+                                         SpectraRange=[3, 53],
+                                         Efixed=1.9)
+
+        self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
+        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+
+        red_ws = wks.getItem(0)
+        self.assertEqual(red_ws.getNumberHistograms(), 51)
+
+
+    def test_reduction_with_manual_efixed_same_as_default(self):
+        """
+        Sanity test to ensure that manually setting the default Efixed value
+        gives the same results as not providing it.
+        """
+
+        ref = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'],
+                                         Instrument='IRIS',
+                                         Analyser='graphite',
+                                         Reflection='002',
+                                         SpectraRange=[3, 53])
+
+        wks = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'],
+                                         Instrument='IRIS',
+                                         Analyser='graphite',
+                                         Reflection='002',
+                                         SpectraRange=[3, 53],
+                                         Efixed=1.845)
+
+        self.assertTrue(CheckWorkspacesMatch(ref, wks), 'Success!')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.ui
@@ -107,22 +107,19 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QLabel" name="lbEFixed">
+       <widget class="QLabel" name="lbEfixed">
         <property name="text">
-         <string>Efixed value:</string>
-        </property>
-        <property name="buddy">
-         <cstring>leEfixed</cstring>
+         <string>Efixed:</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="leEfixed">
-        <property name="enabled">
-         <bool>false</bool>
+       <widget class="QDoubleSpinBox" name="spEfixed">
+        <property name="decimals">
+         <number>4</number>
         </property>
-        <property name="toolTip">
-         <string>Value of Efixed for conversion from time to energy.</string>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
         </property>
        </widget>
       </item>
@@ -963,7 +960,7 @@
   <tabstop>ckSumFiles</tabstop>
   <tabstop>ckLoadLogFiles</tabstop>
   <tabstop>ckUseCalib</tabstop>
-  <tabstop>leEfixed</tabstop>
+  <tabstop>spEfixed</tabstop>
   <tabstop>spSpectraMin</tabstop>
   <tabstop>spSpectraMax</tabstop>
   <tabstop>cbGroupingOptions</tabstop>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -111,9 +111,9 @@ void ISISEnergyTransfer::run() {
   reductionAlg->initialize();
   BatchAlgorithmRunner::AlgorithmRuntimeProps reductionRuntimeProps;
 
-  reductionAlg->setProperty(
-      "Instrument",
-      getInstrumentConfiguration()->getInstrumentName().toStdString());
+  QString instName = getInstrumentConfiguration()->getInstrumentName();
+
+  reductionAlg->setProperty("Instrument", instName.toStdString());
   reductionAlg->setProperty(
       "Analyser",
       getInstrumentConfiguration()->getAnalyserName().toStdString());
@@ -121,7 +121,12 @@ void ISISEnergyTransfer::run() {
       "Reflection",
       getInstrumentConfiguration()->getReflectionName().toStdString());
 
-  reductionAlg->setProperty("Efixed", m_uiForm.spEfixed->value());
+  // Override the efixed for QENS spectrometers only
+  QStringList qens;
+  qens << "IRIS"
+       << "OSIRIS";
+  if (qens.contains(instName))
+    reductionAlg->setProperty("Efixed", m_uiForm.spEfixed->value());
 
   QString files = m_uiForm.dsRunFiles->getFilenames().join(",");
   reductionAlg->setProperty("InputFiles", files.toStdString());
@@ -233,6 +238,11 @@ void ISISEnergyTransfer::setInstrumentDefault() {
 
   // Set the search instrument for runs
   m_uiForm.dsRunFiles->setInstrumentOverride(instDetails["instrument"]);
+
+  QStringList qens;
+  qens << "IRIS"
+       << "OSIRIS";
+  m_uiForm.spEfixed->setEnabled(qens.contains(instDetails["instrument"]));
 
   if (instDetails["spectra-min"].isEmpty() ||
       instDetails["spectra-max"].isEmpty()) {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -9,525 +9,534 @@
 using namespace Mantid::API;
 using MantidQt::API::BatchAlgorithmRunner;
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  //----------------------------------------------------------------------------------------------
-  /** Constructor
-   */
-  ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction * idrUI, QWidget * parent) :
-      IndirectDataReductionTab(idrUI, parent)
-  {
-    m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction *idrUI,
+                                       QWidget *parent)
+    : IndirectDataReductionTab(idrUI, parent) {
+  m_uiForm.setupUi(parent);
 
-    // SIGNAL/SLOT CONNECTIONS
-    // Update instrument information when a new instrument config is selected
-    connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setInstrumentDefault()));
-    // Shows required mapping option UI widgets when a new mapping option is selected from drop down
-    connect(m_uiForm.cbGroupingOptions, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(mappingOptionSelected(const QString&)));
-    // Plots raw input data when user clicks Plot Time
-    connect(m_uiForm.pbPlotTime, SIGNAL(clicked()), this, SLOT(plotRaw()));
-    // Shows message on run button when user is inputting a run number
-    connect(m_uiForm.dsRunFiles, SIGNAL(fileTextChanged(const QString &)), this, SLOT(pbRunEditing()));
-    // Shows message on run button when Mantid is finding the file for a given run number
-    connect(m_uiForm.dsRunFiles, SIGNAL(findingFiles()), this, SLOT(pbRunFinding()));
-    // Reverts run button back to normal when file finding has finished
-    connect(m_uiForm.dsRunFiles, SIGNAL(fileFindingFinished()), this, SLOT(pbRunFinished()));
+  // SIGNAL/SLOT CONNECTIONS
+  // Update instrument information when a new instrument config is selected
+  connect(this, SIGNAL(newInstrumentConfiguration()), this,
+          SLOT(setInstrumentDefault()));
+  // Shows required mapping option UI widgets when a new mapping option is
+  // selected from drop down
+  connect(m_uiForm.cbGroupingOptions,
+          SIGNAL(currentIndexChanged(const QString &)), this,
+          SLOT(mappingOptionSelected(const QString &)));
+  // Plots raw input data when user clicks Plot Time
+  connect(m_uiForm.pbPlotTime, SIGNAL(clicked()), this, SLOT(plotRaw()));
+  // Shows message on run button when user is inputting a run number
+  connect(m_uiForm.dsRunFiles, SIGNAL(fileTextChanged(const QString &)), this,
+          SLOT(pbRunEditing()));
+  // Shows message on run button when Mantid is finding the file for a given run
+  // number
+  connect(m_uiForm.dsRunFiles, SIGNAL(findingFiles()), this,
+          SLOT(pbRunFinding()));
+  // Reverts run button back to normal when file finding has finished
+  connect(m_uiForm.dsRunFiles, SIGNAL(fileFindingFinished()), this,
+          SLOT(pbRunFinished()));
 
-    // Re-validate when certain inputs are changed
-    connect(m_uiForm.spRebinLow, SIGNAL(valueChanged(double)), this, SLOT(validate()));
-    connect(m_uiForm.spRebinWidth, SIGNAL(valueChanged(double)), this, SLOT(validate()));
-    connect(m_uiForm.spRebinHigh, SIGNAL(valueChanged(double)), this, SLOT(validate()));
-    connect(m_uiForm.leRebinString, SIGNAL(textChanged(const QString &)), this, SLOT(validate()));
+  // Re-validate when certain inputs are changed
+  connect(m_uiForm.spRebinLow, SIGNAL(valueChanged(double)), this,
+          SLOT(validate()));
+  connect(m_uiForm.spRebinWidth, SIGNAL(valueChanged(double)), this,
+          SLOT(validate()));
+  connect(m_uiForm.spRebinHigh, SIGNAL(valueChanged(double)), this,
+          SLOT(validate()));
+  connect(m_uiForm.leRebinString, SIGNAL(textChanged(const QString &)), this,
+          SLOT(validate()));
 
-    // Update UI widgets to show default values
-    mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
+  // Update UI widgets to show default values
+  mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
 
-    // Validate to remove invalid markers
-    validateTab();
-  }
+  // Validate to remove invalid markers
+  validateTab();
+}
 
-  //----------------------------------------------------------------------------------------------
-  /** Destructor
-   */
-  ISISEnergyTransfer::~ISISEnergyTransfer()
-  {
-  }
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+ISISEnergyTransfer::~ISISEnergyTransfer() {}
 
+void ISISEnergyTransfer::setup() {}
 
-  void ISISEnergyTransfer::setup()
-  {
-  }
+bool ISISEnergyTransfer::validate() {
+  UserInputValidator uiv;
 
+  // Run files input
+  if (!m_uiForm.dsRunFiles->isValid())
+    uiv.addErrorMessage("Run file range is invalid.");
 
-  bool ISISEnergyTransfer::validate()
-  {
-    UserInputValidator uiv;
+  // Calibration file input
+  if (m_uiForm.ckUseCalib->isChecked() &&
+      !m_uiForm.dsCalibrationFile->isValid())
+    uiv.addErrorMessage("Calibration file/workspace is invalid.");
 
-    // Run files input
-    if(!m_uiForm.dsRunFiles->isValid())
-      uiv.addErrorMessage("Run file range is invalid.");
+  // Mapping file
+  if ((m_uiForm.cbGroupingOptions->currentText() == "File") &&
+      (!m_uiForm.dsMapFile->isValid()))
+    uiv.addErrorMessage("Mapping file is invalid.");
 
-    // Calibration file input
-    if(m_uiForm.ckUseCalib->isChecked() && !m_uiForm.dsCalibrationFile->isValid())
-      uiv.addErrorMessage("Calibration file/workspace is invalid.");
-
-    // Mapping file
-    if((m_uiForm.cbGroupingOptions->currentText() == "File") && (!m_uiForm.dsMapFile->isValid()))
-      uiv.addErrorMessage("Mapping file is invalid.");
-
-    // Rebinning
-    if(!m_uiForm.ckDoNotRebin->isChecked())
-    {
-      if(m_uiForm.cbRebinType->currentText() == "Single")
-      {
-        bool rebinValid = !uiv.checkBins(m_uiForm.spRebinLow->value(), m_uiForm.spRebinWidth->value(), m_uiForm.spRebinHigh->value());
-        m_uiForm.valRebinLow->setVisible(rebinValid);
-        m_uiForm.valRebinWidth->setVisible(rebinValid);
-        m_uiForm.valRebinHigh->setVisible(rebinValid);
-      }
-      else
-      {
-        uiv.checkFieldIsNotEmpty("Rebin string", m_uiForm.leRebinString, m_uiForm.valRebinString);
-      }
+  // Rebinning
+  if (!m_uiForm.ckDoNotRebin->isChecked()) {
+    if (m_uiForm.cbRebinType->currentText() == "Single") {
+      bool rebinValid = !uiv.checkBins(m_uiForm.spRebinLow->value(),
+                                       m_uiForm.spRebinWidth->value(),
+                                       m_uiForm.spRebinHigh->value());
+      m_uiForm.valRebinLow->setVisible(rebinValid);
+      m_uiForm.valRebinWidth->setVisible(rebinValid);
+      m_uiForm.valRebinHigh->setVisible(rebinValid);
+    } else {
+      uiv.checkFieldIsNotEmpty("Rebin string", m_uiForm.leRebinString,
+                               m_uiForm.valRebinString);
     }
+  } else {
+    m_uiForm.valRebinLow->setVisible(false);
+    m_uiForm.valRebinWidth->setVisible(false);
+    m_uiForm.valRebinHigh->setVisible(false);
+    m_uiForm.valRebinString->setVisible(false);
+  }
+
+  return uiv.isAllInputValid();
+}
+
+void ISISEnergyTransfer::run() {
+  IAlgorithm_sptr reductionAlg =
+      AlgorithmManager::Instance().create("ISISIndirectEnergyTransfer");
+  reductionAlg->initialize();
+  BatchAlgorithmRunner::AlgorithmRuntimeProps reductionRuntimeProps;
+
+  reductionAlg->setProperty(
+      "Instrument",
+      getInstrumentConfiguration()->getInstrumentName().toStdString());
+  reductionAlg->setProperty(
+      "Analyser",
+      getInstrumentConfiguration()->getAnalyserName().toStdString());
+  reductionAlg->setProperty(
+      "Reflection",
+      getInstrumentConfiguration()->getReflectionName().toStdString());
+
+  reductionAlg->setProperty("Efixed", m_uiForm.spEfixed->value());
+
+  QString files = m_uiForm.dsRunFiles->getFilenames().join(",");
+  reductionAlg->setProperty("InputFiles", files.toStdString());
+
+  reductionAlg->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
+  reductionAlg->setProperty("LoadLogFiles",
+                            m_uiForm.ckLoadLogFiles->isChecked());
+
+  if (m_uiForm.ckUseCalib->isChecked()) {
+    QString calibWorkspaceName =
+        m_uiForm.dsCalibrationFile->getCurrentDataName();
+    reductionAlg->setProperty("CalibrationWorkspace",
+                              calibWorkspaceName.toStdString());
+  }
+
+  std::vector<long> detectorRange;
+  detectorRange.push_back(m_uiForm.spSpectraMin->value());
+  detectorRange.push_back(m_uiForm.spSpectraMax->value());
+  reductionAlg->setProperty("SpectraRange", detectorRange);
+
+  if (m_uiForm.ckBackgroundRemoval->isChecked()) {
+    std::vector<double> backgroundRange;
+    backgroundRange.push_back(m_uiForm.spBackgroundStart->value());
+    backgroundRange.push_back(m_uiForm.spBackgroundEnd->value());
+    reductionAlg->setProperty("BackgroundRange", backgroundRange);
+  }
+
+  if (!m_uiForm.ckDoNotRebin->isChecked()) {
+    QString rebin;
+    if (m_uiForm.cbRebinType->currentIndex() == 0)
+      rebin = m_uiForm.spRebinLow->text() + "," +
+              m_uiForm.spRebinWidth->text() + "," +
+              m_uiForm.spRebinHigh->text();
     else
-    {
-      m_uiForm.valRebinLow->setVisible(false);
-      m_uiForm.valRebinWidth->setVisible(false);
-      m_uiForm.valRebinHigh->setVisible(false);
-      m_uiForm.valRebinString->setVisible(false);
-    }
+      rebin = m_uiForm.leRebinString->text();
 
-    return uiv.isAllInputValid();
+    reductionAlg->setProperty("RebinString", rebin.toStdString());
   }
 
+  if (m_uiForm.ckDetailedBalance->isChecked())
+    reductionAlg->setProperty("DetailedBalance",
+                              m_uiForm.spDetailedBalance->value());
 
-  void ISISEnergyTransfer::run()
-  {
-    IAlgorithm_sptr reductionAlg = AlgorithmManager::Instance().create("ISISIndirectEnergyTransfer");
-    reductionAlg->initialize();
-    BatchAlgorithmRunner::AlgorithmRuntimeProps reductionRuntimeProps;
+  if (m_uiForm.ckScaleMultiplier->isChecked())
+    reductionAlg->setProperty("ScaleFactor",
+                              m_uiForm.spScaleMultiplier->value());
 
-    reductionAlg->setProperty("Instrument", getInstrumentConfiguration()->getInstrumentName().toStdString());
-    reductionAlg->setProperty("Analyser", getInstrumentConfiguration()->getAnalyserName().toStdString());
-    reductionAlg->setProperty("Reflection", getInstrumentConfiguration()->getReflectionName().toStdString());
+  if (m_uiForm.ckCm1Units->isChecked())
+    reductionAlg->setProperty("UnitX", "DeltaE_inWavenumber");
 
-    QString files = m_uiForm.dsRunFiles->getFilenames().join(",");
-    reductionAlg->setProperty("InputFiles", files.toStdString());
+  QPair<QString, QString> grouping =
+      createMapFile(m_uiForm.cbGroupingOptions->currentText());
+  reductionAlg->setProperty("GroupingMethod", grouping.first.toStdString());
 
-    reductionAlg->setProperty("SumFiles", m_uiForm.ckSumFiles->isChecked());
-    reductionAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
+  if (grouping.first == "Workspace")
+    reductionRuntimeProps["GroupingWorkspace"] = grouping.second.toStdString();
+  else if (grouping.first == "File")
+    reductionAlg->setProperty("MapFile", grouping.second.toStdString());
 
-    if(m_uiForm.ckUseCalib->isChecked())
-    {
-      QString calibWorkspaceName = m_uiForm.dsCalibrationFile->getCurrentDataName();
-      reductionAlg->setProperty("CalibrationWorkspace", calibWorkspaceName.toStdString());
-    }
+  reductionAlg->setProperty("FoldMultipleFrames", m_uiForm.ckFold->isChecked());
+  reductionAlg->setProperty("Plot",
+                            m_uiForm.cbPlotType->currentText().toStdString());
+  reductionAlg->setProperty("SaveFormats", getSaveFormats());
+  reductionAlg->setProperty("OutputWorkspace",
+                            "IndirectEnergyTransfer_Workspaces");
 
-    std::vector<long> detectorRange;
-    detectorRange.push_back(m_uiForm.spSpectraMin->value());
-    detectorRange.push_back(m_uiForm.spSpectraMax->value());
-    reductionAlg->setProperty("SpectraRange", detectorRange);
+  m_batchAlgoRunner->addAlgorithm(reductionAlg, reductionRuntimeProps);
 
-    if(m_uiForm.ckBackgroundRemoval->isChecked())
-    {
-      std::vector<double> backgroundRange;
-      backgroundRange.push_back(m_uiForm.spBackgroundStart->value());
-      backgroundRange.push_back(m_uiForm.spBackgroundEnd->value());
-      reductionAlg->setProperty("BackgroundRange", backgroundRange);
-    }
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(algorithmComplete(bool)));
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(plotRawComplete(bool)));
+  m_batchAlgoRunner->executeBatchAsync();
+}
 
-    if(!m_uiForm.ckDoNotRebin->isChecked())
-    {
-      QString rebin;
-      if(m_uiForm.cbRebinType->currentIndex() == 0)
-        rebin = m_uiForm.spRebinLow->text() + "," + m_uiForm.spRebinWidth->text() + "," + m_uiForm.spRebinHigh->text();
-      else
-        rebin = m_uiForm.leRebinString->text();
+/**
+ * Handles completion of the algorithm.
+ *
+ * Sets result workspace for Python export and ungroups result WorkspaceGroup.
+ *
+ * @param error True if the algorithm was stopped due to error, false otherwise
+ */
+void ISISEnergyTransfer::algorithmComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(algorithmComplete(bool)));
 
-      reductionAlg->setProperty("RebinString", rebin.toStdString());
-    }
+  if (error)
+    return;
 
-    if(m_uiForm.ckDetailedBalance->isChecked())
-      reductionAlg->setProperty("DetailedBalance", m_uiForm.spDetailedBalance->value());
+  WorkspaceGroup_sptr energyTransferOutputGroup =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+          "IndirectEnergyTransfer_Workspaces");
+  if (energyTransferOutputGroup->size() == 0)
+    return;
 
-    if(m_uiForm.ckScaleMultiplier->isChecked())
-      reductionAlg->setProperty("ScaleFactor", m_uiForm.spScaleMultiplier->value());
+  // Set workspace for Python export as the first result workspace
+  m_pythonExportWsName = energyTransferOutputGroup->getNames()[0];
 
-    if(m_uiForm.ckCm1Units->isChecked())
-      reductionAlg->setProperty("UnitX", "DeltaE_inWavenumber");
+  // Ungroup the output workspace
+  energyTransferOutputGroup->removeAll();
+  AnalysisDataService::Instance().remove("IndirectEnergyTransfer_Workspaces");
+}
 
-    QPair<QString, QString> grouping = createMapFile(m_uiForm.cbGroupingOptions->currentText());
-    reductionAlg->setProperty("GroupingMethod", grouping.first.toStdString());
+/**
+ * Called when the instrument has changed, used to update default values.
+ */
+void ISISEnergyTransfer::setInstrumentDefault() {
+  QMap<QString, QString> instDetails = getInstrumentDetails();
 
-    if(grouping.first == "Workspace")
-      reductionRuntimeProps["GroupingWorkspace"] = grouping.second.toStdString();
-    else if(grouping.first == "File")
-      reductionAlg->setProperty("MapFile", grouping.second.toStdString());
+  // Set the search instrument for runs
+  m_uiForm.dsRunFiles->setInstrumentOverride(instDetails["instrument"]);
 
-    reductionAlg->setProperty("FoldMultipleFrames", m_uiForm.ckFold->isChecked());
-    reductionAlg->setProperty("Plot", m_uiForm.cbPlotType->currentText().toStdString());
-    reductionAlg->setProperty("SaveFormats", getSaveFormats());
-    reductionAlg->setProperty("OutputWorkspace", "IndirectEnergyTransfer_Workspaces");
-
-    m_batchAlgoRunner->addAlgorithm(reductionAlg, reductionRuntimeProps);
-
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(plotRawComplete(bool)));
-    m_batchAlgoRunner->executeBatchAsync();
+  if (instDetails["spectra-min"].isEmpty() ||
+      instDetails["spectra-max"].isEmpty()) {
+    emit showMessageBox("Could not gather necessary data from parameter file.");
+    return;
   }
 
+  int specMin = instDetails["spectra-min"].toInt();
+  int specMax = instDetails["spectra-max"].toInt();
 
-  /**
-   * Handles completion of the algorithm.
-   *
-   * Sets result workspace for Python export and ungroups result WorkspaceGroup.
-   *
-   * @param error True if the algorithm was stopped due to error, false otherwise
-   */
-  void ISISEnergyTransfer::algorithmComplete(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
+  m_uiForm.spSpectraMin->setMinimum(specMin);
+  m_uiForm.spSpectraMin->setMaximum(specMax);
+  m_uiForm.spSpectraMin->setValue(specMin);
 
-    if(error)
-      return;
+  m_uiForm.spSpectraMax->setMinimum(specMin);
+  m_uiForm.spSpectraMax->setMaximum(specMax);
+  m_uiForm.spSpectraMax->setValue(specMax);
 
-    WorkspaceGroup_sptr energyTransferOutputGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("IndirectEnergyTransfer_Workspaces");
-    if(energyTransferOutputGroup->size() == 0)
-      return;
+  if (!instDetails["Efixed"].isEmpty())
+    m_uiForm.spEfixed->setValue(instDetails["Efixed"].toDouble());
+  else
+    m_uiForm.spEfixed->setValue(0.0);
 
-    // Set workspace for Python export as the first result workspace
-    m_pythonExportWsName = energyTransferOutputGroup->getNames()[0];
-
-    // Ungroup the output workspace
-    energyTransferOutputGroup->removeAll();
-    AnalysisDataService::Instance().remove("IndirectEnergyTransfer_Workspaces");
+  // Default rebinning parameters can be set in instrument parameter file
+  if (!instDetails["rebin-default"].isEmpty()) {
+    m_uiForm.leRebinString->setText(instDetails["rebin-default"]);
+    m_uiForm.ckDoNotRebin->setChecked(false);
+    QStringList rbp =
+        instDetails["rebin-default"].split(",", QString::SkipEmptyParts);
+    if (rbp.size() == 3) {
+      m_uiForm.spRebinLow->setValue(rbp[0].toDouble());
+      m_uiForm.spRebinWidth->setValue(rbp[1].toDouble());
+      m_uiForm.spRebinHigh->setValue(rbp[2].toDouble());
+      m_uiForm.cbRebinType->setCurrentIndex(0);
+    } else {
+      m_uiForm.cbRebinType->setCurrentIndex(1);
+    }
+  } else {
+    m_uiForm.ckDoNotRebin->setChecked(true);
+    m_uiForm.spRebinLow->setValue(0.0);
+    m_uiForm.spRebinWidth->setValue(0.0);
+    m_uiForm.spRebinHigh->setValue(0.0);
+    m_uiForm.leRebinString->setText("");
   }
 
-
-  /**
-   * Called when the instrument has changed, used to update default values.
-   */
-  void ISISEnergyTransfer::setInstrumentDefault()
-  {
-    QMap<QString, QString> instDetails = getInstrumentDetails();
-
-    // Set the search instrument for runs
-    m_uiForm.dsRunFiles->setInstrumentOverride(instDetails["instrument"]);
-
-    if(instDetails["spectra-min"].isEmpty() || instDetails["spectra-max"].isEmpty())
-    {
-      emit showMessageBox("Could not gather necessary data from parameter file.");
-      return;
-    }
-
-    int specMin = instDetails["spectra-min"].toInt();
-    int specMax = instDetails["spectra-max"].toInt();
-
-    m_uiForm.spSpectraMin->setMinimum(specMin);
-    m_uiForm.spSpectraMin->setMaximum(specMax);
-    m_uiForm.spSpectraMin->setValue(specMin);
-
-    m_uiForm.spSpectraMax->setMinimum(specMin);
-    m_uiForm.spSpectraMax->setMaximum(specMax);
-    m_uiForm.spSpectraMax->setValue(specMax);
-
-    if(!instDetails["Efixed"].isEmpty())
-      m_uiForm.leEfixed->setText(instDetails["Efixed"]);
-    else
-      m_uiForm.leEfixed->clear();
-
-    // Default rebinning parameters can be set in instrument parameter file
-    if(!instDetails["rebin-default"].isEmpty())
-    {
-      m_uiForm.leRebinString->setText(instDetails["rebin-default"]);
-      m_uiForm.ckDoNotRebin->setChecked(false);
-      QStringList rbp = instDetails["rebin-default"].split(",", QString::SkipEmptyParts);
-      if(rbp.size() == 3)
-      {
-        m_uiForm.spRebinLow->setValue(rbp[0].toDouble());
-        m_uiForm.spRebinWidth->setValue(rbp[1].toDouble());
-        m_uiForm.spRebinHigh->setValue(rbp[2].toDouble());
-        m_uiForm.cbRebinType->setCurrentIndex(0);
-      }
-      else
-      {
-        m_uiForm.cbRebinType->setCurrentIndex(1);
-      }
-    }
-    else
-    {
-      m_uiForm.ckDoNotRebin->setChecked(true);
-      m_uiForm.spRebinLow->setValue(0.0);
-      m_uiForm.spRebinWidth->setValue(0.0);
-      m_uiForm.spRebinHigh->setValue(0.0);
-      m_uiForm.leRebinString->setText("");
-    }
-
-    if(!instDetails["cm-1-convert-choice"].isEmpty())
-    {
-      bool defaultOptions = instDetails["cm-1-convert-choice"] == "true";
-      m_uiForm.ckCm1Units->setChecked(defaultOptions);
-    }
-
-    if(!instDetails["save-nexus-choice"].isEmpty())
-    {
-      bool defaultOptions = instDetails["save-nexus-choice"] == "true";
-      m_uiForm.ckSaveNexus->setChecked(defaultOptions);
-    }
-
-    if(!instDetails["save-ascii-choice"].isEmpty())
-    {
-      bool defaultOptions = instDetails["save-ascii-choice"] == "true";
-      m_uiForm.ckSaveASCII->setChecked(defaultOptions);
-    }
-
-    if(!instDetails["fold-frames-choice"].isEmpty())
-    {
-      bool defaultOptions = instDetails["fold-frames-choice"] == "true";
-      m_uiForm.ckFold->setChecked(defaultOptions);
-    }
+  if (!instDetails["cm-1-convert-choice"].isEmpty()) {
+    bool defaultOptions = instDetails["cm-1-convert-choice"] == "true";
+    m_uiForm.ckCm1Units->setChecked(defaultOptions);
   }
 
-  /**
-   * This function runs when the user makes a selection on the cbGroupingOptions QComboBox.
-   * @param groupType :: Value of selection made by user.
-   */
-  void ISISEnergyTransfer::mappingOptionSelected(const QString& groupType)
-  {
-    if ( groupType == "File" )
-    {
-      m_uiForm.swGrouping->setCurrentIndex(0);
-    }
-    else if ( groupType == "Groups" )
-    {
-      m_uiForm.swGrouping->setCurrentIndex(1);
-    }
-    else if ( groupType == "All" || groupType == "Individual" || groupType == "Default" )
-    {
-      m_uiForm.swGrouping->setCurrentIndex(2);
-    }
+  if (!instDetails["save-nexus-choice"].isEmpty()) {
+    bool defaultOptions = instDetails["save-nexus-choice"] == "true";
+    m_uiForm.ckSaveNexus->setChecked(defaultOptions);
   }
 
-  /**
-   * This function creates the mapping/grouping file for the data analysis.
-   * @param groupType :: Type of grouping (All, Group, Indiviual)
-   * @return path to mapping file, or an empty string if file could not be created.
-   */
-  QPair<QString, QString> ISISEnergyTransfer::createMapFile(const QString& groupType)
-  {
-    QString specRange = m_uiForm.spSpectraMin->text() + "," + m_uiForm.spSpectraMax->text();
-
-    if(groupType == "File")
-    {
-      QString groupFile = m_uiForm.dsMapFile->getFirstFilename();
-      if(groupFile == "")
-        emit showMessageBox("You must enter a path to the .map file.");
-
-      return qMakePair(QString("File"), groupFile);
-    }
-    else if(groupType == "Groups")
-    {
-      QString groupWS = "__Grouping";
-
-      IAlgorithm_sptr groupingAlg = AlgorithmManager::Instance().create("CreateGroupingWorkspace");
-      groupingAlg->initialize();
-
-      groupingAlg->setProperty("FixedGroupCount", m_uiForm.spNumberGroups->value());
-      groupingAlg->setProperty("InstrumentName", getInstrumentConfiguration()->getInstrumentName().toStdString());
-      groupingAlg->setProperty("ComponentName", getInstrumentConfiguration()->getAnalyserName().toStdString());
-      groupingAlg->setProperty("OutputWorkspace", groupWS.toStdString());
-
-      m_batchAlgoRunner->addAlgorithm(groupingAlg);
-
-      return qMakePair(QString("Workspace"), groupWS);
-    }
-    else if (groupType == "Default")
-    {
-      return qMakePair(QString("IPF"), QString());
-    }
-    else
-    {
-      // Catch All and Individual
-      return qMakePair(groupType, QString());
-    }
+  if (!instDetails["save-ascii-choice"].isEmpty()) {
+    bool defaultOptions = instDetails["save-ascii-choice"] == "true";
+    m_uiForm.ckSaveASCII->setChecked(defaultOptions);
   }
 
-  /**
-   * Converts the checkbox selection to a comma delimited list of save formats for the
-   * ISISIndirectEnergyTransfer algorithm.
-   *
-   * @return A vector of save formats
-   */
-  std::vector<std::string> ISISEnergyTransfer::getSaveFormats()
-  {
-    std::vector<std::string> fileFormats;
+  if (!instDetails["fold-frames-choice"].isEmpty()) {
+    bool defaultOptions = instDetails["fold-frames-choice"] == "true";
+    m_uiForm.ckFold->setChecked(defaultOptions);
+  }
+}
 
-    if ( m_uiForm.ckSaveNexus->isChecked() )
-      fileFormats.push_back("nxs");
-    if ( m_uiForm.ckSaveSPE->isChecked() )
-      fileFormats.push_back("spe");
-    if ( m_uiForm.ckSaveNXSPE->isChecked() )
-      fileFormats.push_back("nxspe");
-    if ( m_uiForm.ckSaveASCII->isChecked() )
-      fileFormats.push_back("ascii");
-    if ( m_uiForm.ckSaveAclimax->isChecked() )
-      fileFormats.push_back("aclimax");
-    if ( m_uiForm.ckSaveDaveGrp->isChecked() )
-      fileFormats.push_back("davegrp");
+/**
+ * This function runs when the user makes a selection on the cbGroupingOptions
+ * QComboBox.
+ * @param groupType :: Value of selection made by user.
+ */
+void ISISEnergyTransfer::mappingOptionSelected(const QString &groupType) {
+  if (groupType == "File") {
+    m_uiForm.swGrouping->setCurrentIndex(0);
+  } else if (groupType == "Groups") {
+    m_uiForm.swGrouping->setCurrentIndex(1);
+  } else if (groupType == "All" || groupType == "Individual" ||
+             groupType == "Default") {
+    m_uiForm.swGrouping->setCurrentIndex(2);
+  }
+}
 
-    return fileFormats;
+/**
+ * This function creates the mapping/grouping file for the data analysis.
+ * @param groupType :: Type of grouping (All, Group, Indiviual)
+ * @return path to mapping file, or an empty string if file could not be
+ * created.
+ */
+QPair<QString, QString>
+ISISEnergyTransfer::createMapFile(const QString &groupType) {
+  QString specRange =
+      m_uiForm.spSpectraMin->text() + "," + m_uiForm.spSpectraMax->text();
+
+  if (groupType == "File") {
+    QString groupFile = m_uiForm.dsMapFile->getFirstFilename();
+    if (groupFile == "")
+      emit showMessageBox("You must enter a path to the .map file.");
+
+    return qMakePair(QString("File"), groupFile);
+  } else if (groupType == "Groups") {
+    QString groupWS = "__Grouping";
+
+    IAlgorithm_sptr groupingAlg =
+        AlgorithmManager::Instance().create("CreateGroupingWorkspace");
+    groupingAlg->initialize();
+
+    groupingAlg->setProperty("FixedGroupCount",
+                             m_uiForm.spNumberGroups->value());
+    groupingAlg->setProperty(
+        "InstrumentName",
+        getInstrumentConfiguration()->getInstrumentName().toStdString());
+    groupingAlg->setProperty(
+        "ComponentName",
+        getInstrumentConfiguration()->getAnalyserName().toStdString());
+    groupingAlg->setProperty("OutputWorkspace", groupWS.toStdString());
+
+    m_batchAlgoRunner->addAlgorithm(groupingAlg);
+
+    return qMakePair(QString("Workspace"), groupWS);
+  } else if (groupType == "Default") {
+    return qMakePair(QString("IPF"), QString());
+  } else {
+    // Catch All and Individual
+    return qMakePair(groupType, QString());
+  }
+}
+
+/**
+ * Converts the checkbox selection to a comma delimited list of save formats for
+ *the
+ * ISISIndirectEnergyTransfer algorithm.
+ *
+ * @return A vector of save formats
+ */
+std::vector<std::string> ISISEnergyTransfer::getSaveFormats() {
+  std::vector<std::string> fileFormats;
+
+  if (m_uiForm.ckSaveNexus->isChecked())
+    fileFormats.push_back("nxs");
+  if (m_uiForm.ckSaveSPE->isChecked())
+    fileFormats.push_back("spe");
+  if (m_uiForm.ckSaveNXSPE->isChecked())
+    fileFormats.push_back("nxspe");
+  if (m_uiForm.ckSaveASCII->isChecked())
+    fileFormats.push_back("ascii");
+  if (m_uiForm.ckSaveAclimax->isChecked())
+    fileFormats.push_back("aclimax");
+  if (m_uiForm.ckSaveDaveGrp->isChecked())
+    fileFormats.push_back("davegrp");
+
+  return fileFormats;
+}
+
+/**
+ * Plots raw time data from .raw file before any data conversion has been
+ * performed.
+ */
+void ISISEnergyTransfer::plotRaw() {
+  using Mantid::specid_t;
+  using MantidQt::API::BatchAlgorithmRunner;
+
+  if (!m_uiForm.dsRunFiles->isValid()) {
+    emit showMessageBox("You must select a run file.");
+    return;
   }
 
-  /**
-   * Plots raw time data from .raw file before any data conversion has been performed.
-   */
-  void ISISEnergyTransfer::plotRaw()
-  {
-    using Mantid::specid_t;
-    using MantidQt::API::BatchAlgorithmRunner;
+  specid_t detectorMin =
+      static_cast<specid_t>(m_uiForm.spPlotTimeSpecMin->value());
+  specid_t detectorMax =
+      static_cast<specid_t>(m_uiForm.spPlotTimeSpecMax->value());
 
-    if(!m_uiForm.dsRunFiles->isValid())
-    {
-      emit showMessageBox("You must select a run file.");
-      return;
-    }
-
-    specid_t detectorMin = static_cast<specid_t>(m_uiForm.spPlotTimeSpecMin->value());
-    specid_t detectorMax = static_cast<specid_t>(m_uiForm.spPlotTimeSpecMax->value());
-
-    if(detectorMin > detectorMax)
-    {
-      emit showMessageBox("Minimum spectra must be less than or equal to maximum spectra.");
-      return;
-    }
-
-    QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
-    QFileInfo rawFileInfo(rawFile);
-    std::string name = rawFileInfo.baseName().toStdString();
-
-    IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("Load");
-    loadAlg->initialize();
-    loadAlg->setProperty("Filename", rawFile.toStdString());
-    loadAlg->setProperty("OutputWorkspace", name);
-    loadAlg->setProperty("SpectrumMin", detectorMin);
-    loadAlg->setProperty("SpectrumMax", detectorMax);
-    m_batchAlgoRunner->addAlgorithm(loadAlg);
-
-    // Rebin the workspace to its self to ensure constant binning
-    BatchAlgorithmRunner::AlgorithmRuntimeProps inputToRebin;
-    inputToRebin["WorkspaceToMatch"] = name;
-    inputToRebin["WorkspaceToRebin"] = name;
-    inputToRebin["OutputWorkspace"] = name;
-
-    IAlgorithm_sptr rebinAlg = AlgorithmManager::Instance().create("RebinToWorkspace");
-    rebinAlg->initialize();
-    m_batchAlgoRunner->addAlgorithm(rebinAlg, inputToRebin);
-
-    BatchAlgorithmRunner::AlgorithmRuntimeProps inputFromRebin;
-    inputFromRebin["InputWorkspace"] = name;
-
-    std::vector<specid_t> detectorList;
-    for(specid_t i = detectorMin; i <= detectorMax; i++)
-      detectorList.push_back(i);
-
-    if(m_uiForm.ckBackgroundRemoval->isChecked())
-    {
-      std::vector<double> range;
-      range.push_back(m_uiForm.spBackgroundStart->value());
-      range.push_back(m_uiForm.spBackgroundEnd->value());
-
-      IAlgorithm_sptr calcBackAlg = AlgorithmManager::Instance().create("CalculateFlatBackground");
-      calcBackAlg->initialize();
-      calcBackAlg->setProperty("OutputWorkspace", name + "_bg");
-      calcBackAlg->setProperty("Mode", "Mean");
-      calcBackAlg->setProperty("StartX", range[0]);
-      calcBackAlg->setProperty("EndX", range[1]);
-      m_batchAlgoRunner->addAlgorithm(calcBackAlg, inputFromRebin);
-
-      BatchAlgorithmRunner::AlgorithmRuntimeProps inputFromCalcBG;
-      inputFromCalcBG["InputWorkspace"] = name + "_bg";
-
-      IAlgorithm_sptr groupAlg = AlgorithmManager::Instance().create("GroupDetectors");
-      groupAlg->initialize();
-      groupAlg->setProperty("OutputWorkspace", name + "_grp");
-      groupAlg->setProperty("DetectorList", detectorList);
-      m_batchAlgoRunner->addAlgorithm(groupAlg, inputFromCalcBG);
-
-      IAlgorithm_sptr rawGroupAlg = AlgorithmManager::Instance().create("GroupDetectors");
-      rawGroupAlg->initialize();
-      rawGroupAlg->setProperty("OutputWorkspace", name + "_grp_raw");
-      rawGroupAlg->setProperty("DetectorList", detectorList);
-      m_batchAlgoRunner->addAlgorithm(rawGroupAlg, inputFromRebin);
-    }
-    else
-    {
-      IAlgorithm_sptr rawGroupAlg = AlgorithmManager::Instance().create("GroupDetectors");
-      rawGroupAlg->initialize();
-      rawGroupAlg->setProperty("OutputWorkspace", name + "_grp");
-      rawGroupAlg->setProperty("DetectorList", detectorList);
-      m_batchAlgoRunner->addAlgorithm(rawGroupAlg, inputFromRebin);
-    }
-
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(plotRawComplete(bool)));
-    m_batchAlgoRunner->executeBatchAsync();
+  if (detectorMin > detectorMax) {
+    emit showMessageBox(
+        "Minimum spectra must be less than or equal to maximum spectra.");
+    return;
   }
 
-  /**
-   * Handles plotting the result of Plot Raw
-   *
-   * @param error Indicates if the algorithm chain failed
-   */
-  void ISISEnergyTransfer::plotRawComplete(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(plotRawComplete(bool)));
+  QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
+  QFileInfo rawFileInfo(rawFile);
+  std::string name = rawFileInfo.baseName().toStdString();
 
-    if(error)
-      return;
+  IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("Load");
+  loadAlg->initialize();
+  loadAlg->setProperty("Filename", rawFile.toStdString());
+  loadAlg->setProperty("OutputWorkspace", name);
+  loadAlg->setProperty("SpectrumMin", detectorMin);
+  loadAlg->setProperty("SpectrumMax", detectorMax);
+  m_batchAlgoRunner->addAlgorithm(loadAlg);
 
-    QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
-    QFileInfo rawFileInfo(rawFile);
-    std::string name = rawFileInfo.baseName().toStdString();
+  // Rebin the workspace to its self to ensure constant binning
+  BatchAlgorithmRunner::AlgorithmRuntimeProps inputToRebin;
+  inputToRebin["WorkspaceToMatch"] = name;
+  inputToRebin["WorkspaceToRebin"] = name;
+  inputToRebin["OutputWorkspace"] = name;
 
-    plotSpectrum(QString::fromStdString(name) + "_grp");
+  IAlgorithm_sptr rebinAlg =
+      AlgorithmManager::Instance().create("RebinToWorkspace");
+  rebinAlg->initialize();
+  m_batchAlgoRunner->addAlgorithm(rebinAlg, inputToRebin);
+
+  BatchAlgorithmRunner::AlgorithmRuntimeProps inputFromRebin;
+  inputFromRebin["InputWorkspace"] = name;
+
+  std::vector<specid_t> detectorList;
+  for (specid_t i = detectorMin; i <= detectorMax; i++)
+    detectorList.push_back(i);
+
+  if (m_uiForm.ckBackgroundRemoval->isChecked()) {
+    std::vector<double> range;
+    range.push_back(m_uiForm.spBackgroundStart->value());
+    range.push_back(m_uiForm.spBackgroundEnd->value());
+
+    IAlgorithm_sptr calcBackAlg =
+        AlgorithmManager::Instance().create("CalculateFlatBackground");
+    calcBackAlg->initialize();
+    calcBackAlg->setProperty("OutputWorkspace", name + "_bg");
+    calcBackAlg->setProperty("Mode", "Mean");
+    calcBackAlg->setProperty("StartX", range[0]);
+    calcBackAlg->setProperty("EndX", range[1]);
+    m_batchAlgoRunner->addAlgorithm(calcBackAlg, inputFromRebin);
+
+    BatchAlgorithmRunner::AlgorithmRuntimeProps inputFromCalcBG;
+    inputFromCalcBG["InputWorkspace"] = name + "_bg";
+
+    IAlgorithm_sptr groupAlg =
+        AlgorithmManager::Instance().create("GroupDetectors");
+    groupAlg->initialize();
+    groupAlg->setProperty("OutputWorkspace", name + "_grp");
+    groupAlg->setProperty("DetectorList", detectorList);
+    m_batchAlgoRunner->addAlgorithm(groupAlg, inputFromCalcBG);
+
+    IAlgorithm_sptr rawGroupAlg =
+        AlgorithmManager::Instance().create("GroupDetectors");
+    rawGroupAlg->initialize();
+    rawGroupAlg->setProperty("OutputWorkspace", name + "_grp_raw");
+    rawGroupAlg->setProperty("DetectorList", detectorList);
+    m_batchAlgoRunner->addAlgorithm(rawGroupAlg, inputFromRebin);
+  } else {
+    IAlgorithm_sptr rawGroupAlg =
+        AlgorithmManager::Instance().create("GroupDetectors");
+    rawGroupAlg->initialize();
+    rawGroupAlg->setProperty("OutputWorkspace", name + "_grp");
+    rawGroupAlg->setProperty("DetectorList", detectorList);
+    m_batchAlgoRunner->addAlgorithm(rawGroupAlg, inputFromRebin);
   }
 
-  /**
-   * Called when a user starts to type / edit the runs to load.
-   */
-  void ISISEnergyTransfer::pbRunEditing()
-  {
-    emit updateRunButton(false, "Editing...", "Run numbers are currently being edited.");
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(algorithmComplete(bool)));
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(plotRawComplete(bool)));
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Handles plotting the result of Plot Raw
+ *
+ * @param error Indicates if the algorithm chain failed
+ */
+void ISISEnergyTransfer::plotRawComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(plotRawComplete(bool)));
+
+  if (error)
+    return;
+
+  QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
+  QFileInfo rawFileInfo(rawFile);
+  std::string name = rawFileInfo.baseName().toStdString();
+
+  plotSpectrum(QString::fromStdString(name) + "_grp");
+}
+
+/**
+ * Called when a user starts to type / edit the runs to load.
+ */
+void ISISEnergyTransfer::pbRunEditing() {
+  emit updateRunButton(false, "Editing...",
+                       "Run numbers are currently being edited.");
+}
+
+/**
+ * Called when the FileFinder starts finding the files.
+ */
+void ISISEnergyTransfer::pbRunFinding() {
+  emit updateRunButton(
+      false, "Finding files...",
+      "Searching for data files for the run numbers entered...");
+  m_uiForm.dsRunFiles->setEnabled(false);
+}
+
+/**
+ * Called when the FileFinder has finished finding the files.
+ */
+void ISISEnergyTransfer::pbRunFinished() {
+  if (!m_uiForm.dsRunFiles->isValid()) {
+    emit updateRunButton(
+        false, "Invalid Run(s)",
+        "Cannot find data files for some of the run numbers entered.");
+  } else {
+    emit updateRunButton();
   }
 
-  /**
-   * Called when the FileFinder starts finding the files.
-   */
-  void ISISEnergyTransfer::pbRunFinding()
-  {
-    emit updateRunButton(false, "Finding files...", "Searching for data files for the run numbers entered...");
-    m_uiForm.dsRunFiles->setEnabled(false);
-  }
-
-  /**
-   * Called when the FileFinder has finished finding the files.
-   */
-  void ISISEnergyTransfer::pbRunFinished()
-  {
-    if(!m_uiForm.dsRunFiles->isValid())
-    {
-      emit updateRunButton(false, "Invalid Run(s)", "Cannot find data files for some of the run numbers entered.");
-    }
-    else
-    {
-      emit updateRunButton();
-    }
-
-    m_uiForm.dsRunFiles->setEnabled(true);
-  }
+  m_uiForm.dsRunFiles->setEnabled(true);
+}
 
 } // namespace CustomInterfaces
 } // namespace Mantid

--- a/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_DataReduction.rst
@@ -79,6 +79,11 @@ Sum Files
 Load Log Files
   If selected the sample logs will be laoded from each of the run files.
 
+Efixed
+  This option allows you to override the default fixed final energy for the
+  analyser and reflection number setting. This can be useful in correcting an
+  offset peak caused by the sample being slightly out of centre.
+
 Grouping
   Provides option of how data should be grouped.
 


### PR DESCRIPTION
Fixes #13109 

To test:
- Open Indirect > Data Reduction > ISIS Energy Transfer
- Instrument: IRIS, graphite, 002
- Run: 26176
- Run, plot the contour plot
- Change Efixed to 1.9
- Run, elastic peak should shift to the negative energy
- Change Efixed to 1.7
- Run, elastic peak should shift to the positive energy
- See that when you change to an instrument other than IRIS and OSIRIS the option is disabled

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=24546&oldid=24523).
