### PR TITLE
IDR Diagnostics should not restrict spectra numbers

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
@@ -8,83 +8,82 @@
 
 // Suppress a warning coming out of code that isn't ours
 #if defined(__INTEL_COMPILER)
-  #pragma warning disable 1125
+#pragma warning disable 1125
 #elif defined(__GNUC__)
-  #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6 )
-    #pragma GCC diagnostic push
-  #endif
-  #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic push
+#endif
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #endif
 #include <QtCheckBoxFactory>
 #if defined(__INTEL_COMPILER)
-  #pragma warning enable 1125
+#pragma warning enable 1125
 #elif defined(__GNUC__)
-  #if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6 )
-    #pragma GCC diagnostic pop
-  #endif
+#if (__GNUC__ >= 4 && __GNUC_MINOR__ >= 6)
+#pragma GCC diagnostic pop
+#endif
 #endif
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  /** ISISDiagnostics
-    Handles time integration diagnostics for ISIS instruments.
+namespace MantidQt {
+namespace CustomInterfaces {
+/** ISISDiagnostics
+  Handles time integration diagnostics for ISIS instruments.
 
-    @author Dan Nixon
-    @date 23/07/2014
+  @author Dan Nixon
+  @date 23/07/2014
 
-    Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+  Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
 
-    This file is part of Mantid.
+  This file is part of Mantid.
 
-    Mantid is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
 
-    Mantid is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    File change history is stored at: <https://github.com/mantidproject/mantid>
-    Code Documentation is available at: <http://doxygen.mantidproject.org>
-  */
-  class DLLExport ISISDiagnostics : public IndirectDataReductionTab
-  {
-    Q_OBJECT
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport ISISDiagnostics : public IndirectDataReductionTab {
+  Q_OBJECT
 
-  public:
-    ISISDiagnostics(IndirectDataReduction * idrUI, QWidget * parent = 0);
-    virtual ~ISISDiagnostics();
+public:
+  ISISDiagnostics(IndirectDataReduction *idrUI, QWidget *parent = 0);
+  virtual ~ISISDiagnostics();
 
-    virtual void setup();
-    virtual void run();
-    virtual bool validate();
+  virtual void setup();
+  virtual void run();
+  virtual bool validate();
 
-  private slots:
-    void algorithmComplete(bool error);
-    void handleNewFile();
-    void sliceTwoRanges(QtProperty*, bool);
-    void sliceCalib(bool state);
-    void rangeSelectorDropped(double, double);
-    void doublePropertyChanged(QtProperty*, double);
-    void setDefaultInstDetails();
-    void updatePreviewPlot();
-    void sliceAlgDone(bool error);
-    void pbRunEditing();  //< Called when a user starts to type / edit the runs to load.
-    void pbRunFinding();  //< Called when the FileFinder starts finding the files.
-    void pbRunFinished(); //< Called when the FileFinder has finished finding the files.
+private slots:
+  void algorithmComplete(bool error);
+  void handleNewFile();
+  void sliceTwoRanges(QtProperty *, bool);
+  void sliceCalib(bool state);
+  void rangeSelectorDropped(double, double);
+  void doublePropertyChanged(QtProperty *, double);
+  void setDefaultInstDetails();
+  void updatePreviewPlot();
+  void sliceAlgDone(bool error);
+  void
+  pbRunEditing(); //< Called when a user starts to type / edit the runs to load.
+  void pbRunFinding();  //< Called when the FileFinder starts finding the files.
+  void pbRunFinished(); //< Called when the FileFinder has finished finding the
+                        //files.
 
-  private:
-    Ui::ISISDiagnostics m_uiForm;
-
-  };
+private:
+  Ui::ISISDiagnostics m_uiForm;
+};
 } // namespace CustomInterfaces
 } // namespace Mantid
 
