### PR TITLE
Add container subtraction tab to indirect

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -231,7 +231,7 @@ set ( MOC_FILES inc/MantidQtCustomInterfaces/Background.h
                 inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h
                 inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.h
                 inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.h
-				inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+                inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
                 inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
                 inc/MantidQtCustomInterfaces/Indirect/CorrectionsTab.h
                 inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.h
@@ -316,7 +316,7 @@ set ( UI_FILES inc/MantidQtCustomInterfaces/DataComparison.ui
                inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
                inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
                inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.ui
-			   inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+               inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
                inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
                inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.ui
                inc/MantidQtCustomInterfaces/Indirect/Elwin.ui

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -9,6 +9,7 @@ set ( SRC_FILES
   src/Indirect/AbsorptionCorrections.cpp
   src/Indirect/ApplyPaalmanPings.cpp
   src/Indirect/CalculatePaalmanPings.cpp
+  src/Indirect/ContainerSubtraction.cpp
   src/Indirect/ConvFit.cpp
   src/Indirect/CorrectionsTab.cpp
   src/Indirect/DensityOfStates.cpp
@@ -114,6 +115,7 @@ set ( INC_FILES
   inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h
   inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.h
   inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.h
+  inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
   inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
   inc/MantidQtCustomInterfaces/Indirect/CorrectionsTab.h
   inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.h
@@ -229,6 +231,7 @@ set ( MOC_FILES inc/MantidQtCustomInterfaces/Background.h
                 inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h
                 inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.h
                 inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.h
+				inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
                 inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
                 inc/MantidQtCustomInterfaces/Indirect/CorrectionsTab.h
                 inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.h
@@ -313,6 +316,7 @@ set ( UI_FILES inc/MantidQtCustomInterfaces/DataComparison.ui
                inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
                inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
                inc/MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.ui
+			   inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
                inc/MantidQtCustomInterfaces/Indirect/ConvFit.ui
                inc/MantidQtCustomInterfaces/Indirect/DensityOfStates.ui
                inc/MantidQtCustomInterfaces/Indirect/Elwin.ui

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -13,8 +13,6 @@ public:
   ContainerSubtraction(QWidget *parent = 0);
 
 private slots:
-  /// Handles the geometry being changed
-  void handleGeometryChange(int index);
   /// Handles a new sample being loaded
   void newData(const QString &dataName);
   /// Updates the preview mini plot

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -1,0 +1,24 @@
+#ifndef MANTIDQTCUSTOMINTERFACESIDA_CONTAINERSUBTRACTION_H_
+#define MANTIDQTCUSTOMINTERFACESIDA_CONTAINERSUBTRACTION_H_
+
+#include "ui_ContainerSubtraction.h"
+#include "CorrectionsTab.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+class DLLExport ContainerSubtraction : public CorrectionsTab {
+  Q_OBJECT
+
+public:
+  ContainerSubtraction(QWidget *parent = 0);
+
+private slots:
+
+private:
+  Ui::ContainerSubtraction m_uiForm;
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif /* MANTIDQTCUSTOMINTERFACESIDA_CONTAINERSUBTRACTION_H_ */

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -15,6 +15,11 @@ public:
 private slots:
 
 private:
+  virtual void setup();
+  virtual void run();
+  virtual bool validate();
+  virtual void loadSettings(const QSettings &settings);
+
   Ui::ContainerSubtraction m_uiForm;
 };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -13,6 +13,16 @@ public:
   ContainerSubtraction(QWidget *parent = 0);
 
 private slots:
+  /// Handles the geometry being changed
+  void handleGeometryChange(int index);
+  /// Handles a new sample being loaded
+  void newData(const QString &dataName);
+  /// Updates the preview mini plot
+  void plotPreview(int specIndex);
+  /// Handle abs. correction algorithm completion
+  void absCorComplete(bool error);
+  /// Handle convert units and save algorithm completion
+  void postProcessComplete(bool error);
 
 private:
   virtual void setup();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -19,10 +19,11 @@ private slots:
   void newData(const QString &dataName);
   /// Updates the preview mini plot
   void plotPreview(int specIndex);
+
   /// Handle abs. correction algorithm completion
   //void absCorComplete(bool error);
   /// Handle convert units and save algorithm completion
-  //void postProcessComplete(bool error);
+  void postProcessComplete(bool error);
 
 private:
   virtual void setup();
@@ -30,7 +31,10 @@ private:
   virtual bool validate();
   virtual void loadSettings(const QSettings &settings);
 
+  void addRebinStep(QString toRebin, QString toMatch);
+
   Ui::ContainerSubtraction m_uiForm;
+  std::string m_originalSampleUnits;
 };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -20,9 +20,9 @@ private slots:
   /// Updates the preview mini plot
   void plotPreview(int specIndex);
   /// Handle abs. correction algorithm completion
-  void absCorComplete(bool error);
+  //void absCorComplete(bool error);
   /// Handle convert units and save algorithm completion
-  void postProcessComplete(bool error);
+  //void postProcessComplete(bool error);
 
 private:
   virtual void setup();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h
@@ -19,9 +19,8 @@ private slots:
   void newData(const QString &dataName);
   /// Updates the preview mini plot
   void plotPreview(int specIndex);
-
   /// Handle abs. correction algorithm completion
-  //void absCorComplete(bool error);
+  void absCorComplete(bool error);
   /// Handle convert units and save algorithm completion
   void postProcessComplete(bool error);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -111,33 +111,7 @@
             <string>Options</string>
           </property>
           <layout class="QGridLayout" name="gridLayout">
-            <item row="0" column="1">
-              <widget class="QComboBox" name="cbGeometry">
-                <item>
-                  <property name="text">
-                    <string>Flat Plate</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Cylinder</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Annulus</string>
-                  </property>
-                </item>
-              </widget>
-            </item>
             <item row="0" column="0">
-              <widget class="QLabel" name="lbGeometry">
-                <property name="text">
-                  <string>Geometry:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
               <widget class="QCheckBox" name="ckScaleCan">
                 <property name="text">
                   <string>Scale Can by factor:</string>
@@ -147,7 +121,7 @@
                 </property>
               </widget>
             </item>
-            <item row="1" column="1">
+            <item row="0" column="1">
               <layout class="QHBoxLayout" name="loScaleFactor">
                 <item>
                   <widget class="QDoubleSpinBox" name="spCanScale">

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -151,6 +151,9 @@
               <layout class="QHBoxLayout" name="loScaleFactor">
                 <item>
                   <widget class="QDoubleSpinBox" name="spCanScale">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
                     <property name="decimals">
                       <number>5</number>
                     </property>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -111,20 +111,6 @@
             <string>Options</string>
           </property>
           <layout class="QGridLayout" name="gridLayout">
-            <item row="1" column="0">
-              <widget class="QCheckBox" name="ckUseCan">
-                <property name="text">
-                  <string>Use Can:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="4" column="0">
-              <widget class="QCheckBox" name="ckUseCorrections">
-                <property name="text">
-                  <string>Use Corrections:</string>
-                </property>
-              </widget>
-            </item>
             <item row="0" column="1">
               <widget class="QComboBox" name="cbGeometry">
                 <item>
@@ -144,66 +130,6 @@
                 </item>
               </widget>
             </item>
-            <item row="4" column="1">
-              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCorrections" native="true">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="autoLoad" stdset="0">
-                  <bool>true</bool>
-                </property>
-                <property name="workspaceSuffixes" stdset="0">
-                  <stringlist>
-                    <string>_flt_abs</string>
-                  </stringlist>
-                </property>
-                <property name="fileBrowserSuffixes" stdset="0">
-                  <stringlist>
-                    <string>_flt_abs.nxs</string>
-                  </stringlist>
-                </property>
-                <property name="showLoad" stdset="0">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="autoLoad" stdset="0">
-                  <bool>true</bool>
-                </property>
-                <property name="workspaceSuffixes" stdset="0">
-                  <stringlist>
-                    <string>_red</string>
-                    <string>_sqw</string>
-                  </stringlist>
-                </property>
-                <property name="fileBrowserSuffixes" stdset="0">
-                  <stringlist>
-                    <string>_red.nxs</string>
-                    <string>_sqw.nxs</string>
-                  </stringlist>
-                </property>
-                <property name="showLoad" stdset="0">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
             <item row="0" column="0">
               <widget class="QLabel" name="lbGeometry">
                 <property name="text">
@@ -211,11 +137,8 @@
                 </property>
               </widget>
             </item>
-            <item row="3" column="0">
+            <item row="1" column="0">
               <widget class="QCheckBox" name="ckScaleCan">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
                 <property name="text">
                   <string>Scale Can by factor:</string>
                 </property>
@@ -224,13 +147,10 @@
                 </property>
               </widget>
             </item>
-            <item row="3" column="1">
+            <item row="1" column="1">
               <layout class="QHBoxLayout" name="loScaleFactor">
                 <item>
                   <widget class="QDoubleSpinBox" name="spCanScale">
-                    <property name="enabled">
-                      <bool>false</bool>
-                    </property>
                     <property name="decimals">
                       <number>5</number>
                     </property>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui version="4.0">
+ <class>ContainerSubtraction</class>
+  <widget class="QWidget" name="ContainerSubtraction">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>420</width>
+        <height>420</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Form</string>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+        <widget class="QGroupBox" name="gbInput">
+          <property name="title">
+            <string>Input</string>
+          </property>
+          <layout class="QVBoxLayout" name="abscor_loInput">
+            <item>
+              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="autoLoad" stdset="0">
+                  <bool>true</bool>
+                </property>
+                <property name="workspaceSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red</string>
+                    <string>_sqw</string>
+                  </stringlist>
+                </property>
+                <property name="fileBrowserSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red.nxs</string>
+                    <string>_sqw.nxs</string>
+                  </stringlist>
+                </property>
+                <property name="showLoad" stdset="0">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbOptions">
+          <property name="title">
+            <string>Options</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout">
+            <item row="1" column="0">
+              <widget class="QCheckBox" name="ckUseCan">
+                <property name="text">
+                  <string>Use Can:</string>
+                </property>
+              </widget>
+            </item>
+            <item row="4" column="0">
+              <widget class="QCheckBox" name="ckUseCorrections">
+                <property name="text">
+                  <string>Use Corrections:</string>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="1">
+              <widget class="QComboBox" name="cbGeometry">
+                <item>
+                  <property name="text">
+                    <string>Flat Plate</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Cylinder</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Annulus</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item row="4" column="1">
+              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCorrections" native="true">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="autoLoad" stdset="0">
+                  <bool>true</bool>
+                </property>
+                <property name="workspaceSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_flt_abs</string>
+                  </stringlist>
+                </property>
+                <property name="fileBrowserSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_flt_abs.nxs</string>
+                  </stringlist>
+                </property>
+                <property name="showLoad" stdset="0">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="1">
+              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="autoLoad" stdset="0">
+                  <bool>true</bool>
+                </property>
+                <property name="workspaceSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red</string>
+                    <string>_sqw</string>
+                  </stringlist>
+                </property>
+                <property name="fileBrowserSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red.nxs</string>
+                    <string>_sqw.nxs</string>
+                  </stringlist>
+                </property>
+                <property name="showLoad" stdset="0">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="0">
+              <widget class="QLabel" name="lbGeometry">
+                <property name="text">
+                  <string>Geometry:</string>
+                </property>
+              </widget>
+            </item>
+            <item row="3" column="0">
+              <widget class="QCheckBox" name="ckScaleCan">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="text">
+                  <string>Scale Can by factor:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="3" column="1">
+              <layout class="QHBoxLayout" name="loScaleFactor">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spCanScale">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.100000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>1.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>40</width>
+                        <height>20</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbPreview">
+          <property name="title">
+            <string>Preview</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+              <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
+                <property name="canvasColour" stdset="0">
+                  <color>
+                    <red>255</red>
+                    <green>255</green>
+                    <blue>255</blue>
+                  </color>
+                </property>
+                <property name="showLegend" stdset="0">
+                  <bool>true</bool>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <layout class="QVBoxLayout" name="loPlotOptions">
+                <item>
+                  <spacer name="verticalSpacer_0">
+                    <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>20</width>
+                        <height>40</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+                <item>
+                  <widget class="QLabel" name="lbPreviewSpec">
+                    <property name="text">
+                      <string>Spectrum:</string>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <widget class="QSpinBox" name="spPreviewSpec"/>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbOutput">
+          <property name="title">
+            <string>Output Options</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+              <widget class="QLabel" name="lbPlotOutput">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Plot Output:</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QComboBox" name="cbPlotOutput">
+                <item>
+                  <property name="text">
+                    <string>None</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Contour</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Spectra</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Both</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item>
+              <spacer name="horizontalSpacer_1">
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>40</width>
+                    <height>20</height>
+                  </size>
+                </property>
+              </spacer>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="ckSave">
+                <property name="text">
+                  <string>Save Result</string>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
+      </item>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::DataSelector</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/DataSelector.h</header>
+    </customwidget>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::PreviewPlot</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/PreviewPlot.h</header>
+      <container>1</container>
+    </customwidget>
+  </customwidgets>
+  <resources/>
+  <connections>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>ckScaleCan</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>50</x>
+          <y>111</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>61</x>
+          <y>142</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckScaleCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spCanScale</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>133</x>
+          <y>143</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>251</x>
+          <y>147</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsContainer</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>114</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>114</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCorrections</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsCorrections</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>167</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>167</y>
+        </hint>
+      </hints>
+    </connection>
+  </connections>
+</ui>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ContainerSubtraction</class>
+  <class>ContainerSubtraction</class>
   <widget class="QWidget" name="ContainerSubtraction">
     <property name="geometry">
       <rect>
@@ -15,38 +15,92 @@
     </property>
     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-        <widget class="QGroupBox" name="gbInput">
+        <widget class="QGroupBox" name="fileInput">
           <property name="title">
             <string>Input</string>
           </property>
-          <layout class="QVBoxLayout" name="abscor_loInput">
-            <item>
-              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+          <layout class="QGridLayout" name="gbTest">
+            <item row="0" column="0">
+              <widget class="QLabel" name="sampleLabel">
                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                   </sizepolicy>
                 </property>
-                <property name="autoLoad" stdset="0">
-                  <bool>true</bool>
-                </property>
-                <property name="workspaceSuffixes" stdset="0">
-                  <stringlist>
-                    <string>_red</string>
-                    <string>_sqw</string>
-                  </stringlist>
-                </property>
-                <property name="fileBrowserSuffixes" stdset="0">
-                  <stringlist>
-                    <string>_red.nxs</string>
-                    <string>_sqw.nxs</string>
-                  </stringlist>
-                </property>
-                <property name="showLoad" stdset="0">
-                  <bool>false</bool>
+                <property name="text">
+                  <string>Sample</string>
                 </property>
               </widget>
+            </item>
+            <item row="1" column="0">
+              <widget class="QLabel" name="containerLabel">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Container</string>
+                </property>
+              </widget> 
+            </item>
+            <item row="0" column="1">
+                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="autoLoad" stdset="0">
+                    <bool>true</bool>
+                  </property>
+                  <property name="workspaceSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red</string>
+                      <string>_sqw</string>
+                    </stringlist>
+                  </property>
+                  <property name="fileBrowserSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red.nxs</string>
+                      <string>_sqw.nxs</string>
+                    </stringlist>
+                  </property>
+                  <property name="showLoad" stdset="0">
+                    <bool>false</bool>
+                  </property>
+                </widget>
+            </item>
+            <item row="1" column="1">
+                <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="autoLoad" stdset="0">
+                    <bool>true</bool>
+                  </property>
+                  <property name="workspaceSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red</string>
+                      <string>_sqw</string>
+                    </stringlist>
+                  </property>
+                  <property name="fileBrowserSuffixes" stdset="0">
+                    <stringlist>
+                      <string>_red.nxs</string>
+                      <string>_sqw.nxs</string>
+                    </stringlist>
+                  </property>
+                  <property name="showLoad" stdset="0">
+                    <bool>false</bool>
+                  </property>
+                </widget>
             </item>
           </layout>
         </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.h
@@ -15,79 +15,79 @@ class DoubleEditorFactory;
 class QtCheckBoxFactory;
 class QtStringPropertyManager;
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  // The assumption is made elsewhere that the ordering of these enums matches the ordering of the
-  // tabs as they appear in the interface itself.
-  enum CorrectionTabChoice
-  {
-    CALC_CORR,
-    APPLY_CORR,
-    ABSORPTION_CORRECTIONS
-  };
+namespace MantidQt {
+namespace CustomInterfaces {
+// The assumption is made elsewhere that the ordering of these enums matches the
+// ordering of the
+// tabs as they appear in the interface itself.
+enum CorrectionTabChoice {
+  CALC_CORR,
+  APPLY_CORR,
+  ABSORPTION_CORRECTIONS,
+  CONTAINER_SUBTRACTION
+};
 
-  // Forward Declaration
-  class CorrectionsTab;
+// Forward Declaration
+class CorrectionsTab;
 
-  /**
-   * The IndirectCorrections class is the main class that handles the interface and controls
-   * its tabs.
-   *
-   * Is a friend to the CorrectionsTab class.
-   */
-  class IndirectCorrections : public MantidQt::API::UserSubWindow
-  {
-    Q_OBJECT
+/**
+ * The IndirectCorrections class is the main class that handles the interface
+ * and controls
+ * its tabs.
+ *
+ * Is a friend to the CorrectionsTab class.
+ */
+class IndirectCorrections : public MantidQt::API::UserSubWindow {
+  Q_OBJECT
 
-    /// Allow CorrectionsTab to have access.
-    friend class CorrectionsTab;
+  /// Allow CorrectionsTab to have access.
+  friend class CorrectionsTab;
 
-  public:
-    /// The name of the interface as registered into the factory
-    static std::string name() { return "Corrections"; }
-    // This interface's categories.
-    static QString categoryInfo() { return "Indirect"; }
-    /// Default Constructor
-    IndirectCorrections(QWidget *parent = 0);
+public:
+  /// The name of the interface as registered into the factory
+  static std::string name() { return "Corrections"; }
+  // This interface's categories.
+  static QString categoryInfo() { return "Indirect"; }
+  /// Default Constructor
+  IndirectCorrections(QWidget *parent = 0);
 
-  private:
-    /// Initialize the layout
-    virtual void initLayout();
-    /// Initialize Python-dependent sections
-    virtual void initLocalPython();
-    /// Load the settings of the interface (and child tabs).
-    void loadSettings();
+private:
+  /// Initialize the layout
+  virtual void initLayout();
+  /// Initialize Python-dependent sections
+  virtual void initLocalPython();
+  /// Load the settings of the interface (and child tabs).
+  void loadSettings();
 
-    /// Called upon a close event.
-    virtual void closeEvent(QCloseEvent*);
-    /// handle POCO event
-    void handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
+  /// Called upon a close event.
+  virtual void closeEvent(QCloseEvent *);
+  /// handle POCO event
+  void
+  handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
 
-  private slots:
-    /// Called when the user clicks the Py button
-    void exportTabPython();
-    /// Called when the Run button is pressed.  Runs current tab.
-    void run();
-    /// Opens a directory dialog.
-    void openDirectoryDialog();
-    /// Opens the Mantid Wiki web page of the current tab.
-    void help();
-    /// Slot showing a message box to the user
-    void showMessageBox(const QString& message);
+private slots:
+  /// Called when the user clicks the Py button
+  void exportTabPython();
+  /// Called when the Run button is pressed.  Runs current tab.
+  void run();
+  /// Opens a directory dialog.
+  void openDirectoryDialog();
+  /// Opens the Mantid Wiki web page of the current tab.
+  void help();
+  /// Slot showing a message box to the user
+  void showMessageBox(const QString &message);
 
-  private:
-    /// UI form containing all Qt elements.
-    Ui::IndirectCorrections m_uiForm;
+private:
+  /// UI form containing all Qt elements.
+  Ui::IndirectCorrections m_uiForm;
 
-    /// Change Observer for ConfigService (monitors user directories)
-    Poco::NObserver<IndirectCorrections, Mantid::Kernel::ConfigValChangeNotification> m_changeObserver;
+  /// Change Observer for ConfigService (monitors user directories)
+  Poco::NObserver<IndirectCorrections,
+                  Mantid::Kernel::ConfigValChangeNotification> m_changeObserver;
 
-    /// Map of unsigned int (TabChoice enum values) to tabs.
-    std::map<unsigned int, CorrectionsTab*> m_tabs;
-
-  };
+  /// Map of unsigned int (TabChoice enum values) to tabs.
+  std::map<unsigned int, CorrectionsTab *> m_tabs;
+};
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.ui
@@ -41,6 +41,11 @@
         <string>Absorption</string>
        </attribute>
       </widget>
+      <widget class="QWidget" name="tabContainerSubtraction">
+        <attribute name="title">
+          <string>Container Subtraction</string>
+        </attribute>
+      </widget>
      </widget>
     </item>
     <item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -87,12 +87,16 @@ void ContainerSubtraction::run() {
   }
 
   // Generate output workspace name
-  int nameCutIndex = sampleWsName.lastIndexOf("_");
-  if (nameCutIndex == -1)
-    nameCutIndex = sampleWsName.length();
+  QString containerWsName = m_uiForm.dsContainer->getCurrentDataName();
+  int sampleNameCutIndex = sampleWsName.lastIndexOf("_");
+  if (sampleNameCutIndex == -1)
+    sampleNameCutIndex = sampleWsName.length();
+  int containerNameCutIndex = containerWsName.indexOf("_");
+  if(containerNameCutIndex == -1)
+	  containerNameCutIndex = containerWsName.length();
 
   const QString outputWsName =
-      sampleWsName.left(nameCutIndex)+"_Corrected";
+      sampleWsName.left(sampleNameCutIndex)+"_Subtract_"+containerWsName.left(containerNameCutIndex);
 
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -1,0 +1,16 @@
+#include "MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h"
+
+using namespace Mantid::API;
+
+namespace {
+Mantid::Kernel::Logger g_log("ContainerSubtraction");
+}
+
+namespace MantidQt {
+namespace CustomInterfaces {
+ContainerSubtraction::ContainerSubtraction(QWidget *parent)
+    : CorrectionsTab(parent) {
+  m_uiForm.setupUi(parent);
+}
+}
+}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -18,7 +18,6 @@ void ContainerSubtraction::run() {}
 bool ContainerSubtraction::validate() { return false; }
 
 void ContainerSubtraction::loadSettings(const QSettings &settings) {
-  m_uiForm.dsCorrections->readSettings(settings.group());
   m_uiForm.dsContainer->readSettings(settings.group());
   m_uiForm.dsSample->readSettings(settings.group());
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -11,6 +11,17 @@ namespace CustomInterfaces {
 ContainerSubtraction::ContainerSubtraction(QWidget *parent)
     : CorrectionsTab(parent) {
   m_uiForm.setupUi(parent);
+
+  // Connect slots
+  connect(m_uiForm.cbGeometry, SIGNAL(currentIndexChanged(int)), this,
+          SLOT(handleGeometryChanged(int)));
+  connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
+          SLOT(newData(const QString &)));
+  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this,
+          SLOT(plotPreview(int)));
+
+  m_uiForm.spPreviewSpec->setMinimum(0);
+  m_uiForm.spPreviewSpec->setMaximum(0);
 }
 
 void ContainerSubtraction::setup() {}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -63,6 +63,12 @@ void ContainerSubtraction::run() {
     absCorProps["CanWorkspace"] = canWsName.toStdString();
   }
 
+  bool useCanScale = m_uiForm.ckScaleCan->isChecked();
+  if (useCanScale) {
+    double canScaleFactor = m_uiForm.spCanScale->value();
+    applyCorrAlg->setProperty("CanScaleFactor", canScaleFactor);
+  }
+
   // Check for same binning across sample and container
   if (!checkWorkspaceBinningMatches(sampleWs, canWs)) {
     QString text = "Binning on sample and container does not match."
@@ -135,7 +141,7 @@ void ContainerSubtraction::addRebinStep(QString toRebin, QString toMatch) {
   m_batchAlgoRunner->addAlgorithm(rebinAlg, rebinProps);
 }
 
-/** 
+/**
  * Validates the user input in the UI
  * @return if the input was valid
  */
@@ -293,7 +299,6 @@ void ContainerSubtraction::absCorComplete(bool error) {
           SLOT(postProcessComplete(bool)));
   m_batchAlgoRunner->executeBatchAsync();
 }
-
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -32,5 +32,75 @@ void ContainerSubtraction::loadSettings(const QSettings &settings) {
   m_uiForm.dsContainer->readSettings(settings.group());
   m_uiForm.dsSample->readSettings(settings.group());
 }
+
+
+/**
+ * Disables corrections when using S(Q, w) as input data.
+ *
+ * @param dataName Name of new data source
+ */
+void ContainerSubtraction::newData(const QString &dataName) {
+ const MatrixWorkspace_sptr sampleWs =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+          dataName.toStdString());
+  m_uiForm.spPreviewSpec->setMaximum(
+      static_cast<int>(sampleWs->getNumberHistograms()) - 1);
+
+  // Plot the sample curve
+  m_uiForm.ppPreview->clear();
+  m_uiForm.ppPreview->addSpectrum("Sample", sampleWs, 0, Qt::black);
+}
+
+
+/**
+ * Handles when the type of geometry changes
+ *
+ * Updates the file extension to search for
+ */
+void ContainerSubtraction::handleGeometryChange(int index) {
+  QString ext("");
+  switch (index) {
+  case 0:
+    // Geometry is flat
+    ext = "_flt_abs";
+    break;
+  case 1:
+    // Geometry is cylinder
+    ext = "_cyl_abs";
+    break;
+  case 2:
+    // Geometry is annulus
+    ext = "_ann_abs";
+    break;
+  }
+  /*m_uiForm.dsCorrections->setWSSuffixes(QStringList(ext));
+  m_uiForm.dsCorrections->setFBSuffixes(QStringList(ext + ".nxs"));*/
+}
+
+/**
+ * Replots the preview plot.
+ *
+ * @param specIndex Spectrum index to plot
+ */
+void ContainerSubtraction::plotPreview(int specIndex) {
+  //bool useCan = m_uiForm.ckUseCan->isChecked();
+
+  m_uiForm.ppPreview->clear();
+
+  // Plot sample
+  m_uiForm.ppPreview->addSpectrum(
+      "Sample", m_uiForm.dsSample->getCurrentDataName(), specIndex, Qt::black);
+
+  // Plot result
+  if (!m_pythonExportWsName.empty())
+    m_uiForm.ppPreview->addSpectrum(
+        "Corrected", QString::fromStdString(m_pythonExportWsName), specIndex,
+        Qt::green);
+
+  // Plot can
+ /* if (useCan)
+    m_uiForm.ppPreview->addSpectrum(
+        "Can", m_uiForm.dsContainer->getCurrentDataName(), specIndex, Qt::red);*/
+}
 }
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -92,11 +92,12 @@ void ContainerSubtraction::run() {
   if (sampleNameCutIndex == -1)
     sampleNameCutIndex = sampleWsName.length();
   int containerNameCutIndex = containerWsName.indexOf("_");
-  if(containerNameCutIndex == -1)
-	  containerNameCutIndex = containerWsName.length();
+  if (containerNameCutIndex == -1)
+    containerNameCutIndex = containerWsName.length();
 
-  const QString outputWsName =
-      sampleWsName.left(sampleNameCutIndex)+"_Subtract_"+containerWsName.left(containerNameCutIndex);
+  const QString outputWsName = sampleWsName.left(sampleNameCutIndex) +
+                               "_Subtract_" +
+                               containerWsName.left(containerNameCutIndex);
 
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 
@@ -203,7 +204,7 @@ void ContainerSubtraction::plotPreview(int specIndex) {
         "Subtracted", QString::fromStdString(m_pythonExportWsName), specIndex,
         Qt::green);
 
-  // Plot can
+  // Plot container
   m_uiForm.ppPreview->addSpectrum("Container",
                                   m_uiForm.dsContainer->getCurrentDataName(),
                                   specIndex, Qt::red);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -200,7 +200,7 @@ void ContainerSubtraction::plotPreview(int specIndex) {
   // Plot result
   if (!m_pythonExportWsName.empty())
     m_uiForm.ppPreview->addSpectrum(
-        "Corrected", QString::fromStdString(m_pythonExportWsName), specIndex,
+        "Subtracted", QString::fromStdString(m_pythonExportWsName), specIndex,
         Qt::green);
 
   // Plot can

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -12,5 +12,15 @@ ContainerSubtraction::ContainerSubtraction(QWidget *parent)
     : CorrectionsTab(parent) {
   m_uiForm.setupUi(parent);
 }
+
+void ContainerSubtraction::setup() {}
+void ContainerSubtraction::run() {}
+bool ContainerSubtraction::validate() { return false; }
+
+void ContainerSubtraction::loadSettings(const QSettings &settings) {
+  m_uiForm.dsCorrections->readSettings(settings.group());
+  m_uiForm.dsContainer->readSettings(settings.group());
+  m_uiForm.dsSample->readSettings(settings.group());
+}
 }
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -258,5 +258,42 @@ void ContainerSubtraction::postProcessComplete(bool error) {
     plot2D(QString::fromStdString(m_pythonExportWsName));
 }
 
+/**
+ * Handles completion of the abs. correction algorithm.
+ *
+ * @param error True if algorithm failed.
+ */
+void ContainerSubtraction::absCorComplete(bool error) {
+  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+             SLOT(absCorComplete(bool)));
+
+  if (error) {
+    emit showMessageBox(
+        "Unable to apply corrections.\nSee Results Log for more details.");
+    return;
+  }
+
+  // Convert back to original sample units
+  if (m_originalSampleUnits != "Wavelength") {
+    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        m_pythonExportWsName);
+    std::string eMode("");
+    if (m_originalSampleUnits == "dSpacing")
+      eMode = "Elastic";
+    addConvertUnitsStep(ws, m_originalSampleUnits, "", eMode);
+  }
+
+  // Add save algorithms if required
+  bool save = m_uiForm.ckSave->isChecked();
+  if (save)
+    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+
+  // Run algorithm queue
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(postProcessComplete(bool)));
+  m_batchAlgoRunner->executeBatchAsync();
+}
+
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -14,8 +14,6 @@ ContainerSubtraction::ContainerSubtraction(QWidget *parent)
   m_uiForm.setupUi(parent);
 
   // Connect slots
-  connect(m_uiForm.cbGeometry, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(handleGeometryChanged(int)));
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
           SLOT(newData(const QString &)));
   connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this,
@@ -93,17 +91,8 @@ void ContainerSubtraction::run() {
   if (nameCutIndex == -1)
     nameCutIndex = sampleWsName.length();
 
-  QString correctionType;
-  switch (m_uiForm.cbGeometry->currentIndex()) {
-  case 0:
-    correctionType = "flt";
-    break;
-  case 1:
-    correctionType = "cyl";
-    break;
-  }
   const QString outputWsName =
-      sampleWsName.left(nameCutIndex) + +"_" + correctionType + "_Corrected";
+      sampleWsName.left(nameCutIndex)+"_Corrected";
 
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 
@@ -190,31 +179,6 @@ void ContainerSubtraction::newData(const QString &dataName) {
   // Plot the sample curve
   m_uiForm.ppPreview->clear();
   m_uiForm.ppPreview->addSpectrum("Sample", sampleWs, 0, Qt::black);
-}
-
-/**
- * Handles when the type of geometry changes
- *
- * Updates the file extension to search for
- */
-void ContainerSubtraction::handleGeometryChange(int index) {
-  QString ext("");
-  switch (index) {
-  case 0:
-    // Geometry is flat
-    ext = "_flt_abs";
-    break;
-  case 1:
-    // Geometry is cylinder
-    ext = "_cyl_abs";
-    break;
-  case 2:
-    // Geometry is annulus
-    ext = "_ann_abs";
-    break;
-  }
-  /*m_uiForm.dsCorrections->setWSSuffixes(QStringList(ext));
-  m_uiForm.dsCorrections->setFBSuffixes(QStringList(ext + ".nxs"));*/
 }
 
 /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
@@ -1,12 +1,12 @@
 //----------------------
 // Includes
 //----------------------
-#include "MantidQtCustomInterfaces/Indirect/IndirectCorrections.h"
 
-#include "MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.h"
-#include "MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.h"
 #include "MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h"
+#include "MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.h"
+#include "MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.h"
 #include "MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h"
+#include "MantidQtCustomInterfaces/Indirect/IndirectCorrections.h"
 
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtAPI/ManageUserDirectories.h"

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
@@ -6,6 +6,7 @@
 #include "MantidQtCustomInterfaces/Indirect/CalculatePaalmanPings.h"
 #include "MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.h"
 #include "MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h"
+#include "MantidQtCustomInterfaces/Indirect/ContainerSubtraction.h"
 
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtAPI/ManageUserDirectories.h"
@@ -15,151 +16,156 @@
 #include <QDesktopServices>
 #include <QUrl>
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  // Add this class to the list of specialised dialogs in this namespace
-  DECLARE_SUBWINDOW(IndirectCorrections)
+namespace MantidQt {
+namespace CustomInterfaces {
+// Add this class to the list of specialised dialogs in this namespace
+DECLARE_SUBWINDOW(IndirectCorrections)
 
-  /**
-   * Constructor.
-   *
-   * @param parent :: the parent QWidget.
-   */
-  IndirectCorrections::IndirectCorrections(QWidget *parent) :
-    UserSubWindow(parent),
-    m_changeObserver(*this, &IndirectCorrections::handleDirectoryChange)
-  {
-    m_uiForm.setupUi(this);
+/**
+ * Constructor.
+ *
+ * @param parent :: the parent QWidget.
+ */
+IndirectCorrections::IndirectCorrections(QWidget *parent)
+    : UserSubWindow(parent),
+      m_changeObserver(*this, &IndirectCorrections::handleDirectoryChange) {
+  m_uiForm.setupUi(this);
 
-    // Allows us to get a handle on a tab using an enum, for example "m_tabs[ELWIN]".
-    // All tabs MUST appear here to be shown in interface.
-    // We make the assumption that each map key corresponds to the order in which the tabs appear.
-    m_tabs.insert(std::make_pair(CALC_CORR,  new CalculatePaalmanPings(m_uiForm.twTabs->widget(CALC_CORR))));
-    m_tabs.insert(std::make_pair(APPLY_CORR, new ApplyPaalmanPings(m_uiForm.twTabs->widget(APPLY_CORR))));
-    m_tabs.insert(std::make_pair(ABSORPTION_CORRECTIONS, new AbsorptionCorrections(m_uiForm.twTabs->widget(ABSORPTION_CORRECTIONS))));
-  }
+  // Allows us to get a handle on a tab using an enum, for example
+  // "m_tabs[ELWIN]".
+  // All tabs MUST appear here to be shown in interface.
+  // We make the assumption that each map key corresponds to the order in which
+  // the tabs appear.
+  m_tabs.insert(std::make_pair(
+      CALC_CORR,
+      new CalculatePaalmanPings(m_uiForm.twTabs->widget(CALC_CORR))));
+  m_tabs.insert(std::make_pair(
+      APPLY_CORR, new ApplyPaalmanPings(m_uiForm.twTabs->widget(APPLY_CORR))));
+  m_tabs.insert(std::make_pair(
+      ABSORPTION_CORRECTIONS, new AbsorptionCorrections(m_uiForm.twTabs->widget(
+                                  ABSORPTION_CORRECTIONS))));
+  m_tabs.insert(std::make_pair(CONTAINER_SUBTRACTION,
+                               new ContainerSubtraction(m_uiForm.twTabs->widget(
+                                   CONTAINER_SUBTRACTION))));
+}
 
-  /**
-   * @param :: the detected close event
-   */
-  void IndirectCorrections::closeEvent(QCloseEvent*)
-  {
-    Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
-  }
+/**
+ * @param :: the detected close event
+ */
+void IndirectCorrections::closeEvent(QCloseEvent *) {
+  Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
+}
 
-  /**
-   * Handles a change in directory.
-   *
-   * @param pNf :: notification
-   */
-  void IndirectCorrections::handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf)
-  {
-    std::string key = pNf->key();
+/**
+ * Handles a change in directory.
+ *
+ * @param pNf :: notification
+ */
+void IndirectCorrections::handleDirectoryChange(
+    Mantid::Kernel::ConfigValChangeNotification_ptr pNf) {
+  std::string key = pNf->key();
 
-    if ( key == "defaultsave.directory" )
-      loadSettings();
-  }
-
-  /**
-   * Initialised the layout of the interface.  MUST be called.
-   */
-  void IndirectCorrections::initLayout()
-  {
-    // Connect Poco Notification Observer
-    Mantid::Kernel::ConfigService::Instance().addObserver(m_changeObserver);
-
-    // Set up all tabs
-    for(auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab)
-    {
-      tab->second->setupTab();
-      connect(tab->second, SIGNAL(runAsPythonScript(const QString&, bool)), this, SIGNAL(runAsPythonScript(const QString&, bool)));
-      connect(tab->second, SIGNAL(showMessageBox(const QString&)), this, SLOT(showMessageBox(const QString&)));
-    }
-
-    connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this, SLOT(exportTabPython()));
-    connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
-    connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
-    connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this, SLOT(openDirectoryDialog()));
-  }
-
-  /**
-   * Allow Python to be called locally.
-   */
-  void IndirectCorrections::initLocalPython()
-  {
-    QString pyInput = "from mantid.simpleapi import *";
-    QString pyOutput = runPythonCode(pyInput).trimmed();
+  if (key == "defaultsave.directory")
     loadSettings();
+}
+
+/**
+ * Initialised the layout of the interface.  MUST be called.
+ */
+void IndirectCorrections::initLayout() {
+  // Connect Poco Notification Observer
+  Mantid::Kernel::ConfigService::Instance().addObserver(m_changeObserver);
+
+  // Set up all tabs
+  for (auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab) {
+    tab->second->setupTab();
+    connect(tab->second, SIGNAL(runAsPythonScript(const QString &, bool)), this,
+            SIGNAL(runAsPythonScript(const QString &, bool)));
+    connect(tab->second, SIGNAL(showMessageBox(const QString &)), this,
+            SLOT(showMessageBox(const QString &)));
   }
 
-  /**
-   * Load the settings saved for this interface.
-   */
-  void IndirectCorrections::loadSettings()
-  {
-    QSettings settings;
-    QString settingsGroup = "CustomInterfaces/IndirectAnalysis/";
-    QString saveDir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"));
+  connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
+          SLOT(exportTabPython()));
+  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(run()));
+  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
+          SLOT(openDirectoryDialog()));
+}
 
