### PR TITLE
Add flag for dx in spectrum

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -120,7 +120,7 @@ public:
   virtual void unlockData() const;
 
   //-------------------------------------------------------
-  virtual bool useDx() const;
+  virtual bool hasDx() const;
 
 protected:
   /// The spectrum number of this spectrum
@@ -136,7 +136,7 @@ protected:
   MantidVecPtr refDx;
 
   /// Flag to indicate if Dx (X error) is being used or not
-  mutable bool m_useDx;
+  mutable bool m_hasDx;
 };
 
 } // namespace API

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -121,6 +121,7 @@ public:
 
   //-------------------------------------------------------
   virtual bool hasDx() const;
+  virtual void resetHasDx();
 
 protected:
   /// The spectrum number of this spectrum

--- a/Code/Mantid/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -119,6 +119,9 @@ public:
   virtual void lockData() const;
   virtual void unlockData() const;
 
+  //-------------------------------------------------------
+  virtual bool useDx() const;
+
 protected:
   /// The spectrum number of this spectrum
   specid_t m_specNo;
@@ -131,6 +134,9 @@ protected:
 
   /// Copy-on-write pointer to the Dx (X error) vector.
   MantidVecPtr refDx;
+
+  /// Flag to indicate if Dx (X error) is being used or not
+  mutable bool m_useDx;
 };
 
 } // namespace API

--- a/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -290,6 +290,14 @@ public:
     getSpectrum(index)->setData(Y, E);
   }
 
