### PR TITLE
Set package's suffix from jenkins environment

### DIFF
--- a/Code/Mantid/Build/Jenkins/buildscript
+++ b/Code/Mantid/Build/Jenkins/buildscript
@@ -4,10 +4,10 @@
 #
 # Notes:
 #
-# WORKSPACE, JOB_NAME, NODE_LABEL GIT_COMMIT are environment variables that
-# are set by Jenkins. The last one corresponds to any labels set on a slave.
-# BUILD_THREADS & PARAVIEW_DIR should be set in the configuration of each
-# slave.
+# WORKSPACE, JOB_NAME, NODE_LABEL, PACKAGE_SUFFIX, GIT_COMMIT are
+# environment variables that are set by Jenkins. The last one
+# corresponds to any labels set on a slave.  BUILD_THREADS &
+# PARAVIEW_DIR should be set in the configuration of each slave.
 ###############################################################################
 SCRIPT_DIR=$(dirname "$0")
 # Package by default
@@ -142,21 +142,26 @@ fi
 # Packaging options
 ###############################################################################
 if [[ "$BUILDPKG" == true ]]; then
+  PACKAGINGVARS="-DPACKAGE_DOCS=ON"
   # Set some variables relating to the linux packages
   if [[ $(uname) != 'Darwin' ]]; then
     # Use different suffix for linux builds
     if [[ ${JOB_NAME} == *release* ]]; then
-      PACKAGINGVARS="-DENVVARS_ON_INSTALL=True -DCPACK_SET_DESTDIR=ON -DPACKAGE_DOCS=ON"
+      PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=True -DCPACK_SET_DESTDIR=ON"
     elif [[ ${JOB_NAME} == *master* ]]; then
-      PACKAGINGVARS="-DENVVARS_ON_INSTALL=False -DCMAKE_INSTALL_PREFIX=/opt/mantidnightly -DCPACK_PACKAGE_SUFFIX=nightly -DCPACK_SET_DESTDIR=OFF -DPACKAGE_DOCS=ON"
+      PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=False -DCPACK_SET_DESTDIR=OFF"
+      PACKAGE_SUFFIX="nightly"
     elif [[ ${JOB_NAME} == *pvnext* ]]; then
-      PACKAGINGVARS="-DENVVARS_ON_INSTALL=False -DCMAKE_INSTALL_PREFIX=/opt/mantidunstable-pvnext -DCPACK_PACKAGE_SUFFIX=unstable-pvnext -DCPACK_SET_DESTDIR=OFF"
+      PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=False -DCPACK_SET_DESTDIR=OFF"
+      PACKAGE_SUFFIX="mantidunstable-pvnext"
     else
-      PACKAGINGVARS="-DENVVARS_ON_INSTALL=False -DCMAKE_INSTALL_PREFIX=/opt/mantidunstable -DCPACK_PACKAGE_SUFFIX=unstable -DCPACK_SET_DESTDIR=OFF -DPACKAGE_DOCS=ON"
+      PACKAGINGVARS="${PACKAGINGVARS} -DENVVARS_ON_INSTALL=False -DCPACK_SET_DESTDIR=OFF"
+      PACKAGE_SUFFIX="unstable"
     fi
-  else
-    # Mac packaging
-    PACKAGINGVARS="-DPACKAGE_DOCS=ON"
+
+    if [ ! -z "$PACKAGE_SUFFIX" ]; then
+      PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/mantid${PACKAGE_SUFFIX} -DCPACK_PACKAGE_SUFFIX=${PACKAGE_SUFFIX}"
+    fi
   fi
 fi
 


### PR DESCRIPTION
Since we started creating `mantid34`, it has been difficult to set the suffix for the package. This change makes it easier to set from jenkins and have the build server make the new package.

**To test:** If the build servers pass, it is probably ok. Look over the changes to the script anyhow.