-    settings.beginGroup(settingsGroup + "ProcessedFiles");
-    settings.setValue("last_directory", saveDir);
+/**
+ * Allow Python to be called locally.
+ */
+void IndirectCorrections::initLocalPython() {
+  QString pyInput = "from mantid.simpleapi import *";
+  QString pyOutput = runPythonCode(pyInput).trimmed();
+  loadSettings();
+}
 
-    // Load each tab's settings.
-    auto tab = m_tabs.begin();
-    for( ; tab != m_tabs.end(); ++tab )
-      tab->second->loadTabSettings(settings);
+/**
+ * Load the settings saved for this interface.
+ */
+void IndirectCorrections::loadSettings() {
+  QSettings settings;
+  QString settingsGroup = "CustomInterfaces/IndirectAnalysis/";
+  QString saveDir = QString::fromStdString(
+      Mantid::Kernel::ConfigService::Instance().getString(
+          "defaultsave.directory"));
 
-    settings.endGroup();
-  }
+  settings.beginGroup(settingsGroup + "ProcessedFiles");
+  settings.setValue("last_directory", saveDir);
 
-  /**
-   * Private slot, called when the Run button is pressed.  Runs current tab.
-   */
-  void IndirectCorrections::run()
-  {
-    const unsigned int currentTab = m_uiForm.twTabs->currentIndex();
-    m_tabs[currentTab]->runTab();
-  }
+  // Load each tab's settings.
+  auto tab = m_tabs.begin();
+  for (; tab != m_tabs.end(); ++tab)
+    tab->second->loadTabSettings(settings);
 
