### PR TITLE
Re #13736 Improve tooltip on status for local and remote change

### DIFF
--- a/Code/Mantid/MantidQt/API/src/RepoModel.cpp
+++ b/Code/Mantid/MantidQt/API/src/RepoModel.cpp
@@ -313,10 +313,15 @@ QVariant RepoModel::data(const QModelIndex &index, int role) const
         case LOCAL_CHANGED:         
           return "Click here to publish your changes";
         case REMOTE_CHANGED:
+          return (inf.directory)?
+                 "There is a new version of the files inside this folder. Click here to install them.":
+                 "There is a new version of this file available. Click here to install it.";
         case BOTH_CHANGED:
           return (inf.directory)?
-            "There is a new version of the files inside this folder. Click here to install them.":
-            "There is a new version of this file available. Click here to install it.";
+                 "Files in this folder may have changed both locally and remotely.\nClick here to install the remote version, "
+                   "a backup of the local version will also be created.":
+                 "This file may have changed both locally and remotely.\nClick here to install the remote version, "
+                   "a backup of the local version will also be created.";
           break;
         case LOCAL_ONLY:
           return "Click here to share this file with the Mantid community!";


### PR DESCRIPTION
Closes #13736 

Clearer tooltip on the status button to distinguish between the cases of a file having changed remotely only, or both remotely and locally. In the latter case the remote file is offered for download, but the tooltip informs the user that a backup of the local version will be created.

Tester:
Code review may be sufficient, but if you want to see the tooltips in context then you can use the following steps:
- Download any file from the script repository
- In the .local.json file in your script repository directory, edit the "downloaded_pubdate" to an earlier date for the file you downloaded.
- Hit reload in the script repository window.
- The status should be a download button with tooltip "There is a new version of this file available. Click here to install it".
- Now delete the entire entry for your download file from .local.json.
- Also edit the downloaded file and make any change.
- Hit reload in the repository window and the status should be a download button with tooltip "This file may have changed both locally and remotely. Click here to install the remote version, a backup of the local version will also be created."
