### PR TITLE
Fix Slice Viewer Exception for normalized data

### DIFF
--- a/Code/Mantid/MantidQt/API/src/SignalRange.cpp
+++ b/Code/Mantid/MantidQt/API/src/SignalRange.cpp
@@ -84,17 +84,18 @@ namespace MantidQt
       // Combine the overall min/max
       double minSignal = DBL_MAX;
       double maxSignal = -DBL_MAX;
-      auto inf = std::numeric_limits<double>::infinity();
       for (size_t i=0; i < iterators.size(); i++)
       {
         delete iterators[i];
 
         double signal;
         signal = intervals[i].minValue();
-        if (signal != inf && signal < minSignal) minSignal = signal;
+        if (boost::math::isnan(signal) || boost::math::isinf(signal)) continue;
+        if ( signal < minSignal) minSignal = signal;
 
         signal = intervals[i].maxValue();
-        if (signal != inf && signal > maxSignal) maxSignal = signal;
+        if (boost::math::isnan(signal) || boost::math::isinf(signal)) continue;
+        if ( signal > maxSignal) maxSignal = signal;
       }
 
       if (minSignal == DBL_MAX)

--- a/Code/Mantid/MantidQt/API/src/SignalRange.cpp
+++ b/Code/Mantid/MantidQt/API/src/SignalRange.cpp
@@ -1,7 +1,7 @@
 #include "MantidQtAPI/SignalRange.h"
 #include "MantidAPI/IMDIterator.h"
 #include "MantidKernel/MultiThreaded.h"
-
+#include <boost/math/special_functions/fpclassify.hpp>
 namespace MantidQt
 {
   namespace API

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1383,9 +1383,12 @@ void SliceViewer::findRangeFull() {
   // Iterate through the entire workspace
   m_colorRangeFull =
       API::SignalRange(*workspace_used, this->getNormalization()).interval();
-  double maxR = m_colorRangeFull.maxValue();
-  double minR = pow(10., log10(maxR)-10.);
-  if (this->getColorScaleType() == 1) m_colorRangeFull = QwtDoubleInterval(minR, maxR);
+  double minR = m_colorRangeFull.minValue();
+  if (minR <= 0 && this->getColorScaleType() == 1) {
+    double maxR = m_colorRangeFull.maxValue();
+    minR = pow(10., log10(maxR)-10.);
+    m_colorRangeFull = QwtDoubleInterval(minR, maxR);
+  }
 }
 
 //------------------------------------------------------------------------------

--- a/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/Code/Mantid/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -1383,6 +1383,9 @@ void SliceViewer::findRangeFull() {
   // Iterate through the entire workspace
   m_colorRangeFull =
       API::SignalRange(*workspace_used, this->getNormalization()).interval();
+  double maxR = m_colorRangeFull.maxValue();
+  double minR = pow(10., log10(maxR)-10.);
+  if (this->getColorScaleType() == 1) m_colorRangeFull = QwtDoubleInterval(minR, maxR);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #13575 There was a -inf in data

```
Load("/SNS/TOPAZ/IPTS-14803/shared/visualization/combined/T295K_combined", OutputWorkspace="T295K_combined")
Show Slice Viewer of this dataset
Change the color scale from logarithmic to linear
Don't get a std::bad_alloc or a proper segfault
```
