### PR TITLE
13261 improve documentation on workspaces

### DIFF
--- a/Code/Mantid/docs/source/concepts/EventWorkspace.rst
+++ b/Code/Mantid/docs/source/concepts/EventWorkspace.rst
@@ -121,6 +121,8 @@ You can go around this by forcing the parallel loop with a plain
 PARALLEL\_FOR() macro. **Make sure you do not read from the same
 spectrum in parallel!**
 
+.. include:: WorkspaceNavigation.txt
+
 
 
 .. categories:: Concepts

--- a/Code/Mantid/docs/source/concepts/MatrixWorkspace.rst
+++ b/Code/Mantid/docs/source/concepts/MatrixWorkspace.rst
@@ -25,21 +25,10 @@ Optionally:
 Documentation on the :ref:`CreateWorkspace <algm-CreateWorkspace>` 
 algorithm may also be useful.
 
-Concrete Matrix Workspaces
---------------------------
-
--  WorkspaceSingleValue - Holds a single number (and X & error value, if
-   desired). Mainly used for workspace algebra, e.g. to divide all bins
-   in a 2D workspace by a single value.
--  :ref:`Workspace2D <Workspace2D>` - A workspace for holding two
-   dimensional data in memory. This is the most commonly used workspace.
--  :ref:`EventWorkspace <EventWorkspace>` - A workspace that retains the
-   individual neutron event data.
-
+.. include:: WorkspaceNavigation.txt
+   
 More information on working with them: `Interacting with Matrix
 Workspaces <http://www.mantidproject.org/Interacting_with_Workspaces>`__.
-
-.. include:: WorkspaceNavigation.txt
 
 
 

--- a/Code/Mantid/docs/source/concepts/MatrixWorkspace.rst
+++ b/Code/Mantid/docs/source/concepts/MatrixWorkspace.rst
@@ -22,6 +22,9 @@ Optionally:
 -  A distribution flag
 -  A list of 'masked' bins
 
+Documentation on the :ref:`CreateWorkspace <algm-CreateWorkspace>` 
+algorithm may also be useful.
+
 Concrete Matrix Workspaces
 --------------------------
 

--- a/Code/Mantid/docs/source/concepts/MatrixWorkspace.rst
+++ b/Code/Mantid/docs/source/concepts/MatrixWorkspace.rst
@@ -36,6 +36,8 @@ Concrete Matrix Workspaces
 More information on working with them: `Interacting with Matrix
 Workspaces <http://www.mantidproject.org/Interacting_with_Workspaces>`__.
 
+.. include:: WorkspaceNavigation.txt
+
 
 
 .. categories:: Concepts

--- a/Code/Mantid/docs/source/concepts/TableWorkspaces.rst
+++ b/Code/Mantid/docs/source/concepts/TableWorkspaces.rst
@@ -94,6 +94,8 @@ c\_plus\_plus\_type must be a copyable type and operators << and >> must
 be defined. There is also DECLARE\_TABLEPOINTERCOLUMN macro for
 declaring non-copyable types, but it has never been used.
 
+.. include:: WorkspaceNavigation.txt
+
 
 
 .. categories:: Concepts

--- a/Code/Mantid/docs/source/concepts/Workspace2D.rst
+++ b/Code/Mantid/docs/source/concepts/Workspace2D.rst
@@ -15,6 +15,23 @@ only contains bin information and does not contain the underlying event
 data. The :ref:`EventWorkspace <EventWorkspace>` presents itself as a
 histogram (with X,Y,E values) but preserves the underlying event data.
 
+Workspaces Navigation
+=====================
+
+-  :ref:`MatrixWorkspace <MatrixWorkspace>` - A base class that contains
+   among others:
+
+   -  **Workspace2D** - A workspace for holding two
+      dimensional data in memory, this is the most commonly used
+      workspace.
+   -  :ref:`EventWorkspace <EventWorkspace>` - A workspace that retains the
+      individual neutron event data.
+
+-  :ref:`TableWorkspace <Table Workspaces>` - A workspace holding data in
+   rows of columns having a particular type (e.g. text, integer, ...).
+-  :ref:`WorkspaceGroup <WorkspaceGroup>` - A container for a collection of
+   workspaces. Algorithms given a group as input run sequentially on
+   each member of the group.
 
 
 .. categories:: Concepts

--- a/Code/Mantid/docs/source/concepts/Workspace2D.rst
+++ b/Code/Mantid/docs/source/concepts/Workspace2D.rst
@@ -15,23 +15,8 @@ only contains bin information and does not contain the underlying event
 data. The :ref:`EventWorkspace <EventWorkspace>` presents itself as a
 histogram (with X,Y,E values) but preserves the underlying event data.
 
