### PR TITLE
Minor fixes to OS X build.

### DIFF
--- a/Code/Mantid/Build/CMake/DarwinSetup.cmake
+++ b/Code/Mantid/Build/CMake/DarwinSetup.cmake
@@ -80,7 +80,7 @@ endif ()
 # Force 64-bit compiler as that's all we support
 ###########################################################################
 
-set ( CLANG_WARNINGS "-Wall -Wextra -pedantic -Winit-self -Wpointer-arith -Wcast-qual -fno-common  -Wno-deprecated-register")
+set ( CLANG_WARNINGS "-Wall -Wextra -pedantic -Winit-self -Wpointer-arith -Wcast-qual -fno-common  -Wno-deprecated-register -Wno-deprecated-declarations")
 
 set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 ${CLANG_WARNINGS}" )
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -std=c++0x" )
@@ -131,10 +131,6 @@ if (OSX_VERSION VERSION_LESS 10.9)
 else()
  set(CMAKE_MACOSX_RPATH 1)
  # Assume we are using homebrew for now
- # set Deployment target to 10.8
- set ( CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk )
- set ( CMAKE_OSX_ARCHITECTURES x86_64 )
- set ( CMAKE_OSX_DEPLOYMENT_TARGET 10.8 )
  # Follow symlinks so cmake copies the file
  # PYQT4_PATH, SITEPACKAGES_PATH, OPENSSL_ROOT_DIR may be defined externally (cmake -D)
  # it would be good do not overwrite them (important for the compilation with macports)

--- a/Code/Mantid/CMakeLists.txt
+++ b/Code/Mantid/CMakeLists.txt
@@ -78,21 +78,7 @@ ENDIF()
 # Set paths to Third_Party for Mac builds
 ###########################################################################
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-
-  if ( NOT THIRD_PARTY )
-    set ( THIRD_PARTY "${PROJECT_SOURCE_DIR}/../Third_Party" )
-  endif ()
-
-  # Print out where we think we are looking for 3rd party stuff
-  message (STATUS "Setting THIRD_PARTY to be ${THIRD_PARTY}." )
-
-  # Check that the 3rd party directory exists.
-  if (NOT IS_DIRECTORY "${THIRD_PARTY}")
-    message ( WARNING "Specified THIRD_PARTY directory doesn't exist!" )
-  endif()
-
   include ( DarwinSetup )
-
 ENDIF()
 
 # We probably don't want this to run on every build.

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
@@ -4111,7 +4111,7 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item row="12" column="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_24">
+         <layout class="QHBoxLayout" name="horizontalLayout_241">
           <item>
            <widget class="QLabel" name="binning_label">
             <property name="minimumSize">


### PR DESCRIPTION
Since we are no longer supporting OS X 10.8, there is no reason to set the deployment target. This does require setting the `-Wno-deprecated-declarations` flag to suppress warnings we have little/no control over. 

Similarly, I removed code setting THIRD_PARTY, which is no longer used for OS X and is generating a CMake warning. 

Removal of 10.8 support was already noted in v3.4, so nothing needs to go in the release notes.

testing: code review should be sufficient.
