### PR TITLE
Fixes SplineSmoothing bugs and executes the algorithm faster

### DIFF
--- a/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/SplineSmoothing.h
+++ b/Code/Mantid/Framework/CurveFitting/inc/MantidCurveFitting/SplineSmoothing.h
@@ -61,7 +61,7 @@ private:
   void exec();
 
   /// smooth a single spectrum of the workspace
-  void smoothSpectrum(int index);
+  void smoothSpectrum(int index, int maxBreaks);
 
   /// calculate derivatives for a single spectrum
   void calculateSpectrumDerivatives(int index, int order);
@@ -81,7 +81,7 @@ private:
 
   /// choose points to define a spline and smooth the data
   void selectSmoothingPoints(API::MatrixWorkspace_const_sptr inputWorkspace,
-                             size_t row);
+                             size_t row, int maxBreaks);
 
   /// calculate the spline based on the smoothing points chosen
   void calculateSmoothing(API::MatrixWorkspace_const_sptr inputWorkspace,

--- a/Code/Mantid/Framework/CurveFitting/src/SplineSmoothing.cpp
+++ b/Code/Mantid/Framework/CurveFitting/src/SplineSmoothing.cpp
@@ -71,8 +71,8 @@ void SplineSmoothing::init() {
                   "The amount of error we wish to tolerate in smoothing");
 
   auto numOfBreaks = boost::make_shared<BoundedValidator<int>>();
-  numOfBreaks->setLower(M_START_SMOOTH_POINTS);
-  declareProperty("MaxNumberOfBreaks", 0, numOfBreaks,
+  numOfBreaks->setLower(0);
+  declareProperty("MaxNumberOfBreaks", M_START_SMOOTH_POINTS, numOfBreaks,
                   "To set the positions of the break-points");
 }
 

--- a/Code/Mantid/Framework/CurveFitting/test/SplineSmoothingTest.h
+++ b/Code/Mantid/Framework/CurveFitting/test/SplineSmoothingTest.h
@@ -8,94 +8,92 @@
 
 using Mantid::CurveFitting::SplineSmoothing;
 
-class SplineSmoothingTest : public CxxTest::TestSuite
-{
+class SplineSmoothingTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static SplineSmoothingTest *createSuite() { return new SplineSmoothingTest(); }
-  static void destroySuite( SplineSmoothingTest *suite ) { delete suite; }
+  static SplineSmoothingTest *createSuite() {
+    return new SplineSmoothingTest();
+  }
+  static void destroySuite(SplineSmoothingTest *suite) { delete suite; }
 
-  //Functor for generating data
-  struct SplineFunc
-  {
-    double operator()(double x, int)
-    {
-      return std::sin(x);
-    }
+  // Functor for generating data
+  struct SplineFunc {
+    double operator()(double x, int) { return std::sin(x); }
   };
 
-  void test_Init()
-  {
+  void test_Init() {
     SplineSmoothing alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
-  }
-  
-  void testExec()
-  {
-    using namespace Mantid::API;
-
-    //number of derivatives and spectra
-    const int order (2), spectra(2);
-
-    //create a binned workspace
-    MatrixWorkspace_sptr inputWorkspace = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(SplineFunc(), spectra, 0, 5, 0.02, false);
-
-    //setup algorithm
-    SplineSmoothing alg;
-    runAlgorithm(alg, order, inputWorkspace);
-    checkOutput(alg);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
   }
 
-  void testExecHistogramData()
-  {
+  void testExec() {
     using namespace Mantid::API;
 
-    //number of derivatives and spectra
-    const int order (2), spectra(1);
+    // number of derivatives and spectra
+    const int order(2), spectra(2);
 
-    //create a binned workspace
-    MatrixWorkspace_sptr inputWorkspace = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(SplineFunc(), spectra, 0, 5, 0.02, true);
+    // create a binned workspace
+    MatrixWorkspace_sptr inputWorkspace =
+        WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+            SplineFunc(), spectra, 0, 5, 0.02, false);
 
+    // setup algorithm
     SplineSmoothing alg;
     runAlgorithm(alg, order, inputWorkspace);
     checkOutput(alg);
   }
-  
-  void testExecMultipleHistograms()
-  {
+
+  void testExecHistogramData() {
     using namespace Mantid::API;
 
-    //number of derivatives and spectra
-    const int order (2), spectra(3);
+    // number of derivatives and spectra
+    const int order(2), spectra(1);
 
-    //create a binned workspace
-    MatrixWorkspace_sptr inputWorkspace = WorkspaceCreationHelper::Create2DWorkspaceFromFunction(SplineFunc(), spectra, 0, 5, 0.02, true);
+    // create a binned workspace
+    MatrixWorkspace_sptr inputWorkspace =
+        WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+            SplineFunc(), spectra, 0, 5, 0.02, true);
 
     SplineSmoothing alg;
     runAlgorithm(alg, order, inputWorkspace);
     checkOutput(alg);
   }
 
-  void checkOutput(const SplineSmoothing& alg) const
-  {
+  void testExecMultipleHistograms() {
+    using namespace Mantid::API;
+
+    // number of derivatives and spectra
+    const int order(2), spectra(3);
+
+    // create a binned workspace
+    MatrixWorkspace_sptr inputWorkspace =
+        WorkspaceCreationHelper::Create2DWorkspaceFromFunction(
+            SplineFunc(), spectra, 0, 5, 0.02, true);
+
+    SplineSmoothing alg;
+    runAlgorithm(alg, order, inputWorkspace);
+    checkOutput(alg);
+  }
+
+  void checkOutput(const SplineSmoothing &alg) const {
     using namespace Mantid::API;
 
     MatrixWorkspace_const_sptr ows = alg.getProperty("OutputWorkspace");
     WorkspaceGroup_const_sptr derivs = alg.getProperty("OutputWorkspaceDeriv");
 
-    for (size_t i = 0; i < ows->getNumberHistograms(); ++i)
-    {
-      MatrixWorkspace_const_sptr derivsWs = boost::dynamic_pointer_cast<const MatrixWorkspace>(derivs->getItem(i));
-      const auto & xs = ows->readX(i);
-      const auto & ys = ows->readY(i);
-      const auto & d1 = derivsWs->readY(0);
-      const auto & d2 = derivsWs->readY(1);
+    for (size_t i = 0; i < ows->getNumberHistograms(); ++i) {
+      MatrixWorkspace_const_sptr derivsWs =
+          boost::dynamic_pointer_cast<const MatrixWorkspace>(
+              derivs->getItem(i));
+      const auto &xs = ows->readX(i);
+      const auto &ys = ows->readY(i);
+      const auto &d1 = derivsWs->readY(0);
+      const auto &d2 = derivsWs->readY(1);
 
-      //check output for consistency
-      for(size_t j = 0; j < ys.size(); ++j)
-      {
+      // check output for consistency
+      for (size_t j = 0; j < ys.size(); ++j) {
         TS_ASSERT_DELTA(ys[j], std::sin(xs[j]), 1e-4);
         TS_ASSERT_DELTA(d1[j], std::cos(xs[j]), 1e-1);
         TS_ASSERT_DELTA(d2[j], -std::sin(xs[j]), 1e-1);
@@ -103,23 +101,22 @@ public:
     }
   }
 
-  void runAlgorithm(SplineSmoothing& alg, int order, const Mantid::API::MatrixWorkspace_sptr& iws) const
-  {
+  void runAlgorithm(SplineSmoothing &alg, int order,
+                    const Mantid::API::MatrixWorkspace_sptr &iws) const {
     alg.initialize();
     alg.setChild(true);
     alg.setPropertyValue("OutputWorkspace", "Anon");
     alg.setPropertyValue("OutputWorkspaceDeriv", "AnonDerivs");
 
-    TS_ASSERT_THROWS_NOTHING( alg.setProperty("Error", 0.05));
-    TS_ASSERT_THROWS_NOTHING( alg.setProperty("DerivOrder", order));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Error", 0.05));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("DerivOrder", order));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaxNumberOfBreaks", 50));
 
     alg.setProperty("InputWorkspace", iws);
 
-    TS_ASSERT_THROWS_NOTHING( alg.execute() );
-    TS_ASSERT( alg.isExecuted() );
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
   }
-
 };
-
 
 #endif /* MANTID_ALGORITHMS_SPLINETEST_H_ */

--- a/Code/Mantid/docs/source/algorithms/SplineSmoothing-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SplineSmoothing-v1.rst
@@ -30,7 +30,7 @@ breaking points, a detailed smoothing function can also be produced.
 Users are also able to successfully apply the algorithm to a workspace
 with multiple spectrums, which would generate an output of workspace
 with multiple spectrums of :ref:`SplineSmoothing <algm-SplineSmoothing-v1>`
-algorithm. `BSpline <http://www.mantidproject.org/BSpline>`_
+algorithm applied to it. `BSpline <http://www.mantidproject.org/BSpline>`_
 can be used to help you understand break-points in further detail. 
 
 

--- a/Code/Mantid/docs/source/algorithms/SplineSmoothing-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SplineSmoothing-v1.rst
@@ -10,13 +10,29 @@ Description
 -----------
 
 The algorithm performs a smoothing of the input data using a cubic
-spline. The algorithm takes a 2D workspace and generates a spline for
-each of the spectra to approximate a fit of the data.
+spline. The algorithm takes a 2D workspace and generates a spline 
+for each of the spectra to approximate a fit of the data.
 
 Optionally, this algorithm can also calculate the first and second
 derivatives of each of the interpolated points as a side product.
 Setting the DerivOrder property to zero will force the algorithm to
 calculate no derivatives.
+
+The algorithm allows user to include number of breaking points which
+will enable the algorithm to execute functions with large number of
+spikes or noise. With the control of number of breaking points, user
+will be able to execute :ref:`SplineSmoothing <algm-SplineSmoothing-v1>`
+algorithm in small period of time. The lower breaking points number is
+set the faster algorithm will execute the function but it will not
+produce high quality smoothing function. By inserting high number of
+breaking points, a detailed smoothing function can also be produced.
+
+Users are also able to successfully apply the algorithm to a workspace
+with multiple spectrums, which would generate an output of workspace
+with multiple spectrums of :ref:`SplineSmoothing <algm-SplineSmoothing-v1>`
+algorithm. `BSpline <http://www.mantidproject.org/BSpline>`_
+can be used to help you understand break-points in further detail. 
+
 
 For Histogram Workspaces
 ########################


### PR DESCRIPTION
Fixes #13335

The algorithm now allows user to include number of breaking points which will enable the algorithm to execute functions with large number of spikes or noise. The lower breaking points number set the faster algorithm will execute the function but obviously wont produce high quality smoothing graph.

_Also updated the SplineSmoothing-v1 documentation_

**To Test:**
Take the first spectrum of the file `ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs` which can be found in `Data/DocTest`

Apply the algorithm [`SplineSmoothing`](http://docs.mantidproject.org/nightly/algorithms/SplineSmoothing-v1.html).
set `MaxNumberOfBreaks` to: **20**
