### PR TITLE
 Add dx to scale alg

### DIFF
--- a/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/Scale.h
+++ b/Code/Mantid/Framework/Algorithms/inc/MantidAlgorithms/Scale.h
@@ -72,6 +72,8 @@ private:
   void init();
   /// Execution code
   void exec();
+
+
 };
 
 } // namespace Algorithms

--- a/Code/Mantid/Framework/Algorithms/test/ScaleTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ScaleTest.h
@@ -82,6 +82,14 @@ public:
     AnalysisDataService::Instance().remove("added");
   }
 
+  void test_multiply_with_dx_values() {
+
+  }
+
+  void test_add_with_dx_values() {
+
+  }
+
 private:
   void testScaleFactorApplied(const Mantid::API::MatrixWorkspace_const_sptr & inputWS,
                               const Mantid::API::MatrixWorkspace_const_sptr & outputWS,

--- a/Code/Mantid/Framework/Algorithms/test/ScaleTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/ScaleTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 #include "MantidAlgorithms/Scale.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidAPI/FrameworkManager.h"
 
 using Mantid::MantidVec;
 
@@ -83,11 +84,22 @@ public:
   }
 
   void test_multiply_with_dx_values() {
+    bool outputWorkspaceIsInputWorkspace = false;
+    doTestScaleWithDx("Multiply", outputWorkspaceIsInputWorkspace);
+  }
 
+  void test_multiply_with_dx_values_with_out_is_in() {
+    bool outputWorkspaceIsInputWorkspace = true;
+    doTestScaleWithDx("Multiply", outputWorkspaceIsInputWorkspace);
   }
 
   void test_add_with_dx_values() {
-
+    bool outputWorkspaceIsInputWorkspace = false;
+    doTestScaleWithDx("Add", outputWorkspaceIsInputWorkspace);
+  }
+  void test_add_with_dx_values_with_out_is_in() {
+    bool outputWorkspaceIsInputWorkspace = true;
+    doTestScaleWithDx("Add", outputWorkspaceIsInputWorkspace);
   }
 
 private:
@@ -109,7 +121,53 @@ private:
     }
   }
 
+  void doTestScaleWithDx(std::string type, bool outIsIn = false) {
+      // Arrange
+      const double xValue = 1.222;
+      const double value = 5;
+      const double error = 1.5;
+      const double xError = 1.1;
+      int64_t nHist = 4;
+      int64_t nBins = 10; 
+      bool isHist = true;
+      std::string wsName = "input_scaling";
+      Mantid::API::AnalysisDataService::Instance().add(wsName,WorkspaceCreationHelper::Create2DWorkspaceWithValuesAndXerror(nHist, nBins, isHist, xValue, value, error, xError));
+      std::string outWorkspaceName;
+      if (outIsIn) {
+        outWorkspaceName = wsName;
+      } else {
+        outWorkspaceName = "dx_error_workspace_test";
+      }
 
+      // Act
+      auto algScale = Mantid::API::FrameworkManager::Instance().createAlgorithm("Scale");
+      algScale->initialize();
+      algScale->setRethrows(true);
+      algScale->setPropertyValue("InputWorkspace", wsName);
+      algScale->setPropertyValue("OutputWorkspace", outWorkspaceName);
+      algScale->setProperty("Operation",type);
+      algScale->setProperty("Factor", "10");
+      algScale->execute();
+
+      // Assert
+      TS_ASSERT(algScale->isExecuted());
+      auto outWS = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>(outWorkspaceName);
+      TS_ASSERT(outWS.get());
+      TSM_ASSERT("Output should contain x errors", outWS->hasDx(0));
+
+      auto& dx = outWS->dataDx(0);
+      double expectedDx = xError;
+      for (size_t spectra = 0; spectra < outWS->getNumberHistograms(); ++spectra) {
+        for (size_t i = 0; i < static_cast<size_t>(nBins); ++i) {
+          TSM_ASSERT_EQUALS("X Error should be 5", dx[i], expectedDx);
+        }
+      }
+      // Clean the ADS
+      if (!outIsIn) {
+        Mantid::API::AnalysisDataService::Instance().remove(outWorkspaceName);
+      }
+      Mantid::API::AnalysisDataService::Instance().remove(wsName);
+  }
   Mantid::Algorithms::Scale scale;
 };
 

