### PR TITLE
Allow cxxtest test void on previous line

### DIFF
--- a/Code/Mantid/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Code/Mantid/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -31,9 +31,7 @@ public:
     TS_ASSERT_DELTA(0.00030887, absFactor, delta);
   }
 
-  // clang-format off
   void test_Multiple_Scattering_With_Fixed_Mur_And_Absorption_Correction_Factor()
-  // clang-format on
   {
     std::vector<double> dummy(2, 0.0);
     dummy[1] = 1.0;
@@ -73,9 +71,7 @@ public:
     TS_ASSERT_DELTA(0.2660792, error.back(), delta);
   }
 
-  // clang-format off
   void test_Corrects_Both_Absorption_And_Multiple_Scattering_For_Histogram_Data()
-  // clang-format on
   {
     using std::sqrt;
     const size_t nypts(100);

--- a/Code/Mantid/Framework/Kernel/test/HermitePolynomialsTest.h
+++ b/Code/Mantid/Framework/Kernel/test/HermitePolynomialsTest.h
@@ -13,9 +13,7 @@ public:
   static HermitePolynomialsTest *createSuite() { return new HermitePolynomialsTest(); }
   static void destroySuite( HermitePolynomialsTest *suite ) { delete suite; }
 
-  // clang-format off
   void test_hermitePoly_With_SingleValue_Returns_Expected_Values_For_First_Few_Terms()
-  // clang-format on
   {
     using namespace Mantid::Kernel;
     static const unsigned int npoly(6);
@@ -30,9 +28,7 @@ public:
     }
   }
 
-  // clang-format off
   void test_hermitePoly_With_Array_Values_Returns_Expected_Values_For_First_Few_Terms()
-  // clang-format on
   {
     using namespace Mantid::Kernel;
 

--- a/Code/Mantid/Testing/Tools/cxxtest/python/cxxtest/cxxtest_parser.py
+++ b/Code/Mantid/Testing/Tools/cxxtest/python/cxxtest/cxxtest_parser.py
@@ -145,7 +145,7 @@ def lineStartsBlock( line ):
 
 test_re = re.compile( r'^([^/]|/[^/])*\bvoid\s+([Tt]est\w+)\s*\(\s*(void)?\s*\)' )
 void_re = re.compile( r'^([^/]|/[^/])*\bvoid\s*$' )
-test_novoid_re = re.compile( r'^([^/]|/[^/])*([Tt]est\w+)\s*\(\s*(void)?\s*\)' )
+test_novoid_re = re.compile( r'^([^/]|/[^/])*\b([Tt]est\w+)\s*\(\s*(void)?\s*\)' )
 def scanLineForTest( suite, lineNo, line ):
     '''Check if current line starts a test'''
     global lastLineVoid

--- a/Code/Mantid/Testing/Tools/cxxtest/python/cxxtest/cxxtest_parser.py
+++ b/Code/Mantid/Testing/Tools/cxxtest/python/cxxtest/cxxtest_parser.py
@@ -10,6 +10,7 @@ suites = []
 suite = None
 inBlock = 0
 options=None
+lastLineVoid = False
 
 def scanInputFiles(files, _options):
     '''Scan all input files for test suites'''
@@ -143,11 +144,24 @@ def lineStartsBlock( line ):
     return re.search( r'\bCXXTEST_CODE\s*\(', line ) is not None
 
 test_re = re.compile( r'^([^/]|/[^/])*\bvoid\s+([Tt]est\w+)\s*\(\s*(void)?\s*\)' )
+void_re = re.compile( r'^([^/]|/[^/])*\bvoid\s*$' )
+test_novoid_re = re.compile( r'^([^/]|/[^/])*([Tt]est\w+)\s*\(\s*(void)?\s*\)' )
 def scanLineForTest( suite, lineNo, line ):
     '''Check if current line starts a test'''
+    global lastLineVoid
     m = test_re.search( line )
     if m:
         addTest( suite, m.group(2), lineNo )
+        lastLineVoid = False
+    elif lastLineVoid:
+        m2 = test_novoid_re.search(line)
+        if m2:
+            addTest( suite, m2.group(2), lineNo )
+        lastLineVoid = False
+    else:
+        m3 = void_re.search(line)
+        if m3:
+            lastLineVoid = True
 
 def addTest( suite, name, line ):
     '''Add a test function to the current suite'''


### PR DESCRIPTION
This will allows `clang-format` to be run on unit test files that have long test names, which causes the function name to move to the next line after `void`.

**To test**:
Incremental builds will have no changes. For a complete test you should do a clean build of all the unit tests.
`clang-format` should also be run on some unit test file that have long name (eg. `Algorithms/test/ChangeTimeZeroTest.h`) and compare the generated `.cpp` files to see if all the tests are included.
