### PR TITLE
Fix calcuation of IntegrateMDHistoWorkspace extents

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -126,7 +126,6 @@ void setMinMaxBins(Mantid::coord_t &pMin, Mantid::coord_t &pMax,
   // Get workspace extents
   const Mantid::coord_t width = dimension->getBinWidth();
   const Mantid::coord_t max = dimension->getMaximum();
-  const Mantid::coord_t min = dimension->getMinimum();
 
   // Get offset between origin and next bin boundary towards the max value
   const Mantid::coord_t offset = fmod(max,width);

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -191,13 +191,11 @@ createShapedOutput(IMDHistoWorkspace const *const inWS,
               binning.back()) /*max*/); // Set custom min, max and nbins.
     } else if( i < pbins.size() && similarBinning(pbins[i]) ) {
       auto binning = pbins[i];
-      const double width = inDim->getBinWidth(); // Take the width from the input dimension
       Mantid::coord_t pMin = static_cast<Mantid::coord_t>(binning.front());
       Mantid::coord_t pMax = static_cast<Mantid::coord_t>(binning.back());
       size_t numberOfBins;
 
       setMinMaxBins(pMin, pMax, numberOfBins, inDim, logger);
-
       outDim->setRange(
           numberOfBins,
           static_cast<Mantid::coord_t>(pMin) /*min*/,

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -88,6 +88,83 @@ std::string checkBinning(const std::vector<double> &binning) {
   return error;
 }
 
+
+/**
+ * Provide a precision correction for Mantid coordinates
+ * @param position: a position
+ * @returns: a precision corrected position or the original position
+ */
+Mantid::coord_t getPrecisionCorrectedCoordinate(Mantid::coord_t position) {
+  // Find the closest integer value
+  const auto up = std::ceil(position);
+  const auto down = std::floor(position);
+  const auto diffUp = fabs(up - position);
+  const auto diffDown = fabs(down - position);
+  const auto nearest = diffUp < diffDown ? up : down;
+
+  // Check if the relative deviation is larger than 1e-6
+  const auto deviation = fabs(nearest - position)/nearest;
+  const auto tolerance = 1e-6;
+  Mantid::coord_t coordinate(position);
+  if (deviation < tolerance) {
+    coordinate = nearest;
+  }
+  return coordinate;
+}
+
+/**
+ * Sets the min, max and number of bins
+ * @param pMin: set minimum value passed by reference
+ * @param pMax: set maximum value passed by reference
+ * @param numberOfBins: the number of bins passed by reference
+ * @param dimension: the dimension information
+ * @param logger: a logger object
+ */
+void setMinMaxBins(Mantid::coord_t &pMin, Mantid::coord_t &pMax,
+                   size_t &numberOfBins,
+                   const IMDDimension_const_sptr &dimension,Logger& logger) {
+  // Get workspace extents
+  const Mantid::coord_t width = dimension->getBinWidth();
+  const Mantid::coord_t max = dimension->getMaximum();
+  const Mantid::coord_t min = dimension->getMinimum();
+
+  // Get offset between origin and next bin boundary towards the max value
+  const Mantid::coord_t offset = fmod(max,width);
+
+  // Create the shifted pMax and pMin
+  auto minBin = (pMin - offset) / width;
+  auto maxBin = (pMax - offset) / width;
+
+  // Make sure that we don't snap to the wrong value
+  // because of the precision of floats (which coord_t is)
+  minBin = getPrecisionCorrectedCoordinate(minBin);
+  maxBin = getPrecisionCorrectedCoordinate(maxBin);
+  auto snappedPMin = width * std::floor(minBin);
+  auto snappedPMax = width * std::ceil(maxBin);
+
+  // Shift the snappedPMax/snappedPMin values back
+  snappedPMax += offset;
+  snappedPMin += offset;
+
+   if(pMin != snappedPMin) {
+      std::stringstream buffer;
+      buffer << "Rounding min from: " << pMin << " to the nearest whole width at: " << snappedPMin;
+      logger.warning(buffer.str());
+   }
+   if(pMax != snappedPMax) {
+      std::stringstream buffer;
+      buffer << "Rounding max from: " << pMax << " to the nearest whole width at: " << snappedPMax;
+      logger.warning(buffer.str());
+   }
+
+  pMin = snappedPMin;
+  pMax = snappedPMax;
+
+  // Bins
+  numberOfBins = static_cast<size_t>((pMax-pMin)/width+0.5); // round up to a whole number of bins.
+}
+}
+
 /**
  * Create the output workspace in the right shape.
  * @param inWS : Input workspace for dimensionality
@@ -115,44 +192,16 @@ createShapedOutput(IMDHistoWorkspace const *const inWS,
     } else if( i < pbins.size() && similarBinning(pbins[i]) ) {
       auto binning = pbins[i];
       const double width = inDim->getBinWidth(); // Take the width from the input dimension
-      double pmin = binning.front();
-      double pmax = binning.back();
-      auto shifted_pmin = pmin;
-      auto shifted_pmax = pmax;
-      auto max = inDim->getMaximum();
-      auto min = inDim->getMinimum();
+      Mantid::coord_t pMin = static_cast<Mantid::coord_t>(binning.front());
+      Mantid::coord_t pMax = static_cast<Mantid::coord_t>(binning.back());
+      size_t numberOfBins;
 
-      // Correct users, input, output and rounded to the nearest whole width.
-      auto extents_offset = 0.0;
-     
-          extents_offset = fabs(fmod(max,width));
-         /* std::stringstream buffer;
-          buffer << "Shifting Dimension" << i << " extents by " << extents_offset;
-          logger.warning(buffer.str());*/
-          auto temp_ceil = (pmax-extents_offset)/width;
-          auto temp_floor = (pmin-extents_offset)/width;
-          shifted_pmax = width * (std::ceil((pmax-extents_offset)/width));
-          shifted_pmin = width * (std::floor((pmin-extents_offset)/width));
+      setMinMaxBins(pMin, pMax, numberOfBins, inDim, logger);
 
-      
-
-      pmin = shifted_pmin + extents_offset;// Rounded down
-      pmax = shifted_pmax + extents_offset; // Rounded up
-      if(pmin != binning.front()) {
-          std::stringstream buffer;
-          buffer << "Rounding min from: " << binning.front() << " to the nearest whole width at: " << pmin;
-          logger.warning(buffer.str());
-      }
-      if(pmax != binning.back()) {
-          std::stringstream buffer;
-          buffer << "Rounding max from: " << binning.back() << " to the nearest whole width at: " << pmax;
-          logger.warning(buffer.str());
-      }
-      const size_t roundedNBins = static_cast<size_t>((pmax-pmin)/width+0.5); // round up to a whole number of bins.
       outDim->setRange(
-          roundedNBins,
-          static_cast<Mantid::coord_t>(pmin) /*min*/,
-          static_cast<Mantid::coord_t>(pmax) /*max*/); // Set custom min, max and nbins.
+          numberOfBins,
+          static_cast<Mantid::coord_t>(pMin) /*min*/,
+          static_cast<Mantid::coord_t>(pMax) /*max*/); // Set custom min, max and nbins.
     }
     dimensions[i] = outDim;
   }
