### PR TITLE
ConvFit Plot fitted stretchedExp

### DIFF
--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -187,10 +187,10 @@ void ConvolutionFitSequential::exec() {
   const std::string tempFitWsName = "__convfit_fit_ws";
   auto tempFitWs = convertInputToElasticQ(inputWs, tempFitWsName);
 
-  Progress plotPeakStringProg(this, 0.0, 0.05, specMax);
+  Progress plotPeakStringProg(this, 0.0, 0.05, specMax-specMin);
   // Construct plotpeak string
   std::string plotPeakInput = "";
-  for (int i = 0; i < specMax + 1; i++) {
+  for (int i = specMin; i < specMax + 1; i++) {
     std::string nextWs = tempFitWsName + ",i";
     nextWs += boost::lexical_cast<std::string>(i);
     plotPeakInput += nextWs + ";";

--- a/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Code/Mantid/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -346,7 +346,7 @@ void ConvolutionFitSequential::exec() {
   auto renamer = createChildAlgorithm("RenameWorkspace");
   Progress renamerProg(this, 0.98, 1.0, specMax + 1);
   for (int i = specMin; i < specMax + 1; i++) {
-    renamer->setProperty("InputWorkspace", groupWsNames.at(i));
+    renamer->setProperty("InputWorkspace", groupWsNames.at(i - specMin));
     std::string outName = outputWsName + "_";
     outName += boost::lexical_cast<std::string>(i);
     outName += "_Workspace";

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -984,10 +984,11 @@ void ConvFit::updatePlot() {
   }
 
   // If there is a result plot then plot it
-  if (AnalysisDataService::Instance().doesExist(m_pythonExportWsName)) {
+  std::string groupName =  m_baseName.toStdString() + "_Workspaces";
+  if (AnalysisDataService::Instance().doesExist(groupName)) {
     WorkspaceGroup_sptr outputGroup =
         AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            m_pythonExportWsName);
+            groupName);
     if (specNo >= static_cast<int>(outputGroup->size()))
       return;
     MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -337,39 +337,41 @@ void ConvFit::algorithmComplete(bool error) {
   }
 
   // Handle Temperature logs
-  QString temperature = m_uiForm.leTempCorrection->text();
-  double temp = 0.0;
-  if (temperature.toStdString().compare("") != 0) {
-    temp = temperature.toDouble();
-  }
+  if (m_uiForm.ckTempCorrection->isChecked()) {
+    QString temperature = m_uiForm.leTempCorrection->text();
+    double temp = 0.0;
+    if (temperature.toStdString().compare("") != 0) {
+      temp = temperature.toDouble();
+    }
 
-  if (temp != 0.0) {
-    // Obtain WorkspaceGroup from ADS
-    std::string groupName = m_baseName.toStdString() + "_Workspaces";
-    WorkspaceGroup_sptr groupWs =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
+    if (temp != 0.0) {
+      // Obtain WorkspaceGroup from ADS
+      std::string groupName = m_baseName.toStdString() + "_Workspaces";
+      WorkspaceGroup_sptr groupWs =
+          AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
 
-    auto addSample = AlgorithmManager::Instance().create("AddSampleLog");
-    addSample->setProperty("Workspace", resultWs);
-    addSample->setProperty("LogName", "temperature_value");
-    addSample->setProperty("LogText", temperature.toStdString());
-    addSample->setProperty("LogType", "Number");
-    addSample->execute();
-    addSample->setProperty("Workspace", resultWs);
-    addSample->setProperty("LogName", "temperature_correction");
-    addSample->setProperty("LogText", "true");
-    addSample->setProperty("LogType", "String");
-    addSample->execute();
-    addSample->setProperty("Workspace", groupWs);
-    addSample->setProperty("LogName", "temperature_value");
-    addSample->setProperty("LogText", temperature.toStdString());
-    addSample->setProperty("LogType", "Number");
-    addSample->execute();
-    addSample->setProperty("Workspace", groupWs);
-    addSample->setProperty("LogName", "temperature_correction");
-    addSample->setProperty("LogText", "true");
-    addSample->setProperty("LogType", "String");
-    addSample->execute();
+      auto addSample = AlgorithmManager::Instance().create("AddSampleLog");
+      addSample->setProperty("Workspace", resultWs);
+      addSample->setProperty("LogName", "temperature_value");
+      addSample->setProperty("LogText", temperature.toStdString());
+      addSample->setProperty("LogType", "Number");
+      addSample->execute();
+      addSample->setProperty("Workspace", resultWs);
+      addSample->setProperty("LogName", "temperature_correction");
+      addSample->setProperty("LogText", "true");
+      addSample->setProperty("LogType", "String");
+      addSample->execute();
+      addSample->setProperty("Workspace", groupWs);
+      addSample->setProperty("LogName", "temperature_value");
+      addSample->setProperty("LogText", temperature.toStdString());
+      addSample->setProperty("LogType", "Number");
+      addSample->execute();
+      addSample->setProperty("Workspace", groupWs);
+      addSample->setProperty("LogName", "temperature_correction");
+      addSample->setProperty("LogText", "true");
+      addSample->setProperty("LogType", "String");
+      addSample->execute();
+    }
   }
   updatePlot();
 }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -373,6 +373,7 @@ void ConvFit::algorithmComplete(bool error) {
       addSample->execute();
     }
   }
+  m_batchAlgoRunner->executeBatchAsync();
   updatePlot();
 }
 


### PR DESCRIPTION
Fixes #13767

Changed the output name used to find the plotted workspaces.

**To avoid merge conflicts this should be merged after #13737**
- [x] #13737 merged
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Load a suitable Sample and Resolution File which should contain in it's name:
  - An instrument e.g. `irs`
  - A run number e.g. `26176`
  - An Analyser e.g. `graphite002`
  - The sample file should end with `_red.nxs`
  - The resolution file should end with `_res.nxs`
  - I suggest using the files 
    - `irs26176_graphite002_red.nxs` for the sample
    - `irs26173_graphite002_res.nxs` for the resolution
    - **Please avoid using files with additional extension in the filename e.g. `_diffspec` These files will not run in ConvFit validation for this will most likely be implemented for 3.6**
- Run a fit with the StretchedExp fit function _(You don't need to worry about setting input parameter values for anything in the property tree)_
- Ensure that once the plot concludes, the fit is shown in the mini plot in the gui.
