### PR TITLE
Load NOMAD exp.ini

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/PDLoadCharacterizations.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/PDLoadCharacterizations.h
@@ -50,6 +50,7 @@ private:
   void exec();
   void readFocusInfo(std::ifstream &file);
   void readCharInfo(std::ifstream &file, API::ITableWorkspace_sptr &wksp);
+  void readExpIni(const std::string &filename, API::ITableWorkspace_sptr &wksp);
 };
 
 } // namespace DataHandling

--- a/Code/Mantid/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -18,10 +18,15 @@ namespace DataHandling {
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(PDLoadCharacterizations)
 
+namespace {
 /// key for a instrument parameter file being listed
 static const std::string IPARM_KEY("Instrument parameter file:");
 static const std::string L1_KEY("L1");
 static const std::string ZERO("0.");
+static const std::string EXP_INI_VAN_KEY("Vana");
+static const std::string EXP_INI_EMPTY_KEY("VanaBg");
+static const std::string EXP_INI_CAN_KEY("MTc");
+}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor
@@ -55,6 +60,9 @@ void PDLoadCharacterizations::init() {
   exts.push_back(".txt");
   declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
                   "Characterizations file");
+  declareProperty(
+      new FileProperty("ExpIniFilename", "", FileProperty::OptionalLoad, "ini"),
+      "(Optional) exp.ini file used at NOMAD");
 
   declareProperty(new WorkspaceProperty<ITableWorkspace>("OutputWorkspace", "",
                                                          Direction::Output),
@@ -118,6 +126,13 @@ void PDLoadCharacterizations::exec() {
   wksp->addColumn("double", "tof_min");
   wksp->addColumn("double", "tof_max");
   this->readCharInfo(file, wksp);
+
+  // optional exp.ini file for NOMAD
+  std::string iniFilename = this->getProperty("ExpIniFilename");
+  if (!iniFilename.empty()) {
+    this->readExpIni(iniFilename, wksp);
+  }
+
   this->setProperty("OutputWorkspace", wksp);
 }
 
@@ -215,6 +230,50 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
     row << splitted[7];                               // d_max
     row << boost::lexical_cast<double>(splitted[8]);  // tof_min
     row << boost::lexical_cast<double>(splitted[9]);  // tof_max
+  }
+}
+
+/**
+ * Parse the (optional) exp.ini file found on NOMAD
+ * @param filename full path to a exp.ini file
+ * @param wksp The table workspace to modify.
+ */
+void PDLoadCharacterizations::readExpIni(const std::string &filename,
+                                         API::ITableWorkspace_sptr &wksp) {
+  if (wksp->rowCount() == 0)
+    throw std::runtime_error("Characterizations file does not have any "
+                             "characterizations information");
+
+  std::ifstream file(filename.c_str());
+  if (!file) {
+    throw Exception::FileError("Unable to open file", filename);
+  }
+
+  // parse the file
+  for (std::string line = Strings::getLine(file); !file.eof();
+       line = Strings::getLine(file)) {
+    line = Strings::strip(line);
+    // skip empty lines and "comments"
+    if (line.empty())
+      continue;
+    if (line.substr(0, 1) == "#")
+      continue;
+
+    // split the line and see if it has something meaningful
+    std::vector<std::string> splitted;
+    boost::split(splitted, line, boost::is_any_of("\t "),
+                 boost::token_compress_on);
+    if (splitted.size() < 2)
+      continue;
+
+    // update the various charaterization runs
+    if (splitted[0] == EXP_INI_VAN_KEY) {
+      wksp->getRef<std::string>("vanadium", 0) = splitted[1];
+    } else if (splitted[0] == EXP_INI_EMPTY_KEY) {
+      wksp->getRef<std::string>("container", 0) = splitted[1];
+    } else if (splitted[0] == EXP_INI_CAN_KEY) {
+      wksp->getRef<std::string>("empty", 0) = splitted[1];
+    }
   }
 }
 

--- a/Code/Mantid/Framework/DataHandling/test/PDLoadCharacterizationsTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/PDLoadCharacterizationsTest.h
@@ -11,18 +11,19 @@ using Mantid::API::ITableWorkspace;
 using Mantid::API::ITableWorkspace_sptr;
 
 using Mantid::DataHandling::PDLoadCharacterizations;
