### PR TITLE
Change ISIS Mantid configuration script to process Instrument scientists provided files describing files, which should be copied to users

### DIFF
--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -57,6 +57,10 @@ class UserProperties(object):
             self._recent_dateID = recent_date_id
 
     def replace_variables(self,data_string):
+		"""Replace variables defined in USER_PROPERTIES
+		   and enclosed in $ sign with their values
+		   defined for a user
+		"""
         str_parts = data_string.split('$')
         for prop in USER_PROPERTIES:
             try:
@@ -272,6 +276,9 @@ class MantidConfigDirectInelastic(object):
 #
     @property
     def user_file_description(self):
+		"""defines full file name (with path) for an xml file which describes
+		   files, which should be copied to a user
+		"""
         if self._user:
             return os.path.join(self._script_repo,'direct_inelastic',self._user.instrument,
                                 self._user_files_descr)
@@ -316,7 +323,7 @@ class MantidConfigDirectInelastic(object):
         return full_source,full_target
 #
     def copy_reduction_sample(self, users_file_description=None):
-        """copy sample reduction scripts from user script repository
+        """copy sample reduction scripts from Mantid script repository
            to user folder.
         """
         if users_file_description is None:

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -351,8 +351,8 @@ class MantidConfigDirectInelastic(object):
             self._copy_and_parse_user_file(input_file,output_file,replacement_list)
         os.chmod(output_file,0777)
 
-        #if platform.system() != 'Windows':
-        #    os.system('chown '+self._fedid+':'+self._fedid+' '+output_file)
+        if platform.system() != 'Windows':
+            os.system("chown {0}:{0} {1}".format(self._fedid,output_file))
         # Set up the file creation and modification dates to the users start date
         start_date = self._user.start_date
         file_time = time.mktime(start_date.timetuple())

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -57,8 +57,8 @@ class UserProperties(object):
             self._recent_dateID = recent_date_id
 
     def replace_variables(self,data_string):
-		"""Replace variables defined in USER_PROPERTIES
-		   and enclosed in $ sign with their values
+        """Replace variables defined in USER_PROPERTIES
+            and enclosed in $ sign with their values
 		   defined for a user
 		"""
         str_parts = data_string.split('$')
@@ -276,7 +276,7 @@ class MantidConfigDirectInelastic(object):
 #
     @property
     def user_file_description(self):
-		"""defines full file name (with path) for an xml file which describes
+        """defines full file name (with path) for an xml file which describes
 		   files, which should be copied to a user
 		"""
         if self._user:

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -259,6 +259,14 @@ class MantidConfigDirectInelastic(object):
         else:
             return False
 #
+    @property
+    def user_file_description(self):
+        if self._user:
+            return os.path.join(self._script_repo,'direct_inelastic',self._user.instrument,
+                                self._user_files_descr)
+        else:
+            return  self._user_files_descr
+#
     def script_need_replacing(self,target_script_name):
         """Method specifies conditions when existing reduction file should be replaced
            by a sample file.
@@ -585,7 +593,7 @@ class MantidConfigDirectInelastic(object):
         if platform.system() != 'Windows':
             os.system('chown -R {0}:{0} {1}'.format(self._fedid,config_path))
 
-        self.copy_reduction_sample(self._user_files_descr)
+        self.copy_reduction_sample(self.user_file_description)
         #
         self.make_map_mask_links(user_path)
     #

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -471,7 +471,7 @@ class MantidConfigDirectInelastic(object):
         else:
             return False
     #
-    def init_user(self,fedid,theUser):
+    def init_user(self,theUser):
         """Define settings, specific to a user"""
         #
         # pylint: disable=W0212
@@ -483,10 +483,10 @@ class MantidConfigDirectInelastic(object):
 
         # pylint: disable=W0201
         # its init method so the change is reasonable
-        self._fedid = str(fedid)
+        self._fedid =  theUser.userID
         user_folder = os.path.join(self._home_path,self._fedid)
         if not os.path.exists(user_folder):
-            raise RuntimeError("User with fedID {0} does not exist. Create such user folder first".format(fedid))
+            raise RuntimeError("User with fedID {0} does not exist. Create such user folder first".format(self._fedid))
         # pylint: disable=W0212
         # bad practice but I need all rb_dires, not the current one
         for rb_folder in theUser._rb_dirs.values():

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -463,7 +463,7 @@ class MantidConfigDirectInelastic(object):
         self._user=theUser
 
         # pylint: disable=W0201
-        # its init method so the change is reasonable 
+        # its init method so the change is reasonable
         self._fedid = str(fedid)
         user_folder = os.path.join(self._home_path,self._fedid)
         if not os.path.exists(user_folder):
@@ -527,6 +527,7 @@ class MantidConfigDirectInelastic(object):
 
         # define and append user scripts search path
         user_path_part = copy.deepcopy(self._python_user_scripts)
