### PR TITLE
Adding tolerance for sqrt calculation in SetUncertainties

### DIFF
--- a/Code/Mantid/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SetUncertainties.cpp
@@ -14,6 +14,11 @@ DECLARE_ALGORITHM(SetUncertainties)
 using namespace Kernel;
 using namespace API;
 
+namespace {
+/// Used to compare signal to zero
+const double TOLERANCE=1.e-10;
+}
+
 /// (Empty) Constructor
 SetUncertainties::SetUncertainties() : API::Algorithm() {}
 
@@ -70,7 +75,11 @@ void SetUncertainties::exec() {
       MantidVec &E = outputWorkspace->dataE(i);
       std::size_t numE = E.size();
       for (std::size_t j = 0; j < numE; j++) {
-        E[j] = sqrt(fabs(Y[j]));
+        const double y_val = fabs(Y[j]);
+        if (y_val < TOLERANCE)
+            E[j] = 0.;
+        else
+            E[j] = sqrt(y_val);
       }
     }
 

--- a/Code/Mantid/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Code/Mantid/Framework/Algorithms/src/SetUncertainties.cpp
@@ -76,10 +76,8 @@ void SetUncertainties::exec() {
       std::size_t numE = E.size();
       for (std::size_t j = 0; j < numE; j++) {
         const double y_val = fabs(Y[j]);
-        if (y_val < TOLERANCE)
-            E[j] = 0.;
-        else
-            E[j] = sqrt(y_val);
+        if (y_val > TOLERANCE)
+          E[j] = sqrt(y_val);
       }
     }
 


### PR DESCRIPTION
When the `Y` value was very small (zero in many representations), the user would see a non-zero uncertainty. While the calculation was correct, it was a bit counter-intuitive. This is a minor issue with the `sqrt` branch only.

This does not need to be in the release notes.
