### PR TITLE
Background corrections for IntegrateEllipsoids

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -70,7 +70,7 @@ public:
   void addEvents(std::vector<std::pair<double, Mantid::Kernel::V3D> > const &event_qs, bool hkl_integ);
 
   /// Find the net integrated intensity of a peak, using ellipsoidal volumes
-  boost::shared_ptr<const Mantid::Geometry::PeakShape> ellipseIntegrateEvents(Mantid::Kernel::V3D const &peak_q, bool specify_size,
+  boost::shared_ptr<const Mantid::Geometry::PeakShape> ellipseIntegrateEvents(std::vector<Kernel::V3D> E1Vec, Mantid::Kernel::V3D const &peak_q, bool specify_size,
                               double peak_radius, double back_inner_radius,
                               double back_outer_radius,
                               std::vector<double> &axes_radii, double &inti,
@@ -81,6 +81,12 @@ private:
   static double numInEllipsoid(std::vector<std::pair<double, Mantid::Kernel::V3D> > const &events,
                             std::vector<Mantid::Kernel::V3D> const &directions,
                             std::vector<double> const &sizes);
+
+  /// Calculate the number of events in an ellipsoid centered at 0,0,0
+  static double numInEllipsoid(std::vector<std::pair<double, Mantid::Kernel::V3D> > const &events,
+                            std::vector<Mantid::Kernel::V3D> const &directions,
+                            std::vector<double> const &sizes,
+                            std::vector<double> const &sizesIn);
 
   /// Calculate the 3x3 covariance matrix of a list of Q-vectors at 0,0,0
   static void makeCovarianceMatrix(std::vector<std::pair<double, Mantid::Kernel::V3D> > const &events,
@@ -106,11 +112,11 @@ private:
 
   /// Find the net integrated intensity of a list of Q's using ellipsoids
   boost::shared_ptr<const Mantid::DataObjects::PeakShapeEllipsoid> ellipseIntegrateEvents(
-      std::vector<std::pair<double, Mantid::Kernel::V3D> > const &ev_list, std::vector<Mantid::Kernel::V3D> const &directions,
+      std::vector<Kernel::V3D> E1Vec, Kernel::V3D const &peak_q, std::vector<std::pair<double, Mantid::Kernel::V3D> > const &ev_list, std::vector<Mantid::Kernel::V3D> const &directions,
       std::vector<double> const &sigmas, bool specify_size, double peak_radius,
       double back_inner_radius, double back_outer_radius,
       std::vector<double> &axes_radii, double &inti, double &sigi);
-
+  double detectorQ(std::vector<Kernel::V3D> E1Vec, const Mantid::Kernel::V3D QLabFrame, std::vector<double>& r);
   // Private data members
   PeakQMap peak_qs;         // hashtable with peak Q-vectors
   EventListMap event_lists; // hashtable with lists of events for each peak

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -83,7 +83,7 @@ private:
                             std::vector<double> const &sizes);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
-  static double numInEllipsoid(std::vector<std::pair<double, Mantid::Kernel::V3D> > const &events,
+  static double numInEllipsoidBkg(std::vector<std::pair<double, Mantid::Kernel::V3D> > const &events,
                             std::vector<Mantid::Kernel::V3D> const &directions,
                             std::vector<double> const &sizes,
                             std::vector<double> const &sizesIn);

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateEllipsoids.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateEllipsoids.h
@@ -40,7 +40,7 @@ private:
 
   /// Calculate if this Q is on a detector
   void calculateE1(Geometry::Instrument_const_sptr inst) ;
-  bool detectorQ(Mantid::Kernel::V3D QLabFrame, std::vector<double>&  PeakRadius);
+
   void runMaskDetectors(Mantid::DataObjects::PeaksWorkspace_sptr peakWS,
                         std::string property, std::string values);
 

--- a/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateEllipsoids.h
+++ b/Code/Mantid/Framework/MDAlgorithms/inc/MantidMDAlgorithms/IntegrateEllipsoids.h
@@ -9,6 +9,7 @@
 #include "MantidMDAlgorithms/MDTransfInterface.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -36,6 +37,15 @@ private:
   void qListFromHistoWS(Integrate3DEvents &integrator, API::Progress &prog,
                         DataObjects::Workspace2D_sptr &wksp,
                         Kernel::DblMatrix const &UBinv, bool hkl_integ);
+
+  /// Calculate if this Q is on a detector
+  void calculateE1(Geometry::Instrument_const_sptr inst) ;
+  bool detectorQ(Mantid::Kernel::V3D QLabFrame, std::vector<double>&  PeakRadius);
+  void runMaskDetectors(Mantid::DataObjects::PeaksWorkspace_sptr peakWS,
+                        std::string property, std::string values);
+
+  /// save for all detector pixels
+  std::vector<Kernel::V3D> E1Vec;
 
   MDWSDescription m_targWSDescr;
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -111,7 +111,7 @@ void Integrate3DEvents::addEvents(std::vector<std::pair<double, V3D> > const &ev
  *
  */
 Mantid::Geometry::PeakShape_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
-    V3D const &peak_q, bool specify_size, double peak_radius,
+    std::vector<Kernel::V3D> E1Vec, V3D const &peak_q, bool specify_size, double peak_radius,
     double back_inner_radius, double back_outer_radius,
     std::vector<double> &axes_radii, double &inti, double &sigi) {
   inti = 0.0; // default values, in case something
@@ -154,7 +154,7 @@ Mantid::Geometry::PeakShape_const_sptr Integrate3DEvents::ellipseIntegrateEvents
     return boost::make_shared<NoShape>();         // ellipsoids will be zero.
   }
 
-  return ellipseIntegrateEvents(some_events, eigen_vectors, sigmas, specify_size,
+  return ellipseIntegrateEvents(E1Vec, peak_q, some_events, eigen_vectors, sigmas, specify_size,
                          peak_radius, back_inner_radius, back_outer_radius,
                          axes_radii, inti, sigi);
 }
@@ -188,7 +188,47 @@ double Integrate3DEvents::numInEllipsoid(std::vector<std::pair<double, V3D>> con
 
   return count;
 }
+/**
+ * Calculate the number of events in an ellipsoid centered at 0,0,0 with
+ * the three specified axes and the three specified sizes in the direction
+ * of those axes.  NOTE: The three axes must be mutually orthogonal unit
+ *                       vectors.
+ *
+ * @param  events      List of 3D events centered at 0,0,0
+ * @param  directions  List of 3 orthonormal directions for the axes of
+ *                     the ellipsoid.
+ * @param  sizes       List of three values a,b,c giving half the length
+ *                     of the three axes of the ellisoid.
+ * @param  sizesIn       List of three values a,b,c giving half the length
+ *                     of the three inner axes of the ellisoid.
+ * @return Then number of events that are in or on the specified ellipsoid.
+ */
+double Integrate3DEvents::numInEllipsoid(std::vector<std::pair<double, V3D>> const &events,
+                                      std::vector<V3D> const &directions,
+                                      std::vector<double> const &sizes,
+                                      std::vector<double> const &sizesIn) {
+  double count = 0;
+  std::vector<double> eventVec;
+  for (size_t i = 0; i < events.size(); i++) {
+    double sum = 0;
+    double sumIn = 0;
+    for (size_t k = 0; k < 3; k++) {
+      double comp = events[i].second.scalar_prod(directions[k]) / sizes[k];
+      sum += comp * comp;
+      comp = events[i].second.scalar_prod(directions[k]) / sizesIn[k];
+      sumIn += comp * comp;
+    }
+    if (sum <= 1 && sumIn >= 1)
+      eventVec.push_back(events[i].first);
+    }
+  std::sort(eventVec.begin(), eventVec.end());
+  // Remove top 1% of background
+  for (size_t k = 0; k < static_cast<size_t>(0.99 * static_cast<double>(eventVec.size())); k++) {
+    count += eventVec[k];
+  }
 
+  return count;
+}
 /**
  *  Given a list of events, associated with a particular peak
  *  and already SHIFTED to be centered at (0,0,0), calculate the 3x3
@@ -418,7 +458,7 @@ void Integrate3DEvents::addEvent(std::pair<double, V3D> event_Q, bool hkl_integ)
  *
  */
 PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
-    std::vector<std::pair<double, Mantid::Kernel::V3D> > const &ev_list,
+    std::vector<Kernel::V3D> E1Vec, V3D const &peak_q, std::vector<std::pair<double, Mantid::Kernel::V3D> > const &ev_list,
     std::vector<Mantid::Kernel::V3D> const &directions,
     std::vector<double> const &sigmas, bool specify_size, double peak_radius,
     double back_inner_radius, double back_outer_radius,
@@ -460,25 +500,35 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
   }
 
   axes_radii.clear();
+  std::vector<double> abcBackgroundOuterRadii;
+  std::vector<double> abcBackgroundInnerRadii;
+  std::vector<double> abcRadii;
   for (int i = 0; i < 3; i++) {
-    axes_radii.push_back(r3 * sigmas[i]);
+    abcBackgroundOuterRadii.push_back(r3 * sigmas[i]);
+    abcBackgroundInnerRadii.push_back(r2 * sigmas[i]);
+    abcRadii.push_back(r1 * sigmas[i]);
+    axes_radii.push_back(r1 * sigmas[i]);
   }
-  auto abcBackgroundOuterRadii = axes_radii;
-  double back2 = numInEllipsoid(ev_list, directions, axes_radii);
 
-  for (int i = 0; i < 3; i++) {
-    axes_radii[i] = r2 * sigmas[i];
+  if(E1Vec.size() > 0){
+    double h3 = 1.0 - detectorQ(E1Vec, peak_q, abcBackgroundOuterRadii);
+    // scaled from area of circle minus segment when r normalized to 1
+    double m3= std::sqrt(1.0 - (std::acos(1.0-h3)-(1.0-h3)*std::sqrt(2.0*h3-h3*h3))/M_PI);
+    double h1 = 1.0 - detectorQ(E1Vec, peak_q, axes_radii);
+    // Do not use peak if edge of detector is inside integration radius
+    if (h1 > 0.0) return boost::make_shared<const PeakShapeEllipsoid>(directions, abcRadii, abcBackgroundInnerRadii, abcBackgroundOuterRadii, Mantid::Kernel::QLab, "IntegrateEllipsoids");
+    r3 *= m3;
+    if (r2 != r1) {
+      double h2 = 1.0 - detectorQ(E1Vec, peak_q, abcBackgroundInnerRadii);
+      // scaled from area of circle minus segment when r normalized to 1
+      double m2= std::sqrt(1.0 - (std::acos(1.0-h2)-(1.0-h2)*std::sqrt(2.0*h2-h2*h2))/M_PI);
+      r2 *= m2;
+    }
   }
-  auto abcBackgroundInnerRadii = axes_radii;
-  double back1 = numInEllipsoid(ev_list, directions, axes_radii);
 
-  for (int i = 0; i < 3; i++) {
-    axes_radii[i] = r1 * sigmas[i];
-  }
-  auto abcRadii = axes_radii;
+  double backgrd = numInEllipsoid(ev_list, directions, abcBackgroundOuterRadii, abcBackgroundInnerRadii);
+
   double peak_w_back = numInEllipsoid(ev_list, directions, axes_radii);
-
-  double backgrd = back2 - back1;
 
   double ratio = pow(r1, 3) / (pow(r3, 3) - pow(r2, 3));
 
@@ -488,7 +538,27 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
   // Make the shape and return it.
   return boost::make_shared<const PeakShapeEllipsoid>(directions, abcRadii, abcBackgroundInnerRadii, abcBackgroundOuterRadii, Mantid::Kernel::QLab, "IntegrateEllipsoids");
 }
-
+/** Calculate if this Q is on a detector
+ * The distance from C to OE is given by dv=C-E*(C.scalar_prod(E))
+ * If dv.norm<integration_radius, one of the detector trajectories on the edge
+ *is too close to the peak
+ * This method is applied to all masked pixels. If there are masked pixels
+ *trajectories inside an integration volume, the peak must be rejected.
+ *
+ * @param QLabFrame: The Peak center.
+ * @param r: Peak radius.
+ */
+double Integrate3DEvents::detectorQ(std::vector<Kernel::V3D> E1Vec, const Mantid::Kernel::V3D QLabFrame, std::vector<double>& r) {
+  double quot = 1.0;
+  for (auto E1 = E1Vec.begin(); E1 != E1Vec.end(); ++E1) {
+    V3D distv = QLabFrame - *E1 * (QLabFrame.scalar_prod(*E1)); // distance to the trajectory as a vector
+    double quot0 = distv.norm() / *( std::min_element(r.begin(), r.end()));
+    if (quot0 < quot)  {
+      quot = quot0;
+    }
+  }
+return quot;
+}
 } // namespace MDAlgorithms
 
 } // namespace Mantid

