### PR TITLE
TOF converter error messages

### DIFF
--- a/Code/Mantid/scripts/TofConverter/convertUnits.py
+++ b/Code/Mantid/scripts/TofConverter/convertUnits.py
@@ -16,47 +16,51 @@ def input2energy(inputval, inOption, theta, flightpath):
     e2t = 0.086165 #using t = (m*v^2)/(2kb) kb: Boltzmann const
     e2cm = 0.123975 #cm = 8.06554465*E E:energy
     iv2 = inputval ** 2
-
+    
     if inOption == 'Wavelength (Angstroms)':
         Energy = e2lam / iv2
 
     elif inOption == 'Energy (meV)':
         Energy = inputval
 
-    elif inOption == 'Nu (Thz)':
-        Energy = e2nu * inputval
+    elif inOption == 'Nu (THz)':
+        Energy = e2nu*inputval
 
     elif inOption == 'Velocity (m/s)':
-        Energy = e2v *iv2
+        Energy = e2v*iv2
 
     elif inOption == 'Momentum (k Angstroms^-1)':
         Energy = e2k*iv2
 
     elif inOption == 'Temperature (K)':
-        Energy = e2t *inputval
+        Energy = e2t*inputval
 
     elif inOption == 'Energy (cm^-1)':
-        Energy = e2cm * inputval
+        Energy = e2cm*inputval
 
     elif inOption == 'Momentum transfer (Q Angstroms^-1)':
         if theta >= 0.0:
-            k = inputval * 0.5 / math.sin(theta)
-            Energy = e2k * k * k
+            k = inputval*0.5/math.sin(theta)
+            Energy = e2k*k*k
         else:
             raise RuntimeError("Theta > 0 is required for conversion from Q")
 
     elif inOption == 'd-spacing (Angstroms)':
-        lam = 2 * inputval * math.sin(theta)
-        Energy = e2lam / (lam * lam)
+        if theta >= 0.0:
+            lam = 2 * inputval*math.sin(theta)
+            Energy = e2lam / (lam * lam)
+        else:
+            raise RuntimeError("Theta > 0 is required for conversion from Q")
 
     elif  inOption == 'Time of flight (microseconds)':
         if flightpath >= 0.0:
-            Energy = 1000000 * flightpath
-            Energy = e2v * Energy *Energy / iv2
+            Energy = 1000000*flightpath
+            Energy = e2v*Energy*Energy / iv2
         else:
             raise RuntimeError("Flight path >= 0 is required for conversion from TOF")
 
     return Energy
+
 
 # Convert intermediate energy to output type
 def energy2output(Energy, outOption, theta, flightpath):
@@ -70,7 +74,7 @@ def energy2output(Energy, outOption, theta, flightpath):
     if outOption == 'Wavelength (Angstroms)':
         OutputVal =  (e2lam/ Energy)**0.5
 
-    elif outOption == 'Nu (Thz)':
+    elif outOption == 'Nu (THz)':
         OutputVal = Energy / e2nu
 
     elif outOption == 'Velocity (m/s)':
@@ -107,4 +111,5 @@ def energy2output(Energy, outOption, theta, flightpath):
 
     elif outOption == 'Energy (meV)':
         OutputVal = Energy
+
     return OutputVal

--- a/Code/Mantid/scripts/TofConverter/convertUnits.py
+++ b/Code/Mantid/scripts/TofConverter/convertUnits.py
@@ -107,5 +107,4 @@ def energy2output(Energy, outOption, theta, flightpath):
 
     elif outOption == 'Energy (meV)':
         OutputVal = Energy
-
     return OutputVal

--- a/Code/Mantid/scripts/TofConverter/convertUnits.py
+++ b/Code/Mantid/scripts/TofConverter/convertUnits.py
@@ -16,7 +16,7 @@ def input2energy(inputval, inOption, theta, flightpath):
     e2t = 0.086165 #using t = (m*v^2)/(2kb) kb: Boltzmann const
     e2cm = 0.123975 #cm = 8.06554465*E E:energy
     iv2 = inputval ** 2
-    
+
     if inOption == 'Wavelength (Angstroms)':
         Energy = e2lam / iv2
 

--- a/Code/Mantid/scripts/TofConverter/converterGUI.py
+++ b/Code/Mantid/scripts/TofConverter/converterGUI.py
@@ -64,7 +64,7 @@ class MainWindow(QtGui.QMainWindow):
     def helpClicked(self):
         # Temporary import while method is in the wrong place
         from pymantidplot.proxies import showCustomInterfaceHelp
