### PR TITLE
Fix script repository view when files are uploaded

### DIFF
--- a/Code/Mantid/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Code/Mantid/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -161,6 +161,7 @@ private:
   void download_directory(const std::string &);
   void download_file(const std::string &, RepositoryEntry &);
   void updateLocalJson(const std::string &, const RepositoryEntry &);
+  void updateRepositoryJson(const std::string &, const RepositoryEntry &);
 
   /// flag that indicate a valid repository
   bool valid;

--- a/Code/Mantid/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Code/Mantid/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -867,6 +867,7 @@ void ScriptRepositoryImpl::upload(const std::string &file_path,
       if (!published_date.empty())
           remote_entry.pub_date = DateAndTime(published_date);
       remote_entry.status = BOTH_UNCHANGED;
+      g_log.debug() << "ScriptRepository updating repository json " << std::endl;
       updateRepositoryJson(file_path, remote_entry);
 
     } else
@@ -881,9 +882,9 @@ void ScriptRepositoryImpl::upload(const std::string &file_path,
 * Adds an entry to .repository.json
 * This is necessary when uploading a file to keep .repository.json and
 * .local.json in sync, and thus display correct file status in the GUI.
-* Requesting an updated .repository.json from the server is not possible
+* Requesting an updated .repository.json from the server is not viable
 * at such a time as it would create a race condition.
-* @param path: path to repository json files
+* @param path: relative path of uploaded file
 * @param entry: the entry to add to the json file
 */
 void ScriptRepositoryImpl::updateRepositoryJson(const std::string &path,

--- a/Code/Mantid/MantidQt/API/src/RepoModel.cpp
+++ b/Code/Mantid/MantidQt/API/src/RepoModel.cpp
@@ -814,6 +814,8 @@ void RepoModel::setupModelData(RepoItem *root)
 {
 
   QStringList lines;
+  // check server for updates to repository
+  std::vector<std::string> f_list = repo_ptr->check4Update();
   // get the list of entries inside the scriptrepository
   std::vector<std::string> list = repo_ptr->listFiles();
   

--- a/Code/Mantid/MantidQt/API/src/RepoModel.cpp
+++ b/Code/Mantid/MantidQt/API/src/RepoModel.cpp
@@ -814,8 +814,6 @@ void RepoModel::setupModelData(RepoItem *root)
 {
 
   QStringList lines;
-  // check server for updates to repository
-  std::vector<std::string> f_list = repo_ptr->check4Update();
   // get the list of entries inside the scriptrepository
   std::vector<std::string> list = repo_ptr->listFiles();
   


### PR DESCRIPTION
Fixes #11790

File status was was being displayed incorrectly in the script repository window. This was due to the local copy of the remote and local repository descriptions getting out of sync when a file was uploaded. Downloading a new description of the remote repository immediately after uploading a file creates a race condition, therefore the description of the remote repository was changed locally instead. This is consistent with the procedure when a file is deleted from the repository.

For tester:
Follow instructions in original description of issue.
