### PR TITLE
Ensure max is more than min in ISIS Energy Transfer

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -119,6 +119,15 @@ bool ISISEnergyTransfer::validate() {
 	uiv.addErrorMessage("Spectra Min must be less than Spectra Max");
   }
 
+  // Background Removal (TOF)
+  if(m_uiForm.ckBackgroundRemoval->isChecked()){
+	  const int start = m_uiForm.spBackgroundStart->value();
+	  const int end = m_uiForm.spBackgroundEnd->value();
+	  if(start > end){
+		  uiv.addErrorMessage("Background Start must be less than Background End");
+	  }
+  }
+
   QString error = uiv.generateErrorMessage();
   showMessageBox(error);
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -112,6 +112,13 @@ bool ISISEnergyTransfer::validate() {
     }
   }
 
+  // Spectra Number check
+  const int specMin = m_uiForm.spSpectraMin->value();
+  const int specMax = m_uiForm.spSpectraMax->value();
+  if(specMin > specMax){
+	uiv.addErrorMessage("Spectra Min must be less than Spectra Max");
+  }
+
   QString error = uiv.generateErrorMessage();
   showMessageBox(error);
 


### PR DESCRIPTION
Fixes #13653

It should now be the case that all the all the minimum most be lower than the maximum for all range type spinners in ISISEnergyTransfer.
# To Test
- Open ISIS Energy Transfer (Interfaces >Indirect > Data Reduction > ISIS Energy Reduction)
- Put a relevant Run number for the currently selected instrument into the Run Files Input field 
## Spec Min/Max (Convert to Energy Transfer)
- Change the `Spectra Min` to a value larger than the `Spectra Max` in the Conversion to Energy Transfer section
- Click the `Run` button 
- Ensure a relevant warning is produced in a dialog box
## Spec Min/Max (Plot Time)
- Change the `Spectra Min` to a value larger than the `Spectra Max` in the Plot Time section
- Click `Plot` button
- Ensure a relevant warning is produced in a dialog box
## Background Removal (ToF)
- Use plot time to find the time of flight range for the run
- Check the Background Removal check box
### To check for normal functionality
- Select a `Start` and `End` time within those limits 
- Click `Run` button
- Should run with no errors/warnings
### To check for validation
- Select a number for `End` that is smaller than `Start`
- Click `Run` button 
- Ensure a relevant warning is produced in a dialog box
