### PR TITLE
SaveOpenGenieAscii: add fields to the output files

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
@@ -46,23 +46,29 @@ private:
   void writeFileHeader(std::ofstream &outfile);
 
   /// Uses AxisHeader and WriteAxisValues to write out file
-  void writeToFile(const std::string alpha, const std::string singleSpc,
-                   const std::string fourspc, int nBins, bool isHistogram);
+  void axisToFile(const std::string alpha, const std::string singleSpc,
+                  const std::string fourspc, int nBins, bool isHistogram);
 
   /// Generates the header for the axis which saves to file
-  std::string writeAxisHeader(const std::string alpha,
-                              const std::string singleSpc,
-                              const std::string fourspc, int nBins);
+  std::string getAxisHeader(const std::string alpha,
+                            const std::string singleSpc,
+                            const std::string fourspc, int nBins);
 
   /// Reads if alpha is e then reads the E values accordingly
-  std::string writeAxisValues(std::string alpha, int bin,
-                              const std::string singleSpc);
+  std::string getAxisValues(std::string alpha, int bin,
+                            const std::string singleSpc);
 
   /// Generates the header which saves to the openGenie file
-  void writeSampleLogs(std::ofstream &outfile, std::string fourspc);
+  void getSampleLogs(std::string fourspc);
 
-  // vector
-  std::vector<std::string> myVector;
+  /// sort and write out the sample logs
+  void writeSampleLogs(std::ofstream &outfile);
+
+  /// add ntc field which is required for OpenGenie
+  void addNtc(const std::string fourspc, int nBins);
+
+  /// Vector to safe sample log
+  std::vector<std::string> logVector;
   /// Workspace
   API::MatrixWorkspace_sptr ws;
 };

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
@@ -7,6 +7,8 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/cow_ptr.h"
 