-        showCustomInterfaceHelp("TOF_Converter") #need to find a way to import this module
+        showCustomInterfaceHelp("TOF_Converter")
 
     def convert(self):
         #Always reset these values before conversion.
@@ -73,7 +73,8 @@ class MainWindow(QtGui.QMainWindow):
         try:
             if self.ui.InputVal.text() == "":
                 raise RuntimeError("Input value is required for conversion")
-
+            if float(self.ui.InputVal.text()) <= 0:
+                raise RuntimeError("Input value must be greater than 0 for conversion")
             inOption = self.ui.inputUnits.currentText()
             outOption = self.ui.outputUnits.currentText()
             if self.ui.totalFlightPathInput.text() !='':

--- a/Code/Mantid/scripts/TofConverter/converterGUI.py
+++ b/Code/Mantid/scripts/TofConverter/converterGUI.py
@@ -86,3 +86,6 @@ class MainWindow(QtGui.QMainWindow):
         except ArithmeticError, e:
             QtGui.QMessageBox.warning(self, "TofConverter", str(e))
             return
+        except RuntimeError, re:
+            QtGui.QMessageBox.warning(self, "TofConverter", str(re))
+            return

--- a/Code/Mantid/scripts/TofConverter/converterGUI.py
+++ b/Code/Mantid/scripts/TofConverter/converterGUI.py
@@ -67,6 +67,9 @@ class MainWindow(QtGui.QMainWindow):
         showCustomInterfaceHelp("TOF_Converter") #need to find a way to import this module
 
     def convert(self):
+        #Always reset these values before conversion.
+        self.Theta = None
+        self.flightpath = None
         try:
             if self.ui.InputVal.text() == "":
                 raise RuntimeError("Input value is required for conversion")
@@ -84,9 +87,11 @@ class MainWindow(QtGui.QMainWindow):
 
             self.ui.convertedVal.clear()
             self.ui.convertedVal.insert(str(self.output))
-
-        except ArithmeticError, e:
-            QtGui.QMessageBox.warning(self, "TofConverter", str(e))
+        except UnboundLocalError, ule:
+            QtGui.QMessageBox.warning(self, "TofConverter", str(ule))
+            return
+        except ArithmeticError, ae:
+            QtGui.QMessageBox.warning(self, "TofConverter", str(ae))
             return
         except RuntimeError, re:
             QtGui.QMessageBox.warning(self, "TofConverter", str(re))

--- a/Code/Mantid/scripts/TofConverter/converterGUI.py
+++ b/Code/Mantid/scripts/TofConverter/converterGUI.py
@@ -67,9 +67,10 @@ class MainWindow(QtGui.QMainWindow):
         showCustomInterfaceHelp("TOF_Converter") #need to find a way to import this module
 
     def convert(self):
-        if self.ui.InputVal.text() == "":
-            return
         try:
+            if self.ui.InputVal.text() == "":
+                raise RuntimeError("Input value is required for conversion")
+
             inOption = self.ui.inputUnits.currentText()
             outOption = self.ui.outputUnits.currentText()
             if self.ui.totalFlightPathInput.text() !='':
@@ -83,6 +84,7 @@ class MainWindow(QtGui.QMainWindow):
 
             self.ui.convertedVal.clear()
             self.ui.convertedVal.insert(str(self.output))
+
         except ArithmeticError, e:
             QtGui.QMessageBox.warning(self, "TofConverter", str(e))
             return


### PR DESCRIPTION
Fixes #13570
Will display error messages whenever there is any text field missing in the TOF converter

<h3><b>Tester</b></h3>

<b>To test Input Value validation</b>:
- Start Mantid and go to the Interfaces Tab>Utilities>TofConverter
- Leave the Input Value field empty and press `convert` button
- check that a pop-up appears warning about empty input value field

<b> To test Scattering Angle validation</b>:
- Start Mantid and go to the Interfaces Tab>Utilities>TofConverter
- Enter an input value and choose input units to be `d-spacing`
- Leave `Scattering Angle` text field blank and press `convert` button
- check that a pop-up appears warning about empty scattering angle field
- Repeat for output units as `d-spacing` and input units as `Energy`
- Repeat with input units as `Momentum transfer` and the same thing should occur 

<b> To test Flight path validation </b>:
- Start Mantid and go to the Interfaces Tab>Utilities>TofConverter
- Enter an input value and choose input units to be `time of flight (microseconds)`
- Leave `Flight path` text field blank and press `convert` button
- check that a pop-up appears warning about empty Flight path field
- Repeat for output units as `time of flight (microseconds)` and input units as `Energy`
  `
