### PR TITLE
Add start up scripts for Windows

### DIFF
--- a/Code/Mantid/Build/CMake/Packaging/launch_mantidplot.bat
+++ b/Code/Mantid/Build/CMake/Packaging/launch_mantidplot.bat
@@ -1,0 +1,35 @@
+@echo off
+setlocal enableextensions
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Launch script for MantidPlot
+:: 
+:: Sets the required environment variables for MantidPlot to run correctly.
+:: All variables that are passed to this script are passed directly to
+:: MantidPlot.exe
+::
+:: It is not advised to start MantidPlot.exe directly as this is unlikely
+:: to work.
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:: Set base paths
+set _BIN_DIR=%~dp0
+:: Strip the trailing slash so that the ~dp expansion works as expected
+set _BIN_DIR=%_BIN_DIR:~,-1%
+for /f "delims=" %%I in ("%_BIN_DIR%") do (
+    set _INSTALL_DIR=%%~dpI
+)
+set _INSTALL_DIR=%_INSTALL_DIR:~,-1%
+set _EXTRA_PATH_DIRS=%_INSTALL_DIR%\bin;%_INSTALL_DIR%\PVPlugins;%_INSTALL_DIR%\plugins
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Required environment variables for Mantid
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+set MANTIDPATH=%_BIN_DIR%
+set PATH=%_EXTRA_PATH_DIRS%;%PATH%
+set PV_PLUGIN_PATH=%_INSTALL_DIR%\PVPlugins\PVPlugins
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Start MantidPlot
+:: The working directory is whatever is set by the caller
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+start "MantidPlot" /B /WAIT %_BIN_DIR%\MantidPlot.exe %*

--- a/Code/Mantid/Build/CMake/Packaging/launch_mantidplot.vbs
+++ b/Code/Mantid/Build/CMake/Packaging/launch_mantidplot.vbs
@@ -1,0 +1,37 @@
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+' Launch script for launch_mantidplot.bat
+' 
+' This is primarily used when launching via an icon. It ensures that the main
+' launch_mantiplot.bat script is started with a hidden cmd window and only the
+' MantidPlot application is visible.
+'
+' When launched via a shell all output from this is captured and discarded.
+' For that reason most work is done in the main .bat file that can be used
+' to get output and check error codes.
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Set WshShell = CreateObject("WScript.Shell")
+
+' Location of this script
+Set fso = CreateObject("Scripting.FileSystemObject")
+binDir = fso.GetParentFolderName(WScript.ScriptFullName)
+
+' Arguments - build a string. A straight join on Arguments is not possible
+Set scriptArgs = WScript.Arguments
+If scriptArgs.Count > 0 Then
+  ReDim argsArray(scriptArgs.Count-1)
+  For i = 0 To scriptArgs.Count-1
+    argsArray(i) = scriptArgs(i)
+  Next
+  argStr = Join(argsArray)
+Else
+  argStr = ""
+End If
+
+' Assume that the launch bat file is alongside this one.
+cmd = binDir & "\launch_mantidplot.bat" & chr(32) & argStr
+WshShell.Run cmd, 0, false
+
+' Cleanup
+Set fso = Nothing
+Set scriptArgs = Nothing
+Set WshShell = Nothing

