### PR TITLE
Add QENS peaks to CreateSampleWorkspace

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -83,7 +83,8 @@ void CreateSampleWorkspace::init() {
   m_preDefinedFunctionmap.insert(std::pair<std::string, std::string>(
       "Exp Decay", "name=ExpDecay, Height=100, Lifetime=1000;"));
   m_preDefinedFunctionmap.insert(std::pair<std::string, std::string>(
-      "Powder Diffraction", "name= LinearBackground,A0=0.0850208,A1=-4.89583e-06;"
+      "Powder Diffraction",
+      "name= LinearBackground,A0=0.0850208,A1=-4.89583e-06;"
       "name=Gaussian,Height=0.584528,PeakCentre=$PC1$,Sigma=14.3772;"
       "name=Gaussian,Height=1.33361,PeakCentre=$PC2$,Sigma=15.2516;"
       "name=Gaussian,Height=1.74691,PeakCentre=$PC3$,Sigma=15.8395;"
@@ -93,6 +94,18 @@ void CreateSampleWorkspace::init() {
       "name=Gaussian,Height=2.8998,PeakCentre=$PC7$,Sigma=21.1127;"
       "name=Gaussian,Height=2.05237,PeakCentre=$PC8$,Sigma=21.9932;"
       "name=Gaussian,Height=8.40976,PeakCentre=$PC9$,Sigma=25.2751;"));
+  m_preDefinedFunctionmap.insert(std::pair<std::string, std::string>(
+      "Quasielastic", "name=Lorentzian,FWHM=0.3,PeakCentre=$PC5$,Amplitude=0.8;"
+                      "name=Lorentzian,FWHM=0.1,PeakCentre=$PC5$,Amplitude=1;"
+                      "name=LinearBackground,A0=0.1"));
+  m_preDefinedFunctionmap.insert(std::pair<std::string, std::string>(
+      "Quasielastic Tunnelling",
+      "name=LinearBackground,A0=0.1;"
+      "name=Lorentzian,FWHM=0.1,PeakCentre=$PC5$,Amplitude=1;"
+      "name=Lorentzian,FWHM=0.05,PeakCentre=$PC7$,Amplitude=0.04;"
+      "name=Lorentzian,FWHM=0.05,PeakCentre=$PC3$,Amplitude=0.04;"
+      "name=Lorentzian,FWHM=0.05,PeakCentre=$PC8$,Amplitude=0.02;"
+      "name=Lorentzian,FWHM=0.05,PeakCentre=$PC2$,Amplitude=0.02"));
   m_preDefinedFunctionmap.insert(
       std::pair<std::string, std::string>("User Defined", ""));
   std::vector<std::string> functionOptions;
@@ -112,7 +125,8 @@ void CreateSampleWorkspace::init() {
                   "The Number of banks in the instrument (default:2)");
   declareProperty("BankPixelWidth", 10,
                   boost::make_shared<BoundedValidator<int>>(0, 10000),
-                  "The number of pixels in horizontally and vertically in a bank (default:10)");
+                  "The number of pixels in horizontally and vertically in a "
+                  "bank (default:10)");
   declareProperty("NumEvents", 1000,
                   boost::make_shared<BoundedValidator<int>>(0, 100000),
                   "The number of events per detector, this is only used for "
@@ -192,8 +206,8 @@ void CreateSampleWorkspace::exec() {
 
   // Create an instrument with one or more rectangular banks.
   Instrument_sptr inst = createTestInstrumentRectangular(
-      numBanks, bankPixelWidth, pixelSpacing, 
-      bankDistanceFromSample,sourceSampleDistance);
+      numBanks, bankPixelWidth, pixelSpacing, bankDistanceFromSample,
+      sourceSampleDistance);
 
   int num_bins = static_cast<int>((xMax - xMin) / binWidth);
   MatrixWorkspace_sptr ws;
@@ -421,8 +435,7 @@ void CreateSampleWorkspace::replaceAll(std::string &str,
  */
 Instrument_sptr CreateSampleWorkspace::createTestInstrumentRectangular(
     int num_banks, int pixels, double pixelSpacing,
-    const double bankDistanceFromSample,
-    const double sourceSampleDistance) {
+    const double bankDistanceFromSample, const double sourceSampleDistance) {
   boost::shared_ptr<Instrument> testInst(new Instrument("basic_rect"));
   // The instrument is going to be set up with z as the beam axis and y as the
   // vertical axis.

--- a/Code/Mantid/docs/source/algorithms/CreateSampleWorkspace-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CreateSampleWorkspace-v1.rst
@@ -11,14 +11,14 @@ Description
 
 Creates sample workspaces for usage examples and other situations.
 
-You can select a predefined function for the data or enter your own by
-selecting User Defined in the drop down.
+You can select a predefined function for the data or enter your own by selecting
+User Defined in the drop down.
 
-The data will be the same for each spectrum, and is defined by the
-function selected, and a little noise if Random is selected. All values
-are taken converted to absolute values at present so negative values
-will become positive. For event workspaces the intensity of the graph
-will be affected by the number of events selected.
+The data will be the same for each spectrum, and is defined by the function
+selected, and a little noise if Random is selected. All values are taken
+converted to absolute values at present so negative values will become positive.
+For event workspaces the intensity of the graph will be affected by the number
+of events selected.
 
 Here is an example of a user defined formula containing two peaks and a
 background.::
@@ -35,19 +35,26 @@ important set Random to false or uncheck the box.
 Instrument
 ~~~~~~~~~~
 
-The instrument created by CreateSample workspace is very simple and looks like this.
+The instrument created by CreateSample workspace is very simple and looks like
+this.
 
 .. image:: ../images/CreateSampleWorkspaceInstrument.png
     :width: 100%
-    :alt: A labelled image of the instrument created by CreateSampleWorkspace     
+    :alt: A labelled image of the instrument created by CreateSampleWorkspace
 
-The sample is placed at the origin.  The source is seperated from the sample in the negative direction by the vlue you specify in "SourceDistanceFromSample".  The instrument has "NumBanks" detector banks, each bank is moved down the X axis by "BankDistanceFromSample" from the Sample or the previous bank.
-Each bank is a square rectangular bank comprising of "BankPixelWidth" pixels in width and height.  The size of each pixel 4mm square, but additional padding can be set using "PixelSpacing".
+The sample is placed at the origin.  The source is seperated from the sample in
+the negative direction by the vlue you specify in "SourceDistanceFromSample".
+The instrument has "NumBanks" detector banks, each bank is moved down the X axis
+by "BankDistanceFromSample" from the Sample or the previous bank.
+
+Each bank is a square rectangular bank comprising of "BankPixelWidth" pixels in
+width and height.  The size of each pixel 4mm square, but additional padding can
+be set using "PixelSpacing".
 
 Usage
 -----
 
-**Example - create a simple histogram workspace:**  
+**Example - create a simple histogram workspace:**
 
 .. testcode:: ExHistSimple
 
@@ -57,17 +64,17 @@ Usage
    print "Number of spectra: " +  str(ws.getNumberHistograms())
    print "Number of bins: " +  str(ws.blocksize())
    print "Each spectra has a level backgound of " + str(ws.readY(0)[0]) + \
-    " counts and a peak in the centre of " + str(ws.readY(0)[50]) + " counts."		
+    " counts and a peak in the centre of " + str(ws.readY(0)[50]) + " counts."
 
 Output:
 
 .. testoutput:: ExHistSimple
-   
+
    Number of spectra: 200
    Number of bins: 100
    Each spectra has a level backgound of 0.3 counts and a peak in the centre of 10.3 counts.
 
-**Example - create a simple event workspace:**  
+**Example - create a simple event workspace:**
 
 .. testcode:: ExEventSimple
 
@@ -80,22 +87,22 @@ Output:
    print "Event Workspaces come with bins set by default to a bin width of " + str(ws.readX(0)[1]-ws.readX(0)[0])
    #The data itensity of an EventWorkspce is scaled by the number of events used, so the values differ from the histogram above.
    print "Each spectra has a level backgound of " + str(ws.readY(0)[0]) + \
-   	" counts and a peak in the centre of " + str(ws.readY(0)[50]) + " counts."				
-      
+   	" counts and a peak in the centre of " + str(ws.readY(0)[50]) + " counts."
+
 Output:
 
 .. testoutput:: ExEventSimple
-   
+
    Number of spectra: 200
    Number of bins: 100
    Number of events: 800000
    Event Workspaces come with bins set by default to a bin width of 200.0
    Each spectra has a level backgound of 30.0 counts and a peak in the centre of 1030.0 counts.
 
-**Example - Using the preset functions:**  
+**Example - Using the preset functions:**
 
 .. testcode:: ExHistPresets
-   
+
    # create a workspace with Flat Background
    wsFlat = CreateSampleWorkspace("Histogram","Flat background")
    print "Flat background has a constant value of " + str(wsFlat.readY(0)[0]) + " counts."
@@ -103,7 +110,7 @@ Output:
    # create a workspace with multiple peaks
    wsMulti = CreateSampleWorkspace("Histogram","Multiple Peaks")
    print "Multiple Peaks has a level backgound of " + str(wsMulti.readY(0)[0]),
-   print "counts and two gaussian peaks, the largest of which is " + str(wsMulti.readY(0)[60]) + " counts."	
+   print "counts and two gaussian peaks, the largest of which is " + str(wsMulti.readY(0)[60]) + " counts."
 
    # create a workspace with Exponential Decay
    wsExp = CreateSampleWorkspace("Histogram","Exp Decay")
@@ -118,10 +125,10 @@ Output:
    Exp Decay starts high and drops rapidly to 0.03 counts at 8,000 us (with the default binning).
 
 
-**Example - Using the your own function:**  
+**Example - Using the your own function:**
 
 .. testcode:: ExHistUserFunc
-   
+
    # create a workspace with data defined using the function string below
    myFunc = "name=LinearBackground, A0=0.5;name=Gaussian, PeakCentre=10000, Height=50, Sigma=0.5;name=Gaussian, PeakCentre=1000, Height=80, Sigma=0.5"
 
@@ -140,10 +147,10 @@ Output:
    With a peak reaching 80.5 counts at 1,000 us,
    and another reaching 50.5 counts at 10,000 us.
 
-**Example - Setting every Option:**  
+**Example - Setting every Option:**
 
 .. testcode:: ExEveryOption
-   
+
    #Random adds a little random noise to the data function
    ws=CreateSampleWorkspace(WorkspaceType="Event",Function="One Peak",NumBanks=4,BankPixelWidth=5,NumEvents=500,Random=True,XUnit="tof",XMin=0, XMax=8000, BinWidth=100)
 
@@ -156,7 +163,7 @@ Output:
 
    Number of spectra: 100
    Number of bins: 80
-   
+
 .. categories::
 
 .. sourcelink::

--- a/Code/Mantid/docs/source/algorithms/CreateSampleWorkspace-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/CreateSampleWorkspace-v1.rst
@@ -32,6 +32,10 @@ workspaces. If Random is selected the results will differ between runs
 of the algorithm and will not be comparable. If comparing the output is
 important set Random to false or uncheck the box.
 
+.. note::
+  For the Quasielastic and Quasielastic Tunnelling presets the XMin and XMax
+  values should be set to a range symmetrical around x=0.
+
 Instrument
 ~~~~~~~~~~
 
@@ -124,7 +128,6 @@ Output:
    Multiple Peaks has a level backgound of 0.3 counts and two gaussian peaks, the largest of which is 8.3 counts.
    Exp Decay starts high and drops rapidly to 0.03 counts at 8,000 us (with the default binning).
 
-
 **Example - Using the your own function:**
 
 .. testcode:: ExHistUserFunc
@@ -138,7 +141,6 @@ Output:
    print "With a peak reaching "+ str(ws.readY(0)[5]) + " counts at 1,000 us,"
    print "and another reaching "+ str(ws.readY(0)[50]) + " counts at 10,000 us."
 
-
 Output:
 
 .. testoutput:: ExHistUserFunc
@@ -146,6 +148,26 @@ Output:
    My function defined a background of 0.5 counts.
    With a peak reaching 80.5 counts at 1,000 us,
    and another reaching 50.5 counts at 10,000 us.
+
+**Example - Quasielastic:**
+
+.. testcode:: ExQuasielastic
+
+   ws=CreateSampleWorkspace(Function="Quasielastic",
+                            XUnit="DeltaE",
+                            XMin=-0.5,
+                            XMax=0.5,
+                            BinWidth=0.01)
+
+   print "Number of spectra: " +  str(ws.getNumberHistograms())
+   print "Number of bins: " +  str(ws.blocksize())
+
+Output:
+
+.. testoutput:: ExQuasielastic
+
+   Number of spectra: 200
+   Number of bins: 100
 
 **Example - Setting every Option:**
 
@@ -167,6 +189,3 @@ Output:
 .. categories::
 
 .. sourcelink::
-
-
-


### PR DESCRIPTION
Fixes #13383.

To test:
- Run `CreateSampleWorkspace` with:
  - `Function` set to either `Quasielastic` or `Quasielastic Tunneling`, 
  - `XMin`=-0.5
  - `XMax`=0.5
  - `BinWidth`=0.01
- See that the functions are reasonable

Release notes updates [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_Framework_Changes&diff=24977&oldid=24975).
