### PR TITLE
11422 allow x to the n scaling in plots

### DIFF
--- a/Code/Mantid/MantidPlot/CMakeLists.txt
+++ b/Code/Mantid/MantidPlot/CMakeLists.txt
@@ -135,6 +135,7 @@ set ( QTIPLOT_SRCS src/ApplicationWindow.cpp
                    src/origin/OPJFile.cpp
                    src/plot2D/ImageSymbol.cpp
                    src/plot2D/ScaleEngine.cpp
+                   src/plot2D/PowerScaleEngine.cpp
                    src/analysis/fft2D.cpp
                    src/lib/src/CollapsiveGroupBox.cpp
                    src/lib/src/ColorBox.cpp
@@ -377,6 +378,7 @@ set ( QTIPLOT_HDRS src/ApplicationWindow.h
                    src/origin/OPJFile.h
                    src/plot2D/ImageSymbol.h
                    src/plot2D/ScaleEngine.h
+                   src/plot2D/PowerScaleEngine.h
                    src/lib/include/CollapsiveGroupBox.h
                    src/lib/include/ColorBox.h
                    src/lib/include/ColorButton.h

--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -11803,7 +11803,7 @@ void ApplicationWindow::analyzeCurve(Graph *g, Analysis operation, const QString
       ScaleEngine *se = dynamic_cast<ScaleEngine *>(g->plotWidget()->axisScaleEngine(c->xAxis()));
       if(se)
       {
-        if(se->type() == QwtScaleTransformation::Log10)
+        if(se->type() == ScaleTransformation::Log10)
           fitter = new LogisticFit (this, g);
         else
           fitter = new SigmoidalFit (this, g);

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1308,6 +1308,18 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
   if (type == GraphOptions::Log10)
   {
     sc_engine->setType(ScaleTransformation::Log10);
+  }
+  else if (type == GraphOptions::Power)
+  {
+    sc_engine->setType(ScaleTransformation::Power);
+  }
+  else
+  {
+    sc_engine->setType(ScaleTransformation::Linear);
+  }
+
+  if (type == GraphOptions::Log10 || type == GraphOptions::Power)
+  {
     if (start <= 0)
     {
       double s_min = DBL_MAX;
@@ -1352,14 +1364,6 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
     }
     // log scales can't represent zero or negative values, 1e-10 is a low number that I hope will be lower than most of the data but is still sensible for many color plots
     //start = start < 1e-90 ? 1e-10 : start;
-  }
-  else if (type == GraphOptions::Power)
-  {
-    sc_engine->setType(ScaleTransformation::Power);
-  }
-  else
-  {
-    sc_engine->setType(ScaleTransformation::Linear);
   }
 
   if (axis == QwtPlot::yRight)

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -420,7 +420,7 @@ bool Graph::isColorBarEnabled(int axis) const
 bool Graph::isLog(const QwtPlot::Axis& axis) const
 {
   ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
-  return ( sc_engine && sc_engine->type() == QwtScaleTransformation::Log10 );
+  return ( sc_engine && sc_engine->type() == ScaleTransformation::Log10 );
 }
 
 ScaleDraw::ScaleType Graph::axisType(int axis)
@@ -1137,7 +1137,7 @@ void Graph::niceLogScales(QwtPlot::Axis axis)
   setScale(axis, start, end, axisStep(axis),
       scDiv->ticks(QwtScaleDiv::MajorTick).count(),
       d_plot->axisMaxMinor(axis),
-      QwtScaleTransformation::Log10,
+      ScaleTransformation::Log10,
       scaleEng->testAttribute(QwtScaleEngine::Inverted),
       scaleEng->axisBreakLeft(),
       scaleEng->axisBreakRight(),
@@ -1184,24 +1184,24 @@ void Graph::setScale(int axis, double start, double end, double step,
 /** Overload of setScale() to that only allows setting the axis type
  *  to linear or log. Does nothing if the scale is already the that type
  *  @param axis :: the scale to change either QwtPlot::xBottom or QwtPlot::yLeft
- *  @param scaleType :: either QwtScaleTransformation::Log10 or ::Linear
+ *  @param scaleType :: either ScaleTransformation::Log10 or ::Linear
  */
-void Graph::setScale(QwtPlot::Axis axis, QwtScaleTransformation::Type scaleType)
+void Graph::setScale(QwtPlot::Axis axis, ScaleTransformation::Type scaleType)
 {
   //check if the scale is already of the desired type, 
   ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
   if (!sc_engine)
     return;
 
-  QwtScaleTransformation::Type type = sc_engine->type();
-  if ( scaleType == QwtScaleTransformation::Log10 )
+  ScaleTransformation::Type type = sc_engine->type();
+  if ( scaleType == ScaleTransformation::Log10 )
   {
-    if ( type ==  QwtScaleTransformation::Log10 )
+    if ( type ==  ScaleTransformation::Log10 )
     {
       return;
     }
   }
-  else if ( type == QwtScaleTransformation::Linear )
+  else if ( type == ScaleTransformation::Linear )
   {
     return;
   }
@@ -1237,51 +1237,51 @@ void Graph::setScale(QwtPlot::Axis axis, QString logOrLin)
 {
   if ( logOrLin == "log" )
   {
-    setScale(axis, QwtScaleTransformation::Log10);
+    setScale(axis, ScaleTransformation::Log10);
   }
   else if ( logOrLin == "linear" )
   {
-    setScale(axis, QwtScaleTransformation::Linear);
+    setScale(axis, ScaleTransformation::Linear);
   }
 }
 
 void Graph::logLogAxes()
 {
-  setScale(QwtPlot::xBottom, QwtScaleTransformation::Log10);
-  setScale(QwtPlot::yLeft, QwtScaleTransformation::Log10);
+  setScale(QwtPlot::xBottom, ScaleTransformation::Log10);
+  setScale(QwtPlot::yLeft, ScaleTransformation::Log10);
   notifyChanges();
 }
 
 void Graph::logXLinY()
 {
-  setScale(QwtPlot::xBottom, QwtScaleTransformation::Log10);
-  setScale(QwtPlot::yLeft, QwtScaleTransformation::Linear);
+  setScale(QwtPlot::xBottom, ScaleTransformation::Log10);
+  setScale(QwtPlot::yLeft, ScaleTransformation::Linear);
   notifyChanges();
 }
 
 void Graph::logYlinX()
 {
-  setScale(QwtPlot::xBottom, QwtScaleTransformation::Linear);
-  setScale(QwtPlot::yLeft, QwtScaleTransformation::Log10);
+  setScale(QwtPlot::xBottom, ScaleTransformation::Linear);
+  setScale(QwtPlot::yLeft, ScaleTransformation::Log10);
   notifyChanges();
 }
 
 void Graph::linearAxes()
 {
-  setScale(QwtPlot::xBottom, QwtScaleTransformation::Linear);
-  setScale(QwtPlot::yLeft, QwtScaleTransformation::Linear);
+  setScale(QwtPlot::xBottom, ScaleTransformation::Linear);
+  setScale(QwtPlot::yLeft, ScaleTransformation::Linear);
   notifyChanges();
 }
 
 void Graph::logColor()
 {
-  setScale(QwtPlot::yRight, QwtScaleTransformation::Log10);
+  setScale(QwtPlot::yRight, ScaleTransformation::Log10);
   notifyChanges();
 }
 
 void Graph::linColor()
 {
-  setScale(QwtPlot::yRight, QwtScaleTransformation::Linear);
+  setScale(QwtPlot::yRight, ScaleTransformation::Linear);
   notifyChanges();
 }
 
@@ -1292,7 +1292,7 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
   if(!sc_engine)
     return;
 
-  QwtScaleTransformation::Type old_type = sc_engine->type();
+  ScaleTransformation::Type old_type = sc_engine->type();
 
   // If not specified, keep the same as now
   if( type < 0 ) type = axisType(axis);
@@ -1300,12 +1300,12 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
   if (type != old_type)
   {
     // recalculate boundingRect of MantidCurves
-    emit axisScaleChanged(axis,type == QwtScaleTransformation::Log10);
+    emit axisScaleChanged(axis,type == ScaleTransformation::Log10);
   }
 
   if (type == GraphOptions::Log10)
   {
-    sc_engine->setType(QwtScaleTransformation::Log10);
+    sc_engine->setType(ScaleTransformation::Log10);
     if (start <= 0)
     {
       double s_min = DBL_MAX;
@@ -1353,7 +1353,7 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
   }
   else
   {
-    sc_engine->setType(QwtScaleTransformation::Linear);
+    sc_engine->setType(ScaleTransformation::Linear);
   }
 
   if (axis == QwtPlot::yRight)
@@ -1369,7 +1369,7 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
           QwtScaleWidget *rightAxis = d_plot->axisWidget(QwtPlot::yRight);
           if(rightAxis)
           {
-            if (type == QwtScaleTransformation::Log10 && (start <= 0 || start == DBL_MAX))
+            if (type == ScaleTransformation::Log10 && (start <= 0 || start == DBL_MAX))
             {
               start = sp->getMinPositiveValue();
             }

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1318,7 +1318,7 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
     sc_engine->setType(ScaleTransformation::Linear);
   }
 
-  if (type == GraphOptions::Log10 || type == GraphOptions::Power)
+  if (type == GraphOptions::Log10)
   {
     if (start <= 0)
     {
@@ -1364,6 +1364,53 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
     }
     // log scales can't represent zero or negative values, 1e-10 is a low number that I hope will be lower than most of the data but is still sensible for many color plots
     //start = start < 1e-90 ? 1e-10 : start;
+  }
+  else if (type == GraphOptions::Power)
+  {
+    g_log.debug() << "Axis type is: " << axis << std::endl;
+    g_log.debug() << "Start is: " << start << std::endl;
+    if (start <= 0)
+    {
+      double s_min = DBL_MAX;
+      // for the y axis rely on the bounding rects
+      for(int i=0;i<curves();++i)
+      {
+        QwtPlotCurve* c = curve(i);
+        if (c)
+        {
+          double s;
+          if (axis == QwtPlot::yRight || axis == QwtPlot::yLeft)
+          {
+            s = c->boundingRect().y();
+          }
+          else
+          {
+            s = c->boundingRect().x();
+          }
+          if (s > 0 && s < s_min)
+          {
+            s_min = s;
+          }
+        }
+      }
+
+      if (s_min != DBL_MAX && s_min > 0)
+      {
+        start = s_min;
+      }
+      else
+      {
+        if (end <= 0)
+        {
+          start = 1;
+          end = 1000;
+        }
+        else
+        {
+          start = 0.01 * end;
+        }
+      }
+    }
   }
 
   if (axis == QwtPlot::yRight)

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1152,7 +1152,8 @@ void Graph::setScale(int axis, double start, double end, double step,
     int majorTicks, int minorTicks, int type, bool inverted,
     double left_break, double right_break, int breakPos,
     double stepBeforeBreak, double stepAfterBreak, int minTicksBeforeBreak,
-    int minTicksAfterBreak, bool log10AfterBreak, int breakWidth, bool breakDecoration)
+    int minTicksAfterBreak, bool log10AfterBreak, int breakWidth,
+    bool breakDecoration, double nth_power)
 {
   if (ScaleEngine* se = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis))){
     se->setBreakRegion(left_break, right_break);
@@ -1165,6 +1166,7 @@ void Graph::setScale(int axis, double start, double end, double step,
     se->setMinTicksAfterBreak(minTicksAfterBreak);
     se->setLog10ScaleAfterBreak(log10AfterBreak);
     se->setAttribute(QwtScaleEngine::Inverted, inverted);
+    se->setNthPower(nth_power);
   }
 
   setAxisScale(axis, start, end, type, step, majorTicks, minorTicks);

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1367,9 +1367,7 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
   }
   else if (type == GraphOptions::Power)
   {
-    g_log.debug() << "Axis type is: " << axis << std::endl;
-    g_log.debug() << "Start is: " << start << std::endl;
-    if (start <= 0)
+    if (start <= 0 && sc_engine->nthPower() < 0)
     {
       double s_min = DBL_MAX;
       // for the y axis rely on the bounding rects
@@ -1400,15 +1398,15 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
       }
       else
       {
-        if (end <= 0)
-        {
-          start = 1;
-          end = 1000;
-        }
-        else
-        {
-          start = 0.01 * end;
-        }
+        start = 0.01 * end;
+      }
+      if (start == 0)
+      {
+        start = 0.01 * end;
+      }
+      else if (end == 0)
+      {
+        end = 0.01 * start;
       }
     }
   }

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1351,6 +1351,10 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
     // log scales can't represent zero or negative values, 1e-10 is a low number that I hope will be lower than most of the data but is still sensible for many color plots
     //start = start < 1e-90 ? 1e-10 : start;
   }
+  else if (type == GraphOptions::Power)
+  {
+    sc_engine->setType(ScaleTransformation::Power);
+  }
   else
   {
     sc_engine->setType(ScaleTransformation::Linear);

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1367,7 +1367,8 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
   }
   else if (type == GraphOptions::Power)
   {
-    if (start <= 0 && sc_engine->nthPower() < 0)
+    double const nth_power = sc_engine->nthPower();
+    if (start <= 0 && nth_power < 0)
     {
       double s_min = DBL_MAX;
       // for the y axis rely on the bounding rects
@@ -1407,6 +1408,18 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
       else if (end == 0)
       {
         end = 0.01 * start;
+      }
+    }
+    // If n is +ve even integer then negative scale values are not valid
+    // so set start of axis to 0
+    if (start < 0 &&
+      std::floor(nth_power) == nth_power &&
+      (long)nth_power % 2 == 0)
+    {
+      start = 0;
+      if (end < 0)
+      {
+        end = 1;
       }
     }
   }

--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1387,14 +1387,14 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
           {
             s = c->boundingRect().x();
           }
-          if (s > 0 && s < s_min)
+          if (s < s_min)
           {
             s_min = s;
           }
         }
       }
 
-      if (s_min != DBL_MAX && s_min > 0)
+      if (s_min != DBL_MAX)
       {
         start = s_min;
       }

--- a/Code/Mantid/MantidPlot/src/Graph.h
+++ b/Code/Mantid/MantidPlot/src/Graph.h
@@ -53,6 +53,7 @@
 #include "MultiLayer.h"
 #include "ScaleDraw.h"
 #include "MantidQtAPI/GraphOptions.h"
+#include "plot2D/ScaleEngine.h"
 #include <boost/shared_ptr.hpp>
 #include <set>
 
@@ -365,7 +366,7 @@ public slots:
                 double left_break = -DBL_MAX, double right_break = DBL_MAX, int pos = 50,
                 double stepBeforeBreak = 0.0, double stepAfterBreak = 0.0, int minTicksBeforeBreak = 4,
                 int minTicksAfterBreak = 4, bool log10AfterBreak = false, int breakWidth = 4, bool breakDecoration = true);
-  void setScale(QwtPlot::Axis axis, QwtScaleTransformation::Type scaleType);
+  void setScale(QwtPlot::Axis axis, ScaleTransformation::Type scaleType);
   void setScale(QwtPlot::Axis axis, QString logOrLin);
   double axisStep(int axis){return d_user_step[axis];};
   //! Set the axis scale

--- a/Code/Mantid/MantidPlot/src/Graph.h
+++ b/Code/Mantid/MantidPlot/src/Graph.h
@@ -365,7 +365,8 @@ public slots:
                 int majorTicks = 5, int minorTicks = 5, int type = 0, bool inverted = false,
                 double left_break = -DBL_MAX, double right_break = DBL_MAX, int pos = 50,
                 double stepBeforeBreak = 0.0, double stepAfterBreak = 0.0, int minTicksBeforeBreak = 4,
-                int minTicksAfterBreak = 4, bool log10AfterBreak = false, int breakWidth = 4, bool breakDecoration = true);
+                int minTicksAfterBreak = 4, bool log10AfterBreak = false, int breakWidth = 4,
+                bool breakDecoration = true, double nth_power = 2.0);
   void setScale(QwtPlot::Axis axis, ScaleTransformation::Type scaleType);
   void setScale(QwtPlot::Axis axis, QString logOrLin);
   double axisStep(int axis){return d_user_step[axis];};

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -375,6 +375,7 @@ void ScaleDetails::initWidgets()
       m_chkBreakDecoration->setChecked(sc_engine->hasBreakDecoration());
       m_chkInvert->setChecked(sc_engine->testAttribute(QwtScaleEngine::Inverted));
       m_cmbScaleType->setCurrentItem(scale_type);
