### PR TITLE
ConvFit Add label for delta height when using delta

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1316,9 +1316,17 @@ void ConvFit::hwhmUpdateRS(double val) {
 void ConvFit::checkBoxUpdate(QtProperty *prop, bool checked) {
   UNUSED_ARG(checked);
 
-  if (prop == m_properties["UseDeltaFunc"])
+  if (prop == m_properties["UseDeltaFunc"]) {
     updatePlotOptions();
-  else if (prop == m_properties["UseFABADA"]) {
+    if (checked == true) {
+      m_properties["DeltaFunction"]->addSubProperty(
+          m_properties["DeltaHeight"]);
+      m_dblManager->setValue(m_properties["DeltaHeight"], 1.0000);
+    } else {
+      m_properties["DeltaFunction"]->removeSubProperty(
+          m_properties["DeltaHeight"]);
+    }
+  } else if (prop == m_properties["UseFABADA"]) {
     if (checked) {
       // FABADA needs a much higher iteration limit
       m_dblManager->setValue(m_properties["MaxIterations"], 20000);


### PR DESCRIPTION
Fixes #13882

Now when Delta Function is being used the Height is displayed in the parameter tree. This also updates the plot guess when changed.
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Load the sample file `irs26176_graphite002_red.nxs`
- Load the resolution file `irs26173_graphite002_res.nxs` 
  - These are both available from the `\ExternalData\Testing\Data\SystemTest` directory
- Select the `Use Delta` option from the parameter tree
  - Ensure this produces the `Height` label with a value of `1.000000`
- Check the Plot Guess option (just above the Parameter tree)
  - Ensure this produces a Green Guess plot line in the mini plot 
- Change the value for Height in the parameter tree 
  - Ensure this also changes the height of the delta function in the mini plot while plot guess is still enabled
