### PR TITLE
ConvFit requires progress tracking

### DIFF
--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -187,12 +187,14 @@ void ConvolutionFitSequential::exec() {
   const std::string tempFitWsName = "__convfit_fit_ws";
   auto tempFitWs = convertInputToElasticQ(inputWs, tempFitWsName);
 
-  // Fit all spectra in workspace
+  Progress plotPeakStringProg(this, 0.0, 1.0, specMax);
+  // Construct plotpeak string
   std::string plotPeakInput = "";
   for (int i = 0; i < specMax + 1; i++) {
     std::string nextWs = tempFitWsName + ",i";
     nextWs += boost::lexical_cast<std::string>(i);
     plotPeakInput += nextWs + ";";
+	plotPeakStringProg.report(i);
   }
 
   // passWSIndex
@@ -267,8 +269,7 @@ void ConvolutionFitSequential::exec() {
   }
 
   // Run ProcessIndirectFitParameters
-  auto pifp =
-      createChildAlgorithm("ProcessIndirectFitParameters");
+  auto pifp = createChildAlgorithm("ProcessIndirectFitParameters");
   pifp->setProperty("InputWorkspace", outputWs);
   pifp->setProperty("ColumnX", "axis-1");
   pifp->setProperty("XAxisUnit", "MomentumTransfer");
@@ -304,6 +305,7 @@ void ConvolutionFitSequential::exec() {
     logAdder->setProperty("LogName", it->first);
     logAdder->setProperty("LogText", it->second);
     logAdder->setProperty("LogType", "String");
+
     logAdder->executeAsChildAlg();
   }
   // Add Numeric Logs

--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -203,7 +203,7 @@ void ConvolutionFitSequential::exec() {
   }
 
   // Run PlotPeaksByLogValue
-  auto plotPeaks = createChildAlgorithm("PlotPeakByLogValue", 0.0, 0.70, true);
+  auto plotPeaks = createChildAlgorithm("PlotPeakByLogValue");
   plotPeaks->setProperty("Input", plotPeakInput);
   plotPeaks->setProperty("OutputWorkspace", outputWsName);
   plotPeaks->setProperty("Function", function);
@@ -220,11 +220,11 @@ void ConvolutionFitSequential::exec() {
   ITableWorkspace_sptr outputWs = plotPeaks->getProperty("OutputWorkspace");
 
   // Delete workspaces
-  auto deleter = createChildAlgorithm("DeleteWorkspace", 0.70, 0.73, true);
+  auto deleter = createChildAlgorithm("DeleteWorkspace");
   deleter->setProperty("WorkSpace",
                        outputWsName + "_NormalisedCovarianceMatrices");
   deleter->executeAsChildAlg();
-  deleter = createChildAlgorithm("DeleteWorkspace", 0.70, 0.73, true);
+  deleter = createChildAlgorithm("DeleteWorkspace");
   deleter->setProperty("WorkSpace", outputWsName + "_Parameters");
   deleter->executeAsChildAlg();
 
@@ -268,7 +268,7 @@ void ConvolutionFitSequential::exec() {
 
   // Run ProcessIndirectFitParameters
   auto pifp =
-      createChildAlgorithm("ProcessIndirectFitParameters", 0.73, 0.80, true);
+      createChildAlgorithm("ProcessIndirectFitParameters");
   pifp->setProperty("InputWorkspace", outputWs);
   pifp->setProperty("ColumnX", "axis-1");
   pifp->setProperty("XAxisUnit", "MomentumTransfer");
@@ -279,7 +279,7 @@ void ConvolutionFitSequential::exec() {
   MatrixWorkspace_sptr resultWs = pifp->getProperty("OutputWorkspace");
 
   // Handle sample logs
-  auto logCopier = createChildAlgorithm("CopyLogs", 0.80, 0.85, true);
+  auto logCopier = createChildAlgorithm("CopyLogs");
   logCopier->setProperty("InputWorkspace", inputWs);
   logCopier->setProperty("OutputWorkspace", resultWs);
   logCopier->executeAsChildAlg();
@@ -298,7 +298,7 @@ void ConvolutionFitSequential::exec() {
       boost::lexical_cast<std::string>(LorentzNum);
 
   // Add String Logs
-  auto logAdder = createChildAlgorithm("AddSampleLog", 0.85, 0.90, true);
+  auto logAdder = createChildAlgorithm("AddSampleLog");
   for (auto it = sampleLogStrings.begin(); it != sampleLogStrings.end(); ++it) {
     logAdder->setProperty("Workspace", resultWs);
     logAdder->setProperty("LogName", it->first);
@@ -315,7 +315,7 @@ void ConvolutionFitSequential::exec() {
     logAdder->executeAsChildAlg();
   }
   // Copy Logs to GroupWorkspace
-  logCopier = createChildAlgorithm("CopyLogs", 0.90, 0.93, true);
+  logCopier = createChildAlgorithm("CopyLogs");
   logCopier->setProperty("InputWorkspace", resultWs);
   std::string groupName = outputWsName + "_Workspaces";
   logCopier->setProperty("OutputWorkspace", groupName);
@@ -326,7 +326,7 @@ void ConvolutionFitSequential::exec() {
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(outputWsName +
                                                                  "_Workspaces");
   auto groupWsNames = groupWs->getNames();
-  auto renamer = createChildAlgorithm("RenameWorkspace", 0.93, 1., true);
+  auto renamer = createChildAlgorithm("RenameWorkspace");
   for (int i = specMin; i < specMax + 1; i++) {
     renamer->setProperty("InputWorkspace", groupWsNames.at(i));
     std::string outName = outputWsName + "_";
@@ -452,7 +452,7 @@ API::MatrixWorkspace_sptr ConvolutionFitSequential::convertInputToElasticQ(
       "Workspace2D", inputWs->getNumberHistograms(), 2, 1);
   auto axis = inputWs->getAxis(1);
   if (axis->isSpectra()) {
-    auto convSpec = createChildAlgorithm("ConvertSpectrumAxis", -1, -1, true);
+    auto convSpec = createChildAlgorithm("ConvertSpectrumAxis");
     // remains in ADS for use in embedded algorithm call
     convSpec->setAlwaysStoreInADS(true);
     convSpec->setProperty("InputWorkSpace", inputWs);
@@ -465,7 +465,7 @@ API::MatrixWorkspace_sptr ConvolutionFitSequential::convertInputToElasticQ(
     if (axis->unit()->unitID() != "MomentumTransfer") {
       throw std::runtime_error("Input must have axis values of Q");
     }
-    auto cloneWs = createChildAlgorithm("CloneWorkspace", -1, -1, true);
+    auto cloneWs = createChildAlgorithm("CloneWorkspace");
     cloneWs->setProperty("InputWorkspace", inputWs);
     cloneWs->setProperty("OutputWorkspace", wsName);
     cloneWs->executeAsChildAlg();

--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -187,7 +187,7 @@ void ConvolutionFitSequential::exec() {
   const std::string tempFitWsName = "__convfit_fit_ws";
   auto tempFitWs = convertInputToElasticQ(inputWs, tempFitWsName);
 
-  Progress plotPeakStringProg(this, 0.0, 1.0, specMax);
+  Progress plotPeakStringProg(this, 0.0, 0.05, specMax);
   // Construct plotpeak string
   std::string plotPeakInput = "";
   for (int i = 0; i < specMax + 1; i++) {

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -62,6 +62,8 @@ private:
   QString minimizerString(QString outputName) const;
   QStringList getFunctionParameters(QString);
   void updatePlotOptions();
+  QString convertFuncToShort(const QString &);
+  QString convertBackToShort(const std::string &original);
 
   Ui::ConvFit m_uiForm;
   QtStringPropertyManager *m_stringManager;
@@ -74,6 +76,7 @@ private:
   QString m_singleFitOutputName;
   QStringList m_fitStrings;
   QString m_previousFit;
+  QString m_baseName;
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -44,6 +44,7 @@ private slots:
   void showTieCheckbox(QString);
   void singleFitComplete(bool error);
   void fitFunctionSelected(const QString &);
+  void algorithmComplete(bool error);
 
 
 private:

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1597,6 +1597,12 @@ void ConvFit::updatePlotOptions() {
   m_uiForm.cbPlotType->addItems(plotOptions);
 }
 
+/**
+ * Converts the user input for function into short hand for use in the workspace
+ * naming
+ * @param original - The original user input to the function
+ * @return The short hand of the users input
+ */
 QString ConvFit::convertFuncToShort(const QString &original) {
   QString result = "";
   if (original.at(0) == 'E') {
@@ -1615,6 +1621,12 @@ QString ConvFit::convertFuncToShort(const QString &original) {
   return result;
 }
 
+/**
+ * Converts the user input for background into short hand for use in the
+ * workspace naming
+ * @param original - The original user input to the function
+ * @return The short hand of the users input
+ */
 QString ConvFit::convertBackToShort(const std::string &original) {
   QString result = QString::fromStdString(original.substr(0, 3));
   auto pos = original.find(" ");

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -298,6 +298,9 @@ void ConvFit::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(algorithmComplete(bool)));
 
+  if (error)
+    return;
+
   std::string resultName = m_baseName.toStdString() + "_Result";
   MatrixWorkspace_sptr resultWs =
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(resultName);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -242,6 +242,28 @@ void ConvFit::run() {
   int maxIterations =
       static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
 
+  // Construct expected name
+  m_baseName = QString::fromStdString(m_cfInputWS->getName());
+  int pos = m_baseName.lastIndexOf("_");
+  if (pos != -1) {
+    m_baseName = m_baseName.left(pos + 1);
+  }
+  m_baseName += "conv_";
+  if (m_blnManager->value(m_properties["UseDeltaFunc"])) {
+    m_baseName += "Delta";
+  }
+  int fitIndex = m_uiForm.cbFitType->currentIndex();
+  if (fitIndex < 3 && fitIndex != 0) {
+    m_baseName += fitIndex + "L";
+  } else {
+    m_baseName += convertFuncToShort(m_uiForm.cbFitType->currentText());
+  }
+  m_baseName += convertBackToShort(m_uiForm.cbBackground->currentText().toStdString()) + "_s";
+  m_baseName += QString::fromStdString(specMin);
+  m_baseName += "_to_";
+  m_baseName += QString::fromStdString(specMax);
+  std::string test = m_baseName.toStdString();
+
   // Run ConvolutionFitSequential Algorithm
   IAlgorithm_sptr cfs =
       AlgorithmManager::Instance().create("ConvolutionFitSequential");
@@ -263,6 +285,7 @@ void ConvFit::run() {
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
   m_batchAlgoRunner->executeBatchAsync();
+
 }
 
 /**
@@ -1569,6 +1592,33 @@ void ConvFit::updatePlotOptions() {
     plotOptions << "All";
   }
   m_uiForm.cbPlotType->addItems(plotOptions);
+}
+
+QString ConvFit::convertFuncToShort(const QString &original){
+  QString result = "";
+  if (original.at(0) == 'E') {
+    result += "E";
+  } else if (original.at(0) == 'I') {
+    result += "I";
+  } else {
+    return "SFT";
+  }
+  auto pos = original.find("Circle");
+  if (pos != std::string::npos) {
+    result += "DC";
+  } else {
+    result += "DS";
+  }
+  return result;
+}
+
+QString ConvFit::convertBackToShort(const std::string &original) {
+  QString result = QString::fromStdString(original.substr(0, 3));
+  auto pos = original.find(" ");
+  if (pos != std::string::npos) {
+    result += original.at(pos + 1);
+  }
+  return result;
 }
 
 } // namespace IDA

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -265,7 +265,6 @@ void ConvFit::run() {
   m_baseName += QString::fromStdString(specMin);
   m_baseName += "_to_";
   m_baseName += QString::fromStdString(specMax);
-  std::string test = m_baseName.toStdString();
 
   // Run ConvolutionFitSequential Algorithm
   IAlgorithm_sptr cfs =

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -299,7 +299,7 @@ void ConvFit::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(algorithmComplete(bool)));
 
-  std::string resultName = m_baseName + "_Result";
+  std::string resultName = m_baseName.toStdString() + "_Result";
   MatrixWorkspace_sptr resultWs =
       AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(resultName);
 
@@ -342,14 +342,8 @@ void ConvFit::algorithmComplete(bool error) {
   }
 
   if (temp != 0.0) {
-    // Obtain Spectra Min/Max
-    std::string specMin = m_uiForm.spSpectraMin->text().toStdString();
-    std::string specMax = m_uiForm.spSpectraMax->text().toStdString();
-    const int minSpec = boost::lexical_cast<int>(specMin);
-    const int maxSpec = boost::lexical_cast<int>(specMax) + 1;
-
     // Obtain WorkspaceGroup from ADS
-    std::string groupName = m_baseName + "_Workspaces";
+    std::string groupName = m_baseName.toStdString() + "_Workspaces";
     WorkspaceGroup_sptr groupWs =
         AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
 
@@ -1613,7 +1607,7 @@ QString ConvFit::convertFuncToShort(const QString &original) {
     return "SFT";
   }
   auto pos = original.find("Circle");
-  if (pos != std::string::npos) {
+  if (pos != -1) {
     result += "DC";
   } else {
     result += "DS";


### PR DESCRIPTION
Fixes #13636

Progress tracking should now occur on the call to ConvolutionFitSequential in ConvFit.
# To Test
## General
- In all instances of the below, ensure that the algorithm has a progress tracking bar in the bottom right of the Mantid GUI and it is updating reasonably.
- Also ensure that you can do other things **(within reason)** in Mantid whilst the algorithm is running 
### Set up
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Provide reasonable sample and resolution files (recommend `irs26176`/`irs26173`)
- Choose any of the fit functions from the Fit Type combo box 
### Plot
- Change the plot result options and see if the expected result is plotted (If the Y axis is incorrect ignore it. This is a separate issue #13288)
### Temperature
- Check the Temp. Corrections box and add a temperature value. 
- Ensure that the WorkspaceGroup Workspaces include the fact the temperature is used and the value of the temperature in the sample logs.
### Both
- Try running them both together and check all the functionality still works