--- a/Code/Mantid/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -84,6 +84,7 @@ void Integrate3DEvents::addEvents(std::vector<std::pair<double, V3D> > const &ev
  * half the major axis length of the ellipsoids, and the other axes of the
  * ellipsoids will be set proportionally, based on the standard deviations.
  *
+ * @param E1Vec               Vector of values for calculating edge of detectors
  * @param peak_q              The Q-vector for the peak center.
  * @param specify_size        If true the integration will be done using the
  *                            ellipsoids with major axes determined by the
@@ -203,7 +204,7 @@ double Integrate3DEvents::numInEllipsoid(std::vector<std::pair<double, V3D>> con
  *                     of the three inner axes of the ellisoid.
  * @return Then number of events that are in or on the specified ellipsoid.
  */
-double Integrate3DEvents::numInEllipsoid(std::vector<std::pair<double, V3D>> const &events,
+double Integrate3DEvents::numInEllipsoidBkg(std::vector<std::pair<double, V3D>> const &events,
                                       std::vector<V3D> const &directions,
                                       std::vector<double> const &sizes,
                                       std::vector<double> const &sizesIn) {
@@ -427,6 +428,8 @@ void Integrate3DEvents::addEvent(std::pair<double, V3D> event_Q, bool hkl_integ)
  * axes for the events and the standard deviations in the the directions
  * of the principal axes.
  *
+ * @param E1Vec             Vector of values for calculating edge of detectors
+ * @param peak_q            The Q-vector for the peak center.
  * @param ev_list             List of events centered at (0,0,0) for a
  *                            particular peak.
  * @param directions          The three principal axes of the list of events
@@ -526,7 +529,7 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
     }
   }
 
-  double backgrd = numInEllipsoid(ev_list, directions, abcBackgroundOuterRadii, abcBackgroundInnerRadii);
+  double backgrd = numInEllipsoidBkg(ev_list, directions, abcBackgroundOuterRadii, abcBackgroundInnerRadii);
 
   double peak_w_back = numInEllipsoid(ev_list, directions, axes_radii);
 
@@ -545,6 +548,7 @@ PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
  * This method is applied to all masked pixels. If there are masked pixels
  *trajectories inside an integration volume, the peak must be rejected.
  *
+ * @param E1Vec          Vector of values for calculating edge of detectors
  * @param QLabFrame: The Peak center.
  * @param r: Peak radius.
  */

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -279,8 +279,8 @@ void IntegrateEllipsoids::init() {
 
   declareProperty(
       "IntegrateIfOnEdge", true,
-      "Only warning if all of peak outer radius is not on detector (default).\n"
-      "If false, do not integrate if the outer radius is not on a detector.");
+      "Set to false to not integrate if peak radius is off edge of detector."
+      "Background will be scaled if background radius is off edge.");
 }
 
 //---------------------------------------------------------------------
@@ -425,17 +425,6 @@ void IntegrateEllipsoids::exec() {
           integrator.ellipseIntegrateEvents(E1Vec,
               peak_q, specify_size, peak_radius, back_inner_radius,
               back_outer_radius, axes_radii, inti, sigi);
-      // Do not integrate if sphere is off edge of detector
-
-      /*if (!detectorQ(peak_q, axes_radii)) {
-        g_log.warning() << "Warning: sphere/cylinder for integration is off edge "
-                           "of detector for peak " << i << std::endl;
-        if (!integrateEdge) {
-          peaks[i].setIntensity(0.0);
-          peaks[i].setSigmaIntensity(0.0);
-          continue;
-        }
-      }*/
       peaks[i].setIntensity(inti);
       peaks[i].setSigmaIntensity(sigi);
       peaks[i].setPeakShape(shape);
@@ -511,17 +500,6 @@ void IntegrateEllipsoids::exec() {
           integrator.ellipseIntegrateEvents(E1Vec,
               peak_q, specify_size, peak_radius, back_inner_radius,
               back_outer_radius, axes_radii, inti, sigi);
-          // Do not integrate if sphere is off edge of detector
-
-          /*if (!detectorQ(peak_q, axes_radii)) {
-            g_log.warning() << "Warning: sphere/cylinder for integration is off edge "
-                               "of detector for peak " << i << std::endl;
-            if (!integrateEdge) {
-              peaks[i].setIntensity(0.0);
-              peaks[i].setSigmaIntensity(0.0);
-              continue;
-            }
-          }*/
           peaks[i].setIntensity(inti);
           peaks[i].setSigmaIntensity(sigi);
           if (axes_radii.size() == 3) {
@@ -629,26 +607,6 @@ void IntegrateEllipsoids::calculateE1(Geometry::Instrument_const_sptr inst) {
     }
   }
 
-  /** Calculate if this Q is on a detector
-   * The distance from C to OE is given by dv=C-E*(C.scalar_prod(E))
-   * If dv.norm<integration_radius, one of the detector trajectories on the edge
-   *is too close to the peak
-   * This method is applied to all masked pixels. If there are masked pixels
-   *trajectories inside an integration volume, the peak must be rejected.
-   *
-   * @param QLabFrame: The Peak center.
-   * @param r: Peak radius.
-   */
-  bool IntegrateEllipsoids::detectorQ(Mantid::Kernel::V3D QLabFrame, std::vector<double>& r) {
-
-    for (auto E1 = E1Vec.begin(); E1 != E1Vec.end(); ++E1) {
-      V3D distv = QLabFrame - *E1 * (QLabFrame.scalar_prod(*E1)); // distance to the trajectory as a vector
-      if (distv.norm() < *( std::min_element(r.begin(), r.end())))  {
-        return false;
-      }
-    }
-  return true;
-}
 void IntegrateEllipsoids::runMaskDetectors(
     Mantid::DataObjects::PeaksWorkspace_sptr peakWS, std::string property,
     std::string values) {

--- a/Code/Mantid/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -27,8 +27,8 @@ public:
     double inti_all[] = { 755, 704, 603 };
     double sigi_all[] = { 27.4773, 26.533, 24.5561 };
 
-    double inti_some[] = { 691, 648, 603 };
-    double sigi_some[] = { 27.4773, 26.533, 24.5561 };
+    double inti_some[] = { 692, 649, 603 };
+    double sigi_some[] = { 27.4590, 26.5141, 24.5561 };
 
                                           // synthesize three peaks
     std::vector<std::pair<double, V3D> > peak_q_list;
@@ -90,11 +90,12 @@ public:
     double back_inner_radius = 1.2;
     double back_outer_radius = 1.3;
     std::vector<double> new_sigma;
+    std::vector<Kernel::V3D> E1Vec;
     double inti;
     double sigi;
     for ( size_t i = 0; i < peak_q_list.size(); i++ )
     {
-      auto shape = integrator.ellipseIntegrateEvents( peak_q_list[i].second, specify_size,
+      auto shape = integrator.ellipseIntegrateEvents( E1Vec, peak_q_list[i].second, specify_size,
                           peak_radius, back_inner_radius, back_outer_radius,
                           new_sigma, inti, sigi );
       TS_ASSERT_DELTA( inti, inti_all[i], 0.1);      
@@ -110,7 +111,7 @@ public:
     specify_size = false;
     for ( size_t i = 0; i < peak_q_list.size(); i++ )
     {
-      integrator.ellipseIntegrateEvents( peak_q_list[i].second, specify_size,
+      integrator.ellipseIntegrateEvents( E1Vec, peak_q_list[i].second, specify_size,
                           peak_radius, back_inner_radius, back_outer_radius, 
                           new_sigma, inti, sigi );
       TS_ASSERT_DELTA( inti, inti_some[i], 0.1);      

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
@@ -253,17 +253,17 @@ public:
                       m_peaksWS->getNumberPeaks());
 
     TSM_ASSERT_DELTA("Wrong intensity for peak 0",
-          integratedPeaksWS->getPeak(0).getIntensity(), -2, 0.01);
+          integratedPeaksWS->getPeak(0).getIntensity(), -1, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 1",
-          integratedPeaksWS->getPeak(1).getIntensity(), 2, 0.01);
+          integratedPeaksWS->getPeak(1).getIntensity(), 3, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 2",
-          integratedPeaksWS->getPeak(2).getIntensity(), -2, 0.01);
+          integratedPeaksWS->getPeak(2).getIntensity(), -1, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 3",
           integratedPeaksWS->getPeak(3).getIntensity(), 15, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 4",
-          integratedPeaksWS->getPeak(4).getIntensity(), 11, 0.01);
+          integratedPeaksWS->getPeak(4).getIntensity(), 12, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 5",
-          integratedPeaksWS->getPeak(5).getIntensity(), 10, 0.01);
+          integratedPeaksWS->getPeak(5).getIntensity(), 11, 0.01);
 
   }
 
@@ -283,17 +283,17 @@ public:
                       integratedPeaksWS->getNumberPeaks(),
                       m_peaksWS->getNumberPeaks());
     TSM_ASSERT_DELTA("Wrong intensity for peak 0",
-          integratedPeaksWS->getPeak(0).getIntensity(), 1.0, 0.01);
+          integratedPeaksWS->getPeak(0).getIntensity(), 2.0, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 1",
-          integratedPeaksWS->getPeak(1).getIntensity(), 0, 0.01);
+          integratedPeaksWS->getPeak(1).getIntensity(), 1.0, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 2",
-          integratedPeaksWS->getPeak(2).getIntensity(), 1.0, 0.01);
+          integratedPeaksWS->getPeak(2).getIntensity(), 2.0, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 3",
-          integratedPeaksWS->getPeak(3).getIntensity(), 10, 0.01);
+          integratedPeaksWS->getPeak(3).getIntensity(), 11, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 4",
-          integratedPeaksWS->getPeak(4).getIntensity(), 13, 0.01);
+          integratedPeaksWS->getPeak(4).getIntensity(), 14, 0.01);
     TSM_ASSERT_DELTA("Wrong intensity for peak 5",
-          integratedPeaksWS->getPeak(5).getIntensity(), 12, 0.01);
+          integratedPeaksWS->getPeak(5).getIntensity(), 13, 0.01);
 
   }
 };