-  /**
-   * Opens a directory dialog.
-   */
-  void IndirectCorrections::openDirectoryDialog()
-  {
-    MantidQt::API::ManageUserDirectories *ad = new MantidQt::API::ManageUserDirectories(this);
-    ad->show();
-    ad->setFocus();
-  }
+  settings.endGroup();
+}
 
-  /**
-   * Opens the Mantid Wiki web page of the current tab.
-   */
-  void IndirectCorrections::help()
-  {
-    MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Indirect_Corrections"));
-  }
+/**
+ * Private slot, called when the Run button is pressed.  Runs current tab.
+ */
+void IndirectCorrections::run() {
+  const unsigned int currentTab = m_uiForm.twTabs->currentIndex();
+  m_tabs[currentTab]->runTab();
+}
 
-  /**
-   * Handles exporting a Python script for the current tab.
-   */
-  void IndirectCorrections::exportTabPython()
-  {
-    unsigned int currentTab = m_uiForm.twTabs->currentIndex();
-    m_tabs[currentTab]->exportPythonScript();
-  }
+/**
+ * Opens a directory dialog.
+ */
+void IndirectCorrections::openDirectoryDialog() {
+  MantidQt::API::ManageUserDirectories *ad =
+      new MantidQt::API::ManageUserDirectories(this);
+  ad->show();
+  ad->setFocus();
+}
 
