### PR TITLE
Add Container to the ApplyPaalmanPings tab 

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/Code/Mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -1,323 +1,410 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ApplyPaalmanPings</class>
- <widget class="QWidget" name="ApplyPaalmanPings">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>420</width>
-    <height>420</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <widget class="QGroupBox" name="gbInput">
-     <property name="title">
-      <string>Input</string>
-     </property>
-     <layout class="QVBoxLayout" name="abscor_loInput">
+  <class>ApplyPaalmanPings</class>
+  <widget class="QWidget" name="ApplyPaalmanPings">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>420</width>
+        <height>420</height>
+      </rect>
+    </property>
+    <property name="windowTitle">
+      <string>Form</string>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_red</string>
-          <string>_sqw</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_red.nxs</string>
-          <string>_sqw.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbOptions">
-     <property name="title">
-      <string>Options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QComboBox" name="cbGeometry">
-        <item>
-         <property name="text">
-          <string>Flat Plate</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Cylinder</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Annulus</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCorrections" native="true">
-        <property name="enabled">
-         <bool>true</bool>
-        </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="autoLoad" stdset="0">
-         <bool>true</bool>
-        </property>
-        <property name="workspaceSuffixes" stdset="0">
-         <stringlist>
-          <string>_flt_abs</string>
-         </stringlist>
-        </property>
-        <property name="fileBrowserSuffixes" stdset="0">
-         <stringlist>
-          <string>_flt_abs.nxs</string>
-         </stringlist>
-        </property>
-        <property name="showLoad" stdset="0">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="lbGeometry">
-        <property name="text">
-         <string>Geometry:</string>
-        </property>
-       </widget>
-      </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="lbCorrection">
-          <property name="text">
-            <string>Corrections: </string>
+        <widget class="QGroupBox" name="gbInput">
+          <property name="title">
+            <string>Input</string>
           </property>
+          <layout class="QVBoxLayout" name="abscor_loInput">
+            <item>
+              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSample" native="true">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="autoLoad" stdset="0">
+                  <bool>true</bool>
+                </property>
+                <property name="workspaceSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red</string>
+                    <string>_sqw</string>
+                  </stringlist>
+                </property>
+                <property name="fileBrowserSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red.nxs</string>
+                    <string>_sqw.nxs</string>
+                  </stringlist>
+                </property>
+                <property name="showLoad" stdset="0">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+          </layout>
         </widget>
-       </item>S
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbPreview">
-     <property name="title">
-      <string>Preview</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_11">
-      <item>
-       <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
-        <property name="canvasColour" stdset="0">
-         <color>
-          <red>255</red>
-          <green>255</green>
-          <blue>255</blue>
-         </color>
-        </property>
-        <property name="showLegend" stdset="0">
-         <bool>true</bool>
-        </property>
-       </widget>
       </item>
       <item>
-       <layout class="QVBoxLayout" name="loPlotOptions">
-        <item>
-         <spacer name="verticalSpacer_0">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+        <widget class="QGroupBox" name="gbOptions">
+          <property name="title">
+            <string>Options</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
+          <layout class="QGridLayout" name="gridLayout">
+            <item row="1" column="0">
+              <widget class="QCheckBox" name="ckUseCan">
+                <property name="text">
+                  <string>Use Can:</string>
+                </property>
+              </widget>
+            </item>
+            <item row="4" column="0">
+              <widget class="QCheckBox" name="ckUseCorrections">
+                <property name="text">
+                  <string>Use Corrections:</string>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="1">
+              <widget class="QComboBox" name="cbGeometry">
+                <item>
+                  <property name="text">
+                    <string>Flat Plate</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Cylinder</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Annulus</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item row="4" column="1">
+              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCorrections" native="true">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="autoLoad" stdset="0">
+                  <bool>true</bool>
+                </property>
+                <property name="workspaceSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_flt_abs</string>
+                  </stringlist>
+                </property>
+                <property name="fileBrowserSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_flt_abs.nxs</string>
+                  </stringlist>
+                </property>
+                <property name="showLoad" stdset="0">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="1" column="1">
+              <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="autoLoad" stdset="0">
+                  <bool>true</bool>
+                </property>
+                <property name="workspaceSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red</string>
+                    <string>_sqw</string>
+                  </stringlist>
+                </property>
+                <property name="fileBrowserSuffixes" stdset="0">
+                  <stringlist>
+                    <string>_red.nxs</string>
+                    <string>_sqw.nxs</string>
+                  </stringlist>
+                </property>
+                <property name="showLoad" stdset="0">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="0" column="0">
+              <widget class="QLabel" name="lbGeometry">
+                <property name="text">
+                  <string>Geometry:</string>
+                </property>
+              </widget>
+            </item>
+            <item row="3" column="0">
+              <widget class="QCheckBox" name="ckScaleCan">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="text">
+                  <string>Scale Can by factor:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="3" column="1">
+              <layout class="QHBoxLayout" name="loScaleFactor">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spCanScale">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.100000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>1.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>40</width>
+                        <height>20</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbPreview">
+          <property name="title">
+            <string>Preview</string>
           </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="lbPreviewSpec">
