### PR TITLE
Bugfix for IntegrateMDHistoWorkspace in precision corrected coordinates

### DIFF
--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -106,7 +106,7 @@ Mantid::coord_t getPrecisionCorrectedCoordinate(Mantid::coord_t position) {
   const auto deviation = fabs(nearest - position)/nearest;
   const auto tolerance = 1e-6;
   Mantid::coord_t coordinate(position);
-  if (deviation < tolerance) {
+  if (fabs(deviation) < tolerance) {
     coordinate = nearest;
   }
   return coordinate;


### PR DESCRIPTION
The comparison in the `getPrecisionCorrectedCoordinates` now uses the absolute value of the deviation instead of gaining it's polarity from the sign of the `nearest` variable

Fixes #13796
