### PR TITLE
Fix crash with algorithm dialogs and new keep open functionality

### DIFF
--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/AlgorithmDialog.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/AlgorithmDialog.h
@@ -27,6 +27,7 @@
 
 #include <QDialog>
 #include <QString>
+#include <QTimer>
 #include <QHash>
 #include <QVBoxLayout>
 
@@ -240,6 +241,8 @@ protected slots:
   virtual void executeAlgorithmAsync();
   /// Removes the algorithm from the manager.
   virtual void removeAlgorithmFromManager();
+  /// Enable to exit button
+  void enableExitButton();
 
 protected:
 
@@ -257,6 +260,7 @@ protected:
   virtual void finishHandle(const Mantid::API::IAlgorithm *alg);
   /// Handle completion of algorithm started while staying open
   virtual void errorHandle(const Mantid::API::IAlgorithm *alg, const std::string &what);
+  virtual void closeEvent(QCloseEvent *evt);
 
 /// The following methods were made public for testing in GenericDialogDemo.cpp
 public:
@@ -334,10 +338,13 @@ protected:
   //the keep open checkbox control
   QCheckBox* m_keepOpenCheckBox;
 
-  QPushButton* m_okButton;
+  QPushButton* m_okButton, *m_exitButton;
 
   /// A list of AlgorithmObservers to add to the algorithm prior to execution
   std::vector<Mantid::API::AlgorithmObserver *> m_observers;
+
+  /// Enable the close button when the timer fires
+  QTimer m_btnTimer;
   //@}
 };
 

--- a/Code/Mantid/MantidQt/API/inc/MantidQtAPI/AlgorithmDialog.h
+++ b/Code/Mantid/MantidQt/API/inc/MantidQtAPI/AlgorithmDialog.h
@@ -345,6 +345,8 @@ protected:
 
   /// Enable the close button when the timer fires
   QTimer m_btnTimer;
+  /// A flag to track whether the status of the algorithm is being tracked
+  bool m_statusTracked;
   //@}
 };
 

--- a/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
+++ b/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
@@ -56,9 +56,11 @@ AlgorithmDialog::AlgorithmDialog(QWidget* parent) :
 AlgorithmDialog::~AlgorithmDialog()
 {
   m_observers.clear();
-  if(!m_okButton->isEnabled()) {
-    // Keep open was checked but closing while algorithm is running
-    this->stopObserving(m_algorithm);
+  if(isShowKeepOpen() && m_okButton) {
+    if(!m_okButton->isEnabled()) {
+      // Keep open was checked but closing while algorithm is running
+      this->stopObserving(m_algorithm);
+    }
   }
 }
 

--- a/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
+++ b/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
@@ -56,6 +56,10 @@ AlgorithmDialog::AlgorithmDialog(QWidget* parent) :
 AlgorithmDialog::~AlgorithmDialog()
 {
   m_observers.clear();
+  if(!m_okButton->isEnabled()) {
+    // Keep open was checked but closing while algorithm is running
+    this->stopObserving(m_algorithm);
+  }
 }
 
 /**

--- a/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
+++ b/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
@@ -1191,15 +1191,16 @@ void AlgorithmDialog::errorHandle(const IAlgorithm *alg, const std::string &what
  * Only allow close when close is enabled
  */
 void AlgorithmDialog::closeEvent(QCloseEvent *evt) {
-  if(m_exitButton->isEnabled()) {
-    evt->accept();
-  }
-  else {
-    evt->ignore();
+  if (m_exitButton) {
+    if (m_exitButton->isEnabled()) {
+      evt->accept();
+    } else {
+      evt->ignore();
+    }
+  } else {
+    QDialog::closeEvent(evt);
   }
 }
-
-
 
 /**Handle completion of algorithm started while staying open.
  * reenables the OK button when the algorithms finishes.


### PR DESCRIPTION
Fixes #13836 

**Tester**

It's quite possible that you may not be able to reproduce the original problem without playing with Mantid and dialogs for a long time. The problem is described in the commit message of the first commit but the testing scenrios are:
- run algorithms through the dialog, `Load` & `Rebin` etc and ensure _Keep Open_ is disabled
- do the same as above but with _Keep Open_ enabled
- make sure you close a dialog while an algorithm is running and _Keep Open_ is enabled
