### PR TITLE
Replaced ICat Credentials in Unit Tests

### DIFF
--- a/Code/Mantid/Framework/ICat/test/CatalogDownloadDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogDownloadDataFilesTest.h
@@ -71,8 +71,7 @@ public:
 
 				
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("StartRun", "100.0");
-		searchobj.setPropertyValue("EndRun", "102.0");
+		searchobj.setPropertyValue("RunRange", "100-102");
 		searchobj.setPropertyValue("Instrument","HET");
 		searchobj.setPropertyValue("OutputWorkspace","investigations");
 				
@@ -130,8 +129,7 @@ public:
 
 				
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("StartRun", "17440.0");
-		searchobj.setPropertyValue("EndRun", "17556.0");
+		searchobj.setPropertyValue("RunRange", "17440-17556");
 		searchobj.setPropertyValue("Instrument","EMU");
 		searchobj.setPropertyValue("OutputWorkspace","investigations");
 				
@@ -189,8 +187,7 @@ public:
 
 				
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("StartRun", "600.0");
-		searchobj.setPropertyValue("EndRun", "601.0");
+		searchobj.setPropertyValue("RunRange", "600-601");
 		searchobj.setPropertyValue("Instrument","MERLIN");
 		searchobj.setPropertyValue("OutputWorkspace","investigations");
 				

--- a/Code/Mantid/Framework/ICat/test/CatalogDownloadDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogDownloadDataFilesTest.h
@@ -6,6 +6,7 @@
 #include "MantidICat/CatalogLogin.h"
 #include "MantidICat/CatalogGetDataFiles.h"
 #include "MantidICat/CatalogSearch.h"
+#include "ICatTestHelper.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidAPI/AnalysisDataService.h"
@@ -60,15 +61,7 @@ public:
 	}
 	void xtestDownLoadDataFile()
 	{		
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-	
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
-
+		TS_ASSERT( ICatTestHelper::login() );
 				
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		searchobj.setPropertyValue("RunRange", "100-102");
@@ -105,7 +98,8 @@ public:
 		}
 		ofs<<"Time taken to  download files with investigation id 12576918 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
 		
-						
+		ICatTestHelper::logout();
+
 		TS_ASSERT( downloadobj.isExecuted() );
 		//delete the file after execution
 		//remove("HET00097.RAW");
@@ -118,16 +112,8 @@ public:
 
 	void xtestDownLoadNexusFile()
 	{				
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
+		TS_ASSERT( ICatTestHelper::login() );
 
-		// Now set it...
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-			
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
-
-				
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		searchobj.setPropertyValue("RunRange", "17440-17556");
 		searchobj.setPropertyValue("Instrument","EMU");
@@ -165,6 +151,8 @@ public:
 		ofs<<"Time taken to download files with investigation id 24070400 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
 		//ofs.close();
 		
+		ICatTestHelper::logout();
+
 		TS_ASSERT( downloadobj.isExecuted() );
 		//delete the file after execution
 		//remove("EMU00017452.nxs");
@@ -176,16 +164,8 @@ public:
 
 	void xtestDownLoadDataFile_Merlin()
 	{
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
+		TS_ASSERT( ICatTestHelper::login() );
 
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-	
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
-
-				
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		searchobj.setPropertyValue("RunRange", "600-601");
 		searchobj.setPropertyValue("Instrument","MERLIN");
@@ -221,6 +201,7 @@ public:
 		}
 		ofs<<"Time taken to download files with investigation id 24022007 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
 		
+		ICatTestHelper::logout();
 						
 		TS_ASSERT( downloadobj.isExecuted() );
 		AnalysisDataService::Instance().remove("investigations");
@@ -256,6 +237,8 @@ public:
 
      ofs<<"Time taken for http download from mantidwebserver over internet for a small file of size 1KB is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
 
+	 ICatTestHelper::logout();
+
      //delete the file after execution
      remove("test.htm");
 
@@ -269,6 +252,5 @@ private:
    CatalogSearch searchobj;
    CatalogGetDataFiles invstObj;
    CatalogDownloadDataFiles downloadobj;
-   CatalogLogin loginobj;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogDownloadDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogDownloadDataFilesTest.h
@@ -54,161 +54,162 @@ public:
 
   }
 
