### PR TITLE
Add x error to ExtractSpectra algorithm

### DIFF
--- a/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Code/Mantid/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -247,6 +247,11 @@ public:
     return getSpectrum(index)->ptrX();
   }
 
+  /// Returns a pointer to the dX  (X Error) data
+  virtual Kernel::cow_ptr<MantidVec> refDx(const std::size_t index) const {
+    return getSpectrum(index)->ptrDx();
+  }
+
   /// Set the specified X array to point to the given existing array
   virtual void setX(const std::size_t index, const MantidVec &X) {
     getSpectrum(index)->setX(X);
@@ -262,6 +267,24 @@ public:
   /// Set the specified X array to point to the given existing array
   virtual void setX(const std::size_t index, const MantidVecPtr::ptr_type &X) {
     getSpectrum(index)->setX(X);
+    invalidateCommonBinsFlag();
+  }
+
+  /// Set the specified Dx (X Error) array to point to the given existing array
+  virtual void setDx(const std::size_t index, const MantidVec &Dx) {
+    getSpectrum(index)->setDx(Dx);
+    invalidateCommonBinsFlag();
+  }
+
+  /// Set the specified Dx (X Error) array to point to the given existing array
+  virtual void setDx(const std::size_t index, const MantidVecPtr &Dx) {
+    getSpectrum(index)->setDx(Dx);
+    invalidateCommonBinsFlag();
+  }
+
+  /// Set the specified Dx (X Error) array to point to the given existing array
+  virtual void setDx(const std::size_t index, const MantidVecPtr::ptr_type &Dx) {
+    getSpectrum(index)->setX(Dx);
     invalidateCommonBinsFlag();
   }
 

--- a/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -149,17 +149,28 @@ void ExtractSpectra::execHistogram() {
     const MantidVec &oldX = m_inputWorkspace->readX(m_workspaceIndexList.front());
     newX.access().assign(oldX.begin() + m_minX, oldX.begin() + m_maxX);
   }
+
   Progress prog(this, 0.0, 1.0, (m_workspaceIndexList.size()));
   // Loop over the required workspace indices, copying in the desired bins
   for (int j = 0; j < static_cast<int>(m_workspaceIndexList.size()); ++j) {
     auto i = m_workspaceIndexList[j];
+    //auto hasDx = m_inputWorkspace->hasDx(i);
+    bool hasDx = false;
+
     // Preserve/restore sharing if X vectors are the same
     if (m_commonBoundaries) {
       outputWorkspace->setX(j, newX);
+      if (hasDx) {
+        const MantidVec &oldDx = m_inputWorkspace->readDx(i);
+        outputWorkspace->dataDx(j).assign(oldDx.begin() + m_minX, oldDx.begin() + m_maxX);
+      }
     } else {
       // Safe to just copy whole vector 'cos can't be cropping in X if not
       // common
       outputWorkspace->setX(j, m_inputWorkspace->refX(i));
+      if (hasDx) {
+        outputWorkspace->setDx(j, m_inputWorkspace->refDx(i));
+      }
     }
 
     const MantidVec &oldY = m_inputWorkspace->readY(i);
@@ -323,13 +334,27 @@ void ExtractSpectra::execEvent() {
     // Copy spectrum number & detector IDs
     outEL.copyInfoFrom(el);
 
+    // Check if a dx value is required
+    // auto hasDx = eventW->hasDx(i);
+    bool hasDx = true;
+
     if (!m_commonBoundaries)
       // If the X axis is NOT common, then keep the initial X axis, just clear
       // the events
       outEL.setX(el.dataX());
-    else
+      if (hasDx) {
+        outEL.setDx(el.dataDx());
+      }
+    else {
       // Common bin boundaries get all set to the same value
       outEL.setX(XValues_new);
+      if (hasDx) {
+        const MantidVec &oldDx = m_inputWorkspace->readDx(i);
+        cow_ptr<MantidVec> DxValues_new;
+        DxValues_new.access().assign(oldDx.begin() + m_minX, oldDx.begin() + m_maxX);
+        outEL.setDx(DxValues_new);
+      }
+    }
 
     // Propagate bin masking if there is any
     if (m_inputWorkspace->hasMaskedBins(i)) {

--- a/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -336,13 +336,14 @@ void ExtractSpectra::execEvent() {
 
     bool hasDx = eventW->hasDx(i);
 
-    if (!m_commonBoundaries)
+    if (!m_commonBoundaries) {
       // If the X axis is NOT common, then keep the initial X axis, just clear
       // the events
       outEL.setX(el.dataX());
       if (hasDx) {
         outEL.setDx(el.dataDx());
       }
+    }
     else {
       // Common bin boundaries get all set to the same value
       outEL.setX(XValues_new);

--- a/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -154,8 +154,8 @@ void ExtractSpectra::execHistogram() {
   // Loop over the required workspace indices, copying in the desired bins
   for (int j = 0; j < static_cast<int>(m_workspaceIndexList.size()); ++j) {
     auto i = m_workspaceIndexList[j];
-    //auto hasDx = m_inputWorkspace->hasDx(i);
-    bool hasDx = false;
+
+    bool hasDx = m_inputWorkspace->hasDx(i);
 
     // Preserve/restore sharing if X vectors are the same
     if (m_commonBoundaries) {
@@ -334,9 +334,7 @@ void ExtractSpectra::execEvent() {
     // Copy spectrum number & detector IDs
     outEL.copyInfoFrom(el);
 
-    // Check if a dx value is required
-    // auto hasDx = eventW->hasDx(i);
-    bool hasDx = true;
+    bool hasDx = eventW->hasDx(i);
 
     if (!m_commonBoundaries)
       // If the X axis is NOT common, then keep the initial X axis, just clear

--- a/Code/Mantid/Framework/Algorithms/test/ExtractSpectraTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ExtractSpectraTest.h
@@ -187,6 +187,18 @@ public:
     params.testDetectorList(*ws);
   }
 
+  void test_with_dx_data() {
+    // Arrange
+    Parameters params("histo-dx");
+
+    // Act
+    auto ws = runAlgorithm(params);
+    if (!ws) return;
+
+    // Assert
+    TS_ASSERT_EQUALS(ws->blocksize(), nBins);
+    params.testDx(*ws);
+  }
 
 
   // ---- test event ----
@@ -290,7 +302,7 @@ public:
   }
 
 
-    void test_index_and_detector_list_event()
+  void test_index_and_detector_list_event()
   {
     Parameters params("event-detector");
     params.setDetectorList().setIndexRange();
@@ -326,6 +338,15 @@ public:
     params.testDetectorList(*ws);
   }
 
+  void test_with_dx_data_event() {
+    Parameters params("event-dx");
+
+    auto ws = runAlgorithm(params);
+    if (!ws) return;
+
+    TS_ASSERT_EQUALS(ws->blocksize(), nBins);
+    params.testDx(*ws);
+  }
 
   // ---- test histo-ragged ----
 
@@ -373,6 +394,7 @@ public:
     auto ws = runAlgorithm(params, false);
   }
 
+
 private:
 
   // -----------------------  helper methods ------------------------
@@ -393,6 +415,10 @@ private:
       return createInputWithDetectors("histo");
     else if (workspaceType == "event-detector")
       return createInputWithDetectors("event");
+    else if (workspaceType == "histo-dx")
+      return createInputWorkspaceHistWithDx();
+    else if (workspaceType == "event-dx");
+      return createInputWorkspaceEventWithDx();
     throw std::runtime_error("Undefined workspace type");
   }
 
@@ -408,6 +434,18 @@ private:
       space->dataE(j).assign(nBins, sqrt(double(j)));
     }
     return space;
+  }
+
+  MatrixWorkspace_sptr createInputWorkspaceHistWithDx() const {
+    auto ws = createInputWorkspaceHisto();
+    // Add the delta x values
+    for (size_t j = 0; j < nSpec; ++j) {
+      for (size_t k = 0; k <= nBins; ++k) {
+        // Add a constant error to all spectra
+        ws->dataDx(j)[k] = sqrt(double(k));
+      }
+    }
+    return ws;
   }
 
   MatrixWorkspace_sptr createInputWorkspaceHistoRagged() const
@@ -436,6 +474,18 @@ private:
     return ws;
   }
 
+  MatrixWorkspace_sptr createInputWorkspaceEventWithDx() const {
+    auto ws = createInputWorkspaceEvent();
+    // Add the delta x values
+    for (size_t j = 0; j < nSpec; ++j) {
+      for (size_t k = 0; k <= nBins; ++k) {
+        // Add a constant error to all spectra
+        ws->dataDx(j)[k] = sqrt(double(k));
+      }
+    }
+    return ws;
+  }
+
   MatrixWorkspace_sptr createInputWithDetectors(std::string workspaceType) const
   {
     MatrixWorkspace_sptr ws;
@@ -455,8 +505,6 @@ private:
     }
     return ws;
   }
-
-
 
   struct Parameters
   {
@@ -611,6 +659,26 @@ private:
     {
       StartWorkspaceIndex = 1000;
       EndWorkspaceIndex = 1002;
+    }
+
+    // ---- test Dx -------
+    void testDx(const MatrixWorkspace& ws) const {
+      if (wsType == "histo-dx") {
+        TS_ASSERT_EQUALS(ws.blocksize(), 1);
+        TS_ASSERT_EQUALS(ws.readDx(0)[0], 0.0);
+        TS_ASSERT_EQUALS(ws.readDx(0)[1], 1.0);
+        TS_ASSERT_EQUALS(ws.readDx(0)[2], sqrt(2.0));
+
+        // Check that the length of x and dx is the same
+        auto x = ws.readX(0);
+        auto dX = ws.readDx(0);
+        TS_ASSERT_EQUALS(x.size(), dX.size());
+      } else if (wsType == "event-dx") {
+        TS_ASSERT_EQUALS(ws.blocksize(), 1);
+        TS_ASSERT_EQUALS(ws.readDx(0)[0], 0.0);
+        TS_ASSERT_EQUALS(ws.readDx(0)[1], 1.0);
+        TS_ASSERT_EQUALS(ws.readDx(0)[2], sqrt(2.0));
+      }
     }
   };
 

--- a/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Code/Mantid/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -103,6 +103,18 @@ void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
   setSpectrumFromPyObject(self, &MatrixWorkspace::dataE, wsIndex, values);
 }
 
+
+/**
+ * Set the Dx values from an python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the
+ */
+void setDxFromPyObject(MatrixWorkspace &self, const size_t wsIndex,
+                      numeric::array values) {
+  setSpectrumFromPyObject(self, &MatrixWorkspace::dataDx, wsIndex, values);
+}
+
 /**
  * Adds a deprecation warning to the getNumberBins call to warn about using
  * blocksize instead
@@ -257,6 +269,9 @@ void export_MatrixWorkspace() {
            "simple copy into the array.")
       .def("setE", &setEFromPyObject, args("self", "workspaceIndex", "e"),
            "Set E values from a python list or numpy array. It performs a "
+           "simple copy into the array.")
+      .def("setDx", &setDxFromPyObject, args("self", "workspaceIndex", "dX"),
+           "Set Dx values from a python list or numpy array. It performs a "
            "simple copy into the array.")
 
       // --------------------------------------- Extract data


### PR DESCRIPTION
Fixes #13424 
## For testing

Please code review

**Test that croping of a Histo workspace with X error maintains the x error**
1. Run the following script:

``` python
# Create workspace with DX data
ws = CreateSampleWorkspace()
# Add the DX data
numSpec = ws.getNumberHistograms()
for index in range(0, numSpec):
    dxTemp = ws.dataDx(index)
    for element in range(0, len(dxTemp)):
        dxTemp[element] = index

# Make sure we have what we expect
eval_spectrum = 25
dx = ws.dataDx(eval_spectrum )
print "The expected entry should be %d and it is %d" %(eval_spectrum, dx[0])
print "Before cropping: The total number spectra is: %d" % ws.getNumberHistograms()
# Now crop the workspace
start_index = 12
end_index = 45
out_ws = CropWorkspace(InputWorkspace = ws, StartWorkspaceIndex = start_index , EndWorkspaceIndex =  end_index )

diff = end_index - start_index + 1
print "After cropping: The total number spectra is: %d and expecting %d" % (out_ws.getNumberHistograms(), diff)


# Evaluate two spectra and two random locations. Note that the dx data in each spectrum was set constant withing the spectrum
sample_spectrum = 5
sample_max_spectrum = end_index - start_index

expected = sample_spectrum + start_index
dx_out  = out_ws.dataDx(sample_spectrum)
print "The expected entry should be %d and it is %d" %(expected , dx_out[17])

expected_2 = end_index
dx_out_2  = out_ws.dataDx(sample_max_spectrum)
print "The expected entry should be %d and it is %d" %(expected_2 , dx_out_2[6])
```
- Look at the printouts and confirm that the dx values are present and that they are what we expect.
