### PR TITLE
Fix autoscale checkbox in vsi

### DIFF
--- a/Code/Mantid/Vates/VatesAPI/CMakeLists.txt
+++ b/Code/Mantid/Vates/VatesAPI/CMakeLists.txt
@@ -66,6 +66,7 @@ inc/MantidVatesAPI/BoxInfo.h
 inc/MantidVatesAPI/Common.h
 inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
 inc/MantidVatesAPI/ConcretePeaksPresenterVsi.h
+inc/MantidVatesAPI/ColorScaleGuard.h
 inc/MantidVatesAPI/DimensionViewFactory.h
 inc/MantidVatesAPI/EventNexusLoadingPresenter.h
 inc/MantidVatesAPI/FieldDataToMetadata.h

--- a/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
+++ b/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
@@ -1,0 +1,48 @@
+#ifndef MANTID_VATES_API_COLOR_SCALE_LOCK_H
+#define MANTID_VATES_API_COLOR_SCALE_LOCK_H
+#include "MantidKernel/System.h"
+#include "MantidKernel/Logger.h"
+
+namespace {
+Mantid::Kernel::Logger g_log("ColorScaleGuard");
+}
+
+namespace Mantid {
+namespace VATES {
+
+class DLLExport ColorScaleLock {
+public:
+  ColorScaleLock() : m_isLocked(false){};
+  ~ColorScaleLock() {}
+  bool isLocked() { return m_isLocked; }
+  void lock() { m_isLocked = true; }
+  void unlock() { m_isLocked = false; }
+
+private:
+  bool m_isLocked;
+};
+
+class DLLExport ColorScaleLockGuard {
+public:
+  ColorScaleLockGuard(ColorScaleLock *lock) {
+    if (lock->isLocked()) {
+      g_log.warning("Attempted to accept an already locked color scale lock.");
+      m_lock = nullptr;
+    } else {
+      m_lock = lock;
+      m_lock->lock();
+    }
+  }
+
+  ~ColorScaleLockGuard() {
+    if (m_lock != nullptr) {
+      m_lock->unlock();
+    }
+  }
+
+private:
+  ColorScaleLock *m_lock;
+};
+}
+}
+#endif

