### PR TITLE
Fix crash in VSI when rebinning

### DIFF
--- a/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
+++ b/Code/Mantid/MantidQt/API/src/AlgorithmDialog.cpp
@@ -842,7 +842,7 @@ void AlgorithmDialog::executeAlgorithmAsync()
     }
 
     // Only need to observe finish events if we are staying open
-    if(m_keepOpenCheckBox->isChecked()) {
+    if(m_keepOpenCheckBox && m_keepOpenCheckBox->isChecked()) {
       this->observeFinish(algToExec);
       this->observeError(algToExec);
       m_statusTracked = true;

--- a/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Code/Mantid/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -197,8 +197,7 @@ void StandardView::render()
     return;
   }
   pqObjectBuilder* builder = pqApplicationCore::instance()->getObjectBuilder();
-
-  //setRebinAndUnbinButtons();
+  activeSourceChangeListener(this->origSrc);
 
   if (this->isPeaksWorkspace(this->origSrc))
   {


### PR DESCRIPTION
To test simply open an MD workspace in the standard view in the VSI and try to rebin it. It should not crash!
