### PR TITLE
Add x error to binary operations

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -139,6 +139,17 @@ protected:
                                       const MantidVec &rhsE, MantidVec &YOut,
                                       MantidVec &EOut) = 0;
 
+  /** Carries out the binary operation on a single spectrum, with another
+   * spectrum as the right-hand operand -- for DX values
+   * @param lhsDx: The vector of lhs x error values
+   * @param rhsDx: The vector of rhs error values, made available if required
+   * @param outWorkspace: the outputworkspace
+   * @param index: the spectrum to perform the operation on
+   */
+  virtual void
+  performBinaryOperationOnDx(const MantidVec &lhsDx, const MantidVec &rhsDx,
+                             API::MatrixWorkspace_sptr &outWorkspace, const int64_t index);
+
   /** Carries out the binary operation when the right hand operand is a single
    *number.
    *
@@ -157,6 +168,17 @@ protected:
                                       const MantidVec &lhsE, const double rhsY,
                                       const double rhsE, MantidVec &YOut,
                                       MantidVec &EOut) = 0;
+
+  /** Carries out the binary operation when the right hand operand is a single
+   * number only for the x error component
+   * @param lhsDx: The vector of lhs x error values
+   * @param rhsDx: The rhs x error value, made available if required
+   * @param outWorkspace: the outputworkspace
+   * @param index: the spectrum to perform the operation on
+   */
+  virtual void
+  performBinaryOperationOnDx(const MantidVec &lhsDx, const double rhsDx,
+                             API::MatrixWorkspace_sptr &outWorkSpace, const int64_t index);
 
   // ===================================== EVENT LIST BINARY OPERATIONS
   // ==========================================

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/BinaryOperation.h
@@ -178,7 +178,7 @@ protected:
    */
   virtual void
   performBinaryOperationOnDx(const MantidVec &lhsDx, const double rhsDx,
-                             API::MatrixWorkspace_sptr &outWorkSpace, const int64_t index);
+                             API::MatrixWorkspace_sptr &outWorkspace, const int64_t index);
 
   // ===================================== EVENT LIST BINARY OPERATIONS
   // ==========================================

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/Multiply.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/Multiply.h
@@ -71,7 +71,14 @@ private:
                               const MantidVec &lhsE, const double rhsY,
                               const double rhsE, MantidVec &YOut,
                               MantidVec &EOut);
-
+  void performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                  const MantidVec &rhsDx,
+                                  API::MatrixWorkspace_sptr &outWorkspace,
+                                  const int64_t index);
+  void performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                  const double rhsDx,
+                                  API::MatrixWorkspace_sptr &outWorkspace,
+                                  const int64_t index);
   virtual void setOutputUnits(const API::MatrixWorkspace_const_sptr lhs,
                               const API::MatrixWorkspace_const_sptr rhs,
                               API::MatrixWorkspace_sptr out);

--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/Plus.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/Plus.h
@@ -69,10 +69,18 @@ private:
                               const MantidVec &lhsE, const MantidVec &rhsY,
                               const MantidVec &rhsE, MantidVec &YOut,
                               MantidVec &EOut);
+  void performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                  const MantidVec &rhsDx,
+                                  API::MatrixWorkspace_sptr &outWorkspace,
+                                  const int64_t index);
   void performBinaryOperation(const MantidVec &lhsX, const MantidVec &lhsY,
                               const MantidVec &lhsE, const double rhsY,
                               const double rhsE, MantidVec &YOut,
                               MantidVec &EOut);
