### PR TITLE
Add additional property validation to LoadVesuvio

### DIFF
--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -238,6 +238,10 @@ class VesuvioTests(unittest.TestCase):
 
     #================== Failure cases ================================
 
+    def test_run_range_bad_order_raises_error(self):
+        self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188-14187",
+                          OutputWorkspace=self.ws_name)
+
     def test_missing_spectra_property_raises_error(self):
         self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188",
                           OutputWorkspace=self.ws_name)


### PR DESCRIPTION
Fixes #13928

To test: try to run `LoadVesuvio` setting the `Filename` property to a range where the larger number is first (e.g. `19195-19194`), this should now fail validation with a sensible error message.
