### PR TITLE
Engg: improved 'plot focused data'

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -85,6 +85,7 @@ protected:
   void processLogMsg();
   void processInstChange();
   void processShutDown();
+  void processPlotRepChange();
 
 protected slots:
   void calibrationFinished();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -85,7 +85,6 @@ protected:
   void processLogMsg();
   void processInstChange();
   void processShutDown();
-  void processPlotRepChange();
 
 protected slots:
   void calibrationFinished();
@@ -176,6 +175,8 @@ private:
   void calcVanadiumWorkspaces(const std::string &vanNo,
                               Mantid::API::ITableWorkspace_sptr &vanIntegWS,
                               Mantid::API::MatrixWorkspace_sptr &vanCurvesWS);
+
+  void plotFocusedWorkspace(std::string outWSName);
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -7,161 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>614</width>
-    <height>533</height>
+    <height>545</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="6" column="0">
-    <widget class="QGroupBox" name="groupBox_focus_2">
-     <property name="title">
-      <string>Output</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QCheckBox" name="checkBox_FocusedWS">
-          <property name="text">
-           <string>Plot Focused Workspace</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Focus Cropped</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_cropped_run_num">
-          <property name="text">
-           <string>Run #:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="readOnly">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_cropped_spec_ids">
-          <property name="text">
-           <string>Spectrum IDs:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <spacer name="horizontalSpacer_10">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_focus_cropped">
-          <property name="text">
-           <string>Focus</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>388</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
     <widget class="QGroupBox" name="groupBox_focus">
      <property name="title">
       <string>Focus run</string>
@@ -297,7 +150,108 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Focus Cropped</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label_cropped_run_num">
+          <property name="text">
+           <string>Run #:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_cropped_spec_ids">
+          <property name="text">
+           <string>Spectrum IDs:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <spacer name="horizontalSpacer_10">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_focus_cropped">
+          <property name="text">
+           <string>Focus</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Focus Texture</string>
@@ -395,7 +349,153 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_focus_3">
+     <property name="minimumSize">
+      <size>
+       <width>596</width>
+       <height>111</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Output</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_20">
+        <item>
+         <widget class="QCheckBox" name="checkBox_FocusedWS">
+          <property name="text">
+           <string>Plot Focused Workspace</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_18">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_21">
+        <item>
+         <spacer name="horizontalSpacer_19">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Plot Data Representation:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBox_PlotData">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>175</width>
+            <height>10</height>
+           </size>
+          </property>
+          <property name="sizeIncrement">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>One Window - Replacing Plots</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>One Window - Waterfall</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Multiple Windows</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_22">
+        <item>
+         <widget class="QCheckBox" name="checkBox_OutputFiles_">
+          <property name="text">
+           <string>Output Files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_20">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_13">
      <item>
       <spacer name="horizontalSpacer_11">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -121,6 +121,12 @@ public:
 
   virtual void plotFocusedSpectrum(const std::string &wsName);
 
+  virtual void plotWaterfallSpectrum(const std::string &wsName);
+
+  virtual void plotReplacingWindow(const std::string &wsName);
+
+  int currentPlotType() const { return m_currentType; }
+
 private slots:
   /// for buttons, do calibrate, focus and similar
   void loadCalibrationClicked();
@@ -144,6 +150,12 @@ private slots:
 
   // slots of the general part of the interface
   void instrumentChanged(int idx);
+
+  // slots of the focus part of the interface
+  void plotRepChanged(int idx);
+
+  // slots of plot spectrum check box status
+  void plotFocusStatus();
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();
@@ -183,6 +195,10 @@ private:
 
   /// instrument selected (ENGIN-X, etc.)
   std::string m_currentInst;
+
+  // plot data representation type selected
+  int m_currentType;
+
   /// current calibration produced in the 'Calibration' tab
   std::string m_currentCalibFilename;
   /// calibration settings - from/to the 'settings' tab

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -47,7 +47,6 @@ public:
     ResetFocus,        ///< Re-set / clear all focus inputs and options
     LogMsg,            ///< need to send a message to the Mantid log system
     InstrumentChange,  ///< Instrument selection updated