+  /**
+   * Probes if DX (X Error) values were set on a particular spectrum
+   * @param index: the spectrum index
+   */
+  virtual bool hasDx(const std::size_t index) const {
+    return getSpectrum(index)->hasDx();
+  }
+
   /// Generate the histogram or rebin the existing histogram.
   virtual void generateHistogram(const std::size_t index, const MantidVec &X,
                                  MantidVec &Y, MantidVec &E,

--- a/Code/Mantid/Framework/API/src/ISpectrum.cpp
+++ b/Code/Mantid/Framework/API/src/ISpectrum.cpp
@@ -7,20 +7,20 @@ namespace API {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-ISpectrum::ISpectrum() : m_specNo(0), detectorIDs(), refX(), refDx(),m_useDx(false) {}
+ISpectrum::ISpectrum() : m_specNo(0), detectorIDs(), refX(), refDx(),m_hasDx(false) {}
 
 /** Constructor with spectrum number
  * @param specNo :: spectrum # of the spectrum
  */
 ISpectrum::ISpectrum(const specid_t specNo)
-    : m_specNo(specNo), detectorIDs(), refX(), refDx(), m_useDx(false) {}
+    : m_specNo(specNo), detectorIDs(), refX(), refDx(), m_hasDx(false) {}
 
 //----------------------------------------------------------------------------------------------
 /** Copy constructor
  */
 ISpectrum::ISpectrum(const ISpectrum &other)
     : m_specNo(other.m_specNo), detectorIDs(other.detectorIDs),
-    refX(other.refX), refDx(other.refDx), m_useDx(other.m_useDx) {}
+    refX(other.refX), refDx(other.refDx), m_hasDx(other.m_hasDx) {}
 
 //----------------------------------------------------------------------------------------------
 /** Copy spectrum number and detector IDs, but not X vector, from another
@@ -56,7 +56,7 @@ void ISpectrum::setX(const MantidVec &X) { refX.access() = X; }
 /// @param Dx :: vector of X error data
 void ISpectrum::setDx(const MantidVec &Dx) {
   refDx.access() = Dx;
-  m_useDx = true;
+  m_hasDx = true;
 }
 
 /// Sets the x data.
@@ -65,10 +65,7 @@ void ISpectrum::setX(const MantidVecPtr &X) { refX = X; }
 
 /// Sets the x error data.
 /// @param Dx :: vector of X error data
-void ISpectrum::setDx(const MantidVecPtr &Dx) {
-  refDx = Dx;
-  m_useDx = true;
-}
+void ISpectrum::setDx(const MantidVecPtr &Dx) { refDx = Dx; }
 
 /// Sets the x data
 /// @param X :: vector of X data
@@ -78,7 +75,7 @@ void ISpectrum::setX(const MantidVecPtr::ptr_type &X) { refX = X; }
 /// @param Dx :: vector of X error data
 void ISpectrum::setDx(const MantidVecPtr::ptr_type &Dx) {
   refDx = Dx;
-  m_useDx = true;
+  m_hasDx = true;
 }
 
 // =============================================================================================
@@ -92,7 +89,7 @@ MantidVec &ISpectrum::dataX() { return refX.access(); }
  *  Dx vectors and a significant and unnecessary bloating of memory usage.
  */
 MantidVec &ISpectrum::dataDx() {
-  m_useDx = true;
+  m_hasDx = true;
   return refDx.access();
 }
 
@@ -119,7 +116,7 @@ MantidVecPtr ISpectrum::ptrX() const { return refX; }
 
 /// Returns a pointer to the x data
 MantidVecPtr ISpectrum::ptrDx() const {
-  m_useDx = true;
+  m_hasDx = true;
   return refDx;
 }
 
@@ -233,8 +230,8 @@ void ISpectrum::unlockData() const {}
  * Gets the value of the use flag.
  * @returns true if DX has been set, else false
  */
-bool ISpectrum::useDx() const {
-  return m_useDx;
+bool ISpectrum::hasDx() const {
+  return m_hasDx;
 }
 
 } // namespace Mantid

--- a/Code/Mantid/Framework/API/src/ISpectrum.cpp
+++ b/Code/Mantid/Framework/API/src/ISpectrum.cpp
@@ -65,7 +65,10 @@ void ISpectrum::setX(const MantidVecPtr &X) { refX = X; }
 
 /// Sets the x error data.
 /// @param Dx :: vector of X error data
-void ISpectrum::setDx(const MantidVecPtr &Dx) { refDx = Dx; }
+void ISpectrum::setDx(const MantidVecPtr &Dx) {
+  refDx = Dx;
+  m_hasDx = true;
+}
 
 /// Sets the x data
 /// @param X :: vector of X data
@@ -232,6 +235,13 @@ void ISpectrum::unlockData() const {}
  */
 bool ISpectrum::hasDx() const {
   return m_hasDx;
+}
+
+/**
+ * Resets the hasDx flag
+ */
+void ISpectrum::resetHasDx() {
+  m_hasDx = false;
 }
 
 } // namespace Mantid

--- a/Code/Mantid/Framework/API/src/ISpectrum.cpp
+++ b/Code/Mantid/Framework/API/src/ISpectrum.cpp
@@ -7,20 +7,20 @@ namespace API {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-ISpectrum::ISpectrum() : m_specNo(0), detectorIDs(), refX(), refDx() {}
+ISpectrum::ISpectrum() : m_specNo(0), detectorIDs(), refX(), refDx(),m_useDx(false) {}
 
 /** Constructor with spectrum number
  * @param specNo :: spectrum # of the spectrum
  */
 ISpectrum::ISpectrum(const specid_t specNo)
-    : m_specNo(specNo), detectorIDs(), refX(), refDx() {}
+    : m_specNo(specNo), detectorIDs(), refX(), refDx(), m_useDx(false) {}
 
 //----------------------------------------------------------------------------------------------
 /** Copy constructor
  */
 ISpectrum::ISpectrum(const ISpectrum &other)
     : m_specNo(other.m_specNo), detectorIDs(other.detectorIDs),
-      refX(other.refX), refDx(other.refDx) {}
+    refX(other.refX), refDx(other.refDx), m_useDx(other.m_useDx) {}
 
 //----------------------------------------------------------------------------------------------
 /** Copy spectrum number and detector IDs, but not X vector, from another
@@ -54,7 +54,10 @@ void ISpectrum::setX(const MantidVec &X) { refX.access() = X; }
 
 /// Sets the x error data.
 /// @param Dx :: vector of X error data
-void ISpectrum::setDx(const MantidVec &Dx) { refDx.access() = Dx; }
+void ISpectrum::setDx(const MantidVec &Dx) {
+  refDx.access() = Dx;
+  m_useDx = true;
+}
 
 /// Sets the x data.
 /// @param X :: vector of X data
@@ -62,7 +65,10 @@ void ISpectrum::setX(const MantidVecPtr &X) { refX = X; }
 
 /// Sets the x error data.
 /// @param Dx :: vector of X error data
-void ISpectrum::setDx(const MantidVecPtr &Dx) { refDx = Dx; }
+void ISpectrum::setDx(const MantidVecPtr &Dx) {
+  refDx = Dx;
+  m_useDx = true;
+}
 
 /// Sets the x data
 /// @param X :: vector of X data
@@ -70,7 +76,10 @@ void ISpectrum::setX(const MantidVecPtr::ptr_type &X) { refX = X; }
 
 /// Sets the x data error
 /// @param Dx :: vector of X error data
-void ISpectrum::setDx(const MantidVecPtr::ptr_type &Dx) { refDx = Dx; }
+void ISpectrum::setDx(const MantidVecPtr::ptr_type &Dx) {
+  refDx = Dx;
+  m_useDx = true;
+}
 
 // =============================================================================================
 /// Returns the x data
@@ -82,7 +91,10 @@ MantidVec &ISpectrum::dataX() { return refX.access(); }
  *  using X errors. It may result in the breaking of sharing between
  *  Dx vectors and a significant and unnecessary bloating of memory usage.
  */
-MantidVec &ISpectrum::dataDx() { return refDx.access(); }
+MantidVec &ISpectrum::dataDx() {
+  m_useDx = true;
+  return refDx.access();
+}
 
 /// Returns the x data const
 const MantidVec &ISpectrum::dataX() const { return *refX; }
@@ -106,7 +118,10 @@ const MantidVec &ISpectrum::readE() const { return this->dataE(); }
 MantidVecPtr ISpectrum::ptrX() const { return refX; }
 
 /// Returns a pointer to the x data
-MantidVecPtr ISpectrum::ptrDx() const { return refDx; }
+MantidVecPtr ISpectrum::ptrDx() const {
+  m_useDx = true;
+  return refDx;
+}
 
 // =============================================================================================
 // --------------------------------------------------------------------------
@@ -212,6 +227,15 @@ void ISpectrum::lockData() const {}
  * Does nothing unless overridden.
  */
 void ISpectrum::unlockData() const {}
+
+//---------------------------------------------------------
+/**
+ * Gets the value of the use flag.
+ * @returns true if DX has been set, else false
+ */
+bool ISpectrum::useDx() const {
+  return m_useDx;
+}
 
 } // namespace Mantid
 } // namespace API

