### PR TITLE
DNS Vanadium correction

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -15,6 +15,11 @@ class DNSDetEffCorrVana(PythonAlgorithm):
     properties_to_compare = ['deterota', 'wavelength', 'slit_i_left_blade_position',
                              'slit_i_right_blade_position', 'slit_i_lower_blade_position',
                              'slit_i_upper_blade_position', 'polarisation', 'flipper']
+    dataws = None
+    outws_name = None
+    vanaws = None
+    bkgws = None
+    vana_mean_name = None
 
     def category(self):
         """

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -25,7 +25,7 @@ class DNSDetEffCorrVana(PythonAlgorithm):
         """
         Returns category
         """
-        return 'PythonAlgorithms;MLZ\\DNS;CorrectionFunctions;EfficiencyCorrections'
+        return 'PythonAlgorithms\\MLZ\\DNS;CorrectionFunctions\\EfficiencyCorrections'
 
     def name(self):
         """
@@ -171,7 +171,7 @@ class DNSDetEffCorrVana(PythonAlgorithm):
         """
         checks whether properties match in the given runs, produces warnings
             @param lhs_run Left-hand-side run
-            @param phs_run Right-hand-side run
+            @param rhs_run Right-hand-side run
         """
         lhs_title = ""
         rhs_title = ""

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -198,7 +198,7 @@ class DNSDetEffCorrVana(PythonAlgorithm):
                         rhs_title + ": " + str(rhs_property.value)
                     self.log().warning(message)
             else:
-                message = "Property ' + property_name + ' is not present in " +\
+                message = "Property " + property_name + " is not present in " +\
                     lhs_title + " or " + rhs_title + " - skipping comparison."
                 self.log().warning(message)
         return True

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -119,7 +119,7 @@ class DNSDetEffCorrVana(PythonAlgorithm):
     def _cleanup(self, wslist):
         """
         deletes workspaces from list
-            @param wslist List of names workspaces to delete.
+            @param wslist List of names of workspaces to delete.
         """
         for wsname in wslist:
             api.DeleteWorkspace(wsname)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -1,0 +1,238 @@
