### PR TITLE
Fix tolerance and deviation comparison integrate md histo workspace

### DIFF
--- a/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -12,6 +12,50 @@ using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using Mantid::Geometry::IMDDimension_const_sptr;
 
+
+namespace {
+  //To get the rounded difference, we need to take into account precision issues which arise when
+  // the bin centres match
+Mantid::coord_t getDExact(Mantid::coord_t location, Mantid::coord_t origin, Mantid::coord_t binWidth) {
+  auto dExact = (location - origin) / binWidth;
+  const Mantid::coord_t tolerance = Mantid::coord_t(1e-5);
+
+  // Expl. of the steps below
+  // -1     -0.5       0      0.5        1   where integer values are bin boundaries and half-values
+  //  |       |        |       |         |   are bin centres
+  //                               |
+  //                              Location
+  // Goal: Find distance to closest bin centre:
+  // 1. Get the predecimal value of the location: here 0
+  // 2. Add and subtract 0.5 to find two possible centres: here -0.5 adn + 0.5
+  // 3. Find the centre which minimizes the difference to the location
+  // 4. Keep the difference (distance) that was calculation in the step above
+
+  // Get the two centre indices which are the closest to dExact.
+  const auto centre1 = static_cast<Mantid::coord_t>(size_t(dExact)) + 0.5;
+  const auto centre2 = static_cast<Mantid::coord_t>(size_t(dExact)) - 0.5;
+
+  // Calculate the distance of the location to the centres
+  const auto diff1 = static_cast<Mantid::coord_t>(fabs(centre1 - dExact));
+  const auto diff2 = static_cast<Mantid::coord_t>(fabs(centre2 - dExact));
+
+  const auto difference = diff1 < diff2 ? diff1 : diff2;
+
+  // If the differnce is within the tolerance, ie the location is essentially on the centre, then
+  // we want to be on the left of that centre. The correct index for when we are on the centre,
+  // is the lower next integer value.
+  if (difference < tolerance) {
+    if (difference == 0.0f) {
+      dExact -= tolerance; // When we have an exact hit in the centre, give it a nudge to the lower bin boundary
+    } else {
+      dExact -= 2*difference; // Need to subtract twice the differnce, in order to be guaranteed below the centre
+    }
+  }
+  return dExact;
+}
+}
+
+
 namespace Mantid {
 namespace DataObjects {
 
@@ -218,7 +262,7 @@ Mantid::coord_t MDHistoWorkspaceIterator::jumpToNearest(const VMD& fromLocation)
     std::vector<size_t> indexes(m_nd);
     coord_t sqDiff = 0;
     for(size_t d = 0; d < m_nd; ++d) {
-        coord_t dExact = (fromLocation[d] - m_origin[d]) / m_binWidth[d]; // Index position in this space.
+        coord_t dExact =  getDExact(fromLocation[d], m_origin[d], m_binWidth[d]);
         size_t dRound = size_t(dExact + 0.5); // Round to nearest bin edge.
         sqDiff += (dExact - coord_t(dRound)) * (dExact - coord_t(dRound)) * m_binWidth[d] * m_binWidth[d];
         indexes[d] = dRound;

--- a/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Code/Mantid/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -215,7 +215,6 @@ void MDHistoWorkspaceIterator::jumpTo(size_t index) {
  */
 Mantid::coord_t MDHistoWorkspaceIterator::jumpToNearest(const VMD& fromLocation)
 {
-
     std::vector<size_t> indexes(m_nd);
     coord_t sqDiff = 0;
     for(size_t d = 0; d < m_nd; ++d) {

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -349,6 +349,7 @@ void IntegrateMDHistoWorkspace::exec() {
     // Outer loop over the output workspace iterator poistions.
     const int nThreads = Mantid::API::FrameworkManager::Instance()
                              .getNumOMPThreads(); // NThreads to Request
+
     auto outIterators = outWS->createIterators(nThreads, NULL);
 
     PARALLEL_FOR_NO_WSP_CHECK()
@@ -388,11 +389,11 @@ void IntegrateMDHistoWorkspace::exec() {
         /*
         We jump to the iterator position which is closest in the model
         coordinates
-        to the minimum of our output iterator. This allows us to consider a much
+        to the centre of our output iterator. This allows us to consider a much
         smaller region of space as part of our inner loop
         rather than iterating over the full set of boxes of the input workspace.
         */
-        inIterator->jumpToNearest(mins);
+        inIterator->jumpToNearest(outIteratorCenter);
         performWeightedSum(inIterator.get(), box, sumSignal,
                            sumSQErrors, sumNEvents); // Use the present position. neighbours
                                          // below exclude the current position.

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -94,7 +94,7 @@ std::string checkBinning(const std::vector<double> &binning) {
  * @param position: a position
  * @returns: a precision corrected position or the original position
  */
-Mantid::coord_t getPrecisionCorrectedCoordinate(Mantid::coord_t position) {
+Mantid::coord_t getPrecisionCorrectedCoordinate(Mantid::coord_t position, Mantid::coord_t binWidth) {
   // Find the closest integer value
   const auto up = std::ceil(position);
   const auto down = std::floor(position);
@@ -103,10 +103,10 @@ Mantid::coord_t getPrecisionCorrectedCoordinate(Mantid::coord_t position) {
   const auto nearest = diffUp < diffDown ? up : down;
 
   // Check if the relative deviation is larger than 1e-6
-  const auto deviation = fabs(nearest - position)/nearest;
+  const auto deviation = fabs((nearest - position)/binWidth);
   const auto tolerance = 1e-6;
   Mantid::coord_t coordinate(position);
-  if (fabs(deviation) < tolerance) {
+  if (deviation < tolerance) {
     coordinate = nearest;
   }
   return coordinate;
@@ -138,8 +138,8 @@ void setMinMaxBins(Mantid::coord_t &pMin, Mantid::coord_t &pMax,
 
   // Make sure that we don't snap to the wrong value
   // because of the precision of floats (which coord_t is)
-  minBin = getPrecisionCorrectedCoordinate(minBin);
-  maxBin = getPrecisionCorrectedCoordinate(maxBin);
+  minBin = getPrecisionCorrectedCoordinate(minBin, width);
+  maxBin = getPrecisionCorrectedCoordinate(maxBin, width);
   auto snappedPMin = width * std::floor(minBin);
   auto snappedPMax = width * std::ceil(maxBin);
 

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -106,7 +106,7 @@ Mantid::coord_t getPrecisionCorrectedCoordinate(Mantid::coord_t position) {
   const auto deviation = fabs(nearest - position)/nearest;
   const auto tolerance = 1e-6;
   Mantid::coord_t coordinate(position);
-  if (deviation < tolerance) {
+  if (fabs(deviation) < tolerance) {
     coordinate = nearest;
   }
   return coordinate;

--- a/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Code/Mantid/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -197,6 +197,7 @@ createShapedOutput(IMDHistoWorkspace const *const inWS,
       size_t numberOfBins;
 
       setMinMaxBins(pMin, pMax, numberOfBins, inDim, logger);
+
       outDim->setRange(
           numberOfBins,
           static_cast<Mantid::coord_t>(pMin) /*min*/,
@@ -348,7 +349,6 @@ void IntegrateMDHistoWorkspace::exec() {
     // Outer loop over the output workspace iterator poistions.
     const int nThreads = Mantid::API::FrameworkManager::Instance()
                              .getNumOMPThreads(); // NThreads to Request
-
     auto outIterators = outWS->createIterators(nThreads, NULL);
 
     PARALLEL_FOR_NO_WSP_CHECK()
@@ -388,12 +388,11 @@ void IntegrateMDHistoWorkspace::exec() {
         /*
         We jump to the iterator position which is closest in the model
         coordinates
-        to the centre of our output iterator. This allows us to consider a much
+        to the minimum of our output iterator. This allows us to consider a much
         smaller region of space as part of our inner loop
         rather than iterating over the full set of boxes of the input workspace.
         */
-        inIterator->jumpToNearest(outIteratorCenter);
-
+        inIterator->jumpToNearest(mins);
         performWeightedSum(inIterator.get(), box, sumSignal,
                            sumSQErrors, sumNEvents); // Use the present position. neighbours
                                          // below exclude the current position.

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -12,19 +12,10 @@ using namespace Mantid::API;
 
 namespace {
 
-size_t getTheTotalNumberOfBins(IMDHistoWorkspace_sptr ws) {
-  size_t numberOfIndices = 1;
-  for (size_t i = 0; i < ws->getNumDims(); ++i) {
-    auto dim = ws->getDimension(i);
-    numberOfIndices *= dim->getNBins();
-  }
-  return numberOfIndices;
-}
-
 // This helper sets the signal values to the linear index to have some
 // variety
 void resetSignalsToLinearIndexValue(IMDHistoWorkspace_sptr ws) {
-  auto numberOfIndices = getTheTotalNumberOfBins(ws);
+  auto numberOfIndices = static_cast<size_t>(ws->getNPoints());
   for (size_t i = 0; i < numberOfIndices; ++i) {
     auto& signal = ws->signalAt(i);
     signal = static_cast<Mantid::signal_t>(i);

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -14,7 +14,7 @@ namespace {
 
 size_t getTheTotalNumberOfBins(IMDHistoWorkspace_sptr ws) {
   size_t numberOfIndices = 1;
-  for (int i = 0; i < ws->getNumDims(); ++i) {
+  for (size_t i = 0; i < ws->getNumDims(); ++i) {
     auto dim = ws->getDimension(i);
     numberOfIndices *= dim->getNBins();
   }
@@ -25,7 +25,7 @@ size_t getTheTotalNumberOfBins(IMDHistoWorkspace_sptr ws) {
 // variety
 void resetSignalsToLinearIndexValue(IMDHistoWorkspace_sptr ws) {
   auto numberOfIndices = getTheTotalNumberOfBins(ws);
-  for (int i = 0; i < numberOfIndices; ++i) {
+  for (size_t i = 0; i < numberOfIndices; ++i) {
     auto& signal = ws->signalAt(i);
     signal = static_cast<Mantid::signal_t>(i);
   }
@@ -476,7 +476,8 @@ public:
     TSM_ASSERT_DELTA("Should have a signal value of 3", outWS->getSignalAt(2), static_cast<Mantid::signal_t>(3.0), 1e-4);
     TSM_ASSERT_DELTA("Should have a signal value of 4", outWS->getSignalAt(3), static_cast<Mantid::signal_t>(4.0), 1e-4);
   }
-    void test_that_PBin_between_extent_and_bin_boundary_floors_when_pmin_not_contained_in_threshold(){
+
+  void test_that_PBin_between_extent_and_bin_boundary_floors_when_pmin_not_contained_in_threshold(){
      /*
      Input workspace: Is asymmetric about the origina and the origin does not lie on a bin boundary and
      the PMIN and PMAX do not lie on bin boundaries.PMin is defined to be at a greater distance than 1e-06 of a bin boundary
@@ -627,6 +628,11 @@ public:
     TSM_ASSERT_DELTA("Should snap to the second bin boundary.", minimumDim, static_cast<Mantid::coord_t>(secondBinBoundary), 1e-6);
     TSM_ASSERT_DELTA("Should snap to the last bin boundary", maximumDim, static_cast<Mantid::coord_t>(max[0]), 1e-6);
   }
+
+  void test_that_signals_of_workspace_shifted_by_half_a_bin_width_is_correct() {
+
+  }
+
 };
 
 //=====================================================================================

--- a/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
+++ b/Code/Mantid/Framework/MDAlgorithms/test/IntegrateMDHistoWorkspaceTest.h
@@ -484,8 +484,6 @@ public:
     // Assert
     Mantid::coord_t minimumDim = outWS->getDimension(0)->getMinimum();
     Mantid::coord_t maximumDim = outWS->getDimension(0)->getMaximum();
-    std::cerr << std::setprecision(10) <<minimumDim << "   " << std::setprecision(10)<< static_cast<Mantid::coord_t>(secondBinBoundary) << "    " << std::setprecision(10)<< secondBinBoundary <<std::endl;
-    std::cerr << std::setprecision(10) <<maximumDim << "   " << std::setprecision(10) << static_cast<Mantid::coord_t>(max[0]) << "    " << std::setprecision(10) << max[0] <<std::endl;
 
     TSM_ASSERT_DELTA("Should snap to the second bin boundary.", minimumDim, static_cast<Mantid::coord_t>(secondBinBoundary), 1e-6);
     TSM_ASSERT_DELTA("Should snap to the last bin boundary", maximumDim, static_cast<Mantid::coord_t>(max[0]), 1e-6);


### PR DESCRIPTION
Fixes #13796 

**Context**

This fixes an error in the tolerance calcuation. It also addresses a precsion issue that arises when call `JumpToNext()` on an `MDHistoWorkspaceIterator` when the two boxes are essentially equal. 
## For testing

Running the script below takes a sample workspaces and passes it through `IntegrateMDHistoWorkspace`. The Pbins are set to leave everything unchanged. Confirm that the two workspaces are identical. (Note that the signal values show a slight deviation).

The required data file is MDHisto_Osiris. You need to set the path to it in the script. The file can be found here: \olympic\Babylon5\Scratch\Anton\VSI\SAMPLE_WORKSPACES

The script can be found [here](https://gist.github.com/picatess/b17ebd24537edfad2576)
