### PR TITLE
Improved MANDI calibration

### DIFF
--- a/Code/Mantid/instrument/MANDI_Definition_2015_08_01.xml
+++ b/Code/Mantid/instrument/MANDI_Definition_2015_08_01.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="MANDI" valid-from   ="2015-08-01 00:00:00"
               valid-to     ="2100-12-31 23:59:59"
-                      last-modified="2015-09-17 16:37:50.314107">
+                      last-modified="2015-09-24 17:31:16.384625">
   <!--DEFAULTS-->
   <defaults>
     <length unit="metre"/>
@@ -21,7 +21,7 @@
 
   <!--SOURCE-->
   <component type="moderator">
-    <location z="-30.064405"/>
+    <location z="-30.052984"/>
   </component>
   <type name="moderator" is="Source"/>
 
@@ -46,495 +46,495 @@
       <location z="1.042" name="monitor3"/>
     </component>
   </type>
-<!-- XML Code automatically generated on 2015-09-17 16:37:50.415793 for the Mantid instrument definition file from MANDI_2015-09-17.DetCal -->
+<!-- XML Code automatically generated on 2015-09-24 17:31:16.450029 for the Mantid instrument definition file from MaNDi_2015-09-24.DetCal -->
 <component type="panel1" idstart="65536" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.409200" t="66.449623" p="-91.125180" name="bank1" rot="90.541996" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="65.798373">
-    <rot val="89.645083" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.409200" t="66.451303" p="-91.083002" name="bank1" rot="90.570136" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="65.797717">
+    <rot val="89.714809" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel1" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.079160" xstep="0.000621"
-    ypixels="256" ystart="-0.078837" ystep="0.000618" >
+    xpixels="256" xstart="-0.079144" xstep="0.000621"
+    ypixels="256" ystart="-0.078851" ystep="0.000618" >
   <properties/>
 </type> 
 <component type="panel2" idstart="131072" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.439200" t="67.108389" p="-65.511053" name="bank2" rot="85.134335" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="66.590420">
-    <rot val="113.582670" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.439200" t="67.109805" p="-65.487837" name="bank2" rot="85.095578" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="66.586787">
+    <rot val="113.537009" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel2" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.079417" xstep="0.000623"
-    ypixels="256" ystart="-0.078854" ystep="0.000618" >
+    xpixels="256" xstart="-0.079327" xstep="0.000622"
+    ypixels="256" ystart="-0.078769" ystep="0.000618" >
   <properties/>
 </type> 
 <component type="panel5" idstart="327680" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.409200" t="114.664372" p="-91.006800" name="bank5" rot="-90.436043" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="66.018056">
-    <rot val="90.045151" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.409200" t="114.611689" p="-90.961550" name="bank5" rot="-90.419015" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="66.019813">
+    <rot val="90.326087" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel5" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078530" xstep="0.000616"
-    ypixels="256" ystart="-0.078593" ystep="0.000616" >
+    xpixels="256" xstart="-0.078467" xstep="0.000615"
+    ypixels="256" ystart="-0.078511" ystep="0.000616" >
   <properties/>
 </type> 
 <component type="panel7" idstart="458752" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.409200" t="90.635699" p="-115.156137" name="bank7" rot="0.053302" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="64.097080">
-    <rot val="90.001274" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.409200" t="90.613855" p="-115.104965" name="bank7" rot="0.044432" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="64.169598">
+    <rot val="90.001910" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel7" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078649" xstep="0.000617"
-    ypixels="256" ystart="-0.078670" ystep="0.000617" >
+    xpixels="256" xstart="-0.078579" xstep="0.000616"
+    ypixels="256" ystart="-0.078633" ystep="0.000617" >
   <properties/>
 </type> 
 <component type="panel8" idstart="524288" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.439200" t="67.200969" p="-116.623782" name="bank8" rot="-5.273322" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="65.585845">