--- a/Code/Mantid/Framework/API/test/ISpectrumTest.h
+++ b/Code/Mantid/Framework/API/test/ISpectrumTest.h
@@ -95,6 +95,57 @@ public:
   }
 
 
+  void test_use_dx_flag_being_set_when_accessing_dx_with_non_const() {
+    // non-const dataDx()
+    SpectrumTester s;
+    Mantid::MantidVec& dx= s.dataDx();
+    TS_ASSERT(s.useDx());
+
+    // non-const ptrDx()
+    SpectrumTester s2;
+    Mantid::MantidVecPtr ptrDx = s2.ptrDx();
+    TS_ASSERT(s2.useDx());
+
+    // setDX vesion 1
+    SpectrumTester s3;
+    Mantid::MantidVec Dx;
+    s3.setDx(Dx);
+    TS_ASSERT(s3.useDx());
+
+    // setDX vesion 2
+    SpectrumTester s4;
+    Mantid::MantidVecPtr Dx_vec_ptr;
+    s4.setDx(Dx_vec_ptr);
+    TS_ASSERT(s4.useDx());
+
+    // setDX vesion 3
+    SpectrumTester s5;
+    Mantid::MantidVecPtr::ptr_type Dx_vec_ptr_type;
+    s5.setDx(Dx_vec_ptr_type);
+    TS_ASSERT(s5.useDx());
+  }
+
+  void test_use_dx_flag_not_being_set_when_accessing_dx_with_const() {
+    // const dataDx()
+    const SpectrumTester s;
+    const Mantid::MantidVec& element = s.dataDx();
+    TS_ASSERT(!s.useDx());
+  }
+
+  void test_use_dx_flag_is_copied_during_copy_construction() {
+    // Copy spectrum which had the flag set
+    SpectrumTester s;
+    Mantid::MantidVec& dx= s.dataDx();
+    TS_ASSERT(s.useDx());
+
+    SpectrumTester s2(s);
+    TS_ASSERT(s2.useDx());
+
+    // Copy spectrum which did not have the flag set
+    SpectrumTester s3;
+    SpectrumTester s4(s);
+    TS_ASSERT(!s3.useDx());
+  }
 };
 
 

