### PR TITLE
Add cropped and texture focusing in Engg GUI

### DIFF
--- a/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Code/Mantid/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -186,7 +186,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
                                (integWS.blocksize(), integWS.getNumberHistograms(),
                                 vanWS.getNumberHistograms()))
 
-        integTbl = sapi.CreateEmptyTableWorkspace()
+        integTbl = sapi.CreateEmptyTableWorkspace(OutputWorkspace='__vanIntegTbl')
         integTbl.addColumn('double', 'Spectra Integration')
         for i in range(integWS.getNumberHistograms()):
             integTbl.addRow([integWS.readY(i)[0]])

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
@@ -41,15 +41,15 @@ public:
   /// for calibration
   EnggDiffWorker(EnggDiffractionPresenter *pres, const std::string &outFilename,
                  const std::string &vanNo, const std::string &ceriaNo)
-      : m_pres(pres), m_outFilename(outFilename), m_vanNo(vanNo),
-        m_ceriaNo(ceriaNo), m_bank(-1) {}
+      : m_pres(pres), m_outFilenames(), m_outCalibFilename(outFilename),
+        m_vanNo(vanNo), m_ceriaNo(ceriaNo), m_banks() {}
 
   /// for focusing
   EnggDiffWorker(EnggDiffractionPresenter *pres, const std::string &outDir,
-                 const std::string &outFilename, const std::string &runNo,
-                 int bank)
-      : m_pres(pres), m_outFilename(outFilename), m_runNo(runNo),
-        m_outDir(outDir), m_bank(bank) {}
+                 const std::vector<std::string> &outFilenames,
+                 const std::string &runNo, const std::vector<bool> &banks)
+      : m_pres(pres), m_outFilenames(outFilenames), m_outCalibFilename(),
+        m_runNo(runNo), m_outDir(outDir), m_banks(banks) {}
 
 private slots:
 
@@ -58,7 +58,7 @@ private slots:
    * signal.
    */
   void calibrate() {
-    m_pres->doNewCalibration(m_outFilename, m_vanNo, m_ceriaNo);
+    m_pres->doNewCalibration(m_outCalibFilename, m_vanNo, m_ceriaNo);
     emit finished();
   }
 
@@ -67,7 +67,7 @@ private slots:
    * signal.
    */
   void focus() {
-    m_pres->doFocusRun(m_outDir, m_outFilename, m_runNo, m_bank);
+    m_pres->doFocusRun(m_outDir, m_outFilenames, m_runNo, m_banks);
     emit finished();
   }
 
@@ -77,13 +77,14 @@ signals:
 private:
   EnggDiffractionPresenter *m_pres;
   /// parameters for calibration
-  std::string m_outFilename, m_vanNo, m_ceriaNo;
+  const std::vector<std::string> m_outFilenames;
+  const std::string m_outCalibFilename, m_vanNo, m_ceriaNo;
   /// sample run to process
   const std::string m_runNo;
   /// Output directory
   const std::string m_outDir;
-  /// instrument bank
-  int m_bank;
+  /// instrument banks: do focus/don't
+  const std::vector<bool> m_banks;
 };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
@@ -47,9 +47,11 @@ public:
   /// for focusing
   EnggDiffWorker(EnggDiffractionPresenter *pres, const std::string &outDir,
                  const std::vector<std::string> &outFilenames,
-                 const std::string &runNo, const std::vector<bool> &banks)
+                 const std::string &runNo, const std::vector<bool> &banks,
+                 const std::string &specIDs, const std::string &dgFile)
       : m_pres(pres), m_outFilenames(outFilenames), m_outCalibFilename(),
-        m_runNo(runNo), m_outDir(outDir), m_banks(banks) {}
+        m_runNo(runNo), m_outDir(outDir), m_banks(banks), m_specIDs(specIDs),
+        m_dgFile(dgFile) {}
 
 private slots:
 
@@ -67,7 +69,8 @@ private slots:
    * signal.
    */
   void focus() {
-    m_pres->doFocusRun(m_outDir, m_outFilenames, m_runNo, m_banks);
+    m_pres->doFocusRun(m_outDir, m_outFilenames, m_runNo, m_banks, m_specIDs,
+                       m_dgFile);
     emit finished();
   }
 
@@ -76,6 +79,7 @@ signals:
 
 private:
   EnggDiffractionPresenter *m_pres;
+
   /// parameters for calibration
   const std::vector<std::string> m_outFilenames;
   const std::string m_outCalibFilename, m_vanNo, m_ceriaNo;
@@ -85,6 +89,10 @@ private:
   const std::string m_outDir;
   /// instrument banks: do focus/don't
   const std::vector<bool> m_banks;
+  // parameters for specific types of focusing: "cropped"
+  const std::string m_specIDs;
+  // for focusing "texture"
+  const std::string m_dgFile;
 };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -64,8 +64,9 @@ public:
                         const std::string &vanNo, const std::string &ceriaNo);
 
   /// the focusing hard work that a worker / thread will run
-  void doFocusRun(const std::string &dir, const std::string &outFilename,
-                  const std::string &runNo, int bank);
+  void doFocusRun(const std::string &dir,
+                  const std::vector<std::string> &outFilenames,
+                  const std::string &runNo, const std::vector<bool> &banks);
 
 protected:
   void initialize();
@@ -76,7 +77,10 @@ protected:
   void processStart();
   void processLoadExistingCalib();
   void processCalcCalib();
-  void processFocusRun();
+  void processFocusBasic();
+  void processFocusCropped();
+  void processFocusTexture();
+  void processResetFocus();
   void processLogMsg();
   void processInstChange();
   void processShutDown();
@@ -112,17 +116,29 @@ private:
   /// @name Focusing related private methods
   //@{
   /// this may also need to be mocked up in tests
-  virtual void startAsyncFocusWorker(const std::string &dir,
-                                     const std::string &outFilename,
-                                     const std::string &runNo, int bank);
+  void startFocusing(const std::string &runNo, const std::vector<bool> banks,
+                const std::string &specIDs, const std::string &dgFile);
 
