### PR TITLE
plotMD: add menu option to change normalization

### DIFF
--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -300,7 +300,9 @@ def plotMD(source, plot_axis=-2, normalization=DEFAULT_MD_NORMALIZATION, error_b
     Args:
         source: Workspace(s) to plot
         plot_axis: Index of the plot axis (defaults to auto-select)
-        normalization: Type of normalization required (defaults to volume)
+        normalization: Type of normalization required (defaults to volume, options available:
+                       MDNormalization.NoNormalization, MDNormalization.NumEventsNormalization, and
+                       MDNormalization.VolumeNormalization).
         error_bars: Flag for error bar plotting.
         window: window used for plotting. If None a new one will be created
         clearWindow: if is True, the window specified will be cleared before adding new curve

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -10153,6 +10153,7 @@ void ApplicationWindow::showGraphContextMenu() {
   QMenu axes(this);
   QMenu colour(this);
   QMenu normalization(this);
+  QMenu normMD(this);
   QMenu exports(this);
   QMenu copy(this);
   QMenu prints(this);
@@ -10218,6 +10219,27 @@ void ApplicationWindow::showGraphContextMenu() {
     noNorm->setChecked(!ag->isDistribution());
     binNorm->setChecked(ag->isDistribution());
     cm.insertItem(tr("&Normalization"), &normalization);
+  } else if (ag->normalizableMD()) {
+    QAction *noNormMD = new QAction(tr("N&one"), &normMD);
+    noNormMD->setCheckable(true);
+    connect(noNormMD, SIGNAL(activated()), ag, SLOT(noNormalizationMD()));
+    normMD.addAction(noNormMD);
+
+    QAction *volNormMD = new QAction(tr("&Volume"), &normMD);
+    volNormMD->setCheckable(true);
+    connect(volNormMD, SIGNAL(activated()), ag, SLOT(volumeNormalizationMD()));
+    normMD.addAction(volNormMD);
+
+    QAction *eventsNormMD = new QAction(tr("&Events"), &normMD);
+    eventsNormMD->setCheckable(true);
+    connect(eventsNormMD, SIGNAL(activated()), ag, SLOT(numEventsNormalizationMD()));
+    normMD.addAction(eventsNormMD);
+
+    int normalization = ag->normalizationMD();
+    noNormMD->setChecked(0 == normalization);
+    volNormMD->setChecked(1 == normalization);
+    eventsNormMD->setChecked(2 == normalization);
+    cm.insertItem("MD &Normalization", &normMD);
   }
 
   QMenu plotType(this);

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -60,6 +60,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "Mantid/MantidMatrixCurve.h"
+#include "Mantid/MantidMDCurve.h"
 #include "MantidQtAPI/PlotAxis.h"
 #include "MantidQtAPI/QwtRasterDataMD.h"
 #include "MantidQtAPI/QwtWorkspaceSpectrumData.h"
@@ -210,6 +211,9 @@ Graph::Graph(int x, int y, int width, int height, QWidget* parent, Qt::WFlags f)
 
   m_isDistribution = false;
   m_normalizable = false;
+
+  m_normalizableMD = false;
+  m_normalizationMD = 0;
 }
 
 void Graph::notifyChanges()
@@ -5541,6 +5545,57 @@ void Graph::binWidthNormalization()
   notifyChanges();
 }
 
+/**
+ * Set 'None' normalization for MD plots
+ */
+void Graph::noNormalizationMD()
+{
+  if (!normalizableMD())
+    return;
+
+  setNormalizationMD(0);
+
+  updateDataCurves();
+  d_plot->updateAxes();
+  setYAxisTitle(yAxisTitleFromFirstCurve());
+
+  notifyChanges();
+}
+
+/**
+ * Set volume normalization for MD plots
+ */
+void Graph::volumeNormalizationMD()
+{
+  if (!normalizableMD())
+    return;
+
+  setNormalizationMD(1);
+
+  updateDataCurves();
+  d_plot->updateAxes();
+  setYAxisTitle(yAxisTitleFromFirstCurve());
+
+  notifyChanges();
+}
+
+/**
+ * Set number of events normalization for MD plots
+ */
+void Graph::numEventsNormalizationMD()
+{
+  if (!normalizableMD())
+    return;
+
+  setNormalizationMD(2);
+
+  updateDataCurves();
+  d_plot->updateAxes();
+  setYAxisTitle(yAxisTitleFromFirstCurve());
+
+  notifyChanges();
+}
+
 void Graph::setWaterfallXOffset(int offset)
 {
   if (offset == d_waterfall_offset_x)
@@ -5654,6 +5709,15 @@ void Graph::updateDataCurves()
       mc->invalidateBoundingRect();
       mc->loadData();
     }
