### PR TITLE
Silence beam centre warning

### DIFF
--- a/Code/Mantid/scripts/SANS/isis_instrument.py
+++ b/Code/Mantid/scripts/SANS/isis_instrument.py
@@ -429,18 +429,16 @@ class ISISInstrument(BaseInstrument):
            #logger.warning("Failed to find centre-finder-step-size2")
             self.cen_find_step2 = self.cen_find_step
 
-        logger.warning("Trying to find beam-centre-scale-factor1")
         try:
             self.beam_centre_scale_factor1 = float(self.definition.getNumberParameter('beam-centre-scale-factor1')[0])
         except:
-            logger.warning("Failed to find beam-centre-scale-factor1")
+            logger.information("Setting beam-centre-scale-factor1 to default (1000).")
             self.beam_centre_scale_factor1 = 1000.0
 
-        logger.warning("Trying to find beam-centre-scale-factor2")
         try:
             self.beam_centre_scale_factor2 = float(self.definition.getNumberParameter('beam-centre-scale-factor2')[0])
         except:
-            logger.warning("Failed to find beam-centre-scale-factor2")
+            logger.information("Setting beam-centre-scale-factor1 to default (1000).")
             self.beam_centre_scale_factor2 = 1000.0
 
         firstDetect = DetectorBank(self.definition, 'low-angle')


### PR DESCRIPTION
Fixes #13569 

Load any user file (against the correct instrument) and confirm that the warnings

```
Trying to find beam-centre-scale-factor1
Failed to find beam-centre-scale-factor1
Trying to find beam-centre-scale-factor2
Failed to find beam-centre-scale-factor2
```

are gone
