### PR TITLE
Engg:: Save focused data in 3 formats

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -178,10 +178,12 @@ private:
 
   void plotFocusedWorkspace(std::string outWSName);
 
-  // Algorithms to save the generate workspace
-  void saveGSS(std::string inputWorkspace, std::string bank);
-  void saveFocusedXYE(std::string inputWorkspace, std::string bank);
-  void saveOpenGenie(std::string inputWorkspace, std::string specNums);
+  // Algorithms to save the generated workspace
+  void saveGSS(std::string inputWorkspace, std::string bank, std::string runNo);
+  void saveFocusedXYE(std::string inputWorkspace, std::string bank,
+                      std::string runNo);
+  void saveOpenGenie(std::string inputWorkspace, std::string specNums,
+                     std::string bank, std::string runNo);
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;
@@ -198,6 +200,9 @@ private:
   bool m_calibFinishedOK;
   /// true if the last focusing completed successfully
   bool m_focusFinishedOK;
+
+  /// Counter for the cropped output files
+  static int g_croppedCounter;
 
   /// Associated view for this presenter (MVP pattern)
   IEnggDiffractionView *const m_view;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -176,7 +176,7 @@ private:
                               Mantid::API::ITableWorkspace_sptr &vanIntegWS,
                               Mantid::API::MatrixWorkspace_sptr &vanCurvesWS);
 
-  void plotFocusedWorkspace(std::string outWSName);
+  void plotFocusedWorkspace(std::string outWSName, std::string bank);
 
   // Algorithms to save the generated workspace
   void saveGSS(std::string inputWorkspace, std::string bank, std::string runNo);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -178,9 +178,10 @@ private:
 
   void plotFocusedWorkspace(std::string outWSName);
 
-  void saveGSS(std::string inputWorkspace);
-  void saveFocusedXYE(std::string inputWorkspace);
-  void saveOpenGenie(std::string inputWorkspace);
+  // Algorithms to save the generate workspace
+  void saveGSS(std::string inputWorkspace, std::string bank);
+  void saveFocusedXYE(std::string inputWorkspace, std::string bank);
+  void saveOpenGenie(std::string inputWorkspace, std::string specNums);
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -178,6 +178,10 @@ private:
 
   void plotFocusedWorkspace(std::string outWSName);
 
+  void saveGSS(std::string inputWorkspace);
+  void saveFocusedXYE(std::string inputWorkspace);
+  void saveOpenGenie(std::string inputWorkspace);
+
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -176,6 +176,7 @@ private:
                               Mantid::API::ITableWorkspace_sptr &vanIntegWS,
                               Mantid::API::MatrixWorkspace_sptr &vanCurvesWS);
 
+  // plots workspace according to the user selection
   void plotFocusedWorkspace(std::string outWSName, std::string bank);
 
   // Algorithms to save the generated workspace

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -85,6 +85,7 @@ protected:
   void processLogMsg();
   void processInstChange();
   void processShutDown();
+  void processPlotRepChange();
 
 protected slots:
   void calibrationFinished();

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -85,7 +85,6 @@ protected:
   void processLogMsg();
   void processInstChange();
   void processShutDown();
-  void processPlotRepChange();
 
 protected slots:
   void calibrationFinished();
@@ -176,6 +175,8 @@ private:
   void calcVanadiumWorkspaces(const std::string &vanNo,
                               Mantid::API::ITableWorkspace_sptr &vanIntegWS,
                               Mantid::API::MatrixWorkspace_sptr &vanCurvesWS);
+
+  void plotFocusedWorkspace(std::string outWSName);
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -11,6 +11,8 @@
 
 #include <boost/scoped_ptr.hpp>
 
+#include <Poco/Path.h>
+
 #include <QObject>
 
 class QThread;
@@ -179,12 +181,19 @@ private:
   // plots workspace according to the user selection
   void plotFocusedWorkspace(std::string outWSName, std::string bank);
 
-  // Algorithms to save the generated workspace
+  // algorithms to save the generated workspace
   void saveGSS(std::string inputWorkspace, std::string bank, std::string runNo);
   void saveFocusedXYE(std::string inputWorkspace, std::string bank,
                       std::string runNo);
   void saveOpenGenie(std::string inputWorkspace, std::string specNums,
                      std::string bank, std::string runNo);
+
+  // generates the required file name of the output files
+  std::string outFileNameFactory(std::string inputWorkspace, std::string runNo,
+                                 std::string bank, std::string format);
+
+  // generates a directory if not found and handles the path
+  Poco::Path outFilesDir(std::string runNo);
 
   /// string to use for ENGINX file names (as a prefix, etc.)
   const static std::string g_enginxStr;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -168,31 +168,29 @@
         <bool>false</bool>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_new_vanadium_num">
-          <property name="text">
+        <item row="0" column="1" colspan="2">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_vanadium_num" native="true">
+          <property name="text" stdset="0">
+           <string>241391</string>
+          </property>
+          <property name="label" stdset="0">
            <string>Vanadium #:</string>
           </property>
-         </widget>
-        </item>
-        <item row="0" column="1" colspan="2">
-         <widget class="QLineEdit" name="lineEdit_new_vanadium_num">
-          <property name="text">
-           <string>236516</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_new_ceria_num">
-          <property name="text">
-           <string>Calibration sample #:</string>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item row="1" column="1" colspan="2">
-         <widget class="QLineEdit" name="lineEdit_new_ceria_num">
-          <property name="text">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_ceria_num" native="true">
+          <property name="text" stdset="0">
            <string>241391</string>
+          </property>
+          <property name="label" stdset="0">
+           <string>Calibration sample #:</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -216,6 +214,20 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_new_ceria_num">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_new_vanadium_num">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -236,6 +248,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::MWRunFiles</class>
+   <extends>QWidget</extends>
+   <header>MantidQtMantidWidgets/MWRunFiles.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -171,7 +171,7 @@
         <item row="0" column="1" colspan="2">
          <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_new_vanadium_num" native="true">
           <property name="text" stdset="0">
-           <string>241391</string>
+           <string>236516</string>
           </property>
           <property name="label" stdset="0">
            <string>Vanadium #:</string>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -20,30 +20,6 @@
       <string>Focus run</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>238</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_focus">
-          <property name="text">
-           <string>Focus</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
       <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
@@ -113,12 +89,36 @@
         </item>
        </layout>
       </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>238</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_focus">
+          <property name="text">
+           <string>Focus</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_run_num">
           <property name="text">
-           <string>Run #:</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -136,12 +136,18 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEdit_run_num">
-          <property name="text">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_run_num" native="true">
+          <property name="text" stdset="0">
            <string/>
           </property>
