### PR TITLE
13302 load nexus fails when the file only has monitors

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -174,9 +174,12 @@ void LoadISISNexus2::exec() {
           entry.openNXInt(std::string(it->nxname) + "/spectrum_index");
       index.load();
       int64_t ind = *index();
-      m_monitors[ind] = it->nxname;
-
-      ++nmons;
+      // Spectrum index of 0 means no spectrum associated with that monitor,
+      // so only count those with index > 0
+      if (ind > 0){
+        m_monitors[ind] = it->nxname;
+        ++nmons;
+      }
     }
   }
 
@@ -272,7 +275,7 @@ void LoadISISNexus2::exec() {
   createPeriodLogs(firstentry, local_workspace);
 
   WorkspaceGroup_sptr wksp_group(new WorkspaceGroup);
-  if (m_detBlockInfo.numberOfPeriods > 1 && m_entrynumber == 0) {
+  if (m_loadBlockInfo.numberOfPeriods > 1 && m_entrynumber == 0) {
 
     wksp_group->setTitle(local_workspace->getTitle());
 
@@ -280,7 +283,7 @@ void LoadISISNexus2::exec() {
     const std::string base_name = getPropertyValue("OutputWorkspace") + "_";
     const std::string prop_name = "OutputWorkspace_";
 
-    for (int p = 1; p <= m_detBlockInfo.numberOfPeriods; ++p) {
+    for (int p = 1; p <= m_loadBlockInfo.numberOfPeriods; ++p) {
       std::ostringstream os;
       os << p;
       m_progress->report("Loading period " + os.str());
@@ -1190,9 +1193,13 @@ bool LoadISISNexus2::findSpectraDetRangeInFile(
     m_loadBlockInfo = m_monBlockInfo;
   }
 
+  g_log.debug() << "Number of monitors nmons: "
+                << nmons << std::endl;
+
   if (ndets == 0) {
     separateMonitors = false; // only monitors in the main workspace. No
                               // detectors. Will be loaded in the main workspace
+    // Function exit point
     return separateMonitors;
   }
 

--- a/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -1196,6 +1196,7 @@ bool LoadISISNexus2::findSpectraDetRangeInFile(
   if (ndets == 0) {
     separateMonitors = false; // only monitors in the main workspace. No
                               // detectors. Will be loaded in the main workspace
+    // Possible function exit point
     return separateMonitors;
   }
 

--- a/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -1193,13 +1193,9 @@ bool LoadISISNexus2::findSpectraDetRangeInFile(
     m_loadBlockInfo = m_monBlockInfo;
   }
 
-  g_log.debug() << "Number of monitors nmons: "
-                << nmons << std::endl;
-
   if (ndets == 0) {
     separateMonitors = false; // only monitors in the main workspace. No
                               // detectors. Will be loaded in the main workspace
-    // Function exit point
     return separateMonitors;
   }
 


### PR DESCRIPTION
Fixes #13302 

Two bugs were present when loading a nexus file containing monitors and no detectors:
- Only one period was loaded, despite there being two in the provided file.
- One more spectrum was produced in the workspace than was present in the file.

The number of periods was already calculated correctly, but then the wrong variable was used. The number of spectra was detected incorrectly, as monitors with spectrum_index = 0 were counted as having an associated spectrum.

For tester:
File LARMOR00004732 was demonstrating the bug. There is a .raw file with the same name and the workspaces loaded from each file can be compared.
