### PR TITLE
Removed use of OutputVertexes for ConvertSpectrumAxis

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/test/ConvertToReflectometryQTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/ConvertToReflectometryQTest.h
@@ -285,8 +285,6 @@ public:
     specaxisalg->initialize();
     specaxisalg->setPropertyValue("InputWorkspace", "testws");
     specaxisalg->setPropertyValue("OutputWorkspace", "testws");
-    specaxisalg->setPropertyValue("OutputVertexes", "vertexes");
-    
     specaxisalg->setPropertyValue("Target", "signed_theta");
     specaxisalg->execute();
     


### PR DESCRIPTION
Fixes #13482 

Removed the type that set output vertexes value in the
convertSpectrumAxis algorithm
