### PR TITLE
Name of Detector ID column of PeaksWorkspace saved to Nexus

### DIFF
--- a/Code/Mantid/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -656,7 +656,7 @@ void PeaksWorkspace::saveNexus(::NeXus::File *file) const {
   // Detectors column
   file->writeData("column_1", detectorID);
   file->openData("column_1");
-  file->putAttr("name", "Dectector ID");
+  file->putAttr("name", "Detector ID");
   file->putAttr("interpret_as", specifyInteger);
   file->putAttr("units", "Not known");
   file->closeData();

--- a/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -151,10 +151,13 @@ public:
     nexusHelper.reopenFile();
 
     // Verify that this test_entry has a peaks_workspace entry
-    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openGroup("peaks_workspace","NXentry") );
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openGroup("peaks_workspace","NXentry") )
 
     // Check detector IDs
     TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openData("column_1") );
+    std::string columnName;
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->getAttr("name", columnName) );
+    TS_ASSERT_EQUALS( columnName, "Detector ID");
     std::vector<int> detIDs;
     TS_ASSERT_THROWS_NOTHING(nexusHelper.file->getData(detIDs));
     nexusHelper.file->closeData();

--- a/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -151,7 +151,7 @@ public:
     nexusHelper.reopenFile();
 
     // Verify that this test_entry has a peaks_workspace entry
-    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openGroup("peaks_workspace","NXentry") )
+    TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openGroup("peaks_workspace","NXentry") );
 
     // Check detector IDs
     TS_ASSERT_THROWS_NOTHING(nexusHelper.file->openData("column_1") );


### PR DESCRIPTION
fixes #8590 

To test:

Review the code change (very simple)

Run SaveNexus on a PeaksWorkspace. The usage example of CreatePeaksWorkspace will create a simple one. Check that it works without error. You may use HDFView to check the Nexus file produced and see that column 1 data has a "name" attribute of "Detector ID".

Check that the unit test is adequate.
