### PR TITLE
Changing URIs for ADARA instruments

### DIFF
--- a/Code/Mantid/instrument/Facilities.xml
+++ b/Code/Mantid/instrument/Facilities.xml
@@ -394,7 +394,7 @@
 
    <instrument name="USANS" shortname="USANS" beamline="1A">
       <technique>Small Angle Scattering</technique>
-      <livedata address="usans-daq1.sns.gov:31415" />
+      <livedata address="bl1a-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="VULCAN" beamline="7">
@@ -404,7 +404,7 @@
    <instrument name="CORELLI" beamline="9">
 	<technique>Neutron Diffraction</technique>
 	<technique>Diffuse Scattering</technique>
-	<livedata address="corelli-daq1.sns.gov:31415" />
+	<livedata address="bl9-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="POWGEN" shortname="PG3" beamline="11A">
@@ -434,14 +434,14 @@
     <technique>Neutron Spectroscopy</technique>
     <technique>TOF Indirect Geometry Spectroscopy</technique>
     <technique>Neutron Diffraction</technique>
-    <livedata address="vision-daq1.sns.gov:31415" />
+    <livedata address="bl16b-daq1.sns.gov:31415" />
   </instrument>
 
    <instrument name="SEQUOIA" shortname="SEQ" beamline="17">
     <technique>Neutron Spectroscopy</technique>
     <technique>TOF Direct Geometry Spectroscopy</technique>
     <technique>Neutron Diffraction</technique>
-    <livedata address="sequoia-sms.sns.gov:31415" />
+    <livedata address="bl17-daq1.sns.gov:31415" />
    </instrument>
 
    <instrument name="ARCS" beamline="18">


### PR DESCRIPTION
The suggested changes are (from Jim's email):

Looks like the following adjustments are needed (needs to be tried/verified):
- USANS: `usans-daq1.sns.gov:31415`  -->  `bl1a-daq1.sns.gov`
- CORELLI: `corelli-daq1.sns.gov:31415`  -->  `bl9-daq1.sns.gov`
- HYSPEC: `bl14b-daq1.sns.gov:31415`  OK
- VISION: `vision-daq1.sns.gov:31415`  -->  `bl16b-daq1.sns.gov`
- SEQUOIA: `sequoia-sms.sns.gov:31415`  -->  `bl17-daq1.sns.gov`
