### PR TITLE
Add Python NeXus bindings to debian package list 

### DIFF
--- a/Code/Mantid/CMakeLists.txt
+++ b/Code/Mantid/CMakeLists.txt
@@ -281,7 +281,7 @@ if ( ENABLE_CPACK )
                            "libboost-python${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}.${Boost_SUBMINOR_VERSION},"
                            "libnexus0 (>= 4.3),libgsl0ldbl,libqtcore4 (>= 4.2),libqtgui4 (>= 4.2),libqt4-opengl (>= 4.2),"
                            "libqt4-xml (>= 4.2),libqt4-svg (>= 4.2),libqt4-qt3support (>= 4.2),qt4-dev-tools,"
-                           "libqwt5-qt4,libqwtplot3d-qt4-0,python-numpy,python-sip,python-qt4,libjsoncpp0" )
+                           "libqwt5-qt4,libqwtplot3d-qt4-0,python-numpy,python-sip,python-qt4,python-nxs (>= 4.3),libjsoncpp0" )
         set ( PERFTOOLS_DEB_PACKAGE "libgoogle-perftools0 (>= 1.7)" )
         if( "${UNIX_CODENAME}" MATCHES "lucid" )
           list ( APPEND DEPENDS_LIST ",libqscintilla2-5,"


### PR DESCRIPTION
Fixes #13277

**Tester**
Download the package built by the pull request and check that installing it pulls down `python-nxs`.

You may have to remove the package on your machine first:

``` sh
apt-get purge python-nxs
gdebi package.deb # this should reinstall `python-nxs`
```