-    <rot val="115.766970" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.439200" t="67.200120" p="-116.583341" name="bank8" rot="-5.044368" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="66.111678">
+    <rot val="115.718111" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel8" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078749" xstep="0.000618"
-    ypixels="256" ystart="-0.079043" ystep="0.000620" >
+    xpixels="256" xstart="-0.078695" xstep="0.000617"
+    ypixels="256" ystart="-0.079044" ystep="0.000620" >
   <properties/>
 </type> 
 <component type="panel11" idstart="720896" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="46.965426" p="-47.686713" name="bank11" rot="-170.288946" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="52.911898">
-    <rot val="41.106958" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="46.974211" p="-47.697668" name="bank11" rot="-170.401757" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="52.884816">
+    <rot val="41.099924" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel11" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078546" xstep="0.000616"
-    ypixels="256" ystart="-0.078567" ystep="0.000616" >
+    xpixels="256" xstart="-0.078492" xstep="0.000616"
+    ypixels="256" ystart="-0.078476" ystep="0.000615" >
   <properties/>
 </type> 
 <component type="panel12" idstart="786432" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="75.281365" p="-34.177490" name="bank12" rot="-136.308426" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.790959">
-    <rot val="43.294528" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="75.257017" p="-34.182564" name="bank12" rot="-136.701453" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="54.071800">
+    <rot val="43.620552" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel12" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077836" xstep="0.000610"
-    ypixels="256" ystart="-0.078326" ystep="0.000614" >
+    xpixels="256" xstart="-0.077823" xstep="0.000610"
+    ypixels="256" ystart="-0.078259" ystep="0.000614" >
   <properties/>
 </type> 
 <component type="panel13" idstart="851968" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="105.752695" p="-34.125057" name="bank13" rot="-100.253456" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.154508">
-    <rot val="40.848257" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="105.694087" p="-34.142346" name="bank13" rot="-100.334201" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.235950">
+    <rot val="41.446364" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel13" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078123" xstep="0.000613"
-    ypixels="256" ystart="-0.077986" ystep="0.000612" >
+    xpixels="256" xstart="-0.078025" xstep="0.000612"
+    ypixels="256" ystart="-0.077866" ystep="0.000611" >
   <properties/>
 </type> 
 <component type="panel17" idstart="1114112" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="105.705075" p="-147.918564" name="bank17" rot="45.306867" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="52.169244">
-    <rot val="40.382561" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="105.676561" p="-147.861331" name="bank17" rot="45.389838" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="52.113605">
+    <rot val="40.311416" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel17" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077958" xstep="0.000611"
-    ypixels="256" ystart="-0.077954" ystep="0.000611" >
+    xpixels="256" xstart="-0.077910" xstep="0.000611"
+    ypixels="256" ystart="-0.077937" ystep="0.000611" >
   <properties/>
 </type> 
 <component type="panel18" idstart="1179648" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="75.292822" p="-147.889763" name="bank18" rot="79.779981" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.872168">
-    <rot val="40.623261" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="75.292431" p="-147.839737" name="bank18" rot="79.719694" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.840508">
+    <rot val="40.420670" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel18" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078258" xstep="0.000614"
-    ypixels="256" ystart="-0.078245" ystep="0.000614" >
+    xpixels="256" xstart="-0.078146" xstep="0.000613"
+    ypixels="256" ystart="-0.078181" ystep="0.000613" >
   <properties/>
 </type> 
 <component type="panel19" idstart="1245184" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="46.987645" p="-134.348127" name="bank19" rot="115.942909" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="54.081469">
-    <rot val="40.281113" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="47.004176" p="-134.304836" name="bank19" rot="115.906660" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="54.047911">
+    <rot val="40.364891" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel19" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078499" xstep="0.000616"
-    ypixels="256" ystart="-0.078656" ystep="0.000617" >
+    xpixels="256" xstart="-0.078441" xstep="0.000615"
+    ypixels="256" ystart="-0.078564" ystep="0.000616" >
   <properties/>
 </type> 
 <component type="panel20" idstart="1310720" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="24.060193" p="-43.744985" name="bank20" rot="-176.505501" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.474230">
