### PR TITLE
Refactoring of DNS algorithms

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -1,7 +1,13 @@
+import sys
+import os
 import mantid.simpleapi as api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
 from mantid.kernel import Direction
 import numpy as np
+
+sys.path.insert(0, os.path.dirname(__file__))
+import mlzutils
+sys.path.pop(0)
 
 
 class DNSDetEffCorrVana(PythonAlgorithm):
@@ -56,42 +62,6 @@ class DNSDetEffCorrVana(PythonAlgorithm):
 
         return
 
-    def _dimensions_valid(self):
-        """
-        Checks validity of the workspace dimensions:
-        all given workspaces must have the same number of dimensions
-        and the same number of histograms
-        and the same number of bins
-        """
-        ndim = self.dataws.getNumDims()
-        nhist = self.dataws.getNumberHistograms()
-        nbin = self.dataws.blocksize()
-
-        if self.vanaws.getNumDims() != ndim or self.vanaws.getNumberHistograms() != nhist or self.vanaws.blocksize() != nbin:
-            self.log().error("The dimensions of Vanadium workspace are not valid.")
-            return False
-
-        if self.bkgws.getNumDims() != ndim or self.bkgws.getNumberHistograms() != nhist or self.bkgws.blocksize() != nbin:
-            self.log().error("The dimensions of Background workspace are not valid.")
-            return False
-
-        return True
-
-    def _norm_ws_exist(self):
-        """
-        Checks whether the normalization workspaces exist
-        normalization workspaces are created by the loader,
-        but could be ocasionally deleted by the user
-        """
-        if not api.mtd.doesExist(self.bkgws.getName() + '_NORM'):
-            self.log().error("Normalization workspace for " + self.bkgws.getName() + " is not found!")
-            return False
-        if not api.mtd.doesExist(self.vanaws.getName() + '_NORM'):
-            self.log().error("Normalization workspace for " + self.vanaws.getName() + " is not found!")
-            return False
-
-        return True
-
     def _vana_mean(self, vanaws):
         """
         checks whether the workspace with mean counts for Vanadium exists
@@ -120,15 +90,6 @@ class DNSDetEffCorrVana(PythonAlgorithm):
             vmean = api.SumSpectra(vanaws, IncludeMonitors=False) / nhists
 
         return vmean
-
-    def _cleanup(self, wslist):
-        """
-        deletes workspaces from list
-            @param wslist List of names of workspaces to delete.
-        """
-        for wsname in wslist:
-            api.DeleteWorkspace(wsname)
-        return
 
     def _vana_correct(self):
         """
@@ -161,58 +122,16 @@ class DNSDetEffCorrVana(PythonAlgorithm):
             self._cleanup(wslist)
             return None
         if not self.vana_mean_name:
-            wslist.append(_vana_mean_ws_)
+            wslist.append(_vana_mean_ws_.getName())
         _coef_ws_ = api.Divide(LHSWorkspace=_vana_bg_, RHSWorkspace=_vana_mean_ws_, WarnOnZeroDivide=True)
-        wslist.append(_coef_ws_)
+        wslist.append(_coef_ws_.getName())
         # 4. correct raw data (not normalized!)
         api.Divide(LHSWorkspace=self.dataws, RHSWorkspace=_coef_ws_, WarnOnZeroDivide=True,
                    OutputWorkspace=self.outws_name)
         outws = api.mtd[self.outws_name]
         # cleanup
-        self._cleanup(wslist)
+        mlzutils.cleanup(wslist)
         return outws
-
-    def _check_properties(self, lhs_run, rhs_run):
-        """
-        checks whether properties match in the given runs, produces warnings
-            @param lhs_run Left-hand-side run
-            @param rhs_run Right-hand-side run
-        """
-        lhs_title = ""
-        rhs_title = ""
-        if lhs_run.hasProperty('run_title'):
-            lhs_title = lhs_run.getProperty('run_title').value
-        if rhs_run.hasProperty('run_title'):
-            rhs_title = rhs_run.getProperty('run_title').value
-
-        for property_name in self.properties_to_compare:
-            if lhs_run.hasProperty(property_name) and rhs_run.hasProperty(property_name):
-                lhs_property = lhs_run.getProperty(property_name)
-                rhs_property = rhs_run.getProperty(property_name)
-                if lhs_property.type == rhs_property.type:
-                    if lhs_property.type == 'string':
-                        if lhs_property.value != rhs_property.value:
-                            message = "Property " + property_name + " does not match! " + \
-                                lhs_title + ": " + lhs_property.value + ", but " + \
-                                rhs_title + ": " + rhs_property.value
-                            self.log().warning(message)
-                    if lhs_property.type == 'number':
-                        if abs(lhs_property.value - rhs_property.value) > 5e-3:
-                            message = "Property " + property_name + " does not match! " + \
-                                lhs_title + ": " + str(lhs_property.value) + ", but " + \
-                                rhs_title + ": " + str(rhs_property.value)
-                            self.log().warning(message)
-                else:
-                    message = "Property " + property_name + " does not match! " + \
-                        lhs_title + ": " + str(lhs_property.value) + " has type " + \
-                        str(lhs_property.type) + ", but " + rhs_title + ": " + \
-                        str(rhs_property.value) + " has type " + str(rhs_property.type)
-                    self.log().warning(message)
-            else:
-                message = "Property " + property_name + " is not present in " +\
-                    lhs_title + " or " + rhs_title + " - skipping comparison."
-                self.log().warning(message)
-        return
 
     def PyExec(self):
         # Input
@@ -222,18 +141,19 @@ class DNSDetEffCorrVana(PythonAlgorithm):
         self.bkgws = api.mtd[self.getPropertyValue("BkgWorkspace")]
         self.vana_mean_name = self.getPropertyValue("VanadiumMean")
 
-        if not self._dimensions_valid():
-            raise RuntimeError("Error: all input workspaces must have the same dimensions!.")
+        # check dimensions
+        wslist = [self.dataws.getName(), self.vanaws.getName(), self.bkgws.getName()]
+        mlzutils.same_dimensions(wslist)
         # check if the _NORM workspaces exist
-        if not self._norm_ws_exist():
-            message = "Normalization workspace is not found!"
-            raise RuntimeError(message)
+        wslist = [self.vanaws.getName() + '_NORM', self.bkgws.getName() + '_NORM']
+        mlzutils.ws_exist(wslist, self.log())
+
         # check sample logs, produce warnings if different
         drun = self.dataws.getRun()
         vrun = self.vanaws.getRun()
         brun = self.bkgws.getRun()
-        self._check_properties(drun, vrun)
-        self._check_properties(vrun, brun)
+        mlzutils.compare_properties(drun, vrun, self.properties_to_compare, self.log())
+        mlzutils.compare_properties(vrun, brun, self.properties_to_compare, self.log())
         # apply correction
         outws = self._vana_correct()
         if not outws:

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -110,7 +110,7 @@ class DNSDetEffCorrVana(PythonAlgorithm):
         arr = np.array(_vana_bg_.extractY()).flatten()
         neg_values = np.where(arr < 0)[0]
         if len(neg_values):
-            self._cleanup(wslist)
+            mlzutils.cleanup(wslist)
             message = "Background " + self.bkgws.getName() + " is higher than Vanadium " + \
                 self.vanaws.getName() + " signal!"
             self.log().error(message)