-          <property name="text">
-           <string>Spectrum:</string>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+              <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPreview" native="true">
+                <property name="canvasColour" stdset="0">
+                  <color>
+                    <red>255</red>
+                    <green>255</green>
+                    <blue>255</blue>
+                  </color>
+                </property>
+                <property name="showLegend" stdset="0">
+                  <bool>true</bool>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <layout class="QVBoxLayout" name="loPlotOptions">
+                <item>
+                  <spacer name="verticalSpacer_0">
+                    <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>20</width>
+                        <height>40</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+                <item>
+                  <widget class="QLabel" name="lbPreviewSpec">
+                    <property name="text">
+                      <string>Spectrum:</string>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <widget class="QSpinBox" name="spPreviewSpec"/>
+                </item>
+              </layout>
+            </item>
+          </layout>
+        </widget>
+      </item>
+      <item>
+        <widget class="QGroupBox" name="gbOutput">
+          <property name="title">
+            <string>Output Options</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="spPreviewSpec"/>
-        </item>
-       </layout>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+              <widget class="QLabel" name="lbPlotOutput">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="text">
+                  <string>Plot Output:</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QComboBox" name="cbPlotOutput">
+                <item>
+                  <property name="text">
+                    <string>None</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Contour</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Spectra</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Both</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item>
+              <spacer name="horizontalSpacer_1">
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                  <size>
+                    <width>40</width>
+                    <height>20</height>
+                  </size>
+                </property>
+              </spacer>
+            </item>
+            <item>
+              <widget class="QCheckBox" name="ckSave">
+                <property name="text">
+                  <string>Save Result</string>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="gbOutput">
-     <property name="title">
-      <string>Output Options</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QLabel" name="lbPlotOutput">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Plot Output:</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="cbPlotOutput">
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Contour</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Spectra</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Both</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_1">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="ckSave">
-        <property name="text">
-         <string>Save Result</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  </layout>
- </widget>
- <customwidgets>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtMantidWidgets/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::PreviewPlot</class>
-   <extends>QWidget</extends>
-   <header>MantidQtMantidWidgets/PreviewPlot.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
- <resources/>
- <connections>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>ckScaleCan</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>50</x>
-     <y>111</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>61</x>
-     <y>142</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckScaleCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spCanScale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>133</x>
-     <y>143</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>251</x>
-     <y>147</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>dsContainer</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>119</x>
-     <y>114</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>324</x>
-     <y>114</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckUseCorrections</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>dsCorrections</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>119</x>
-     <y>167</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>324</x>
-     <y>167</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+    </layout>
+  </widget>
+  <customwidgets>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::DataSelector</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/DataSelector.h</header>
+    </customwidget>
+    <customwidget>
+      <class>MantidQt::MantidWidgets::PreviewPlot</class>
+      <extends>QWidget</extends>
+      <header>MantidQtMantidWidgets/PreviewPlot.h</header>
+      <container>1</container>
+    </customwidget>
+  </customwidgets>
+  <resources/>
+  <connections>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>ckScaleCan</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>50</x>
+          <y>111</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>61</x>
+          <y>142</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckScaleCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spCanScale</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>133</x>
+          <y>143</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>251</x>
+          <y>147</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsContainer</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>114</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>114</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckUseCorrections</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>dsCorrections</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>119</x>
+          <y>167</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>324</x>
+          <y>167</y>
+        </hint>
+      </hints>
+    </connection>
+  </connections>
 </ui>


### PR DESCRIPTION
Fixes #13806

The `Can` option has been re-added after being incorrectly removed previously.
# To Test
- Open ApplyPaalmanPings (Interfaces > Indirect > Corrections > ApplyPaalmanPings)
- Attempt to run the algorithm with the Can and Correction file
  - These can be found on the Babylon5 server under the folder `ElliotOram\corrections_set`
  - `irs26176_red` = Sample
  - `irs26174_red` = Can
  - `irs26176_flt_abs` = Corrections
- This should run and produce 3 sensible plots for `Sample`, `Corrected` and `Can` 
