### PR TITLE
Add x errors to RKH file format

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadRKH.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadRKH.h
@@ -91,6 +91,9 @@ private:
 
   // Remove lines from an input stream
   void skipLines(std::istream &strm, int nlines);
+
+  /// Check if we the data set stores an X-Error values
+  bool hasXerror(std::ifstream &stream);
 };
 }
 }

--- a/Code/Mantid/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRKH.cpp
@@ -26,6 +26,45 @@ using namespace Mantid::Kernel;
 
 DECLARE_FILELOADER_ALGORITHM(LoadRKH)
 
+namespace {
+void readLinesForRKH1D(std::istream& stream, int readStart, int readEnd, std::vector<double>& columnOne,
+                       std::vector<double>& ydata, std::vector<double>& errdata, Progress& prog) {
+  std::string fileline = "";
+  for (int index = 1; index <= readEnd; ++index) {
+    getline(stream, fileline);
+    if (index < readStart)
+      continue;
+    double x(0.), y(0.), yerr(0.);
+    std::istringstream datastr(fileline);
+    datastr >> x >> y >> yerr;
+    columnOne.push_back(x);
+    ydata.push_back(y);
+    errdata.push_back(yerr);
+    prog.report();
+  }
+}
+
+void readLinesWithXErrorForRKH1D(std::istream& stream, int readStart, int readEnd, std::vector<double>& columnOne,
+                                 std::vector<double>& ydata, std::vector<double>& errdata, std::vector<double>& xError,
+                                 Progress& prog) {
+  std::string fileline = "";
+  for (int index = 1; index <= readEnd; ++index) {
+    getline(stream, fileline);
+    if (index < readStart)
+      continue;
+    double x(0.), y(0.), yerr(0.), xerr(0.);
+    std::istringstream datastr(fileline);
+    datastr >> x >> y >> yerr>>xerr;
+    columnOne.push_back(x);
+    ydata.push_back(y);
+    errdata.push_back(yerr);
+    xError.push_back(xerr);
+    prog.report();
+  }
+}
+}
+
+
 /**
  * Return the confidence with with this algorithm can load the file
  * @param descriptor A descriptor for the file
@@ -222,29 +261,32 @@ const API::MatrixWorkspace_sptr LoadRKH::read1D() {
   int pointsToRead = readEnd - readStart + 1;
   // Now stream sits at the first line of data
   fileline = "";
-  std::vector<double> columnOne, ydata, errdata;
+  std::vector<double> columnOne, ydata, errdata, xError;
   columnOne.reserve(readEnd);
   ydata.reserve(readEnd);
   errdata.reserve(readEnd);
 
+  auto hasXError = hasXerror(m_fileIn);
+
   Progress prog(this, 0.0, 1.0, readEnd);
-  for (int index = 1; index <= readEnd; ++index) {
-    getline(m_fileIn, fileline);
-    if (index < readStart)
-      continue;
-    double x(0.), y(0.), yerr(0.);
-    std::istringstream datastr(fileline);
-    datastr >> x >> y >> yerr;
-    columnOne.push_back(x);
-    ydata.push_back(y);
-    errdata.push_back(yerr);
-    prog.report();
+
+  if (hasXError) {
+    xError.reserve(readEnd);
+    readLinesWithXErrorForRKH1D(m_fileIn, readStart, readEnd,
+                                columnOne, ydata, errdata, xError,  prog);
+  } else {
+    readLinesForRKH1D(m_fileIn, readStart, readEnd,
+                      columnOne, ydata, errdata, prog);
   }
   m_fileIn.close();
 
   assert(pointsToRead == static_cast<int>(columnOne.size()));
   assert(pointsToRead == static_cast<int>(ydata.size()));
   assert(pointsToRead == static_cast<int>(errdata.size()));
+
+  if (hasXError) {
+    assert(pointsToRead == static_cast<int>(xError.size()));
+  }
 
   if (colIsUnit) {
     MatrixWorkspace_sptr localworkspace = WorkspaceFactory::Instance().create(
@@ -254,7 +296,9 @@ const API::MatrixWorkspace_sptr LoadRKH::read1D() {
     localworkspace->dataX(0) = columnOne;
     localworkspace->dataY(0) = ydata;
     localworkspace->dataE(0) = errdata;
-
+    if (hasXError) {
+      localworkspace->dataDx(0) = xError;
+    }
     return localworkspace;
   } else {
     MatrixWorkspace_sptr localworkspace =
@@ -265,6 +309,12 @@ const API::MatrixWorkspace_sptr LoadRKH::read1D() {
           ->setSpectrumNo(static_cast<int>(columnOne[index]));
       localworkspace->dataY(index)[0] = ydata[index];
       localworkspace->dataE(index)[0] = errdata[index];
+    }
+
+    if (hasXError) {
+      for (int index = 0; index < pointsToRead; ++index) {
+        localworkspace->dataDx(index)[0] = xError[index];
+      }
     }
     return localworkspace;
   }
@@ -480,5 +530,28 @@ void LoadRKH::binCenter(const MantidVec oldBoundaries,
                         MantidVec &toCenter) const {
   VectorHelper::convertToBinCentre(oldBoundaries, toCenter);
 }
+
+/**
+ * Checks if there is an x error present in the data set
+ * @param stream:: the stream object
+ * @param line: the 
+ */
+bool LoadRKH::hasXerror(std::ifstream &stream) {
+  auto containsXerror = false;
+  auto currentPutLocation = stream.tellg();
+  std::string line;
+  getline(stream, line);
+
+  std::string x,y, yerr, xerr;
+  std::istringstream datastr(line);
+  datastr >> x >> y >> yerr >> xerr;
+  if (!xerr.empty()) {
+    containsXerror = true;
+  }
+  // Reset the original location of the stream
+  stream.seekg(currentPutLocation, stream.beg);
+  return containsXerror;
+}
+
 }
 }

