### PR TITLE
Add Input for OutputWorkspace to GetNegMuMuonicXRDDialog

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/GetNegMuMuonicXRD.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/GetNegMuMuonicXRD.py
@@ -55,8 +55,7 @@ class GetNegMuMuonicXRD(PythonAlgorithm):
             curr_workspace = self.create_muonic_xr_ws(element, y_position)
             workspace_list[idx] = curr_workspace
 
-        muonic_xr_group = GroupWorkspaces(workspace_list)
-        self.setProperty('OutputWorkspace', muonic_xr_group)
-        self.log().information(str("Created Group: "+muonic_xr_group.name()))
+        self.setProperty("OutputWorkspace", GroupWorkspaces(workspace_list))
+        self.log().information(str("Created Group: "+ self.getPropertyValue("OutputWorkspace")))
 
 AlgorithmFactory.subscribe(GetNegMuMuonicXRD)

--- a/Code/Mantid/MantidQt/CustomDialogs/inc/MantidQtCustomDialogs/GetNegMuMuonicXRDDialog.h
+++ b/Code/Mantid/MantidQt/CustomDialogs/inc/MantidQtCustomDialogs/GetNegMuMuonicXRDDialog.h
@@ -45,7 +45,8 @@ class GetNegMuMuonicXRDDialog : public API::AlgorithmDialog {
   PeriodicTableWidget *periodicTable;
   /// QLineEdit used for input of y-position property
   QLineEdit *yPosition;
-
+  /// QLineEdit used for input of GroupWorkspaceSpace
+  QLineEdit *groupWorkspaceNameInput;
   //Check box for showing or hiding the Legend for PeriodicTableWidget
   QCheckBox *showLegendCheck;
   /// Validate that the input is not empty before running algorithm
@@ -63,7 +64,6 @@ class GetNegMuMuonicXRDDialog : public API::AlgorithmDialog {
   protected:
   // create the initial layout
   void initLayout();
-
   signals:
   /// signal emitted when validateDialogInput passes
   void validInput();

--- a/Code/Mantid/MantidQt/CustomDialogs/src/GetNegMuMuonicXRDDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomDialogs/src/GetNegMuMuonicXRDDialog.cpp
@@ -30,7 +30,10 @@ void GetNegMuMuonicXRDDialog::initLayout() {
 
   // assign yPosition member to a new QLineEdit
   yPosition = new QLineEdit();
-
+  //assign GroupWorkspaceName member to a new QLineEdit
+  groupWorkspaceNameInput = new QLineEdit();
+  auto *groupWsInputLabel = new QLabel("OutputWorkspace");
+  groupWorkspaceNameInput->setMaximumWidth(250);
   // Disable all buttons on the periodicTable
   // as we only have a select few that need to be
   // enabled.
@@ -75,6 +78,8 @@ void GetNegMuMuonicXRDDialog::initLayout() {
   main_layout->addWidget(showLegendCheck);
   main_layout->addWidget(yPositionLabel);
   main_layout->addWidget(yPosition);
+  main_layout->addWidget(groupWsInputLabel);
+  main_layout->addWidget(groupWorkspaceNameInput);
   main_layout->addWidget(runButton);
 }
 
@@ -142,6 +147,9 @@ void GetNegMuMuonicXRDDialog::runClicked() {
       // used as default value for yPosition property if the user does not input
       // one.
       storePropertyValue("YAxisPosition", yPosition->placeholderText());
+    }
+    if (validateDialogInput(groupWorkspaceNameInput->text())){
+        storePropertyValue("OutputWorkspace", groupWorkspaceNameInput->text());
     }
     emit validInput();
   }


### PR DESCRIPTION
Fixes #13562 

In a previous fix #13262 the option for the user to input a name for the output workspace was added.
This option was not updated in the GUI and therefore the GUI reported the invalid input.

There is now an input field for the OutputWorkspace name and the algorithm runs fine locally, with unit tests unaffected by the changes.

To Test:
- Execute algorithm 'GetNegMuMuonicXRD' in mantid
- Choose any enabled elements from PeriodicTable
- Enter a value for y-position and OutputWorkspace
- click the run button to execute the algorithm.

You should find that a Grouped workspace is produced with the same name as the value entered for OutputWorkspace.
