### PR TITLE
Removed PeakCentre from the dropdown list for lorentzians

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1512,6 +1512,9 @@ void ConvFit::updatePlotOptions() {
   } else {
     params = getFunctionParameters(QString("One Lorentzian"));
   }
+  if (fitFunctionType < 3 && fitFunctionType != 0) {
+    params.removeAll("PeakCentre");
+  }
   if (fitFunctionType != 0) {
     plotOptions.append(params);
   }


### PR DESCRIPTION
Fixes #13503

The PeakCentre option should now be removed form the drop down list of possible plot options in the bottom left corner for the Lorentzian fit types
# To Test:
- Open the ConvFit Tab (Interfaces > Indirect > DataAnalysis > ConvFit)
- Select a One Lorentzian fit from the FitType drop down menu
- Ensure that the following options are present in the Plot Options drop down menu:
  - None
  - Amplitude
  - FWHM
  - All
- Ensure that PeakCentre does **NOT** feature in the list
- Repeat this for FitType option Two Lorentzians 
  - The options should be the same as One Lorentzian 
