### PR TITLE
Capitalisation in ResNorm causing error

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -122,8 +122,7 @@ void ResNorm::run() {
   m_pythonExportWsName = outputWsName.toStdString();
   m_batchAlgoRunner->executeBatchAsync();
 
-  loadFile(m_uiForm.dsResolution->getFullFilePath(),
-           m_uiForm.dsResolution->getCurrentDataName());
+
 }
 
 /**
@@ -135,9 +134,16 @@ void ResNorm::handleAlgorithmComplete(bool error) {
   if (error)
     return;
 
+  QString outputBase = (m_uiForm.dsVanadium->getCurrentDataName()).toLower();
+  const int indexCut = outputBase.lastIndexOf("_");
+  outputBase = outputBase.left(indexCut);
+  outputBase += "_ResNorm";
+
+  std::string outputBaseStr = outputBase.toStdString();
+
   WorkspaceGroup_sptr fitWorkspaces =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-          m_pythonExportWsName + "_Fit_Workspaces");
+          outputBaseStr + "_Fit_Workspaces");
   QString fitWsName("");
   if (fitWorkspaces)
     fitWsName =
@@ -151,6 +157,9 @@ void ResNorm::handleAlgorithmComplete(bool error) {
     plotSpectrum(QString::fromStdString(m_pythonExportWsName) + "_Stretch");
   if (plotOptions == "Fit" || plotOptions == "All")
     plotSpectrum(fitWsName, 0, 1);
+
+  loadFile(m_uiForm.dsResolution->getFullFilePath(),
+           m_uiForm.dsResolution->getCurrentDataName());
 
   // Update preview plot
   previewSpecChanged(m_previewSpec);

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -57,7 +57,8 @@ bool ResNorm::validate() {
   // Check vanadium input is _red ws
   QString vanadiumName = m_uiForm.dsVanadium->getCurrentDataName();
   int cutIndex = vanadiumName.lastIndexOf("_");
-  QString vanadiumSuffix = vanadiumName.right(vanadiumName.size() - (cutIndex + 1));
+  QString vanadiumSuffix =
+      vanadiumName.right(vanadiumName.size() - (cutIndex + 1));
   if (vanadiumSuffix.compare("red") != 0) {
     uiv.addErrorMessage("The Vanadium run is not a reduction (_red) workspace");
   }
@@ -65,14 +66,18 @@ bool ResNorm::validate() {
   // Check Res and Vanadium are the same Run
 
   // Check that Res file is still in ADS if not, load it
-  auto resolutionWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(m_uiForm.dsResolution->getCurrentDataName().toStdString());
-  auto vanadiumWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(vanadiumName.toStdString());
+  auto resolutionWs =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+          m_uiForm.dsResolution->getCurrentDataName().toStdString());
+  auto vanadiumWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      vanadiumName.toStdString());
 
-  const int resNum = resolutionWs->getRunNumber();
-  const int vanNum = vanadiumWs->getRunNumber();
+  const int resRun = resolutionWs->getRunNumber();
+  const int vanRun = vanadiumWs->getRunNumber();
 
-  if(resNum != vanNum){
-	 uiv.addErrorMessage("The provided Vanadium and Resolution do not have matching run numbers");
+  if (resRun != vanRun) {
+    uiv.addErrorMessage("The provided Vanadium and Resolution do not have "
+                        "matching run numbers");
   }
 
   uiv.checkDataSelectorIsValid("Vanadium", m_uiForm.dsVanadium);
@@ -116,6 +121,9 @@ void ResNorm::run() {
 
   m_pythonExportWsName = outputWsName.toStdString();
   m_batchAlgoRunner->executeBatchAsync();
+
+  loadFile(m_uiForm.dsResolution->getFullFilePath(),
+           m_uiForm.dsResolution->getCurrentDataName());
 }
 
 /**

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -55,11 +55,24 @@ bool ResNorm::validate() {
   UserInputValidator uiv;
 
   // Check vanadium input is _red ws
-  QString vanadiumSuffix = m_uiForm.dsVanadium->getCurrentDataName();
-  int cutIndex = vanadiumSuffix.lastIndexOf("_");
-  vanadiumSuffix = vanadiumSuffix.right(vanadiumSuffix.size() - (cutIndex + 1));
+  QString vanadiumName = m_uiForm.dsVanadium->getCurrentDataName();
+  int cutIndex = vanadiumName.lastIndexOf("_");
+  QString vanadiumSuffix = vanadiumName.right(vanadiumName.size() - (cutIndex + 1));
   if (vanadiumSuffix.compare("red") != 0) {
-    return false;
+    uiv.addErrorMessage("The Vanadium run is not a reduction (_red) workspace");
+  }
+
+  // Check Res and Vanadium are the same Run
+
+  // Check that Res file is still in ADS if not, load it
+  auto resolutionWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(m_uiForm.dsResolution->getCurrentDataName().toStdString());
+  auto vanadiumWs = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(vanadiumName.toStdString());
+
+  const int resNum = resolutionWs->getRunNumber();
+  const int vanNum = vanadiumWs->getRunNumber();
+
+  if(resNum != vanNum){
+	 uiv.addErrorMessage("The provided Vanadium and Resolution do not have matching run numbers");
   }
 
   uiv.checkDataSelectorIsValid("Vanadium", m_uiForm.dsVanadium);


### PR DESCRIPTION
Fixes #13610 

Vanadium and Resolution capitalisation should no longer affect the output of ResNorm. This is not the best fix for this. #13717 should fix this properly but this will not be implemented until after 3.5 Release.

**This should be merged after #13650**
- [x] #13650 merged
# To Test
- Open ResNorm (Interfaces > Indirect > Bayes > ResNorm)
- Load matching run number files for Vanadium and Resolution
  - These should have the following criteria in common to be valid for ResNorm:
    - The same instrument            e.g. `irs`
    - The same run numbers        e.g. `26173`  
    - The same Analyser               e.g. `graphite`
    - The same Reflection             e.g. `002`
    - Resolution must be a `_res.nxs` file
    - Vanadium must be a `_red.nxs` file
    - **Ask me if you are struggling to obtain these files**
    - **Files that include additional extensions such as `_diffspec_` will not run correctly**
- Run ResNorm using different capitalisation 
  - Ensure that if you have changed the capitalisation of a file using something like the `RenameWorkspace` algorithm you save it to `.nxs` and reload it before use.
- Ensure that various capitalisations of the Vanadium and Resolution file do not produce an error.
