### PR TITLE
Process indirect fit parameters algorithm

### DIFF
--- a/Code/Mantid/Framework/Algorithms/CMakeLists.txt
+++ b/Code/Mantid/Framework/Algorithms/CMakeLists.txt
@@ -178,6 +178,7 @@ set ( SRC_FILES
 	src/PolynomialCorrection.cpp
 	src/Power.cpp
 	src/PowerLawCorrection.cpp
+	src/ProcessIndirectFitParameters.cpp
 	src/Q1D2.cpp
 	src/Q1DWeighted.cpp
 	src/Qhelper.cpp
@@ -449,6 +450,7 @@ set ( INC_FILES
 	inc/MantidAlgorithms/PolynomialCorrection.h
 	inc/MantidAlgorithms/Power.h
 	inc/MantidAlgorithms/PowerLawCorrection.h
+	inc/MantidAlgorithms/ProcessIndirectFitParameters.h
 	inc/MantidAlgorithms/Q1D2.h
 	inc/MantidAlgorithms/Q1DWeighted.h
 	inc/MantidAlgorithms/Qhelper.h
@@ -719,6 +721,7 @@ set ( TEST_FILES
 	PolynomialCorrectionTest.h
 	PowerLawCorrectionTest.h
 	PowerTest.h
+	ProcessIndirectFitParametersTest.h
 	Q1D2Test.h
 	Q1DWeightedTest.h
 	QxyTest.h
@@ -778,8 +781,8 @@ set ( TEST_FILES
 	SumNeighboursTest.h
 	SumRowColumnTest.h
 	SumSpectraTest.h
-	TOFSANSResolutionByPixelTest.h
 	TOFSANSResolutionByPixelCalculatorTest.h
+	TOFSANSResolutionByPixelTest.h
 	TimeAtSampleStrategyDirectTest.h
 	TimeAtSampleStrategyElasticTest.h
 	TimeAtSampleStrategyIndirectTest.h

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
@@ -50,6 +50,8 @@ private:
   std::vector<std::string> listToVector(std::string &);
   std::vector<std::string> searchForFitParams(const std::string &,
                                               const std::vector<std::string> &);
+  std::vector<std::vector<std::string>>
+  reorderWorkspaceParams(const std::vector<std::vector<std::string>> &);
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
@@ -51,7 +51,7 @@ private:
   std::vector<std::string> searchForFitParams(const std::string &,
                                               const std::vector<std::string> &);
   std::vector<std::vector<std::string>>
-  reorderWorkspaceParams(const std::vector<std::vector<std::string>> &);
+  reorder2DVector(const std::vector<std::vector<std::string>> &);
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
@@ -48,8 +48,9 @@ private:
   void init();
   void exec();
   std::vector<std::string> listToVector(std::string &);
+  std::vector<std::string> searchForFitParams(const std::string &,
+                                              const std::vector<std::string> &);
 };
-
 } // namespace Algorithms
 } // namespace Mantid
 

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
@@ -47,6 +47,7 @@ public:
 private:
   void init();
   void exec();
+  std::vector<std::string> listToVector(std::string &);
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/ProcessIndirectFitParameters.h
@@ -1,0 +1,55 @@
+#ifndef MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERS_H_
+#define MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERS_H_
+
+#include "MantidKernel/System.h"
+#include "MantidAPI/Algorithm.h"
+namespace Mantid {
+namespace Algorithms {
+
+/** ProcessIndirectFitParameters : Convert a parameter table output by
+  PlotPeakByLogValue to a MatrixWorkspace. This will make a spectrum for each
+  parameter name using the x_column vairable as the x values for the spectrum.
+
+  @author Elliot Oram, ISIS, RAL
+  @date 12/08/2015
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport ProcessIndirectFitParameters : public API::Algorithm {
+public:
+  ProcessIndirectFitParameters();
+  virtual ~ProcessIndirectFitParameters();
+
+  virtual const std::string name() const;
+  virtual int version() const;
+  virtual const std::string category() const;
+  virtual const std::string summary() const;
+
+private:
+  void init();
+  void exec();
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERS_H_ */

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -204,7 +204,9 @@ std::vector<std::vector<std::string>> ProcessIndirectFitParameters::reorderWorks
 	for(int i = 0; i < maximumLength; i++){
 		std::vector<std::string> temp;
 		for(int j = 0; j < original.size(); j++){
+			if(original.at(j).size() > i){
 			temp.push_back(original.at(j).at(i));
+			}
 		}
 		reorderedVector.push_back(temp);
 	}

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -143,7 +143,7 @@ void ProcessIndirectFitParameters::exec() {
   renamer->setProperty("InputWorkspace", tempWorkspace);
   renamer->setProperty("OutputWorkspace", outputWs);
   renamer->executeAsChildAlg();
-  auto groupWorkspace = renamer->getProperty("OutputWorkspace");
+  MatrixWorkspace_sptr groupWorkspace = renamer->getProperty("OutputWorkspace");
 
   // Replace axis on workspaces with text axis
   auto axis = TextAxis(outputWs->getNumberHistograms());
@@ -155,6 +155,8 @@ void ProcessIndirectFitParameters::exec() {
     }
   }
   outputWs->replaceAxis(1, axisPtr);
+
+
 }
 
 std::vector<std::string>

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -139,6 +139,7 @@ std::vector<std::string> ProcessIndirectFitParameters::searchForFitParams(
       fitParams.push_back(columns.at(i));
     }
   }
+  return fitParams;
 }
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -1,8 +1,6 @@
 #include "MantidAlgorithms/ProcessIndirectFitParameters.h"
 
-#include "MantidKernel/DateTimeValidator.h"
 #include "MantidKernel/MandatoryValidator.h"
-#include "MantidKernel/TimeSeriesProperty.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -39,7 +37,8 @@ const std::string ProcessIndirectFitParameters::category() const {
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
 const std::string ProcessIndirectFitParameters::summary() const {
-  return "Convert a parameter table output by PlotPeakByLogValue to a MatrixWorkspace.";
+  return "Convert a parameter table output by PlotPeakByLogValue to a "
+         "MatrixWorkspace.";
 }
 
 //----------------------------------------------------------------------------------------------
@@ -48,19 +47,35 @@ const std::string ProcessIndirectFitParameters::summary() const {
 void ProcessIndirectFitParameters::init() {
   declareProperty(
       new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
-      "An input workspace.");
+      "The table workspace to convert to a MatrixWorkspace.");
 
   declareProperty(
+      "X Column", "", boost::make_shared<MandatoryValidator<std::string>>(),
+      "The column in the table to use for the x values.", Direction::Input);
+
+  declareProperty("Parameter Names", "",
+                  boost::make_shared<MandatoryValidator<std::string>>(),
+                  "List of the parameter names to add to the workspace.",
+                  Direction::Input);
+  /*May change to a string*/
+  declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
-      "An output workspace.");
+      "The name to call the output workspace.");
 }
 
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
  */
 void ProcessIndirectFitParameters::exec() {
-  // TODO Auto-generated execute stub
+  ITableWorkspace_sptr inputWs = getProperty("InputWorkspace");
+  std::string xColumn = getProperty("X Column");
+  std::string parameterNames = getProperty("Parameter Names");
+  MatrixWorkspace_sptr outputWs = getProperty("OutputWorkspace");
+
+
 }
