### PR TITLE
DetectorFloodWeighting algorithm additions for SANS

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DetectorFloodWeighting.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DetectorFloodWeighting.py
@@ -24,7 +24,7 @@ class DetectorFloodWeighting(DataProcessorAlgorithm):
                                                      direction=Direction.Input, validator=WorkspaceUnitValidator("Wavelength")),
                                                      doc='Flood weighting measurement')
         self.declareProperty(MatrixWorkspaceProperty('TransmissionWorkspace', '',
-                                                     direction=Direction.Input, optional=PropertyMode.Optional, 
+                                                     direction=Direction.Input, optional=PropertyMode.Optional,
                                                      validator=WorkspaceUnitValidator("Wavelength")),
                                                      doc='Flood weighting measurement')
 
@@ -86,14 +86,14 @@ class DetectorFloodWeighting(DataProcessorAlgorithm):
         divide.setProperty("RHSWorkspace", rhs)
         divide.execute()
         return divide.getProperty("OutputWorkspace").value
-    
+        
     def _add(self, lhs, rhs):
         divide = self.createChildAlgorithm("Plus")
         divide.setProperty("LHSWorkspace", lhs)
         divide.setProperty("RHSWorkspace", rhs)
         divide.execute()
         return divide.getProperty("OutputWorkspace").value
-    
+        
     def _integrate_bands(self, bands, in_ws):
         # Formulate bands, integrate and sum
         accumulated_output = None
@@ -101,7 +101,6 @@ class DetectorFloodWeighting(DataProcessorAlgorithm):
             lower = bands[i]
             upper = bands[i+1]
             step = upper - lower
-            
             rebin = self.createChildAlgorithm("Rebin")
             rebin.setProperty("Params", [lower, step, upper])
             rebin.setProperty("InputWorkspace", in_ws) # Always integrating the same input workspace
@@ -126,7 +125,6 @@ class DetectorFloodWeighting(DataProcessorAlgorithm):
         accumulated_output = self._integrate_bands(bands, in_ws)
         if trans_ws:
             accumulated_trans_output = self._integrate_bands(bands, trans_ws)
-        
         progress.report()
 
         # Perform solid angle correction. Calculate solid angle then divide through.
@@ -138,7 +136,6 @@ class DetectorFloodWeighting(DataProcessorAlgorithm):
             solid_angle_weighting = solidAngle.getProperty("OutputWorkspace").value
             normalized = self._divide(normalized, solid_angle_weighting)
         progress.report()
-        
         # Divide through by the transmission workspace provided
         if trans_ws:
             normalized = self._divide(normalized, accumulated_trans_output)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/DetectorFloodWeightingTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/DetectorFloodWeightingTest.py
@@ -70,6 +70,29 @@ class DetectorFloodWeightingTest(unittest.TestCase):
         self.assertEquals(x_axis[-1], bands[-1])
         print out_ws.readY(0)[0]
         self.assertEquals(out_ws.readY(0)[0], 1.0)
+        
+    def test_execute_multiple_bands_no_solid_angle(self):
+        alg = AlgorithmManager.create("DetectorFloodWeighting")
+        alg.setChild(True)
+        alg.initialize()
+        alg.setProperty("SolidAngleCorrection", False)
+        signal_value = 2
+        in_ws = self._create_ws(units="Wavelength", signal_value=signal_value, data_x=range(0,10,1))
+        alg.setProperty("InputWorkspace", in_ws)
+        bands = [1,2,3,4]
+        alg.setProperty("Bands", bands) # One band
+        alg.setPropertyValue("OutputWorkspace", "dummy")
+        alg.execute()
+
+        out_ws = alg.getProperty("OutputWorkspace").value
+        self.assertEqual(1, out_ws.blocksize())
+        self.assertEqual("Wavelength", out_ws.getAxis(0).getUnit().unitID())
+        self.assertEqual(in_ws.getNumberHistograms(), out_ws.getNumberHistograms(), msg="Number of histograms should be unchanged.")
+        x_axis = out_ws.readX(0)
+        self.assertEquals(x_axis[0], bands[0])
+        self.assertEquals(x_axis[-1], bands[-1])
+        print out_ws.readY(0)[0]
+        self.assertEquals(out_ws.readY(0)[0], 1.0)
 
     def test_execute_single_with_solid_angle(self):
         alg = AlgorithmManager.create("DetectorFloodWeighting")
@@ -88,6 +111,7 @@ class DetectorFloodWeightingTest(unittest.TestCase):
         self.assertEqual(1, out_ws.blocksize())
         self.assertEqual("Wavelength", out_ws.getAxis(0).getUnit().unitID())
         self.assertEqual(in_ws.getNumberHistograms(), out_ws.getNumberHistograms(), msg="Number of histograms should be unchanged.")