-  void inputChecksBeforeFocus(const std::string &runNo, int bank);
+  void startAsyncFocusWorker(const std::string &dir,
+                        const std::vector<std::string> &outFilenames,
+                        const std::string &runNo, const std::vector<bool> &banks);
 
-  std::string outputFocusFilename(const std::string &runNo, int bank);
+  void inputChecksBeforeFocusBasic(const std::string &runNo,
+                                   const std::vector<bool> &banks);
+  void inputChecksBeforeFocusCropped(const std::string &runNo,
+                                     const std::vector<bool> &banks,
+                                     const std::string &specIDs);
+  void inputChecksBeforeFocusTexture(const std::string &runNo,
+                                     const std::string &dgfile);
+  void inputChecksBeforeFocus();
+  void inputChecksBanks(const std::vector<bool> &banks);
+
+  std::vector<std::string> outputFocusFilename(const std::string &runNo,
+                                               const std::vector<bool> &banks);
 
   void doFocusing(const EnggDiffCalibSettings &cs,
                   const std::string &fullFilename, const std::string &runNo,
-                  int bank);
+                  size_t bank);
 
   void loadOrCalcVanadiumWorkspaces(
       const std::string &vanNo, const std::string &inputDirCalib,
@@ -167,4 +183,4 @@ private:
 } // namespace CustomInterfaces
 } // namespace MantidQt
 
-# endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESENTER_H_
+#endif // MANTIDQTCUSTOMINTERFACES_ENGGDIFFRACTION_ENGGDIFFRACTIONPRESENTER_H_

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -66,7 +66,8 @@ public:
   /// the focusing hard work that a worker / thread will run
   void doFocusRun(const std::string &dir,
                   const std::vector<std::string> &outFilenames,
-                  const std::string &runNo, const std::vector<bool> &banks);
+                  const std::string &runNo, const std::vector<bool> &banks,
+                  const std::string &specIDs, const std::string &dgFile);
 
 protected:
   void initialize();
@@ -116,12 +117,16 @@ private:
   /// @name Focusing related private methods
   //@{
   /// this may also need to be mocked up in tests
-  void startFocusing(const std::string &runNo, const std::vector<bool> banks,
-                const std::string &specIDs, const std::string &dgFile);
+  void startFocusing(const std::string &runNo, const std::vector<bool> &banks,
+                     const std::string &specIDs = "",
+                     const std::string &dgFile = "");
 
   void startAsyncFocusWorker(const std::string &dir,
-                        const std::vector<std::string> &outFilenames,
-                        const std::string &runNo, const std::vector<bool> &banks);
+                             const std::vector<std::string> &outFilenames,
+                             const std::string &runNo,
+                             const std::vector<bool> &banks,
+                             const std::string &specIDs,
+                             const std::string &dgFile);
 
   void inputChecksBeforeFocusBasic(const std::string &runNo,
                                    const std::vector<bool> &banks);
@@ -133,12 +138,23 @@ private:
   void inputChecksBeforeFocus();
   void inputChecksBanks(const std::vector<bool> &banks);
 
-  std::vector<std::string> outputFocusFilename(const std::string &runNo,
-                                               const std::vector<bool> &banks);
+  std::vector<std::string> outputFocusFilenames(const std::string &runNo,
+                                                const std::vector<bool> &banks);
+
+  std::string outputFocusCroppedFilename(const std::string &runNo);
+
+  std::vector<std::string>
+  outputFocusTextureFilenames(const std::string &runNo,
+                              const std::vector<size_t> &bankIDs);
+
+  void loadDetectorGroupingCSV(const std::string &dgFile,
+                               std::vector<size_t> &bankIDs,
+                               std::vector<std::string> &specs);
 
   void doFocusing(const EnggDiffCalibSettings &cs,
                   const std::string &fullFilename, const std::string &runNo,
-                  size_t bank);
+                  size_t bank, const std::string &specIDs,
+                  const std::string &dgFile);
 
   void loadOrCalcVanadiumWorkspaces(
       const std::string &vanNo, const std::string &inputDirCalib,
@@ -165,6 +181,9 @@ private:
 
   /// whether to allow users to give the output calibration filename
   const static bool g_askUserCalibFilename;
+
+  // name of the workspace with the vanadium integration (of spectra)
+  static const std::string g_vanIntegrationWSName;
 
   QThread *m_workerThread;
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -67,7 +67,7 @@ public:
   void doFocusRun(const std::string &dir,
                   const std::vector<std::string> &outFilenames,
                   const std::string &runNo, const std::vector<bool> &banks,
-                  const std::string &specIDs, const std::string &dgFile);
+                  const std::string &specNos, const std::string &dgFile);
 
 protected:
   void initialize();
@@ -118,21 +118,21 @@ private:
   //@{
   /// this may also need to be mocked up in tests
   void startFocusing(const std::string &runNo, const std::vector<bool> &banks,
-                     const std::string &specIDs = "",
+                     const std::string &specNos = "",
                      const std::string &dgFile = "");
 
   void startAsyncFocusWorker(const std::string &dir,
                              const std::vector<std::string> &outFilenames,
                              const std::string &runNo,
                              const std::vector<bool> &banks,
-                             const std::string &specIDs,
+                             const std::string &specNos,
                              const std::string &dgFile);
 
   void inputChecksBeforeFocusBasic(const std::string &runNo,
                                    const std::vector<bool> &banks);
   void inputChecksBeforeFocusCropped(const std::string &runNo,
                                      const std::vector<bool> &banks,
-                                     const std::string &specIDs);
+                                     const std::string &specNos);
   void inputChecksBeforeFocusTexture(const std::string &runNo,
                                      const std::string &dgfile);
   void inputChecksBeforeFocus();
