### PR TITLE
correct workspace index vs spectra number ambiguitities

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/VesuvioResolution.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/VesuvioResolution.py
@@ -7,7 +7,7 @@ import mantid
 
 class VesuvioResolution(PythonAlgorithm):
 
-    _spectrum_index = None
+    _workspace_index = None
     _mass = None
 
     def category(self):
@@ -22,8 +22,8 @@ class VesuvioResolution(PythonAlgorithm):
                                                direction=Direction.Input),
                              doc='Sample workspace')
 
-        self.declareProperty(name='SpectrumIndex', defaultValue=0,
-                             doc='Spectra index to use for resolution')
+        self.declareProperty(name='WorkspaceIndex', defaultValue=0,
+                             doc='Workspace index to use for resolution')
 
         self.declareProperty(name='Mass', defaultValue=100.0,
                              doc='The mass defining the recoil peak in AMU')
@@ -49,10 +49,10 @@ class VesuvioResolution(PythonAlgorithm):
         issues = dict()
 
         sample_ws = self.getProperty('Workspace').value
-        spectrum_index = self.getProperty('SpectrumIndex').value
+        workspace_index = self.getProperty('WorkspaceIndex').value
 
-        if spectrum_index > sample_ws.getNumberHistograms() - 1:
-            issues['SpectrumIndex'] = 'Spectrum index is out of range'
+        if workspace_index > sample_ws.getNumberHistograms() - 1:
+            issues['WorkspaceIndex'] = 'Workspace index is out of range'
 
         out_ws_tof = self.getPropertyValue('OutputWorkspaceTOF')
         out_ws_ysp = self.getPropertyValue('OutputWorkspaceYSpace')
@@ -72,7 +72,7 @@ class VesuvioResolution(PythonAlgorithm):
         sample_ws = self.getProperty('Workspace').value
         out_ws_tof = self.getPropertyValue('OutputWorkspaceTOF')
         out_ws_ysp = self.getPropertyValue('OutputWorkspaceYSpace')
-        self._spectrum_index = self.getProperty('SpectrumIndex').value
+        self._workspace_index = self.getProperty('WorkspaceIndex').value
         self._mass = self.getProperty('Mass').value
 
         output_tof = (out_ws_tof != '')
@@ -116,7 +116,7 @@ class VesuvioResolution(PythonAlgorithm):
         fit.setChild(True)
         mantid.simpleapi.set_properties(fit, function, InputWorkspace=workspace, MaxIterations=0,
                                         CreateOutput=True, Output=fit_naming_stem,
-                                        WorkspaceIndex=self._spectrum_index,
+                                        WorkspaceIndex=self._workspace_index,
                                         OutputCompositeMembers=True)
         fit.execute()
         fit_ws = fit.getProperty('OutputWorkspace').value

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioResolutionTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioResolutionTest.py
@@ -36,13 +36,13 @@ class VesuvioResolutionTest(unittest.TestCase):
                           Workspace=self._sample_ws, Mass=1.0079)
 
 
-    def test_spec_index_validation(self):
+    def test_ws_index_validation(self):
         """
-        Tests that validation fails if spectra index is out of range.
+        Tests that validation fails if ws index is out of range.
         """
 
         self.assertRaises(RuntimeError, VesuvioResolution,
-                          Workspace=self._sample_ws, Mass=1.0079, SpectrumIndex=50)
+                          Workspace=self._sample_ws, Mass=1.0079, WorkspaceIndex=50)
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/docs/source/algorithms/GetDetOffsetsMultiPeaks-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/GetDetOffsetsMultiPeaks-v1.rst
@@ -88,7 +88,7 @@ FitwindowTableWorkspace contains the fit window for each individual peak in the 
 to find.
 It contains :math:`1+2\times N` columns, where N is the number of peaks positions specified in 'DReference'.
 
-- Column 0: spectrum number (workspace index) :math:`iws`.  If :math:`iws < 0`, then it is a 'universal' spectrum;
+- Column 0: spectrum number :math:`spNum`.  If :math:`spNum < 0`, then it is a 'universal' spectrum;
 - Column :math:`2i+1`: left boundary of peak :math:`i` defined in 'DReference' of spectrum :math:`iws`;
 - Column :math:`2i+2`: right boundary of peak :math:`i` defined in 'DReference' of spectrum :math:`iws`;
 
@@ -123,13 +123,13 @@ much fewer events received, i.e., poorer signal.
 :math:`\chi^2` of the offset fitting function
 #############################################
 
-The goodness of fit, :math:`\chi^2_{iws}`, of the offset fitting
+The goodness of fit, :math:`\chi^2_{spNum}`, of the offset fitting
 function
 
 .. math:: \sum_{p} |X_{0, p} - (1+offset)X_{0, p}|\cdot H^2_{p}
 
 is an important measure of fitting quality on each spectrum (indexed as
-iws).
+spNum).
 
 Deviation of highest peaks
 ##########################
@@ -161,7 +161,7 @@ has not been implemented yet.
 On the other hand, since GetDetOffsetsMultiPeaks always operates on an
 EventWorkspace with thousands or several ten thousands of spectra, it is
 very hard to tell the quality of fitting by looking at
-:math:`\chi^2_{iws}` of all spectra. Hence, Here are two other
+:math:`\chi^2_{spNum}` of all spectra. Hence, Here are two other
 parameters are defined for comparison of results.
 
     :math:`g_1 = \frac{\sum_{s}D_{s}^2}{N_{nm}}`

--- a/Code/Mantid/docs/source/algorithms/GroupDetectors-v2.rst
+++ b/Code/Mantid/docs/source/algorithms/GroupDetectors-v2.rst
@@ -12,7 +12,7 @@ Description
 This algorithm sums, bin-by-bin, multiple spectra into a single spectra.
 The errors are summed in quadrature and the algorithm checks that the
 bin boundaries in X are the same. The new summed spectra are created at
-the start of the output workspace and have spectra index numbers that
+the start of the output workspace and have spectra numbers that
 start at zero and increase in the order the groups are specified. All
 detectors from the grouped spectra will be moved to belong to the new
 spectrum.


### PR DESCRIPTION
All rst based documentation checked:
- 1st pass regexes for files containing both spectra number and workspace index
- 2nd pass visual inspection of all 1st pass files

fixes #12069

release notes
added the following lines
- Several areas of the documentation have been improved to remove inconsistent use of Spectrum number and workspace index.
- VesuvioResolution the SpectrumIndex parameter has been renamed to WorkspaceIndex
### To test
1. take a look at the corrected files, they should make sense

This includes an input parameter change to the VesuvioResolution algorithm, however this is known to either be unused, or very rarely used and was requested by an instrument scientist who has since left, so no need to follow up further on this.