@@ -177,7 +226,7 @@ void performWeightedSum(MDHistoWorkspaceIterator const *const iterator,
   sumSQErrors += weight * (error * error);
   sumNEvents += weight * double(iterator->getNumEventsFraction());
 }
-}
+
 
 namespace Mantid {
 namespace MDAlgorithms {

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -128,7 +128,9 @@ void setMinMaxBins(Mantid::coord_t &pMin, Mantid::coord_t &pMax,
   const Mantid::coord_t max = dimension->getMaximum();
 
   // Get offset between origin and next bin boundary towards the max value
-  const Mantid::coord_t offset = fmod(max,width);
+  // NOTE: GCC shows a conversion warning from double to float here. This
+  // is incorrect. Silence warning with explicit cast.
+  const Mantid::coord_t offset = static_cast<Mantid::coord_t>(fmod(max,width));
 
   // Create the shifted pMax and pMin
   auto minBin = (pMin - offset) / width;

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -119,8 +119,15 @@ createShapedOutput(IMDHistoWorkspace const *const inWS,
       double max = binning.back();
 
       // Correct users, input, output and rounded to the nearest whole width.
-      min = width * std::floor(min/width); // Rounded down
-      max = width * std::ceil(max/width); // Rounded up
+      auto extents_offset = 0.0;
+      if (fmod(max,width) != 0){
+          extents_offset = fmod(max,width);
+          std::stringstream buffer;
+          buffer << "Shifting Dimension" << i << " extents by " << extents_offset;
+          logger.warning(buffer.str());
+      }
+      min = width * std::floor((min-extents_offset)/width); // Rounded down
+      max = width * std::ceil((max-extents_offset)/width); // Rounded up
 
       if(min != binning.front()) {
           std::stringstream buffer;

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -106,60 +106,8 @@ public:
     TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
     TSM_ASSERT_THROWS("Step has been specified", alg.execute(), std::runtime_error&);
   }
-  void test_binning_when_similar_with_extents_as_pbins(){
-#if 0
-      using namespace Mantid::DataObjects;
-      MDHistoWorkspace_sptr ws = MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3, 7); //3 dimensions, 10 bins
-      IntegrateMDHistoWorkspace alg;
-      alg.setChild(true);
-      alg.setRethrows(true);
-      alg.initialize();
-      alg.setProperty("InputWorkspace", ws);
-      alg.setPropertyValue("OutputWorkspace", "output_ws");
-      double max_first_dim = ws->getDimension(0)->getMaximum();
-      double min_first_dim = ws->getDimension(0)->getMinimum();
-      double max_second_dim = ws->getDimension(1)->getMaximum();
-      double min_second_dim = ws->getDimension(1)->getMinimum();
-      double max_third_dim = ws->getDimension(2)->getMaximum();
-      double min_third_dim = ws->getDimension(2)->getMinimum();
-      double step = 0.0;
-      alg.setProperty("P1Bin", boost::assign::list_of(min_first_dim)(step)(max_first_dim).convert_to_container<std::vector<double> >());
-      alg.setProperty("P2Bin", boost::assign::list_of(min_second_dim)(step)(max_second_dim).convert_to_container<std::vector<double> >());
-      alg.setProperty("P3Bin", boost::assign::list_of(min_third_dim)(step)(max_third_dim).convert_to_container<std::vector<double> >());
-      TSM_ASSERT_THROWS_NOTHING("Shouldn't Throw an error: ", alg.execute());
 
-      //checking the extents of the output workspace from the integration alg
-      IMDHistoWorkspace_sptr output = alg.getProperty("OutputWorkspace");
-      /*TS_ASSERT_EQUALS(output->getNumDims(), ws->getNumDims());
-      TS_ASSERT_EQUALS(output->getNPoints(), ws->getNPoints());
-      TS_ASSERT_EQUALS(output->getSignalAt(0), ws->getSignalAt(0));
-      TS_ASSERT_EQUALS(output->getSignalAt(1), ws->getSignalAt(1));*/
 
-      // Because we integrated with similar binning method from min to max extents, nothing should happen.
-      //extents for first dimension
-      TS_ASSERT_EQUALS(output->getDimension(0)->getMinimum(),ws->getDimension(0)->getMinimum());
-      TS_ASSERT_EQUALS(output->getDimension(0)->getMaximum(),ws->getDimension(0)->getMaximum());
-      std::cout << "COMPARE MIN EXTENTS DIMENSION 1: " << "out: " << output->getDimension(0)->getMinimum();
-      std::cout << " input: " << ws->getDimension(0)->getMinimum() << "\n";
-      std::cout << "COMPARE MAX EXTENTS DIMENSION 1: " << "out: " << output->getDimension(0)->getMaximum();
-      std::cout << " input: " << ws->getDimension(0)->getMaximum() << "\n";
-      //extents for second dimension
-      TS_ASSERT_EQUALS(output->getDimension(1)->getMinimum(),ws->getDimension(1)->getMinimum());
-      TS_ASSERT_EQUALS(output->getDimension(1)->getMaximum(),ws->getDimension(1)->getMaximum());
-      std::cout << "COMPARE MIN EXTENTS DIMENSION 2: " << "out: " << output->getDimension(1)->getMinimum();
-      std::cout << " input: " << ws->getDimension(1)->getMinimum() << "\n";
-      std::cout << "COMPARE MAX EXTENTS DIMENSION 2: " << "out: " << output->getDimension(1)->getMaximum();
-      std::cout << " input: " << ws->getDimension(1)->getMaximum() << "\n";
-      //extents for third dimension
-      TS_ASSERT_EQUALS(output->getDimension(2)->getMinimum(),ws->getDimension(2)->getMinimum());
-      TS_ASSERT_EQUALS(output->getDimension(2)->getMaximum(),ws->getDimension(2)->getMaximum());
-      std::cout << "COMPARE MIN EXTENTS DIMENSION 3: " << "out: " << output->getDimension(2)->getMinimum();
-      std::cout << " input: " << ws->getDimension(2)->getMinimum() << "\n";
-      std::cout << "COMPARE MAX EXTENTS DIMENSION 3: " << "out: " << output->getDimension(2)->getMaximum();
-      std::cout << " input: " << ws->getDimension(2)->getMaximum() << "\n";
-
-#endif
-  }
   // Users may set all binning parameter to [] i.e. direct copy, no integration.
   void test_exec_do_nothing_but_clone()
   {

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -106,7 +106,59 @@ public:
     TSM_ASSERT("Expect validation errors", alg.validateInputs().size() > 0);
     TSM_ASSERT_THROWS("Step has been specified", alg.execute(), std::runtime_error&);
   }
+  void test_binning_when_similar_with_extents_as_pbins(){
+      using namespace Mantid::DataObjects;
+      MDHistoWorkspace_sptr ws = MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3, 7); //3 dimensions, 10 bins
+      IntegrateMDHistoWorkspace alg;
+      alg.setChild(true);
+      alg.setRethrows(true);
+      alg.initialize();
+      alg.setProperty("InputWorkspace", ws);
+      alg.setPropertyValue("OutputWorkspace", "output_ws");
+      double max_first_dim = ws->getDimension(0)->getMaximum();
+      double min_first_dim = ws->getDimension(0)->getMinimum();
+      double max_second_dim = ws->getDimension(1)->getMaximum();
+      double min_second_dim = ws->getDimension(1)->getMinimum();
+      double max_third_dim = ws->getDimension(2)->getMaximum();
+      double min_third_dim = ws->getDimension(2)->getMinimum();
+      double step = 0.0;
+      alg.setProperty("P1Bin", boost::assign::list_of(min_first_dim)(step)(max_first_dim).convert_to_container<std::vector<double> >());
+      alg.setProperty("P2Bin", boost::assign::list_of(min_second_dim)(step)(max_second_dim).convert_to_container<std::vector<double> >());
+      alg.setProperty("P3Bin", boost::assign::list_of(min_third_dim)(step)(max_third_dim).convert_to_container<std::vector<double> >());
+      TSM_ASSERT_THROWS_NOTHING("Shouldn't Throw an error: ", alg.execute());
 
+      //checking the extents of the output workspace from the integration alg
+      IMDHistoWorkspace_sptr output = alg.getProperty("OutputWorkspace");
+      /*TS_ASSERT_EQUALS(output->getNumDims(), ws->getNumDims());
+      TS_ASSERT_EQUALS(output->getNPoints(), ws->getNPoints());
+      TS_ASSERT_EQUALS(output->getSignalAt(0), ws->getSignalAt(0));
+      TS_ASSERT_EQUALS(output->getSignalAt(1), ws->getSignalAt(1));*/
+
+      // Because we integrated with similar binning method from min to max extents, nothing should happen.
+      //extents for first dimension
+      TS_ASSERT_EQUALS(output->getDimension(0)->getMinimum(),ws->getDimension(0)->getMinimum());
+      TS_ASSERT_EQUALS(output->getDimension(0)->getMaximum(),ws->getDimension(0)->getMaximum());
+      std::cout << "COMPARE MIN EXTENTS DIMENSION 1: " << "out: " << output->getDimension(0)->getMinimum();
+      std::cout << " input: " << ws->getDimension(0)->getMinimum() << "\n";
+      std::cout << "COMPARE MAX EXTENTS DIMENSION 1: " << "out: " << output->getDimension(0)->getMaximum();
+      std::cout << " input: " << ws->getDimension(0)->getMaximum() << "\n";
+      //extents for second dimension
+      TS_ASSERT_EQUALS(output->getDimension(1)->getMinimum(),ws->getDimension(1)->getMinimum());
+      TS_ASSERT_EQUALS(output->getDimension(1)->getMaximum(),ws->getDimension(1)->getMaximum());
+      std::cout << "COMPARE MIN EXTENTS DIMENSION 2: " << "out: " << output->getDimension(1)->getMinimum();
+      std::cout << " input: " << ws->getDimension(1)->getMinimum() << "\n";
+      std::cout << "COMPARE MAX EXTENTS DIMENSION 2: " << "out: " << output->getDimension(1)->getMaximum();
+      std::cout << " input: " << ws->getDimension(1)->getMaximum() << "\n";
+      //extents for third dimension
+      TS_ASSERT_EQUALS(output->getDimension(2)->getMinimum(),ws->getDimension(2)->getMinimum());
+      TS_ASSERT_EQUALS(output->getDimension(2)->getMaximum(),ws->getDimension(2)->getMaximum());
+      std::cout << "COMPARE MIN EXTENTS DIMENSION 3: " << "out: " << output->getDimension(2)->getMinimum();
+      std::cout << " input: " << ws->getDimension(2)->getMinimum() << "\n";
+      std::cout << "COMPARE MAX EXTENTS DIMENSION 3: " << "out: " << output->getDimension(2)->getMaximum();
+      std::cout << " input: " << ws->getDimension(2)->getMaximum() << "\n";
+
+
+  }
   // Users may set all binning parameter to [] i.e. direct copy, no integration.
   void test_exec_do_nothing_but_clone()
   {

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -107,6 +107,7 @@ public:
     TSM_ASSERT_THROWS("Step has been specified", alg.execute(), std::runtime_error&);
   }
   void test_binning_when_similar_with_extents_as_pbins(){
+#if 0
       using namespace Mantid::DataObjects;
       MDHistoWorkspace_sptr ws = MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3, 7); //3 dimensions, 10 bins
       IntegrateMDHistoWorkspace alg;
@@ -157,7 +158,7 @@ public:
       std::cout << "COMPARE MAX EXTENTS DIMENSION 3: " << "out: " << output->getDimension(2)->getMaximum();
       std::cout << " input: " << ws->getDimension(2)->getMaximum() << "\n";
 
-
+#endif
   }
   // Users may set all binning parameter to [] i.e. direct copy, no integration.
   void test_exec_do_nothing_but_clone()
@@ -444,6 +445,103 @@ public:
   }
 
 
