### PR TITLE
Detailed balance error in ISIS Energy Transfer

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -69,18 +69,21 @@ bool ISISEnergyTransfer::validate() {
   UserInputValidator uiv;
 
   // Run files input
-  if (!m_uiForm.dsRunFiles->isValid())
+  if (!m_uiForm.dsRunFiles->isValid()){
     uiv.addErrorMessage("Run file range is invalid.");
+  }
 
   // Calibration file input
   if (m_uiForm.ckUseCalib->isChecked() &&
-      !m_uiForm.dsCalibrationFile->isValid())
+      !m_uiForm.dsCalibrationFile->isValid()){
     uiv.addErrorMessage("Calibration file/workspace is invalid.");
+  }
 
   // Mapping file
   if ((m_uiForm.cbGroupingOptions->currentText() == "File") &&
-      (!m_uiForm.dsMapFile->isValid()))
+      (!m_uiForm.dsMapFile->isValid())){
     uiv.addErrorMessage("Mapping file is invalid.");
+  }
 
   // Rebinning
   if (!m_uiForm.ckDoNotRebin->isChecked()) {
@@ -101,6 +104,9 @@ bool ISISEnergyTransfer::validate() {
     m_uiForm.valRebinHigh->setVisible(false);
     m_uiForm.valRebinString->setVisible(false);
   }
+
+  QString error = uiv.generateErrorMessage();
+  showMessageBox(error);
 
   return uiv.isAllInputValid();
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -107,7 +107,7 @@ bool ISISEnergyTransfer::validate() {
 
   // DetailedBalance
   if (m_uiForm.ckDetailedBalance->isChecked()) {
-    if (m_uiForm.spDetailedBalance->value() == 0) {
+    if (m_uiForm.spDetailedBalance->value() == 0.0) {
       uiv.addErrorMessage("Detailed Balance must be more than 0K");
     }
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -105,6 +105,13 @@ bool ISISEnergyTransfer::validate() {
     m_uiForm.valRebinString->setVisible(false);
   }
 
+  // DetailedBalance
+  if (m_uiForm.ckDetailedBalance->isChecked()) {
+    if (m_uiForm.spDetailedBalance->value() == 0) {
+      uiv.addErrorMessage("Detailed Balance must be more than 0K");
+    }
+  }
+
   QString error = uiv.generateErrorMessage();
   showMessageBox(error);
 


### PR DESCRIPTION
Fixes #13654

The interface will no longer pass validation if in has a detailed balance of 0K.
Also, an error dialog box is now used on incorrect validation over the previously used result log warning.
# To Test
- Open ISIS Energy Transfer (Interfaces > Indirect > Data Reduction > ISIS Energy Transfer)
- Enter an appropriate run number (e.g. `21360`) in the `Run Files` input field.
- Check the Detailed Balance box (in the Analysis tab) 
- Set the Detailed Balance to 0K
- Click run
- Ensure that a warning box is produced stating: `Detailed Balance must be more than 0K`
- Change the value of Detailed Balance to a value larger than 0
- Ensure this runs correctly
