### PR TITLE
SCD interface error

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MantidEVWorker.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MantidEVWorker.h
@@ -143,11 +143,13 @@ public:
   /// Select conventional cell using the cell type and centering
   bool selectCellOfType( const std::string & peaks_ws_name,
                          const std::string & cell_type,
-                         const std::string & centering );
+                         const std::string & centering,
+                         bool          allow_perm);
 
   /// Select conventional cell using the form number from the Mighell paper
   bool selectCellWithForm( const std::string & peaks_ws_name,
-                                 size_t        form_num );
+                                 size_t        form_num,
+                                 bool          allow_perm);
 
   /// Apply a mapping to the h,k,l indices and the UB matrix 
   bool changeHKL( const std::string & peaks_ws_name,

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MantidEV.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MantidEV.cpp
@@ -1040,11 +1040,11 @@ void MantidEV::chooseCell_slot()
    bool show_cells       = m_uiForm.ShowPossibleCells_rbtn->isChecked();
    bool select_cell_type = m_uiForm.SelectCellOfType_rbtn->isChecked();
    bool select_cell_form = m_uiForm.SelectCellWithForm_rbtn->isChecked();
+   bool allow_perm          = m_uiForm.AllowPermutations_ckbx->isChecked();
 
    if ( show_cells )
    {
      bool best_only          = m_uiForm.BestCellOnly_ckbx->isChecked();
-     bool allow_perm          = m_uiForm.AllowPermutations_ckbx->isChecked();
      double max_scalar_error = 0;
      if ( !getPositiveDouble( m_uiForm.MaxScalarError_ledt, max_scalar_error ) )
        return;
@@ -1058,7 +1058,7 @@ void MantidEV::chooseCell_slot()
    {
      std::string cell_type = m_uiForm.CellType_cmbx->currentText().toStdString();
      std::string centering = m_uiForm.CellCentering_cmbx->currentText().toStdString();
-     if ( !worker->selectCellOfType( peaks_ws_name, cell_type, centering ) )
+     if ( !worker->selectCellOfType( peaks_ws_name, cell_type, centering, allow_perm ) )
      {
        errorMessage("Failed to Select Specified Conventional Cell");
      }
@@ -1069,7 +1069,7 @@ void MantidEV::chooseCell_slot()
      std::string form = m_uiForm.CellFormNumber_cmbx->currentText().toStdString();
      double form_num = 0;
      getDouble( form, form_num );
-     if ( !worker->selectCellWithForm( peaks_ws_name, (size_t)form_num ) )
+     if ( !worker->selectCellWithForm( peaks_ws_name, (size_t)form_num, allow_perm ) )
      {
        errorMessage("Failed to Select the Requested Form Number");
      }

--- a/Code/Mantid/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/MantidEVWorker.cpp
@@ -711,12 +711,16 @@ bool MantidEVWorker::showCells( const std::string & peaks_ws_name,
  *  @param peaks_ws_name     The name of the peaks workspace.
  *  @param cell_type         String with the cell type, such as "Cubic".
  *  @param centering         String with the centering such as "F".
+ *  @param allow_perm        If true, permutations are used to find the
+ *                           best fitting cell of any
+ *                           particular type.
  *
  *  @return true if the SelectCellOfType algorithm completes successfully.
  */
 bool MantidEVWorker::selectCellOfType( const std::string & peaks_ws_name,
                                        const std::string & cell_type,
-                                       const std::string & centering )
+                                       const std::string & centering, 
+                                       bool          allow_perm)
 {
   if ( !isPeaksWorkspace( peaks_ws_name ) )
     return false;
@@ -727,6 +731,7 @@ bool MantidEVWorker::selectCellOfType( const std::string & peaks_ws_name,
   alg->setProperty("Centering",centering);
   alg->setProperty("Apply",true);
   alg->setProperty("tolerance",0.12);
+  alg->setProperty("AllowPermutations",allow_perm);
 
   if ( alg->execute() )
     return true;
@@ -743,11 +748,15 @@ bool MantidEVWorker::selectCellOfType( const std::string & peaks_ws_name,
  *
  *  @param peaks_ws_name     The name of the peaks workspace.
  *  @param form_num          The form number, 1..44.
+ *  @param allow_perm        If true, permutations are used to find the
+ *                           best fitting cell of any
+ *                           particular type.
  *
  *  @return true if the SelectCellWithForm algorithm completes successfully.
  */
 bool MantidEVWorker::selectCellWithForm(  const std::string & peaks_ws_name,
-                                                size_t        form_num )
+                                                size_t        form_num,
+                                                bool          allow_perm)
 {
   if ( !isPeaksWorkspace( peaks_ws_name ) )
     return false;
@@ -757,6 +766,7 @@ bool MantidEVWorker::selectCellWithForm(  const std::string & peaks_ws_name,
   alg->setProperty("FormNumber",(int)form_num);
   alg->setProperty("Apply",true);
   alg->setProperty("tolerance",0.12);
+  alg->setProperty("AllowPermutations",allow_perm);
   
   if ( alg->execute() )
     return true;


### PR DESCRIPTION
fixes #13803 

Test by running SCD interface and make sure that AllowPermutations in in history for SelectCell algorithms.  History before fix:

``` python
Load(Filename='/SNS/TOPAZ/IPTS-10509/data/TOPAZ_9320_event.nxs', OutputWorkspace='TOPAZ_9320_event', LoadMonitors=True)
LoadIsawDetCal(InputWorkspace='TOPAZ_9320_event', Filename='/SNS/TOPAZ/IPTS-10509/shared/calibrations/TOPAZ_21March2014.DetCal')
ConvertToMD(InputWorkspace='TOPAZ_9320_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_9320_md', MinValues='-15,-15,-15', MaxValues='15,15,15', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)
FindPeaksMD(InputWorkspace='TOPAZ_9320_md', PeakDistanceThreshold=0.25690909090909092, MaxPeaks=600, DensityThresholdFactor=50, OutputWorkspace='TOPAZ_9320_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_9320_peaks', MinD=5, MaxD=22, Tolerance=0.12)
IndexPeaks(PeaksWorkspace='TOPAZ_9320_peaks', Tolerance=0.12, RoundHKLs=False)
ShowPossibleCells(PeaksWorkspace='TOPAZ_9320_peaks', AllowPermutations=False)
SelectCellWithForm(PeaksWorkspace='TOPAZ_9320_peaks', FormNumber=40, Apply=True)
#SelectCellOfType(PeaksWorkspace='TOPAZ_9320_peaks', CellType='Orthorhombic', Centering='C', Apply=True)
```