+  //-----------------------------------------------
+  //Snapping Tests
+  //------------------------------------------------
+  void test_that_PBin_on_boundaries_are_detected_for_asymmetric_workspace_with_no_bin_boundary_at_origin() {
+    /**
+     Input workspace: Is asymmetric about the origina and the origin does not lie on a bin boundary, but
+     the PMIN and PMAX boundaries lie on bin boundaries.
+     Bins: 6
+     XMin: -2.4359
+     XMAX: 2.1001
+
+    XMIN                          XMAX
+     |                             |
+     |    |    |     |    |    |   |
+          |            |       |
+         PMIN          0      PMAX
+    **/
+    // Arrange
+    using namespace Mantid::DataObjects;
+    const size_t numDims = 1;
+    const double signal = 3.4;
+    const double errorSquared = 1.3;
+    size_t numBins[static_cast<int>(numDims)] = {6};
+    Mantid::coord_t min[static_cast<int>(numDims)] = {-2.4359f};
+    Mantid::coord_t max[static_cast<int>(numDims)] = {2.1001f};
+    const std::string name("test");
+    auto ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(numDims, signal, errorSquared, numBins, min, max, name);
+    const double pMin = -1.6799;
+    const double pMax = 1.3441;
+
+    // Act
+    IntegrateMDHistoWorkspace alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", ws);
+    alg.setProperty("P1Bin", boost::assign::list_of(pMin)(0.0)(pMax).convert_to_container<std::vector<double> >());
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    alg.execute();
+    IMDHistoWorkspace_sptr outWS=alg.getProperty("OutputWorkspace");
+
+    // Assert
+    // At this point we need to take into account the precision of a float value
+    TSM_ASSERT_DELTA("Should have a lower bound set to exactly PMIN", outWS->getDimension(0)->getMinimum(), static_cast<Mantid::coord_t>(pMin), 1e-6);
+    TSM_ASSERT_DELTA("Should have an upper bound set to exactly PMAX", outWS->getDimension(0)->getMaximum(), static_cast<Mantid::coord_t>(pMax), 1e-6);
+  }
+
+  void test_that_PBin_NOT_on_boundary_are_detected_for_asymmetric_workspace_with_no_bin_boundary_at_origin() {
+    /**
+     Input workspace: Is asymmetric about the origina and the origin does not lie on a bin boundary and
+     the PMIN and PMAX do not lie on bin boundaries.
+     Bins: 6
+     XMin: -2.4359
+     XMAX: 2.1001
+
+    XMIN                          XMAX
+     |                             |
+     |    |    |     |    |    |   |
+           |            |        |
+          PMIN          0       PMAX
+    **/
+    // Arrange
+    using namespace Mantid::DataObjects;
+    const size_t numDims = 1;
+    const double signal = 3.4;
+    const double errorSquared = 1.3;
+    size_t numBins[static_cast<int>(numDims)] = {6};
+    Mantid::coord_t min[static_cast<int>(numDims)];
+    min[0] = -2.4359f;
+    Mantid::coord_t max[static_cast<int>(numDims)];
+    max[0] = 2.1001f;
+    const std::string name("test");
+    auto ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(numDims, signal, errorSquared, numBins, min, max, name);
+    const double secondBinBoundary = -1.6799;
+    const double pMin = secondBinBoundary + 0.16729;
+    const double pMax = 1.3441 + 0.08792;
+
+    // Act
+    IntegrateMDHistoWorkspace alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", ws);
+    alg.setProperty("P1Bin", boost::assign::list_of(pMin)(0.0)(pMax).convert_to_container<std::vector<double> >());
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    alg.execute();
+    IMDHistoWorkspace_sptr outWS=alg.getProperty("OutputWorkspace");
+
+    // Assert
+    Mantid::coord_t minimumDim = outWS->getDimension(0)->getMinimum();
+    Mantid::coord_t maximumDim = outWS->getDimension(0)->getMaximum();
+    std::cerr << std::setprecision(10) <<minimumDim << "   " << std::setprecision(10)<< static_cast<Mantid::coord_t>(secondBinBoundary) << "    " << std::setprecision(10)<< secondBinBoundary <<std::endl;
+    std::cerr << std::setprecision(10) <<maximumDim << "   " << std::setprecision(10) << static_cast<Mantid::coord_t>(max[0]) << "    " << std::setprecision(10) << max[0] <<std::endl;
+
+    TSM_ASSERT_DELTA("Should snap to the second bin boundary.", minimumDim, static_cast<Mantid::coord_t>(secondBinBoundary), 1e-6);
+    TSM_ASSERT_DELTA("Should snap to the last bin boundary", maximumDim, static_cast<Mantid::coord_t>(max[0]), 1e-6);
+  }
 };
 
 //=====================================================================================
