### PR TITLE
Xcode 7 fixes

### DIFF
--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -217,8 +217,9 @@ void IFittingAlgorithm::addWorkspace(const std::string &workspacePropertyName,
         boost::dynamic_pointer_cast<MultiDomainCreator>(m_domainCreator);
     if (!multiCreator) {
       throw std::runtime_error(
+          auto &reference = *m_domainCreator.get();
           std::string("MultiDomainCreator expected, found ") +
-          typeid(*m_domainCreator.get()).name());
+          typeid(reference).name());
     }
     if (!multiCreator->hasCreator(index)) {
       creator->declareDatasetProperties(suffix, addProperties);

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -216,8 +216,8 @@ void IFittingAlgorithm::addWorkspace(const std::string &workspacePropertyName,
     boost::shared_ptr<MultiDomainCreator> multiCreator =
         boost::dynamic_pointer_cast<MultiDomainCreator>(m_domainCreator);
     if (!multiCreator) {
+      auto &reference = *m_domainCreator.get();
       throw std::runtime_error(
-          auto &reference = *m_domainCreator.get();
           std::string("MultiDomainCreator expected, found ") +
           typeid(reference).name());
     }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -42,7 +42,7 @@ typedef void (*declarePropertyType3)(boost::python::object &self,
 typedef void (*declarePropertyType4)(boost::python::object &self,
                                      const std::string &,
                                      const boost::python::object &, const int);
-fdef __clang__
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -46,24 +46,22 @@ typedef void (*declarePropertyType4)(boost::python::object &self,
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
-    // Overload types
-    BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
-                                    PythonAlgorithm::declarePyAlgProperty, 2, 3)
-        BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
-                                        PythonAlgorithm::declarePyAlgProperty,
-                                        3, 6)
-            BOOST_PYTHON_FUNCTION_OVERLOADS(
-                declarePropertyType3_Overload,
-                PythonAlgorithm::declarePyAlgProperty, 4, 5)
+// Overload types
+BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
+                                PythonAlgorithm::declarePyAlgProperty, 2, 3)
+BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
+                                PythonAlgorithm::declarePyAlgProperty, 3, 6)
+BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
+                                PythonAlgorithm::declarePyAlgProperty, 4, 5)
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-    /**
-     * Map a CancelException to a Python KeyboardInterupt
-     * @param exc A cancel exception to translate. Unused here as the message is
-     * ignored
-     */
-    void translateCancel(const Algorithm::CancelException &exc) {
+/**
+ * Map a CancelException to a Python KeyboardInterupt
+ * @param exc A cancel exception to translate. Unused here as the message is
+ * ignored
+ */
+void translateCancel(const Algorithm::CancelException &exc) {
   UNUSED_ARG(exc);
   PyErr_SetString(PyExc_KeyboardInterrupt, "");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -44,6 +44,7 @@ typedef void (*declarePropertyType4)(boost::python::object &self,
                                      const boost::python::object &, const int);
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Overload types

--- a/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp
@@ -42,21 +42,28 @@ typedef void (*declarePropertyType3)(boost::python::object &self,
 typedef void (*declarePropertyType4)(boost::python::object &self,
                                      const std::string &,
                                      const boost::python::object &, const int);
-
-// Overload types
-BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
-                                PythonAlgorithm::declarePyAlgProperty, 2, 3)
-BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
-                                PythonAlgorithm::declarePyAlgProperty, 3, 6)
-BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType3_Overload,
-                                PythonAlgorithm::declarePyAlgProperty, 4, 5)
-
-/**
- * Map a CancelException to a Python KeyboardInterupt
- * @param exc A cancel exception to translate. Unused here as the message is
- * ignored
- */
-void translateCancel(const Algorithm::CancelException &exc) {
+fdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+    // Overload types
+    BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType1_Overload,
+                                    PythonAlgorithm::declarePyAlgProperty, 2, 3)
+        BOOST_PYTHON_FUNCTION_OVERLOADS(declarePropertyType2_Overload,
+                                        PythonAlgorithm::declarePyAlgProperty,
+                                        3, 6)
+            BOOST_PYTHON_FUNCTION_OVERLOADS(
+                declarePropertyType3_Overload,
+                PythonAlgorithm::declarePyAlgProperty, 4, 5)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+    /**
+     * Map a CancelException to a Python KeyboardInterupt
+     * @param exc A cancel exception to translate. Unused here as the message is
+     * ignored
+     */
+    void translateCancel(const Algorithm::CancelException &exc) {
   UNUSED_ARG(exc);
   PyErr_SetString(PyExc_KeyboardInterrupt, "");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -99,8 +99,14 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
   // from the FileLoaderRegistry
   FileLoaderRegistry::Instance().unsubscribe(descr.first, descr.second);
 }