+      m_dspnN->setValue(sc_engine->nthPower());
       m_cmbMinorValue->clear();
       if (scale_type == ScaleTransformation::Log10)
       {

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -350,9 +350,9 @@ void ScaleDetails::initWidgets()
       m_dspnStepBeforeBreak->setValue(sc_engine->stepBeforeBreak());
       m_dspnStepAfterBreak->setValue(sc_engine->stepAfterBreak());
 
-      QwtScaleTransformation::Type scale_type = sc_engine->type();
+      ScaleTransformation::Type scale_type = sc_engine->type();
       m_cmbMinorTicksBeforeBreak->clear();
-      if (scale_type == QwtScaleTransformation::Log10)
+      if (scale_type == ScaleTransformation::Log10)
       {
         m_cmbMinorTicksBeforeBreak->addItems(QStringList() << "0" << "2" << "4" << "8");
       }
@@ -368,7 +368,7 @@ void ScaleDetails::initWidgets()
       m_chkInvert->setChecked(sc_engine->testAttribute(QwtScaleEngine::Inverted));
       m_cmbScaleType->setCurrentItem(scale_type);
       m_cmbMinorValue->clear();
-      if (scale_type == QwtScaleTransformation::Log10)
+      if (scale_type == ScaleTransformation::Log10)
       {
         m_cmbMinorValue->addItems(QStringList() << "0" << "2" << "4" << "8");
       }

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -573,7 +573,8 @@ void ScaleDetails::apply()
     m_graph->setScale(m_mappedaxis, start, end, step, m_spnMajorValue->value(), m_cmbMinorValue->currentText().toInt(),
       m_cmbScaleType->currentIndex(), m_chkInvert->isChecked(), breakLeft, breakRight, m_spnBreakPosition->value(),
       m_dspnStepBeforeBreak->value(),m_dspnStepAfterBreak->value(), m_cmbMinorTicksBeforeBreak->currentText().toInt(),
-      m_cmbMinorTicksAfterBreak->currentText().toInt(), m_chkLog10AfterBreak->isChecked(), m_spnBreakWidth->value(), m_chkBreakDecoration->isChecked());
+      m_cmbMinorTicksAfterBreak->currentText().toInt(), m_chkLog10AfterBreak->isChecked(), m_spnBreakWidth->value(),
+      m_chkBreakDecoration->isChecked(), m_dspnN->value());
     m_graph->changeIntensity(true);
     m_graph->notifyChanges();
     m_modified = false;

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -95,6 +95,7 @@ ScaleDetails::ScaleDetails(ApplicationWindow* app, Graph* graph, int mappedaxis,
   m_cmbScaleType = new QComboBox();
   m_cmbScaleType->addItem(tr("linear"));
   m_cmbScaleType->addItem(tr("logarithmic"));
+  m_cmbScaleType->addItem(tr("power (X^n)"));
   middleLayout->addWidget(m_lblScaleTypeLabel, 2, 0);
   middleLayout->addWidget(m_cmbScaleType, 2, 1);
 

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -106,6 +106,10 @@ ScaleDetails::ScaleDetails(ApplicationWindow* app, Graph* graph, int mappedaxis,
   middleLayout->addWidget(m_lblN, 3, 0);
   middleLayout->addWidget(m_dspnN, 3, 1);
 
+  m_lblWarn = new QLabel(tr("Ensure axis and data ranges are\ncompatible with chosen axis scale."));
+  middleLayout->addWidget(m_lblWarn, 4, 0, 1, 2);
+  m_lblWarn->setVisible(false);
+
   m_chkInvert = new QCheckBox();
   m_chkInvert->setText(tr("Inverted"));
   m_chkInvert->setChecked(false);
@@ -638,7 +642,8 @@ void ScaleDetails::checkstep()
 }
 
 /*
- * Enable the "n =" widget if X^n scale type is selected
+ * Enable the "n =" widget and display warning message
+ * if power scale type is selected
  */
 void ScaleDetails::checkscaletype()
 {
@@ -646,10 +651,12 @@ void ScaleDetails::checkscaletype()
   if (m_cmbScaleType->currentIndex() == 2)
   {
     m_dspnN->setEnabled(true);
+    m_lblWarn->setVisible(true);
   }
   else
   {
     m_dspnN->setEnabled(false);
+    m_lblWarn->setVisible(false);
   }
 }
 

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -95,7 +95,7 @@ ScaleDetails::ScaleDetails(ApplicationWindow* app, Graph* graph, int mappedaxis,
   m_cmbScaleType = new QComboBox();
   m_cmbScaleType->addItem(tr("linear"));
   m_cmbScaleType->addItem(tr("logarithmic"));
-  m_cmbScaleType->addItem(tr("power (X^n)"));
+  m_cmbScaleType->addItem(tr("power"));
   middleLayout->addWidget(m_lblScaleTypeLabel, 2, 0);
   middleLayout->addWidget(m_cmbScaleType, 2, 1);
 

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -403,6 +403,7 @@ void ScaleDetails::initWidgets()
     m_spnMajorValue->setValue(lst.count());
 
     checkstep();
+    checkscaletype();
 
     connect(m_grpAxesBreaks,SIGNAL(clicked()), this, SLOT(setModified()));
     connect(m_chkInvert,SIGNAL(clicked()), this, SLOT(setModified()));
@@ -415,8 +416,10 @@ void ScaleDetails::initWidgets()
     connect(m_cmbMinorValue,SIGNAL(currentIndexChanged(int)), this, SLOT(setModified()));
     connect(m_cmbUnit,SIGNAL(currentIndexChanged(int)), this, SLOT(setModified()));
     connect(m_cmbScaleType,SIGNAL(currentIndexChanged(int)), this, SLOT(setModified()));
+    connect(m_cmbScaleType,SIGNAL(currentIndexChanged(int)), this, SLOT(checkscaletype()));
     connect(m_dspnEnd, SIGNAL(valueChanged(double)), this, SLOT(setModified()));
     connect(m_dspnStart, SIGNAL(valueChanged(double)), this, SLOT(setModified()));
+    connect(m_dspnN, SIGNAL(valueChanged(double)), this, SLOT(setModified()));
     connect(m_dspnStep, SIGNAL(valueChanged(double)), this, SLOT(setModified()));
     connect(m_dspnBreakStart, SIGNAL(valueChanged(double)), this, SLOT(setModified()));
     connect(m_dspnStepBeforeBreak, SIGNAL(valueChanged(double)), this, SLOT(setModified()));
@@ -629,6 +632,22 @@ void ScaleDetails::checkstep()
     m_cmbUnit->setEnabled(false);
     m_radMajor->setChecked(true);
     m_spnMajorValue->setEnabled(true);
+  }
+}
+
+/*
+ * Enable the "n =" widget if X^n scale type is selected
+ */
+void ScaleDetails::checkscaletype()
+{
+  // If "power X^n" scale option is selected
+  if (m_cmbScaleType->currentIndex() == 2)
+  {
+    m_dspnN->setEnabled(true);
+  }
+  else
+  {
+    m_dspnN->setEnabled(false);
   }
 }
 

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.cpp
@@ -99,6 +99,13 @@ ScaleDetails::ScaleDetails(ApplicationWindow* app, Graph* graph, int mappedaxis,
   middleLayout->addWidget(m_lblScaleTypeLabel, 2, 0);
   middleLayout->addWidget(m_cmbScaleType, 2, 1);
 
+  m_lblN = new QLabel(tr("n ="));
+  m_dspnN = new DoubleSpinBox();
+  m_dspnN->setLocale(m_app->locale());
+  m_dspnN->setDecimals(m_app->d_graphing_digits);
+  middleLayout->addWidget(m_lblN, 3, 0);
+  middleLayout->addWidget(m_dspnN, 3, 1);
+
   m_chkInvert = new QCheckBox();
   m_chkInvert->setText(tr("Inverted"));
   m_chkInvert->setChecked(false);

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.h
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.h
@@ -81,7 +81,7 @@ private:
   QSpinBox *m_spnMajorValue, *m_spnBreakPosition, *m_spnBreakWidth;
   QGroupBox *m_grpAxesBreaks;
   QComboBox *m_cmbMinorTicksBeforeBreak, *m_cmbMinorTicksAfterBreak, *m_cmbScaleType, *m_cmbMinorValue, *m_cmbUnit;
-  QLabel *m_lblScaleTypeLabel, *m_lblMinorBox, *m_lblStart, *m_lblEnd, *m_lblN;
+  QLabel *m_lblScaleTypeLabel, *m_lblMinorBox, *m_lblStart, *m_lblEnd, *m_lblN, *m_lblWarn;
   QDateTimeEdit *m_dteStartDateTime, *m_dteEndDateTime;
   QTimeEdit *m_timStartTime, *m_timEndTime;
 

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.h
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.h
@@ -74,13 +74,13 @@ private:
   ApplicationWindow* m_app;
   Graph* m_graph;
 
-  DoubleSpinBox *m_dspnEnd, *m_dspnStart, *m_dspnStep, *m_dspnBreakStart, *m_dspnBreakEnd, *m_dspnStepBeforeBreak, *m_dspnStepAfterBreak;
+  DoubleSpinBox *m_dspnEnd, *m_dspnStart, *m_dspnStep, *m_dspnBreakStart, *m_dspnBreakEnd, *m_dspnStepBeforeBreak, *m_dspnStepAfterBreak, *m_dspnN;
   QCheckBox *m_chkInvert, *m_chkLog10AfterBreak, *m_chkBreakDecoration;
   QRadioButton *m_radStep, *m_radMajor;
   QSpinBox *m_spnMajorValue, *m_spnBreakPosition, *m_spnBreakWidth;
   QGroupBox *m_grpAxesBreaks;
   QComboBox *m_cmbMinorTicksBeforeBreak, *m_cmbMinorTicksAfterBreak, *m_cmbScaleType, *m_cmbMinorValue, *m_cmbUnit;
-  QLabel *m_lblScaleTypeLabel, *m_lblMinorBox, *m_lblStart, *m_lblEnd;
+  QLabel *m_lblScaleTypeLabel, *m_lblMinorBox, *m_lblStart, *m_lblEnd, *m_lblN;
   QDateTimeEdit *m_dteStartDateTime, *m_dteEndDateTime;
   QTimeEdit *m_timStartTime, *m_timEndTime;
 

--- a/Code/Mantid/MantidPlot/src/ScaleDetails.h
+++ b/Code/Mantid/MantidPlot/src/ScaleDetails.h
@@ -67,6 +67,7 @@ private slots:
   void radiosSwitched();
   void setModified();
   void recalcStepMin();
+  void checkscaletype();
 
 private:
   bool m_modified, m_initialised;

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -28,6 +28,7 @@
  ***************************************************************************/
 
 #include "PowerScaleEngine.h"
+#include "ScaleEngine.h"
 
 /*!
   Return a dummy transformation

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -141,6 +141,16 @@ void PowerScaleEngine::buildTicks(
     for ( int i = 0; i < QwtScaleDiv::NTickTypes; i++ )
     {
         ticks[i] = strip(ticks[i], interval);
+
+        // ticks very close to 0.0 are
+        // explicitly set to 0.0
+        // important if nth_power is set to -ve value
+
+        for ( int j = 0; j < (int)ticks[i].count(); j++ )
+        {
+            if ( QwtScaleArithmetic::compareEps(ticks[i][j], 0.0, stepSize) == 0 )
+                ticks[i][j] = 0.0;
+        }
     }
 }
 

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -1,0 +1,258 @@
+/***************************************************************************
+    File                 : PowerScaleEngine.cpp
+    Project              : QtiPlot
+    --------------------------------------------------------------------
+    Copyright            : (C) 2009 by Ion Vasilief
+    Email (use @ for *)  : ion_vasilief*yahoo.fr
+    Description          : Return a transformation for reciprocal (1/t) scales
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *  This program is free software; you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation; either version 2 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the Free Software           *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                    *
+ *   Boston, MA  02110-1301  USA                                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PowerScaleEngine.h"
+
+/*!
+  Return a dummy transformation
+*/
+QwtScaleTransformation *PowerScaleEngine::transformation() const
+{
+    return new QwtScaleTransformation(QwtScaleTransformation::Other);
+}
+
+/*!
+    Align and divide an interval
+
+   \param maxNumSteps Max. number of steps
+   \param x1 First limit of the interval (In/Out)
+   \param x2 Second limit of the interval (In/Out)
+   \param stepSize Step size (Out)
+*/
+void PowerScaleEngine::autoScale(int maxNumSteps,
+    double &x1, double &x2, double &stepSize) const
+{
+    QwtDoubleInterval interval(x1, x2);
+    interval = interval.normalized();
+
+    interval.setMinValue(interval.minValue() - lowerMargin());
+    interval.setMaxValue(interval.maxValue() + upperMargin());
+
+    if (testAttribute(QwtScaleEngine::Symmetric))
+        interval = interval.symmetrize(reference());
+
+    if (testAttribute(QwtScaleEngine::IncludeReference))
+        interval = interval.extend(reference());
+
+    if (interval.width() == 0.0)
+        interval = buildInterval(interval.minValue());
+
+    stepSize = divideInterval(interval.width(), qwtMax(maxNumSteps, 1));
+
+    if ( !testAttribute(QwtScaleEngine::Floating) )
+        interval = align(interval, stepSize);
+
+    x1 = interval.minValue();
+    x2 = interval.maxValue();
+
+    if (testAttribute(QwtScaleEngine::Inverted))
+    {
+        qSwap(x1, x2);
+        stepSize = -stepSize;
+    }
+}
+
+/*!
+   \brief Calculate a scale division
+
+   \param x1 First interval limit
+   \param x2 Second interval limit
+   \param maxMajSteps Maximum for the number of major steps
+   \param maxMinSteps Maximum number of minor steps
+   \param stepSize Step size. If stepSize == 0, the scaleEngine
+                   calculates one.
+
+   \sa QwtScaleEngine::stepSize(), QwtScaleEngine::subDivide()
+*/
+QwtScaleDiv PowerScaleEngine::divideScale(double x1, double x2,
+    int maxMajSteps, int maxMinSteps, double stepSize) const
+{
+    QwtDoubleInterval interval = QwtDoubleInterval(x1, x2).normalized();
+    if (interval.width() <= 0 )
+        return QwtScaleDiv();
+
+    stepSize = qwtAbs(stepSize);
+    if ( stepSize == 0.0 )
+    {
+        if ( maxMajSteps < 1 )
+            maxMajSteps = 1;
+
+        stepSize = divideInterval(interval.width(), maxMajSteps);
+    }
+
+    QwtScaleDiv scaleDiv;
+
+    if ( stepSize != 0.0 )
+    {
+        QwtValueList ticks[QwtScaleDiv::NTickTypes];
+        buildTicks(interval, stepSize, maxMinSteps, ticks);
+
+        scaleDiv = QwtScaleDiv(interval, ticks);
+    }
+
+    if ( x1 > x2 )
+        scaleDiv.invert();
+
+    return scaleDiv;
+}
+
+void PowerScaleEngine::buildTicks(
+    const QwtDoubleInterval& interval, double stepSize, int maxMinSteps,
+    QwtValueList ticks[QwtScaleDiv::NTickTypes]) const
+{
+    const QwtDoubleInterval boundingInterval =
+        align(interval, stepSize);
+
+    ticks[QwtScaleDiv::MajorTick] =
+        buildMajorTicks(boundingInterval, stepSize);
+
+    if ( maxMinSteps > 0 )
+    {
+        buildMinorTicks(ticks[QwtScaleDiv::MajorTick], maxMinSteps, stepSize,
+            ticks[QwtScaleDiv::MinorTick], ticks[QwtScaleDiv::MediumTick]);
+    }
+
+    for ( int i = 0; i < QwtScaleDiv::NTickTypes; i++ )
+    {
+        ticks[i] = strip(ticks[i], interval);
+
+        // ticks very close to 0.0 are
+        // explicitely set to 0.0
+
+        for ( int j = 0; j < (int)ticks[i].count(); j++ )
+        {
+            if ( QwtScaleArithmetic::compareEps(ticks[i][j], 0.0, stepSize) == 0 )
+                ticks[i][j] = 0.0;
+        }
+    }
+}
+
+QwtValueList PowerScaleEngine::buildMajorTicks(
+    const QwtDoubleInterval &interval, double stepSize) const
+{
+    int numTicks = qRound(interval.width() / stepSize) + 1;
+    if ( numTicks > 10000 )
+        numTicks = 10000;
+
+    QwtValueList ticks;
+
+    ticks += interval.minValue();
+    for (int i = 1; i < numTicks - 1; i++)
+        ticks += interval.minValue() + i * stepSize;
+    ticks += interval.maxValue();
+
+    return ticks;
+}
+
+void PowerScaleEngine::buildMinorTicks(
+    const QwtValueList& majorTicks,
+    int maxMinSteps, double stepSize,
+    QwtValueList &minorTicks,
+    QwtValueList &mediumTicks) const
+{
+    double minStep = divideInterval(stepSize, maxMinSteps);
+    if (minStep == 0.0)
+        return;
+
+    // # ticks per interval
+    int numTicks = (int)::ceil(qwtAbs(stepSize / minStep)) - 1;
+
+    // Do the minor steps fit into the interval?
+    if ( QwtScaleArithmetic::compareEps((numTicks +  1) * qwtAbs(minStep),
+        qwtAbs(stepSize), stepSize) > 0)
+    {
+        numTicks = 1;
+        minStep = stepSize * 0.5;
+    }
+
+    int medIndex = -1;
+    if ( numTicks % 2 )
+        medIndex = numTicks / 2;
+
+    // calculate minor ticks
+
+    for (int i = 0; i < (int)majorTicks.count(); i++)
+    {
+        double val = majorTicks[i];
+        for (int k = 0; k < numTicks; k++)
+        {
+            val += minStep;
+
+            double alignedValue = val;
+            if (QwtScaleArithmetic::compareEps(val, 0.0, stepSize) == 0)
+                alignedValue = 0.0;
+
+            if ( k == medIndex )
+                mediumTicks += alignedValue;
+            else
+                minorTicks += alignedValue;
+        }
+    }
+}
+
+/*!
+  \brief Align an interval to a step size
+
+  The limits of an interval are aligned that both are integer
+  multiples of the step size.
+
+  \param interval Interval
+  \param stepSize Step size
+
+  \return Aligned interval
+*/
+QwtDoubleInterval PowerScaleEngine::align(
+    const QwtDoubleInterval &interval, double stepSize) const
+{
+    const double x1 =
+        QwtScaleArithmetic::floorEps(interval.minValue(), stepSize);
+    const double x2 =
+        QwtScaleArithmetic::ceilEps(interval.maxValue(), stepSize);
+
+    return QwtDoubleInterval(x1, x2);
+}
+
+//! Create a clone of the transformation
+QwtScaleTransformation *PowerScaleTransformation::copy() const
+{
+	return new PowerScaleTransformation(d_engine);
+}
+
+double PowerScaleTransformation::xForm(
+    double s, double s1, double s2, double p1, double p2) const
+{
+	return p1 + (p2 - p1) * s2 * (s1 - s)/(s * (s1 - s2));
+}
+
+double PowerScaleTransformation::invXForm(double p, double p1, double p2,
+    double s1, double s2) const
+{
+	return s1*s2*(p2 - p1)/(s2*(p2 - p) + s1*(p - p1));
+}
+

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -28,7 +28,6 @@
  ***************************************************************************/
 
 #include "PowerScaleEngine.h"
-#include "ScaleEngine.h"
 
 /*!
   Return a dummy transformation
@@ -37,6 +36,8 @@ QwtScaleTransformation *PowerScaleEngine::transformation() const
 {
     return new QwtScaleTransformation(QwtScaleTransformation::Other);
 }
+
+PowerScaleEngine::~PowerScaleEngine() {}
 
 /*!
     Align and divide an interval
@@ -244,6 +245,8 @@ QwtScaleTransformation *PowerScaleTransformation::copy() const
 {
 	return new PowerScaleTransformation(d_engine);
 }
+
+PowerScaleTransformation::~PowerScaleTransformation() {}
 
 /*
  * Transform a value between 2 linear intervals

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -4,7 +4,7 @@
     --------------------------------------------------------------------
     Copyright            : (C) 2009 by Ion Vasilief
     Email (use @ for *)  : ion_vasilief*yahoo.fr
-    Description          : Return a transformation for reciprocal (1/t) scales
+    Description          : Return a transformation for power (X^n) scales
 
  ***************************************************************************/
 
@@ -141,15 +141,6 @@ void PowerScaleEngine::buildTicks(
     for ( int i = 0; i < QwtScaleDiv::NTickTypes; i++ )
     {
         ticks[i] = strip(ticks[i], interval);
-
-        // ticks very close to 0.0 are
-        // explicitely set to 0.0
-
-        for ( int j = 0; j < (int)ticks[i].count(); j++ )
-        {
-            if ( QwtScaleArithmetic::compareEps(ticks[i][j], 0.0, stepSize) == 0 )
-                ticks[i][j] = 0.0;
-        }
     }
 }
 
@@ -244,15 +235,33 @@ QwtScaleTransformation *PowerScaleTransformation::copy() const
 	return new PowerScaleTransformation(d_engine);
 }
 