-	void testInit()
-	{
-		TS_ASSERT_THROWS_NOTHING( downloadobj.initialize());
-		TS_ASSERT( downloadobj.isInitialized() );
-	}
-	void xtestDownLoadDataFile()
-	{		
-		TS_ASSERT( ICatTestHelper::login() );
-				
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("RunRange", "100-102");
-		searchobj.setPropertyValue("Instrument","HET");
-		searchobj.setPropertyValue("OutputWorkspace","investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
+    void testInit()
+    {
+        TS_ASSERT_THROWS_NOTHING( downloadobj.initialize());
+        TS_ASSERT( downloadobj.isInitialized() );
+    }
+    void xtestDownLoadDataFile()
+    {
+        TS_ASSERT( ICatTestHelper::login() );
 
-		if ( !invstObj.isInitialized() ) invstObj.initialize();
-		invstObj.setPropertyValue("InvestigationId","13539191");
-		invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
-		//		
-		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
-		TS_ASSERT( invstObj.isExecuted() );
-		
-		clock_t start=clock();
-		if ( !downloadobj.isInitialized() ) downloadobj.initialize();
+        if ( !searchobj.isInitialized() ) searchobj.initialize();
+        searchobj.setPropertyValue("RunRange", "100-102");
+        searchobj.setPropertyValue("Instrument","HET");
+        searchobj.setPropertyValue("OutputWorkspace","investigations");
 
-		downloadobj.setPropertyValue("Filenames","HET00097.RAW");
-		
-		TS_ASSERT_THROWS_NOTHING(downloadobj.execute());
+        TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+        TS_ASSERT( searchobj.isExecuted() );
 
-		clock_t end=clock();
-		float diff = float(end - start)/CLOCKS_PER_SEC;
+        if ( !invstObj.isInitialized() ) invstObj.initialize();
+        invstObj.setPropertyValue("InvestigationId","13539191");
+        invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
+        //
+        TS_ASSERT_THROWS_NOTHING(invstObj.execute());
+        TS_ASSERT( invstObj.isExecuted() );
 
-		std::string filepath=Kernel::ConfigService::Instance().getString("defaultsave.directory");
-		filepath += "download_time.txt";
+        clock_t start=clock();
+        if ( !downloadobj.isInitialized() ) downloadobj.initialize();
 
-		std::ofstream ofs(filepath.c_str(), std::ios_base::out );
-		if ( ofs.rdstate() & std::ios::failbit )
-		{
-			throw Mantid::Kernel::Exception::FileError("Error on creating File","download_time.txt");
-		}
-		ofs<<"Time taken to  download files with investigation id 12576918 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
-		
-		ICatTestHelper::logout();
+        downloadobj.setPropertyValue("Filenames","HET00097.RAW");
 
-		TS_ASSERT( downloadobj.isExecuted() );
-		//delete the file after execution
-		//remove("HET00097.RAW");
+        TS_ASSERT_THROWS_NOTHING(downloadobj.execute());
 
-		AnalysisDataService::Instance().remove("investigations");
-		AnalysisDataService::Instance().remove("investigation");
+        clock_t end=clock();
+        float diff = float(end - start)/CLOCKS_PER_SEC;
+
+        std::string filepath=Kernel::ConfigService::Instance().getString("defaultsave.directory");
+        filepath += "download_time.txt";
+
+        std::ofstream ofs(filepath.c_str(), std::ios_base::out );
+        if ( ofs.rdstate() & std::ios::failbit )
+        {
+            throw Mantid::Kernel::Exception::FileError("Error on creating File","download_time.txt");
+        }
+        ofs<<"Time taken to  download files with investigation id 12576918 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
+
+        ICatTestHelper::logout();
+
+        TS_ASSERT( downloadobj.isExecuted() );
+        //delete the file after execution
+        //remove("HET00097.RAW");
+
+        AnalysisDataService::Instance().remove("investigations");
+        AnalysisDataService::Instance().remove("investigation");
     // Clean up test files
     if (Poco::File(filepath).exists()) Poco::File(filepath).remove();
-	}
+    }
 
-	void xtestDownLoadNexusFile()
-	{				
-		TS_ASSERT( ICatTestHelper::login() );
+    void xtestDownLoadNexusFile()
+    {
+      TS_ASSERT( ICatTestHelper::login() );
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("RunRange", "17440-17556");
-		searchobj.setPropertyValue("Instrument","EMU");
-		searchobj.setPropertyValue("OutputWorkspace","investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
+      if ( !searchobj.isInitialized() ) searchobj.initialize();
+      searchobj.setPropertyValue("RunRange", "17440-17556");
+      searchobj.setPropertyValue("Instrument","EMU");
+      searchobj.setPropertyValue("OutputWorkspace","investigations");
 
-		if ( !invstObj.isInitialized() ) invstObj.initialize();
-	
-		invstObj.setPropertyValue("InvestigationId", "24070400");
+      TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+      TS_ASSERT( searchobj.isExecuted() );
 
-		invstObj.setPropertyValue("OutputWorkspace","investigation");
-		//		
-		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
-		TS_ASSERT( invstObj.isExecuted() );
-		
-		clock_t start=clock();
-		if ( !downloadobj.isInitialized() ) downloadobj.initialize();
+      if ( !invstObj.isInitialized() ) invstObj.initialize();
 
-		downloadobj.setPropertyValue("Filenames","EMU00017452.nxs");
-		TS_ASSERT_THROWS_NOTHING(downloadobj.execute());
+      invstObj.setPropertyValue("InvestigationId", "24070400");
 
-		clock_t end=clock();
-		float diff = float(end -start)/CLOCKS_PER_SEC;
-		
-		std::string filepath=Kernel::ConfigService::Instance().getString("defaultsave.directory");
-		filepath += "download_time.txt";
-		
-		std::ofstream ofs(filepath.c_str(), std::ios_base::out | std::ios_base::app);
-		if ( ofs.rdstate() & std::ios::failbit )
-		{
-			throw Mantid::Kernel::Exception::FileError("Error on creating File","download_time.txt");
-		}
-		ofs<<"Time taken to download files with investigation id 24070400 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
-		//ofs.close();
-		
-		ICatTestHelper::logout();
+      invstObj.setPropertyValue("OutputWorkspace","investigation");
 
-		TS_ASSERT( downloadobj.isExecuted() );
-		//delete the file after execution
-		//remove("EMU00017452.nxs");
-		AnalysisDataService::Instance().remove("investigations");
-		AnalysisDataService::Instance().remove("investigation");
-    // Clean up test files
-    if (Poco::File(filepath).exists()) Poco::File(filepath).remove();
-	}
+      TS_ASSERT_THROWS_NOTHING(invstObj.execute());
+      TS_ASSERT( invstObj.isExecuted() );
 
-	void xtestDownLoadDataFile_Merlin()
-	{
-		TS_ASSERT( ICatTestHelper::login() );
+      clock_t start=clock();
+      if ( !downloadobj.isInitialized() ) downloadobj.initialize();
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("RunRange", "600-601");
-		searchobj.setPropertyValue("Instrument","MERLIN");
-		searchobj.setPropertyValue("OutputWorkspace","investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
+      downloadobj.setPropertyValue("Filenames","EMU00017452.nxs");
+      TS_ASSERT_THROWS_NOTHING(downloadobj.execute());
 
-		if ( !invstObj.isInitialized() ) invstObj.initialize();
-		invstObj.setPropertyValue("InvestigationId","24022007");
-		invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
-		//		
-		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
-		TS_ASSERT( invstObj.isExecuted() );
-		
-		clock_t start=clock();
-		if ( !downloadobj.isInitialized() ) downloadobj.initialize();
+      clock_t end=clock();
+      float diff = float(end -start)/CLOCKS_PER_SEC;
 
-		downloadobj.setPropertyValue("Filenames","MER00599.raw");
-			
-		TS_ASSERT_THROWS_NOTHING(downloadobj.execute());
+      std::string filepath=Kernel::ConfigService::Instance().getString("defaultsave.directory");
+      filepath += "download_time.txt";
 
-		clock_t end=clock();
-		float diff = float(end - start)/CLOCKS_PER_SEC;
+      std::ofstream ofs(filepath.c_str(), std::ios_base::out | std::ios_base::app);
+      if ( ofs.rdstate() & std::ios::failbit )
+      {
+        throw Mantid::Kernel::Exception::FileError("Error on creating File","download_time.txt");
+      }
+      ofs<<"Time taken to download files with investigation id 24070400 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
+      //ofs.close();
 
-		std::string filepath=Kernel::ConfigService::Instance().getString("defaultsave.directory");
-		filepath += "download_time.txt";
+      ICatTestHelper::logout();
 
-		std::ofstream ofs(filepath.c_str(), std::ios_base::out | std::ios_base::app);
-		if ( ofs.rdstate() & std::ios::failbit )
-		{
-			throw Mantid::Kernel::Exception::FileError("Error on creating File","download_time.txt");
-		}
-		ofs<<"Time taken to download files with investigation id 24022007 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
-		
-		ICatTestHelper::logout();
-						
-		TS_ASSERT( downloadobj.isExecuted() );
-		AnalysisDataService::Instance().remove("investigations");
-		AnalysisDataService::Instance().remove("investigation");
-    // Clean up test files
-    if (Poco::File(filepath).exists()) Poco::File(filepath).remove();
-	}
+      TS_ASSERT( downloadobj.isExecuted() );
+      //delete the file after execution
+      //remove("EMU00017452.nxs");
+      AnalysisDataService::Instance().remove("investigations");
+      AnalysisDataService::Instance().remove("investigation");
+      // Clean up test files
+      if (Poco::File(filepath).exists()) Poco::File(filepath).remove();
+    }
+
+    void xtestDownLoadDataFile_Merlin()
+    {
+      TS_ASSERT( ICatTestHelper::login() );
+
+      if ( !searchobj.isInitialized() ) searchobj.initialize();
+      searchobj.setPropertyValue("RunRange", "600-601");
+      searchobj.setPropertyValue("Instrument","MERLIN");
+      searchobj.setPropertyValue("OutputWorkspace","investigations");
+
+      TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+      TS_ASSERT( searchobj.isExecuted() );
+
+      if ( !invstObj.isInitialized() ) invstObj.initialize();
+      invstObj.setPropertyValue("InvestigationId","24022007");
+      invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
+      //
+      TS_ASSERT_THROWS_NOTHING(invstObj.execute());
+      TS_ASSERT( invstObj.isExecuted() );
+
+      clock_t start=clock();
+      if ( !downloadobj.isInitialized() ) downloadobj.initialize();
+
+      downloadobj.setPropertyValue("Filenames","MER00599.raw");
+
+      TS_ASSERT_THROWS_NOTHING(downloadobj.execute());
+
+      clock_t end=clock();
+      float diff = float(end - start)/CLOCKS_PER_SEC;
+
+      std::string filepath=Kernel::ConfigService::Instance().getString("defaultsave.directory");
+      filepath += "download_time.txt";
+
+      std::ofstream ofs(filepath.c_str(), std::ios_base::out | std::ios_base::app);
+      if ( ofs.rdstate() & std::ios::failbit )
+      {
+        throw Mantid::Kernel::Exception::FileError("Error on creating File","download_time.txt");
+      }
+      ofs<<"Time taken to download files with investigation id 24022007 is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
+
+      ICatTestHelper::logout();
+
+      TS_ASSERT( downloadobj.isExecuted() );
+      AnalysisDataService::Instance().remove("investigations");
+      AnalysisDataService::Instance().remove("investigation");
+
+      // Clean up test files
+      if (Poco::File(filepath).exists()) Poco::File(filepath).remove();
+    }
 
    void xtestDownloaddataFile1()
    {
@@ -237,7 +238,7 @@ public:
 
      ofs<<"Time taken for http download from mantidwebserver over internet for a small file of size 1KB is "<<std::fixed << std::setprecision(2) << diff << " seconds" << std::endl;
 
-	 ICatTestHelper::logout();
+     ICatTestHelper::logout();
 
      //delete the file after execution
      remove("test.htm");

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
@@ -31,16 +31,15 @@ public:
 	{	
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 	
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
-
+		
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("StartRun", "100.0");
-		searchobj.setPropertyValue("EndRun", "102.0");
+		searchobj.setPropertyValue("RunRange", "100-102");
 		searchobj.setPropertyValue("Instrument","LOQ");
 		searchobj.setPropertyValue("OutputWorkspace","investigations");
 				
@@ -51,7 +50,7 @@ public:
 		invstObj.setPropertyValue("InvestigationId","12576918");
 		//invstObj.setPropertyValue("InputWorkspace", "investigations");//records of investigations
 		invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation data files
-		//		
+		
 		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
 		TS_ASSERT( invstObj.isExecuted() );
 	}

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
@@ -20,27 +20,27 @@ public:
     return ICatTestHelper::skipTests();
   }
 
-	void testInit()
-	{
-		Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
-		TS_ASSERT_THROWS_NOTHING( invstObj.initialize());
-		TS_ASSERT( invstObj.isInitialized() );
-	}
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
+    TS_ASSERT_THROWS_NOTHING( invstObj.initialize());
+    TS_ASSERT( invstObj.isInitialized() );
+  }
 
-	void testgetDataFilesExecutes()
-	{	
-		TS_ASSERT( ICatTestHelper::login() );
+  void testgetDataFilesExecutes()
+  {
+    TS_ASSERT( ICatTestHelper::login() );
 
-		if (!invstObj.isInitialized() ) invstObj.initialize();
-		invstObj.setPropertyValue("InvestigationId","12576918");
-		invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation data files
-		
-		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
-		TS_ASSERT( invstObj.isExecuted() );
+    if (!invstObj.isInitialized() ) invstObj.initialize();
+    invstObj.setPropertyValue("InvestigationId","12576918");
+    invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation data files
 
-		ICatTestHelper::logout();
-	}
+    TS_ASSERT_THROWS_NOTHING(invstObj.execute());
+    TS_ASSERT( invstObj.isExecuted() );
+
+    ICatTestHelper::logout();
+  }
 private:
-	CatalogGetDataFiles invstObj;
+  CatalogGetDataFiles invstObj;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
@@ -29,13 +29,7 @@ public:
 
 	void testgetDataFilesExecutes()
 	{	
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if (!invstObj.isInitialized() ) invstObj.initialize();
 		invstObj.setPropertyValue("InvestigationId","12576918");
@@ -43,9 +37,10 @@ public:
 		
 		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
 		TS_ASSERT( invstObj.isExecuted() );
+
+		ICatTestHelper::logout();
 	}
 private:
-	CatalogLogin loginobj;
 	CatalogGetDataFiles invstObj;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataFilesTest.h
@@ -27,28 +27,18 @@ public:
 		TS_ASSERT( invstObj.isInitialized() );
 	}
 
-	void testgetDataFiles()
+	void testgetDataFilesExecutes()
 	{	
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
 		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
 		loginobj.setPropertyValue("Password", "MantidTestUser4");
-	
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
-		
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("RunRange", "100-102");
-		searchobj.setPropertyValue("Instrument","LOQ");
-		searchobj.setPropertyValue("OutputWorkspace","investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
 
 		if (!invstObj.isInitialized() ) invstObj.initialize();
 		invstObj.setPropertyValue("InvestigationId","12576918");
-		//invstObj.setPropertyValue("InputWorkspace", "investigations");//records of investigations
 		invstObj.setPropertyValue("OutputWorkspace","investigation");//selected invesigation data files
 		
 		TS_ASSERT_THROWS_NOTHING(invstObj.execute());
@@ -56,7 +46,6 @@ public:
 	}
 private:
 	CatalogLogin loginobj;
-	CatalogSearch searchobj;
 	CatalogGetDataFiles invstObj;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
@@ -32,16 +32,15 @@ public:
 	{	
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 	
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("StartRun", "100.0");
-		searchobj.setPropertyValue("EndRun", "102.0");
+		searchobj.setPropertyValue("RunRange", "100-102");
 		searchobj.setPropertyValue("Instrument","LOQ");
 		searchobj.setPropertyValue("OutputWorkspace","investigations");
 				

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
@@ -30,13 +30,7 @@ public:
 
 	void testgetDataFilesExecutes()
 	{	
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if(!datasets.isInitialized()) datasets.initialize();
 		datasets.setPropertyValue("InvestigationId","12576918");
@@ -44,9 +38,10 @@ public:
 				
 		TS_ASSERT_THROWS_NOTHING(datasets.execute());
 		TS_ASSERT( datasets.isExecuted() );
+
+		ICatTestHelper::logout();
 	}
 private:
-	CatalogLogin loginobj;
 	CatalogGetDataSets datasets;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
@@ -20,28 +20,28 @@ public:
     return ICatTestHelper::skipTests();
   }
 
-	void testInit()
-	{
-		Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
 
-		TS_ASSERT_THROWS_NOTHING( datasets.initialize());
-		TS_ASSERT( datasets.isInitialized() );
-	}
+    TS_ASSERT_THROWS_NOTHING( datasets.initialize());
+    TS_ASSERT( datasets.isInitialized() );
+  }
 
-	void testgetDataFilesExecutes()
-	{	
-		TS_ASSERT( ICatTestHelper::login() );
+  void testgetDataFilesExecutes()
+  {
+    TS_ASSERT( ICatTestHelper::login() );
 
-		if(!datasets.isInitialized()) datasets.initialize();
-		datasets.setPropertyValue("InvestigationId","12576918");
-		datasets.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
-				
-		TS_ASSERT_THROWS_NOTHING(datasets.execute());
-		TS_ASSERT( datasets.isExecuted() );
+    if(!datasets.isInitialized()) datasets.initialize();
+    datasets.setPropertyValue("InvestigationId","12576918");
+    datasets.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
 
-		ICatTestHelper::logout();
-	}
+    TS_ASSERT_THROWS_NOTHING(datasets.execute());
+    TS_ASSERT( datasets.isExecuted() );
+
+    ICatTestHelper::logout();
+  }
 private:
-	CatalogGetDataSets datasets;
+  CatalogGetDataSets datasets;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogGetDataSetsTest.h
@@ -28,36 +28,25 @@ public:
 		TS_ASSERT( datasets.isInitialized() );
 	}
 
