### PR TITLE
EventList assignment fix

### DIFF
--- a/Code/Mantid/Framework/DataObjects/src/EventList.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/EventList.cpp
@@ -289,6 +289,7 @@ void EventList::createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
  * @return reference to this
  * */
 EventList &EventList::operator=(const EventList &rhs) {
+  IEventList::operator=(rhs);
   // Copy all data from the rhs.
   this->events.assign(rhs.events.begin(), rhs.events.end());
   this->weightedEvents.assign(rhs.weightedEvents.begin(),
@@ -296,10 +297,7 @@ EventList &EventList::operator=(const EventList &rhs) {
   this->weightedEventsNoTime.assign(rhs.weightedEventsNoTime.begin(),
                                     rhs.weightedEventsNoTime.end());
   this->eventType = rhs.eventType;
-  this->refX = rhs.refX;
   this->order = rhs.order;
-  // Copy the detector ID set
-  this->detectorIDs = rhs.detectorIDs;
   return *this;
 }
 

--- a/Code/Mantid/Framework/DataObjects/src/EventList.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/EventList.cpp
@@ -290,14 +290,11 @@ void EventList::createFromHistogram(const ISpectrum *inSpec, bool GenerateZeros,
  * */
 EventList &EventList::operator=(const EventList &rhs) {
   IEventList::operator=(rhs);
-  // Copy all data from the rhs.
-  this->events.assign(rhs.events.begin(), rhs.events.end());
-  this->weightedEvents.assign(rhs.weightedEvents.begin(),
-                              rhs.weightedEvents.end());
-  this->weightedEventsNoTime.assign(rhs.weightedEventsNoTime.begin(),
-                                    rhs.weightedEventsNoTime.end());
-  this->eventType = rhs.eventType;
-  this->order = rhs.order;
+  events = rhs.events;
+  weightedEvents = rhs.weightedEvents;
+  weightedEventsNoTime = rhs.weightedEventsNoTime;
+  eventType = rhs.eventType;
+  order = rhs.order;
   return *this;
 }
 

--- a/Code/Mantid/Framework/DataObjects/test/EventListTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/EventListTest.h
@@ -76,7 +76,10 @@ public:
   void test_AssignmentOperator() {
     // Modify EventList such that is does not contain default values.
     el.setSpectrumNo(42);
-    MantidVec x = {0.1, 0.2, 0.3};
+    MantidVec x;
+    x.push_back(0.1);
+    x.push_back(0.2);
+    x.push_back(0.3);
     el.setX(x);
     el.setDx(x);
 

--- a/Code/Mantid/Framework/DataObjects/test/EventListTest.h
+++ b/Code/Mantid/Framework/DataObjects/test/EventListTest.h
@@ -73,6 +73,24 @@ public:
     TS_ASSERT_EQUALS(rel[2].tof(), 50);
   }
 
+  void test_AssignmentOperator() {
+    // Modify EventList such that is does not contain default values.
+    el.setSpectrumNo(42);
+    MantidVec x = {0.1, 0.2, 0.3};
+    el.setX(x);
+    el.setDx(x);
+
+    EventList other;
+    other = el;
+
+    TS_ASSERT_EQUALS(other, el);
+    // operator== does not compare everything, so we do some extra comparisons
+    TS_ASSERT_EQUALS(other.getSpectrumNo(), el.getSpectrumNo());
+    TS_ASSERT_EQUALS(other.getDetectorIDs(), el.getDetectorIDs());
+    TS_ASSERT_EQUALS(other.readX(), el.readX());
+    TS_ASSERT_EQUALS(other.readDx(), el.readDx());
+  }
+
   //==================================================================================
   //--- Plus Operators  ----
   //==================================================================================


### PR DESCRIPTION
Fixes #13559.

Added unit test for operator= that exposed the bug. Completed `EventList::operator=` by calling the base class assignment operator `IEventList::operator=`.
