### PR TITLE
Initialize member variable in VSIApplyBehavior

### DIFF
--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/VsiApplyBehaviour.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/VsiApplyBehaviour.cpp
@@ -8,7 +8,7 @@ namespace SimpleGui
 {
 
 
-VsiApplyBehaviour::VsiApplyBehaviour(Mantid::VATES::ColorScaleLock* lock, QObject* parent) : pqApplyBehavior(parent) {
+VsiApplyBehaviour::VsiApplyBehaviour(Mantid::VATES::ColorScaleLock* lock, QObject* parent) : pqApplyBehavior(parent), m_colorScaleLock(NULL) {
   if (lock != NULL) {
     m_colorScaleLock = lock;
   }


### PR DESCRIPTION
Fixes #13770 

This fixes an uninitialized member variable in the VSI.

Code review should be enough.