@@ -153,7 +153,7 @@ private:
 
   void doFocusing(const EnggDiffCalibSettings &cs,
                   const std::string &fullFilename, const std::string &runNo,
-                  size_t bank, const std::string &specIDs,
+                  size_t bank, const std::string &specNos,
                   const std::string &dgFile);
 
   void loadOrCalcVanadiumWorkspaces(

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QGroupBox" name="groupBox_focus_2">
      <property name="title">
       <string>Output</string>
@@ -394,6 +394,30 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="5" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_13">
+     <item>
+      <spacer name="horizontalSpacer_11">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>188</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton_reset">
+       <property name="text">
+        <string>Reset</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -14,6 +14,52 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="groupBox_focus_2">
+     <property name="title">
+      <string>Output</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QCheckBox" name="checkBox_FocusedWS">
+          <property name="text">
+           <string>Plot Focused Workspace</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>388</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox_focus">
      <property name="title">
@@ -45,40 +91,71 @@
        </layout>
       </item>
       <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Bank:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>128</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QComboBox" name="comboBox_bank_num">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <property name="text">
-            <string>1</string>
-           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="label_banks_sel">
+              <property name="text">
+               <string>Banks:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>298</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
           <item>
-           <property name="text">
-            <string>2</string>
-           </property>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>18</height>
+             </size>
+            </property>
+           </spacer>
           </item>
-         </widget>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="QCheckBox" name="checkBox_focus_bank1">
+            <property name="text">
+             <string>1</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="checkBox_focus_bank2">
+            <property name="text">
+             <string>2</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </item>
@@ -120,35 +197,22 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>388</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox_focus_2">
+    <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Output</string>
+      <string>Focus Texture</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
+     <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
-         <widget class="QCheckBox" name="checkBox_FocusedWS">
+         <widget class="QLabel" name="label_texture_run_num">
           <property name="text">
-           <string>Plot Focused Workspace</string>
+           <string>Run #:</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="horizontalSpacer_4">
+         <spacer name="horizontalSpacer_6">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -159,6 +223,124 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_texture_run_num">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Detector Grouping File:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_texture_grouping_file">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_texture_browse_grouping_file">
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Focus Cropped</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label_cropped_run_num">
+          <property name="text">
+           <string>Run #:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_cropped_spec_ids">
+          <property name="text">
+           <string>Spectrum IDs:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QGroupBox" name="groupBox_focus_2">
      <property name="title">
       <string>Output</string>
@@ -47,7 +47,84 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Focus Cropped</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label_cropped_run_num">
+          <property name="text">
+           <string>Run #:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_cropped_spec_ids">
+          <property name="text">
+           <string>Spectrum IDs:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -196,7 +273,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Focus Texture</string>
@@ -254,7 +331,7 @@
            </sizepolicy>
           </property>
           <property name="readOnly">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -262,83 +339,6 @@
          <widget class="QPushButton" name="pushButton_texture_browse_grouping_file">
           <property name="text">
            <string>Browse</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Focus Cropped</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_cropped_run_num">
-          <property name="text">
-           <string>Run #:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="readOnly">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_cropped_spec_ids">
-          <property name="text">
-           <string>Spectrum IDs:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
           </property>
          </widget>
         </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -121,6 +121,30 @@
         </item>
        </layout>
       </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <spacer name="horizontalSpacer_10">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_focus_cropped">
+          <property name="text">
+           <string>Focus</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -339,6 +363,30 @@
          <widget class="QPushButton" name="pushButton_texture_browse_grouping_file">
           <property name="text">
            <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <spacer name="horizontalSpacer_9">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_focus_texture">
+          <property name="text">
+           <string>Focus</string>
           </property>
          </widget>
         </item>

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -119,7 +119,7 @@ public:
 
   virtual void resetFocus();
 
-  virtual void plotFocusedSpectrum();
+  virtual void plotFocusedSpectrum(size_t bank, const std::string &suffix="bank");
 
 private slots:
   /// for buttons, do calibrate, focus and similar

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -105,18 +105,31 @@ public:
 
   virtual std::string focusingRunNo() const;
 
-  virtual int focusingBank() const;
+  virtual std::string focusingCroppedRunNo() const;
+
+  virtual std::string focusingTextureRunNo() const;
+
+  virtual std::vector<bool> focusingBanks() const;
+
+  virtual std::string focusingCroppedSpectrumIDs() const;
+
+  virtual std::string focusingTextureGroupingFile() const;
 
   virtual bool focusedOutWorkspace() const;
+
+  virtual void resetFocus();
 
   virtual void plotFocusedSpectrum();
 
 private slots:
-  /// for buttons, do calibrate and similar
+  /// for buttons, do calibrate, focus and similar
   void loadCalibrationClicked();
   void calibrateClicked();
   void focusClicked();
+  void focusCroppedClicked();
+  void focusTextureClicked();
 
+  void focusResetClicked();
 
   // slots of the settings tab/section of the interface
   void browseInputDirCalib();

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -119,7 +119,7 @@ public:
 
   virtual void resetFocus();
 
-  virtual void plotFocusedSpectrum(size_t bank, const std::string &suffix="bank");
+  virtual void plotFocusedSpectrum(const std::string &wsName);
 
 private slots:
   /// for buttons, do calibrate, focus and similar
@@ -129,14 +129,17 @@ private slots:
   void focusCroppedClicked();
   void focusTextureClicked();
 
-  void focusResetClicked();
-
   // slots of the settings tab/section of the interface
   void browseInputDirCalib();
   void browseInputDirRaw();
   void browsePixelCalibFilename();
   void browseTemplateGSAS_PRM();
   void browseDirFocusing();
+
+  // slots for the focusing options
+  void browseTextureDetGroupingFile();
+  void focusResetClicked();
+
   // slots of the calibration tab/section of the interface
 
   // slots of the general part of the interface
@@ -197,6 +200,9 @@ private:
   static const std::string g_iparmExtStr;
   /// supported file extensions string for the pixel (full) claibration
   static const std::string g_pixelCalibExt;
+  /// supported/suggested file extensions for the detector groups file
+  /// (focusing)
+  static const std::string g_DetGrpExtStr;
 
   /// presenter as in the model-view-presenter
   boost::scoped_ptr<IEnggDiffractionPresenter> m_presenter;

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -41,7 +41,10 @@ public:
     Start,                 ///< Start and setup interface
     LoadExistingCalib,     ///< Load a calibration already availble on disk
     CalcCalib,             ///< Calculate a (new) calibration
-    FocusRun,              ///< Focus a run file
+    FocusRun,              ///< Focus one or more run files
+    FocusCropped,          ///< Focus one or more run files, cropped variant
+    FocusTexture,          ///< Focus one or more run files, texture variant
+    ResetFocus,            ///< Re-set / clear all focus inputs and options
     LogMsg,                ///< need to send a message to the Mantid log system
     InstrumentChange,      ///< Instrument selection updated
     ShutDown               ///< closing the interface

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -206,18 +206,54 @@ public:
   virtual std::string focusingRunNo() const = 0;
 
   /**
-   * Bank to consider when focusing
+   * A (sample) run to focus, in "cropped" mode
    *
-   * @return instrument bank number
+   * @return run number, as a string
    */
-  virtual int focusingBank() const = 0;
+  virtual std::string focusingCroppedRunNo() const = 0;
+
+  /**
+   * A (sample) run to focus, in "texture" mode
+   *
+   * @return run number, as a string
+   */
+  virtual std::string focusingTextureRunNo() const = 0;
+
+  /**
+   * Banks to consider when focusing
+   *
+   * @return vector with a boolean value that tells if the
+   * corresponding instrument bank numbers should be focused
+   */
+  virtual std::vector<bool> focusingBanks() const = 0;
+
+  /**
+   * Specification of spectrum IDs for focus in "cropped" mode.
+   *
+   * @return spectrum IDs, expected as a comma separated list of
+   * integers or ranges of integers.
+   */
+  virtual std::string focusingCroppedSpectrumIDs() const = 0;
+
+  /**
+   * Detector grouping file, used when focusing in "texture" mode.
+   *
+   * @return name of the grouping file with texture bank definitions
+   */
+  virtual std::string focusingTextureGroupingFile() const = 0;
 
   /**
    * Check box to consider when focusing
    * whether to plot focused workspace
+   *
    * @return bool
    */
   virtual bool focusedOutWorkspace() const = 0;
+
+  /**
+   * Reset all focus inputs/options
+   */
+  virtual void resetFocus() = 0;
 
   /**
    * Save settings (normally when closing the interface). This

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -263,15 +263,12 @@ public:
   virtual void saveSettings() const = 0;
 
   /**
-  * Runs plotSpectrum function via python
+  * Produces a single spectrum graph for focused output. Runs
+  * plotSpectrum function via python.
   *
-  * @param bank number of the focused workspace to plot
-  * @param suffix suffix used in the name of the output plot, for example: focused_ws_bank_1,
-  * focused_ws_texture_4, focused_ws_cropped_1
-  *
-  * @returns single spectrum graph for focused output
+  * @param wsName name of the workspace to plot (must be in the ADS)
   */
-  virtual void plotFocusedSpectrum(size_t bank, const std::string &suffix="bank") = 0;
+  virtual void plotFocusedSpectrum(const std::string &wsName) = 0;
 };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -264,9 +264,14 @@ public:
 
   /**
   * Runs plotSpectrum function via python
+  *
+  * @param bank number of the focused workspace to plot
+  * @param suffix suffix used in the name of the output plot, for example: focused_ws_bank_1,
+  * focused_ws_texture_4, focused_ws_cropped_1
+  *
   * @returns single spectrum graph for focused output
   */
