### PR TITLE
Re #13399 Changed "Ask for Help" to point to forum

### DIFF
--- a/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/ApplicationWindow.cpp
@@ -14048,7 +14048,7 @@ void ApplicationWindow::showmantidplotHelp()
 
 void ApplicationWindow::showBugTracker()
 {
-  QDesktopServices::openUrl(QUrl("mailto:mantid-help@mantidproject.org"));
+  QDesktopServices::openUrl(QUrl("http://forum.mantidproject.org/"));
 }
 
 /*


### PR DESCRIPTION
Closes #13399 

Changes the "Ask for Help" and "Report a Bug" options in the "Help" menu to point to the forum rather than create an email.
