### PR TITLE
Fixing crash in CorrectHe3Tube efficiency algorithm.

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/He3TubeEfficiency.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/He3TubeEfficiency.h
@@ -79,7 +79,7 @@ private:
   /// Correct the given spectra index for efficiency
   void correctForEfficiency(std::size_t spectraIndex);
   /// Sets the detector geometry cache if necessary
-  void getDetectorGeometry(boost::shared_ptr<const Geometry::IDetector> det,
+  void getDetectorGeometry(const boost::shared_ptr<const Geometry::IDetector> &det,
                            double &detRadius, Kernel::V3D &detAxis);
   /// Computes the distance to the given shape from a starting point
   double distToSurface(const Kernel::V3D start,

--- a/Code/Mantid/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -243,12 +243,13 @@ double He3TubeEfficiency::calculateExponential(
  * @param detAxis :: An output parameter that contains the detector axis vector
  */
 void He3TubeEfficiency::getDetectorGeometry(
-    boost::shared_ptr<const Geometry::IDetector> det, double &detRadius,
+    const boost::shared_ptr<const Geometry::IDetector> &det, double &detRadius,
     Kernel::V3D &detAxis) {
   boost::shared_ptr<const Geometry::Object> shape_sptr = det->shape();
   if(!shape_sptr){
     throw std::runtime_error("Detector geometry error: detector with id: "+boost::lexical_cast<std::string>(det->getID())+
-                            " does not have shape");
+                            " does not have shape. Is this a detectors group?\n"
+                            "The algorithm works for instruments with one-to-one spectra-to-detector maps only!");
   }
   std::map<const Geometry::Object *,
            std::pair<double, Kernel::V3D>>::const_iterator it =

--- a/Code/Mantid/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -246,6 +246,10 @@ void He3TubeEfficiency::getDetectorGeometry(
     boost::shared_ptr<const Geometry::IDetector> det, double &detRadius,
     Kernel::V3D &detAxis) {
   boost::shared_ptr<const Geometry::Object> shape_sptr = det->shape();
+  if(!shape_sptr){
+    throw std::runtime_error("Detector geometry error: detector with id: "+boost::lexical_cast<std::string>(det->getID())+
+                            " does not have shape");
+  }
   std::map<const Geometry::Object *,
            std::pair<double, Kernel::V3D>>::const_iterator it =
       this->shapeCache.find(shape_sptr.get());


### PR DESCRIPTION
This fixes #10918 (https://github.com/mantidproject/mantid/issues/10918). The fix and the check are really simple -- try to run script, provided with the ticket - Mantid crashes, when after the fix it refuses to work with ISIS workspaces generating meaningful (I hope) error message.

There is a desire to make the algorithm working  for ISIS workspaces, but the solution would be non-trivial, as proper solution needs calculating a path length within a detector group (or defining shape of a detectors group) and current solution does this for single detector and (seems) for special detector's orientations only. 

If such solution is indeed required, a separate ticket should be created and it would requests much more then a one day job. 