+/*
+ * Transform a value between 2 linear intervals
+ *
+ * \param s value related to the interval [s1, s2]
+ * \param s1 first border of scale interval
+ * \param s2 second border of scale interval
+ * \param p1 first border of target interval
+ * \param p2 second border of target interval
+ */
 double PowerScaleTransformation::xForm(
     double s, double s1, double s2, double p1, double p2) const
 {
-	return p1 + (p2 - p1) * s2 * (s1 - s)/(s * (s1 - s2));
+	return p1 + (p2 - p1) / (pow(s2, nth_power) - pow(s1, nth_power)) * (pow(s, nth_power) - pow(s1, nth_power));
 }
 
+/*
+ * Transform a value from a linear to a power scale interval
+ *
+ * \param p value related to the linear interval [p1, p2]
+ * \param p1 first border of linear interval
+ * \param p2 second border of linear interval
+ * \param s1 first border of logarithmic interval
+ * \param s2 second border of logarithmic interval
+ */
 double PowerScaleTransformation::invXForm(double p, double p1, double p2,
     double s1, double s2) const
 {
-	return s1*s2*(p2 - p1)/(s2*(p2 - p) + s1*(p - p1));
+	return pow((p - p1) / (p2 - p1) * (pow(s2, nth_power) - pow(s1, nth_power)), 1.0/nth_power) * s1;
 }
 

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -28,6 +28,7 @@
  ***************************************************************************/
 
 #include "PowerScaleEngine.h"
