### PR TITLE
Fixing symlinks in file open dialog on Mac OS

### DIFF
--- a/Code/Mantid/MantidQt/MantidWidgets/src/MWRunFiles.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/MWRunFiles.cpp
@@ -998,10 +998,10 @@ QString MWRunFiles::openFileDialog() {
       filenames.append(file);
   } else if (m_allowMultipleFiles) {
     filenames =
-        QFileDialog::getOpenFileNames(this, "Open file", dir, m_fileFilter);
+        QFileDialog::getOpenFileNames(this, "Open file", dir, m_fileFilter, 0, QFileDialog::DontResolveSymlinks);
   } else {
     QString file =
-        QFileDialog::getOpenFileName(this, "Open file", dir, m_fileFilter);
+        QFileDialog::getOpenFileName(this, "Open file", dir, m_fileFilter, 0, QFileDialog::DontResolveSymlinks);
     if (!file.isEmpty())
       filenames.append(file);
   }


### PR DESCRIPTION
This fixes #13478.

This has to be tested by someone with Mac OS and probably also with Windows to see if setting the flag changes behavior on that system in any way.

**Testing information**
Follow the steps described in the issue before and after the changes. After the changes you should be able to select a file from the external data storage through its symlink in the build directory.
