### PR TITLE
13647 create launch shortcut for ipython notebooks

### DIFF
--- a/Code/Mantid/Build/CMake/Packaging/mantidpython.bat
+++ b/Code/Mantid/Build/CMake/Packaging/mantidpython.bat
@@ -28,5 +28,5 @@ set PATH=%_EXTRA_PATH_DIRS%;%PATH%
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Start python
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-start "Mantid Python" /B /WAIT %_BIN_DIR%\python.exe %*
+start "Mantid Python" /B /WAIT %_BIN_DIR%\python.exe %_BIN_DIR%\Scripts\ipython.py %*
 

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -174,11 +174,11 @@ install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/Build/CMake/Packaging/mantidpython.b
 ###########################################################################
 # On install. The blank lines seem to be required or it doesn't create the shortcut
 set (CPACK_NSIS_CREATE_ICONS_EXTRA "
-  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
-
+  CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPlot.lnk' '$SYSDIR\\\\wscript.exe' '\\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\"' '$INSTDIR\\\\bin\\\\MantidPlot.exe' 0
+  
   CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
   
-  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%"\\\"
+  CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk' '$INSTDIR\\\\bin\\\\mantidpython.bat' 'notebook --notebook-dir=%userprofile%'
 ")
 set (CPACK_NSIS_DELETE_ICONS_EXTRA "
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPlot.lnk\\\"
@@ -187,11 +187,11 @@ set (CPACK_NSIS_DELETE_ICONS_EXTRA "
 ")
 # The blank lines seem to be required or it doesn't create the shortcut
 set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
-  CreateShortCut \\\"$DESKTOP\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
+  CreateShortCut '$DESKTOP\\\\MantidPlot.lnk' '$SYSDIR\\\\wscript.exe' '\\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\"' '$INSTDIR\\\\bin\\\\MantidPlot.exe' 0
 
   CreateShortCut \\\"$DESKTOP\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
-
-  CreateShortCut \\\"$DESKTOP\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%"\\\"
+  
+  CreateShortCut '$DESKTOP\\\\MantidIPythonNotebook.lnk' '$INSTDIR\\\\bin\\\\mantidpython.bat' 'notebook --notebook-dir=%userprofile%'
   
   CreateDirectory \\\"$INSTDIR\\\\logs\\\"
 

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -183,6 +183,7 @@ set (CPACK_NSIS_CREATE_ICONS_EXTRA "
 set (CPACK_NSIS_DELETE_ICONS_EXTRA "
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPlot.lnk\\\"
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPython.lnk\\\"
+  Delete \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk\\\"
 ")
 # The blank lines seem to be required or it doesn't create the shortcut
 set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
@@ -190,6 +191,8 @@ set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
 
   CreateShortCut \\\"$DESKTOP\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
 
+  CreateShortCut \\\"$DESKTOP\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%\\\"
+  
   CreateDirectory \\\"$INSTDIR\\\\logs\\\"
 
   CreateDirectory \\\"$INSTDIR\\\\docs\\\"
@@ -198,6 +201,7 @@ set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
 set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
   Delete \\\"$DESKTOP\\\\MantidPlot.lnk\\\"
   Delete \\\"$DESKTOP\\\\MantidPython.lnk\\\"
+  Delete \\\"$DESKTOP\\\\MantidIPythonNotebook.lnk\\\"
   RMDir \\\"$INSTDIR\\\\logs\\\"
   RMDir \\\"$INSTDIR\\\\docs\\\"
 ")

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -178,12 +178,12 @@ set (CPACK_NSIS_CREATE_ICONS_EXTRA "
 
   CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
   
-  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%\\\"
+  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%"\\\"
 ")
 set (CPACK_NSIS_DELETE_ICONS_EXTRA "
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPlot.lnk\\\"
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPython.lnk\\\"
-  Delete \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk\\\"
+  Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidIPythonNotebook.lnk\\\"
 ")
 # The blank lines seem to be required or it doesn't create the shortcut
 set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
@@ -191,7 +191,7 @@ set (CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
 
   CreateShortCut \\\"$DESKTOP\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
 
-  CreateShortCut \\\"$DESKTOP\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%\\\"
+  CreateShortCut \\\"$DESKTOP\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%"\\\"
   
   CreateDirectory \\\"$INSTDIR\\\\logs\\\"
 

--- a/Code/Mantid/Build/CMake/WindowsNSIS.cmake
+++ b/Code/Mantid/Build/CMake/WindowsNSIS.cmake
@@ -177,6 +177,8 @@ set (CPACK_NSIS_CREATE_ICONS_EXTRA "
   CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPlot.lnk\\\" \\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\" \\\"\\\" \\\"$INSTDIR\\\\bin\\\\MantidPlot.exe\\\" 0
 
   CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidPython.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat\\\"
+  
+  CreateShortCut \\\"$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\MantidIPythonNotebook.lnk\\\" \\\"$INSTDIR\\\\bin\\\\mantidpython.bat notebook --notebook-dir=%userprofile%\\\"
 ")
 set (CPACK_NSIS_DELETE_ICONS_EXTRA "
   Delete \\\"$SMPROGRAMS\\\\$MUI_TEMP\\\\MantidPlot.lnk\\\"


### PR DESCRIPTION
Fixes #13647 and #13658 

The mantid installer for windows now creates a shortcut on the desktop and the start menu called "MantidIPythonNotebook". This starts a local ipython notebook server using the mantid python environment.
It was efficient to also fix bug #13658 at the same time as testing involves rebuilding the installer and reinstalling Mantid each time.

For Tester:
Install Mantid in Windows from [the built package](http://builds.mantidproject.org/job/pull_requests-win7/2675/artifact/build/mantid-3.4.20150917.1305-win64.exe). Three shortcuts should be created on the desktop and in the start menu: "MantidPlot", "MantidPython" and "MantidIPythonNotebook".

"MantidPlot" should correctly launch MantidPlot. After dragging the shortcut onto the launchbar, the pinned application should appear with the Mantid icon and successfully launch MantidPlot.
"MantidPython" should start ipython where Mantid should be able to be imported with "from mantid.simpleapi import *".
"MantidIPythonNotebook" should start an ipython notebook server and open the notebook interface in your browser and display _your user directory_, i.e. C:\Users\username. Create a new notebook and run a code cell with "from mantid.simpleapi import *".

Uninstalling mantid should remove the three shortcuts from the desktop and the start menu.