--- a/Code/Mantid/Build/CMake/Packaging/mantidpython.bat
+++ b/Code/Mantid/Build/CMake/Packaging/mantidpython.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal enableextensions
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Launch script for command line python
+:: 
+:: Sets the required environment variables for the Python to run correctly.
+:: All variables that are passed to this script are passed directly to
+:: python.exe
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:: Set base paths
+set _BIN_DIR=%~dp0
+:: Strip the trailing slash so that the ~dp expansion works as expected
+set _BIN_DIR=%_BIN_DIR:~,-1%
+for /f "delims=" %%I in ("%_BIN_DIR%") do (
+    set _INSTALL_DIR=%%~dpI
+)
+set _INSTALL_DIR=%_INSTALL_DIR:~,-1%
+set _EXTRA_PATH_DIRS=%_INSTALL_DIR%\bin;%_INSTALL_DIR%\PVPlugins;%_INSTALL_DIR%\plugins
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Required environment variables for Mantid
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+set MANTIDPATH=%_BIN_DIR%
+set PYTHONPATH=%MANTIDPATH%;%PYTHONPATH%
+set PATH=%_EXTRA_PATH_DIRS%;%PATH%
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Start python
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+start "Mantid Python" /B /WAIT %_BIN_DIR%\python.exe %*
+

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -164,27 +164,37 @@ install ( FILES ${CMAKE_LIBRARY_PATH}/boost_date_time-vc110-mt-1_52.lib DESTINAT
 ###########################################################################
 install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/launch_mantidplot.bat DESTINATION bin )
 install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/launch_mantidplot.vbs DESTINATION bin )
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/mantidpython.bat DESTINATION bin )
 
 ###########################################################################
 # Extra NSIS commands for shortcuts, start menu items etc
 # Three backward slashes are required to escape a character to get the
 # character through to NSIS.
 ###########################################################################