+
+
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -1,0 +1,66 @@
+#include "MantidAlgorithms/ProcessIndirectFitParameters.h"
+
+#include "MantidKernel/DateTimeValidator.h"
+#include "MantidKernel/MandatoryValidator.h"
+#include "MantidKernel/TimeSeriesProperty.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+
+using namespace API;
+using namespace Kernel;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(ProcessIndirectFitParameters)
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+ProcessIndirectFitParameters::ProcessIndirectFitParameters() {}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+ProcessIndirectFitParameters::~ProcessIndirectFitParameters() {}
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string ProcessIndirectFitParameters::name() const { return "ProcessIndirectFitParameters"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int ProcessIndirectFitParameters::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string ProcessIndirectFitParameters::category() const {
+  return "Workflow\\MIDAS";
+}
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string ProcessIndirectFitParameters::summary() const {
+  return "Convert a parameter table output by PlotPeakByLogValue to a MatrixWorkspace.";
+}
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void ProcessIndirectFitParameters::init() {
+  declareProperty(
+      new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
+      "An input workspace.");
+
+  declareProperty(
+      new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
+      "An output workspace.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void ProcessIndirectFitParameters::exec() {
+  // TODO Auto-generated execute stub
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -142,14 +142,14 @@ void ProcessIndirectFitParameters::exec() {
     tempWorkspace = std::string(conjoin->getProperty("InputWorkspace1"));
   }
 
-  //Rename the workspace to the specified outputName
+  // Rename the workspace to the specified outputName
   auto renamer = createChildAlgorithm("RenameWorkspace", -1, -1, true);
   renamer->setProperty("InputWorkspace", tempWorkspace);
   renamer->setProperty("OutputWorkspace", outputWsName);
   renamer->executeAsChildAlg();
   Workspace_sptr renameWs = renamer->getProperty("OutputWorkspace");
   auto outputWs = boost::dynamic_pointer_cast<MatrixWorkspace>(renameWs);
-  
+
   // Replace axis on workspaces with text axis
   auto axis = new TextAxis(outputWs->getNumberHistograms());
   size_t offset = 0;
@@ -158,7 +158,7 @@ void ProcessIndirectFitParameters::exec() {
     for (size_t k = 0; k < peakWs.size(); k++) {
       axis->setLabel((k + offset), peakWs.at(k));
     }
-	offset += peakWs.size();
+    offset += peakWs.size();
   }
   outputWs->replaceAxis(1, axis);
 }
@@ -178,7 +178,9 @@ ProcessIndirectFitParameters::listToVector(std::string &commaList) {
     commaList = commaList.substr(pos + 1, commaList.size());
     pos = commaList.find(",");
   }
-  listVector.push_back(commaList);
+  if (commaList.compare("") != 0) {
+    listVector.push_back(commaList);
+  }
   return listVector;
 }
 

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -49,7 +49,7 @@ const std::string ProcessIndirectFitParameters::summary() const {
  */
 void ProcessIndirectFitParameters::init() {
 
-  declareProperty(new WorkspaceProperty<API::ITableWorkspace>(
+  declareProperty(new WorkspaceProperty<ITableWorkspace>(
                       "InputWorkspace", "", Direction::Input),
                   "The table workspace to convert to a MatrixWorkspace.");
 
@@ -62,9 +62,9 @@ void ProcessIndirectFitParameters::init() {
                   "List of the parameter names to add to the workspace.",
                   Direction::Input);
 
-  declareProperty("OutputWorkspaceName", "",
-                  boost::make_shared<MandatoryValidator<std::string>>(),
-                  "The name to call the output workspace.", Direction::Input);
+  declareProperty(new WorkspaceProperty<MatrixWorkspace>("OutputWorkspace", "",
+                                                         Direction::Output),
+                  "The name to give the output workspace");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -76,7 +76,7 @@ void ProcessIndirectFitParameters::exec() {
   std::string xColumn = getProperty("ColumnX");
   std::string parameterNamesProp = getProperty("ParameterNames");
   auto parameterNames = listToVector(parameterNamesProp);
-  std::string outputWsName = getProperty("OutputWorkspaceName");
+  MatrixWorkspace_sptr outputWsName = getProperty("OutputWorkspace");
 
   // Search for any parameters in the table with the given parameter names,
   // ignoring their function index and output them to a workspace
@@ -161,6 +161,8 @@ void ProcessIndirectFitParameters::exec() {
     offset += peakWs.size();
   }
   outputWs->replaceAxis(1, axis);
+
+  setProperty("OutputWorkspace", outputWs);
 }
 
 /**

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -128,7 +128,7 @@ void ProcessIndirectFitParameters::exec() {
       conjoin->setProperty("InputWorkspace1", tempPeakWs);
       conjoin->setProperty("InputWorkspace2", paramWs);
       conjoin->executeAsChildAlg();
-      tempPeakWs = conjoin->getProperty("InputWorkspace1");
+      tempPeakWs = std::string(conjoin->getProperty("InputWorkspace1"));
     }
     tempWorkspaces.push_back(tempPeakWs);
   }
@@ -139,7 +139,7 @@ void ProcessIndirectFitParameters::exec() {
     conjoin->setProperty("InputWorkspace1", tempWorkspace);
     conjoin->setProperty("InputWorkspace2", *it);
     conjoin->executeAsChildAlg();
-    tempWorkspace = conjoin->getProperty("InputWorkspace1");
+    tempWorkspace = std::string(conjoin->getProperty("InputWorkspace1"));
   }
 
   //Rename the workspace to the specified outputName
@@ -156,7 +156,6 @@ void ProcessIndirectFitParameters::exec() {
   for (size_t j = 0; j < workspaceNames.size(); j++) {
     auto peakWs = workspaceNames.at(j);
     for (size_t k = 0; k < peakWs.size(); k++) {
-      std::string kString = peakWs.at(k);
       axis->setLabel((k + offset), peakWs.at(k));
     }
 	offset += peakWs.size();

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -121,7 +121,7 @@ void ProcessIndirectFitParameters::exec() {
   conjoin->setProperty("CheckOverlapping", false);
   const size_t wsMax = workspaceNames.size();
   for (size_t j = 0; j < wsMax; j++) {
-    auto tempPeakWs = workspaceNames.at(j).at(0);
+    std::string tempPeakWs = workspaceNames.at(j).at(0);
     const size_t paramMax = workspaceNames.at(j).size();
     for (size_t k = 1; k < paramMax; k++) {
       auto paramWs = workspaceNames.at(j).at(k);
@@ -134,7 +134,7 @@ void ProcessIndirectFitParameters::exec() {
   }
 
   // Join all peaks into a single workspace
-  auto tempWorkspace = tempWorkspaces.at(0);
+  std::string tempWorkspace = tempWorkspaces.at(0);
   for (auto it = tempWorkspaces.begin() + 1; it != tempWorkspaces.end(); ++it) {
     conjoin->setProperty("InputWorkspace1", tempWorkspace);
     conjoin->setProperty("InputWorkspace2", *it);
@@ -152,7 +152,7 @@ void ProcessIndirectFitParameters::exec() {
   
   // Replace axis on workspaces with text axis
   auto axis = new TextAxis(outputWs->getNumberHistograms());
-  int offset = 0;
+  size_t offset = 0;
   for (size_t j = 0; j < workspaceNames.size(); j++) {
     auto peakWs = workspaceNames.at(j);
     for (size_t k = 0; k < peakWs.size(); k++) {
@@ -220,16 +220,16 @@ std::vector<std::vector<std::string>>
 ProcessIndirectFitParameters::reorder2DVector(
     const std::vector<std::vector<std::string>> &original) {
   size_t maximumLength = original.at(0).size();
-  for (int i = 1; i < original.size(); i++) {
+  for (size_t i = 1; i < original.size(); i++) {
     if (original.at(i).size() > maximumLength) {
       maximumLength = original.at(i).size();
     }
   }
 
   auto reorderedVector = std::vector<std::vector<std::string>>();
-  for (int i = 0; i < maximumLength; i++) {
+  for (size_t i = 0; i < maximumLength; i++) {
     std::vector<std::string> temp;
-    for (int j = 0; j < original.size(); j++) {
+    for (size_t j = 0; j < original.size(); j++) {
       if (original.at(j).size() > i) {
         temp.push_back(original.at(j).at(i));
       }

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -167,6 +167,7 @@ ProcessIndirectFitParameters::listToVector(std::string &commaList) {
     commaList = commaList.substr(pos, commaList.size());
     pos = commaList.find(",");
   }
+  listVector.push_back(commaList);
   return listVector;
 }
 

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -69,13 +69,23 @@ void ProcessIndirectFitParameters::init() {
 void ProcessIndirectFitParameters::exec() {
   ITableWorkspace_sptr inputWs = getProperty("InputWorkspace");
   std::string xColumn = getProperty("X Column");
-  std::string parameterNames = getProperty("Parameter Names");
+  std::string parameterNamesProp = getProperty("Parameter Names");
+  auto parameterNames = listToVector(parameterNamesProp);
   MatrixWorkspace_sptr outputWs = getProperty("OutputWorkspace");
-
-
 }
 
-
+std::vector<std::string>
+ProcessIndirectFitParameters::listToVector(std::string &commaList) {
+  auto listVector = std::vector<std::string>();
+  auto pos = commaList.find(",");
+  while (pos != std::string::npos) {
+	  std::string nextItem = commaList.substr(0, pos);
+	  listVector.push_back(nextItem);
+	  commaList = commaList.substr(pos, commaList.size());
+	  pos = commaList.find(",");
+  }
+  return listVector;
+}
 
 } // namespace Algorithms
 } // namespace Mantid

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -5,7 +5,6 @@
 namespace Mantid {
 namespace Algorithms {
 
-
 using namespace API;
 using namespace Kernel;
 
@@ -25,7 +24,9 @@ ProcessIndirectFitParameters::~ProcessIndirectFitParameters() {}
 //----------------------------------------------------------------------------------------------
 
 /// Algorithms name for identification. @see Algorithm::name
-const std::string ProcessIndirectFitParameters::name() const { return "ProcessIndirectFitParameters"; }
+const std::string ProcessIndirectFitParameters::name() const {
+  return "ProcessIndirectFitParameters";
+}
 
 /// Algorithm's version for identification. @see Algorithm::version
 int ProcessIndirectFitParameters::version() const { return 1; }
@@ -67,11 +68,28 @@ void ProcessIndirectFitParameters::init() {
 /** Execute the algorithm.
  */
 void ProcessIndirectFitParameters::exec() {
+  // Get Properties
   ITableWorkspace_sptr inputWs = getProperty("InputWorkspace");
   std::string xColumn = getProperty("X Column");
   std::string parameterNamesProp = getProperty("Parameter Names");
   auto parameterNames = listToVector(parameterNamesProp);
   MatrixWorkspace_sptr outputWs = getProperty("OutputWorkspace");
+
+  // Search for any parameters in the table with the given parameter names,
+  // ignoring their function index and output them to a workspace
+
+
+  // Transpose list of workspaces, ignoring unequal length of lists
+  // this handles the case where a parameter occurs only once in the whole
+  // workspace
+
+
+  // Join all the parameters for each peak into a single workspace per peak
+
+
+  // Join all peaks into a single workspace
+
+
 }
 
 std::vector<std::string>
@@ -79,10 +97,10 @@ ProcessIndirectFitParameters::listToVector(std::string &commaList) {
   auto listVector = std::vector<std::string>();
   auto pos = commaList.find(",");
   while (pos != std::string::npos) {
-	  std::string nextItem = commaList.substr(0, pos);
-	  listVector.push_back(nextItem);
-	  commaList = commaList.substr(pos, commaList.size());
-	  pos = commaList.find(",");
+    std::string nextItem = commaList.substr(0, pos);
+    listVector.push_back(nextItem);
+    commaList = commaList.substr(pos, commaList.size());
+    pos = commaList.find(",");
   }
   return listVector;
 }

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -107,6 +107,12 @@ void ProcessIndirectFitParameters::exec() {
     workspaceNames.push_back(paramWorkspaces);
   }
 
+  // Transpose list of workspaces, ignoring unequal length of lists
+  // this handles the case where a parameter occurs only once in the whole
+  // workspace
+  workspaceNames = reorderWorkspaceParams(workspaceNames); 
+
+
   // Join all the parameters for each peak into a single workspace per peak
   auto tempWorkspaces = std::vector<std::string>();
   auto conjoin = createChildAlgorithm("ConjoinWorkspaces", -1, -1, true);
@@ -183,6 +189,28 @@ std::vector<std::string> ProcessIndirectFitParameters::searchForFitParams(
     }
   }
   return fitParams;
+}
+
+std::vector<std::vector<std::string>> ProcessIndirectFitParameters::reorderWorkspaceParams(const std::vector<std::vector<std::string>> &original){
+	size_t maximumLength = original.at(0).size();
+	for(int i = 1; i < original.size(); i++){
+		if(original.at(i).size() > maximumLength){
+			maximumLength = original.at(i).size();
+		}
+	}
+
+	auto reorderedVector = std::vector<std::vector<std::string>>();
+
+	for(int i = 0; i < maximumLength; i++){
+		std::vector<std::string> temp;
+		for(int j = 0; j < original.size(); j++){
+			temp.push_back(original.at(j).at(i));
+		}
+		reorderedVector.push_back(temp);
+	}
+
+	return reorderedVector;
+
 }
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -54,15 +54,15 @@ void ProcessIndirectFitParameters::init() {
                   "The table workspace to convert to a MatrixWorkspace.");
 
   declareProperty(
-      "X Column", "", boost::make_shared<MandatoryValidator<std::string>>(),
+      "ColumnX", "", boost::make_shared<MandatoryValidator<std::string>>(),
       "The column in the table to use for the x values.", Direction::Input);
 
-  declareProperty("Parameter Names", "",
+  declareProperty("ParameterNames", "",
                   boost::make_shared<MandatoryValidator<std::string>>(),
                   "List of the parameter names to add to the workspace.",
                   Direction::Input);
 
-  declareProperty("OutputWorkspace Name", "",
+  declareProperty("OutputWorkspaceName", "",
                   boost::make_shared<MandatoryValidator<std::string>>(),
                   "The name to call the output workspace.", Direction::Input);
 }
@@ -73,10 +73,10 @@ void ProcessIndirectFitParameters::init() {
 void ProcessIndirectFitParameters::exec() {
   // Get Properties
   ITableWorkspace_sptr inputWs = getProperty("InputWorkspace");
-  std::string xColumn = getProperty("X Column");
-  std::string parameterNamesProp = getProperty("Parameter Names");
+  std::string xColumn = getProperty("ColumnX");
+  std::string parameterNamesProp = getProperty("ParameterNames");
   auto parameterNames = listToVector(parameterNamesProp);
-  std::string outputWsName = getProperty("OutputWorkspace Name");
+  std::string outputWsName = getProperty("OutputWorkspaceName");
 
   // Search for any parameters in the table with the given parameter names,
   // ignoring their function index and output them to a workspace

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -78,7 +78,7 @@ void ProcessIndirectFitParameters::exec() {
 
   // Search for any parameters in the table with the given parameter names,
   // ignoring their function index and output them to a workspace
-  auto workspaceNames = std::vector<std::string>();
+  auto workspaceNames = std::vector<MatrixWorkspace_sptr>();
   const size_t totalNames = parameterNames.size();
   for (size_t i = 0; i < totalNames; i++) {
     auto const allColumnNames = inputWs->getColumnNames();
@@ -102,17 +102,37 @@ void ProcessIndirectFitParameters::exec() {
       convertToMatrix->executeAsChildAlg();
       paramWorkspaces.push_back(
           convertToMatrix->getProperty("OutputWorkspace"));
-      workspaceNames.push_back(paramWorkspaces.at(j)->getName());
+      workspaceNames.push_back(paramWorkspaces.at(j));
     }
 
     // Transpose list of workspaces, ignoring unequal length of lists
     // this handles the case where a parameter occurs only once in the whole
     // workspace
-
+	
     // Join all the parameters for each peak into a single workspace per peak
+	auto tempWorkspaces = std::vector<MatrixWorkspace_sptr>();
+
+	for(auto it = workspaceNames.begin(); it != workspaceNames.end(); ++it){
+		auto tempPeakWs = workspaceNames.at(0);
+	}
 
     // Join all peaks into a single workspace
-	
+	auto tempWorkspace = tempWorkspaces.at(0);
+	auto conjoin = createChildAlgorithm("ConjoinWorkspaces",-1 , -1, true); 
+	conjoin->setProperty("CheckOverlapping", false);
+	for(auto it = tempWorkspaces.begin(); it != tempWorkspaces.end(); ++it){
+		conjoin->setProperty("InputWorkspace1", tempWorkspace);
+		conjoin->setProperty("InputWorkspace2", *it);
+		conjoin->executeAsChildAlg();
+		tempWorkspace = conjoin->getProperty("InputWorkspace1");
+	}
+
+	auto renamer = createChildAlgorithm("RenameWorkspace", -1, -1, true);
+	renamer->setProperty("InputWorkspace", tempWorkspace);
+	renamer->setProperty("OutputWorkspace", outputWs);
+	renamer->executeAsChildAlg();
+	auto groupWorkspace = renamer->getProperty("OutputWorkspace");
+
 	// Replace axis on workspaces with text axis
   }
 }

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -96,9 +96,10 @@ void ProcessIndirectFitParameters::exec() {
     auto convertToMatrix =
         createChildAlgorithm("ConvertTableToMatrixWorkspace", -1, -1, true);
     convertToMatrix->setAlwaysStoreInADS(true);
-    convertToMatrix->setProperty("InputWorkspace", inputWs);
-    convertToMatrix->setProperty("ColumnX", xColumn);
+
     for (size_t j = 0; j < min; j++) {
+      convertToMatrix->setProperty("InputWorkspace", inputWs);
+      convertToMatrix->setProperty("ColumnX", xColumn);
       convertToMatrix->setProperty("ColumnY", columns.at(j));
       convertToMatrix->setProperty("ColumnE", errColumns.at(j));
       convertToMatrix->setProperty("OutputWorkspace", columns.at(j));
@@ -118,7 +119,6 @@ void ProcessIndirectFitParameters::exec() {
   auto conjoin = createChildAlgorithm("ConjoinWorkspaces", -1, -1, true);
   conjoin->setAlwaysStoreInADS(true);
   conjoin->setProperty("CheckOverlapping", false);
-
   const size_t wsMax = workspaceNames.size();
   for (size_t j = 0; j < wsMax; j++) {
     auto tempPeakWs = workspaceNames.at(j).at(0);
@@ -152,11 +152,14 @@ void ProcessIndirectFitParameters::exec() {
   
   // Replace axis on workspaces with text axis
   auto axis = new TextAxis(outputWs->getNumberHistograms());
+  int offset = 0;
   for (size_t j = 0; j < workspaceNames.size(); j++) {
     auto peakWs = workspaceNames.at(j);
     for (size_t k = 0; k < peakWs.size(); k++) {
-      axis->setLabel(k, peakWs.at(k));
+      std::string kString = peakWs.at(k);
+      axis->setLabel((k + offset), peakWs.at(k));
     }
+	offset += peakWs.size();
   }
   outputWs->replaceAxis(1, axis);
 }

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -1,6 +1,7 @@
 #include "MantidAlgorithms/ProcessIndirectFitParameters.h"
 
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidKernel/MandatoryValidator.h"
 
 namespace Mantid {
@@ -109,6 +110,7 @@ void ProcessIndirectFitParameters::exec() {
     // this handles the case where a parameter occurs only once in the whole
     // workspace
 
+
     // Join all the parameters for each peak into a single workspace per peak
     auto tempWorkspaces = std::vector<MatrixWorkspace_sptr>();
     auto conjoin = createChildAlgorithm("ConjoinWorkspace", -1, -1, true);
@@ -120,8 +122,8 @@ void ProcessIndirectFitParameters::exec() {
       const size_t paramMax = workspaceNames.at(j).size();
       for (size_t k = 1; k < paramMax; k++) {
         auto paramWs = workspaceNames.at(j).at(k);
-        conjoin->setProperty("", tempPeakWs);
-        conjoin->setProperty("", paramWs);
+        conjoin->setProperty("InputWorkspace1", tempPeakWs);
+        conjoin->setProperty("InputWorkspace2", paramWs);
         conjoin->executeAsChildAlg();
         tempPeakWs = conjoin->getProperty("InputWorkspace1");
       }
@@ -144,6 +146,14 @@ void ProcessIndirectFitParameters::exec() {
     auto groupWorkspace = renamer->getProperty("OutputWorkspace");
 
     // Replace axis on workspaces with text axis
+    auto axis = TextAxis(outputWs->getNumberHistograms());
+    for (size_t j = 0; j < workspaceNames.size(); j++) {
+      auto peakWs = workspaceNames.at(j);
+      for (size_t k = 0; k < peakWs.size(); k++) {
+        // axis.setLabel(i, name)
+      }
+    }
+    outputWs->replaceAxis(1, axis);
   }
 }
 

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -80,7 +80,7 @@ void ProcessIndirectFitParameters::exec() {
 
   // Search for any parameters in the table with the given parameter names,
   // ignoring their function index and output them to a workspace
-  auto workspaceNames = std::vector<std::vector<MatrixWorkspace_sptr>>();
+  auto workspaceNames = std::vector<std::vector<std::string>>();
   const size_t totalNames = parameterNames.size();
   for (size_t i = 0; i < totalNames; i++) {
     auto const allColumnNames = inputWs->getColumnNames();
@@ -88,7 +88,7 @@ void ProcessIndirectFitParameters::exec() {
     auto errColumns =
         searchForFitParams((parameterNames.at(i) + "_Err"), allColumnNames);
 
-    auto paramWorkspaces = std::vector<MatrixWorkspace_sptr>();
+    auto paramWorkspaces = std::vector<std::string>();
     size_t min = columns.size();
     if (errColumns.size() < min) {
       min = errColumns.size();
@@ -102,8 +102,7 @@ void ProcessIndirectFitParameters::exec() {
       convertToMatrix->setProperty("ColumnE", errColumns.at(j));
       convertToMatrix->setProperty("OutputWorkspace", columns.at(j));
       convertToMatrix->executeAsChildAlg();
-      paramWorkspaces.push_back(
-          convertToMatrix->getProperty("OutputWorkspace"));
+      paramWorkspaces.push_back(columns.at(j));
     }
     workspaceNames.push_back(paramWorkspaces);
   }
@@ -113,7 +112,7 @@ void ProcessIndirectFitParameters::exec() {
   // workspace
 
   // Join all the parameters for each peak into a single workspace per peak
-  auto tempWorkspaces = std::vector<MatrixWorkspace_sptr>();
+  auto tempWorkspaces = std::vector<std::string>();
   auto conjoin = createChildAlgorithm("ConjoinWorkspace", -1, -1, true);
   conjoin->setProperty("CheckOverlapping", false);
 
@@ -152,7 +151,7 @@ void ProcessIndirectFitParameters::exec() {
   for (size_t j = 0; j < workspaceNames.size(); j++) {
     auto peakWs = workspaceNames.at(j);
     for (size_t k = 0; k < peakWs.size(); k++) {
-      axisPtr->setLabel(k, peakWs.at(k)->getName());
+      axisPtr->setLabel(k, peakWs.at(k));
     }
   }
   outputWs->replaceAxis(1, axisPtr);

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -48,9 +48,10 @@ const std::string ProcessIndirectFitParameters::summary() const {
 /** Initialize the algorithm's properties.
  */
 void ProcessIndirectFitParameters::init() {
-  declareProperty(
-      new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
-      "The table workspace to convert to a MatrixWorkspace.");
+
+  declareProperty(new WorkspaceProperty<API::ITableWorkspace>(
+                      "InputWorkspace", "", Direction::Input),
+                  "The table workspace to convert to a MatrixWorkspace.");
 
   declareProperty(
       "X Column", "", boost::make_shared<MandatoryValidator<std::string>>(),

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -110,8 +110,7 @@ void ProcessIndirectFitParameters::exec() {
   // Transpose list of workspaces, ignoring unequal length of lists
   // this handles the case where a parameter occurs only once in the whole
   // workspace
-  workspaceNames = reorderWorkspaceParams(workspaceNames); 
-
+  workspaceNames = reorder2DVector(workspaceNames);
 
   // Join all the parameters for each peak into a single workspace per peak
   auto tempWorkspaces = std::vector<std::string>();
@@ -157,10 +156,13 @@ void ProcessIndirectFitParameters::exec() {
     }
   }
   outputWs->replaceAxis(1, axisPtr);
-
-
 }
 
+/**
+ * Transforms a comma separated list into a vector of strings
+ * @param commaList - The comma separated list to be separated
+ * @return - The vector of string composed of the elements of the comma list
+ */
 std::vector<std::string>
 ProcessIndirectFitParameters::listToVector(std::string &commaList) {
   auto listVector = std::vector<std::string>();
@@ -175,6 +177,15 @@ ProcessIndirectFitParameters::listToVector(std::string &commaList) {
   return listVector;
 }
 
+/**
+ * Searchs for a particular word within all of the fit params in the columns of
+ * a table workspace (note: This method only matches strings that are at the end
+ * of a column name this is to ensure that "Amplitude" will match
+ * "f0.f0.f1.Amplitude" but not f0.f0.f1.Amplitude_Err")
+ * @param suffix - The string to search for
+ * @param columns - A string vector of all the column names in a table workspace
+ * @return - The full column names in which the string is present
+ */
 std::vector<std::string> ProcessIndirectFitParameters::searchForFitParams(
     const std::string &suffix, const std::vector<std::string> &columns) {
   auto fitParams = std::vector<std::string>();
@@ -191,28 +202,36 @@ std::vector<std::string> ProcessIndirectFitParameters::searchForFitParams(
   return fitParams;
 }
 
-std::vector<std::vector<std::string>> ProcessIndirectFitParameters::reorderWorkspaceParams(const std::vector<std::vector<std::string>> &original){
-	size_t maximumLength = original.at(0).size();
-	for(int i = 1; i < original.size(); i++){
-		if(original.at(i).size() > maximumLength){
-			maximumLength = original.at(i).size();
-		}
-	}
+/**
+ * Changes the ordering of a 2D vector of strings such that
+ * [[1a,2a,3a], [1b,2b,3b], [1c,2c,3c]]
+ * becomes
+ * [[1a,1b,1c], [2a,2b,2c], [3a,3b,3c]]
+ * @param original - The original vector to be transformed
+ * @return - The vector after it has been transformed
+ */
+std::vector<std::vector<std::string>>
+ProcessIndirectFitParameters::reorder2DVector(
+    const std::vector<std::vector<std::string>> &original) {
+  size_t maximumLength = original.at(0).size();
+  for (int i = 1; i < original.size(); i++) {
+    if (original.at(i).size() > maximumLength) {
+      maximumLength = original.at(i).size();
+    }
+  }
 
-	auto reorderedVector = std::vector<std::vector<std::string>>();
+  auto reorderedVector = std::vector<std::vector<std::string>>();
+  for (int i = 0; i < maximumLength; i++) {
+    std::vector<std::string> temp;
+    for (int j = 0; j < original.size(); j++) {
+      if (original.at(j).size() > i) {
+        temp.push_back(original.at(j).at(i));
+      }
+    }
+    reorderedVector.push_back(temp);
+  }
 
-	for(int i = 0; i < maximumLength; i++){
-		std::vector<std::string> temp;
-		for(int j = 0; j < original.size(); j++){
-			if(original.at(j).size() > i){
-			temp.push_back(original.at(j).at(i));
-			}
-		}
-		reorderedVector.push_back(temp);
-	}
-
-	return reorderedVector;
-
+  return reorderedVector;
 }
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ProcessIndirectFitParameters.cpp
@@ -107,10 +107,6 @@ void ProcessIndirectFitParameters::exec() {
     workspaceNames.push_back(paramWorkspaces);
   }
 
-  // Transpose list of workspaces, ignoring unequal length of lists
-  // this handles the case where a parameter occurs only once in the whole
-  // workspace
-
   // Join all the parameters for each peak into a single workspace per peak
   auto tempWorkspaces = std::vector<std::string>();
   auto conjoin = createChildAlgorithm("ConjoinWorkspace", -1, -1, true);
@@ -178,8 +174,12 @@ std::vector<std::string> ProcessIndirectFitParameters::searchForFitParams(
   auto fitParams = std::vector<std::string>();
   const size_t totalColumns = columns.size();
   for (size_t i = 0; i < totalColumns; i++) {
-    if (columns.at(i).rfind(suffix) != std::string::npos) {
-      fitParams.push_back(columns.at(i));
+    auto pos = columns.at(i).rfind(suffix);
+    if (pos != std::string::npos) {
+      auto endCheck = pos + suffix.size();
+      if (endCheck == columns.at(i).size()) {
+        fitParams.push_back(columns.at(i));
+      }
     }
   }
   return fitParams;

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -80,7 +80,7 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
-    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspace", ""),
+    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspace Name", ""),
                      std::invalid_argument);
   }
 
@@ -96,7 +96,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
-    alg.setProperty("OutputWorkspace", outputName);
+    alg.setProperty("OutputWorkspace Name", outputName);
 
     ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
 
@@ -104,14 +104,14 @@ public:
     TS_ASSERT_EQUALS(std::string(alg.getProperty("X Column")), xColumn);
     TS_ASSERT_EQUALS(std::string(alg.getProperty("Parameter Names")),
                      parameterValues);
-    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")),
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace Name")),
                      outputName);
   }
 
   void test_output() {
     auto tableWs = createTable();
     std::string xColumn = "axis-1";
-    std::string parameterValues = "Amplitude";
+    std::string parameterValues = "Height,Amplitude";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
@@ -119,7 +119,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
-    alg.setProperty("OutputWorkspace", outputName);
+    alg.setProperty("OutputWorkspace Name", outputName);
 
     alg.execute();
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAlgorithms/ProcessIndirectFitParameters.h"
+#include "MantidAPI/ITableWorkspace.h"
 
 using Mantid::Algorithms::ProcessIndirectFitParameters;
 using namespace Mantid::API;
@@ -51,33 +52,40 @@ public:
                      std::invalid_argument);
   }
 
-  void test_property_input() {
-    auto tableWs = WorkspaceFactory::Instance().createTable();
+ void test_property_input() {
+	auto tableWs = WorkspaceFactory::Instance().createTable();
+	tableWs->addColumn("double", "Amplitude");
+	tableWs->addColumn("double", "Amplitude_Err");
+	tableWs->addColumn("double", "testColumn");
     std::string xColumn = "axis-1";
     std::string parameterValues = "Amplitude";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
+	TS_ASSERT_THROWS_NOTHING(alg.initialize());
+	TS_ASSERT( alg.isInitialized() );
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
     alg.setProperty("OutputWorkspace", outputName);
 
-    TS_ASSERT_EQUALS(alg.getProperty("InputWorkspace", tableWs);
-	TS_ASSERT_EQUALS(alg.getProperty("X Column", xColumn);
-	TS_ASSERT_EQUALS(alg.getProperty("Parameter Names",parameterValues);
-	TS_ASSERT_EQUALS(alg.getProperty("OutputWorkspace", outputName);
+	ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
+
+    TS_ASSERT_EQUALS(tableProp, tableWs);
+	TS_ASSERT_EQUALS(std::string(alg.getProperty("X Column")), xColumn);
+	TS_ASSERT_EQUALS(std::string(alg.getProperty("Parameter Names")),parameterValues);
+	TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")), outputName);
 
   }
 
   void test_output(){
     auto tableWs = WorkspaceFactory::Instance().createTable();
-	tableWs
     std::string xColumn = "axis-1";
     std::string parameterValues = "Amplitude";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
+	TS_ASSERT_THROWS_NOTHING(alg.initialize());
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
@@ -85,13 +93,12 @@ public:
 
 	alg.execute();
 
-	auto outMatrixWs = alg.getProperty("InputWorkspace");
-	/*Check output*/
-	TSM_ASSERT_EQUALS(outMatrixWs.getName(), outputName);
+	MatrixWorkspace_sptr outMatrixWs = alg.getProperty("InputWorkspace");
+
+	TS_ASSERT_EQUALS(outMatrixWs->getName(), outputName);
 
 
   }
-
 
 };
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -50,6 +50,49 @@ public:
     TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspace", ""),
                      std::invalid_argument);
   }
+
+  void test_property_input() {
+    auto tableWs = WorkspaceFactory::Instance().createTable();
+    std::string xColumn = "axis-1";
+    std::string parameterValues = "Amplitude";
+    std::string outputName = "outMatrix";
+
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    alg.setProperty("InputWorkspace", tableWs);
+    alg.setPropertyValue("X Column", xColumn);
+    alg.setPropertyValue("Parameter Names", parameterValues);
+    alg.setProperty("OutputWorkspace", outputName);
+
+    TS_ASSERT_EQUALS(alg.getProperty("InputWorkspace", tableWs);
+	TS_ASSERT_EQUALS(alg.getProperty("X Column", xColumn);
+	TS_ASSERT_EQUALS(alg.getProperty("Parameter Names",parameterValues);
+	TS_ASSERT_EQUALS(alg.getProperty("OutputWorkspace", outputName);
+
+  }
+
+  void test_output(){
+    auto tableWs = WorkspaceFactory::Instance().createTable();
+	tableWs
+    std::string xColumn = "axis-1";
+    std::string parameterValues = "Amplitude";
+    std::string outputName = "outMatrix";
+
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    alg.setProperty("InputWorkspace", tableWs);
+    alg.setPropertyValue("X Column", xColumn);
+    alg.setPropertyValue("Parameter Names", parameterValues);
+    alg.setProperty("OutputWorkspace", outputName);
+
+	alg.execute();
+
+	auto outMatrixWs = alg.getProperty("InputWorkspace");
+	/*Check output*/
+	TSM_ASSERT_EQUALS(outMatrixWs.getName(), outputName);
+
+
+  }
+
+
 };
 
 #endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_ */

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -159,21 +159,21 @@ public:
   }
 
   void test_output_of_irregular_shaped_table_workspace() {
-	auto tableWs = createIrregularTable();
-	std::string xColumn = "axis-1";
-	std::string parameterValues = "Height,Amplitude";
+    auto tableWs = createIrregularTable();
+    std::string xColumn = "axis-1";
+    std::string parameterValues = "Height,Amplitude";
     std::string outputName = "outMatrix";
 
-	Mantid::Algorithms::ProcessIndirectFitParameters alg;
-	TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
     alg.setProperty("OutputWorkspace Name", outputName);
 
-	alg.execute();
+    alg.execute();
 
-	MatrixWorkspace_sptr outws;
+    MatrixWorkspace_sptr outws;
     TS_ASSERT_THROWS_NOTHING(
         outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputName));

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -42,6 +42,35 @@ private:
     return tableWs;
   }
 
+  ITableWorkspace_sptr createIrregularTable() {
+    auto tableWs = WorkspaceFactory::Instance().createTable();
+    tableWs->addColumn("double", "axis-1");
+    tableWs->addColumn("double", "f1.f1.f0.Height");
+    tableWs->addColumn("double", "f1.f1.f0.Height_Err");
+    tableWs->addColumn("double", "f1.f1.f0.Amplitude");
+    tableWs->addColumn("double", "f1.f1.f0.Amplitude_Err");
+    tableWs->addColumn("double", "f1.f1.f1.Height");
+    tableWs->addColumn("double", "f1.f1.f1.Height_Err");
+    tableWs->addColumn("double", "f1.f1.f2.Height");
+    tableWs->addColumn("double", "f1.f1.f2.Height_Err");
+
+    size_t n = 5;
+    for (size_t i = 0; i < n; ++i) {
+      TableRow row = tableWs->appendRow();
+      double ax1 = int(i) * 1.0;
+      double h = int(i) * 1.02;
+      double he = sqrt(h);
+      double am = int(i) * 2.43;
+      double ame = sqrt(am);
+      double h1 = -0.0567;
+      double he1 = sqrt(h);
+      double h2 = int(i) * -0.25;
+      double he2 = sqrt(h2);
+      row << ax1 << h << he << am << ame << h1 << he1 << h2 << he2;
+    }
+    return tableWs;
+  }
+
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -108,7 +137,7 @@ public:
                      outputName);
   }
 
-  void test_output() {
+  void test_output_of_regular_shaped_table_workspace() {
     auto tableWs = createTable();
     std::string xColumn = "axis-1";
     std::string parameterValues = "Height,Amplitude";
@@ -124,6 +153,27 @@ public:
     alg.execute();
 
     MatrixWorkspace_sptr outws;
+    TS_ASSERT_THROWS_NOTHING(
+        outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            outputName));
+  }
+
+  void test_output_of_irregular_shaped_table_workspace() {
+	auto tableWs = createIrregularTable();
+	std::string xColumn = "axis-1";
+	std::string parameterValues = "Height,Amplitude";
+    std::string outputName = "outMatrix";
+
+	Mantid::Algorithms::ProcessIndirectFitParameters alg;
+	TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    alg.setProperty("InputWorkspace", tableWs);
+    alg.setPropertyValue("X Column", xColumn);
+    alg.setPropertyValue("Parameter Names", parameterValues);
+    alg.setProperty("OutputWorkspace Name", outputName);
+
+	alg.execute();
+
+	MatrixWorkspace_sptr outws;
     TS_ASSERT_THROWS_NOTHING(
         outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputName));

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -12,49 +12,44 @@ class ProcessIndirectFitParametersTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static ProcessIndirectFitParametersTest *createSuite() { return new ProcessIndirectFitParametersTest(); }
-  static void destroySuite( ProcessIndirectFitParametersTest *suite ) { delete suite; }
-
-
-  void test_Init()
-  {
-    ProcessIndirectFitParameters alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
+  static ProcessIndirectFitParametersTest *createSuite() {
+    return new ProcessIndirectFitParametersTest();
+  }
+  static void destroySuite(ProcessIndirectFitParametersTest *suite) {
+    delete suite;
   }
 
-  void test_exec()
-  {
-    // Name of the output workspace.
-    std::string outWSName("ProcessIndirectFitParametersTest_OutputWS");
+  void test_empty_input_is_not_allowed() {
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
-    ProcessIndirectFitParameters alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
-    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("REPLACE_PROPERTY_NAME_HERE!!!!", "value") );
-    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", outWSName) );
-    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
-    TS_ASSERT( alg.isExecuted() );
-
-    // Retrieve the workspace from data service. TODO: Change to your desired type
-    Workspace_sptr ws;
-    TS_ASSERT_THROWS_NOTHING( ws = AnalysisDataService::Instance().retrieveWS<Workspace>(outWSName) );
-    TS_ASSERT(ws);
-    if (!ws) return;
-
-    // TODO: Check the results
-
-    // Remove workspace from the data service.
-    AnalysisDataService::Instance().remove(outWSName);
-  }
-  
-  void test_Something()
-  {
-    TSM_ASSERT( "You forgot to write a test!", 0);
+    TS_ASSERT_THROWS(alg.setPropertyValue("InputWorkspace", ""),
+                     std::invalid_argument);
   }
 
+  void test_empty_x_column_is_not_allowed() {
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
+    TS_ASSERT_THROWS(alg.setPropertyValue("X Column", ""),
+                     std::invalid_argument);
+  }
+
+  void test_that_empty_param_names_is_not_allowed() {
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+
+    TS_ASSERT_THROWS(alg.setPropertyValue("Parameter Names", ""),
+                     std::invalid_argument);
+  }
+
+  void test_empty_output_is_not_allowed() {
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+
+    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspace", ""),
+                     std::invalid_argument);
+  }
 };
-
 
 #endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_ */

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -105,13 +105,6 @@ public:
                      std::invalid_argument);
   }
 
-  void test_empty_units_is_not_allowed() {
-    Mantid::Algorithms::ProcessIndirectFitParameters alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT_THROWS(alg.setPropertyValue("XAxisUnit", ""),
-                     std::invalid_argument);
-  }
-
   void test_empty_output_is_not_allowed() {
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -153,17 +153,28 @@ public:
 
     alg.execute();
 
-    MatrixWorkspace_sptr outws;
+    MatrixWorkspace_sptr outWs;
     TS_ASSERT_THROWS_NOTHING(
-        outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        outWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputName));
-    size_t const histNum = outws->getNumberHistograms();
+    size_t const histNum = outWs->getNumberHistograms();
     TS_ASSERT_EQUALS(histNum, 2);
-    TS_ASSERT_EQUALS(outws->getAxis(1)->label(0), "f1.f1.f0.Height");
-    TS_ASSERT_EQUALS(outws->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
+    TS_ASSERT_EQUALS(outWs->getAxis(1)->label(0), "f1.f1.f0.Height");
+    TS_ASSERT_EQUALS(outWs->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
 
 	// 5 = The initial number of rows in the table workspace
-	TS_ASSERT_EQUALS(outws->blocksize(), 5); 
+	TS_ASSERT_EQUALS(outWs->blocksize(), 5); 
+
+	// Test output values
+	auto heightY = outWs->readY(0);
+	auto heightTest = std::vector<double>();
+	tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
+	TS_ASSERT_EQUALS(heightY, heightTest);
+
+	auto ampY = outWs->readY(1);
+	auto ampTest = std::vector<double>();
+	tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
+	TS_ASSERT_EQUALS(ampY, ampTest);
 
     AnalysisDataService::Instance().remove(outputName);
   }
@@ -183,21 +194,43 @@ public:
 
     alg.execute();
 
-    MatrixWorkspace_sptr outws;
+    MatrixWorkspace_sptr outWs;
     TS_ASSERT_THROWS_NOTHING(
-        outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        outWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputName));
-    size_t const histNum = outws->getNumberHistograms();
+    size_t const histNum = outWs->getNumberHistograms();
     TS_ASSERT_EQUALS(histNum, 4);
-    TS_ASSERT_EQUALS(outws->getAxis(1)->label(0), "f1.f1.f0.Height");
-    TS_ASSERT_EQUALS(outws->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
-    TS_ASSERT_EQUALS(outws->getAxis(1)->label(2), "f1.f1.f1.Height");
-    TS_ASSERT_EQUALS(outws->getAxis(1)->label(3), "f1.f1.f2.Height");
+    TS_ASSERT_EQUALS(outWs->getAxis(1)->label(0), "f1.f1.f0.Height");
+    TS_ASSERT_EQUALS(outWs->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
+    TS_ASSERT_EQUALS(outWs->getAxis(1)->label(2), "f1.f1.f1.Height");
+    TS_ASSERT_EQUALS(outWs->getAxis(1)->label(3), "f1.f1.f2.Height");
 
 	// 5 = The initial number of rows in the table workspace
-	TS_ASSERT_EQUALS(outws->blocksize(), 5); 
+	TS_ASSERT_EQUALS(outWs->blocksize(), 5); 
 
-    AnalysisDataService::Instance().remove(outputName);
+	// Test output values
+	auto heightY = outWs->readY(0);
+	auto heightTest = std::vector<double>();
+	tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
+	TS_ASSERT_EQUALS(heightY, heightTest);
+
+	auto ampY = outWs->readY(1);
+	auto ampTest = std::vector<double>();
+	tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
+	TS_ASSERT_EQUALS(ampY, ampTest);
+
+	auto height1Y = outWs->readY(2);
+	auto height1Test = std::vector<double>();
+	tableWs->getColumn("f1.f1.f1.Height")->numeric_fill(height1Test);
+	TS_ASSERT_EQUALS(height1Y, height1Test);
+
+	auto height2Y = outWs->readY(3);
+	auto height2Test = std::vector<double>();
+	tableWs->getColumn("f1.f1.f2.Height")->numeric_fill(height2Test);
+	TS_ASSERT_EQUALS(height2Y, height2Test);
+
+	AnalysisDataService::Instance().remove(outputName);
+
   }
 };
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -117,6 +117,7 @@ public:
     auto tableWs = createTable();
     std::string xColumn = "axis-1";
     std::string parameterValues = "Amplitude";
+    std::string inAxis = "Degrees";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
@@ -125,7 +126,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
-    alg.setPropertyValue("XAxisUnit", "SpectraNumber");
+    alg.setPropertyValue("XAxisUnit", inAxis);
     alg.setProperty("OutputWorkspace", outputName);
 
     ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
@@ -134,8 +135,7 @@ public:
     TS_ASSERT_EQUALS(std::string(alg.getProperty("ColumnX")), xColumn);
     TS_ASSERT_EQUALS(std::string(alg.getProperty("ParameterNames")),
                      parameterValues);
-    TS_ASSERT_EQUALS(std::string(alg.getProperty("XAxisUnit")),
-                     "SpectraNumber");
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("XAxisUnit")), inAxis);
     TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")),
                      outputName);
   }
@@ -144,6 +144,7 @@ public:
     auto tableWs = createTable();
     std::string xColumn = "axis-1";
     std::string parameterValues = "Height,Amplitude";
+    std::string inAxis = "Degrees";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
@@ -151,7 +152,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
-	alg.setPropertyValue("XAxisUnit", "SpectraNumber");
+    alg.setPropertyValue("XAxisUnit", inAxis);
     alg.setProperty("OutputWorkspace", outputName);
 
     alg.execute();
@@ -179,6 +180,10 @@ public:
     tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
     TS_ASSERT_EQUALS(ampY, ampTest);
 
+    // Test axis units
+    std::string outAxis = outWs->getAxis(0)->unit()->unitID();
+    TS_ASSERT_EQUALS(inAxis, outAxis);
+
     AnalysisDataService::Instance().remove(outputName);
   }
 
@@ -186,6 +191,7 @@ public:
     auto tableWs = createIrregularTable();
     std::string xColumn = "axis-1";
     std::string parameterValues = "Height,Amplitude";
+    std::string inAxis = "Degrees";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
@@ -193,7 +199,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
-	alg.setPropertyValue("XAxisUnit", "SpectraNumber");
+    alg.setPropertyValue("XAxisUnit", inAxis);
     alg.setProperty("OutputWorkspace", outputName);
 
     alg.execute();
@@ -232,6 +238,10 @@ public:
     auto height2Test = std::vector<double>();
     tableWs->getColumn("f1.f1.f2.Height")->numeric_fill(height2Test);
     TS_ASSERT_EQUALS(height2Y, height2Test);
+
+    // Test axis units
+    std::string outAxis = outWs->getAxis(0)->unit()->unitID();
+    TS_ASSERT_EQUALS(inAxis, outAxis);
 
     AnalysisDataService::Instance().remove(outputName);
   }

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -54,7 +54,6 @@ private:
     tableWs->addColumn("double", "f1.f1.f2.Height");
     tableWs->addColumn("double", "f1.f1.f2.Height_Err");
 
-
     size_t n = 5;
     for (size_t i = 0; i < n; ++i) {
       TableRow row = tableWs->appendRow();
@@ -162,19 +161,19 @@ public:
     TS_ASSERT_EQUALS(outWs->getAxis(1)->label(0), "f1.f1.f0.Height");
     TS_ASSERT_EQUALS(outWs->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
 
-	// 5 = The initial number of rows in the table workspace
-	TS_ASSERT_EQUALS(outWs->blocksize(), 5); 
+    // 5 = The initial number of rows in the table workspace
+    TS_ASSERT_EQUALS(outWs->blocksize(), 5);
 
-	// Test output values
-	auto heightY = outWs->readY(0);
-	auto heightTest = std::vector<double>();
-	tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
-	TS_ASSERT_EQUALS(heightY, heightTest);
+    // Test output values
+    auto heightY = outWs->readY(0);
+    auto heightTest = std::vector<double>();
+    tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
+    TS_ASSERT_EQUALS(heightY, heightTest);
 
-	auto ampY = outWs->readY(1);
-	auto ampTest = std::vector<double>();
-	tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
-	TS_ASSERT_EQUALS(ampY, ampTest);
+    auto ampY = outWs->readY(1);
+    auto ampTest = std::vector<double>();
+    tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
+    TS_ASSERT_EQUALS(ampY, ampTest);
 
     AnalysisDataService::Instance().remove(outputName);
   }
@@ -205,32 +204,31 @@ public:
     TS_ASSERT_EQUALS(outWs->getAxis(1)->label(2), "f1.f1.f1.Height");
     TS_ASSERT_EQUALS(outWs->getAxis(1)->label(3), "f1.f1.f2.Height");
 
-	// 5 = The initial number of rows in the table workspace
-	TS_ASSERT_EQUALS(outWs->blocksize(), 5); 
+    // 5 = The initial number of rows in the table workspace
+    TS_ASSERT_EQUALS(outWs->blocksize(), 5);
 
-	// Test output values
-	auto heightY = outWs->readY(0);
-	auto heightTest = std::vector<double>();
-	tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
-	TS_ASSERT_EQUALS(heightY, heightTest);
+    // Test output values
+    auto heightY = outWs->readY(0);
+    auto heightTest = std::vector<double>();
+    tableWs->getColumn("f1.f1.f0.Height")->numeric_fill(heightTest);
+    TS_ASSERT_EQUALS(heightY, heightTest);
 
-	auto ampY = outWs->readY(1);
-	auto ampTest = std::vector<double>();
-	tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
-	TS_ASSERT_EQUALS(ampY, ampTest);
+    auto ampY = outWs->readY(1);
+    auto ampTest = std::vector<double>();
+    tableWs->getColumn("f1.f1.f0.Amplitude")->numeric_fill(ampTest);
+    TS_ASSERT_EQUALS(ampY, ampTest);
 
-	auto height1Y = outWs->readY(2);
-	auto height1Test = std::vector<double>();
-	tableWs->getColumn("f1.f1.f1.Height")->numeric_fill(height1Test);
-	TS_ASSERT_EQUALS(height1Y, height1Test);
+    auto height1Y = outWs->readY(2);
+    auto height1Test = std::vector<double>();
+    tableWs->getColumn("f1.f1.f1.Height")->numeric_fill(height1Test);
+    TS_ASSERT_EQUALS(height1Y, height1Test);
 
-	auto height2Y = outWs->readY(3);
-	auto height2Test = std::vector<double>();
-	tableWs->getColumn("f1.f1.f2.Height")->numeric_fill(height2Test);
-	TS_ASSERT_EQUALS(height2Y, height2Test);
+    auto height2Y = outWs->readY(3);
+    auto height2Test = std::vector<double>();
+    tableWs->getColumn("f1.f1.f2.Height")->numeric_fill(height2Test);
+    TS_ASSERT_EQUALS(height2Y, height2Test);
 
-	AnalysisDataService::Instance().remove(outputName);
-
+    AnalysisDataService::Instance().remove(outputName);
   }
 };
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -97,11 +97,18 @@ public:
                      std::invalid_argument);
   }
 
-  void test_that_empty_param_names_is_not_allowed() {
+  void test_empty_param_names_is_not_allowed() {
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
     TS_ASSERT_THROWS(alg.setPropertyValue("ParameterNames", ""),
+                     std::invalid_argument);
+  }
+
+  void test_empty_units_is_not_allowed() {
+    Mantid::Algorithms::ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_THROWS(alg.setPropertyValue("XAxisUnit", ""),
                      std::invalid_argument);
   }
 
@@ -125,6 +132,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
+    alg.setPropertyValue("XAxisUnit", "SpectraNumber");
     alg.setProperty("OutputWorkspace", outputName);
 
     ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
@@ -133,6 +141,8 @@ public:
     TS_ASSERT_EQUALS(std::string(alg.getProperty("ColumnX")), xColumn);
     TS_ASSERT_EQUALS(std::string(alg.getProperty("ParameterNames")),
                      parameterValues);
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("XAxisUnit")),
+                     "SpectraNumber");
     TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")),
                      outputName);
   }
@@ -148,6 +158,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
+	alg.setPropertyValue("XAxisUnit", "SpectraNumber");
     alg.setProperty("OutputWorkspace", outputName);
 
     alg.execute();
@@ -189,6 +200,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
+	alg.setPropertyValue("XAxisUnit", "SpectraNumber");
     alg.setProperty("OutputWorkspace", outputName);
 
     alg.execute();

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -54,6 +54,7 @@ private:
     tableWs->addColumn("double", "f1.f1.f2.Height");
     tableWs->addColumn("double", "f1.f1.f2.Height_Err");
 
+
     size_t n = 5;
     for (size_t i = 0; i < n; ++i) {
       TableRow row = tableWs->appendRow();
@@ -156,6 +157,15 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputName));
+    size_t const histNum = outws->getNumberHistograms();
+    TS_ASSERT_EQUALS(histNum, 2);
+    TS_ASSERT_EQUALS(outws->getAxis(1)->label(0), "f1.f1.f0.Height");
+    TS_ASSERT_EQUALS(outws->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
+
+	// 5 = The initial number of rows in the table workspace
+	TS_ASSERT_EQUALS(outws->blocksize(), 5); 
+
+    AnalysisDataService::Instance().remove(outputName);
   }
 
   void test_output_of_irregular_shaped_table_workspace() {
@@ -177,6 +187,17 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputName));
+    size_t const histNum = outws->getNumberHistograms();
+    TS_ASSERT_EQUALS(histNum, 4);
+    TS_ASSERT_EQUALS(outws->getAxis(1)->label(0), "f1.f1.f0.Height");
+    TS_ASSERT_EQUALS(outws->getAxis(1)->label(1), "f1.f1.f0.Amplitude");
+    TS_ASSERT_EQUALS(outws->getAxis(1)->label(2), "f1.f1.f1.Height");
+    TS_ASSERT_EQUALS(outws->getAxis(1)->label(3), "f1.f1.f2.Height");
+
+	// 5 = The initial number of rows in the table workspace
+	TS_ASSERT_EQUALS(outws->blocksize(), 5); 
+
+    AnalysisDataService::Instance().remove(outputName);
   }
 };
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -5,6 +5,7 @@
 
 #include "MantidAlgorithms/ProcessIndirectFitParameters.h"
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/TableRow.h"
 
 using Mantid::Algorithms::ProcessIndirectFitParameters;
 using namespace Mantid::API;
@@ -14,9 +15,30 @@ class ProcessIndirectFitParametersTest : public CxxTest::TestSuite {
 private:
   ITableWorkspace_sptr createTable() {
     auto tableWs = WorkspaceFactory::Instance().createTable();
-    tableWs->addColumn("double", "Amplitude");
-    tableWs->addColumn("double", "Amplitude_Err");
-    tableWs->addColumn("double", "testColumn");
+    tableWs->addColumn("double", "axis-1");
+    tableWs->addColumn("double", "f0.A0");
+    tableWs->addColumn("double", "f0.A0_Err");
+    tableWs->addColumn("double", "f1.f1.f0.Height");
+    tableWs->addColumn("double", "f1.f1.f0.Height_Err");
+    tableWs->addColumn("double", "f1.f1.f0.Amplitude");
+    tableWs->addColumn("double", "f1.f1.f0.Amplitude_Err");
+    tableWs->addColumn("double", "f1.f1.f0.PeakCentre");
+    tableWs->addColumn("double", "f1.f1.f0.PeakCentre_Err");
+
+    size_t n = 5;
+    for (size_t i = 0; i < n; ++i) {
+      TableRow row = tableWs->appendRow();
+      double ax1 = int(i) * 1.0;
+      double a0 = 0.0;
+      double a0e = 0.0;
+      double h = int(i) * 1.02;
+      double he = sqrt(h);
+      double am = int(i) * 2.43;
+      double ame = sqrt(am);
+      double pc = -0.0567;
+      double pce = sqrt(pc);
+      row << ax1 << a0 << a0e << h << he << am << ame << pc << pce;
+    }
     return tableWs;
   }
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -109,7 +109,7 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
-    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspaceName", ""),
+    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspace", ""),
                      std::invalid_argument);
   }
 