-    <rot val="22.130422" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="24.070112" p="-43.813263" name="bank20" rot="-176.489865" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="47.429933">
+    <rot val="22.126098" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel20" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078134" xstep="0.000613"
-    ypixels="256" ystart="-0.078992" ystep="0.000620" >
+    xpixels="256" xstart="-0.078143" xstep="0.000613"
+    ypixels="256" ystart="-0.078883" ystep="0.000619" >
   <properties/>
 </type> 
 <component type="panel21" idstart="1376256" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="55.998696" p="-20.348530" name="bank21" rot="-142.175977" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.969060">
-    <rot val="22.083604" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="55.982433" p="-20.384355" name="bank21" rot="-142.844804" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="48.161657">
+    <rot val="22.277621" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel21" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077864" xstep="0.000611"
-    ypixels="256" ystart="-0.078111" ystep="0.000613" >
+    xpixels="256" xstart="-0.077993" xstep="0.000612"
+    ypixels="256" ystart="-0.078052" ystep="0.000612" >
   <properties/>
 </type> 
 <component type="panel22" idstart="1441792" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="90.570945" p="-16.812340" name="bank22" rot="-108.415654" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="48.044685">
-    <rot val="23.208579" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="90.524163" p="-16.850395" name="bank22" rot="-108.460614" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="48.067945">
+    <rot val="23.229455" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel22" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077938" xstep="0.000611"
-    ypixels="256" ystart="-0.078138" ystep="0.000613" >
+    xpixels="256" xstart="-0.077913" xstep="0.000611"
+    ypixels="256" ystart="-0.078061" ystep="0.000612" >
   <properties/>
 </type> 
 <component type="panel27" idstart="1769472" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="90.523758" p="-165.193162" name="bank27" rot="75.524465" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.018744">
-    <rot val="20.748739" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="90.505423" p="-165.138258" name="bank27" rot="75.213160" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="47.092431">
+    <rot val="21.143081" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel27" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077887" xstep="0.000611"
-    ypixels="256" ystart="-0.077849" ystep="0.000611" >
+    xpixels="256" xstart="-0.077833" xstep="0.000610"
+    ypixels="256" ystart="-0.077879" ystep="0.000611" >
   <properties/>
 </type> 
 <component type="panel28" idstart="1835008" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="55.985523" p="-161.664984" name="bank28" rot="109.072505" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="48.097427">
-    <rot val="22.083220" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="56.005364" p="-161.608758" name="bank28" rot="109.131571" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="48.038294">
+    <rot val="22.301736" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel28" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078155" xstep="0.000613"
-    ypixels="256" ystart="-0.078344" ystep="0.000614" >
+    xpixels="256" xstart="-0.078133" xstep="0.000613"
+    ypixels="256" ystart="-0.078306" ystep="0.000614" >
   <properties/>
 </type> 
 <component type="panel29" idstart="1900544" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="24.102154" p="-138.370902" name="bank29" rot="149.419766" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.412486">
-    <rot val="20.500211" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="24.128551" p="-138.318615" name="bank29" rot="148.822523" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="47.547214">
+    <rot val="20.390660" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel29" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078972" xstep="0.000619"
-    ypixels="256" ystart="-0.078175" ystep="0.000613" >
+    xpixels="256" xstart="-0.079024" xstep="0.000620"
+    ypixels="256" ystart="-0.078148" ystep="0.000613" >
   <properties/>
 </type> 
 <component type="panel31" idstart="2031616" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="36.278107" p="-0.747956" name="bank31" rot="-142.156840" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="45.794158">
-    <rot val="0.542751" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.395000" t="36.229786" p="-0.812142" name="bank31" rot="-141.426537" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="45.732332">
+    <rot val="0.467861" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel31" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078655" xstep="0.000617"
-    ypixels="256" ystart="-0.078438" ystep="0.000615" >
+    xpixels="256" xstart="-0.078761" xstep="0.000618"
+    ypixels="256" ystart="-0.078411" ystep="0.000615" >
   <properties/>
 </type> 
 <component type="panel32" idstart="2097152" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="72.506660" p="-0.803194" name="bank32" rot="-107.624791" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="45.133414">