+#include "qwt_compat.h"
 
 /*!
   Return a dummy transformation

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -144,7 +144,6 @@ void PowerScaleEngine::buildTicks(
 
         // ticks very close to 0.0 are
         // explicitly set to 0.0
-        // important if nth_power is set to -ve value
 
         for ( int j = 0; j < (int)ticks[i].count(); j++ )
         {

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -4,7 +4,7 @@
     --------------------------------------------------------------------
     Copyright            : (C) 2009 by Ion Vasilief
     Email (use @ for *)  : ion_vasilief*yahoo.fr
-    Description          : Return a transformation for reciprocal (1/t) scales
+    Description          : Return a transformation for power (X^n) scales
 
  ***************************************************************************/
 
@@ -46,7 +46,7 @@ private:
 };
 
 /*!
-  \brief A scale engine for reciprocal (1/t) scales
+  \brief A scale engine for power (X^n) scales
 */
 
 class PowerScaleEngine: public QwtScaleEngine

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -37,7 +37,7 @@
 class PowerScaleTransformation: public ScaleTransformation
 {
 public:
-	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine){nth_power = 2.0;};
+	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine){nth_power = -1.0;};
 	virtual double xForm(double x, double, double, double p1, double p2) const;
 	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
 	QwtScaleTransformation* copy() const;

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -41,6 +41,7 @@ public:
 	virtual double xForm(double x, double, double, double p1, double p2) const;
 	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
 	QwtScaleTransformation* copy() const;