@@ -119,7 +119,7 @@ class DNSDetEffCorrVana(PythonAlgorithm):
         # 3. calculate correction coefficients
         _vana_mean_ws_ = self._vana_mean(_vana_bg_)
         if not _vana_mean_ws_:
-            self._cleanup(wslist)
+            mlzutils.cleanup(wslist)
             return None
         if not self.vana_mean_name:
             wslist.append(_vana_mean_ws_.getName())

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -1,4 +1,3 @@
-# pylint: disable=no-init
 import mantid.simpleapi as api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
 from mantid.kernel import Direction
@@ -15,11 +14,17 @@ class DNSDetEffCorrVana(PythonAlgorithm):
     properties_to_compare = ['deterota', 'wavelength', 'slit_i_left_blade_position',
                              'slit_i_right_blade_position', 'slit_i_lower_blade_position',
                              'slit_i_upper_blade_position', 'polarisation', 'flipper']
-    dataws = None
-    outws_name = None
-    vanaws = None
-    bkgws = None
-    vana_mean_name = None
+
+    def __init__(self):
+        """
+        Init
+        """
+        PythonAlgorithm.__init__(self)
+        self.dataws = None
+        self.outws_name = None
+        self.vanaws = None
+        self.bkgws = None
+        self.vana_mean_name = None
 
     def category(self):
         """

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSDetEffCorrVana.py
@@ -1,13 +1,9 @@
-import sys
-import os
 import mantid.simpleapi as api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
 from mantid.kernel import Direction
 import numpy as np
 
-sys.path.insert(0, os.path.dirname(__file__))
 import mlzutils
-sys.path.pop(0)
 
 
 class DNSDetEffCorrVana(PythonAlgorithm):

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSFlippingRatioCorr.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSFlippingRatioCorr.py
@@ -1,14 +1,10 @@
 # pylint: disable=too-many-locals
-import sys
-import os
 import mantid.simpleapi as api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
 from mantid.kernel import Direction, FloatBoundedValidator
 import numpy as np
 
-sys.path.insert(0, os.path.dirname(__file__))
 import mlzutils
-sys.path.pop(0)
 
 
 class DNSFlippingRatioCorr(PythonAlgorithm):

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSFlippingRatioCorr.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSFlippingRatioCorr.py
@@ -198,7 +198,7 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
         sf_neg_values = np.where(sf_arr < 0)[0]
         nsf_neg_values = np.where(nsf_arr < 0)[0]
         if len(sf_neg_values) or len(nsf_neg_values):
-            self._cleanup(wslist)
+            mlzutils.cleanup(wslist)
             message = "Background is higher than NiCr signal!"
             self.log().error(message)
             raise RuntimeError(message)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSFlippingRatioCorr.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSFlippingRatioCorr.py
@@ -1,8 +1,14 @@
 # pylint: disable=too-many-locals
+import sys
+import os
 import mantid.simpleapi as api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
 from mantid.kernel import Direction, FloatBoundedValidator
 import numpy as np
+
+sys.path.insert(0, os.path.dirname(__file__))
+import mlzutils
+sys.path.pop(0)
 
 
 class DNSFlippingRatioCorr(PythonAlgorithm):
@@ -63,51 +69,6 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
 
         return
 
-    def _dimensions_valid(self):
-        """
-        Checks validity of the workspace dimensions:
-        all given workspaces must have the same number of dimensions
-        and the same number of histograms
-        and the same number of bins
-        """
-        ndims = []
-        nhists = []
-        nbins = []
-        for wsname in self.input_workspaces.values():
-            wks = api.AnalysisDataService.retrieve(wsname)
-            ndims.append(wks.getNumDims())
-            nhists.append(wks.getNumberHistograms())
-            nbins.append(wks.blocksize())
-
-        ndi = ndims[0]
-        nhi = nhists[0]
-        nbi = nbins[0]
-        if ndims.count(ndi) == len(ndims) and nhists.count(nhi) == len(nhists) and nbins.count(nbi) == len(nbins):
-            return True
-        else:
-            message = "Input workspaces have different dimensions. Cannot correct flipping ratio."
-            self.log().error(message)
-            raise RuntimeError(message)
-
-    def _ws_exist(self):
-        """
-        Checks whether the workspaces and their normalization workspaces exist
-        """
-        # normws for data workspaces are not required
-        dataws_names = [self.input_workspaces['SF_Data'], self.input_workspaces['NSF_Data']]
-        for wsname in self.input_workspaces.values():
-            if not api.AnalysisDataService.doesExist(wsname):
-                message = "Workspace " + wsname + " does not exist! Cannot correct flipping ratio."
-                self.log().error(message)
-                raise RuntimeError(message)
-            if not api.AnalysisDataService.doesExist(wsname + '_NORM'):
-                if wsname not in dataws_names:
-                    message = "Workspace " + wsname + "_NORM does not exist! Cannot correct flipping ratio."
-                    self.log().error(message)
-                    raise RuntimeError(message)
-
-        return True
-
     def _same_polarisation(self):
         """
         Checks whether all workspaces have the same polarisation.
@@ -132,14 +93,6 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
             message = "Cannot apply correction to workspaces with different polarisation!"
             self.log().error(message)
             raise RuntimeError(message)
