### PR TITLE
13932 fix loose coupling of reflmainviewpresenter

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QtReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QtReflMainView.h
@@ -62,6 +62,7 @@ namespace MantidQt
       virtual void giveUserWarning(std::string prompt, std::string title);
       virtual void giveUserCritical(std::string prompt, std::string title);
       virtual void showAlgorithmDialog(const std::string& algorithm);
+      virtual std::string requestNotebookPath();
 
       //Plotting
       virtual void plotWorkspaces(const std::set<std::string>& workspaces);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainView.h
@@ -57,6 +57,7 @@ namespace MantidQt
       virtual void giveUserWarning(std::string prompt, std::string title) = 0;
       virtual void giveUserCritical(std::string prompt, std::string title) = 0;
       virtual void showAlgorithmDialog(const std::string& algorithm) = 0;
+      virtual std::string requestNotebookPath() = 0;
 
       //Plotting
       virtual void plotWorkspaces(const std::set<std::string>& workspaces) = 0;

--- a/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
@@ -435,6 +435,17 @@ namespace MantidQt
     }
 
     /**
+    Show the user file dialog to choose save location of notebook
+    */
+    std::string QtReflMainView::requestNotebookPath()
+    {
+      QString qfilename = QFileDialog::getSaveFileName(0, "Save notebook file", QDir::currentPath(),
+                                                       "IPython Notebook files (*.ipynb);;All files (*.*)",
+                                                       new QString("IPython Notebook files (*.ipynb)"));
+      return qfilename.toStdString();
+    }
+
+    /**
     Plot a workspace
     */
     void QtReflMainView::plotWorkspaces(const std::set<std::string>& workspaces)

--- a/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -295,16 +295,15 @@ namespace MantidQt
     */
     void ReflMainViewPresenter::saveNotebook(std::map<int,std::set<int>> groups, std::set<int> rows)
     {
-      std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
-        m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
-        COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE, COL_GROUP));
-      QString qfilename = QFileDialog::getSaveFileName(0, "Save notebook file", QDir::currentPath(),
-                                                       "IPython Notebook files (*.ipynb);;All files (*.*)",
-                                                       new QString("IPython Notebook files (*.ipynb)"));
-      std::string filename = qfilename.toStdString();
+
+      std::string filename = m_view->requestNotebookPath();
       if (filename == "") {
         return;
       }
+
+      std::unique_ptr<ReflGenerateNotebook> notebook(new ReflGenerateNotebook(
+        m_wsName, m_model, m_view->getProcessInstrument(), COL_RUNS, COL_TRANSMISSION, COL_OPTIONS, COL_ANGLE,
+        COL_QMIN, COL_QMAX, COL_DQQ, COL_SCALE, COL_GROUP));
       std::string generatedNotebook = notebook->generateNotebook(groups, rows);
 
       std::ofstream file(filename.c_str(), std::ofstream::trunc);

--- a/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -33,6 +33,7 @@ public:
   MOCK_METHOD2(giveUserCritical, void(std::string, std::string));
   MOCK_METHOD2(giveUserInfo, void(std::string, std::string));
   MOCK_METHOD2(giveUserWarning, void(std::string, std::string));
+  MOCK_METHOD0(requestNotebookPath, std::string());
 
   MOCK_METHOD1(showAlgorithmDialog, void(const std::string&));
   MOCK_METHOD1(plotWorkspaces, void(const std::set<std::string>&));
@@ -46,6 +47,7 @@ public:
   MOCK_CONST_METHOD0(getClipboard, std::string());
   MOCK_CONST_METHOD0(getSearchString, std::string());
   MOCK_CONST_METHOD0(getSearchInstrument, std::string());
+  MOCK_METHOD0(getEnableNotebook, bool());
 
   //Calls we don't care about
   virtual void showTable(QReflTableModel_sptr) {};
@@ -53,7 +55,6 @@ public:
   virtual void setOptionsHintStrategy(MantidQt::MantidWidgets::HintStrategy*) {};
   virtual void setProgressRange(int,int) {};
   virtual void setProgress(int) {};
-  virtual bool getEnableNotebook() {return false;};
   virtual void setTableList(const std::set<std::string>&) {};
   virtual void setInstrumentList(const std::vector<std::string>&, const std::string&) {};
   virtual std::string getProcessInstrument() const {return "FAKE";}

--- a/MantidQt/CustomInterfaces/test/ReflMainViewPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewPresenterTest.h
@@ -13,6 +13,7 @@
 #include "MantidQtCustomInterfaces/ReflMainViewPresenter.h"
 
 #include "ReflMainViewMockObjects.h"
+#include "../inc/MantidQtCustomInterfaces/IReflPresenter.h"
 
 using namespace MantidQt::CustomInterfaces;
 using namespace Mantid::API;