-	void testgetDataFiles()
+	void testgetDataFilesExecutes()
 	{	
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
 		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
 		loginobj.setPropertyValue("Password", "MantidTestUser4");
-	
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		searchobj.setPropertyValue("RunRange", "100-102");
-		searchobj.setPropertyValue("Instrument","LOQ");
-		searchobj.setPropertyValue("OutputWorkspace","investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
-
 		if(!datasets.isInitialized()) datasets.initialize();
 		datasets.setPropertyValue("InvestigationId","12576918");
 		datasets.setPropertyValue("OutputWorkspace","investigation");//selected invesigation
-		//		
+				
 		TS_ASSERT_THROWS_NOTHING(datasets.execute());
 		TS_ASSERT( datasets.isExecuted() );
 	}
 private:
 	CatalogLogin loginobj;
-	CatalogSearch searchobj;
-	//CatalogGetDataFiles datafiles;
 	CatalogGetDataSets datasets;
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogListInstrumentsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogListInstrumentsTest.h
@@ -20,28 +20,28 @@ public:
     return ICatTestHelper::skipTests();
   }
 
-	void testInit()
-	{
-		Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
-		TS_ASSERT_THROWS_NOTHING( instrList.initialize());
-		TS_ASSERT( instrList.isInitialized() );
-	}
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
+    TS_ASSERT_THROWS_NOTHING( instrList.initialize());
+    TS_ASSERT( instrList.isInitialized() );
+  }
 
