### PR TITLE
Remove extra class declarations in PoldiFitPeaks1D Tests

### DIFF
--- a/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1D2Test.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1D2Test.h
@@ -24,8 +24,6 @@ using namespace Mantid::CurveFitting;
 using namespace Mantid::Kernel;
 using namespace Mantid::DataObjects;
 
-class PoldiFitPeaks1D2;
-
 class TestablePoldiFitPeaks1D2 : public Mantid::Poldi::PoldiFitPeaks1D2 {
   friend class PoldiFitPeaks1D2Test;
 

--- a/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1DTest.h
+++ b/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1DTest.h
@@ -20,8 +20,6 @@ using namespace Mantid::API;
 using namespace Mantid::CurveFitting;
 using namespace Mantid::Kernel;
 
-class PoldiFitPeaks1D;
-
 class TestablePoldiFitPeaks1D : public Mantid::Poldi::PoldiFitPeaks1D
 {
     friend class PoldiFitPeaks1DTest;


### PR DESCRIPTION
clang 3.7 can't compile these tests. You get the following errors.

```
In file included from Framework/SINQ/test/PoldiFitPeaks1DTest.cpp:16:
/home/rwp/mantid/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1DTest.h:23:1: error: declaration conflicts with target of using declaration already in scope
class PoldiFitPeaks1D;
^
/home/rwp/mantid/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks1D.h:43:23: note: target of using declaration
class MANTID_SINQ_DLL PoldiFitPeaks1D : public API::Algorithm {
                      ^
/home/rwp/mantid/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1DTest.h:17:22: note: using declaration
using Mantid::Poldi::PoldiFitPeaks1D;
                     ^
1 warning and 1 error generated.

In file included from Framework/SINQ/test/PoldiFitPeaks1D2Test.cpp:17:
/home/rwp/mantid/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1D2Test.h:27:1: error: declaration conflicts with target of using declaration already in scope
class PoldiFitPeaks1D2;
^
/home/rwp/mantid/Code/Mantid/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks1D2.h:81:23: note: target of using declaration
class MANTID_SINQ_DLL PoldiFitPeaks1D2 : public API::Algorithm {
                      ^
/home/rwp/mantid/Code/Mantid/Framework/SINQ/test/PoldiFitPeaks1D2Test.h:20:22: note: using declaration
using Mantid::Poldi::PoldiFitPeaks1D2;
                     ^
1 warning and 1 error generated.
```

**To test:**
Code review and see that the unit tests still pass.