-    <rot val="-1.063319" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.395000" t="72.459964" p="-0.849651" name="bank32" rot="-107.314383" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="45.131912">
+    <rot val="-1.094101" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel32" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077993" xstep="0.000612"
-    ypixels="256" ystart="-0.078299" ystep="0.000614" >
+    xpixels="256" xstart="-0.077955" xstep="0.000611"
+    ypixels="256" ystart="-0.078249" ystep="0.000614" >
   <properties/>
 </type> 
 <component type="panel33" idstart="2162688" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="108.517845" p="-0.694973" name="bank33" rot="-72.853945" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="44.561009">
-    <rot val="1.807639" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.395000" t="108.473489" p="-0.757347" name="bank33" rot="-72.475171" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="44.586341">
+    <rot val="1.692678" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel33" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077611" xstep="0.000609"
-    ypixels="256" ystart="-0.077768" ystep="0.000610" >
+    xpixels="256" xstart="-0.077662" xstep="0.000609"
+    ypixels="256" ystart="-0.077804" ystep="0.000610" >
   <properties/>
 </type> 
 <component type="panel37" idstart="2424832" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="108.483277" p="178.708146" name="bank37" rot="72.944910" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="44.664724">
-    <rot val="-1.352799" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.395000" t="108.449939" p="178.800472" name="bank37" rot="72.758615" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="44.671684">
+    <rot val="-1.313473" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel37" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077675" xstep="0.000609"
-    ypixels="256" ystart="-0.077676" ystep="0.000609" >
+    xpixels="256" xstart="-0.077570" xstep="0.000608"
+    ypixels="256" ystart="-0.077658" ystep="0.000609" >
   <properties/>
 </type> 
 <component type="panel39" idstart="2555904" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.395000" t="36.347181" p="178.795535" name="bank39" rot="144.013511" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="45.900406">
-    <rot val="-0.179090" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.395000" t="36.377518" p="178.884469" name="bank39" rot="143.645356" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="45.846105">
+    <rot val="-0.124236" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel39" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078155" xstep="0.000613"
-    ypixels="256" ystart="-0.077941" ystep="0.000611" >
+    xpixels="256" xstart="-0.078147" xstep="0.000613"
+    ypixels="256" ystart="-0.077946" ystep="0.000611" >
   <properties/>
 </type> 
 <component type="panel40" idstart="2621440" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="24.167108" p="42.090723" name="bank40" rot="-146.512298" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="48.186932">
-    <rot val="-21.151976" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="24.106776" p="42.071242" name="bank40" rot="-146.790634" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="48.046881">
+    <rot val="-21.275223" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel40" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078474" xstep="0.000615"
-    ypixels="256" ystart="-0.078112" ystep="0.000613" >
+    xpixels="256" xstart="-0.078421" xstep="0.000615"
+    ypixels="256" ystart="-0.078067" ystep="0.000612" >
   <properties/>
 </type> 
 <component type="panel41" idstart="2686976" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="56.015119" p="18.696185" name="bank41" rot="-111.777860" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.370845">
-    <rot val="-21.178723" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="55.965353" p="18.662590" name="bank41" rot="-111.965993" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="47.283734">
+    <rot val="-21.473589" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel41" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078359" xstep="0.000615"
-    ypixels="256" ystart="-0.078239" ystep="0.000614" >
+    xpixels="256" xstart="-0.078418" xstep="0.000615"
+    ypixels="256" ystart="-0.078249" ystep="0.000614" >
   <properties/>
 </type> 
 <component type="panel42" idstart="2752512" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="90.494233" p="15.248982" name="bank42" rot="-77.471974" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="46.291186">
-    <rot val="-19.632418" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="90.446642" p="15.205705" name="bank42" rot="-77.365624" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="46.309839">
+    <rot val="-19.787640" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel42" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077997" xstep="0.000612"
-    ypixels="256" ystart="-0.077968" ystep="0.000612" >
+    xpixels="256" xstart="-0.078081" xstep="0.000612"
+    ypixels="256" ystart="-0.077967" ystep="0.000612" >
   <properties/>
 </type> 
 <component type="panel47" idstart="3080192" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="90.436531" p="162.773490" name="bank47" rot="106.663577" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.548415">