+        # pylint: disable=W0212
         for instr in self._user._instrument.values():
             user_path_part.add(os.path.join('direct_inelastic',instr.upper()))
         for part in user_path_part:
@@ -616,7 +617,7 @@ class MantidConfigDirectInelastic(object):
         """Write existing dynamic configuration from memory to
            user defined configuration file
         """
-        # pylint: disable=C0101
+        # pylint: disable=C0103
         # What is wrong with fp variable name here?
         fp = open(config_file_name,'w')
         fp.write(self._header)

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -69,6 +69,17 @@ class UserProperties(object):
         return data_string
 #
     @property
+    def GID(self):
+        """Returns user's group ID which coincide with
+           number part of the rb directory
+        """
+        if self._user_id:
+            RBfolder = os.path.basename(self.rb_dir)
+            return RBfolder[2:]
+        else:
+            return None
+#
+    @property
     def start_date(self):
         """Last start date"""
         if self._recent_dateID:

--- a/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/Code/Mantid/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -126,7 +126,11 @@ class UserProperties(object):
     @property
     def userID(self):
         return self._user_id
+    @userID.setter
+    def userID(self,val):
+        self._user_id = str(val)
 
+#
     def check_input(self,instrument,start_date,cycle,rb_folder):
         """Verify that input is correct"""
         if not instrument in INELASTIC_INSTRUMENTS:
@@ -478,8 +482,23 @@ class MantidConfigDirectInelastic(object):
         else:
             return False
     #
-    def init_user(self,theUser):
-        """Define settings, specific to a user"""
+    def init_user(self,fedIDorUser,theUser=None):
+        """Define settings, specific to a user
+           Supports two interfaces -- old and the new one 
+           where
+           OldInterface: requested two input parameters 
+           fedID   -- users federal id
+           theUser -- class defining all other user property
+           NewInterface: requested single parameter: 
+           theUser -- class defining all user's properties including fedID
+        """
+        if not theUser:
+            if isinstance(fedIDorUser,UserProperties):
+                theUser = fedIDorUser
+            else:
+                raise RuntimeError("self.init_user(val) has to have val of UserProperty type only")
+        else:
+            theUser.userID = fedIDorUser
         #
         # pylint: disable=W0212
         # bad practice but I need all instruments, not the current one

--- a/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
@@ -362,6 +362,25 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
             if os.path.exists(source):
                 os.remove(source)
 
+    def test_init_user(self):
+        MantidDir = os.path.split(os.path.realpath(__file__))[0]
+        HomeRootDir = self.get_save_dir()
+        mcf = MantidConfigDirectInelastic(MantidDir,HomeRootDir,self.UserScriptRepoDir,self.MapMaskDir)
+
+        
+        user = UserProperties(self.userID)
+        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+
+        mcf.init_user(self.userID,user)
+        user1 = mcf._user
+        self.assertEqual(user,user1)
+
+        mcf.init_user(user)
+        user2 = mcf._user
+        self.assertEqual(user,user2)
+
+        self.assertRaises(RuntimeError,mcf.init_user,'bla_bla_bla')
+
 
 
 

--- a/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
@@ -165,7 +165,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         self.assertRaises(RuntimeError,MantidConfigDirectInelastic,MantidDir,HomeRootDir,'MissingUserScriptRepoDir',self.MapMaskDir)
         self.assertRaises(RuntimeError,MantidConfigDirectInelastic,MantidDir,HomeRootDir,self.UserScriptRepoDir,'MissingMapMaskDir')
 
-        user = UserProperties()
+        user = UserProperties(self.userID)
         user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
 
         # clear up the previous
@@ -173,7 +173,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
             shutil.rmtree(os.path.join(self.userRootDir,'.mantid'))
 
 
-        mcf.init_user(self.userID,user)
+        mcf.init_user(user)
         self.makeFakeSourceReductionFile(mcf)
 
         self.assertEqual(len(mcf._dynamic_configuration),6)
@@ -209,7 +209,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         HomeRootDir = self.get_save_dir()
         mcf = MantidConfigDirectInelastic(MantidDir,HomeRootDir,self.UserScriptRepoDir,self.MapMaskDir)
 
-        user = UserProperties()
+        user = UserProperties(self.userID)
         user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
 
 
@@ -232,7 +232,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
             shutil.rmtree(os.path.join(self.userRootDir,'.mantid'))
 
 
-        mcf.init_user(self.userID,user)
+        mcf.init_user(user)
 
         fake_source=self.makeFakeSourceReductionFile(mcf)
         self.assertEqual(len(mcf._dynamic_configuration),6)
@@ -256,10 +256,10 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         if not os.path.exists(user1RootDir):
             os.makedirs(user1RootDir)
         #
-        user1 = UserProperties()
+        user1 = UserProperties(user1ID)
         user1.set_user_properties('MARI','20990124','CYCLE20991',rbdir2)
 
-        mcf.init_user(user1ID,user1)
+        mcf.init_user(user1)
         source_file = self.makeFakeSourceReductionFile(mcf)
 
         mcf.generate_config()
