### PR TITLE
Set axis to something Mantid understands better in nMoldyn 4 loader

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
@@ -5,6 +5,7 @@ from mantid.kernel import *
 from mantid.api import *
 
 import numpy as np
+import scipy.constants as sc
 import ast
 import fnmatch
 import re
@@ -82,6 +83,10 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
                 v_axis = self._load_axis(function[2][0])
                 x_axis = self._load_axis(function[2][1])
 
+                # Perform axis unit conversions
+                v_axis = self._axis_conversion(*v_axis)
+                x_axis = self._axis_conversion(*x_axis)
+
                 # Create the workspace for function
                 create_workspace = AlgorithmManager.Instance().create('CreateWorkspace')
                 create_workspace.initialize()
@@ -93,7 +98,7 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
                 create_workspace.setProperty('UnitX', x_axis[1])
                 create_workspace.setProperty('YUnitLabel', function[1])
                 create_workspace.setProperty('VerticalAxisValues', v_axis[0])
-                create_workspace.setProperty('VerticalAxisUnit', 'Empty')
+                create_workspace.setProperty('VerticalAxisUnit', v_axis[1])
                 create_workspace.setProperty('WorkspaceTitle', func_name)
                 create_workspace.execute()
 
@@ -173,7 +178,7 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
         Loads an axis by name from the data directory.
 
         @param axis_name Name of axis to load