@@ -125,7 +125,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
-    alg.setProperty("OutputWorkspaceName", outputName);
+    alg.setProperty("OutputWorkspace", outputName);
 
     ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
 
@@ -133,7 +133,7 @@ public:
     TS_ASSERT_EQUALS(std::string(alg.getProperty("ColumnX")), xColumn);
     TS_ASSERT_EQUALS(std::string(alg.getProperty("ParameterNames")),
                      parameterValues);
-    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspaceName")),
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")),
                      outputName);
   }
 
@@ -148,7 +148,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
-    alg.setProperty("OutputWorkspaceName", outputName);
+    alg.setProperty("OutputWorkspace", outputName);
 
     alg.execute();
 
@@ -189,7 +189,7 @@ public:
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("ColumnX", xColumn);
     alg.setPropertyValue("ParameterNames", parameterValues);
-    alg.setProperty("OutputWorkspaceName", outputName);
+    alg.setProperty("OutputWorkspace", outputName);
 
     alg.execute();
 

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -1,0 +1,60 @@
+#ifndef MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_
+#define MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/ProcessIndirectFitParameters.h"
+
+using Mantid::Algorithms::ProcessIndirectFitParameters;
+using namespace Mantid::API;
+
+class ProcessIndirectFitParametersTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ProcessIndirectFitParametersTest *createSuite() { return new ProcessIndirectFitParametersTest(); }
+  static void destroySuite( ProcessIndirectFitParametersTest *suite ) { delete suite; }
+
+
+  void test_Init()
+  {
+    ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+  }
+
+  void test_exec()
+  {
+    // Name of the output workspace.
+    std::string outWSName("ProcessIndirectFitParametersTest_OutputWS");
+
+    ProcessIndirectFitParameters alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("REPLACE_PROPERTY_NAME_HERE!!!!", "value") );
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", outWSName) );
+    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
+    TS_ASSERT( alg.isExecuted() );
+
+    // Retrieve the workspace from data service. TODO: Change to your desired type
+    Workspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING( ws = AnalysisDataService::Instance().retrieveWS<Workspace>(outWSName) );
+    TS_ASSERT(ws);
+    if (!ws) return;
+
+    // TODO: Check the results
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+  
+  void test_Something()
+  {
+    TSM_ASSERT( "You forgot to write a test!", 0);
+  }
+
+
+};
+
+
+#endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_ */

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -10,6 +10,16 @@ using Mantid::Algorithms::ProcessIndirectFitParameters;
 using namespace Mantid::API;
 
 class ProcessIndirectFitParametersTest : public CxxTest::TestSuite {
+
+private:
+  ITableWorkspace_sptr createTable() {
+    auto tableWs = WorkspaceFactory::Instance().createTable();
+    tableWs->addColumn("double", "Amplitude");
+    tableWs->addColumn("double", "Amplitude_Err");
+    tableWs->addColumn("double", "testColumn");
+    return tableWs;
+  }
+
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -52,54 +62,50 @@ public:
                      std::invalid_argument);
   }
 