--- a/Code/Mantid/Testing/SystemTests/tests/analysis/EllipsoidIntegr.py
+++ b/Code/Mantid/Testing/SystemTests/tests/analysis/EllipsoidIntegr.py
@@ -18,11 +18,11 @@ class EllipsoidIntegr( stresstesting.MantidStressTest):
     def runTest(self):
                                           # expected results with size determined
                                            # automatically from projected event sigmas
-        inti_auto = [ 88, 99, 23, 33, 8, 8, 4 ]
+        inti_auto = [ 89, 101, 24, 34, 9, 9, 5 ]
         sigi_auto = [ 13.784, 18.1384, 13.1529, 9.94987, 5.83095, 10.2956, 10.2956]
                                             # expected results with fixed size
                                              # ellipsoids
-        inti_fixed = [ 87.541, 95.3934, 21.3607, 33.4262, 7.36066, 9.68852, 3.54098 ]
+        inti_fixed = [ 88.5902, 97.4918, 22.4098, 34.4754, 8.40984, 10.7377, 4.59016 ]
         sigi_fixed = [ 13.9656, 18.4523, 13.4335, 10.1106, 5.94223, 10.5231, 10.5375 ]
 
                                               # first, load peaks into a peaks workspace

--- a/Code/Mantid/docs/source/algorithms/IntegrateEllipsoids-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/IntegrateEllipsoids-v1.rst
@@ -165,6 +165,43 @@ surface.
 
 This algorithm uses principle component analysis to determine the principle axis for each peak. For the event list (QLab) associated with each peak, the algorithm determines a covariance matrix, and uses that to establish eigenvectors corresponding to the principle axis (all orthogonal). The sizes of each principle axis are used define the region of which events will be counted/integrated from those already associated with each peak.
 