-	void testListInstruments()
-	{
-		TS_ASSERT( ICatTestHelper::login() );
+  void testListInstruments()
+  {
+    TS_ASSERT( ICatTestHelper::login() );
 
-		if (!instrList.isInitialized() ) instrList.initialize();
-		//instrList.setPropertyValue("OutputWorkspace","instrument_list");
-						
-		TS_ASSERT_THROWS_NOTHING(instrList.execute());
-		TS_ASSERT( instrList.isExecuted() );
+    if (!instrList.isInitialized() ) instrList.initialize();
+    //instrList.setPropertyValue("OutputWorkspace","instrument_list");
 
-		ICatTestHelper::logout();
-	}
+    TS_ASSERT_THROWS_NOTHING(instrList.execute());
+    TS_ASSERT( instrList.isExecuted() );
+
+    ICatTestHelper::logout();
+  }
 private:
-	CatalogListInstruments instrList;
+  CatalogListInstruments instrList;
 };
 
- 
+
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogListInstrumentsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogListInstrumentsTest.h
@@ -29,13 +29,7 @@ public:
 
 	void testListInstruments()
 	{
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-			
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if (!instrList.isInitialized() ) instrList.initialize();
 		//instrList.setPropertyValue("OutputWorkspace","instrument_list");
@@ -43,11 +37,10 @@ public:
 		TS_ASSERT_THROWS_NOTHING(instrList.execute());
 		TS_ASSERT( instrList.isExecuted() );
 
-
+		ICatTestHelper::logout();
 	}
 private:
 	CatalogListInstruments instrList;
-	CatalogLogin loginobj;
 };
 
  

--- a/Code/Mantid/Framework/ICat/test/CatalogListInstrumentsTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogListInstrumentsTest.h
@@ -31,8 +31,8 @@ public:
 	{
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 			
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );

--- a/Code/Mantid/Framework/ICat/test/CatalogListInvestigationTypesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogListInvestigationTypesTest.h
@@ -20,28 +20,28 @@ public:
     return ICatTestHelper::skipTests();
   }
 
-	void testInit()
-	{
-		Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
-		TS_ASSERT_THROWS_NOTHING( invstTypesList.initialize());
-		TS_ASSERT( invstTypesList.isInitialized() );
-	}
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
+    TS_ASSERT_THROWS_NOTHING( invstTypesList.initialize());
+    TS_ASSERT( invstTypesList.isInitialized() );
+  }
 
-	void testListInvestigationTypes()
-	{
-		TS_ASSERT( ICatTestHelper::login() );
+  void testListInvestigationTypes()
+  {
+    TS_ASSERT( ICatTestHelper::login() );
 
-		if (!invstTypesList.isInitialized() ) invstTypesList.initialize();
-		//invstTypesList.setPropertyValue("OutputWorkspace","investigationtypes_list");
-						
-		TS_ASSERT_THROWS_NOTHING(invstTypesList.execute());
-		TS_ASSERT( invstTypesList.isExecuted() );
+    if (!invstTypesList.isInitialized() ) invstTypesList.initialize();
+    //invstTypesList.setPropertyValue("OutputWorkspace","investigationtypes_list");
 
-		ICatTestHelper::logout();
-	}
+    TS_ASSERT_THROWS_NOTHING(invstTypesList.execute());
+    TS_ASSERT( invstTypesList.isExecuted() );
+
+    ICatTestHelper::logout();
+  }
 private:
-	CatalogListInvestigationTypes invstTypesList;
+  CatalogListInvestigationTypes invstTypesList;
 };
 
- 
+
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogListInvestigationTypesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogListInvestigationTypesTest.h
@@ -29,13 +29,7 @@ public:
 
 	void testListInvestigationTypes()
 	{
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-			
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if (!invstTypesList.isInitialized() ) invstTypesList.initialize();
 		//invstTypesList.setPropertyValue("OutputWorkspace","investigationtypes_list");
@@ -43,11 +37,10 @@ public:
 		TS_ASSERT_THROWS_NOTHING(invstTypesList.execute());
 		TS_ASSERT( invstTypesList.isExecuted() );
 
-
+		ICatTestHelper::logout();
 	}
 private:
 	CatalogListInvestigationTypes invstTypesList;
-	CatalogLogin loginobj;
 };
 
  

--- a/Code/Mantid/Framework/ICat/test/CatalogListInvestigationTypesTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogListInvestigationTypesTest.h
@@ -31,8 +31,8 @@ public:
 	{
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 			
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );

--- a/Code/Mantid/Framework/ICat/test/CatalogLoginTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogLoginTest.h
@@ -15,58 +15,58 @@ public:
     return ICatTestHelper::skipTests();
   }
 
-	void testInit()
-	{    
-		Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
 
-		CatalogLogin loginobj;
-		TS_ASSERT_THROWS_NOTHING( loginobj.initialize());
-		TS_ASSERT( loginobj.isInitialized() );
-	}
+    CatalogLogin loginobj;
+    TS_ASSERT_THROWS_NOTHING( loginobj.initialize());
+    TS_ASSERT( loginobj.isInitialized() );
+  }
 
