### PR TITLE
Render inverse angstrom symbol with mathtex.

### DIFF
--- a/Code/Mantid/Vates/VatesAPI/src/Common.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/Common.cpp
@@ -9,6 +9,7 @@
 #include "vtkPVChangeOfBasisHelper.h"
 
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/regex.hpp>
 
 // using namespace Mantid::Geometry;
 namespace Mantid {
@@ -18,7 +19,10 @@ std::string makeAxisTitle(Dimension_const_sptr dim) {
   title += " (";
   title += dim->getUnits();
   title += ")";
-  return title;
+  // update inverse angstrom symbol so it is rendered in mathtex.
+  // Consider removing after ConvertToMD provides unit labels with latex symbols.
+  boost::regex re("A\\^-1");
+  return boost::regex_replace(title, re, "$\\\\AA^{-1}$");
 }
 
 void setAxisLabel(std::string metadataLabel, std::string labelString,

--- a/Code/Mantid/Vates/VatesAPI/src/Common.cpp
+++ b/Code/Mantid/Vates/VatesAPI/src/Common.cpp
@@ -20,7 +20,8 @@ std::string makeAxisTitle(Dimension_const_sptr dim) {
   title += dim->getUnits();
   title += ")";
   // update inverse angstrom symbol so it is rendered in mathtex.
-  // Consider removing after ConvertToMD provides unit labels with latex symbols.
+  // Consider removing after ConvertToMD provides unit labels with latex
+  // symbols.
   boost::regex re("A\\^-1");
   return boost::regex_replace(title, re, "$\\\\AA^{-1}$");
 }

--- a/Code/Mantid/Vates/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
@@ -175,13 +175,13 @@ void testAxisLabels()
   TSM_ASSERT_THROWS_NOTHING("Should pass", presenter.setAxisLabels(product));
   TSM_ASSERT_EQUALS("X Label should match exactly",
                     getStringFieldDataValue(product, "AxisTitleForX"),
-                    "[H,0,0] (in 1.992 A^-1)");
+                    "[H,0,0] (in 1.992 $\\AA^{-1}$)");
   TSM_ASSERT_EQUALS("Y Label should match exactly",
                     getStringFieldDataValue(product, "AxisTitleForY"),
-                    "[0,K,0] (in 1.992 A^-1)");
+                    "[0,K,0] (in 1.992 $\\AA^{-1}$)");
   TSM_ASSERT_EQUALS("Z Label should match exactly",
                     getStringFieldDataValue(product, "AxisTitleForZ"),
-                    "[0,0,L] (in 1.087 A^-1)");
+                    "[0,0,L] (in 1.087 $\\AA^{-1}$)");
 
   TS_ASSERT(Mock::VerifyAndClearExpectations(view));
   TS_ASSERT(Mock::VerifyAndClearExpectations(&factory));

--- a/Code/Mantid/Vates/VatesAPI/test/SQWLoadingPresenterTest.h
+++ b/Code/Mantid/Vates/VatesAPI/test/SQWLoadingPresenterTest.h
@@ -231,13 +231,13 @@ void testAxisLabels()
   TSM_ASSERT_THROWS_NOTHING("Should pass", presenter.setAxisLabels(product));
   TSM_ASSERT_EQUALS("X Label should match exactly",
                     getStringFieldDataValue(product, "AxisTitleForX"),
-                    "qx (A^-1)");
+                    "qx ($\\AA^{-1}$)");
   TSM_ASSERT_EQUALS("Y Label should match exactly",
                     getStringFieldDataValue(product, "AxisTitleForY"),
-                    "qy (A^-1)");
+                    "qy ($\\AA^{-1}$)");
   TSM_ASSERT_EQUALS("Z Label should match exactly",
                     getStringFieldDataValue(product, "AxisTitleForZ"),
-                    "qz (A^-1)");
+                    "qz ($\\AA^{-1}$)");
 
   TS_ASSERT(Mock::VerifyAndClearExpectations(view));
   TS_ASSERT(Mock::VerifyAndClearExpectations(&factory));


### PR DESCRIPTION
This changes the axis labels in the VSI so that the inverse angstrom symbol is rendered using MathTex. The regex works around the problem that ConvertToMD is using a hardcoded string instead of real units.

@OwenArnold is working on a proper solution in issue #12185.

testing: Open a MD workspace in the VSI and verify that the axes grid shows the pretty inverse angstrom symbol.