-          <property name="readOnly">
+          <property name="readOnly" stdset="0">
            <bool>false</bool>
+          </property>
+          <property name="label" stdset="0">
+           <string>Run #:</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -161,7 +167,7 @@
         <item>
          <widget class="QLabel" name="label_cropped_run_num">
           <property name="text">
-           <string>Run #:</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -179,12 +185,18 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
-          <property name="text">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_cropped_run_num" native="true">
+          <property name="text" stdset="0">
            <string/>
           </property>
-          <property name="readOnly">
+          <property name="readOnly" stdset="0">
            <bool>false</bool>
+          </property>
+          <property name="label" stdset="0">
+           <string>Run #:</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -262,7 +274,7 @@
         <item>
          <widget class="QLabel" name="label_texture_run_num">
           <property name="text">
-           <string>Run #:</string>
+           <string/>
           </property>
          </widget>
         </item>
@@ -280,12 +292,18 @@
          </spacer>
         </item>
         <item>
-         <widget class="QLineEdit" name="lineEdit_texture_run_num">
-          <property name="text">
+         <widget class="MantidQt::MantidWidgets::MWRunFiles" name="lineEdit_texture_run_num" native="true">
+          <property name="text" stdset="0">
            <string/>
           </property>
-          <property name="readOnly">
+          <property name="readOnly" stdset="0">
            <bool>false</bool>
+          </property>
+          <property name="label" stdset="0">
+           <string>Run #:</string>
+          </property>
+          <property name="multipleFiles" stdset="0">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -521,6 +539,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::MWRunFiles</class>
+   <extends>QWidget</extends>
+   <header>MantidQtMantidWidgets/MWRunFiles.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>614</width>
-    <height>545</height>
+    <height>551</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -471,7 +471,7 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_22">
         <item>
-         <widget class="QCheckBox" name="checkBox_OutputFiles_">
+         <widget class="QCheckBox" name="checkBox_SaveOutputFiles">
           <property name="text">
            <string>Output Files</string>
           </property>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -7,161 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>614</width>
-    <height>533</height>
+    <height>545</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="6" column="0">
-    <widget class="QGroupBox" name="groupBox_focus_2">
-     <property name="title">
-      <string>Output</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_6">
-        <item>
-         <widget class="QCheckBox" name="checkBox_FocusedWS">
-          <property name="text">
-           <string>Plot Focused Workspace</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_4">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Focus Cropped</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_9">
-        <item>
-         <widget class="QLabel" name="label_cropped_run_num">
-          <property name="text">
-           <string>Run #:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>98</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
-          <property name="text">
-           <string/>
-          </property>
-          <property name="readOnly">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_10">
-        <item>
-         <widget class="QLabel" name="label_cropped_spec_ids">
-          <property name="text">
-           <string>Spectrum IDs:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>38</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>1</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="2" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_12">
-        <item>
-         <spacer name="horizontalSpacer_10">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton_focus_cropped">
-          <property name="text">
-           <string>Focus</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>388</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
     <widget class="QGroupBox" name="groupBox_focus">
      <property name="title">
       <string>Focus run</string>
@@ -297,7 +150,108 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Focus Cropped</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label_cropped_run_num">
+          <property name="text">
+           <string>Run #:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_run_num">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="readOnly">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_cropped_spec_ids">
+          <property name="text">
+           <string>Spectrum IDs:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>38</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="lineEdit_cropped_spec_ids">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <spacer name="horizontalSpacer_10">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_focus_cropped">
+          <property name="text">
+           <string>Focus</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Focus Texture</string>
@@ -395,7 +349,153 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0">
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_focus_3">
+     <property name="minimumSize">
+      <size>
+       <width>596</width>
+       <height>111</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Output</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_20">
+        <item>
+         <widget class="QCheckBox" name="checkBox_FocusedWS">
+          <property name="text">
+           <string>Plot Focused Workspace</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_18">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_21">
+        <item>
+         <spacer name="horizontalSpacer_19">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Plot Data Representation:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBox_PlotData">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>175</width>
+            <height>10</height>
+           </size>
+          </property>
+          <property name="sizeIncrement">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>One Window - Replacing Plots</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>One Window - Waterfall</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Multiple Windows</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_22">
+        <item>
+         <widget class="QCheckBox" name="checkBox_OutputFiles_">
+          <property name="text">
+           <string>Output Files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_20">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>98</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_13">
      <item>
       <spacer name="horizontalSpacer_11">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -121,6 +121,12 @@ public:
 
   virtual void plotFocusedSpectrum(const std::string &wsName);
 
+  virtual void plotWaterfallSpectrum(const std::string &wsName);
+
+  virtual void plotReplacingWindow(const std::string &wsName);
+
+  int currentPlotType() const { return m_currentType; }
+
 private slots:
   /// for buttons, do calibrate, focus and similar
   void loadCalibrationClicked();
@@ -144,6 +150,12 @@ private slots:
 
   // slots of the general part of the interface
   void instrumentChanged(int idx);
+
+  // slots of the focus part of the interface
+  void plotRepChanged(int idx);
+
+  // slots of plot spectrum check box status
+  void plotFocusStatus();
 
   // show the standard Mantid help window with this interface's help
   void openHelpWin();
@@ -183,6 +195,10 @@ private:
 
   /// instrument selected (ENGIN-X, etc.)
   std::string m_currentInst;
+
+  // plot data representation type selected
+  int m_currentType;
+
   /// current calibration produced in the 'Calibration' tab
   std::string m_currentCalibFilename;
   /// calibration settings - from/to the 'settings' tab

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -199,7 +199,7 @@ private:
   std::string m_currentInst;
 
   // plot data representation type selected
-  int m_currentType;
+  int static m_currentType;
 
   /// current calibration produced in the 'Calibration' tab
   std::string m_currentCalibFilename;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -125,6 +125,8 @@ public:
 
   virtual void plotReplacingWindow(const std::string &wsName);
 
+  virtual bool saveOutputFiles() const;
+
   int currentPlotType() const { return m_currentType; }
 
 private slots:

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -47,7 +47,6 @@ public:
     ResetFocus,        ///< Re-set / clear all focus inputs and options
     LogMsg,            ///< need to send a message to the Mantid log system
     InstrumentChange,  ///< Instrument selection updated
