### PR TITLE
Preserve Fit Parameters of 1L to 2L in Convfit

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -72,6 +72,7 @@ private:
   Mantid::API::IAlgorithm_sptr m_singleFitAlg;
   QString m_singleFitOutputName;
   QStringList m_fitStrings;
+  QString m_previousFit;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -208,6 +208,8 @@ void ConvFit::setup() {
           SLOT(showTieCheckbox(QString)));
   showTieCheckbox(m_uiForm.cbFitType->currentText());
 
+  m_previousFit = m_uiForm.cbFitType->currentText();
+
   updatePlotOptions();
 }
 
@@ -1408,6 +1410,16 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
  * @param functionName Name of new fit function
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
+  double oneLValues[3] = {0.0, 0.0, 0.0};
+  std::string p = m_previousFit.toStdString();
+  std::string c =  m_uiForm.cbFitType->currentText().toStdString();
+  if (m_previousFit.compare("One Lorentzian") == 0 &&
+      m_uiForm.cbFitType->currentText().compare("Two Lorentzians") == 0) {
+		  oneLValues[0] = m_dblManager->value(m_properties["Lorentzian 1.Amplitude"]);
+		  oneLValues[1] = m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
+		  oneLValues[2] = m_dblManager->value(m_properties["Lorentzian 1.FWHM"]);
+  }
+
   // remove previous parameters from tree
   m_cfTree->removeProperty(m_properties["FitFunction1"]);
   m_cfTree->removeProperty(m_properties["FitFunction2"]);
@@ -1420,7 +1432,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
   QStringList parameters = getFunctionParameters(functionName);
   updatePlotOptions();
 
-  // Two Loremtzians Fit
+  // Two Lorentzians Fit
   if (fitFunctionIndex == 2) {
     m_properties["FitFunction1"] = m_grpManager->addProperty("Lorentzian 1");
     m_cfTree->addProperty(m_properties["FitFunction1"]);
@@ -1447,12 +1459,11 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
 
         if (QString(*it).compare("FWHM") == 0) {
           m_dblManager->setValue(m_properties[name], 0.0175);
+        } else if (QString(*it).compare("Amplitude") == 0 ||
+                   QString(*it).compare("Intensity") == 0) {
+          m_dblManager->setValue(m_properties[name], 1.0);
         } else {
           m_dblManager->setValue(m_properties[name], 0.0);
-        }
-        if (QString(*it).compare("Amplitude") == 0 ||
-            QString(*it).compare("Intensity") == 0) {
-          m_dblManager->setValue(m_properties[name], 1.0);
         }
 
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
@@ -1475,12 +1486,11 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
 
         if (QString(*it).compare("FWHM") == 0) {
           m_dblManager->setValue(m_properties[name], 0.0175);
+        } else if (QString(*it).compare("Amplitude") == 0 ||
+                   QString(*it).compare("Intensity") == 0) {
+          m_dblManager->setValue(m_properties[name], 1.0);
         } else {
           m_dblManager->setValue(m_properties[name], 0.0);
-        }
-        if (QString(*it).compare("Amplitude") == 0 ||
-            QString(*it).compare("Intensity") == 0) {
-          m_dblManager->setValue(m_properties[name], 1.0);
         }
 
         m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
@@ -1488,6 +1498,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
       }
     }
   }
