### PR TITLE
Ensure AlgorithmProxy keeps everything up to date with CopyPropertiesfrom

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmProxy.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProxy.h
@@ -116,6 +116,8 @@ public:
   void setPropertyValue(const std::string &name, const std::string &value);
   /// Do something after a property was set
   void afterPropertySet(const std::string &);
+  /// Make m_properties point to the same PropertyManager as po.
+  void copyPropertiesFrom(const PropertyManagerOwner &po);
   //@}
 
   void cancel();

--- a/Framework/API/src/AlgorithmProxy.cpp
+++ b/Framework/API/src/AlgorithmProxy.cpp
@@ -218,7 +218,19 @@ void AlgorithmProxy::afterPropertySet(const std::string &name) {
   copyPropertiesFrom(*m_alg);
 }
 
-//----------------------------------------------------------------------
+/**
+ * Copy properties from another property manager
+ * Making sure that the concrete alg is kept in sync
+ * @param po :: The property manager to copy
+ */
+void AlgorithmProxy::copyPropertiesFrom(const PropertyManagerOwner& po)
+{
+  PropertyManagerOwner::copyPropertiesFrom(po);
+  createConcreteAlg(true);
+  m_alg->copyPropertiesFrom(*this);
+}
+
+  //----------------------------------------------------------------------
 // Private methods
 //----------------------------------------------------------------------
 

--- a/Framework/API/src/AlgorithmProxy.cpp
+++ b/Framework/API/src/AlgorithmProxy.cpp
@@ -223,14 +223,13 @@ void AlgorithmProxy::afterPropertySet(const std::string &name) {
  * Making sure that the concrete alg is kept in sync
  * @param po :: The property manager to copy
  */
-void AlgorithmProxy::copyPropertiesFrom(const PropertyManagerOwner& po)
-{
+void AlgorithmProxy::copyPropertiesFrom(const PropertyManagerOwner &po) {
   PropertyManagerOwner::copyPropertiesFrom(po);
   createConcreteAlg(true);
   m_alg->copyPropertiesFrom(*this);
 }
 
-  //----------------------------------------------------------------------
+//----------------------------------------------------------------------
 // Private methods
 //----------------------------------------------------------------------
 

--- a/Framework/API/test/AlgorithmProxyTest.h
+++ b/Framework/API/test/AlgorithmProxyTest.h
@@ -214,27 +214,27 @@ public:
   }
 
   void test_copyPropertiesFrom() {
-      IAlgorithm_sptr alg =
+    IAlgorithm_sptr alg =
         AlgorithmManager::Instance().create("ToyAlgorithmProxy");
-      alg->initialize();
-      alg->setPropertyValue( "prop1", "string" );
-      alg->setPropertyValue("prop2","1");
-      IAlgorithm_sptr algCopy =
+    alg->initialize();
+    alg->setPropertyValue("prop1", "string");
+    alg->setPropertyValue("prop2", "1");
+    IAlgorithm_sptr algCopy =
         AlgorithmManager::Instance().create("ToyAlgorithmProxy");
 
-      auto algProxy = boost::dynamic_pointer_cast<AlgorithmProxy>(alg);
-      auto algCopyProxy = boost::dynamic_pointer_cast<AlgorithmProxy>(algCopy);
-      algCopyProxy->copyPropertiesFrom(*algProxy);
+    auto algProxy = boost::dynamic_pointer_cast<AlgorithmProxy>(alg);
+    auto algCopyProxy = boost::dynamic_pointer_cast<AlgorithmProxy>(algCopy);
+    algCopyProxy->copyPropertiesFrom(*algProxy);
 
-      int val = boost::lexical_cast<int>(algCopy->getPropertyValue("prop2"));
+    int val = boost::lexical_cast<int>(algCopy->getPropertyValue("prop2"));
 
-      TS_ASSERT_EQUALS(val,1);
+    TS_ASSERT_EQUALS(val, 1);
 
-      //set another value and check the other value is unaffected
-      algCopy->setPropertyValue( "prop1", "A difference" );
-      int val2 = boost::lexical_cast<int>(algCopy->getPropertyValue("prop2"));
+    // set another value and check the other value is unaffected
+    algCopy->setPropertyValue("prop1", "A difference");
+    int val2 = boost::lexical_cast<int>(algCopy->getPropertyValue("prop2"));
 
-      TS_ASSERT_EQUALS(val,val2);
+    TS_ASSERT_EQUALS(val, val2);
   }
 };
 

--- a/Framework/API/test/AlgorithmProxyTest.h
+++ b/Framework/API/test/AlgorithmProxyTest.h
@@ -212,6 +212,30 @@ public:
     }
     TS_ASSERT_EQUALS("InputWorkspace", alg->workspaceMethodInputProperty());
   }
+
+  void test_copyPropertiesFrom() {
+      IAlgorithm_sptr alg =
+        AlgorithmManager::Instance().create("ToyAlgorithmProxy");
+      alg->initialize();
+      alg->setPropertyValue( "prop1", "string" );
+      alg->setPropertyValue("prop2","1");
+      IAlgorithm_sptr algCopy =
+        AlgorithmManager::Instance().create("ToyAlgorithmProxy");
+
+      auto algProxy = boost::dynamic_pointer_cast<AlgorithmProxy>(alg);
+      auto algCopyProxy = boost::dynamic_pointer_cast<AlgorithmProxy>(algCopy);
+      algCopyProxy->copyPropertiesFrom(*algProxy);
+
+      int val = boost::lexical_cast<int>(algCopy->getPropertyValue("prop2"));
+
+      TS_ASSERT_EQUALS(val,1);
+
+      //set another value and check the other value is unaffected
+      algCopy->setPropertyValue( "prop1", "A difference" );
+      int val2 = boost::lexical_cast<int>(algCopy->getPropertyValue("prop2"));
+
+      TS_ASSERT_EQUALS(val,val2);
+  }
 };
 
 #endif /*ALGORITHMPROXYTEST_H_*/

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
@@ -65,7 +65,9 @@ public:
   void setPropertyOrdinal(const int &index, const std::string &value);
 
   /// Make m_properties point to the same PropertyManager as po.
-  virtual void copyPropertiesFrom(const PropertyManagerOwner &po) { *this = po; }
+  virtual void copyPropertiesFrom(const PropertyManagerOwner &po) {
+    *this = po;
+  }
 
   bool existsProperty(const std::string &name) const;
   bool validateProperties() const;

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
@@ -65,7 +65,7 @@ public:
   void setPropertyOrdinal(const int &index, const std::string &value);
 
   /// Make m_properties point to the same PropertyManager as po.
-  void copyPropertiesFrom(const PropertyManagerOwner &po) { *this = po; }
+  virtual void copyPropertiesFrom(const PropertyManagerOwner &po) { *this = po; }
 
   bool existsProperty(const std::string &name) const;
   bool validateProperties() const;


### PR DESCRIPTION
Fixes a bug that allowed AlgorithmProxies to forget properties when they had been created using CopyPropertiesfrom from another algorithm 

closes #13925
## release notes

Too minor
## To test
1. A new unit test has been added to check the bug is removed if that passed all is good.
2. Code review might be worth while