+#include "MantidKernel/TimeSeriesProperty.h"
+
 namespace Mantid {
 namespace DatHandling {
 
@@ -41,6 +43,9 @@ private:
   /// Execution code
   void exec();
 
+  // write file header
+  void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile);
+
   /// Uses AxisHeader and WriteAxisValues to write out file
   void writeToFile(const std::string alpha, std::ofstream &outfile,
                    const std::string comment, const std::string fourspc,
@@ -54,6 +59,11 @@ private:
   /// Reads if alpha is e then reads the E values accordingly
   void writeAxisValues(std::string alpha, std::ofstream &outfile, int bin,
                        const std::string singleSpc);
+
+  /// Generates the header which saves to the openGenie file
+  void writeSampleLogs(std::ofstream &outfile, std::string fourspc);
+
+
 
   /// Workspace
   API::MatrixWorkspace_sptr ws;

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
@@ -44,7 +44,7 @@ private:
   void exec();
 
   // write file header
-  void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile);
+  void writeFileHeader(std::ofstream &outfile);
 
   /// Uses AxisHeader and WriteAxisValues to write out file
   void writeToFile(const std::string alpha, std::ofstream &outfile,

--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
@@ -6,7 +6,6 @@
 //---------------------------------------------------
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/cow_ptr.h"
-
 #include "MantidKernel/TimeSeriesProperty.h"
 
 namespace Mantid {
@@ -47,24 +46,23 @@ private:
   void writeFileHeader(std::ofstream &outfile);
 
   /// Uses AxisHeader and WriteAxisValues to write out file
-  void writeToFile(const std::string alpha, std::ofstream &outfile,
-                   const std::string comment, const std::string fourspc,
-                   int nBins, bool isHistogram);
+  void writeToFile(const std::string alpha, const std::string singleSpc,
+                   const std::string fourspc, int nBins, bool isHistogram);
 
   /// Generates the header for the axis which saves to file
-  void writeAxisHeader(const std::string alpha, std::ofstream &outfile,
-                       const std::string singleSpc, const std::string fourspc,
-                       int nBins);
+  std::string writeAxisHeader(const std::string alpha,
+                              const std::string singleSpc,
+                              const std::string fourspc, int nBins);
 
   /// Reads if alpha is e then reads the E values accordingly
-  void writeAxisValues(std::string alpha, std::ofstream &outfile, int bin,
-                       const std::string singleSpc);
+  std::string writeAxisValues(std::string alpha, int bin,
+                              const std::string singleSpc);
 
   /// Generates the header which saves to the openGenie file
   void writeSampleLogs(std::ofstream &outfile, std::string fourspc);
 
-
-
+  // vector
+  std::vector<std::string> myVector;
   /// Workspace
   API::MatrixWorkspace_sptr ws;
 };

--- a/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
@@ -1,19 +1,18 @@
 //---------------------------------------------------
 // Includes
 //---------------------------------------------------
-#include "MantidDataHandling/SaveOpenGenieAscii.h"
 #include "MantidAPI/FileProperty.h"
+#include "MantidDataHandling/SaveOpenGenieAscii.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Property.h"
+
+#include <exception>
+#include <fstream>
+#include <list>
+#include <vector>
 #include <Poco/File.h>
 #include <Poco/Path.h>
-#include <fstream>
-#include <exception>
-
-#include <vector>
-
-#include <list>
 
 namespace Mantid {
 namespace DatHandling {
@@ -89,13 +88,22 @@ void SaveOpenGenieAscii::exec() {
 
   bool isHistogram = ws->isHistogramData();
   Progress progress(this, 0, 1, nBins);
+
+  // writes out x, y, e to vector
   std::string alpha;
   for (int Num = 0; Num < 3; Num++) {
     alpha = Alpha[Num];
-    writeToFile(alpha, singleSpc, fourspc, nBins, isHistogram);
+    axisToFile(alpha, singleSpc, fourspc, nBins, isHistogram);
   }
 
-  writeSampleLogs(outfile, fourspc);
+  // get all the sample in workspace
+  getSampleLogs(fourspc);
+
+  // add ntc sample log
+  addNtc(fourspc, nBins);
+
+  // write out all samples in the vector
+  writeSampleLogs(outfile);
 
   progress.report();
   return;
@@ -123,56 +131,48 @@ void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile) {
 //------------------------------------------------------------------------------
 /** generates the header for the axis which saves to file
    *  @param alpha ::   onstant string Axis letter that is being used
-   *  @param outfile :: File it will save it out to
    *  @param singleSpc :: Constant string for single space
    *  @param fourspc :: Constant string for four spaces
    *  @param nBins ::  Number of bins
+   *  @return A string of of the header for the x y and e
    */
-std::string SaveOpenGenieAscii::writeAxisHeader(const std::string alpha,
-                                                const std::string singleSpc,
-                                                const std::string fourspc,
-                                                int nBins) {
-  std::string outstr = "";
+std::string SaveOpenGenieAscii::getAxisHeader(const std::string alpha,
+                                              const std::string singleSpc,
+                                              const std::string fourspc,
+                                              int nBins) {
+  std::string outStr = "";
   const std::string GXR = "GXRealarray";
   const std::string banknum = "1";
   const std::string twospc = " ";
 
-  // outfile << twospc << singleSpc << alpha << std::endl;
-  outstr += twospc + singleSpc + alpha + "\n";
+  outStr += twospc + singleSpc + alpha + "\n";
+  outStr += fourspc + GXR + "\n";
+  outStr += fourspc + banknum + "\n";
+  outStr += fourspc + boost::lexical_cast<std::string>(nBins) + "\n";
 
-  // outfile << fourspc << GXR << std::endl;
-  outstr += fourspc + GXR + "\n";
-
-  // outfile << fourspc << banknum << std::endl;
-  outstr += fourspc + banknum + "\n";
-
-  // outfile << fourspc << nBins << std::endl;
-  outstr += fourspc + boost::lexical_cast<std::string>(nBins) + "\n";
-
-  return outstr;
+  return outStr;
 }
 
 //-----------------------------------------------------------------------------
-/** Uses AxisHeader and WriteAxisValues to write out file
+/** Uses AxisHeader and WriteAxisValues to write in vector
    *  @param alpha ::   Axis letter that is being used
-   *  @param outfile :: File it will save it out to
    *  @param singleSpc :: Constant string for single space
    *  @param fourspc :: Constant string for four spaces
    *  @param nBins ::  number of bins
    *  @param isHistogram ::  If its a histogram
    */
-void SaveOpenGenieAscii::writeToFile(const std::string alpha,
-                                     const std::string singleSpc,
-                                     const std::string fourspc, int nBins,
-                                     bool isHistogram) {
-  std::string out_str = writeAxisHeader(alpha, singleSpc, fourspc, nBins);
+void SaveOpenGenieAscii::axisToFile(const std::string alpha,
+                                    const std::string singleSpc,
+                                    const std::string fourspc, int nBins,
+                                    bool isHistogram) {
+  std::string out_str = getAxisHeader(alpha, singleSpc, fourspc, nBins);
   for (int bin = 0; bin < nBins; bin++) {
     if (isHistogram) // bin centres
     {
       if (bin == 0) {
         out_str += fourspc;
       }
-      auto axisStr = writeAxisValues(alpha, bin, singleSpc);
+      auto axisStr = getAxisValues(alpha, bin, singleSpc);
       out_str += axisStr;
 
       if ((bin + 1) % 10 == 0 && bin != (nBins - 1)) {
@@ -181,18 +181,18 @@ void SaveOpenGenieAscii::writeToFile(const std::string alpha,
     }
   }
   out_str += "\n";
-  myVector.push_back(out_str);
+  logVector.push_back(out_str);
 }
 
 //------------------------------------------------------------------------
 /** Reads if alpha is e then reads the E values accordingly
-   *  @param alpha ::   Axis letter that is being used
-   *  @param outfile :: File it will save it out to
+   *  @param alpha :: Axis letter that is being used
    *  @param bin :: bin counter which goes through all the bin
    *  @param singleSpc :: Constant string for single space
+   *  @return A string of either e, x or y
    */
-std::string SaveOpenGenieAscii::writeAxisValues(std::string alpha, int bin,
-                                                const std::string singleSpc) {
+std::string SaveOpenGenieAscii::getAxisValues(std::string alpha, int bin,
+                                              const std::string singleSpc) {
   std::string output = "";
   if (alpha == "\"e\"") {
     output += boost::lexical_cast<std::string>(ws->readE(0)[bin]) + singleSpc;
@@ -207,16 +207,12 @@ std::string SaveOpenGenieAscii::writeAxisValues(std::string alpha, int bin,
 }
 
 //-----------------------------------------------------------------------
-/** Reads the sample logs
-   *  @param outfile :: File it will save it out to
+/** Reads the sample logs and writes to vector
    *  @param fourspc :: Constant string for four spaces
    */
-void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
-                                         std::string fourspc) {
+void SaveOpenGenieAscii::getSampleLogs(std::string fourspc) {
   const std::vector<Property *> &logData = ws->run().getLogData();
 
-  // vector
-  // std::vector<std::string> myVector;
   for (auto log = logData.begin(); log != logData.end(); ++log) {
     std::string name = (*log)->name();
     std::string type = (*log)->type();
@@ -230,21 +226,21 @@ void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
     }
 
     else if (type.std::string::find("vector") &&
-        type.std::string::find("int") != std::string::npos) {
+             type.std::string::find("int") != std::string::npos) {
 
       auto tsp = ws->run().getTimeSeriesProperty<int>(name);
       value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
     }
 
     else if (type.std::string::find("vector") &&
-        type.std::string::find("bool") != std::string::npos) {
+             type.std::string::find("bool") != std::string::npos) {
 
       auto tsp = ws->run().getTimeSeriesProperty<bool>(name);
       value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
     }
 
     else if (type.std::string::find("vector") &&
-        type.std::string::find("char") != std::string::npos) {
+             type.std::string::find("char") != std::string::npos) {
 
       auto tsp = ws->run().getTimeSeriesProperty<std::string>(name);
       value = (tsp->lastValue());
@@ -256,8 +252,10 @@ void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
       type = "Float";
     }
 
-    else if ((type.std::string::find("TimeValueUnit<bool>") != std::string::npos) ||
-        (type.std::string::find("TimeValueUnit<int>") != std::string::npos)) {
+    else if ((type.std::string::find("TimeValueUnit<bool>") !=
+              std::string::npos) ||
+             (type.std::string::find("TimeValueUnit<int>") !=
+              std::string::npos)) {
       type = "Integer";
     }
 
@@ -266,18 +264,40 @@ void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
     }
 
     if (name != "x" && name != "y" && name != "e") {
-      std::string output = ("  \"" + name + "\"" + "\n" + fourspc + type +
+      std::string outStr = ("  \"" + name + "\"" + "\n" + fourspc + type +
                             "\n" + fourspc + value + "\n");
 
-      myVector.push_back(output);
+      logVector.push_back(outStr);
     }
   }
-  sort(myVector.begin(), myVector.end());
+}
 
-  for (std::vector<std::string>::const_iterator i = myVector.begin();
-       i != myVector.end(); ++i) {
+//------------------------------------------------------------------------------
+/** Sorts the vector and writes outt he sample logs to file
+   *  @param outfile :: File it will save it out to
+   */
+void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile) {
+  sort(logVector.begin(), logVector.end());
+
+  for (std::vector<std::string>::const_iterator i = logVector.begin();
+       i != logVector.end(); ++i) {
     outfile << *i << ' ';
   }
+}
+
+//------------------------------------------------------------------------------
+/** Add ntc field (num of bins) required to run open genie
+   *  @param fourspc :: Constant string for four spaces
+   *  @param nBins ::  Number of bins
+   */
+void SaveOpenGenieAscii::addNtc(const std::string fourspc, int nBins) {
+  std::string outStr = "";
+  std::string ntc = "ntc";
+
+  outStr += ("  \"" + ntc + "\"" + "\n" + fourspc + "Integer" + "\n" + fourspc +
+             boost::lexical_cast<std::string>(nBins) + "\n");
+
+  logVector.push_back(outStr);
 }
 
 } // namespace DataHandling

--- a/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
@@ -17,256 +17,272 @@
 #include <list>
 
 namespace Mantid {
-namespace DatHandling {
-
-using namespace Kernel;
-using namespace Mantid::API;
-
-// Register the algorithm into the AlgorithmFactory
-DECLARE_ALGORITHM(SaveOpenGenieAscii)
-
-/// Empty constructor
-SaveOpenGenieAscii::SaveOpenGenieAscii() : Mantid::API::Algorithm() {}
-
-//---------------------------------------------------
-// Private member functions
-//---------------------------------------------------
-/**
- * Initialise the algorithm
- */
-
-void SaveOpenGenieAscii::init() {
-  declareProperty(
-      new API::WorkspaceProperty<>("InputWorkspace", "",
-                                   Kernel::Direction::Input),
-      "The name of the workspace containing the data you wish to save");
-
-  // Declare required parameters, filename with ext {.his} and input
-  // workspac
-  std::vector<std::string> his_exts;
-  his_exts.push_back(".his");
-  his_exts.push_back(".txt");
-  his_exts.push_back("");
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Save, his_exts),
-      "The filename to use for the saved data");
-  declareProperty("IncludeHeader", true,
-                  "Whether to include the header lines (default: true)");
-}
-
-void SaveOpenGenieAscii::exec() {
-  // Process properties
-
-  // Retrieve the input workspace
-  /// Workspace
-  ws = getProperty("InputWorkspace");
-  int nSpectra = static_cast<int>(ws->getNumberHistograms());
-  int nBins = static_cast<int>(ws->blocksize());
-
-  // Retrieve the filename from the properties
-  std::string filename = getProperty("Filename");
-
-  // Output string variables
-  const std::string singleSpc = " ";
-  const std::string fourspc = "    ";
-
-  // file
-  std::ofstream outfile(filename.c_str());
-  if (!outfile) {
-    g_log.error("Unable to create file: " + filename);
-    throw Exception::FileError("Unable to create file: ", filename);
-  }
-  if (nBins == 0 || nSpectra == 0)
-    throw std::runtime_error("Trying to save an empty workspace");
-
-  // Axis alphabets
-  const std::string Alpha[] = {"\"e\"", "\"x\"", "\"y\""};
-
-  const bool headers = getProperty("IncludeHeader");
-  // if true write file header
-  if (headers) {
-    writeFileHeader(outfile);
-  }
-
-  bool isHistogram = ws->isHistogramData();
-  Progress progress(this, 0, 1, nBins);
-  std::string alpha;
-  for (int Num = 0; Num < 3; Num++) {
-    alpha = Alpha[Num];
-    writeToFile(alpha, outfile, singleSpc, fourspc, nBins, isHistogram);
-  }
-
-  // outfile << std::endl;
-
-  writeSampleLogs(outfile, fourspc);
-
-  progress.report();
-  return;
-}
-
-// -----------------------------------------------------------------------------
-/** generates the OpenGenie file header
-   *  @param outfile :: File it will save it out to
-   */
-void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile) {
-
-  const std::vector<Property *> &logData = ws->run().getLogData();
-  auto &log = logData;
-  // get total number of sample logs
-  auto samplenumber = (&log)->size();
-  samplenumber += 3; // x, y, e
-
-  outfile << "# Open Genie ASCII File #" << std::endl
-          << "# label " << std::endl
-          << "GXWorkspace" << std::endl
-          // number of entries
-          << samplenumber << std::endl;
-}
-
-//------------------------------------------------------------------------------
-/** generates the header for the axis which saves to file
-   *  @param alpha ::   onstant string Axis letter that is being used
-   *  @param outfile :: File it will save it out to
-   *  @param singleSpc :: Constant string for single space
-   *  @param fourspc :: Constant string for four spaces
-   *  @param nBins ::  Number of bins
-   */
-void SaveOpenGenieAscii::writeAxisHeader(const std::string alpha,
-                                         std::ofstream &outfile,
-                                         const std::string singleSpc,
-                                         const std::string fourspc, int nBins) {
-  const std::string GXR = "GXRealarray";
-  const std::string banknum = "1";
-  const std::string twospc = " ";
-
-  outfile << twospc << singleSpc << alpha << std::endl;
-  outfile << fourspc << GXR << std::endl;
-  outfile << fourspc << banknum << std::endl;
-  outfile << fourspc << nBins << std::endl;
-}
-
-//-----------------------------------------------------------------------------
-/** Uses AxisHeader and WriteAxisValues to write out file
-   *  @param alpha ::   Axis letter that is being used
-   *  @param outfile :: File it will save it out to
-   *  @param singleSpc :: Constant string for single space
-   *  @param fourspc :: Constant string for four spaces
-   *  @param nBins ::  number of bins
-   *  @param isHistogram ::  If its a histogram
-   */
-void SaveOpenGenieAscii::writeToFile(const std::string alpha,
-                                     std::ofstream &outfile,
-                                     const std::string singleSpc,
-                                     const std::string fourspc, int nBins,
-                                     bool isHistogram) {
-
-  writeAxisHeader(alpha, outfile, singleSpc, fourspc, nBins);
-
-  for (int bin = 0; bin < nBins; bin++) {
-    if (isHistogram) // bin centres
-    {
-      if (bin == 0) {
-        outfile << fourspc;
-      }
-
-      writeAxisValues(alpha, outfile, bin, singleSpc);
-
-      if ((bin + 1) % 10 == 0 && bin != (nBins - 1)) {
-        outfile << std::endl << fourspc;
-      }
-    }
-  }
-  outfile << std::endl;
-}
-
-//------------------------------------------------------------------------
-/** Reads if alpha is e then reads the E values accordingly
-   *  @param alpha ::   Axis letter that is being used
-   *  @param outfile :: File it will save it out to
-   *  @param bin :: bin counter which goes through all the bin
-   *  @param singleSpc :: Constant string for single space
-   */
-void SaveOpenGenieAscii::writeAxisValues(std::string alpha,
-                                         std::ofstream &outfile, int bin,
-                                         const std::string singleSpc) {
-  if (alpha == "\"e\"") {
-    outfile << ws->readE(0)[bin] << singleSpc;
-  }
-  if (alpha == "\"x\"") {
-    outfile << (ws->readX(0)[bin]) << singleSpc;
-  }
-  if (alpha == "\"y\"") {
-    outfile << ws->readY(0)[bin] << singleSpc;
-  }
-}
-
-//-----------------------------------------------------------------------
-/** Reads the sample logs
-   *  @param outfile :: File it will save it out to
-   *  @param fourspc :: Constant string for four spaces
-   */
-void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
-                                         std::string fourspc) {
-  const std::vector<Property *> &logData = ws->run().getLogData();
-
-  // std::vector<std::string> myVector;
-  for (auto log = logData.begin(); log != logData.end(); ++log) {
-    std::string name = (*log)->name();
-    std::string type = (*log)->type();
-    std::string value = (*log)->value();
-
-    if (type.std::string::find("vector") &&
-        type.std::string::find("double") != std::string::npos) {
-
-      auto tsp = ws->run().getTimeSeriesProperty<double>(name);
-      value = std::to_string(tsp->timeAverageValue());
-    }
-
-    if (type.std::string::find("vector") &&
-        type.std::string::find("int") != std::string::npos) {
-
-      auto tsp = ws->run().getTimeSeriesProperty<int>(name);
-      value = std::to_string(tsp->timeAverageValue());
-    }
-
-    if (type.std::string::find("vector") &&
-        type.std::string::find("bool") != std::string::npos) {
-
-      auto tsp = ws->run().getTimeSeriesProperty<bool>(name);
-      value = std::to_string(tsp->timeAverageValue());
-    }
-
-    if (type.std::string::find("vector") &&
-        type.std::string::find("char") != std::string::npos) {
-
-      auto tsp = ws->run().getTimeSeriesProperty<std::string>(name);
-      value = (tsp->lastValue());
-    }
-
-    if ((type.std::string::find("number") != std::string::npos) ||
-        (type.std::string::find("double") != std::string::npos) ||
-        (type.std::string::find("dbl list") != std::string::npos)) {
-      type = "Float";
-    }
-
-    if ((type.std::string::find("TimeValueUnit<bool>") != std::string::npos) ||
-        (type.std::string::find("TimeValueUnit<int>") != std::string::npos)) {
-      type = "Integer";
-    }
-
-    if (type.std::string::find("string") != std::string::npos) {
-      type = "String";
-    }
-
-    // sort(&logData.begin(), &logData.end());
-
-	if(name != "x" && name != "y" && name != "e" ) {
-      outfile << "  \"" << name << "\"" << std::endl
-              << fourspc << type << std::endl
-              << fourspc << value << std::endl;
-    }
-  }
-}
-
-} // namespace DataHandling
+    namespace DatHandling {
+        
+        using namespace Kernel;
+        using namespace Mantid::API;
+        
+        // Register the algorithm into the AlgorithmFactory
+        DECLARE_ALGORITHM(SaveOpenGenieAscii)
+        
+        /// Empty constructor
+        SaveOpenGenieAscii::SaveOpenGenieAscii() : Mantid::API::Algorithm() {}
+        
+        //---------------------------------------------------
+        // Private member functions
+        //---------------------------------------------------
+        /**
+         * Initialise the algorithm
+         */
+        
+        void SaveOpenGenieAscii::init() {
+            declareProperty(
+                            new API::WorkspaceProperty<>("InputWorkspace", "",
+                                                         Kernel::Direction::Input),
+                            "The name of the workspace containing the data you wish to save");
+            
+            // Declare required parameters, filename with ext {.his} and input
+            // workspac
+            std::vector<std::string> his_exts;
+            his_exts.push_back(".his");
+            his_exts.push_back(".txt");
+            his_exts.push_back("");
+            declareProperty(
+                            new API::FileProperty("Filename", "", API::FileProperty::Save, his_exts),
+                            "The filename to use for the saved data");
+            declareProperty("IncludeHeader", true,
+                            "Whether to include the header lines (default: true)");
+        }
+        
+        void SaveOpenGenieAscii::exec() {
+            // Process properties
+            
+            // Retrieve the input workspace
+            /// Workspace
+            ws = getProperty("InputWorkspace");
+            int nSpectra = static_cast<int>(ws->getNumberHistograms());
+            int nBins = static_cast<int>(ws->blocksize());
+            
+            // Retrieve the filename from the properties
+            std::string filename = getProperty("Filename");
+            
+            // Output string variables
+            const std::string singleSpc = " ";
+            const std::string fourspc = "    ";
+            
+            // file
+            std::ofstream outfile(filename.c_str());
+            if (!outfile) {
+                g_log.error("Unable to create file: " + filename);
+                throw Exception::FileError("Unable to create file: ", filename);
+            }
+            if (nBins == 0 || nSpectra == 0)
+                throw std::runtime_error("Trying to save an empty workspace");
+            
+            // Axis alphabets
+            const std::string Alpha[] = {"\"e\"", "\"x\"", "\"y\""};
+            
+            const bool headers = getProperty("IncludeHeader");
+            // if true write file header
+            if (headers) {
+                writeFileHeader(outfile);
+            }
+            
+            bool isHistogram = ws->isHistogramData();
+            Progress progress(this, 0, 1, nBins);
+            std::string alpha;
+            for (int Num = 0; Num < 3; Num++) {
+                alpha = Alpha[Num];
+                writeToFile(alpha, outfile, singleSpc, fourspc, nBins, isHistogram);
+            }
+            
+            // outfile << std::endl;
+            
+            writeSampleLogs(outfile, fourspc);
+            
+            progress.report();
+            return;
+        }
+        
+        // -----------------------------------------------------------------------------
+        /** generates the OpenGenie file header
+         *  @param outfile :: File it will save it out to
+         */
+        void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile) {
+            
+            const std::vector<Property *> &logData = ws->run().getLogData();
+            auto &log = logData;
+            // get total number of sample logs
+            auto samplenumber = (&log)->size();
+            samplenumber += 3; // x, y, e
+            
+            outfile << "# Open Genie ASCII File #" << std::endl
+            << "# label " << std::endl
+            << "GXWorkspace" << std::endl
+            // number of entries
+            << samplenumber << std::endl;
+        }
+        
+        //------------------------------------------------------------------------------
+        /** generates the header for the axis which saves to file
+         *  @param alpha ::   onstant string Axis letter that is being used
+         *  @param outfile :: File it will save it out to
+         *  @param singleSpc :: Constant string for single space
+         *  @param fourspc :: Constant string for four spaces
+         *  @param nBins ::  Number of bins
+         */
+        void SaveOpenGenieAscii::writeAxisHeader(const std::string alpha,
+                                                 std::ofstream &outfile,
+                                                 const std::string singleSpc,
+                                                 const std::string fourspc, int nBins) {
+            const std::string GXR = "GXRealarray";
+            const std::string banknum = "1";
+            const std::string twospc = " ";
+            
+            outfile << twospc << singleSpc << alpha << std::endl;
+            outfile << fourspc << GXR << std::endl;
+            outfile << fourspc << banknum << std::endl;
+            outfile << fourspc << nBins << std::endl;
+        }
+        
+        //-----------------------------------------------------------------------------
+        /** Uses AxisHeader and WriteAxisValues to write out file
+         *  @param alpha ::   Axis letter that is being used
+         *  @param outfile :: File it will save it out to
+         *  @param singleSpc :: Constant string for single space
+         *  @param fourspc :: Constant string for four spaces
+         *  @param nBins ::  number of bins
+         *  @param isHistogram ::  If its a histogram
+         */
+        void SaveOpenGenieAscii::writeToFile(const std::string alpha,
+                                             std::ofstream &outfile,
+                                             const std::string singleSpc,
+                                             const std::string fourspc, int nBins,
+                                             bool isHistogram) {
+            
+            writeAxisHeader(alpha, outfile, singleSpc, fourspc, nBins);
+            
+            for (int bin = 0; bin < nBins; bin++) {
+                if (isHistogram) // bin centres
+                {
+                    if (bin == 0) {
+                        outfile << fourspc;
+                    }
+                    
+                    writeAxisValues(alpha, outfile, bin, singleSpc);
+                    
+                    if ((bin + 1) % 10 == 0 && bin != (nBins - 1)) {
+                        outfile << std::endl << fourspc;
+                    }
+                }
+            }
+            outfile << std::endl;
+        }
+        
+        //------------------------------------------------------------------------
+        /** Reads if alpha is e then reads the E values accordingly
+         *  @param alpha ::   Axis letter that is being used
+         *  @param outfile :: File it will save it out to
+         *  @param bin :: bin counter which goes through all the bin
+         *  @param singleSpc :: Constant string for single space
+         */
+        void SaveOpenGenieAscii::writeAxisValues(std::string alpha,
+                                                 std::ofstream &outfile, int bin,
+                                                 const std::string singleSpc) {
+            if (alpha == "\"e\"") {
+                outfile << ws->readE(0)[bin] << singleSpc;
+            }
+            if (alpha == "\"x\"") {
+                outfile << (ws->readX(0)[bin]) << singleSpc;
+            }
+            if (alpha == "\"y\"") {
+                outfile << ws->readY(0)[bin] << singleSpc;
+            }
+        }
+        
+        //-----------------------------------------------------------------------
+        /** Reads the sample logs
+         *  @param outfile :: File it will save it out to
+         *  @param fourspc :: Constant string for four spaces
+         */
+        void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
+                                                 std::string fourspc) {
+            const std::vector<Property *> &logData = ws->run().getLogData();
+            
+            // vector
+            std::vector<std::string> myVector;
+            for (auto log = logData.begin(); log != logData.end(); ++log) {
+                std::string name = (*log)->name();
+                std::string type = (*log)->type();
+                std::string value = (*log)->value();
+                
+                if (type.std::string::find("vector") &&
+                    type.std::string::find("double") != std::string::npos) {
+                    
+                    auto tsp = ws->run().getTimeSeriesProperty<double>(name);
+                    // value = std::to_string(tsp->timeAverageValue());
+                    value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
+                }
+                
+                if (type.std::string::find("vector") &&
+                    type.std::string::find("int") != std::string::npos) {
+                    
+                    auto tsp = ws->run().getTimeSeriesProperty<int>(name);
+                    value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
+                }
+                
+                if (type.std::string::find("vector") &&
+                    type.std::string::find("bool") != std::string::npos) {
+                    
+                    auto tsp = ws->run().getTimeSeriesProperty<bool>(name);
+                    value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
+                }
+                
+                if (type.std::string::find("vector") &&
+                    type.std::string::find("char") != std::string::npos) {
+                    
+                    auto tsp = ws->run().getTimeSeriesProperty<std::string>(name);
+                    value = (tsp->lastValue());
+                }
+                
+                if ((type.std::string::find("number") != std::string::npos) ||
+                    (type.std::string::find("double") != std::string::npos) ||
+                    (type.std::string::find("dbl list") != std::string::npos)) {
+                    type = "Float";
+                }
+                
+                if ((type.std::string::find("TimeValueUnit<bool>") != std::string::npos) ||
+                    (type.std::string::find("TimeValueUnit<int>") != std::string::npos)) {
+                    type = "Integer";
+                }
+                
+                if (type.std::string::find("string") != std::string::npos) {
+                    type = "String";
+                }
+                
+                // sort(&logData.begin(), &logData.end());
+                
+                /*
+                 if(name != "x" && name != "y" && name != "e" ) {
+                 outfile << "  \"" << name << "\"" << std::endl
+                 << fourspc << type << std::endl
+                 << fourspc << value << std::endl;
+                 } */
+                
+                if (name != "x" && name != "y" && name != "e") {
+                    std::string output = ("  \"" + name + "\"" + "\n" + fourspc + type +
+                                          "\n" + fourspc + value + "\n");
+                    
+                    myVector.push_back(output);
+                }
+            }
+            sort(myVector.begin(), myVector.end());
+            
+            for (std::vector<std::string>::const_iterator i = myVector.begin();
+                 i != myVector.end(); ++i) {
+                outfile << *i << ' ';
+            }
+        }
+        
+    } // namespace DataHandling
 } // namespace Mantid

--- a/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
@@ -6,7 +6,6 @@
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Property.h"
-#include "MantidKernel/TimeSeriesProperty.h"
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <fstream>
@@ -17,272 +16,269 @@
 #include <list>
 
 namespace Mantid {
-    namespace DatHandling {
-        
-        using namespace Kernel;
-        using namespace Mantid::API;
-        
-        // Register the algorithm into the AlgorithmFactory
-        DECLARE_ALGORITHM(SaveOpenGenieAscii)
-        
-        /// Empty constructor
-        SaveOpenGenieAscii::SaveOpenGenieAscii() : Mantid::API::Algorithm() {}
-        
-        //---------------------------------------------------
-        // Private member functions
-        //---------------------------------------------------
-        /**
-         * Initialise the algorithm
-         */
-        
-        void SaveOpenGenieAscii::init() {
-            declareProperty(
-                            new API::WorkspaceProperty<>("InputWorkspace", "",
-                                                         Kernel::Direction::Input),
-                            "The name of the workspace containing the data you wish to save");
-            
-            // Declare required parameters, filename with ext {.his} and input
-            // workspac
-            std::vector<std::string> his_exts;
-            his_exts.push_back(".his");
-            his_exts.push_back(".txt");
-            his_exts.push_back("");
-            declareProperty(
-                            new API::FileProperty("Filename", "", API::FileProperty::Save, his_exts),
-                            "The filename to use for the saved data");
-            declareProperty("IncludeHeader", true,
-                            "Whether to include the header lines (default: true)");
-        }
-        
-        void SaveOpenGenieAscii::exec() {
-            // Process properties
-            
-            // Retrieve the input workspace
-            /// Workspace
-            ws = getProperty("InputWorkspace");
-            int nSpectra = static_cast<int>(ws->getNumberHistograms());
-            int nBins = static_cast<int>(ws->blocksize());
-            
-            // Retrieve the filename from the properties
-            std::string filename = getProperty("Filename");
-            
-            // Output string variables
-            const std::string singleSpc = " ";
-            const std::string fourspc = "    ";
-            
-            // file
-            std::ofstream outfile(filename.c_str());
-            if (!outfile) {
-                g_log.error("Unable to create file: " + filename);
-                throw Exception::FileError("Unable to create file: ", filename);
-            }
-            if (nBins == 0 || nSpectra == 0)
-                throw std::runtime_error("Trying to save an empty workspace");
-            
-            // Axis alphabets
-            const std::string Alpha[] = {"\"e\"", "\"x\"", "\"y\""};
-            
-            const bool headers = getProperty("IncludeHeader");
-            // if true write file header
-            if (headers) {
-                writeFileHeader(outfile);
-            }
-            
-            bool isHistogram = ws->isHistogramData();
-            Progress progress(this, 0, 1, nBins);
-            std::string alpha;
-            for (int Num = 0; Num < 3; Num++) {
-                alpha = Alpha[Num];
-                writeToFile(alpha, outfile, singleSpc, fourspc, nBins, isHistogram);
-            }
-            
-            // outfile << std::endl;
-            
-            writeSampleLogs(outfile, fourspc);
-            
-            progress.report();
-            return;
-        }
-        
-        // -----------------------------------------------------------------------------
-        /** generates the OpenGenie file header
-         *  @param outfile :: File it will save it out to
-         */
-        void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile) {
-            
-            const std::vector<Property *> &logData = ws->run().getLogData();
-            auto &log = logData;
-            // get total number of sample logs
-            auto samplenumber = (&log)->size();
-            samplenumber += 3; // x, y, e
-            
-            outfile << "# Open Genie ASCII File #" << std::endl
-            << "# label " << std::endl
-            << "GXWorkspace" << std::endl
-            // number of entries
-            << samplenumber << std::endl;
-        }
-        
-        //------------------------------------------------------------------------------
-        /** generates the header for the axis which saves to file
-         *  @param alpha ::   onstant string Axis letter that is being used
-         *  @param outfile :: File it will save it out to
-         *  @param singleSpc :: Constant string for single space
-         *  @param fourspc :: Constant string for four spaces
-         *  @param nBins ::  Number of bins
-         */
-        void SaveOpenGenieAscii::writeAxisHeader(const std::string alpha,
-                                                 std::ofstream &outfile,
-                                                 const std::string singleSpc,
-                                                 const std::string fourspc, int nBins) {
-            const std::string GXR = "GXRealarray";
-            const std::string banknum = "1";
-            const std::string twospc = " ";
-            
-            outfile << twospc << singleSpc << alpha << std::endl;
-            outfile << fourspc << GXR << std::endl;
-            outfile << fourspc << banknum << std::endl;
-            outfile << fourspc << nBins << std::endl;
-        }
-        
-        //-----------------------------------------------------------------------------
-        /** Uses AxisHeader and WriteAxisValues to write out file
-         *  @param alpha ::   Axis letter that is being used
-         *  @param outfile :: File it will save it out to
-         *  @param singleSpc :: Constant string for single space
-         *  @param fourspc :: Constant string for four spaces
-         *  @param nBins ::  number of bins
-         *  @param isHistogram ::  If its a histogram
-         */
-        void SaveOpenGenieAscii::writeToFile(const std::string alpha,
-                                             std::ofstream &outfile,
-                                             const std::string singleSpc,
-                                             const std::string fourspc, int nBins,
-                                             bool isHistogram) {
-            
-            writeAxisHeader(alpha, outfile, singleSpc, fourspc, nBins);
-            
-            for (int bin = 0; bin < nBins; bin++) {
-                if (isHistogram) // bin centres
-                {
-                    if (bin == 0) {
-                        outfile << fourspc;
-                    }
-                    
-                    writeAxisValues(alpha, outfile, bin, singleSpc);
-                    
-                    if ((bin + 1) % 10 == 0 && bin != (nBins - 1)) {
-                        outfile << std::endl << fourspc;
-                    }
-                }
-            }
-            outfile << std::endl;
-        }
-        
-        //------------------------------------------------------------------------
-        /** Reads if alpha is e then reads the E values accordingly
-         *  @param alpha ::   Axis letter that is being used
-         *  @param outfile :: File it will save it out to
-         *  @param bin :: bin counter which goes through all the bin
-         *  @param singleSpc :: Constant string for single space
-         */
-        void SaveOpenGenieAscii::writeAxisValues(std::string alpha,
-                                                 std::ofstream &outfile, int bin,
-                                                 const std::string singleSpc) {
-            if (alpha == "\"e\"") {
-                outfile << ws->readE(0)[bin] << singleSpc;
-            }
-            if (alpha == "\"x\"") {
-                outfile << (ws->readX(0)[bin]) << singleSpc;
-            }
-            if (alpha == "\"y\"") {
-                outfile << ws->readY(0)[bin] << singleSpc;
-            }
-        }
-        
-        //-----------------------------------------------------------------------
-        /** Reads the sample logs
-         *  @param outfile :: File it will save it out to
-         *  @param fourspc :: Constant string for four spaces
-         */
-        void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
-                                                 std::string fourspc) {
-            const std::vector<Property *> &logData = ws->run().getLogData();
-            
-            // vector
-            std::vector<std::string> myVector;
-            for (auto log = logData.begin(); log != logData.end(); ++log) {
-                std::string name = (*log)->name();
-                std::string type = (*log)->type();
-                std::string value = (*log)->value();
-                
-                if (type.std::string::find("vector") &&
-                    type.std::string::find("double") != std::string::npos) {
-                    
-                    auto tsp = ws->run().getTimeSeriesProperty<double>(name);
-                    // value = std::to_string(tsp->timeAverageValue());
-                    value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
-                }
-                
-                if (type.std::string::find("vector") &&
-                    type.std::string::find("int") != std::string::npos) {
-                    
-                    auto tsp = ws->run().getTimeSeriesProperty<int>(name);
-                    value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
-                }
-                
-                if (type.std::string::find("vector") &&
-                    type.std::string::find("bool") != std::string::npos) {
-                    
-                    auto tsp = ws->run().getTimeSeriesProperty<bool>(name);
-                    value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
-                }
-                
-                if (type.std::string::find("vector") &&
-                    type.std::string::find("char") != std::string::npos) {
-                    
-                    auto tsp = ws->run().getTimeSeriesProperty<std::string>(name);
-                    value = (tsp->lastValue());
-                }
-                
-                if ((type.std::string::find("number") != std::string::npos) ||
-                    (type.std::string::find("double") != std::string::npos) ||
-                    (type.std::string::find("dbl list") != std::string::npos)) {
-                    type = "Float";
-                }
-                
-                if ((type.std::string::find("TimeValueUnit<bool>") != std::string::npos) ||
-                    (type.std::string::find("TimeValueUnit<int>") != std::string::npos)) {
-                    type = "Integer";
-                }
-                
-                if (type.std::string::find("string") != std::string::npos) {
-                    type = "String";
-                }
-                
-                // sort(&logData.begin(), &logData.end());
-                
-                /*
-                 if(name != "x" && name != "y" && name != "e" ) {
-                 outfile << "  \"" << name << "\"" << std::endl
-                 << fourspc << type << std::endl
-                 << fourspc << value << std::endl;
-                 } */
-                
-                if (name != "x" && name != "y" && name != "e") {
-                    std::string output = ("  \"" + name + "\"" + "\n" + fourspc + type +
-                                          "\n" + fourspc + value + "\n");
-                    
-                    myVector.push_back(output);
-                }
-            }
-            sort(myVector.begin(), myVector.end());
-            
-            for (std::vector<std::string>::const_iterator i = myVector.begin();
-                 i != myVector.end(); ++i) {
-                outfile << *i << ' ';
-            }
-        }
-        
-    } // namespace DataHandling
+namespace DatHandling {
+
+using namespace Kernel;
+using namespace Mantid::API;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(SaveOpenGenieAscii)
+
+/// Empty constructor
+SaveOpenGenieAscii::SaveOpenGenieAscii() : Mantid::API::Algorithm() {}
+
+//---------------------------------------------------
+// Private member functions
+//---------------------------------------------------
+/**
+ * Initialise the algorithm
+ */
+
+void SaveOpenGenieAscii::init() {
+  declareProperty(
+      new API::WorkspaceProperty<>("InputWorkspace", "",
+                                   Kernel::Direction::Input),
+      "The name of the workspace containing the data you wish to save");
+
+  // Declare required parameters, filename with ext {.his} and input
+  // workspac
+  std::vector<std::string> his_exts;
+  his_exts.push_back(".his");
+  his_exts.push_back(".txt");
+  his_exts.push_back("");
+  declareProperty(
+      new API::FileProperty("Filename", "", API::FileProperty::Save, his_exts),
+      "The filename to use for the saved data");
+  declareProperty("IncludeHeader", true,
+                  "Whether to include the header lines (default: true)");
+}
+
+void SaveOpenGenieAscii::exec() {
+  // Process properties
+
+  // Retrieve the input workspace
+  /// Workspace
+  ws = getProperty("InputWorkspace");
+  int nSpectra = static_cast<int>(ws->getNumberHistograms());
+  int nBins = static_cast<int>(ws->blocksize());
+
+  // Retrieve the filename from the properties
+  std::string filename = getProperty("Filename");
+
+  // Output string variables
+  const std::string singleSpc = " ";
+  const std::string fourspc = "    ";
+
+  // file
+  std::ofstream outfile(filename.c_str());
+  if (!outfile) {
+    g_log.error("Unable to create file: " + filename);
+    throw Exception::FileError("Unable to create file: ", filename);
+  }
+  if (nBins == 0 || nSpectra == 0)
+    throw std::runtime_error("Trying to save an empty workspace");
+
+  // Axis alphabets
+  const std::string Alpha[] = {"\"e\"", "\"x\"", "\"y\""};
+
+  const bool headers = getProperty("IncludeHeader");
+  // if true write file header
+  if (headers) {
+    writeFileHeader(outfile);
+  }
+
+  bool isHistogram = ws->isHistogramData();
+  Progress progress(this, 0, 1, nBins);
+  std::string alpha;
+  for (int Num = 0; Num < 3; Num++) {
+    alpha = Alpha[Num];
+    writeToFile(alpha, singleSpc, fourspc, nBins, isHistogram);
+  }
+
+  writeSampleLogs(outfile, fourspc);
+
+  progress.report();
+  return;
+}
+
+// -----------------------------------------------------------------------------
+/** generates the OpenGenie file header
+   *  @param outfile :: File it will save it out to
+   */
+void SaveOpenGenieAscii::writeFileHeader(std::ofstream &outfile) {
+
+  const std::vector<Property *> &logData = ws->run().getLogData();
+  auto &log = logData;
+  // get total number of sample logs
+  auto samplenumber = (&log)->size();
+  samplenumber += 3; // x, y, e
+
+  outfile << "# Open Genie ASCII File #" << std::endl
+          << "# label " << std::endl
+          << "GXWorkspace" << std::endl
+          // number of entries
+          << samplenumber << std::endl;
+}
+
+//------------------------------------------------------------------------------
+/** generates the header for the axis which saves to file
+   *  @param alpha ::   onstant string Axis letter that is being used
+   *  @param outfile :: File it will save it out to
+   *  @param singleSpc :: Constant string for single space
+   *  @param fourspc :: Constant string for four spaces
+   *  @param nBins ::  Number of bins
+   */
+std::string SaveOpenGenieAscii::writeAxisHeader(const std::string alpha,
+                                                const std::string singleSpc,
+                                                const std::string fourspc,
+                                                int nBins) {
+  std::string outstr = "";
+  const std::string GXR = "GXRealarray";
+  const std::string banknum = "1";
+  const std::string twospc = " ";
+
+  // outfile << twospc << singleSpc << alpha << std::endl;
+  outstr += twospc + singleSpc + alpha + "\n";
+
+  // outfile << fourspc << GXR << std::endl;
+  outstr += fourspc + GXR + "\n";
+
+  // outfile << fourspc << banknum << std::endl;
+  outstr += fourspc + banknum + "\n";
+
+  // outfile << fourspc << nBins << std::endl;
+  outstr += fourspc + boost::lexical_cast<std::string>(nBins) + "\n";
+
+  return outstr;
+}
+
+//-----------------------------------------------------------------------------
+/** Uses AxisHeader and WriteAxisValues to write out file
+   *  @param alpha ::   Axis letter that is being used
+   *  @param outfile :: File it will save it out to
+   *  @param singleSpc :: Constant string for single space
+   *  @param fourspc :: Constant string for four spaces
+   *  @param nBins ::  number of bins
+   *  @param isHistogram ::  If its a histogram
+   */
+void SaveOpenGenieAscii::writeToFile(const std::string alpha,
+                                     const std::string singleSpc,
+                                     const std::string fourspc, int nBins,
+                                     bool isHistogram) {
+  std::string out_str = writeAxisHeader(alpha, singleSpc, fourspc, nBins);
+  for (int bin = 0; bin < nBins; bin++) {
+    if (isHistogram) // bin centres
+    {
+      if (bin == 0) {
+        out_str += fourspc;
+      }
+      auto axisStr = writeAxisValues(alpha, bin, singleSpc);
+      out_str += axisStr;
+
+      if ((bin + 1) % 10 == 0 && bin != (nBins - 1)) {
+        out_str += "\n" + fourspc;
+      }
+    }
+  }
+  out_str += "\n";
+  myVector.push_back(out_str);
+}
+
+//------------------------------------------------------------------------
+/** Reads if alpha is e then reads the E values accordingly
+   *  @param alpha ::   Axis letter that is being used
+   *  @param outfile :: File it will save it out to
+   *  @param bin :: bin counter which goes through all the bin
+   *  @param singleSpc :: Constant string for single space
+   */
+std::string SaveOpenGenieAscii::writeAxisValues(std::string alpha, int bin,
+                                                const std::string singleSpc) {
+  std::string output = "";
+  if (alpha == "\"e\"") {
+    output += boost::lexical_cast<std::string>(ws->readE(0)[bin]) + singleSpc;
+  }
+  if (alpha == "\"x\"") {
+    output += boost::lexical_cast<std::string>(ws->readX(0)[bin]) + singleSpc;
+  }
+  if (alpha == "\"y\"") {
+    output += boost::lexical_cast<std::string>(ws->readY(0)[bin]) + singleSpc;
+  }
+  return output;
+}
+
+//-----------------------------------------------------------------------
+/** Reads the sample logs
+   *  @param outfile :: File it will save it out to
+   *  @param fourspc :: Constant string for four spaces
+   */
+void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
+                                         std::string fourspc) {
+  const std::vector<Property *> &logData = ws->run().getLogData();
+
+  // vector
+  // std::vector<std::string> myVector;
+  for (auto log = logData.begin(); log != logData.end(); ++log) {
+    std::string name = (*log)->name();
+    std::string type = (*log)->type();
+    std::string value = (*log)->value();
+
+    if (type.std::string::find("vector") &&
+        type.std::string::find("double") != std::string::npos) {
+
+      auto tsp = ws->run().getTimeSeriesProperty<double>(name);
+      value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
+    }
+
+    else if (type.std::string::find("vector") &&
+        type.std::string::find("int") != std::string::npos) {
+
+      auto tsp = ws->run().getTimeSeriesProperty<int>(name);
+      value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
+    }
+
+    else if (type.std::string::find("vector") &&
+        type.std::string::find("bool") != std::string::npos) {
+
+      auto tsp = ws->run().getTimeSeriesProperty<bool>(name);
+      value = boost::lexical_cast<std::string>(tsp->timeAverageValue());
+    }
+
+    else if (type.std::string::find("vector") &&
+        type.std::string::find("char") != std::string::npos) {
+
+      auto tsp = ws->run().getTimeSeriesProperty<std::string>(name);
+      value = (tsp->lastValue());
+    }
+
+    if ((type.std::string::find("number") != std::string::npos) ||
+        (type.std::string::find("double") != std::string::npos) ||
+        (type.std::string::find("dbl list") != std::string::npos)) {
+      type = "Float";
+    }
+
+    else if ((type.std::string::find("TimeValueUnit<bool>") != std::string::npos) ||
+        (type.std::string::find("TimeValueUnit<int>") != std::string::npos)) {
+      type = "Integer";
+    }
+
+    else if (type.std::string::find("string") != std::string::npos) {
+      type = "String";
+    }
+
+    if (name != "x" && name != "y" && name != "e") {
+      std::string output = ("  \"" + name + "\"" + "\n" + fourspc + type +
+                            "\n" + fourspc + value + "\n");
+
+      myVector.push_back(output);
+    }
+  }
+  sort(myVector.begin(), myVector.end());
+
+  for (std::vector<std::string>::const_iterator i = myVector.begin();
+       i != myVector.end(); ++i) {
+    outfile << *i << ' ';
+  }
+}
+
+} // namespace DataHandling
 } // namespace Mantid

--- a/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
@@ -209,7 +209,7 @@ void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
                                          std::string fourspc) {
   const std::vector<Property *> &logData = ws->run().getLogData();
 
-  std::vector<std::string> myVector;
+  // std::vector<std::string> myVector;
   for (auto log = logData.begin(); log != logData.end(); ++log) {
     std::string name = (*log)->name();
     std::string type = (*log)->type();
@@ -243,19 +243,14 @@ void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
       value = (tsp->lastValue());
     }
 
-    if (type.std::string::find("number") != std::string::npos) {
+    if ((type.std::string::find("number") != std::string::npos) ||
+        (type.std::string::find("double") != std::string::npos) ||
+        (type.std::string::find("dbl list") != std::string::npos)) {
       type = "Float";
     }
 
-    if (type.std::string::find("double") != std::string::npos) {
-      type = "Float";
-    }
-
-    if (type.std::string::find("TimeValueUnit<bool>") != std::string::npos) {
-      type = "Integer";
-    }
-
-    if (type.std::string::find("TimeValueUnit<int>") != std::string::npos) {
+    if ((type.std::string::find("TimeValueUnit<bool>") != std::string::npos) ||
+        (type.std::string::find("TimeValueUnit<int>") != std::string::npos)) {
       type = "Integer";
     }
 
@@ -263,12 +258,9 @@ void SaveOpenGenieAscii::writeSampleLogs(std::ofstream &outfile,
       type = "String";
     }
 
-    sort(&logData.begin(), &logData.end());
+    // sort(&logData.begin(), &logData.end());
 
-    if ((name.std::string::find("x") != std::string::npos) ||
-        (name.std::string::find("y") != std::string::npos) ||
-        (name.std::string::find("") != std::string::npos)) {
-
+	if(name != "x" && name != "y" && name != "e" ) {
       outfile << "  \"" << name << "\"" << std::endl
               << fourspc << type << std::endl
               << fourspc << value << std::endl;

--- a/Code/Mantid/docs/source/algorithms/SaveOpenGenieAscii-v1.rst
+++ b/Code/Mantid/docs/source/algorithms/SaveOpenGenieAscii-v1.rst
@@ -16,9 +16,14 @@ OpenGenie ASCII file with data saved inside. The algorithm will
 assume focused data (which contains single spectrum) has been
 provided, but if a workspace with multiple spectra is passed, the
 algorithm will save the first spectrum, while ignoring the rest.
-The algorithms will write out the x, y and e axis for each spectra.
-The x, y, e axis are sorted by ascending alphabetical order within
-the file, which matches the format of OpenGenie ASCII file.
+The algorithms will write out the x, y and e axis for each spectra
+along with all the sample logs which are available in the nexus
+file which is provided. The x, y, e axis and the sample logs are
+sorted by ascending alphabetical order within the file, which
+matches the format of OpenGenie ASCII file. The`ntc` field is
+also included, which is required in order to run the generated
+file on OpenGenie, the value for `ntc` is the number of bins of
+the provided workspace.
 
 Usage
 -----


### PR DESCRIPTION
Fixes #13752

**To Test**
- Input: a (matrix) workspace (_Preferably with many sample logs_)
  e.g:`ExternalData\Testing\Data\UnitTest\ENGINX00228061`
- Execute `SaveOpenGenieAscii` with the input workspace
- Save the OpenGenie ascii file where appropriate 
