### PR TITLE
13540 generate ipython notebook from refl polref gui

### DIFF
--- a/Code/Mantid/Framework/API/src/NotebookWriter.cpp
+++ b/Code/Mantid/Framework/API/src/NotebookWriter.cpp
@@ -153,8 +153,9 @@ void NotebookWriter::headerCode() {
   import_matplotlib.append(Json::Value("#Import matplotlib's pyplot interface under the name 'plt'\n"));
   import_matplotlib.append(Json::Value("import matplotlib.pyplot as plt\n\n"));
 
-  import_matplotlib.append(Json::Value("#Some magic to tell matplotlib how to behave in IPython Notebook\n"));
-  import_matplotlib.append(Json::Value("%matplotlib inline"));
+  import_matplotlib.append(Json::Value("#Some magic to tell matplotlib how to behave in IPython Notebook. "
+                                         "Use '%matplotlib inline' if '%matplotlib nbagg' fails.\n"));
+  import_matplotlib.append(Json::Value("%matplotlib nbagg"));
 
   codeCell(import_matplotlib);
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -364,6 +364,7 @@ set ( TEST_FILES
   IO_MuonGroupingTest.h
   MuonAnalysisHelperTest.h
   ParseKeyValueStringTest.h
+  ReflGenerateNotebookTest.h
   ReflLegacyTransferStrategyTest.h
   ReflMainViewPresenterTest.h
   TomographyIfacePresenterTest.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -93,7 +93,7 @@ set ( SRC_FILES
   src/Tomography/TomoToolConfigDialog.cpp
   src/Tomography/ToolConfig.cpp
   src/UserInputValidator.cpp
-  src/ReflGenerateNotebook.cpp)
+  src/ReflGenerateNotebook.cpp src/ParseKeyValueString.cpp)
 
 # Include files aren't required, but this makes them appear in Visual Studio
 set ( INC_FILES
@@ -207,7 +207,7 @@ set ( INC_FILES
   inc/MantidQtCustomInterfaces/Tomography/ToolConfigTomoPy.h
   inc/MantidQtCustomInterfaces/Updateable.h
   inc/MantidQtCustomInterfaces/UserInputValidator.h
-  inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h)
+  inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h inc/MantidQtCustomInterfaces/ParseKeyValueString.h)
 
 set ( SRC_UNITY_IGNORE_FILES )
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -70,10 +70,12 @@ set ( SRC_FILES
   src/Muon/MuonAnalysisHelper.cpp
   src/Muon/MuonAnalysisOptionTab.cpp
   src/Muon/MuonAnalysisResultTableTab.cpp
+  src/ParseKeyValueString.cpp
   src/QReflTableModel.cpp
   src/QtReflMainView.cpp
   src/QtReflOptionsDialog.cpp
   src/ReflCatalogSearcher.cpp
+  src/ReflGenerateNotebook.cpp
   src/ReflLegacyTransferStrategy.cpp
   src/ReflMainViewPresenter.cpp
   src/ReflSearchModel.cpp
@@ -93,7 +95,7 @@ set ( SRC_FILES
   src/Tomography/TomoToolConfigDialog.cpp
   src/Tomography/ToolConfig.cpp
   src/UserInputValidator.cpp
-  src/ReflGenerateNotebook.cpp src/ParseKeyValueString.cpp)
+)
 
 # Include files aren't required, but this makes them appear in Visual Studio
 set ( INC_FILES

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -363,6 +363,7 @@ set ( TEST_FILES
   ALCPeakFittingPresenterTest.h
   IO_MuonGroupingTest.h
   MuonAnalysisHelperTest.h
+  ParseKeyValueStringTest.h
   ReflLegacyTransferStrategyTest.h
   ReflMainViewPresenterTest.h
   TomographyIfacePresenterTest.h

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -207,7 +207,10 @@ set ( INC_FILES
   inc/MantidQtCustomInterfaces/Tomography/ToolConfigTomoPy.h
   inc/MantidQtCustomInterfaces/Updateable.h
   inc/MantidQtCustomInterfaces/UserInputValidator.h
-  inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h inc/MantidQtCustomInterfaces/ParseKeyValueString.h)
+  inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+  inc/MantidQtCustomInterfaces/ParseKeyValueString.h
+  inc/MantidQtCustomInterfaces/ReflVectorString.h
+)
 
 set ( SRC_UNITY_IGNORE_FILES )
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
+++ b/Code/Mantid/MantidQt/CustomInterfaces/CMakeLists.txt
@@ -93,7 +93,7 @@ set ( SRC_FILES
   src/Tomography/TomoToolConfigDialog.cpp
   src/Tomography/ToolConfig.cpp
   src/UserInputValidator.cpp
-)
+  src/ReflGenerateNotebook.cpp)
 
 # Include files aren't required, but this makes them appear in Visual Studio
 set ( INC_FILES
@@ -207,7 +207,7 @@ set ( INC_FILES
   inc/MantidQtCustomInterfaces/Tomography/ToolConfigTomoPy.h
   inc/MantidQtCustomInterfaces/Updateable.h
   inc/MantidQtCustomInterfaces/UserInputValidator.h
-)
+  inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h)
 
 set ( SRC_UNITY_IGNORE_FILES )
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ParseKeyValueString.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ParseKeyValueString.h
@@ -26,6 +26,8 @@ File change history is stored at: <https://github.com/mantidproject/mantid>.
 Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 
+#include "MantidKernel/System.h"
+
 #include <string>
 #include <map>
 
@@ -33,7 +35,7 @@ Code Documentation is available at: <http://doxygen.mantidproject.org>
 namespace MantidQt {
   namespace CustomInterfaces {
 
-    std::map<std::string,std::string> parseKeyValueString(const std::string& str);
+    std::map<std::string,std::string> DLLExport parseKeyValueString(const std::string& str);
 
   }
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ParseKeyValueString.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ParseKeyValueString.h
@@ -1,7 +1,7 @@
 #ifndef MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRING_H
 #define MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRING_H
 
-/** @function parseKeyValueString
+/** parseKeyValueString
 
 Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'` into a map of key/value pairs.
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ParseKeyValueString.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ParseKeyValueString.h
@@ -1,0 +1,41 @@
+#ifndef MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRING_H
+#define MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRING_H
+
+/** @function parseKeyValueString
+
+Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'` into a map of key/value pairs.
+
+Copyright &copy; 2011-14 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+
+This file is part of Mantid.
+
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+File change history is stored at: <https://github.com/mantidproject/mantid>.
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
+#include <string>
+#include <map>
+
+
+namespace MantidQt {
+  namespace CustomInterfaces {
+
+    std::map<std::string,std::string> parseKeyValueString(const std::string& str);
+
+  }
+}
+
+#endif //MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRING_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QReflTableModel.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QReflTableModel.h
@@ -2,6 +2,7 @@
 #define MANTID_CUSTOMINTERFACES_QREFLTABLEMODEL_H_
 
 #include "MantidAPI/ITableWorkspace_fwd.h"
+#include "MantidQtCustomInterfaces/DllConfig.h"
 #include <QAbstractTableModel>
 #include <boost/shared_ptr.hpp>
 #include <map>
@@ -35,7 +36,7 @@ namespace MantidQt
     File change history is stored at: <https://github.com/mantidproject/mantid>
     Code Documentation is available at: <http://doxygen.mantidproject.org>
     */
-    class QReflTableModel : public QAbstractTableModel
+    class MANTIDQT_CUSTOMINTERFACES_DLL QReflTableModel : public QAbstractTableModel
     {
       Q_OBJECT
     public:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QtReflMainView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QtReflMainView.h
@@ -70,6 +70,9 @@ namespace MantidQt
       virtual void setProgressRange(int min, int max);
       virtual void setProgress(int progress);
 
+      //Get status of the checkbox which dictates whether an ipython notebook is produced
+      virtual bool getEnableNotebook();
+
       //Settor methods
       virtual void setSelection(const std::set<int>& rows);
       virtual void setTableList(const std::set<std::string>& tables);

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -34,6 +34,7 @@
 #include <set>
 #include <map>
 #include <string>
+#include <sstream>
 
 
 namespace MantidQt {
@@ -65,9 +66,6 @@ namespace MantidQt {
 
     std::string tableString(QReflTableModel_sptr model, ColNumbers col_nums, const std::set<int> & rows);
 
-    template<typename T, typename A>
-    std::string vectorString(const std::vector<T,A> &param_vec);
-
     std::string titleString(const std::string & wsName);
 
     std::tuple<std::string, std::string>
@@ -92,13 +90,47 @@ namespace MantidQt {
 
     std::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
 
-    template<typename T, typename A>
-    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec);
-
     std::tuple<std::string, std::string>
       rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, ColNumbers col_nums);
 
     std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
+
+    /**
+    Create string of comma separated list of values from a vector
+    @param param_vec : vector of values
+    @return string of comma separated list of values
+    */
+    template<typename T, typename A>
+    std::string vectorString(const std::vector<T,A> &param_vec)
+    {
+      std::ostringstream vector_string;
+      const char* separator = "";
+      for(auto paramIt = param_vec.begin(); paramIt != param_vec.end(); ++paramIt)
+      {
+        vector_string << separator << *paramIt;
+        separator = ", ";
+      }
+
+      return vector_string.str();
+    }
+
+    /**
+    Create string of comma separated list of parameter values from a vector
+    @param param_name : name of the parameter we are creating a list of
+    @param param_vec : vector of parameter values
+    @return string of comma separated list of parameter values
+    */
+    template<typename T, typename A>
+    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec)
+    {
+      std::ostringstream param_vector_string;
+
+      param_vector_string << param_name << " = '";
+      param_vector_string << vectorString(param_vec);
+      param_vector_string << "'";
+
+      return param_vector_string.str();
+    }
 
 
     class DLLExport ReflGenerateNotebook {

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -56,7 +56,7 @@ namespace MantidQt {
 
       std::string plotIvsQ(std::vector<std::string> ws_names);
 
-      std::string stitchGroupString();
+      std::tuple<std::string, std::string> stitchGroupString(std::set<int> rows);
 
       std::tuple<std::string, std::string> reduceRowString(int rowNo);
 
@@ -71,6 +71,9 @@ namespace MantidQt {
       std::tuple<std::string, std::string> scaleString(std::string runNo, double scale);
 
       std::tuple<std::string, std::string> convertToPointString(std::string wsName);
+
+      template<typename T, typename A>
+      std::string vectorParamString(std::string param_name, std::vector<T,A> &param_vec);
 
       std::tuple<std::string, std::string> rebinString(int rowNo, std::string runNo);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -74,8 +74,6 @@ namespace MantidQt {
 
       std::tuple<std::string, std::string> transWSString(std::string trans_ws_str);
 
-      std::map<std::string, std::string> parseKeyValueString(const std::string &str);
-
       std::string m_wsName;
       QReflTableModel_sptr m_model;
       const std::string m_instrument;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -68,11 +68,16 @@ namespace MantidQt {
     template<typename T, typename A>
     std::string vectorString(const std::vector<T,A> &param_vec);
 
+    std::string titleString(const std::string & wsName);
+
     std::tuple<std::string, std::string>
       stitchGroupString(const std::set<int> & rows, const std::string & instrument, QReflTableModel_sptr model,
                         ColNumbers col_nums);
 
     std::string plotsFunctionString();
+
+    std::string plotsString(const std::vector<std::string> & unstitched_ws,
+                            const std::vector<std::string> & IvsLam_ws, const std::string & stitched_wsStr);
 
     std::tuple<std::string, std::string, std::string>
       reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, ColNumbers col_nums);
@@ -120,7 +125,6 @@ namespace MantidQt {
       const std::string m_instrument;
 
       ColNumbers col_nums;
-
     };
 
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -39,14 +39,69 @@
 namespace MantidQt {
   namespace CustomInterfaces {
 
+
+    // Column numbers to find data in model
+    struct col_numbers {
+
+      col_numbers(const int runs_column, const int transmission_column, const int options_column, const int angle_column,
+                  const int qmin_column, const int qmax_column, const int dqq_column, const int scale_column)
+        : runs(runs_column), transmission(transmission_column), options(options_column), angle(angle_column),
+          qmin(qmin_column), qmax(qmax_column), dqq(dqq_column), scale(scale_column) {}
+
+      const int runs;
+      const int transmission;
+      const int options;
+      const int angle;
+      const int qmin;
+      const int qmax;
+      const int dqq;
+      const int scale;
+    };
+
+
+    std::string plot1DString(const std::vector<std::string> & ws_names, const std::string & axes,
+                             const std::string & title, const int legendLocation);
+
+    std::string printThetaString(const std::vector<std::string> & runNos,
+                                 const std::vector<std::string> & theta);
+
+    std::tuple<std::string, std::string>
+      stitchGroupString(const std::set<int> & rows, const std::string & instrument, QReflTableModel_sptr model,
+                        col_numbers col_nums);
+
+    std::tuple<std::string, std::string, std::string, std::string, std::string>
+      reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, col_numbers col_nums);
+
+    std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument);
+
+    std::string plusString(const std::string & input_name, const std::string & output_name);
+
+    std::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument);
+
+    std::string getRunNumber(const std::string & ws_name);
+
+    std::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
+
+    std::tuple<std::string, std::string> convertToPointString(const std::string & wsName);
+
+    template<typename T, typename A>
+    std::string vectorParamString(const std::string & param_name, std::vector<T,A> &param_vec);
+
+    std::tuple<std::string, std::string>
+      rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, col_numbers col_nums);
+
+    std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
+
+
     class DLLExport ReflGenerateNotebook {
+
     public:
 
       ReflGenerateNotebook(std::string name,
                            QReflTableModel_sptr model,
                            const std::string instrument,
-                           const int COL_RUNS, const int COL_TRANSMISSION, const int COL_OPTIONS, const int COL_ANGLE,
-                           const int COL_QMIN, const int COL_QMAX, const int COL_DQQ, const int COL_SCALE);
+                           const int col_runs, const int col_transmission, const int col_options, const int col_angle,
+                           const int col_qmin, const int col_qmax, const int col_dqq, const int col_scale);
 
       virtual ~ReflGenerateNotebook(){};
 
@@ -54,47 +109,11 @@ namespace MantidQt {
 
     private:
 
-      std::string plot1D(const std::vector<std::string> & ws_names, const std::string & axes,
-                         const std::string & title, const int legendLocation);
-
-      std::string printThetaString(const std::vector<std::string> & runNos,
-                                   const std::vector<std::string> & theta);
-
-      std::tuple<std::string, std::string> stitchGroupString(const std::set<int> & rows);
-
-      std::tuple<std::string, std::string, std::string, std::string, std::string> reduceRowString(const int rowNo);
-
-      std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr);
-
-      std::string plusString(const std::string & input_name, const std::string & output_name);
-
-      std::tuple<std::string, std::string> loadRunString(const std::string & run);
-
-      std::string getRunNumber(const std::string & ws_name);
-
-      std::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
-
-      std::tuple<std::string, std::string> convertToPointString(const std::string & wsName);
-
-      template<typename T, typename A>
-      std::string vectorParamString(const std::string & param_name, std::vector<T,A> &param_vec);
-
-      std::tuple<std::string, std::string> rebinString(const int rowNo, const std::string & runNo);
-
-      std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str);
-
       std::string m_wsName;
       QReflTableModel_sptr m_model;
       const std::string m_instrument;
 
-      const int COL_RUNS;
-      const int COL_TRANSMISSION;
-      const int COL_OPTIONS;
-      const int COL_ANGLE;
-      const int COL_QMIN;
-      const int COL_QMAX;
-      const int COL_DQQ;
-      const int COL_SCALE;
+      col_numbers col_nums;
 
     };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -50,7 +50,7 @@ namespace MantidQt {
 
       virtual ~ReflGenerateNotebook(){};
 
-      void generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows, std::string filename);
+      std::string generateNotebook(std::map<int, std::set<int>> groups);
 
     private:
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -54,32 +54,34 @@ namespace MantidQt {
 
     private:
 
-      std::string plot1D(std::vector<std::string> ws_names, std::string axes, std::string title, int legendLocation);
+      std::string plot1D(const std::vector<std::string> & ws_names, const std::string & axes,
+                         const std::string & title, const int legendLocation);
 
-      std::string printThetaString(std::vector<std::string> runNos, std::vector<std::string> theta);
+      std::string printThetaString(const std::vector<std::string> & runNos,
+                                   const std::vector<std::string> & theta);
 
-      std::tuple<std::string, std::string> stitchGroupString(std::set<int> rows);
+      std::tuple<std::string, std::string> stitchGroupString(const std::set<int> & rows);
 
-      std::tuple<std::string, std::string, std::string, std::string, std::string> reduceRowString(int rowNo);
+      std::tuple<std::string, std::string, std::string, std::string, std::string> reduceRowString(const int rowNo);
 
-      std::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
+      std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr);
 
-      std::string plusString(std::string input_name, std::string output_name);
+      std::string plusString(const std::string & input_name, const std::string & output_name);
 
-      std::tuple<std::string, std::string> loadRunString(std::string run);
+      std::tuple<std::string, std::string> loadRunString(const std::string & run);
 
-      std::string getRunNumber(std::string ws_name);
+      std::string getRunNumber(const std::string & ws_name);
 
-      std::tuple<std::string, std::string> scaleString(std::string runNo, double scale);
+      std::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
 
-      std::tuple<std::string, std::string> convertToPointString(std::string wsName);
+      std::tuple<std::string, std::string> convertToPointString(const std::string & wsName);
 
       template<typename T, typename A>
-      std::string vectorParamString(std::string param_name, std::vector<T,A> &param_vec);
+      std::string vectorParamString(const std::string & param_name, std::vector<T,A> &param_vec);
 
-      std::tuple<std::string, std::string> rebinString(int rowNo, std::string runNo);
+      std::tuple<std::string, std::string> rebinString(const int rowNo, const std::string & runNo);
 
-      std::tuple<std::string, std::string> transWSString(std::string trans_ws_str);
+      std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str);
 
       std::string m_wsName;
       QReflTableModel_sptr m_model;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -34,7 +34,7 @@
 #include <set>
 #include <map>
 #include <string>
-//#include <tuple>
+
 
 namespace MantidQt {
   namespace CustomInterfaces {

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -54,11 +54,11 @@ namespace MantidQt {
 
     private:
 
-      std::string plotIvsQ(std::vector<std::string> ws_names, std::string axes);
+      std::string plot1D(std::vector<std::string> ws_names, std::string axes, std::string title);
 
       std::tuple<std::string, std::string> stitchGroupString(std::set<int> rows);
 
-      std::tuple<std::string, std::string> reduceRowString(int rowNo);
+      std::tuple<std::string, std::string, std::string> reduceRowString(int rowNo);
 
       std::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -43,7 +43,7 @@ namespace MantidQt {
 
 
     // Column numbers to find data in model
-    struct ColNumbers {
+    struct DLLExport ColNumbers {
 
       ColNumbers(const int runs_column, const int transmission_column, const int options_column,
                  const int angle_column, const int qmin_column, const int qmax_column,
@@ -62,39 +62,39 @@ namespace MantidQt {
       const int group;
     };
 
-    std::string plot1DString(const std::vector<std::string> & ws_names,
+    std::string DLLExport plot1DString(const std::vector<std::string> & ws_names,
                              const std::string & title);
 
-    std::string tableString(QReflTableModel_sptr model, ColNumbers col_nums, const std::set<int> & rows);
+    std::string DLLExport tableString(QReflTableModel_sptr model, ColNumbers col_nums, const std::set<int> & rows);
 
-    std::string titleString(const std::string & wsName);
+    std::string DLLExport titleString(const std::string & wsName);
 
-    boost::tuple<std::string, std::string>
+    boost::tuple<std::string, std::string> DLLExport
       stitchGroupString(const std::set<int> & rows, const std::string & instrument, QReflTableModel_sptr model,
                         ColNumbers col_nums);
 
-    std::string plotsFunctionString();
+    std::string DLLExport plotsFunctionString();
 
-    std::string plotsString(const std::vector<std::string> & unstitched_ws,
+    std::string DLLExport plotsString(const std::vector<std::string> & unstitched_ws,
                             const std::vector<std::string> & IvsLam_ws, const std::string & stitched_wsStr);
 
-    boost::tuple<std::string, std::string, std::string>
+    boost::tuple<std::string, std::string, std::string> DLLExport
       reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, ColNumbers col_nums);
 
     boost::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument);
 
-    std::string plusString(const std::string & input_name, const std::string & output_name);
+    std::string DLLExport plusString(const std::string & input_name, const std::string & output_name);
 
-    boost::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument);
+    boost::tuple<std::string, std::string> DLLExport loadRunString(const std::string & run, const std::string & instrument);
 
-    std::string getRunNumber(const std::string & ws_name);
+    std::string DLLExport getRunNumber(const std::string & ws_name);
 
-    boost::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
+    boost::tuple<std::string, std::string> DLLExport scaleString(const std::string & runNo, const double scale);
 
-    boost::tuple<std::string, std::string>
+    boost::tuple<std::string, std::string> DLLExport
       rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, ColNumbers col_nums);
 
-    boost::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
+    boost::tuple<std::string, std::string> DLLExport transWSString(const std::string & trans_ws_str, const std::string & instrument);
 
     class DLLExport ReflGenerateNotebook {
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -46,7 +46,7 @@ namespace MantidQt {
                            QReflTableModel_sptr model,
                            const std::string instrument,
                            const int COL_RUNS, const int COL_TRANSMISSION, const int COL_OPTIONS, const int COL_ANGLE,
-                           const int COL_QMIN, const int COL_QMAX, const int COL_DQQ);
+                           const int COL_QMIN, const int COL_QMAX, const int COL_DQQ, const int COL_SCALE);
 
       virtual ~ReflGenerateNotebook(){};
 
@@ -68,6 +68,8 @@ namespace MantidQt {
 
       std::string getRunNumber(std::string ws_name);
 
+      std::tuple<std::string, std::string> scaleString(std::string runNo, double scale);
+
       std::tuple<std::string, std::string> convertToPointString(std::string wsName);
 
       std::tuple<std::string, std::string> rebinString(int rowNo, std::string runNo);
@@ -85,6 +87,7 @@ namespace MantidQt {
       const int COL_QMIN;
       const int COL_QMAX;
       const int COL_DQQ;
+      const int COL_SCALE;
 
     };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -54,7 +54,7 @@ namespace MantidQt {
 
     private:
 
-      std::string plotIvsQ(std::vector<std::string> ws_names);
+      std::string plotIvsQ(std::vector<std::string> ws_names, std::string axes);
 
       std::tuple<std::string, std::string> stitchGroupString(std::set<int> rows);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <string>
 #include <sstream>
+#include <boost/tuple/tuple.hpp>
 
 
 namespace MantidQt {
@@ -68,7 +69,7 @@ namespace MantidQt {
 
     std::string titleString(const std::string & wsName);
 
-    std::tuple<std::string, std::string>
+    boost::tuple<std::string, std::string>
       stitchGroupString(const std::set<int> & rows, const std::string & instrument, QReflTableModel_sptr model,
                         ColNumbers col_nums);
 
@@ -77,23 +78,23 @@ namespace MantidQt {
     std::string plotsString(const std::vector<std::string> & unstitched_ws,
                             const std::vector<std::string> & IvsLam_ws, const std::string & stitched_wsStr);
 
-    std::tuple<std::string, std::string, std::string>
+    boost::tuple<std::string, std::string, std::string>
       reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, ColNumbers col_nums);
 
-    std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument);
+    boost::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument);
 
     std::string plusString(const std::string & input_name, const std::string & output_name);
 
-    std::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument);
+    boost::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument);
 
     std::string getRunNumber(const std::string & ws_name);
 
-    std::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
+    boost::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
 
-    std::tuple<std::string, std::string>
+    boost::tuple<std::string, std::string>
       rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, ColNumbers col_nums);
 
-    std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
+    boost::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
 
     class DLLExport ReflGenerateNotebook {
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -62,13 +62,15 @@ namespace MantidQt {
 
       std::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
 
+      std::string plusString(std::string input_name, std::string output_name);
+
       std::tuple<std::string, std::string> loadRunString(std::string run);
 
       std::string getRunNumber(std::string ws_name);
 
       std::tuple<std::string, std::string> convertToPointString(std::string wsName);
 
-      std::tuple<std::string, std::string> reductionString(int rowNo, std::string runNo);
+      std::tuple<std::string, std::string> rebinString(int rowNo, std::string runNo);
 
       std::tuple<std::string, std::string> transWSString(std::string trans_ws_str);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -95,44 +95,6 @@ namespace MantidQt {
 
     std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
 
-    /**
-    Create string of comma separated list of values from a vector
-    @param param_vec : vector of values
-    @return string of comma separated list of values
-    */
-    template<typename T, typename A>
-    std::string vectorString(const std::vector<T,A> &param_vec)
-    {
-      std::ostringstream vector_string;
-      const char* separator = "";
-      for(auto paramIt = param_vec.begin(); paramIt != param_vec.end(); ++paramIt)
-      {
-        vector_string << separator << *paramIt;
-        separator = ", ";
-      }
-
-      return vector_string.str();
-    }
-
-    /**
-    Create string of comma separated list of parameter values from a vector
-    @param param_name : name of the parameter we are creating a list of
-    @param param_vec : vector of parameter values
-    @return string of comma separated list of parameter values
-    */
-    template<typename T, typename A>
-    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec)
-    {
-      std::ostringstream param_vector_string;
-
-      param_vector_string << param_name << " = '";
-      param_vector_string << vectorString(param_vec);
-      param_vector_string << "'";
-
-      return param_vector_string.str();
-    }
-
-
     class DLLExport ReflGenerateNotebook {
 
     public:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -92,8 +92,6 @@ namespace MantidQt {
 
     std::tuple<std::string, std::string> scaleString(const std::string & runNo, const double scale);
 
-    std::tuple<std::string, std::string> convertToPointString(const std::string & wsName);
-
     template<typename T, typename A>
     std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -58,9 +58,11 @@ namespace MantidQt {
       const int scale;
     };
 
+    std::string plot1DString(const std::vector<std::string> & ws_names,
+                             const std::string & title);
 
-    std::string plot1DString(const std::vector<std::string> & ws_names, const std::string & axes,
-                             const std::string & title, const int legendLocation);
+    template<typename T, typename A>
+    std::string vectorString(const std::vector<T,A> &param_vec);
 
     std::string printThetaString(const std::vector<std::string> & runNos,
                                  const std::vector<std::string> & theta);
@@ -68,6 +70,8 @@ namespace MantidQt {
     std::tuple<std::string, std::string>
       stitchGroupString(const std::set<int> & rows, const std::string & instrument, QReflTableModel_sptr model,
                         col_numbers col_nums);
+
+    std::string plotsFunctionString();
 
     std::tuple<std::string, std::string, std::string, std::string, std::string>
       reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, col_numbers col_nums);
@@ -85,7 +89,7 @@ namespace MantidQt {
     std::tuple<std::string, std::string> convertToPointString(const std::string & wsName);
 
     template<typename T, typename A>
-    std::string vectorParamString(const std::string & param_name, std::vector<T,A> &param_vec);
+    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec);
 
     std::tuple<std::string, std::string>
       rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, col_numbers col_nums);

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -41,12 +41,13 @@ namespace MantidQt {
 
 
     // Column numbers to find data in model
-    struct col_numbers {
+    struct ColNumbers {
 
-      col_numbers(const int runs_column, const int transmission_column, const int options_column, const int angle_column,
-                  const int qmin_column, const int qmax_column, const int dqq_column, const int scale_column)
+      ColNumbers(const int runs_column, const int transmission_column, const int options_column,
+                 const int angle_column, const int qmin_column, const int qmax_column,
+                 const int dqq_column, const int scale_column, const int group_column)
         : runs(runs_column), transmission(transmission_column), options(options_column), angle(angle_column),
-          qmin(qmin_column), qmax(qmax_column), dqq(dqq_column), scale(scale_column) {}
+          qmin(qmin_column), qmax(qmax_column), dqq(dqq_column), scale(scale_column), group(group_column) {}
 
       const int runs;
       const int transmission;
@@ -56,25 +57,25 @@ namespace MantidQt {
       const int qmax;
       const int dqq;
       const int scale;
+      const int group;
     };
 
     std::string plot1DString(const std::vector<std::string> & ws_names,
                              const std::string & title);
 
+    std::string tableString(QReflTableModel_sptr model, ColNumbers col_nums, const std::set<int> & rows);
+
     template<typename T, typename A>
     std::string vectorString(const std::vector<T,A> &param_vec);
 
-    std::string printThetaString(const std::vector<std::string> & runNos,
-                                 const std::vector<std::string> & theta);
-
     std::tuple<std::string, std::string>
       stitchGroupString(const std::set<int> & rows, const std::string & instrument, QReflTableModel_sptr model,
-                        col_numbers col_nums);
+                        ColNumbers col_nums);
 
     std::string plotsFunctionString();
 
-    std::tuple<std::string, std::string, std::string, std::string, std::string>
-      reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, col_numbers col_nums);
+    std::tuple<std::string, std::string, std::string>
+      reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, ColNumbers col_nums);
 
     std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument);
 
@@ -92,7 +93,7 @@ namespace MantidQt {
     std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec);
 
     std::tuple<std::string, std::string>
-      rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, col_numbers col_nums);
+      rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, ColNumbers col_nums);
 
     std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument);
 
@@ -105,11 +106,12 @@ namespace MantidQt {
                            QReflTableModel_sptr model,
                            const std::string instrument,
                            const int col_runs, const int col_transmission, const int col_options, const int col_angle,
-                           const int col_qmin, const int col_qmax, const int col_dqq, const int col_scale);
+                           const int col_qmin, const int col_qmax, const int col_dqq,
+                           const int col_scale, const int col_group);
 
       virtual ~ReflGenerateNotebook(){};
 
-      std::string generateNotebook(std::map<int, std::set<int>> groups);
+      std::string generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows);
 
     private:
 
@@ -117,7 +119,7 @@ namespace MantidQt {
       QReflTableModel_sptr m_model;
       const std::string m_instrument;
 
-      col_numbers col_nums;
+      ColNumbers col_nums;
 
     };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -1,0 +1,81 @@
+#ifndef MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOK_H
+#define MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOK_H
+
+/** @class ReflGenerateNotebook
+
+    This class creates ipython notebooks from the ISIS Reflectometry
+    (Polref) interface
+
+    Copyright &copy; 2007-8 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+    National Laboratory & European Spallation Source
+
+    This file is part of Mantid.
+
+    Mantid is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Mantid is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    File change history is stored at: <https://github.com/mantidproject/mantid>.
+    Code Documentation is available at: <http://doxygen.mantidproject.org>
+    */
+
+#include "MantidQtCustomInterfaces/QReflTableModel.h"
+#include "MantidKernel/System.h"
+
+#include <set>
+#include <map>
+#include <string>
+#include <boost/tuple/tuple.hpp>
+
+namespace MantidQt {
+  namespace CustomInterfaces {
+
+    class DLLExport ReflGenerateNotebook {
+    public:
+
+      ReflGenerateNotebook(std::string name,
+                           QReflTableModel_sptr model,
+                           const std::string instrument,
+                           const int COL_RUNS, const int COL_TRANSMISSION, const int COL_OPTIONS, const int COL_ANGLE);
+
+      virtual ~ReflGenerateNotebook(){};
+
+      void generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows);
+
+    private:
+      std::string reduceRowString(int rowNo);
+
+      boost::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
+
+      boost::tuple<std::string, std::string> loadRunString(std::string run);
+
+      std::string getRunNumber(std::string ws_name);
+
+      boost::tuple<std::string, std::string> transWSString(std::string trans_ws_str);
+
+      std::map<std::string, std::string> parseKeyValueString(const std::string &str);
+
+      std::string m_wsName;
+      QReflTableModel_sptr m_model;
+      const std::string m_instrument;
+
+      const int COL_RUNS;
+      const int COL_TRANSMISSION;
+      const int COL_OPTIONS;
+      const int COL_ANGLE;
+
+    };
+
+  }
+}
+
+#endif //MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOK_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -34,7 +34,7 @@
 #include <set>
 #include <map>
 #include <string>
-#include <boost/tuple/tuple.hpp>
+//#include <tuple>
 
 namespace MantidQt {
   namespace CustomInterfaces {
@@ -45,22 +45,32 @@ namespace MantidQt {
       ReflGenerateNotebook(std::string name,
                            QReflTableModel_sptr model,
                            const std::string instrument,
-                           const int COL_RUNS, const int COL_TRANSMISSION, const int COL_OPTIONS, const int COL_ANGLE);
+                           const int COL_RUNS, const int COL_TRANSMISSION, const int COL_OPTIONS, const int COL_ANGLE,
+                           const int COL_QMIN, const int COL_QMAX, const int COL_DQQ);
 
       virtual ~ReflGenerateNotebook(){};
 
       void generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows);
 
     private:
-      std::string reduceRowString(int rowNo);
 
-      boost::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
+      std::string plotIvsQ(std::vector<std::string> ws_names);
 
-      boost::tuple<std::string, std::string> loadRunString(std::string run);
+      std::string stitchGroupString();
+
+      std::tuple<std::string, std::string> reduceRowString(int rowNo);
+
+      std::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
+
+      std::tuple<std::string, std::string> loadRunString(std::string run);
 
       std::string getRunNumber(std::string ws_name);
 
-      boost::tuple<std::string, std::string> transWSString(std::string trans_ws_str);
+      std::tuple<std::string, std::string> convertToPointString(std::string wsName);
+
+      std::tuple<std::string, std::string> reductionString(int rowNo, std::string runNo);
+
+      std::tuple<std::string, std::string> transWSString(std::string trans_ws_str);
 
       std::map<std::string, std::string> parseKeyValueString(const std::string &str);
 
@@ -72,6 +82,9 @@ namespace MantidQt {
       const int COL_TRANSMISSION;
       const int COL_OPTIONS;
       const int COL_ANGLE;
+      const int COL_QMIN;
+      const int COL_QMAX;
+      const int COL_DQQ;
 
     };
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -54,7 +54,7 @@ namespace MantidQt {
 
     private:
 
-      std::string plot1D(std::vector<std::string> ws_names, std::string axes, std::string title);
+      std::string plot1D(std::vector<std::string> ws_names, std::string axes, std::string title, int legendLocation);
 
       std::tuple<std::string, std::string> stitchGroupString(std::set<int> rows);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -56,9 +56,11 @@ namespace MantidQt {
 
       std::string plot1D(std::vector<std::string> ws_names, std::string axes, std::string title, int legendLocation);
 
+      std::string printThetaString(std::vector<std::string> runNos, std::vector<std::string> theta);
+
       std::tuple<std::string, std::string> stitchGroupString(std::set<int> rows);
 
-      std::tuple<std::string, std::string, std::string> reduceRowString(int rowNo);
+      std::tuple<std::string, std::string, std::string, std::string, std::string> reduceRowString(int rowNo);
 
       std::tuple<std::string, std::string> loadWorkspaceString(std::string runStr);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflGenerateNotebook.h
@@ -50,7 +50,7 @@ namespace MantidQt {
 
       virtual ~ReflGenerateNotebook(){};
 
-      void generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows);
+      void generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows, std::string filename);
 
     private:
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainView.h
@@ -65,6 +65,9 @@ namespace MantidQt
       virtual void setProgressRange(int min, int max) = 0;
       virtual void setProgress(int progress) = 0;
 
+      //Get status of the checkbox which dictates whether an ipython notebook is produced
+      virtual bool getEnableNotebook() = 0;
+
       //Settor methods
       virtual void setSelection(const std::set<int>& rows) = 0;
       virtual void setTableList(const std::set<std::string>& tables) = 0;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -149,7 +149,7 @@ namespace MantidQt
       void handleRenameEvent(Mantid::API::WorkspaceRenameNotification_ptr pNf);
       void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
 
-      void saveNotebook(std::map<int,std::set<int>> groups);
+      void saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows);
 
     public:
       static const int COL_RUNS         = 0;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -71,10 +71,6 @@ namespace MantidQt
 
       //process selected rows
       void process();
-      //generate an ipython notebook
-      void generateNotebook(std::map<int,std::set<int>> groups, std::set<int> rows);
-      //add a code cell to notebook which uses reduction algorithm on the specified row
-      std::string reduceRowNotebookCell(int rowNo);
       //process groups of rows
       bool processGroups(std::map<int,std::set<int>> groups, std::set<int> rows);
       //Reduce a row

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -71,6 +71,8 @@ namespace MantidQt
 
       //process selected rows
       void process();
+      //process groups of rows
+      void processGroups(std::map<int,std::set<int>> groups, std::set<int> rows);
       //Reduce a row
       void reduceRow(int rowNo);
       //prepare a run or list of runs for processing
@@ -83,6 +85,8 @@ namespace MantidQt
       int getUnusedGroup(std::set<int> ignoredRows = std::set<int>()) const;
       //make a transmission workspace
       Mantid::API::Workspace_sptr makeTransWS(const std::string& transString);
+      //Validate rows
+      bool rowsValid(std::set<int> rows);
       //Validate a row
       void validateRow(int rowNo) const;
       //Autofill a row with sensible values

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -9,6 +9,7 @@
 #include "MantidQtCustomInterfaces/ReflMainView.h"
 #include "MantidQtCustomInterfaces/ReflTransferStrategy.h"
 #include "MantidQtCustomInterfaces/QReflTableModel.h"
+#include "MantidAPI/NotebookWriter.h"
 
 #include <Poco/AutoPtr.h>
 #include <Poco/NObserver.h>
@@ -71,8 +72,12 @@ namespace MantidQt
 
       //process selected rows
       void process();
+      //generate an ipython notebook
+      void generateNotebook(std::map<int,std::set<int>> groups, std::set<int> rows);
+      //add a code cell to notebook which uses reduction algorithm on the specified row
+      void reduceRowNotebookCell(Mantid::API::NotebookWriter& notebook, int rowNo);
       //process groups of rows
-      void processGroups(std::map<int,std::set<int>> groups, std::set<int> rows);
+      bool processGroups(std::map<int,std::set<int>> groups, std::set<int> rows);
       //Reduce a row
       void reduceRow(int rowNo);
       //prepare a run or list of runs for processing

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -149,6 +149,8 @@ namespace MantidQt
       void handleRenameEvent(Mantid::API::WorkspaceRenameNotification_ptr pNf);
       void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
 
+      void saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows);
+
     public:
       static const int COL_RUNS         = 0;
       static const int COL_ANGLE        = 1;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -49,8 +49,6 @@ namespace MantidQt
       virtual void notify(IReflPresenter::Flag flag);
       virtual const std::map<std::string,QVariant>& options() const;
       virtual void setOptions(const std::map<std::string,QVariant>& options);
-      //Public for the purposes of unit testing
-      static std::map<std::string,std::string> parseKeyValueString(const std::string& str);
     protected:
       //the workspace the model is currently representing
       Mantid::API::ITableWorkspace_sptr m_ws;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -149,7 +149,7 @@ namespace MantidQt
       void handleRenameEvent(Mantid::API::WorkspaceRenameNotification_ptr pNf);
       void handleReplaceEvent(Mantid::API::WorkspaceAfterReplaceNotification_ptr pNf);
 
-      void saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows);
+      void saveNotebook(std::map<int,std::set<int>> groups);
 
     public:
       static const int COL_RUNS         = 0;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainViewPresenter.h
@@ -9,7 +9,6 @@
 #include "MantidQtCustomInterfaces/ReflMainView.h"
 #include "MantidQtCustomInterfaces/ReflTransferStrategy.h"
 #include "MantidQtCustomInterfaces/QReflTableModel.h"
-#include "MantidAPI/NotebookWriter.h"
 
 #include <Poco/AutoPtr.h>
 #include <Poco/NObserver.h>
@@ -75,7 +74,7 @@ namespace MantidQt
       //generate an ipython notebook
       void generateNotebook(std::map<int,std::set<int>> groups, std::set<int> rows);
       //add a code cell to notebook which uses reduction algorithm on the specified row
-      void reduceRowNotebookCell(Mantid::API::NotebookWriter& notebook, int rowNo);
+      std::string reduceRowNotebookCell(int rowNo);
       //process groups of rows
       bool processGroups(std::map<int,std::set<int>> groups, std::set<int> rows);
       //Reduce a row

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainWidget.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainWidget.ui
@@ -313,6 +313,13 @@
              </widget>
             </item>
             <item>
+             <widget class="QCheckBox" name="checkEnableNotebook">
+              <property name="text">
+               <string>Output Notebook</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QToolButton" name="buttonProcess">
               <property name="text">
                <string>Process</string>
@@ -341,7 +348,7 @@
      <x>0</x>
      <y>0</y>
      <width>959</width>
-     <height>23</height>
+     <height>25</height>
     </rect>
    </property>
    <property name="nativeMenuBar">

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflVectorString.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflVectorString.h
@@ -1,0 +1,48 @@
+#ifndef MANTID_CUSTOMINTERFACES_REFLVECTORSTRING_H
+#define MANTID_CUSTOMINTERFACES_REFLVECTORSTRING_H
+
+namespace MantidQt {
+  namespace CustomInterfaces {
+
+    /**
+    Create string of comma separated list of values from a vector
+    @param param_vec : vector of values
+    @return string of comma separated list of values
+    */
+    template<typename T, typename A>
+    std::string vectorString(const std::vector<T,A> &param_vec)
+    {
+      std::ostringstream vector_string;
+      const char* separator = "";
+      for(auto paramIt = param_vec.begin(); paramIt != param_vec.end(); ++paramIt)
+      {
+        vector_string << separator << *paramIt;
+        separator = ", ";
+      }
+
+      return vector_string.str();
+    }
+
+    /**
+    Create string of comma separated list of parameter values from a vector
+    @param param_name : name of the parameter we are creating a list of
+    @param param_vec : vector of parameter values
+    @return string of comma separated list of parameter values
+    */
+    template<typename T, typename A>
+    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec)
+    {
+      std::ostringstream param_vector_string;
+
+      param_vector_string << param_name << " = '";
+      param_vector_string << vectorString(param_vec);
+      param_vector_string << "'";
+
+      return param_vector_string.str();
+    }
+
+  }
+}
+
+
+#endif //MANTID_CUSTOMINTERFACES_REFLVECTORSTRING_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflVectorString.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflVectorString.h
@@ -1,6 +1,33 @@
 #ifndef MANTID_CUSTOMINTERFACES_REFLVECTORSTRING_H
 #define MANTID_CUSTOMINTERFACES_REFLVECTORSTRING_H
 