-  /**
-   * Slot to wrap the protected showInformationBox method defined
-   * in UserSubWindow and provide access to composed tabs.
-   *
-   * @param message The message to display in the message box
-   */
-  void IndirectCorrections::showMessageBox(const QString& message)
-  {
-    showInformationBox(message);
-  }
+/**
+ * Opens the Mantid Wiki web page of the current tab.
+ */
+void IndirectCorrections::help() {
+  MantidQt::API::HelpWindow::showCustomInterface(
+      NULL, QString("Indirect_Corrections"));
+}
+
+/**
+ * Handles exporting a Python script for the current tab.
+ */
+void IndirectCorrections::exportTabPython() {
+  unsigned int currentTab = m_uiForm.twTabs->currentIndex();
+  m_tabs[currentTab]->exportPythonScript();
+}
+
+/**
+ * Slot to wrap the protected showInformationBox method defined
+ * in UserSubWindow and provide access to composed tabs.
+ *
+ * @param message The message to display in the message box
+ */
+void IndirectCorrections::showMessageBox(const QString &message) {
+  showInformationBox(message);
+}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/Code/Mantid/docs/source/interfaces/Indirect_Corrections.rst
+++ b/Code/Mantid/docs/source/interfaces/Indirect_Corrections.rst
@@ -353,5 +353,41 @@ Container Radius
 
 Neutron Events
   Number of events to use in the Monte Carlo simulation.
