### PR TITLE
Fix Qt plugin packaging in Windows

### DIFF
--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -124,10 +124,10 @@ install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Installers/WinInstaller/qt.conf DEST
 # imageformats
 set ( QT_PLUGINS_IMAGEFORMAT qgif4.dll qico4.dll qjpeg4.dll qmng4.dll qsvg4.dll qtga4.dll qtiff4.dll )
 foreach( DLL ${QT_PLUGINS_IMAGEFORMAT} )
-  install ( FILES ${CMAKE_LIBRARY_PATH}/qt_plugins/imageformats/${DLL} DESTINATION plugins/qtplugins/imageformats/${DLL} )
+  install ( FILES ${CMAKE_LIBRARY_PATH}/qt_plugins/imageformats/${DLL} DESTINATION plugins/qt/imageformats )
 endforeach()
 # sqlite
-install ( FILES ${CMAKE_LIBRARY_PATH}/qt_plugins/sqldrivers/qsqlite4.dll DESTINATION plugins/qtplugins/sqldrivers/qsqlite4.dll )
+install ( FILES ${CMAKE_LIBRARY_PATH}/qt_plugins/sqldrivers/qsqlite4.dll DESTINATION plugins/qt/sqldrivers )
 
 ###########################################################################
 # Include files/libraries required for User compilation

--- a/Code/Mantid/Installers/WinInstaller/qt.conf
+++ b/Code/Mantid/Installers/WinInstaller/qt.conf
@@ -1,2 +1,2 @@
 [Paths]
-plugins = ../plugins/qtplugins
+plugins = ../plugins/qt


### PR DESCRIPTION
A CMake error meant that they went to individual sub directories
rather than one single directories per type.

This fixed a bug introduced by [b9e1b20](https://github.com/mantidproject/mantid/commit/b9e1b202b626366156d39557103495bae2c0b4b0)

**Tester**
- Check that the Qt help can now be viewed on Windows.
- Check that the Help->About menu contains all of the expected icons
