### PR TITLE
Adding property for force updating instrument download directory

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -70,6 +70,7 @@ const std::string DownloadInstrument::summary() const {
 void DownloadInstrument::init() {
   using Kernel::Direction;
 
+  declareProperty("ForceUpdate", false, "Ignore cache information");
   declareProperty("FileDownloadCount", 0,
                   "The number of files downloaded by this algorithm",
                   Direction::Output);
@@ -127,7 +128,8 @@ DownloadInstrument::StringToStringMap DownloadInstrument::processRepository() {
   Poco::Path gitHubJson(localPath, "github.json");
   Poco::File gitHubJsonFile(gitHubJson);
   Poco::DateTime gitHubJsonDate(1900, 1, 1);
-  if (gitHubJsonFile.exists() && gitHubJsonFile.isFile()) {
+  bool forceUpdate = this->getProperty("ForceUpdate");
+  if ((!forceUpdate) && gitHubJsonFile.exists() && gitHubJsonFile.isFile()) {
     gitHubJsonDate = gitHubJsonFile.getLastModified();
   }
 


### PR DESCRIPTION
This is to address an issue when instrument definitions were not updated, but the json document describing the repository did. The solution is to ignore that there is already a cache file and start from scratch.

**To test:**
1. Look at the system time and look at the timestamp of (on linux) `~/.mantid/instrument/github.json`
2. Run `DownloadInstrument(ForceUpdate=False)`
3. Wait until the system clock changes the minute
4. Run `DownloadInstrument(ForceUpdate=False)` and notice that the file was not modified
5. Run `DownloadInstrument(ForceUpdate=True)` and notice that the file was modified

This doesn't need to be added to the release notes.