-class PDLoadCharacterizationsTest : public CxxTest::TestSuite
-{
+class PDLoadCharacterizationsTest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
-  static PDLoadCharacterizationsTest *createSuite() { return new PDLoadCharacterizationsTest(); }
-  static void destroySuite( PDLoadCharacterizationsTest *suite ) { delete suite; }
+  static PDLoadCharacterizationsTest *createSuite() {
+    return new PDLoadCharacterizationsTest();
+  }
+  static void destroySuite(PDLoadCharacterizationsTest *suite) { delete suite; }
 
-  void runAlg(PDLoadCharacterizations &alg, ITableWorkspace_sptr &wksp, const std::string &filename)
-  {
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() );
-    TS_ASSERT( alg.isInitialized() );
+  void runAlg(PDLoadCharacterizations &alg, ITableWorkspace_sptr &wksp,
+              const std::string &filename) {
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
 
     // run the algorithm
     alg.setProperty("Filename", filename);
@@ -31,15 +32,15 @@ public:
     TS_ASSERT(alg.isExecuted());
 
     // test the table workspace
-    wksp = boost::dynamic_pointer_cast<Mantid::API::ITableWorkspace>
-        (Mantid::API::AnalysisDataService::Instance().retrieve(filename));
+    wksp = boost::dynamic_pointer_cast<Mantid::API::ITableWorkspace>(
+        Mantid::API::AnalysisDataService::Instance().retrieve(filename));
     TS_ASSERT(wksp);
   }
 
   // checks the focus positions for NOMAD
-  void checkNOMAD(PDLoadCharacterizations &alg)
-  {
-    TS_ASSERT_EQUALS(alg.getPropertyValue("IParmFilename"), std::string("NOMAD_11_22_11.prm"));
+  void checkNOMAD(PDLoadCharacterizations &alg) {
+    TS_ASSERT_EQUALS(alg.getPropertyValue("IParmFilename"),
+                     std::string("NOMAD_11_22_11.prm"));
     double l1 = alg.getProperty("PrimaryFlightPath");
     TS_ASSERT_EQUALS(l1, 19.5);
 
@@ -47,24 +48,21 @@ public:
 
     std::vector<int32_t> specIds = alg.getProperty("SpectrumIDs");
     TS_ASSERT_EQUALS(specIds.size(), NUM_SPEC);
-    if (!specIds.empty())
-    {
+    if (!specIds.empty()) {
       for (int i = 0; i < NUM_SPEC; ++i)
-        TS_ASSERT_EQUALS(specIds[i], i+1);
+        TS_ASSERT_EQUALS(specIds[i], i + 1);
     }
 
     std::vector<double> l2 = alg.getProperty("L2");
     TS_ASSERT_EQUALS(l2.size(), NUM_SPEC);
-    if (!l2.empty())
-    {
+    if (!l2.empty()) {
       for (int i = 0; i < NUM_SPEC; ++i)
         TS_ASSERT_EQUALS(l2[i], 2.);
     }
 
     std::vector<double> polar = alg.getProperty("Polar");
     TS_ASSERT_EQUALS(polar.size(), NUM_SPEC);
-    if (!polar.empty())
-    {
+    if (!polar.empty()) {
       TS_ASSERT_EQUALS(polar[0], 15.);
       TS_ASSERT_EQUALS(polar[1], 31.);
       TS_ASSERT_EQUALS(polar[2], 67.);
@@ -75,52 +73,48 @@ public:
 
     std::vector<double> azi = alg.getProperty("Azimuthal");
     TS_ASSERT_EQUALS(azi.size(), NUM_SPEC);
-    if (!azi.empty())
-    {
+    if (!azi.empty()) {
       for (int i = 0; i < NUM_SPEC; ++i)
         TS_ASSERT_EQUALS(azi[0], 0.);
     }
   }
 
-  void checkPG3(ITableWorkspace_sptr &wksp)
-  {
+  void checkPG3(ITableWorkspace_sptr &wksp) {
     TS_ASSERT_EQUALS(wksp->columnCount(), 10);
     TS_ASSERT_EQUALS(wksp->rowCount(), 6);
 
     // check all of the contents of row 0
-    TS_ASSERT_EQUALS(wksp->Double(0,0), 60.);
-    TS_ASSERT_EQUALS(wksp->Double(0,1), 0.900);
-    TS_ASSERT_EQUALS(wksp->Int(0,2), 1);
-    TS_ASSERT_EQUALS(wksp->String(0,3), "15030");
-    TS_ASSERT_EQUALS(wksp->String(0,4), "15039");
-    TS_ASSERT_EQUALS(wksp->String(0,5), "0");
-    TS_ASSERT_EQUALS(wksp->String(0,6), "0.20");
-    TS_ASSERT_EQUALS(wksp->String(0,7), "4.12");
-    TS_ASSERT_EQUALS(wksp->Double(0,8), 4700.);
-    TS_ASSERT_EQUALS(wksp->Double(0,9), 21200.);
+    TS_ASSERT_EQUALS(wksp->Double(0, 0), 60.);
+    TS_ASSERT_EQUALS(wksp->Double(0, 1), 0.900);
+    TS_ASSERT_EQUALS(wksp->Int(0, 2), 1);
+    TS_ASSERT_EQUALS(wksp->String(0, 3), "15030");
+    TS_ASSERT_EQUALS(wksp->String(0, 4), "15039");
+    TS_ASSERT_EQUALS(wksp->String(0, 5), "0");
+    TS_ASSERT_EQUALS(wksp->String(0, 6), "0.20");
+    TS_ASSERT_EQUALS(wksp->String(0, 7), "4.12");
+    TS_ASSERT_EQUALS(wksp->Double(0, 8), 4700.);
+    TS_ASSERT_EQUALS(wksp->Double(0, 9), 21200.);
 
     // check all of the contents of row 5
-    TS_ASSERT_EQUALS(wksp->Double(5,0), 10.);
-    TS_ASSERT_EQUALS(wksp->Double(5,1), 3.198);
-    TS_ASSERT_EQUALS(wksp->Int(5,2), 1);
-    TS_ASSERT_EQUALS(wksp->String(5,3), "15033");
-    TS_ASSERT_EQUALS(wksp->String(5,4), "15042");
-    TS_ASSERT_EQUALS(wksp->String(5,5), "0");
-    TS_ASSERT_EQUALS(wksp->String(5,6), "0.05");
-    TS_ASSERT_EQUALS(wksp->String(5,7), "15.40");
-    TS_ASSERT_EQUALS(wksp->Double(5,8), 0.);
-    TS_ASSERT_EQUALS(wksp->Double(5,9), 100000.);
+    TS_ASSERT_EQUALS(wksp->Double(5, 0), 10.);
+    TS_ASSERT_EQUALS(wksp->Double(5, 1), 3.198);
+    TS_ASSERT_EQUALS(wksp->Int(5, 2), 1);
+    TS_ASSERT_EQUALS(wksp->String(5, 3), "15033");
+    TS_ASSERT_EQUALS(wksp->String(5, 4), "15042");
+    TS_ASSERT_EQUALS(wksp->String(5, 5), "0");
+    TS_ASSERT_EQUALS(wksp->String(5, 6), "0.05");
+    TS_ASSERT_EQUALS(wksp->String(5, 7), "15.40");
+    TS_ASSERT_EQUALS(wksp->Double(5, 8), 0.);
+    TS_ASSERT_EQUALS(wksp->Double(5, 9), 100000.);
   }
 
-  void test_Init()
-  {
+  void test_Init() {
     PDLoadCharacterizations alg;
-    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
-    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
   }
 
-  void test_FocusAndChar()
-  {
+  void test_FocusAndChar() {
     const std::string CHAR_FILE("Test_characterizations_focus_and_char.txt");
     ITableWorkspace_sptr wksp;
 
@@ -132,7 +126,8 @@ public:
     checkPG3(wksp);
 
     // test the other output properties
-    TS_ASSERT_EQUALS(alg.getPropertyValue("IParmFilename"), std::string("dummy.iparm"));
+    TS_ASSERT_EQUALS(alg.getPropertyValue("IParmFilename"),
+                     std::string("dummy.iparm"));
     double l1 = alg.getProperty("PrimaryFlightPath");
     TS_ASSERT_EQUALS(l1, 60.);
 
@@ -157,8 +152,7 @@ public:
       TS_ASSERT_EQUALS(azi[0], 0.);
   }
 
-  void test_FocusAndChar2()
-  {
+  void test_FocusAndChar2() {
     const std::string CHAR_FILE("Test_characterizations_focus_and_char2.txt");
     ITableWorkspace_sptr wksp;
 
@@ -171,23 +165,22 @@ public:
     TS_ASSERT_EQUALS(wksp->rowCount(), 1);
 
     // check all of the contents of row 0
-    TS_ASSERT_EQUALS(wksp->Double(0,0), 60.);
-    TS_ASSERT_EQUALS(wksp->Double(0,1), 1.4);
-    TS_ASSERT_EQUALS(wksp->Int(0,2), 1);
-    TS_ASSERT_EQUALS(wksp->String(0,3), "0");
-    TS_ASSERT_EQUALS(wksp->String(0,4), "0");
-    TS_ASSERT_EQUALS(wksp->String(0,5), "0");
-    TS_ASSERT_EQUALS(wksp->String(0,6), ".31,.25,.13,.13,.13,.42");
-    TS_ASSERT_EQUALS(wksp->String(0,7), "13.66,5.83,3.93,2.09,1.57,31.42");
-    TS_ASSERT_EQUALS(wksp->Double(0,8), 300.00);
-    TS_ASSERT_EQUALS(wksp->Double(0,9), 16666.67);
+    TS_ASSERT_EQUALS(wksp->Double(0, 0), 60.);
+    TS_ASSERT_EQUALS(wksp->Double(0, 1), 1.4);
+    TS_ASSERT_EQUALS(wksp->Int(0, 2), 1);
+    TS_ASSERT_EQUALS(wksp->String(0, 3), "0");
+    TS_ASSERT_EQUALS(wksp->String(0, 4), "0");
+    TS_ASSERT_EQUALS(wksp->String(0, 5), "0");
+    TS_ASSERT_EQUALS(wksp->String(0, 6), ".31,.25,.13,.13,.13,.42");
+    TS_ASSERT_EQUALS(wksp->String(0, 7), "13.66,5.83,3.93,2.09,1.57,31.42");
+    TS_ASSERT_EQUALS(wksp->Double(0, 8), 300.00);
+    TS_ASSERT_EQUALS(wksp->Double(0, 9), 16666.67);
 
     // test the other output properties
     checkNOMAD(alg);
   }
 
-  void test_Focus()
-  {
+  void test_Focus() {
     const std::string CHAR_FILE("Test_characterizations_focus.txt");
     ITableWorkspace_sptr wksp;
 
@@ -203,8 +196,7 @@ public:
     checkNOMAD(alg);
   }
 
-  void test_Char()
-  {
+  void test_Char() {
     const std::string CHAR_FILE("Test_characterizations_char.txt");
     ITableWorkspace_sptr wksp;
 
@@ -277,6 +269,5 @@ public:
     TS_ASSERT(!alg.isExecuted());
   }
 };
-
 
 #endif /* MANTID_DATAHANDLING_LOADPDCHARACTERIZATIONSTEST_H_ */

--- a/Code/Mantid/Framework/DataHandling/test/PDLoadCharacterizationsTest.h
+++ b/Code/Mantid/Framework/DataHandling/test/PDLoadCharacterizationsTest.h
@@ -232,6 +232,50 @@ public:
     std::vector<double> azi = alg.getProperty("Azimuthal");
     TS_ASSERT_EQUALS(azi.size(), 0);
   }
+
+  void test_ExpIni() {
+    // this file doesn't have enough information
+    const std::string CHAR_FILE("Test_characterizations_focus_and_char2.txt");
+    const std::string WKSP_NAME("test_ExpIni");
+
+    // initialize and run the algorithm
+    PDLoadCharacterizations alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    alg.setProperty("Filename", CHAR_FILE);
+    alg.setPropertyValue("ExpIniFilename", "NOMAD_exp.ini");
+    alg.setPropertyValue("OutputWorkspace", WKSP_NAME);
+    TS_ASSERT(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    // test the table workspace
+    ITableWorkspace_sptr wksp;
+    wksp = boost::dynamic_pointer_cast<Mantid::API::ITableWorkspace>(
+        Mantid::API::AnalysisDataService::Instance().retrieve(WKSP_NAME));
+    TS_ASSERT(wksp);
+
+    TS_ASSERT_EQUALS(wksp->rowCount(), 1);
+    TS_ASSERT_EQUALS(wksp->String(0, 3), "49258"); // vanadium
+    TS_ASSERT_EQUALS(wksp->String(0, 4), "49086"); // container
+    TS_ASSERT_EQUALS(wksp->String(0, 5), "49257"); // empty
+  }
+
+  void test_ExpIni_failing() {
+    // this file doesn't have enough information
+    const std::string CHAR_FILE("Test_characterizations_focus.txt");
+    const std::string WKSP_NAME("test_ExpIni_failing");
+
+    // initialize and run the algorithm
+    PDLoadCharacterizations alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    alg.setProperty("Filename", CHAR_FILE);
+    alg.setPropertyValue("ExpIniFilename", "NOMAD_exp.ini");
+    alg.setPropertyValue("OutputWorkspace", WKSP_NAME);
+    alg.setRethrows(true); // so the exception can be seen by testing
+    TS_ASSERT_THROWS(alg.execute(), std::runtime_error);
+    TS_ASSERT(!alg.isExecuted());
+  }
 };
 
 

--- a/Code/Mantid/Testing/Data/UnitTest/NOMAD_exp.ini.md5
+++ b/Code/Mantid/Testing/Data/UnitTest/NOMAD_exp.ini.md5
@@ -1,0 +1,1 @@
+a0c3bce344c8fdbe62b3797fb1f930b7

--- a/Code/Mantid/docs/source/algorithms/PDLoadCharacterizations-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/PDLoadCharacterizations-v1.rst
@@ -10,9 +10,9 @@ Description
 -----------
 
 This algorithm loads information into a
-`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ for the 
-characterization information and a collection of output parameters for 
-the focus positions to be used in :ref:`algm-EditInstrumentGeometry`. If 
+`TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ for the
+characterization information and a collection of output parameters for
+the focus positions to be used in :ref:`algm-EditInstrumentGeometry`. If
 a section is missing then those parameters will be empty. This includes an empty
 table (zero rows) if that information is missing. The resulting TableWorkspace
 is intented to be used by :ref:`algm-PDDetermineCharacterizations`
@@ -23,7 +23,7 @@ This algorithm is one of the workflow algorithms that helps
 Characterization File
 #####################
 
-An example from POWGEN shows both of the available portions of a 
+An example from POWGEN shows both of the available portions of a
 characterization file::
 
   Instrument parameter file:
@@ -41,15 +41,17 @@ characterization file::
 
 The first line ``Instrument parameter file:`` must be present to mark the
 beginning of the first section. Whatever string appears after the semicolon
-is copied into the ``IParmFilename`` output property. The following lines 
+is copied into the ``IParmFilename`` output property. The following lines
 are of the form "bank l2 polar" with the last line being the keyword ``L1``
-followed by the effective primary flight path. This information is saved 
-in the ``IParmFilename``, ``SpectrumIDs``, ``L2``, ``Polar``, and 
+followed by the effective primary flight path. This information is saved
+in the ``IParmFilename``, ``SpectrumIDs``, ``L2``, ``Polar``, and
 ``PrimaryFlightPath`` properties. The ``Azimuthal`` properties is filled with zeros
 and is the same length as ``SpectrumIDs``, ``L2``, ``Polar``, and ``PrimaryFlightPath``.
 
 The second section of the characterizations file is read into the output
 `TableWorkspace <http://www.mantidproject.org/TableWorkspace>`__ as described below.
+
+The :literal:`exp.ini` file is specific to the NOMAD instrument at SNS and is optional.
 
 Characterization TableWorkspace
 ###############################


### PR DESCRIPTION
`autoNOM` is partially driveen by the contents of a file named `exp.ini`. Load this into the characterizations workspace to get the information into mantid more easily.

This is mentioned in the release notes [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_5_Diffraction&diff=25124&oldid=25107).