-	void testLoginMandatoryParams()
-	{
-		CatalogLogin loginobj;
+  void testLoginMandatoryParams()
+  {
+    CatalogLogin loginobj;
 
-	   if ( !loginobj.isInitialized() ) loginobj.initialize();
+    if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		// Should fail because mandatory parameter has not been set
-		TS_ASSERT_THROWS(loginobj.execute(),std::runtime_error);
-	}
+    // Should fail because mandatory parameter has not been set
+    TS_ASSERT_THROWS(loginobj.execute(),std::runtime_error);
+  }
 
-	void testLogin()
-	{
-		CatalogLogin loginobj;
+  void testLogin()
+  {
+    CatalogLogin loginobj;
 
-	   if ( !loginobj.isInitialized() ) loginobj.initialize();
+    if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		loginobj.setProperty("KeepSessionAlive", false);
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT(loginobj.isExecuted() );
+    loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+    loginobj.setPropertyValue("Password", "MantidTestUser4");
+    loginobj.setProperty("KeepSessionAlive", false);
 
-		ICatTestHelper::logout();
-		
-	}
-	void testLoginFail()
-	{
-		
-		CatalogLogin loginobj;
+    TS_ASSERT_THROWS_NOTHING(loginobj.execute());
+    TS_ASSERT(loginobj.isExecuted() );
 
-	   if ( !loginobj.isInitialized() ) loginobj.initialize();
+    ICatTestHelper::logout();
 
-		//invalid username
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser1");
-		//loginobj.setPropertyValue("DBServer", "");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		//should fail
-		TS_ASSERT( !loginobj.isExecuted() );
-	}
+  }
+  void testLoginFail()
+  {
 
-		
+    CatalogLogin loginobj;
+
+    if ( !loginobj.isInitialized() ) loginobj.initialize();
+
+    //invalid username
+    loginobj.setPropertyValue("Username", "mantid_test");
+    loginobj.setPropertyValue("Password", "mantidtestuser1");
+    //loginobj.setPropertyValue("DBServer", "");
+
+    TS_ASSERT_THROWS_NOTHING(loginobj.execute());
+    //should fail
+    TS_ASSERT( !loginobj.isExecuted() );
+  }
+
+
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogLoginTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogLoginTest.h
@@ -42,9 +42,12 @@ public:
 
 		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
 		loginobj.setPropertyValue("Password", "MantidTestUser4");
+		loginobj.setProperty("KeepSessionAlive", false);
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT(loginobj.isExecuted() );
+
+		ICatTestHelper::logout();
 		
 	}
 	void testLoginFail()

--- a/Code/Mantid/Framework/ICat/test/CatalogLoginTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogLoginTest.h
@@ -23,7 +23,8 @@ public:
 		TS_ASSERT_THROWS_NOTHING( loginobj.initialize());
 		TS_ASSERT( loginobj.isInitialized() );
 	}
-	void testLogin()
+
+	void testLoginMandatoryParams()
 	{
 		CatalogLogin loginobj;
 
@@ -31,11 +32,16 @@ public:
 
 		// Should fail because mandatory parameter has not been set
 		TS_ASSERT_THROWS(loginobj.execute(),std::runtime_error);
+	}
 
-		// Now set it...
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
-		//loginobj.setPropertyValue("DBServer", "");
+	void testLogin()
+	{
+		CatalogLogin loginobj;
+
+	   if ( !loginobj.isInitialized() ) loginobj.initialize();
+
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT(loginobj.isExecuted() );
@@ -47,9 +53,6 @@ public:
 		CatalogLogin loginobj;
 
 	   if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		// Should fail because mandatory parameter has not been set
-		TS_ASSERT_THROWS(loginobj.execute(),std::runtime_error);
 
 		//invalid username
 		loginobj.setPropertyValue("Username", "mantid_test");

--- a/Code/Mantid/Framework/ICat/test/CatalogMyDataSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogMyDataSearchTest.h
@@ -34,8 +34,8 @@ public:
 
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 	
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());

--- a/Code/Mantid/Framework/ICat/test/CatalogMyDataSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogMyDataSearchTest.h
@@ -30,16 +30,8 @@ public:
 	void testMyDataSearch()
 	{
 		CatalogMyDataSearch mydata;
-		CatalogLogin loginobj;
 
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-	
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if ( !mydata.isInitialized() ) mydata.initialize();
 			
@@ -48,6 +40,7 @@ public:
 		TS_ASSERT_THROWS_NOTHING(mydata.execute());
 		TS_ASSERT( mydata.isExecuted() );
 
+		ICatTestHelper::logout();
 	}
 			
 };

--- a/Code/Mantid/Framework/ICat/test/CatalogMyDataSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogMyDataSearchTest.h
@@ -20,28 +20,28 @@ public:
     return ICatTestHelper::skipTests();
   }
 
-	void testInit()
-	{
-		Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
-		CatalogMyDataSearch mydata;
-		TS_ASSERT_THROWS_NOTHING( mydata.initialize());
-		TS_ASSERT( mydata.isInitialized() );
-	}
-	void testMyDataSearch()
-	{
-		CatalogMyDataSearch mydata;
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
+    CatalogMyDataSearch mydata;
+    TS_ASSERT_THROWS_NOTHING( mydata.initialize());
+    TS_ASSERT( mydata.isInitialized() );
+  }
+  void testMyDataSearch()
+  {
+    CatalogMyDataSearch mydata;
 
-		TS_ASSERT( ICatTestHelper::login() );
+    TS_ASSERT( ICatTestHelper::login() );
 
-		if ( !mydata.isInitialized() ) mydata.initialize();
-			
-		mydata.setPropertyValue("OutputWorkspace","MyInvestigations");
-				
-		TS_ASSERT_THROWS_NOTHING(mydata.execute());
-		TS_ASSERT( mydata.isExecuted() );
+    if ( !mydata.isInitialized() ) mydata.initialize();
 
-		ICatTestHelper::logout();
-	}
-			
+    mydata.setPropertyValue("OutputWorkspace","MyInvestigations");
+
+    TS_ASSERT_THROWS_NOTHING(mydata.execute());
+    TS_ASSERT( mydata.isExecuted() );
+
+    ICatTestHelper::logout();
+  }
+
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
@@ -41,8 +41,8 @@ public:
 
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 		//loginobj.setPropertyValue("DBServer", "");
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
@@ -50,8 +50,7 @@ public:
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
-		searchobj.setPropertyValue("StartRun", "100.0");
-		searchobj.setPropertyValue("EndRun", "109.0");
+		searchobj.setPropertyValue("RunRange", "100-109");
 		searchobj.setPropertyValue("Instrument","LOQ");
 		searchobj.setPropertyValue("OutputWorkspace","Investigations");
 					
@@ -67,8 +66,8 @@ public:
 
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 		//loginobj.setPropertyValue("DBServer", "");
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
@@ -91,8 +90,8 @@ public:
 
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 			
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
@@ -114,8 +113,8 @@ public:
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
 		// Now set it...
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 		//loginobj.setPropertyValue("DBServer", "");
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
@@ -124,8 +123,7 @@ public:
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
 		// start run number > end run number