-    PlotRepChange,     ///< Data Plot representation selection updated
     ShutDown           ///< closing the interface
   };
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -38,16 +38,17 @@ public:
   /// These are user actions, triggered from the (passive) view, that need
   /// handling by the presenter
   enum Notification {
-    Start,                 ///< Start and setup interface
-    LoadExistingCalib,     ///< Load a calibration already availble on disk
-    CalcCalib,             ///< Calculate a (new) calibration
-    FocusRun,              ///< Focus one or more run files
-    FocusCropped,          ///< Focus one or more run files, cropped variant
-    FocusTexture,          ///< Focus one or more run files, texture variant
-    ResetFocus,            ///< Re-set / clear all focus inputs and options
-    LogMsg,                ///< need to send a message to the Mantid log system
-    InstrumentChange,      ///< Instrument selection updated
-    ShutDown               ///< closing the interface
+    Start,             ///< Start and setup interface
+    LoadExistingCalib, ///< Load a calibration already availble on disk
+    CalcCalib,         ///< Calculate a (new) calibration
+    FocusRun,          ///< Focus one or more run files
+    FocusCropped,      ///< Focus one or more run files, cropped variant
+    FocusTexture,      ///< Focus one or more run files, texture variant
+    ResetFocus,        ///< Re-set / clear all focus inputs and options
+    LogMsg,            ///< need to send a message to the Mantid log system
+    InstrumentChange,  ///< Instrument selection updated
+    PlotRepChange,     ///< Data Plot representation selection updated
+    ShutDown           ///< closing the interface
   };
 
   /**

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -116,6 +116,14 @@ public:
   virtual std::string currentInstrument() const = 0;
 
   /**
+  * Selected plot data representation will be applied, which will
+  * ran through python script
+  *
+  * @return which format should to applied for plotting data
+  */
+  virtual int currentPlotType() const = 0;
+
+  /**
    * The Vanadium run number used in the current calibration
    *
    * @return Vanadium run number, as a string
@@ -263,6 +271,14 @@ public:
   virtual void saveSettings() const = 0;
 
   /**
+ * Saves the ouput files which are generated, this can be done
+ * via Output Files checkbox on the focus tab
+ *
+ * @return bool
+ */
+  virtual bool saveOutputFiles() const = 0;
+
+  /**
   * Produces a single spectrum graph for focused output. Runs
   * plotSpectrum function via python.
   *
@@ -285,14 +301,6 @@ public:
   * @param wsName name of the workspace to plot (must be in the ADS)
   */
   virtual void plotReplacingWindow(const std::string &wsName) = 0;
-
-  /*
- * Selected plot data representation will be applied, which will
- * ran through python script
- *
- * @return which format should to applied for plotting data
- */
-  virtual int currentPlotType() const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -269,6 +269,30 @@ public:
   * @param wsName name of the workspace to plot (must be in the ADS)
   */
   virtual void plotFocusedSpectrum(const std::string &wsName) = 0;
+
+  /**
+ * Produces a waterfall spectrum graph for focused output. Runs
+ * plotSpectrum function via python.
+ *
+ * @param wsName name of the workspace to plot (must be in the ADS)
+ */
+  virtual void plotWaterfallSpectrum(const std::string &wsName) = 0;
+
+  /**
+  * Produces a replaceable spectrum graph for focused output. Runs
+  * plotSpectrum function via python.
+  *
+  * @param wsName name of the workspace to plot (must be in the ADS)
+  */
+  virtual void plotReplacingWindow(const std::string &wsName) = 0;
+
+  /*
+ * Selected plot data representation will be applied, which will
+ * ran through python script
+ *
+ * @return which format should to applied for plotting data
+ */
+  virtual int currentPlotType() const = 0;
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1333,12 +1333,11 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
  * Checks the plot type selected and applies the appropriate
  * python function to apply during first bank and second bank
  *
- * @param std::string outWSName; title of focused workspace
+ * @param outWSName; title of the focused workspace
  */
 void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName) {
   const bool plotFocusedWS = m_view->focusedOutWorkspace();
   int plotType = m_view->currentPlotType();
-
   if (plotFocusedWS == true && 0 == plotType) {
     if (outWSName == "engggui_focusing_output_ws_bank_1")
       m_view->plotFocusedSpectrum(outWSName);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -110,10 +110,6 @@ void EnggDiffractionPresenter::notify(
   case IEnggDiffractionPresenter::ShutDown:
     processShutDown();
     break;
-
-  case IEnggDiffractionPresenter::PlotRepChange:
-    processPlotRepChange();
-    break;
   }
 }
 
@@ -267,11 +263,6 @@ void EnggDiffractionPresenter::processInstChange() {
 }
 
 void EnggDiffractionPresenter::processShutDown() {
-  m_view->saveSettings();
-  cleanup();
-}
-
-void EnggDiffractionPresenter::processPlotRepChange() {
   m_view->saveSettings();
   cleanup();
 }
@@ -1097,36 +1088,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     // TODO: use detector positions (from calibrate full) when available
     // alg->setProperty(DetectorPositions, TableWorkspace)
     alg->execute();
-
-    const bool plotFocusedWS = m_view->focusedOutWorkspace();
-    int plotType = m_view->currentPlotType();
-    g_log.debug() << "...Plot Type return: " << plotType << std::endl;
-
-    // Qt comboBox returns absurd number for index of 0
-    if (plotType > 3) {
-      plotType = 1;
-    } else {
-      plotType += 1;
-    }
-
-    if (plotFocusedWS == true && 1 == plotType) {
-      if (outWSName == "engggui_focusing_output_ws_bank_1")
-        m_view->plotFocusedSpectrum(outWSName);
-      if (outWSName == "engggui_focusing_output_ws_bank_2")
-        m_view->plotReplacingWindow(outWSName);
-    }
-
-    else if (plotFocusedWS == true && 2 == plotType) {
-      if (outWSName == "engggui_focusing_output_ws_bank_1")
-        m_view->plotFocusedSpectrum(outWSName);
-      if (outWSName == "engggui_focusing_output_ws_bank_2")
-        m_view->plotWaterfallSpectrum(outWSName);
-    }
-
-    else if (plotFocusedWS == true && 3 == plotType) {
-      m_view->plotFocusedSpectrum(outWSName);
-    }
-
+	// plot Focused workspace according to the data type selected
+	plotFocusedWorkspace(outWSName);
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
@@ -1364,6 +1327,31 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
 
   vanIntegWS = ADS.retrieveWS<ITableWorkspace>(integName);
   vanCurvesWS = ADS.retrieveWS<MatrixWorkspace>(curvesName);
+}
+
+/**
+ * Checks the plot type selected and applies the appropriate
+ * python function to apply during first bank and second bank
+ *
+ * @param std::string outWSName; title of focused workspace
+ */
+void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName) {
+  const bool plotFocusedWS = m_view->focusedOutWorkspace();
+  int plotType = m_view->currentPlotType();
+
+  if (plotFocusedWS == true && 0 == plotType) {
+    if (outWSName == "engggui_focusing_output_ws_bank_1")
+      m_view->plotFocusedSpectrum(outWSName);
+    if (outWSName == "engggui_focusing_output_ws_bank_2")
+      m_view->plotReplacingWindow(outWSName);
+  } else if (plotFocusedWS == true && 1 == plotType) {
+    if (outWSName == "engggui_focusing_output_ws_bank_1")
+      m_view->plotFocusedSpectrum(outWSName);
+    if (outWSName == "engggui_focusing_output_ws_bank_2")
+      m_view->plotWaterfallSpectrum(outWSName);
+  } else if (plotFocusedWS == true && 2 == plotType) {
+    m_view->plotFocusedSpectrum(outWSName);
+  }
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1088,8 +1088,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     // TODO: use detector positions (from calibrate full) when available
     // alg->setProperty(DetectorPositions, TableWorkspace)
     alg->execute();
-	// plot Focused workspace according to the data type selected
-	plotFocusedWorkspace(outWSName);
+    // plot Focused workspace according to the data type selected
+    plotFocusedWorkspace(outWSName);
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
@@ -1097,8 +1097,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
             re.what() + " Please check also the log messages for details.";
     throw;
   }
