### PR TITLE
Custom ties for local parameters in multi-data fitting interface.

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
@@ -26,12 +26,15 @@ public:
   EditLocalParameterDialog(MultiDatasetFit *parent, const QString &parName);
   QList<double> getValues() const;
   QList<bool> getFixes() const;
+  QStringList getTies() const;
   bool isFixed(int i) const {return m_fixes[i];}
+  QString getTie(int i) const {return m_ties[i];}
 private slots:
   void valueChanged(int,int);
   void setAllValues(double);
   void fixParameter(int,bool);
   void setAllFixed(bool);
+  void setTie(int,QString);
   void copy();
   void paste();
 private:
@@ -45,6 +48,8 @@ private:
   /// Cache for the "fixed" attribute. If changes are accepted
   /// parameters for which m_fixes[i] is true are fixed to their m_values[i]
   QList<bool> m_fixes;
+  /// Cache for the ties
+  QStringList m_ties;
 };
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
@@ -35,11 +35,13 @@ private slots:
   void fixParameter(int,bool);
   void setAllFixed(bool);
   void setTie(int,QString);
+  void setTieAll(QString);
   void copy();
   void paste();
 private:
   bool eventFilter(QObject * obj, QEvent * ev);
   void showContextMenu();
+  void redrawCells();
   Ui::EditLocalParameterDialog m_uiForm;
   /// Parameter name
   QString m_parName;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
@@ -21,22 +21,26 @@ class LocalParameterEditor: public QWidget
 {
   Q_OBJECT
 public:
-  LocalParameterEditor(QWidget *parent, int index, bool fixed);
+  LocalParameterEditor(QWidget *parent, int index, bool fixed, QString tie);
 signals:
   void setAllValues(double);
   void fixParameter(int,bool);
   void setAllFixed(bool);
+  void setTie(int,QString);
 private slots:
   void setAll();
   void fixParameter();
   void fixAll();
   void unfixAll();
+  void setTie();
+  void removeTie();
 private:
   bool eventFilter(QObject *widget, QEvent *evn);
   QLineEdit* m_editor;
   QAction *m_fixAction;
   int m_index;
   bool m_fixed;
+  QString m_tie;
 };
 
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterEditor.h
@@ -27,6 +27,7 @@ signals:
   void fixParameter(int,bool);
   void setAllFixed(bool);
   void setTie(int,QString);
+  void setTieAll(QString);
 private slots:
   void setAll();
   void fixParameter();
@@ -34,6 +35,8 @@ private slots:
   void unfixAll();
   void setTie();
   void removeTie();
+  void setTieAll();
+  void removeAllTies();
 private:
   bool eventFilter(QObject *widget, QEvent *evn);
   QLineEdit* m_editor;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
@@ -35,6 +35,7 @@ signals:
   void fixParameter(int,bool);
   void setAllFixed(bool);
   void setTie(int,QString);
+  void setTieAll(QString);
 protected:
   void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const;
 private:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
@@ -34,6 +34,7 @@ signals:
   void setAllValues(double);
   void fixParameter(int,bool);
   void setAllFixed(bool);
+  void setTie(int,QString);
 protected:
   void paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const;
 private:

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MultiDatasetFit/MultiDatasetFit.h
@@ -77,6 +77,10 @@ public:
   bool isLocalParameterFixed(const QString& parName, int i) const;
   /// Fix/unfix local parameter
   void setLocalParameterFixed(const QString& parName, int i, bool fixed);
+  /// Get the tie for a local parameter.
+  QString getLocalParameterTie(const QString& parName, int i) const;
+  /// Set a tie for a local parameter.
+  void setLocalParameterTie(const QString& parName, int i, QString tie);
 
 public slots:
   void reset();

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFEditLocalParameterDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFEditLocalParameterDialog.cpp
@@ -47,6 +47,7 @@ EditLocalParameterDialog::EditLocalParameterDialog(MultiDatasetFit *multifit, co
   connect(deleg,SIGNAL(fixParameter(int,bool)),this,SLOT(fixParameter(int,bool)));
   connect(deleg,SIGNAL(setAllFixed(bool)),this,SLOT(setAllFixed(bool)));
   connect(deleg,SIGNAL(setTie(int,QString)),this,SLOT(setTie(int,QString)));
+  connect(deleg,SIGNAL(setTieAll(QString)),this,SLOT(setTieAll(QString)));
 
   m_uiForm.tableWidget->installEventFilter(this);
 }