-		searchobj.setPropertyValue("StartRun", "150.0");
-		searchobj.setPropertyValue("EndRun", "102.0");
+		searchobj.setPropertyValue("RunRange", "150-102");
 		searchobj.setPropertyValue("Instrument","LOQ");
 				
     	searchobj.setPropertyValue("OutputWorkspace","Investigations");
@@ -142,8 +140,8 @@ public:
 
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
@@ -166,8 +164,8 @@ public:
 
 		if ( !loginobj.isInitialized() ) loginobj.initialize();
 
-		loginobj.setPropertyValue("Username", "mantid_test");
-		loginobj.setPropertyValue("Password", "mantidtestuser");
+		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+		loginobj.setPropertyValue("Password", "MantidTestUser4");
 		
 		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
 		TS_ASSERT( loginobj.isExecuted() );
@@ -176,7 +174,7 @@ public:
 				
 		TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","39/22/2009"),std::runtime_error);
 		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","aaaaa"),std::runtime_error);
-		searchobj.setPropertyValue("OutputWorkspace","Investigations");
+		//searchobj.setPropertyValue("OutputWorkspace","Investigations");
 		
 		TS_ASSERT_THROWS(searchobj.execute(),std::runtime_error);
 

--- a/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
@@ -23,132 +23,132 @@ public:
   {
     Mantid::API::FrameworkManager::Instance();
   }
-	
-	void testInit()
-	{
-	  Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
 
-		CatalogSearch searchobj;
-		CatalogLogin loginobj;
-		TS_ASSERT_THROWS_NOTHING( searchobj.initialize());
-		TS_ASSERT( searchobj.isInitialized() );
-	}
-	void testSearchByRunNumberandInstrumentExecutes()
-	{
-		// Uses an unused keyword to produce an empty workspace and be fast
-		
-		CatalogSearch searchobj;
+  void testInit()
+  {
+    Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
 
-		TS_ASSERT( ICatTestHelper::login() );
+    CatalogSearch searchobj;
+    CatalogLogin loginobj;
+    TS_ASSERT_THROWS_NOTHING( searchobj.initialize());
+    TS_ASSERT( searchobj.isInitialized() );
+  }
+  void testSearchByRunNumberandInstrumentExecutes()
+  {
+    // Uses an unused keyword to produce an empty workspace and be fast
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		
-		searchobj.setPropertyValue("RunRange", "1000000-1000001");
-		searchobj.setPropertyValue("Instrument","LOQ");
-		searchobj.setPropertyValue("OutputWorkspace","Investigations");
-					
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
+    CatalogSearch searchobj;
 
-		ICatTestHelper::logout();
+    TS_ASSERT( ICatTestHelper::login() );
 
-	}
-	void testSearchByKeywordsExecutes()
-	{
-		
-		CatalogSearch searchobj;
+    if ( !searchobj.isInitialized() ) searchobj.initialize();
 
-		TS_ASSERT( ICatTestHelper::login() );
+    searchobj.setPropertyValue("RunRange", "1000000-1000001");
+    searchobj.setPropertyValue("Instrument","LOQ");
+    searchobj.setPropertyValue("OutputWorkspace","Investigations");
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-				
-		searchobj.setPropertyValue("Keywords","000117");
-		searchobj.setPropertyValue("Instrument","HRPD");
-		searchobj.setPropertyValue("OutputWorkspace","Investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
+    TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+    TS_ASSERT( searchobj.isExecuted() );
 
-		ICatTestHelper::logout();
+    ICatTestHelper::logout();
 
-	}
-	void testSearchByStartDateEndDateExecutes()
-	{
-		// Uses a search date outside of general operation to produce an empty workspace and be fast
+  }
+  void testSearchByKeywordsExecutes()
+  {
 
-		CatalogSearch searchobj;
+    CatalogSearch searchobj;
 
-		TS_ASSERT( ICatTestHelper::login() );
+    TS_ASSERT( ICatTestHelper::login() );
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		
-		searchobj.setPropertyValue("StartDate","10/08/1980");
-		searchobj.setPropertyValue("EndDate","22/08/1980");
-		searchobj.setPropertyValue("OutputWorkspace","Investigations");
-				
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		TS_ASSERT( searchobj.isExecuted() );
+    if ( !searchobj.isInitialized() ) searchobj.initialize();
 
-		ICatTestHelper::logout();
+    searchobj.setPropertyValue("Keywords","000117");
+    searchobj.setPropertyValue("Instrument","HRPD");
+    searchobj.setPropertyValue("OutputWorkspace","Investigations");
 
-	}
-	void testSearchByRunNumberInvalidInput()
-	{		
-		CatalogSearch searchobj;
+    TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+    TS_ASSERT( searchobj.isExecuted() );
 
-		TS_ASSERT( ICatTestHelper::login() );
+    ICatTestHelper::logout();
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		
-		// start run number > end run number
-		searchobj.setPropertyValue("RunRange", "150-102");
-		searchobj.setPropertyValue("Instrument","LOQ");
-				
-    	searchobj.setPropertyValue("OutputWorkspace","Investigations");
-		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
-		//should fail
-		TS_ASSERT( !searchobj.isExecuted() );
+  }
+  void testSearchByStartDateEndDateExecutes()
+  {
+    // Uses a search date outside of general operation to produce an empty workspace and be fast
 
-		ICatTestHelper::logout();
+    CatalogSearch searchobj;
 
-	}
+    TS_ASSERT( ICatTestHelper::login() );
 
-	void testSearchByInvalidDates1()
-	{
-		CatalogSearch searchobj;
+    if ( !searchobj.isInitialized() ) searchobj.initialize();
 
-		TS_ASSERT( ICatTestHelper::login() );
+    searchobj.setPropertyValue("StartDate","10/08/1980");
+    searchobj.setPropertyValue("EndDate","22/08/1980");
+    searchobj.setPropertyValue("OutputWorkspace","Investigations");
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-		std::string errorMsg="Invalid value for property StartDate (string) ""sssss"": Invalid Date:date format must be DD/MM/YYYY";
+    TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+    TS_ASSERT( searchobj.isExecuted() );
 
-		TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","sssss"),std::invalid_argument(errorMsg));
-		
-		errorMsg="Invalid value for property EndDate (string) ""aaaaa"": Invalid Date:date format must be DD/MM/YYYY";
-		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","aaaaa"),std::invalid_argument(errorMsg));
+    ICatTestHelper::logout();
 
-		ICatTestHelper::logout();
+  }
+  void testSearchByRunNumberInvalidInput()
+  {
+    CatalogSearch searchobj;
 
-	}
+    TS_ASSERT( ICatTestHelper::login() );
 
-	void testSearchByInvalidDates2()
-	{
+    if ( !searchobj.isInitialized() ) searchobj.initialize();
 
-		CatalogSearch searchobj;
+    // start run number > end run number
+    searchobj.setPropertyValue("RunRange", "150-102");
+    searchobj.setPropertyValue("Instrument","LOQ");
 
-		TS_ASSERT( ICatTestHelper::login() );
+    searchobj.setPropertyValue("OutputWorkspace","Investigations");
+    TS_ASSERT_THROWS_NOTHING(searchobj.execute());
+    //should fail
+    TS_ASSERT( !searchobj.isExecuted() );
 
-		if ( !searchobj.isInitialized() ) searchobj.initialize();
-				
-		std::string errorMsg="Invalid value for property StartDate (string) ""39/22/2009"": Invalid Date:Day part of the Date parameter must be between 1 and 31";
-		TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","39/22/2009"),std::invalid_argument(errorMsg));
+    ICatTestHelper::logout();
 
-		errorMsg="Invalid value for property EndDate (string) ""1/22/2009"": Invalid Date:Month part of the Date parameter must be between 1 and 12";
-		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","1/22/2009"),std::invalid_argument(errorMsg));
+  }
 
-		ICatTestHelper::logout();
+  void testSearchByInvalidDates1()
+  {
+    CatalogSearch searchobj;
 
-	}
-		
+    TS_ASSERT( ICatTestHelper::login() );
+
+    if ( !searchobj.isInitialized() ) searchobj.initialize();
+    std::string errorMsg="Invalid value for property StartDate (string) ""sssss"": Invalid Date:date format must be DD/MM/YYYY";
+
+    TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","sssss"),std::invalid_argument(errorMsg));
+
+    errorMsg="Invalid value for property EndDate (string) ""aaaaa"": Invalid Date:date format must be DD/MM/YYYY";
+    TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","aaaaa"),std::invalid_argument(errorMsg));
+
+    ICatTestHelper::logout();
+
+  }
+
+  void testSearchByInvalidDates2()
+  {
+
+    CatalogSearch searchobj;
+
+    TS_ASSERT( ICatTestHelper::login() );
+
+    if ( !searchobj.isInitialized() ) searchobj.initialize();
+
+    std::string errorMsg="Invalid value for property StartDate (string) ""39/22/2009"": Invalid Date:Day part of the Date parameter must be between 1 and 31";
+    TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","39/22/2009"),std::invalid_argument(errorMsg));
+
+    errorMsg="Invalid value for property EndDate (string) ""1/22/2009"": Invalid Date:Month part of the Date parameter must be between 1 and 12";
+    TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","1/22/2009"),std::invalid_argument(errorMsg));
+
+    ICatTestHelper::logout();
+
+  }
+
 };
 #endif

