### PR TITLE
Remove container subtraction from apply paalman pings

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -57,20 +57,6 @@
       <string>Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="ckUseCan">
-        <property name="text">
-         <string>Use Can:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QCheckBox" name="ckUseCorrections">
-        <property name="text">
-         <string>Use Corrections:</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="cbGeometry">
         <item>
@@ -90,10 +76,10 @@
         </item>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="1" column="1">
        <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCorrections" native="true">
         <property name="enabled">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -119,37 +105,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-          <string>_sqw</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-          <string>_sqw.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="lbGeometry">
         <property name="text">
@@ -157,55 +112,13 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="ckScaleCan">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Scale Can by factor:</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <layout class="QHBoxLayout" name="loScaleFactor">
-        <item>
-         <widget class="QDoubleSpinBox" name="spCanScale">
-          <property name="enabled">
-           <bool>false</bool>
+       <item row="1" column="0">
+        <widget class="QLabel" name="lbCorrection">
+          <property name="text">
+            <string>Corrections: </string>
           </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
+        </widget>
+       </item>S
      </layout>
     </widget>
    </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -68,97 +68,50 @@ void ApplyPaalmanPings::run() {
     absCorProps["SampleWorkspace"] = sampleWsName.toStdString();
   }
 
-  bool useCan = m_uiForm.ckUseCan->isChecked();
-  if (useCan) {
-    QString canWsName = m_uiForm.dsContainer->getCurrentDataName();
-    MatrixWorkspace_sptr canWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            canWsName.toStdString());
+  QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
 