-
   g_log.notice() << "Produced focused workspace: " << outWSName << std::endl;
+
   try {
     g_log.debug() << "Going to save focused output into nexus file: "
                   << fullFilename << std::endl;
@@ -1116,6 +1116,13 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   }
   g_log.notice() << "Saved focused workspace as file: " << fullFilename
                  << std::endl;
+
+  bool saveOutputFiles = m_view->saveOutputFiles();
+  if (saveOutputFiles) {
+    saveGSS(outWSName);
+    saveFocusedXYE(outWSName);
+    saveOpenGenie(outWSName);
+  }
 }
 
 /**
@@ -1351,6 +1358,97 @@ void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName) {
   } else if (plotFocusedWS == true && 2 == plotType) {
     m_view->plotFocusedSpectrum(outWSName);
   }
+}
+
+/**
+ * Convert the generated output files and saves them in
+ * FocusedXYE format
+ *
+ * @param inputWorkspace; title of the focused workspace
+ */
+void EnggDiffractionPresenter::saveFocusedXYE(
+    const std::string inputWorkspace) {
+  auto alg = Algorithm::fromString("SaveFocusedXYE");
+  std::string fullFilename = inputWorkspace + "_FocusedxyeFile.dat";
+  try {
+    g_log.debug() << "Going to save focused output into OpenGenie file: "
+                  << fullFilename << std::endl;
+    alg->initialize();
+    alg->setProperty("InputWorkspace", inputWorkspace);
+
+    std::string filename(fullFilename);
+    alg->setPropertyValue("Filename", filename);
+    alg->execute();
+  } catch (std::runtime_error &re) {
+    g_log.error() << "Error in saving focused XYE file. ",
+        "Could not run the algorithm SaveFocusedXYE succesfully for "
+        "workspace " +
+            inputWorkspace + ". Error description: " + re.what() +
+            " Please check also the log messages for details.";
+    throw;
+  }
+  g_log.notice() << "Saved focused workspace as file: " << fullFilename
+                 << std::endl;
+}
+
+/**
+ * Convert the generated output files and saves them in
+ * GSS format
+ *
+ * @param inputWorkspace; title of the focused workspace
+ */
+void EnggDiffractionPresenter::saveGSS(const std::string inputWorkspace) {
+  auto alg = Algorithm::fromString("SaveGSS");
+  std::string fullFilename = inputWorkspace + "_GssFile.gss";
+  try {
+    g_log.debug() << "Going to save focused output into OpenGenie file: "
+                  << fullFilename << std::endl;
+    alg->initialize();
+    alg->setProperty("InputWorkspace", inputWorkspace);
+
+    std::string filename(fullFilename);
+    alg->setPropertyValue("Filename", filename);
+    alg->execute();
+  } catch (std::runtime_error &re) {
+    g_log.error() << "Error in saving focused XYE file. ",
+        "Could not run the algorithm SaveFocusedXYE succesfully for "
+        "workspace " +
+            inputWorkspace + ". Error description: " + re.what() +
+            " Please check also the log messages for details.";
+    throw;
+  }
+  g_log.notice() << "Saved focused workspace as file: " << fullFilename
+                 << std::endl;
+}
+
+/**
+ * Convert the generated output files and saves them in
+ * OpenGenie format
+ *
+ * @param inputWorkspace; title of the focused workspace
+ */
+void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace) {
+  auto alg = Algorithm::fromString("SaveOpenGenieAscii");
+  std::string fullFilename = inputWorkspace + "_OpenGenieFile.his";
+  try {
+    g_log.debug() << "Going to save focused output into OpenGenie file: "
+                  << fullFilename << std::endl;
+    alg->initialize();
+    alg->setProperty("InputWorkspace", inputWorkspace);
+
+    std::string filename(fullFilename);
+    alg->setPropertyValue("Filename", filename);
+    alg->execute();
+  } catch (std::runtime_error &re) {
+    g_log.error() << "Error in saving focused XYE file. ",
+        "Could not run the algorithm SaveFocusedXYE succesfully for "
+        "workspace " +
+            inputWorkspace + ". Error description: " + re.what() +
+            " Please check also the log messages for details.";
+    throw;
+  }
+  g_log.notice() << "Saved focused workspace as file: " << fullFilename
+                 << std::endl;
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1103,7 +1103,7 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     // alg->setProperty(DetectorPositions, TableWorkspace)
     alg->execute();
     // plot Focused workspace according to the data type selected
-    plotFocusedWorkspace(outWSName);
+    plotFocusedWorkspace(outWSName, boost::lexical_cast<std::string>(bank));
   } catch (std::runtime_error &re) {
     g_log.error() << "Error in calibration. ",
         "Could not run the algorithm EnggCalibrate succesfully for bank " +
@@ -1357,21 +1357,23 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
  *
  * @param outWSName title of the focused workspace
  */
-void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName) {
+void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName, std::string bank) {
   const bool plotFocusedWS = m_view->focusedOutWorkspace();
   int plotType = m_view->currentPlotType();
-  if (plotFocusedWS == true && 0 == plotType) {
-    if (outWSName == "engggui_focusing_output_ws_bank_1")
+  if (plotFocusedWS) {
+    if (plotType == 0) {
+      if (bank == "1")
+        m_view->plotFocusedSpectrum(outWSName);
+      if (bank == "2")
+        m_view->plotReplacingWindow(outWSName);
+    } else if (1 == plotType) {
+      if (bank == "1")
+        m_view->plotFocusedSpectrum(outWSName);
+      if (bank == "2")
+        m_view->plotWaterfallSpectrum(outWSName);
+    } else if (2 == plotType) {
       m_view->plotFocusedSpectrum(outWSName);
-    if (outWSName == "engggui_focusing_output_ws_bank_2")
-      m_view->plotReplacingWindow(outWSName);
-  } else if (plotFocusedWS == true && 1 == plotType) {
-    if (outWSName == "engggui_focusing_output_ws_bank_1")
-      m_view->plotFocusedSpectrum(outWSName);
-    if (outWSName == "engggui_focusing_output_ws_bank_2")
-      m_view->plotWaterfallSpectrum(outWSName);
-  } else if (plotFocusedWS == true && 2 == plotType) {
-    m_view->plotFocusedSpectrum(outWSName);
+    }
   }
 }
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -13,7 +13,6 @@
 #include <boost/lexical_cast.hpp>
 
 #include <Poco/File.h>
-#include <Poco/Path.h>
 
 #include <QThread>
 
@@ -1390,36 +1389,24 @@ void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName,
 void EnggDiffractionPresenter::saveFocusedXYE(const std::string inputWorkspace,
                                               std::string bank,
                                               std::string runNo) {
-  auto alg = Algorithm::fromString("SaveFocusedXYE");
-  std::string fullFilename;
-  if (inputWorkspace.std::string::find("texture") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_texture_" + bank + ".dat";
-  }
-  if (inputWorkspace.std::string::find("cropped") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_cropped_" +
-                   boost::lexical_cast<std::string>(g_croppedCounter) + ".dat";
-    g_croppedCounter++;
-  } else {
-    fullFilename = "ENGINX_" + runNo + "_bank_" + bank + ".dat";
-  }
-  std::string saveDir;
-  try {
-    // takes to the root of directory according to the platform
-    // and appends the following string provided
-    saveDir =
-        Poco::Path(saveDir).expand("/EnginX_Mantid/User/" + runNo + "/Focus/");
-    if (!Poco::File(saveDir).exists()) {
-      Poco::File(saveDir).createDirectories();
-    }
-  } catch (std::runtime_error &re) {
-    g_log.error() << "Error while using Poco: " << re.what();
-  }
+
+  // Generates the file name in the appropriate format
+  std::string fullFilename =
+      outFileNameFactory(inputWorkspace, runNo, bank, ".dat");
+
+  // Creates appropriate directory
+  Poco::Path saveDir = outFilesDir(runNo);
+
+  // append the full file name in the end
+  saveDir.append(fullFilename);
+
   try {
     g_log.debug() << "Going to save focused output into OpenGenie file: "
                   << fullFilename << std::endl;
+    auto alg = Algorithm::fromString("SaveFocusedXYE");
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWorkspace);
-    std::string filename(saveDir + fullFilename);
+    std::string filename(saveDir.toString());
     alg->setPropertyValue("Filename", filename);
     alg->setProperty("SplitFiles", false);
     alg->setPropertyValue("StartAtBankNumber", bank);
@@ -1432,7 +1419,7 @@ void EnggDiffractionPresenter::saveFocusedXYE(const std::string inputWorkspace,
             " Please check also the log messages for details.";
     throw;
   }
-  g_log.notice() << "Saved focused workspace as file: " << fullFilename
+  g_log.notice() << "Saved focused workspace as file: " << saveDir.toString()
                  << std::endl;
 }
 
@@ -1446,38 +1433,24 @@ void EnggDiffractionPresenter::saveFocusedXYE(const std::string inputWorkspace,
  */
 void EnggDiffractionPresenter::saveGSS(const std::string inputWorkspace,
                                        std::string bank, std::string runNo) {
-  auto alg = Algorithm::fromString("SaveGSS");
-  std::string fullFilename;
-  if (inputWorkspace.std::string::find("texture") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_texture_" + bank + ".gss";
-  }
-  if (inputWorkspace.std::string::find("cropped") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_cropped_" +
-                   boost::lexical_cast<std::string>(g_croppedCounter) + ".gss";
-    g_croppedCounter++;
-  } else {
-    fullFilename = "ENGINX_" + runNo + "_bank_" + bank + ".gss";
-  }
 
-  std::string saveDir;
-  try {
-    // takes to the root of directory according to the platform
-    // and appends the following string provided
-    saveDir =
-        Poco::Path(saveDir).expand("/EnginX_Mantid/User/" + runNo + "/Focus/");
-    if (!Poco::File(saveDir).exists()) {
-      Poco::File(saveDir).createDirectories();
-    }
-  } catch (std::runtime_error &re) {
-    g_log.error() << "Error while using Poco: " << re.what();
-  }
+  // Generates the file name in the appropriate format
+  std::string fullFilename =
+      outFileNameFactory(inputWorkspace, runNo, bank, ".gss");
+
+  // Creates appropriate directory
+  Poco::Path saveDir = outFilesDir(runNo);
+
+  // append the full file name in the end
+  saveDir.append(fullFilename);
 
   try {
     g_log.debug() << "Going to save focused output into OpenGenie file: "
                   << fullFilename << std::endl;
+    auto alg = Algorithm::fromString("SaveGSS");
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWorkspace);
-    std::string filename(saveDir + fullFilename);
+    std::string filename(saveDir.toString());
     alg->setPropertyValue("Filename", filename);
     alg->setProperty("SplitFiles", false);
     alg->setPropertyValue("Bank", bank);
@@ -1490,7 +1463,7 @@ void EnggDiffractionPresenter::saveGSS(const std::string inputWorkspace,
             " Please check also the log messages for details.";
     throw;
   }
-  g_log.notice() << "Saved focused workspace as file: " << fullFilename
+  g_log.notice() << "Saved focused workspace as file: " << saveDir.toString()
                  << std::endl;
 }
 
@@ -1507,39 +1480,24 @@ void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace,
                                              std::string specNums,
                                              std::string bank,
                                              std::string runNo) {
-  auto alg = Algorithm::fromString("SaveOpenGenieAscii");
-  std::string fullFilename;
-  if (inputWorkspace.std::string::find("texture") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_texture_" + bank + ".his";
-  }
-  if (inputWorkspace.std::string::find("cropped") != std::string::npos) {
-    fullFilename = "ENGINX_" + runNo + "_cropped_" +
-                   boost::lexical_cast<std::string>(g_croppedCounter) + ".his";
-    g_croppedCounter++;
-  } else {
-    fullFilename = "ENGINX_" + runNo + "_bank_" + bank + ".his";
-  }
 
-  std::string saveDir;
-  try {
-    // takes to the root of directory according to the platform
-    // and appends the following string provided
-    saveDir =
-        Poco::Path(saveDir).expand("/EnginX_Mantid/User/" + runNo + "/Focus/");
+  // Generates the file name in the appropriate format
+  std::string fullFilename =
+      outFileNameFactory(inputWorkspace, runNo, bank, ".his");
 
-    if (!Poco::File(saveDir).exists()) {
-      Poco::File(saveDir).createDirectories();
-    }
-  } catch (std::runtime_error &re) {
-    g_log.error() << "Error while using Poco: " << re.what();
-  }
+  // Creates appropriate directory
+  Poco::Path saveDir = outFilesDir(runNo);
+
+  // append the full file name in the end
+  saveDir.append(fullFilename);
 
   try {
     g_log.debug() << "Going to save focused output into OpenGenie file: "
                   << fullFilename << std::endl;
+    auto alg = Algorithm::fromString("SaveOpenGenieAscii");
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWorkspace);
-    std::string filename(saveDir + fullFilename);
+    std::string filename(saveDir.toString());
     alg->setPropertyValue("Filename", filename);
     alg->setPropertyValue("SpecNumberField", specNums);
     alg->execute();
@@ -1551,8 +1509,66 @@ void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace,
             " Please check also the log messages for details.";
     throw;
   }
-  g_log.notice() << "Saved focused workspace as file: " << fullFilename
+  g_log.notice() << "Saved focused workspace as file: " << saveDir.toString()
                  << std::endl;
+}
+
+/**
+ * Generates the required file name of the output files
+ *
+ * @param inputWorkspace title of the focused workspace
+ * @param runNo the run number as a string
+ * @param bank the number of the bank as a string
+ * @param format the format of the file to be saved as
+ */
+std::string EnggDiffractionPresenter::outFileNameFactory(
+    std::string inputWorkspace, std::string runNo, std::string bank,
+    std::string format) {
+  std::string fullFilename;
+  if (inputWorkspace.std::string::find("texture") != std::string::npos) {
+    fullFilename = "ENGINX_" + runNo + "_texture_" + bank + format;
+  }
+  if (inputWorkspace.std::string::find("cropped") != std::string::npos) {
+    fullFilename = "ENGINX_" + runNo + "_cropped_" +
+                   boost::lexical_cast<std::string>(g_croppedCounter) + format;
+    g_croppedCounter++;
+  } else {
+    fullFilename = "ENGINX_" + runNo + "_bank_" + bank + format;
+  }
+  return fullFilename;
+}
+
+/**
+ * Generates a directory if not found and handles the path
+ *
+ * @param runNo the run number as a string
+ */
+Poco::Path EnggDiffractionPresenter::outFilesDir(std::string runNo) {
+  Poco::Path saveDir;
+  try {
+
+// takes to the root of directory according to the platform
+// and appends the following string provided
+#ifdef __unix__
+    saveDir = Poco::Path().home();
+    saveDir.append("EnginX_Mantid");
+    saveDir.append("User");
+    saveDir.append(runNo);
+    saveDir.append("Focus");
+#else
+    // else or for windows run this
+    saveDir = (saveDir).expand("C:/EnginX_Mantid/User/" + runNo + "/Focus/");
+#endif
+
+    if (!Poco::File(saveDir.toString()).exists()) {
+      Poco::File(saveDir.toString()).createDirectories();
+    }
+  } catch (Poco::FileAccessDeniedException &e) {
+    g_log.error() << "error caused by file access/permission: " << e.what();
+  } catch (std::runtime_error &re) {
+    g_log.error() << "Error while find/creating a path: " << re.what();
+  }
+  return saveDir;
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1356,8 +1356,10 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
  * python function to apply during first bank and second bank
  *
  * @param outWSName title of the focused workspace
+ * @param bank the number of bank
  */
-void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName, std::string bank) {
+void EnggDiffractionPresenter::plotFocusedWorkspace(std::string outWSName,
+                                                    std::string bank) {
   const bool plotFocusedWS = m_view->focusedOutWorkspace();
   int plotType = m_view->currentPlotType();
   if (plotFocusedWS) {
@@ -1467,7 +1469,7 @@ void EnggDiffractionPresenter::saveGSS(const std::string inputWorkspace,
       Poco::File(saveDir).createDirectories();
     }
   } catch (std::runtime_error &re) {
-     g_log.error() << "Error while using Poco: " << re.what();
+    g_log.error() << "Error while using Poco: " << re.what();
   }
 
   try {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -288,7 +288,7 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabCalib.lineEdit_new_ceria_num->getText());
 
   // user params - focusing
-  qs.setValue("user-params-focus-runno", m_uiTabFocus.lineEdit_run_num->text());
+  qs.setValue("user-params-focus-runno", m_uiTabFocus.lineEdit_run_num->getText());
 
   qs.beginWriteArray("user-params-focus-bank_i");
   qs.setArrayIndex(0);
@@ -298,12 +298,12 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
   qs.endArray();
 
   qs.setValue("user-params-focus-cropped-runno",
-              m_uiTabFocus.lineEdit_cropped_run_num->text());
+              m_uiTabFocus.lineEdit_cropped_run_num->getText());
   qs.setValue("user-params-focus-cropped-spectrum-nos",
               m_uiTabFocus.lineEdit_cropped_spec_ids->text());
 
   qs.setValue("user-params-focus-texture-runno",
-              m_uiTabFocus.lineEdit_texture_run_num->text());
+              m_uiTabFocus.lineEdit_texture_run_num->getText());
   qs.setValue("user-params-focus-texture-detector-grouping-file",
               m_uiTabFocus.lineEdit_texture_grouping_file->text());
 