--- a/Code/Mantid/Framework/API/test/ISpectrumTest.h
+++ b/Code/Mantid/Framework/API/test/ISpectrumTest.h
@@ -112,11 +112,17 @@ public:
     s3.setDx(Dx);
     TS_ASSERT(s3.hasDx());
 
-    // setDX vesion 3
+    // setDX vesion 2
     SpectrumTester s4;
     Mantid::MantidVecPtr::ptr_type Dx_vec_ptr_type;
     s4.setDx(Dx_vec_ptr_type);
     TS_ASSERT(s4.hasDx());
+
+    // setDX version 3
+    SpectrumTester s5;
+    Mantid::MantidVecPtr Dx_vec_ptr;
+    s5.setDx(Dx_vec_ptr);
+    TS_ASSERT(s5.hasDx());
   }
 
   void test_use_dx_flag_not_being_set_when_accessing_dx_with_const() {
@@ -124,14 +130,8 @@ public:
     const SpectrumTester s;
     s.dataDx();
     TS_ASSERT(!s.hasDx());
-
-    // setDX vesion 2, not this version is used in Workspace2D to have an initial DX array.
-    // This we don't consider to be a properly set DX array.
-    SpectrumTester s2;
-    Mantid::MantidVecPtr Dx_vec_ptr;
-    s2.setDx(Dx_vec_ptr);
-    TS_ASSERT(!s2.hasDx());
   }
+
 
   void test_use_dx_flag_is_copied_during_copy_construction() {
     // Copy spectrum which had the flag set

--- a/Code/Mantid/Framework/API/test/ISpectrumTest.h
+++ b/Code/Mantid/Framework/API/test/ISpectrumTest.h
@@ -99,52 +99,53 @@ public:
     // non-const dataDx()
     SpectrumTester s;
     Mantid::MantidVec& dx= s.dataDx();
-    TS_ASSERT(s.useDx());
+    TS_ASSERT(s.hasDx());
 
     // non-const ptrDx()
     SpectrumTester s2;
     Mantid::MantidVecPtr ptrDx = s2.ptrDx();
-    TS_ASSERT(s2.useDx());
+    TS_ASSERT(s2.hasDx());
 
     // setDX vesion 1
     SpectrumTester s3;
     Mantid::MantidVec Dx;
     s3.setDx(Dx);
-    TS_ASSERT(s3.useDx());
-
-    // setDX vesion 2
-    SpectrumTester s4;
-    Mantid::MantidVecPtr Dx_vec_ptr;
-    s4.setDx(Dx_vec_ptr);
-    TS_ASSERT(s4.useDx());
+    TS_ASSERT(s3.hasDx());
 
     // setDX vesion 3
-    SpectrumTester s5;
+    SpectrumTester s4;
     Mantid::MantidVecPtr::ptr_type Dx_vec_ptr_type;
-    s5.setDx(Dx_vec_ptr_type);
-    TS_ASSERT(s5.useDx());
+    s4.setDx(Dx_vec_ptr_type);
+    TS_ASSERT(s4.hasDx());
   }
 
   void test_use_dx_flag_not_being_set_when_accessing_dx_with_const() {
     // const dataDx()
     const SpectrumTester s;
     const Mantid::MantidVec& element = s.dataDx();
-    TS_ASSERT(!s.useDx());
+    TS_ASSERT(!s.hasDx());
+
+    // setDX vesion 2, not this version is used in Workspace2D to have an initial DX array.
+    // This we don't consider to be a properly set DX array.
+    SpectrumTester s2;
+    Mantid::MantidVecPtr Dx_vec_ptr;
+    s2.setDx(Dx_vec_ptr);
+    TS_ASSERT(!s2.hasDx());
   }
 
   void test_use_dx_flag_is_copied_during_copy_construction() {
     // Copy spectrum which had the flag set
     SpectrumTester s;
     Mantid::MantidVec& dx= s.dataDx();
-    TS_ASSERT(s.useDx());
+    TS_ASSERT(s.hasDx());
 
     SpectrumTester s2(s);
-    TS_ASSERT(s2.useDx());
+    TS_ASSERT(s2.hasDx());
 
     // Copy spectrum which did not have the flag set
     SpectrumTester s3;
     SpectrumTester s4(s);
-    TS_ASSERT(!s3.useDx());
+    TS_ASSERT(!s3.hasDx());
   }
 };
 