-# On install
+# On install. The blank lines seem to be required or it doesn't create the shortcut
 set (CPACK_NSIS_CREATE_ICONS_EXTRA "
   CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
+
+  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
 ")
 set (CPACK_NSIS_DELETE_ICONS_EXTRA "
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPlot.lnk\\\"
+  Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPython.lnk\\\"
 ")
+# The blank lines seem to be required or it doesn't create the shortcut
 set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
   CreateShortCut \\\"$DESKTOP\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
+
+  CreateShortCut \\\"$DESKTOP\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
+
   CreateDirectory \\\"$INSTDIR\\\\logs\\\"
+
   CreateDirectory \\\"$INSTDIR\\\\docs\\\"
 ")
 # On uninstall reverse stages listed above.
 set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
   Delete \\\"$DESKTOP\\\\MantidPlot.lnk\\\"
+  Delete \\\"$DESKTOP\\\\MantidPython.lnk\\\"
   RMDir \\\"$INSTDIR\\\\logs\\\"
   RMDir \\\"$INSTDIR\\\\docs\\\"
 ")

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -174,6 +174,9 @@ install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/launch_mantidp
 set (CPACK_NSIS_CREATE_ICONS_EXTRA "
   CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
 ")
+set (CPACK_NSIS_DELETE_ICONS_EXTRA "
+  Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPlot.lnk\\\"
+")
 set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
   CreateShortCut \\\"$DESKTOP\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
   CreateDirectory \\\"$INSTDIR\\\\logs\\\"

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -11,8 +11,6 @@ set( CPACK_NSIS_DISPLAY_NAME "Mantid${CPACK_PACKAGE_SUFFIX}")
 set( CPACK_PACKAGE_NAME "mantid${CPACK_PACKAGE_SUFFIX}" )
 set( CPACK_PACKAGE_INSTALL_DIRECTORY "MantidInstall${CPACK_PACKAGE_SUFFIX}")
 set( CPACK_NSIS_INSTALL_ROOT "C:")
-set( CPACK_PACKAGE_EXECUTABLES "MantidPlot;MantidPlot")
-set( CPACK_NSIS_MENU_LINKS "bin\\\\MantidPlot.exe" "MantidPlot")
 set( CPACK_PACKAGE_ICON "${CMAKE_CURRENT_SOURCE_DIR}/Images\\\\MantidPlot_Icon_32offset.png" )
 set( CPACK_NSIS_MUI_ICON "${CMAKE_CURRENT_SOURCE_DIR}/Images\\\\MantidPlot_Icon_32offset.ico" )
 set( CPACK_NSIS_MUI_UNIICON "${CMAKE_CURRENT_SOURCE_DIR}/Images\\\\MantidPlot_Icon_32offset.ico" )
@@ -162,114 +160,28 @@ install ( FILES ${CMAKE_LIBRARY_PATH}/PocoFoundation.lib ${CMAKE_LIBRARY_PATH}/P
 install ( FILES ${CMAKE_LIBRARY_PATH}/boost_date_time-vc110-mt-1_52.lib DESTINATION UserAlgorithms )
 
 ###########################################################################
-# Environment variables
+# Startup files
 ###########################################################################
-# Release deployments do modify environmental variables, other deployments do not.
-if ( CPACK_PACKAGE_SUFFIX STREQUAL "" )
-    # On install
-    set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "Push \\\"MANTIDPATH\\\"
-        Push \\\"A\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\bin\\\"
-        Call EnvVarUpdate
-        Pop  \\\$0
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/launch_mantidplot.bat DESTINATION bin )
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/launch_mantidplot.vbs DESTINATION bin )
 
-        Push \\\"PATH\\\"
-        Push \\\"A\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\bin\\\"
-        Call EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"PATH\\\"
-        Push \\\"A\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\${PVPLUGINS_DIR}\\\"
-        Call EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"PATH\\\"
-        Push \\\"A\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\${PLUGINS_DIR}\\\"
-        Call EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"PV_PLUGIN_PATH\\\"
-        Push \\\"A\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\${PVPLUGINS_DIR}\\\\${PVPLUGINS_DIR}\\\"
-        Call EnvVarUpdate
-        Pop  \\\$0
-
-        CreateShortCut \\\"$DESKTOP\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\"
-
-        CreateDirectory \\\"$INSTDIR\\\\logs\\\"
-
-        CreateDirectory \\\"$INSTDIR\\\\docs\\\"
-    ")
-    # On unistall reverse stages listed above.
-    set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-        "Push \\\"PATH\\\"
-        Push \\\"R\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\bin\\\"
-        Call un.EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"PATH\\\"
-        Push \\\"R\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\${PVPLUGINS_DIR}\\\"
-        Call un.EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"PATH\\\"
-        Push \\\"R\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\${PLUGINS_DIR}\\\"
-        Call un.EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"MANTIDPATH\\\"
-        Push \\\"R\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\bin\\\"
-        Call un.EnvVarUpdate
-        Pop  \\\$0
-
-        Push \\\"PV_PLUGIN_PATH\\\"
-        Push \\\"R\\\"
-        Push \\\"HKCU\\\"
-        Push \\\"$INSTDIR\\\\${PVPLUGINS_DIR}\\\\${PVPLUGINS_DIR}\\\"
-        Call un.EnvVarUpdate
-        Pop  \\\$0
-
-        Delete \\\"$DESKTOP\\\\MantidPlot.lnk\\\"
-
-        RMDir \\\"$INSTDIR\\\\logs\\\"
-
-        RMDir \\\"$INSTDIR\\\\docs\\\"
-    ")
-else ()
-  set( CPACK_PACKAGE_INSTALL_DIRECTORY "MantidInstall${CPACK_PACKAGE_SUFFIX}")
-  set( CPACK_NSIS_INSTALL_ROOT "C:")
-  # On install
-  set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS
-    "CreateShortCut \\\"$DESKTOP\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\"
-
-     CreateDirectory \\\"$INSTDIR\\\\logs\\\"
-
-     CreateDirectory \\\"$INSTDIR\\\\docs\\\"
-    "
-  )
-  # On unistall reverse stages listed above.
-  set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS
-    "Delete \\\"$DESKTOP\\\\MantidPlot.lnk\\\"
-
-     RMDir \\\"$INSTDIR\\\\logs\\\"
-
-     RMDir \\\"$INSTDIR\\\\docs\\\"
-    "
-  )
-endif()
+###########################################################################
+# Extra NSIS commands for shortcuts, start menu items etc
+# Three backward slashes are required to escape a character to get the
+# character through to NSIS.
+###########################################################################
+# On install
+set (CPACK_NSIS_CREATE_ICONS_EXTRA "
+  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
+")
+set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
+  CreateShortCut \\\"$DESKTOP\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
+  CreateDirectory \\\"$INSTDIR\\\\logs\\\"
+  CreateDirectory \\\"$INSTDIR\\\\docs\\\"
+")
+# On uninstall reverse stages listed above.
+set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
+  Delete \\\"$DESKTOP\\\\MantidPlot.lnk\\\"
+  RMDir \\\"$INSTDIR\\\\logs\\\"
+  RMDir \\\"$INSTDIR\\\\docs\\\"
+")

--- a/Code/Mantid/Framework/CMakeLists.txt
+++ b/Code/Mantid/Framework/CMakeLists.txt
@@ -156,7 +156,8 @@ install ( DIRECTORY ../instrument/ DESTINATION ${INBUNDLE}instrument
           DIRECTORY_PERMISSIONS OWNER_READ OWNER_EXECUTE OWNER_WRITE
                                 GROUP_READ GROUP_EXECUTE GROUP_WRITE
                                 WORLD_READ WORLD_EXECUTE WORLD_WRITE
-          PATTERN "*UNIT_TESTING*" EXCLUDE
+          PATTERN "*UNIT_TESTING*" EXCLUDE 
+          PATTERN ".gitignore" EXCLUDE
 )
 
 # Ships .py files but only ship compiled pyd files for supported platforms.

--- a/Code/Mantid/Framework/DataObjects/CMakeLists.txt
+++ b/Code/Mantid/Framework/DataObjects/CMakeLists.txt
@@ -220,10 +220,5 @@ add_subdirectory ( test )
 # Installation settings
 ###########################################################################
 
-if ( WIN32 )
-  install ( TARGETS DataObjects ${SYSTEM_PACKAGE_TARGET} DESTINATION ${PLUGINS_DIR} )
-else()
-  install ( TARGETS DataObjects DESTINATION ${LIB_DIR} )
-endif ()
-
+install ( TARGETS DataObjects ${SYSTEM_PACKAGE_TARGET} DESTINATION ${LIB_DIR} )
 

--- a/Code/Mantid/Framework/PostInstall/CMakeLists.txt
+++ b/Code/Mantid/Framework/PostInstall/CMakeLists.txt
@@ -18,6 +18,6 @@ set ( PACKAGE_ROOT \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX} )
 set ( EXCLUDE_REGEX ".*_template|.*port_v3" )
 
 set ( COMPILE_SCRIPT "message ( \"Byte-compiling Python in ${PACKAGE_ROOT}\")" )
-set ( COMPILE_SCRIPT "${COMPILE_SCRIPT}\n  execute_process ( COMMAND ${PYTHON_EXECUTABLE} -m compileall -q -x \"${EXCLUDE_REGEX}\" \"${PACKAGE_ROOT}\")" )
+set ( COMPILE_SCRIPT "${COMPILE_SCRIPT}\n  execute_process ( COMMAND ${PYTHON_EXECUTABLE} -m compileall -q -x \"${EXCLUDE_REGEX}\" \"${PACKAGE_ROOT}\" OUTPUT_QUIET ERROR_QUIET )" )
 
 install ( CODE ${COMPILE_SCRIPT} )


### PR DESCRIPTION
Fixes #13337

**Tester**
The changes are solely around the packaging so must be tested using an installer. Download the 
[package](http://builds.mantidproject.org/job/pull_requests-win7/2094/artifact/build/mantid-3.4.20150810.835-win64.exe) with the changes.
- install the package
- verify that the PATH, MANTIDPATH & PV_PLUGIN_PATH variables are now empty or don't exist
- check that a MantidPlot & MantidPython shortcut exists on the Desktop and in the start menu
- start MantidPlot from the icons and confirm it starts correctly
- start MantidPython and verify that it brings up a Python console and you can type `import mantid`
- check the uninstall works correctly

[Release notes](http://www.mantidproject.org/ReleaseNotes_3_5_UI_Changes#Installation)