@@ -321,7 +321,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         
         user = UserProperties(self.userID)
         user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
-        mcf.init_user(self.userID,user)
+        mcf.init_user(user)
 
         # test old defaults, deployed if no User_files_description are defined
         files_to_copy = mcf._parse_user_files_description(None)

--- a/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
@@ -305,6 +305,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         targ_string = user.replace_variables('$instrument$ReductionScript$cycleID$.py')
         self.assertEqual(self.instrument+'ReductionScript2015_1.py',targ_string)
+        self.assertEqual(user.GID,'1310168')
         
     def test_parse_file_description(self):
 

--- a/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
@@ -1,5 +1,5 @@
-import os
-#os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
+﻿import os
+os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
 import unittest
 import shutil
 import datetime

--- a/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
@@ -278,13 +278,13 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         full_target_file = os.path.join(full_rb_path,target_file)
         self.assertTrue(os.path.exists(full_target_file))
         # Fresh target file should always be replaced
-        self.assertTrue(mcf.script_need_replacing(source_file,full_target_file))
+        self.assertTrue(mcf.script_need_replacing(full_target_file))
         # modify target file access time:
         access_time = os.path.getmtime(full_target_file)
         now = time.time()
         os.utime(full_target_file,(access_time ,now))
         # should not replace modified target file
-        self.assertFalse(mcf.script_need_replacing(source_file,full_target_file))
+        self.assertFalse(mcf.script_need_replacing(full_target_file))
 
         #--------------------------------------------------------------------
         # clean up

--- a/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/Code/Mantid/scripts/test/ISISDirecInelasticConfigTest.py
@@ -1,5 +1,5 @@
 ﻿import os
-os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
+#os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
 import unittest
 import shutil
 import datetime

--- a/Code/Mantid/scripts/test/User_files_description_test.xml
+++ b/Code/Mantid/scripts/test/User_files_description_test.xml
@@ -16,10 +16,12 @@
  <!--Simple file copying -->  
   <file_to_copy file_name="Test_reduction_file1.py" copy_as="Test_reduction_file2.py"/>
 
- <!--Advanced file copying -->    
-  <file_to_copy file_name="Test_reduction_file.py" copy_as="Test_reduction_file$cycleID$.py">
-    <replace variable  ="Test_reduction_file" by_variable="Test_reduction_file$instrument$"/>
-    <replace variable  ="AAAA" by_variable="BBB"/>  
+ <!--Advanced file copying 
+    Variables have to be either strings or strings with variables, described above
+  -->    
+  <file_to_copy file_name="Test_reduction_file.py" copy_as="Test_reduction_file_$cycleID$.py">
+    <replace var  ="Test_reduction_file" by_var="$instrument$Test_reduction_file_$cycleID$"/>
+    <replace var  ="AAAA" by_var="BBB"/>  
   </file_to_copy>
 
 </user_files_description>

--- a/Code/Mantid/scripts/test/User_files_description_test.xml
+++ b/Code/Mantid/scripts/test/User_files_description_test.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--The file describes list of files to copy to a user's RB folder from Mantid users script repository 
+    and operations to perform with these files during copying.
+    
+    At the moment, supported operations are:
+    Copy file(s) with specified name into RB folder with name which may depend on cycle ID, instrument or other variables below.
+    On request, replace any instances of variable specified by its value.
+-->
+<user_files_description>
+  <!-- the file descriptions support the following variables defined and parsed by 
+    ISISDirectInelasticConfig.py module. $instrument$, $cycleID$ $start_date$, $rb_folder$
+    $rb_folder$ value is short rb folder path (e.g. RB1501020)  
+    not full rb folder path (/home/wkc26243/RB1501020), 
+    The values of these variables are taken from archive for current cycle and user
+  -->
+ <!--Simple file copying -->  
+  <file_to_copy file_name="Test_reduction_file1.py" copy_as="Test_reduction_file2.py"/>
+
+ <!--Advanced file copying -->    
+  <file_to_copy file_name="Test_reduction_file.py" copy_as="Test_reduction_file$cycleID$.py">
+    <replace variable  ="Test_reduction_file" by_variable="Test_reduction_file$instrument$"/>
+    <replace variable  ="AAAA" by_variable="BBB"/>  
+  </file_to_copy>
+
+</user_files_description>


### PR DESCRIPTION
This is relatively simple change to ISISDirectConfiguration script, written on an IS request (fixes #13217 ) which allows instrument scientists to define files, they want to copy to users and to make simple changes to contents of these files to account for python referencing these files. The files themselves usually reside in MantidScriptRepository and sample files for ISIS inelastic instruments have been pushed there for instrument scientists to try. 

Logic is relatively simple, there is unit test, which verifies this functionality and the changes have been tested together with administrative script on the live test server so they work.

Test by code review. 

Its administrative rather then Mantid change so no release notes. 
