### PR TITLE
Added Number Density optional property to call of SetSampleMaterial

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/CalculateSampleTransmission.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/CalculateSampleTransmission.py
@@ -63,7 +63,7 @@ class CalculateSampleTransmission(PythonAlgorithm):
                         VerticalAxisUnit='Text', VerticalAxisValues='Transmission,Scattering')
         Rebin(InputWorkspace=self._output_ws, OutputWorkspace=self._output_ws,
               Params=self._bin_params)
-        SetSampleMaterial(InputWorkspace=self._output_ws, ChemicalFormula=self._chemical_formula)
+        SetSampleMaterial(InputWorkspace=self._output_ws, ChemicalFormula=self._chemical_formula, SampleNumberDensity=self._density)
         ConvertToPointData(InputWorkspace=self._output_ws, OutputWorkspace=self._output_ws)
 
         ws = mtd[self._output_ws]


### PR DESCRIPTION
Fixes #13664

Number Density should now use the input from the GUI in the SetSampleMaterial algorithm rather than the previous default value.

The functionality here needs to be double checked with Spencer to ensure it is correct
- [x] Confirmed by Spencer
# To Test
- Open Sample Transmission Calculator (Interfaces > General > Sample Transmission Calculator)
- Enter reasonable inputs for the `Input Wavelength Range` and `Sample Details`
- Click `Calculate`
- Ensure that the in the Result log the value for `Sample number density` is equal to the input value for `Number Density`
