### PR TITLE
Increase chain length of FABADA in ConvFit

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -93,7 +93,7 @@ void ConvFit::setup() {
   m_properties["OutputFABADAChain"] = m_blnManager->addProperty("Output Chain");
   m_properties["FABADAChainLength"] = m_dblManager->addProperty("Chain Length");
   m_dblManager->setDecimals(m_properties["FABADAChainLength"], 0);
-  m_dblManager->setValue(m_properties["FABADAChainLength"], 10000);
+  m_dblManager->setValue(m_properties["FABADAChainLength"], 1000000);
   m_properties["FABADAConvergenceCriteria"] =
       m_dblManager->addProperty("Convergence Criteria");
   m_dblManager->setValue(m_properties["FABADAConvergenceCriteria"], 0.1);


### PR DESCRIPTION
Fixes #13607

The default chain length of FABADA in ConvFit has been increased
# To Test
- Open ConvFit tab (Interfaces > Indirect > Data Analysis > ConvFit)
- Check the `Use FABADA` option in the property tree
- Ensure that the Chain length is now 1e +06 (1,000,000)
