### PR TITLE
Re #12334 Give HDF5 API full filepath, not just filename

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/test/LoadMDTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/LoadMDTest.h
@@ -654,7 +654,7 @@ public:
       // Remove the coordinate_system entry so it falls back on the log. NeXus
       // can't do this
       // so use the HDF5 API directly
-      auto fid = H5Fopen(fileName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+      auto fid = H5Fopen(this_fileName.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
       auto gid = H5Gopen(fid, rootGroup, H5P_DEFAULT);
       if (gid > 0) {
         H5Ldelete(gid, "coordinate_system", H5P_DEFAULT);


### PR DESCRIPTION
Fixes #12334 

The unit test LoadMDTest was failing while in release but not in debug. Martyn tracked down the issue to be related to the defaultsave.directory being set to a custom path. The problem was with not giving a call to the HDF5 API the correct full path of a test file.

For tester:
I suggest running the unit test with defaultsave.directory in Mantid.user.properties set, and again when unset, and confirming it passes in both cases.
