### PR TITLE
ISIS Energy Transfer Plot Time causes crashing

### DIFF
--- a/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/Code/Mantid/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -438,10 +438,8 @@ void ISISEnergyTransfer::plotRaw() {
     return;
   }
 
-  specid_t detectorMin =
-      static_cast<specid_t>(m_uiForm.spPlotTimeSpecMin->value());
-  specid_t detectorMax =
-      static_cast<specid_t>(m_uiForm.spPlotTimeSpecMax->value());
+  int detectorMin = m_uiForm.spPlotTimeSpecMin->value();
+  int detectorMax = m_uiForm.spPlotTimeSpecMax->value();
 
   if (detectorMin > detectorMax) {
     emit showMessageBox(
@@ -450,15 +448,26 @@ void ISISEnergyTransfer::plotRaw() {
   }
 
   QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
+  auto pos = rawFile.lastIndexOf(".");
+  auto extension = rawFile.right(rawFile.length() - pos);
   QFileInfo rawFileInfo(rawFile);
   std::string name = rawFileInfo.baseName().toStdString();
 
-  IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("Load");
+   IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("Load");
   loadAlg->initialize();
   loadAlg->setProperty("Filename", rawFile.toStdString());
   loadAlg->setProperty("OutputWorkspace", name);
-  loadAlg->setProperty("SpectrumMin", detectorMin);
-  loadAlg->setProperty("SpectrumMax", detectorMax);
+  if (extension.compare(".nxs") == 0) {
+    int64_t detectorMin =
+        static_cast<int64_t>(m_uiForm.spPlotTimeSpecMin->value());
+    int64_t detectorMax =
+        static_cast<int64_t>(m_uiForm.spPlotTimeSpecMax->value());
+    loadAlg->setProperty("SpectrumMin", detectorMin);
+    loadAlg->setProperty("SpectrumMax", detectorMax);
+  } else {
+    loadAlg->setProperty("SpectrumMin", detectorMin);
+    loadAlg->setProperty("SpectrumMax", detectorMax);
+  }
   m_batchAlgoRunner->addAlgorithm(loadAlg);
 
   // Rebin the workspace to its self to ensure constant binning


### PR DESCRIPTION
Fixes #13799

It is now possible to use the Plot time function for both .raw files and .nxs files
# To Test
- Open ISIS Energy Transfer (Interfaces > Indirect > Data Reduction > Energy Transfer)
- Try using the plot time functionality with a .raw file 
  - Run number 26176  (From the Data Archive)
- Try using the plot time functionality with a .nxs file
  - Run number 0055116 (From the Data Archive)
- Ensure that reasonable plots are produced for both these files and no crashes caused.