--- a/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
@@ -38,16 +38,8 @@ public:
 		// Uses an unused keyword to produce an empty workspace and be fast
 		
 		CatalogSearch searchobj;
-		CatalogLogin loginobj;
 
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		//loginobj.setPropertyValue("DBServer", "");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
@@ -58,21 +50,15 @@ public:
 		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
 		TS_ASSERT( searchobj.isExecuted() );
 
+		ICatTestHelper::logout();
+
 	}
 	void testSearchByKeywordsExecutes()
 	{
 		
 		CatalogSearch searchobj;
-		CatalogLogin loginobj;
 
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		//loginobj.setPropertyValue("DBServer", "");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 				
@@ -83,21 +69,16 @@ public:
 		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
 		TS_ASSERT( searchobj.isExecuted() );
 
+		ICatTestHelper::logout();
+
 	}
 	void testSearchByStartDateEndDateExecutes()
 	{
 		// Uses a search date outside of general operation to produce an empty workspace and be fast
 
 		CatalogSearch searchobj;
-		CatalogLogin loginobj;
 
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-			
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
@@ -108,21 +89,15 @@ public:
 		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
 		TS_ASSERT( searchobj.isExecuted() );
 
+		ICatTestHelper::logout();
+
 	}
 	void testSearchByRunNumberInvalidInput()
 	{		
-		CatalogLogin loginobj;
-
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		// Now set it...
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		//loginobj.setPropertyValue("DBServer", "");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
 		CatalogSearch searchobj;
+
+		TS_ASSERT( ICatTestHelper::login() );
+
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
 		// start run number > end run number
@@ -134,20 +109,15 @@ public:
 		//should fail
 		TS_ASSERT( !searchobj.isExecuted() );
 
+		ICatTestHelper::logout();
+
 	}
 
 	void testSearchByInvalidDates1()
 	{
 		CatalogSearch searchobj;
-		CatalogLogin loginobj;
 
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		std::string errorMsg="Invalid value for property StartDate (string) ""sssss"": Invalid Date:date format must be DD/MM/YYYY";
@@ -157,21 +127,16 @@ public:
 		errorMsg="Invalid value for property EndDate (string) ""aaaaa"": Invalid Date:date format must be DD/MM/YYYY";
 		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","aaaaa"),std::invalid_argument(errorMsg));
 
+		ICatTestHelper::logout();
+
 	}
 
 	void testSearchByInvalidDates2()
 	{
 
 		CatalogSearch searchobj;
-		CatalogLogin loginobj;
 
-		if ( !loginobj.isInitialized() ) loginobj.initialize();
-
-		loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-		loginobj.setPropertyValue("Password", "MantidTestUser4");
-		
-		TS_ASSERT_THROWS_NOTHING(loginobj.execute());
-		TS_ASSERT( loginobj.isExecuted() );
+		TS_ASSERT( ICatTestHelper::login() );
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 				
@@ -180,6 +145,8 @@ public:
 
 		errorMsg="Invalid value for property EndDate (string) ""1/22/2009"": Invalid Date:Month part of the Date parameter must be between 1 and 12";
 		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","1/22/2009"),std::invalid_argument(errorMsg));
+
+		ICatTestHelper::logout();
 
 	}
 		

--- a/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
@@ -35,7 +35,7 @@ public:
 	}
 	void testSearchByRunNumberandInstrumentExecutes()
 	{
-		// Uses an unused runrange to produce an empty workspace and be fast
+		// Uses an unused keyword to produce an empty workspace and be fast
 		
 		CatalogSearch searchobj;
 		CatalogLogin loginobj;
@@ -154,7 +154,7 @@ public:
 
 		TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","sssss"),std::invalid_argument(errorMsg));
 		
-		errorMsg="Invalid value for property StartDate (string) ""aaaaa"": Invalid Date:date format must be DD/MM/YYYY";
+		errorMsg="Invalid value for property EndDate (string) ""aaaaa"": Invalid Date:date format must be DD/MM/YYYY";
 		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","aaaaa"),std::invalid_argument(errorMsg));
 
 	}
@@ -175,14 +175,11 @@ public:
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 				
-		TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","39/22/2009"),std::runtime_error);
-		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","aaaaa"),std::runtime_error);
-		//searchobj.setPropertyValue("OutputWorkspace","Investigations");
-		
-		TS_ASSERT_THROWS(searchobj.execute(),std::runtime_error);
+		std::string errorMsg="Invalid value for property StartDate (string) ""39/22/2009"": Invalid Date:Day part of the Date parameter must be between 1 and 31";
+		TS_ASSERT_THROWS(searchobj.setPropertyValue("StartDate","39/22/2009"),std::invalid_argument(errorMsg));
 
-		//should fail
-		TS_ASSERT(! searchobj.isExecuted() );
+		errorMsg="Invalid value for property EndDate (string) ""1/22/2009"": Invalid Date:Month part of the Date parameter must be between 1 and 12";
+		TS_ASSERT_THROWS(searchobj.setPropertyValue("EndDate","1/22/2009"),std::invalid_argument(errorMsg));
 
 	}
 		

