### PR TITLE
Crash in ConvetTo MD

### DIFF
--- a/Code/Mantid/Framework/Kernel/src/Matrix.cpp
+++ b/Code/Mantid/Framework/Kernel/src/Matrix.cpp
@@ -1103,7 +1103,7 @@ void Matrix<T>::lubcmp(int *rowperm, int &interchange)
   Find biggest pivot and move to top row. Then
   divide by pivot.
   @param interchange :: odd/even nterchange (+/-1)
-  @param rowperm :: row permuations [nx values]
+  @param rowperm :: row permutations [nx values]
 */
 {
   double sum, dum, big, temp;
@@ -1122,6 +1122,9 @@ void Matrix<T>::lubcmp(int *rowperm, int &interchange)
 
     if (big == 0.0) {
       delete[] vv;
+      for (int j=0;j<static_cast<int>(nx); j++){
+        rowperm[j] = j;
+      }
       return;
     }
     vv[i] = 1.0 / big;

--- a/Code/Mantid/Framework/MDAlgorithms/src/MDTransfNoQ.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/MDTransfNoQ.cpp
@@ -67,11 +67,13 @@ void MDTransfNoQ::initialize(const MDWSDescription &ConvParams) {
 */
 bool MDTransfNoQ::calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) {
   if (m_YAxis) {
+    Coord[1] = (coord_t)(m_YAxis->operator()(i));
     if (Coord[1] < m_DimMin[1] || Coord[1] >= m_DimMax[1])
       return false;
-    Coord[1] = (coord_t)(m_YAxis->operator()(i));
+    else
+      return true;
   }
-  return true;
+  return false;
 }
 bool MDTransfNoQ::calcMatrixCoord(const double &X, std::vector<coord_t> &Coord,
                                   double & /*s*/, double & /*errSq*/) const {


### PR DESCRIPTION
should fix #13061 

See the ticket -- the check is very simple -- take the data from ftp site, referred in the ticket and run the script provided in the ticket -- this  crashes Mantid. After the fix Mantid does not crash any more. The script is actually incorrect so ConvertToMD refuse to do anything -- this is correct behaviour
