### PR TITLE
Fix output when skipping missing run numbers

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/PlotAsymmetryByLogValue.cpp
@@ -180,7 +180,7 @@ void PlotAsymmetryByLogValue::exec() {
 
   // Create the 2D workspace for the output
   int nplots = m_greenY.size() ? 4 : 1;
-  size_t npoints = ie - is + 1;
+  size_t npoints = m_logValue.size();
   MatrixWorkspace_sptr outWS = WorkspaceFactory::Instance().create(
       "Workspace2D",
       nplots,  //  the number of plots


### PR DESCRIPTION
Fixes #13276 

For tester: test as described in #13269

Release notes: no changes since this was introduced in #13269
