### PR TITLE
Fix font size for script output window on OS X

### DIFF
--- a/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
+++ b/Code/Mantid/MantidPlot/src/ScriptOutputDisplay.cpp
@@ -17,8 +17,13 @@
  */
 ScriptOutputDisplay::ScriptOutputDisplay(QWidget * parent) :
   QTextEdit(parent), m_copy(NULL), m_clear(NULL), m_save(NULL),
-  m_origFontSize(8),m_zoomLevel(0)
+  m_origFontSize(8), m_zoomLevel(0)
 {
+#ifdef __APPLE__
+    // Make all fonts 4 points bigger on the Mac because otherwise they're tiny!
+  m_zoomLevel += 4;
+#endif
+
   //the control is readonly, but if you set it read only then ctrl+c for copying does not work
   //this approach allows ctrl+c and disables user editing through the use of the KeyPress handler
   //and disabling drag and drop


### PR DESCRIPTION
Fixes #13672 

No release notes update as we broke this in this release

**Tester**
This needs to be tested on OS X.
- start MantidPlot
- open the script window
- type some python commands that will print something to the output window
- the font should be the same size as the main editor and zooming should keep them matched.
