### PR TITLE
Moved Container Subtraction to first tab in Indirect Corrections

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.h
@@ -21,10 +21,11 @@ namespace CustomInterfaces {
 // ordering of the
 // tabs as they appear in the interface itself.
 enum CorrectionTabChoice {
+  CONTAINER_SUBTRACTION,
   CALC_CORR,
   APPLY_CORR,
-  ABSORPTION_CORRECTIONS,
-  CONTAINER_SUBTRACTION
+  ABSORPTION_CORRECTIONS
+
 };
 
 // Forward Declaration

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectCorrections.ui
@@ -26,6 +26,11 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
+       <widget class="QWidget" name="tabContainerSubtraction">
+         <attribute name="title">
+           <string>Container Subtraction</string>
+         </attribute>
+       </widget>
       <widget class="QWidget" name="tabCalculatePaalmanPings">
        <attribute name="title">
         <string>Calculate Paalman Pings</string>
@@ -40,11 +45,6 @@
        <attribute name="title">
         <string>Absorption</string>
        </attribute>
-      </widget>
-      <widget class="QWidget" name="tabContainerSubtraction">
-        <attribute name="title">
-          <string>Container Subtraction</string>
-        </attribute>
       </widget>
      </widget>
     </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/IndirectCorrections.cpp
@@ -36,6 +36,9 @@ IndirectCorrections::IndirectCorrections(QWidget *parent)
   // All tabs MUST appear here to be shown in interface.
   // We make the assumption that each map key corresponds to the order in which
   // the tabs appear.
+  m_tabs.insert(std::make_pair(CONTAINER_SUBTRACTION,
+                               new ContainerSubtraction(m_uiForm.twTabs->widget(
+                                   CONTAINER_SUBTRACTION))));
   m_tabs.insert(std::make_pair(
       CALC_CORR,
       new CalculatePaalmanPings(m_uiForm.twTabs->widget(CALC_CORR))));
@@ -44,9 +47,6 @@ IndirectCorrections::IndirectCorrections(QWidget *parent)
   m_tabs.insert(std::make_pair(
       ABSORPTION_CORRECTIONS, new AbsorptionCorrections(m_uiForm.twTabs->widget(
                                   ABSORPTION_CORRECTIONS))));
-  m_tabs.insert(std::make_pair(CONTAINER_SUBTRACTION,
-                               new ContainerSubtraction(m_uiForm.twTabs->widget(
-                                   CONTAINER_SUBTRACTION))));
 }
 
 /**


### PR DESCRIPTION
Fixes #13651 

The Container Subtraction tab should now be the first (left most) in the list of tabs in the Indirect Corrections interface.
# To Test
- Open Indirect Corrections (Interfaces > Indirect > Corrections)
- Ensure that the left most tab is Container Subtraction
- Ensure this tab is also open (active) below
