### PR TITLE
display name instead of path in error message

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1024,10 +1024,19 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
   // Get information from all but data group
   std::string parameterStr;
   // Hop to the right point /mantid_workspace_1
-  m_cppFile->openPath(entry.path()); // This is
+  try {
+    m_cppFile->openPath(entry.path()); // This is
+  } catch (std::runtime_error &re) {
+    throw std::runtime_error("Error while opening a path in a Peaks entry in a "
+                             "Nexus processed file. "
+                             "This path is wrong: " +
+                             entry.path() +
+                             ". Lower level error description: " + re.what());
+  }
   try {
     // This loads logs, sample, and instrument.
-    peakWS->loadExperimentInfoNexus(getPropertyValue("Filename"), m_cppFile, parameterStr);
+    peakWS->loadExperimentInfoNexus(getPropertyValue("Filename"), m_cppFile,
+                                    parameterStr);
   } catch (std::exception &e) {
     g_log.information("Error loading Instrument section of nxs file");
     g_log.information(e.what());
@@ -1036,7 +1045,15 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
   // Coordinates - Older versions did not have the separate field but used a log
   // value
   uint32_t loadCoord(0);
-  m_cppFile->openGroup("peaks_workspace", "NXentry");
+  const std::string peaksWSName = "peaks_workspace";
+  try {
+    m_cppFile->openGroup(peaksWSName, "NXentry");
+  } catch (std::runtime_error &re) {
+    throw std::runtime_error(
+        "Error while opening a peaks workspace in a Nexus processed file. "
+        "Cannot open gropu " +
+        peaksWSName + ". Lower level error description: " + re.what());
+  }
   try {
     m_cppFile->readData("coordinate_system", loadCoord);
     peakWS->setCoordinateSystem(

--- a/Code/Mantid/Framework/Nexus/src/NexusClasses.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusClasses.cpp
@@ -178,10 +178,11 @@ bool NXClass::isValid(const std::string &path) const {
 void NXClass::open() {
   // if (NX_ERROR == NXopengroup(m_fileID,name().c_str(),NX_class().c_str()))
   //{
-  if (NX_ERROR == NXopengrouppath(m_fileID, name().c_str())) {
+  if (NX_ERROR == NXopengrouppath(m_fileID, m_path.c_str())) {
 
     throw std::runtime_error("Cannot open group " + name() + " of class " +
-                             NX_class());
+                             NX_class() + " (trying to open path " + m_path +
+                             ")");
   }
   //}
   m_open = true;
@@ -217,7 +218,8 @@ bool NXClass::openLocal(const std::string &nxclass) {
 void NXClass::close() {
   if (NX_ERROR == NXclosegroup(m_fileID)) {
     throw std::runtime_error("Cannot close group " + name() + " of class " +
-                             NX_class());
+                             NX_class() + " (trying to close path " + m_path +
+                             ")");
   }
   m_open = false;
 }

--- a/Code/Mantid/Framework/Nexus/src/NexusClasses.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusClasses.cpp
@@ -178,8 +178,9 @@ bool NXClass::isValid(const std::string &path) const {
 void NXClass::open() {
   // if (NX_ERROR == NXopengroup(m_fileID,name().c_str(),NX_class().c_str()))
   //{
-  if (NX_ERROR == NXopengrouppath(m_fileID, m_path.c_str())) {
-    throw std::runtime_error("Cannot open group " + m_path + " of class " +
+  if (NX_ERROR == NXopengrouppath(m_fileID, name().c_str())) {
+
+    throw std::runtime_error("Cannot open group " + name() + " of class " +
                              NX_class());
   }
   //}
@@ -215,7 +216,7 @@ bool NXClass::openLocal(const std::string &nxclass) {
 
 void NXClass::close() {
   if (NX_ERROR == NXclosegroup(m_fileID)) {
-    throw std::runtime_error("Cannot close group " + m_path + " of class " +
+    throw std::runtime_error("Cannot close group " + name() + " of class " +
                              NX_class());
   }
   m_open = false;


### PR DESCRIPTION
Fixes #12653 

To Test:
- Download the [Nexus File](http://we.tl/YyEDHMG4uP) which should reproduce this error message
- Load the file 
- Should display the following error message `Cannot open group workspace of class NXdata` instead of `Cannot open group /mantid_workspace_1/workspace of class NXdata`