@@ -486,6 +584,9 @@ public:
       IMDHistoWorkspace_sptr outWS=alg.getProperty("OutputWorkspace");
       TS_ASSERT(outWS);
   }
+
+
+
 
 };
 


### PR DESCRIPTION
Fixes #13731
# For Testing

Please code review.

**Check MDHistoOsiris workspace**

You will needneed to the sample data set MDHistoOsirs.nxs which can be found here:
\olympic\Babylon5\Scratch\Anton\VSI\SAMPLE_WORKSPACES
1. Execute the following script

``` python

ws = Load(Filename = "YOUR_PATH_TO_MDHISTO_OSIRIS")
min = []
max = []

for index in range(0,ws.getNumDims()):
    dimension = ws.getDimension(index)
    min.append(dimension.getMinimum())
    max.append(dimension.getMaximum())

ws_out = IntegrateMDHistoWorkspace(InputWorkspace=ws, 
                                                    P1Bin =[min[0], 0.0, max[0]], 
                                                    P2Bin =[min[1], 0.0, max[1]], 
                                                    P3Bin =[min[2], 0.0, max[2]], 
                                                    P4Bin =[min[3], 0.0, max[3]])

for index in range(0, ws.getNumDims()):
    dim_in = ws.getDimension(index)
    dim_out = ws_out.getDimension(index)
    print "-------"
    print "Dimension " + str(index)
    print "Bins were: " + str(dim_in.getNBins()) + " and are now " + str(dim_out.getNBins())
    print "Min was: " + str(dim_in.getMinimum()) + " and is now " + str(dim_out.getMinimum())
    print "Max was: " + str(dim_in.getMaximum()) + " and is now " + str(dim_out.getMaximum())

```
- Confirm that the dimensions and bins are the same.
### Check other workspace scenarios

