### PR TITLE
Changed Add to ADS to AddOrReplace to allow multiple runs in ConvFit

### DIFF
--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -336,7 +336,7 @@ void ConvolutionFitSequential::exec() {
     renamer->executeAsChildAlg();
   }
 
-  AnalysisDataService::Instance().add(resultWsName, resultWs);
+  AnalysisDataService::Instance().addOrReplace(resultWsName, resultWs);
   setProperty("OutputWorkspace", resultWsName);
 }
 


### PR DESCRIPTION
Fixes #13618

Changed the Add to Ads call in favor of an AddOrReplace.
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Set reasonable parameters and run
- Run again with the same parameters
- Ensure that this does not fail