-
-    def _cleanup(self, wslist):
-        """
-        deletes workspaces from list
-        """
-        for wsname in wslist:
-            api.DeleteWorkspace(wsname)
-        return
 
     def _flipper_valid(self):
         """
@@ -180,10 +133,17 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
             self.log().error(message)
             raise RuntimeError(message)
         # workspaces and normalization workspaces must exist
-        self._ws_exist()
+        wslist = self.input_workspaces.values()
+        # for data workspaces normalization is not mandatory
+        dataws_names = [self.input_workspaces['SF_Data'], self.input_workspaces['NSF_Data']]
+        for wsname in self.input_workspaces.values():
+            if wsname not in dataws_names:
+                wslist.append(wsname + '_NORM')
+
+        mlzutils.ws_exist(wslist, self.log())
 
         # they must have the same dimensions
-        self._dimensions_valid()
+        mlzutils.same_dimensions(self.input_workspaces.values())
 
         # and the same polarisation
         self._same_polarisation()
@@ -197,7 +157,7 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
         for wsname in self.input_workspaces.values()[1:]:
             wks = api.AnalysisDataService.retrieve(wsname)
             run = wks.getRun()
-            self._check_properties(run1, run)
+            mlzutils.compare_properties(run1, run, self.properties_to_compare, self.log())
         return True
 
     def _fr_correction(self):
@@ -250,12 +210,14 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
         sf_data_ws = api.AnalysisDataService.retrieve(self.input_workspaces['SF_Data'])
         nsf_data_ws = api.AnalysisDataService.retrieve(self.input_workspaces['NSF_Data'])
         # NSF_corr[i] = NSF[i] - SF[i]/c[i]
-        _tmp_ws_ = api.Divide(LHSWorkspace=sf_data_ws, RHSWorkspace=_coef_ws_, WarnOnZeroDivide=True,)
+        _tmp_ws_ = api.Divide(LHSWorkspace=sf_data_ws, RHSWorkspace=_coef_ws_, WarnOnZeroDivide=True)
+        _tmp_ws_.setYUnit(nsf_data_ws.YUnit())
         api.Minus(LHSWorkspace=nsf_data_ws, RHSWorkspace=_tmp_ws_, OutputWorkspace=self.nsf_outws_name)
         nsf_outws = api.AnalysisDataService.retrieve(self.nsf_outws_name)
         api.DeleteWorkspace(_tmp_ws_)
         # SF_corr[i] = SF[i] - NSF[i]/c[i]
         _tmp_ws_ = api.Divide(LHSWorkspace=nsf_data_ws, RHSWorkspace=_coef_ws_, WarnOnZeroDivide=True)
+        _tmp_ws_.setYUnit(sf_data_ws.YUnit())
         api.Minus(LHSWorkspace=sf_data_ws, RHSWorkspace=_tmp_ws_, OutputWorkspace=self.sf_outws_name)
         sf_outws = api.AnalysisDataService.retrieve(self.sf_outws_name)
         api.DeleteWorkspace(_tmp_ws_)
@@ -263,52 +225,14 @@ class DNSFlippingRatioCorr(PythonAlgorithm):
         # 5. Apply correction for a double spin-flip scattering
         if self.dfr > 1e-7:
             _tmp_ws_ = sf_outws * self.dfr
+            _tmp_ws_.setYUnit(nsf_outws.YUnit())
             wslist.append(_tmp_ws_.getName())
             # NSF_corr[i] = NSF_prev_corr[i] - SF_prev_corr*dfr, SF_corr = SF_prev_corr
             api.Minus(LHSWorkspace=nsf_outws, RHSWorkspace=_tmp_ws_, OutputWorkspace=self.nsf_outws_name)
 
         # cleanup
-        self._cleanup(wslist)
+        mlzutils.cleanup(wslist)
         return
-
-    def _check_properties(self, lhs_run, rhs_run):
-        """
-        checks whether properties match
-        """
-        lhs_title = ""
-        rhs_title = ""
-        if lhs_run.hasProperty('run_title'):
-            lhs_title = lhs_run.getProperty('run_title').value
-        if rhs_run.hasProperty('run_title'):
-            rhs_title = rhs_run.getProperty('run_title').value
-
-        for property_name in self.properties_to_compare:
-            if lhs_run.hasProperty(property_name) and rhs_run.hasProperty(property_name):
-                lhs_property = lhs_run.getProperty(property_name)
-                rhs_property = rhs_run.getProperty(property_name)
-                if lhs_property.type == rhs_property.type:
-                    if lhs_property.type == 'string':
-                        if lhs_property.value != rhs_property.value:
-                            message = "Property " + property_name + " does not match! " + \
-                                lhs_title + ": " + lhs_property.value + ", but " + \
-                                rhs_title + ": " + rhs_property.value
-                            self.log().warning(message)
-                    if lhs_property.type == 'number':
-                        if abs(lhs_property.value - rhs_property.value) > 5e-3:
-                            message = "Property " + property_name + " does not match! " + \
-                                lhs_title + ": " + str(lhs_property.value) + ", but " + \
-                                rhs_title + ": " + str(rhs_property.value)
-                            self.log().warning(message)
-                else:
-                    message = "Property " + property_name + " does not match! " + \
-                        lhs_title + ": " + str(lhs_property.value) + ", but " + \
-                        rhs_title + ": " + str(rhs_property.value)
-                    self.log().warning(message)
-            else:
-                message = "Property " + property_name + " is not present in " +\
-                    lhs_title + " or " + rhs_title + " - skipping comparison."
-                self.log().warning(message)
-        return True
 
     def PyExec(self):
         # Input

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSMergeRuns.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSMergeRuns.py
@@ -1,13 +1,9 @@
-import sys
-import os
 import mantid.simpleapi as api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty
 from mantid.kernel import Direction, StringArrayProperty, StringListValidator, V3D
 import numpy as np
 
-sys.path.insert(0, os.path.dirname(__file__))
 import mlzutils
-sys.path.pop(0)
 
 
 class DNSMergeRuns(PythonAlgorithm):

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSMergeRuns.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/DNSMergeRuns.py
@@ -25,6 +25,7 @@ class DNSMergeRuns(PythonAlgorithm):
         self.wavelength = 0
         self.xaxis = '2theta'
         self.outws_name = None
+        self.is_normalized = False
 
     def category(self):
         """
@@ -78,7 +79,7 @@ class DNSMergeRuns(PythonAlgorithm):
         else:
             message = "Cannot merge workspaces with different dimensions."
             self.log().error(message)
-            return False
+            raise RuntimeError(message)
 
     def _ws_exist(self):
         """
@@ -88,11 +89,19 @@ class DNSMergeRuns(PythonAlgorithm):
             if not api.AnalysisDataService.doesExist(wsname):
                 message = "Workspace " + wsname + " does not exist! Cannot merge."
                 self.log().error(message)
-                return False
+                raise RuntimeError(message)
+
+        return True
+
+    def _normws_exist(self):
+        """
+        Checks whether the workspace and its normalization workspaces exist
+        """
+        for wsname in self.workspace_names:
             if not api.AnalysisDataService.doesExist(wsname + '_NORM'):
                 message = "Workspace " + wsname + "_NORM does not exist! Cannot merge."
                 self.log().error(message)
-                return False
+                raise RuntimeError(message)
 
         return True
 
@@ -104,16 +113,24 @@ class DNSMergeRuns(PythonAlgorithm):
         if not self.workspace_names:
             message = "No workspace names has been specified! Nothing to merge."
             self.log().error(message)
-            return False
-        # workspaces and normalization workspaces must exist
-        if not self._ws_exist():
-            return False
+            raise RuntimeError(message)
+
+        # workspaces must exist
+        self._ws_exist()
+
+        # all workspaces must be either normalized or not normalized
+        self._are_normalized()
+
+        # if data are not normalized, normalization workspaces must exist
+        if not self.is_normalized:
+            self._normws_exist()
+
         # they must have the same dimensions
-        if not self._dimensions_valid():
-            return False
+        self._dimensions_valid()
+
         # and the same wavelength
-        if not self._same_wavelength():
-            return False
+        self._same_wavelength()
+
         # algorithm must warn if some properties_to_compare are different
         ws1 = api.AnalysisDataService.retrieve(self.workspace_names[0])
         run1 = ws1.getRun()
@@ -160,7 +177,7 @@ class DNSMergeRuns(PythonAlgorithm):
                 message = "Property " + property_name + " is not present in " +\
                     lhs_title + " or " + rhs_title + " - skipping comparison."
                 self.log().warning(message)
-        return True
+        return
 
     def _same_wavelength(self):
         """
@@ -177,7 +194,7 @@ class DNSMergeRuns(PythonAlgorithm):
             else:
                 message = " Workspace " + wks.getName() + " does not have property wavelength! Cannot merge."
                 self.log().error(message)
-                return False
+                raise RuntimeError(message)
         wlength = wls[0]
         if wls.count(wlength) == len(wls):
             self.wavelength = wlength
@@ -186,7 +203,43 @@ class DNSMergeRuns(PythonAlgorithm):
         else:
             message = "Cannot merge workspaces with different wavelength!"
             self.log().error(message)
