### PR TITLE
ISIS Reflectometry GUI "Save Workspaces" dialog is too small

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_save.py
+++ b/scripts/Interface/ui/reflectometer/refl_save.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+#pylint: disable-all
 from PyQt4 import QtCore, QtGui
 import os
 from mantid.simpleapi import *

--- a/scripts/Interface/ui/reflectometer/refl_save.py
+++ b/scripts/Interface/ui/reflectometer/refl_save.py
@@ -32,10 +32,12 @@ class Ui_SaveWindow(object):
     def setupUi(self, SaveWindow):
         self.SavePath=""
         SaveWindow.setObjectName(_fromUtf8("SaveWindow"))
-        SaveWindow.resize(700, 450)
+        SaveWindow.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Expanding))
         SaveWindow.setAcceptDrops(True)
-
+        main_layout = QtGui.QHBoxLayout()
+        SaveWindow.setLayout(main_layout)
         self.centralWidget = QtGui.QWidget(SaveWindow)
+        main_layout.addWidget(self.centralWidget)
         self.centralWidget.setObjectName(_fromUtf8("centralWidget"))
         self.gridLayout_2 = QtGui.QGridLayout(self.centralWidget)
         self.gridLayout_2.setObjectName(_fromUtf8("gridLayout_2"))
@@ -236,7 +238,7 @@ class Ui_SaveWindow(object):
 
     def retranslateUi(self, SaveWindow):
         SaveWindow.setWindowTitle(QtGui.QApplication.translate("SaveWindow", "SaveWindow", None, QtGui.QApplication.UnicodeUTF8))
-        self.pushButton.setText(QtGui.QApplication.translate("SaveWindow", "SAVE", None, QtGui.QApplication.UnicodeUTF8))
+        self.pushButton.setText(QtGui.QApplication.translate("SaveWindow", "Save", None, QtGui.QApplication.UnicodeUTF8))
         self.pushButton_2.setText(QtGui.QApplication.translate("SaveWindow", "Refresh", None, QtGui.QApplication.UnicodeUTF8))
 
     def filterWksp(self):


### PR DESCRIPTION
Fixes  #13659

The requested fixes have been made. It should still be worth bearing in mind that this interface is unlikely be be long-lived in Mantid, so as I mentioned in #13660, we are not going to reverse engineer a UI file out of this.

**Tester**
- Open the `ISIS Reflectometry` GUI from MantidPlot `Interfaces`
- On the file menu of that interface select `Save Workspaces`
- The Save button will be called `Save`
- The window should automatically resize the the right size and be expanding