+# pylint: disable=no-init,invalid-name
+import mantid.simpleapi as api
+from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
+from mantid.kernel import Direction
+import numpy as np
+
+
+class DNSDetEffCorrVana(PythonAlgorithm):
+    """
+    Peforms detector efficiency correction on a given data workspace
+    using the Vanadium data.
+    This algorithm is written for the DNS @ MLZ,
+    but can be used for other instruments if needed.
+    """
+    properties_to_compare = ['deterota', 'wavelength', 'slit_i_left_blade_position',
+                             'slit_i_right_blade_position', 'slit_i_lower_blade_position',
+                             'slit_i_upper_blade_position', 'polarisation', 'flipper']
+
+    def category(self):
+        """
+        Returns category
+        """
+        return 'PythonAlgorithms\\MLZ\\DNS\\CorrectionFunctions\\EfficiencyCorrections'
+
+    def name(self):
+        """
+        Returns name
+        """
+        return "DNSDetEffCorrVana"
+
+    def summary(self):
+        return " Peforms detector efficiency correction \
+                on a given data workspace using the Vanadium data."
+
+    def PyInit(self):
+        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", direction=Direction.Input),
+                             doc="A workspace with experimental data from sample.")
+        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
+                             doc="A workspace to save the corrected data.")
+        self.declareProperty(MatrixWorkspaceProperty("VanaWorkspace", "", direction=Direction.Input),
+                             doc="A workspace with Vanadium data.")
+        self.declareProperty(MatrixWorkspaceProperty("BkgWorkspace", "", direction=Direction.Input),
+                             doc="A workspace with background for Vanadium data.")
+        self.declareProperty("VanadiumMean", "", direction=Direction.Input,
+                             doc="A 2x1 matrix workspace with mean Vanadium counts (optional).")
+
+        return
+
+    def _dimensions_valid(self, data_ws, vana_ws, bkgr_ws):
+        """
+        Checks validity of the workspace dimensions:
+        all given workspaces must have the same number of dimensions
+        and the same number of histograms
+        and the same number of bins
+        """
+        nd = data_ws.getNumDims()
+        nh = data_ws.getNumberHistograms()
+        nb = data_ws.blocksize()
+
+        if (vana_ws.getNumDims() != nd or vana_ws.getNumberHistograms() != nh or vana_ws.blocksize() != nb):
+            self.log().error("The dimensions of Vanadium workspace are not valid.")
+            return False
+
+        if (bkgr_ws.getNumDims() != nd or bkgr_ws.getNumberHistograms() != nh or bkgr_ws.blocksize() != nb):
+            self.log().error("The dimensions of Background workspace are not valid.")
+            return False
+
+        return True
+
+    def _norm_ws_exist(self, vana_ws, bkgr_ws):
+        """
+        Checks whether the normalization workspaces exist
+        normalization workspaces are created by the loader,
+        but could be ocasionally deleted by the user
+        """
+        if not api.mtd.doesExist(bkgr_ws.getName() + '_NORM'):
+            self.log().error("Normalization workspace for " + bkgr_ws.getName() + " is not found!")
+            return False
+        if not api.mtd.doesExist(vana_ws.getName() + '_NORM'):
+            self.log().error("Normalization workspace for " + vana_ws.getName() + " is not found!")
+            return False
+
+        return True
+
+    def _vana_mean(self, vana_ws, vana_mean_ws_name, nd=2):
+        """
+        checks whether the workspace with mean counts for Vanadium exists
+        creates one if not
+        """
+        if api.mtd.doesExist(vana_mean_ws_name):
+            vana_mean = api.mtd[vana_mean_ws_name]
+            if vana_mean.getNumDims() != nd:
+                message = "Specified VanadiumMean Workspace has wrong dimensions! Must be 2."
+                self.log().error(message)
+                return None
+            if vana_mean.getNumberHistograms() != 1:
+                message = "Specified VanadiumMean Workspace has wrong number of histograms! Must be 1."
+                self.log().error(message)
+                return None
+            if vana_mean.blocksize() != 1:
+                message = "Specified VanadiumMean Workspace has wrong number of bins! Must be 1."
+                self.log().error(message)
+                return None
+
+        else:
+            nh = vana_ws.getNumberHistograms()
+            vana_mean = api.SumSpectra(vana_ws, IncludeMonitors=False) / nh
+
+        return vana_mean
+
+    def _cleanup(self, wslist):
+        """
+        deletes workspaces from list
+        """
+        for w in wslist:
+            api.DeleteWorkspace(w)
+        return
+
+    def _vana_correct(self, data_ws, vana_ws, bkgr_ws, vana_mean_ws_name, outws_name):
+        """
+        creates the corrected workspace
+        """
+        wslist = []
+        # 1. normalize Vanadium and Background
+        vana_normws = api.mtd[vana_ws.getName() + '_NORM']
+        bkg_normws = api.mtd[bkgr_ws.getName() + '_NORM']
+        _vana_norm_ = api.Divide(vana_ws, vana_normws)
+        wslist.append(_vana_norm_.getName())
+        _bkg_norm_ = api.Divide(bkgr_ws, bkg_normws)
+        wslist.append(_bkg_norm_.getName())
+        # 2. substract background from Vanadium
+        _vana_bg_ = _vana_norm_ - _bkg_norm_
+        wslist.append(_vana_bg_.getName())
+        # check negative values, throw exception
+        arr = np.array(_vana_bg_.extractY()).flatten()
+        neg_values = np.where(arr < 0)[0]
+        if len(neg_values):
+            self._cleanup(wslist)
+            message = "Background " + bkgr_ws.getName() + " is higher than Vanadium " + \
+                vana_ws.getName() + " signal!"
+            self.log().error(message)
+            raise RuntimeError(message)
+
+        # 3. calculate correction coefficients
+        _vana_mean_ws_ = self._vana_mean(_vana_bg_, vana_mean_ws_name, data_ws.getNumDims())
+        if not _vana_mean_ws_:
+            self._cleanup(wslist)
+            return None
+        if not vana_mean_ws_name:
+            wslist.append(_vana_mean_ws_)
+        _coef_ws_ = api.Divide(LHSWorkspace=_vana_bg_, RHSWorkspace=_vana_mean_ws_, WarnOnZeroDivide=True)
+        wslist.append(_coef_ws_)
+        # 4. correct raw data (not normalized!)
+        api.Divide(LHSWorkspace=data_ws, RHSWorkspace=_coef_ws_, WarnOnZeroDivide=True,
+                   OutputWorkspace=outws_name)
+        outws = api.mtd[outws_name]
+        # cleanup
+        self._cleanup(wslist)
+        return outws
+
+    def _check_properties(self, lhs_run, rhs_run):
+        """
+        checks whether properties match
+        """
+        lhs_title = ""
+        rhs_title = ""
+        if lhs_run.hasProperty('run_title'):
+            lhs_title = lhs_run.getProperty('run_title').value
+        if rhs_run.hasProperty('run_title'):
+            rhs_title = rhs_run.getProperty('run_title').value
+
+        for property_name in self.properties_to_compare:
+            if lhs_run.hasProperty(property_name) and rhs_run.hasProperty(property_name):
+                lhs_property = lhs_run.getProperty(property_name)
+                rhs_property = rhs_run.getProperty(property_name)
+                if lhs_property.type == rhs_property.type:
+                    if lhs_property.type == 'string':
+                        if lhs_property.value != rhs_property.value:
+                            message = "Property " + property_name + " does not match! " + \
+                                lhs_title + ": " + lhs_property.value + ", but " + \
+                                rhs_title + ": " + rhs_property.value
+                            self.log().warning(message)
+                    if lhs_property.type == 'number':
+                        if abs(lhs_property.value - rhs_property.value) > 5e-3:
+                            message = "Property " + property_name + " does not match! " + \
+                                lhs_title + ": " + str(lhs_property.value) + ", but " + \
+                                rhs_title + ": " + str(rhs_property.value)
+                            self.log().warning(message)
+                else:
+                    message = "Property " + property_name + " does not match! " + \
+                        lhs_title + ": " + str(lhs_property.value) + ", but " + \
+                        rhs_title + ": " + str(rhs_property.value)
+                    self.log().warning(message)
+            else:
+                message = "Property ' + property_name + ' is not present in " +\
+                    lhs_title + " or " + rhs_title + " - skipping comparison."
+                self.log().warning(message)
+        return True
+
+    def PyExec(self):
+        # Input
+        dataws = api.mtd[self.getPropertyValue("InputWorkspace")]
+        outws_name = self.getPropertyValue("OutputWorkspace")
+        vanaws = api.mtd[self.getPropertyValue("VanaWorkspace")]
+        bkgws = api.mtd[self.getPropertyValue("BkgWorkspace")]
+        vana_mean = self.getPropertyValue("VanadiumMean")
+
+        if not self._dimensions_valid(dataws, vanaws, bkgws):
+            raise RuntimeError("Error: all input workspaces must have the same dimensions!.")
+        # check if the _NORM workspaces exist
+        if not self._norm_ws_exist(vanaws, bkgws):
+            message = "Normalization workspace is not found!"
+            raise RuntimeError(message)
+        # check sample logs, produce warnings if different
+        drun = dataws.getRun()
+        vrun = vanaws.getRun()
+        brun = bkgws.getRun()
+        self._check_properties(drun, vrun)
+        self._check_properties(vrun, brun)
+        # apply correction
+        outws = self._vana_correct(dataws, vanaws, bkgws, vana_mean, outws_name)
+        if not outws:
+            raise RuntimeError("Correction failed. Invalid VanadiumMean workspace dimensions.")
+
+        # copy sample logs from data workspace to the output workspace
+        api.CopyLogs(InputWorkspace=dataws.getName(), OutputWorkspace=outws.getName(),
+                     MergeStrategy='MergeReplaceExisting')
+        self.setProperty("OutputWorkspace", outws)
+
+        # clone the normalization workspace for data if it exists
+        if api.mtd.doesExist(dataws.getName()+'_NORM'):
+            api.CloneWorkspace(InputWorkspace=dataws.getName()+'_NORM', OutputWorkspace=outws_name+'_NORM')
+        self.log().debug('DNSDetEffCorrVana: OK. The result has been saved to ' + outws_name)
+
+        return
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(DNSDetEffCorrVana)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -57,11 +57,11 @@ class DNSDetEffCorrVana(PythonAlgorithm):
         nh = data_ws.getNumberHistograms()
         nb = data_ws.blocksize()
 