-  virtual void plotFocusedSpectrum() = 0;
+  virtual void plotFocusedSpectrum(size_t bank, const std::string &suffix="bank") = 0;
 };
 
 } // namespace CustomInterfaces

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -132,8 +132,8 @@ void EnggDiffractionPresenter::processLoadExistingCalib() {
 }
 
 void EnggDiffractionPresenter::processCalcCalib() {
-  std::string vanNo = m_view->newVanadiumNo();
-  std::string ceriaNo = m_view->newCeriaNo();
+  const std::string vanNo = m_view->newVanadiumNo();
+  const std::string ceriaNo = m_view->newCeriaNo();
   try {
     inputChecksBeforeCalibrate(vanNo, ceriaNo);
   } catch (std::invalid_argument &ia) {
@@ -177,7 +177,7 @@ void EnggDiffractionPresenter::processFocusCropped() {
     inputChecksBeforeFocusCropped(runNo, banks, specIDs);
   } catch (std::invalid_argument &ia) {
     m_view->userWarning(
-        "Error in the inputs required to focus a run in cropped mode",
+        "Error in the inputs required to focus a run (in cropped mode)",
         ia.what());
     return;
   }
@@ -186,20 +186,19 @@ void EnggDiffractionPresenter::processFocusCropped() {
 }
 
 void EnggDiffractionPresenter::processFocusTexture() {
-  std::string runNo = m_view->focusingTextureRunNo();
-  const std::vector<bool> banks = m_view->focusingBanks();
-  std::string dgFile = m_view->focusingTextureGroupingFile();
+  const std::string runNo = m_view->focusingTextureRunNo();
+  const std::string dgFile = m_view->focusingTextureGroupingFile();
 
   try {
     inputChecksBeforeFocusTexture(runNo, dgFile);
   } catch (std::invalid_argument &ia) {
     m_view->userWarning(
-        "Error in the inputs required to focus a run in texture mode",
+        "Error in the inputs required to focus a run (in texture mode)",
         ia.what());
     return;
   }
 
-  startFocusing(runNo, banks, "", dgFile);
+  startFocusing(runNo, std::vector<bool>(), "", dgFile);
 }
 
 /**
@@ -697,10 +696,17 @@ void EnggDiffractionPresenter::inputChecksBeforeFocusTexture(
     throw std::invalid_argument("A detector grouping file needs to be "
                                 "specified when focusing texture banks.");
   }
+  Poco::File dgf(dgFile);
+  if (!dgf.exists()) {
+    throw std::invalid_argument(
+        "The detector grouping file coult not be found: " + dgFile);
+  }
+
   inputChecksBeforeFocus();
 }
 
-void EnggDiffractionPresenter::inputChecksBanks(const std::vector<bool> &banks) {
+void
+EnggDiffractionPresenter::inputChecksBanks(const std::vector<bool> &banks) {
   if (0 == banks.size()) {
     const std::string msg =
         "Error in specification of banks found when starting the "

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -801,6 +801,8 @@ std::vector<std::string> EnggDiffractionPresenter::outputFocusTextureFilenames(
  * @param outFilenames full names for the output focused runs
  * @param runNo input run number
  * @param bank instrument bank to focus
+ * @param specNos list of spectra (as usual csv list of spectra in Mantid)
+ * @param dgFile detector grouping file name
  */
 void EnggDiffractionPresenter::startAsyncFocusWorker(
     const std::string &dir, const std::vector<std::string> &outFilenames,
@@ -1014,7 +1016,10 @@ void EnggDiffractionPresenter::focusingFinished() {
  * @param bank instrument bank number to focus
  *
  * @param specNos string specifying a list of spectra (for cropped
- * focusing)
+ * focusing), only considered if not empty
+ *
+ * @param dgFile detector grouping file name. If not empty implies
+ * texture focusing
  */
 void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
                                           const std::string &fullFilename,

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -800,7 +800,7 @@ std::vector<std::string> EnggDiffractionPresenter::outputFocusTextureFilenames(
  * @param dir directory (full path) for the focused output files
  * @param outFilenames full names for the output focused runs
  * @param runNo input run number
- * @param bank instrument bank to focus
+ * @param banks instrument bank to focus
  * @param specNos list of spectra (as usual csv list of spectra in Mantid)
  * @param dgFile detector grouping file name
  */

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -355,8 +355,9 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.pushButton_focus_texture->setEnabled(enable);
 }
 
-void EnggDiffractionViewQtGUI::plotFocusedSpectrum() {
-  std::string pyCode = "plotSpectrum('engggui_focusing_output_ws', 0)";
+void EnggDiffractionViewQtGUI::plotFocusedSpectrum(size_t bank, const std::string &suffix) {
+  std::string pyCode = "plotSpectrum('engggui_focusing_output_ws_" + suffix +"_" +
+                       boost::lexical_cast<std::string>(bank) + "', 0)";
 
   std::string status =
       runPythonCode(QString::fromStdString(pyCode), false).toStdString();
@@ -383,7 +384,8 @@ EnggDiffractionViewQtGUI::writeOutCalibFile(const std::string &outFilename,
                                             const std::vector<double> &tzero) {
   // TODO: this is horrible and should not last much here.
   // Avoid running Python code
-  // Update this as soon as we have a more stable way of generating IPARM files
+  // Update this as soon as we have a more stable way of generating IPARM
+  // files
   // Writes a file doing this:
   // write_ENGINX_GSAS_iparam_file(output_file, difc, zero, ceria_run=241391,
   // vanadium_run=236516, template_file=None):

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -40,6 +40,11 @@ const std::string EnggDiffractionViewQtGUI::g_pixelCalibExt =
     "(*.csv *.nxs *.nexus);;"
     "Other extensions/all files (*.*)";
 
+const std::string EnggDiffractionViewQtGUI::g_DetGrpExtStr =
+    "Detector Grouping File: CSV "
+    "(*.csv *.txt);;"
+    "Other extensions/all files (*.*)";
+
 const std::string EnggDiffractionViewQtGUI::m_settingsGroup =
     "CustomInterfaces/EnggDiffractionView";
 
@@ -149,6 +154,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
 
   connect(m_uiTabFocus.pushButton_focus_cropped, SIGNAL(released()), this,
           SLOT(focusCroppedClicked()));
+
+  connect(m_uiTabFocus.pushButton_texture_browse_grouping_file,
+          SIGNAL(released()), this, SLOT(browseTextureDetGroupingFile()));
 
   connect(m_uiTabFocus.pushButton_focus_texture, SIGNAL(released()), this,
           SLOT(focusTextureClicked()));
@@ -355,9 +363,8 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.pushButton_focus_texture->setEnabled(enable);
 }
 
-void EnggDiffractionViewQtGUI::plotFocusedSpectrum(size_t bank, const std::string &suffix) {
-  std::string pyCode = "plotSpectrum('engggui_focusing_output_ws_" + suffix +"_" +
-                       boost::lexical_cast<std::string>(bank) + "', 0)";
+void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {
+  std::string pyCode = "plotSpectrum('" + wsName + "', 0)";
 
   std::string status =
       runPythonCode(QString::fromStdString(pyCode), false).toStdString();
@@ -559,6 +566,25 @@ void EnggDiffractionViewQtGUI::browseDirFocusing() {
       QString::fromStdString(m_focusDir));
 }
 
+void EnggDiffractionViewQtGUI::browseTextureDetGroupingFile() {
+  QString prevPath = QString::fromStdString(m_calibSettings.m_inputDirRaw);
+  if (prevPath.isEmpty()) {
+    prevPath =
+        MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
+  }
+
+  QString path(QFileDialog::getOpenFileName(
+      this, tr("Open detector grouping file"), prevPath,
+      QString::fromStdString(g_DetGrpExtStr)));
+
+  if (path.isEmpty()) {
+    return;
+  }
+
+  MantidQt::API::AlgorithmInputHistory::Instance().setPreviousDirectory(path);
+  m_uiTabFocus.lineEdit_texture_grouping_file->setText(path);
+}
+
 std::string EnggDiffractionViewQtGUI::focusingRunNo() const {
   return m_uiTabFocus.lineEdit_run_num->text().toStdString();
 }
@@ -578,7 +604,7 @@ std::string EnggDiffractionViewQtGUI::focusingDir() const {
 std::vector<bool> EnggDiffractionViewQtGUI::focusingBanks() const {
   std::vector<bool> res;
   res.push_back(m_uiTabFocus.checkBox_focus_bank1->isChecked());
-  res.push_back(m_uiTabFocus.checkBox_focus_bank1->isChecked());
+  res.push_back(m_uiTabFocus.checkBox_focus_bank2->isChecked());
   return res;
 }
 

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -197,9 +197,43 @@ void EnggDiffractionViewQtGUI::readSettings() {
   m_uiTabCalib.lineEdit_new_ceria_num->setText(
       qs.value("user-params-new-ceria-num", "").toString());
 
+  m_uiTabCalib.lineEdit_new_vanadium_num->setText(
+      qs.value("user-params-new-vanadium-num", "").toString());
+
+  m_uiTabCalib.lineEdit_new_ceria_num->setText(
+      qs.value("user-params-new-ceria-num", "").toString());
+
+  // user params - focusing
+  m_uiTabFocus.lineEdit_run_num->setText(
+      qs.value("user-params-focus-runno", "").toString());
+
+  qs.beginReadArray("user-params-focus-bank_i");
+  qs.setArrayIndex(0);
+  m_uiTabFocus.checkBox_focus_bank1->setChecked(qs.value("value", true).toBool());
+  qs.setArrayIndex(1);
+  m_uiTabFocus.checkBox_focus_bank2->setChecked(qs.value("value", true).toBool());
+  qs.endArray();
+
+  m_uiTabFocus.lineEdit_cropped_run_num->setText(
+      qs.value("user-params-focus-cropped-runno", "").toString());
+
+  m_uiTabFocus.lineEdit_cropped_spec_ids->setText(
+      qs.value("user-params-focus-cropped-spectrum-nos", "").toString());
+
+  m_uiTabFocus.lineEdit_texture_run_num->setText(
+      qs.value("user-params-focus-texture-runno", "").toString());
+
+  m_uiTabFocus.lineEdit_texture_grouping_file->setText(
+      qs.value("user-params-focus-texture-detector-grouping-file", "")
+          .toString());
+
+  m_uiTabFocus.checkBox_FocusedWS->setChecked(
+      qs.value("user-params-focus-plot-ws", true).toBool());
+
   QString lastPath =
       MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
-  // TODO: this should become << >> operators on EnggDiffCalibSettings
+  // TODO: this should become << >> operators on
+  // EnggDiffCalibSettings
   m_calibSettings.m_inputDirCalib =
       qs.value("input-dir-calib-files", lastPath).toString().toStdString();
   m_calibSettings.m_inputDirRaw =
@@ -241,6 +275,29 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabCalib.lineEdit_new_vanadium_num->text());
   qs.setValue("user-params-new-ceria-num",
               m_uiTabCalib.lineEdit_new_ceria_num->text());
+
+  // user params - focusing
+  qs.setValue("user-params-focus-runno", m_uiTabFocus.lineEdit_run_num->text());
+
+  qs.beginWriteArray("user-params-focus-bank_i");
+  qs.setArrayIndex(0);
+  qs.setValue("value", m_uiTabFocus.checkBox_focus_bank1->isChecked());
+  qs.setArrayIndex(1);
+  qs.setValue("value", m_uiTabFocus.checkBox_focus_bank2->isChecked());
+  qs.endArray();
+
+  qs.setValue("user-params-focus-cropped-runno",
+              m_uiTabFocus.lineEdit_cropped_run_num->text());
+  qs.setValue("user-params-focus-cropped-spectrum-nos",
+              m_uiTabFocus.lineEdit_cropped_spec_ids->text());
+
+  qs.setValue("user-params-focus-texture-runno",
+              m_uiTabFocus.lineEdit_texture_run_num->text());
+  qs.setValue("user-params-focus-texture-detector-grouping-file",
+              m_uiTabFocus.lineEdit_texture_grouping_file->text());
+
+  qs.setValue("user-params-focus-plot-ws",
+              m_uiTabFocus.checkBox_FocusedWS->checkState());
 
   // TODO: this should become << >> operators on EnggDiffCalibSettings
   qs.setValue("input-dir-calib-files",

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -32,8 +32,10 @@ private:
   void startAsyncFocusWorker(const std::string &dir,
                              const std::vector<std::string> &outFilenames,
                              const std::string &runNo,
-                             const std::vector<bool> banks) {
-    doFocusRun(dir, outFilenames, runNo, banks);
+                             const std::vector<bool> banks,
+                             const std::string &specIDs,
+                             const std::string &dgFile) {
+    doFocusRun(dir, outFilenames, runNo, banks, specIDs, dgFile);
     focusingFinished();
   }
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -287,6 +287,8 @@ public:
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
     EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
@@ -316,6 +318,8 @@ public:
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // 1 warning pop-up to user, 0 errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
@@ -349,6 +353,8 @@ public:
     EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
     EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // it should not get there
     EXPECT_CALL(mockView, enableCalibrateAndFocusActions(false)).Times(0);
@@ -375,6 +381,10 @@ public:
     EnggDiffCalibSettings calibSettings;
     EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
         Return(calibSettings));
+
+    // check automatic plotting
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(1);
 
     // Should not try to use options for other types of focusing
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
@@ -405,6 +415,9 @@ public:
     EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
         Return(calibSettings));
 
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
+
     // No errors/warnings
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
@@ -431,6 +444,8 @@ public:
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
     EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // 1 warning pop-up to user, 0 errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
@@ -455,6 +470,8 @@ public:
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
@@ -483,6 +500,8 @@ public:
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
@@ -511,6 +530,9 @@ public:
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
 
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
+
     // 1 warning pop-up to user, 0 errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
@@ -535,6 +557,9 @@ public:
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
 
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
+
     // 1 warning pop-up to user, 0 errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
@@ -558,6 +583,9 @@ public:
 
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
+
+    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
+    EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
 
     // 1 warning pop-up to user, 0 errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -280,6 +280,11 @@ public:
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return(""));
     EXPECT_CALL(mockView, focusingBanks()).Times(0);
 
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
     EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
@@ -387,8 +392,7 @@ public:
     std::vector<bool> banks;
     banks.push_back(false);
     banks.push_back(false);
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(banks));
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(Return(banks));
 
     // will need basic calibration settings from the user
     EnggDiffCalibSettings calibSettings;
@@ -398,6 +402,90 @@ public:
     // No errors/warnings
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffractionPresenter::FocusRun);
+  }
+
+  void test_focusCropped_withoutRunNo() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // empty run number!
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(Return(""));
+
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+
+    // should not get that far that it tries to get these parameters
+    EXPECT_CALL(mockView, currentInstrument()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+
+    // 1 warning pop-up to user, 0 errors
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffractionPresenter::FocusCropped);
+  }
+
+  void test_focusTexture_withoutRunNo() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // empty run number!
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(Return(""));
+
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+
+    // 1 warning pop-up to user, 0 errors
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffractionPresenter::FocusTexture);
+  }
+
+  void test_resetFocus() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    EXPECT_CALL(mockView, resetFocus()).Times(1);
+
+    // No errors/warnings when resetting options
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffractionPresenter::ResetFocus);
+  }
+
+  void test_resetFocus_thenFocus() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // No errors/warnings when resetting options
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffractionPresenter::ResetFocus);
+
+    // empty run number!
+    EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+
+    // should not get that far that it tries to get these parameters
+    EXPECT_CALL(mockView, currentInstrument()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+
+    // Now one error shown as a warning-pop-up cause inputs and options are
+    // empty
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
 
     pres.notify(IEnggDiffractionPresenter::FocusRun);
   }

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -278,7 +278,8 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return(""));
-    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
+        Return(m_ex_enginx_banks));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
@@ -302,12 +303,14 @@ public:
 
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return("999999"));
     // missing bank on/off vector!
