### PR TITLE
Adding tools subtree to pylint

### DIFF
--- a/buildconfig/CMake/PylintSetup.cmake
+++ b/buildconfig/CMake/PylintSetup.cmake
@@ -33,6 +33,7 @@ if ( PYLINT_FOUND )
         Framework/PythonInterface/plugins
         scripts
         Testing/SystemTests/tests/analysis
+        tools
   )
   set ( PYLINT_EXCLUDES
         scripts/lib1to2


### PR DESCRIPTION
The pylint build will fail because this is adding a new directory tree. Look at the console to see if what actually happened is that the build succeeded as unstable. Before merging into master the number of acceptable pylint warnings should be increased in jenkins.

This does not need to appear in the release notes.
