### PR TITLE
Add FirstGoodData to list of log values

### DIFF
--- a/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Code/Mantid/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -200,6 +200,13 @@ void LoadMuonNexus1::exec() {
   localWorkspace->setComment(notes);
   localWorkspace->mutableRun().addLogData(
       new PropertyWithValue<std::string>("run_number", run_num));
+
+  // Add 'FirstGoodData' to list of logs if possible
+  if ( existsProperty("FirstGoodData") && existsProperty("TimeZero")) {
+    double fgd = getProperty("FirstGoodData");
+    double tz = getProperty("TimeZero");
+    localWorkspace->mutableRun().addLogData(new PropertyWithValue<double>("FirstGoodData",fgd-tz));
+  }
   // Set the unit on the workspace to muon time, for now in the form of a Label
   // Unit
   boost::shared_ptr<Kernel::Units::Label> lblUnit =

--- a/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/Code/Mantid/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -173,7 +173,7 @@ public:
   {
     EXPECT_CALL(*m_view, firstRun()).WillRepeatedly(Return("MUSR00015189.nxs"));
     // Test logs
-    EXPECT_CALL(*m_view, setAvailableLogs(AllOf(Property(&std::vector<std::string>::size, 37),
+    EXPECT_CALL(*m_view, setAvailableLogs(AllOf(Property(&std::vector<std::string>::size, 38),
                                                 Contains("run_number"),
                                                 Contains("sample_magn_field"),
                                                 Contains("Field_Danfysik")))).Times(1);


### PR DESCRIPTION
Fixes  #13819

For tester:

Load a muon nexus file, for instance MUSR00015189.nxs, right-click on the workspace to show sample logs. Check that there is an entry called 'FirstGoodData'.

No need to mention this in the release notes.
