### PR TITLE
13250 example saveascii python algorithm

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/Examples/ExampleSaveAscii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/Examples/ExampleSaveAscii.py
@@ -1,0 +1,72 @@
+"""
+This is an example Python algorithm, showing how
+to write a workspace to file in ascii format.
+Note that the SaveAscii algorithm should be used instead in most cases.
+"""
+
+from mantid.kernel import *
+from mantid.api import *
+
+
+class ExampleSaveAscii(PythonAlgorithm):
+
+    def PyInit(self):
+
+        # Declare properties
+
+        # Declare a property for the output filename with a default of default_output.txt
+        self.declareProperty(FileProperty(name='OutputFilename',
+                                          defaultValue='default_output.txt',
+                                          action=FileAction.Save,
+                                          extensions=['txt']))
+
+        # Declare a property for the input workspace which will be written to file
+        self.declareProperty(WorkspaceProperty(name='InputWorkspace',
+                                               defaultValue='',
+                                               direction=Direction.Input),
+                             doc='Documentation for this property')
+
+    def PyExec(self):
+
+        # Save the workspace to file in ascii format
+
+        input_workspace = self.getProperty('InputWorkspace').value
+
+        # Open the file with write permissions
+        # The 'with' statement will take care of closing the file when we are done,
+        # or if an error occurs
+        with open(self.getPropertyValue('OutputFilename'), 'w') as f:
+
+            # Get the units from the workspace to use in the file header
+            x_label = input_workspace.getAxis(0).getUnit().caption()
+            y_label = input_workspace.getAxis(1).getUnit().caption()
+
+            # Write column header to file
+            f.write('# ' + x_label + ' , ' + y_label + ' , E\n')
+
+            # Loop through each spectrum histogram
+            for histogram_n in range(input_workspace.getNumberHistograms()):
+
+                # Read the histogram data from the workspace
+                xdata = input_workspace.readX(histogram_n)
+                ydata = input_workspace.readY(histogram_n)
+                edata = input_workspace.readE(histogram_n)
+
+                # Write the spectrum histogram index to file
+                f.write(str(histogram_n+1) + '\n')  # +1 to convert to 1 indexed
+
+                # Loop through each bin
+                for bin_n in range(input_workspace.blocksize()):
+
+                    # Calculate bin center from bin boundaries
+                    bin_center = xdata[bin_n]+(xdata[bin_n+1]-xdata[bin_n])/2.
+
+                    # Write the data for the nth bin to file
+                    # with a precision of 4 decimal places
+                    f.write('{0:.4f},{1:.4f},{2:.4f}\n'.format(bin_center,
+                                                               ydata[bin_n],
+                                                               edata[bin_n]))
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(ExampleSaveAscii)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/Examples/ExampleSaveAscii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/Examples/ExampleSaveAscii.py
@@ -35,14 +35,14 @@ class ExampleSaveAscii(PythonAlgorithm):
         # Open the file with write permissions
         # The 'with' statement will take care of closing the file when we are done,
         # or if an error occurs
-        with open(self.getPropertyValue('OutputFilename'), 'w') as f:
+        with open(self.getPropertyValue('OutputFilename'), 'w') as file_handle:
 
             # Get the units from the workspace to use in the file header
             x_label = input_workspace.getAxis(0).getUnit().caption()
             y_label = input_workspace.getAxis(1).getUnit().caption()
 
             # Write column header to file
-            f.write('# ' + x_label + ' , ' + y_label + ' , E\n')
+            file_handle.write('# ' + x_label + ' , ' + y_label + ' , E\n')
 
             # Loop through each spectrum histogram
             for histogram_n in range(input_workspace.getNumberHistograms()):
@@ -53,7 +53,7 @@ class ExampleSaveAscii(PythonAlgorithm):
                 edata = input_workspace.readE(histogram_n)
 
                 # Write the spectrum histogram index to file
-                f.write(str(histogram_n+1) + '\n')  # +1 to convert to 1 indexed
+                file_handle.write(str(histogram_n+1) + '\n')  # +1 to convert to 1 indexed
 
                 # Loop through each bin
                 for bin_n in range(input_workspace.blocksize()):