+  virtual ~PowerScaleTransformation();
 private:
   double nth_power;
 };
@@ -60,6 +61,8 @@ public:
         double stepSize = 0.0) const;
 
     virtual QwtScaleTransformation *transformation() const;
+
+    virtual ~PowerScaleEngine();
 
 protected:
     QwtDoubleInterval align(const QwtDoubleInterval&,

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -37,7 +37,7 @@
 class PowerScaleTransformation: public ScaleTransformation
 {
 public:
-	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine){nth_power = -1.0;};
+	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine), nth_power(engine->nthPower()){};
 	virtual double xForm(double x, double, double, double p1, double p2) const;
 	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
 	QwtScaleTransformation* copy() const;

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -37,10 +37,12 @@
 class PowerScaleTransformation: public ScaleTransformation
 {
 public:
-	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine){};
+	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine){nth_power = 2.0;};
 	virtual double xForm(double x, double, double, double p1, double p2) const;
 	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
 	QwtScaleTransformation* copy() const;
+private:
+  double nth_power;
 };
 
 /*!

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -1,0 +1,80 @@
+/***************************************************************************
+    File                 : PowerScaleEngine.h
+    Project              : QtiPlot
+    --------------------------------------------------------------------
+    Copyright            : (C) 2009 by Ion Vasilief
+    Email (use @ for *)  : ion_vasilief*yahoo.fr
+    Description          : Return a transformation for reciprocal (1/t) scales
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *  This program is free software; you can redistribute it and/or modify   *
+ *  it under the terms of the GNU General Public License as published by   *
+ *  the Free Software Foundation; either version 2 of the License, or      *
+ *  (at your option) any later version.                                    *
+ *                                                                         *
+ *  This program is distributed in the hope that it will be useful,        *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *  GNU General Public License for more details.                           *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the Free Software           *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor,                    *
+ *   Boston, MA  02110-1301  USA                                           *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef RECIPROCAL_SCALE_ENGINE_H
+#define RECIPROCAL_SCALE_ENGINE_H
+
+#include <qwt_scale_engine.h>
+#include <qwt_scale_map.h>
+#include "ScaleEngine.h"
+
+class PowerScaleTransformation: public ScaleTransformation
+{
+public:
+	PowerScaleTransformation(const ScaleEngine *engine):ScaleTransformation(engine){};
+	virtual double xForm(double x, double, double, double p1, double p2) const;
+	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
+	QwtScaleTransformation* copy() const;
+};
+
+/*!
+  \brief A scale engine for reciprocal (1/t) scales
+*/
+
+class PowerScaleEngine: public QwtScaleEngine
+{
+public:
+    virtual void autoScale(int maxSteps,
+        double &x1, double &x2, double &stepSize) const;
+
+    virtual QwtScaleDiv divideScale(double x1, double x2,
+        int numMajorSteps, int numMinorSteps,
+        double stepSize = 0.0) const;
+
+    virtual QwtScaleTransformation *transformation() const;
+
+protected:
+    QwtDoubleInterval align(const QwtDoubleInterval&,
+        double stepSize) const;
+
+private:
+    void buildTicks(
+        const QwtDoubleInterval &, double stepSize, int maxMinSteps,
+        QwtValueList ticks[QwtScaleDiv::NTickTypes]) const;
+
+    void buildMinorTicks(
+        const QwtValueList& majorTicks,
+        int maxMinMark, double step,
+        QwtValueList &, QwtValueList &) const;
+
+    QwtValueList buildMajorTicks(
+        const QwtDoubleInterval &interval, double stepSize) const;
+};
+
+#endif

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
@@ -28,6 +28,7 @@
  ***************************************************************************/
 #include "ScaleEngine.h"
 #include "PowerScaleEngine.h"