@@ -136,6 +137,8 @@ public:
 
     TS_ASSERT(AnalysisDataService::Instance().doesExist("TestWorkspace"));
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testSaveExisting() {
@@ -152,6 +155,8 @@ public:
     presenter.notify(IReflPresenter::SaveFlag);
 
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testSaveAs() {
@@ -180,6 +185,8 @@ public:
 
     AnalysisDataService::Instance().remove("TestWorkspace");
     AnalysisDataService::Instance().remove("Workspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testAppendRow() {
@@ -220,6 +227,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testAppendRowSpecify() {
@@ -263,6 +272,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testAppendRowSpecifyPlural() {
@@ -305,6 +316,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPrependRow() {
@@ -344,6 +357,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPrependRowSpecify() {
@@ -386,6 +401,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPrependRowSpecifyPlural() {
@@ -429,6 +446,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testDeleteRowNone() {
@@ -460,6 +479,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testDeleteRowSingle() {
@@ -495,6 +516,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testDeleteRowPlural() {
@@ -533,6 +556,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testProcess() {
@@ -559,6 +584,11 @@ public:
     EXPECT_CALL(mockView, getSelectedRows())
         .Times(1)
         .WillRepeatedly(Return(rowlist));
+    EXPECT_CALL(mockView, getEnableNotebook())
+      .Times(1)
+      .WillRepeatedly(Return(false));
+    EXPECT_CALL(mockView, requestNotebookPath())
+      .Times(0);
     presenter.notify(IReflPresenter::ProcessFlag);
 
     // Check output workspaces were created as expected
@@ -579,6 +609,52 @@ public:
     AnalysisDataService::Instance().remove("IvsLam_12346");
     AnalysisDataService::Instance().remove("TOF_12346");
     AnalysisDataService::Instance().remove("IvsQ_12345_12346");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
+  }
+
+  void testProcessWithNotebook() {
+    MockView mockView;
+    ReflMainViewPresenter presenter(&mockView);
+
+    createPrefilledWorkspace("TestWorkspace");
+    EXPECT_CALL(mockView, getWorkspaceToOpen())
+      .Times(1)
+      .WillRepeatedly(Return("TestWorkspace"));
+    presenter.notify(IReflPresenter::OpenTableFlag);
+
+    std::set<int> rowlist;
+    rowlist.insert(0);
+    rowlist.insert(1);
+
+    createTOFWorkspace("TOF_12345", "12345");
+    createTOFWorkspace("TOF_12346", "12346");
+
+    // We should not receive any errors
+    EXPECT_CALL(mockView, giveUserCritical(_, _)).Times(0);
+
+    // The user hits the "process" button with the first two rows selected
+    EXPECT_CALL(mockView, getSelectedRows())
+      .Times(1)
+      .WillRepeatedly(Return(rowlist));
+    EXPECT_CALL(mockView, getEnableNotebook())
+      .Times(1)
+      .WillRepeatedly(Return(true));
+    EXPECT_CALL(mockView, requestNotebookPath())
+      .Times(1);
+    presenter.notify(IReflPresenter::ProcessFlag);
+
+    // Tidy up
+    AnalysisDataService::Instance().remove("TestWorkspace");
+    AnalysisDataService::Instance().remove("IvsQ_12345");
+    AnalysisDataService::Instance().remove("IvsLam_12345");
+    AnalysisDataService::Instance().remove("TOF_12345");
+    AnalysisDataService::Instance().remove("IvsQ_12346");
+    AnalysisDataService::Instance().remove("IvsLam_12346");
+    AnalysisDataService::Instance().remove("TOF_12346");
+    AnalysisDataService::Instance().remove("IvsQ_12345_12346");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   /*
@@ -641,6 +717,8 @@ public:
     AnalysisDataService::Instance().remove("IvsQ_12346");
     AnalysisDataService::Instance().remove("IvsLam_12346");
     AnalysisDataService::Instance().remove("IvsQ_dataA_12346");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testBadWorkspaceType() {
@@ -671,6 +749,8 @@ public:
     presenter.notify(IReflPresenter::OpenTableFlag);
 
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testBadWorkspaceLength() {
@@ -705,6 +785,8 @@ public:
     presenter.notify(IReflPresenter::OpenTableFlag);
 
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPromptSaveAfterAppendRow() {
@@ -732,6 +814,8 @@ public:
     // The user tries to create a new table again, and does not get bothered
     EXPECT_CALL(mockView, askUserYesNo(_, _)).Times(0);
     presenter.notify(IReflPresenter::NewTableFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPromptSaveAfterDeleteRow() {
@@ -771,6 +855,8 @@ public:
     // The user tries to create a new table again, and does not get bothered
     EXPECT_CALL(mockView, askUserYesNo(_, _)).Times(0);
     presenter.notify(IReflPresenter::NewTableFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPromptSaveAndDiscard() {
@@ -791,6 +877,8 @@ public:
     // These next two times they don't get prompted - they have a new table
     presenter.notify(IReflPresenter::NewTableFlag);
     presenter.notify(IReflPresenter::NewTableFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPromptSaveOnOpen() {
@@ -823,6 +911,8 @@ public:
         .WillRepeatedly(Return("TestWorkspace"));
     EXPECT_CALL(mockView, askUserYesNo(_, _)).Times(0);
     presenter.notify(IReflPresenter::OpenTableFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testExpandSelection() {
@@ -984,6 +1074,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testClearRows() {
@@ -1043,6 +1135,8 @@ public:
 
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testCopyRow() {
@@ -1066,6 +1160,8 @@ public:
         .Times(1)
         .WillRepeatedly(Return(rowlist));
     presenter.notify(IReflPresenter::CopySelectedFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testCopyRows() {
@@ -1095,6 +1191,8 @@ public:
         .Times(1)
         .WillRepeatedly(Return(rowlist));
     presenter.notify(IReflPresenter::CopySelectedFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testCutRow() {
@@ -1129,6 +1227,8 @@ public:
     TS_ASSERT_EQUALS(ws->String(0, RunCol), "12345");
     TS_ASSERT_EQUALS(ws->String(1, RunCol), "24681");
     TS_ASSERT_EQUALS(ws->String(2, RunCol), "24682");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testCutRows() {
@@ -1165,6 +1265,8 @@ public:
     TS_ASSERT_EQUALS(ws->rowCount(), 1);
     // Check the only unselected row is left behind
     TS_ASSERT_EQUALS(ws->String(0, RunCol), "24682");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPasteRow() {
@@ -1212,6 +1314,8 @@ public:
     TS_ASSERT_EQUALS(ws->Double(1, ScaleCol), 5.0);
     TS_ASSERT_EQUALS(ws->Int(1, GroupCol), 6);
     TS_ASSERT_EQUALS(ws->String(1, OptionsCol), "abc");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPasteNewRow() {
@@ -1257,6 +1361,8 @@ public:
     TS_ASSERT_EQUALS(ws->Double(4, ScaleCol), 5.0);
     TS_ASSERT_EQUALS(ws->Int(4, GroupCol), 6);
     TS_ASSERT_EQUALS(ws->String(4, OptionsCol), "abc");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPasteRows() {
@@ -1315,6 +1421,8 @@ public:
     TS_ASSERT_EQUALS(ws->Double(2, ScaleCol), 3.0);
     TS_ASSERT_EQUALS(ws->Int(2, GroupCol), 2);
     TS_ASSERT_EQUALS(ws->String(2, OptionsCol), "def");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPasteNewRows() {
@@ -1371,6 +1479,8 @@ public:
     TS_ASSERT_EQUALS(ws->Double(5, ScaleCol), 3.0);
     TS_ASSERT_EQUALS(ws->Int(5, GroupCol), 2);
     TS_ASSERT_EQUALS(ws->String(5, OptionsCol), "def");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testImportTable() {
@@ -1378,6 +1488,8 @@ public:
     ReflMainViewPresenter presenter(&mockView);
     EXPECT_CALL(mockView, showAlgorithmDialog("LoadReflTBL"));
     presenter.notify(IReflPresenter::ImportTableFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testExportTable() {
@@ -1385,6 +1497,8 @@ public:
     ReflMainViewPresenter presenter(&mockView);
     EXPECT_CALL(mockView, showAlgorithmDialog("SaveReflTBL"));
     presenter.notify(IReflPresenter::ExportTableFlag);
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPlotRowWarn() {
@@ -1416,6 +1530,8 @@ public:
     // Tidy up
     AnalysisDataService::Instance().remove("TestWorkspace");
     AnalysisDataService::Instance().remove("TOF_12345");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 
   void testPlotGroupWarn() {
@@ -1447,6 +1563,8 @@ public:
     AnalysisDataService::Instance().remove("TestWorkspace");
     AnalysisDataService::Instance().remove("TOF_12345");
     AnalysisDataService::Instance().remove("TOF_12346");
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));
   }
 };
 


### PR DESCRIPTION
Fixes #13932 
Problem and solution explained fully in [issue](#13932).

For Tester:
Please review code.
I suggest loading "INTER_NR_test2.tbl" as described in the [documentation](http://docs.mantidproject.org/nightly/interfaces/ISIS_Reflectometry.html).
Select the "Output Notebook" checkbox next to the "Process" button before processing. Check that you are prompted for a save location for the notebook at this point.
