### PR TITLE
Re #13304 Ask server for updated repository state on click Reload

### DIFF
--- a/Code/Mantid/MantidQt/API/src/RepoModel.cpp
+++ b/Code/Mantid/MantidQt/API/src/RepoModel.cpp
@@ -814,6 +814,8 @@ void RepoModel::setupModelData(RepoItem *root)
 {
 
   QStringList lines;
+  // check server for updates to repository
+  std::vector<std::string> f_list = repo_ptr->check4Update();
   // get the list of entries inside the scriptrepository
   std::vector<std::string> list = repo_ptr->listFiles();
   

--- a/Code/Mantid/MantidQt/API/src/RepoModel.cpp
+++ b/Code/Mantid/MantidQt/API/src/RepoModel.cpp
@@ -815,7 +815,7 @@ void RepoModel::setupModelData(RepoItem *root)
 
   QStringList lines;
   // check server for updates to repository
-  std::vector<std::string> f_list = repo_ptr->check4Update();
+  repo_ptr->check4Update();
   // get the list of entries inside the scriptrepository
   std::vector<std::string> list = repo_ptr->listFiles();
   


### PR DESCRIPTION
Fixes #13304 

In the Script Repository window, the state of the remote repository is only checked when MantidPlot is started. A user would likely expect this to also occur when the "Reload" button is clicked.

An update of the state of the remote repository is now requested from the server in the constructor for RepoModel. A new RepoModel is created when starting MantidPlot and when the "Reload" button is clicked.

For tester:
Add the following to the Mantid.user.properties file to use the sandbox repository for testing:
UploaderWebServer = http://upload.mantidproject.org/scriptrepository/payload/publish_debug
ScriptRepository = http://download.mantidproject.org/dev-scriptrepository/

One way to test this would be to start MantidPlot and open the Script Repository window. Then either directly in the [sandbox repository](https://github.com/mantidproject/sandbox) or from another instance of MantidPlot, upload a test file. In the original instance of MantidPlot, the newly added file should be visible after clicking "Reload". 