@@ -107,11 +108,28 @@ QStringList EditLocalParameterDialog::getTies() const
 void EditLocalParameterDialog::fixParameter(int index, bool fix)
 {
   m_fixes[index] = fix;
+  m_ties[index] = "";
 }
 
+/// Set a new tie for a parameter
+/// @param index :: Index of a paramter to tie.
+/// @param tie :: A tie string.
 void EditLocalParameterDialog::setTie(int index, QString tie)
 {
   m_ties[index] = tie;
+  m_fixes[index] = false;
+}
+
+/// Set the same tie to all parameters.
+/// @param tie :: A tie string.
+void EditLocalParameterDialog::setTieAll(QString tie)
+{
+  for(int i = 0; i < m_ties.size(); ++i)
+  {
+    m_ties[i] = tie;
+    m_fixes[i] = false;
+  }
+  redrawCells();
 }
 
 /// Fix/unfix all parameters.
@@ -122,11 +140,9 @@ void EditLocalParameterDialog::setAllFixed(bool fix)
   for(int i = 0; i < m_fixes.size(); ++i)
   {
     m_fixes[i] = fix;
-    // it's the only way I am able to make the table to repaint itself
-    auto text = makeNumber(m_values[i]);
-    m_uiForm.tableWidget->item(i,1)->setText( text + " " );
-    m_uiForm.tableWidget->item(i,1)->setText( text );
+    m_ties[i] = "";
   }
+  redrawCells();
 }
 
 /// Event filter for managing the context menu.
@@ -198,6 +214,18 @@ void EditLocalParameterDialog::paste()
     m_values[i] = str.toDouble(&ok);
     if ( !ok ) str = "0";
     m_uiForm.tableWidget->item(i,1)->setText( str );
+  }
+}
+
+/// Force the table to redraw its cells.
+void EditLocalParameterDialog::redrawCells()
+{
+  for(int i = 0; i < m_values.size(); ++i)
+  {
+    // it's the only way I am able to make the table to repaint itself
+    auto text = makeNumber(m_values[i]);
+    m_uiForm.tableWidget->item(i,1)->setText( text + " " );
+    m_uiForm.tableWidget->item(i,1)->setText( text );
   }
 }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFEditLocalParameterDialog.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFEditLocalParameterDialog.cpp
@@ -33,6 +33,8 @@ EditLocalParameterDialog::EditLocalParameterDialog(MultiDatasetFit *multifit, co
     m_values.push_back(value);
     bool fixed = multifit->isLocalParameterFixed(parName,i);
     m_fixes.push_back(fixed);
+    auto tie = multifit->getLocalParameterTie(parName,i);
+    m_ties.push_back(tie);
     m_uiForm.tableWidget->insertRow(i);
     auto cell = new QTableWidgetItem( QString("f%1.").arg(i) + parName );
     m_uiForm.tableWidget->setItem( i, 0, cell );
@@ -44,6 +46,7 @@ EditLocalParameterDialog::EditLocalParameterDialog(MultiDatasetFit *multifit, co
   connect(deleg,SIGNAL(setAllValues(double)),this,SLOT(setAllValues(double)));
   connect(deleg,SIGNAL(fixParameter(int,bool)),this,SLOT(fixParameter(int,bool)));
   connect(deleg,SIGNAL(setAllFixed(bool)),this,SLOT(setAllFixed(bool)));
+  connect(deleg,SIGNAL(setTie(int,QString)),this,SLOT(setTie(int,QString)));
 
   m_uiForm.tableWidget->installEventFilter(this);
 }
@@ -92,12 +95,23 @@ QList<bool> EditLocalParameterDialog::getFixes() const
   return m_fixes;
 }
 