-Workspaces Navigation
-=====================
+.. include:: WorkspaceNavigation.txt
 
--  :ref:`MatrixWorkspace <MatrixWorkspace>` - A base class that contains
-   among others:
-
-   -  **Workspace2D** - A workspace for holding two
-      dimensional data in memory, this is the most commonly used
-      workspace.
-   -  :ref:`EventWorkspace <EventWorkspace>` - A workspace that retains the
-      individual neutron event data.
-
--  :ref:`TableWorkspace <Table Workspaces>` - A workspace holding data in
-   rows of columns having a particular type (e.g. text, integer, ...).
--  :ref:`WorkspaceGroup <WorkspaceGroup>` - A container for a collection of
-   workspaces. Algorithms given a group as input run sequentially on
-   each member of the group.
 
 
 .. categories:: Concepts

--- a/Code/Mantid/docs/source/concepts/Workspace2D.rst
+++ b/Code/Mantid/docs/source/concepts/Workspace2D.rst
@@ -15,6 +15,9 @@ only contains bin information and does not contain the underlying event
 data. The :ref:`EventWorkspace <EventWorkspace>` presents itself as a
 histogram (with X,Y,E values) but preserves the underlying event data.
 
+For more information on what a Workspace2D contains, see 
+:ref:`MatrixWorkspace <MatrixWorkspace>`.
+
 .. include:: WorkspaceNavigation.txt
 
 

--- a/Code/Mantid/docs/source/concepts/WorkspaceGroup.rst
+++ b/Code/Mantid/docs/source/concepts/WorkspaceGroup.rst
@@ -21,6 +21,8 @@ Un-grouping Workspaces
 -  Select the WorkspaceGroup and click "Ungroup".
 -  Use the :ref:`UnGroupWorkspace <algm-UnGroupWorkspace>` algorithm.
 
+.. include:: WorkspaceNavigation.txt
+
 
 
 .. categories:: Concepts

--- a/Code/Mantid/docs/source/concepts/WorkspaceNavigation.txt
+++ b/Code/Mantid/docs/source/concepts/WorkspaceNavigation.txt
@@ -5,6 +5,9 @@ Other Information on Workspaces
     -  :ref:`MatrixWorkspace <MatrixWorkspace>` - A base class that contains
        among others:
 
+       -  WorkspaceSingleValue - Holds a single number (and X & error value, 
+          if desired). Mainly used for workspace algebra, e.g. to divide all 
+          bins in a 2D workspace by a single value.
        -  :ref:`Workspace2D <Workspace2D>` - A workspace for holding two
           dimensional data in memory, this is the most commonly used
           workspace.

--- a/Code/Mantid/docs/source/concepts/WorkspaceNavigation.txt
+++ b/Code/Mantid/docs/source/concepts/WorkspaceNavigation.txt
@@ -1,0 +1,19 @@
+Other Information on Workspaces
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  :ref:`Workspace <Workspace>` - Overview of workspaces, which include the following classes:
+    -  :ref:`MatrixWorkspace <MatrixWorkspace>` - A base class that contains
+       among others:
+
+       -  :ref:`Workspace2D <Workspace2D>` - A workspace for holding two
+          dimensional data in memory, this is the most commonly used
+          workspace.
+       -  :ref:`EventWorkspace <EventWorkspace>` - A workspace that retains the
+          individual neutron event data.
+
+    -  :ref:`TableWorkspace <Table Workspaces>` - A workspace holding data in
+       rows of columns having a particular type (e.g. text, integer, ...).
+    -  :ref:`WorkspaceGroup <WorkspaceGroup>` - A container for a collection of
+       workspaces. Algorithms given a group as input run sequentially on
+       each member of the group.
+       

--- a/Code/Mantid/docs/source/concepts/WorkspaceNavigation.txt
+++ b/Code/Mantid/docs/source/concepts/WorkspaceNavigation.txt
@@ -1,5 +1,5 @@
 Other Information on Workspaces
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 -  :ref:`Workspace <Workspace>` - Overview of workspaces, which include the following classes:
     -  :ref:`MatrixWorkspace <MatrixWorkspace>` - A base class that contains


### PR DESCRIPTION
Closes #13261 

Improved navigation between documentation on different Workspaces. Relevant information, for example in the documentation for the superclass, should be found more easily.

For tester: perhaps start on the MatrixWorkspace doc, note the section "Other Information on Workspaces".
