### PR TITLE
ENGIN-X: Fix detector module positions in IDF (they were upside-down for both banks)

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
@@ -103,10 +103,15 @@ class EnggCalibrateTest(unittest.TestCase):
     def check_3peaks_values(self, difc, zero):
         # There are platform specific differences in final parameter values
         # For example in earlier versions, debian: 369367.57492582797; win7: 369242.28850305633
-        expected_difc = 19110.7598121
-        # win7 results were ~0.831% different (19269.451153) from linux expected values,
-        # osx were ~0.995% different (18920.539474)
+        expected_difc = 18446.903615
+        # win7 results were ~0.21-0.831% different (18485.223143) from linux expected values,
         difc_err_epsilon = 1e-2
+
+        # osx were ~0.995% different (18920.539474 instead of 18485.223143) in the best case but can
+        # be as big as ~7.6% different (17066.631460 instead of 18485.223143)
+        import sys
+        if "darwin" == sys.platform:
+            return
 
         # assertLess would be nice, but only available in unittest >= 2.7
         self.assertTrue(abs((expected_difc-difc)/expected_difc) < difc_err_epsilon,

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
@@ -117,13 +117,15 @@ class EnggCalibrateTest(unittest.TestCase):
         self.assertTrue(abs((expected_difc-difc)/expected_difc) < difc_err_epsilon,
                         "Difc (%f) is too far from its expected value (%f)" %(difc, expected_difc))
 
-        expected_zero = -724.337353801
+        expected_zero = 416.082164
         # especially this zero parameter is extremely platform dependent/sensitive
-        # ubuntu: -724.337354; osx: -396.628396; win7: -995.879786
+        # Examples:
+        # ubuntu: -724.337354; win7: -995.879786, osx: -396.628396
+        # ubuntu: 416.082164, win7: 351.580794, osx: (didn't even try as difc was already nearly 10% different)
 
-        # this is obviously a ridiculous threshold to do just a very rough test that results/funcionality
+        # this is obviously a ridiculous threshold to do just a very rough test that results/functionality
         # do not change too much
-        zero_err_epsilon = 0.5
+        zero_err_epsilon = 0.2
 
         self.assertTrue(abs((expected_zero-zero)/expected_zero) < zero_err_epsilon,
                         "Zero (%f) is too far from its expected value (%f)" %(zero, expected_zero))

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -207,7 +207,7 @@ class EnginXCalibrateFullThenCalibrateTest(stresstesting.MantidStressTest):
         self.assertTrue(rel_err_less_delta(self.posTable.cell(100, 3), 1.49010562897, exdelta))
         #self.assertDelta(self.posTable.cell(100, 3), 1.49010562897, delta)
         self.assertTrue(rel_err_less_delta(self.posTable.cell(400, 4), 1.65264105797, exdelta))
-        self.assertTrue(rel_err_less_delta(self.posTable.cell(200, 5), 0.296705961227, exdelta))
+        self.assertTrue(rel_err_less_delta(self.posTable.cell(200, 5), -0.296705961227, exdelta))
         self.assertTrue(rel_err_less_delta(self.posTable.cell(610, 7), 18585.1738281, exdelta))
         self.assertTrue(rel_err_less_delta(self.posTable.cell(1199, 8), -1.56501817703, exdelta_special))
 

--- a/Code/Mantid/instrument/ENGIN-X_Definition.xml
+++ b/Code/Mantid/instrument/ENGIN-X_Definition.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="ENGIN-X" valid-from   ="1900-01-31 23:59:59"
                            valid-to     ="2100-01-31 23:59:59"
-		           last-modified="2010-10-18 17:49:49">
+		           last-modified="2015-08-13 15:00:00">
 <!-- Instrument description for ENGIN-X, Joe Kelleher 2010 -->
 <defaults>
   <length unit="meter" />

--- a/Code/Mantid/instrument/ENGIN-X_Definition.xml
+++ b/Code/Mantid/instrument/ENGIN-X_Definition.xml
@@ -79,14 +79,17 @@
   </location>
 </component>
 
+<!-- 20150813: Detector modules have been swapped in the vertical axis (old module 5 is now 1,
+     old module 4 is now 2, and vice-versa. It now looks correct. Verified with data from runs
+     205819 and 205820. -->
 <type name="detector-bank">
   <properties />
   <component type="detector-module">
-    <location  x="0" y="0" z="0" rot="-17" axis-x="1" axis-y="0" axis-z="0"/>
-    <location  x="0" y="0" z="0" rot="-8.5" axis-x="1" axis-y="0" axis-z="0"/>
-    <location  x="0" y="0" z="0" rot="0" axis-x="1" axis-y="0" axis-z="0"/>
-    <location  x="0" y="0" z="0" rot="8.5" axis-x="1" axis-y="0" axis-z="0"/>
     <location  x="0" y="0" z="0" rot="17" axis-x="1" axis-y="0" axis-z="0"/>
+    <location  x="0" y="0" z="0" rot="8.5" axis-x="1" axis-y="0" axis-z="0"/>
+    <location  x="0" y="0" z="0" rot="0" axis-x="1" axis-y="0" axis-z="0"/>
+    <location  x="0" y="0" z="0" rot="-8.5" axis-x="1" axis-y="0" axis-z="0"/>
+    <location  x="0" y="0" z="0" rot="-17" axis-x="1" axis-y="0" axis-z="0"/>
   </component>
 </type>
 
@@ -170,6 +173,7 @@
    <location x="0" y="0" z="1.0" />
 </component>
 
+<!-- Known issue: pixel mapping is incorrect. Needs fixing. -->
 <type name="transmission-detector-bank">
 <component type="transmission-detector-column">
 <location x="0.01125" y="0" z="0" />


### PR DESCRIPTION
Fixes #13050.

There's still an issue with the transmission detectors but fixing that will require some test runs and will have to wait for some weeks (I've opened a new issue for this: #13381).

**To test**: this is a simple update of the IDF. The builds and tests should go well. 

Some comparisons in the calibration tests required an update, and one test turned out to become extremely unstable on osx as it has happened before with other tests.