+#include "qwt_compat.h"
 #include <limits.h>
 
 QwtScaleTransformation* ScaleEngine::transformation() const

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
@@ -213,7 +213,8 @@ d_minor_ticks_before(1),
 d_minor_ticks_after(1),
 d_log10_scale_after(false),
 d_break_width(4),
-d_break_decoration(true)
+d_break_decoration(true),
+d_nth_power(2.0)
 {}
 
 bool ScaleEngine::hasBreak() const
@@ -276,6 +277,11 @@ bool ScaleEngine::hasBreakDecoration() const
 	return d_break_decoration;
 }
 
+double ScaleEngine::nthPower() const
+{
+  return d_nth_power;
+}
+
 void ScaleEngine::clone(const ScaleEngine *engine)
 {
 	d_type = engine->type();
@@ -289,6 +295,7 @@ void ScaleEngine::clone(const ScaleEngine *engine)
 	d_log10_scale_after = engine->log10ScaleAfterBreak();
 	d_break_width = engine->breakWidth();
 	d_break_decoration = engine->hasBreakDecoration();
+  d_nth_power = engine->nthPower();
 	setAttributes(engine->attributes());
 	setMargins(engine->lowerMargin(), engine->upperMargin());
 }

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
@@ -26,8 +26,9 @@
  *   Boston, MA  02110-1301  USA                                           *
  *                                                                         *
  ***************************************************************************/
-#include "qwt_compat.h"
 #include "ScaleEngine.h"
