### PR TITLE
Fix coverity issue 1316474.

### DIFF
--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
@@ -180,11 +180,14 @@ int vtkMDHWNexusReader::RequestInformation(
   
   m_presenter->executeLoadMetadata();
   setTimeRange(outputVector);
-  std::vector<int> extents = dynamic_cast<MDHWNexusLoadingPresenter*>(m_presenter)->getExtents();
-  outputVector->GetInformationObject(0)
-      ->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), &extents[0],
-            static_cast<int>(extents.size()));
-
+  MDHWNexusLoadingPresenter *castPresenter =
+      dynamic_cast<MDHWNexusLoadingPresenter *>(m_presenter);
+  if (castPresenter) {
+    std::vector<int> extents = castPresenter->getExtents();
+    outputVector->GetInformationObject(0)
+        ->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), &extents[0],
+              static_cast<int>(extents.size()));
+  }
   return 1;
 }
 

--- a/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Code/Mantid/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -234,12 +234,14 @@ int vtkMDHWSource::RequestInformation(vtkInformation *vtkNotUsed(request), vtkIn
     } else {
       m_presenter->executeLoadMetadata();
       setTimeRange(outputVector);
-      std::vector<int> extents =
-          dynamic_cast<MDHWInMemoryLoadingPresenter *>(m_presenter)
-              ->getExtents();
-      outputVector->GetInformationObject(0)
-          ->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), &extents[0],
-                static_cast<int>(extents.size()));
+      MDHWInMemoryLoadingPresenter *castPresenter =
+          dynamic_cast<MDHWInMemoryLoadingPresenter *>(m_presenter);
+      if (castPresenter) {
+        std::vector<int> extents = castPresenter->getExtents();
+        outputVector->GetInformationObject(0)
+            ->Set(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), &extents[0],
+                  static_cast<int>(extents.size()));
+      }
       return 1;
     }
   } else //(m_presenter == NULL)


### PR DESCRIPTION
This fixes coverity issue 1316474 by checking if dynamic_cast<> yields a NULL pointer. 

No release notes since this a) fixes code added after the current release and b) should not be noticed by users.

testing: code review
