### PR TITLE
Remove static variables in PABLV

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -79,9 +79,9 @@ private:
   void init();
   void exec();
   // Load run, apply dead time corrections and detector grouping
-  API::Workspace_sptr doLoad(int64_t runNumber);
+  API::Workspace_sptr doLoad(size_t runNumber);
   // Analyse loaded run
-  void doAnalysis(API::Workspace_sptr loadedWs, int64_t index);
+  void doAnalysis(API::Workspace_sptr loadedWs, size_t index);
   // Parse run names
   void parseRunNames(std::string &firstFN, std::string &lastFN,
                      std::string &fnBase, std::string &fnExt, int &fnZeros);
@@ -132,23 +132,21 @@ private:
   int m_red;
   /// Store green period
   int m_green;
-  // Mantid vectors to store results
-  // Red mantid vectors
-  std::map<int64_t, double> m_redX;
-  std::map<int64_t, double> m_redY;
-  std::map<int64_t, double> m_redE;
-  // Green mantid vectors
-  std::map<int64_t, double> m_greenX;
-  std::map<int64_t, double> m_greenY;
-  std::map<int64_t, double> m_greenE;
-  // Mantid vectors to store Red + Green
-  std::map<int64_t, double> m_sumX;
-  std::map<int64_t, double> m_sumY;
-  std::map<int64_t, double> m_sumE;
-  // Mantid vectors to store Red - Green
-  std::map<int64_t, double> m_diffX;
-  std::map<int64_t, double> m_diffY;
-  std::map<int64_t, double> m_diffE;
+  // Mantid maps to store intermediate results
+  // Map to store log value
+  std::map<size_t, double> m_logValue;
+  // Red values
+  std::map<size_t, double> m_redY;
+  std::map<size_t, double> m_redE;
+  // Green values
+  std::map<size_t, double> m_greenY;
+  std::map<size_t, double> m_greenE;
+  // Sum values (Red + Green)
+  std::map<size_t, double> m_sumY;
+  std::map<size_t, double> m_sumE;
+  // Diff values (Red - Green)
+  std::map<size_t, double> m_diffY;
+  std::map<size_t, double> m_diffE;
   // LogValue name
   std::string m_logName;
   // LogValue function

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -137,15 +137,13 @@ private:
   int m_red;
   /// Green period
   int m_green;
-  // LogValue name
-  // Type of computation: integral or differential
-  std::string m_stype;
   /// Minimum time for the analysis
   double m_minTime;
   /// Maximum time for the analysis
   double m_maxTime;
 
   /// Properties needed to get the log value
+  // LogValue name
   std::string m_logName;
   /// LogValue function
   std::string m_logFunc;

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -111,56 +111,54 @@ private:
   void populateOutputWorkspace(API::MatrixWorkspace_sptr &outWS, int nplots);
   /// Check input properties
   void checkProperties(size_t &is, size_t &ie);
-  /// Clear previous results
-  void clearResultsFromTo(size_t is, size_t ie);
 
   /// Stores base name shared by all runs
-  static std::string g_filenameBase;
+  std::string m_filenameBase;
   /// Stores extension shared by all runs
-  static std::string g_filenameExt;
+  std::string m_filenameExt;
   /// Sotres number of zeros in run name
-  static int g_filenameZeros;
+  int m_filenameZeros;
   /// Stores property "Int"
   bool m_int;
   /// Store forward spectra
-  static std::vector<int> g_forward_list;
+  std::vector<int> m_forward_list;
   /// Store backward spectra
-  static std::vector<int> g_backward_list;
+  std::vector<int> m_backward_list;
   /// Store type of dead time corrections
-  static std::string g_dtcType;
+  std::string m_dtcType;
   /// File to read corrections from
-  static std::string g_dtcFile;
+  std::string m_dtcFile;
   /// Store red period
-  static int g_red;
+  int m_red;
   /// Store green period
-  static int g_green;
+  int m_green;
   // Mantid vectors to store results
   // Red mantid vectors
