### PR TITLE
Improves general error message when retrieve() fails

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -133,10 +133,17 @@ public:
   template <typename WSTYPE>
   boost::shared_ptr<WSTYPE> retrieveWS(const std::string &name) const {
     // Get as a bare workspace
-    boost::shared_ptr<Mantid::API::Workspace> workspace =
-        Kernel::DataService<API::Workspace>::retrieve(name);
-    // Cast to the desired type and return that.
-    return boost::dynamic_pointer_cast<WSTYPE>(workspace);
+    try {
+      boost::shared_ptr<Mantid::API::Workspace> workspace =
+          Kernel::DataService<API::Workspace>::retrieve(name);
+      // Cast to the desired type and return that.
+      return boost::dynamic_pointer_cast<WSTYPE>(workspace);
+    } catch (...) {
+      throw Kernel::Exception::NotFoundError(
+          "Unable to find workspace type with name '" + name +
+              "': data service ",
+          name);
+    }
   }
 
   /** @name Methods to work with workspace groups */
@@ -183,33 +190,29 @@ typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::AddNotification
 typedef const Poco::AutoPtr<Mantid::Kernel::DataService<
     Mantid::API::Workspace>::AddNotification> &WorkspaceAddNotification_ptr;
 
-typedef Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::BeforeReplaceNotification
-    WorkspaceBeforeReplaceNotification;
+typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::
+    BeforeReplaceNotification WorkspaceBeforeReplaceNotification;
 typedef const Poco::AutoPtr<Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::BeforeReplaceNotification> &
-    WorkspaceBeforeReplaceNotification_ptr;
+    Mantid::API::Workspace>::BeforeReplaceNotification>
+    &WorkspaceBeforeReplaceNotification_ptr;
 
-typedef Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::AfterReplaceNotification
-    WorkspaceAfterReplaceNotification;
+typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::
+    AfterReplaceNotification WorkspaceAfterReplaceNotification;
 typedef const Poco::AutoPtr<Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::AfterReplaceNotification> &
-    WorkspaceAfterReplaceNotification_ptr;
+    Mantid::API::Workspace>::AfterReplaceNotification>
+    &WorkspaceAfterReplaceNotification_ptr;
 
-typedef Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::PreDeleteNotification
-    WorkspacePreDeleteNotification;
-typedef const Poco::AutoPtr<Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::PreDeleteNotification> &
-    WorkspacePreDeleteNotification_ptr;
+typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::
+    PreDeleteNotification WorkspacePreDeleteNotification;
+typedef const Poco::AutoPtr<
+    Mantid::Kernel::DataService<Mantid::API::Workspace>::PreDeleteNotification>
+    &WorkspacePreDeleteNotification_ptr;
 
-typedef Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::PostDeleteNotification
-    WorkspacePostDeleteNotification;
-typedef const Poco::AutoPtr<Mantid::Kernel::DataService<
-    Mantid::API::Workspace>::PostDeleteNotification> &
-    WorkspacePostDeleteNotification_ptr;
+typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::
+    PostDeleteNotification WorkspacePostDeleteNotification;
+typedef const Poco::AutoPtr<
+    Mantid::Kernel::DataService<Mantid::API::Workspace>::PostDeleteNotification>
+    &WorkspacePostDeleteNotification_ptr;
 
 typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::ClearNotification
     ClearADSNotification;
@@ -219,25 +222,25 @@ typedef const Poco::AutoPtr<Mantid::Kernel::DataService<
 typedef Mantid::Kernel::DataService<Mantid::API::Workspace>::RenameNotification
     WorkspaceRenameNotification;
 typedef const Poco::AutoPtr<
-    Mantid::Kernel::DataService<Mantid::API::Workspace>::RenameNotification> &
-    WorkspaceRenameNotification_ptr;
+    Mantid::Kernel::DataService<Mantid::API::Workspace>::RenameNotification>
+    &WorkspaceRenameNotification_ptr;
 
 typedef AnalysisDataServiceImpl::GroupWorkspacesNotification
     WorkspacesGroupedNotification;
 typedef const Poco::AutoPtr<
-    AnalysisDataServiceImpl::GroupWorkspacesNotification> &
-    WorkspacesGroupedNotification_ptr;
+    AnalysisDataServiceImpl::GroupWorkspacesNotification>
+    &WorkspacesGroupedNotification_ptr;
 
 typedef AnalysisDataServiceImpl::UnGroupingWorkspaceNotification
     WorkspaceUnGroupingNotification;
 typedef const Poco::AutoPtr<
-    AnalysisDataServiceImpl::UnGroupingWorkspaceNotification> &
-    WorkspaceUnGroupingNotification_ptr;
+    AnalysisDataServiceImpl::UnGroupingWorkspaceNotification>
+    &WorkspaceUnGroupingNotification_ptr;
 
 typedef AnalysisDataServiceImpl::GroupUpdatedNotification
     GroupUpdatedNotification;
-typedef const Poco::AutoPtr<AnalysisDataServiceImpl::GroupUpdatedNotification> &
-    GroupUpdatedNotification_ptr;
+typedef const Poco::AutoPtr<AnalysisDataServiceImpl::GroupUpdatedNotification>
+    &GroupUpdatedNotification_ptr;
 
 } // Namespace API
 } // Namespace Mantid

--- a/Code/Mantid/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -138,7 +138,8 @@ public:
           Kernel::DataService<API::Workspace>::retrieve(name);
       // Cast to the desired type and return that.
       return boost::dynamic_pointer_cast<WSTYPE>(workspace);
-    } catch (...) {
+
+    } catch (Kernel::Exception::NotFoundError &) {
       throw Kernel::Exception::NotFoundError(
           "Unable to find workspace type with name '" + name +
               "': data service ",

--- a/Code/Mantid/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Code/Mantid/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -363,7 +363,10 @@ public:
     if (it != datamap.end()) {
       return it->second;
     } else {
-      throw Kernel::Exception::NotFoundError("Data Object", name);
+      throw Kernel::Exception::NotFoundError(
+          "Unable to find Data Object type with name '" + name +
+              "': data service ",
+          name);
     }
   }
 


### PR DESCRIPTION
Fixes #13293
Improves the general error message when the `retrieve()` fails to find a workspace or data object 