-#endif //MANTIDQTCUSTOMINTERFACES_ISISDIAGNOSTICS_H_
+#endif // MANTIDQTCUSTOMINTERFACES_ISISDIAGNOSTICS_H_

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -388,7 +388,7 @@ void ISISDiagnostics::doublePropertyChanged(QtProperty *prop, double val) {
     handleNewFile();
   else if (prop == m_properties["SpecMin"]) {
     m_dblManager->setMinimum(m_properties["SpecMax"], val + 1);
-    m_dblManager->setMinimum(m_properties["PreviewSpec"], val + 1);
+    m_dblManager->setMinimum(m_properties["PreviewSpec"], val);
   } else if (prop == m_properties["SpecMax"]) {
     m_dblManager->setMaximum(m_properties["SpecMin"], val - 1);
     m_dblManager->setMaximum(m_properties["PreviewSpec"], val);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -252,16 +252,11 @@ namespace CustomInterfaces
     double specMax = instDetails["spectra-max"].toDouble();
 
     // Set spectra range
-    m_dblManager->setMinimum(m_properties["SpecMin"], specMin);
     m_dblManager->setMaximum(m_properties["SpecMin"], specMax);
-    m_dblManager->setValue(m_properties["SpecMin"], specMin);
-
     m_dblManager->setMinimum(m_properties["SpecMax"], specMin);
-    m_dblManager->setMaximum(m_properties["SpecMax"], specMax);
-    m_dblManager->setValue(m_properties["SpecMax"], specMax);
 
-    m_dblManager->setMinimum(m_properties["PreviewSpec"], specMin);
-    m_dblManager->setMaximum(m_properties["PreviewSpec"], specMax);
+    m_dblManager->setValue(m_properties["SpecMin"], specMin);
+    m_dblManager->setValue(m_properties["SpecMax"], specMax);
     m_dblManager->setValue(m_properties["PreviewSpec"], specMin);
 
     // Set peak and background ranges
@@ -366,6 +361,16 @@ namespace CustomInterfaces
     else if(prop == m_properties["BackgroundStart"])  backgroundRangeSelector->setMinimum(val);
     else if(prop == m_properties["BackgroundEnd"])    backgroundRangeSelector->setMaximum(val);
     else if(prop == m_properties["PreviewSpec"])      handleNewFile();
+    else if(prop == m_properties["SpecMin"])
+    {
+      m_dblManager->setMinimum(m_properties["SpecMax"], val+1);
+      m_dblManager->setMinimum(m_properties["PreviewSpec"], val+1);
+    }
+    else if(prop == m_properties["SpecMax"])
+    {
+      m_dblManager->setMaximum(m_properties["SpecMin"], val-1);
+      m_dblManager->setMaximum(m_properties["PreviewSpec"], val);
+    }
 
     if(prop != m_properties["PreviewSpec"])
       updatePreviewPlot();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -8,503 +8,526 @@
 
 using namespace Mantid::API;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("ISISDiagnostics");
+namespace {
+Mantid::Kernel::Logger g_log("ISISDiagnostics");
 }
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  //----------------------------------------------------------------------------------------------
-  /** Constructor
-   */
-  ISISDiagnostics::ISISDiagnostics(IndirectDataReduction * idrUI, QWidget * parent) :
-    IndirectDataReductionTab(idrUI, parent)
-  {
-    m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+ISISDiagnostics::ISISDiagnostics(IndirectDataReduction *idrUI, QWidget *parent)
+    : IndirectDataReductionTab(idrUI, parent) {
+  m_uiForm.setupUi(parent);
 
-    // Property Tree
-    m_propTrees["SlicePropTree"] = new QtTreePropertyBrowser();
-    m_uiForm.properties->addWidget(m_propTrees["SlicePropTree"]);
+  // Property Tree
+  m_propTrees["SlicePropTree"] = new QtTreePropertyBrowser();
+  m_uiForm.properties->addWidget(m_propTrees["SlicePropTree"]);
 
-    // Editor Factories
-    DoubleEditorFactory *doubleEditorFactory = new DoubleEditorFactory();
-    QtCheckBoxFactory *checkboxFactory = new QtCheckBoxFactory();
-    m_propTrees["SlicePropTree"]->setFactoryForManager(m_dblManager, doubleEditorFactory);
-    m_propTrees["SlicePropTree"]->setFactoryForManager(m_blnManager, checkboxFactory);
+  // Editor Factories
+  DoubleEditorFactory *doubleEditorFactory = new DoubleEditorFactory();
+  QtCheckBoxFactory *checkboxFactory = new QtCheckBoxFactory();
+  m_propTrees["SlicePropTree"]->setFactoryForManager(m_dblManager,
+                                                     doubleEditorFactory);
+  m_propTrees["SlicePropTree"]->setFactoryForManager(m_blnManager,
+                                                     checkboxFactory);
 
-    // Create Properties
-    m_properties["PreviewSpec"] = m_dblManager->addProperty("Preview Spectrum");
-    m_dblManager->setDecimals(m_properties["PreviewSpec"], 0);
-    m_dblManager->setMinimum(m_properties["PreviewSpec"], 1);
+  // Create Properties
+  m_properties["PreviewSpec"] = m_dblManager->addProperty("Preview Spectrum");
+  m_dblManager->setDecimals(m_properties["PreviewSpec"], 0);
+  m_dblManager->setMinimum(m_properties["PreviewSpec"], 1);
 
-    m_properties["SpecMin"] = m_dblManager->addProperty("Spectra Min");
-    m_dblManager->setDecimals(m_properties["SpecMin"], 0);
-    m_dblManager->setMinimum(m_properties["SpecMin"], 1);
+  m_properties["SpecMin"] = m_dblManager->addProperty("Spectra Min");
+  m_dblManager->setDecimals(m_properties["SpecMin"], 0);
+  m_dblManager->setMinimum(m_properties["SpecMin"], 1);
 
-    m_properties["SpecMax"] = m_dblManager->addProperty("Spectra Max");
-    m_dblManager->setDecimals(m_properties["SpecMax"], 0);
-    m_dblManager->setMinimum(m_properties["SpecMax"], 1);
+  m_properties["SpecMax"] = m_dblManager->addProperty("Spectra Max");
+  m_dblManager->setDecimals(m_properties["SpecMax"], 0);
+  m_dblManager->setMinimum(m_properties["SpecMax"], 1);
 
-    m_properties["PeakStart"] = m_dblManager->addProperty("Start");
-    m_properties["PeakEnd"] = m_dblManager->addProperty("End");
+  m_properties["PeakStart"] = m_dblManager->addProperty("Start");
+  m_properties["PeakEnd"] = m_dblManager->addProperty("End");
 
-    m_properties["BackgroundStart"] = m_dblManager->addProperty("Start");
-    m_properties["BackgroundEnd"] = m_dblManager->addProperty("End");
+  m_properties["BackgroundStart"] = m_dblManager->addProperty("Start");
+  m_properties["BackgroundEnd"] = m_dblManager->addProperty("End");
 
-    m_properties["UseTwoRanges"] = m_blnManager->addProperty("Use Two Ranges");
+  m_properties["UseTwoRanges"] = m_blnManager->addProperty("Use Two Ranges");
 
-    m_properties["PeakRange"] = m_grpManager->addProperty("Peak");
-    m_properties["PeakRange"]->addSubProperty(m_properties["PeakStart"]);
-    m_properties["PeakRange"]->addSubProperty(m_properties["PeakEnd"]);
+  m_properties["PeakRange"] = m_grpManager->addProperty("Peak");
+  m_properties["PeakRange"]->addSubProperty(m_properties["PeakStart"]);
+  m_properties["PeakRange"]->addSubProperty(m_properties["PeakEnd"]);
 
-    m_properties["BackgroundRange"] = m_grpManager->addProperty("Background");
-    m_properties["BackgroundRange"]->addSubProperty(m_properties["BackgroundStart"]);
-    m_properties["BackgroundRange"]->addSubProperty(m_properties["BackgroundEnd"]);
+  m_properties["BackgroundRange"] = m_grpManager->addProperty("Background");
+  m_properties["BackgroundRange"]->addSubProperty(
+      m_properties["BackgroundStart"]);
+  m_properties["BackgroundRange"]->addSubProperty(
+      m_properties["BackgroundEnd"]);
 
-    m_propTrees["SlicePropTree"]->addProperty(m_properties["PreviewSpec"]);
-    m_propTrees["SlicePropTree"]->addProperty(m_properties["SpecMin"]);
-    m_propTrees["SlicePropTree"]->addProperty(m_properties["SpecMax"]);
-    m_propTrees["SlicePropTree"]->addProperty(m_properties["PeakRange"]);
-    m_propTrees["SlicePropTree"]->addProperty(m_properties["UseTwoRanges"]);
-    m_propTrees["SlicePropTree"]->addProperty(m_properties["BackgroundRange"]);
+  m_propTrees["SlicePropTree"]->addProperty(m_properties["PreviewSpec"]);
+  m_propTrees["SlicePropTree"]->addProperty(m_properties["SpecMin"]);
+  m_propTrees["SlicePropTree"]->addProperty(m_properties["SpecMax"]);
+  m_propTrees["SlicePropTree"]->addProperty(m_properties["PeakRange"]);
+  m_propTrees["SlicePropTree"]->addProperty(m_properties["UseTwoRanges"]);
+  m_propTrees["SlicePropTree"]->addProperty(m_properties["BackgroundRange"]);
 
-    // Slice plot
-    auto peakRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("SlicePeak");
-    auto backgroundRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("SliceBackground");
+  // Slice plot
+  auto peakRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("SlicePeak");
+  auto backgroundRangeSelector =
+      m_uiForm.ppRawPlot->addRangeSelector("SliceBackground");
 
-    // Setup second range
-    backgroundRangeSelector->setColour(Qt::darkGreen); // Dark green for background
-    backgroundRangeSelector->setRange(peakRangeSelector->getRange());
+  // Setup second range
+  backgroundRangeSelector->setColour(
+      Qt::darkGreen); // Dark green for background
+  backgroundRangeSelector->setRange(peakRangeSelector->getRange());
 
-    // SIGNAL/SLOT CONNECTIONS
+  // SIGNAL/SLOT CONNECTIONS
 
-    // Update instrument information when a new instrument config is selected
-    connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setDefaultInstDetails()));
+  // Update instrument information when a new instrument config is selected
+  connect(this, SIGNAL(newInstrumentConfiguration()), this,
+          SLOT(setDefaultInstDetails()));
 
-    // Update properties when a range selector is changed
-    connect(peakRangeSelector, SIGNAL(selectionChangedLazy(double, double)), this, SLOT(rangeSelectorDropped(double, double)));
-    connect(backgroundRangeSelector, SIGNAL(selectionChangedLazy(double, double)), this, SLOT(rangeSelectorDropped(double, double)));
+  // Update properties when a range selector is changed
+  connect(peakRangeSelector, SIGNAL(selectionChangedLazy(double, double)), this,
+          SLOT(rangeSelectorDropped(double, double)));
+  connect(backgroundRangeSelector, SIGNAL(selectionChangedLazy(double, double)),
+          this, SLOT(rangeSelectorDropped(double, double)));
 
-    // Update range selctors when a property is changed
-    connect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(doublePropertyChanged(QtProperty*, double)));
-    // Enable/disable second range options when checkbox is toggled
-    connect(m_blnManager, SIGNAL(valueChanged(QtProperty*, bool)), this, SLOT(sliceTwoRanges(QtProperty*, bool)));
-    // Enables/disables calibration file selection when user toggles Use Calibratin File checkbox
-    connect(m_uiForm.ckUseCalibration, SIGNAL(toggled(bool)), this, SLOT(sliceCalib(bool)));
+  // Update range selctors when a property is changed
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(doublePropertyChanged(QtProperty *, double)));
+  // Enable/disable second range options when checkbox is toggled
+  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
+          SLOT(sliceTwoRanges(QtProperty *, bool)));
+  // Enables/disables calibration file selection when user toggles Use
+  // Calibratin File checkbox
+  connect(m_uiForm.ckUseCalibration, SIGNAL(toggled(bool)), this,
+          SLOT(sliceCalib(bool)));
 
