### PR TITLE
SaveOpenGenie::Add missing variables & included different formatting style

### DIFF
--- a/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
+++ b/Code/Mantid/Framework/DataHandling/inc/MantidDataHandling/SaveOpenGenieAscii.h
@@ -67,6 +67,9 @@ private:
   /// add ntc field which is required for OpenGenie
   void addNtc(const std::string fourspc, int nBins);
 
+  /// apply enginX format field which is required for OpenGenie
+  void applyEnginxFormat(const std::string fourspc);
+
   /// Vector to safe sample log
   std::vector<std::string> logVector;
   /// Workspace


### PR DESCRIPTION
Fixes #13816 

**To Test**

Following variables can be found in ascii file when `ENGIN-X Format` is applied:
- xunits
- run_no
- spec_no
- title
- ylabel

Following variables can be found in ascii file when `Basic Format` is applied:
- run_no
- title

SpecNumberField only accepts valid format which is something like... `1200 - 2000`.
SpecNumberField is **not** accessible when basic format is selected in the `SaveOpenGenieAscii` input dialog.
