### PR TITLE
Rename ResNorm output

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -144,7 +144,7 @@ class ResNorm(PythonAlgorithm):
         NormaliseToUnity(InputWorkspace=self._res_ws,
                          OutputWorkspace=norm_res_ws)
 
-        ws_name = '__ResNorm_res_%s_%dspec' % (self._res_ws, num_hist)
+        ws_name = '%s_%ds' % (self._res_ws, num_hist)
 
         for idx in range(num_hist):
             input_ws_1 = ws_name

--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -144,7 +144,7 @@ class ResNorm(PythonAlgorithm):
         NormaliseToUnity(InputWorkspace=self._res_ws,
                          OutputWorkspace=norm_res_ws)
 
-        ws_name = '%s_%ds' % (self._res_ws, num_hist)
+        ws_name = '%s' % (self._res_ws)
 
         for idx in range(num_hist):
             input_ws_1 = ws_name


### PR DESCRIPTION
Fixes #13495

The internal Workspaces within the WorkspaceGroup produced by ResNorm should now be in the form 
`resolutionFileName + currentSpec + GroupWorkspaceSuffix`

e.g. 

If ResNorm is run with `irs26173_graphite002_red` and `irs26173_graphite002_res` then in the group `irs26173_graphite002_ResNorm_Fit_Parameters` the first workspace should be called `irs26173_graphite002_res_0_Parameters`
# To Test
- Open the ResNorm tab (Interfaces > Indirect > Bayes > ResNorm)
- Run the ResNorm Algorithm with reasonable inputs for `Vanadium` and `Resolution`
- Ensure that the output WorkspaceGroups have reasonable file names of the form:
  `resolutionFileName + currentSpec + GroupWorkspaceSuffix` (Or Similar)