-    // Plot slice miniplot when file has finished loading
-    connect(m_uiForm.dsInputFiles, SIGNAL(filesFoundChanged()), this, SLOT(handleNewFile()));
-    connect(m_uiForm.dsInputFiles, SIGNAL(filesFoundChanged()), this, SLOT(updatePreviewPlot()));
-    // Shows message on run buton when user is inputting a run number
-    connect(m_uiForm.dsInputFiles, SIGNAL(fileTextChanged(const QString &)), this, SLOT(pbRunEditing()));
-    // Shows message on run button when Mantid is finding the file for a given run number
-    connect(m_uiForm.dsInputFiles, SIGNAL(findingFiles()), this, SLOT(pbRunFinding()));
-    // Reverts run button back to normal when file finding has finished
-    connect(m_uiForm.dsInputFiles, SIGNAL(fileFindingFinished()), this, SLOT(pbRunFinished()));
+  // Plot slice miniplot when file has finished loading
+  connect(m_uiForm.dsInputFiles, SIGNAL(filesFoundChanged()), this,
+          SLOT(handleNewFile()));
+  connect(m_uiForm.dsInputFiles, SIGNAL(filesFoundChanged()), this,
+          SLOT(updatePreviewPlot()));
+  // Shows message on run buton when user is inputting a run number
+  connect(m_uiForm.dsInputFiles, SIGNAL(fileTextChanged(const QString &)), this,
+          SLOT(pbRunEditing()));
+  // Shows message on run button when Mantid is finding the file for a given run
+  // number
+  connect(m_uiForm.dsInputFiles, SIGNAL(findingFiles()), this,
+          SLOT(pbRunFinding()));
+  // Reverts run button back to normal when file finding has finished
+  connect(m_uiForm.dsInputFiles, SIGNAL(fileFindingFinished()), this,
+          SLOT(pbRunFinished()));
 
-    connect(m_blnManager, SIGNAL(valueChanged(QtProperty*, bool)), this, SLOT(updatePreviewPlot()));
+  connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this,
+          SLOT(updatePreviewPlot()));
 