+#include "PowerScaleEngine.h"
+#include <limits.h>
 
 QwtScaleTransformation* ScaleEngine::transformation() const
 {
@@ -36,12 +37,13 @@ QwtScaleTransformation* ScaleEngine::transformation() const
 
 double ScaleTransformation::invXForm(double p, double p1, double p2, double s1, double s2) const
 {
-    if (!d_engine->hasBreak()){
-        QwtScaleTransformation tr(d_engine->type());
-        double res = tr.invXForm(p, p1, p2, s1, s2);
-        return res;
-    }
-	
+	if (!d_engine->hasBreak()){
+		QwtScaleTransformation *tr = newScaleTransformation();
+		double res = tr->invXForm(p, p1, p2, s1, s2);
+		delete tr;
+		return res;
+	}
+
     const int d_break_space = d_engine->breakWidth();
 	const double lb = d_engine->axisBreakLeft();
     const double rb = d_engine->axisBreakRight();
@@ -57,31 +59,31 @@ double ScaleTransformation::invXForm(double p, double p1, double p2, double s1, 
 
 	if (p > pml && p < pmr)
 		return pm;
-	
+
 	bool invertedScale = d_engine->testAttribute(QwtScaleEngine::Inverted);
-	QwtScaleTransformation::Type d_type = d_engine->type();
+	ScaleTransformation::Type d_type = d_engine->type();
 
 	if (invertedScale){
 		if ((p2 > p1 && p <= pml) || (p2 < p1 && p >= pml)){
 			if (d_engine->log10ScaleAfterBreak())
 				return s1*exp((p - p1)/(pml - p1)*log(rb/s1));
-            else 
+            else
 				return s1 + (rb - s1)/(pml - p1)*(p - p1);
 		}
-		
+
 		if ((p2 > p1 && p >= pmr) || (p2 < p1 && p <= pmr)){
-			if (d_type == QwtScaleTransformation::Log10)
+			if (d_type == ScaleTransformation::Log10)
 				return lb * exp((p - pmr)/(p2 - pmr)*log(s2/lb));
-			else if (d_type == QwtScaleTransformation::Linear)
+			else if (d_type == ScaleTransformation::Linear)
 				return lb + (p - pmr)/(p2 - pmr)*(s2 - lb);
 		}
 
 	}
 
     if ((p2 > p1 && p <= pml) || (p2 < p1 && p >= pml)){
-        if (d_type == QwtScaleTransformation::Linear)
+        if (d_type == ScaleTransformation::Linear)
             return s1 + (lb - s1)*(p - p1)/(pml - p1);
-        else if (d_type == QwtScaleTransformation::Log10)
+        else if (d_type == ScaleTransformation::Log10)
             return s1 * exp((p - p1)/(pml - p1)*log(lb/s1));
     }
 
@@ -97,23 +99,23 @@ double ScaleTransformation::invXForm(double p, double p1, double p2, double s1, 
 
 double ScaleTransformation::xForm(double s, double s1, double s2, double p1, double p2) const
 {
-  if ((d_engine->type() != ScaleTransformation::Linear) && s <= 0.0){
-          double maxScreenCoord = 1e4;
-          if (p1 < p2){
-                  if (d_engine->testAttribute(QwtScaleEngine::Inverted))
-                          return maxScreenCoord;
-                  return -DBL_MAX;
-          }
+	if ((d_engine->type() == ScaleTransformation::Log10) && s < 0.0){
+		if (p1 < p2){
+			if (d_engine->testAttribute(QwtScaleEngine::Inverted))
+				return DBL_MAX;
+			return -DBL_MAX;
+		}
 
-          if (d_engine->testAttribute(QwtScaleEngine::Inverted))
-                  return -DBL_MAX;
+		if (d_engine->testAttribute(QwtScaleEngine::Inverted))
+			return -DBL_MAX;
 
-          return maxScreenCoord;
-  }
+		return DBL_MAX;
+	}
 
 	if (!d_engine->hasBreak()){
-		QwtScaleTransformation tr(d_engine->type());
-		double res = tr.xForm(s, s1, s2, p1, p2);
+		QwtScaleTransformation *tr = newScaleTransformation();
+		double res = tr->xForm(s, s1, s2, p1, p2);
+		delete tr;
 		return res;
 	}
 
@@ -134,17 +136,17 @@ double ScaleTransformation::xForm(double s, double s1, double s2, double p1, dou
 		return pm;
 
 	bool invertedScale = d_engine->testAttribute(QwtScaleEngine::Inverted);
-	QwtScaleTransformation::Type d_type = d_engine->type();
+	ScaleTransformation::Type d_type = d_engine->type();
 
 	if (invertedScale){
 		if (s <= lb){
-			if (d_type == QwtScaleTransformation::Linear)
+			if (d_type == ScaleTransformation::Linear)
 				return pmr + (lb - s)/(lb - s2)*(p2 - pmr);
-			else if (d_type == QwtScaleTransformation::Log10){
+			else if (d_type == ScaleTransformation::Log10){
 				return pmr + log(lb/s)/log(lb/s2)*(p2 - pmr);
 			}
 		}
-		
+
 		if (s >= rb){
 			if (d_engine->log10ScaleAfterBreak())
 				return p1 + log(s1/s)/log(s1/rb)*(pml - p1);
@@ -155,9 +157,9 @@ double ScaleTransformation::xForm(double s, double s1, double s2, double p1, dou
 	}
 
     if (s <= lb){
-        if (d_type == QwtScaleTransformation::Linear)
+        if (d_type == ScaleTransformation::Linear)
             return p1 + (s - s1)/(lb - s1)*(pml - p1);
-        else if (d_type == QwtScaleTransformation::Log10)
+        else if (d_type == ScaleTransformation::Log10)
             return p1 + log(s/s1)/log(lb/s1)*(pml - p1);
     }
 
@@ -176,13 +178,31 @@ QwtScaleTransformation *ScaleTransformation::copy() const
     return new ScaleTransformation(d_engine);
 }
 
+QwtScaleTransformation* ScaleTransformation::newScaleTransformation() const
+{
+	QwtScaleTransformation *transform = NULL;
+	switch (d_engine->type()){
+		case ScaleTransformation::Log10:
+			transform = new QwtScaleTransformation(QwtScaleTransformation::Log10);
+		break;
+
+		case ScaleTransformation::Power:
+			transform = new PowerScaleTransformation(d_engine);
+		break;
+
+		case ScaleTransformation::Linear:
+		default:
+			transform = new QwtScaleTransformation (QwtScaleTransformation::Linear);
+	}
+	return transform;
+}
 /*****************************************************************************
  *
  * Class ScaleEngine
  *
  *****************************************************************************/
 
-ScaleEngine::ScaleEngine(QwtScaleTransformation::Type type,double left_break, double right_break): QwtScaleEngine(),
+ScaleEngine::ScaleEngine(ScaleTransformation::Type type,double left_break, double right_break): QwtScaleEngine(),
 d_type(type),
 d_break_left(left_break),
 d_break_right(right_break),
@@ -231,7 +251,7 @@ double ScaleEngine::stepAfterBreak() const
     return d_step_after;
 }
 
-QwtScaleTransformation::Type ScaleEngine::type() const
+ScaleTransformation::Type ScaleEngine::type() const
 {
     return d_type;
 }
@@ -258,19 +278,19 @@ bool ScaleEngine::hasBreakDecoration() const
 
 void ScaleEngine::clone(const ScaleEngine *engine)
 {
-    d_type = engine->type();
+	d_type = engine->type();
 	d_break_left = engine->axisBreakLeft();
 	d_break_right = engine->axisBreakRight();
-    d_break_pos = engine->breakPosition();
+	d_break_pos = engine->breakPosition();
 	d_step_before = engine->stepBeforeBreak();
 	d_step_after = engine->stepAfterBreak();
 	d_minor_ticks_before = engine->minTicksBeforeBreak();
 	d_minor_ticks_after = engine->minTicksAfterBreak();
-    d_log10_scale_after = engine->log10ScaleAfterBreak();
-    d_break_width = engine->breakWidth();
+	d_log10_scale_after = engine->log10ScaleAfterBreak();
+	d_break_width = engine->breakWidth();
 	d_break_decoration = engine->hasBreakDecoration();
 	setAttributes(engine->attributes());
-    setMargins(engine->loMargin(), engine->hiMargin());
+	setMargins(engine->lowerMargin(), engine->upperMargin());
 }
 
 QwtScaleDiv ScaleEngine::divideScale(double x1, double x2, int maxMajSteps,
@@ -278,10 +298,7 @@ QwtScaleDiv ScaleEngine::divideScale(double x1, double x2, int maxMajSteps,
 {
 	QwtScaleEngine *engine;
 	if (!hasBreak()){
-        if (d_type == QwtScaleTransformation::Log10)
-            engine = new QwtLog10ScaleEngine();
-        else
-            engine = new QwtLinearScaleEngine();
+        engine = newScaleEngine();
 		QwtScaleDiv div = engine->divideScale(x1, x2, maxMajSteps, maxMinSteps, stepSize);
 		delete engine;
 		return div;
@@ -300,10 +317,8 @@ QwtScaleDiv ScaleEngine::divideScale(double x1, double x2, int maxMajSteps,
             engine = new QwtLog10ScaleEngine();
         else
             engine = new QwtLinearScaleEngine();
-    } else if (d_type == QwtScaleTransformation::Log10)
-        engine = new QwtLog10ScaleEngine();
-      else
-        engine = new QwtLinearScaleEngine();
+    } else
+		engine = newScaleEngine();
 
     int max_min_intervals = d_minor_ticks_before;
 	if (d_minor_ticks_before == 1)
@@ -320,15 +335,12 @@ QwtScaleDiv ScaleEngine::divideScale(double x1, double x2, int maxMajSteps,
 		max_min_intervals = d_minor_ticks_after + 1;
 
     delete engine;
-    if (testAttribute(QwtScaleEngine::Inverted)){
-        if (d_type == QwtScaleTransformation::Log10)
-            engine = new QwtLog10ScaleEngine();
-        else
-            engine = new QwtLinearScaleEngine();
-    } else if (d_log10_scale_after)
-            engine = new QwtLog10ScaleEngine();
-      else
-            engine = new QwtLinearScaleEngine();
+    if (testAttribute(QwtScaleEngine::Inverted))
+		engine = newScaleEngine();
+    else if (d_log10_scale_after)
+		engine = new QwtLog10ScaleEngine();
+	else
+		engine = new QwtLinearScaleEngine();
 
     QwtScaleDiv div2 = engine->divideScale(rb, x2, maxMajSteps/2, max_min_intervals, step2);
 
@@ -344,33 +356,50 @@ QwtScaleDiv ScaleEngine::divideScale(double x1, double x2, int maxMajSteps,
 void ScaleEngine::autoScale (int maxNumSteps, double &x1, double &x2, double &stepSize) const
 {
 	if (!hasBreak() || testAttribute(QwtScaleEngine::Inverted)){
-		QwtScaleEngine *engine;
-		if (d_type == QwtScaleTransformation::Log10)
-			engine = new QwtLog10ScaleEngine();
-		else
-			engine = new QwtLinearScaleEngine();
-		
+		QwtScaleEngine *engine = newScaleEngine();
 		engine->setAttributes(attributes());
-    	engine->setReference(reference());
-    	engine->setMargins(loMargin(), hiMargin());
+		engine->setReference(reference());
+		engine->setMargins(lowerMargin(), upperMargin());
+
+		if (type() == ScaleTransformation::Log10){
+			if (x1 <= 0.0)
+				x1 = 1e-4;
+			if (x2 <= 0.0)
+				x2 = 1e-3;
+		}
+
 		engine->autoScale(maxNumSteps, x1, x2, stepSize);
 		delete engine;
 	} else {
-		QwtScaleEngine *engine;
-		if (d_type == QwtScaleTransformation::Log10)
-			engine = new QwtLog10ScaleEngine();
-		else
-			engine = new QwtLinearScaleEngine();
-		
+		QwtScaleEngine *engine = newScaleEngine();
 		engine->setAttributes(attributes());
 		double breakLeft = d_break_left;
 		engine->autoScale(maxNumSteps, x1, breakLeft, stepSize);
 		delete engine;
-		
+
 		engine = new QwtLinearScaleEngine();
 		engine->setAttributes(attributes());
 		double breakRight = d_break_right;
 		engine->autoScale(maxNumSteps, breakRight, x2, stepSize);
 		delete engine;
 	}
+}
+
+QwtScaleEngine *ScaleEngine::newScaleEngine() const
+{
+	QwtScaleEngine *engine = NULL;
+	switch (d_type){
+		case ScaleTransformation::Log10:
+			engine = new QwtLog10ScaleEngine();
+		break;
+
+		case ScaleTransformation::Power:
+			engine = new PowerScaleEngine();
+		break;
+
+		case ScaleTransformation::Linear:
+		default:
+			engine = new QwtLinearScaleEngine();
+	}
+	return engine;
 }

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.cpp
@@ -35,6 +35,8 @@ QwtScaleTransformation* ScaleEngine::transformation() const
 	return new ScaleTransformation(this);
 }
 
+ScaleTransformation::~ScaleTransformation() {}
+
 double ScaleTransformation::invXForm(double p, double p1, double p2, double s1, double s2) const
 {
 	if (!d_engine->hasBreak()){
@@ -216,6 +218,8 @@ d_break_width(4),
 d_break_decoration(true),
 d_nth_power(2.0)
 {}
+
+ScaleEngine::~ScaleEngine() {}
 
 bool ScaleEngine::hasBreak() const
 {

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.h
@@ -44,6 +44,7 @@ public:
 	virtual double xForm(double x, double, double, double p1, double p2) const;
 	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
 	QwtScaleTransformation* copy() const;
+  virtual ~ScaleTransformation();
 
 protected:
 	QwtScaleTransformation* newScaleTransformation() const;
@@ -56,6 +57,9 @@ class ScaleEngine: public QwtScaleEngine
 public:
 	ScaleEngine(ScaleTransformation::Type type = ScaleTransformation::Linear,
 				double left_break = -DBL_MAX, double right_break = DBL_MAX);
+
+  virtual ~ScaleEngine();
+
 	QwtScaleTransformation* transformation() const;
 	virtual QwtScaleDiv divideScale(double x1, double x2, int maxMajSteps,
 		int maxMinSteps, double stepSize = 0.0) const;

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.h
@@ -33,10 +33,28 @@
 #include <qwt_scale_map.h>
 #include <float.h>
 
+class ScaleEngine;
+
+class ScaleTransformation: public QwtScaleTransformation
+{
+public:
+	enum Type{Linear, Log10, Power};
+
+	ScaleTransformation(const ScaleEngine *engine):QwtScaleTransformation(Other), d_engine(engine){};
+	virtual double xForm(double x, double, double, double p1, double p2) const;
+	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
+	QwtScaleTransformation* copy() const;
+
+protected:
+	QwtScaleTransformation* newScaleTransformation() const;
+    //! The scale engine that generates the transformation
+	const ScaleEngine* d_engine;
+};
+
 class ScaleEngine: public QwtScaleEngine
 {
 public:
-	ScaleEngine(QwtScaleTransformation::Type type = QwtScaleTransformation::Linear,
+	ScaleEngine(ScaleTransformation::Type type = ScaleTransformation::Linear,
 				double left_break = -DBL_MAX, double right_break = DBL_MAX);
 	QwtScaleTransformation* transformation() const;
 	virtual QwtScaleDiv divideScale(double x1, double x2, int maxMajSteps,
@@ -68,8 +86,8 @@ public:
     bool log10ScaleAfterBreak() const;
     void setLog10ScaleAfterBreak(bool on){d_log10_scale_after = on;};
 
-	QwtScaleTransformation::Type type() const;
-	void setType(QwtScaleTransformation::Type type){d_type = type;};
+	ScaleTransformation::Type type() const;
+	void setType(ScaleTransformation::Type type){d_type = type;};
 
 	bool hasBreak() const;
 	void clone(const ScaleEngine *engine);
@@ -78,7 +96,10 @@ public:
 	void drawBreakDecoration(bool draw){d_break_decoration = draw;};
 
 private:
-	QwtScaleTransformation::Type d_type;
+
+	QwtScaleEngine *newScaleEngine() const;
+
+	ScaleTransformation::Type d_type;
 	double d_break_left, d_break_right;
 	//! Position of axis break (% of axis length)
 	int d_break_pos;
@@ -92,19 +113,6 @@ private:
 	int d_break_width;
 	//! If true draw the break decoration
 	bool d_break_decoration;
-};
-
-class ScaleTransformation: public QwtScaleTransformation
-{
-public:
-	ScaleTransformation(const ScaleEngine *engine):QwtScaleTransformation(Other), d_engine(engine){};
-	virtual double xForm(double x, double, double, double p1, double p2) const;
-	virtual double invXForm(double x, double s1, double s2, double p1, double p2) const;
-	QwtScaleTransformation* copy() const;
-
-private:
-    //! The scale engine that generates the transformation
-	const ScaleEngine* d_engine;
 };
 
 #endif

--- a/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/ScaleEngine.h
@@ -86,6 +86,9 @@ public:
     bool log10ScaleAfterBreak() const;
     void setLog10ScaleAfterBreak(bool on){d_log10_scale_after = on;};
 
+    double nthPower() const;
+    void setNthPower(double nth_power){d_nth_power = nth_power;};
+
 	ScaleTransformation::Type type() const;
 	void setType(ScaleTransformation::Type type){d_type = type;};
 
@@ -113,6 +116,8 @@ private:
 	int d_break_width;
 	//! If true draw the break decoration
 	bool d_break_decoration;
+  //! Nth Power for a power scale
+  double d_nth_power;
 };
 
 #endif

--- a/Code/Mantid/MantidPlot/src/qwt_compat.h
+++ b/Code/Mantid/MantidPlot/src/qwt_compat.h
@@ -14,8 +14,6 @@
 #   define loMargin() lowerMargin()
 #   define hiMargin() upperMargin()
 #else
-#   define lowerBound()   lBound()
-#   define upperBound()   hBound()
 #   define lowerMargin()  loMargin()
 #   define upperMargin()  hiMargin()
 #endif /* QWT_VERSION >= 0x050200 */

--- a/Code/Mantid/MantidPlot/src/qwt_compat.h
+++ b/Code/Mantid/MantidPlot/src/qwt_compat.h
@@ -13,6 +13,11 @@
 #   define hBound() upperBound()
 #   define loMargin() lowerMargin()
 #   define hiMargin() upperMargin()
+#else
+#   define lowerBound()   lBound()
+#   define upperBound()   hBound()
+#   define lowerMargin()  loMargin()
+#   define upperMargin()  hiMargin()
 #endif /* QWT_VERSION >= 0x050200 */
 
 #endif /* MANTID_QWT_COMPAT */

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/GraphOptions.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/GraphOptions.h
@@ -12,7 +12,7 @@ namespace GraphOptions
 /**
  * Scale type enumeration
  */
-  EXPORT_OPT_MANTIDQT_API enum ScaleType { Linear = 0, Log10 };
+  EXPORT_OPT_MANTIDQT_API enum ScaleType { Linear = 0, Log10, Power };
 
   /**
    * Axis choice


### PR DESCRIPTION
Closes #11422 

A "power" option is added to the "Scale" tab of the "General Plot Options" window. Selecting it enables entry of exponent value "n". For example, n=2 corresponds to a quadratic axis scale, whilst n=-1 corresponds to a reciprocal scale. Both negative and non-integer values of n are permitted.

It is mostly left to the user to choose a sensible combination of axis limits, data to plot, and value of n. Some situations which may be more commonly met, such as having an axis limit at 0 but having a diverging scale length at 0, are resolved automatically by plotting only to near 0 (0.01 times the other axis limit). However, other situations may lead to apparently blank plots, which is consistent with what happens if you try to plot negative data on a logarithmic scale.

A warning is visible to the user in the GUI when "power" is selected, alerting them to ensure axis scaling and ranges are compatible. I believe this is preferable to reducing the versatility of the "power" option by restricting possible values of n.

For tester:
One method to test that scales are correct is to plot, for example, data with y = x^0.5 and then set the scale to quadratic and see that the curve now looks like a straight line.
When "power" is selected as scale type:
- the warning message should be visible in the GUI, and
- the value of n should be editable.