--- a/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
+++ b/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
@@ -26,8 +26,7 @@ class DLLExport ColorScaleLockGuard {
 public:
   ColorScaleLockGuard(ColorScaleLock *lock) {
     if (lock->isLocked()) {
-      g_log.warning("Attempted to accept an already locked color scale lock.");
-      m_lock = nullptr;
+      m_lock = NULL;
     } else {
       m_lock = lock;
       m_lock->lock();
@@ -35,7 +34,7 @@ public:
   }
 
   ~ColorScaleLockGuard() {
-    if (m_lock != nullptr) {
+    if (m_lock != NULL) {
       m_lock->unlock();
     }
   }

--- a/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
+++ b/Code/Mantid/Vates/VatesAPI/inc/MantidVatesAPI/ColorScaleGuard.h
@@ -25,7 +25,7 @@ private:
 class DLLExport ColorScaleLockGuard {
 public:
   ColorScaleLockGuard(ColorScaleLock *lock) {
-    if (lock->isLocked()) {
+    if (lock == NULL || lock->isLocked()) {
       m_lock = NULL;
     } else {
       m_lock = lock;

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/CMakeLists.txt
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/CMakeLists.txt
@@ -25,6 +25,7 @@ set( INCLUDE_FILES
   inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
   inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
   inc/MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h
+  inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
 )
 
 set( SOURCE_FILES
@@ -49,6 +50,7 @@ set( SOURCE_FILES
   src/TimeControlWidget.cpp
   src/VatesParaViewApplication.cpp
   src/ViewBase.cpp
+  src/VsiApplyBehaviour.cpp
 )
 
 set( TEST_FILES
@@ -73,6 +75,7 @@ qt4_wrap_cpp( MOC_SOURCES
   inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
   inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
   inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+  inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
 )
 
 # These are the ui files to be processed using

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
@@ -2,10 +2,11 @@
 #define COLORSELECTIONWIDGET_H_
 
 #include "ui_ColorSelectionWidget.h"
+#include "MantidVatesSimpleGuiViewWidgets/ColorMapManager.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
+#include "MantidVatesAPI/ColorScaleGuard.h"
 #include "MantidQtAPI/MdConstants.h"
 #include "boost/scoped_ptr.hpp"
-#include "MantidVatesSimpleGuiViewWidgets/ColorMapManager.h"
 #include <QWidget>
 
 class pqColorMapModel;
@@ -76,6 +77,10 @@ public:
   /// To effectively block callbacks from external (Paraview) color changes
   void ignoreColorChangeCallbacks(bool ignore);
   bool isIgnoringColorCallbacks();
+  /// Set the color scale lock
+  void setColorScaleLock(Mantid::VATES::ColorScaleLock* lock);
+  /// Is the color scale locked
+  bool isColorScaleLocked() const;
 
 public slots:
   /// Set state for all control widgets.
@@ -152,6 +157,8 @@ private:
 
   /// this is a flag that is set while updating the color scale triggered by the user clicking on the auto-scale box
   bool m_inProcessUserRequestedAutoScale;
+
+  Mantid::VATES::ColorScaleLock* m_colorScaleLock;
 };
 
 } // SimpleGui

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
@@ -10,6 +10,7 @@
 #include "MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h"
 #include "MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
+#include "MantidVatesAPI/ColorScaleGuard.h"
 
 #include "boost/shared_ptr.hpp"
 
@@ -159,6 +160,7 @@ private:
   RebinnedSourcesManager m_rebinnedSourcesManager; ///<Holds the rebinned sources manager
   QString m_rebinnedWorkspaceIdentifier; ///< Holds the identifier for temporary workspaces
   ColorMapEditorPanel* m_colorMapEditorPanel; ///< Holder for the color map editor panel.
+  Mantid::VATES::ColorScaleLock m_colorScaleLock; ///< Holds a color scale lock object
 
   /// Holds the 'visual state' of the views. This relies on Load/SaveXMLState which
   /// produce/consume a vtk XML tree object. Otherwise, the properties to save would be,

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
@@ -6,7 +6,7 @@
 #include "MantidVatesSimpleGuiViewWidgets/ColorUpdater.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
 #include "MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h"
-
+#include "MantidVatesAPI/ColorScaleGuard.h"
 #include <QPointer>
 #include <QWidget>
 
@@ -141,6 +141,8 @@ public:
   void setVisibilityListener();
   /// Undo visibiltiy listener
   void removeVisibilityListener();
+  /// Set color scale lock
+  void setColorScaleLock(Mantid::VATES::ColorScaleLock* colorScaleLock);
 
   QPointer<pqPipelineSource> origSrc; ///< The original source
   QPointer<pqPipelineRepresentation> origRep; ///< The original source representation
@@ -261,6 +263,8 @@ private:
 
   vtkSmartPointer<vtkEventQtSlotConnect> m_vtkConnections;
   PyGILStateService m_gilStateStore; ///< Python GIL state storage
+  Mantid::VATES::ColorScaleLock* m_colorScaleLock;
+
 };
 
 }

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
@@ -1,0 +1,37 @@
+#ifndef MANTID_VATES_SIMPLEGUIVIEWWIDGETS_VSI_APPLY_BEHAVIOUR_H
+#define MANTID_VATES_SIMPLEGUIVIEWWIDGETS_VSI_APPLY_BEHAVIOUR_H
+
+#include <QObject>
+#include "MantidVatesAPI/ColorScaleGuard.h"
+#include <pqApplyBehavior.h>
+#include <pqPropertiesPanel.h>
+#include <pqProxy.h>
+
+namespace Mantid
+{
+namespace Vates
+{
+namespace SimpleGui
+{
+class VsiApplyBehaviour : public pqApplyBehavior {
+public:
+  Q_OBJECT
+  typedef QObject Superclass;
+public:
+  VsiApplyBehaviour(Mantid::VATES::ColorScaleLock* lock, QObject* parent=0);
+  virtual ~VsiApplyBehaviour() {};
+
+  /// Register/unregister pqPropertiesPanel instances to monitor.
+  void registerPanel(pqPropertiesPanel* panel);
+  void unregisterPanel(pqPropertiesPanel* panel);
+protected slots:
+  virtual void applied(pqPropertiesPanel*, pqProxy*);
+  virtual void applied(pqPropertiesPanel*);
+
+private:
+  Mantid::VATES::ColorScaleLock* m_colorScaleLock;
+};
+}
+}
+}
+#endif

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/BackgroundRgbProvider.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/BackgroundRgbProvider.cpp
@@ -128,7 +128,6 @@ namespace Mantid
       {
         // For more information http://www.vtk.org/Wiki/VTK/Tutorials/Callbacks
         vtkSmartPointer<vtkCallbackCommand> backgroundColorChangeCallback = vtkSmartPointer<vtkCallbackCommand>::New();
-
         backgroundColorChangeCallback->SetCallback(backgroundColorChangeCallbackFunction);
 
         view->getViewProxy()->GetProperty("Background")->AddObserver(vtkCommand::ModifiedEvent, backgroundColorChangeCallback);

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
@@ -555,7 +555,7 @@ void ColorSelectionWidget::setColorScaleLock(
  */
 bool ColorSelectionWidget::isColorScaleLocked() const {
   if (m_colorScaleLock) {
-    m_colorScaleLock->isLocked();
+    return m_colorScaleLock->isLocked();
   } else {
     return false;
   }

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
@@ -43,7 +43,7 @@ namespace SimpleGui
  */
 ColorSelectionWidget::ColorSelectionWidget(QWidget *parent): QWidget(parent),
     colorMapManager(new ColorMapManager()), m_minHistoric(0.01), m_maxHistoric(0.01),
-    m_ignoreColorChangeCallbacks(false), m_inProcessUserRequestedAutoScale(false)
+    m_ignoreColorChangeCallbacks(false), m_inProcessUserRequestedAutoScale(false), m_colorScaleLock(NULL)
 {
   this->m_ui.setupUi(this);
   this->m_ui.autoColorScaleCheckBox->setChecked(true);
@@ -537,6 +537,28 @@ void ColorSelectionWidget::reset()
   this->m_ui.useLogScaleCheckBox->setChecked(false);
   this->m_ui.minValLineEdit->setText("");
   this->m_ui.maxValLineEdit->setText("");
+}
+
+/**
+ * Set the color scale lock
+ * @param lock
+ */
+void ColorSelectionWidget::setColorScaleLock(
+    Mantid::VATES::ColorScaleLock *lock) {
+  if (m_colorScaleLock == NULL) {
+    m_colorScaleLock = lock;
+  }
+}
+
+/**
+ * Is the color selection widget locked or not
+ */
+bool ColorSelectionWidget::isColorScaleLocked() const {
+  if (m_colorScaleLock) {
+    m_colorScaleLock->isLocked();
+  } else {
+    return false;
+  }
 }
 
 } // SimpleGui

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -274,6 +274,10 @@ void MdViewerWidget::setupUiAndConnections()
                    SIGNAL(triggerAcceptForNewFilters()),
                    this->ui.propertiesPanel,
                    SLOT(apply()));
+
+  // Add the color scale lock to the ColoSelectionWidget, which should
+  // now be initialized
+  ui.colorSelectionWidget->setColorScaleLock(&m_colorScaleLock);
 }
 
 void MdViewerWidget::panelChanged()
@@ -710,6 +714,7 @@ void MdViewerWidget::renderingDone()
 void MdViewerWidget::renderWorkspace(QString workspaceName, int workspaceType, std::string instrumentName)
 {
   GlobalInterpreterLock gil;
+  Mantid::VATES::ColorScaleLockGuard colorScaleLockGuard(&m_colorScaleLock);
   // Workaround: Note that setting to the standard view was part of the eventFilter. This causes the
   //             VSI window to not close properly. Moving it here ensures that we have the switch, but
   //             after the window is started again.

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/MdViewerWidget.cpp
@@ -28,6 +28,7 @@
 #include "MantidVatesSimpleGuiViewWidgets/ThreesliceView.h"
 #include "MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h"
 #include "MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h"
+#include "MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h"
 
 #include "boost/shared_ptr.hpp"
 #include "boost/scoped_ptr.hpp"
@@ -260,7 +261,9 @@ void MdViewerWidget::setupUiAndConnections()
   pqDeleteReaction* deleteHandler = new pqDeleteReaction(temp);
   deleteHandler->connect(this->ui.propertiesPanel,SIGNAL(deleteRequested(pqPipelineSource*)),SLOT(deleteSource(pqPipelineSource*)));
 
-  pqApplyBehavior* applyBehavior = new pqApplyBehavior(this);
+  //pqApplyBehavior* applyBehavior = new pqApplyBehavior(this);
+  VsiApplyBehaviour* applyBehavior = new VsiApplyBehaviour(&m_colorScaleLock, this);
+
   applyBehavior->registerPanel(this->ui.propertiesPanel);
   VatesParaViewApplication::instance()->setupParaViewBehaviors();
   //this->ui.pipelineBrowser->enableAnnotationFilter(m_widgetName);
@@ -361,6 +364,9 @@ ViewBase* MdViewerWidget::createAndSetMainViewWidget(QWidget *container,
     view = NULL;
     break;
   }
+
+  // Set the colorscale lock
+  view->setColorScaleLock(&m_colorScaleLock);
 
   return view;
 }
@@ -978,6 +984,7 @@ void MdViewerWidget::setupPluginMode()
  */
 void MdViewerWidget::renderAndFinalSetup()
 {
+  Mantid::VATES::ColorScaleLockGuard colorScaleLockGuard(&m_colorScaleLock);
   this->setColorForBackground();
   this->currentView->render();
   this->setColorMap();
@@ -1014,6 +1021,7 @@ void MdViewerWidget::setColorForBackground()
  */
 void MdViewerWidget::checkForUpdates()
 {
+  Mantid::VATES::ColorScaleLockGuard colorScaleLockGuard(&m_colorScaleLock);
   pqPipelineSource *src = pqActiveObjects::instance().activeSource();
   if (NULL == src)
   {

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ViewBase.cpp
@@ -5,6 +5,7 @@
 #include "MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h"
 #include "MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h"
 #include "MantidVatesAPI/ADSWorkspaceProvider.h"
+#include "MantidVatesAPI/ColorScaleGuard.h"
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidVatesAPI/BoxInfo.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -63,7 +64,7 @@ ViewBase::ViewBase(QWidget *parent, RebinnedSourcesManager* rebinnedSourcesManag
   QWidget(parent), m_rebinnedSourcesManager(rebinnedSourcesManager),
   m_currentColorMapModel(NULL), m_internallyRebinnedWorkspaceIdentifier("rebinned_vsi"),
   m_vtkConnections(vtkSmartPointer<vtkEventQtSlotConnect>::New()),
-  m_gilStateStore()
+  m_gilStateStore(), m_colorScaleLock(NULL)
 {
 }
 
@@ -835,6 +836,15 @@ void ViewBase::setColorForBackground(bool useCurrentColorSettings)
   backgroundRgbProvider.observe(this->getView());
 }
 
+
+/**
+ * Set color scale lock
+ * @param colorScaleLock: the color scale lock
+ */
+void ViewBase::setColorScaleLock(Mantid::VATES::ColorScaleLock* colorScaleLock) {
+  m_colorScaleLock = colorScaleLock;
+}
+
 /**
  * React to a change of the visibility of a representation of a source.
  * This can be a change of the status if the "eye" symbol in the PipelineBrowserWidget
@@ -844,6 +854,7 @@ void ViewBase::setColorForBackground(bool useCurrentColorSettings)
  */
 void ViewBase::onVisibilityChanged(pqPipelineSource*, pqDataRepresentation*)
 {
+  Mantid::VATES::ColorScaleLockGuard colorScaleLockGuard(m_colorScaleLock);
   // Reset the colorscale if it is set to autoscale
   if (colorUpdater.isAutoScale())
   {

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/VsiApplyBehaviour.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/VsiApplyBehaviour.cpp
@@ -1,0 +1,47 @@
+#include "MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h"
+
+namespace Mantid
+{
+namespace Vates
+{
+namespace SimpleGui
+{
+
+
+VsiApplyBehaviour::VsiApplyBehaviour(Mantid::VATES::ColorScaleLock* lock, QObject* parent) : pqApplyBehavior(parent) {
+  if (lock != NULL) {
+    m_colorScaleLock = lock;
+  }
+}
+
+/**
+ * Forward the register request
+ * @param panel: the properies panel
+ */
+void VsiApplyBehaviour::registerPanel(pqPropertiesPanel* panel) {
+  this->pqApplyBehavior::registerPanel(panel);
+}
+
+/* Forward the unregister request
+ * @param panel: the properties panel
+ */
+void VsiApplyBehaviour::unregisterPanel(pqPropertiesPanel* panel) {
+  this->pqApplyBehavior::unregisterPanel(panel);
+}
+
+
+/// React to the apply button press. We forward the request, but we add a lock
+void VsiApplyBehaviour::applied(pqPropertiesPanel*, pqProxy* pqproxy) {
+  Mantid::VATES::ColorScaleLockGuard colorScaleLockGuard(m_colorScaleLock);
+  this->pqApplyBehavior::applied(NULL, pqproxy);
+}
+
+/// React to the apply button press. We forward the request, but we add a lock
+void VsiApplyBehaviour::applied(pqPropertiesPanel*) {
+  Mantid::VATES::ColorScaleLockGuard colorScaleLockGuard(m_colorScaleLock);
+  this->pqApplyBehavior::applied(NULL);
+}
+
+}
+}
+}


### PR DESCRIPTION
Fixes #13578 

**Context**

The auto scale button was unchecking itself whenever we did something, e.g. loading a workspace, adding a filter, ...
## For testing

Could can find a sample workspace here: \olympic\Babylon5\Scratch\Anton\VSI\SAMPLE_WORKSPACES

Relevant file is MDEvent_Osiris.nxs

A windows installer can be found here: \olympic\Babylon5\Scratch\Anton\VSI\13578_Fix_AutoScale_button

Convention: auto scale checkbox = CB1

**Test checkbox when loading and with filter**
1. Load the workspace into the VSI
   - Confirm that CB1 is checked
2. Press the scale filter, set the a scale and press apply
   - Confirm that CB1 remains checked
3. Delete the scale filter
   - Confirm that CB1 remains checked
4. Manually uncheck CB1
5. Press the scale filter, set the a scale and press apply
   - Confirm that CB1 remains **unchecked**
6. Delete the scale filter
   - Confirm that CB1 remains  **unchecked**

**Test checkbox when resetting color scale**
1. Load the workspace into the VSI
   - Confirm that CB1 is checked
2. Press the **Reset** button in the PorpertiesPanel or in the ColorPanel
   - Confirm that CB1 is **unchecked**