+  m_previousFit = m_uiForm.cbFitType->currentText();
 }
 
 /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -495,7 +495,8 @@ std::string createParName(size_t index, size_t subIndex,
  *					+- Temperature Correction(yes/no)
  *				+- ProductFunction
  *					|
- *					+- InelasticDiffRotDiscreteCircle(yes/no)
+ *					+-
+ *InelasticDiffRotDiscreteCircle(yes/no)
  *					+- Temperature Correction(yes/no)
  *
  * @param tieCentres :: whether to tie centres of the two lorentzians.
@@ -1412,12 +1413,15 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
 void ConvFit::fitFunctionSelected(const QString &functionName) {
   double oneLValues[3] = {0.0, 0.0, 0.0};
   std::string p = m_previousFit.toStdString();
-  std::string c =  m_uiForm.cbFitType->currentText().toStdString();
+  std::string c = m_uiForm.cbFitType->currentText().toStdString();
+  bool previouslyOneL = false;
   if (m_previousFit.compare("One Lorentzian") == 0 &&
       m_uiForm.cbFitType->currentText().compare("Two Lorentzians") == 0) {
-		  oneLValues[0] = m_dblManager->value(m_properties["Lorentzian 1.Amplitude"]);
-		  oneLValues[1] = m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
-		  oneLValues[2] = m_dblManager->value(m_properties["Lorentzian 1.FWHM"]);
+    previouslyOneL = true;
+    oneLValues[0] = m_dblManager->value(m_properties["Lorentzian 1.Amplitude"]);
+    oneLValues[1] =
+        m_dblManager->value(m_properties["Lorentzian 1.PeakCentre"]);
+    oneLValues[2] = m_dblManager->value(m_properties["Lorentzian 1.FWHM"]);
   }
 
   // remove previous parameters from tree
@@ -1458,10 +1462,23 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[name] = m_dblManager->addProperty(*it);
 
         if (QString(*it).compare("FWHM") == 0) {
-          m_dblManager->setValue(m_properties[name], 0.0175);
-        } else if (QString(*it).compare("Amplitude") == 0 ||
-                   QString(*it).compare("Intensity") == 0) {
-          m_dblManager->setValue(m_properties[name], 1.0);
+          if (previouslyOneL) {
+            m_dblManager->setValue(m_properties[name], oneLValues[2]);
+          } else {
+            m_dblManager->setValue(m_properties[name], 0.0175);
+          }
+        } else if (QString(*it).compare("Amplitude") == 0) {
+          if (previouslyOneL) {
+            m_dblManager->setValue(m_properties[name], oneLValues[0]);
+          } else {
+            m_dblManager->setValue(m_properties[name], 1.0);
+          }
+        } else if (QString(*it).compare("PeakCentre") == 0) {
+          if (previouslyOneL) {
+            m_dblManager->setValue(m_properties[name], oneLValues[1]);
+          } else {
+            m_dblManager->setValue(m_properties[name], 1.0);
+          }
         } else {
           m_dblManager->setValue(m_properties[name], 0.0);
         }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1412,8 +1412,6 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
  */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
   double oneLValues[3] = {0.0, 0.0, 0.0};
-  std::string p = m_previousFit.toStdString();
-  std::string c = m_uiForm.cbFitType->currentText().toStdString();
   bool previouslyOneL = false;
   if (m_previousFit.compare("One Lorentzian") == 0 &&
       m_uiForm.cbFitType->currentText().compare("Two Lorentzians") == 0) {
@@ -1424,7 +1422,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
     oneLValues[2] = m_dblManager->value(m_properties["Lorentzian 1.FWHM"]);
   }
 
-  // remove previous parameters from tree
+  // Remove previous parameters from tree
   m_cfTree->removeProperty(m_properties["FitFunction1"]);
   m_cfTree->removeProperty(m_properties["FitFunction2"]);
 
@@ -1462,22 +1460,22 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[name] = m_dblManager->addProperty(*it);
 
         if (QString(*it).compare("FWHM") == 0) {
-          if (previouslyOneL) {
+          if (previouslyOneL && count < 3) {
             m_dblManager->setValue(m_properties[name], oneLValues[2]);
           } else {
             m_dblManager->setValue(m_properties[name], 0.0175);
           }
         } else if (QString(*it).compare("Amplitude") == 0) {
-          if (previouslyOneL) {
+          if (previouslyOneL && count < 3) {
             m_dblManager->setValue(m_properties[name], oneLValues[0]);
           } else {
             m_dblManager->setValue(m_properties[name], 1.0);
           }
         } else if (QString(*it).compare("PeakCentre") == 0) {
-          if (previouslyOneL) {
+          if (previouslyOneL && count < 3) {
             m_dblManager->setValue(m_properties[name], oneLValues[1]);
           } else {
-            m_dblManager->setValue(m_properties[name], 1.0);
+            m_dblManager->setValue(m_properties[name], 0.0);
           }
         } else {
           m_dblManager->setValue(m_properties[name], 0.0);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1512,6 +1512,9 @@ void ConvFit::updatePlotOptions() {
   } else {
     params = getFunctionParameters(QString("One Lorentzian"));
   }
+  if (fitFunctionType < 3 && fitFunctionType != 0) {
+    params.removeAll("PeakCentre");
+  }
   if (fitFunctionType != 0) {
     plotOptions.append(params);
   }


### PR DESCRIPTION
Fixes #13499

If single fit is run in ConvFit with the fit type being 1 lorentzian, when you change to 2 Lorentzians fit fit type, the values for the first lorentzian should now be preserved.
# Please Note

**Please ensure that #13503 is merged BEFORE this to avoid merge conflicts**
- [x] #13503 merged (PR - https://github.com/mantidproject/mantid/pull/13579)
# To Test
- Open the ConvFit tab (Interfaces > Indirect > Data Analysis > ConvFit)
- Load in suitable `Sample` and `Resolution` files
- Change the Fit Type to One Lorentzian
- Run the `Fit Single Spectrum`
  - Ensure values for Amplitude, PeakCentre and FWHM are updated in the tree
- Change the Fit type to Two Lorentzians
- Ensure that `Lorentzian 1` in the tree is populated by the data from the One Lorentzian fit
# Failure cases
- Ensure that data is not preserved from 2L -> 1L
- Ensure that no other other is preserved between fits 
  - This should only take place from 1L -> 2L