Test the following using the script below:
1. **Large Extents, asymmetric, no bin boundary on origin and leaving the extents as they are**
2. **Large Extents, asymmetric, no bin boundary on origin and extents next to boundary (we expect to snap to original extents)**

```
ELEMENTS = 77
S  =range(0,ELEMENTS);
ERR=range(0,ELEMENTS);

print "################"
print "Large Extents, asymmetric, no bin boundary on origin and leaving the extents as they are"
print "################"
ws1=CreateMDHistoWorkspace(Dimensionality=1,Extents='-240.23967,780.27372',SignalInput=S,ErrorInput=ERR,\
                           NumberOfBins=str(ELEMENTS),Names='Dim1',Units='MomentumTransfer')
integrated1 = IntegrateMDHistoWorkspace(InputWorkspace=ws1, P1Bin=[ws1.getDimension(0).getMinimum(),0,ws1.getDimension(0).getMaximum()])
print "Expected bins are " + str(ws1.getDimension(0).getNBins()) + " and are: " + str(integrated1.getDimension(0).getNBins()) 
print "Expected minimum is " + str(ws1.getDimension(0).getMinimum()) + " and is: " + str(integrated1.getDimension(0).getMinimum()) 
print "Expected maximum is " + str(ws1.getDimension(0).getMaximum()) + " and are: " + str(integrated1.getDimension(0).getMaximum()) 


print "################"
print "Large Extents, asymmetric, no bin boundary on origin and extents next to boundary (we expect to snap to original extents)"
print "################"
ws2=CreateMDHistoWorkspace(Dimensionality=1,Extents='-240.23967,780.27372',SignalInput=S,ErrorInput=ERR,\
                           NumberOfBins=str(ELEMENTS),Names='Dim1',Units='MomentumTransfer')
integrated2 = IntegrateMDHistoWorkspace(InputWorkspace=ws2, P1Bin=[ws1.getDimension(0).getMinimum()+0.5,0,ws1.getDimension(0).getMaximum()-0.5])
print "Expected bins are " + str(ws2.getDimension(0).getNBins()) + " and are: " + str(integrated2.getDimension(0).getNBins()) 
print "Expected minimum is " + str(ws2.getDimension(0).getMinimum()) + " and is: " + str(integrated2.getDimension(0).getMinimum()) 
print "Expected maximum is " + str(ws2.getDimension(0).getMaximum()) + " and are: " + str(integrated2.getDimension(0).getMaximum()) 
```
