### PR TITLE
Update data automatically in ALC interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCBaselineModellingView.h
@@ -63,6 +63,7 @@ namespace CustomInterfaces
     SectionRow sectionRow(int row) const;
     SectionSelector sectionSelector(int index) const;
     int noOfSectionRows() const;
+    void emitFitRequested();
 
   public slots:
     void initialize();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingPresenter.h
@@ -60,6 +60,10 @@ namespace CustomInterfaces
     /// Updates the list of logs and number of periods
     void updateAvailableInfo();
 
+  signals:
+    /// Signal emitted when data get changed
+    void dataChanged();
+
   private:
     /// View which the object works with
     IALCDataLoadingView* const m_view;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
@@ -18,9 +18,11 @@ namespace CustomInterfaces
 
   class ALCDataLoadingPresenter;
 
+  class ALCBaselineModellingView;
   class ALCBaselineModellingPresenter;
   class ALCBaselineModellingModel;
 
+  class ALCPeakFittingView;
   class ALCPeakFittingPresenter;
   class ALCPeakFittingModel;
 
@@ -68,10 +70,16 @@ namespace CustomInterfaces
     void exportResults();
     void importResults();
 
+    void updateBaselineData();
+
   private:
 
     /// UI form
     Ui::ALCInterface m_ui;
+
+    // Step views
+    ALCBaselineModellingView* m_baselineModellingView;
+    ALCPeakFittingView* m_peakFittingView;
 
     // Step presenters
     ALCDataLoadingPresenter* m_dataLoading;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCInterface.h
@@ -71,6 +71,7 @@ namespace CustomInterfaces
     void importResults();
 
     void updateBaselineData();
+    void updatePeakData();
 
   private:
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
@@ -58,6 +58,7 @@ namespace CustomInterfaces
     IFunction_const_sptr function(QString index) const;
     boost::optional<QString> currentFunctionIndex() const;
     IPeakFunction_const_sptr peakPicker() const;
+    void emitFitRequested();
 
   public slots:
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -135,6 +135,9 @@ namespace CustomInterfaces
     /// User has selected the first run
     void firstRunSelected();
 
+    /// New data have been loaded
+    void dataChanged();
+
   };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -272,5 +272,9 @@ namespace CustomInterfaces
     MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Muon_ALC"));
   }
 
+  void ALCBaselineModellingView::emitFitRequested() {
+    emit fitRequested();
+  }
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -108,6 +108,8 @@ namespace CustomInterfaces
       m_view->setDataCurve(*(ALCHelper::curveDataFromWs(m_loadedData, 0)),
                            ALCHelper::curveErrorsFromWs(m_loadedData, 0));
 
