### PR TITLE
Fix incorrect reporting of background estimation failure in FindPeaks

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/FindPeaks.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/FindPeaks.cpp
@@ -335,9 +335,9 @@ void FindPeaks::generateOutputPeakParameterTable() {
   * @param fitwindows :: vector of windows around each peak. Otherwise, windows
  * will be determined automatically.
   */
-void
-FindPeaks::findPeaksGivenStartingPoints(const std::vector<double> &peakcentres,
-                                        const std::vector<double> &fitwindows) {
+void FindPeaks::findPeaksGivenStartingPoints(
+    const std::vector<double> &peakcentres,
+    const std::vector<double> &fitwindows) {
   bool useWindows = (!fitwindows.empty());
   std::size_t numPeaks = peakcentres.size();
 
@@ -1087,14 +1087,15 @@ int FindPeaks::findPeakBackground(const MatrixWorkspace_sptr &input,
 
   // Determine whether to use FindPeakBackground's result.
   int fitresult = -1;
-  if (peaklisttablews->columnCount() < 7)
-    throw std::runtime_error(
-        "No 7th column for use FindPeakBackground result or not. ");
-
-  if (peaklisttablews->rowCount() > 0) {
-    int fitresult = peaklisttablews->Int(0, 6);
-    g_log.information() << "fitresult=" << fitresult << "\n";
+  if (peaklisttablews->columnCount() == 7) {
+    fitresult = peaklisttablews->Int(0, 6);
+  } else {
+    std::ostringstream os;
+    os << "Unexpected column count for output table from FindPeakBackground."
+          "Expected 7 columns, found " << peaklisttablews->columnCount();
+    throw std::runtime_error(os.str());
   }
+  g_log.information() << "fitresult=" << fitresult << "\n";
 
   // Local check whether FindPeakBackground gives a reasonable value
   vecpeakrange.resize(2);

--- a/Code/Mantid/Framework/Algorithms/test/FindPeaksTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/FindPeaksTest.h
@@ -103,7 +103,7 @@ public:
     getParameterMap(outtablews, 0, parammap);
 
     TS_ASSERT_DELTA(parammap["PeakCentre"], 1.2356, 0.03);
-    TS_ASSERT_DELTA(parammap["Height"], 595., 5.00);
+    TS_ASSERT_DELTA(parammap["Height"], 520.4654, 5.00);
 
     // Clean
     AnalysisDataService::Instance().remove(wsname);

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -160,9 +160,9 @@ public:
     std::string fnct = "Gaussian";
     doRun(0.1,0.0,"IntegratePeaksMD2Test_peaks",0.0,true,true,fnct);
     // More accurate integration changed values
-    TS_ASSERT_DELTA( peakWS0->getPeak(0).getIntensity(), 2.0, 1e-2);
+    TS_ASSERT_DELTA( peakWS0->getPeak(0).getIntensity(), 3.5077, 1e-2);
     // Error is also calculated
-    TS_ASSERT_DELTA( peakWS0->getPeak(0).getSigmaIntensity(), sqrt(2.0), 1e-2);
+    TS_ASSERT_DELTA( peakWS0->getPeak(0).getSigmaIntensity(), 1.9308, 1e-2);
     Poco::File(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory") + "IntegratePeaksMD2Test_MDEWSGaussian.dat").remove();
 
     // Test profile back to back exponential

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
@@ -156,9 +156,9 @@ public:
     std::string fnct = "Gaussian";
     doRun(0.1,0.0,"IntegratePeaksMDTest_peaks",0.0,true,true,fnct);
     // More accurate integration changed values
-    TS_ASSERT_DELTA( peakWS0->getPeak(0).getIntensity(), 2.0, 1e-2);
+    TS_ASSERT_DELTA( peakWS0->getPeak(0).getIntensity(), 3.5077, 1e-2);
     // Error is also calculated
-    TS_ASSERT_DELTA( peakWS0->getPeak(0).getSigmaIntensity(), sqrt(2.0), 1e-2);
+    TS_ASSERT_DELTA( peakWS0->getPeak(0).getSigmaIntensity(), 1.9308, 1e-2);
     Poco::File(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory") + "IntegratePeaksMDTest_MDEWSGaussian.dat").remove();
 
     // Test profile back to back exponential


### PR DESCRIPTION
A variable had been redefined in an inner scope that shadowing the outer one.