-    PlotRepChange,     ///< Data Plot representation selection updated
     ShutDown           ///< closing the interface
   };
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -38,16 +38,17 @@ public:
   /// These are user actions, triggered from the (passive) view, that need
   /// handling by the presenter
   enum Notification {
-    Start,                 ///< Start and setup interface
-    LoadExistingCalib,     ///< Load a calibration already availble on disk
-    CalcCalib,             ///< Calculate a (new) calibration
-    FocusRun,              ///< Focus one or more run files
-    FocusCropped,          ///< Focus one or more run files, cropped variant
-    FocusTexture,          ///< Focus one or more run files, texture variant
-    ResetFocus,            ///< Re-set / clear all focus inputs and options
-    LogMsg,                ///< need to send a message to the Mantid log system
-    InstrumentChange,      ///< Instrument selection updated
-    ShutDown               ///< closing the interface
+    Start,             ///< Start and setup interface
+    LoadExistingCalib, ///< Load a calibration already availble on disk
+    CalcCalib,         ///< Calculate a (new) calibration
+    FocusRun,          ///< Focus one or more run files
+    FocusCropped,      ///< Focus one or more run files, cropped variant
+    FocusTexture,      ///< Focus one or more run files, texture variant
+    ResetFocus,        ///< Re-set / clear all focus inputs and options
+    LogMsg,            ///< need to send a message to the Mantid log system
+    InstrumentChange,  ///< Instrument selection updated
+    PlotRepChange,     ///< Data Plot representation selection updated
+    ShutDown           ///< closing the interface
   };
 
   /**

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -269,6 +269,30 @@ public:
   * @param wsName name of the workspace to plot (must be in the ADS)
   */
   virtual void plotFocusedSpectrum(const std::string &wsName) = 0;
+
+  /**
+ * Produces a waterfall spectrum graph for focused output. Runs
+ * plotSpectrum function via python.
+ *
+ * @param wsName name of the workspace to plot (must be in the ADS)
+ */
+  virtual void plotWaterfallSpectrum(const std::string &wsName) = 0;
+
+  /**
+  * Produces a replaceable spectrum graph for focused output. Runs
+  * plotSpectrum function via python.
+  *
+  * @param wsName name of the workspace to plot (must be in the ADS)
+  */
+  virtual void plotReplacingWindow(const std::string &wsName) = 0;
+
+  /*
+ * Selected plot data representation will be applied, which will
+ * ran through python script
+ *
+ * @return which format should to applied for plotting data
+ */
+  virtual int currentPlotType() const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1333,12 +1333,11 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
  * Checks the plot type selected and applies the appropriate
  * python function to apply during first bank and second bank
  *