+      emit dataChanged();
+
     }
     catch(std::exception& e)
     {

--- a/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -105,9 +105,6 @@ namespace CustomInterfaces
   {
     int next = m_ui.stepView->currentIndex() + 1;
 
-    auto nextWidget = m_ui.stepView->widget(next);
-    assert(nextWidget);
-
     switchStep(next);
   }
 

--- a/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -86,13 +86,6 @@ namespace CustomInterfaces
     auto nextWidget = m_ui.stepView->widget(next);
     assert(nextWidget);
 
-    if (nextWidget == m_ui.baselineModellingView)
-    {
-      if (m_dataLoading->loadedData())
-      {
-        m_baselineModellingModel->setData(m_dataLoading->loadedData());
-      }
-    }
     if (nextWidget == m_ui.peakFittingView)
     {
       if (m_baselineModellingModel->correctedData())

--- a/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -58,6 +58,7 @@ namespace CustomInterfaces
     m_peakFitting->initialize();
 
     connect(m_dataLoading, SIGNAL(dataChanged()), SLOT(updateBaselineData()));
+    connect(m_baselineModellingModel, SIGNAL(correctedDataChanged()), SLOT(updatePeakData()));
 
     assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps
 
@@ -66,15 +67,36 @@ namespace CustomInterfaces
 
   void ALCInterface::updateBaselineData() {
 
+    // Make sure we do have some data
     if (m_dataLoading->loadedData()) {
 
+      // Send the data to BaselineModelling
       m_baselineModellingModel->setData(m_dataLoading->loadedData());
 
+      // If we have a fitting function and a fitting range
+      // we can update the baseline model
       if ((!m_baselineModellingView->function().isEmpty()) &&
           (m_baselineModellingView->noOfSectionRows() > 0)) {
 
             // Fit the data
             m_baselineModellingView->emitFitRequested();
+      }
+    }
+  }
+
+  void ALCInterface::updatePeakData() {
+
+    // Make sure we do have some data
+    if (m_baselineModellingModel->correctedData()) {
+
+      // Send the data to PeakFitting
+      m_peakFittingModel->setData(m_baselineModellingModel->correctedData());
+
+      // If we have a fitting function
+      if (m_peakFittingView->function("")) {
+
+        // Fit the data
+        m_peakFittingView->emitFitRequested();
       }
     }
   }
@@ -85,14 +107,6 @@ namespace CustomInterfaces
 
     auto nextWidget = m_ui.stepView->widget(next);
     assert(nextWidget);
-
-    if (nextWidget == m_ui.peakFittingView)
-    {
-      if (m_baselineModellingModel->correctedData())
-      {
-        m_peakFittingModel->setData(m_baselineModellingModel->correctedData());
-      }
-    }
 
     switchStep(next);
   }

--- a/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCInterface.cpp
@@ -49,17 +49,34 @@ namespace CustomInterfaces
     m_dataLoading = new ALCDataLoadingPresenter(dataLoadingView);
     m_dataLoading->initialize();
 
-    auto baselineModellingView = new ALCBaselineModellingView(m_ui.baselineModellingView);
-    m_baselineModelling = new ALCBaselineModellingPresenter(baselineModellingView, m_baselineModellingModel);
+    m_baselineModellingView = new ALCBaselineModellingView(m_ui.baselineModellingView);
+    m_baselineModelling = new ALCBaselineModellingPresenter(m_baselineModellingView, m_baselineModellingModel);
     m_baselineModelling->initialize();
 
-    auto peakFittingView = new ALCPeakFittingView(m_ui.peakFittingView);
-    m_peakFitting = new ALCPeakFittingPresenter(peakFittingView, m_peakFittingModel);
+    m_peakFittingView = new ALCPeakFittingView(m_ui.peakFittingView);
+    m_peakFitting = new ALCPeakFittingPresenter(m_peakFittingView, m_peakFittingModel);
     m_peakFitting->initialize();
+
+    connect(m_dataLoading, SIGNAL(dataChanged()), SLOT(updateBaselineData()));
 
     assert(m_ui.stepView->count() == STEP_NAMES.count()); // Should have names for all steps
 
     switchStep(0); // We always start from the first step
+  }
+
+  void ALCInterface::updateBaselineData() {
+
+    if (m_dataLoading->loadedData()) {
+
+      m_baselineModellingModel->setData(m_dataLoading->loadedData());
+
+      if ((!m_baselineModellingView->function().isEmpty()) &&
+          (m_baselineModellingView->noOfSectionRows() > 0)) {
+
+            // Fit the data
+            m_baselineModellingView->emitFitRequested();
+      }
+    }
   }
 
   void ALCInterface::nextStep()

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
@@ -147,6 +147,10 @@ void ALCPeakFittingView::displayError(const QString& message)
   QMessageBox::critical(m_widget, "Error", message);
 }
 
+void ALCPeakFittingView::emitFitRequested() {
+  emit fitRequested();
+}
+
 } // namespace CustomInterfaces
 } // namespace Mantid
 


### PR DESCRIPTION
Fixes #13862 

For tester:

See original issue for a detailed description. To test this, the first thing you should do is get hold of some appropriate muon data. I suggest HIFI runs from 83077 to 83157, which can be found here \\ISIS\inst$\NDXHIFI\Instrument\data\cycle_15_1. Once you have these:
- Open Interfaces > Muon > ALC. Load the first half of the data: select HIFI00083077.nxs as First and HIFI00083120.nxs as Last. 
- Go to BaselineModelling. Add a new fitting function, a Chebyshev function (EndX=83120, StartX=83077, n=2) should give good results. Add two sections, [83077 to 83094] and [83110 to 83120] for instance. Fit the data.
- Go to PeakFitting. Add a gaussian peak (initial values: Height ~ -0.002, PeakCentre ~ 83100, Sigma ~ 2). Fit.
- Go back to DataLoading and load the second half of the data: replace HIFI00083120.nxs by HIFI000157.nxs in "Last". Click on "Load", don't wait for the new data points to appear, go to BaselineModelling and wait there. As soon as the progress bar reaches 100% the fitting curve and the corrected data will be updated.
- Go to PeakFitting and check that data have been added there too.
- Try to break the interface (fitting with no ranges, empty function browsers, etc).

Release notes: No need to mention this for the moment, as this PR is part of the work on #10057 