- void test_property_input() {
-	auto tableWs = WorkspaceFactory::Instance().createTable();
-	tableWs->addColumn("double", "Amplitude");
-	tableWs->addColumn("double", "Amplitude_Err");
-	tableWs->addColumn("double", "testColumn");
+  void test_property_input() {
+    auto tableWs = createTable();
     std::string xColumn = "axis-1";
     std::string parameterValues = "Amplitude";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
-	TS_ASSERT_THROWS_NOTHING(alg.initialize());
-	TS_ASSERT( alg.isInitialized() );
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
     alg.setProperty("OutputWorkspace", outputName);
 
-	ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
+    ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
 
     TS_ASSERT_EQUALS(tableProp, tableWs);
-	TS_ASSERT_EQUALS(std::string(alg.getProperty("X Column")), xColumn);
-	TS_ASSERT_EQUALS(std::string(alg.getProperty("Parameter Names")),parameterValues);
-	TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")), outputName);
-
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("X Column")), xColumn);
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("Parameter Names")),
+                     parameterValues);
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace")),
+                     outputName);
   }
 
-  void test_output(){
-    auto tableWs = WorkspaceFactory::Instance().createTable();
+  void test_output() {
+    auto tableWs = createTable();
     std::string xColumn = "axis-1";
     std::string parameterValues = "Amplitude";
     std::string outputName = "outMatrix";
 
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
-	TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
     alg.setProperty("InputWorkspace", tableWs);
     alg.setPropertyValue("X Column", xColumn);
     alg.setPropertyValue("Parameter Names", parameterValues);
     alg.setProperty("OutputWorkspace", outputName);
 
-	alg.execute();
+    alg.execute();
 
-	MatrixWorkspace_sptr outMatrixWs = alg.getProperty("InputWorkspace");
-
-	TS_ASSERT_EQUALS(outMatrixWs->getName(), outputName);
-
-
+    MatrixWorkspace_sptr outws;
+    TS_ASSERT_THROWS_NOTHING(
+        outws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            outputName));
   }
