### PR TITLE
ISIS Energy Transfer check for background start/end in Plot Time validation

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -447,6 +447,15 @@ void ISISEnergyTransfer::plotRaw() {
     return;
   }
 
+  if (m_uiForm.ckBackgroundRemoval->isChecked() == true) {
+    int startBack = m_uiForm.spBackgroundStart->value();
+    int endBack = m_uiForm.spBackgroundEnd->value();
+    if (startBack > endBack) {
+      emit showMessageBox("Background Start must be less than Background End");
+      return;
+    }
+  }
+
   QString rawFile = m_uiForm.dsRunFiles->getFirstFilename();
   auto pos = rawFile.lastIndexOf(".");
   auto extension = rawFile.right(rawFile.length() - pos);


### PR DESCRIPTION
Fixes #13769

Ensured that the Removal of Background (ToF) is also validated when using `Plot Time` in Indirect Energy Transfer.
# To Test
- Ensure your default facility is ISIS (View > Preferences... > Mantid)
- Open ISIS Energy Transfer (Interfaces > Indirect > Data Reduction > ISIS Energy Transfer)
- Enter a run that matches the Instrument details 
  - For IRIS / Graphite / 002 some examples would be `26173`, `26174`, `26175`, `26176`
  - The above will only work if they are either already in you directory paths or you are using the Data Archives. 
    - You can turn on using the `Data Archive` by clicking Manage Directories (bottom right) and checking the `Search in Data Archive` box
- Check the `Background Removal` box in the `Background Removal (ToF) section.
- Set the Start to be greater than the End
- In the `Plot Time` tab click `Plot` 
- Ensure a warning message is produced `Background Start must be less than Background End`

**Note To Tester**
Currently running `Plot Time` or `Run` with a Background Start/End not in the data range produces an error. This is being solved in a separate issue. If you wish to check a normal run, use Plot Time with Background Removal unchecked, observe the X Data Range and select Background Start/End values within the range. 