-    // Set default UI state
-    sliceTwoRanges(0, false);
-    m_uiForm.ckUseCalibration->setChecked(false);
-    sliceCalib(false);
+  // Set default UI state
+  sliceTwoRanges(0, false);
+  m_uiForm.ckUseCalibration->setChecked(false);
+  sliceCalib(false);
+}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+ISISDiagnostics::~ISISDiagnostics() {}
+
+void ISISDiagnostics::setup() {}
+
+void ISISDiagnostics::run() {
+  QString suffix = "_" + getInstrumentConfiguration()->getAnalyserName() +
+                   getInstrumentConfiguration()->getReflectionName() + "_slice";
+  QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
+
+  std::vector<long> spectraRange;
+  spectraRange.push_back(
+      static_cast<long>(m_dblManager->value(m_properties["SpecMin"])));
+  spectraRange.push_back(
+      static_cast<long>(m_dblManager->value(m_properties["SpecMax"])));
+
+  std::vector<double> peakRange;
+  peakRange.push_back(m_dblManager->value(m_properties["PeakStart"]));
+  peakRange.push_back(m_dblManager->value(m_properties["PeakEnd"]));
+
+  IAlgorithm_sptr sliceAlg = AlgorithmManager::Instance().create("TimeSlice");
+  sliceAlg->initialize();
+
+  sliceAlg->setProperty("InputFiles", filenames.toStdString());
+  sliceAlg->setProperty("SpectraRange", spectraRange);
+  sliceAlg->setProperty("PeakRange", peakRange);
+  sliceAlg->setProperty("OutputNameSuffix", suffix.toStdString());
+  sliceAlg->setProperty("OutputWorkspace", "IndirectDiagnostics_Workspaces");
+
+  if (m_uiForm.ckUseCalibration->isChecked()) {
+    QString calibWsName = m_uiForm.dsCalibration->getCurrentDataName();
+    sliceAlg->setProperty("CalibrationWorkspace", calibWsName.toStdString());
   }
 
-  //----------------------------------------------------------------------------------------------
-  /** Destructor
-   */
-  ISISDiagnostics::~ISISDiagnostics()
-  {
+  if (m_blnManager->value(m_properties["UseTwoRanges"])) {
+    std::vector<double> backgroundRange;
+    backgroundRange.push_back(
+        m_dblManager->value(m_properties["BackgroundStart"]));
+    backgroundRange.push_back(
+        m_dblManager->value(m_properties["BackgroundEnd"]));
+    sliceAlg->setProperty("BackgroundRange", backgroundRange);
   }
 
-  void ISISDiagnostics::setup()
-  {
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(algorithmComplete(bool)));
+  runAlgorithm(sliceAlg);
+}
+
+bool ISISDiagnostics::validate() {
+  UserInputValidator uiv;
+
+  // Check raw input
+  uiv.checkMWRunFilesIsValid("Input", m_uiForm.dsInputFiles);
+  if (m_uiForm.ckUseCalibration->isChecked())
+    uiv.checkMWRunFilesIsValid("Calibration", m_uiForm.dsInputFiles);
+
+  // Check peak range
+  auto rangeOne = std::make_pair(m_dblManager->value(m_properties["PeakStart"]),
+                                 m_dblManager->value(m_properties["PeakEnd"]));
+  uiv.checkValidRange("Range One", rangeOne);
+
+  // Check background range
+  bool useTwoRanges = m_blnManager->value(m_properties["UseTwoRanges"]);
+  if (useTwoRanges) {
+    auto rangeTwo =
+        std::make_pair(m_dblManager->value(m_properties["BackgroundStart"]),
+                       m_dblManager->value(m_properties["BackgroundEnd"]));
+    uiv.checkValidRange("Range Two", rangeTwo);
+
+    uiv.checkRangesDontOverlap(rangeOne, rangeTwo);
   }
 
-  void ISISDiagnostics::run()
-  {
-    QString suffix = "_" + getInstrumentConfiguration()->getAnalyserName()
-                     + getInstrumentConfiguration()->getReflectionName() + "_slice";
-    QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
+  // Check spectra range
+  auto specRange =
+      std::make_pair(m_dblManager->value(m_properties["SpecMin"]),
+                     m_dblManager->value(m_properties["SpecMax"]) + 1);
+  uiv.checkValidRange("Spectra Range", specRange);
 
-    std::vector<long> spectraRange;
-    spectraRange.push_back(static_cast<long>(m_dblManager->value(m_properties["SpecMin"])));
-    spectraRange.push_back(static_cast<long>(m_dblManager->value(m_properties["SpecMax"])));
+  QString error = uiv.generateErrorMessage();
+  bool isError = error != "";
 
-    std::vector<double> peakRange;
-    peakRange.push_back(m_dblManager->value(m_properties["PeakStart"]));
-    peakRange.push_back(m_dblManager->value(m_properties["PeakEnd"]));
+  if (isError)
+    g_log.warning(error.toStdString());
 
-    IAlgorithm_sptr sliceAlg = AlgorithmManager::Instance().create("TimeSlice");
-    sliceAlg->initialize();
+  return !isError;
+}
 
-    sliceAlg->setProperty("InputFiles", filenames.toStdString());
-    sliceAlg->setProperty("SpectraRange", spectraRange);
-    sliceAlg->setProperty("PeakRange", peakRange);
-    sliceAlg->setProperty("OutputNameSuffix", suffix.toStdString());
-    sliceAlg->setProperty("OutputWorkspace", "IndirectDiagnostics_Workspaces");
+/**
+ * Handles completion of the algorithm.
+ *
+ * @param error If the algorithm failed
+ */
+void ISISDiagnostics::algorithmComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(algorithmComplete(bool)));
 
-    if(m_uiForm.ckUseCalibration->isChecked())
-    {
-      QString calibWsName = m_uiForm.dsCalibration->getCurrentDataName();
-      sliceAlg->setProperty("CalibrationWorkspace", calibWsName.toStdString());
-    }
+  if (error)
+    return;
 
-    if(m_blnManager->value(m_properties["UseTwoRanges"]))
-    {
-      std::vector<double> backgroundRange;
-      backgroundRange.push_back(m_dblManager->value(m_properties["BackgroundStart"]));
-      backgroundRange.push_back(m_dblManager->value(m_properties["BackgroundEnd"]));
-      sliceAlg->setProperty("BackgroundRange", backgroundRange);
-    }
+  WorkspaceGroup_sptr sliceOutputGroup =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+          "IndirectDiagnostics_Workspaces");
+  if (sliceOutputGroup->size() == 0) {
+    g_log.warning("No result workspaces, cannot plot preview.");
+    return;
+  }
 
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
+  for (size_t i = 0; i < sliceOutputGroup->size(); i++) {
+    QString wsName =
+        QString::fromStdString(sliceOutputGroup->getItem(i)->name());
+
+    if (m_uiForm.ckPlot->isChecked())
+      plotSpectrum(wsName);
+
+    if (m_uiForm.ckSave->isChecked())
+      addSaveWorkspaceToQueue(wsName);
+  }
+
+  // Update the preview plots
+  sliceAlgDone(false);
+
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
+/**
+ * Sets default spectra, peak and background ranges.
+ */
+void ISISDiagnostics::setDefaultInstDetails() {
+  // Get spectra, peak and background details
+  QMap<QString, QString> instDetails = getInstrumentDetails();
+
+  // Set the search instrument for runs
+  m_uiForm.dsInputFiles->setInstrumentOverride(instDetails["instrument"]);
+
+  double specMin = instDetails["spectra-min"].toDouble();
+  double specMax = instDetails["spectra-max"].toDouble();
+
+  // Set spectra range
+  m_dblManager->setMaximum(m_properties["SpecMin"], specMax);
+  m_dblManager->setMinimum(m_properties["SpecMax"], specMin);
+
+  m_dblManager->setValue(m_properties["SpecMin"], specMin);
+  m_dblManager->setValue(m_properties["SpecMax"], specMax);
+  m_dblManager->setValue(m_properties["PreviewSpec"], specMin);
+
+  // Set peak and background ranges
+  if (instDetails.size() >= 8) {
+    setRangeSelector(m_uiForm.ppRawPlot->getRangeSelector("SlicePeak"),
+                     m_properties["PeakStart"], m_properties["PeakEnd"],
+                     qMakePair(instDetails["peak-start"].toDouble(),
+                               instDetails["peak-end"].toDouble()));
+
+    setRangeSelector(m_uiForm.ppRawPlot->getRangeSelector("SliceBackground"),
+                     m_properties["BackgroundStart"],
+                     m_properties["BackgroundEnd"],
+                     qMakePair(instDetails["back-start"].toDouble(),
+                               instDetails["back-end"].toDouble()));
+  }
+}
+
+void ISISDiagnostics::handleNewFile() {
+  if (!m_uiForm.dsInputFiles->isValid())
+    return;
+
+  QString filename = m_uiForm.dsInputFiles->getFirstFilename();
+
+  QFileInfo fi(filename);
+  QString wsname = fi.baseName();
+
+  int specMin = static_cast<int>(m_dblManager->value(m_properties["SpecMin"]));
+  int specMax = static_cast<int>(m_dblManager->value(m_properties["SpecMax"]));
+
+  if (!loadFile(filename, wsname, specMin, specMax)) {
+    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                        "and matches the selected instrument in the "
+                        "EnergyTransfer tab.");
+    return;
+  }
+
+  Mantid::API::MatrixWorkspace_sptr input =
+      boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+          Mantid::API::AnalysisDataService::Instance().retrieve(
+              wsname.toStdString()));
+
+  const Mantid::MantidVec &dataX = input->readX(0);
+  QPair<double, double> range(dataX.front(), dataX.back());
+  int previewSpec =
+      static_cast<int>(m_dblManager->value(m_properties["PreviewSpec"])) -
+      specMin;
+
+  m_uiForm.ppRawPlot->clear();
+  m_uiForm.ppRawPlot->addSpectrum("Raw", input, previewSpec);
+
+  setPlotPropertyRange(m_uiForm.ppRawPlot->getRangeSelector("SlicePeak"),
+                       m_properties["PeakStart"], m_properties["PeakEnd"],
+                       range);
+  setPlotPropertyRange(m_uiForm.ppRawPlot->getRangeSelector("SliceBackground"),
+                       m_properties["BackgroundStart"],
+                       m_properties["BackgroundEnd"], range);
+
+  m_uiForm.ppRawPlot->resizeX();
+}
+
+/**
+ * Set if the second slice range selectors should be shown on the plot
+ *
+ * @param state :: True to show the second range selectors, false to hide
+ */
+void ISISDiagnostics::sliceTwoRanges(QtProperty *, bool state) {
+  m_uiForm.ppRawPlot->getRangeSelector("SliceBackground")->setVisible(state);
+}
+
+/**
+ * Enables/disables the calibration file field and validator
+ *
+ * @param state :: True to enable calibration file, false otherwise
+ */
+void ISISDiagnostics::sliceCalib(bool state) {
+  m_uiForm.dsCalibration->setEnabled(state);
+}
+
+void ISISDiagnostics::rangeSelectorDropped(double min, double max) {
+  MantidWidgets::RangeSelector *from =
+      qobject_cast<MantidWidgets::RangeSelector *>(sender());
+
+  if (from == m_uiForm.ppRawPlot->getRangeSelector("SlicePeak")) {
+    m_dblManager->setValue(m_properties["PeakStart"], min);
+    m_dblManager->setValue(m_properties["PeakEnd"], max);
+  } else if (from == m_uiForm.ppRawPlot->getRangeSelector("SliceBackground")) {
+    m_dblManager->setValue(m_properties["BackgroundStart"], min);
+    m_dblManager->setValue(m_properties["BackgroundEnd"], max);
+  }
+}
+
+/**
+ * Handles a double property being changed in the property browser.
+ *
+ * @param prop :: Pointer to the QtProperty
+ * @param val :: New value
+ */
+void ISISDiagnostics::doublePropertyChanged(QtProperty *prop, double val) {
+  auto peakRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("SlicePeak");
+  auto backgroundRangeSelector =
+      m_uiForm.ppRawPlot->getRangeSelector("SliceBackground");
+
+  if (prop == m_properties["PeakStart"])
+    peakRangeSelector->setMinimum(val);
+  else if (prop == m_properties["PeakEnd"])
+    peakRangeSelector->setMaximum(val);
+  else if (prop == m_properties["BackgroundStart"])
+    backgroundRangeSelector->setMinimum(val);
+  else if (prop == m_properties["BackgroundEnd"])
+    backgroundRangeSelector->setMaximum(val);
+  else if (prop == m_properties["PreviewSpec"])
+    handleNewFile();
+  else if (prop == m_properties["SpecMin"]) {
+    m_dblManager->setMinimum(m_properties["SpecMax"], val + 1);
+    m_dblManager->setMinimum(m_properties["PreviewSpec"], val + 1);
+  } else if (prop == m_properties["SpecMax"]) {
+    m_dblManager->setMaximum(m_properties["SpecMin"], val - 1);
+    m_dblManager->setMaximum(m_properties["PreviewSpec"], val);
+  }
+
+  if (prop != m_properties["PreviewSpec"])
+    updatePreviewPlot();
+}
+
+/**
+ * Runs the slice algorithm with preview properties.
+ */
+void ISISDiagnostics::updatePreviewPlot() {
+  if (!m_uiForm.dsInputFiles->isValid())
+    return;
+
+  QString suffix = getInstrumentConfiguration()->getAnalyserName() +
+                   getInstrumentConfiguration()->getReflectionName() + "_slice";
+  QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
+
+  std::vector<long> spectraRange;
+  spectraRange.push_back(
+      static_cast<long>(m_dblManager->value(m_properties["SpecMin"])));
+  spectraRange.push_back(
+      static_cast<long>(m_dblManager->value(m_properties["SpecMax"])));
+
+  std::vector<double> peakRange;
+  peakRange.push_back(m_dblManager->value(m_properties["PeakStart"]));
+  peakRange.push_back(m_dblManager->value(m_properties["PeakEnd"]));
+
+  IAlgorithm_sptr sliceAlg = AlgorithmManager::Instance().create("TimeSlice");
+  sliceAlg->initialize();
+
+  sliceAlg->setProperty("InputFiles", filenames.toStdString());
+  sliceAlg->setProperty("SpectraRange", spectraRange);
+  sliceAlg->setProperty("PeakRange", peakRange);
+  sliceAlg->setProperty("OutputNameSuffix", suffix.toStdString());
+  sliceAlg->setProperty("OutputWorkspace", "IndirectDiagnostics_Workspaces");
+
+  if (m_uiForm.ckUseCalibration->isChecked()) {
+    QString calibWsName = m_uiForm.dsCalibration->getCurrentDataName();
+    sliceAlg->setProperty("CalibrationWorkspace", calibWsName.toStdString());
+  }
+
+  if (m_blnManager->value(m_properties["UseTwoRanges"])) {
+    std::vector<double> backgroundRange;
+    backgroundRange.push_back(
+        m_dblManager->value(m_properties["BackgroundStart"]));
+    backgroundRange.push_back(
+        m_dblManager->value(m_properties["BackgroundEnd"]));
+    sliceAlg->setProperty("BackgroundRange", backgroundRange);
+  }
+
+  // Stop the algorithm conflicting with it's self if it is already running
+  if (m_batchAlgoRunner->queueLength() == 0) {
+    // Update preview plot when slice algorithm completes
+    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+            SLOT(sliceAlgDone(bool)));
+
     runAlgorithm(sliceAlg);
   }