-            return False
+            raise RuntimeError(message)
+
+    def _are_normalized(self):
+        """
+        Checks whether the given workspaces are normalized
+            @ returns True if all given workspaces are normalized
+            @ returns False if all given workspaces are not normalized
+            raises exception if mixed workspaces are given
+            or if no 'normalized' sample log has been found
+        """
+        norms = []
+        for wsname in self.workspace_names:
+            wks = api.AnalysisDataService.retrieve(wsname)
+            run = wks.getRun()
+            if run.hasProperty('normalized'):
+                norms.append(run.getProperty('normalized').value)
+            else:
+                message = " Workspace " + wks.getName() + " does not have property normalized! Cannot merge."
+                self.log().error(message)
+                raise RuntimeError(message)
+
+        is_normalized = norms[0]
+        if norms.count(is_normalized) == len(norms):
+            if is_normalized == 'yes':
+                self.is_normalized = True
+                self.log().information("Merge normalized workspaces")
+                return True
+            else:
+                self.is_normalized = False
+                self.log().information("Merge not normalized workspaces")
+                return False
+        else:
+            message = "Cannot merge workspaces with different wavelength!"
+            self.log().error(message)
+            raise RuntimeError(message)
+
+        return True
 
     def _merge_workspaces(self):
         """
@@ -261,6 +314,62 @@ class DNSMergeRuns(PythonAlgorithm):
                             UnitX=unitx, OutputWorkspace=self.outws_name + '_NORM')
         return
 
+    def _merge_normalized(self):
+        """
+        merges given workspaces into one,
+        corresponding normalization workspaces are also merged
+        """
+        arr = []
+        beamDirection = V3D(0, 0, 1)
+        # merge workspaces, existance has been checked by _can_merge function
+        for ws_name in self.workspace_names:
+            wks = api.AnalysisDataService.retrieve(ws_name)
+            samplePos = wks.getInstrument().getSample().getPos()
+            n_hists = wks.getNumberHistograms()
+            two_theta = np.array([wks.getDetector(i).getTwoTheta(samplePos, beamDirection) for i in range(0, n_hists)])
+            # round to approximate hardware accuracy 0.05 degree ~ 1 mrad
+            two_theta = np.round(two_theta, 4)
+            dataY = np.rot90(wks.extractY())[0]
+            dataE = np.rot90(wks.extractE())[0]
+            for i in range(n_hists):
+                arr.append([two_theta[i], dataY[i], dataE[i]])
+        data = np.array(arr)
+        # sum up intensities for dublicated angles
+        data_sorted = data[np.argsort(data[:, 0])]
+        # unique values
+        unX = np.unique(data_sorted[:, 0])
+        if len(data_sorted[:, 0]) - len(unX) > 0:
+            arr = []
+            self.log().information("There are dublicated 2Theta angles in the dataset. Sum up the intensities.")
+            # we must sum up the values
+            for i in range(len(unX)):
+                idx = np.where(np.fabs(data_sorted[:, 0] - unX[i]) < 1e-4)
+                new_y = sum(data_sorted[idx][:, 1])
+                err = data_sorted[idx][:, 2]
+                new_e = np.sqrt(np.dot(err, err))
+                arr.append([unX[i], new_y, new_e])
+            data = np.array(arr)
+
+        # define x axis
+        if self.xaxis == "2theta":
+            data[:, 0] = np.round(np.degrees(data[:, 0]), 2)
+            unitx = "Degrees"
+        elif self.xaxis == "|Q|":
+            data[:, 0] = np.fabs(4.0*np.pi*np.sin(0.5*data[:, 0])/self.wavelength)
+            unitx = "MomentumTransfer"
+        elif self.xaxis == "d-Spacing":
+            data[:, 0] = np.fabs(0.5*self.wavelength/np.sin(0.5*data[:, 0]))
+            unitx = "dSpacing"
+        else:
+            message = "The value for X axis " + self.xaxis + " is invalid! Cannot merge."
+            self.log().error(message)
+            raise RuntimeError(message)
+
+        data_sorted = data[np.argsort(data[:, 0])]
+        api.CreateWorkspace(dataX=data_sorted[:, 0], dataY=data_sorted[:, 1], dataE=data_sorted[:, 2],
+                            UnitX=unitx, OutputWorkspace=self.outws_name)
+        return
+
     def PyExec(self):
         # Input
         normalize = self.getProperty("Normalize").value
@@ -270,11 +379,16 @@ class DNSMergeRuns(PythonAlgorithm):
 
         self.log().information("Workspaces to merge: %i" % (len(self.workspace_names)))
         # check whether given workspaces can be merged
-        if not self._can_merge():
-            message = "Impossible to merge given workspaces."
-            raise RuntimeError(message)
+        self._can_merge()
 
-        self._merge_workspaces()
+        if self.is_normalized:
+            if normalize:
+                message = "Invalid setting for Normalize property. The given workspaces are already normalized."
+                self.log().error(message)
+                raise RuntimeError(message)
+            self._merge_normalized()
+        else:
+            self._merge_workspaces()
         outws = api.AnalysisDataService.retrieve(self.outws_name)
         api.CopyLogs(self.workspace_names[0], outws)
         api.RemoveLogs(outws, self.sample_logs)
@@ -283,10 +397,20 @@ class DNSMergeRuns(PythonAlgorithm):
 
         if normalize:
             normws = api.AnalysisDataService.retrieve(self.outws_name + '_NORM')
+            run = normws.getRun()
+            if run.hasProperty('normalization'):
+                norm = run.getProperty('normalization').value
+                if norm == 'duration':
+                    yunit = "Counts per second"
+                elif norm == 'monitor':
+                    yunit = "Counts per monitor"
+                else:
+                    yunit = ""
+            else:
+                yunit = ""
+            ylabel = "Normalized Intensity"
             api.Divide(LHSWorkspace=outws, RHSWorkspace=normws, OutputWorkspace=self.outws_name)
             api.DeleteWorkspace(normws)
-            yunit = ""
-            ylabel = "Normalized Intensity"
 
         outws.setYUnit(yunit)
         outws.setYUnitLabel(ylabel)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -6,9 +6,7 @@ from mantid.api import PythonAlgorithm, AlgorithmFactory, WorkspaceProperty, \
     FileProperty, FileAction
 from mantid.kernel import Direction, StringListValidator, DateAndTime
 
-sys.path.insert(0, os.path.dirname(__file__))
 from dnsdata import DNSdata
-sys.path.pop(0)
 
 POLARISATIONS = ['0', 'x', 'y', 'z', '-x', '-y', '-z']
 NORMALIZATIONS = ['duration', 'monitor']

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -181,6 +181,7 @@ class LoadDNSLegacy(PythonAlgorithm):
                             DataE=dataE, NSpec=ndet, UnitX="Wavelength")
         monws = api.AnalysisDataService.retrieve(monws_name)
         api.LoadInstrument(monws, InstrumentName='DNS')
+        api.RotateInstrumentComponent(monws, "bank0", X=0, Y=1, Z=0, Angle=metadata.deterota)
         api.CopyLogs(InputWorkspace=outws_name, OutputWorkspace=monws_name, MergeStrategy='MergeReplaceExisting')
         api.AddSampleLog(monws, 'normalization',
                          LogText=norm, LogType='String')

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadDNSLegacy.py
@@ -1,4 +1,3 @@
-#pylint: disable=no-init
 import mantid.simpleapi as api
 import numpy as np
 import os
@@ -20,11 +19,18 @@ class LoadDNSLegacy(PythonAlgorithm):
     Load the DNS Legacy data file to the matrix workspace
     Monitor/duration data are loaded to the separate workspace
     """
+
+    def __init__(self):
+        """
+        Init
+        """
+        PythonAlgorithm.__init__(self)
+
     def category(self):
         """
         Returns category
         """