-    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    std::vector<bool> banks;
+    banks.push_back(false);
+    banks.push_back(false);
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(Return(banks));
 
-    // needs basic calibration settings from the user to start focusing
-    EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    // would needs basic calibration settings, but only if there was at least
+    // one bank selected
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
@@ -331,7 +334,8 @@ public:
 
     // wrong run number!
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return("999999"));
-    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
+        Return(m_ex_enginx_banks));
 
     // needs basic calibration settings from the user to start focusing
     EnggDiffCalibSettings calibSettings;
@@ -412,12 +416,70 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
+        Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(1).WillOnce(
+        Return("1"));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
-    EXPECT_CALL(mockView, focusingBanks()).Times(0);
     EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
-    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+
+    // should not get that far that it tries to get these parameters
+    EXPECT_CALL(mockView, currentInstrument()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+
+    // 1 warning pop-up to user, 0 errors
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffractionPresenter::FocusCropped);
+  }
+
+  void test_focusCropped_withoutBanks() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // ok run number
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(
+        Return("228061"));
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
+        Return(std::vector<bool>()));
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(1).WillOnce(
+        Return("1,5"));
+
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+
+    // should not get that far that it tries to get these parameters
+    EXPECT_CALL(mockView, currentInstrument()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+
+    // 1 warning pop-up to user, 0 errors
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffractionPresenter::FocusCropped);
+  }
+
+  void test_focusCropped_withoutSpectrumIDs() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // ok run number
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(
+        Return("228061"));
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
+        Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(1).WillOnce(
+        Return(""));
+
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
 
     // should not get that far that it tries to get these parameters