- * @param std::string outWSName; title of focused workspace
+ * @param outWSName; title of the focused workspace
  */
 void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName) {
   const bool plotFocusedWS = m_view->focusedOutWorkspace();
   int plotType = m_view->currentPlotType();
-
   if (plotFocusedWS == true && 0 == plotType) {
     if (outWSName == "engggui_focusing_output_ws_bank_1")
       m_view->plotFocusedSpectrum(outWSName);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -110,10 +110,6 @@ void EnggDiffractionPresenter::notify(
   case IEnggDiffractionPresenter::ShutDown:
     processShutDown();
     break;
-
-  case IEnggDiffractionPresenter::PlotRepChange:
-    processPlotRepChange();
-    break;
   }
 }
 
@@ -267,11 +263,6 @@ void EnggDiffractionPresenter::processInstChange() {
 }
 
 void EnggDiffractionPresenter::processShutDown() {
-  m_view->saveSettings();
-  cleanup();
-}
-
-void EnggDiffractionPresenter::processPlotRepChange() {
   m_view->saveSettings();
   cleanup();
 }
@@ -1097,36 +1088,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     // TODO: use detector positions (from calibrate full) when available
     // alg->setProperty(DetectorPositions, TableWorkspace)
     alg->execute();
-
-    const bool plotFocusedWS = m_view->focusedOutWorkspace();
-    int plotType = m_view->currentPlotType();
-    g_log.debug() << "...Plot Type return: " << plotType << std::endl;
-
-    // Qt comboBox returns absurd number for index of 0
-    if (plotType > 3) {
-      plotType = 1;
-    } else {
-      plotType += 1;
-    }
-
-    if (plotFocusedWS == true && 1 == plotType) {
-      if (outWSName == "engggui_focusing_output_ws_bank_1")
-        m_view->plotFocusedSpectrum(outWSName);
-      if (outWSName == "engggui_focusing_output_ws_bank_2")
-        m_view->plotReplacingWindow(outWSName);
-    }
-
-    else if (plotFocusedWS == true && 2 == plotType) {
-      if (outWSName == "engggui_focusing_output_ws_bank_1")
-        m_view->plotFocusedSpectrum(outWSName);
-      if (outWSName == "engggui_focusing_output_ws_bank_2")
-        m_view->plotWaterfallSpectrum(outWSName);
-    }
-
-    else if (plotFocusedWS == true && 3 == plotType) {
-      m_view->plotFocusedSpectrum(outWSName);
-    }
-
+	// plot Focused workspace according to the data type selected
+	plotFocusedWorkspace(outWSName);
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
@@ -1364,6 +1327,31 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
 
   vanIntegWS = ADS.retrieveWS<ITableWorkspace>(integName);
   vanCurvesWS = ADS.retrieveWS<MatrixWorkspace>(curvesName);
+}
+
+/**
+ * Checks the plot type selected and applies the appropriate
+ * python function to apply during first bank and second bank
+ *
+ * @param std::string outWSName; title of focused workspace
+ */
+void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName) {
+  const bool plotFocusedWS = m_view->focusedOutWorkspace();
+  int plotType = m_view->currentPlotType();
+
+  if (plotFocusedWS == true && 0 == plotType) {
+    if (outWSName == "engggui_focusing_output_ws_bank_1")
+      m_view->plotFocusedSpectrum(outWSName);
+    if (outWSName == "engggui_focusing_output_ws_bank_2")
+      m_view->plotReplacingWindow(outWSName);
+  } else if (plotFocusedWS == true && 1 == plotType) {
+    if (outWSName == "engggui_focusing_output_ws_bank_1")
+      m_view->plotFocusedSpectrum(outWSName);
+    if (outWSName == "engggui_focusing_output_ws_bank_2")
+      m_view->plotWaterfallSpectrum(outWSName);
+  } else if (plotFocusedWS == true && 2 == plotType) {
+    m_view->plotFocusedSpectrum(outWSName);
+  }
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -149,6 +149,8 @@ void EnggDiffractionViewQtGUI::doSetupTabSettings() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabFocus() {
+  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
+
   connect(m_uiTabFocus.pushButton_focus, SIGNAL(released()), this,
           SLOT(focusClicked()));
 
@@ -163,6 +165,12 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
 
   connect(m_uiTabFocus.pushButton_reset, SIGNAL(released()), this,
           SLOT(focusResetClicked()));
+
+  connect(m_uiTabFocus.comboBox_PlotData, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(plotRepChanged(int)));
+
+  connect(m_uiTabFocus.checkBox_FocusedWS, SIGNAL(clicked()), this,
+          SLOT(plotFocusStatus()));
 }
 
 void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
@@ -209,9 +217,11 @@ void EnggDiffractionViewQtGUI::readSettings() {
 
   qs.beginReadArray("user-params-focus-bank_i");
   qs.setArrayIndex(0);
-  m_uiTabFocus.checkBox_focus_bank1->setChecked(qs.value("value", true).toBool());
+  m_uiTabFocus.checkBox_focus_bank1->setChecked(
+      qs.value("value", true).toBool());
   qs.setArrayIndex(1);
-  m_uiTabFocus.checkBox_focus_bank2->setChecked(qs.value("value", true).toBool());
+  m_uiTabFocus.checkBox_focus_bank2->setChecked(
+      qs.value("value", true).toBool());
   qs.endArray();
 
   m_uiTabFocus.lineEdit_cropped_run_num->setText(
@@ -421,10 +431,33 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
 }
 
 void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {
-  std::string pyCode = "plotSpectrum('" + wsName + "', 0)";
+  std::string pyCode = "win = plotSpectrum('" + wsName + "', 0)";
 
   std::string status =
       runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+  m_logMsgs.push_back("Plotted output focused data, with status string " +
+                      status);
+  m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
+}
+
+void EnggDiffractionViewQtGUI::plotWaterfallSpectrum(
+    const std::string &wsName) {
+  // parameter of list ?
+  std::string pyCode =
+      "plotSpectrum('" + wsName + "', 0, waterfall = True, window = win)";
+  std::string status =
+      runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+  m_logMsgs.push_back("Plotted output focused data, with status string " +
+                      status);
+  m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
+}
+
+void EnggDiffractionViewQtGUI::plotReplacingWindow(const std::string &wsName) {
+  std::string pyCode =
+      "plotSpectrum('" + wsName + "', 0, window = win, clearWindow = True)";
+  std::string status =
+      runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+
   m_logMsgs.push_back("Plotted output focused data, with status string " +
                       status);
   m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
@@ -442,10 +475,9 @@ void EnggDiffractionViewQtGUI::resetFocus() {
   m_uiTabFocus.lineEdit_texture_grouping_file->setText("");
 }
 
-void
-EnggDiffractionViewQtGUI::writeOutCalibFile(const std::string &outFilename,
-                                            const std::vector<double> &difc,
-                                            const std::vector<double> &tzero) {
+void EnggDiffractionViewQtGUI::writeOutCalibFile(
+    const std::string &outFilename, const std::vector<double> &difc,
+    const std::vector<double> &tzero) {
   // TODO: this is horrible and should not last much here.
   // Avoid running Python code
   // Update this as soon as we have a more stable way of generating IPARM
@@ -675,6 +707,22 @@ std::string EnggDiffractionViewQtGUI::focusingTextureGroupingFile() const {
 
 bool EnggDiffractionViewQtGUI::focusedOutWorkspace() const {
   return m_uiTabFocus.checkBox_FocusedWS->checkState();
+}
+
+void EnggDiffractionViewQtGUI::plotFocusStatus() {
+  if (focusedOutWorkspace()) {
+    m_uiTabFocus.comboBox_PlotData->setEnabled(true);
+  } else {
+    m_uiTabFocus.comboBox_PlotData->setEnabled(false);
+  }
+}
+
+void EnggDiffractionViewQtGUI::plotRepChanged(int /*idx*/) {
+  QComboBox *inst = m_uiTabFocus.comboBox_PlotData;
+  if (!inst)
+    return;
+  m_currentType = inst->currentIndex();
+  m_presenter->notify(IEnggDiffractionPresenter::PlotRepChange);
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -149,7 +149,6 @@ void EnggDiffractionViewQtGUI::doSetupTabSettings() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabFocus() {
-  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
 
   connect(m_uiTabFocus.pushButton_focus, SIGNAL(released()), this,
           SLOT(focusClicked()));
@@ -239,6 +238,8 @@ void EnggDiffractionViewQtGUI::readSettings() {
 
   m_uiTabFocus.checkBox_FocusedWS->setChecked(
       qs.value("user-params-focus-plot-ws", true).toBool());
+
+  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
 
   QString lastPath =
       MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
@@ -722,7 +723,6 @@ void EnggDiffractionViewQtGUI::plotRepChanged(int /*idx*/) {
   if (!inst)
     return;
   m_currentType = inst->currentIndex();
-  m_presenter->notify(IEnggDiffractionPresenter::PlotRepChange);
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -385,6 +385,8 @@ public:
     // check automatic plotting
     EXPECT_CALL(mockView, focusedOutWorkspace()).Times(1).WillOnce(Return(true));
     EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(1);
+	// There are two/three other tests that have the disabled_ prefix so they
+	// normally run
 
     // Should not try to use options for other types of focusing
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -105,7 +105,19 @@ public:
   MOCK_CONST_METHOD0(saveSettings, void());
 
   // virtual void plotFocusedSpectrum();
-  MOCK_METHOD1(plotFocusedSpectrum, void(const std::string&));
+  MOCK_METHOD1(plotFocusedSpectrum, void(const std::string &));
+
+  // void plotFocusStatus();
+  MOCK_METHOD0(plotFocusStatus, void());
+
+  // void plotRepChanged();
+  MOCK_METHOD1(plotRepChanged, void(int idx));
+
+  // virtual void plotWaterfallSpectrum
+  MOCK_METHOD1(plotWaterfallSpectrum, void(const std::string &wsName));
+
+  // std::string currentPlotType
+  MOCK_CONST_METHOD0(currentPlotType, int());
 };
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -116,6 +116,9 @@ public:
   // virtual void plotWaterfallSpectrum
   MOCK_METHOD1(plotWaterfallSpectrum, void(const std::string &wsName));
 
+  // virtual void plotReplacingWindow
+  MOCK_METHOD1(plotReplacingWindow, void(const std::string &wsName));
+
   // std::string currentPlotType
   MOCK_CONST_METHOD0(currentPlotType, int());
 };


### PR DESCRIPTION
Fixes #13811

**To Test**

Provide user with an option of selecting one of the following data representation option while plotting data
- One window - replacing plots
- One window - waterfall: _new plots are combined with existing plots in a waterfall-style plot_
- Multiple windows

Extra features to be tested: 
- When `Plot Focused Workspace` is not checked, `Plot Data Representation` comboBox will be disabled
- For now Plot Data Representation requires both banks to be checked unless it should display `PlotSpectrum(...)` of either bank 1 or bank 2 

_The new `output` checkbox doesn't trigger anything yet but will be in operation once #13854 is implemented_