+IntegrateIfOnEdge=False option
+###################################
+
+Edges for each bank or pack of tubes of the instrument are defined by masking the edges in the PeaksWorkspace instrument. 
+e.g. For CORELLI, tubes 1 and 16, and pixels 0 and 255.
+Q in the lab frame for every peak is calculated, call it C
+For every point on the edge, the trajectory in reciprocal space is a straight line, going through:
+
+:math:`\vec{O}=(0,0,0)`
+
+Calculate a point at a fixed momentum, say k=1. 
+Q in the lab frame:
+
+:math:`\vec{E}=(-k*sin(\theta)*cos(\phi),-k*sin(\theta)*sin(\phi),k-k*cos(\phi))`
+
+Normalize E to 1: 
+
+:math:`\vec{E}=\vec{E}*(1./\left|\vec{E}\right|)`
+
+The distance from C to OE is given by:
+
+:math:`dv=\vec{C}-\vec{E}*(\vec{C} \cdot \vec{E})`
+
+If:
+
+:math:`\left|dv\right|<PeakRadius`
+
+for the integration, one of the detector trajectories on the edge is too close to the peak 
+This method is also applied to all masked pixels.  If there are masked pixels trajectories inside an integration volume, the peak must be rejected.
+If there are masked pixel trajectories inside the background volume, the background events are scaled by estimating the volume of the ellipsoid
+on the detector.
+
+Sigma from the background
+###################################
+The sigma from the background could be too small because the background contains events from other peaks.  In an effort to reduce this, all the 
+background events are sorted and the top 1% are removed.
+
 Usage
 ------
 


