### PR TITLE
 Fix main and hab for detector in user file

### DIFF
--- a/Code/Mantid/scripts/SANS/isis_reduction_steps.py
+++ b/Code/Mantid/scripts/SANS/isis_reduction_steps.py
@@ -2248,8 +2248,9 @@ class UserFile(ReductionStep):
                 self._readDetectorCorrections(upper_line[8:], reducer)
             elif det_specif.startswith('RESCALE') or det_specif.startswith('SHIFT'):
                 self._readFrontRescaleShiftSetup(det_specif, reducer)
-            elif any(it == det_specif.strip() for it in ['FRONT','REAR','BOTH','MERGE','MERGED']):
+            elif any(it == det_specif.strip() for it in ['FRONT','REAR','BOTH','MERGE','MERGED', 'MAIN', 'HAB']):
                 # for /DET/FRONT, /DET/REAR, /DET/BOTH, /DET/MERGE and /DET/MERGED commands
+                # we also accomodate DET/MAIN and DET/HAB here which are specificially for LOQ
                 det_specif = det_specif.strip()
                 if det_specif == 'MERGE':
                     det_specif = 'MERGED'


### PR DESCRIPTION
Fixes  #13487 
## For testing:

Please find relevant test files here: \olympic\Babylon5\Scratch\Anton\Testing\13487_fix_user_file

Make sure that the files are in your search directory.

**Testing DET/MAIN**
1. Open the ISIS SANS GUI
2. Set the instrument LOQ and load/relaod the user file LOQ_MAIN.txt
3. Confirm that there is no warning saying "DET line not recognized ..."
4. Go to the Reduction Settings tab and confirm that as a detecotor bank  **main-detector-bank** was selcected 

**Testing DET/HAB**
1. Open the ISIS SANS GUI
2. Set the instrument LOQ and load/relaod the user file LOQ_HAB.txt
3. Confirm that there is no warning saying "DET line not recognized ..."
4. Go to the Reduction Settings tab and confirm that as a detecotor bank  **HAB** was selcected 