-
 };
 
 #endif /* MANTID_ALGORITHMS_PROCESSINDIRECTFITPARAMETERSTEST_H_ */

--- a/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ProcessIndirectFitParametersTest.h
@@ -94,7 +94,7 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
-    TS_ASSERT_THROWS(alg.setPropertyValue("X Column", ""),
+    TS_ASSERT_THROWS(alg.setPropertyValue("ColumnX", ""),
                      std::invalid_argument);
   }
 
@@ -102,7 +102,7 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
-    TS_ASSERT_THROWS(alg.setPropertyValue("Parameter Names", ""),
+    TS_ASSERT_THROWS(alg.setPropertyValue("ParameterNames", ""),
                      std::invalid_argument);
   }
 
@@ -110,7 +110,7 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
 
-    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspace Name", ""),
+    TS_ASSERT_THROWS(alg.setPropertyValue("OutputWorkspaceName", ""),
                      std::invalid_argument);
   }
 
@@ -124,17 +124,17 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace", tableWs);
-    alg.setPropertyValue("X Column", xColumn);
-    alg.setPropertyValue("Parameter Names", parameterValues);
-    alg.setProperty("OutputWorkspace Name", outputName);
+    alg.setPropertyValue("ColumnX", xColumn);
+    alg.setPropertyValue("ParameterNames", parameterValues);
+    alg.setProperty("OutputWorkspaceName", outputName);
 
     ITableWorkspace_sptr tableProp = alg.getProperty("InputWorkspace");
 
     TS_ASSERT_EQUALS(tableProp, tableWs);
