### PR TITLE
Error in Doctest for ProcessIndirectFitParameters

### DIFF
--- a/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -38,7 +38,7 @@ Usage
    wsName = "outputWorkspace"
 
    # "D" is not included in the algorithm params list
-   ProcessIndirectFitParameters(tws, 'A', "B", wsName)
+   ProcessIndirectFitParameters(tws, 'A', "B", "" ,wsName)
 
    wsOut = mtd[wsName]
 

--- a/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/ProcessIndirectFitParameters-v1.rst
@@ -38,7 +38,7 @@ Usage
    wsName = "outputWorkspace"
 
    # "D" is not included in the algorithm params list
-   ProcessIndirectFitParameters(tws, 'A', "B", "" ,wsName)
+   ProcessIndirectFitParameters(tws, 'A', "B", OutputWorkspace=wsName)
 
    wsOut = mtd[wsName]
 


### PR DESCRIPTION
Fixes #13441

An extra parameter has been added to the call to ProcessIndirectFitParameters algorithm in the .rst I believe this should fix the issue that was causing the failure.
