### PR TITLE
Disable widgets when loading data

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -81,6 +81,8 @@ namespace CustomInterfaces
     void setTimeLimits(double tMin, double tMax);
     void setTimeRange (double tMin, double tMax);
     void help();
+    void disableAll();
+    void enableAll();
 
     // -- End of IALCDataLoadingView interface -----------------------------------------------------
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.h
@@ -80,8 +80,6 @@ namespace CustomInterfaces
     void setAvailablePeriods(const std::vector<std::string> &periods);
     void setTimeLimits(double tMin, double tMax);
     void setTimeRange (double tMin, double tMax);
-    void setWaitingCursor();
-    void restoreCursor();
     void help();
 
     // -- End of IALCDataLoadingView interface -----------------------------------------------------

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCDataLoadingView.ui
@@ -383,7 +383,7 @@
                 </widget>
               </item>
               <item>
-                <widget class="QGroupBox" name="groupBox_2">
+                <widget class="QGroupBox" name="calculationGroup">
                   <property name="title">
                     <string>Calculation</string>
                   </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -122,6 +122,12 @@ namespace CustomInterfaces
     /// Opens the Mantid Wiki web page
     virtual void help() = 0;
 
+    /// Disables all the widgets
+    virtual void disableAll() = 0;
+
+    /// Enables all the widgets
+    virtual void enableAll() = 0;
+
   signals:
     /// Request to load data
     void loadRequested();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCDataLoadingView.h
@@ -119,12 +119,6 @@ namespace CustomInterfaces
     /// @param tMax :: Maximum X value available
     virtual void setTimeRange(double tMin, double tMax) = 0;
 
-    /// Set waiting cursor for long operation
-    virtual void setWaitingCursor() = 0;
-
-    /// Restore the original cursor
-    virtual void restoreCursor() = 0;
-
     /// Opens the Mantid Wiki web page
     virtual void help() = 0;
 

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -36,7 +36,6 @@ namespace CustomInterfaces
 
   void ALCDataLoadingPresenter::load()
   {
-    m_view->setWaitingCursor();
 
     try
     {
@@ -114,7 +113,6 @@ namespace CustomInterfaces
       m_view->displayError(e.what());
     }
 
-    m_view->restoreCursor();
   }
 
   void ALCDataLoadingPresenter::updateAvailableInfo()

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingPresenter.cpp
@@ -36,6 +36,7 @@ namespace CustomInterfaces
 
   void ALCDataLoadingPresenter::load()
   {
+    m_view->disableAll();
 
     try
     {
@@ -113,6 +114,7 @@ namespace CustomInterfaces
       m_view->displayError(e.what());
     }
 
+    m_view->enableAll();
   }
 
   void ALCDataLoadingPresenter::updateAvailableInfo()

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -221,15 +221,5 @@ namespace CustomInterfaces
     MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Muon_ALC"));
   }
 
-  void ALCDataLoadingView::setWaitingCursor()
-  {
-    QApplication::setOverrideCursor(Qt::WaitCursor);
-  }
-
-  void ALCDataLoadingView::restoreCursor()
-  {
-    QApplication::restoreOverrideCursor();
-  }
-
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -40,6 +40,18 @@ namespace CustomInterfaces
     m_dataCurve->setSymbol(QwtSymbol(QwtSymbol::Ellipse, QBrush(), QPen(), QSize(7,7)));
     m_dataCurve->setRenderHint(QwtPlotItem::RenderAntialiased, true);
     m_dataCurve->attach(m_ui.dataPlot);
+
+    // The following lines disable the groups' titles when the
+    // group is disabled
+    QPalette palette;
+    palette.setColor(QPalette::Disabled, QPalette::WindowText,
+                     QApplication::palette().color(QPalette::Disabled,
+                                                   QPalette::WindowText));
+    m_ui.dataGroup->setPalette(palette);
+    m_ui.deadTimeGroup->setPalette(palette);
+    m_ui.detectorGroupingGroup->setPalette(palette);
+    m_ui.periodsGroup->setPalette(palette);
+    m_ui.calculationGroup->setPalette(palette);
   }
 
   std::string ALCDataLoadingView::firstRun() const