-    // If not in wavelength then do conversion
-    std::string originalCanUnits = canWs->getAxis(0)->unit()->unitID();
-    if (originalCanUnits != "Wavelength") {
-      g_log.information("Container workspace not in wavelength, need to "
-                        "convert to continue.");
-      absCorProps["CanWorkspace"] = addConvertUnitsStep(canWs, "Wavelength");
-    } else {
-      absCorProps["CanWorkspace"] = canWsName.toStdString();
-    }
+  WorkspaceGroup_sptr corrections =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+          correctionsWsName.toStdString());
+  bool interpolateAll = false;
+  for (size_t i = 0; i < corrections->size(); i++) {
+    MatrixWorkspace_sptr factorWs =
+        boost::dynamic_pointer_cast<MatrixWorkspace>(corrections->getItem(i));
 
-    bool useCanScale = m_uiForm.ckScaleCan->isChecked();
-    if (useCanScale) {
-      double canScaleFactor = m_uiForm.spCanScale->value();
-      applyCorrAlg->setProperty("CanScaleFactor", canScaleFactor);
-    }
-
-    // Check for same binning across sample and container
-    if (!checkWorkspaceBinningMatches(sampleWs, canWs)) {
-      QString text =
-          "Binning on sample and container does not match."
-          "Would you like to rebin the sample to match the container?";
-
-      int result = QMessageBox::question(NULL, tr("Rebin sample?"), tr(text),
-                                         QMessageBox::Yes, QMessageBox::No,
-                                         QMessageBox::NoButton);
-
-      if (result == QMessageBox::Yes) {
-        addRebinStep(sampleWsName, canWsName);
+    // Check for matching binning
+    if (sampleWs && (sampleWs->blocksize() != factorWs->blocksize())) {
+      int result;
+      if (interpolateAll) {
+        result = QMessageBox::Yes;
       } else {
+        QString text = "Number of bins on sample and " +
+                       QString::fromStdString(factorWs->name()) +
+                       " workspace does not match.\n" +
+                       "Would you like to interpolate this workspace to "
+                       "match the sample?";
+
+        result = QMessageBox::question(NULL, tr("Interpolate corrections?"),
+                                       tr(text), QMessageBox::YesToAll,
+                                       QMessageBox::Yes, QMessageBox::No);
+      }
+
+      switch (result) {
+      case QMessageBox::YesToAll:
+        interpolateAll = true;
+      case QMessageBox::Yes:
+        addInterpolationStep(factorWs, absCorProps["SampleWorkspace"]);
+        break;
+      default:
         m_batchAlgoRunner->clearQueue();
-        g_log.error("Cannot apply absorption corrections using a sample and "
-                    "container with different binning.");
+        g_log.error("ApplyPaalmanPings cannot run with corrections that do "
+                    "not match sample binning.");
         return;
       }
     }
   }
 
-  bool useCorrections = m_uiForm.ckUseCorrections->isChecked();
-  if (useCorrections) {
-    QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
-
-    WorkspaceGroup_sptr corrections =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            correctionsWsName.toStdString());
-    bool interpolateAll = false;
-    for (size_t i = 0; i < corrections->size(); i++) {
-      MatrixWorkspace_sptr factorWs =
-          boost::dynamic_pointer_cast<MatrixWorkspace>(corrections->getItem(i));
-
-      // Check for matching binning
-      if (sampleWs && (sampleWs->blocksize() != factorWs->blocksize())) {
-        int result;
-        if (interpolateAll) {
-          result = QMessageBox::Yes;
-        } else {
-          QString text = "Number of bins on sample and " +
-                         QString::fromStdString(factorWs->name()) +
-                         " workspace does not match.\n" +
-                         "Would you like to interpolate this workspace to "
-                         "match the sample?";
-
-          result = QMessageBox::question(NULL, tr("Interpolate corrections?"),
-                                         tr(text), QMessageBox::YesToAll,
-                                         QMessageBox::Yes, QMessageBox::No);
-        }
-
-        switch (result) {
-        case QMessageBox::YesToAll:
-          interpolateAll = true;
-        case QMessageBox::Yes:
-          addInterpolationStep(factorWs, absCorProps["SampleWorkspace"]);
-          break;
-        default:
-          m_batchAlgoRunner->clearQueue();
-          g_log.error("ApplyPaalmanPings cannot run with corrections that do "
-                      "not match sample binning.");
-          return;
-        }
-      }
-    }
-
-    applyCorrAlg->setProperty("CorrectionsWorkspace",
-                              correctionsWsName.toStdString());
-  }
+  applyCorrAlg->setProperty("CorrectionsWorkspace",
+                            correctionsWsName.toStdString());
 
   // Generate output workspace name
   int nameCutIndex = sampleWsName.lastIndexOf("_");
@@ -308,63 +261,35 @@ bool ApplyPaalmanPings::validate() {
 
   MatrixWorkspace_sptr sampleWs;
 
-  bool useCan = m_uiForm.ckUseCan->isChecked();
-  bool useCorrections = m_uiForm.ckUseCorrections->isChecked();
+  uiv.addErrorMessage("Must use either container subtraction or corrections");
 
-  if (!(useCan || useCorrections))
-    uiv.addErrorMessage("Must use either container subtraction or corrections");
+  if (m_uiForm.dsCorrections->getCurrentDataName().compare("") == 0) {
+    uiv.addErrorMessage(
+        "Use Correction must contain a corrections file or workspace.");
+  } else {
 
-  if (useCan) {
-    uiv.checkDataSelectorIsValid("Container", m_uiForm.dsContainer);
+    QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
+    WorkspaceGroup_sptr corrections =
+        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+            correctionsWsName.toStdString());
+    for (size_t i = 0; i < corrections->size(); i++) {
+      // Check it is a MatrixWorkspace
+      MatrixWorkspace_sptr factorWs =
+          boost::dynamic_pointer_cast<MatrixWorkspace>(corrections->getItem(i));
+      if (!factorWs) {
+        QString msg = "Correction factor workspace " + QString::number(i) +
+                      " is not a MatrixWorkspace";
+        uiv.addErrorMessage(msg);
+        continue;
+      }
 
-    // Check can and sample workspaces are the same "type" (reduced or S(Q, w))
-    QString sample = m_uiForm.dsSample->getCurrentDataName();
-    QString sampleType =
-        sample.right(sample.length() - sample.lastIndexOf("_"));
-    QString container = m_uiForm.dsContainer->getCurrentDataName();
-    QString containerType =
-        container.right(container.length() - container.lastIndexOf("_"));
-
-    g_log.debug() << "Sample type is: " << sampleType.toStdString()
-                  << std::endl;
-    g_log.debug() << "Can type is: " << containerType.toStdString()
-                  << std::endl;
-
-    if (containerType != sampleType)
-      uiv.addErrorMessage(
-          "Sample and can workspaces must contain the same type of data.");
-  }
-
-  if (useCorrections) {
-    if (m_uiForm.dsCorrections->getCurrentDataName().compare("") == 0) {
-      uiv.addErrorMessage(
-          "Use Correction must contain a corrections file or workspace.");
-    } else {
-
-      QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
-      WorkspaceGroup_sptr corrections =
-          AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-              correctionsWsName.toStdString());
-      for (size_t i = 0; i < corrections->size(); i++) {
-        // Check it is a MatrixWorkspace
-        MatrixWorkspace_sptr factorWs =
-            boost::dynamic_pointer_cast<MatrixWorkspace>(
-                corrections->getItem(i));
-        if (!factorWs) {
-          QString msg = "Correction factor workspace " + QString::number(i) +
-                        " is not a MatrixWorkspace";
-          uiv.addErrorMessage(msg);
-          continue;
-        }
-
-        // Check X unit is wavelength
-        Mantid::Kernel::Unit_sptr xUnit = factorWs->getAxis(0)->unit();
-        if (xUnit->caption() != "Wavelength") {
-          QString msg = "Correction factor workspace " +
-                        QString::fromStdString(factorWs->name()) +
-                        " is not in wavelength";
-          uiv.addErrorMessage(msg);
-        }
+      // Check X unit is wavelength
+      Mantid::Kernel::Unit_sptr xUnit = factorWs->getAxis(0)->unit();
+      if (xUnit->caption() != "Wavelength") {
+        QString msg = "Correction factor workspace " +
+                      QString::fromStdString(factorWs->name()) +
+                      " is not in wavelength";
+        uiv.addErrorMessage(msg);
       }
     }
   }
@@ -378,7 +303,6 @@ bool ApplyPaalmanPings::validate() {
 
 void ApplyPaalmanPings::loadSettings(const QSettings &settings) {
   m_uiForm.dsCorrections->readSettings(settings.group());
-  m_uiForm.dsContainer->readSettings(settings.group());
   m_uiForm.dsSample->readSettings(settings.group());
 }
 
@@ -413,7 +337,6 @@ void ApplyPaalmanPings::handleGeometryChange(int index) {
  * @param specIndex Spectrum index to plot
  */
 void ApplyPaalmanPings::plotPreview(int specIndex) {
-  bool useCan = m_uiForm.ckUseCan->isChecked();
 
   m_uiForm.ppPreview->clear();
 
@@ -426,11 +349,6 @@ void ApplyPaalmanPings::plotPreview(int specIndex) {
     m_uiForm.ppPreview->addSpectrum(
         "Corrected", QString::fromStdString(m_pythonExportWsName), specIndex,
         Qt::green);
-
-  // Plot can
-  if (useCan)
-    m_uiForm.ppPreview->addSpectrum(
-        "Can", m_uiForm.dsContainer->getCurrentDataName(), specIndex, Qt::red);
 }
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -261,8 +261,6 @@ bool ApplyPaalmanPings::validate() {
 
   MatrixWorkspace_sptr sampleWs;
 
-  uiv.addErrorMessage("Must use either container subtraction or corrections");
-
   if (m_uiForm.dsCorrections->getCurrentDataName().compare("") == 0) {
     uiv.addErrorMessage(
         "Use Correction must contain a corrections file or workspace.");


### PR DESCRIPTION
Fixes #13657 

There is no longer any Container Subtraction functionality in the ApplyPaalmanPings Tab. And therefore all Can Subtraction should be done in the new ContainerSubtraction Tab 
# To Test
- Open ApplyPaalmanPings (Interfaces > Indirect > corrections > ApplyPaalmanPings)
- Enter relevant Sample and correction files
  - If you do not have any relevant files (`_red` and matching `_flt_abs` or other correction) Ask me and I can provide some.
- Ensure the run works and that no errors are produced