-    TS_ASSERT_EQUALS(std::string(alg.getProperty("X Column")), xColumn);
-    TS_ASSERT_EQUALS(std::string(alg.getProperty("Parameter Names")),
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("ColumnX")), xColumn);
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("ParameterNames")),
                      parameterValues);
-    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspace Name")),
+    TS_ASSERT_EQUALS(std::string(alg.getProperty("OutputWorkspaceName")),
                      outputName);
   }
 
@@ -147,9 +147,9 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     alg.setProperty("InputWorkspace", tableWs);
-    alg.setPropertyValue("X Column", xColumn);
-    alg.setPropertyValue("Parameter Names", parameterValues);
-    alg.setProperty("OutputWorkspace Name", outputName);
+    alg.setPropertyValue("ColumnX", xColumn);
+    alg.setPropertyValue("ParameterNames", parameterValues);
+    alg.setProperty("OutputWorkspaceName", outputName);
 
     alg.execute();
 
@@ -177,9 +177,9 @@ public:
     Mantid::Algorithms::ProcessIndirectFitParameters alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     alg.setProperty("InputWorkspace", tableWs);
-    alg.setPropertyValue("X Column", xColumn);
-    alg.setPropertyValue("Parameter Names", parameterValues);
-    alg.setProperty("OutputWorkspace Name", outputName);
+    alg.setPropertyValue("ColumnX", xColumn);
+    alg.setPropertyValue("ParameterNames", parameterValues);
+    alg.setProperty("OutputWorkspaceName", outputName);
 
     alg.execute();
 