### PR DESCRIPTION
Fixes #12867.  Sort background events and remove top 1%.  Also add option, IntegrateIfOnEdge=False to check if integration radius if off edge of detectors and correct background if background radius is off edge.

To test

``` python
Load(Filename='TOPAZ_11052_event.nxs', OutputWorkspace='TOPAZ_11052_event', LoadMonitors=True)
ConvertToMD(InputWorkspace='TOPAZ_11052_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_11052_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='TOPAZ_11052_md', PeakDistanceThreshold=0.37680000000000002, MaxPeaks=1000, DensityThresholdFactor=1, OutputWorkspace='TOPAZ_11052_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_11052_peaks', MinD=3, MaxD=15, Tolerance=0.12)
IndexPeaks(PeaksWorkspace='TOPAZ_11052_peaks', Tolerance=0.12)
ShowPossibleCells(PeaksWorkspace='TOPAZ_11052_peaks', BestOnly=False, AllowPermutations=False)
SelectCellOfType(PeaksWorkspace='TOPAZ_11052_peaks', CellType='Monoclinic', Apply=True)
IntegratePeaksMD(InputWorkspace='TOPAZ_11052_md', PeakRadius=0.23999999999999999, BackgroundOuterRadius=0.27000000000000002, PeaksWorkspace='TOPAZ_11052_peaks', OutputWorkspace='sphere', IntegrateIfOnEdge=False)
IntegrateEllipsoids(InputWorkspace='TOPAZ_11052_event', PeaksWorkspace='TOPAZ_11052_peaks', RegionRadius=0.24, OutputWorkspace='ellipsoid')
IntegrateEllipsoids(InputWorkspace='TOPAZ_11052_event', PeaksWorkspace='TOPAZ_11052_peaks', RegionRadius=0.24, OutputWorkspace='ellipsoid_NotEdge',IntegrateIfOnEdge=False)
```