-    <rot val="-23.827024" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="90.429116" p="162.871738" name="bank47" rot="106.524237" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="47.515657">
+    <rot val="-23.678193" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel47" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077904" xstep="0.000611"
-    ypixels="256" ystart="-0.077925" ystep="0.000611" >
+    xpixels="256" xstart="-0.077779" xstep="0.000610"
+    ypixels="256" ystart="-0.077835" ystep="0.000610" >
   <properties/>
 </type> 
 <component type="panel48" idstart="3145728" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="56.012843" p="159.310099" name="bank48" rot="142.883154" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="48.501713">
-    <rot val="-23.151380" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="56.026825" p="159.404874" name="bank48" rot="142.178239" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="48.204588">
+    <rot val="-22.850473" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel48" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078268" xstep="0.000614"
-    ypixels="256" ystart="-0.078245" ystep="0.000614" >
+    xpixels="256" xstart="-0.078213" xstep="0.000613"
+    ypixels="256" ystart="-0.078172" ystep="0.000613" >
   <properties/>
 </type> 
 <component type="panel49" idstart="3211264" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.425000" t="24.179289" p="135.910045" name="bank49" rot="176.882353" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="47.844960">
-    <rot val="-23.007518" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.425000" t="24.166778" p="136.064654" name="bank49" rot="175.961275" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="47.476752">
+    <rot val="-22.971310" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel49" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078719" xstep="0.000617"
-    ypixels="256" ystart="-0.079188" ystep="0.000621" >
+    xpixels="256" xstart="-0.078784" xstep="0.000618"
+    ypixels="256" ystart="-0.079112" ystep="0.000620" >
   <properties/>
 </type> 
 <component type="panel50" idstart="3276800" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="32.326887" p="89.025283" name="bank50" rot="-153.310795" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.065836">
-    <rot val="-41.447034" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="32.280231" p="89.160326" name="bank50" rot="-153.289807" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.042181">
+    <rot val="-41.461672" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel50" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077879" xstep="0.000611"
-    ypixels="256" ystart="-0.078467" ystep="0.000615" >
+    xpixels="256" xstart="-0.077948" xstep="0.000611"
+    ypixels="256" ystart="-0.078405" ystep="0.000615" >
   <properties/>
 </type> 
 <component type="panel51" idstart="3342336" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="47.056837" p="45.870593" name="bank51" rot="-116.137113" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.735945">
-    <rot val="-40.662334" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="46.988507" p="45.880209" name="bank51" rot="-116.151786" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.673939">
+    <rot val="-40.817428" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel51" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077707" xstep="0.000609"
-    ypixels="256" ystart="-0.078346" ystep="0.000614" >
+    xpixels="256" xstart="-0.077699" xstep="0.000609"
+    ypixels="256" ystart="-0.078357" ystep="0.000615" >
   <properties/>
 </type> 
 <component type="panel52" idstart="3407872" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="75.233056" p="32.502814" name="bank52" rot="-80.479961" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="52.957595">
-    <rot val="-40.140486" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="75.177052" p="32.490474" name="bank52" rot="-80.365326" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.002018">
+    <rot val="-40.464882" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel52" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078188" xstep="0.000613"
-    ypixels="256" ystart="-0.078237" ystep="0.000614" >
+    xpixels="256" xstart="-0.078308" xstep="0.000614"
+    ypixels="256" ystart="-0.078307" ystep="0.000614" >
   <properties/>
 </type> 
 <component type="panel53" idstart="3473408" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="105.577446" p="32.574152" name="bank53" rot="-44.067409" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="52.784604">
-    <rot val="-42.329787" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="105.546335" p="32.543501" name="bank53" rot="-43.475977" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.236925">
+    <rot val="-42.875181" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel53" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077554" xstep="0.000608"
-    ypixels="256" ystart="-0.077604" ystep="0.000609" >
+    xpixels="256" xstart="-0.077710" xstep="0.000609"
+    ypixels="256" ystart="-0.077747" ystep="0.000610" >
   <properties/>
 </type> 
 <component type="panel57" idstart="3735552" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="105.522025" p="145.429054" name="bank57" rot="100.567447" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="53.299842">
