### PR TITLE
Add the Python plugin directories to sys.path

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/mantid/__init__.py
+++ b/Code/Mantid/Framework/PythonInterface/mantid/__init__.py
@@ -99,11 +99,13 @@ __version__ = kernel.version_str()
 ################################################################################
 from . import simpleapi as _simpleapi
 from mantid.kernel import plugins as _plugins
+from mantid.kernel.packagesetup import update_sys_paths as _update_sys_paths
 
 _plugins_key = 'python.plugins.directories'
 _user_key = 'user.%s' % _plugins_key
 plugin_dirs = _plugins.get_plugin_paths_as_set(_plugins_key)
 plugin_dirs.update(_plugins.get_plugin_paths_as_set(_user_key))
+_update_sys_paths(plugin_dirs, recursive=True)
 
 # Load
 plugin_files = []
@@ -119,7 +121,7 @@ for directory in plugin_dirs:
 
 # Mockup the full API first so that any Python algorithm module has something to import
 _simpleapi._mockup(alg_files)
-# Load the plugins
+# Load the plugins.
 plugin_modules = _plugins.load(plugin_files)
 # Create the proper algorithm definitions in the module
 new_attrs = _simpleapi._translate()

--- a/Code/Mantid/Framework/PythonInterface/mantid/kernel/packagesetup.py.in
+++ b/Code/Mantid/Framework/PythonInterface/mantid/kernel/packagesetup.py.in
@@ -4,30 +4,34 @@
     Handles set up of aspects related to extra Python packages e.g. adding
     any required paths to sys.path, setting environment variables etc.
 """
-
+import os as _os
+import sys as _sys
 ###############################################################################
 
-def update_sys_paths(paths):
+def update_sys_paths(paths, recursive=False):
     """
         Add the required script directories to the path
         @param paths A list of path strings or a string using a semi-colon
                      separator
+        @param recursive If true then all directories below the given paths
+                         are added as well
     """
     if paths == "":
         return
 
-    import sys as _sys
     if type(paths) == str:
-        dirs = paths.split(";")
-    elif type(dirs) == list:
-        dirs = paths
-    else:
-        raise RuntimeError("Expected a either a semicolon-separated string or list of paths")
+        paths = paths.split(";")
 
-    for _path in dirs:
-        _path = _path.rstrip("\\").rstrip("/") #sys.path doesn't like trailing slashes
-        if _path not in _sys.path:
-            _sys.path.append(_path)
+    def _append_to_path(path):
+        #sys.path doesn't like trailing slashes
+        _sys.path.append(path.rstrip("\\").rstrip("/"))
+
+    for path in paths:
+        _append_to_path(path)
+        if recursive:
+            for dirpath, dirnames, filenames in _os.walk(path):
+                for dirname in dirnames:
+                    _append_to_path(_os.path.join(dirpath, dirname))
 
 ########################################################################################
 
@@ -37,7 +41,7 @@ def set_NEXUSLIB_var():
     """
     import os as _os
     _nexuslib = r"@NEXUSLIB@"
-    if _nexuslib == "": 
+    if _nexuslib == "":
         return
 
     if not _os.path.isabs(_nexuslib):


### PR DESCRIPTION
Fixes #13309

No release note updates are required.

**Tester**
Some systems load the Python plugins in a different order so their directories need to be on `sys.path` or they cannot find any dependent modules in the same directory. All tests should pass and a code review should be sufficient.
