### PR TITLE
Fix Cut then Scale in the VSI

### DIFF
--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/vtkScaleWorkspace.h
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewFilters/ScaleWorkspace/vtkScaleWorkspace.h
@@ -24,6 +24,7 @@ protected:
   ~vtkScaleWorkspace();
   int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
   int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
+  int FillInputPortInformation (int port, vtkInformation *info);
 
 private:
   vtkScaleWorkspace(const vtkScaleWorkspace&);


### PR DESCRIPTION
Fixes #12368

**Context**

The VSI produced an error when the user tried to first use the Cut filter and then the Scale filter. This is because the output of the Cut filter is Polydata and the Scale filter requires vtkUnstructuredGrid data.
## For testing

Please find the test data here: \olympic\Babylon5\Scratch\Anton\VSI\12368_cut_then_scale

The folder also contains a Windows installer with the proposed changes.

Perform the following test with both the MDEvent data set and the MDHisto data set

**Cut and Scale the sample workspace**
1. Load the data set into the VSI
2. Press the Cut filter button, select a slice plane  and press apply
3. Press the Scale filter button, set the scaling values and press apply.
   - Confirm that no error appears
   - Confirm that the data set is both sliced and scaled
4. Remove the scale filter
5. Remove the cut filter
6. Apply the scale filter with some settings
7. Apply the cut filter
   - Confirm that no error occurs
   - Confirm that the data set is both sliced and scaled

Release note [update](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_UI_Changes&diff=24946&oldid=24930)
