### PR TITLE
Added container run number in Indirect corrections

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -175,8 +175,17 @@ void ApplyPaalmanPings::run() {
     correctionType = "cyl";
     break;
   }
-  const QString outputWsName =
+  QString outputWsName =
       sampleWsName.left(nameCutIndex) + +"_" + correctionType + "_Corrected";
+
+  if (useCan) {
+    auto containerWsName = m_uiForm.dsContainer->getCurrentDataName();
+    int cutIndex = containerWsName.indexOf("_");
+    if (cutIndex == -1) {
+      cutIndex = containerWsName.length();
+    }
+	outputWsName += "_Subtract_" + containerWsName.left(cutIndex);
+  }
 
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 

--- a/MantidQt/CustomInterfaces/src/Indirect/CalculatePaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/CalculatePaalmanPings.cpp
@@ -122,8 +122,17 @@ void CalculatePaalmanPings::run() {
     break;
   }
 
-  const QString outputWsName =
+  QString outputWsName =
       sampleWsName.left(nameCutIndex) + "_" + correctionType + "_abs";
+  if (useCan) {
+    auto containerWsName = m_uiForm.dsContainer->getCurrentDataName();
+    int cutIndex = containerWsName.indexOf("_");
+    if (cutIndex == -1) {
+      cutIndex = containerWsName.length();
+    }
+    outputWsName += "_Subtract_" + containerWsName.left(cutIndex);
+  }
+
   absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
 
   // Add corrections algorithm to queue


### PR DESCRIPTION
Fixes #13915

Container run numbers should now be present in the output of Indirect Correction (ApplyPaalmanPings & CalculatePaalmanPings) 
# To Test (ApplyPaalmanPings)
- Open ApplyPaalmanPings (Interfaces > Indirect > Corrections > ApplyPaalmanPings)
- Input file = irs26176_graphite002_red.nxs
- Container = irs26174_graphite002_red.nxs
- Correction file = irs26176_graphite002_flt_abs.nxs
  - These files are available from the babylon 5 server (\olympic\Babylon5\Public\ElliotOram\correction_set)
- Click run with all the files added to the interface.
- Ensure the output has the name IRS26176_graphite002_Corrected_Subtract_IRS26174
- Run the same without the Container being used and then ensure the name is: IRS26176_graphite002_Corrected
# To Test (Calculate)
- Open CalculatePaalmanPings (Interfaces > Indirect > Corrections > CalculatePaalmanPings)
- Input file = irs26176_graphite002_red.nxs
- Container = irs26174_graphite002_red.nxs
  - These files are available from the babylon 5 server (\olympic\Babylon5\Public\ElliotOram\correction_set)
- For shape details:
  - Sample Thickness: 0.5
  - Container Thickness (Front/Back) : 0.1
  - Sample angle: 45
  - Sample Chemical Formula: H2-O
  - Can Chemical Formula: V
  - Both Number densities are 0.1
- Click run with all the files added to the interface.
- Ensure the output group workspace is IRS26176_graphite002_flt_abs_Subtraced_IRS26173