-        if (vana_ws.getNumDims() != nd or vana_ws.getNumberHistograms() != nh or vana_ws.blocksize() != nb):
+        if vana_ws.getNumDims() != nd or vana_ws.getNumberHistograms() != nh or vana_ws.blocksize() != nb:
             self.log().error("The dimensions of Vanadium workspace are not valid.")
             return False
 
-        if (bkgr_ws.getNumDims() != nd or bkgr_ws.getNumberHistograms() != nh or bkgr_ws.blocksize() != nb):
+        if bkgr_ws.getNumDims() != nd or bkgr_ws.getNumberHistograms() != nh or bkgr_ws.blocksize() != nb:
             self.log().error("The dimensions of Background workspace are not valid.")
             return False
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -70,7 +70,7 @@ class LoadDNSLegacy(PythonAlgorithm):
         try:
             metadata.read_legacy(filename)
         except RuntimeError as err:
-            message = "Error of loading of file " + filename + ": " + err
+            message = "Error of loading of file " + filename + ": " + str(err)
             self.log().error(message)
             raise RuntimeError(message)
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -16,6 +16,7 @@ set ( TEST_PY_FILES
   CylinderPaalmanPingsCorrectionTest.py
   CylinderPaalmanPingsCorrection2Test.py
   DakotaChiSquaredTest.py
+  DNSDetEffCorrVanaTest.py
   DSFinterpTest.py
   EnggCalibrateFullTest.py
   EnggCalibrateTest.py

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSDetEffCorrVanaTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSDetEffCorrVanaTest.py
@@ -93,6 +93,13 @@ class DNSDetEffCorrVanaTest(unittest.TestCase):
         run_algorithm("DeleteWorkspace", Workspace=outputWorkspaceName)
         return
 
+    def test_NegativeValues(self):
+        outputWorkspaceName = "DNSDetCorrVanaTest_Test4"
+        self.assertRaises(RuntimeError, DNSDetEffCorrVana, InputWorkspace=self.__dataws.getName(),
+                          OutputWorkspace=outputWorkspaceName, VanaWorkspace=self.__bkgrws.getName(),
+                          BkgWorkspace=self.__vanaws.getName())
+        return
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSDetEffCorrVanaTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSDetEffCorrVanaTest.py
@@ -1,0 +1,98 @@
+import unittest
+from testhelpers import run_algorithm
+from mantid.api import AnalysisDataService
+import numpy as np
+import mantid.simpleapi as api
+from mantid.simpleapi import DNSDetEffCorrVana
+
+
+class DNSDetEffCorrVanaTest(unittest.TestCase):
+    __dataws = None
+    __vanaws = None
+    __bkgrws = None
+
+    def _create_fake_workspace(self, wsname, dataY):
+        """
+        creates DNS workspace with fake data
+        """
+        ndet = 24
+        dataX = np.zeros(2*ndet)
+        dataX.fill(4.2 + 0.00001)
+        dataX[::2] -= 0.000002
+        dataE = np.sqrt(dataY)
+        # create workspace
+        api.CreateWorkspace(OutputWorkspace=wsname, DataX=dataX, DataY=dataY,
+                            DataE=dataE, NSpec=ndet, UnitX="Wavelength")
+        outws = api.mtd[wsname]
+        api.LoadInstrument(outws, InstrumentName='DNS')
+        p_names = 'deterota,wavelength,slit_i_left_blade_position,slit_i_right_blade_position,\
+            slit_i_lower_blade_position,slit_i_upper_blade_position,polarisation,flipper'
+        p_values = '-7.53,4.2,10,10,5,20,x,ON'
+        api.AddSampleLogMultiple(Workspace=outws, LogNames=p_names, LogValues=p_values, ParseType=True)
+        # create the normalization workspace
+        dataY.fill(1.0)
+        dataE.fill(1.0)
+        api.CreateWorkspace(OutputWorkspace=wsname + '_NORM', DataX=dataX, DataY=dataY,
+                            DataE=dataE, NSpec=ndet, UnitX="Wavelength")
+        normws = api.mtd[wsname + '_NORM']
+        api.LoadInstrument(normws, InstrumentName='DNS')
+        api.AddSampleLogMultiple(Workspace=normws, LogNames=p_names, LogValues=p_values, ParseType=True)
+
+        return outws
+
+    def setUp(self):
+        dataY = np.zeros(24)
+        dataY.fill(1.5)
+        self.__bkgrws = self._create_fake_workspace('__bkgrws', dataY)
+        dataY = np.linspace(2, 13.5, 24)
+        self.__vanaws = self._create_fake_workspace('__vanaws', dataY)
+        dataY = np.arange(1, 25)
+        self.__dataws = self._create_fake_workspace('__dataws', dataY)
+
+    def tearDown(self):
+        api.DeleteWorkspace(self.__vanaws.getName() + '_NORM')
+        api.DeleteWorkspace(self.__dataws.getName() + '_NORM')
+        if api.mtd.doesExist(self.__bkgrws.getName() + '_NORM'):
+            api.DeleteWorkspace(self.__bkgrws.getName() + '_NORM')
+        api.DeleteWorkspace(self.__bkgrws)
+        api.DeleteWorkspace(self.__vanaws)
+        api.DeleteWorkspace(self.__dataws)
+
+    def test_DNSNormWorkspaceExists(self):
+        outputWorkspaceName = "DNSDetCorrVanaTest_Test1"
+        api.DeleteWorkspace(self.__bkgrws.getName() + '_NORM')
+        self.assertRaises(RuntimeError, DNSDetEffCorrVana, InputWorkspace=self.__dataws.getName(),
+                          OutputWorkspace=outputWorkspaceName, VanaWorkspace=self.__vanaws.getName(),
+                          BkgWorkspace=self.__bkgrws.getName())
+        return
+
+    def test_VanaMeanDimensions(self):
+        outputWorkspaceName = "DNSDetCorrVanaTest_Test2"
+        _dataT_ = api.Transpose(self.__dataws)    # correct dimensions, but wrong number of bins
+        self.assertRaises(RuntimeError, DNSDetEffCorrVana, InputWorkspace=self.__dataws.getName(),
+                          OutputWorkspace=outputWorkspaceName, VanaWorkspace=self.__vanaws.getName(),
+                          BkgWorkspace=self.__bkgrws.getName(), VanadiumMean=_dataT_)
+        api.DeleteWorkspace(_dataT_)
+        return
+
+    def test_DNSVanadiumCorrection(self):
+        outputWorkspaceName = "DNSDetCorrVanaTest_Test3"
+        alg_test = run_algorithm("DNSDetEffCorrVana", InputWorkspace=self.__dataws.getName(),
+                                 OutputWorkspace=outputWorkspaceName, VanaWorkspace=self.__vanaws.getName(),
+                                 BkgWorkspace=self.__bkgrws.getName())
+
+        self.assertTrue(alg_test.isExecuted())
+        # check whether the data are correct
+        ws = AnalysisDataService.retrieve(outputWorkspaceName)
+        # dimensions
+        self.assertEqual(24, ws.getNumberHistograms())
+        self.assertEqual(2,  ws.getNumDims())
+        # data array
+        for i in range(24):
+            self.assertAlmostEqual(12.5, ws.readY(i))
+        run_algorithm("DeleteWorkspace", Workspace=outputWorkspaceName)
+        return
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Code/Mantid/docs/source/algorithms/DNSDetEffCorrVana-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DNSDetEffCorrVana-v1.rst
@@ -17,7 +17,7 @@ Description
 This algorithm applies detector efficiency correction to a given data :ref:`Workspace2D <Workspace2D>`. As a result, two workspaces will be created: 
 
 -  output workspace with corrected data. Sample logs will be copied from the data workspace. 
--  workspace with normalization data (monitor counts or experiment duration by user's choice; copied from the data workspace). The normalization workspace is named same as the data workspace, but has suffix "_NORM". 
+-  if **InputWorkspace** has the normalization workspace (which contains monitor counts or experiment duration by user's choice), the copy of it will be created with name **OutputWorkspace_NORM**. 
 
 Detector efficiency correction is performed using the measurements of vanadium standard sample (hereafter Vanadium). Background for Vanadium must be also measured and provided to the algorithm as an input **BkgWorkspace**. Vanadium and its background can be measured at several detector bank positions.  This algorithm does the detector efficiency for a particular run in following steps:
 
@@ -36,7 +36,7 @@ Detector efficiency correction is performed using the measurements of vanadium s
 .. warning::
 
     Normalization workspaces are created by the :ref:`algm-LoadDNSLegacy` algorithm. 
-    It is responsibility of the user to take care about the same type of normalization for Vanadium and Background.
+    It is responsibility of the user to take care about the same type of normalization (monitor counts or run duration) for Vanadium and Background.
 
 3. Subtract Background from Vanadium:
 
@@ -69,11 +69,11 @@ The input workspaces (**InputWorkspace**, **VanaWorkspace**, **BkgWorkspace**) h
 -  The same number of dimensions
 -  The same number of spectra
 -  The same number of bins
--  Have the corresponding normalization workspace
+-  **VanaWorkspace** and **BkgWorkspace** must have the corresponding normalization workspaces
 
-For the physically meaningfull correction it is also important that these workspaces have the same slits size, polarisation, detector bank rotation angle, flipper status and the neutron wavelength. If some of these parameters are different, algorithm produces warning. If these properties are not specified in the workspace sample logs, no comparison is performed.
+For the physically meaningful correction it is also important that these workspaces have the same slits size, polarisation, detector bank rotation angle, flipper status and the neutron wavelength. If some of these parameters are different, algorithm produces warning. If these properties are not specified in the workspace sample logs, no comparison is performed.
 
-The workspace **VanadiumMean** is an optional parameter. However, if it is specified, it must be a :ref:`Workspace2D <Workspace2D>` with 2 dimensions, 1 histogramm and 1 bin.
+The workspace **VanadiumMean** is an optional parameter. However, if it is specified, it must be a :ref:`Workspace2D <Workspace2D>` with 2 dimensions, 1 histogram and 1 bin.
 
 
 Usage

--- a/Code/Mantid/docs/source/algorithms/DNSDetEffCorrVana-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DNSDetEffCorrVana-v1.rst
@@ -1,0 +1,111 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+.. warning::
+
+   This algorithm is being developed for a specific instrument. It might get changed or even 
+   removed without a notification, should instrument scientists decide to do so.
+
+This algorithm applies detector efficiency correction to a given data :ref:`Workspace2D <Workspace2D>`. As a result, two workspaces will be created: 
+
+-  output workspace with corrected data. Sample logs will be copied from the data workspace. 
+-  workspace with normalization data (monitor counts or experiment duration by user's choice; copied from the data workspace). The normalization workspace is named same as the data workspace, but has suffix "_NORM". 
+
+Detector efficiency correction is performed using the measurements of vanadium standard sample (hereafter Vanadium). Background for Vanadium must be also measured and provided to the algorithm as an input **BkgWorkspace**. Vanadium and its background can be measured at several detector bank positions.  This algorithm does the detector efficiency for a particular run in following steps:
+
+1. Normalize Vanadium workspace to a chosen normalization:
+
+   :math:`(V_i)_{Norm} = \frac{(V_i)_{Raw}}{(C_i)_V}`
+
+   where :math:`(V_i)_{Raw}` is the signal from the :math:`i` th detector in the Vanadium workspace and :math:`(C_i)_V` is the number in the corresponding bin of the normalization workspace. The :ref:`algm-Divide` algorithm is used for this step.
+
+2. Normalize Background workspace to a chosen normalization:
+
+   :math:`(B_i)_{Norm} = \frac{(B_i)_{Raw}}{(C_i)_B}`
+   
+   where :math:`(B_i)_{Raw}` is the signal from the :math:`i` th detector in the Background workspace and :math:`(C_i)_B` is the number in the corresponding bin of the normalization workspace. The :ref:`algm-Divide` algorithm is used for this step.
+
+.. warning::
+
+    Normalization workspaces are created by the :ref:`algm-LoadDNSLegacy` algorithm. 
+    It is responsibility of the user to take care about the same type of normalization for Vanadium and Background.
+
+3. Subtract Background from Vanadium:
+
+   :math:`V_i = (V_i)_{Norm} - (B_i)_{Norm}`
+
+   The :ref:`algm-Minus` algorithm is used for this step. In the case of negative result, the error message will be produced and the algorithm terminates.
+
+4. Calculate the correction coefficients:
+
+   :math:`k_i = \frac{<V>}{V_i}`
+
+   where :math:`<V>` is a mean value of Vanadium counts. The :ref:`algm-Divide` algorithm is used for this step.
+
+.. note::
+    
+    If no **VanadiumMean** workspace is given as an input, the :math:`<V>` will be calculated as :math:`<V> = \frac{1}{n}\sum V_i`. However, in the case if correction is applied to a group of runs, :math:`<V>` must be calculated as for the whole group, saved to **VanadiumMean** workspace and provided to this algorithm as an input.
+
+5. Apply correction to the data:
+
+   :math:`(I_i)_{corr} = k_i\times I_i`
+
+   where :math:`I_i` are the neutron counts in the **InputWorkspace**.
+
+
+Valid input workspaces
+######################
+
+The input workspaces (**InputWorkspace**, **VanaWorkspace**, **BkgWorkspace**) have to have the following in order to be valid inputs for this algorithm.
+
+-  The same number of dimensions
+-  The same number of spectra
+-  The same number of bins
+-  Have the corresponding normalization workspace
+
+For the physically meaningfull correction it is also important that these workspaces have the same slits size, polarisation, detector bank rotation angle, flipper status and the neutron wavelength. If some of these parameters are different, algorithm produces warning. If these properties are not specified in the workspace sample logs, no comparison is performed.
+
+The workspace **VanadiumMean** is an optional parameter. However, if it is specified, it must be a :ref:`Workspace2D <Workspace2D>` with 2 dimensions, 1 histogramm and 1 bin.
+
+
+Usage
+-----
+
+**Example - Apply correction to a single run:**
+
+.. code-block:: python
+
+   # data, vanadium and background files.
+   datafile = 'oi196012pbi.d_dat'
+   vanafile = 'dn134011vana.d_dat'
+   bkgrfile = 'dn134031leer.d_dat'
+
+   # Load datasets, loader will create an additional normalization workspace
+   data_ws = LoadDNSLegacy(datafile, Polarisation='x', Normalization='monitor')
+   vana_ws = LoadDNSLegacy(vanafile, Polarisation='x', Normalization='monitor')
+   bkgr_ws = LoadDNSLegacy(bkgrfile, Polarisation='x', Normalization='monitor')
+
+   corrected = DNSDetEffCorrVana(data_ws, vana_ws, bkgr_ws)
+
+   for i in range(3):
+    print round(corrected.readY(i), 2)
+
+Output:
+
+   99180.91
+
+   77190.96
+   
+   77265.61
+
+.. categories::
+
+.. sourcelink::


### PR DESCRIPTION
Python algorithm which performs detector efficiency correction using the Vanadium measurement. Algorithm is instrument-specific and developed for DNS@MLZ. However, it uses standard workspace arithmetic and can be easily adapted for other instruments if needed. 

Please, review the code. Let me know whether the documentation is understandable. This algorithm can be tested on the fake workspaces, but let me know if you need additional data files for testing.

Please, recommend me an appropriate label for the detector efficiency correction algorithm.
