### PR TITLE
ResNorm error with sqw files

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ResNorm.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ResNorm.ui
@@ -43,13 +43,11 @@
        <property name="workspaceSuffixes" stdset="0">
         <stringlist>
          <string>_res</string>
-         <string>_sqw</string>
         </stringlist>
        </property>
        <property name="fileBrowserSuffixes" stdset="0">
         <stringlist>
          <string>_res.nxs</string>
-         <string>_sqw.nxs</string>
         </stringlist>
        </property>
        <property name="showLoad" stdset="0">
@@ -81,13 +79,11 @@
        <property name="workspaceSuffixes" stdset="0">
         <stringlist>
          <string>_red</string>
-         <string>_sqw</string>
         </stringlist>
        </property>
        <property name="fileBrowserSuffixes" stdset="0">
         <stringlist>
          <string>_red.nxs</string>
-         <string>_sqw.nxs</string>
         </stringlist>
        </property>
       </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -53,6 +53,15 @@ void ResNorm::setup() {}
  */
 bool ResNorm::validate() {
   UserInputValidator uiv;
+
+  // Check vanadium input is _red ws
+  QString vanadiumSuffix = m_uiForm.dsVanadium->getCurrentDataName();
+  int cutIndex = vanadiumSuffix.lastIndexOf("_");
+  vanadiumSuffix = vanadiumSuffix.right(vanadiumSuffix.size() - (cutIndex + 1));
+  if (vanadiumSuffix.compare("red") != 0) {
+    return false;
+  }
+
   uiv.checkDataSelectorIsValid("Vanadium", m_uiForm.dsVanadium);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 


### PR DESCRIPTION
Fixes #13620 

ResNorm should no longer accept non `_red` files as input for vanadium and non `_res` files resolution.
# To Test
- Open ResNorm (Interfaces > Indirect > Bayes > ResNorm)
- Attempt to add a file for either the Vanadium or Resolution run
- Ensure that:
  - only `_red` files are valid for Vanadium runs
  - only `_res` files are valid for Resolution runs
    - These files should match e.g. `irs26173_graphite002_red.nxs` and `irs26173_graphite002_res.nxs`
- Run the ResNorm Algorithm (click run in the interface) 
- Ensure that the files validate when run