--- a/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
+++ b/Code/Mantid/Framework/ICat/test/CatalogSearchTest.h
@@ -33,8 +33,9 @@ public:
 		TS_ASSERT_THROWS_NOTHING( searchobj.initialize());
 		TS_ASSERT( searchobj.isInitialized() );
 	}
-	void testSearchByRunNumberandInstrument()
+	void testSearchByRunNumberandInstrumentExecutes()
 	{
+		// Uses an unused runrange to produce an empty workspace and be fast
 		
 		CatalogSearch searchobj;
 		CatalogLogin loginobj;
@@ -50,7 +51,7 @@ public:
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
-		searchobj.setPropertyValue("RunRange", "100-109");
+		searchobj.setPropertyValue("RunRange", "1000000-1000001");
 		searchobj.setPropertyValue("Instrument","LOQ");
 		searchobj.setPropertyValue("OutputWorkspace","Investigations");
 					
@@ -58,7 +59,7 @@ public:
 		TS_ASSERT( searchobj.isExecuted() );
 
 	}
-	void testSearchByKeywords()
+	void testSearchByKeywordsExecutes()
 	{
 		
 		CatalogSearch searchobj;
@@ -83,8 +84,10 @@ public:
 		TS_ASSERT( searchobj.isExecuted() );
 
 	}
-	void testSearchByStartDateEndDate()
+	void testSearchByStartDateEndDateExecutes()
 	{
+		// Uses a search date outside of general operation to produce an empty workspace and be fast
+
 		CatalogSearch searchobj;
 		CatalogLogin loginobj;
 
@@ -98,8 +101,8 @@ public:
 
 		if ( !searchobj.isInitialized() ) searchobj.initialize();
 		
-		searchobj.setPropertyValue("StartDate","10/08/2008");
-		searchobj.setPropertyValue("EndDate","22/08/2008");
+		searchobj.setPropertyValue("StartDate","10/08/1980");
+		searchobj.setPropertyValue("EndDate","22/08/1980");
 		searchobj.setPropertyValue("OutputWorkspace","Investigations");
 				
 		TS_ASSERT_THROWS_NOTHING(searchobj.execute());
@@ -156,7 +159,7 @@ public:
 
 	}
 
-	void xtestSearchByInvalidDates2()
+	void testSearchByInvalidDates2()
 	{
 
 		CatalogSearch searchobj;

--- a/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
+++ b/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
@@ -12,27 +12,27 @@ namespace ICatTestHelper
       return true;
     }
     else {
-	  logout();
-	  return false;
-	}
+      logout();
+      return false;
+    }
   }
 
   bool login()
   {
     Mantid::ICat::CatalogLogin loginobj;
-	loginobj.initialize();
-	loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+    loginobj.initialize();
+    loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
     loginobj.setPropertyValue("Password", "MantidTestUser4");
-	loginobj.setProperty("KeepSessionAlive", false);
-	loginobj.execute();
-	return loginobj.isExecuted();
+    loginobj.setProperty("KeepSessionAlive", false);
+    loginobj.execute();
+    return loginobj.isExecuted();
   }
 
   void logout()
   {
-	  Mantid::ICat::CatalogLogout logoutobj;
-	  logoutobj.initialize();
-	  logoutobj.execute();
+    Mantid::ICat::CatalogLogout logoutobj;
+    logoutobj.initialize();
+    logoutobj.execute();
   }
 
 }

--- a/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
+++ b/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
@@ -8,9 +8,8 @@ namespace ICatTestHelper
     Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
     Mantid::ICat::CatalogLogin loginobj;
     loginobj.initialize();
-    loginobj.setPropertyValue("Username", "mantid_test");
-    loginobj.setPropertyValue("Password", "mantidtestuser");
-    loginobj.setPropertyValue("FacilityName", "ISIS");
+    loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+    loginobj.setPropertyValue("Password", "MantidTestUser4");
 
     loginobj.execute();
     if (!loginobj.isExecuted())

--- a/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
+++ b/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
@@ -7,6 +7,7 @@ namespace ICatTestHelper
   {
     Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
     Mantid::ICat::CatalogLogin loginobj;
+	Mantid::ICat::CatalogLogout logoutobj;
     loginobj.initialize();
     loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
     loginobj.setPropertyValue("Password", "MantidTestUser4");
@@ -17,8 +18,11 @@ namespace ICatTestHelper
       std::cerr << "ICat server seems to be down. Skipping tests" << std::endl;
       return true;
     }
-    else
-      return false;
+    else {
+	  logoutobj.initialize();
+	  logoutobj.execute();
+	  return false;
+	}
   }
 
 }

--- a/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
+++ b/Code/Mantid/Framework/ICat/test/ICatTestHelper.cpp
@@ -6,23 +6,33 @@ namespace ICatTestHelper
   bool skipTests()
   {
     Mantid::Kernel::ConfigService::Instance().setString("default.facility", "ISIS");
-    Mantid::ICat::CatalogLogin loginobj;
-	Mantid::ICat::CatalogLogout logoutobj;
-    loginobj.initialize();
-    loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
-    loginobj.setPropertyValue("Password", "MantidTestUser4");
-
-    loginobj.execute();
-    if (!loginobj.isExecuted())
+    if (!login())
     {
       std::cerr << "ICat server seems to be down. Skipping tests" << std::endl;
       return true;
     }
     else {
-	  logoutobj.initialize();
-	  logoutobj.execute();
+	  logout();
 	  return false;
 	}
+  }
+
+  bool login()
+  {
+    Mantid::ICat::CatalogLogin loginobj;
+	loginobj.initialize();
+	loginobj.setPropertyValue("Username", "mantidtest@fitsp10.isis.cclrc.ac.uk");
+    loginobj.setPropertyValue("Password", "MantidTestUser4");
+	loginobj.setProperty("KeepSessionAlive", false);
+	loginobj.execute();
+	return loginobj.isExecuted();
+  }
+
+  void logout()
+  {
+	  Mantid::ICat::CatalogLogout logoutobj;
+	  logoutobj.initialize();
+	  logoutobj.execute();
   }
 
 }

--- a/Code/Mantid/Framework/ICat/test/ICatTestHelper.h
+++ b/Code/Mantid/Framework/ICat/test/ICatTestHelper.h
@@ -2,6 +2,7 @@
 #define ICATTESTHELPER_H_
 
 #include "MantidICat/CatalogLogin.h"
+#include "MantidICat/CatalogLogout.h"
 #include "MantidKernel/ConfigService.h"
 
 namespace ICatTestHelper

--- a/Code/Mantid/Framework/ICat/test/ICatTestHelper.h
+++ b/Code/Mantid/Framework/ICat/test/ICatTestHelper.h
@@ -9,6 +9,12 @@ namespace ICatTestHelper
 {
   /// Skip all unit tests if ICat server is down
   bool skipTests();
+
+  /// Helper to login with test credentials, returns true if login successful
+  bool login();
+
+  /// Helper to logout of ICat
+  void logout();
 }
 
 #endif


### PR DESCRIPTION
Fixes #10506 

This code replaced the credentials used for logging into ICat when running unit tests. It was then found that test were taking ~55 seconds each to run and so tests were refactored to improve speed.

To Test:
- Run the ICat unit tests
- Confirm that the tests are successfully logging into ICat (via the test output)
- Confirm that the tests take a reasonable amount of time