--- a/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -26,7 +26,7 @@ Usage
    tws = WorkspaceFactory.createTable()
    tws.addColumn("double", "A")
    tws.addColumn("double", "B")
-   tws.addColumn("double", "C")
+   tws.addColumn("double", "B_Err")
    tws.addColumn("double", "D")
    tws.addRow([1,2,3,4])
    tws.addRow([5,6,7,8])
@@ -35,9 +35,12 @@ Usage
    
    # Add to Mantid Workspace list
    mtd.addOrReplace("TableWs",tws)
-   
-   # "D" is not included in the algorithm params list 
-   wsOut = ProcessIndirectFitParameters(tws, "A", "B,C", "outputWorkspace")
+   wsName = "outputWorkspace"
+
+   # "D" is not included in the algorithm params list
+   ProcessIndirectFitParameters(tws, 'A', "B", wsName)
+
+   wsOut = mtd[wsName]
 
    # Print the result
    print "%s is a %s and the Y values are:" % (wsOut, wsOut.id())
@@ -49,7 +52,7 @@ Output:
     :options: +NORMALIZE_WHITESPACE
 	
     outputWorkspace is a Workspace2D and the Y values are:
-	[ 2.  6.  0.]
+	[ 2.  6.  0.  0.]
 	
 .. categories::
 

