### PR TITLE
Fix unchecking of autocolorscale when color preset button is pressed

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/ColorSelectionWidget.cpp
@@ -5,6 +5,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidVatesSimpleGuiViewWidgets/ColorMapManager.h"
 #include "MantidQtAPI/MdConstants.h"
+#include "MantidVatesAPI/ColorScaleGuard.h"
 
 // Have to deal with ParaView warnings and Intel compiler the hard way.
 #if defined(__INTEL_COMPILER)
@@ -105,7 +106,6 @@ void ColorSelectionWidget::loadBuiltinColorPresets()
 
   // create xml parser
   vtkPVXMLParser *xmlParser = vtkPVXMLParser::New();
-  
 
   // 1. Get builtinw color maps (Reading fragment requires: InitializeParser, ParseChunk, CleanupParser) 
   const char *xml = pqComponentsGetColorMapsXML();
@@ -274,6 +274,7 @@ void ColorSelectionWidget::autoCheckBoxClicked(bool wasOn)
  */
 void ColorSelectionWidget::loadPreset()
 {
+  Mantid::VATES::ColorScaleLockGuard guard(m_colorScaleLock);
   this->m_presets->setUsingCloseButton(false);
   if (this->m_presets->exec() == QDialog::Accepted)
   {


### PR DESCRIPTION
Fixes #13697 

Sample data set is MDHisto_Osiris which can be found here: \olympic\Babylon5\Scratch\Anton\VSI\SAMPLE_WORKSPACES
## For testing:
1. Load a sample MD data set into Mantid. In the Mantid Dock right-click on it and select the VatesSimpleInterface(VSI). The VSI will open.
   - Confirm that the auto scale check box is checked (left upper corner).
2. Press the "Color Preset" button and select a color map. Press OK
   - Confirm that the auto scale check box is still checked.
