### PR TITLE
Modify entry number description for loading of multi-entry nexus files

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadISISNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadISISNexus.cpp
@@ -31,9 +31,9 @@ void LoadISISNexus::init() {
   declareProperty("SpectrumMin", 0);
   declareProperty("SpectrumMax", Mantid::EMPTY_INT());
   declareProperty(new ArrayProperty<int>("SpectrumList"));
-  declareProperty("EntryNumber", 0, "The particular entry number to read "
-                                    "(default: Load all workspaces and creates "
-                                    "a workspace group)");
+  declareProperty("EntryNumber", 0, 
+                  "0 indicates that every entry is loaded into a separate workspace within a group. "
+                  "A positive number identifies one entry to be loaded into one worskspace");
 }
 
 /** Prints a message indicating that this algorithm has been removed.

--- a/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -82,8 +82,8 @@ void LoadISISNexus2::init() {
   declareProperty("SpectrumMax", (int64_t)EMPTY_INT(), mustBePositive);
   declareProperty(new ArrayProperty<int64_t>("SpectrumList"));
   declareProperty("EntryNumber", (int64_t)0, mustBePositive,
-                  "The particular entry number to read (default: Load all "
-                  "workspaces and creates a workspace group)");
+                  "0 indicates that every entry is loaded, into a separate workspace within a group. "
+                  "A positive number identifies one entry to be loaded, into one worskspace");
 
   std::vector<std::string> monitorOptions;
   monitorOptions.push_back("Include");

--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus.cpp
@@ -70,8 +70,8 @@ void LoadMuonNexus::init() {
   auto mustBeNonNegative = boost::make_shared<BoundedValidator<int64_t>>();
   mustBeNonNegative->setLower(0);
   declareProperty("EntryNumber", (int64_t)0, mustBeNonNegative,
-                  "The particular entry number to read (default: Load all "
-                  "workspaces and creates a workspace group)");
+                  "0 indicates that every entry is loaded, into a separate workspace within a group. "
+                  "A positive number identifies one entry to be loaded, into one worskspace");
 
   std::vector<std::string> FieldOptions;
   FieldOptions.push_back("Transverse");

--- a/Code/Mantid/Framework/DataHandling/src/LoadNexus.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexus.cpp
@@ -66,8 +66,8 @@ void LoadNexus::init() {
       "List of spectrum numbers to read, only for single period data.");
 
   declareProperty("EntryNumber", 0, mustBePositive,
-                  "The particular entry number to read (default: Load all "
-                  "workspaces and creates a workspace group)");
+                  "0 indicates that every entry is loaded, into a separate workspace within a group. "
+                  "A positive number identifies one entry to be loaded, into one worskspace");
 }
 
 /** Executes the algorithm. Reading in the file and creating and populating

--- a/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -243,9 +243,8 @@ void LoadNexusProcessed::init() {
   declareProperty(new ArrayProperty<int64_t>("SpectrumList"),
                   "List of spectrum numbers to read.");
   declareProperty("EntryNumber", (int64_t)0, mustBePositive,
-                  "The particular entry number to read. Default load all "
-                  "workspaces and creates a workspacegroup (default: read all "
-                  "entries).");
+                  "0 indicates that every entry is loaded, into a separate workspace within a group. "
+                  "A positive number identifies one entry to be loaded, into one worskspace");
   declareProperty("LoadHistory", true,
                   "If true, the workspace history will be loaded");
   declareProperty(


### PR DESCRIPTION
Fixes #10361 

Check that new description of the entry number is easy to understand and meets the concerns of the suggested change in the issue. 

The change is so small, that it does not merit an entry in the release notes.
