### PR TITLE
Added aliases into the alg search box

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/AlgorithmFactory.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/AlgorithmFactory.h
@@ -18,6 +18,7 @@ namespace API {
 /// version.
 struct Algorithm_descriptor {
   std::string name;     ///< name
+  std::string alias;    ///< alias
   std::string category; ///< category
   int version;          ///< version
 };

--- a/Code/Mantid/Framework/API/src/AlgorithmFactory.cpp
+++ b/Code/Mantid/Framework/API/src/AlgorithmFactory.cpp
@@ -350,6 +350,7 @@ AlgorithmFactoryImpl::getDescriptors(bool includeHidden) const {
 
     boost::shared_ptr<IAlgorithm> alg = create(desc.name, desc.version);
     std::vector<std::string> categories = alg->categories();
+    desc.alias = alg->alias();
 
     // For each category
     auto itCategoriesEnd = categories.end();

--- a/Code/Mantid/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Code/Mantid/Framework/API/test/AlgorithmFactoryTest.h
@@ -25,7 +25,7 @@ public:
   {
     Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>* newTwo = new Mantid::Kernel::Instantiator<ToyAlgorithmTwo, Algorithm>;
     
-    //get the nubmer of algorithms it already has
+    //get the number of algorithms it already has
     std::vector<std::string> keys = AlgorithmFactory::Instance().getKeys();
     size_t noOfAlgs = keys.size();
 
@@ -34,7 +34,7 @@ public:
 
     TS_ASSERT_THROWS_ANYTHING(AlgorithmFactory::Instance().subscribe<ToyAlgorithm>());
    
-    //get the nubmer of algorithms it has now
+    //get the number of algorithms it has now
     keys = AlgorithmFactory::Instance().getKeys();
     size_t noOfAlgsAfter = keys.size();
     TS_ASSERT_EQUALS(noOfAlgsAfter, noOfAlgs + 2);
@@ -160,7 +160,10 @@ public:
     bool foundAlg = false;
     while (descItr != descriptors.end() && !foundAlg)
     {
-      foundAlg = ("Cat" == descItr->category)&&("ToyAlgorithm" == descItr->name)&&(1 == descItr->version);
+      foundAlg = ("Cat" == descItr->category) &&
+        ("ToyAlgorithm" == descItr->name) &&
+        ("Dog" == descItr->alias) &&
+        (1 == descItr->version);
       descItr++;
     }
     TS_ASSERT(foundAlg);
@@ -170,7 +173,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(descriptors = AlgorithmFactory::Instance().getDescriptors(true));
 
     TS_ASSERT_EQUALS(noOfAlgs - 1, descriptors.size());
-  }
+  }  
 
   void testGetCategories()
   {

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/AlgorithmSelectorWidget.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/AlgorithmSelectorWidget.h
@@ -5,13 +5,20 @@
 #include "MantidAPI/AlgorithmFactory.h"
 #include "WidgetDllOption.h"
 
+#include <vector>
 #include <Poco/NObserver.h>
 
 #include <QtGui>
-
 //------------------------------------------------------------------------------
 // Forward declaration
 //------------------------------------------------------------------------------
+namespace Mantid
+{
+namespace API
+{
+  struct Algorithm_descriptor;
+}
+}
 namespace MantidQt
 {
 namespace MantidWidgets
@@ -113,6 +120,10 @@ signals:
 
   protected:
     void keyPressEvent(QKeyEvent *e);
+  private:
+    typedef std::vector<Mantid::API::Algorithm_descriptor> AlgNamesType;
+    void addAliases(AlgNamesType& algNamesList);
+    QString stripAlias(const QString& text) const;
   };
 
 


### PR DESCRIPTION
Added entries for aliases into the algorithm search box
### release notes

http://www.mantidproject.org/ReleaseNotes_3_5_UI_Changes#Algorithm_Toolbox

fixes #8120
### To Test
1. Look for some algorithms using the algorithm search text box.
2. Simple duplicates (case insensitive) should not appear
3. you should execute the correct algorithm when selecting an alias
### Sample algorithms with aliases

```
ChangeBinOffset -> OffsetX
Rebin -> rebin (case only)
SofQWNormalisedPolygon -> SofQW3
SofQWPolygon -> SofQW2
Minus -> Subtract
```