+}
 
-  bool ISISDiagnostics::validate()
-  {
-    UserInputValidator uiv;
+/**
+ * Updates the preview plot when the algorithm is complete.
+ *
+ * @param error True if the algorithm was stopped due to error, false otherwise
+ */
+void ISISDiagnostics::sliceAlgDone(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(sliceAlgDone(bool)));
 
-    // Check raw input
-    uiv.checkMWRunFilesIsValid("Input", m_uiForm.dsInputFiles);
-    if(m_uiForm.ckUseCalibration->isChecked())
-      uiv.checkMWRunFilesIsValid("Calibration", m_uiForm.dsInputFiles);
+  if (error)
+    return;
 
-    // Check peak range
-    auto rangeOne = std::make_pair(m_dblManager->value(m_properties["PeakStart"]), m_dblManager->value(m_properties["PeakEnd"]));
-    uiv.checkValidRange("Range One", rangeOne);
+  QStringList filenames = m_uiForm.dsInputFiles->getFilenames();
+  if (filenames.size() < 1)
+    return;
 
-    // Check background range
-    bool useTwoRanges = m_blnManager->value(m_properties["UseTwoRanges"]);
-    if(useTwoRanges)
-    {
-      auto rangeTwo = std::make_pair(m_dblManager->value(m_properties["BackgroundStart"]), m_dblManager->value(m_properties["BackgroundEnd"]));
-      uiv.checkValidRange("Range Two", rangeTwo);
-
-      uiv.checkRangesDontOverlap(rangeOne, rangeTwo);
-    }
-
-    // Check spectra range
-    auto specRange = std::make_pair(m_dblManager->value(m_properties["SpecMin"]), m_dblManager->value(m_properties["SpecMax"]) + 1);
-    uiv.checkValidRange("Spectra Range", specRange);
-
-    QString error = uiv.generateErrorMessage();
-    bool isError = error != "";
-
-    if(isError)
-      g_log.warning(error.toStdString());
-
-    return !isError;
+  WorkspaceGroup_sptr sliceOutputGroup =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+          "IndirectDiagnostics_Workspaces");
+  if (sliceOutputGroup->size() == 0) {
+    g_log.warning("No result workspaces, cannot plot preview.");
+    return;
   }
 