+  
+  
+Container Subtraction
+---------------------
+
+.. interface:: Corrections
+  :widget: tabContainerSubtraction
+  
+The Container Subtraction Tab is used to remove the containers contribution to a run.
+
+Once run the corrected output and can correction is shown in the preview plot, the Spectrum 
+spin box can be used to scroll through each spectrum. Note that when this plot shows the 
+result of a calculation the X axis is always in wavelength, however when data is initially 
+selected the X axis unit matches that of the sample workspace.
+
+The input and container workspaces will be converted to wavelength (using
+:ref:`ConvertUnits <algm-ConvertUnits>`) if they do not already have wavelength
+as their X unit.
+ 
+Options
+~~~~~~~
+
+Input Sample
+  Either a reduced file (_red.nxs) or workspace (_red) or an S(Q,\omega) file (_sqw.nxs) or workspace (_sqw) that represents the sample.
+  
+Input Container
+  Either a reduced file (_red.nxs) or workspace (_red) or an S(Q,\omega) file (_sqw.nxs) or workspace (_sqw) that represents the container.
+  
+Scale Can by Factor
+  Allows the container intensity to be scaled by a given scale factor before being used in the corrections calculation.
+
+Plot Output
+  Gives the option to create either a spectra or contour plot (or both) of the corrected workspace.
+  
+Save Result
+  If enabled the result will be saved as a NeXus file in the default save directory.
 
 .. categories:: Interfaces Indirect


### PR DESCRIPTION
Fixes #13110 

The new ContainerSubtraction tab is now in the Indirect Corrections tab.
# To Test
- Open the ContainerSubtraction tab (Interfaces > Indirect > Corrections > ContainerSubtraction)
- Select a suitable `Sample` File and matching `Container` file.
- Optionally Scale the container
- Run the Subtraction
- Several features need to be checked to ensure that the new tab functions correctly:
  - The plot options plot the correct things
  - The plot preview displays correct and reasonable data
    - This can be checked against the ApplyPaalmanPings tab (without using corrections only can). The can subtraction will be removed from the ApplyPaalmanPings tab at a later date.
  - The relevant files appear in the ADS 
    - Original files
    - Wavelength converted versions of the originals (if they were not in wavelength originally)
    - The container subtraction

This has should now feature in the Indirect_Corrections.rst

ToDo:
- [x] update release notes (http://www.mantidproject.org/Release_Notes_3_5_Indirect_Inelastic#New_features)
