### PR TITLE
LoadIsawDetCal works for PeaksWorkspaces

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/ResizeRectangularDetector.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/ResizeRectangularDetector.cpp
@@ -5,6 +5,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -48,7 +49,7 @@ const std::string ResizeRectangularDetector::category() const {
 void ResizeRectangularDetector::init() {
   // When used as a Child Algorithm the workspace name is not used - hence the
   // "Anonymous" to satisfy the validator
-  declareProperty(new WorkspaceProperty<MatrixWorkspace>(
+  declareProperty(new WorkspaceProperty<Workspace>(
       "Workspace", "Anonymous", Direction::InOut));
   declareProperty("ComponentName", "",
                   "The name of the RectangularDetector to resize.");
@@ -62,7 +63,20 @@ void ResizeRectangularDetector::init() {
 /** Execute the algorithm.
  */
 void ResizeRectangularDetector::exec() {
-  MatrixWorkspace_sptr WS = getProperty("Workspace");
+  // Get the input workspace
+  Workspace_sptr ws = getProperty("Workspace");
+  MatrixWorkspace_sptr inputW = boost::dynamic_pointer_cast<MatrixWorkspace>(ws);
+  DataObjects::PeaksWorkspace_sptr inputP = boost::dynamic_pointer_cast<DataObjects::PeaksWorkspace>(ws);
+
+  // Get some stuff from the input workspace
+  Instrument_sptr inst;
+  if (inputW) {
+    inst= boost::const_pointer_cast<Instrument>(inputW->getInstrument());
+  }
+  else if (inputP) {
+    inst= boost::const_pointer_cast<Instrument>(inputP->getInstrument());
+  }
+
   std::string ComponentName = getPropertyValue("ComponentName");
   double ScaleX = getProperty("ScaleX");
   double ScaleY = getProperty("ScaleY");
@@ -70,7 +84,6 @@ void ResizeRectangularDetector::exec() {
   if (ComponentName.empty())
     throw std::runtime_error("You must specify a ComponentName.");
 
-  Instrument_const_sptr inst = WS->getInstrument();
   IComponent_const_sptr comp;
 
   comp = inst->getComponentByName(ComponentName);
@@ -83,13 +96,23 @@ void ResizeRectangularDetector::exec() {
   if (!det)
     throw std::runtime_error("Component with name " + ComponentName +
                              " is not a RectangularDetector.");
+  if (inputW) {
+    Geometry::ParameterMap &pmap = inputW->instrumentParameters();
+    // Add a parameter for the new scale factors
+    pmap.addDouble(det->getComponentID(), "scalex", ScaleX);
+    pmap.addDouble(det->getComponentID(), "scaley", ScaleY);
 
-  Geometry::ParameterMap &pmap = WS->instrumentParameters();
-  // Add a parameter for the new scale factors
-  pmap.addDouble(det->getComponentID(), "scalex", ScaleX);
-  pmap.addDouble(det->getComponentID(), "scaley", ScaleY);
+    pmap.clearPositionSensitiveCaches();
+  }
+  else if (inputP) {
+    Geometry::ParameterMap &pmap = inputP->instrumentParameters();
+    // Add a parameter for the new scale factors
+    pmap.addDouble(det->getComponentID(), "scalex", ScaleX);
+    pmap.addDouble(det->getComponentID(), "scaley", ScaleY);
 
-  pmap.clearPositionSensitiveCaches();
+    pmap.clearPositionSensitiveCaches();
+  }
+
 }
 
 } // namespace Mantid

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadIsawDetCal.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/LoadIsawDetCal.h
@@ -64,14 +64,13 @@ public:
   }
   /// Function to optimize
   void center(double x, double y, double z, std::string detname,
-              std::string inname);
+      API::Workspace_sptr ws);
 
 private:
   // Overridden Algorithm methods
   void init();
   void exec();
-  // Matrix workspace pointer
-  // API::MatrixWorkspace_sptr inputW;
+
 };
 
 } // namespace DataHandling

--- a/Code/Mantid/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/ObjCompAssembly.h"
+#include "MantidGeometry/Instrument/ComponentHelper.h"
 #include "MantidKernel/V3D.h"
 #include <Poco/File.h>
 #include <sstream>
@@ -47,19 +48,44 @@ LoadIsawDetCal::~LoadIsawDetCal() {}
  * @param y :: The shift along the Y-axis
  * @param z :: The shift along the Z-axis
  * @param detname :: The detector name
- * @param inname :: The workspace name
+ * @param ws :: The workspace
  */
 
 void LoadIsawDetCal::center(double x, double y, double z, std::string detname,
-                            std::string inname) {
-  IAlgorithm_sptr alg1 = createChildAlgorithm("MoveInstrumentComponent");
-  alg1->setProperty("Workspace", inname);
-  alg1->setPropertyValue("ComponentName", detname);
-  alg1->setProperty("X", x);
-  alg1->setProperty("Y", y);
-  alg1->setProperty("Z", z);
-  alg1->setPropertyValue("RelativePosition", "0");
-  alg1->executeAsChildAlg();
+    API::Workspace_sptr ws) {
+  MatrixWorkspace_sptr inputW = boost::dynamic_pointer_cast<MatrixWorkspace>(ws);
+  PeaksWorkspace_sptr inputP = boost::dynamic_pointer_cast<PeaksWorkspace>(ws);
+
+  // Get some stuff from the input workspace
+  Instrument_sptr inst;
+  if (inputW) {
+    inst= boost::const_pointer_cast<Instrument>(inputW->getInstrument());
+  }
+  else if (inputP) {
+    inst= boost::const_pointer_cast<Instrument>(inputP->getInstrument());
+  }
+
+  IComponent_const_sptr comp = inst->getComponentByName(detname);
+  if (comp == 0) {
+    std::ostringstream mess;
+    mess << "Component with name " << detname << " was not found.";
+    g_log.error(mess.str());
+    throw std::runtime_error(mess.str());
+  }
+
+  // Do the move
+  using namespace Geometry::ComponentHelper;
+  TransformType positionType = Absolute;
+  if (inputW) {
+    Geometry::ParameterMap &pmap = inputW->instrumentParameters();
+    Geometry::ComponentHelper::moveComponent(*comp, pmap, V3D(x, y, z),
+                                             positionType);
+  }
+  else if (inputP) {
+    Geometry::ParameterMap &pmap = inputP->instrumentParameters();
+    Geometry::ComponentHelper::moveComponent(*comp, pmap, V3D(x, y, z),
+                                             positionType);
+  }
 }
 
 /** Initialisation method
@@ -106,7 +132,6 @@ void LoadIsawDetCal::exec() {
 
   // set-up minimizer
 
-  std::string inname = getProperty("InputWorkspace");
   std::string filename = getProperty("Filename");
   std::string filename2 = getProperty("Filename2");
 
@@ -185,8 +210,8 @@ void LoadIsawDetCal::exec() {
       std::stringstream(line) >> count >> mL1 >> mT0;
       setProperty("TimeOffset", mT0);
       // Convert from cm to m
-      if (instname .compare("WISH") == 0) center(0.0, 0.0, -0.01 * mL1, "undulator", inname);
-      else center(0.0, 0.0, -0.01 * mL1, "moderator", inname);
+      if (instname .compare("WISH") == 0) center(0.0, 0.0, -0.01 * mL1, "undulator", ws);
+      else center(0.0, 0.0, -0.01 * mL1, "moderator", ws);
       // mT0 and time of flight are both in microsec
       if (inputW) {
       API::Run &run = inputW->mutableRun();
@@ -247,7 +272,7 @@ void LoadIsawDetCal::exec() {
       x *= 0.01;
       y *= 0.01;
       z *= 0.01;
-      center(x, y, z, detname, inname);
+      center(x, y, z, detname, ws);
 
       // These are the ISAW axes
       V3D rX = V3D(base_x, base_y, base_z);
@@ -340,7 +365,7 @@ void LoadIsawDetCal::exec() {
       y *= 0.01;
       z *= 0.01;
       detname = comp->getFullName();
-      center(x, y, z, detname, inname);
+      center(x, y, z, detname, ws);
 
       // These are the ISAW axes
       V3D rX = V3D(base_x, base_y, base_z);

--- a/Code/Mantid/Framework/DataHandling/src/MoveInstrumentComponent.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/MoveInstrumentComponent.cpp
@@ -5,6 +5,7 @@
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/Exception.h"
 #include "MantidGeometry/Instrument/ComponentHelper.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 
 namespace Mantid {
 namespace DataHandling {
@@ -23,7 +24,7 @@ MoveInstrumentComponent::MoveInstrumentComponent() {}
 void MoveInstrumentComponent::init() {
   // When used as a Child Algorithm the workspace name is not used - hence the
   // "Anonymous" to satisfy the validator
-  declareProperty(new WorkspaceProperty<MatrixWorkspace>(
+  declareProperty(new WorkspaceProperty<Workspace>(
                       "Workspace", "Anonymous", Direction::InOut),
                   "The name of the workspace for which the new instrument "
                   "configuration will have an effect. Any other workspaces "
@@ -50,8 +51,20 @@ void MoveInstrumentComponent::init() {
  *  @throw std::runtime_error Thrown with Workspace problems
  */
 void MoveInstrumentComponent::exec() {
-  // Get the workspace
-  MatrixWorkspace_sptr WS = getProperty("Workspace");
+  // Get the input workspace
+  Workspace_sptr ws = getProperty("Workspace");
+  MatrixWorkspace_sptr inputW = boost::dynamic_pointer_cast<MatrixWorkspace>(ws);
+  DataObjects::PeaksWorkspace_sptr inputP = boost::dynamic_pointer_cast<DataObjects::PeaksWorkspace>(ws);
+
+  // Get some stuff from the input workspace
+  Instrument_sptr inst;
+  if (inputW) {
+    inst= boost::const_pointer_cast<Instrument>(inputW->getInstrument());
+  }
+  else if (inputP) {
+    inst= boost::const_pointer_cast<Instrument>(inputP->getInstrument());
+  }
+
   const std::string ComponentName = getProperty("ComponentName");
   const int DetID = getProperty("DetectorID");
   const double X = getProperty("X");
@@ -59,10 +72,6 @@ void MoveInstrumentComponent::exec() {
   const double Z = getProperty("Z");
   const bool relativePosition = getProperty("RelativePosition");
 
-  // Get the ParameterMap reference before the instrument so that
-  // we avoid a copy
-  Geometry::ParameterMap &pmap = WS->instrumentParameters();
-  Instrument_const_sptr inst = WS->getInstrument();
   IComponent_const_sptr comp;
 
   // Find the component to move
@@ -92,8 +101,16 @@ void MoveInstrumentComponent::exec() {
   TransformType positionType = Absolute;
   if (relativePosition)
     positionType = Relative;
-  Geometry::ComponentHelper::moveComponent(*comp, pmap, V3D(X, Y, Z),
-                                           positionType);
+  if (inputW) {
+    Geometry::ParameterMap &pmap = inputW->instrumentParameters();
+    Geometry::ComponentHelper::moveComponent(*comp, pmap, V3D(X, Y, Z),
+                                             positionType);
+  }
+  else if (inputP) {
+    Geometry::ParameterMap &pmap = inputP->instrumentParameters();
+    Geometry::ComponentHelper::moveComponent(*comp, pmap, V3D(X, Y, Z),
+                                             positionType);
+  }
 
   return;
 }


### PR DESCRIPTION
Fixes #13631 

To test check that bank moves for both event workspace and peaks workspace.  All files are in system tests data.  DgsConvertToEnergyTransfer expects a MatrixWorkspace to be returned from MoveInstrumentComponent, so could not enable this for PeaksWorkspaces.  Instead I moved the coding inside the center function of LoadIsawDetCal.

``` python
Load(Filename='TOPAZ_3132_event.nxs', OutputWorkspace='ws_event')
ws = mtd['ws_event']
inst = ws.getInstrument()
comp = inst.getComponentByName('bank17')
print comp.getPos()
LoadIsawDetCal(InputWorkspace='ws_event', Filename='TOPAZ_2011_02_16.DetCal')
ws = mtd['ws_event']
inst = ws.getInstrument()
comp = inst.getComponentByName('bank17')
print comp.getPos()
LoadIsawPeaks(Filename='TOPAZ_3007.peaks', OutputWorkspace='peaks')
ws = mtd['peaks']
inst = ws.getInstrument()
comp = inst.getComponentByName('bank17')
print comp.getPos()
LoadIsawDetCal(InputWorkspace='peaks', Filename='TOPAZ_2011_02_16.DetCal')
ws = mtd['peaks']
inst = ws.getInstrument()
comp = inst.getComponentByName('bank17')
print comp.getPos()
```