-        @return Tuple of (Numpy array of data, unit)
+        @return Tuple of (Numpy array of data, unit, name)
         @exception ValueError If axis is not found
         """
         if axis_name in self._axis_cache:
@@ -212,7 +217,7 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
                         # Now parse the data
                         data = self._load_1d_slice(f_handle, length)
 
-        return (data, unit)
+        return (data, unit, axis_name)
 
 #------------------------------------------------------------------------------
 
@@ -260,6 +265,41 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
             data[v_idx] = np.array(values)
 
         return data
+
+#------------------------------------------------------------------------------
+
+    def _axis_conversion(self, data, unit, name):
+        """
+        Converts an axis to a Mantid axis type (possibly performing a unit
+        conversion).
+
+        @param data The axis data as Numpy array
+        @param unit The axis unit as read from the file
+        @param name The axis name as read from the file
+        @return Tuple containing updated axis details
+        """
+        logger.debug('Axis for conversion: name={0}, unit={1}'.format(name, unit))
+
+        # Q (nm**-1) to Q (Angstrom**-1)
+        if name.lower() == 'q' and unit.lower() == 'inv_nm':
+            logger.information('Axis {0} will be converted to Q in Angstrom**-1'.format(name))
+            unit = 'MomentumTransfer'
+            data /= sc.nano # nm to m
+            data *= sc.angstrom # m to Angstrom
+
+        # Frequency (THz) to Energy (meV)
+        elif name.lower() == 'frequency' and unit.lower() == 'thz':
+            logger.information('Axis {0} will be converted to energy in meV'.format(name))
+            unit = 'Energy'
+            data *= sc.tera # THz to Hz
+            data *= sc.value('Planck constant in eV s') # Hz to eV
+            data *= sc.milli # eV to meV
+
+        # No conversion
+        else:
+            unit = 'Empty'
+
+        return (data, unit, name)
 
 #------------------------------------------------------------------------------
 

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
@@ -284,8 +284,8 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
         if name.lower() == 'q' and unit.lower() == 'inv_nm':
             logger.information('Axis {0} will be converted to Q in Angstrom**-1'.format(name))
             unit = 'MomentumTransfer'
-            data /= sc.nano # nm to m
-            data *= sc.angstrom # m to Angstrom
+            data *= sc.nano # nm to m
+            data /= sc.angstrom # m to Angstrom
 
         # Frequency (THz) to Energy (meV)
         elif name.lower() == 'frequency' and unit.lower() == 'thz':
@@ -293,7 +293,7 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
             unit = 'Energy'
             data *= sc.tera # THz to Hz
             data *= sc.value('Planck constant in eV s') # Hz to eV
-            data *= sc.milli # eV to meV
+            data /= sc.milli # eV to meV
 
         # Time (ps) to TOF (s)
         elif name.lower() == 'time' and unit.lower() == 'ps':

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
@@ -284,8 +284,8 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
         if name.lower() == 'q' and unit.lower() == 'inv_nm':
             logger.information('Axis {0} will be converted to Q in Angstrom**-1'.format(name))
             unit = 'MomentumTransfer'
-            data *= sc.nano # nm to m
-            data /= sc.angstrom # m to Angstrom
+            data /= sc.nano # nm to m
+            data *= sc.angstrom # m to Angstrom
 
         # Frequency (THz) to Energy (meV)
         elif name.lower() == 'frequency' and unit.lower() == 'thz':

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
@@ -295,6 +295,12 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
             data *= sc.value('Planck constant in eV s') # Hz to eV
             data *= sc.milli # eV to meV
 
+        # Time (ps) to TOF (s)
+        elif name.lower() == 'time' and unit.lower() == 'ps':
+            logger.information('Axis {0} will be converted to time in microsecond'.format(name))
+            unit = 'TOF'
+            data *= sc.micro # ps to us
+
         # No conversion
         else:
             unit = 'Empty'

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4AsciiTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4AsciiTest.py
@@ -29,7 +29,8 @@ class LoadNMoldyn4AsciiTest(unittest.TestCase):
         self.assertTrue(isinstance(workspace, MatrixWorkspace))
         self.assertEqual(workspace.getNumberHistograms(), 21)
         self.assertEqual(workspace.blocksize(), 100)
-        self.assertEqual(str(workspace.getAxis(0).getUnit().symbol()), 'ps')
+        self.assertEqual(str(workspace.getAxis(0).getUnit().unitID()), 'TOF')
+        self.assertEqual(str(workspace.getAxis(1).getUnit().unitID()), 'MomentumTransfer')
 
 
     def _validate_sqf_ws(self, workspace):
@@ -41,7 +42,8 @@ class LoadNMoldyn4AsciiTest(unittest.TestCase):
         self.assertTrue(isinstance(workspace, MatrixWorkspace))
         self.assertEqual(workspace.getNumberHistograms(), 21)
         self.assertEqual(workspace.blocksize(), 199)
-        self.assertEqual(str(workspace.getAxis(0).getUnit().symbol()), 'THz')
+        self.assertEqual(str(workspace.getAxis(0).getUnit().unitID()), 'Energy')
+        self.assertEqual(str(workspace.getAxis(1).getUnit().unitID()), 'MomentumTransfer')
 
 
     def test_load_single_fqt_function(self):

--- a/Code/Mantid/docs/source/algorithms/LoadNMoldyn4Ascii-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/LoadNMoldyn4Ascii-v1.rst
@@ -20,8 +20,27 @@ Assumptions on data format
 --------------------------
 
 The ``Directory`` property must be given the directory that is produced when you
-extract the ``.tar`` archive from nMMOLDYN without modifications which must only
+extract the ``.tar`` archive from nMOLDYN without modifications which must only
 contain the data files produces from a single export operation from nMOLDYN.
+
+Axis Unit Conversions
+---------------------
+
+When loading certain axis from nMOLDYN 4 the units may be converted to an
+equivalent unit in Mantid. The possible conversions are shown in the table
+below:
+
++-----------+---------+------------------+--------------+
+| nMOLDYN             | Mantid                          |
++-----------+---------+------------------+--------------+
+| name      | unit    | name             | unit         |
++===========+=========+==================+==============+
+| frequency | THz     | Energy           | meV          |
++-----------+---------+------------------+--------------+
+| q         | nm**-1  | MomentumTransfer | Angstrom**-1 |
++-----------+---------+------------------+--------------+
+| Time      | pSecond | TOF              | uSecond      |
++-----------+---------+------------------+--------------+
 
 Usage
 -----


### PR DESCRIPTION
Fixes #13400.

To test:
- Load data from #13294
- See that `fqt_total` has axis:
  - X: TOF
  - Y: Q
- See that `sqf_total` has axis:
  - X: Energy
  - Y: Q
- Look in the original files (axis values are in `frequency.dat`, `time.dat` and `q.dat`) and see that the values are correct.

This algorithm was only added in this release no no release notes are updated.