@@ -436,14 +498,64 @@ public:
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
     // empty run number!
-    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(1).WillOnce(
+        Return(""));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingBanks()).Times(0);
+
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
     EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
-    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(0);
+
+    // 1 warning pop-up to user, 0 errors
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffractionPresenter::FocusTexture);
+  }
+
+  void test_focusTexture_withoutFilename() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // goo run number
+    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(1).WillOnce(
+        Return("228061"));
+    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(1).WillOnce(
+        Return(""));
+
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingRunNo()).Times(0);
+
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
+
+    // 1 warning pop-up to user, 0 errors
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+
+    pres.notify(IEnggDiffractionPresenter::FocusTexture);
+  }
+
+  void test_focusTexture_withInexistentTextureFile() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // goo run number
+    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(1).WillOnce(
+        Return("228061"));
+    // non empty but absurd csv file of detector groups
+    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(1).WillOnce(
+        Return("i_dont_exist_dont_look_for_me.csv"));
+
+    // should not try to use these ones
+    EXPECT_CALL(mockView, focusingRunNo()).Times(0);
+
+    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(0);
 
     // 1 warning pop-up to user, 0 errors
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
@@ -477,7 +589,8 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return(""));
-    EXPECT_CALL(mockView, focusingBanks()).Times(0);
+    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
+        Return(m_ex_enginx_banks));
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -105,7 +105,7 @@ public:
   MOCK_CONST_METHOD0(saveSettings, void());
 
   // virtual void plotFocusedSpectrum();