@@ -219,6 +231,30 @@ namespace CustomInterfaces
   void ALCDataLoadingView::help()
   {
     MantidQt::API::HelpWindow::showCustomInterface(NULL, QString("Muon_ALC"));
+  }
+
+  void ALCDataLoadingView::disableAll() {
+
+    // Disable all the widgets in the view
+    m_ui.dataGroup->setEnabled(false);
+    m_ui.deadTimeGroup->setEnabled(false);
+    m_ui.detectorGroupingGroup->setEnabled(false);
+    m_ui.periodsGroup->setEnabled(false);
+    m_ui.calculationGroup->setEnabled(false);
+    m_ui.load->setEnabled(false);
+
+  }
+
+  void ALCDataLoadingView::enableAll() {
+
+    // Enable all the widgets in the view
+    m_ui.deadTimeGroup->setEnabled(true);
+    m_ui.dataGroup->setEnabled(true);
+    m_ui.detectorGroupingGroup->setEnabled(true);
+    m_ui.periodsGroup->setEnabled(true);
+    m_ui.calculationGroup->setEnabled(true);
+    m_ui.load->setEnabled(true);
+
   }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCDataLoadingPresenterTest.h
@@ -51,8 +51,8 @@ public:
   MOCK_METHOD1(setAvailablePeriods, void(const std::vector<std::string>&));
   MOCK_METHOD2(setTimeLimits, void(double,double));
   MOCK_METHOD2(setTimeRange, void(double,double));
-  MOCK_METHOD0(setWaitingCursor, void());
-  MOCK_METHOD0(restoreCursor, void());
+  MOCK_METHOD0(disableAll, void());
+  MOCK_METHOD0(enableAll, void());
   MOCK_METHOD0(help, void());
 
   void requestLoading() { emit loadRequested(); }
@@ -116,7 +116,7 @@ public:
   void test_defaultLoad()
   {
     InSequence s;
-    EXPECT_CALL(*m_view, setWaitingCursor());
+    EXPECT_CALL(*m_view, disableAll());
 
     EXPECT_CALL(*m_view, setDataCurve(AllOf(Property(&QwtData::size,3),
                                             QwtDataX(0, 1350, 1E-8),
@@ -130,7 +130,7 @@ public:
                                             VectorValue(1,1.284E-3,1E-6),
                                             VectorValue(2,1.280E-3,1E-6))));
 
-    EXPECT_CALL(*m_view, restoreCursor());
+    EXPECT_CALL(*m_view, enableAll());
 
     m_view->requestLoading();
   }
@@ -232,7 +232,7 @@ public:
     ON_CALL(*m_view, deadTimeType()).WillByDefault(Return("FromRunData"));
     EXPECT_CALL(*m_view, deadTimeType()).Times(2);
     EXPECT_CALL(*m_view, deadTimeFile()).Times(0);
-    EXPECT_CALL(*m_view, restoreCursor()).Times(1);
+    EXPECT_CALL(*m_view, enableAll()).Times(1);
     EXPECT_CALL(*m_view, setDataCurve(AllOf(Property(&QwtData::size,3),
                                             QwtDataY(0, 0.150616, 1E-3),
                                             QwtDataY(1, 0.143444, 1E-3),
@@ -251,7 +251,7 @@ public:
     ON_CALL(*m_view, deadTimeType()).WillByDefault(Return("FromSpecifiedFile"));
     EXPECT_CALL(*m_view, deadTimeType()).Times(2);
     EXPECT_CALL(*m_view, deadTimeFile()).Times(1);
-    EXPECT_CALL(*m_view, restoreCursor()).Times(1);
+    EXPECT_CALL(*m_view, enableAll()).Times(1);
     m_view->requestLoading();
   }
 
@@ -264,7 +264,7 @@ public:
     ON_CALL(*m_view, getBackwardGrouping()).WillByDefault(Return("1-32"));
     EXPECT_CALL(*m_view, getForwardGrouping()).Times(1);
     EXPECT_CALL(*m_view, getBackwardGrouping()).Times(1);
-    EXPECT_CALL(*m_view, restoreCursor()).Times(1);
+    EXPECT_CALL(*m_view, enableAll()).Times(1);
     EXPECT_CALL(*m_view, setDataCurve(AllOf(Property(&QwtData::size, 3),
                                             QwtDataX(0, 1350, 1E-8),
                                             QwtDataX(1, 1360, 1E-8),


### PR DESCRIPTION
Fixes #13899 

For tester:
- Open Interfaces > Muon > ALC
- Load "MUSR00015189.nxs" as "First" and "MUSR00015193.nxs" as "Last", hit "Load".
- Check that all the widgets related to the input properties are disabled and re-enabled when the loading process finishes. (The help button, "?", and the buttons "Import results...", "Export results..." and "Baseline modelling" should not be modified, as they are unrelated to the loading process).

Release notes: this is a minor change, so no need to mention it in the release notes.
