### PR TITLE
Changed hard coded default value for SaveNexusProcessed duration

### DIFF
--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -370,7 +370,7 @@ WorkspaceHistory::parseAlgorithmHistory(const std::string &rawData) {
   // Get the duration
   getWordsInString(info[EXEC_DUR], dummy, dummy, temp, dummy);
   double dur = boost::lexical_cast<double>(temp);
-  if (dur < 0.0) {
+  if (dur < -1.0) {
     g_log.warning() << "Error parsing duration in algorithm history entry."
                     << "\n";
     dur = -1.0;

--- a/Framework/DataHandling/src/SaveNexus.cpp
+++ b/Framework/DataHandling/src/SaveNexus.cpp
@@ -147,7 +147,7 @@ void SaveNexus::runSaveNexusProcessed() {
   // If we're tracking history, add the entry before we save it to file
   if (trackingHistory()) {
     m_history->fillAlgorithmHistory(
-        this, Mantid::Kernel::DateAndTime::getCurrentTime(), -1,
+        this, Mantid::Kernel::DateAndTime::getCurrentTime(), 0,
         Algorithm::g_execCount);
     if (!isChild()) {
       m_inputWorkspace->history().addHistory(m_history);

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -291,7 +291,7 @@ void SaveNexusProcessed::doExec(Workspace_sptr inputWorkspace,
   // Switch to the Cpp API for the algorithm history
   if (trackingHistory()) {
     m_history->fillAlgorithmHistory(
-        this, Mantid::Kernel::DateAndTime::getCurrentTime(), -1,
+        this, Mantid::Kernel::DateAndTime::getCurrentTime(), 0,
         Algorithm::g_execCount);
     if (!isChild()) {
       inputWorkspace->history().addHistory(m_history);


### PR DESCRIPTION
from -1 to 0 which should parse fine when reloading
closes #13936
## Release Notes

http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Algorithms
## To test

This should not create an error like "Error parsing duration in algorithm history entry."

``` python
ws = CreateSampleWorkspace()
file_name = "YOUR_PATH_HERE.nxs"
SaveNexus(Filename = file_name, InputWorkspace = ws)
ws_loaded= Load(file_name)
```