-    <rot val="-42.386897" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="105.503076" p="145.552811" name="bank57" rot="100.343121" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="53.209371">
+    <rot val="-41.781867" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel57" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.077591" xstep="0.000609"
-    ypixels="256" ystart="-0.077632" ystep="0.000609" >
+    xpixels="256" xstart="-0.077526" xstep="0.000608"
+    ypixels="256" ystart="-0.077525" ystep="0.000608" >
   <properties/>
 </type> 
 <component type="panel58" idstart="3801088" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="75.263006" p="145.502522" name="bank58" rot="137.251707" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="54.743958">
-    <rot val="-42.118265" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="75.265741" p="145.621245" name="bank58" rot="137.190245" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="54.674558">
+    <rot val="-42.039674" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel58" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078095" xstep="0.000613"
-    ypixels="256" ystart="-0.077743" ystep="0.000610" >
+    xpixels="256" xstart="-0.078004" xstep="0.000612"
+    ypixels="256" ystart="-0.077815" ystep="0.000610" >
   <properties/>
 </type> 
 <component type="panel59" idstart="3866624" idfillbyfirst="y" idstepbyrow="256">
-<location r="0.455000" t="47.061137" p="132.092922" name="bank59" rot="171.844321" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="54.298975">
-    <rot val="-41.557853" axis-x="0" axis-y="1" axis-z="0" />
+<location r="0.455000" t="47.057353" p="132.226096" name="bank59" rot="171.535377" axis-x="0" axis-y="1" axis-z="0">
+  <rot val="54.031579">
+    <rot val="-41.510666" axis-x="0" axis-y="1" axis-z="0" />
   </rot>
 </location>
 </component> 
 
 <!-- Rectangular Detector Panel optimized size for each bank -->
 <type name="panel59" is="rectangular_detector" type="pixel"
-    xpixels="256" xstart="-0.078334" xstep="0.000614"
-    ypixels="256" ystart="-0.078350" ystep="0.000615" >
+    xpixels="256" xstart="-0.078340" xstep="0.000614"
+    ypixels="256" ystart="-0.078330" ystep="0.000614" >
   <properties/>
 </type> 
 <!-- List of all the bank names:

--- a/Code/Mantid/instrument/MANDI_Parameters_2015_08_01.xml
+++ b/Code/Mantid/instrument/MANDI_Parameters_2015_08_01.xml
@@ -4,7 +4,7 @@
 <component-link name = "MANDI">
 <!-- Specify that any banks not in NeXus file are to be removed -->
 <parameter name="T0">
- <value val="-1.886000"/>
+ <value val="-0.904000"/>
 </parameter>
 </component-link>
 


### PR DESCRIPTION
Fixed #13765 

To test load MANDI_4363, look at Show Instrument in 3D view (banks 2 and 8). Check that peaks index from all banks.

``` python
Load(Filename='/SNS/MANDI/IPTS-8776/0/4362/NeXus/MANDI_4362_event.nxs', OutputWorkspace='MANDI_4362_event', LoadMonitors=True)
ConvertToMD(InputWorkspace='MANDI_4362_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='MANDI_4362_md', MinValues='-25,-25,-25', MaxValues='25,25,25', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='MANDI_4362_md', PeakDistanceThreshold=0.28260000000000002, MaxPeaks=50, DensityThresholdFactor=100, OutputWorkspace='MANDI_4362_peaks')
FindUBUsingFFT(PeaksWorkspace='MANDI_4362_peaks', MinD=3, MaxD=20, Tolerance=0.12)
IndexPeaks(PeaksWorkspace='MANDI_4362_peaks', Tolerance=0.12, RoundHKLs=False)
ShowPossibleCells(PeaksWorkspace='MANDI_4362_peaks')
SelectCellWithForm(PeaksWorkspace='MANDI_4362_peaks', FormNumber=26, Apply=True)
IntegratePeaksMD(InputWorkspace='MANDI_4362_md', PeakRadius=0.16, BackgroundInnerRadius=0.16, BackgroundOuterRadius=0.17999999999999999, PeaksWorkspace='MANDI_4362_peaks', OutputWorkspace='MANDI_4362_peaks')

```
