### PR TITLE
Shift TOF using value in TOPAZ Param file

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -102,6 +102,7 @@ public:
   void populateInstrumentParameters();
   void setTitle(std::string title);
   void applyFilter(boost::function<void (API::MatrixWorkspace_sptr)> filter);
+  virtual bool threadSafe() const;
 };
 
 typedef boost::shared_ptr<EventWorkspaceCollection> EventWorkspaceCollection_sptr;

--- a/Code/Mantid/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -290,5 +290,14 @@ void EventWorkspaceCollection::applyFilter(boost::function<void (MatrixWorkspace
   }
 }
 
+//-----------------------------------------------------------------------------
+/** Returns true if the EventWorkspace is safe for multithreaded operations.
+ */
+bool EventWorkspaceCollection::threadSafe() const {
+  // Since there is a mutex lock around sorting, EventWorkspaces are always
+  // safe.
+  return true;
+}
+
 } // namespace DataHandling
 } // namespace Mantid

--- a/Code/Mantid/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -180,15 +180,18 @@ void LoadIsawDetCal::exec() {
       if (instname .compare("WISH") == 0) center(0.0, 0.0, -0.01 * mL1, "undulator", inname);
       else center(0.0, 0.0, -0.01 * mL1, "moderator", inname);
       // mT0 and time of flight are both in microsec
-      IAlgorithm_sptr alg1 = createChildAlgorithm("ChangeBinOffset");
-      alg1->setProperty<MatrixWorkspace_sptr>("InputWorkspace", inputW);
-      alg1->setProperty<MatrixWorkspace_sptr>("OutputWorkspace", inputW);
-      alg1->setProperty("Offset", mT0);
-      alg1->executeAsChildAlg();
-      inputW = alg1->getProperty("OutputWorkspace");
-      // set T0 in the run parameters
       API::Run &run = inputW->mutableRun();
-      run.addProperty<double>("T0", mT0, true);
+      // Check to see if LoadEventNexus had T0 from TOPAZ Parameter file
+      if (!run.hasProperty("T0")) {
+        IAlgorithm_sptr alg1 = createChildAlgorithm("ChangeBinOffset");
+        alg1->setProperty<MatrixWorkspace_sptr>("InputWorkspace", inputW);
+        alg1->setProperty<MatrixWorkspace_sptr>("OutputWorkspace", inputW);
+        alg1->setProperty("Offset", mT0);
+        alg1->executeAsChildAlg();
+        inputW = alg1->getProperty("OutputWorkspace");
+        // set T0 in the run parameters
+        run.addProperty<double>("T0", mT0, true);
+      }
     }
 
     if (line[0] != '5')


### PR DESCRIPTION
Fixes #13494.   To test check verify that LoadEventNexus works with present TOPAZ geometry. Then use new TOPAZ parameter file and check that data shifts in TOF.

``` python
LoadEventAndCompress(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='one')
SumSpectra(InputWorkspace='one', OutputWorkspace='sum')
Rebin(InputWorkspace='sum', OutputWorkspace='sum', Params='1')
LoadIsawDetCal(InputWorkspace='sum', Filename='TOPAZ_2011_02_16.DetCal')
topaz=mtd["sum"]
run = topaz.getRun()
print run.getProperty('T0').value
```

Then replace Code/Mantid/instrument/TOPAZ_Parameters.xml with the following and retest:

```
<?xml version="1.0" encoding="UTF-8" ?>
<parameter-file instrument = "TOPAZ" valid-from   ="2005-08-27 09:42:38.725231" valid-to     ="2100-12-31 23:59:59">

<component-link name = "TOPAZ">
<!-- Specify that any banks not in NeXus file are to be removed -->
<parameter name="T0">
 <value val="-2.40"/>
</parameter>
</component-link>

</parameter-file> 
```