-  /**
-   * Handles completion of the algorithm.
-   *
-   * @param error If the algorithm failed
-   */
-  void ISISDiagnostics::algorithmComplete(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-
-    if(error)
-      return;
-
-    WorkspaceGroup_sptr sliceOutputGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("IndirectDiagnostics_Workspaces");
-    if(sliceOutputGroup->size() == 0)
-    {
-      g_log.warning("No result workspaces, cannot plot preview.");
-      return;
-    }
-
-    for(size_t i = 0; i < sliceOutputGroup->size(); i++)
-    {
-      QString wsName = QString::fromStdString(sliceOutputGroup->getItem(i)->name());
-
-      if(m_uiForm.ckPlot->isChecked())
-        plotSpectrum(wsName);
-
-      if(m_uiForm.ckSave->isChecked())
-        addSaveWorkspaceToQueue(wsName);
-    }
-
-    // Update the preview plots
-    sliceAlgDone(false);
-
-    m_batchAlgoRunner->executeBatchAsync();
+  MatrixWorkspace_sptr sliceWs = boost::dynamic_pointer_cast<MatrixWorkspace>(
+      sliceOutputGroup->getItem(0));
+  if (!sliceWs) {
+    g_log.warning("No result workspaces, cannot plot preview.");
+    return;
   }
 
-  /**
-   * Sets default spectra, peak and background ranges.
-   */
-  void ISISDiagnostics::setDefaultInstDetails()
-  {
-    // Get spectra, peak and background details
-    QMap<QString, QString> instDetails = getInstrumentDetails();
+  // Set workspace for Python export as the first result workspace
+  m_pythonExportWsName = sliceWs->getName();
 
-    // Set the search instrument for runs
-    m_uiForm.dsInputFiles->setInstrumentOverride(instDetails["instrument"]);
+  // Plot result spectrum
+  m_uiForm.ppSlicePreview->clear();
+  m_uiForm.ppSlicePreview->addSpectrum("Slice", sliceWs, 0);
+  m_uiForm.ppSlicePreview->resizeX();
 
-    double specMin = instDetails["spectra-min"].toDouble();
-    double specMax = instDetails["spectra-max"].toDouble();
+  // Ungroup the output workspace
+  sliceOutputGroup->removeAll();
+  AnalysisDataService::Instance().remove("IndirectDiagnostics_Workspaces");
+}
 
-    // Set spectra range
-    m_dblManager->setMaximum(m_properties["SpecMin"], specMax);
-    m_dblManager->setMinimum(m_properties["SpecMax"], specMin);
+/**
+ * Called when a user starts to type / edit the runs to load.
+ */
+void ISISDiagnostics::pbRunEditing() {
+  emit updateRunButton(false, "Editing...",
+                       "Run numbers are curently being edited.");
+}
 
-    m_dblManager->setValue(m_properties["SpecMin"], specMin);
-    m_dblManager->setValue(m_properties["SpecMax"], specMax);
-    m_dblManager->setValue(m_properties["PreviewSpec"], specMin);
+/**
+ * Called when the FileFinder starts finding the files.
+ */
+void ISISDiagnostics::pbRunFinding() {
+  emit updateRunButton(
+      false, "Finding files...",
+      "Searchig for data files for the run numbers entered...");
+  m_uiForm.dsInputFiles->setEnabled(false);
+}
 
-    // Set peak and background ranges
-    if(instDetails.size() >= 8)
-    {
-      setRangeSelector(m_uiForm.ppRawPlot->getRangeSelector("SlicePeak"),
-                       m_properties["PeakStart"], m_properties["PeakEnd"],
-                       qMakePair(instDetails["peak-start"].toDouble(), instDetails["peak-end"].toDouble()));
-
-      setRangeSelector(m_uiForm.ppRawPlot->getRangeSelector("SliceBackground"),
-                       m_properties["BackgroundStart"], m_properties["BackgroundEnd"],
-                       qMakePair(instDetails["back-start"].toDouble(), instDetails["back-end"].toDouble()));
-    }
+/**
+ * Called when the FileFinder has finished finding the files.
+ */
+void ISISDiagnostics::pbRunFinished() {
+  if (!m_uiForm.dsInputFiles->isValid()) {
+    emit updateRunButton(
+        false, "Invalid Run(s)",
+        "Cannot find data files for some of the run numbers enetered.");
+  } else {
+    emit updateRunButton();
   }
 
-  void ISISDiagnostics::handleNewFile()
-  {
-    if(!m_uiForm.dsInputFiles->isValid())
-      return;
-
-    QString filename = m_uiForm.dsInputFiles->getFirstFilename();
-
-    QFileInfo fi(filename);
-    QString wsname = fi.baseName();
-
-    int specMin = static_cast<int>(m_dblManager->value(m_properties["SpecMin"]));
-    int specMax = static_cast<int>(m_dblManager->value(m_properties["SpecMax"]));
-
-    if(!loadFile(filename, wsname, specMin, specMax))
-    {
-      emit showMessageBox("Unable to load file.\nCheck whether your file exists and matches the selected instrument in the EnergyTransfer tab.");
-      return;
-    }
-
-    Mantid::API::MatrixWorkspace_sptr input = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-        Mantid::API::AnalysisDataService::Instance().retrieve(wsname.toStdString()));
-
-    const Mantid::MantidVec & dataX = input->readX(0);
-    QPair<double, double> range(dataX.front(), dataX.back());
-    int previewSpec = static_cast<int>(m_dblManager->value(m_properties["PreviewSpec"])) - specMin;
-
-    m_uiForm.ppRawPlot->clear();
-    m_uiForm.ppRawPlot->addSpectrum("Raw", input, previewSpec);
-
-    setPlotPropertyRange(m_uiForm.ppRawPlot->getRangeSelector("SlicePeak"),
-                         m_properties["PeakStart"], m_properties["PeakEnd"], range);
-    setPlotPropertyRange(m_uiForm.ppRawPlot->getRangeSelector("SliceBackground"),
-                         m_properties["BackgroundStart"], m_properties["BackgroundEnd"], range);
-
-    m_uiForm.ppRawPlot->resizeX();
-  }
-
-  /**
-   * Set if the second slice range selectors should be shown on the plot
-   *
-   * @param state :: True to show the second range selectors, false to hide
-   */
-  void ISISDiagnostics::sliceTwoRanges(QtProperty*, bool state)
-  {
-    m_uiForm.ppRawPlot->getRangeSelector("SliceBackground")->setVisible(state);
-  }
-
-  /**
-   * Enables/disables the calibration file field and validator
-   *
-   * @param state :: True to enable calibration file, false otherwise
-   */
-  void ISISDiagnostics::sliceCalib(bool state)
-  {
-    m_uiForm.dsCalibration->setEnabled(state);
-  }
-
-  void ISISDiagnostics::rangeSelectorDropped(double min, double max)
-  {
-    MantidWidgets::RangeSelector* from = qobject_cast<MantidWidgets::RangeSelector*>(sender());
-
-    if(from == m_uiForm.ppRawPlot->getRangeSelector("SlicePeak"))
-    {
-      m_dblManager->setValue(m_properties["PeakStart"], min);
-      m_dblManager->setValue(m_properties["PeakEnd"], max);
-    }
-    else if(from == m_uiForm.ppRawPlot->getRangeSelector("SliceBackground"))
-    {
-      m_dblManager->setValue(m_properties["BackgroundStart"], min);
-      m_dblManager->setValue(m_properties["BackgroundEnd"], max);
-    }
-  }
-
-  /**
-   * Handles a double property being changed in the property browser.
-   *
-   * @param prop :: Pointer to the QtProperty
-   * @param val :: New value
-   */
-  void ISISDiagnostics::doublePropertyChanged(QtProperty* prop, double val)
-  {
-    auto peakRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("SlicePeak");
-    auto backgroundRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("SliceBackground");
-
-    if(prop == m_properties["PeakStart"])             peakRangeSelector->setMinimum(val);
-    else if(prop == m_properties["PeakEnd"])          peakRangeSelector->setMaximum(val);
-    else if(prop == m_properties["BackgroundStart"])  backgroundRangeSelector->setMinimum(val);
-    else if(prop == m_properties["BackgroundEnd"])    backgroundRangeSelector->setMaximum(val);
-    else if(prop == m_properties["PreviewSpec"])      handleNewFile();
-    else if(prop == m_properties["SpecMin"])
-    {
-      m_dblManager->setMinimum(m_properties["SpecMax"], val+1);
-      m_dblManager->setMinimum(m_properties["PreviewSpec"], val+1);
-    }
-    else if(prop == m_properties["SpecMax"])
-    {
-      m_dblManager->setMaximum(m_properties["SpecMin"], val-1);
-      m_dblManager->setMaximum(m_properties["PreviewSpec"], val);
-    }
-
-    if(prop != m_properties["PreviewSpec"])
-      updatePreviewPlot();
-  }
-
-  /**
-   * Runs the slice algorithm with preview properties.
-   */
-  void ISISDiagnostics::updatePreviewPlot()
-  {
-    if (!m_uiForm.dsInputFiles->isValid())
-      return;
-
-    QString suffix = getInstrumentConfiguration()->getAnalyserName()
-                     + getInstrumentConfiguration()->getReflectionName() + "_slice";
-    QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
-
-    std::vector<long> spectraRange;
-    spectraRange.push_back(static_cast<long>(m_dblManager->value(m_properties["SpecMin"])));
-    spectraRange.push_back(static_cast<long>(m_dblManager->value(m_properties["SpecMax"])));
-
-    std::vector<double> peakRange;
-    peakRange.push_back(m_dblManager->value(m_properties["PeakStart"]));
-    peakRange.push_back(m_dblManager->value(m_properties["PeakEnd"]));
-
-    IAlgorithm_sptr sliceAlg = AlgorithmManager::Instance().create("TimeSlice");
-    sliceAlg->initialize();
-
-    sliceAlg->setProperty("InputFiles", filenames.toStdString());
-    sliceAlg->setProperty("SpectraRange", spectraRange);
-    sliceAlg->setProperty("PeakRange", peakRange);
-    sliceAlg->setProperty("OutputNameSuffix", suffix.toStdString());
-    sliceAlg->setProperty("OutputWorkspace", "IndirectDiagnostics_Workspaces");
-
-    if(m_uiForm.ckUseCalibration->isChecked())
-    {
-      QString calibWsName = m_uiForm.dsCalibration->getCurrentDataName();
-      sliceAlg->setProperty("CalibrationWorkspace", calibWsName.toStdString());
-    }
-
-    if(m_blnManager->value(m_properties["UseTwoRanges"]))
-    {
-      std::vector<double> backgroundRange;
-      backgroundRange.push_back(m_dblManager->value(m_properties["BackgroundStart"]));
-      backgroundRange.push_back(m_dblManager->value(m_properties["BackgroundEnd"]));
-      sliceAlg->setProperty("BackgroundRange", backgroundRange);
-    }
-
-    // Stop the algorithm conflicting with it's self if it is already running
-    if(m_batchAlgoRunner->queueLength() == 0)
-    {
-      // Update preview plot when slice algorithm completes
-      connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(sliceAlgDone(bool)));
-
-      runAlgorithm(sliceAlg);
-    }
-  }
-
-  /**
-   * Updates the preview plot when the algorithm is complete.
-   *
-   * @param error True if the algorithm was stopped due to error, false otherwise
-   */
-  void ISISDiagnostics::sliceAlgDone(bool error)
-  {
-    disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(sliceAlgDone(bool)));
-
-    if(error)
-      return;
-
-    QStringList filenames = m_uiForm.dsInputFiles->getFilenames();
-    if(filenames.size() < 1)
-      return;
-
-    WorkspaceGroup_sptr sliceOutputGroup = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>("IndirectDiagnostics_Workspaces");
-    if(sliceOutputGroup->size() == 0)
-    {
-      g_log.warning("No result workspaces, cannot plot preview.");
-      return;
-    }
-
-    MatrixWorkspace_sptr sliceWs = boost::dynamic_pointer_cast<MatrixWorkspace>(sliceOutputGroup->getItem(0));
-    if(!sliceWs)
-    {
-      g_log.warning("No result workspaces, cannot plot preview.");
-      return;
-    }
-
-    // Set workspace for Python export as the first result workspace
-    m_pythonExportWsName = sliceWs->getName();
-
-    // Plot result spectrum
-    m_uiForm.ppSlicePreview->clear();
-    m_uiForm.ppSlicePreview->addSpectrum("Slice", sliceWs, 0);
-    m_uiForm.ppSlicePreview->resizeX();
-
-    // Ungroup the output workspace
-    sliceOutputGroup->removeAll();
-    AnalysisDataService::Instance().remove("IndirectDiagnostics_Workspaces");
-  }
-
-  /**
-   * Called when a user starts to type / edit the runs to load.
-   */
-  void ISISDiagnostics::pbRunEditing()
-  {
-    emit updateRunButton(false, "Editing...", "Run numbers are curently being edited.");
-  }
-
-  /**
-   * Called when the FileFinder starts finding the files.
-   */
-  void ISISDiagnostics::pbRunFinding()
-  {
-    emit updateRunButton(false, "Finding files...", "Searchig for data files for the run numbers entered...");
-    m_uiForm.dsInputFiles->setEnabled(false);
-  }
-
-  /**
-   * Called when the FileFinder has finished finding the files.
-   */
-  void ISISDiagnostics::pbRunFinished()
-  {
-    if(!m_uiForm.dsInputFiles->isValid())
-    {
-      emit updateRunButton(false, "Invalid Run(s)", "Cannot find data files for some of the run numbers enetered.");
-    }
-    else
-    {
-      emit updateRunButton();
-    }
-
-    m_uiForm.dsInputFiles->setEnabled(true);
-  }
+  m_uiForm.dsInputFiles->setEnabled(true);
+}
 
 } // namespace CustomInterfaces
 } // namespace Mantid


### PR DESCRIPTION
Fixes #13525

To test:
- Open Indirect > Data Reduction > ISIS Diagnostics
- Instrument: OSIRIS
- Load run: osi89757.raw (from system test data)
- Set `Spectra Min` to 1
- Set `Preview Spectrum` to 1
- See that the plot shows the monitor spectrum

Release notes updates [here](http://www.mantidproject.org/index.php?title=Release_Notes_3_5_Indirect_Inelastic&diff=25103&oldid=25093).