+
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/DetectorFloodWeightingTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/DetectorFloodWeightingTest.py
@@ -68,7 +68,6 @@ class DetectorFloodWeightingTest(unittest.TestCase):
         x_axis = out_ws.readX(0)
         self.assertEquals(x_axis[0], bands[0])
         self.assertEquals(x_axis[-1], bands[-1])
-        print out_ws.readY(0)[0]
         self.assertEquals(out_ws.readY(0)[0], 1.0)
         
     def test_execute_multiple_bands_no_solid_angle(self):
@@ -91,8 +90,31 @@ class DetectorFloodWeightingTest(unittest.TestCase):
         x_axis = out_ws.readX(0)
         self.assertEquals(x_axis[0], bands[0])
         self.assertEquals(x_axis[-1], bands[-1])
-        print out_ws.readY(0)[0]
         self.assertEquals(out_ws.readY(0)[0], 1.0)
+
+    def test_execute_multiple_bands_no_solid_angle_with_transmission(self):
+        alg = AlgorithmManager.create("DetectorFloodWeighting")
+        alg.setChild(True)
+        alg.initialize()
+        alg.setProperty("SolidAngleCorrection", False)
+        signal_value = 2
+        in_ws = self._create_ws(units="Wavelength", signal_value=signal_value, data_x=range(0,10,1))
+        alg.setProperty("InputWorkspace", in_ws)
+        alg.setProperty("TransmissionWorkspace", in_ws)
+        bands = [1,2,3,4]
+        alg.setProperty("Bands", bands) # One band
+        alg.setPropertyValue("OutputWorkspace", "dummy")
+        alg.execute()
+
+        out_ws = alg.getProperty("OutputWorkspace").value
+        self.assertEqual(1, out_ws.blocksize())
+        self.assertEqual("Wavelength", out_ws.getAxis(0).getUnit().unitID())
+        self.assertEqual(in_ws.getNumberHistograms(), out_ws.getNumberHistograms(), msg="Number of histograms should be unchanged.")
+        x_axis = out_ws.readX(0)
+        self.assertEquals(x_axis[0], bands[0])
+        self.assertEquals(x_axis[-1], bands[-1])
+        self.assertEquals(out_ws.readY(0)[0], 1.0)
+
 
     def test_execute_single_with_solid_angle(self):
         alg = AlgorithmManager.create("DetectorFloodWeighting")

--- a/docs/source/algorithms/DetectorFloodWeighting-v1.rst
+++ b/docs/source/algorithms/DetectorFloodWeighting-v1.rst
@@ -10,8 +10,7 @@ Description
 -----------
 This algorithm is used to calculate the detector flood weighting workspace use for pixel flood corrections. It was originally developed for the ANSTO Bilby instrument.
 
-This algorithm crops the data over the specified wavelength region, then normalizes each spectrum to the workspace spectrum maxima. The algorithm will then
-perform a solid angle correction on each spectra via :ref:`algm-SolidAngle`.
+This algorithm crops the data over the specified wavelength region, and sums it. The algorithm will then perform a solid angle correction on each spectra via :ref:`algm-SolidAngle` if specified, and divides through by the provided transmission workspace if provided. The result is divided by the mean spectrum value in the previous result.
 
 Usage
 -----

--- a/docs/source/algorithms/DetectorFloodWeighting-v1.rst
+++ b/docs/source/algorithms/DetectorFloodWeighting-v1.rst
@@ -29,8 +29,6 @@ Usage
    
    print 'Number Histograms',out_ws.getNumberHistograms()
    print 'Min X:', out_ws.readX(0)[0], 'Max X:', out_ws.readX(0)[1]  
-   y_data = out_ws.extractY()
-   print  'Min Y:', np.amin(y_data), 'Max Y:', np.amax(y_data)   
 
 Output:
 
@@ -38,7 +36,6 @@ Output:
 
    Number Histograms 2
    Min X: 0.0 Max X: 10.0
-   Min Y: 0.5 Max Y: 1.0
 
 **Example - With Solid Angle Correction **
 


### PR DESCRIPTION
Fixes #13919. Problems with current implementation have been listed there.

**Tester**

Running this should work.

``` python
def do_test():
   ws = CreateSimulationWorkspace(Instrument='LOQ', BinParams=[1,1,10], UnitX="Wavelength")
   trans_ws = CreateSimulationWorkspace(Instrument='LOQ', BinParams=[1,1,10], UnitX="Wavelength")
   out_ws = DetectorFloodWeighting(InputWorkspace=ws, TransmissionWorkspace=trans_ws, Bands=[0,10], SolidAngleCorrection=True)

   print 'Number Histograms',out_ws.getNumberHistograms()
   print 'Number of Bins', out_ws.blocksize()
   print 'X units', out_ws.getAxis(0).getUnit().unitID()

do_test()
```
