### PR TITLE
RefAxis wastes memory by calling NumericAxis constructor.

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/NumericAxis.h
@@ -63,7 +63,7 @@ public:
                             const std::size_t &verticalIndex = 0) const;
   /// Set the value at a specific index
   virtual void setValue(const std::size_t &index, const double &value);
-  size_t indexOfValue(const double value) const;
+  virtual size_t indexOfValue(const double value) const;
   virtual bool operator==(const Axis &) const;
   virtual bool equalWithinTolerance(const Axis &axis2,
                                     const double tolerance) const;
@@ -71,7 +71,7 @@ public:
   /// Create bin boundaries from the point values
   virtual std::vector<double> createBinBoundaries() const;
   /// Return a const reference to the values
-  const std::vector<double> &getValues() const;
+  virtual const std::vector<double> &getValues() const;
   /// returns min value defined on axis
   double getMin() const { return m_values.front(); }
   /// returns max value defined on axis

--- a/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
@@ -56,6 +56,19 @@ public:
   virtual bool operator==(const Axis &) const;
   virtual bool equalWithinTolerance(const Axis &axis2,
                                     const double tolerance) const;
+  // We must override these to prevent access to NumericAxis::m_values and
+  // m_edges, which are unused by RefAxis and thus do not hold sensible values.
+  virtual size_t indexOfValue(const double value) const {
+    UNUSED_ARG(value)
+    throw std::runtime_error("Calling indexOfValue() on RefAxis is forbidden.");
+  }
+  virtual std::vector<double> createBinBoundaries() const {
+    throw std::runtime_error(
+        "Calling createBinBoundaries() on RefAxis is forbidden.");
+  }
+  virtual const std::vector<double> &getValues() const {
+    throw std::runtime_error("Calling getValues() on RefAxis is forbidded.");
+  }
   virtual double getMin() const;
   virtual double getMax() const;
 

--- a/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/RefAxis.h
@@ -58,17 +58,9 @@ public:
                                     const double tolerance) const;
   // We must override these to prevent access to NumericAxis::m_values and
   // m_edges, which are unused by RefAxis and thus do not hold sensible values.
-  virtual size_t indexOfValue(const double value) const {
-    UNUSED_ARG(value)
-    throw std::runtime_error("Calling indexOfValue() on RefAxis is forbidden.");
-  }
-  virtual std::vector<double> createBinBoundaries() const {
-    throw std::runtime_error(
-        "Calling createBinBoundaries() on RefAxis is forbidden.");
-  }
-  virtual const std::vector<double> &getValues() const {
-    throw std::runtime_error("Calling getValues() on RefAxis is forbidded.");
-  }
+  virtual size_t indexOfValue(const double value) const;
+  virtual std::vector<double> createBinBoundaries() const;
+  virtual const std::vector<double> &getValues() const;
   virtual double getMin() const;
   virtual double getMax() const;
 

--- a/Code/Mantid/Framework/API/src/RefAxis.cpp
+++ b/Code/Mantid/Framework/API/src/RefAxis.cpp
@@ -11,9 +11,11 @@ namespace API {
  *  @param length :: The length of this axis
  *  @param parentWorkspace :: A pointer to the workspace that holds this axis
  */
+// NumericAxis is set to length 0 since we do not need its internal storage. We
+// override public functions of NumericAxis that would access it.
 RefAxis::RefAxis(const std::size_t &length,
                  const MatrixWorkspace *const parentWorkspace)
-    : NumericAxis(length), m_parentWS(parentWorkspace), m_size(length) {}
+    : NumericAxis(0), m_parentWS(parentWorkspace), m_size(length) {}
 
 /** Private, specialised copy constructor. Needed because it's necessary to pass
  * in

--- a/Code/Mantid/Framework/API/src/RefAxis.cpp
+++ b/Code/Mantid/Framework/API/src/RefAxis.cpp
@@ -103,6 +103,20 @@ bool RefAxis::equalWithinTolerance(const Axis &axis2,
   return this->operator==(axis2);
 }
 
+size_t RefAxis::indexOfValue(const double value) const {
+  UNUSED_ARG(value)
+  throw std::runtime_error("Calling indexOfValue() on RefAxis is forbidden.");
+}
+
+std::vector<double> RefAxis::createBinBoundaries() const {
+  throw std::runtime_error(
+      "Calling createBinBoundaries() on RefAxis is forbidden.");
+}
+
+const std::vector<double> &RefAxis::getValues() const {
+  throw std::runtime_error("Calling getValues() on RefAxis is forbidded.");
+}
+
 double RefAxis::getMin() const {
   throw std::runtime_error("RefAxis cannot determine minimum value. Use readX "
                            "on the workspace instead");


### PR DESCRIPTION
Closes #12033.

Simple change, unit tests pass, reviewed by quantumsteve.
