### PR TITLE
Reflectometry Python UI not filtering Workspaces to Save

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_save.py
+++ b/scripts/Interface/ui/reflectometer/refl_save.py
@@ -2,7 +2,7 @@
 from PyQt4 import QtCore, QtGui
 import os
 from mantid.simpleapi import *
-from mantid.api import WorkspaceGroup
+from mantid.api import WorkspaceGroup, AnalysisDataService
 import xml.etree.ElementTree as xml
 from isis_reflectometry.quick import *
 from isis_reflectometry.procedures import *
@@ -239,9 +239,15 @@ class Ui_SaveWindow(object):
         self.pushButton.setText(QtGui.QApplication.translate("SaveWindow", "SAVE", None, QtGui.QApplication.UnicodeUTF8))
         self.pushButton_2.setText(QtGui.QApplication.translate("SaveWindow", "Refresh", None, QtGui.QApplication.UnicodeUTF8))
 
+    def _get_saveable_workspace_names(self):
+        names = mtd.getObjectNames()
+        # Exclude WorkspaceGroups from our list. We cannot save them to ASCII.
+        names = [i for i in names if not isinstance(AnalysisDataService.retrieve(i), WorkspaceGroup)]
+        return names
+    
     def filterWksp(self):
         self.listWidget.clear()
-        names = mtd.getObjectNames()
+        names = self._get_saveable_workspace_names()
         if self.regExCheckBox.isChecked():
             regex=re.compile(self.filterEdit.text())
             filtered = list()
@@ -268,7 +274,7 @@ class Ui_SaveWindow(object):
 
     def populateList(self):
         self.listWidget.clear()
-        names = mtd.getObjectNames()
+        names = self._get_saveable_workspace_names()
         if len(names):
             RB_Number=groupGet(names[0],'samp','rb_proposal')
             for ws in names:

--- a/scripts/Interface/ui/reflectometer/refl_save.py
+++ b/scripts/Interface/ui/reflectometer/refl_save.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+#pylint: disable-all
 from PyQt4 import QtCore, QtGui
 import os
 from mantid.simpleapi import *


### PR DESCRIPTION
Fixes #13660. Filter out Workspace Groups.

Note that the author of this original UI, ran the ui to py conversion script and then modified the resulting file by hand rather than inheriting from it. Since this user interface may be depricated, and has a more complete replacement [here](http://docs.mantidproject.org/nightly/interfaces/ISIS_Reflectometry.html) I don't think that the reverse engineering of the ui file is worth the effort.

**Tester**

Re-run the scenario mentioned in the issue. You should find that the TOF group does not show up in the Save Workspaces dialog.

The squish test job should not break upon these changes.
