### PR TITLE
Fix several issues loading nMoldyn data

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn4Ascii.py
@@ -111,12 +111,8 @@ class LoadNMoldyn4Ascii(PythonAlgorithm):
         out_ws_name = self.getPropertyValue('OutputWorkspace')
         if len(loaded_function_workspaces) == 0:
             raise RuntimeError('Failed to load any functions for data')
-        elif len(functions) == 1:
-            RenameWorkspace(InputWorkspace=loaded_function_workspaces[0],
-                            OutputWorkspace=out_ws_name)
-        else:
-            GroupWorkspaces(InputWorkspaces=loaded_function_workspaces,
-                            OutputWorkspace=out_ws_name)
+        GroupWorkspaces(InputWorkspaces=loaded_function_workspaces,
+                        OutputWorkspace=out_ws_name)
 
         # Set the output workspace
         self.setProperty('OutputWorkspace', out_ws_name)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
@@ -62,9 +62,6 @@ class MolDyn(PythonAlgorithm):
         if res_ws != '' and max_energy == Property.EMPTY_DBL:
             issues['MaxEnergy'] = 'MaxEnergy must be set when convolving with an instrument resolution'
 
-        if res_ws != '' and not symm:
-            issues['SymmetriseEnergy'] = 'Must symmetrise energy when convolving with instrument resolution'
-
         return issues
 
 
@@ -118,17 +115,18 @@ class MolDyn(PythonAlgorithm):
                     elif max_energy_param != Property.EMPTY_DBL:
                         CropWorkspace(InputWorkspace=ws_name,
                                       OutputWorkspace=ws_name,
+                                      XMin=-max_energy,
                                       XMax=max_energy)
 
         # Do convolution if given a resolution workspace
-        if self.getPropertyValue('Resolution') is not '':
+        if self.getPropertyValue('Resolution') != '':
             # Create a workspace with enough spectra for convolution
             num_sample_hist = mtd[output_ws_name].getItem(0).getNumberHistograms()
             resolution_ws = self._create_res_ws(num_sample_hist)
 
             # Convolve all workspaces in output group
             for ws_name in mtd[output_ws_name].getNames():
-                if ws_name.lower().find('sqw') != -1:
+                if 'Energy' in mtd[ws_name].getAxis(0).getUnit().unitID():
                     self._convolve_with_res(resolution_ws, ws_name)
                 else:
                     logger.information('Ignoring workspace %s in convolution step' % ws_name)

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
@@ -55,7 +55,6 @@ class MolDyn(PythonAlgorithm):
         except ValueError, vex:
             issues['Data'] = str(vex)
 
-        symm = self.getProperty('SymmetriseEnergy').value
         res_ws = self.getPropertyValue('Resolution')
         max_energy = self.getPropertyValue('MaxEnergy')
 

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4AsciiTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4AsciiTest.py
@@ -50,20 +50,26 @@ class LoadNMoldyn4AsciiTest(unittest.TestCase):
         """
         Tests loading a single F(Q, t) function.
         """
-        function_ws = LoadNMoldyn4Ascii(Directory=self._data_directory,
-                                        Functions=['fqt_total'],
-                                        OutputWorkspace='__LoadNMoldyn4Ascii_test')
-        self._validate_fqt_ws(function_ws)
+        function_wsg = LoadNMoldyn4Ascii(Directory=self._data_directory,
+                                         Functions=['fqt_total'],
+                                         OutputWorkspace='__LoadNMoldyn4Ascii_test')
+        self.assertTrue(isinstance(function_wsg, WorkspaceGroup))
+        self.assertEqual(len(function_wsg), 1)
+        self.assertTrue(function_wsg.contains('fqt_total'))
+        self._validate_fqt_ws(mtd['fqt_total'])
 
 
     def test_load_single_sqf_function(self):
         """
         Tests loading a single S(Q, f) function.
         """
-        function_ws = LoadNMoldyn4Ascii(Directory=self._data_directory,
-                                        Functions=['sqf_total'],
-                                        OutputWorkspace='__LoadNMoldyn4Ascii_test')
-        self._validate_sqf_ws(function_ws)
+        function_wsg = LoadNMoldyn4Ascii(Directory=self._data_directory,
+                                         Functions=['sqf_total'],
+                                         OutputWorkspace='__LoadNMoldyn4Ascii_test')
+        self.assertTrue(isinstance(function_wsg, WorkspaceGroup))
+        self.assertEqual(len(function_wsg), 1)
+        self.assertTrue(function_wsg.contains('sqf_total'))
+        self._validate_sqf_ws(mtd['sqf_total'])
 
 
     def test_load_multiple_functions_list_short_name(self):

--- a/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/MolDynTest.py
+++ b/Code/Mantid/Framework/PythonInterface/test/python/plugins/algorithms/MolDynTest.py
@@ -44,7 +44,7 @@ class MolDynTest(unittest.TestCase):
                              Functions=['fqt_total'],
                              OutputWorkspace='__LoadNMoldyn4Ascii_test')
 
-        self.assertTrue(isinstance(function_ws, MatrixWorkspace))
+        self.assertTrue(isinstance(function_ws, WorkspaceGroup))
 
 
     def test_loadSqwWithEMax(self):
@@ -103,27 +103,6 @@ class MolDynTest(unittest.TestCase):
         self.assertTrue(isinstance(moldyn_group, WorkspaceGroup))
         self.assertEqual(len(moldyn_group), 1)
         self.assertEqual(moldyn_group[0].name(), 'NaF_DISF_Sqw-total')
-
-
-    def test_loadSqwWithResWithNoEMaxFails(self):
-        """
-        Tests that trying to use an instrument resolution without a Max Energy will fail.
-        """
-
-        # Create a sample workspace thet looks like an instrument resolution
-        sample_res = CreateSampleWorkspace(NumBanks=1,
-                                           BankPixelWidth=1,
-                                           XUnit='Energy',
-                                           XMin=-10,
-                                           XMax=10,
-                                           BinWidth=0.1)
-
-        # Load an Sqw function from a nMOLDYN file
-        self.assertRaises(RuntimeError, MolDyn,
-                          Data='NaF_DISF.cdl',
-                          Functions=['Sqw-total'],
-                          Resolution=sample_res,
-                          OutputWorkspace='moldyn_group')
 
 
 if __name__ == '__main__':

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectMolDyn.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectMolDyn.cpp
@@ -53,10 +53,6 @@ bool IndirectMolDyn::validate() {
   if (m_uiForm.ckResolution->isChecked())
     uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
-  // Validate symmetrise on when resolution is convolved
-  if (m_uiForm.ckResolution->isChecked() && !m_uiForm.ckSymmetrise->isChecked())
-    uiv.addErrorMessage("Must symmetrise when convolving with resolution.");
-
   emit showMessageBox(uiv.generateErrorMessage());
   return uiv.isAllInputValid();
 }


### PR DESCRIPTION
Fixes #13529.

To test:
- Get the data from `Babylon5/Public/DanNixon/pcbm`
- Open Indirect > Simulation > MolDyn
- Select version 4
- Select the `moldyn` directory as Data
- Function: `s(qf)_total`
- Crop Energy: 0.5meV
- No Symmetrise
- Use Resolution: `osiris00111951_graphite002_res.nxs`
- Select Contour plot

Run and see that the convolution happens (run without to notice the difference).

No release notes mention as issues added this release.
