### PR TITLE
Extract fitting data after a fit using QtiPlot's Fit Wizard.

### DIFF
--- a/Code/Mantid/MantidPlot/src/PlotDialog.cpp
+++ b/Code/Mantid/MantidPlot/src/PlotDialog.cpp
@@ -3200,10 +3200,7 @@ void LayerItem::insertCurvesList()
     {
       PlotCurve *c = dynamic_cast<PlotCurve *>(it);
       DataCurve* dc = dynamic_cast<DataCurve *>(it);
-      if (!c || !dc)
-        continue;
-
-      if (dc && c->type() != Graph::Function && dc->table())
+      if (c && dc && c->type() != Graph::Function && dc->table())
       {
         QString s = dc->plotAssociation();
         QString table = dc->table()->name();


### PR DESCRIPTION
Fixes #13393.

Test steps are in the issue.
