### PR TITLE
Fix bug when setting green period in single-period mode data

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -79,16 +79,18 @@ private:
   void init();
   void exec();
   // Load run, apply dead time corrections and detector grouping
-  API::Workspace_sptr doLoad (int64_t runNumber );
+  API::Workspace_sptr doLoad(int64_t runNumber);
   // Analyse loaded run
-  void doAnalysis (API::Workspace_sptr loadedWs, int64_t index);
+  void doAnalysis(API::Workspace_sptr loadedWs, int64_t index);
   // Parse run names
-  void parseRunNames (std::string& firstFN, std::string& lastFN, std::string& fnBase, std::string& fnExt, int& fnZeros);
+  void parseRunNames(std::string &firstFN, std::string &lastFN,
+                     std::string &fnBase, std::string &fnExt, int &fnZeros);
   // Load dead-time corrections from specified file
   API::Workspace_sptr PlotAsymmetryByLogValue::loadCorrectionsFromFile(
       const std::string &deadTimeFile);
   // Apply dead-time corrections
-  void applyDeadtimeCorr (API::Workspace_sptr &loadedWs, API::Workspace_sptr deadTimes);
+  void applyDeadtimeCorr(API::Workspace_sptr &loadedWs,
+                         API::Workspace_sptr deadTimes);
   /// Create custom detector grouping
   API::Workspace_sptr createCustomGrouping(const std::vector<int> &fwd,
                                            const std::vector<int> &bwd);
@@ -98,17 +100,20 @@ private:
   /// Calculate the integral asymmetry for a workspace (single period)
   void calcIntAsymmetry(API::MatrixWorkspace_sptr ws, double &Y, double &E);
   /// Calculate the integral asymmetry for a workspace (red & green)
-  void calcIntAsymmetry(API::MatrixWorkspace_sptr ws_red, API::MatrixWorkspace_sptr ws_geen, double &Y, double &E);
+  void calcIntAsymmetry(API::MatrixWorkspace_sptr ws_red,
+                        API::MatrixWorkspace_sptr ws_geen, double &Y,
+                        double &E);
   /// Group detectors
-  void groupDetectors (API::MatrixWorkspace_sptr &ws, const std::vector<int> &spectraList);
+  void groupDetectors(API::MatrixWorkspace_sptr &ws,
+                      const std::vector<int> &spectraList);
   /// Get log value
   double getLogValue(API::MatrixWorkspace &ws);
   /// Populate output workspace with results
-  void populateOutputWorkspace (API::MatrixWorkspace_sptr &outWS, int nplots);
+  void populateOutputWorkspace(API::MatrixWorkspace_sptr &outWS, int nplots);
   /// Check input properties
-  void checkProperties (size_t &is, size_t &ie);
+  void checkProperties(size_t &is, size_t &ie);
   /// Clear previous results
-  void clearResultsFromTo (size_t is, size_t ie);
+  void clearResultsFromTo(size_t is, size_t ie);
 
   /// Stores base name shared by all runs
   static std::string g_filenameBase;

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -86,8 +86,7 @@ private:
   void parseRunNames(std::string &firstFN, std::string &lastFN,
                      std::string &fnBase, std::string &fnExt, int &fnZeros);
   // Load dead-time corrections from specified file
-  API::Workspace_sptr PlotAsymmetryByLogValue::loadCorrectionsFromFile(
-      const std::string &deadTimeFile);
+  API::Workspace_sptr loadCorrectionsFromFile(const std::string &deadTimeFile);
   // Apply dead-time corrections
   void applyDeadtimeCorr(API::Workspace_sptr &loadedWs,
                          API::Workspace_sptr deadTimes);

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -89,8 +89,12 @@ private:
       const std::string &deadTimeFile);
   // Apply dead-time corrections
   void applyDeadtimeCorr (API::Workspace_sptr &loadedWs, API::Workspace_sptr deadTimes);
-  /// Group detectors from run file
-  void groupDetectors (API::Workspace_sptr &loadedWs, API::Workspace_sptr loadedDetGrouping);
+  /// Create custom detector grouping
+  API::Workspace_sptr createCustomGrouping(const std::vector<int> &fwd,
+                                           const std::vector<int> &bwd);
+  /// Group detectors
+  void groupDetectors(API::Workspace_sptr &loadedWs,
+                      API::Workspace_sptr grouping);
   /// Calculate the integral asymmetry for a workspace (single period)
   void calcIntAsymmetry(API::MatrixWorkspace_sptr ws, double &Y, double &E);
   /// Calculate the integral asymmetry for a workspace (red & green)