--- a/Code/Mantid/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadRKH.cpp
@@ -260,7 +260,6 @@ const API::MatrixWorkspace_sptr LoadRKH::read1D() {
 
   int pointsToRead = readEnd - readStart + 1;
   // Now stream sits at the first line of data
-  fileline = "";
   std::vector<double> columnOne, ydata, errdata, xError;
   columnOne.reserve(readEnd);
   ydata.reserve(readEnd);
@@ -533,8 +532,7 @@ void LoadRKH::binCenter(const MantidVec oldBoundaries,
 
 /**
  * Checks if there is an x error present in the data set
- * @param stream:: the stream object
- * @param line: the 
+ * @param stream:: the stream object 
  */
 bool LoadRKH::hasXerror(std::ifstream &stream) {
   auto containsXerror = false;

--- a/Code/Mantid/Framework/DataHandling/src/SaveRKH.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveRKH.cpp
@@ -164,18 +164,35 @@ void SaveRKH::write1D() {
       specid = static_cast<specid_t>(i + 1);
     }
 
+    auto hasDx = m_workspace->hasDx(i);
+    //hasDx = false;
+    // We only want to access the dx values if they exist. In case they don't exist
+    // set the dXData const reference to the X value. The value will not be used later on.
+    const auto &dXdata = hasDx ? m_workspace->readDx(i) : m_workspace->readX(i);
+
     for (size_t j = 0; j < nbins; ++j) {
       // Calculate/retrieve the value to go in the first column
       double xval(0.0);
+      double dXval(0.0);
       if (horizontal)
         xval = histogram ? 0.5 * (xdata[j] + xdata[j + 1]) : xdata[j];
       else {
         xval = static_cast<double>(specid);
       }
 
+      if (hasDx) {
+        dXval = histogram ? 0.5 * (dXdata[j] + dXdata[j + 1]) : dXdata[j];
+      }
+
       m_outRKH << std::fixed << std::setw(12) << std::setprecision(5) << xval
                << std::scientific << std::setw(16) << std::setprecision(6)
-               << ydata[j] << std::setw(16) << edata[j] << "\n";
+               << ydata[j] << std::setw(16) << edata[j];
+
+      if (hasDx) {
+        m_outRKH << std::setw(16) << dXval;
+      }
+
+      m_outRKH << "\n";
 
       prg.report();
     }


### PR DESCRIPTION
Fixes #13431
## For testing:

The windows installer can be found here:  \olympic\Babylon5\Scratch\Anton\Testing\13431_RKH_Loading_And_Saving_With_DX

**Test that data without x errors is processed without issues**
1. Run the following script

``` python
file_path = os.path.join(config["defaultsave.directory"], "no_x_errors.out")
if os.path.exists(file_path):
    os.remove(file_path)

dataX1 = [1,2,3,4,5,6]
dataY1 = [8,4,9,7,4]
dataE1 = [2,1,1,3,3]
ws1 = CreateWorkspace(dataX1, dataY1, dataE1, UnitX="MomentumTransfer")

SaveRKH(InputWorkspace=ws1, Filename = file_path)
DeleteWorkspace(ws1)
# Read the workspace back in
ws_out = LoadRKH(Filename=file_path)
dataX_out = ws_out.dataX(0)
dataDX_out = ws_out.dataDx(0)
dataY_out = ws_out.dataY(0)
dataE_out = ws_out.dataE(0)

print '-------------'
for index in range(0,len(dataX_out)):
    print "x: %d, y: %d, e: %d, dx: %d" %(dataX_out[index] , dataY_out[index], dataE_out[index], dataDX_out[index])
```

This will create save out a file and read it in again. 
- Open the file in a text editor and confirm that it has 3 columns
- Confirm that the DX values are 0 in the loaded workspace (they will be printed as 0, because as soon as we access the dx data structure it is being created with a 0 initialization).

Note that the number of x entries is being changed during this process, so that should not worry you.

**Test that data with x errors is processed without issues**
1. Run the script:

``` python
file_path = os.path.join(config["defaultsave.directory"], "x_errors_2.out")
if os.path.exists(file_path):
    os.remove(file_path)

dataX1 = [1,2,3,4,5,6]
dataDX1 = [3.,4.,5.,6.,7., 8.]
dataY1 = [8.,4.,9.,7.,4.]
dataY2 = [1.,1.,1.,1.,1.]
dataE1 = [2.,1.,1.,3.,3.]
ws1 = CreateWorkspace(dataX1, dataY1, dataE1, UnitX="MomentumTransfer")

# Set the DX values
dx = ws1.dataDx(0)
for index in range(0, len(dataDX1)):
    dx[index] = dataDX1[index]

# Save them out
SaveRKH(InputWorkspace=ws1, Filename = file_path)
DeleteWorkspace(ws1)
# Read the workspace back in
ws_out = LoadRKH(Filename=file_path)
dataX_out = ws_out.dataX(0)
dataDX_out = ws_out.dataDx(0)
dataY_out = ws_out.dataY(0)
dataE_out = ws_out.dataE(0)
print '-------------'
for index in range(0,len(dataX_out)):
    print "x: %d, y: %d, e: %d, dx: %d" %(dataX_out[index] , dataY_out[index], dataE_out[index], dataDX_out[index])

```
- Confirm that the output in the file has a fourth column
- Confirm the print out shows dx values