+    else if (MantidMDCurve *mdc = dynamic_cast<MantidMDCurve*>(pc))
+    {
+      //mdc->setDrawAsDistribution(m_isDistribution);
+      // yes, using int in Graph and ApplicationWindow instead of the proper enum, just so that
+      // IMDWorkspace.h does not need to be included in more places in MantidPlot
+      mdc->mantidData()->setNormalization(static_cast<Mantid::API::MDNormalization>(m_normalizationMD));
+      mdc->invalidateBoundingRect();
+    }
+
   }
   QApplication::restoreOverrideCursor();
 }

--- a/MantidPlot/src/Graph.h
+++ b/MantidPlot/src/Graph.h
@@ -827,6 +827,8 @@ private:
 
   QString yAxisTitleFromFirstCurve();
   
+  void updateCurvesAndAxes();
+
   Plot *d_plot;
   QwtPlotZoomer *d_zoomer[2];
   TitlePicker *titlePicker;

--- a/MantidPlot/src/Graph.h
+++ b/MantidPlot/src/Graph.h
@@ -209,6 +209,20 @@ public slots:
   bool isDistribution() const { return m_isDistribution; }
   void setDistribution(const bool on) { m_isDistribution = on; }
 
+  void noNormalizationMD();
+  void numEventsNormalizationMD();
+  void volumeNormalizationMD();
+
+  /// normalizable in the MD sense, don't confuse with (bin width) normalizable(),
+  /// True if this is a plot MD
+  bool normalizableMD() const { return m_normalizableMD; }
+  void setNormalizableMD(const bool on) { m_normalizableMD = on; }
+
+  /// when using MD curves (true == normalizbleMD()), what type of normalization
+  int normalizationMD() const { return m_normalizationMD; }
+  void setNormalizationMD(const int normalization) { m_normalizationMD = normalization; }
+
+
 
   //! Accessor method for #d_plot.
   Plot* plotWidget(){return d_plot;};
@@ -877,6 +891,12 @@ private:
   bool m_isDistribution;
   // True, if the graph can be plotted as distribution
   bool m_normalizable;
+
+  // True if the graph is an MD plot and can be normalized (none, volume, events)
+  bool m_normalizableMD;
+  /// type of normalization for MD curves
+  int m_normalizationMD;
+
   // x and y units of MantidCurves
   boost::shared_ptr<Mantid::Kernel::Unit> m_xUnits;
   boost::shared_ptr<Mantid::Kernel::Unit> m_yUnits;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -618,6 +618,9 @@ MultiLayer* MantidUI::plotMDList(const QStringList& wsNames, const int plotAxis,
       data->setPlotAxisChoice(plotAxis);
       data->setNormalization(normalization);
 
+      g->setNormalizableMD(true);
+      g->setNormalizationMD(normalization);
+
       // Using information from the first graph
       if( i == 0 && isGraphNew )
         g->setAutoScale();


### PR DESCRIPTION
Fixes #12551. This adds an "MD normalization" option to the context menu of MD plots, similar to the "normalization"->"none/bin width" option that was added for plotSpectrum plots.

**To test**: this needs manual testing. Here is an example script to produce a plot. This one uses a small file from unit tests. Alternatively you can use your favorite MD workspace.

```
# this file is availabe in Testing/Data/UnitTest
ws=Load('SEQ_MDEW.nxs')
BinMD(InputWorkspace='ws', AxisAligned=True, AlignedDim0='DeltaE,17,22,10', OutputWorkspace='simple_rebin')
plotMD('simple_rebin', error_bars=True)
```

This will open an MD plot. Right click on the plot and see that you have an "MD normalization" menu where you can switch between the three types of normalization: none/volume/num_events. Compare the three plots that you get by changing the "MD normalization" with the plots that you get by right clicking on the workspace "simple_rebin", and then selecting "Plot MD" and choosing different normalizations. They should look the same, including the Y axis.
