### PR TITLE
Fix variable OPENCASCADE_LIBRARY_DIR on OS X.

### DIFF
--- a/buildconfig/CMake/FindOpenCascade.cmake
+++ b/buildconfig/CMake/FindOpenCascade.cmake
@@ -18,7 +18,8 @@ if ( WIN32 )
   add_definitions ( -DWNT )
 endif ( WIN32 )
 
-find_path ( OPENCASCADE_LIBRARY_DIR libTKernel.so PATHS
+find_path ( OPENCASCADE_LIBRARY_DIR NAMES libTKernel.so libTKernel.dylib PATHS
+                /usr/local/lib
                 /opt/OpenCASCADE/lib64
                 $ENV{CASROOT}/lib64
                 /opt/OpenCASCADE/lib


### PR DESCRIPTION
Currently cmake is failing to find variable `OPENCASCADE_LIBRARY_DIR` on OS X. This can be fixed by adding  `libTKernel.dylib` to `NAMES` and `/usr/local/lib` to `PATHS`.

No release notes necessary because this doesn't change the binary package.

testing: code review is sufficient.