-        return 'PythonAlgorithms\\MLZ\\DNS\\DataHandling'
+        return 'PythonAlgorithms\\MLZ\\DNS;DataHandling'
 
     def name(self):
         """
@@ -84,7 +90,7 @@ class LoadDNSLegacy(PythonAlgorithm):
         # create workspace
         api.CreateWorkspace(OutputWorkspace=outws_name, DataX=dataX, DataY=dataY,
                             DataE=dataE, NSpec=ndet, UnitX="Wavelength")
-        outws = api.mtd[outws_name]
+        outws = api.AnalysisDataService.retrieve(outws_name)
         api.LoadInstrument(outws, InstrumentName='DNS')
 
         run = outws.mutableRun()
@@ -113,9 +119,9 @@ class LoadDNSLegacy(PythonAlgorithm):
                          LogType='Number', LogUnit='Degrees')
         api.AddSampleLog(outws, LogName='omega', LogText=str(metadata.huber - metadata.deterota),
                          LogType='Number', LogUnit='Degrees')
-        api.AddSampleLog(outws, LogName='T1', LogText=str(metadata.t1),
+        api.AddSampleLog(outws, LogName='T1', LogText=str(metadata.temp1),
                          LogType='Number', LogUnit='K')
-        api.AddSampleLog(outws, LogName='T2', LogText=str(metadata.t2),
+        api.AddSampleLog(outws, LogName='T2', LogText=str(metadata.temp2),
                          LogType='Number', LogUnit='K')
         api.AddSampleLog(outws, LogName='Tsp', LogText=str(metadata.tsp),
                          LogType='Number', LogUnit='K')
@@ -156,19 +162,32 @@ class LoadDNSLegacy(PythonAlgorithm):
         api.AddSampleLog(outws, 'slit_i_right_blade_position',
                          LogText=str(metadata.slit_i_right_blade_position),
                          LogType='Number', LogUnit='mm')
+        # add information whether the data are normalized (yes/no):
+        api.AddSampleLog(outws, LogName='normalized',
+                         LogText='no', LogType='String')
 
         # create workspace with normalization data (monitor or duration)
         if norm == 'duration':
             dataY.fill(metadata.duration)
             dataE.fill(0.001)
+            yunit = 'Seconds'
+            ylabel = 'Duration'
         else:
             dataY.fill(metadata.monitor_counts)
             dataE = np.sqrt(dataY)
+            yunit = 'Counts'
+            ylabel = 'Monitor Counts'
         api.CreateWorkspace(OutputWorkspace=monws_name, DataX=dataX, DataY=dataY,
                             DataE=dataE, NSpec=ndet, UnitX="Wavelength")
-        monws = api.mtd[monws_name]
+        monws = api.AnalysisDataService.retrieve(monws_name)
         api.LoadInstrument(monws, InstrumentName='DNS')
         api.CopyLogs(InputWorkspace=outws_name, OutputWorkspace=monws_name, MergeStrategy='MergeReplaceExisting')
+        api.AddSampleLog(monws, 'normalization',
+                         LogText=norm, LogType='String')
+        monws.setYUnit(yunit)
+        monws.setYUnitLabel(ylabel)
+        outws.setYUnit("Counts")
+        outws.setYUnitLabel("Intensity")
 
         self.setProperty("OutputWorkspace", outws)
         self.log().debug('LoadDNSLegacy: data are loaded to the workspace ' + outws_name)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/dnsdata.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/dnsdata.py
@@ -1,5 +1,4 @@
-#pylint: disable=invalid-name,too-many-instance-attributes,too-few-public-methods,anomalous-backslash-in-string
-import sys
+# pylint: disable=too-many-instance-attributes,too-few-public-methods
 import re
 import datetime
 
@@ -47,8 +46,8 @@ class DNSdata(object):
         self.b_coil_current = None
         self.c_coil_current = None
         self.z_coil_current = None
-        self.t1 = None       # T1
-        self.t2 = None       # T2
+        self.temp1 = None       # T1
+        self.temp2 = None       # T2
         self.tsp = None      # T_setpoint
         self.tof_channel_number = None
         self.tof_channel_width = None
@@ -87,10 +86,10 @@ class DNSdata(object):
             # parse block 1 (general information)
             b1splitted = [s.strip() for s in blocks[1].split('#')]
             b1rest = [el for el in b1splitted]
-            r_user = re.compile("User:\s*(?P<name>.*?$)")
-            r_sample = re.compile("Sample:\s*(?P<sample>.*?$)")
-            r_coil = re.compile("^(?P<coil>.*?)\s*xyz-coil.*")
-            r_filter = re.compile("^(?P<filter>.*?)\s*Be-filter.*")
+            r_user = re.compile(r"User:\s*(?P<name>.*?$)")
+            r_sample = re.compile(r"Sample:\s*(?P<sample>.*?$)")
+            r_coil = re.compile(r"^(?P<coil>.*?)\s*xyz-coil.*")
+            r_filter = re.compile(r"^(?P<filter>.*?)\s*Be-filter.*")
             for line in b1splitted:
                 res = r_user.match(line)
                 if res:
@@ -164,8 +163,8 @@ class DNSdata(object):
             # parse block 5 (Temperatures)
             # assume: T1=cold_head_temperature, T2=sample_temperature
             b5splitted = [s.strip() for s in blocks[5].split('#')]
-            self.t1 = float(b5splitted[2].split()[1])
-            self.t2 = float(b5splitted[3].split()[1])
+            self.temp1 = float(b5splitted[2].split()[1])
+            self.temp2 = float(b5splitted[3].split()[1])
             self.tsp = float(b5splitted[4].split()[1])
 
             # parse block 6 (TOF parameters)
@@ -201,20 +200,13 @@ class DNSdata(object):
                 pass
 
 
-def parse_header(h):
+def parse_header(header):
     """
     parses the header string and returns the parsed dictionary
     """
-    d = {}
-    regexp = re.compile("(\w+)=(\w+)")
-    result = regexp.finditer(h)
-    for r in result:
-        d[r.groups()[0]] = r.groups()[1]
-    return d
-
-
-if __name__ == '__main__':
-    fname = sys.argv[1]
-    dns_data = DNSdata()
-    dns_data.read_legacy(fname)
-    print dns_data.__dict__
+    header_dict = {}
+    regexp = re.compile(r"(\w+)=(\w+)")
+    result = regexp.finditer(header)
+    for res in result:
+        header_dict[res.groups()[0]] = res.groups()[1]
+    return header_dict

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/mlzutils.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/mlzutils.py
@@ -1,0 +1,100 @@
+import mantid.simpleapi as api
+
+
+def cleanup(wslist):
+    """
+    deletes workspaces from list
+        @param wslist List of names of workspaces to delete.
+    """
+    for wsname in wslist:
+        if api.AnalysisDataService.doesExist(wsname):
+            api.DeleteWorkspace(wsname)
+    return
+
+
+def same_dimensions(wslist):
+    """
+    Checks whether all given workspaces have
+    the same number of dimensions
+    and the same number of histograms
+    and the same number of bins
+        @param wslist List of workspace names
+        @returns True if all dimensions are the same or raises exception if not
+    """
+    ndims = []
+    nhists = []
+    nbins = []
+    for wsname in wslist:
+        wks = api.AnalysisDataService.retrieve(wsname)
+        ndims.append(wks.getNumDims())
+        nhists.append(wks.getNumberHistograms())
+        nbins.append(wks.blocksize())
+
+    ndi = ndims[0]
+    nhi = nhists[0]
+    nbi = nbins[0]
+    if ndims.count(ndi) == len(ndims) and nhists.count(nhi) == len(nhists) and nbins.count(nbi) == len(nbins):
+        return True
+    else:
+        raise RuntimeError("Error: all input workspaces must have the same dimensions!.")
+
+
+def ws_exist(wslist, logger):
+    """
+    Checks whether all workspaces from the given list exist
+        @param wslist List of workspaces
+        @param logger Logger self.log()
+        @returns True if all workspaces exist or raises exception if not
+    """
+    for wsname in wslist:
+        if not api.AnalysisDataService.doesExist(wsname):
+            message = "Workspace " + wsname + " does not exist!"
+            logger.error(message)
+            raise RuntimeError(message)
+
+    return True
+
+
+def compare_properties(lhs_run, rhs_run, plist, logger):
+    """
+    checks whether properties match in the given runs, produces warnings
+        @param lhs_run Left-hand-side run
+        @param rhs_run Right-hand-side run
+        @param plist   List of properties to compare
+        @param logger  Logger self.log()
+    """
+    lhs_title = ""
+    rhs_title = ""
+    if lhs_run.hasProperty('run_title'):
+        lhs_title = lhs_run.getProperty('run_title').value
+    if rhs_run.hasProperty('run_title'):
+        rhs_title = rhs_run.getProperty('run_title').value
+
+    for property_name in plist:
+        if lhs_run.hasProperty(property_name) and rhs_run.hasProperty(property_name):
+            lhs_property = lhs_run.getProperty(property_name)
+            rhs_property = rhs_run.getProperty(property_name)
+            if lhs_property.type == rhs_property.type:
+                if lhs_property.type == 'string':
+                    if lhs_property.value != rhs_property.value:
+                        message = "Property " + property_name + " does not match! " + \
+                            lhs_title + ": " + lhs_property.value + ", but " + \
+                            rhs_title + ": " + rhs_property.value
+                        logger.warning(message)
+                if lhs_property.type == 'number':
+                    if abs(lhs_property.value - rhs_property.value) > 5e-3:
+                        message = "Property " + property_name + " does not match! " + \
+                            lhs_title + ": " + str(lhs_property.value) + ", but " + \
+                            rhs_title + ": " + str(rhs_property.value)
+                        logger.warning(message)
+            else:
+                message = "Property " + property_name + " does not match! " + \
+                    lhs_title + ": " + str(lhs_property.value) + " has type " + \
+                    str(lhs_property.type) + ", but " + rhs_title + ": " + \
+                    str(rhs_property.value) + " has type " + str(rhs_property.type)
+                logger.warning(message)
+        else:
+            message = "Property " + property_name + " is not present in " +\
+                lhs_title + " or " + rhs_title + " - skipping comparison."
+            logger.warning(message)
+    return

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSDetEffCorrVanaTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSDetEffCorrVanaTest.py
@@ -1,5 +1,6 @@
 import unittest
 from testhelpers import run_algorithm
+from testhelpers.mlzhelpers import create_fake_dns_workspace
 from mantid.api import AnalysisDataService
 import numpy as np
 import mantid.simpleapi as api
@@ -11,43 +12,14 @@ class DNSDetEffCorrVanaTest(unittest.TestCase):
     __vanaws = None
     __bkgrws = None
 
-    def _create_fake_workspace(self, wsname, dataY):
-        """
-        creates DNS workspace with fake data
-        """
-        ndet = 24
-        dataX = np.zeros(2*ndet)
-        dataX.fill(4.2 + 0.00001)
-        dataX[::2] -= 0.000002
-        dataE = np.sqrt(dataY)
-        # create workspace
-        api.CreateWorkspace(OutputWorkspace=wsname, DataX=dataX, DataY=dataY,
-                            DataE=dataE, NSpec=ndet, UnitX="Wavelength")
-        outws = api.mtd[wsname]
-        api.LoadInstrument(outws, InstrumentName='DNS')
-        p_names = 'deterota,wavelength,slit_i_left_blade_position,slit_i_right_blade_position,\
-            slit_i_lower_blade_position,slit_i_upper_blade_position,polarisation,flipper'
-        p_values = '-7.53,4.2,10,10,5,20,x,ON'
-        api.AddSampleLogMultiple(Workspace=outws, LogNames=p_names, LogValues=p_values, ParseType=True)
-        # create the normalization workspace
-        dataY.fill(1.0)
-        dataE.fill(1.0)
-        api.CreateWorkspace(OutputWorkspace=wsname + '_NORM', DataX=dataX, DataY=dataY,
-                            DataE=dataE, NSpec=ndet, UnitX="Wavelength")
-        normws = api.mtd[wsname + '_NORM']
-        api.LoadInstrument(normws, InstrumentName='DNS')
-        api.AddSampleLogMultiple(Workspace=normws, LogNames=p_names, LogValues=p_values, ParseType=True)
-
-        return outws
-
     def setUp(self):
         dataY = np.zeros(24)
         dataY.fill(1.5)
-        self.__bkgrws = self._create_fake_workspace('__bkgrws', dataY)
+        self.__bkgrws = create_fake_dns_workspace('__bkgrws', dataY=dataY)
         dataY = np.linspace(2, 13.5, 24)
-        self.__vanaws = self._create_fake_workspace('__vanaws', dataY)
+        self.__vanaws = create_fake_dns_workspace('__vanaws', dataY=dataY)
         dataY = np.arange(1, 25)
-        self.__dataws = self._create_fake_workspace('__dataws', dataY)
+        self.__dataws = create_fake_dns_workspace('__dataws', dataY=dataY)
 
     def tearDown(self):
         api.DeleteWorkspace(self.__vanaws.getName() + '_NORM')
@@ -104,6 +76,10 @@ class DNSDetEffCorrVanaTest(unittest.TestCase):
         # check whether the 2theta angles the same as in the data workspace
         outputWorkspaceName = "DNSDetCorrVanaTest_Test5"
         # rotate detector bank to different angles
+        api.LoadInstrument(self.__dataws, InstrumentName='DNS')
+        api.LoadInstrument(self.__vanaws, InstrumentName='DNS')
+        api.LoadInstrument(self.__bkgrws, InstrumentName='DNS')
+
         api.RotateInstrumentComponent(self.__dataws, "bank0", X=0, Y=1, Z=0, Angle=-7.53)
         api.RotateInstrumentComponent(self.__vanaws, "bank0", X=0, Y=1, Z=0, Angle=-8.02)
         api.RotateInstrumentComponent(self.__bkgrws, "bank0", X=0, Y=1, Z=0, Angle=-8.54)

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSMergeRunsTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSMergeRunsTest.py
@@ -1,5 +1,6 @@
 import unittest
 from testhelpers import run_algorithm
+from testhelpers.mlzhelpers import create_fake_dns_workspace
 from mantid.api import AnalysisDataService
 import numpy as np
 import mantid.simpleapi as api
@@ -10,46 +11,12 @@ class DNSMergeRunsTest(unittest.TestCase):
     workspaces = []
     angles = None
 
-    def _create_fake_workspace(self, wsname, angle):
-        """
-        creates DNS workspace with fake data
-        """
-        ndet = 24
-        dataX = np.zeros(2*ndet)
-        dataX.fill(4.2 + 0.00001)
-        dataX[::2] -= 0.000002
-        dataY = np.ones(ndet)
-        dataE = np.sqrt(dataY)
-        # create workspace
-        api.CreateWorkspace(OutputWorkspace=wsname, DataX=dataX, DataY=dataY,
-                            DataE=dataE, NSpec=ndet, UnitX="Wavelength")
-        outws = api.mtd[wsname]
-        api.LoadInstrument(outws, InstrumentName='DNS')
-        p_names = 'wavelength,slit_i_left_blade_position,slit_i_right_blade_position,normalized,\
-            slit_i_lower_blade_position,slit_i_upper_blade_position,polarisation,flipper'
-        p_values = '4.2,10,10,no,5,20,x,ON'
-        api.AddSampleLogMultiple(Workspace=outws, LogNames=p_names, LogValues=p_values, ParseType=True)
-        # rotate instrument component ans set deterota
-        api.RotateInstrumentComponent(outws, "bank0", X=0, Y=1, Z=0, Angle=angle)
-        api.AddSampleLog(outws, LogName='deterota', LogText=str(angle),
-                         LogType='Number', LogUnit='Degrees')
-        # create the normalization workspace
-        dataY.fill(1.0)
-        dataE.fill(1.0)
-        api.CreateWorkspace(OutputWorkspace=wsname + '_NORM', DataX=dataX, DataY=dataY,
-                            DataE=dataE, NSpec=ndet, UnitX="Wavelength")
-        normws = api.mtd[wsname + '_NORM']
-        api.LoadInstrument(normws, InstrumentName='DNS')
-        api.AddSampleLogMultiple(Workspace=normws, LogNames=p_names, LogValues=p_values, ParseType=True)
-
-        return outws
-
     def setUp(self):
         self.workspaces = []
         for i in range(4):
             angle = -7.5 - i*0.5
             wsname = "__testws" + str(i)
-            self._create_fake_workspace(wsname, angle)
+            create_fake_dns_workspace(wsname, angle=angle, loadinstrument=True)
             self.workspaces.append(wsname)
         # create reference values
         angles = np.empty(0)

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSMergeRunsTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/DNSMergeRunsTest.py
@@ -25,9 +25,9 @@ class DNSMergeRunsTest(unittest.TestCase):
                             DataE=dataE, NSpec=ndet, UnitX="Wavelength")
         outws = api.mtd[wsname]
         api.LoadInstrument(outws, InstrumentName='DNS')
-        p_names = 'wavelength,slit_i_left_blade_position,slit_i_right_blade_position,\
+        p_names = 'wavelength,slit_i_left_blade_position,slit_i_right_blade_position,normalized,\
             slit_i_lower_blade_position,slit_i_upper_blade_position,polarisation,flipper'
-        p_values = '4.2,10,10,5,20,x,ON'
+        p_values = '4.2,10,10,no,5,20,x,ON'
         api.AddSampleLogMultiple(Workspace=outws, LogNames=p_names, LogValues=p_values, ParseType=True)
         # rotate instrument component ans set deterota
         api.RotateInstrumentComponent(outws, "bank0", X=0, Y=1, Z=0, Angle=angle)

--- a/Code/Mantid/Framework/PythonInterface/test/testhelpers/CMakeLists.txt
+++ b/Code/Mantid/Framework/PythonInterface/test/testhelpers/CMakeLists.txt
@@ -6,6 +6,7 @@ set ( PY_FILES
   __init__.py
   algorithm_decorator.py
   tempfile_wrapper.py
+  mlzhelpers.py
 )
 
 # Copy python files to output directory

--- a/Code/Mantid/Framework/PythonInterface/test/testhelpers/mlzhelpers.py
+++ b/Code/Mantid/Framework/PythonInterface/test/testhelpers/mlzhelpers.py
@@ -1,0 +1,42 @@
+import numpy as np
+import mantid.simpleapi as api
+
+
+def create_fake_dns_workspace(wsname, angle=-7.53, flipper='ON', dataY=None, loadinstrument=False):
+    """
+    creates DNS workspace with fake data
+        @param angle   Angle of detector bank rotation
+        @param flipper Flipper state (ON/OFF)
+        @param dataY   Data array to set as DataY of the created workspace, will be set to np.ones if None
+        @param loadinstrument  If True api.LoadInstrument will be executed, needed for DNSMergeRuns
+    """
+    ndet = 24
+    dataX = np.zeros(2*ndet)
+    dataX.fill(4.2 + 0.00001)
+    dataX[::2] -= 0.000002
+    if dataY is None:
+        dataY = np.ones(ndet)
+    dataE = np.sqrt(dataY)
+    # create workspace
+    api.CreateWorkspace(OutputWorkspace=wsname, DataX=dataX, DataY=dataY,
+                        DataE=dataE, NSpec=ndet, UnitX="Wavelength")
+    outws = api.mtd[wsname]
+    p_names = 'deterota,wavelength,slit_i_left_blade_position,slit_i_right_blade_position,normalized,\
+            slit_i_lower_blade_position,slit_i_upper_blade_position,polarisation,flipper'
+    p_values = str(angle) + ',4.2,10,10,no,5,20,x,' + flipper
+    api.AddSampleLogMultiple(Workspace=outws, LogNames=p_names, LogValues=p_values, ParseType=True)
+    # create the normalization workspace
+    dataY.fill(1.0)
+    dataE.fill(1.0)
+    api.CreateWorkspace(OutputWorkspace=wsname + '_NORM', DataX=dataX, DataY=dataY,
+                        DataE=dataE, NSpec=ndet, UnitX="Wavelength")
+    normws = api.mtd[wsname + '_NORM']
+    api.AddSampleLogMultiple(Workspace=normws, LogNames=p_names, LogValues=p_values, ParseType=True)
+    # rotate instrument component
+    if loadinstrument:
+        api.LoadInstrument(outws, InstrumentName='DNS')
+        api.RotateInstrumentComponent(outws, "bank0", X=0, Y=1, Z=0, Angle=angle)
+        api.LoadInstrument(normws, InstrumentName='DNS')
+        api.RotateInstrumentComponent(normws, "bank0", X=0, Y=1, Z=0, Angle=angle)
+
+    return outws

--- a/Code/Mantid/docs/source/algorithms/DNSFlippingRatioCorr-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DNSFlippingRatioCorr-v1.rst
@@ -17,29 +17,30 @@ Description
 This algorithm applies flipping ratio correction to a given data workspaces. As a result, following workspaces will be created: 
 
 -  output workspace with corrected spin-flip data. Sample logs will be copied from the data spin-flip workspace. 
--  output workspace with corrected non spin-flip data. Sample logs will be copied from the data non spin-flip workspace. 
+-  output workspace with corrected non-spin-flip data. Sample logs will be copied from the data non-spin-flip workspace. 
 -  if data workspaces have workspaces with normalization data (monitor counts or experiment duration by user's choice), this normalization workspaces will be cloned. The normalization workspace is named same as the output workspace, but has suffix "_NORM". 
 
-Flipping ratio correction is performed using the measurements of :math:`Ni_{0.89}\,Cr_{0.11}` standard sample (hereafter NiCr). Background for NiCr must be also measured and provided to the algorithm as an input. Both, spin-flip anf non spin-flip measurements are required. This algorithm performs the flipping ratio correction for a particular run in following steps:
+Flipping ratio correction is performed using the measurements of :math:`Ni_{0.89}\,Cr_{0.11}` standard sample (hereafter NiCr). Background for NiCr must be also measured and provided to the algorithm as an input. Both, spin-flip anf non-spin-flip measurements are required. This algorithm performs the flipping ratio correction for a particular run in following steps:
 
-1. Normalize both, spin-flip (hereafter SF) and non spin-flip (hereafter NSF), workspaces to a chosen normalization:
+1. Normalize both, spin-flip (hereafter SF) and non-spin-flip (hereafter NSF), workspaces to a chosen normalization:
 
    :math:`(N^{SF}_i)_{Norm} = \frac{(N^{SF}_i)_{Raw}}{(C^{SF}_i)_N}`
 
    :math:`(N^{NSF}_i)_{Norm} = \frac{(N^{NSF}_i)_{Raw}}{(C^{NSF}_i)_N}`
 
-   where :math:`(N^{SF,\,NSF}_i)_{Raw}` is the signal from the :math:`i` th detector in the NiCr spin-flip and non spin-flip workspace, respectively and :math:`(C^{SF,\,NSF}_i)_N` is the number in the corresponding bin of the normalization workspace. The :ref:`algm-Divide` algorithm is used for this step.
+   where :math:`(N^{SF,\,NSF}_i)_{Raw}` is the signal from the :math:`i` th detector in the NiCr spin-flip and non-spin-flip workspace, respectively and :math:`(C^{SF,\,NSF}_i)_N` is the number in the corresponding bin of the normalization workspace. The :ref:`algm-Divide` algorithm is used for this step.
 
 2. Normalize Background workspace to a chosen normalization:
 
    :math:`(B^{SF,\,NSF}_i)_{Norm} = \frac{(B^{SF,\,NSF}_i)_{Raw}}{(C^{SF,\,NSF}_i)_B}`
    
-   where :math:`(B^{SF,\,NSF}_i)_{Raw}` is the signal from the :math:`i` th detector in the spin-flip and non spin-flip background workspace, respectively and :math:`(C^{SF,\,NSF}_i)_B` is the number in the corresponding bin of the normalization workspace. The :ref:`algm-Divide` algorithm is used for this step.
+   where :math:`(B^{SF,\,NSF}_i)_{Raw}` is the signal from the :math:`i` th detector in the spin-flip and non-spin-flip background workspace, respectively and :math:`(C^{SF,\,NSF}_i)_B` is the number in the corresponding bin of the normalization workspace. The :ref:`algm-Divide` algorithm is used for this step.
 
 .. warning::
 
     Normalization workspaces are created by the :ref:`algm-LoadDNSLegacy` algorithm. 
-    It is responsibility of the user to take care about the same type of normalization for given workspaces.
+    It is responsibility of the user to take care about the same type of normalization (either monitor counts or run duration) 
+    for given workspaces.
 
 3. Subtract Background from NiCr:
 
@@ -80,7 +81,7 @@ The input workspaces have to have the following in order to be valid inputs for 
 -  The same number of bins
 -  All workspaces except of **SFDataWorkspace** and **NSFDataWorkspace** must have the corresponding normalization workspace
 -  All given workspaces must have the same polarisation (algorithm checks for the 'polarisation' sample log)
--  All given workspaces must have the appropriate flipper status (algorithm checks for 'flipper' sample log): spin-flip workspaces must have flipper 'ON' and non spin-flip workspaces must have flipper 'OFF'
+-  All given workspaces must have the appropriate flipper status (algorithm checks for 'flipper' sample log): spin-flip workspaces must have flipper 'ON' and non-spin-flip workspaces must have flipper 'OFF'
 
 If any of these conditions is not fulfilled, the algorithm terminates.
 
@@ -139,7 +140,7 @@ Usage
     sf_corrected = mtd['sf_corrected']
     nsf_corrected = mtd['nsf_corrected']
 
-    # calculate ratio of spin-flip to non spin-flip
+    # calculate ratio of spin-flip to non-spin-flip
     vana_ratio = sf_corrected/nsf_corrected
 
     # ratio must be around 2, print first 5 points of the data array

--- a/Code/Mantid/docs/source/algorithms/DNSMergeRuns-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DNSMergeRuns-v1.rst
@@ -46,7 +46,8 @@ The input workspaces (**WorkspaceNames**) have to have the following in order to
 -  The same number of dimensions
 -  The same number of spectra
 -  The same number of bins
--  Have the corresponding normalization workspace
+-  Must have sample log **normalized** set to "yes" for normalized data or "no" for not normalized data. Important: this value must be the same for all given workspaces. The mixture of normalized and not normalized workspaces is not accepted: algorithm will terminate with an error message.
+-  If sample log **normalized** is set to "no", all workspaces must have the corresponding normalization workspace.
 -  Have the same wavelength in the sample logs
 
 For the physically meaningful merge result, it is also important that these workspaces have the same slits size, polarisation, and flipper status. If some of these parameters are different, algorithm produces warning. If these properties are not specified in the workspace sample logs, no comparison is performed.

--- a/Code/Mantid/docs/source/algorithms/DNSMergeRuns-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/DNSMergeRuns-v1.rst
@@ -19,8 +19,10 @@ This algorithm merges given matrix workspaces to a :ref:`Workspace2D <Workspace2
 .. note::
     The **OutputWorkspace** will have no connection to the instrument. Part of the sample logs will be lost either. This algorithm can be executed at any step of the data reduction to view the result. However, further data reduction must be performed on the original workspaces.
 
-As a result, following output will be produced: 
+As a result, following output will be produced:
+
 -  Output workspace with corrected data. Part of sample logs will be copied from the first data workspace. The data will be normalized to monitor or run duration if the **Normalize** option is checked. 
+  
 -  If the **Normalize** option is unchecked, workspace with normalization data (monitor counts or run duration) will be created. The normalization workspace is named same as the data workspace, but has suffix "_NORM". 
 
 .. warning::
@@ -46,9 +48,9 @@ The input workspaces (**WorkspaceNames**) have to have the following in order to
 -  The same number of dimensions
 -  The same number of spectra
 -  The same number of bins
--  Must have sample log **normalized** set to "yes" for normalized data or "no" for not normalized data. Important: this value must be the same for all given workspaces. The mixture of normalized and not normalized workspaces is not accepted: algorithm will terminate with an error message.
+-  The same wavelength in the sample logs
+-  Sample log **normalized** must be set to "yes" for normalized data or "no" for not normalized data. **Important:** this value must be the same for all given workspaces. The mixture of normalized and not normalized workspaces is not accepted: algorithm will terminate with an error message.
 -  If sample log **normalized** is set to "no", all workspaces must have the corresponding normalization workspace.
--  Have the same wavelength in the sample logs
 
 For the physically meaningful merge result, it is also important that these workspaces have the same slits size, polarisation, and flipper status. If some of these parameters are different, algorithm produces warning. If these properties are not specified in the workspace sample logs, no comparison is performed.
 


### PR DESCRIPTION
All DNS algorithms have been modified to be in the same style (init, YUnits, variable names > 3 symbols, etc). Code duplications have been removed. Modules mlzutils.py and testhelpers/mlzhelpers.py have been created to collect fuctions which can be reused by all algorithms and unittests, respectively. Minor corrections to documentation have been made.

To test: test that nothing has got broken after the refactoring :-)

Label: Diffraction