-  MOCK_METHOD2(plotFocusedSpectrum, void(size_t, const std::string&));
+  MOCK_METHOD1(plotFocusedSpectrum, void(const std::string&));
 };
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -95,17 +95,17 @@ public:
   // virtual std::string focusingTextureGroupingFile() const;
   MOCK_CONST_METHOD0(focusingTextureGroupingFile, std::string());
 
-  // virtual bool focusedOutWorkspace() const;
-  MOCK_CONST_METHOD0(focusedOutWorkspace, bool());
-
-  // virtual void plotFocusedSpectrum();
-  MOCK_METHOD0(plotFocusedSpectrum, void());
-
   // virtual void resetFocus();
   MOCK_METHOD0(resetFocus, void());
 
+  // virtual bool focusedOutWorkspace() const;
+  MOCK_CONST_METHOD0(focusedOutWorkspace, bool());
+
   // void saveSettings() const;
   MOCK_CONST_METHOD0(saveSettings, void());
+
+  // virtual void plotFocusedSpectrum();
+  MOCK_METHOD2(plotFocusedSpectrum, void(size_t, const std::string&));
 };
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -101,6 +101,9 @@ public:
   // virtual void plotFocusedSpectrum();
   MOCK_METHOD0(plotFocusedSpectrum, void());
 
+  // virtual void resetFocus();
+  MOCK_METHOD0(resetFocus, void());
+
   // void saveSettings() const;
   MOCK_CONST_METHOD0(saveSettings, void());
 };

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -80,8 +80,20 @@ public:
   // virtual std::string focusingRunNo() const;
   MOCK_CONST_METHOD0(focusingRunNo, std::string());
 
+  // virtual std::string focusingCroppedRunNo() const;
+  MOCK_CONST_METHOD0(focusingCroppedRunNo, std::string());
+
+  // virtual std::string focusingTextureRunNo() const;
+  MOCK_CONST_METHOD0(focusingTextureRunNo, std::string());
+
   // virtual int focusingBank() const;