--- a/Code/Mantid/Framework/API/test/ISpectrumTest.h
+++ b/Code/Mantid/Framework/API/test/ISpectrumTest.h
@@ -98,12 +98,12 @@ public:
   void test_use_dx_flag_being_set_when_accessing_dx_with_non_const() {
     // non-const dataDx()
     SpectrumTester s;
-    Mantid::MantidVec& dx= s.dataDx();
+    s.dataDx();
     TS_ASSERT(s.hasDx());
 
     // non-const ptrDx()
     SpectrumTester s2;
-    Mantid::MantidVecPtr ptrDx = s2.ptrDx();
+    s2.ptrDx();
     TS_ASSERT(s2.hasDx());
 
     // setDX vesion 1
@@ -122,7 +122,7 @@ public:
   void test_use_dx_flag_not_being_set_when_accessing_dx_with_const() {
     // const dataDx()
     const SpectrumTester s;
-    const Mantid::MantidVec& element = s.dataDx();
+    s.dataDx();
     TS_ASSERT(!s.hasDx());
 
     // setDX vesion 2, not this version is used in Workspace2D to have an initial DX array.
@@ -136,7 +136,7 @@ public:
   void test_use_dx_flag_is_copied_during_copy_construction() {
     // Copy spectrum which had the flag set
     SpectrumTester s;
-    Mantid::MantidVec& dx= s.dataDx();
+    s.dataDx();
     TS_ASSERT(s.hasDx());
 
     SpectrumTester s2(s);

--- a/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/Workspace2D.cpp
@@ -67,6 +67,7 @@ void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
     // Set the data and X
     spec->setX(t1);
     spec->setDx(t1);
+    spec->resetHasDx();
     // Y,E arrays populated
     spec->setData(t2, t2);
     // Default spectrum number = starts at 1, for workspace index 0.

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/ISpectrum.cpp
@@ -26,5 +26,7 @@ void export_ISpectrum() {
       .def("clearDetectorIDs", &ISpectrum::clearDetectorIDs,
            "Clear the set of detector IDs")
       .def("setSpectrumNo", &ISpectrum::setSpectrumNo,
-           "Set the spectrum number for this spectrum");
+           "Set the spectrum number for this spectrum")
+      .def("hasDx", &ISpectrum::hasDx,
+           "Returns True if the spectrum uses the DX (X Error) array, else False.");
 }

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -229,7 +229,8 @@ void export_MatrixWorkspace() {
            args("self", "workspaceIndex"), "Creates a read-only numpy wrapper "
                                            "around the original Dx data at the "
                                            "given index")
-
+      .def("hasDx", &MatrixWorkspace::hasDx,args("self", "workspaceIndex"),
+           "Returns True if the spectrum uses the DX (X Error) array, else False.")
       //--------------------------------------- Write spectrum data
       //------------------------
       .def("dataX", (data_modifier)&MatrixWorkspace::dataX,


### PR DESCRIPTION
Fixes #13419 
## For tester:

Please code review.

Running the following script and confirm that the first part has the flag set to "False" and the second bit has the flag set to "True"

``` python
# Flag should be false
ws = CreateSampleWorkspace()
sp = ws.getSpectrum(0)
print "The spectrum should not have the flag set and the flag is: " + str(sp.hasDx())

# Flag should be true
ws2 = CreateSampleWorkspace()
sp2 = ws2.getSpectrum(0)
data = ws2.dataDx(0)
print "The spectrum should have the flag set and the flag is: " +  str(sp2.hasDx())
```
