### PR TITLE
Update Script Repository URLs

### DIFF
--- a/Code/Mantid/Framework/Kernel/CMakeLists.txt
+++ b/Code/Mantid/Framework/Kernel/CMakeLists.txt
@@ -473,7 +473,7 @@ set ( ENABLE_USAGE_REPORTS "0" )
 set ( PYTHONPLUGIN_DIRS "${MANTID_ROOT}/Framework/PythonInterface/plugins" )
 set ( DATADIRS ${ExternalData_BINARY_ROOT}/Testing/Data/UnitTest;${ExternalData_BINARY_ROOT}/Testing/Data/DocTest;${MANTID_ROOT}/instrument )
 set ( COLORMAPS_FOLDER ${MANTID_ROOT}/Installers/colormaps/ )
-set ( MANTIDPUBLISHER "http://upload.mantidproject.org/scriptrepository/payload/publish_debug" )
+set ( MANTIDPUBLISHER "http://upload.mantidproject.org/scriptrepository?debug=1" )
 set ( HTML_ROOT ${DOCS_BUILDDIR}/html )
 
 # Construct script paths.
@@ -550,7 +550,7 @@ set ( UPDATE_INSTRUMENT_DEFINTITIONS "1" )
 set ( CHECK_FOR_NEW_MANTID_VERSION "1" )
 set ( ENABLE_USAGE_REPORTS "1" )
 set ( DATADIRS "" )
-set ( MANTIDPUBLISHER "http://upload.mantidproject.org/scriptrepository/payload/publish" )
+set ( MANTIDPUBLISHER "http://upload.mantidproject.org/scriptrepository" )
 set ( HTML_ROOT ../share/doc/html )
 
 # Construct script paths by replacing the old MANTID_ROOT with the new one.

--- a/Code/Mantid/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Code/Mantid/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1010,10 +1010,8 @@ void ScriptRepositoryImpl::remove(const std::string &file_path,
 
     // prepare the request, and call doDeleteRemoteFile to request the server to
     // remove the file
-    std::string remote_delete = remote_upload;
-    boost::replace_all(remote_delete, "publish", "remove");
     std::stringstream answer;
-    answer << doDeleteRemoteFile(remote_delete, file_path, author, email,
+    answer << doDeleteRemoteFile(remote_upload, file_path, author, email,
                                  comment);
     g_log.debug() << "Answer from doDelete: " << answer.str() << std::endl;
 

--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.h
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.h
@@ -1092,8 +1092,6 @@ private:
   void openScriptWindow     (const QStringList& lines);
   //@}
 
-  ApplicationWindow* loadScript(const QString& fn, bool existingProject = false);
-
 private slots:
   //! \name Initialization
   //@{
@@ -1186,6 +1184,8 @@ private slots:
   bool shouldWeShowFirstTimeSetup(const QStringList& commandArguments);
   /// Open up the FirstRunSetup dialog
   void showFirstTimeSetup();
+  
+  ApplicationWindow* loadScript(const QString& fn, bool existingProject = false);
 
 public:
   // TODO: a lot of this stuff should be private


### PR DESCRIPTION
Fixes #13308 

No release note updates required.

**Tester**
Using a locally built copy of Mantid, in the user properties file add

```
ScriptRepository = http://download.mantidproject.org/dev-scriptrepository/
```

Install the script repository and try to update something. The updates should appear at https://github.com/mantidproject/sandbox