-  MOCK_CONST_METHOD0(focusingBank, int());
+  MOCK_CONST_METHOD0(focusingBanks, std::vector<bool>());
+
+  // virtual std::string focusingCroppedSpectrumIDs() const;
+  MOCK_CONST_METHOD0(focusingCroppedSpectrumIDs, std::string());
+
+  // virtual std::string focusingTextureGroupingFile() const;
+  MOCK_CONST_METHOD0(focusingTextureGroupingFile, std::string());
 
   // virtual bool focusedOutWorkspace() const;
   MOCK_CONST_METHOD0(focusedOutWorkspace, bool());

--- a/Code/Mantid/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/Code/Mantid/docs/source/interfaces/Engineering_Diffraction.rst
@@ -54,10 +54,10 @@ Calibration sample #
 Focus
 -----
 
-Here it is possible to focus run files, provided a run number and an
-instrument bank. The focusing process uses the algorithm
-:ref:`EnggFocus <algm-EnggFocus>`. In the documentation of the
-algorithm you can find the details on how the input runs are focused.
+Here it is possible to focus run files, provided a run number or run
+file. The focusing process uses the algorithm :ref:`EnggFocus
+<algm-EnggFocus>`. In the documentation of the algorithm you can find
+the details on how the input runs are focused.
 
 The interface will also create workspaces that can be inspected in the
 workspaces window:
@@ -65,6 +65,32 @@ workspaces window:
 1. The *engg_focusing_input_ws workspace* for the data being focused
 2. The *engg_focusing_input_ws workspace* for the corresponding
    focused data
+
+Three focusing alternatives are provided:
+
+1. Normal focusing, which includes all the spectra from the input run.
+2. Cropped focusing, where several spectra or ranges of spectra can
+   be specified, as a list separated by commas.
+3. Texture focusing, where the *texture* group of detectors is given
+   in a Detector Gropuing File.
+
+Depending on the alternative chosen, the focusing operation will
+include all the selected banks and all the spectra present in the
+input runs (first alternative: normal focusing), all the banks but
+only a list of spectra provided manually (second alternative: cropped
+focusing), or a user-defined list of banks provided in a file (third
+alternative: texture focusing)
+
+For texture focusing, the detector grouping file is a text (csv) file
+with one line per bank. Each line must contain at least two numeric
+fields, where the first one specifies the bank ID, and the second and
+subsequent ones different spectrum numbers or ranges of spectrum
+numbers. For example:
+::
+   # Bank ID, spectrum numbers
+   1, 205-210
+   2, 100, 102, 107
+   3, 300, 310, 320-329, 350-370
 
 Settings
 --------

--- a/Code/Mantid/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/Code/Mantid/docs/source/interfaces/Engineering_Diffraction.rst
@@ -8,10 +8,10 @@ Overview
 --------
 
 This custom interface integrates several tasks related to engineeering
-diffraction. The interface is under heavy development, and at the
-moment it only provides calibration related functionality. The
-following sections will describe the different sections or tabs of the
-interface.
+diffraction. It provides calibration and focusing functionality which
+can be expected to expand for next releases as it is under active
+development. The following sections describe the different tabs or
+functionality areas of the interface.
 
 .. interface:: Engineering Diffraction
   :align: center
@@ -63,8 +63,8 @@ The interface will also create workspaces that can be inspected in the
 workspaces window:
 
 1. The *engg_focusing_input_ws workspace* for the data being focused
-2. The *engg_focusing_input_ws workspace* for the corresponding
-   focused data
+2. The *engg_focusing_output_ws... workspace* for the corresponding
+   focused data (where the ... denotes a suffix explained below).
 
 Three focusing alternatives are provided:
 
@@ -75,11 +75,18 @@ Three focusing alternatives are provided:
    in a Detector Gropuing File.
 
 Depending on the alternative chosen, the focusing operation will
-include all the selected banks and all the spectra present in the
-input runs (first alternative: normal focusing), all the banks but
-only a list of spectra provided manually (second alternative: cropped
-focusing), or a user-defined list of banks provided in a file (third
-alternative: texture focusing)
+include different banks and/or combinations of spectra (detectors). In
+the firs option, normal focusing, all the selected banks and all the
+spectra present in the input runs are considered. In the second
+alternative, cropped focusing, all the banks are considered in
+principle but only a list of spectra provided manually are
+processed. In the third option, *texture focusing*, the banks are
+defined by a user-defined list of banks and corresponding spectrum IDs
+provided in a file. For these alternatives, the output focused
+workspace will take different suffixes: *_bank_1, _bank_2*, and so on
+for normal focusing, *_cropped* for cropped focusing, and
+*_texture_bank_1, _texture_bank_2*, and so on for texture focusing
+(using the bank IDs given in the detector grouping file).
 
 For texture focusing, the detector grouping file is a text (csv) file
 with one line per bank. Each line must contain at least two numeric


### PR DESCRIPTION
Fixes #13486. Adds more options and focusing modes to the focusing tab of the Engg GUI.

**To test:** test should pass (there are new test cases for the new focusing modes). For manual testing you can use the same files given in #13501 (for focusing). Example inputs:
- focus run: 228061 or 213855.
- spectrum IDs: for example 1-1200 should produce same results as normal focusing with bank1
- for texture focusing you can use this example definition of detector groups and put it in a file:

```
# BankID, spectrum numbers
1, 100-200
2, 1-1000
3, 1400-1500
4, 1600-2000
```

(if you need settings for calibration, use files as given in #13370).

Notes:
- you can also check that the user inputs are saved/restored when
  the interface is closed/started again.
- Loading the detector grouping file is done with a small method (it 
  could be added to the algorithm LoadDetectorsGroupingFile which 
  can load .xml and .map files with similar information)
- As it stands now, run numbers are entered in simple text edits to
  keep it consistent with the normal focusing and the other tab. All
  of them should be upgraded to MWRun in follow up issues.
- A few incremental improvements described in the list of optional
  improvements in the original issue have been left out. One or
  several new issues should be created for these (updated for the 
  current status of the Engg GUI).

Release notes: this could go in the diffraction section, as a new subsection, with screenshots: http://www.mantidproject.org/ReleaseNotes_3_5_Diffraction#Engineering_Diffraction