@@ -118,8 +122,6 @@ private:
   static std::vector<int> g_forward_list;
   /// Store backward spectra
   static std::vector<int> g_backward_list;
-  /// If true call LoadMuonNexus with Autogroup on
-  bool m_autogroup;
   /// Store type of dead time corrections
   static std::string g_dtcType;
   /// File to read corrections from

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -100,7 +100,7 @@ private:
   void calcIntAsymmetry(API::MatrixWorkspace_sptr ws, double &Y, double &E);
   /// Calculate the integral asymmetry for a workspace (red & green)
   void calcIntAsymmetry(API::MatrixWorkspace_sptr ws_red,
-                        API::MatrixWorkspace_sptr ws_geen, double &Y,
+                        API::MatrixWorkspace_sptr ws_green, double &Y,
                         double &E);
   /// Group detectors
   void groupDetectors(API::MatrixWorkspace_sptr &ws,

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -85,7 +85,8 @@ private:
   // Parse run names
   void parseRunNames (std::string& firstFN, std::string& lastFN, std::string& fnBase, std::string& fnExt, int& fnZeros);
   // Load dead-time corrections from specified file
-  void loadCorrectionsFromFile (API::Workspace_sptr &customDeadTimes, std::string deadTimeFile );
+  API::Workspace_sptr PlotAsymmetryByLogValue::loadCorrectionsFromFile(
+      const std::string &deadTimeFile);
   // Apply dead-time corrections
   void applyDeadtimeCorr (API::Workspace_sptr &loadedWs, API::Workspace_sptr deadTimes);
   /// Group detectors from run file

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -376,17 +376,20 @@ Workspace_sptr PlotAsymmetryByLogValue::doLoad(int64_t runNumber) {
 
   // Check if dead-time corrections have to be applied
   if (g_dtcType != "None") {
-    if (g_dtcType == "FromSpecifiedFile") {
 
-      // If user specifies a file, load corrections now
-      Workspace_sptr customDeadTimes;
-      loadCorrectionsFromFile(customDeadTimes, g_dtcFile);
-      applyDeadtimeCorr(loadedWs, customDeadTimes);
+    Workspace_sptr deadTimes;
+
+    if (g_dtcType == "FromSpecifiedFile") {
+      // Load corrections from file
+      deadTimes = loadCorrectionsFromFile(g_dtcFile);
     } else {
       // Load corrections from run
-      Workspace_sptr deadTimes = load->getProperty("DeadTimeTable");
-      applyDeadtimeCorr(loadedWs, deadTimes);
+      deadTimes = load->getProperty("DeadTimeTable");
     }
+    if (!deadTimes) {
+      throw std::runtime_error("Couldn't load dead times");
+    }
+    applyDeadtimeCorr(loadedWs, deadTimes);
   }
 
   // If m_autogroup, group detectors
@@ -403,18 +406,20 @@ Workspace_sptr PlotAsymmetryByLogValue::doLoad(int64_t runNumber) {
 }
 
 /**  Load dead-time corrections from specified file
-*   @param customDeadTimes :: [input/output] Output workspace to store
-* corrections
 *   @param deadTimeFile :: [input] File to read corrections from
+*   @return :: Deadtime corrections loaded from file
 */
-void PlotAsymmetryByLogValue::loadCorrectionsFromFile(
-    Workspace_sptr &customDeadTimes, std::string deadTimeFile) {
-  IAlgorithm_sptr loadDeadTimes = createChildAlgorithm("LoadNexusProcessed");
-  loadDeadTimes->setPropertyValue("Filename", deadTimeFile);
-  loadDeadTimes->setProperty("OutputWorkspace", customDeadTimes);
-  loadDeadTimes->executeAsChildAlg();
-  customDeadTimes = loadDeadTimes->getProperty("OutputWorkspace");
+Workspace_sptr PlotAsymmetryByLogValue::loadCorrectionsFromFile(
+    const std::string &deadTimeFile) {
+
+  IAlgorithm_sptr alg = createChildAlgorithm("LoadNexusProcessed");
+  alg->setPropertyValue("Filename", deadTimeFile);
+  alg->setLogging(false);
+  alg->execute();
+  Workspace_sptr deadTimes = alg->getProperty("OutputWorkspace");
+  return deadTimes;
 }
+
 /**  Populate output workspace with results
 *   @param outWS :: [input/output] Output workspace to populate
 *   @param nplots :: [input] Number of histograms

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -3,9 +3,6 @@
 //----------------------------------------------------------------------
 #include <cmath>
 #include <vector>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 
 #include "MantidAPI/FileProperty.h"
 #include <MantidAPI/FileFinder.h>
@@ -15,7 +12,6 @@
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAlgorithms/PlotAsymmetryByLogValue.h"
-#include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ListValidator.h"
@@ -23,9 +19,6 @@
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "Poco/File.h"
-
-#include <boost/shared_ptr.hpp>
-#include <boost/lexical_cast.hpp>
 
 namespace // anonymous
     {
@@ -351,6 +344,7 @@ void PlotAsymmetryByLogValue::clearResultsFromTo(size_t is, size_t ie) {
 /**  Loads one run and applies dead-time corrections and detector grouping if
 * required
 *   @param runNumber :: [input] Run number specifying run to load
+*   @return :: Loaded workspace
 */
 Workspace_sptr PlotAsymmetryByLogValue::doLoad(int64_t runNumber) {
 
@@ -704,8 +698,7 @@ void PlotAsymmetryByLogValue::doAnalysis(Workspace_sptr loadedWs,
 }
 
 /**  Calculate the integral asymmetry for a workspace.
-*   The calculation is done by MuonAsymmetryCalc and SimpleIntegration
-* algorithms.
+*   The calculation is done by AsymmetryCalc and Integration algorithms.
 *   @param ws :: The workspace
 *   @param Y :: Reference to a variable receiving the value of asymmetry
 *   @param E :: Reference to a variable receiving the value of the error
@@ -751,9 +744,7 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
   }
 }
 
-/**  Calculate the integral asymmetry for a workspace (red & green).
-*   The calculation is done by MuonAsymmetryCalc and SimpleIntegration
-* algorithms.
+/**  Calculate the integral asymmetry for a pair of workspaces (red & green).
 *   @param ws_red :: The red workspace
 *   @param ws_green :: The green workspace
 *   @param Y :: Reference to a variable receiving the value of asymmetry
@@ -822,7 +813,7 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws_red,
 /**
  * Get log value from a workspace. Convert to double if possible.
  *
- * @param ws :: The input workspace.
+ * @param ws :: [Input] The input workspace.
  * @return :: Log value.
  * @throw :: std::invalid_argument if the log cannot be converted to a double or
  *doesn't exist.

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -211,7 +211,7 @@ void PlotAsymmetryByLogValue::exec() {
   }
 
   // Create the 2D workspace for the output
-  int nplots = (g_green != EMPTY_INT()) ? 4 : 1;
+  int nplots = g_greenX.size() ? 4 : 1;
   size_t npoints = ie - is + 1;
   MatrixWorkspace_sptr outWS = WorkspaceFactory::Instance().create(
       "Workspace2D",

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -426,9 +426,8 @@ Workspace_sptr PlotAsymmetryByLogValue::loadCorrectionsFromFile(
 *   @param outWS :: [input/output] Output workspace to populate
 *   @param nplots :: [input] Number of histograms
 */
-void
-PlotAsymmetryByLogValue::populateOutputWorkspace(MatrixWorkspace_sptr &outWS,
-                                                 int nplots) {
+void PlotAsymmetryByLogValue::populateOutputWorkspace(
+    MatrixWorkspace_sptr &outWS, int nplots) {
   TextAxis *tAxis = new TextAxis(nplots);
   if (nplots == 1) {
 
@@ -760,10 +759,9 @@ void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws,
 *   @param Y :: Reference to a variable receiving the value of asymmetry
 *   @param E :: Reference to a variable receiving the value of the error
 */
-void
-PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws_red,
-                                          MatrixWorkspace_sptr ws_green,
-                                          double &Y, double &E) {
+void PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws_red,
+                                               MatrixWorkspace_sptr ws_green,
+                                               double &Y, double &E) {
   if (!m_int) { //  "Differential asymmetry"
 
     MatrixWorkspace_sptr tmpWS = WorkspaceFactory::Instance().create(
@@ -796,16 +794,14 @@ PlotAsymmetryByLogValue::calcIntAsymmetry(MatrixWorkspace_sptr ws_red,
     integr->setProperty("RangeLower", g_minTime);
     integr->setProperty("RangeUpper", g_maxTime);
     integr->execute();
-    MatrixWorkspace_sptr intWS_red =
-        integr->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr intWS_red = integr->getProperty("OutputWorkspace");
 
     integr = createChildAlgorithm("Integration");
     integr->setProperty("InputWorkspace", ws_green);
     integr->setProperty("RangeLower", g_minTime);
     integr->setProperty("RangeUpper", g_maxTime);
     integr->execute();
-    MatrixWorkspace_sptr intWS_green =
-        integr->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr intWS_green = integr->getProperty("OutputWorkspace");
 
     double YIF = (intWS_green->readY(0)[0] - intWS_red->readY(0)[0]) /
                  (intWS_green->readY(0)[0] + intWS_red->readY(0)[0]);

--- a/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
@@ -354,6 +354,40 @@ public:
 
     TS_ASSERT_THROWS (alg.execute(),std::runtime_error);
     TS_ASSERT (!alg.isExecuted());
+
+    AnalysisDataService::Instance().remove(ws);
+  }
+
+  void test_singlePeriodGreen() {
+    // Load a single-period dataset and set the green period to a
+    // number. The algorithm should ignore the supplied green and/or red periods
+    // as the input nexus file is single-period
+    const std::string ws = "Test_singlePeriodGreen";
+
+    PlotAsymmetryByLogValue alg;
+    alg.initialize();
+    alg.setPropertyValue("FirstRun", "emu00006473.nxs");
+    alg.setPropertyValue("LastRun", "emu00006473.nxs");
+    alg.setPropertyValue("OutputWorkspace", ws);
+    alg.setPropertyValue("LogValue", "run_number");
+    alg.setPropertyValue("Red", "3");
+    alg.setPropertyValue("Green", "1");
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr outWS = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve(ws));
+
+    TS_ASSERT(outWS);
+    TS_ASSERT_EQUALS(outWS->blocksize(), 1);
+    TS_ASSERT_EQUALS(outWS->getNumberHistograms(), 1);
+
+    TS_ASSERT_EQUALS(outWS->readX(0)[0], 6473);
+    TS_ASSERT_DELTA(outWS->readY(0)[0], 0.283444, 0.000001);
+    TS_ASSERT_DELTA(outWS->readE(0)[0], 0.000145, 0.000001);
+
+    AnalysisDataService::Instance().remove(ws);
   }
 
 private:

--- a/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
@@ -302,8 +302,38 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
-  void test_LogValueFunction ()
-  {
+  void test_customTimeLimits() {
+    const std::string ws = "Test_customTimeLimits";
+
+    PlotAsymmetryByLogValue alg;
+
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+
+    alg.setPropertyValue("FirstRun", firstRun);
+    alg.setPropertyValue("LastRun", lastRun);
+    alg.setPropertyValue("OutputWorkspace", ws);
+    alg.setPropertyValue("LogValue", "run_number");
+    alg.setPropertyValue("TimeMin", "0.5");
+    alg.setPropertyValue("TimeMax", "0.6");
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    MatrixWorkspace_sptr outWs = boost::dynamic_pointer_cast<MatrixWorkspace>(
+        AnalysisDataService::Instance().retrieve(ws));
+
+    TS_ASSERT(outWs);
+    TS_ASSERT_EQUALS(outWs->blocksize(), 2);
+    TS_ASSERT_EQUALS(outWs->getNumberHistograms(), 1);
+
+    const Mantid::MantidVec &Y = outWs->readY(0);
+    TS_ASSERT_DELTA(Y[0], 0.14700, 0.00001);
+    TS_ASSERT_DELTA(Y[1], 0.13042, 0.00001);
+
+    AnalysisDataService::Instance().remove(ws);
+  }
+
+  void test_LogValueFunction() {
     const std::string ws = "Test_LogValueFunction";
 
     PlotAsymmetryByLogValue alg;


### PR DESCRIPTION
Fixes #13194

For tester:

In addition to code review, there are three things to test:
1. Check that the bug was fixed (see issue's description): Execute PlotAsymmetryByLogValue with "HIFI00051636.nxs" as "First" and "HIFI00051639.nxs" as "Last". These are single-period dataset, so just check that the output workspace has only one spectrum even when you set "Green" to a number (try for instance 3). 
2. Check that the ability to skip missing run numbers has not been lost (at this moment, there is no unit test for this, so it has to be manually checked): Use "MUSR00015189.nxs" and "MUSR00015191.nxs" as "First" and "Last". Before executing the algorithm, move temporarily "MUSR00015190.nxs" out of the current directory. See that the algorithm works and prints a warning message indicating that the run is missing.
3. Check the ability to re-use previous results (again, there is no test for this functionality at the moment): Load "MUSR00015189.nxs" as "First" and "MUSR00015191.nxs" as "Last". Execute the algorithm. When the execution finishes, run the algorithm again with the same property values. Check the Results Log window, it should have been executed in ~0 seconds (as it is re-using previous results, the algorithm does not need to load and analyse the runs again).

Repeat steps 2 and 3 with single-period datasets (you can use "HIFI00051636" and "HIFI00051696", which can be found in: \ISIS\inst$\NDXHIFI\Instrument\data\cycle_13_1)

Release notes: I'm not adding this fix to the release notes as it seems that nobody has noticed the issue.
