### PR TITLE
Changed RUntimeError to RuntimeError

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn3Ascii.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/LoadNMoldyn3Ascii.py
@@ -197,7 +197,7 @@ class LoadNMoldyn3Ascii(PythonAlgorithm):
         lq2 = _find_starts(data, ' q =', lq1 - 1)
         Qlist = _make_list(data, lq1, lq2)
         if num_spec != len(Qlist):
-            raise RUntimeError('Error reading Q values')
+            raise RuntimeError('Error reading Q values')
         Qf = Qlist[0].split()
         Q = [float(Qf[2]) / 10.0]
         for m in range(1, num_spec - 1):


### PR DESCRIPTION
Fixes  #13584

To test:
- Run MolDyn algorithm with a .cdl file that has an issue with the format of the q vectors. [This file should give the issue](https://slack-files.com/T02J4MMEW-F0ACDT56Z-c7a940c4d9)
- Verify that the error thrown is "Error reading Q values" 
