### PR TITLE
Unexpected Exception in Apply Apply Paalman Pings

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -336,30 +336,35 @@ bool ApplyPaalmanPings::validate() {
   }
 
   if (useCorrections) {
-    uiv.checkDataSelectorIsValid("Corrections", m_uiForm.dsCorrections);
+    if (m_uiForm.dsCorrections->getCurrentDataName().compare("") == 0) {
+      uiv.addErrorMessage(
+          "Use Correction must contain a corrections file or workspace.");
+    } else {
 
-    QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
-    WorkspaceGroup_sptr corrections =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            correctionsWsName.toStdString());
-    for (size_t i = 0; i < corrections->size(); i++) {
-      // Check it is a MatrixWorkspace
-      MatrixWorkspace_sptr factorWs =
-          boost::dynamic_pointer_cast<MatrixWorkspace>(corrections->getItem(i));
-      if (!factorWs) {
-        QString msg = "Correction factor workspace " + QString::number(i) +
-                      " is not a MatrixWorkspace";
-        uiv.addErrorMessage(msg);
-        continue;
-      }
+      QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
+      WorkspaceGroup_sptr corrections =
+          AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+              correctionsWsName.toStdString());
+      for (size_t i = 0; i < corrections->size(); i++) {
+        // Check it is a MatrixWorkspace
+        MatrixWorkspace_sptr factorWs =
+            boost::dynamic_pointer_cast<MatrixWorkspace>(
+                corrections->getItem(i));
+        if (!factorWs) {
+          QString msg = "Correction factor workspace " + QString::number(i) +
+                        " is not a MatrixWorkspace";
+          uiv.addErrorMessage(msg);
+          continue;
+        }
 
-      // Check X unit is wavelength
-      Mantid::Kernel::Unit_sptr xUnit = factorWs->getAxis(0)->unit();
-      if (xUnit->caption() != "Wavelength") {
-        QString msg = "Correction factor workspace " +
-                      QString::fromStdString(factorWs->name()) +
-                      " is not in wavelength";
-        uiv.addErrorMessage(msg);
+        // Check X unit is wavelength
+        Mantid::Kernel::Unit_sptr xUnit = factorWs->getAxis(0)->unit();
+        if (xUnit->caption() != "Wavelength") {
+          QString msg = "Correction factor workspace " +
+                        QString::fromStdString(factorWs->name()) +
+                        " is not in wavelength";
+          uiv.addErrorMessage(msg);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #13264

Apply Paalman Pings no longer throws and unexpected exception when Use Corrections is checked but no corrections file specified. 
# To test:
- Open Apply Paalman Pings (Interfaces > Indirect > Corrections    then navigate to the Apply Paalman Pings tab)
- Add an input file
- Check the "Use Corrections" CheckBox
- Leave the input field for this blank and click Run
- This should produce an error (**Not an expection**) message asking for either a corrections file or Workspace