@@ -676,15 +676,15 @@ void EnggDiffractionViewQtGUI::browseTextureDetGroupingFile() {
 }
 
 std::string EnggDiffractionViewQtGUI::focusingRunNo() const {
-  return m_uiTabFocus.lineEdit_run_num->text().toStdString();
+  return m_uiTabFocus.lineEdit_run_num->getText().toStdString();
 }
 
 std::string EnggDiffractionViewQtGUI::focusingCroppedRunNo() const {
-  return m_uiTabFocus.lineEdit_cropped_run_num->text().toStdString();
+  return m_uiTabFocus.lineEdit_cropped_run_num->getText().toStdString();
 }
 
 std::string EnggDiffractionViewQtGUI::focusingTextureRunNo() const {
-  return m_uiTabFocus.lineEdit_texture_run_num->text().toStdString();
+  return m_uiTabFocus.lineEdit_texture_run_num->getText().toStdString();
 }
 
 std::string EnggDiffractionViewQtGUI::focusingDir() const {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -307,8 +307,7 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
   qs.setValue("user-params-focus-texture-detector-grouping-file",
               m_uiTabFocus.lineEdit_texture_grouping_file->text());
 
-  qs.setValue("user-params-focus-plot-ws",
-              m_uiTabFocus.checkBox_FocusedWS->checkState());
+  qs.setValue("value", m_uiTabFocus.checkBox_FocusedWS->isChecked());
 
   // TODO: this should become << >> operators on EnggDiffCalibSettings
   qs.setValue("input-dir-calib-files",

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -425,6 +425,7 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.lineEdit_run_num->setEnabled(enable);
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
   m_uiTabFocus.checkBox_FocusedWS->setEnabled(enable);
+  m_uiTabFocus.checkBox_SaveOutputFiles->setEnabled(enable);
 
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
   m_uiTabFocus.pushButton_focus_cropped->setEnabled(enable);
@@ -708,6 +709,10 @@ std::string EnggDiffractionViewQtGUI::focusingTextureGroupingFile() const {
 
 bool EnggDiffractionViewQtGUI::focusedOutWorkspace() const {
   return m_uiTabFocus.checkBox_FocusedWS->checkState();
+}
+
+bool EnggDiffractionViewQtGUI::saveOutputFiles() const {
+  return m_uiTabFocus.checkBox_SaveOutputFiles->checkState();
 }
 
 void EnggDiffractionViewQtGUI::plotFocusStatus() {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -289,7 +289,8 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabCalib.lineEdit_new_ceria_num->getText());
 
   // user params - focusing
-  qs.setValue("user-params-focus-runno", m_uiTabFocus.lineEdit_run_num->getText());
+  qs.setValue("user-params-focus-runno",
+              m_uiTabFocus.lineEdit_run_num->getText());
 
   qs.beginWriteArray("user-params-focus-bank_i");
   qs.setArrayIndex(0);

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -25,6 +25,7 @@ namespace CustomInterfaces {
 DECLARE_SUBWINDOW(EnggDiffractionViewQtGUI)
 
 const double EnggDiffractionViewQtGUI::g_defaultRebinWidth = -0.0005;
+int EnggDiffractionViewQtGUI::m_currentType = 0;
 
 const std::string EnggDiffractionViewQtGUI::g_iparmExtStr =
     "GSAS instrument parameters, IPARM file: PRM, PAR, IPAR, IPARAM "
@@ -723,10 +724,10 @@ void EnggDiffractionViewQtGUI::plotFocusStatus() {
 }
 
 void EnggDiffractionViewQtGUI::plotRepChanged(int /*idx*/) {
-  QComboBox *inst = m_uiTabFocus.comboBox_PlotData;
-  if (!inst)
+  QComboBox *plotType = m_uiTabFocus.comboBox_PlotData;
+  if (!plotType)
     return;
-  m_currentType = inst->currentIndex();
+  m_currentType = plotType->currentIndex();
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -283,9 +283,9 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabCalib.lineEdit_current_calib_filename->text());
 
   qs.setValue("user-params-new-vanadium-num",
-              m_uiTabCalib.lineEdit_new_vanadium_num->text());
+              m_uiTabCalib.lineEdit_new_vanadium_num->getText());
   qs.setValue("user-params-new-ceria-num",
-              m_uiTabCalib.lineEdit_new_ceria_num->text());
+              m_uiTabCalib.lineEdit_new_ceria_num->getText());
 
   // user params - focusing
   qs.setValue("user-params-focus-runno", m_uiTabFocus.lineEdit_run_num->text());
@@ -384,11 +384,11 @@ std::string EnggDiffractionViewQtGUI::currentCeriaNo() const {
 }
 
 std::string EnggDiffractionViewQtGUI::newVanadiumNo() const {
-  return m_uiTabCalib.lineEdit_new_vanadium_num->text().toStdString();
+  return m_uiTabCalib.lineEdit_new_vanadium_num->getText().toStdString();
 }
 
 std::string EnggDiffractionViewQtGUI::newCeriaNo() const {
-  return m_uiTabCalib.lineEdit_new_ceria_num->text().toStdString();
+  return m_uiTabCalib.lineEdit_new_ceria_num->getText().toStdString();
 }
 
 std::string EnggDiffractionViewQtGUI::currentCalibFile() const {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -149,6 +149,8 @@ void EnggDiffractionViewQtGUI::doSetupTabSettings() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabFocus() {
+  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
+
   connect(m_uiTabFocus.pushButton_focus, SIGNAL(released()), this,
           SLOT(focusClicked()));
 
@@ -163,6 +165,12 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
 
   connect(m_uiTabFocus.pushButton_reset, SIGNAL(released()), this,
           SLOT(focusResetClicked()));
+
+  connect(m_uiTabFocus.comboBox_PlotData, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(plotRepChanged(int)));
+
+  connect(m_uiTabFocus.checkBox_FocusedWS, SIGNAL(clicked()), this,
+          SLOT(plotFocusStatus()));
 }
 
 void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
@@ -209,9 +217,11 @@ void EnggDiffractionViewQtGUI::readSettings() {
 
   qs.beginReadArray("user-params-focus-bank_i");
   qs.setArrayIndex(0);
-  m_uiTabFocus.checkBox_focus_bank1->setChecked(qs.value("value", true).toBool());
+  m_uiTabFocus.checkBox_focus_bank1->setChecked(
+      qs.value("value", true).toBool());
   qs.setArrayIndex(1);
-  m_uiTabFocus.checkBox_focus_bank2->setChecked(qs.value("value", true).toBool());
+  m_uiTabFocus.checkBox_focus_bank2->setChecked(
+      qs.value("value", true).toBool());
   qs.endArray();
 
   m_uiTabFocus.lineEdit_cropped_run_num->setText(
@@ -421,10 +431,33 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
 }
 
 void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {
-  std::string pyCode = "plotSpectrum('" + wsName + "', 0)";
+  std::string pyCode = "win = plotSpectrum('" + wsName + "', 0)";
 
   std::string status =
       runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+  m_logMsgs.push_back("Plotted output focused data, with status string " +
+                      status);
+  m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
+}
+
+void EnggDiffractionViewQtGUI::plotWaterfallSpectrum(
+    const std::string &wsName) {
+  // parameter of list ?
+  std::string pyCode =
+      "plotSpectrum('" + wsName + "', 0, waterfall = True, window = win)";
+  std::string status =
+      runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+  m_logMsgs.push_back("Plotted output focused data, with status string " +
+                      status);
+  m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
+}
+
+void EnggDiffractionViewQtGUI::plotReplacingWindow(const std::string &wsName) {
+  std::string pyCode =
+      "plotSpectrum('" + wsName + "', 0, window = win, clearWindow = True)";
+  std::string status =
+      runPythonCode(QString::fromStdString(pyCode), false).toStdString();
+
   m_logMsgs.push_back("Plotted output focused data, with status string " +
                       status);
   m_presenter->notify(IEnggDiffractionPresenter::LogMsg);
@@ -442,10 +475,9 @@ void EnggDiffractionViewQtGUI::resetFocus() {
   m_uiTabFocus.lineEdit_texture_grouping_file->setText("");
 }
 
-void
-EnggDiffractionViewQtGUI::writeOutCalibFile(const std::string &outFilename,
-                                            const std::vector<double> &difc,
-                                            const std::vector<double> &tzero) {
+void EnggDiffractionViewQtGUI::writeOutCalibFile(
+    const std::string &outFilename, const std::vector<double> &difc,
+    const std::vector<double> &tzero) {
   // TODO: this is horrible and should not last much here.
   // Avoid running Python code
   // Update this as soon as we have a more stable way of generating IPARM
@@ -675,6 +707,22 @@ std::string EnggDiffractionViewQtGUI::focusingTextureGroupingFile() const {
 
 bool EnggDiffractionViewQtGUI::focusedOutWorkspace() const {
   return m_uiTabFocus.checkBox_FocusedWS->checkState();
+}
+
+void EnggDiffractionViewQtGUI::plotFocusStatus() {
+  if (focusedOutWorkspace()) {
+    m_uiTabFocus.comboBox_PlotData->setEnabled(true);
+  } else {
+    m_uiTabFocus.comboBox_PlotData->setEnabled(false);
+  }
+}
+
+void EnggDiffractionViewQtGUI::plotRepChanged(int /*idx*/) {
+  QComboBox *inst = m_uiTabFocus.comboBox_PlotData;
+  if (!inst)
+    return;
+  m_currentType = inst->currentIndex();
+  m_presenter->notify(IEnggDiffractionPresenter::PlotRepChange);
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -149,7 +149,6 @@ void EnggDiffractionViewQtGUI::doSetupTabSettings() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabFocus() {
-  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
 
   connect(m_uiTabFocus.pushButton_focus, SIGNAL(released()), this,
           SLOT(focusClicked()));
@@ -239,6 +238,8 @@ void EnggDiffractionViewQtGUI::readSettings() {
 
   m_uiTabFocus.checkBox_FocusedWS->setChecked(
       qs.value("user-params-focus-plot-ws", true).toBool());
+
+  m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
 
   QString lastPath =
       MantidQt::API::AlgorithmInputHistory::Instance().getPreviousDirectory();
@@ -722,7 +723,6 @@ void EnggDiffractionViewQtGUI::plotRepChanged(int /*idx*/) {
   if (!inst)
     return;
   m_currentType = inst->currentIndex();
-  m_presenter->notify(IEnggDiffractionPresenter::PlotRepChange);
 }
 
 void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -385,6 +385,8 @@ public:
     // check automatic plotting
     EXPECT_CALL(mockView, focusedOutWorkspace()).Times(1).WillOnce(Return(true));
     EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(1);
+	// There are two/three other tests that have the disabled_ prefix so they
+	// normally run
 
     // Should not try to use options for other types of focusing
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -105,7 +105,19 @@ public:
   MOCK_CONST_METHOD0(saveSettings, void());
 
   // virtual void plotFocusedSpectrum();
-  MOCK_METHOD1(plotFocusedSpectrum, void(const std::string&));
+  MOCK_METHOD1(plotFocusedSpectrum, void(const std::string &));
+
+  // void plotFocusStatus();
+  MOCK_METHOD0(plotFocusStatus, void());
+
+  // void plotRepChanged();
+  MOCK_METHOD1(plotRepChanged, void(int idx));
+
+  // virtual void plotWaterfallSpectrum
+  MOCK_METHOD1(plotWaterfallSpectrum, void(const std::string &wsName));
+
+  // std::string currentPlotType
+  MOCK_CONST_METHOD0(currentPlotType, int());
 };
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -50,6 +50,9 @@ public:
   // virtual std::string currentCalibFile() const;
   MOCK_CONST_METHOD0(currentCalibFile, std::string());
 
+  // std::string currentPlotType
+  MOCK_CONST_METHOD0(currentPlotType, int());
+
   // virtual std::string newVanadiumNo() const;
   MOCK_CONST_METHOD0(newVanadiumNo, std::string());
 
@@ -104,6 +107,9 @@ public:
   // void saveSettings() const;
   MOCK_CONST_METHOD0(saveSettings, void());
 
+  // std::string saveOutputFiles
+  MOCK_CONST_METHOD0(saveOutputFiles, bool());
+
   // virtual void plotFocusedSpectrum();
   MOCK_METHOD1(plotFocusedSpectrum, void(const std::string &));
 
@@ -119,8 +125,7 @@ public:
   // virtual void plotReplacingWindow
   MOCK_METHOD1(plotReplacingWindow, void(const std::string &wsName));
 
-  // std::string currentPlotType
-  MOCK_CONST_METHOD0(currentPlotType, int());
+
 };
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -116,6 +116,9 @@ public:
   // virtual void plotWaterfallSpectrum
   MOCK_METHOD1(plotWaterfallSpectrum, void(const std::string &wsName));
 
+  // virtual void plotReplacingWindow
+  MOCK_METHOD1(plotReplacingWindow, void(const std::string &wsName));
+
   // std::string currentPlotType
   MOCK_CONST_METHOD0(currentPlotType, int());
 };

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -99,6 +99,24 @@ numbers. For example:
    2, 100, 102, 107
    3, 300, 310, 320-329, 350-370
 
+Output
+^^^^^^
+
+Under the output section, the user is provided with an option of
+plotting data in three different formats. One Window - Replacing
+Plots: will replace the previous graph and plot a new graph on top.
+One Window - Waterfall: will plot all the generated focused
+workspace graphs in one window which can be useful while comparing
+various graphs. The Multiple Windows: will plot graph in
+separate windows.
+
+The user also has an option of generated GSS, XYE and OpenGenie
+formatted file by clicking the Output Files checkbox. This will
+generated three different files for each focused output workspace
+in Mantid. These files can be found with appropriate name at location:
+C:\EnginX_Mantid\User\236516\Focus on Windows, the
+EnginX_Mantid folder can be found on Desktop/Home on other platforms.
+
 Settings
 --------
 


### PR DESCRIPTION
**This should be merged after the following issue has been merged #13903**
- [x] #13903 merged

_Fixes #13854 & #13783 & #13853_ 

**To Test**
#13854

Click the `Output Files` check-box which should save the generated files/focused workspaces in to `OpenGenie`, `GSS` & `FocusedXYE` formats with appropriate labels. 

 #13783
Saves File As:
- `ENGINX_...<RUN_NUMBER>_..._bank_1` .his, .gss, .dat, etc. for banks 1, 2, etc.
#13853
- In the GUI use the MWRun widget instead of raw numbers