-  static std::map<int64_t, double> g_redX;
-  static std::map<int64_t, double> g_redY;
-  static std::map<int64_t, double> g_redE;
+  std::map<int64_t, double> m_redX;
+  std::map<int64_t, double> m_redY;
+  std::map<int64_t, double> m_redE;
   // Green mantid vectors
-  static std::map<int64_t, double> g_greenX;
-  static std::map<int64_t, double> g_greenY;
-  static std::map<int64_t, double> g_greenE;
+  std::map<int64_t, double> m_greenX;
+  std::map<int64_t, double> m_greenY;
+  std::map<int64_t, double> m_greenE;
   // Mantid vectors to store Red + Green
-  static std::map<int64_t, double> g_sumX;
-  static std::map<int64_t, double> g_sumY;
-  static std::map<int64_t, double> g_sumE;
+  std::map<int64_t, double> m_sumX;
+  std::map<int64_t, double> m_sumY;
+  std::map<int64_t, double> m_sumE;
   // Mantid vectors to store Red - Green
-  static std::map<int64_t, double> g_diffX;
-  static std::map<int64_t, double> g_diffY;
-  static std::map<int64_t, double> g_diffE;
+  std::map<int64_t, double> m_diffX;
+  std::map<int64_t, double> m_diffY;
+  std::map<int64_t, double> m_diffE;
   // LogValue name
-  static std::string g_logName;
+  std::string m_logName;
   // LogValue function
-  static std::string g_logFunc;
+  std::string m_logFunc;
   // Type of computation: integral or differential
-  static std::string g_stype;
+  std::string m_stype;
   // Minimum time for the analysis
-  static double g_minTime;
+  double m_minTime;
   // Maximum time for the analysis
-  static double g_maxTime;
+  double m_maxTime;
 };
 
 } // namespace Algorithm

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -114,27 +114,43 @@ private:
   /// Check input properties
   void checkProperties(size_t &is, size_t &ie);
 
+  /// Properties needed to load a run
   /// Stores base name shared by all runs
   std::string m_filenameBase;
   /// Stores extension shared by all runs
   std::string m_filenameExt;
   /// Sotres number of zeros in run name
   int m_filenameZeros;
-  /// Stores property "Int"
-  bool m_int;
-  /// Store forward spectra
-  std::vector<int> m_forward_list;
-  /// Store backward spectra
-  std::vector<int> m_backward_list;
   /// Store type of dead time corrections
   std::string m_dtcType;
   /// File to read corrections from
   std::string m_dtcFile;
-  /// Store red period
+  /// Store forward spectra
+  std::vector<int> m_forward_list;
+  /// Store backward spectra
+  std::vector<int> m_backward_list;
+
+  /// Properties needed to analyse a run
+  /// Type of calculation: integral or differential
+  bool m_int;
+  /// Red period
   int m_red;
-  /// Store green period
+  /// Green period
   int m_green;
-  // Mantid maps to store intermediate results
+  // LogValue name
+  // Type of computation: integral or differential
+  std::string m_stype;
+  /// Minimum time for the analysis
+  double m_minTime;
+  /// Maximum time for the analysis
+  double m_maxTime;
+
+  /// Properties needed to get the log value
+  std::string m_logName;
+  /// LogValue function
+  std::string m_logFunc;
+
+  /// Mantid maps to store intermediate results
   // Map to store log value
   std::map<size_t, double> m_logValue;
   // Red values
@@ -149,16 +165,6 @@ private:
   // Diff values (Red - Green)
   std::map<size_t, double> m_diffY;
   std::map<size_t, double> m_diffE;
-  // LogValue name
-  std::string m_logName;
-  // LogValue function
-  std::string m_logFunc;
-  // Type of computation: integral or differential
-  std::string m_stype;
-  // Minimum time for the analysis
-  double m_minTime;
-  // Maximum time for the analysis
-  double m_maxTime;
 
   // String containing all the properties
   std::string m_allProperties;

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -109,6 +109,8 @@ private:
   double getLogValue(API::MatrixWorkspace &ws);
   /// Populate output workspace with results
   void populateOutputWorkspace(API::MatrixWorkspace_sptr &outWS, int nplots);