--- a/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Code/Mantid/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -91,6 +91,9 @@ Mantid::DataObjects::Workspace2D_sptr Create1DWorkspaceRand(int size);
 Mantid::DataObjects::Workspace2D_sptr
 Create1DWorkspaceConstant(int size, double value, double error);
 Mantid::DataObjects::Workspace2D_sptr Create1DWorkspaceFib(int size);
+Mantid::DataObjects::Workspace2D_sptr
+Create1DWorkspaceConstantWithXerror(int size, double value, double error,
+                                    double xError);
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace(int nHist, int nBins);
 Mantid::DataObjects::Workspace2D_sptr
 Create2DWorkspaceWhereYIsWorkspaceIndex(int nhist, int numBoundaries);
@@ -99,6 +102,10 @@ Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace123(
     const std::set<int64_t> &maskedWorkspaceIndices = std::set<int64_t>());
 Mantid::DataObjects::Workspace2D_sptr Create2DWorkspace154(
     int64_t nHist, int64_t nBins, bool isHist = false,
+    const std::set<int64_t> &maskedWorkspaceIndices = std::set<int64_t>());
+Mantid::DataObjects::Workspace2D_sptr Create2DWorkspaceWithValuesAndXerror(
+    int64_t nHist, int64_t nBins, bool isHist, double xVal, double yVal,
+    double eVal, double dxVal,
     const std::set<int64_t> &maskedWorkspaceIndices = std::set<int64_t>());
 Mantid::DataObjects::Workspace2D_sptr
 maskSpectra(Mantid::DataObjects::Workspace2D_sptr workspace,

--- a/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Code/Mantid/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -90,6 +90,16 @@ Workspace2D_sptr Create1DWorkspaceConstant(int size, double value,
   return retVal;
 }
 
+Workspace2D_sptr Create1DWorkspaceConstantWithXerror(int size, double value,
+                                                     double error,
+                                                     double xError) {
+  auto ws = Create1DWorkspaceConstant(size, value, error);
+  MantidVecPtr dx1;
+  dx1.access().resize(size, xError);
+  ws->setDx(0, dx1);
+  return ws;
+}
+
 Workspace2D_sptr Create1DWorkspaceFib(int size) {
   MantidVecPtr x1, y1, e1;
   x1.access().resize(size, 1);
@@ -106,6 +116,7 @@ Workspace2D_sptr Create1DWorkspaceFib(int size) {
 Workspace2D_sptr Create2DWorkspace(int nhist, int numBoundaries) {
   return Create2DWorkspaceBinned(nhist, numBoundaries);
 }
+
 
 /** Create a Workspace2D where the Y value at each bin is
  * == to the workspace index
@@ -153,6 +164,21 @@ Create2DWorkspaceWithValues(int64_t nHist, int64_t nBins, bool isHist,
   }
   retVal = maskSpectra(retVal, maskedWorkspaceIndices);
   return retVal;
+}
+
+
+Workspace2D_sptr Create2DWorkspaceWithValuesAndXerror(
+    int64_t nHist, int64_t nBins, bool isHist, double xVal, double yVal,
+    double eVal, double dxVal,
+    const std::set<int64_t> &maskedWorkspaceIndices) {
+  auto ws = Create2DWorkspaceWithValues(
+      nHist, nBins, isHist, maskedWorkspaceIndices, xVal, yVal, eVal);
+  MantidVecPtr dx1;
+  dx1.access().resize(isHist ? nBins + 1 : nBins, dxVal);
+  for (int i = 0; i < nHist; i++) {
+    ws->setDx(i, dx1);
+  }
+  return ws;
 }
 
 Workspace2D_sptr


### PR DESCRIPTION
Fixes #13557 
### For testing:

Requires code review

Run the following script and confirm that the outputs are correct. Note that this case and the other cases( i.e. Add/Multiply + InPlace/NotInPlace) are covered in the unit tests.

``` python
# DATA FOR DX
dataX1 = [1,2,3,4,5,6]
dataY1 = [1.,1.,1.,1.,1.]
dataE1 = [3.,3.,3.,3.,3.]
ws_dx1 = CreateWorkspace(dataX1, dataY1, dataE1, UnitX="MomentumTransfer")

# Set the DX values
dataDX1 = [5.,5.,5.,5.,5., 5.]
dx1 = ws_dx1.dataDx(0)
for index in range(0, len(dataDX1)):
    dx1[index] = dataDX1[index]

out = Scale(ws_dx1,12, "Multiply")
print "The output has Dx values :" + str(out.hasDx(0))
print "The outputs are expected to have the value %d and they have %d" %(dataDX1[0], out.readDx(0)[0])
```