@@ -63,7 +63,7 @@ class ExampleSaveAscii(PythonAlgorithm):
 
                     # Write the data for the nth bin to file
                     # with a precision of 4 decimal places
-                    f.write('{0:.4f},{1:.4f},{2:.4f}\n'.format(bin_center,
+                    file_handle.write('{0:.4f},{1:.4f},{2:.4f}\n'.format(bin_center,
                                                                ydata[bin_n],
                                                                edata[bin_n]))
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/Examples/ExampleSaveAscii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/Examples/ExampleSaveAscii.py
@@ -1,3 +1,4 @@
+#pylint: disable=no-init
 """
 This is an example Python algorithm, showing how
 to write a workspace to file in ascii format.

--- a/Code/Mantid/docs/source/algorithms/ExampleSaveAscii-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExampleSaveAscii-v1.rst
@@ -45,6 +45,9 @@ Usage
         print f.readline()
         print f.readline()
         print f.readline()
+    
+    # Delete the test file
+    os.remove(filepath)
 
 Output:
 

--- a/Code/Mantid/docs/source/algorithms/ExampleSaveAscii-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExampleSaveAscii-v1.rst
@@ -27,8 +27,6 @@ Usage
 
 .. testcode:: ExSaveAscii
 
-    from IndirectCommon import getDefaultWorkingDirectory
-
     # Load sample workspace
     temp_ws_ = CreateSampleWorkspace()
 
@@ -37,14 +35,14 @@ Usage
     ExampleSaveAscii(temp_ws_, filename)
 
     # Get the default save path
-    workdir = getDefaultWorkingDirectory()
+    workdir = config['defaultsave.directory']
     filepath = os.path.join(workdir, filename)
     
     # Read and print first 3 lines from file
     with open(filepath, 'r') as f:
-        print f.readline()
-        print f.readline()
-        print f.readline()
+        print f.readline()[:-1]
+        print f.readline()[:-1]
+        print f.readline()[:-1]
     
     # Delete the test file
     os.remove(filepath)
@@ -53,11 +51,10 @@ Output:
 
 .. testoutput:: ExSaveAscii
 
-# Time-of-flight , Spectrum , E
-1
-100.0000,0.3000,0.5477
+    # Time-of-flight , Spectrum , E
+    1
+    100.0000,0.3000,0.5477
 
-  
 .. categories::
 
 .. sourcelink::

--- a/Code/Mantid/docs/source/algorithms/ExampleSaveAscii-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ExampleSaveAscii-v1.rst
@@ -1,0 +1,60 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+This example python algorithm saves a workspace to file in ascii format. The
+algorithm exists for demonstration purposes only; ordinarily SaveAscii should
+be used instead.
+
+Inputs are a filename and a workspace.
+The output is a file in the default save directory with the input filename and
+containing data from the input workspace in ascii format. Bin centers, rather
+than bin boundaries, are saved.
+
+.. _exsaveascii-usage:
+
+Usage
+-----
+
+**Example - save example workspace:**
+
+.. testcode:: ExSaveAscii
+
+    from IndirectCommon import getDefaultWorkingDirectory
+
+    # Load sample workspace
+    temp_ws_ = CreateSampleWorkspace()
+
+    # Use algorithm to save workspace
+    filename = 'ExSaveAsciiFile.txt'
+    ExampleSaveAscii(temp_ws_, filename)
+
+    # Get the default save path
+    workdir = getDefaultWorkingDirectory()
+    filepath = os.path.join(workdir, filename)
+    
+    # Read and print first 3 lines from file
+    with open(filepath, 'r') as f:
+        print f.readline()
+        print f.readline()
+        print f.readline()
+
+Output:
+
+.. testoutput:: ExSaveAscii
+
+# Time-of-flight , Spectrum , E
+1
+100.0000,0.3000,0.5477
+
+  
+.. categories::
+
+.. sourcelink::


### PR DESCRIPTION
Closes #13250 

Added an example python algorithm which writes a workspace to file in ascii format. The algorithm serves only as a demonstration, the SaveAscii algorithm should ordinarily be used instead.
A documentation file with test is also added. The test writes the workspace obtained by CreateSampleWorkspace() to file and compares the first three lines of the file with what is expected.