+  /// Populate the hidden ws storing current results
+  void saveResultsToADS(API::MatrixWorkspace_sptr &outWS, int nplots);
   /// Check input properties
   void checkProperties(size_t &is, size_t &ie);
 

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/PlotAsymmetryByLogValue.h
@@ -157,6 +157,11 @@ private:
   double m_minTime;
   // Maximum time for the analysis
   double m_maxTime;
+
+  // String containing all the properties
+  std::string m_allProperties;
+  // Name of the hidden ws
+  std::string m_currResName;
 };
 
 } // namespace Algorithm

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -258,9 +258,11 @@ void PlotAsymmetryByLogValue::checkProperties(size_t &is, size_t &ie) {
             // The first spectrum contains: X -> run number, Y -> log value
             // The second spectrum contains: Y -> redY, E -> redE
             size_t run = static_cast<size_t>(prevResults->readX(0)[i]);
-            m_logValue[run] = prevResults->readY(0)[i];
-            m_redY[run] = prevResults->readY(1)[i];
-            m_redE[run] = prevResults->readE(1)[i];
+            if ( (run>=is) && (run<=ie) ) {
+              m_logValue[run] = prevResults->readY(0)[i];
+              m_redY[run] = prevResults->readY(1)[i];
+              m_redE[run] = prevResults->readE(1)[i];
+            }
           }
         } else {
           // 'Red' and 'Green' data
@@ -271,15 +273,17 @@ void PlotAsymmetryByLogValue::checkProperties(size_t &is, size_t &ie) {
             // The fourth spectrum contains: Y -> greenY, E -> greeE
             // The fifth spectrum contains: Y -> sumY, E -> sumE
             size_t run = static_cast<size_t>(prevResults->readX(0)[i]);
-            m_logValue[run] = prevResults->readY(0)[i];
-            m_diffY[run] = prevResults->readY(1)[i];
-            m_diffE[run] = prevResults->readE(1)[i];
-            m_redY[run] = prevResults->readY(2)[i];
-            m_redE[run] = prevResults->readE(2)[i];
-            m_greenY[run] = prevResults->readY(3)[i];
-            m_greenE[run] = prevResults->readE(3)[i];
-            m_sumY[run] = prevResults->readY(4)[i];
-            m_sumE[run] = prevResults->readE(4)[i];
+            if ((run >= is) && (run <= ie)) {
+              m_logValue[run] = prevResults->readY(0)[i];
+              m_diffY[run] = prevResults->readY(1)[i];
+              m_diffE[run] = prevResults->readE(1)[i];
+              m_redY[run] = prevResults->readY(2)[i];
+              m_redE[run] = prevResults->readE(2)[i];
+              m_greenY[run] = prevResults->readY(3)[i];
+              m_greenE[run] = prevResults->readE(3)[i];
+              m_sumY[run] = prevResults->readY(4)[i];
+              m_sumE[run] = prevResults->readE(4)[i];
+            }
           }
         }
       }

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -242,6 +242,11 @@ void PlotAsymmetryByLogValue::checkProperties(size_t &is, size_t &ie) {
   m_allProperties = ss.str();
 
   // Check if we can re-use results from previous run
+  // We can reuse results if:
+  // 1. There is a ws in the ADS with name m_currResName
+  // 2. It is a MatrixWorkspace
+  // 3. It has a title equatl to m_allProperties
+  // This ws stores previous results as described below
   if (AnalysisDataService::Instance().doesExist(m_currResName)) {
     MatrixWorkspace_sptr prevResults =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -161,7 +161,7 @@ void PlotAsymmetryByLogValue::exec() {
   for (size_t i = is; i <= ie; i++) {
 
     // Check if run i was already loaded
-    if (!m_redX.count(i)) {
+    if (!m_logValue.count(i)) {
       // Load run, apply dead time corrections and detector grouping
       Workspace_sptr loadedWs = doLoad(i);
 
@@ -174,7 +174,7 @@ void PlotAsymmetryByLogValue::exec() {
   }
 
   // Create the 2D workspace for the output
-  int nplots = m_greenX.size() ? 4 : 1;
+  int nplots = m_greenY.size() ? 4 : 1;
   size_t npoints = ie - is + 1;
   MatrixWorkspace_sptr outWS = WorkspaceFactory::Instance().create(
       "Workspace2D",
@@ -236,7 +236,7 @@ void PlotAsymmetryByLogValue::checkProperties(size_t &is, size_t &ie) {
 *   @param runNumber :: [input] Run number specifying run to load
 *   @return :: Loaded workspace
 */
-Workspace_sptr PlotAsymmetryByLogValue::doLoad(int64_t runNumber) {
+Workspace_sptr PlotAsymmetryByLogValue::doLoad(size_t runNumber) {
 
   // Get complete run name
   std::ostringstream fn, fnn;
@@ -316,8 +316,8 @@ void PlotAsymmetryByLogValue::populateOutputWorkspace(
   if (nplots == 1) {
 
     std::vector<double> vecRedX, vecRedY, vecRedE;
-    for (auto it = m_redX.begin(); it != m_redX.end(); ++it) {
-      vecRedX.push_back(m_redX[it->first]);
+    for (auto it = m_logValue.begin(); it != m_logValue.end(); ++it) {
+      vecRedX.push_back(m_logValue[it->first]);
       vecRedY.push_back(m_redY[it->first]);
       vecRedE.push_back(m_redE[it->first]);
     }
@@ -332,17 +332,17 @@ void PlotAsymmetryByLogValue::populateOutputWorkspace(
     std::vector<double> vecGreenX, vecGreenY, vecGreenE;
     std::vector<double> vecSumX, vecSumY, vecSumE;
     std::vector<double> vecDiffX, vecDiffY, vecDiffE;
-    for (auto it = m_redX.begin(); it != m_redX.end(); ++it) {
-      vecRedX.push_back(m_redX[it->first]);
+    for (auto it = m_logValue.begin(); it != m_logValue.end(); ++it) {
+      vecRedX.push_back(m_logValue[it->first]);
       vecRedY.push_back(m_redY[it->first]);
       vecRedE.push_back(m_redE[it->first]);
-      vecGreenX.push_back(m_greenX[it->first]);
+      vecGreenX.push_back(m_logValue[it->first]);
       vecGreenY.push_back(m_greenY[it->first]);
       vecGreenE.push_back(m_greenE[it->first]);
-      vecSumX.push_back(m_sumX[it->first]);
+      vecSumX.push_back(m_logValue[it->first]);
       vecSumY.push_back(m_sumY[it->first]);
       vecSumE.push_back(m_sumE[it->first]);
-      vecDiffX.push_back(m_diffX[it->first]);
+      vecDiffX.push_back(m_logValue[it->first]);
       vecDiffY.push_back(m_diffY[it->first]);
       vecDiffE.push_back(m_diffE[it->first]);
     }
@@ -520,7 +520,7 @@ void PlotAsymmetryByLogValue::groupDetectors(Workspace_sptr &loadedWs,
 *   @param index :: [input] Vector index where results will be stored
 */
 void PlotAsymmetryByLogValue::doAnalysis(Workspace_sptr loadedWs,
-                                         int64_t index) {
+                                         size_t index) {
 
   // Check if workspace is a workspace group
   WorkspaceGroup_sptr group =
@@ -533,7 +533,7 @@ void PlotAsymmetryByLogValue::doAnalysis(Workspace_sptr loadedWs,
 
     double Y, E;
     calcIntAsymmetry(ws_red, Y, E);
-    m_redX[index] = getLogValue(*ws_red);
+    m_logValue[index] = getLogValue(*ws_red);
     m_redY[index] = Y;
     m_redE[index] = E;
 
@@ -551,7 +551,7 @@ void PlotAsymmetryByLogValue::doAnalysis(Workspace_sptr loadedWs,
     double YR, ER;
     calcIntAsymmetry(ws_red, YR, ER);
     double logValue = getLogValue(*ws_red);
-    m_redX[index] = logValue;
+    m_logValue[index] = logValue;
     m_redY[index] = YR;
     m_redE[index] = ER;
 
@@ -567,20 +567,16 @@ void PlotAsymmetryByLogValue::doAnalysis(Workspace_sptr loadedWs,
       double YG, EG;
       calcIntAsymmetry(ws_green, YG, EG);
       // Red data
-      m_redX[index] = logValue;
       m_redY[index] = YR;
       m_redE[index] = ER;
       // Green data
-      m_greenX[index] = logValue;
       m_greenY[index] = YG;
       m_greenE[index] = EG;
       // Sum
-      m_sumX[index] = logValue;
       m_sumY[index] = YR + YG;
       m_sumE[index] = sqrt(ER * ER + EG * EG);
       // Diff
       calcIntAsymmetry(ws_red, ws_green, YR, ER);
-      m_diffX[index] = logValue;
       m_diffY[index] = YR;
       m_diffE[index] = ER;
     }

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -312,57 +312,39 @@ Workspace_sptr PlotAsymmetryByLogValue::loadCorrectionsFromFile(
 */
 void PlotAsymmetryByLogValue::populateOutputWorkspace(
     MatrixWorkspace_sptr &outWS, int nplots) {
+
   TextAxis *tAxis = new TextAxis(nplots);
   if (nplots == 1) {
-
-    std::vector<double> vecRedX, vecRedY, vecRedE;
+    size_t i=0;
     for (auto it = m_logValue.begin(); it != m_logValue.end(); ++it) {
-      vecRedX.push_back(m_logValue[it->first]);
-      vecRedY.push_back(m_redY[it->first]);
-      vecRedE.push_back(m_redE[it->first]);
+      outWS->dataX(0)[i] = it->second;
+      outWS->dataY(0)[i] = m_redY[it->first];
+      outWS->dataE(0)[i] = m_redE[it->first];
+      i++;
     }
-
     tAxis->setLabel(0, "Asymmetry");
-    outWS->dataX(0) = vecRedX;
-    outWS->dataY(0) = vecRedY;
-    outWS->dataE(0) = vecRedE;
+
   } else {
-
-    std::vector<double> vecRedX, vecRedY, vecRedE;
-    std::vector<double> vecGreenX, vecGreenY, vecGreenE;
-    std::vector<double> vecSumX, vecSumY, vecSumE;
-    std::vector<double> vecDiffX, vecDiffY, vecDiffE;
+    size_t i=0;
     for (auto it = m_logValue.begin(); it != m_logValue.end(); ++it) {
-      vecRedX.push_back(m_logValue[it->first]);
-      vecRedY.push_back(m_redY[it->first]);
-      vecRedE.push_back(m_redE[it->first]);
-      vecGreenX.push_back(m_logValue[it->first]);
-      vecGreenY.push_back(m_greenY[it->first]);
-      vecGreenE.push_back(m_greenE[it->first]);
-      vecSumX.push_back(m_logValue[it->first]);
-      vecSumY.push_back(m_sumY[it->first]);
-      vecSumE.push_back(m_sumE[it->first]);
-      vecDiffX.push_back(m_logValue[it->first]);
-      vecDiffY.push_back(m_diffY[it->first]);
-      vecDiffE.push_back(m_diffE[it->first]);
+      outWS->dataX(0)[i] = it->second;
+      outWS->dataY(0)[i] = m_diffY[it->first];
+      outWS->dataE(0)[i] = m_diffE[it->first];
+      outWS->dataX(1)[i] = it->second;
+      outWS->dataY(1)[i] = m_redY[it->first];
+      outWS->dataE(1)[i] = m_redE[it->first];
+      outWS->dataX(2)[i] = it->second;
+      outWS->dataY(2)[i] = m_greenY[it->first];
+      outWS->dataE(2)[i] = m_greenE[it->first];
+      outWS->dataX(3)[i] = it->second;
+      outWS->dataY(3)[i] = m_sumY[it->first];
+      outWS->dataE(3)[i] = m_sumE[it->first];
+      i++;
     }
-
     tAxis->setLabel(0, "Red-Green");
     tAxis->setLabel(1, "Red");
     tAxis->setLabel(2, "Green");
     tAxis->setLabel(3, "Red+Green");
-    outWS->dataX(0) = vecDiffX;
-    outWS->dataY(0) = vecDiffY;
-    outWS->dataE(0) = vecDiffE;
-    outWS->dataX(1) = vecRedX;
-    outWS->dataY(1) = vecRedY;
-    outWS->dataE(1) = vecRedE;
-    outWS->dataX(2) = vecGreenX;
-    outWS->dataY(2) = vecGreenY;
-    outWS->dataE(2) = vecGreenE;
-    outWS->dataX(3) = vecSumX;
-    outWS->dataY(3) = vecSumY;
-    outWS->dataE(3) = vecSumE;
   }
   outWS->replaceAxis(1, tAxis);
   outWS->getAxis(0)->title() = m_logName;

--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -71,7 +71,12 @@ using namespace DataObjects;
 DECLARE_ALGORITHM(PlotAsymmetryByLogValue)
 
 PlotAsymmetryByLogValue::PlotAsymmetryByLogValue()
-    : Algorithm(), m_int(false), m_currResName("__PABLV_results") {}
+    : Algorithm(), m_filenameBase(), m_filenameExt(), m_filenameZeros(),
+      m_dtcType(), m_dtcFile(), m_forward_list(), m_backward_list(),
+      m_int(true), m_red(-1), m_green(-1), m_minTime(-1.0), m_maxTime(-1.0),
+      m_logName(), m_logFunc(), m_logValue(), m_redY(), m_redE(), m_greenY(),
+      m_greenE(), m_sumY(), m_sumE(), m_diffY(), m_diffE(), m_allProperties("default"),
+      m_currResName("__PABLV_results") {}
 
 /** Initialisation method. Declares properties to be used in algorithm.
 *

--- a/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlotAsymmetryByLogValueTest.h
@@ -216,8 +216,7 @@ public:
     TS_ASSERT_DELTA(Y[0], 0.15214, 0.00001);
     TS_ASSERT_DELTA(Y[1], 0.14492, 0.00001);
 
-    AnalysisDataService::Instance().remove(ws);
-    AnalysisDataService::Instance().remove(deadTimeWs);
+    AnalysisDataService::Instance().clear();
     Poco::File(deadTimeFile).remove();
   }
 
@@ -252,7 +251,7 @@ public:
     TS_ASSERT_DELTA(Y[0], 0.151202, 0.00001);
     TS_ASSERT_DELTA(Y[1], 0.144008, 0.00001);
 
-    AnalysisDataService::Instance().remove(ws);
+    AnalysisDataService::Instance().clear();
   }
 
     void test_customGrouping()
@@ -330,7 +329,7 @@ public:
     TS_ASSERT_DELTA(Y[0], 0.14700, 0.00001);
     TS_ASSERT_DELTA(Y[1], 0.13042, 0.00001);
 
-    AnalysisDataService::Instance().remove(ws);
+    AnalysisDataService::Instance().clear();
   }
 
   void test_LogValueFunction() {
@@ -367,7 +366,7 @@ public:
     TS_ASSERT_DELTA(X[0], 178.740476, 0.00001);
     TS_ASSERT_DELTA(X[1], 178.849998, 0.00001);
 
-    AnalysisDataService::Instance().remove(ws);
+    AnalysisDataService::Instance().clear();
   }
 
   void test_invalidRunNumbers ()
@@ -385,7 +384,7 @@ public:
     TS_ASSERT_THROWS (alg.execute(),std::runtime_error);
     TS_ASSERT (!alg.isExecuted());
 
-    AnalysisDataService::Instance().remove(ws);
+    AnalysisDataService::Instance().clear();
   }
 
   void test_singlePeriodGreen() {
@@ -417,7 +416,7 @@ public:
     TS_ASSERT_DELTA(outWS->readY(0)[0], 0.283444, 0.000001);
     TS_ASSERT_DELTA(outWS->readE(0)[0], 0.000145, 0.000001);
 
-    AnalysisDataService::Instance().remove(ws);
+    AnalysisDataService::Instance().clear();
   }
 
 private:


### PR DESCRIPTION
Fixes #13151

For tester: Follow steps 2 and 3 in #13256. Try the same steps but running the Muon ALC interface this time (which calls PlotAsymmetryByLogValue as a child algorithm).

Release notes: no updates, since this is a purely internal issue.
