### PR TITLE
ResNorm "plot result: fit" plots only data

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -120,7 +120,7 @@ void ResNorm::handleAlgorithmComplete(bool error) {
   if (plotOptions == "Stretch" || plotOptions == "All")
     plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_Stretch");
   if (plotOptions == "Fit" || plotOptions == "All")
-    plotSpectrum(fitWsName);
+    plotSpectrum(fitWsName, 0, 1);
 
   // Update preview plot
   previewSpecChanged(m_previewSpec);


### PR DESCRIPTION
Fixes #13594

When using the Plot option: Fit in ResNorm, this should now plot both the original spectrum data, and the calculated fit.
# To Test
- Open ResNorm interface (Interfaces > Indirect > Bayes > ResNorm)
- Load in relevant Vanadium and Resolution data
- Run ResNorm **with the plot Option set to Fit**
- Ensure that a plot of the original data **AND** the calculated fit is produced when the algorithm concludes