+/// Get a list of the ties.
+QStringList EditLocalParameterDialog::getTies() const
+{
+  return m_ties;
+}
+
 /// Fix/unfix a single parameter.
 /// @param index :: Index of a paramter to fix or unfix.
 /// @param fix :: Fix (true) or unfix (false).
 void EditLocalParameterDialog::fixParameter(int index, bool fix)
 {
   m_fixes[index] = fix;
+}
+
+void EditLocalParameterDialog::setTie(int index, QString tie)
+{
+  m_ties[index] = tie;
 }
 
 /// Fix/unfix all parameters.

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
@@ -80,6 +80,16 @@ LocalParameterEditor::LocalParameterEditor(QWidget *parent, int index, bool fixe
   connect(action,SIGNAL(activated()),this,SLOT(removeTie()));
   setMenu->addAction(action);
 
+  action = new QAction("Set tie to all",this);
+  action->setToolTip("Set this tie for all parameters.");
+  connect(action,SIGNAL(activated()),this,SLOT(setTieAll()));
+  setMenu->addAction(action);
+
+  action = new QAction("Remove all ties",this);
+  action->setToolTip("Remove ties for all parameters.");
+  connect(action,SIGNAL(activated()),this,SLOT(removeAllTies()));
+  setMenu->addAction(action);
+
   button->setMenu(setMenu);
 
   m_editor->installEventFilter(this);
@@ -128,6 +138,18 @@ void LocalParameterEditor::setTie()
 void LocalParameterEditor::removeTie()
 {
   emit setTie(m_index, "");
+}
+
+/// Set all ties for all parameters
+void LocalParameterEditor::setTieAll()
+{
+  emit setTieAll(m_tie);
+}
+
+/// Remove ties form all parameters
+void LocalParameterEditor::removeAllTies()
+{
+  emit setTieAll("");
 }
 
 /// Filter events in the line editor to emulate a shortcut (F to fix/unfix).

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
@@ -20,6 +20,7 @@ namespace MDF
 /// @param parent :: Parent widget.
 /// @param index :: Index of the spectrum which parameter is edited.
 /// @param fixed :: Is the parameter fixed initially?
+/// @param tie :: Parameter's current tie (or empty string).
 LocalParameterEditor::LocalParameterEditor(QWidget *parent, int index, bool fixed, QString tie):
   QWidget(parent), m_index(index),m_fixed(fixed), m_tie(tie)
 {

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterEditor.cpp
@@ -8,6 +8,7 @@
 #include <QDoubleValidator>
 #include <QEvent>
 #include <QKeyEvent>
+#include <QInputDialog>
 
 namespace MantidQt
 {
@@ -19,8 +20,8 @@ namespace MDF
 /// @param parent :: Parent widget.
 /// @param index :: Index of the spectrum which parameter is edited.
 /// @param fixed :: Is the parameter fixed initially?
-LocalParameterEditor::LocalParameterEditor(QWidget *parent, int index, bool fixed):
-  QWidget(parent), m_index(index),m_fixed(fixed)
+LocalParameterEditor::LocalParameterEditor(QWidget *parent, int index, bool fixed, QString tie):
+  QWidget(parent), m_index(index),m_fixed(fixed), m_tie(tie)
 {
   auto layout = new QHBoxLayout(this);
   layout->setMargin(0);
@@ -52,6 +53,7 @@ LocalParameterEditor::LocalParameterEditor(QWidget *parent, int index, bool fixe
   connect(action,SIGNAL(activated()),this,SLOT(setAll()));
   setMenu->addAction(action);
 
+  setMenu->addSeparator();
   m_fixAction = new QAction(m_fixed? "Unfix" : "Fix", this);
   m_fixAction->setToolTip("Fix value of this parameter");
   connect(m_fixAction,SIGNAL(activated()),this,SLOT(fixParameter()));
@@ -65,6 +67,17 @@ LocalParameterEditor::LocalParameterEditor(QWidget *parent, int index, bool fixe
   action = new QAction("Unfix all",this);
   action->setToolTip("Unfix all parameters.");
   connect(action,SIGNAL(activated()),this,SLOT(unfixAll()));
+  setMenu->addAction(action);
+
+  setMenu->addSeparator();
+  action = new QAction("Set tie",this);
+  action->setToolTip("Set a tie for this parameter.");
+  connect(action,SIGNAL(activated()),this,SLOT(setTie()));
+  setMenu->addAction(action);
+
+  action = new QAction("Remove tie",this);
+  action->setToolTip("Remove the tie for this parameter.");
+  connect(action,SIGNAL(activated()),this,SLOT(removeTie()));
   setMenu->addAction(action);
 
   button->setMenu(setMenu);
@@ -97,6 +110,24 @@ void LocalParameterEditor::fixAll()
 void LocalParameterEditor::unfixAll()
 {
   emit setAllFixed(false);
+}
+
+/// Send a signal to tie a parameter.
+void LocalParameterEditor::setTie()
+{
+  QInputDialog input;
+  input.setWindowTitle("Set a tie.");
+  input.setTextValue(m_tie);
+  if (input.exec() == QDialog::Accepted) {
+    auto tie = input.textValue();
+    emit setTie(m_index, tie);
+  }
+}
+
+/// Send a signal to remove a tie.
+void LocalParameterEditor::removeTie()
+{
+  emit setTie(m_index, "");
 }
 
 /// Filter events in the line editor to emulate a shortcut (F to fix/unfix).

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
@@ -28,6 +28,7 @@ QWidget* LocalParameterItemDelegate::createEditor(QWidget * parent, const QStyle
   connect(m_currentEditor,SIGNAL(fixParameter(int,bool)),this,SIGNAL(fixParameter(int,bool)));
   connect(m_currentEditor,SIGNAL(setAllFixed(bool)),this,SIGNAL(setAllFixed(bool)));
   connect(m_currentEditor,SIGNAL(setTie(int,QString)),this,SIGNAL(setTie(int,QString)));
+  connect(m_currentEditor,SIGNAL(setTieAll(QString)),this,SIGNAL(setTieAll(QString)));
   m_currentEditor->installEventFilter(const_cast<LocalParameterItemDelegate*>(this));
  return m_currentEditor;
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
@@ -22,10 +22,12 @@ LocalParameterItemDelegate::LocalParameterItemDelegate(EditLocalParameterDialog 
 /// Create a custom editor LocalParameterEditor.
 QWidget* LocalParameterItemDelegate::createEditor(QWidget * parent, const QStyleOptionViewItem &, const QModelIndex & index) const
 {
-  m_currentEditor = new LocalParameterEditor(parent,index.row(), owner()->isFixed(index.row()));
+  auto row = index.row();
+  m_currentEditor = new LocalParameterEditor(parent,row, owner()->isFixed(row), owner()->getTie(row));
   connect(m_currentEditor,SIGNAL(setAllValues(double)),this,SIGNAL(setAllValues(double)));
   connect(m_currentEditor,SIGNAL(fixParameter(int,bool)),this,SIGNAL(fixParameter(int,bool)));
   connect(m_currentEditor,SIGNAL(setAllFixed(bool)),this,SIGNAL(setAllFixed(bool)));
+  connect(m_currentEditor,SIGNAL(setTie(int,QString)),this,SIGNAL(setTie(int,QString)));
   m_currentEditor->installEventFilter(const_cast<LocalParameterItemDelegate*>(this));
  return m_currentEditor;
 }
@@ -58,26 +60,38 @@ bool LocalParameterItemDelegate::eventFilter(QObject * obj, QEvent * ev)
 /// Paint the table cell.
 void LocalParameterItemDelegate::paint(QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index) const
 {
-  QStyledItemDelegate::paint(painter, option, index);
+  auto tie = owner()->getTie(index.row());
 
-  if ( owner()->isFixed(index.row()) )
+  if (!tie.isEmpty())
   {
     auto rect = option.rect;
-
-    auto text = index.model()->data(index).asString();
-    int textWidth = option.fontMetrics.width(text);
-
-    QString fixedStr(" (fixed)");
-    int fWidth = option.fontMetrics.width(fixedStr);
-    if ( textWidth + fWidth > rect.width() )
-    {
-      fixedStr = "(f)";
-      fWidth = option.fontMetrics.width(fixedStr);
-    }
-
     auto dHeight = (option.rect.height() - option.fontMetrics.height()) / 2;
-    rect.adjust(rect.width() - fWidth, dHeight, 0 ,-dHeight);
-    painter->drawText(rect,fixedStr);
+    rect.adjust(0, dHeight, 0 ,-dHeight);
+    painter->drawText(rect, tie);
+  }
+  else
+  {
+    QStyledItemDelegate::paint(painter, option, index);
+
+    if ( owner()->isFixed(index.row()) )
+    {
+      auto rect = option.rect;
+
+      auto text = index.model()->data(index).asString();
+      int textWidth = option.fontMetrics.width(text);
+
+      QString fixedStr(" (fixed)");
+      int fWidth = option.fontMetrics.width(fixedStr);
+      if ( textWidth + fWidth > rect.width() )
+      {
+        fixedStr = "(f)";
+        fWidth = option.fontMetrics.width(fixedStr);
+      }
+
+      auto dHeight = (option.rect.height() - option.fontMetrics.height()) / 2;
+      rect.adjust(rect.width() - fWidth, dHeight, 0 ,-dHeight);
+      painter->drawText(rect,fixedStr);
+    }
   }
 }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MultiDatasetFit/MultiDatasetFit.cpp
@@ -318,11 +318,13 @@ void MultiDatasetFit::editLocalParameterValues(const QString& parName)
   {
     auto values = dialog.getValues();
     auto fixes = dialog.getFixes();
+    auto ties = dialog.getTies();
     assert( values.size() == getNumberOfSpectra() );
     for(int i = 0; i < values.size(); ++i)
     {
       setLocalParameterValue(parName, i, values[i]);
       setLocalParameterFixed(parName, i, fixes[i]);
+      setLocalParameterTie(parName, i, ties[i]);
     }
   }
 }
@@ -531,6 +533,23 @@ bool MultiDatasetFit::isLocalParameterFixed(const QString& parName, int i) const
 void MultiDatasetFit::setLocalParameterFixed(const QString& parName, int i, bool fixed)
 {
   m_functionBrowser->setLocalParameterFixed(parName, i, fixed);
+}
+
+/// Get the tie for a local parameter.
+/// @param parName : Name of a local parameter.
+/// @param i :: Index of the dataset (spectrum).
+QString MultiDatasetFit::getLocalParameterTie(const QString& parName, int i) const
+{
+  return m_functionBrowser->getLocalParameterTie(parName, i);
+}
+
+/// Set a tie for a local parameter.
+/// @param parName : Name of a local parameter.
+/// @param i :: Index of the dataset (spectrum).
+/// @param tie :: A tie string to set.
+void MultiDatasetFit::setLocalParameterTie(const QString& parName, int i, QString tie)
+{
+  m_functionBrowser->setLocalParameterTie(parName, i, tie);
 }
 
 /// Load settings

--- a/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FunctionBrowser.h
+++ b/Code/Mantid/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FunctionBrowser.h
@@ -132,6 +132,11 @@ public:
   bool isLocalParameterFixed(const QString& parName, int i) const;
   /// Fix/unfix local parameter
   void setLocalParameterFixed(const QString& parName, int i, bool fixed);
+  /// Get the tie for a local parameter.
+  QString getLocalParameterTie(const QString& parName, int i) const;
+  /// Set a tie for a local parameter.
+  void setLocalParameterTie(const QString& parName, int i, QString tie);
+
   /// Return the multidomain function if number of datasets is greater than 1
   Mantid::API::IFunction_sptr getGlobalFunction();
   /// Update parameter values in the browser to match those of a function.
@@ -370,6 +375,7 @@ protected:
     explicit LocalParameterData(double v = 0.0):value(v),fixed(false){}
     double value;
     bool fixed;
+    QString tie;
   };
 
   /// Set true if the constructed function is intended to be used in a multi-dataset fit

--- a/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
@@ -2201,6 +2201,8 @@ bool FunctionBrowser::isLocalParameterFixed(const QString& parName, int i) const
 
 
 /// Get the tie for a local parameter.
+/// @param parName :: Parameter name
+/// @param i :: Index of a dataset.
 QString FunctionBrowser::getLocalParameterTie(const QString& parName, int i) const
 {
   checkLocalParameter(parName);
@@ -2208,10 +2210,17 @@ QString FunctionBrowser::getLocalParameterTie(const QString& parName, int i) con
 }
 
 /// Set a tie for a local parameter.
+/// @param parName :: Parameter name
+/// @param i :: Index of a dataset.
+/// @param tie :: A tie string.
 void FunctionBrowser::setLocalParameterTie(const QString& parName, int i, QString tie)
 {
   checkLocalParameter(parName);
   m_localParameterValues[parName][i].tie = tie;
+  if ( i == m_currentDataset )
+  {
+    updateLocalTie(parName);
+  }
 }
 
 

--- a/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
+++ b/Code/Mantid/MantidQt/MantidWidgets/src/FunctionBrowser.cpp
@@ -1243,6 +1243,7 @@ void FunctionBrowser::popupMenu(const QPoint &)
   }
   else if (isParameter(prop))
   {// parameters
+    if ( prop->hasOption(globalOptionName) && !prop->checkOption(globalOptionName) ) return;
     QMenu context(this);
     if ( hasTie(prop) )
     {
@@ -2128,7 +2129,15 @@ Mantid::API::IFunction_sptr FunctionBrowser::getGlobalFunction()
       }
       else
       {
-        fun1->setParameter(j, getLocalParameterValue(parName,i));
+        auto tie = getLocalParameterTie(parName, i);
+        if ( !tie.isEmpty() )
+        {
+          fun1->tie(parName.toStdString(), tie.toStdString());
+        }
+        else
+        {
+          fun1->setParameter(j, getLocalParameterValue(parName,i));
+        }
       }
     }
   }
@@ -2147,9 +2156,18 @@ void FunctionBrowser::updateLocalTie(const QString& parName)
       auto tieProp = getTieProperty(prop);
       removeProperty(tieProp);
     }
-    if ( m_localParameterValues[parName][m_currentDataset].fixed )
+    auto &localParam = m_localParameterValues[parName][m_currentDataset];
+    if ( localParam.fixed )
     {
       auto ap = addTieProperty(prop, QString::number(m_localParameterValues[parName][m_currentDataset].value));
+      if (ap.prop)
+      {
+        ap.prop->setEnabled(false);
+      }
+    }
+    else if (!localParam.tie.isEmpty())
+    {
+      auto ap = addTieProperty(prop, localParam.tie);
       if (ap.prop)
       {
         ap.prop->setEnabled(false);
@@ -2180,6 +2198,22 @@ bool FunctionBrowser::isLocalParameterFixed(const QString& parName, int i) const
   checkLocalParameter(parName);
   return m_localParameterValues[parName][i].fixed;
 }
+
+
+/// Get the tie for a local parameter.
+QString FunctionBrowser::getLocalParameterTie(const QString& parName, int i) const
+{
+  checkLocalParameter(parName);
+  return m_localParameterValues[parName][i].tie;
+}
+
+/// Set a tie for a local parameter.
+void FunctionBrowser::setLocalParameterTie(const QString& parName, int i, QString tie)
+{
+  checkLocalParameter(parName);
+  m_localParameterValues[parName][i].tie = tie;
+}
+
 
 /// Update the interface to have the same parameter values as in a function.
 /// @param fun :: A function to get parameter values from.


### PR DESCRIPTION
Fixes #13749.

**To test**
1. Add a few spectra to fit.
2. Define a function ideally with more than two parameters.
3. Set ties for some local parameters. To do that start editing local parameters by clicking on the parameter's value and then on the appeared button. 
4. In the dialog that shows double-click on a value cell to start editing it.
5. Don't edit the value but instead use the "Set" menu and select "Set tie" option.
6. Define a tie (a math expression involving numbers, usual functions and names of other parameters in the same function).
7. Run Fit.
8. Check that the tie(s) were applied.
9. Check that after fit finishes ties stay in the browser.
