### PR TITLE
13368 implement quadratic scaling for color fill plots

### DIFF
--- a/Code/Mantid/MantidPlot/src/Graph.cpp
+++ b/Code/Mantid/MantidPlot/src/Graph.cpp
@@ -1442,6 +1442,7 @@ void Graph::setAxisScale(int axis, double start, double end, int type, double st
               start = sp->getMinPositiveValue();
             }
             sp->mutableColorMap().changeScaleType((GraphOptions::ScaleType)type);
+            sp->mutableColorMap().setNthPower(sc_engine->nthPower());
             rightAxis->setColorMap(QwtDoubleInterval(start, end), sp->getColorMap());
             sp->setColorMap(sp->getColorMap());
             // we could check if(sp->isIntensityChanged()) but this doesn't work when one value is changing from zero to say 10^-10, which is a big problem for log plots
@@ -4371,6 +4372,7 @@ void Graph::copy(Graph* g)
         rightAxis->setColorBarEnabled(false);
       sp->plot()->enableAxis(QwtPlot::yRight, true);
       sp->mutableColorMap().changeScaleType(sp->getColorMap().getScaleType());
+      sp->mutableColorMap().setNthPower(sp->getColorMap().getNthPower());
 
       rightAxis->setColorMap(sp->data().range(),sp->mutableColorMap());
       sp->plot()->setAxisScale(QwtPlot::yRight,

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
@@ -1,8 +1,10 @@
 #include "ColorMapWidget.h"
 #include "MantidQtAPI/MantidColorMap.h"
 #include "MantidQtAPI/GraphOptions.h"
+#include "plot2D/PowerScaleEngine.h"
 
 #include <QVBoxLayout>
+#include <QGridLayout>
 #include <QHBoxLayout>
 #include <QComboBox>
 #include <QLineEdit>
@@ -10,6 +12,8 @@
 #include <QApplication>
 #include <qwt_scale_widget.h>
 #include <qwt_scale_engine.h>
+#include <DoubleSpinBox.h>
+#include <QLabel>
 
 /**
   * Constructor.
@@ -18,7 +22,7 @@
   * @param minPositiveValue A minimum positive value for the Log10 scale
   */
 ColorMapWidget::ColorMapWidget(int type,QWidget* parent,const double& minPositiveValue):
-  QFrame(parent), m_minPositiveValue(minPositiveValue), m_dragging(false), m_y(0), m_dtype()
+  QFrame(parent), m_minPositiveValue(minPositiveValue), m_dragging(false), m_y(0), m_dtype(), m_nth_power(2.0)
 {
   m_scaleWidget = new QwtScaleWidget(QwtScaleDraw::RightScale);
   m_scaleWidget->setColorBarEnabled(true);
@@ -49,12 +53,23 @@ ColorMapWidget::ColorMapWidget(int type,QWidget* parent,const double& minPositiv
   m_scaleOptions = new QComboBox;
   m_scaleOptions->addItem("Log10", QVariant(GraphOptions::Log10));
   m_scaleOptions->addItem("Linear", QVariant(GraphOptions::Linear));
+  m_scaleOptions->addItem("Power", QVariant(GraphOptions::Power));
   m_scaleOptions->setCurrentIndex(m_scaleOptions->findData(type));
   connect(m_scaleOptions, SIGNAL(currentIndexChanged(int)), this, SLOT(scaleOptionsChanged(int)));
 
-  QVBoxLayout* options_layout = new QVBoxLayout;
-  options_layout->addStretch();
-  options_layout->addWidget(m_scaleOptions);
+  // Controls for exponent for power scale type
+  m_lblN = new QLabel(tr("n ="));
+  m_lblN->setAlignment(Qt::AlignVCenter | Qt::AlignRight);
+  m_dspnN = new DoubleSpinBox();
+  m_dspnN->setValue(m_nth_power);
+
+  QGridLayout* options_layout = new QGridLayout;
+  options_layout->addWidget(m_scaleOptions, 1, 0, 1, 2);
+  options_layout->addWidget(m_lblN, 2, 0);
+  options_layout->addWidget(m_dspnN, 2, 1);
+  options_layout->setRowStretch(0, 4);
+  options_layout->setRowStretch(1, 1);
+  options_layout->setRowStretch(2, 1);
 
   QHBoxLayout *colourmap_layout = new QHBoxLayout;
   colourmap_layout->addLayout(lColormapLayout);
@@ -65,6 +80,11 @@ ColorMapWidget::ColorMapWidget(int type,QWidget* parent,const double& minPositiv
 
 void ColorMapWidget::scaleOptionsChanged(int i)
 {
+  if (m_scaleOptions->itemData(i).toUInt() == 2) {
+    m_dspnN->setEnabled(true);
+  }
+  else m_dspnN->setEnabled(false);
+
   emit scaleTypeChanged(m_scaleOptions->itemData(i).toUInt());
 }
 
@@ -83,6 +103,12 @@ void ColorMapWidget::setupColorBarScaling(const MantidColorMap& colorMap)
     QwtLinearScaleEngine linScaler;
     m_scaleWidget->setScaleDiv(linScaler.transformation(), linScaler.divideScale(minValue, maxValue,  20, 5));
     m_scaleWidget->setColorMap(QwtDoubleInterval(minValue, maxValue),colorMap);
+  }
+  else if( type == GraphOptions::Power )
+  {
+      PowerScaleEngine powerScaler;
+      m_scaleWidget->setScaleDiv(powerScaler.transformation(), powerScaler.divideScale(minValue, maxValue,  20, 5));
+      m_scaleWidget->setColorMap(QwtDoubleInterval(minValue, maxValue),colorMap);
   }
   else
  {
@@ -107,6 +133,10 @@ void ColorMapWidget::setupColorBarScaling(const MantidColorMap& colorMap)
   }
   m_scaleOptions->blockSignals(true);
   m_scaleOptions->setCurrentIndex(m_scaleOptions->findData(type));
+  m_dspnN->setEnabled(false);
+  if (m_scaleOptions->findData(type) == 2) {
+    m_dspnN->setEnabled(true);
+  }
   m_scaleOptions->blockSignals(false);
 }
 
@@ -205,6 +235,11 @@ void ColorMapWidget::updateScale()
   {
     QwtLinearScaleEngine linScaler;
     m_scaleWidget->setScaleDiv(linScaler.transformation(), linScaler.divideScale(minValue, maxValue,  20, 5));
+  }
+  else if( type == GraphOptions::Power )
+  {
+    PowerScaleEngine powerScaler;
+    m_scaleWidget->setScaleDiv(powerScaler.transformation(), powerScaler.divideScale(minValue, maxValue,  20, 5));
   }
   else
  {

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
@@ -62,6 +62,7 @@ ColorMapWidget::ColorMapWidget(int type,QWidget* parent,const double& minPositiv
   m_lblN->setAlignment(Qt::AlignVCenter | Qt::AlignRight);
   m_dspnN = new DoubleSpinBox();
   m_dspnN->setValue(m_nth_power);
+  connect(m_dspnN, SIGNAL(valueChanged(double)), this, SLOT(nPowerChanged(double)));
 
   QGridLayout* options_layout = new QGridLayout;
   options_layout->addWidget(m_scaleOptions, 1, 0, 1, 2);
@@ -86,6 +87,11 @@ void ColorMapWidget::scaleOptionsChanged(int i)
   else m_dspnN->setEnabled(false);
 
   emit scaleTypeChanged(m_scaleOptions->itemData(i).toUInt());
+}
+
+void ColorMapWidget::nPowerChanged(double nth_power)
+{
+  emit nthPowerChanged(nth_power);
 }
 
 /**
@@ -221,6 +227,11 @@ int ColorMapWidget::getScaleType()const
 void ColorMapWidget::setScaleType(int type)
 {
   m_scaleOptions->setCurrentIndex(m_scaleOptions->findData(type));
+}
+
+void ColorMapWidget::setNthPower(double nth_power)
+{
+  m_dspnN->setValue(nth_power);
 }
 
 /**

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
@@ -28,10 +28,12 @@ public:
   void setMinPositiveValue(double);
   int getScaleType()const;
   void setScaleType(int);
+  void setNthPower(double);
 signals:
   void scaleTypeChanged(int);
   void minValueChanged(double);
   void maxValueChanged(double);
+  void nthPowerChanged(double);
 protected:
   void mousePressEvent(QMouseEvent*);
   void mouseMoveEvent(QMouseEvent*);
@@ -41,6 +43,7 @@ protected:
   void setMaxValueText(double);
 private slots:
   void scaleOptionsChanged(int);
+  void nPowerChanged(double);
   void minValueChanged();
   void maxValueChanged();
 private:

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
@@ -2,12 +2,15 @@
 #define COLORMAPWIDGET_H_
 
 #include <QFrame>
+#include <src/lib/include/DoubleSpinBox.h>
 
 class MantidColorMap;
 
 class QwtScaleWidget;
 class QLineEdit;
 class QComboBox;
+class QLabel;
+class DoubleSpinBox;
 
 
 /**
@@ -44,7 +47,10 @@ private:
   QwtScaleWidget *m_scaleWidget;
   QLineEdit *m_minValueBox, *m_maxValueBox;
   QComboBox *m_scaleOptions;
+  QLabel *m_lblN;
+  DoubleSpinBox *m_dspnN;
   double m_minPositiveValue;
+  double m_nth_power;
   bool m_dragging;
   int m_y;
   DragType m_dtype;

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
@@ -53,10 +53,10 @@ private:
   QLabel *m_lblN;
   DoubleSpinBox *m_dspnN;
   double m_minPositiveValue;
-  double m_nth_power;
   bool m_dragging;
   int m_y;
   DragType m_dtype;
+  double m_nth_power;
 };
 
 

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentActor.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentActor.cpp
@@ -796,6 +796,12 @@ void InstrumentActor::changeScaleType(int type)
   resetColors();
 }
 
+void InstrumentActor::changeNthPower(double nth_power)
+{
+  m_colorMap.setNthPower(nth_power);
+  resetColors();
+}
+
 void InstrumentActor::loadSettings()
 {
   QSettings settings;

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentActor.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentActor.h
@@ -86,6 +86,8 @@ public:
   void loadColorMap(const QString& ,bool reset_colors = true);
   /// Change the colormap scale type.
   void changeScaleType(int);
+  /// Change the colormap power scale exponent.
+  void changeNthPower(double);
   /// Get the file name of the current color map.
   QString getCurrentColorMap()const{return m_currentColorMapFilename;}
   /// Toggle colormap scale autoscaling.

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -581,6 +581,14 @@ void InstrumentWindow::setScaleType(GraphOptions::ScaleType type) {
 }
 
 /**
+ * Set the exponent for the Power scale type
+ * @param nth_power :: The exponent choice
+ */
+void InstrumentWindow::setExponent(double nth_power) {
+  emit nthPowerChanged(nth_power);
+}
+
+/**
  * This method opens a color dialog to pick the background color,
  * and then sets it.
  */
@@ -791,6 +799,12 @@ void InstrumentWindow::finishHandle(const Mantid::API::IAlgorithm *alg) {
 
 void InstrumentWindow::changeScaleType(int type) {
   m_instrumentActor->changeScaleType(type);
+  setupColorMap();
+  updateInstrumentView();
+}
+
+void InstrumentWindow::changeNthPower(double nth_power) {
+  m_instrumentActor->changeNthPower(nth_power);
   setupColorMap();
   updateInstrumentView();
 }

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
@@ -90,6 +90,7 @@ public:
   void setColorMapRange(double minValue, double maxValue);
   void selectComponent(const QString & name);
   void setScaleType(GraphOptions::ScaleType type);
+  void setExponent(double nth_power);
   void setViewType(const QString& type);
   InstrumentActor* getInstrumentActor() const {return m_instrumentActor;}
   bool blocked()const{return m_blocked;}
@@ -120,6 +121,7 @@ signals:
   void colorMapMaxValueChanged(double);
   void colorMapRangeChanged(double,double);
   void scaleTypeChanged(int);
+  void nthPowerChanged(double);
   void integrationRangeChanged(double,double);
   void glOptionChanged(bool);
   void requestSelectComponent(const QString&);
@@ -143,6 +145,7 @@ public slots:
 
   void changeColormap(const QString & filename = ""); // Deprecated
   void changeScaleType(int);// Deprecated
+  void changeNthPower(double);
   void changeColorMapMinValue(double minValue); // Deprecated
   void changeColorMapMaxValue(double maxValue); // Deprecated
   void changeColorMapRange(double minValue, double maxValue); // Deprecated

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowRenderTab.cpp
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowRenderTab.cpp
@@ -47,6 +47,7 @@ InstrumentWindowTab(instrWindow)
   connect(m_instrWindow,SIGNAL(colorMapMinValueChanged(double)),this,SLOT(setMinValue(double)));
   connect(m_instrWindow,SIGNAL(colorMapRangeChanged(double,double)),this,SLOT(setRange(double,double)));
   connect(m_instrWindow,SIGNAL(scaleTypeChanged(int)),this,SLOT(scaleTypeChanged(int)));
+  connect(m_instrWindow,SIGNAL(nthPowerChanged(double)),this,SLOT(nthPowerChanged(double)));
   connect(m_instrWindow,SIGNAL(glOptionChanged(bool)),this,SLOT(glOptionChanged(bool)));
 
   // Surface type controls
@@ -167,6 +168,7 @@ InstrumentWindowTab(instrWindow)
   // Colormap widget
   m_colorMapWidget = new ColorMapWidget(0,this);
   connect(m_colorMapWidget, SIGNAL(scaleTypeChanged(int)), m_instrWindow, SLOT(changeScaleType(int)));
+  connect(m_colorMapWidget, SIGNAL(nthPowerChanged(double)), m_instrWindow, SLOT(changeNthPower(double)));
   connect(m_colorMapWidget,SIGNAL(minValueChanged(double)),m_instrWindow, SLOT(changeColorMapMinValue(double)));
   connect(m_colorMapWidget,SIGNAL(maxValueChanged(double)),m_instrWindow, SLOT(changeColorMapMaxValue(double)));
 
@@ -649,6 +651,11 @@ void InstrumentWindowRenderTab::colorMapChanged()
 void InstrumentWindowRenderTab::scaleTypeChanged(int type)
 {
     setScaleType((GraphOptions::ScaleType)type);
+}
+
+void InstrumentWindowRenderTab::nthPowerChanged(double nth_power)
+{
+    m_colorMapWidget->setNthPower(nth_power);
 }
 
 /**

--- a/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowRenderTab.h
+++ b/Code/Mantid/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindowRenderTab.h
@@ -65,6 +65,7 @@ private slots:
   void surfaceTypeChanged(int index);
   void colorMapChanged();
   void scaleTypeChanged(int);
+  void nthPowerChanged(double);
   void glOptionChanged(bool);
   void showMenuToolTip(QAction*);
   void setUCorrection();

--- a/Code/Mantid/MantidPlot/src/Spectrogram.cpp
+++ b/Code/Mantid/MantidPlot/src/Spectrogram.cpp
@@ -400,6 +400,7 @@ Spectrogram* Spectrogram::copy()
   new_s->setLevelsNumber(levels());
 
   new_s->mutableColorMap().changeScaleType(getColorMap().getScaleType());
+  new_s->mutableColorMap().setNthPower(getColorMap().getNthPower());
   return new_s;
 }
 

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.cpp
@@ -276,6 +276,6 @@ double PowerScaleTransformation::xForm(
 double PowerScaleTransformation::invXForm(double p, double p1, double p2,
     double s1, double s2) const
 {
-	return pow((p - p1) / (p2 - p1) * (pow(s2, nth_power) - pow(s1, nth_power)), 1.0/nth_power) * s1;
+	return pow((p - p1) / (p2 - p1) * (pow(s2, nth_power) - pow(s1, nth_power)), 1.0/nth_power) + s1;
 }
 

--- a/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
+++ b/Code/Mantid/MantidPlot/src/plot2D/PowerScaleEngine.h
@@ -27,8 +27,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef RECIPROCAL_SCALE_ENGINE_H
-#define RECIPROCAL_SCALE_ENGINE_H
+#ifndef POWER_SCALE_ENGINE_H
+#define POWER_SCALE_ENGINE_H
 
 #include <qwt_scale_engine.h>
 #include <qwt_scale_map.h>

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidColorMap.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidColorMap.h
@@ -127,13 +127,14 @@ private:
   /// Cached NAN value
   double m_nan;
 
-  double m_nth_power;
-
   ///the name of the color map
   QString m_name;
 
   ///the path to the map file
   QString m_path;
+
+  double m_nth_power;
+
 };
 
 

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidColorMap.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/MantidColorMap.h
@@ -45,6 +45,10 @@ public:
 
   void changeScaleType(GraphOptions::ScaleType type);
 
+  void setNthPower(double nth_power){m_nth_power = nth_power;};
+
+  double getNthPower() const {return m_nth_power;};
+
   bool loadMap(const QString & filename);
   
   static QString loadMapDialog(QString previousFile, QWidget * parent);
@@ -122,6 +126,8 @@ private:
 
   /// Cached NAN value
   double m_nan;
+
+  double m_nth_power;
 
   ///the name of the color map
   QString m_name;

--- a/Code/Mantid/MantidQt/API/src/MantidColorMap.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidColorMap.cpp
@@ -32,7 +32,7 @@ namespace
  * Default
  */
 MantidColorMap::MantidColorMap() : QwtColorMap(QwtColorMap::Indexed), m_scale_type(GraphOptions::Log10),
-				     m_colors(0), m_num_colors(0), m_name(), m_path()
+				     m_colors(0), m_num_colors(0), m_name(), m_path(), m_nth_power(2.0)
 {
   m_nan = std::numeric_limits<double>::quiet_NaN();
   this->setNanColor(255,255,255);
@@ -46,7 +46,8 @@ MantidColorMap::MantidColorMap() : QwtColorMap(QwtColorMap::Indexed), m_scale_ty
  * @param type :: The scale type, currently Linear or Log10 
  */
 MantidColorMap::MantidColorMap(const QString & filename, GraphOptions::ScaleType type) : 
-  QwtColorMap(QwtColorMap::Indexed), m_scale_type(type), m_colors(0), m_num_colors(0), m_name(), m_path()
+  QwtColorMap(QwtColorMap::Indexed), m_scale_type(type), m_colors(0), m_num_colors(0),
+  m_name(), m_path(), m_nth_power(2.0)
 {
   m_nan = std::numeric_limits<double>::quiet_NaN();
   this->setNanColor(255,255,255);
@@ -256,6 +257,11 @@ double MantidColorMap::normalize(const QwtDoubleInterval &interval, double value
   if( m_scale_type == GraphOptions::Linear)
   {
     ratio = (value - interval.minValue()) / width;
+  }
+  else if (m_scale_type == GraphOptions::Power)
+  {
+    ratio = (pow(value, m_nth_power) - pow(interval.minValue(), m_nth_power)) /
+            (pow(interval.maxValue(), m_nth_power) - pow(interval.minValue(), m_nth_power));
   }
   else
   {

--- a/Code/Mantid/MantidQt/API/src/MantidColorMap.cpp
+++ b/Code/Mantid/MantidQt/API/src/MantidColorMap.cpp
@@ -43,7 +43,7 @@ MantidColorMap::MantidColorMap() : QwtColorMap(QwtColorMap::Indexed), m_scale_ty
 /**
  * Constructor with filename and type
  * @param filename :: color map file to load
- * @param type :: The scale type, currently Linear or Log10 
+ * @param type :: The scale type
  */
 MantidColorMap::MantidColorMap(const QString & filename, GraphOptions::ScaleType type) : 
   QwtColorMap(QwtColorMap::Indexed), m_scale_type(type), m_colors(0), m_num_colors(0),
@@ -265,6 +265,7 @@ double MantidColorMap::normalize(const QwtDoubleInterval &interval, double value
   }
   else
   {
+    // Assume log10 type
     // Have to deal with the possibility that a user has entered 0 as a minimum
     double minValue = interval.minValue();
     if( minValue < LOG_ZERO_CUTOFF )

--- a/Code/Mantid/MantidQt/API/test/MantidColorMapTest.h
+++ b/Code/Mantid/MantidQt/API/test/MantidColorMapTest.h
@@ -40,6 +40,15 @@ public:
     TS_ASSERT_DELTA( map.normalize(range, 1000.), 0.75, 1e-5);
   }
 
+  void test_normalize_power()
+  {
+    MantidColorMap map;
+    QwtDoubleInterval range(10.0, 20.0);
+    map.changeScaleType( GraphOptions::Power );
+    map.setNthPower( 2.0 );
+    TS_ASSERT_DELTA( map.normalize(range, 16.), 0.52, 1e-5);
+  }
+
   /// Setting a NAN color
   void test_nan_color()
   {


### PR DESCRIPTION
Closes #13368 and  #13369 

Adds Power scale option to the instrument view, including a control for the exponent ("n=").
Power scale option now works correctly for axes and colorbar for color fill plots and is configured in the "General Plot Options" window (Format->Scales...).

For tester:
Load an example workspace and try instrument view and color fill plots. Power scaling should work for axes and colorbar. Power scaling with n=1 should be consistent with linear scaling.