+/** @class ReflGenerateNotebook
+
+    This class creates ipython notebooks from the ISIS Reflectometry
+    (Polref) interface
+
+    Copyright &copy; 2007-8 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+    National Laboratory & European Spallation Source
+
+    This file is part of Mantid.
+
+    Mantid is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    Mantid is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+    File change history is stored at: <https://github.com/mantidproject/mantid>.
+    Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+
 namespace MantidQt {
   namespace CustomInterfaces {
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ParseKeyValueString.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ParseKeyValueString.cpp
@@ -1,0 +1,50 @@
+#include "MantidQtCustomInterfaces/ParseKeyValueString.h"
+#include <vector>
+#include <boost/algorithm/string.hpp>
+#include <boost/tokenizer.hpp>
+
+
+namespace MantidQt {
+  namespace CustomInterfaces {
+/**
+    Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'` into a map of key/value pairs
+    @param str The input string
+    @throws std::runtime_error on an invalid input string
+    */
+    std::map<std::string, std::string> parseKeyValueString(const std::string &str) {
+      //Tokenise, using '\' as an escape character, ',' as a delimiter and " and ' as quote characters
+      boost::tokenizer <boost::escaped_list_separator<char>> tok(str,
+                                                                 boost::escaped_list_separator<char>("\\", ",", "\"'"));
+
+      std::map<std::string, std::string> kvp;
+
+      for (auto it = tok.begin(); it != tok.end(); ++it) {
+        std::vector<std::string> valVec;
+        boost::split(valVec, *it, boost::is_any_of("="));
+
+        if (valVec.size() > 1) {
+          //We split on all '='s. The first delimits the key, the rest are assumed to be part of the value
+          std::string key = valVec[0];
+          //Drop the key from the values vector
+          valVec.erase(valVec.begin());
+          //Join the remaining sections,
+          std::string value = boost::algorithm::join(valVec, "=");
+
+          //Remove any unwanted whitespace
+          boost::trim(key);
+          boost::trim(value);
+
+          if (key.empty() || value.empty())
+            throw std::runtime_error("Invalid key value pair, '" + *it + "'");
+
+
+          kvp[key] = value;
+        }
+        else {
+          throw std::runtime_error("Invalid key value pair, '" + *it + "'");
+        }
+      }
+      return kvp;
+    }
+  }
+}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
@@ -472,6 +472,15 @@ namespace MantidQt
     }
 
     /**
+     Get status of checkbox which determines whether an ipython notebook is produced
+     @return true if a notebook should be output on process, false otherwise
+     */
+    bool QtReflMainView::getEnableNotebook()
+    {
+      return ui.checkEnableNotebook->isChecked();
+    }
+
+    /**
     Set which rows are selected
     @param rows : The set of rows to select
     */

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -25,6 +25,7 @@ namespace MantidQt {
       Generate an ipython notebook
       @param rows : rows in the model which were processed
       @param groups : groups of rows which were stitched
+      @param filename : location to save notebook to
       */
     void ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows, std::string filename) {
       std::unique_ptr<Mantid::API::NotebookWriter> notebook(new Mantid::API::NotebookWriter());
@@ -148,6 +149,12 @@ namespace MantidQt {
       return std::make_tuple(stitch_string.str(), outputWSName);
     }
 
+    /**
+      Create string of comma separated list of parameter values from a vector
+      @param param_name : name of the parameter we are creating a list of
+      @param param_vec : vector of parameter values
+      @return string of comma separated list of parameter values
+      */
     template<typename T, typename A>
     std::string ReflGenerateNotebook::vectorParamString(std::string param_name, std::vector<T,A> &param_vec)
     {
@@ -164,6 +171,12 @@ namespace MantidQt {
       return vector_string.str();
     }
 
+    /**
+      Create string of python code to plot I vs Q from workspaces
+      @param ws_names : vector of workspace names to plot on the same axes
+      @param axes : handle of axes to plot in
+      @return string  of python code to plot I vs Q
+      */
     std::string ReflGenerateNotebook::plotIvsQ(std::vector<std::string> ws_names, std::string axes) {
 
       std::ostringstream plot_string;
@@ -184,9 +197,9 @@ namespace MantidQt {
     }
 
     /**
-    Add a code cell to the notebook which runs reduce algorithm on the row specified
-    @param notebook : the notebook to add the cell to
-    @param rowNo : the row in the model to run the reduction algorithm on
+     Create string of python code to run reduction algorithm on the specified row
+     @param rowNo : the row in the model to run the reduction algorithm on
+     @return tuple containing the python string and the output workspace name
     */
     std::tuple<std::string, std::string> ReflGenerateNotebook::reduceRowString(int rowNo) {
       std::ostringstream code_string;
@@ -241,6 +254,12 @@ namespace MantidQt {
       return std::make_tuple(code_string.str(), std::get<1>(rebin_string));
     }
 
+     /**
+      Create string of python code to run the scale algorithm
+      @param runNo : the number of the run to scale
+      @param scale : value of scaling factor to use
+      @return tuple of strings of python code and output workspace name
+      */
     std::tuple<std::string, std::string> ReflGenerateNotebook::scaleString(std::string runNo, double scale)
     {
       std::ostringstream scale_string;
@@ -253,6 +272,11 @@ namespace MantidQt {
       return std::make_tuple(scale_string.str(), "IvsQ" + runNo);
     }
 
+    /**
+      Create string of python code to convert to point data, which can be plotted
+      @param wsName : name of workspace to convert to point data
+      @return tuple of strings of python code and output workspace name
+      */
     std::tuple<std::string, std::string> ReflGenerateNotebook::convertToPointString(std::string wsName)
     {
       const std::string output_name = wsName + "_plot";
@@ -262,6 +286,12 @@ namespace MantidQt {
       return std::make_tuple(convert_string.str(), output_name);
     }
 
+    /**
+     Create string of python code to rebin data in a workspace
+     @param rowNo : the number of the row to rebin
+     @param runNo : the number of the run to rebin
+     @return tuple of strings of python code and output workspace name
+    */
     std::tuple<std::string, std::string> ReflGenerateNotebook::rebinString(int rowNo, std::string runNo)
     {
       //We need to make sure that qmin and qmax are respected, so we rebin to
@@ -282,6 +312,11 @@ namespace MantidQt {
       return std::make_tuple(rebin_string.str(), "IvsQ_" + runNo);
     }
 
+    /**
+     Create string of python code to create a transmission workspace
+     @param trans_ws_str : string of workspaces to create transmission workspace from
+     @return tuple of strings of python code and output workspace name
+    */
     std::tuple<std::string, std::string> ReflGenerateNotebook::transWSString(std::string trans_ws_str)
     {
       const size_t maxTransWS = 2;
@@ -315,6 +350,11 @@ namespace MantidQt {
       return std::make_tuple(trans_string.str(), wsName);
     }
 
+    /**
+     Get run number from workspace name
+     @param ws_name : workspace name
+     @return run number, as a string
+    */
     std::string ReflGenerateNotebook::getRunNumber(std::string ws_name) {
       //Matches TOF_13460 -> 13460
       boost::regex outputRegex("(TOF|IvsQ|IvsLam)_([0-9]+)");
@@ -335,6 +375,11 @@ namespace MantidQt {
       return ws_name;
     }
 
+    /**
+     Create string of python code to load workspaces
+     @param runStr : string of workspaces to load
+     @return tuple of strings of python code and output workspace name
+    */
     std::tuple<std::string, std::string> ReflGenerateNotebook::loadWorkspaceString(std::string runStr) {
       std::vector<std::string> runs;
       boost::split(runs, runStr, boost::is_any_of("+"));
@@ -369,6 +414,12 @@ namespace MantidQt {
       return std::make_tuple(load_strings.str(), outputName);
     }
 
+    /**
+     Create string of python code to run the Plus algorithm on specified workspaces
+     @param input_name : name of workspace to add to the other workspace
+     @param output_name : other workspace will be added to the one with this name
+     @return string of python code
+    */
     std::string ReflGenerateNotebook::plusString(std::string input_name, std::string output_name)
     {
       std::ostringstream plus_string;
@@ -380,6 +431,11 @@ namespace MantidQt {
       return plus_string.str();
     }
 
+    /**
+     Create string of python code to load a single workspace
+     @param run : run to load
+     @return tuple of strings of python code and output workspace name
+    */
     std::tuple<std::string, std::string> ReflGenerateNotebook::loadRunString(std::string run) {
       std::ostringstream load_string;
       // We do not have access to AnalysisDataService from notebook, so must load run from file

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -88,8 +88,8 @@ namespace MantidQt {
       return notebook->writeNotebook();
     }
 
-    std::string ReflGenerateNotebook::printThetaString(std::vector<std::string> runNos,
-                                                       std::vector<std::string> theta)
+    std::string ReflGenerateNotebook::printThetaString(const std::vector<std::string> & runNos,
+                                                       const std::vector<std::string> & theta)
     {
       std::ostringstream theta_string;
 
@@ -109,7 +109,7 @@ namespace MantidQt {
       @param rows : rows in the stitch group
       @return tuple containing the python code string and the output workspace name
       */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::stitchGroupString(std::set<int> rows)
+    std::tuple<std::string, std::string> ReflGenerateNotebook::stitchGroupString(const std::set<int> & rows)
     {
       std::ostringstream stitch_string;
 
@@ -178,7 +178,7 @@ namespace MantidQt {
       @return string of comma separated list of parameter values
       */
     template<typename T, typename A>
-    std::string ReflGenerateNotebook::vectorParamString(std::string param_name, std::vector<T,A> &param_vec)
+    std::string ReflGenerateNotebook::vectorParamString(const std::string & param_name, std::vector<T,A> &param_vec)
     {
       std::ostringstream vector_string;
       const char* separator = "";
@@ -199,8 +199,8 @@ namespace MantidQt {
       @param axes : handle of axes to plot in
       @return string  of python code to plot I vs Q
       */
-    std::string ReflGenerateNotebook::plot1D(std::vector<std::string> ws_names, std::string axes, std::string title,
-                                             int legendLocation) {
+    std::string ReflGenerateNotebook::plot1D(const std::vector<std::string> & ws_names, const std::string & axes,
+                                             const std::string & title, const int legendLocation) {
 
       std::ostringstream plot_string;
 
@@ -231,7 +231,7 @@ namespace MantidQt {
      @param rowNo : the row in the model to run the reduction algorithm on
      @return tuple containing the python string and the output workspace name
     */
-    std::tuple<std::string, std::string, std::string, std::string, std::string> ReflGenerateNotebook::reduceRowString(int rowNo) {
+    std::tuple<std::string, std::string, std::string, std::string, std::string> ReflGenerateNotebook::reduceRowString(const int rowNo) {
       std::ostringstream code_string;
 
       const std::string runStr = m_model->data(m_model->index(rowNo, COL_RUNS)).toString().toStdString();
@@ -298,7 +298,7 @@ namespace MantidQt {
       @param scale : value of scaling factor to use
       @return tuple of strings of python code and output workspace name
       */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::scaleString(std::string runNo, double scale)
+    std::tuple<std::string, std::string> ReflGenerateNotebook::scaleString(const std::string & runNo, const double scale)
     {
       std::ostringstream scale_string;
 
@@ -315,7 +315,7 @@ namespace MantidQt {
       @param wsName : name of workspace to convert to point data
       @return tuple of strings of python code and output workspace name
       */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::convertToPointString(std::string wsName)
+    std::tuple<std::string, std::string> ReflGenerateNotebook::convertToPointString(const std::string & wsName)
     {
       const std::string output_name = wsName + "_plot";
       std::ostringstream convert_string;
@@ -330,7 +330,7 @@ namespace MantidQt {
      @param runNo : the number of the run to rebin
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::rebinString(int rowNo, std::string runNo)
+    std::tuple<std::string, std::string> ReflGenerateNotebook::rebinString(const int rowNo, const std::string & runNo)
     {
       //We need to make sure that qmin and qmax are respected, so we rebin to
       //those limits here.
@@ -355,7 +355,7 @@ namespace MantidQt {
      @param trans_ws_str : string of workspaces to create transmission workspace from
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::transWSString(std::string trans_ws_str)
+    std::tuple<std::string, std::string> ReflGenerateNotebook::transWSString(const std::string & trans_ws_str)
     {
       const size_t maxTransWS = 2;
 
@@ -393,7 +393,7 @@ namespace MantidQt {
      @param ws_name : workspace name
      @return run number, as a string
     */
-    std::string ReflGenerateNotebook::getRunNumber(std::string ws_name) {
+    std::string ReflGenerateNotebook::getRunNumber(const std::string & ws_name) {
       //Matches TOF_13460 -> 13460
       boost::regex outputRegex("(TOF|IvsQ|IvsLam)_([0-9]+)");
 
@@ -418,7 +418,7 @@ namespace MantidQt {
      @param runStr : string of workspaces to load
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::loadWorkspaceString(std::string runStr) {
+    std::tuple<std::string, std::string> ReflGenerateNotebook::loadWorkspaceString(const std::string & runStr) {
       std::vector<std::string> runs;
       boost::split(runs, runStr, boost::is_any_of("+"));
 
@@ -458,7 +458,7 @@ namespace MantidQt {
      @param output_name : other workspace will be added to the one with this name
      @return string of python code
     */
-    std::string ReflGenerateNotebook::plusString(std::string input_name, std::string output_name)
+    std::string ReflGenerateNotebook::plusString(const std::string & input_name, const std::string & output_name)
     {
       std::ostringstream plus_string;
 
@@ -474,7 +474,7 @@ namespace MantidQt {
      @param run : run to load
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::loadRunString(std::string run) {
+    std::tuple<std::string, std::string> ReflGenerateNotebook::loadRunString(const std::string & run) {
       std::ostringstream load_string;
       // We do not have access to AnalysisDataService from notebook, so must load run from file
       const std::string filename = m_instrument + run;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -52,24 +52,24 @@ namespace MantidQt {
 
         //Reduce each row
         std::ostringstream code_string;
-        std::tuple<std::string, std::string, std::string> reduce_row_string;
+        boost::tuple<std::string, std::string, std::string> reduce_row_string;
         std::vector<std::string> unstitched_ws;
         std::vector<std::string> IvsLam_ws;
         code_string << "#Load and reduce\n";
         for (auto rIt = groupRows.begin(); rIt != groupRows.end(); ++rIt) {
           reduce_row_string = reduceRowString(*rIt, m_instrument, m_model, col_nums);
-          code_string << std::get<0>(reduce_row_string);
-          unstitched_ws.push_back(std::get<1>(reduce_row_string));
-          IvsLam_ws.push_back(std::get<2>(reduce_row_string));
+          code_string << boost::get<0>(reduce_row_string);
+          unstitched_ws.push_back(boost::get<1>(reduce_row_string));
+          IvsLam_ws.push_back(boost::get<2>(reduce_row_string));
         }
         notebook->codeCell(code_string.str());
 
         // Stitch group
-        std::tuple<std::string, std::string> stitch_string = stitchGroupString(groupRows, m_instrument, m_model, col_nums);
-        notebook->codeCell(std::get<0>(stitch_string));
+        boost::tuple<std::string, std::string> stitch_string = stitchGroupString(groupRows, m_instrument, m_model, col_nums);
+        notebook->codeCell(boost::get<0>(stitch_string));
 
         // Draw plots
-        notebook->codeCell(plotsString(unstitched_ws, IvsLam_ws, std::get<1>(stitch_string)));
+        notebook->codeCell(plotsString(unstitched_ws, IvsLam_ws, boost::get<1>(stitch_string)));
       }
 
       return notebook->writeNotebook();
@@ -240,7 +240,7 @@ namespace MantidQt {
       @param col_nums : column numbers used to find data in model
       @return tuple containing the python code string and the output workspace name
       */
-    std::tuple<std::string, std::string> stitchGroupString(const std::set<int> & rows, const std::string & instrument,
+    boost::tuple<std::string, std::string> stitchGroupString(const std::set<int> & rows, const std::string & instrument,
                                                            QReflTableModel_sptr model, ColNumbers col_nums)
     {
       std::ostringstream stitch_string;
@@ -249,7 +249,7 @@ namespace MantidQt {
 
       //If we can get away with doing nothing, do.
       if(rows.size() < 2)
-        return std::make_tuple("", "");
+        return boost::make_tuple("", "");
 
       //Properties for Stitch1DMany
       std::vector<std::string> workspaceNames;
@@ -266,9 +266,9 @@ namespace MantidQt {
         const double         qmin = model->data(model->index(*rowIt, col_nums.qmin)).toDouble();
         const double         qmax = model->data(model->index(*rowIt, col_nums.qmax)).toDouble();
 
-        const std::tuple<std::string, std::string> load_ws_string = loadWorkspaceString(runStr, instrument);
+        const boost::tuple<std::string, std::string> load_ws_string = loadWorkspaceString(runStr, instrument);
 
-        const std::string runNo = getRunNumber(std::get<1>(load_ws_string));
+        const std::string runNo = getRunNumber(boost::get<1>(load_ws_string));
         runs.push_back(runNo);
         workspaceNames.push_back("IvsQ_" + runNo);
 
@@ -300,7 +300,7 @@ namespace MantidQt {
       stitch_string << vectorParamString("EndOverlaps", endOverlaps);
       stitch_string << ")\n";
 
-      return std::make_tuple(stitch_string.str(), outputWSName);
+      return boost::make_tuple(stitch_string.str(), outputWSName);
     }
 
     /**
@@ -328,7 +328,7 @@ namespace MantidQt {
      @param col_nums : column numbers used to find data in model
      @return tuple containing the python string and the output workspace name
     */
-    std::tuple<std::string, std::string, std::string>
+    boost::tuple<std::string, std::string, std::string>
     reduceRowString(const int rowNo, const std::string & instrument, QReflTableModel_sptr model, ColNumbers col_nums) {
       std::ostringstream code_string;
 
@@ -343,23 +343,23 @@ namespace MantidQt {
       if (thetaGiven)
         theta = model->data(model->index(rowNo, col_nums.angle)).toDouble();
 
-      const std::tuple<std::string, std::string> load_ws_string = loadWorkspaceString(runStr, instrument);
-      code_string << std::get<0>(load_ws_string);
+      const boost::tuple<std::string, std::string> load_ws_string = loadWorkspaceString(runStr, instrument);
+      code_string << boost::get<0>(load_ws_string);
 
-      const std::string runNo = getRunNumber(std::get<1>(load_ws_string));
+      const std::string runNo = getRunNumber(boost::get<1>(load_ws_string));
       const std::string IvsLamName = "IvsLam_" + runNo;
       const std::string thetaName = "theta_" + runNo;
 
       if (!transStr.empty()) {
-        const std::tuple<std::string, std::string> trans_string = transWSString(transStr, instrument);
-        code_string << std::get<0>(trans_string);
+        const boost::tuple<std::string, std::string> trans_string = transWSString(transStr, instrument);
+        code_string << boost::get<0>(trans_string);
         code_string << "IvsQ_" << runNo << ", " << IvsLamName << ", " << thetaName << " = ";
-        code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << std::get<1>(load_ws_string) << "'";
-        code_string << ", " << "FirstTransmissionRun = '" << std::get<1>(trans_string) << "'";
+        code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << boost::get<1>(load_ws_string) << "'";
+        code_string << ", " << "FirstTransmissionRun = '" << boost::get<1>(trans_string) << "'";
       }
       else {
         code_string << "IvsQ_" << runNo << ", " << IvsLamName << ", " << thetaName << " = ";
-        code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << std::get<1>(load_ws_string) << "'";
+        code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << boost::get<1>(load_ws_string) << "'";
       }
 
       if (thetaGiven) {
@@ -375,14 +375,14 @@ namespace MantidQt {
 
       const double scale = model->data(model->index(rowNo, col_nums.scale)).toDouble();
       if(scale != 1.0) {
-        const std::tuple<std::string, std::string> scale_string = scaleString(runNo, scale);
-        code_string << std::get<0>(scale_string);
+        const boost::tuple<std::string, std::string> scale_string = scaleString(runNo, scale);
+        code_string << boost::get<0>(scale_string);
       }
 
-      const std::tuple<std::string, std::string> rebin_string = rebinString(rowNo, runNo, model, col_nums);
-      code_string << std::get<0>(rebin_string);
+      const boost::tuple<std::string, std::string> rebin_string = rebinString(rowNo, runNo, model, col_nums);
+      code_string << boost::get<0>(rebin_string);
 
-      return std::make_tuple(code_string.str(), std::get<1>(rebin_string), IvsLamName);
+      return boost::make_tuple(code_string.str(), boost::get<1>(rebin_string), IvsLamName);
     }
 
      /**
@@ -391,7 +391,7 @@ namespace MantidQt {
       @param scale : value of scaling factor to use
       @return tuple of strings of python code and output workspace name
       */
-    std::tuple<std::string, std::string>
+    boost::tuple<std::string, std::string>
      scaleString(const std::string & runNo, const double scale)
     {
       std::ostringstream scale_string;
@@ -401,7 +401,7 @@ namespace MantidQt {
       scale_string << ", Factor = " << 1.0 / scale;
       scale_string << ")\n";
 
-      return std::make_tuple(scale_string.str(), "IvsQ" + runNo);
+      return boost::make_tuple(scale_string.str(), "IvsQ" + runNo);
     }
 
     /**
@@ -412,7 +412,7 @@ namespace MantidQt {
      @param col_nums : column numbers used to find data in model
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string>
+    boost::tuple<std::string, std::string>
       rebinString(const int rowNo, const std::string & runNo, QReflTableModel_sptr model, ColNumbers col_nums)
     {
       //We need to make sure that qmin and qmax are respected, so we rebin to
@@ -430,7 +430,7 @@ namespace MantidQt {
       rebin_string << "'" << qmin << ", " << -dqq << ", " << qmax << "'";
       rebin_string << ")\n";
 
-      return std::make_tuple(rebin_string.str(), "IvsQ_" + runNo);
+      return boost::make_tuple(rebin_string.str(), "IvsQ_" + runNo);
     }
 
     /**
@@ -439,7 +439,7 @@ namespace MantidQt {
      @param instrument : name of the instrument
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument)
+    boost::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument)
     {
       const size_t maxTransWS = 2;
 
@@ -452,11 +452,11 @@ namespace MantidQt {
       if(transVec.size() > maxTransWS)
         transVec.resize(maxTransWS);
 
-      std::tuple<std::string, std::string> load_tuple;
+      boost::tuple<std::string, std::string> load_tuple;
       for(auto it = transVec.begin(); it != transVec.end(); ++it)
         load_tuple = loadWorkspaceString(*it, instrument);
-        trans_ws_name.push_back(std::get<1>(load_tuple));
-        trans_string << std::get<0>(load_tuple);
+        trans_ws_name.push_back(boost::get<1>(load_tuple));
+        trans_string << boost::get<0>(load_tuple);
 
       //The runs are loaded, so we can create a TransWS
       std::string wsName = "TRANS_" + getRunNumber(trans_ws_name[0]);
@@ -469,7 +469,7 @@ namespace MantidQt {
         trans_string << ", SecondTransmissionRun = '" << trans_ws_name[1] << "'";
       trans_string << ")\n";
 
-      return std::make_tuple(trans_string.str(), wsName);
+      return boost::make_tuple(trans_string.str(), wsName);
     }
 
     /**
@@ -503,7 +503,7 @@ namespace MantidQt {
      @param instrument : name of the instrument
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument) {
+    boost::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument) {
       std::vector<std::string> runs;
       boost::split(runs, runStr, boost::is_any_of("+"));
 
@@ -515,26 +515,26 @@ namespace MantidQt {
 
       const std::string outputName = "TOF_" + boost::algorithm::join(runs, "_");
 
-      std::tuple<std::string, std::string> load_string;
+      boost::tuple<std::string, std::string> load_string;
 
       load_string = loadRunString(runs[0], instrument);
-      load_strings << std::get<0>(load_string);
+      load_strings << boost::get<0>(load_string);
 
       // EXIT POINT if there is only one run
       if(runs.size() == 1) {
-        return std::make_tuple(load_strings.str(), std::get<1>(load_string));
+        return boost::make_tuple(load_strings.str(), boost::get<1>(load_string));
       }
-      load_strings << outputName << " = " << std::get<1>(load_string) << "\n";
+      load_strings << outputName << " = " << boost::get<1>(load_string) << "\n";
 
       // Load each subsequent run and add it to the first run
       for(auto runIt = std::next(runs.begin()); runIt != runs.end(); ++runIt)
       {
         load_string = loadRunString(*runIt, instrument);
-        load_strings << std::get<0>(load_string);
-        load_strings << plusString(std::get<1>(load_string), outputName);
+        load_strings << boost::get<0>(load_string);
+        load_strings << plusString(boost::get<1>(load_string), outputName);
       }
 
-      return std::make_tuple(load_strings.str(), outputName);
+      return boost::make_tuple(load_strings.str(), outputName);
     }
 
     /**
@@ -560,7 +560,7 @@ namespace MantidQt {
      @param instrument : name of the instrument
      @return tuple of strings of python code and output workspace name
     */
-    std::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument) {
+    boost::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument) {
       std::ostringstream load_string;
       // We do not have access to AnalysisDataService from notebook, so must load run from file
       const std::string filename = instrument + run;
@@ -570,7 +570,7 @@ namespace MantidQt {
       load_string << "Filename = '" << filename << "'";
       load_string << ")\n";
 
-      return std::make_tuple(load_string.str(), ws_name);
+      return boost::make_tuple(load_string.str(), ws_name);
     }
 
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -74,7 +74,7 @@ namespace MantidQt {
 
         // Group workspaces which should be plotted on same axes
         std::ostringstream plot_string;
-        plot_string << "#Group workspaces which should be plotted on same axes\n";
+        plot_string << "#Group workspaces to be plotted on same axes\n";
         plot_string << "unstitchedGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", unstitched_ws) << ")\n";
         plot_string << "IvsLamGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", IvsLam_ws) << ")\n";
 
@@ -128,7 +128,6 @@ namespace MantidQt {
         "    else:\n"
         "        ax.plot(ws_plot.readX(0), ws_plot.readY(0), label=ws.name())\n"
         "    \n"
-        "    if ops['legend']: ax.legend(loc=ops['legendLocation'])\n"
         "    ax.grid(ops['grid'])\n"
         "    ax.set_xscale(ops['xScale']); ax.set_yscale(ops['yScale'])\n"
         "    if ops['xLimits'] != 'auto': ax.set_xlim(ops['xLimits'])\n"
@@ -137,6 +136,10 @@ namespace MantidQt {
         "    # If a list of titles was given, use it to title each subplot\n"
         "    if hasattr(ops['title'], \"__iter__\"):\n"
         "        ax.set_title(ops['title'][n])\n"
+        "    if ops['legend'] and hasattr(ops['legendLocation'], \"__iter__\"):\n"
+        "        ax.legend(loc=ops['legendLocation'][n])\n"
+        "    elif ops['legend']:\n"
+        "        ax.legend(loc=ops['legendLocation'])"
         "    \n"
         "\n"
         "def plots(listOfWorkspaces, *args, **kwargs):\n"
@@ -299,7 +302,8 @@ namespace MantidQt {
 
       std::ostringstream plot_string;
 
-      plot_string << "fig = plots([" << vectorString(ws_names) << "], title=" << title << ")\n";
+      plot_string << "fig = plots([" << vectorString(ws_names) << "], title=" << title
+                  << ", legendLocation=[1, 1, 4])\n";
 
       return plot_string.str();
     }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -66,7 +66,7 @@ namespace MantidQt {
 
         // Plot the unstitched and stitched I vs Q
         std::ostringstream plot_string;
-        plot_string << "f, (ax1, ax2) = plt.subplots(1, 2, sharey=True)\n";
+        plot_string << "f, (ax1, ax2) = plt.subplots(1, 2, sharey=True, figsize=(12,4))\n";
         std::vector<std::string> stitched_ws;
         stitched_ws.push_back(std::get<1>(stitch_string));
         plot_string << plotIvsQ(ws_names, "ax1"); // unstitched

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -70,9 +70,9 @@ namespace MantidQt {
         plot_string << "f, (ax1, ax2, ax3) = plt.subplots(1, 3, sharey=True, figsize=(18,4))\n";
         std::vector<std::string> stitched_ws;
         stitched_ws.push_back(std::get<1>(stitch_string));
-        plot_string << plot1D(unstitched_ws, "ax1", "I vs Q Unstitched");
-        plot_string << plot1D(stitched_ws, "ax2", "I vs Q Stitiched");
-        plot_string << plot1D(IvsLam_ws, "ax3", "I vs Lambda");
+        plot_string << plot1D(unstitched_ws, "ax1", "I vs Q Unstitched", 1) << "\n";
+        plot_string << plot1D(stitched_ws, "ax2", "I vs Q Stitiched", 1) << "\n";
+        plot_string << plot1D(IvsLam_ws, "ax3", "I vs Lambda", 4);
         plot_string << "plt.show() #Draw the plot\n";
         notebook->codeCell(plot_string.str());
       }
@@ -175,7 +175,8 @@ namespace MantidQt {
       @param axes : handle of axes to plot in
       @return string  of python code to plot I vs Q
       */
-    std::string ReflGenerateNotebook::plot1D(std::vector<std::string> ws_names, std::string axes, std::string title) {
+    std::string ReflGenerateNotebook::plot1D(std::vector<std::string> ws_names, std::string axes, std::string title,
+                                             int legendLocation) {
 
       std::ostringstream plot_string;
       for (auto it = ws_names.begin(); it != ws_names.end(); ++it) {
@@ -190,12 +191,12 @@ namespace MantidQt {
                     << "yerr=" << std::get<1>(convert_point_string) << ".readE(0), "
                     << "label='" << *it << "')\n";
 
-        plot_string << axes << ".set_yscale('log')\n";
+        plot_string << axes << ".set_yscale('log'); ";
         plot_string << axes << ".set_xscale('log')\n";
       }
       plot_string << axes << ".set_title('" << title << "')\n";
       plot_string << axes << ".grid() #Show a grid\n";
-      plot_string << axes << ".legend() #Show a legend\n";
+      plot_string << axes << ".legend(loc=" << legendLocation << ") #Show a legend\n";
 
       return plot_string.str();
     }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -235,6 +235,9 @@ namespace MantidQt {
     /**
       Create string of python code to stitch workspaces in the same group
       @param rows : rows in the stitch group
+      @param instrument : name of the instrument
+      @param model : table model containing details of runs and processing settings
+      @param col_nums : column numbers used to find data in model
       @return tuple containing the python code string and the output workspace name
       */
     std::tuple<std::string, std::string> stitchGroupString(const std::set<int> & rows, const std::string & instrument,
@@ -303,6 +306,7 @@ namespace MantidQt {
     /**
       Create string of python code to create 1D plots from workspaces
       @param ws_names : vector of workspace names to plot
+      @param title : title for figure
       @return string  of python code to plot I vs Q
       */
     std::string plot1DString(const std::vector<std::string> & ws_names,
@@ -319,6 +323,9 @@ namespace MantidQt {
     /**
      Create string of python code to run reduction algorithm on the specified row
      @param rowNo : the row in the model to run the reduction algorithm on
+     @param instrument : name of the instrument
+     @param model : table model containing details of runs and processing settings
+     @param col_nums : column numbers used to find data in model
      @return tuple containing the python string and the output workspace name
     */
     std::tuple<std::string, std::string, std::string>
@@ -401,6 +408,8 @@ namespace MantidQt {
      Create string of python code to rebin data in a workspace
      @param rowNo : the number of the row to rebin
      @param runNo : the number of the run to rebin
+     @param model : table model containing details of runs and processing settings
+     @param col_nums : column numbers used to find data in model
      @return tuple of strings of python code and output workspace name
     */
     std::tuple<std::string, std::string>
@@ -427,6 +436,7 @@ namespace MantidQt {
     /**
      Create string of python code to create a transmission workspace
      @param trans_ws_str : string of workspaces to create transmission workspace from
+     @param instrument : name of the instrument
      @return tuple of strings of python code and output workspace name
     */
     std::tuple<std::string, std::string> transWSString(const std::string & trans_ws_str, const std::string & instrument)
@@ -490,6 +500,7 @@ namespace MantidQt {
     /**
      Create string of python code to load workspaces
      @param runStr : string of workspaces to load
+     @param instrument : name of the instrument
      @return tuple of strings of python code and output workspace name
     */
     std::tuple<std::string, std::string> loadWorkspaceString(const std::string & runStr, const std::string & instrument) {
@@ -546,6 +557,7 @@ namespace MantidQt {
     /**
      Create string of python code to load a single workspace
      @param run : run to load
+     @param instrument : name of the instrument
      @return tuple of strings of python code and output workspace name
     */
     std::tuple<std::string, std::string> loadRunString(const std::string & run, const std::string & instrument) {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -10,7 +10,6 @@
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/foreach.hpp>
-#include <boost/range/combine.hpp>
 
 namespace MantidQt {
   namespace CustomInterfaces {
@@ -47,8 +46,9 @@ namespace MantidQt {
         const std::set<int> groupRows = gIt->second;
 
         // Announce the stitch group in the notebook
-        notebook->markdownCell(
-          "Stitch group " + static_cast<std::ostringstream*>( &(std::ostringstream() << groupNo) )->str());
+        std::ostringstream stitch_title_string;
+        stitch_title_string << "Stitch group " << groupNo;
+        notebook->markdownCell(stitch_title_string.str());
 
         //Reduce each row
         std::ostringstream code_string;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -32,17 +32,10 @@ namespace MantidQt {
 
       const std::string plotFunctionsTitle = "Plot functions\n---------------";
       notebook->markdownCell(plotFunctionsTitle);
+
       notebook->codeCell(plotsFunctionString());
 
-      std::string title_string;
-      if (!m_wsName.empty()) {
-        title_string = "Processed data from workspace: " + m_wsName + "\n---------------------";
-      }
-      else {
-        title_string = "Processed data\n---------------------";
-      }
-      title_string += "\nNotebook generated from the ISIS Reflectometry (Polref) Interface";
-      notebook->markdownCell(title_string);
+      notebook->markdownCell(titleString(m_wsName));
 
       notebook->markdownCell(tableString(m_model, col_nums, rows));
 
@@ -72,24 +65,45 @@ namespace MantidQt {
         std::tuple<std::string, std::string> stitch_string = stitchGroupString(groupRows, m_instrument, m_model, col_nums);
         notebook->codeCell(std::get<0>(stitch_string));
 
-        // Group workspaces which should be plotted on same axes
-        std::ostringstream plot_string;
-        plot_string << "#Group workspaces to be plotted on same axes\n";
-        plot_string << "unstitchedGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", unstitched_ws) << ")\n";
-        plot_string << "IvsLamGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", IvsLam_ws) << ")\n";
-
-        // Plot I vs Q and I vs Lambda graphs
-        plot_string << "#Plot workspaces\n";
-        std::vector<std::string> workspaceList;
-        workspaceList.push_back("unstitchedGroupWS");
-        workspaceList.push_back(std::get<1>(stitch_string));
-        workspaceList.push_back("IvsLamGroupWS");
-
-        plot_string << plot1DString(workspaceList, "['I vs Q Unstitched', 'I vs Q Stitiched', 'I vs Lambda']");
-        notebook->codeCell(plot_string.str());
+        // Draw plots
+        notebook->codeCell(plotsString(unstitched_ws, IvsLam_ws, std::get<1>(stitch_string)));
       }
 
       return notebook->writeNotebook();
+    }
+
+    std::string titleString(const std::string & wsName) {
+      std::string title_string;
+
+      if (!wsName.empty()) {
+        title_string = "Processed data from workspace: " + wsName + "\n---------------";
+      }
+      else {
+        title_string = "Processed data\n---------------";
+      }
+      title_string += "\nNotebook generated from the ISIS Reflectometry (Polref) Interface";
+
+      return title_string;
+    }
+
+    std::string plotsString(const std::vector<std::string> & unstitched_ws,
+                            const std::vector<std::string> & IvsLam_ws, const std::string & stitched_wsStr)
+    {
+      // Group workspaces which should be plotted on same axes
+      std::ostringstream plot_string;
+      plot_string << "#Group workspaces to be plotted on same axes\n";
+      plot_string << "unstitchedGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", unstitched_ws) << ")\n";
+      plot_string << "IvsLamGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", IvsLam_ws) << ")\n";
+
+      // Plot I vs Q and I vs Lambda graphs
+      plot_string << "#Plot workspaces\n";
+      std::vector<std::string> workspaceList;
+      workspaceList.push_back("unstitchedGroupWS");
+      workspaceList.push_back(stitched_wsStr);
+      workspaceList.push_back("IvsLamGroupWS");
+
+      plot_string << plot1DString(workspaceList, "['I vs Q Unstitched', 'I vs Q Stitiched', 'I vs Lambda']");
+      return plot_string.str();
     }
 
     std::string tableString(QReflTableModel_sptr model, ColNumbers col_nums, const std::set<int> & rows)

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -15,11 +15,11 @@ namespace MantidQt {
                                                const std::string instrument, const int runs_column,
                                                const int transmission_column, const int options_column,
                                                const int angle_column, const int min_q, const int max_q,
-                                               const int d_qq) :
+                                               const int d_qq, const int scale_column) :
       m_wsName(name), m_model(model), m_instrument(instrument),
       COL_RUNS(runs_column), COL_TRANSMISSION(transmission_column),
       COL_OPTIONS(options_column), COL_ANGLE(angle_column),
-      COL_QMIN(min_q), COL_QMAX(max_q), COL_DQQ(d_qq){ }
+      COL_QMIN(min_q), COL_QMAX(max_q), COL_DQQ(d_qq), COL_SCALE(scale_column){ }
 
     /**
       Generate an ipython notebook
@@ -148,10 +148,28 @@ namespace MantidQt {
       }
       code_string << ")\n";
 
+      const double scale = m_model->data(m_model->index(rowNo, COL_SCALE)).toDouble();
+      if(scale != 1.0) {
+        const std::tuple<std::string, std::string> scale_string = scaleString(runNo, scale);
+        code_string << std::get<0>(scale_string);
+      }
+
       const std::tuple<std::string, std::string> rebin_string = rebinString(rowNo, runNo);
       code_string << std::get<0>(rebin_string);
 
       return std::make_tuple(code_string.str(), std::get<1>(rebin_string));
+    }
+
+    std::tuple<std::string, std::string> ReflGenerateNotebook::scaleString(std::string runNo, double scale)
+    {
+      std::ostringstream scale_string;
+
+      scale_string << "IvsQ_" << runNo << " = Scale(";
+      scale_string << "InputWorkspace = IvsQ_" << runNo;
+      scale_string << ", Factor = " << 1.0 / scale;
+      scale_string << ")\n";
+
+      return std::make_tuple(scale_string.str(), "IvsQ" + runNo);
     }
 
     std::tuple<std::string, std::string> ReflGenerateNotebook::convertToPointString(std::string wsName)

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -23,11 +23,10 @@ namespace MantidQt {
 
     /**
       Generate an ipython notebook
-      @param rows : rows in the model which were processed
       @param groups : groups of rows which were stitched
-      @param filename : location to save notebook to
+      @returns ipython notebook string
       */
-    void ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows, std::string filename) {
+    std::string ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups) {
       std::unique_ptr<Mantid::API::NotebookWriter> notebook(new Mantid::API::NotebookWriter());
 
       std::string title_string;
@@ -75,11 +74,7 @@ namespace MantidQt {
         notebook->codeCell(plot_string.str());
       }
 
-      std::string generatedNotebook = notebook->writeNotebook();
-      std::ofstream file(filename.c_str(), std::ofstream::trunc);
-      file << generatedNotebook;
-      file.flush();
-      file.close();
+      return notebook->writeNotebook();
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -1,5 +1,6 @@
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidAPI/NotebookWriter.h"
+#include "MantidQtCustomInterfaces/ParseKeyValueString.h"
 
 #include <sstream>
 #include <fstream>
@@ -108,7 +109,6 @@ namespace MantidQt {
     */
     std::tuple<std::string, std::string> ReflGenerateNotebook::reduceRowString(int rowNo) {
       std::ostringstream code_string;
-      std::vector<std::string> workspace_names;
 
       const std::string runStr = m_model->data(m_model->index(rowNo, COL_RUNS)).toString().toStdString();
       const std::string transStr = m_model->data(m_model->index(rowNo, COL_TRANSMISSION)).toString().toStdString();
@@ -292,47 +292,6 @@ namespace MantidQt {
       load_string << ")\n";
 
       return std::make_tuple(load_string.str(), ws_name);
-    }
-
-    /**
-    Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'` into a map of key/value pairs
-    @param str The input string
-    @throws std::runtime_error on an invalid input string
-    */
-    std::map<std::string, std::string> ReflGenerateNotebook::parseKeyValueString(const std::string &str) {
-      //Tokenise, using '\' as an escape character, ',' as a delimiter and " and ' as quote characters
-      boost::tokenizer<boost::escaped_list_separator<char> > tok(str,
-                                                                 boost::escaped_list_separator<char>("\\", ",", "\"'"));
-
-      std::map<std::string, std::string> kvp;
-
-      for (auto it = tok.begin(); it != tok.end(); ++it) {
-        std::vector<std::string> valVec;
-        boost::split(valVec, *it, boost::is_any_of("="));
-
-        if (valVec.size() > 1) {
-          //We split on all '='s. The first delimits the key, the rest are assumed to be part of the value
-          std::string key = valVec[0];
-          //Drop the key from the values vector
-          valVec.erase(valVec.begin());
-          //Join the remaining sections,
-          std::string value = boost::algorithm::join(valVec, "=");
-
-          //Remove any unwanted whitespace
-          boost::trim(key);
-          boost::trim(value);
-
-          if (key.empty() || value.empty())
-            throw std::runtime_error("Invalid key value pair, '" + *it + "'");
-
-
-          kvp[key] = value;
-        }
-        else {
-          throw std::runtime_error("Invalid key value pair, '" + *it + "'");
-        }
-      }
-      return kvp;
     }
 
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -49,13 +49,15 @@ namespace MantidQt {
 
         //Reduce each row
         std::ostringstream code_string;
-        std::tuple<std::string, std::string> reduce_row_string;
-        std::vector<std::string> ws_names;
+        std::tuple<std::string, std::string, std::string> reduce_row_string;
+        std::vector<std::string> unstitched_ws;
+        std::vector<std::string> IvsLam_ws;
         code_string << "#Load and reduce\n";
         for (auto rIt = groupRows.begin(); rIt != groupRows.end(); ++rIt) {
           reduce_row_string = reduceRowString(*rIt);
           code_string << std::get<0>(reduce_row_string);
-          ws_names.push_back(std::get<1>(reduce_row_string));
+          unstitched_ws.push_back(std::get<1>(reduce_row_string));
+          IvsLam_ws.push_back(std::get<2>(reduce_row_string));
         }
         notebook->codeCell(code_string.str());
 
@@ -65,11 +67,12 @@ namespace MantidQt {
 
         // Plot the unstitched and stitched I vs Q
         std::ostringstream plot_string;
-        plot_string << "f, (ax1, ax2) = plt.subplots(1, 2, sharey=True, figsize=(12,4))\n";
+        plot_string << "f, (ax1, ax2, ax3) = plt.subplots(1, 3, sharey=True, figsize=(18,4))\n";
         std::vector<std::string> stitched_ws;
         stitched_ws.push_back(std::get<1>(stitch_string));
-        plot_string << plotIvsQ(ws_names, "ax1"); // unstitched
-        plot_string << plotIvsQ(stitched_ws, "ax2"); // stitched
+        plot_string << plot1D(unstitched_ws, "ax1", "I vs Q Unstitched");
+        plot_string << plot1D(stitched_ws, "ax2", "I vs Q Stitiched");
+        plot_string << plot1D(IvsLam_ws, "ax3", "I vs Lambda");
         plot_string << "plt.show() #Draw the plot\n";
         notebook->codeCell(plot_string.str());
       }
@@ -172,19 +175,25 @@ namespace MantidQt {
       @param axes : handle of axes to plot in
       @return string  of python code to plot I vs Q
       */
-    std::string ReflGenerateNotebook::plotIvsQ(std::vector<std::string> ws_names, std::string axes) {
+    std::string ReflGenerateNotebook::plot1D(std::vector<std::string> ws_names, std::string axes, std::string title) {
 
       std::ostringstream plot_string;
-      plot_string << "#Plot I vs Q\n";
       for (auto it = ws_names.begin(); it != ws_names.end(); ++it) {
         std::tuple<std::string, std::string> convert_point_string = convertToPointString(*it);
         plot_string << std::get<0>(convert_point_string);
 
-        plot_string << axes << ".loglog(" << std::get<1>(convert_point_string) << ".readX(0), "
+        plot_string << "#" << axes << ".plot(" << std::get<1>(convert_point_string) << ".readX(0), "
                     << std::get<1>(convert_point_string) << ".readY(0), "
-                    << "basex=10, label='" << *it << "')\n";
+                    << "label='" << *it << "')\n";
+        plot_string << axes << ".errorbar(" << std::get<1>(convert_point_string) << ".readX(0), "
+                    << std::get<1>(convert_point_string) << ".readY(0), "
+                    << "yerr=" << std::get<1>(convert_point_string) << ".readE(0), "
+                    << "label='" << *it << "')\n";
+
+        plot_string << axes << ".set_yscale('log')\n";
+        plot_string << axes << ".set_xscale('log')\n";
       }
-      plot_string << axes << ".set_title('I vs Q')\n";
+      plot_string << axes << ".set_title('" << title << "')\n";
       plot_string << axes << ".grid() #Show a grid\n";
       plot_string << axes << ".legend() #Show a legend\n";
 
@@ -196,7 +205,7 @@ namespace MantidQt {
      @param rowNo : the row in the model to run the reduction algorithm on
      @return tuple containing the python string and the output workspace name
     */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::reduceRowString(int rowNo) {
+    std::tuple<std::string, std::string, std::string> ReflGenerateNotebook::reduceRowString(int rowNo) {
       std::ostringstream code_string;
 
       const std::string runStr = m_model->data(m_model->index(rowNo, COL_RUNS)).toString().toStdString();
@@ -214,16 +223,17 @@ namespace MantidQt {
       code_string << std::get<0>(load_ws_string);
 
       const std::string runNo = getRunNumber(std::get<1>(load_ws_string));
+      const std::string IvsLamName = "IvsLam_" + runNo;
 
       if (!transStr.empty()) {
         const std::tuple<std::string, std::string> trans_string = transWSString(transStr);
         code_string << std::get<0>(trans_string);
-        code_string << "IvsQ_" << runNo << ", " << "IvsLam_" << runNo << ", _ = ";
+        code_string << "IvsQ_" << runNo << ", " << IvsLamName << ", _ = ";
         code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << std::get<1>(load_ws_string) << "'";
         code_string << ", " << "FirstTransmissionRun = '" << std::get<1>(trans_string) << "'";
       }
       else {
-        code_string << "IvsQ_" << runNo << ", " << "IvsLam_" << runNo << ", _ = ";
+        code_string << "IvsQ_" << runNo << ", " << IvsLamName << ", _ = ";
         code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << std::get<1>(load_ws_string) << "'";
       }
 
@@ -246,7 +256,7 @@ namespace MantidQt {
       const std::tuple<std::string, std::string> rebin_string = rebinString(rowNo, runNo);
       code_string << std::get<0>(rebin_string);
 
-      return std::make_tuple(code_string.str(), std::get<1>(rebin_string));
+      return std::make_tuple(code_string.str(), std::get<1>(rebin_string), IvsLamName);
     }
 
      /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -26,7 +26,7 @@ namespace MantidQt {
       @param rows : rows in the model which were processed
       @param groups : groups of rows which were stitched
       */
-    void ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows) {
+    void ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows, std::string filename) {
       std::unique_ptr<Mantid::API::NotebookWriter> notebook(new Mantid::API::NotebookWriter());
 
       std::string title_string;
@@ -71,9 +71,6 @@ namespace MantidQt {
         stitched_ws.push_back(std::get<1>(stitch_string));
         notebook->codeCell(plotIvsQ(stitched_ws));
       }
-
-      //TODO prompt for filename to save notebook
-      const std::string filename = "/home/jonmd/refl_notebook.ipynb";
 
       std::string generatedNotebook = notebook->writeNotebook();
       std::ofstream file(filename.c_str(), std::ofstream::trunc);
@@ -163,7 +160,7 @@ namespace MantidQt {
     std::string ReflGenerateNotebook::plotIvsQ(std::vector<std::string> ws_names) {
 
       std::ostringstream plot_string;
-      plot_string << "#Plot unstitched I vs Q\n";
+      plot_string << "#Plot I vs Q\n";
       for (auto it = ws_names.begin(); it != ws_names.end(); ++it) {
         std::tuple<std::string, std::string> convert_point_string = convertToPointString(*it);
         plot_string << std::get<0>(convert_point_string);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -21,7 +21,7 @@ namespace MantidQt {
                                                const int angle_column, const int min_q, const int max_q,
                                                const int d_qq, const int scale_column, const int group_column) :
       m_wsName(name), m_model(model), m_instrument(instrument),
-      col_nums{runs_column, transmission_column, options_column, angle_column, min_q, max_q, d_qq, scale_column, group_column} { }
+      col_nums(runs_column, transmission_column, options_column, angle_column, min_q, max_q, d_qq, scale_column, group_column) { }
 
     /**
       Generate an ipython notebook

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -355,13 +355,8 @@ namespace MantidQt {
         code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << std::get<1>(load_ws_string) << "'";
       }
 
-      std::string thetaStr;
       if (thetaGiven) {
         code_string << ", " << "ThetaIn = " << theta;
-        thetaStr = static_cast<std::ostringstream *>( &(std::ostringstream() << theta))->str();
-      }
-      else {
-        thetaStr = "theta_" + runNo; // Use variable name if we don't have the value
       }
 
       //Parse and set any user-specified options

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -116,7 +116,7 @@ namespace MantidQt {
 
       double theta = 0;
 
-      bool thetaGiven = !m_model->data(m_model->index(rowNo, COL_ANGLE)).toString().isEmpty();
+      const bool thetaGiven = !m_model->data(m_model->index(rowNo, COL_ANGLE)).toString().isEmpty();
 
       if (thetaGiven)
         theta = m_model->data(m_model->index(rowNo, COL_ANGLE)).toDouble();
@@ -127,7 +127,7 @@ namespace MantidQt {
       const std::string runNo = getRunNumber(std::get<1>(load_ws_string));
 
       if (!transStr.empty()) {
-        std::tuple<std::string, std::string> trans_string = transWSString(transStr);
+        const std::tuple<std::string, std::string> trans_string = transWSString(transStr);
         code_string << std::get<0>(trans_string);
         code_string << "IvsQ_" << runNo << ", " << "IvsLam_" << runNo << ", _ = ";
         code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << std::get<1>(load_ws_string) << "'";
@@ -148,7 +148,7 @@ namespace MantidQt {
       }
       code_string << ")\n";
 
-      std::tuple<std::string, std::string> rebin_string = rebinString(rowNo, runNo);
+      const std::tuple<std::string, std::string> rebin_string = rebinString(rowNo, runNo);
       code_string << std::get<0>(rebin_string);
 
       return std::make_tuple(code_string.str(), std::get<1>(rebin_string));

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -439,20 +439,6 @@ namespace MantidQt {
     }
 
     /**
-      Create string of python code to convert to point data, which can be plotted
-      @param wsName : name of workspace to convert to point data
-      @return tuple of strings of python code and output workspace name
-      */
-    std::tuple<std::string, std::string> convertToPointString(const std::string & wsName)
-    {
-      const std::string output_name = wsName + "_plot";
-      std::ostringstream convert_string;
-      convert_string << output_name << " = ConvertToPointData(" << wsName << ")\n";
-
-      return std::make_tuple(convert_string.str(), output_name);
-    }
-
-    /**
      Create string of python code to rebin data in a workspace
      @param rowNo : the number of the row to rebin
      @param runNo : the number of the run to rebin

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -88,6 +88,12 @@ namespace MantidQt {
       return notebook->writeNotebook();
     }
 
+    /**
+      Create string of markdown to display a table of run numbers and theta values
+      @param runNos : vector of run numbers
+      @param theta : vector of theta values
+      @return markdown string of table
+      */
     std::string ReflGenerateNotebook::printThetaString(const std::vector<std::string> & runNos,
                                                        const std::vector<std::string> & theta)
     {
@@ -231,7 +237,8 @@ namespace MantidQt {
      @param rowNo : the row in the model to run the reduction algorithm on
      @return tuple containing the python string and the output workspace name
     */
-    std::tuple<std::string, std::string, std::string, std::string, std::string> ReflGenerateNotebook::reduceRowString(const int rowNo) {
+    std::tuple<std::string, std::string, std::string, std::string, std::string>
+    ReflGenerateNotebook::reduceRowString(const int rowNo) {
       std::ostringstream code_string;
 
       const std::string runStr = m_model->data(m_model->index(rowNo, COL_RUNS)).toString().toStdString();
@@ -298,7 +305,8 @@ namespace MantidQt {
       @param scale : value of scaling factor to use
       @return tuple of strings of python code and output workspace name
       */
-    std::tuple<std::string, std::string> ReflGenerateNotebook::scaleString(const std::string & runNo, const double scale)
+    std::tuple<std::string, std::string>
+     ReflGenerateNotebook::scaleString(const std::string & runNo, const double scale)
     {
       std::ostringstream scale_string;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -1,0 +1,247 @@
+#include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
+#include "MantidAPI/NotebookWriter.h"
+
+#include <sstream>
+#include <fstream>
+#include <memory>
+#include <boost/tokenizer.hpp>
+#include <boost/regex.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace MantidQt {
+  namespace CustomInterfaces {
+    ReflGenerateNotebook::ReflGenerateNotebook(std::string name, QReflTableModel_sptr model,
+                                               const std::string instrument, const int runs_column,
+                                               const int transmission_column, const int options_column,
+                                               const int angle_column) :
+      m_wsName(name), m_model(model), m_instrument(instrument),
+      COL_RUNS(runs_column), COL_TRANSMISSION(transmission_column),
+      COL_OPTIONS(options_column), COL_ANGLE(angle_column) { }
+
+    /**
+      Generate an ipython notebook
+      @param rows : rows in the model which were processed
+      @param groups : groups of rows which were stitched
+      */
+    void ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows) {
+      std::unique_ptr<Mantid::API::NotebookWriter> notebook(new Mantid::API::NotebookWriter());
+
+      std::string title_string;
+      if (!m_wsName.empty()) {
+        title_string = "Processed data from workspace: " + m_wsName + "\n---------------------";
+      }
+      else {
+        title_string = "Processed data\n---------------------";
+      }
+      title_string += "\nNotebook generated from the ISIS Reflectometry (Polref) Interface";
+      notebook->markdownCell(title_string);
+
+      int groupNo = 1;
+      for (auto gIt = groups.begin(); gIt != groups.end(); ++gIt, ++groupNo) {
+        const std::set<int> groupRows = gIt->second;
+
+        // Announce the stitch group in the notebook
+        notebook->markdownCell(
+          "Stitch group " + static_cast<std::ostringstream*>( &(std::ostringstream() << groupNo) )->str());
+
+        //Reduce each row
+        std::ostringstream code_string;
+        for (auto rIt = groupRows.begin(); rIt != groupRows.end(); ++rIt) {
+          code_string << reduceRowString(*rIt);
+        }
+        notebook->codeCell(code_string.str());
+
+        //todo stitch rows cell
+      }
+
+      //todo plot the unstitched I vs Q
+      //todo plot the stitched I vs Q
+
+      //TODO prompt for filename to save notebook
+      const std::string filename = "/home/jonmd/refl_notebook.ipynb";
+
+      std::string generatedNotebook = notebook->writeNotebook();
+      std::ofstream file(filename.c_str(), std::ofstream::trunc);
+      file << generatedNotebook;
+      file.flush();
+      file.close();
+    }
+
+    /**
+    Add a code cell to the notebook which runs reduce algorithm on the row specified
+    @param notebook : the notebook to add the cell to
+    @param rowNo : the row in the model to run the reduction algorithm on
+    */
+    std::string ReflGenerateNotebook::reduceRowString(int rowNo) {
+      std::ostringstream code_string;
+
+      const std::string runStr = m_model->data(m_model->index(rowNo, COL_RUNS)).toString().toStdString();
+      const std::string transStr = m_model->data(m_model->index(rowNo, COL_TRANSMISSION)).toString().toStdString();
+      const std::string options = m_model->data(m_model->index(rowNo, COL_OPTIONS)).toString().toStdString();
+
+      double theta = 0;
+
+      bool thetaGiven = !m_model->data(m_model->index(rowNo, COL_ANGLE)).toString().isEmpty();
+
+      if (thetaGiven)
+        theta = m_model->data(m_model->index(rowNo, COL_ANGLE)).toDouble();
+
+      const boost::tuple<std::string, std::string> load_ws_string = loadWorkspaceString(runStr);
+      code_string << boost::get<0>(load_ws_string);
+
+      const std::string runNo = getRunNumber(boost::get<1>(load_ws_string));
+
+      if (!transStr.empty()) {
+        boost::tuple<std::string, std::string> trans_string = transWSString(transStr);
+        code_string << boost::get<0>(trans_string);
+        code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << boost::get<1>(load_ws_string) << "'";
+        code_string << ", " << "FirstTransmissionRun = '" << boost::get<1>(trans_string) << "'";
+      }
+      else {
+        code_string << "ReflectometryReductionOneAuto(InputWorkspace = '" << boost::get<1>(load_ws_string) << "'";
+      }
+
+      code_string << ", " << "OutputWorkspace = '" << "IvsQ_" << runNo << "'";
+      code_string << ", " << "OutputWorkspaceWaveLength = '" << "IvsLam_" << runNo << "'";
+      if (thetaGiven)
+        code_string << ", " << "ThetaIn = " << theta;
+
+      //Parse and set any user-specified options
+      auto optionsMap = parseKeyValueString(options);
+      for (auto kvp = optionsMap.begin(); kvp != optionsMap.end(); ++kvp) {
+        code_string << ", " << kvp->first << " = " << kvp->second;
+      }
+      code_string << ")\n";
+
+      //todo rebin etc (look in reduceRow())
+
+      return code_string.str();
+    }
+
+    boost::tuple<std::string, std::string> ReflGenerateNotebook::transWSString(std::string trans_ws_str)
+    {
+      const size_t maxTransWS = 2;
+
+      std::vector<std::string> transVec;
+      std::ostringstream trans_string;
+      std::vector<std::string> trans_ws_name;
+
+      //Take the first two run numbers
+      boost::split(transVec, trans_ws_str, boost::is_any_of(","));
+      if(transVec.size() > maxTransWS)
+        transVec.resize(maxTransWS);
+
+      boost::tuple<std::string, std::string> load_tuple;
+      for(auto it = transVec.begin(); it != transVec.end(); ++it)
+        load_tuple = loadWorkspaceString(*it);
+        trans_ws_name.push_back(boost::get<1>(load_tuple));
+        trans_string << boost::get<0>(load_tuple);
+
+      //The runs are loaded, so we can create a TransWS
+      trans_string << "CreateTransmissionWorkspaceAuto(";
+      trans_string << "FirstTransmissionRun = '" << trans_ws_name[0] << "'";
+      if(trans_ws_name.size() > 1)
+        trans_string << ", SecondTransmissionRun = '" << trans_ws_name[1] << "'";
+
+      std::string wsName = "TRANS_" + getRunNumber(trans_ws_name[0]);
+      if(trans_ws_name.size() > 1)
+        wsName += "_" + getRunNumber(trans_ws_name[1]);
+
+      trans_string << ", OutputWorkspace = '" << wsName << "')\n";
+
+      return boost::make_tuple(trans_string.str(), wsName);
+    }
+
+    std::string ReflGenerateNotebook::getRunNumber(std::string ws_name) {
+      //Matches TOF_13460 -> 13460
+      boost::regex outputRegex("(TOF|IvsQ|IvsLam)_([0-9]+)");
+
+      //Matches INTER13460 -> 13460
+      boost::regex instrumentRegex("[a-zA-Z]{3,}([0-9]{3,})");
+
+      boost::smatch matches;
+
+      if (boost::regex_match(ws_name, matches, outputRegex)) {
+        return matches[2].str();
+      }
+      else if (boost::regex_match(ws_name, matches, instrumentRegex)) {
+        return matches[1].str();
+      }
+
+      //Resort to using the workspace name
+      return ws_name;
+    }
+
+    boost::tuple<std::string, std::string> ReflGenerateNotebook::loadWorkspaceString(std::string runStr) {
+      std::vector<std::string> runs;
+      boost::split(runs, runStr, boost::is_any_of("+"));
+
+      //Remove leading/trailing whitespace from each run
+      for (auto runIt = runs.begin(); runIt != runs.end(); ++runIt)
+        boost::trim(*runIt);
+
+      //If it is only one run, just load that
+      if (runs.size() == 1)
+        return loadRunString(runs[0]);
+
+      // todo deal with case of more than one run to load
+      //const std::string outputName = "TOF_" + boost::algorithm::join(runs, "_");
+      return boost::make_tuple("temp", "temp");
+    }
+
+    boost::tuple<std::string, std::string> ReflGenerateNotebook::loadRunString(std::string run) {
+      std::ostringstream load_string;
+      // We do not have access to AnalysisDataService from notebook, so must load run from file
+      const std::string filename = m_instrument + run;
+      const std::string ws_name = "TOF_" + run;
+      load_string << "Load(";
+      load_string << "Filename = '" << filename << "'";
+      load_string << ", OutputWorkspace = '" << ws_name <<"'";
+      load_string << ")\n";
+
+      return boost::make_tuple(load_string.str(), ws_name);
+    }
+
+    /**
+    Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'` into a map of key/value pairs
+    @param str The input string
+    @throws std::runtime_error on an invalid input string
+    */
+    std::map<std::string, std::string> ReflGenerateNotebook::parseKeyValueString(const std::string &str) {
+      //Tokenise, using '\' as an escape character, ',' as a delimiter and " and ' as quote characters
+      boost::tokenizer<boost::escaped_list_separator<char> > tok(str,
+                                                                 boost::escaped_list_separator<char>("\\", ",", "\"'"));
+
+      std::map<std::string, std::string> kvp;
+
+      for (auto it = tok.begin(); it != tok.end(); ++it) {
+        std::vector<std::string> valVec;
+        boost::split(valVec, *it, boost::is_any_of("="));
+
+        if (valVec.size() > 1) {
+          //We split on all '='s. The first delimits the key, the rest are assumed to be part of the value
+          std::string key = valVec[0];
+          //Drop the key from the values vector
+          valVec.erase(valVec.begin());
+          //Join the remaining sections,
+          std::string value = boost::algorithm::join(valVec, "=");
+
+          //Remove any unwanted whitespace
+          boost::trim(key);
+          boost::trim(value);
+
+          if (key.empty() || value.empty())
+            throw std::runtime_error("Invalid key value pair, '" + *it + "'");
+
+
+          kvp[key] = value;
+        }
+        else {
+          throw std::runtime_error("Invalid key value pair, '" + *it + "'");
+        }
+      }
+      return kvp;
+    }
+
+  }
+}

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -1,6 +1,7 @@
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidAPI/NotebookWriter.h"
 #include "MantidQtCustomInterfaces/ParseKeyValueString.h"
+#include "MantidQtCustomInterfaces/ReflVectorString.h"
 
 #include <sstream>
 #include <fstream>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -300,43 +300,6 @@ namespace MantidQt {
     }
 
     /**
-      Create string of comma separated list of parameter values from a vector
-      @param param_name : name of the parameter we are creating a list of
-      @param param_vec : vector of parameter values
-      @return string of comma separated list of parameter values
-      */
-    template<typename T, typename A>
-    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec)
-    {
-      std::ostringstream param_vector_string;
-
-      param_vector_string << param_name << " = '";
-      param_vector_string << vectorString(param_vec);
-      param_vector_string << "'";
-
-      return param_vector_string.str();
-    }
-
-    /**
-      Create string of comma separated list of values from a vector
-      @param param_vec : vector of values
-      @return string of comma separated list of values
-      */
-    template<typename T, typename A>
-    std::string vectorString(const std::vector<T,A> &param_vec)
-    {
-      std::ostringstream vector_string;
-      const char* separator = "";
-      for(auto paramIt = param_vec.begin(); paramIt != param_vec.end(); ++paramIt)
-      {
-        vector_string << separator << *paramIt;
-        separator = ", ";
-      }
-
-      return vector_string.str();
-    }
-
-    /**
       Create string of python code to create 1D plots from workspaces
       @param ws_names : vector of workspace names to plot
       @return string  of python code to plot I vs Q

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -25,9 +25,11 @@ namespace MantidQt {
     /**
       Generate an ipython notebook
       @param groups : groups of rows which were stitched
+      @param rows : rows which were processed
       @returns ipython notebook string
       */
     std::string ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups, std::set<int> rows) {
+
       std::unique_ptr<Mantid::API::NotebookWriter> notebook(new Mantid::API::NotebookWriter());
 
       const std::string plotFunctionsTitle = "Plot functions\n---------------";
@@ -72,6 +74,11 @@ namespace MantidQt {
       return notebook->writeNotebook();
     }
 
+    /**
+      Create string of markdown code for title of the data processing part of the notebook
+      @param wsName : name of the table workspace
+      @return string containing markdown code
+      */
     std::string titleString(const std::string & wsName) {
       std::string title_string;
 
@@ -86,6 +93,13 @@ namespace MantidQt {
       return title_string;
     }
 
+    /**
+      Create string of python code to call plots() with the required workspaces
+      @param unstitched_ws : vector of unstitched data workspace names to be plotted together
+      @param IvsLam_ws : vector of I vs lambda data workspace names to be plotted together
+      @param stitched_wsStr : name of stitched data workspace
+      @return string containing the python code
+      */
     std::string plotsString(const std::vector<std::string> & unstitched_ws,
                             const std::vector<std::string> & IvsLam_ws, const std::string & stitched_wsStr)
     {
@@ -106,6 +120,13 @@ namespace MantidQt {
       return plot_string.str();
     }
 
+    /**
+      Create string of markdown code to display a table of data from the GUI
+      @param model : tablemodel for the full table
+      @param col_nums : column number for each column title
+      @param rows : rows from full table to include
+      @return string containing the markdown code
+      */
     std::string tableString(QReflTableModel_sptr model, ColNumbers col_nums, const std::set<int> & rows)
     {
       std::ostringstream table_string;
@@ -128,6 +149,10 @@ namespace MantidQt {
       return table_string.str();
     }
 
+    /**
+      Create string of python code for plotting functions
+      @return string containing the python code
+      */
     std::string plotsFunctionString()
     {
       return "def plotWithOptions(ax, ws, ops, n):\n"
@@ -292,6 +317,11 @@ namespace MantidQt {
       return param_vector_string.str();
     }
 
+    /**
+      Create string of comma separated list of values from a vector
+      @param param_vec : vector of values
+      @return string of comma separated list of values
+      */
     template<typename T, typename A>
     std::string vectorString(const std::vector<T,A> &param_vec)
     {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflGenerateNotebook.cpp
@@ -30,6 +30,10 @@ namespace MantidQt {
     std::string ReflGenerateNotebook::generateNotebook(std::map<int, std::set<int>> groups) {
       std::unique_ptr<Mantid::API::NotebookWriter> notebook(new Mantid::API::NotebookWriter());
 
+      const std::string plotFunctionsTitle = "Plot functions\n---------------";
+      notebook->markdownCell(plotFunctionsTitle);
+      notebook->codeCell(plotsFunctionString());
+
       std::string title_string;
       if (!m_wsName.empty()) {
         title_string = "Processed data from workspace: " + m_wsName + "\n---------------------";
@@ -70,15 +74,20 @@ namespace MantidQt {
         std::tuple<std::string, std::string> stitch_string = stitchGroupString(groupRows, m_instrument, m_model, col_nums);
         notebook->codeCell(std::get<0>(stitch_string));
 
-        // Plot I vs Q and I vs Lambda graphs
+        // Group workspaces which should be plotted on same axes
         std::ostringstream plot_string;
-        plot_string << "f, (ax1, ax2, ax3) = plt.subplots(1, 3, sharey=True, figsize=(18,4))\n";
-        std::vector<std::string> stitched_ws;
-        stitched_ws.push_back(std::get<1>(stitch_string));
-        plot_string << plot1DString(unstitched_ws, "ax1", "I vs Q Unstitched", 1) << "\n";
-        plot_string << plot1DString(stitched_ws, "ax2", "I vs Q Stitiched", 1) << "\n";
-        plot_string << plot1DString(IvsLam_ws, "ax3", "I vs Lambda", 4);
-        plot_string << "plt.show() #Draw the plot\n";
+        plot_string << "#Group workspaces which should be plotted on same axes\n";
+        plot_string << "unstitchedGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", unstitched_ws) << ")\n";
+        plot_string << "IvsLamGroupWS = GroupWorkspaces(" << vectorParamString("InputWorkspaces", IvsLam_ws) << ")\n";
+
+        // Plot I vs Q and I vs Lambda graphs
+        plot_string << "#Plot workspaces\n";
+        std::vector<std::string> workspaceList;
+        workspaceList.push_back("unstitchedGroupWS");
+        workspaceList.push_back(std::get<1>(stitch_string));
+        workspaceList.push_back("IvsLamGroupWS");
+
+        plot_string << plot1DString(workspaceList, "['I vs Q Unstitched', 'I vs Q Stitiched', 'I vs Lambda']");
         notebook->codeCell(plot_string.str());
 
         notebook->markdownCell(printThetaString(runNos, theta));
@@ -107,6 +116,81 @@ namespace MantidQt {
       }
 
       return theta_string.str();
+    }
+
+    std::string plotsFunctionString()
+    {
+      return "def plotWithOptions(ax, ws, ops, n):\n"
+        "    \"\"\"\n"
+        "    Enable/disable legend, grid, limits according to\n"
+        "    options (ops) for the given axes (ax).\n"
+        "    Plot with or without errorbars.\n"
+        "    \"\"\"\n"
+        "    ws_plot = ConvertToPointData(ws)\n"
+        "    if ops['errorbars']:\n"
+        "        ax.errorbar(ws_plot.readX(0), ws_plot.readY(0), yerr=ws_plot.readE(0), label=ws.name())\n"
+        "    else:\n"
+        "        ax.plot(ws_plot.readX(0), ws_plot.readY(0), label=ws.name())\n"
+        "    \n"
+        "    if ops['legend']: ax.legend(loc=ops['legendLocation'])\n"
+        "    ax.grid(ops['grid'])\n"
+        "    ax.set_xscale(ops['xScale']); ax.set_yscale(ops['yScale'])\n"
+        "    if ops['xLimits'] != 'auto': ax.set_xlim(ops['xLimits'])\n"
+        "    if ops['yLimits'] != 'auto': ax.set_ylim(ops['yLimits'])\n"
+        "    \n"
+        "    # If a list of titles was given, use it to title each subplot\n"
+        "    if hasattr(ops['title'], \"__iter__\"):\n"
+        "        ax.set_title(ops['title'][n])\n"
+        "    \n"
+        "\n"
+        "def plots(listOfWorkspaces, *args, **kwargs):\n"
+        "    \"\"\"\n"
+        "    Draw a default reflectivity plot.\n"
+        "    Workspaces within a group workspace are plotted together on the same axes.\n"
+        "\n"
+        "    Examples:\n"
+        "    plots(rr)\n"
+        "    plots(rr, 'TheGraphTitle')\n"
+        "    plots(rr, 'TheGraphTitle', grid=True, legend=True, xScale='linear', yScale='log', xLimits=[0.008, 0.16])\n"
+        "    plots(rr, sharedAxes = False, xLimits = [0, 0.1], yLimits = [1e-5, 2], Title='ASF070_07 I=1A T=3K dq/q=2%', legend=True, legendLocation=3, errorbars=False)\n"
+        "    \"\"\"\n"
+        "\n"
+        "    if not hasattr(listOfWorkspaces, \"__iter__\"):\n"
+        "        listOfWorkspaces = [listOfWorkspaces]\n"
+        "\n"
+        "    # Process the function arguments.  In either case(named or unnamed) build a dictionary of options)\n"
+        "    keylist = ['title', 'grid', 'legend', 'legendLocation', 'xScale', 'yScale', 'xLimits', 'yLimits', 'sharedAxes', 'errorbars']\n"
+        "    defaultValues = ['', True, True, 1, 'log', 'log', 'auto', 'auto', True, 'True']\n"
+        "\n"
+        "    # Fill ops with the default values\n"
+        "    ops=dict(zip(keylist,defaultValues))\n"
+        "    for i in range(len(args)):  # copy in values provided in args\n"
+        "        defaultValues[i]=args[i]\n"
+        "    ops=dict(zip(keylist,defaultValues))\n"
+        "\n"
+        "    for k in ops.keys():  # copy in any key word given arguments\n"
+        "        ops[k]= kwargs.get(k,ops[k])\n"
+        "\n"
+        "    # Create subplots for workspaces in the list\n"
+        "    fig, ax = plt.subplots(1, len(listOfWorkspaces), sharey=ops['sharedAxes'], figsize=(6*len(listOfWorkspaces),4))\n"
+        "\n"
+        "    if not hasattr(ax, \"__iter__\"):\n"
+        "        ax = [ax]\n"
+        "\n"
+        "    for n, ws in enumerate(listOfWorkspaces):\n"
+        "        if type(ws) == mantid.api._api.WorkspaceGroup:\n"
+        "            # Plot grouped workspaces on the same axes\n"
+        "            for sub_ws in ws:\n"
+        "                plotWithOptions(ax[n], sub_ws, ops, n)\n"
+        "        else:\n"
+        "            plotWithOptions(ax[n], ws, ops, n)\n"
+        "            \n"
+        "    # If a single title was given, use it to title the whole figure\n"
+        "    if not hasattr(ops['title'], \"__iter__\"):\n"
+        "        fig.suptitle(ops['title'])\n"
+        "    plt.show()\n"
+        "    \n"
+        "    return plt.gcf()";
     }
 
     /**
@@ -184,50 +268,42 @@ namespace MantidQt {
       @return string of comma separated list of parameter values
       */
     template<typename T, typename A>
-    std::string vectorParamString(const std::string & param_name, std::vector<T,A> &param_vec)
+    std::string vectorParamString(const std::string & param_name, const std::vector<T,A> &param_vec)
+    {
+      std::ostringstream param_vector_string;
+
+      param_vector_string << param_name << " = '";
+      param_vector_string << vectorString(param_vec);
+      param_vector_string << "'";
+
+      return param_vector_string.str();
+    }
+
+    template<typename T, typename A>
+    std::string vectorString(const std::vector<T,A> &param_vec)
     {
       std::ostringstream vector_string;
       const char* separator = "";
-      vector_string << param_name << " = '";
       for(auto paramIt = param_vec.begin(); paramIt != param_vec.end(); ++paramIt)
       {
         vector_string << separator << *paramIt;
         separator = ", ";
       }
-      vector_string << "'";
 
       return vector_string.str();
     }
 
     /**
-      Create string of python code to plot I vs Q from workspaces
-      @param ws_names : vector of workspace names to plot on the same axes
-      @param axes : handle of axes to plot in
+      Create string of python code to create 1D plots from workspaces
+      @param ws_names : vector of workspace names to plot
       @return string  of python code to plot I vs Q
       */
-    std::string plot1DString(const std::vector<std::string> & ws_names, const std::string & axes,
-                                             const std::string & title, const int legendLocation) {
+    std::string plot1DString(const std::vector<std::string> & ws_names,
+                             const std::string & title) {
 
       std::ostringstream plot_string;
 
-      for (auto it = ws_names.begin(); it != ws_names.end(); ++it) {
-        std::tuple<std::string, std::string> convert_point_string = convertToPointString(*it);
-        plot_string << std::get<0>(convert_point_string);
-
-        plot_string << "#" << axes << ".plot(" << std::get<1>(convert_point_string) << ".readX(0), "
-                    << std::get<1>(convert_point_string) << ".readY(0), "
-                    << "label='" << *it << "')\n";
-        plot_string << axes << ".errorbar(" << std::get<1>(convert_point_string) << ".readX(0), "
-                    << std::get<1>(convert_point_string) << ".readY(0), "
-                    << "yerr=" << std::get<1>(convert_point_string) << ".readE(0), "
-                    << "label='" << *it << "')\n";
-
-        plot_string << axes << ".set_yscale('log'); ";
-        plot_string << axes << ".set_xscale('log')\n";
-      }
-      plot_string << axes << ".set_title('" << title << "')\n";
-      plot_string << axes << ".grid() #Show a grid\n";
-      plot_string << axes << ".legend(loc=" << legendLocation << ") #Show a legend\n";
+      plot_string << "fig = plots([" << vectorString(ws_names) << "], title=" << title << ")\n";
 
       return plot_string.str();
     }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -296,7 +296,7 @@ namespace MantidQt
       std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
         m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
         COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE));
-      QString qfilename = QFileDialog::getSaveFileName(0, "Save file", QDir::currentPath(),
+      QString qfilename = QFileDialog::getSaveFileName(0, "Save notebook file", QDir::currentPath(),
                                                        "IPython Notebook files (*.ipynb);;All files (*.*)",
                                                        new QString("IPython Notebook files (*.ipynb)"));
       std::string filename = qfilename.toStdString();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -15,6 +15,7 @@
 #include "MantidQtCustomInterfaces/ReflSearchModel.h"
 #include "MantidQtCustomInterfaces/QReflTableModel.h"
 #include "MantidQtCustomInterfaces/QtReflOptionsDialog.h"
+#include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidQtMantidWidgets/AlgorithmHintStrategy.h"
 
 #include <boost/regex.hpp>
@@ -321,100 +322,11 @@ namespace MantidQt
       if(!processGroups(groups, rows)) {
         return;
       }
+
       //TODO else if notebook flag set from gui
-      generateNotebook(groups, rows);
-    }
-
-    /**
-    Generate an ipython notebook
-    @param rows : rows in the model which were processed
-    @param groups : groups of rows which were stitched
-    */
-    void ReflMainViewPresenter::generateNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
-    {
-      std::unique_ptr<NotebookWriter> notebook(new NotebookWriter());
-
-      std::string title_string;
-      if(!m_wsName.empty()) {
-        title_string = "Processed data from workspace: " + m_wsName + "\n---------------------";
-      }
-      else {
-        title_string = "Processed data\n---------------------";
-      }
-      notebook->markdownCell(title_string);
-
-      for(auto gIt = groups.begin(); gIt != groups.end(); ++gIt) {
-        const std::set<int> groupRows = gIt->second;
-
-        //Reduce each row
-        std::ostringstream code_string;
-        for (auto rIt = groupRows.begin(); rIt != groupRows.end(); ++rIt) {
-          code_string << reduceRowNotebookCell(*rIt);
-        }
-        notebook->codeCell(code_string.str());
-
-        //todo stitch rows cell
-      }
-
-      //todo plot the unstitched I vs Q
-      //todo plot the stitched I vs Q
-
-      //TODO prompt for filename to save notebook
-      const std::string filename = "/home/jonmd/refl_notebook.ipynb";
-
-      std::string generatedNotebook = notebook->writeNotebook();
-      std::ofstream file(filename.c_str(), std::ofstream::trunc);
-      file << generatedNotebook;
-      file.flush();
-      file.close();
-    }
-
-    /**
-    Add a code cell to the notebook which runs reduce algorithm on the row specified
-    @param notebook : the notebook to add the cell to
-    @param rowNo : the row in the model to run the reduction algorithm on
-    */
-    std::string ReflMainViewPresenter::reduceRowNotebookCell(int rowNo)
-    {
-      std::ostringstream code_string;
-
-      const std::string   runStr = m_model->data(m_model->index(rowNo, COL_RUNS)).toString().toStdString();
-      const std::string transStr = m_model->data(m_model->index(rowNo, COL_TRANSMISSION)).toString().toStdString();
-      const std::string  options = m_model->data(m_model->index(rowNo, COL_OPTIONS)).toString().toStdString();
-
-      double theta = 0;
-
-      bool thetaGiven = !m_model->data(m_model->index(rowNo, COL_ANGLE)).toString().isEmpty();
-
-      if(thetaGiven)
-        theta = m_model->data(m_model->index(rowNo, COL_ANGLE)).toDouble();
-
-      auto runWS = prepareRunWorkspace(runStr);
-      const std::string runNo = getRunNumber(runWS);
-
-      Workspace_sptr transWS;
-      if(!transStr.empty())
-        transWS = makeTransWS(transStr);
-
-      code_string << "ReflectometryReductionOneAuto(InputWorkspace = " << runWS->name();
-      if(transWS)
-        code_string << ", " << "FirstTransmissionRun = " << transWS->name();
-      code_string << ", " << "OutputWorkspace = " << "IvsQ_" << runNo;
-      code_string << ", " << "OutputWorkspaceWaveLength = " << "IvsLam_" << runNo;
-      if(thetaGiven)
-        code_string << ", " << "ThetaIn = " << theta;
-
-      //Parse and set any user-specified options
-      auto optionsMap = parseKeyValueString(options);
-      for(auto kvp = optionsMap.begin(); kvp != optionsMap.end(); ++kvp)
-      {
-        code_string << ", " << kvp->first << " = " << kvp->second;
-      }
-      code_string << ")\n";
-
-      //todo rebin etc (look in reduceRow())
-
-      return code_string.str();
+      std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
+        m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE));
+      notebook->generateNotebook(groups, rows);
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -25,6 +25,8 @@
 #include <sstream>
 
 #include <QSettings>
+#include <QFileDialog>
+
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -280,11 +282,28 @@ namespace MantidQt
         return;
       }
 
-      //TODO else if notebook flag set from gui
+      //TODO if notebook flag set from gui
+      saveNotebook(groups, rows);
+    }
+
+    /**
+    Display a dialog to choose save location for notebook, then save the notebook there
+    @param rows : rows in the model
+    @param groups : groups of rows to stitch
+    */
+    void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
+    {
       std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
         m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
         COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE));
-      notebook->generateNotebook(groups, rows);
+      QString qfilename = QFileDialog::getSaveFileName(0, "Save file", QDir::currentPath(),
+                                                       "IPython Notebook files (*.ipynb);;All files (*.*)",
+                                                       new QString("IPython Notebook files (*.ipynb)"));
+      std::string filename = qfilename.toStdString();
+      if (filename == "") {
+        return;
+      }
+      notebook->generateNotebook(groups, rows, filename);
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -284,16 +284,15 @@ namespace MantidQt
 
       // If "Output Notebook" checkbox is checked then create an ipython notebook
       if(m_view->getEnableNotebook()) {
-        saveNotebook(groups, rows);
+        saveNotebook(groups);
       }
     }
 
     /**
     Display a dialog to choose save location for notebook, then save the notebook there
-    @param rows : rows in the model
     @param groups : groups of rows to stitch
     */
-    void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
+    void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups)
     {
       std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
         m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
@@ -305,7 +304,12 @@ namespace MantidQt
       if (filename == "") {
         return;
       }
-      notebook->generateNotebook(groups, rows, filename);
+      std::string generatedNotebook = notebook->generateNotebook(groups);
+
+      std::ofstream file(filename.c_str(), std::ofstream::trunc);
+      file << generatedNotebook;
+      file.flush();
+      file.close();
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -291,6 +291,7 @@ namespace MantidQt
     /**
     Display a dialog to choose save location for notebook, then save the notebook there
     @param groups : groups of rows to stitch
+    @param groups : rows selected for processing
     */
     void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
     {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -291,7 +291,7 @@ namespace MantidQt
     /**
     Display a dialog to choose save location for notebook, then save the notebook there
     @param groups : groups of rows to stitch
-    @param groups : rows selected for processing
+    @param rows : rows selected for processing
     */
     void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
     {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -282,8 +282,10 @@ namespace MantidQt
         return;
       }
 
-      //TODO if notebook flag set from gui
-      saveNotebook(groups, rows);
+      // If "Output Notebook" checkbox is checked then create an ipython notebook
+      if(m_view->getEnableNotebook()) {
+        saveNotebook(groups, rows);
+      }
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -17,6 +17,7 @@
 #include "MantidQtCustomInterfaces/QtReflOptionsDialog.h"
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidQtMantidWidgets/AlgorithmHintStrategy.h"
+#include "MantidQtCustomInterfaces/ParseKeyValueString.h"
 
 #include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
@@ -221,50 +222,6 @@ namespace MantidQt
         groupId++;
 
       return groupId;
-    }
-
-    /**
-    Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'` into a map of key/value pairs
-    @param str The input string
-    @throws std::runtime_error on an invalid input string
-    */
-    std::map<std::string,std::string> ReflMainViewPresenter::parseKeyValueString(const std::string& str)
-    {
-      //Tokenise, using '\' as an escape character, ',' as a delimiter and " and ' as quote characters
-      boost::tokenizer<boost::escaped_list_separator<char> > tok(str, boost::escaped_list_separator<char>("\\", ",", "\"'"));
-
-      std::map<std::string,std::string> kvp;
-
-      for(auto it = tok.begin(); it != tok.end(); ++it)
-      {
-        std::vector<std::string> valVec;
-        boost::split(valVec, *it, boost::is_any_of("="));
-
-        if(valVec.size() > 1)
-        {
-          //We split on all '='s. The first delimits the key, the rest are assumed to be part of the value
-          std::string key = valVec[0];
-          //Drop the key from the values vector
-          valVec.erase(valVec.begin());
-          //Join the remaining sections,
-          std::string value = boost::algorithm::join(valVec, "=");
-
-          //Remove any unwanted whitespace
-          boost::trim(key);
-          boost::trim(value);
-
-          if(key.empty() || value.empty())
-            throw std::runtime_error("Invalid key value pair, '" + *it + "'");
-
-
-          kvp[key] = value;
-        }
-        else
-        {
-          throw std::runtime_error("Invalid key value pair, '" + *it + "'");
-        }
-      }
-      return kvp;
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -284,7 +284,7 @@ namespace MantidQt
 
       // If "Output Notebook" checkbox is checked then create an ipython notebook
       if(m_view->getEnableNotebook()) {
-        saveNotebook(groups);
+        saveNotebook(groups, rows);
       }
     }
 
@@ -292,11 +292,11 @@ namespace MantidQt
     Display a dialog to choose save location for notebook, then save the notebook there
     @param groups : groups of rows to stitch
     */
-    void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups)
+    void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
     {
       std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
         m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
-        COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE));
+        COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE, COL_GROUP));
       QString qfilename = QFileDialog::getSaveFileName(0, "Save notebook file", QDir::currentPath(),
                                                        "IPython Notebook files (*.ipynb);;All files (*.*)",
                                                        new QString("IPython Notebook files (*.ipynb)"));
@@ -304,7 +304,7 @@ namespace MantidQt
       if (filename == "") {
         return;
       }
-      std::string generatedNotebook = notebook->generateNotebook(groups);
+      std::string generatedNotebook = notebook->generateNotebook(groups, rows);
 
       std::ofstream file(filename.c_str(), std::ofstream::trunc);
       file << generatedNotebook;

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -283,7 +283,7 @@ namespace MantidQt
       //TODO else if notebook flag set from gui
       std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
         m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
-        COL_QMIN, COL_QMAX, COL_DQQ));
+        COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE));
       notebook->generateNotebook(groups, rows);
     }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -325,7 +325,8 @@ namespace MantidQt
 
       //TODO else if notebook flag set from gui
       std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
-        m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE));
+        m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
+        COL_QMIN, COL_QMAX, COL_DQQ));
       notebook->generateNotebook(groups, rows);
     }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -310,26 +310,20 @@ namespace MantidQt
         }
       }
 
-      //Validate the rows
-      for(auto it = rows.begin(); it != rows.end(); ++it)
-      {
-        try
-        {
-          validateRow(*it);
-          autofillRow(*it);
-        }
-        catch(std::exception& ex)
-        {
-          //Allow two theta to be blank
-          if(ex.what() == std::string("Value for two theta could not be found in log."))
-            continue;
-
-          const std::string rowNo = Mantid::Kernel::Strings::toString<int>(*it + 1);
-          m_view->giveUserCritical("Error found in row " + rowNo + ":\n" + ex.what(), "Error");
-          return;
-        }
+      if(!rowsValid(rows)) {
+        return;
       }
 
+      processGroups(groups, rows);
+    }
+
+    /**
+    Process stitch groups
+    @param rows : rows in the model
+    @param groups : groups of rows to stitch
+    */
+    void ReflMainViewPresenter::processGroups(std::map<int,std::set<int>> groups, std::set<int> rows)
+    {
       int progress = 0;
       //Each group and each row within count as a progress step.
       const int maxProgress = (int)(rows.size() + groups.size());
@@ -372,6 +366,34 @@ namespace MantidQt
           return;
         }
       }
+    }
+
+    /**
+    Validate rows.
+    @param rows : Rows in the model to validate
+    @returns true if all rows are valid and false otherwise
+    */
+    bool ReflMainViewPresenter::rowsValid(std::set<int> rows)
+    {
+      for(auto it = rows.begin(); it != rows.end(); ++it)
+      {
+        try
+        {
+          validateRow(*it);
+          autofillRow(*it);
+        }
+        catch(std::exception& ex)
+        {
+          //Allow two theta to be blank
+          if(ex.what() == std::string("Value for two theta could not be found in log."))
+            continue;
+
+          const std::string rowNo = Mantid::Kernel::Strings::toString<int>(*it + 1);
+          m_view->giveUserCritical("Error found in row " + rowNo + ":\n" + ex.what(), "Error");
+          return false;
+        }
+      }
+      return true;
     }
 
     /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ParseKeyValueStringTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ParseKeyValueStringTest.h
@@ -1,0 +1,40 @@
+#ifndef MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRINGTEST_H
+#define MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRINGTEST_H
+
+#include <cxxtest/TestSuite.h>
+#include "MantidQtCustomInterfaces/ParseKeyValueString.h"
+
+class ParseKeyValueStringTest : public CxxTest::TestSuite {
+
+public:
+
+  void testParseKeyValueString() {
+    std::map<std::string, std::string> kvp =
+    MantidQt::CustomInterfaces::parseKeyValueString(
+        "a = 1,b=2.0, c=3, d='1,2,3',e=\"4,5,6\",f=1+1=2, g = '\\''");
+
+    TS_ASSERT_EQUALS(kvp["a"], "1");
+    TS_ASSERT_EQUALS(kvp["b"], "2.0");
+    TS_ASSERT_EQUALS(kvp["c"], "3");
+    TS_ASSERT_EQUALS(kvp["d"], "1,2,3");
+    TS_ASSERT_EQUALS(kvp["e"], "4,5,6");
+    TS_ASSERT_EQUALS(kvp["f"], "1+1=2");
+    TS_ASSERT_EQUALS(kvp["g"], "'");
+
+    TS_ASSERT_THROWS(
+      MantidQt::CustomInterfaces::parseKeyValueString("a = 1, b = 2, c = 3,"),
+      std::runtime_error);
+    TS_ASSERT_THROWS(
+      MantidQt::CustomInterfaces::parseKeyValueString("a = 1, b = 2, c = 3,d"),
+      std::runtime_error);
+    TS_ASSERT_THROWS(MantidQt::CustomInterfaces::parseKeyValueString(",a = 1"),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(MantidQt::CustomInterfaces::parseKeyValueString(",a = 1 = 2,="),
+                     std::runtime_error);
+    TS_ASSERT_THROWS(MantidQt::CustomInterfaces::parseKeyValueString("=,=,="),
+                     std::runtime_error);
+  }
+
+};
+
+#endif //MANTID_CUSTOMINTERFACES_PARSEKEYVALUESTRINGTEST_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -4,13 +4,144 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
+#include "MantidQtCustomInterfaces/QReflTableModel.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidAPI/TableRow.h"
+#include "MantidAPI/ITableWorkspace.h"
 
+using namespace MantidQt::CustomInterfaces;
+using namespace Mantid::API;
 
 class ReflGenerateNotebookTest : public CxxTest::TestSuite {
 
+private:
+
+  ITableWorkspace_sptr createWorkspace(const std::string &wsName) {
+    ITableWorkspace_sptr ws = WorkspaceFactory::Instance().createTable();
+
+    auto colRuns = ws->addColumn("str", "Run(s)");
+    auto colTheta = ws->addColumn("str", "ThetaIn");
+    auto colTrans = ws->addColumn("str", "TransRun(s)");
+    auto colQmin = ws->addColumn("str", "Qmin");
+    auto colQmax = ws->addColumn("str", "Qmax");
+    auto colDqq = ws->addColumn("str", "dq/q");
+    auto colScale = ws->addColumn("double", "Scale");
+    auto colStitch = ws->addColumn("int", "StitchGroup");
+    auto colOptions = ws->addColumn("str", "Options");
+
+    colRuns->setPlotType(0);
+    colTheta->setPlotType(0);
+    colTrans->setPlotType(0);
+    colQmin->setPlotType(0);
+    colQmax->setPlotType(0);
+    colDqq->setPlotType(0);
+    colScale->setPlotType(0);
+    colStitch->setPlotType(0);
+    colOptions->setPlotType(0);
+
+    if (wsName.length() > 0)
+      AnalysisDataService::Instance().addOrReplace(wsName, ws);
+
+    return ws;
+  }
+
+  ITableWorkspace_sptr createPrefilledWorkspace(const std::string &wsName) {
+    auto ws = createWorkspace(wsName);
+    TableRow row = ws->appendRow();
+    row << "12345"
+    << "0.5"
+    << ""
+    << "0.1"
+    << "1.6"
+    << "0.04" << 1.0 << 0 << "";
+    row = ws->appendRow();
+    row << "12346"
+    << "1.5"
+    << ""
+    << "1.4"
+    << "2.9"
+    << "0.04" << 1.0 << 0 << "";
+    row = ws->appendRow();
+    row << "24681"
+    << "0.5"
+    << ""
+    << "0.1"
+    << "1.6"
+    << "0.04" << 1.0 << 1 << "";
+    row = ws->appendRow();
+    row << "24682"
+    << "1.5"
+    << ""
+    << "1.4"
+    << "2.9"
+    << "0.04" << 1.0 << 1 << "";
+    return ws;
+  }
+
+  void createModel(const std::string &wsName)
+  {
+    ITableWorkspace_sptr m_ws = createPrefilledWorkspace(wsName);
+    m_model.reset(new QReflTableModel(m_ws));
+  }
+
+  const std::string m_wsName = "TESTWORKSPACE";
+  const std::string m_instrument = "INSTRUMENT";
+  QReflTableModel_sptr m_model;
+  std::set<int> m_rows;
+  std::map<int,std::set<int> > m_groups;
+  const ColNumbers col_nums{0, 2, 8, 1, 3, 4, 5, 6, 7};
+
 public:
 
+  // Create a notebook to test
+  void setUp()
+  {
+    createModel(m_wsName);
 
+    std::set<int> rows;
+    // Populate rows with every index in the model
+    for(int idx = 0; idx < m_model->rowCount(); ++idx)
+      rows.insert(idx);
+
+    //Map group numbers to the set of rows in that group we want to process
+    std::map<int,std::set<int> > groups;
+    for(auto it = rows.begin(); it != rows.end(); ++it)
+      groups[m_model->data(m_model->index(*it, col_nums.group)).toInt()].insert(*it);
+  }
+
+  void testGenerateNotebook() {
+
+    std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(m_wsName, m_model, m_instrument,
+                                                   col_nums.runs, col_nums.transmission, col_nums.options, col_nums.angle,
+                                                   col_nums.qmin, col_nums.qmax, col_nums.dqq, col_nums.scale, col_nums.group));
+
+    std::string generatedNotebook = notebook->generateNotebook(m_groups, m_rows);
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, generatedNotebook, boost::is_any_of("\n"));
+
+    const std::string result[] = {
+      "{",
+      "   \"metadata\" : {",
+      "      \"name\" : \"Mantid Notebook\"",
+      "   },",
+      "   \"nbformat\" : 3,",
+      "   \"nbformat_minor\" : 0,",
+      "   \"worksheets\" : [",
+      "      {",
+      "         \"cells\" : [",
+      "            {",
+      "               \"cell_type\" : \"markdown\",",
+    };
+
+    // Check that the first 10 lines are output as expected
+    for (int i=0; i<11; ++i)
+    {
+      TS_ASSERT_EQUALS(notebookLines[i], result[i])
+    }
+
+  }
+  
 };
 
 #endif //MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOKTEST_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -243,22 +243,111 @@ public:
 
   void testStitchGroupString() {
 
+    std::tuple<std::string, std::string> output = stitchGroupString(m_rows, m_instrument, m_model, col_nums);
+
+    const std::string result[] = {
+      "#Stitch workspaces",
+      "IvsQ_12345_12346_24681_24682, _ = Stitch1DMany(InputWorkspaces = 'IvsQ_12345, IvsQ_12346, IvsQ_24681,"
+        " IvsQ_24682', Params = '0.1, -0.04, 2.9', StartOverlaps = '1.4, 0.1, 1.4', EndOverlaps = '1.6, 2.9, 1.6')",
+      ""
+    };
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, std::get<0>(output), boost::is_any_of("\n"));
+
+    int i=0;
+    for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
+    {
+      TS_ASSERT_EQUALS(*it, result[i])
+    }
+
   }
 
   void testPlotsFunctionString() {
+
+    std::string output = plotsFunctionString();
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, output, boost::is_any_of("\n"));
+
+    const std::string result[] = {
+      "def plotWithOptions(ax, ws, ops, n):",
+      "    \"\"\"",
+      "    Enable/disable legend, grid, limits according to",
+      "    options (ops) for the given axes (ax).",
+      "    Plot with or without errorbars.",
+      "    \"\"\"",
+      "    ws_plot = ConvertToPointData(ws)",
+      "    if ops['errorbars']:",
+      "        ax.errorbar(ws_plot.readX(0), ws_plot.readY(0), yerr=ws_plot.readE(0), label=ws.name())",
+      "    else:",
+      "        ax.plot(ws_plot.readX(0), ws_plot.readY(0), label=ws.name())",
+    };
+
+    // Check that the first 10 lines are output as expected
+    for (int i=0; i<11; ++i)
+    {
+      TS_ASSERT_EQUALS(notebookLines[i], result[i])
+    }
 
   }
 
   void testPlotsString() {
 
+    std::vector<std::string> unstitched_ws;
+    unstitched_ws.push_back("TEST_WS1");
+    unstitched_ws.push_back("TEST_WS2");
+
+    std::vector<std::string> IvsLam_ws;
+    IvsLam_ws.push_back("TEST_WS3");
+    IvsLam_ws.push_back("TEST_WS4");
+
+    std::string output = plotsString(unstitched_ws, IvsLam_ws, "TEST_WS5");
+
+    const std::string result[] = {
+      "#Group workspaces to be plotted on same axes",
+      "unstitchedGroupWS = GroupWorkspaces(InputWorkspaces = 'TEST_WS1, TEST_WS2')",
+      "IvsLamGroupWS = GroupWorkspaces(InputWorkspaces = 'TEST_WS3, TEST_WS4')",
+      "#Plot workspaces",
+      "fig = plots([unstitchedGroupWS, TEST_WS5, IvsLamGroupWS], title=['I vs Q Unstitched', 'I vs Q Stitiched', 'I vs Lambda'], legendLocation=[1, 1, 4])",
+      ""
+    };
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, output, boost::is_any_of("\n"));
+
+    int i=0;
+    for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
+    {
+      TS_ASSERT_EQUALS(*it, result[i])
+    }
+
   }
 
   void testReduceRowString() {
 
+    std::tuple<std::string, std::string, std::string> output = reduceRowString(1, m_instrument, m_model, col_nums);
+
+    const std::string result[] = {
+      "TOF_12346 = Load(Filename = 'INSTRUMENT12346')",
+      "IvsQ_12346, IvsLam_12346, theta_12346 = ReflectometryReductionOneAuto(InputWorkspace = 'TOF_12346', ThetaIn = 1.5)",
+      "IvsQ_12346 = Rebin(IvsQ_12346, Params = '1.4, -0.04, 2.9')",
+      ""
+    };
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, std::get<0>(output), boost::is_any_of("\n"));
+
+    int i=0;
+    for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
+    {
+      TS_ASSERT_EQUALS(*it, result[i])
+    }
+
   }
 
   void testLoadWorkspaceString() {
-
+    
   }
 
   void testPlusString() {

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -1,0 +1,16 @@
+#ifndef MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOKTEST_H
+#define MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOKTEST_H
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
+
+
+class ReflGenerateNotebookTest : public CxxTest::TestSuite {
+
+public:
+
+
+};
+
+#endif //MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOKTEST_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -4,6 +4,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
+#include "MantidQtCustomInterfaces/ReflVectorString.h"
 #include "MantidQtCustomInterfaces/QReflTableModel.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidAPI/TableRow.h"

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -3,7 +3,7 @@
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
-#include <gtest\gtest.h>
+#include <gtest/gtest.h>
 
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidQtCustomInterfaces/ReflVectorString.h"

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -6,12 +6,14 @@
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidQtCustomInterfaces/ReflVectorString.h"
 #include "MantidQtCustomInterfaces/QReflTableModel.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/ITableWorkspace.h"
 
 using namespace MantidQt::CustomInterfaces;
 using namespace Mantid::API;
+using namespace Mantid::Kernel;
 
 class ReflGenerateNotebookTest : public CxxTest::TestSuite {
 
@@ -85,18 +87,30 @@ private:
     m_model.reset(new QReflTableModel(prefilled_ws));
   }
 
-  const std::string m_wsName = "TESTWORKSPACE";
-  const std::string m_instrument = "INSTRUMENT";
+  std::string m_wsName;
+  std::string m_instrument;
   QReflTableModel_sptr m_model;
   std::set<int> m_rows;
   std::map<int,std::set<int> > m_groups;
-  ColNumbers col_nums{0, 2, 8, 1, 3, 4, 5, 6, 7};
+  ColNumbers col_nums;
 
 public:
+
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ReflGenerateNotebookTest *createSuite() {
+    return new ReflGenerateNotebookTest();
+  }
+  static void destroySuite(ReflGenerateNotebookTest *suite) { delete suite; }
+
+  ReflGenerateNotebookTest() : col_nums(0, 2, 8, 1, 3, 4, 5, 6, 7) { FrameworkManager::Instance(); }
 
   // Create a notebook to test
   void setUp()
   {
+    m_wsName = "TESTWORKSPACE";
+    m_instrument = "INSTRUMENT";
+
     createModel(m_wsName);
 
     // Populate rows with every index in the model
@@ -244,7 +258,7 @@ public:
 
   void testStitchGroupString()
   {
-    std::tuple<std::string, std::string> output = stitchGroupString(m_rows, m_instrument, m_model, col_nums);
+    boost::tuple<std::string, std::string> output = stitchGroupString(m_rows, m_instrument, m_model, col_nums);
 
     const std::string result[] = {
       "#Stitch workspaces",
@@ -254,7 +268,7 @@ public:
     };
 
     std::vector<std::string> notebookLines;
-    boost::split(notebookLines, std::get<0>(output), boost::is_any_of("\n"));
+    boost::split(notebookLines, boost::get<0>(output), boost::is_any_of("\n"));
 
     int i=0;
     for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
@@ -327,7 +341,7 @@ public:
 
   void testReduceRowString()
   {
-    std::tuple<std::string, std::string, std::string> output = reduceRowString(1, m_instrument, m_model, col_nums);
+    boost::tuple<std::string, std::string, std::string> output = reduceRowString(1, m_instrument, m_model, col_nums);
 
     const std::string result[] = {
       "TOF_12346 = Load(Filename = 'INSTRUMENT12346')",
@@ -337,7 +351,7 @@ public:
     };
 
     std::vector<std::string> notebookLines;
-    boost::split(notebookLines, std::get<0>(output), boost::is_any_of("\n"));
+    boost::split(notebookLines, boost::get<0>(output), boost::is_any_of("\n"));
 
     int i=0;
     for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
@@ -356,9 +370,9 @@ public:
 
   void testLoadRunString()
   {
-    std::tuple<std::string, std::string> output = loadRunString("12345", m_instrument);
+    boost::tuple<std::string, std::string> output = loadRunString("12345", m_instrument);
     const std::string result = "TOF_12345 = Load(Filename = 'INSTRUMENT12345')\n";
-    TS_ASSERT_EQUALS(std::get<0>(output), result)
+    TS_ASSERT_EQUALS(boost::get<0>(output), result)
   }
 
   void testGetRunNumber()
@@ -376,9 +390,9 @@ public:
 
   void testScaleString()
   {
-    std::tuple<std::string, std::string> output = scaleString("12345", 1.0);
+    boost::tuple<std::string, std::string> output = scaleString("12345", 1.0);
     const std::string result = "IvsQ_12345 = Scale(InputWorkspace = IvsQ_12345, Factor = 1)\n";
-    TS_ASSERT_EQUALS(std::get<0>(output), result)
+    TS_ASSERT_EQUALS(boost::get<0>(output), result)
   }
 
   void testVectorParamString()
@@ -395,9 +409,9 @@ public:
 
   void testRebinString()
   {
-    std::tuple<std::string, std::string> output = rebinString(1, "12345", m_model, col_nums);
+    boost::tuple<std::string, std::string> output = rebinString(1, "12345", m_model, col_nums);
     const std::string result = "IvsQ_12345 = Rebin(IvsQ_12345, Params = '1.4, -0.04, 2.9')\n";
-    TS_ASSERT_EQUALS(std::get<0>(output), result)
+    TS_ASSERT_EQUALS(boost::get<0>(output), result)
   }
 
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -107,8 +107,8 @@ public:
       m_groups[m_model->data(m_model->index(*it, col_nums.group)).toInt()].insert(*it);
   }
 
-  void testGenerateNotebook() {
-
+  void testGenerateNotebook()
+  {
     std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(m_wsName, m_model, m_instrument,
                                                    col_nums.runs, col_nums.transmission, col_nums.options, col_nums.angle,
                                                    col_nums.qmin, col_nums.qmax, col_nums.dqq, col_nums.scale, col_nums.group));
@@ -140,8 +140,8 @@ public:
 
   }
 
-  void testPlot1DString() {
-
+  void testPlot1DString()
+  {
     std::vector<std::string> ws_names;
     ws_names.push_back("workspace1");
     ws_names.push_back("workspace2");
@@ -153,8 +153,8 @@ public:
     TS_ASSERT_EQUALS(output, result)
   }
 
-  void testTableString() {
-
+  void testTableString()
+  {
     std::string output = tableString(m_model, col_nums, m_rows);
 
     std::vector<std::string> notebookLines;
@@ -178,8 +178,8 @@ public:
 
   }
 
-  void testVectorString() {
-
+  void testVectorString()
+  {
     std::vector<std::string> stringVector;
     stringVector.push_back("A");
     stringVector.push_back("B");
@@ -199,8 +199,8 @@ public:
     TS_ASSERT_EQUALS(intOutput, "1, 2, 3")
   }
 
-  void testTitleString() {
-
+  void testTitleString()
+  {
     // Test with workspace name
     std::string output = titleString("TEST_WORKSPACE");
 
@@ -241,8 +241,8 @@ public:
 
   }
 
-  void testStitchGroupString() {
-
+  void testStitchGroupString()
+  {
     std::tuple<std::string, std::string> output = stitchGroupString(m_rows, m_instrument, m_model, col_nums);
 
     const std::string result[] = {
@@ -263,8 +263,8 @@ public:
 
   }
 
-  void testPlotsFunctionString() {
-
+  void testPlotsFunctionString()
+  {
     std::string output = plotsFunctionString();
 
     std::vector<std::string> notebookLines;
@@ -292,8 +292,8 @@ public:
 
   }
 
-  void testPlotsString() {
-
+  void testPlotsString()
+  {
     std::vector<std::string> unstitched_ws;
     unstitched_ws.push_back("TEST_WS1");
     unstitched_ws.push_back("TEST_WS2");
@@ -324,8 +324,8 @@ public:
 
   }
 
-  void testReduceRowString() {
-
+  void testReduceRowString()
+  {
     std::tuple<std::string, std::string, std::string> output = reduceRowString(1, m_instrument, m_model, col_nums);
 
     const std::string result[] = {
@@ -346,36 +346,57 @@ public:
 
   }
 
-  void testLoadWorkspaceString() {
-    
+  void testPlusString()
+  {
+    std::string output = plusString("INPUT_WS", "OUTPUT_WS");
+    const std::string result = "OUTPUT_WS = Plus('LHSWorkspace' = OUTPUT_WS, 'RHSWorkspace' = INPUT_WS)\n";
+    TS_ASSERT_EQUALS(output, result)
   }
 
-  void testPlusString() {
-
+  void testLoadRunString()
+  {
+    std::tuple<std::string, std::string> output = loadRunString("12345", m_instrument);
+    const std::string result = "TOF_12345 = Load(Filename = 'INSTRUMENT12345')\n";
+    TS_ASSERT_EQUALS(std::get<0>(output), result)
   }
 
-  void testLoadRunString() {
+  void testGetRunNumber()
+  {
+    // Test with no run number in string
+    std::string output = getRunNumber("TEST_WORKSPACE");
+    const std::string result = "TEST_WORKSPACE";
+    TS_ASSERT_EQUALS(output, result)
 
+    // Test with instrument and number
+    std::string output1 = getRunNumber("INSTRUMENT12345");
+    const std::string result1 = "12345";
+    TS_ASSERT_EQUALS(output1, result1)
   }
 
-  void testGetRunNumber() {
-
+  void testScaleString()
+  {
+    std::tuple<std::string, std::string> output = scaleString("12345", 1.0);
+    const std::string result = "IvsQ_12345 = Scale(InputWorkspace = IvsQ_12345, Factor = 1)\n";
+    TS_ASSERT_EQUALS(std::get<0>(output), result)
   }
 
-  void testScaleString() {
+  void testVectorParamString()
+  {
+    std::vector<std::string> stringVector;
+    stringVector.push_back("A");
+    stringVector.push_back("B");
+    stringVector.push_back("C");
 
+    const std::string stringOutput = vectorParamString("PARAM_NAME", stringVector);
+
+    TS_ASSERT_EQUALS(stringOutput, "PARAM_NAME = 'A, B, C'")
   }
 
-  void testVectorParamString() {
-
-  }
-
-  void testRebinString() {
-
-  }
-
-  void testTransWSString() {
-
+  void testRebinString()
+  {
+    std::tuple<std::string, std::string> output = rebinString(1, "12345", m_model, col_nums);
+    const std::string result = "IvsQ_12345 = Rebin(IvsQ_12345, Params = '1.4, -0.04, 2.9')\n";
+    TS_ASSERT_EQUALS(std::get<0>(output), result)
   }
 
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -90,7 +90,7 @@ private:
   QReflTableModel_sptr m_model;
   std::set<int> m_rows;
   std::map<int,std::set<int> > m_groups;
-  const ColNumbers col_nums{0, 2, 8, 1, 3, 4, 5, 6, 7};
+  ColNumbers col_nums{0, 2, 8, 1, 3, 4, 5, 6, 7};
 
 public:
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -80,8 +80,8 @@ private:
 
   void createModel(const std::string &wsName)
   {
-    ITableWorkspace_sptr m_ws = createPrefilledWorkspace(wsName);
-    m_model.reset(new QReflTableModel(m_ws));
+    ITableWorkspace_sptr prefilled_ws = createPrefilledWorkspace(wsName);
+    m_model.reset(new QReflTableModel(prefilled_ws));
   }
 
   const std::string m_wsName = "TESTWORKSPACE";
@@ -98,15 +98,13 @@ public:
   {
     createModel(m_wsName);
 
-    std::set<int> rows;
     // Populate rows with every index in the model
     for(int idx = 0; idx < m_model->rowCount(); ++idx)
-      rows.insert(idx);
+      m_rows.insert(idx);
 
     //Map group numbers to the set of rows in that group we want to process
-    std::map<int,std::set<int> > groups;
-    for(auto it = rows.begin(); it != rows.end(); ++it)
-      groups[m_model->data(m_model->index(*it, col_nums.group)).toInt()].insert(*it);
+    for(auto it = m_rows.begin(); it != m_rows.end(); ++it)
+      m_groups[m_model->data(m_model->index(*it, col_nums.group)).toInt()].insert(*it);
   }
 
   void testGenerateNotebook() {
@@ -141,7 +139,156 @@ public:
     }
 
   }
-  
+
+  void testPlot1DString() {
+
+    std::vector<std::string> ws_names;
+    ws_names.push_back("workspace1");
+    ws_names.push_back("workspace2");
+
+    std::string output = plot1DString(ws_names, "Plot Title");
+
+    const std::string result = "fig = plots([workspace1, workspace2], title=Plot Title, legendLocation=[1, 1, 4])\n";
+
+    TS_ASSERT_EQUALS(output, result)
+  }
+
+  void testTableString() {
+
+    std::string output = tableString(m_model, col_nums, m_rows);
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, output, boost::is_any_of("\n"));
+
+    const std::string result[] = {
+      "Run(s) | Angle | Transmission Run(s) | Q min | Q max | dQ/Q | Scale | Group | Options",
+      "------ | ----- | ------------------- | ----- | ----- | ---- | ----- | ----- | -------",
+      "12345 | 0.5 |  | 0.1 | 1.6 | 0.04 | 1 | 0 | ",
+      "12346 | 1.5 |  | 1.4 | 2.9 | 0.04 | 1 | 0 | ",
+      "24681 | 0.5 |  | 0.1 | 1.6 | 0.04 | 1 | 1 | ",
+      "24682 | 1.5 |  | 1.4 | 2.9 | 0.04 | 1 | 1 | ",
+      ""
+    };
+
+    int i=0;
+    for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
+    {
+      TS_ASSERT_EQUALS(*it, result[i])
+    }
+
+  }
+
+  void testVectorString() {
+
+    std::vector<std::string> stringVector;
+    stringVector.push_back("A");
+    stringVector.push_back("B");
+    stringVector.push_back("C");
+
+    const std::string stringOutput = vectorString(stringVector);
+
+    std::vector<int> intVector;
+    intVector.push_back(1);
+    intVector.push_back(2);
+    intVector.push_back(3);
+
+    const std::string intOutput = vectorString(intVector);
+
+    // Test string list output is correct for vector of strings and vector of ints
+    TS_ASSERT_EQUALS(stringOutput, "A, B, C")
+    TS_ASSERT_EQUALS(intOutput, "1, 2, 3")
+  }
+
+  void testTitleString() {
+
+    // Test with workspace name
+    std::string output = titleString("TEST_WORKSPACE");
+
+    const std::string result[] = {
+      "Processed data from workspace: TEST_WORKSPACE",
+      "---------------",
+      "Notebook generated from the ISIS Reflectometry (Polref) Interface",
+      ""
+    };
+
+    std::vector<std::string> notebookLines;
+    boost::split(notebookLines, output, boost::is_any_of("\n"));
+
+    int i=0;
+    for (auto it = notebookLines.begin(); it != notebookLines.end(); ++it, ++i)
+    {
+      TS_ASSERT_EQUALS(*it, result[i])
+    }
+
+    // Test without workspace name
+    std::string outputEmptyStr = titleString("");
+
+    const std::string resultEmptyStr[] = {
+      "Processed data",
+      "---------------",
+      "Notebook generated from the ISIS Reflectometry (Polref) Interface",
+      ""
+    };
+
+    std::vector<std::string> notebookLinesEmptyStr;
+    boost::split(notebookLinesEmptyStr, outputEmptyStr, boost::is_any_of("\n"));
+
+    i=0;
+    for (auto it = notebookLinesEmptyStr.begin(); it != notebookLinesEmptyStr.end(); ++it, ++i)
+    {
+      TS_ASSERT_EQUALS(*it, resultEmptyStr[i])
+    }
+
+  }
+
+  void testStitchGroupString() {
+
+  }
+
+  void testPlotsFunctionString() {
+
+  }
+
+  void testPlotsString() {
+
+  }
+
+  void testReduceRowString() {
+
+  }
+
+  void testLoadWorkspaceString() {
+
+  }
+
+  void testPlusString() {
+
+  }
+
+  void testLoadRunString() {
+
+  }
+
+  void testGetRunNumber() {
+
+  }
+
+  void testScaleString() {
+
+  }
+
+  void testVectorParamString() {
+
+  }
+
+  void testRebinString() {
+
+  }
+
+  void testTransWSString() {
+
+  }
+
 };
 
 #endif //MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOKTEST_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflGenerateNotebookTest.h
@@ -2,6 +2,8 @@
 #define MANTID_CUSTOMINTERFACES_REFLGENERATENOTEBOOKTEST_H
 
 #include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <gtest\gtest.h>
 
 #include "MantidQtCustomInterfaces/ReflGenerateNotebook.h"
 #include "MantidQtCustomInterfaces/ReflVectorString.h"
@@ -14,6 +16,7 @@
 using namespace MantidQt::CustomInterfaces;
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
+using namespace testing;
 
 class ReflGenerateNotebookTest : public CxxTest::TestSuite {
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -53,6 +53,7 @@ public:
   virtual void setOptionsHintStrategy(MantidQt::MantidWidgets::HintStrategy*) {};
   virtual void setProgressRange(int,int) {};
   virtual void setProgress(int) {};
+  virtual bool getEnableNotebook() {return false;};
   virtual void setTableList(const std::set<std::string>&) {};
   virtual void setInstrumentList(const std::vector<std::string>&, const std::string&) {};
   virtual std::string getProcessInstrument() const {return "FAKE";}

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ReflMainViewPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ReflMainViewPresenterTest.h
@@ -707,33 +707,6 @@ public:
     AnalysisDataService::Instance().remove("TestWorkspace");
   }
 
-  void testParseKeyValueString() {
-    std::map<std::string, std::string> kvp =
-        ReflMainViewPresenter::parseKeyValueString(
-            "a = 1,b=2.0, c=3, d='1,2,3',e=\"4,5,6\",f=1+1=2, g = '\\''");
-
-    TS_ASSERT_EQUALS(kvp["a"], "1");
-    TS_ASSERT_EQUALS(kvp["b"], "2.0");
-    TS_ASSERT_EQUALS(kvp["c"], "3");
-    TS_ASSERT_EQUALS(kvp["d"], "1,2,3");
-    TS_ASSERT_EQUALS(kvp["e"], "4,5,6");
-    TS_ASSERT_EQUALS(kvp["f"], "1+1=2");
-    TS_ASSERT_EQUALS(kvp["g"], "'");
-
-    TS_ASSERT_THROWS(
-        ReflMainViewPresenter::parseKeyValueString("a = 1, b = 2, c = 3,"),
-        std::runtime_error);
-    TS_ASSERT_THROWS(
-        ReflMainViewPresenter::parseKeyValueString("a = 1, b = 2, c = 3,d"),
-        std::runtime_error);
-    TS_ASSERT_THROWS(ReflMainViewPresenter::parseKeyValueString(",a = 1"),
-                     std::runtime_error);
-    TS_ASSERT_THROWS(ReflMainViewPresenter::parseKeyValueString(",a = 1 = 2,="),
-                     std::runtime_error);
-    TS_ASSERT_THROWS(ReflMainViewPresenter::parseKeyValueString("=,=,="),
-                     std::runtime_error);
-  }
-
   void testPromptSaveAfterAppendRow() {
     MockView mockView;
     ReflMainViewPresenter presenter(&mockView);

--- a/Code/Mantid/docs/source/interfaces/ISIS_Reflectometry.rst
+++ b/Code/Mantid/docs/source/interfaces/ISIS_Reflectometry.rst
@@ -18,6 +18,9 @@ data is being processed, and easy to adjust any of the options used.
 Integration with data archives is also provided, allowing for data to
 be located and prepared for reduction automatically.
 
+IPython notebooks which document the processing steps and output 
+relevant plots can also be produced from the interface.
+
 Information on how to resolve common problems can be found in the
 `Troubleshooting`_ section of this document.
 
@@ -151,9 +154,15 @@ Above the processing table is a tool bar containing various actions for
 manipulating the processing table.
 
 Below the table is a progress bar, which shows the current progress of any
-processing that is in progress. And at the bottom right, by the **Process**
+processing that is in progress. And at the bottom, near the **Process**
 button is the processing instrument selector. The processing instrument is
 used to help identify the correct data to load when processing runs.
+
+Next to the **Process** button there is a checkbox which allows enabling and 
+disabling output to an ipython notebook. If the checkbox is enabled, a dialog 
+window will ask for a save location for the notebook after processing is 
+complete. A generated notebook contains python code to repeat the processing 
+steps and output relevant plots.
 
 Tool Bar
 ~~~~~~~~


### PR DESCRIPTION
Closes #13540

Implemented IPython notebook generation from the ISIS Reflectometry (polref) interface. Added checkbox next to the "process" button in GUI to enable notebook generation when "process" is clicked. The notebook displays the full table, carries out the processing and outputs relevant plots.

For tester:
I suggest loading "INTER_NR_test2.tbl" as described in the [documentation](http://docs.mantidproject.org/nightly/interfaces/ISIS_Reflectometry.html), and then outputting a notebook.

If you are not familiar with ipython notebooks:
- Type "ipython notebook" in a console and the ipython notebook interface should appear in your web browser.
- Code cells in the notebook can be evaluated individually by shift+enter in the cell.