+  void performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                  const double rhsDx,
+                                  API::MatrixWorkspace_sptr &outWorkspace,
+                                  const int64_t index);
   void performEventBinaryOperation(DataObjects::EventList &lhs,
                                    const DataObjects::EventList &rhs);
   void performEventBinaryOperation(DataObjects::EventList &lhs,

--- a/Code/Mantid/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/BinaryOperation.cpp
@@ -508,6 +508,9 @@ void BinaryOperation::doSingleValue() {
     for (int64_t i = 0; i < numHists; ++i) {
       PARALLEL_START_INTERUPT_REGION
       m_out->setX(i, m_lhs->refX(i));
+      if (m_lhs->hasDx(i)) {
+        m_out->setDx(i, m_lhs->refDx(i));
+      }
       performEventBinaryOperation(m_eout->getEventList(i), rhsY, rhsE);
       m_progress->report(this->name());
       PARALLEL_END_INTERUPT_REGION
@@ -519,6 +522,9 @@ void BinaryOperation::doSingleValue() {
     for (int64_t i = 0; i < numHists; ++i) {
       PARALLEL_START_INTERUPT_REGION
       m_out->setX(i, m_lhs->refX(i));
+      if (m_lhs->hasDx(i)) {
+        m_out->setDx(i, m_lhs->refDx(i));
+      }
       // Get reference to output vectors here to break any sharing outside the
       // function call below
       // where the order of argument evaluation is not guaranteed (if it's L->R

--- a/Code/Mantid/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/BinaryOperation.cpp
@@ -10,9 +10,14 @@
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidGeometry/IDetector.h"
 #include "MantidKernel/Timer.h"
+#include "MantidKernel/Logger.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
 
 #include <boost/make_shared.hpp>
+
+namespace {
+  Mantid::Kernel::Logger g_log("BinaryOperation");
+}
 
 using namespace Mantid::Geometry;
 using namespace Mantid::API;
@@ -508,10 +513,12 @@ void BinaryOperation::doSingleValue() {
     for (int64_t i = 0; i < numHists; ++i) {
       PARALLEL_START_INTERUPT_REGION
       m_out->setX(i, m_lhs->refX(i));
-      if (m_lhs->hasDx(i)) {
-        m_out->setDx(i, m_lhs->refDx(i));
-      }
       performEventBinaryOperation(m_eout->getEventList(i), rhsY, rhsE);
+      if (m_lhs->hasDx(i)) {
+        g_log.warning("Binary Operation: Cannot operate on X Error for "
+                      "EventLists. Functionality is "
+                      "not implemented. The X Errors are ignored.");
+      }
       m_progress->report(this->name());
       PARALLEL_END_INTERUPT_REGION
     }
@@ -522,9 +529,6 @@ void BinaryOperation::doSingleValue() {
     for (int64_t i = 0; i < numHists; ++i) {
       PARALLEL_START_INTERUPT_REGION
       m_out->setX(i, m_lhs->refX(i));
-      if (m_lhs->hasDx(i)) {
-        m_out->setDx(i, m_lhs->refDx(i));
-      }
       // Get reference to output vectors here to break any sharing outside the
       // function call below
       // where the order of argument evaluation is not guaranteed (if it's L->R
@@ -533,6 +537,10 @@ void BinaryOperation::doSingleValue() {
       MantidVec &outE = m_out->dataE(i);
       performBinaryOperation(m_lhs->readX(i), m_lhs->readY(i), m_lhs->readE(i),
                              rhsY, rhsE, outY, outE);
+      if (m_lhs->hasDx(i)) {
+        performBinaryOperationOnDx(m_lhs->dataDx(i), m_rhs->readDx(0)[0], m_out,
+                                   i);
+      }
       m_progress->report(this->name());
       PARALLEL_END_INTERUPT_REGION
     }
@@ -564,6 +572,11 @@ void BinaryOperation::doSingleColumn() {
       // m_out->setX(i, m_lhs->refX(i)); //unnecessary - that was copied before.
       if (propagateSpectraMask(m_lhs, m_rhs, i, m_out)) {
         performEventBinaryOperation(m_eout->getEventList(i), rhsY, rhsE);
+        if (m_lhs->hasDx(i)) {
+          g_log.warning("Binary Operation: Cannot operate on X Error for "
+                        "EventLists. Functionality is "
+                        "not implemented. The X Errors are ignored.");
+        }
       }
       m_progress->report(this->name());
       PARALLEL_END_INTERUPT_REGION
@@ -587,6 +600,10 @@ void BinaryOperation::doSingleColumn() {
         MantidVec &outE = m_out->dataE(i);
         performBinaryOperation(m_lhs->readX(i), m_lhs->readY(i),
                                m_lhs->readE(i), rhsY, rhsE, outY, outE);
+        if (m_lhs->hasDx(i)) {
+          performBinaryOperationOnDx(m_lhs->dataDx(i), m_rhs->readDx(i)[0],
+                                     m_out, i);
+        }
       }
       m_progress->report(this->name());
       PARALLEL_END_INTERUPT_REGION
@@ -625,6 +642,11 @@ void BinaryOperation::doSingleSpectrum() {
 
         // Perform the operation on the event list on the output (== lhs)
         performEventBinaryOperation(m_eout->getEventList(i), rhs_spectrum);
+        if (m_lhs->hasDx(i)) {
+          g_log.warning("Binary Operation: Cannot operate on X Error for "
+                        "EventLists. Functionality is "
+                        "not implemented. The X Errors are ignored.");
+        }
         m_progress->report(this->name());
         PARALLEL_END_INTERUPT_REGION
       }
@@ -647,6 +669,11 @@ void BinaryOperation::doSingleSpectrum() {
         // before.
         // Perform the operation on the event list on the output (== lhs)
         performEventBinaryOperation(m_eout->getEventList(i), rhsX, rhsY, rhsE);
+        if (m_lhs->hasDx(i)) {
+          g_log.warning("Binary Operation: Cannot operate on X Error for "
+                        "EventLists. Functionality is "
+                        "not implemented. The X Errors are ignored.");
+        }
         m_progress->report(this->name());
         PARALLEL_END_INTERUPT_REGION
       }
@@ -678,6 +705,9 @@ void BinaryOperation::doSingleSpectrum() {
       MantidVec &outE = m_out->dataE(i);
       performBinaryOperation(m_lhs->readX(i), m_lhs->readY(i), m_lhs->readE(i),
                              rhsY, rhsE, outY, outE);
+      if (m_lhs->hasDx(i)) {
+        performBinaryOperationOnDx(m_lhs->readDx(i), m_rhs->readDx(0), m_out, i);
+      }
       m_progress->report(this->name());
       PARALLEL_END_INTERUPT_REGION
     }
@@ -730,7 +760,11 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
         // Perform the operation on the event list on the output (== lhs)
         performEventBinaryOperation(m_eout->getEventList(i),
                                     m_erhs->getEventList(rhs_wi));
-
+        if (m_lhs->hasDx(i)) {
+          g_log.warning("Binary Operation: Cannot operate on X Error for "
+                        "EventLists. Functionality is "
+                        "not implemented. The X Errors are ignored.");
+        }
         // Free up memory on the RHS if that is possible
         if (m_ClearRHSWorkspace)
           const_cast<EventList &>(m_erhs->getEventList(rhs_wi)).clear();
@@ -763,7 +797,11 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
         performEventBinaryOperation(m_eout->getEventList(i),
                                     m_rhs->readX(rhs_wi), m_rhs->readY(rhs_wi),
                                     m_rhs->readE(rhs_wi));
-
+        if (m_lhs->hasDx(i)) {
+          g_log.warning("Binary Operation: Cannot operate on X Error for "
+                        "EventLists. Functionality is "
+                        "not implemented. The X Errors are ignored.");
+        }
         // Free up memory on the RHS if that is possible
         if (m_ClearRHSWorkspace)
           const_cast<EventList &>(m_erhs->getEventList(rhs_wi)).clear();
@@ -806,7 +844,9 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
       performBinaryOperation(m_lhs->readX(i), m_lhs->readY(i), m_lhs->readE(i),
                              m_rhs->readY(rhs_wi), m_rhs->readE(rhs_wi), outY,
                              outE);
-
+      if (m_lhs->hasDx(i)) {
+        performBinaryOperationOnDx(m_lhs->readDx(i), m_rhs->readDx(rhs_wi), m_out, i);
+      }
       // Free up memory on the RHS if that is possible
       if (m_ClearRHSWorkspace)
         const_cast<EventList &>(m_erhs->getEventList(rhs_wi)).clear();
@@ -1107,6 +1147,23 @@ BinaryOperation::buildBinaryOperationTable(
   }
 
   return table;
+}
+
+// --------------------------------------
+void BinaryOperation::performBinaryOperationOnDx(const MantidVec &,
+                                                 const MantidVec &,
+                                                 API::MatrixWorkspace_sptr &,
+                                                 const int64_t) {
+  g_log.warning("Binary Operation: Cannot operate on X Error. Functionality is "
+                "not implemented. The X Errors are ignored.");
+}
+
+void BinaryOperation::performBinaryOperationOnDx(const MantidVec &,
+                                                 const double,
+                                                 API::MatrixWorkspace_sptr &,
+                                                 const int64_t) {
+  g_log.warning("Binary Operation: Cannot operate on X Error. Functionality is "
+                "not implemented. The X Errors are ignored.");
 }
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/src/Multiply.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Multiply.cpp
@@ -74,6 +74,7 @@ void Multiply::performBinaryOperation(const MantidVec &lhsX,
 void Multiply::performBinaryOperationOnDx(
     const MantidVec &lhsDx, const double rhsDx,
     API::MatrixWorkspace_sptr &outWorkspace, const int64_t index) {
+    UNUSED_ARG(rhsDx);
     // Copy the data over from the lhs. The x error should not be affected by a multiplication.
     auto &DxOut = outWorkspace->dataDx(index);
     DxOut = lhsDx;

--- a/Code/Mantid/Framework/Algorithms/src/Multiply.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Multiply.cpp
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAlgorithms/Multiply.h"
 #include "MantidDataObjects/WorkspaceSingleValue.h"
+#include "MantidKernel/VectorHelper.h"
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
@@ -40,6 +41,16 @@ void Multiply::performBinaryOperation(const MantidVec &lhsX,
   }
 }
 
+void Multiply::performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                  const MantidVec &rhsDx,
+                                  API::MatrixWorkspace_sptr &outWorkspace,
+                                  const int64_t index) {
+  auto &DxOut = outWorkspace->dataDx(index);
+  std::transform(lhsDx.begin(), lhsDx.end(), rhsDx.begin(), DxOut.begin(),
+                 VectorHelper::SumGaussError<double>());
+}
+
+
 void Multiply::performBinaryOperation(const MantidVec &lhsX,
                                       const MantidVec &lhsY,
                                       const MantidVec &lhsE, const double rhsY,
@@ -58,6 +69,14 @@ void Multiply::performBinaryOperation(const MantidVec &lhsX,
     // output
     YOut[j] = leftY * rhsY;
   }
+}
+
+void Multiply::performBinaryOperationOnDx(
+    const MantidVec &lhsDx, const double rhsDx,
+    API::MatrixWorkspace_sptr &outWorkspace, const int64_t index) {
+    // Copy the data over from the lhs. The x error should not be affected by a multiplication.
+    auto &DxOut = outWorkspace->dataDx(index);
+    DxOut = lhsDx;
 }
 
 void Multiply::setOutputUnits(const API::MatrixWorkspace_const_sptr lhs,

--- a/Code/Mantid/Framework/Algorithms/src/Plus.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/Plus.cpp
@@ -27,6 +27,15 @@ void Plus::performBinaryOperation(const MantidVec &lhsX, const MantidVec &lhsY,
                  VectorHelper::SumGaussError<double>());
 }
 
+void Plus::performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                      const MantidVec &rhsDx,
+                                      API::MatrixWorkspace_sptr &outWorkspace,
+                                      const int64_t index) {
+  auto &DxOut = outWorkspace->dataDx(index);
+  std::transform(lhsDx.begin(), lhsDx.end(), rhsDx.begin(), DxOut.begin(),
+                 VectorHelper::SumGaussError<double>());
+}
+
 //---------------------------------------------------------------------------------------------
 void Plus::performBinaryOperation(const MantidVec &lhsX, const MantidVec &lhsY,
                                   const MantidVec &lhsE, const double rhsY,
@@ -41,6 +50,19 @@ void Plus::performBinaryOperation(const MantidVec &lhsX, const MantidVec &lhsY,
                    std::bind2nd(VectorHelper::SumGaussError<double>(), rhsE));
   else
     EOut = lhsE;
+}
+
+void Plus::performBinaryOperationOnDx(const MantidVec &lhsDx,
+                                      const double rhsDx,
+                                      API::MatrixWorkspace_sptr &outWorkspace,
+                                      const int64_t index) {
+  auto& DxOut = outWorkspace->dataDx(index);
+  // Only do Dx if non-zero, otherwise just copy
+  if (rhsDx != 0)
+    std::transform(lhsDx.begin(), lhsDx.end(), DxOut.begin(),
+                   std::bind2nd(VectorHelper::SumGaussError<double>(), rhsDx));
+  else
+    DxOut = lhsDx;
 }
 
 // ===================================== EVENT LIST BINARY OPERATIONS

--- a/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -9,6 +9,7 @@
 #include "MantidAlgorithms/Divide.h"
 #include "MantidAlgorithms/Multiply.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidAPI/WorkspaceProperty.h"
@@ -284,6 +285,89 @@ public:
   }
 
 
+    void test_1D_1D_Histograms_withDX_for_Multiply() {
+    if (!DO_DIVIDE) {
+      // Arrange
+      const int size = 10;
+      const double value1 = 5;
+      const double value2 = 3;
+      const double error1 = 1.5;
+      const double error2 = 2.5;
+      const double xError1 = 1.1;
+      const double xError2 = 2.1;
+      auto ws1 = WorkspaceCreationHelper::Create1DWorkspaceConstantWithXerror(size, value1, error1, xError1);
+      auto ws2 = WorkspaceCreationHelper::Create1DWorkspaceConstantWithXerror(size, value2, error2, xError2);
+      std::string outWorkspaceName = "dx_error_workspace_test";
+      // Act
+      auto algPlus = Mantid::API::FrameworkManager::Instance().createAlgorithm("Multiply");
+      algPlus->initialize();
+      algPlus->setRethrows(true);
+      algPlus->setProperty("LHSWorkspace", ws1);
+      algPlus->setProperty("RHSWorkspace", ws2);
+      algPlus->setProperty("OutputWorkspace", outWorkspaceName);
+      algPlus->execute();
+      // Assert
+      TS_ASSERT(algPlus->isExecuted());
+      auto outWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWorkspaceName);
+      TS_ASSERT(outWS.get());
+      TSM_ASSERT("Output should contain x errors", outWS->hasDx(0));
+
+      auto& dx = outWS->dataDx(0);
+      double expectedDx = sqrt(xError1*xError1 + xError2*xError2);
+      for (size_t i = 0; i < size; ++i) {
+        TSM_ASSERT_EQUALS("Should be sqrt(1.1^2 + 2.1^2)", dx[i], expectedDx);
+      }
+      // Clean the ADS
+      AnalysisDataService::Instance().remove(outWorkspaceName);
+    }
+  }
+
+
+  void test_2D_2D_Histograms_withDX_for_Multiply() {
+    if (!DO_DIVIDE) {
+      // Arrange
+      const double xValue = 1.222;
+      const double value1 = 5;
+      const double value2 = 3;
+      const double error1 = 1.5;
+      const double error2 = 2.5;
+      const double xError1 = 1.1;
+      const double xError2 = 2.1;
+
+      int64_t nHist = 4;
+      int64_t nBins = 10; 
+      bool isHist = true;
+
+      auto ws1 = WorkspaceCreationHelper::Create2DWorkspaceWithValuesAndXerror(nHist, nBins, isHist, xValue, value1, error1, xError1);
+      auto ws2 = WorkspaceCreationHelper::Create2DWorkspaceWithValuesAndXerror(nHist, nBins, isHist, xValue, value2, error2, xError2);
+      std::string outWorkspaceName = "dx_error_workspace_test";
+
+      // Act
+      auto algPlus = Mantid::API::FrameworkManager::Instance().createAlgorithm("Multiply");
+      algPlus->initialize();
+      algPlus->setRethrows(true);
+      algPlus->setProperty("LHSWorkspace", ws1);
+      algPlus->setProperty("RHSWorkspace", ws2);
+      algPlus->setProperty("OutputWorkspace", outWorkspaceName);
+      algPlus->execute();
+
+      // Assert
+      TS_ASSERT(algPlus->isExecuted());
+      auto outWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWorkspaceName);
+      TS_ASSERT(outWS.get());
+      TSM_ASSERT("Output should contain x errors", outWS->hasDx(0));
+
+      auto& dx = outWS->dataDx(0);
+      double expectedDx = sqrt(xError1*xError1 + xError2*xError2);
+      for (size_t spectra = 0; spectra < outWS->getNumberHistograms(); ++spectra) {
+        for (size_t i = 0; i < nBins; ++i) {
+          TSM_ASSERT_EQUALS("Should be sqrt(1.1^2 + 2.1^2)", dx[i], expectedDx);
+        }
+      }
+      // Clean the ADS
+      AnalysisDataService::Instance().remove(outWorkspaceName);
+    }
+  }
 
 
   //========================================= EventWorkspaces ==================================

--- a/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -22,10 +22,10 @@ using namespace Mantid::DataObjects;
 using Mantid::Geometry::IDetector_const_sptr;
 
 /*****************************************************************************************/
-/********** PLEASE NOTE! THIS FILE WAS AUTO-GENERATED FROM CMAKE.  ***********************/
-/********** Source = MultiplyDivideTest.h.in *********************************************/
+/********** PLEASE NOTE! CMAKE IS BEING USED TO CREATE AUTO-GENERATED CODE. **************/
+/********** Source = MultiplyDivideTest.h.in => edit here ********************************/
+/********** Targets = MultiplyTest.h, DivideTest.h => don't edit *************************/
 /*****************************************************************************************/
-
 class @MULTIPLYDIVIDETEST_CLASS@ : public CxxTest::TestSuite
 {
 private:

--- a/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/MultiplyDivideTest.in.h
@@ -314,7 +314,7 @@ public:
 
       auto& dx = outWS->dataDx(0);
       double expectedDx = sqrt(xError1*xError1 + xError2*xError2);
-      for (size_t i = 0; i < size; ++i) {
+      for (size_t i = 0; i < static_cast<size_t>(size); ++i) {
         TSM_ASSERT_EQUALS("Should be sqrt(1.1^2 + 2.1^2)", dx[i], expectedDx);
       }
       // Clean the ADS
@@ -360,7 +360,7 @@ public:
       auto& dx = outWS->dataDx(0);
       double expectedDx = sqrt(xError1*xError1 + xError2*xError2);
       for (size_t spectra = 0; spectra < outWS->getNumberHistograms(); ++spectra) {
-        for (size_t i = 0; i < nBins; ++i) {
+        for (size_t i = 0; i < static_cast<size_t>(nBins); ++i) {
           TSM_ASSERT_EQUALS("Should be sqrt(1.1^2 + 2.1^2)", dx[i], expectedDx);
         }
       }

--- a/Code/Mantid/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -366,7 +366,7 @@ public:
 
       auto& dx = outWS->dataDx(0);
       double expectedDx = sqrt(xError1*xError1 + xError2*xError2);
-      for (size_t i = 0; i < size; ++i) {
+      for (size_t i = 0; i < static_cast<size_t>(size); ++i) {
         TSM_ASSERT_EQUALS("Should be sqrt(1.1^2 + 2.1^2)", dx[i], expectedDx);
       }
       // Clean the ADS
@@ -412,7 +412,7 @@ public:
       auto& dx = outWS->dataDx(0);
       double expectedDx = sqrt(xError1*xError1 + xError2*xError2);
       for (size_t spectra = 0; spectra < outWS->getNumberHistograms(); ++spectra) {
-        for (size_t i = 0; i < nBins; ++i) {
+        for (size_t i = 0; i < static_cast<size_t>(nBins); ++i) {
           TSM_ASSERT_EQUALS("Should be sqrt(1.1^2 + 2.1^2)", dx[i], expectedDx);
         }
       }

--- a/Code/Mantid/Framework/Algorithms/test/PlusMinusTest.in.h
+++ b/Code/Mantid/Framework/Algorithms/test/PlusMinusTest.in.h
@@ -25,7 +25,7 @@ using namespace Mantid::DataObjects;
 /*****************************************************************************************/
 /********** PLEASE NOTE! CMAKE IS BEING USED TO CREATE AUTO-GENERATED CODE. **************/
 /********** Source = PlusMinusTest.h.in => edit here *************************************/
-/********** Targets = PlusTest.h, MinusTest.h ********************************************/
+/********** Targets = PlusTest.h, MinusTest.h => don't edit ******************************/
 /*****************************************************************************************/
 
 class @PLUSMINUSTEST_CLASS@ : public CxxTest::TestSuite

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -91,7 +91,14 @@ Mantid::DataObjects::Workspace2D_sptr Create1DWorkspaceRand(int size);
 Mantid::DataObjects::Workspace2D_sptr
 Create1DWorkspaceConstant(int size, double value, double error);
 Mantid::DataObjects::Workspace2D_sptr Create1DWorkspaceFib(int size);
+Mantid::DataObjects::Workspace2D_sptr
+Create1DWorkspaceConstantWithXerror(int size, double value, double error,
+                                    double xError);
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace(int nHist, int nBins);
+Mantid::DataObjects::Workspace2D_sptr Create2DWorkspaceWithValuesAndXerror(
+    int64_t nHist, int64_t nBins, bool isHist, double xVal, double yVal,
+    double eVal, double dxVal,
+    const std::set<int64_t> &maskedWorkspaceIndices = std::set<int64_t>());
 Mantid::DataObjects::Workspace2D_sptr
 Create2DWorkspaceWhereYIsWorkspaceIndex(int nhist, int numBoundaries);
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace123(

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -103,6 +103,15 @@ Workspace2D_sptr Create1DWorkspaceFib(int size) {
   return retVal;
 }
 
+Workspace2D_sptr Create1DWorkspaceConstantWithXerror(int size, double value, double error, double xError) {
+  auto ws = Create1DWorkspaceConstant(size, value, error);
+  MantidVecPtr dx1;
+  dx1.access().resize(size, xError);
+  ws->setDx(0,dx1);
+  return ws;
+}
+
+
 Workspace2D_sptr Create2DWorkspace(int nhist, int numBoundaries) {
   return Create2DWorkspaceBinned(nhist, numBoundaries);
 }
@@ -153,6 +162,18 @@ Create2DWorkspaceWithValues(int64_t nHist, int64_t nBins, bool isHist,
   }
   retVal = maskSpectra(retVal, maskedWorkspaceIndices);
   return retVal;
+}
+
+Workspace2D_sptr Create2DWorkspaceWithValuesAndXerror(int64_t nHist, int64_t nBins, bool isHist, double xVal, double yVal,
+    double eVal, double dxVal,
+    const std::set<int64_t> &maskedWorkspaceIndices) {
+  auto ws = Create2DWorkspaceWithValues(nHist, nBins, isHist, maskedWorkspaceIndices, xVal, yVal, eVal);
+  MantidVecPtr dx1;
+  dx1.access().resize(isHist ? nBins + 1 : nBins, dxVal);
+  for (int i = 0; i < nHist; i++) {
+    ws->setDx(i, dx1);
+  }
+  return ws;
 }
 
 Workspace2D_sptr


### PR DESCRIPTION
Fixes #13524

**Context**

The binary operations did not respect x errors, but rather stripped them. For the SANS reduction with x errors we need to multiply and add a scalar value to the workspace (all in python).
In this ticket we extend the functionality for Multiply and Plus algorithms to handle X errors. 

Other binary algorithms (Multiply, Divide, PoissonErrors, WieghtedMean) will not respect x errors (in fact it is not clear how to handle them with these algorithms. If one of these algorithms is called with workspaces containing x errors, a warning is issued, but the data is processed in the old style.
# For testing

**Test**

Run the following script. Compare the outputs and make sure that only Plus and Mutliply respect DX values. For the other algorihtms check that a warning has been issued.

``` python
import math
# DATA FOR DX
dataX = [1,2,3,4,5,6]
dataY1 = [1.,1.,1.,1.,1.]
dataY2 = [2.,2.,2.,2.,2.]
dataE1 = [3.,3.,3.,3.,3.]
dataE2 = [4.,4.,4.,4.,4.]
ws_dx = CreateWorkspace(dataX, dataY1, dataE1, UnitX="MomentumTransfer")
ws_dx2 = CreateWorkspace(dataX, dataY2, dataE2, UnitX="MomentumTransfer")

# Set the DX values
dataDX1 = [5.,5.,5.,5.,5., 5.]
dx = ws_dx.dataDx(0)
for index in range(0, len(dataDX1)):
    dx[index] = dataDX1[index]

# Set the DX values
dataDX2 = [6.,6.,6.,6.,6., 6.]
dx2 = ws_dx2.dataDx(0)
for index in range(0, len(dataDX2)):
    dx2[index] = dataDX2[index]


# DATA FOR NO_DX
dataX_no_Dx = [1,2,3,4,5,6]
dataY1_no_Dx = [1.,1.,1.,1.,1.]
dataY2_no_Dx = [2.,2.,2.,2.,2.]
dataE1_no_Dx = [3.,3.,3.,3.,3.]
dataE2_no_Dx = [4.,4.,4.,4.,4.]
ws_no_Dx = CreateWorkspace(dataX_no_Dx, dataY1_no_Dx, dataE1_no_Dx, UnitX="MomentumTransfer")
ws_no_Dx2 = CreateWorkspace(dataX_no_Dx, dataY2_no_Dx, dataE2_no_Dx, UnitX="MomentumTransfer")


# PLUS
print "====== START  CHECKING PLUS FOR SINGLE SPECTRUM"
ws_new = Plus(ws_dx, ws_dx2)
ws_new_no_Dx = Plus(ws_no_Dx, ws_no_Dx2)
print "Output with Dx:"
print "Are there any DX values: " + str(ws_new.hasDx(0))
added_errors =  ws_new.dataDx(0)
print "Expecting %f for each entry" %(math.sqrt(5*5 + 6*6))
print "Entries are" + str(added_errors)
print
print "Output without Dx:"
print "Are there any DX values: " + str(ws_new_no_Dx.hasDx(0))
print 
print "Test DX scalar addition:"
a = 5
ws_new_scalar_add = ws_dx2+a
print "Added Workspace has DX values: " + str(ws_new_scalar_add.hasDx(0))
print "Expecting %f and have %f" % (ws_dx2.readDx(0)[0], ws_new_scalar_add.readDx(0)[0]) # A scalar value should not be added to DX
print "====== STOP  CHECKING PLUS FOR SINGLE SPECTRUM"
print


# Multiply
print "====== START  CHECKING MULTIPLY FOR SINGLE SPECTRUM"
ws_new = Multiply(ws_dx, ws_dx2)
ws_new_no_Dx = Multiply(ws_no_Dx, ws_no_Dx2)
print "Output with Dx:"
print "Are there any DX values: " + str(ws_new.hasDx(0))
added_errors =  ws_new.dataDx(0)
print "Expecting %f for each entry" %(math.sqrt(5*5 + 6*6))
print "Entries are" + str(added_errors)
print
print "Output without Dx:"
print "Are there any DX values: " + str(ws_new_no_Dx.hasDx(0))
print
print "Test DX scalar multiplication:"
a = 5
ws_new_scalar_add = ws_dx2*a
print "Added Workspace has DX values: " + str(ws_new_scalar_add.hasDx(0))
print "Expecting %f and have %f" % (ws_dx2.readDx(0)[0], ws_new_scalar_add.readDx(0)[0]) # A scalar value should not be multiplied to DX
print "====== STOP  CHECKING MULTIPLY FOR SINGLE SPECTRUM"
print

# Minus
print "====== START  CHECKING MINUS FOR SINGLE SPECTRUM"
ws_new = Minus(ws_dx, ws_dx2)
ws_new_no_Dx = Minus(ws_no_Dx, ws_no_Dx2)
print "Output with Dx:"
print "Are there any DX values: " + str(ws_new.hasDx(0))
print
print "Output without Dx:"
print "Are there any DX values: " + str(ws_new_no_Dx.hasDx(0))
print "====== STOP  CHECKING MINUS FOR SINGLE SPECTRUM"
print

# DIVIDE
print "====== START  CHECKING DIVIDE FOR SINGLE SPECTRUM"
ws_new = Divide(ws_dx, ws_dx2)
ws_new_no_Dx = Divide(ws_no_Dx, ws_no_Dx2)
print "Output with Dx:"
print "Are there any DX values: " + str(ws_new.hasDx(0))
print
print "Output without Dx:"
print "Are there any DX values: " + str(ws_new_no_Dx.hasDx(0))
print "====== STOP  CHECKING DIVIDE FOR SINGLE SPECTRUM"
print


# POISONERRORS
print "====== START  CHECKING POISSONERRORS FOR SINGLE SPECTRUM"
ws_new = PoissonErrors(ws_dx, ws_dx2)
ws_new_no_Dx = PoissonErrors(ws_no_Dx, ws_no_Dx2)
print "Output with Dx:"
print "Are there any DX values: " + str(ws_new.hasDx(0))
print
print "Output without Dx:"
print "Are there any DX values: " + str(ws_new_no_Dx.hasDx(0))
print "====== STOP  CHECKING POISSONERRORS FOR SINGLE SPECTRUM"
print

# WEIGHTEDMEAN
print "====== START  CHECKING WEIGHTEDMEAN FOR SINGLE SPECTRUM"
ws_new = WeightedMean(ws_dx, ws_dx2)
ws_new_no_Dx = WeightedMean(ws_no_Dx, ws_no_Dx2)
print "Output with Dx:"
print "Are there any DX values: " + str(ws_new.hasDx(0))
print
print "Output without Dx:"
print "Are there any DX values: " + str(ws_new_no_Dx.hasDx(0))
print "====== STOP  CHECKING WEIGHTEDMEAN FOR SINGLE SPECTRUM"
print
```
