### PR TITLE
Indirect Bayes Quasi save result crash

### DIFF
--- a/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Code/Mantid/Framework/Nexus/src/NexusFileIO.cpp
@@ -476,7 +476,7 @@ int NexusFileIO::writeNexusProcessedData2D(
       textAxis += label + "\n";
     }
     dims_array[0] = static_cast<int>(textAxis.size());
-    NXmakedata(fileID, "axis2", NX_CHAR, 2, dims_array);
+    NXmakedata(fileID, "axis2", NX_CHAR, 1, dims_array);
     NXopendata(fileID, "axis2");
     NXputdata(fileID,
               reinterpret_cast<void *>(const_cast<char *>(textAxis.c_str())));


### PR DESCRIPTION
Fixes #13817

When Save Result is checked in the Quasi interface in Indirect Bayes Workspaces are now saved correctly without error.
- [x] tested multiple input workspaces to ensure correct functionality
# To Test
- Open Quasi (Interfaces > Indirect > Bayes > Quasi)
- Select reasonable input files: 
  - I have been using `irs26176_graphite002_red` and `irs26173_graphite002_res`
- Check the `Save Result` option
- Click `Run` _(ensure you have a default save directory set)_
- Ensure that the following files are produced in the default save directory _(all files start with the input prefix e.g. for `irs26176_graphite002_red` the input prefix is `irs26176_graphite002`)_ :
  - `_QLr_Result.nxs`
  - `_QLr_Workspaces.nxs`

_This will also produce:_
-  _`_QLr.lpt`_
-  _`_QLr.ql1`_
-  _`_QLr.ql2`_
-  _`_QLr.ql3`_

_but we are only interested in the above 2 .nxs files for this issue_