--- a/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -10,36 +10,47 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+An Algorithm designed to allow for the TableWorkspace output of the 
+PlotPeakByLogValue algorithm to be transformed into a Matrix workspace 
+based on the desired parameters.
 
 
 Usage
 -----
-..  Try not to use files in your examples,
-    but if you cannot avoid it then the (small) files must be added to
-    autotestdata\UsageData and the following tag unindented
-    .. include:: ../usagedata-note.txt
 
 **Example - ProcessIndirectFitParameters**
 
 .. testcode:: ProcessIndirectFitParametersExample
 
    # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
-
-   wsOut = ProcessIndirectFitParameters()
+   tws = WorkspaceFactory.createTable()
+   tws.addColumn("double", "A")
+   tws.addColumn("double", "B")
+   tws.addcolumn("double", "C")
+   tws.addColumn("double", "D")
+   tws.addRow([1,2,3,4])
+   tws.addRow([5,6,7,8])
+   tws.addRow([9,0,1,2])
+   tws.addRow([0,0,0,1])
+   
+   # Add to Mantid Workspace list
+   mtd.addOrReplace("TableWs",tws)
+   
+   # "D" is not included in the algorithm params list 
+   wsOut = ProcessIndirectFitParameters(tws, "A", "B,C", "outputWorkspace")
 
    # Print the result
-   print "The output workspace has %i spectra" % wsOut.getNumberHistograms()
-
+   print "%s is a %s and the Y values are:" % (wsOut, wsOut.id())
+   print wsOut.readY(0)
+   
 Output:
 
 .. testoutput:: ProcessIndirectFitParametersExample
-
-  The output workspace has ?? spectra
-
+    :options: +NORMALIZE_WHITESPACE
+	
+    outputWorkspace is a Workspace2D and the Y values are:
+	[ 2.  6.  0.]
+	
 .. categories::
 
 .. sourcelink::

--- a/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -26,7 +26,7 @@ Usage
    tws = WorkspaceFactory.createTable()
    tws.addColumn("double", "A")
    tws.addColumn("double", "B")
-   tws.addcolumn("double", "C")
+   tws.addColumn("double", "C")
    tws.addColumn("double", "D")
    tws.addRow([1,2,3,4])
    tws.addRow([5,6,7,8])

--- a/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - ProcessIndirectFitParameters**
+
+.. testcode:: ProcessIndirectFitParametersExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = ProcessIndirectFitParameters()
+
+   # Print the result
+   print "The output workspace has %i spectra" % wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: ProcessIndirectFitParametersExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+


### PR DESCRIPTION
Fixes #13336 

An algorithm designed to transform the table workspace output of the PlotPeakByLogValue algorithm to a MatrixWorkspace to enable further manipulation by the (currently under development #12419) ConvolutionFitSequential algorithm.

I am currently producing the .rst for this algorithm and will shortly be adding mention of it in the release notes.
- [x] .rst file
- [x] Release notes
