### PR TITLE
PoldiFitPeaks2D should use hexagonal lattice in Pawley fit for trigonal structures in hexagonal setting

### DIFF
--- a/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -6,6 +6,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/IPeakFunction.h"
+#include "MantidGeometry/Crystal/PointGroup.h"
 
 #include "MantidKernel/Matrix.h"
 
@@ -103,6 +104,9 @@ protected:
   Poldi2DFunction_sptr
   getFunctionPawley(std::string profileFunctionName,
                     const PoldiPeakCollection_sptr &peakCollection);
+
+  std::string getCrystalSystemFromPointGroup(
+      const Geometry::PointGroup_sptr &pointGroup) const;
 
   std::string
   getRefinedStartingCell(const std::string &initialCell,

--- a/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -546,8 +546,7 @@ Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionPawley(
                                 "peaks do not have point group.");
   }
 
-  std::string crystalSystem =
-      getCrystalSystemAsString(pointGroup->crystalSystem());
+  std::string crystalSystem = getCrystalSystemFromPointGroup(pointGroup);
   pawleyFunction->setCrystalSystem(crystalSystem);
 
   UnitCell cell = peakCollection->unitCell();
@@ -573,6 +572,35 @@ Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionPawley(
   mdFunction->addFunction(poldiPawleyFunction);
 
   return mdFunction;
+}
+
+/**
+ * Returns the crystal system for the specified point group
+ *
+ * This function simply uses Geometry::getCrystalSystemAsString(), except when
+ * the crystal system is trigonal but the point group uses hexagonal axes. In
+ * that case this function returns the string for PointGroup::Hexagonal.
+ *
+ * @param pointGroup :: The point group for which to find the crystal system
+ * @return The crystal system for the point group
+ */
+std::string PoldiFitPeaks2D::getCrystalSystemFromPointGroup(
+    const PointGroup_sptr &pointGroup) const {
+  if (!pointGroup) {
+    throw std::invalid_argument(
+        "Cannot return crystal system for null PointGroup.");
+  }
+
+  PointGroup::CrystalSystem crystalSystem = pointGroup->crystalSystem();
+
+  if (crystalSystem == PointGroup::Trigonal) {
+    if (pointGroup->getCoordinateSystem() ==
+        Group::CoordinateSystem::Hexagonal) {
+      return getCrystalSystemAsString(PointGroup::Hexagonal);
+    }
+  }
+
+  return getCrystalSystemAsString(crystalSystem);
 }
 
 /**

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -433,6 +433,40 @@ public:
     TS_ASSERT_EQUALS(refinedCell, "5 5 5 90 90 90");
   }
 
+  void testGetCrystalSystemFromPointGroup() {
+    TestablePoldiFitPeaks2D alg;
+
+    auto pgCubic = PointGroupFactory::Instance().createPointGroup("m-3m");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgCubic), "Cubic");
+
+    auto pgTetra = PointGroupFactory::Instance().createPointGroup("4/mmm");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTetra), "Tetragonal");
+
+    auto pgOrtho = PointGroupFactory::Instance().createPointGroup("mmm");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgOrtho),
+                     "Orthorhombic");
+
+    auto pgMono = PointGroupFactory::Instance().createPointGroup("2/m");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgMono), "Monoclinic");
+
+    auto pgTric = PointGroupFactory::Instance().createPointGroup("-1");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTric), "Triclinic");
+
+    auto pgHex = PointGroupFactory::Instance().createPointGroup("6/mmm");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgHex), "Hexagonal");
+
+    auto pgTrigRh = PointGroupFactory::Instance().createPointGroup("-3m r");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTrigRh), "Trigonal");
+
+    auto pgTrigHex = PointGroupFactory::Instance().createPointGroup("-3m");
+    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTrigHex),
+                     "Hexagonal");
+
+    PointGroup_sptr invalid;
+    TS_ASSERT_THROWS(alg.getCrystalSystemFromPointGroup(invalid),
+                     std::invalid_argument);
+  }
+
 private:
   PoldiInstrumentAdapter_sptr m_instrument;
   PoldiTimeTransformer_sptr m_timeTransformer;
@@ -449,11 +483,10 @@ private:
       strm << "Error in Peak " << i << ": " << peak->intensity().value()
            << " != " << referencePeak->intensity().value();
 
-      TSM_ASSERT_DELTA(
-          strm.str().c_str(),
-          fabs(1.0 -
-               peak->intensity().value() / referencePeak->intensity().value()),
-          0.0, relativePrecision);
+      TSM_ASSERT_DELTA(strm.str().c_str(),
+                       fabs(1.0 - peak->intensity().value() /
+                                      referencePeak->intensity().value()),
+                       0.0, relativePrecision);
     }
   }
 

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -483,10 +483,11 @@ private:
       strm << "Error in Peak " << i << ": " << peak->intensity().value()
            << " != " << referencePeak->intensity().value();
 
-      TSM_ASSERT_DELTA(strm.str().c_str(),
-                       fabs(1.0 - peak->intensity().value() /
-                                      referencePeak->intensity().value()),
-                       0.0, relativePrecision);
+      TSM_ASSERT_DELTA(
+          strm.str().c_str(),
+          fabs(1.0 -
+               peak->intensity().value() / referencePeak->intensity().value()),
+          0.0, relativePrecision);
     }
   }
 


### PR DESCRIPTION
This fixes #13924.

**Testing information**
Code review should suffice. The behavior is covered by a new unit test. Release notes have been updated (http://www.mantidproject.org/index.php?title=ReleaseNotes_3_6_Diffraction&diff=25359&oldid=25333).