-
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 ///@endcond
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -101,6 +101,7 @@ void subscribe(AlgorithmFactoryImpl &self, const boost::python::object &obj) {
 }
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(existsOverloader, exists, 1, 2)

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -59,6 +59,7 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 //------------------------------------------------------------------------------------------------------
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 /// Define overload generators

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -57,12 +57,19 @@ boost::python::list runningInstancesOf(AlgorithmManagerImpl &self,
 
 ///@cond
 //------------------------------------------------------------------------------------------------------
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 /// Define overload generators
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(create_overloads,
                                        AlgorithmManagerImpl::create, 1, 2)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createUnmanaged_overloads,
                                        AlgorithmManagerImpl::createUnmanaged, 1,
                                        2)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -25,8 +25,17 @@ namespace {
 namespace bpl = boost::python;
 
 //------------------------------- Overload macros ---------------------------
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+
 // Overloads for operator() function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Axis_getValue, Axis::getValue, 1, 2)
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 /**
  * Extract the axis values as a sequence. A numpy array is used if the

--- a/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp
@@ -27,6 +27,7 @@ namespace bpl = boost::python;
 //------------------------------- Overload macros ---------------------------
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -10,9 +10,16 @@ using Mantid::API::ExperimentInfo;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 using namespace boost::python;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 /// Overload generator for getInstrumentFilename
 BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -12,6 +12,7 @@ using namespace boost::python;
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 /// Overload generator for getInstrumentFilename

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -10,6 +10,7 @@ using namespace boost::python;
 namespace {
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -8,7 +8,14 @@ using Mantid::API::FileFinderImpl;
 using namespace boost::python;
 
 namespace {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getFullPathOverloader, getFullPath, 1, 2)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }
 
 void export_FileFinder() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -36,6 +36,7 @@ PyObject *getCategories(IFunction &self) {
 typedef void (IFunction::*setParameterType1)(size_t, const double &value, bool);
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -34,14 +34,20 @@ PyObject *getCategories(IFunction &self) {
 // -- Set property overloads --
 // setProperty(index,value,explicit)
 typedef void (IFunction::*setParameterType1)(size_t, const double &value, bool);
-BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
-                                       setParameter, 2, 3)
-// setProperty(index,value,explicit)
-typedef void (IFunction::*setParameterType2)(const std::string &,
-                                             const double &value, bool);
+fdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+    BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
+                                           setParameter, 2, 3)
+    // setProperty(index,value,explicit)
+    typedef void (IFunction::*setParameterType2)(const std::string &,
+                                                 const double &value, bool);
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
-
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -38,11 +38,11 @@ typedef void (IFunction::*setParameterType1)(size_t, const double &value, bool);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
-    BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
-                                           setParameter, 2, 3)
-    // setProperty(index,value,explicit)
-    typedef void (IFunction::*setParameterType2)(const std::string &,
-                                                 const double &value, bool);
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType1_Overloads,
+                                       setParameter, 2, 3)
+// setProperty(index,value,explicit)
+typedef void (IFunction::*setParameterType2)(const std::string &,
+                                             const double &value, bool);
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(setParameterType2_Overloads,
                                        setParameter, 2, 3)
 #ifdef __clang__

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -34,7 +34,7 @@ PyObject *getCategories(IFunction &self) {
 // -- Set property overloads --
 // setProperty(index,value,explicit)
 typedef void (IFunction::*setParameterType1)(size_t, const double &value, bool);
-fdef __clang__
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -34,10 +34,16 @@ typedef return_value_policy<VectorRefToNumpy<WrapReadWrite>>
     return_readwrite_numpy;
 
 //------------------------------- Overload macros ---------------------------
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // Overloads for binIndexOf function which has 1 optional argument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(MatrixWorkspace_binIndexOfOverloads,
                                        MatrixWorkspace::binIndexOf, 1, 2)
-
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 /**
  * Set the values from an python array-style object into the given spectrum in
  * the workspace

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -36,6 +36,7 @@ typedef return_value_policy<VectorRefToNumpy<WrapReadWrite>>
 //------------------------------- Overload macros ---------------------------
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Overloads for binIndexOf function which has 1 optional argument

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -14,8 +14,15 @@ using namespace boost::python;
 
 namespace {
 ///@cond
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,
                                        Workspace::isDirty, 0, 1)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -16,6 +16,7 @@ namespace {
 ///@cond
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Workspace_isDirtyOverloads,

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -42,6 +42,7 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 /// Overload generator for create
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr,

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -40,10 +40,17 @@ Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self,
 }
 
 /// Overload generator for create
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 BOOST_PYTHON_FUNCTION_OVERLOADS(createFromParent_Overload, createFromParentPtr,
                                 2, 5)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createTable_Overload, createTable, 0, 1)
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(createPeaks_Overload, createPeaks, 0, 1)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }
 
 void export_WorkspaceFactory() {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -7,6 +7,10 @@ using Mantid::Geometry::IComponent;
 using namespace boost::python;
 
 namespace {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // Default parameter function overloads
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParameterNames,
                                        Component::getParameterNames, 0, 1)
@@ -36,6 +40,9 @@ BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamShortDescription,
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Component_getParamDescription,
                                        Component::getParamDescription, 1, 2)
 }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 void export_Component() {
   class_<Component, bases<IComponent>, boost::noncopyable>("Component", no_init)

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Component.cpp
@@ -9,6 +9,7 @@ using namespace boost::python;
 namespace {
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Default parameter function overloads

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -13,9 +13,16 @@ using namespace boost::python;
 namespace //<unnamed>
     {
 ///@cond
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // define overloaded functions
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getEulerAngles_overloads,
                                        Goniometer::getEulerAngles, 0, 1)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 ///@endcond
 
 /// Set the U vector via a numpy array

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Goniometer.cpp
@@ -15,6 +15,7 @@ namespace //<unnamed>
 ///@cond
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // define overloaded functions

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -28,11 +28,19 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
   return self.getString(key, true);
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
+
 /// Overload generator for getInstrument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
-                                       1)
+
 /// Overload generator for getString
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }
 
 void export_ConfigService() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -30,6 +30,7 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -35,7 +35,7 @@ std::string getStringUsingCache(ConfigServiceImpl &self,
 
 /// Overload generator for getInstrument
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getInstrument_Overload, getInstrument, 0,
-
+                                       1)
 /// Overload generator for getString
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(getString_Overload, getString, 1, 2)
 #ifdef __clang__

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -104,7 +104,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
-///============================ Z score
+//============================ Z score
 //============================================
 
 /**

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -93,11 +93,18 @@ Statistics getStatisticsNumpy(const numeric::array &data,
     throw UnknownDataType();
   }
 }
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getStatisticsOverloads, getStatisticsNumpy, 1,
                                 2)
-
-//============================ Z score
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+///============================ Z score
 //============================================
 
 /**
@@ -145,9 +152,16 @@ std::vector<double> getModifiedZscoreNumpy(const numeric::array &data,
   }
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getModifiedZscoreOverloads,
                                 getModifiedZscoreNumpy, 1, 2)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 //============================ getMoments
 //============================================
@@ -198,10 +212,16 @@ std::vector<double> getMomentsAboutOriginNumpy(const numeric::array &indep,
   return getMomentsNumpyImpl(&getMomentsAboutOrigin, indep, depend, maxMoment);
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutOriginOverloads,
                                 getMomentsAboutOriginNumpy, 2, 3)
-
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 /**
  * Proxy for @see Mantid::Kernel::getMomentsAboutMean so that it can accept
  * numpy arrays
@@ -213,9 +233,17 @@ std::vector<double> getMomentsAboutMeanNumpy(const numeric::array &indep,
   return getMomentsNumpyImpl(&getMomentsAboutMean, indep, depend, maxMoment);
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 // Define an overload to handle the default argument
 BOOST_PYTHON_FUNCTION_OVERLOADS(getMomentsAboutMeanOverloads,
                                 getMomentsAboutMeanNumpy, 2, 3)
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 ///@endcond
 }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -96,6 +96,7 @@ Statistics getStatisticsNumpy(const numeric::array &data,
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Define an overload to handle the default argument
@@ -154,6 +155,7 @@ std::vector<double> getModifiedZscoreNumpy(const numeric::array &data,
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Define an overload to handle the default argument
@@ -214,6 +216,7 @@ std::vector<double> getMomentsAboutOriginNumpy(const numeric::array &indep,
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Define an overload to handle the default argument
@@ -235,6 +238,7 @@ std::vector<double> getMomentsAboutMeanNumpy(const numeric::array &indep,
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 // Define an overload to handle the default argument

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -21,6 +21,10 @@ using namespace Mantid::DataObjects::MDEventsTestHelper;
 using namespace Mantid::PythonInterface::Policies;
 using namespace WorkspaceCreationHelper;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 BOOST_PYTHON_FUNCTION_OVERLOADS(create2DWorkspaceWithFullInstrument_overloads,
                                 create2DWorkspaceWithFullInstrument, 2, 4)
 
@@ -30,6 +34,10 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(makeFakeMDHistoWorkspace_overloads,
 BOOST_PYTHON_FUNCTION_OVERLOADS(
     create2DWorkspaceWithRectangularInstrument_overloads,
     create2DWorkspaceWithRectangularInstrument, 3, 3)
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {
   using namespace boost::python;

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelperModule.cpp
@@ -23,6 +23,7 @@ using namespace WorkspaceCreationHelper;
 
 #ifdef __clang__
 #pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic ignored "-Wunused-local-typedef"
 #endif
 BOOST_PYTHON_FUNCTION_OVERLOADS(create2DWorkspaceWithFullInstrument_overloads,


### PR DESCRIPTION
This fixes all [warnings the occur when building mantid with Xcode 7.0.1](https://gist.github.com/quantumsteve/08d00df1b5027c9efe27)

No release notes since we are still using Xcode 6.2 on the build servers.

testing: code review is probably sufficient. Extra credit for doing a clean build of mantid from source on a machine with Xcode 7 installed.
