### PR TITLE
ISIS Energy Transfer validation on data range 

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISEnergyTransfer.h
@@ -6,68 +6,66 @@
 #include "MantidKernel/System.h"
 #include "MantidQtCustomInterfaces/Background.h"
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  /** ISISEnergyTransfer
-    Handles an energy transfer reduction for ISIS instruments.
+namespace MantidQt {
+namespace CustomInterfaces {
+/** ISISEnergyTransfer
+  Handles an energy transfer reduction for ISIS instruments.
 
-    @author Dan Nixon
-    @date 23/07/2014
+  @author Dan Nixon
+  @date 23/07/2014
 
-    Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+  Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
 
-    This file is part of Mantid.
+  This file is part of Mantid.
 
-    Mantid is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
 
-    Mantid is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    File change history is stored at: <https://github.com/mantidproject/mantid>
-    Code Documentation is available at: <http://doxygen.mantidproject.org>
-  */
-  class DLLExport ISISEnergyTransfer : public IndirectDataReductionTab
-  {
-    Q_OBJECT
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport ISISEnergyTransfer : public IndirectDataReductionTab {
+  Q_OBJECT
 
-  public:
-    ISISEnergyTransfer(IndirectDataReduction * idrUI, QWidget * parent = 0);
-    virtual ~ISISEnergyTransfer();
+public:
+  ISISEnergyTransfer(IndirectDataReduction *idrUI, QWidget *parent = 0);
+  virtual ~ISISEnergyTransfer();
 
-    virtual void setup();
-    virtual void run();
+  virtual void setup();
+  virtual void run();
 
-  public slots:
-    virtual bool validate();
+public slots:
+  virtual bool validate();
 
-  private slots:
-    void algorithmComplete(bool error);
-    void setInstrumentDefault(); ///< Sets default parameters for current instrument
-    void mappingOptionSelected(const QString& groupType); ///< change ui to display appropriate options
-    void plotRaw(); ///< plot raw data from instrument
-    void pbRunEditing();  //< Called when a user starts to type / edit the runs to load.
-    void pbRunFinding();  //< Called when the FileFinder starts finding the files.
-    void pbRunFinished(); //< Called when the FileFinder has finished finding the files.
-    void plotRawComplete(bool error); //< Called when the Plot Raw algorithmm chain completes
+private slots:
+  void algorithmComplete(bool error);
+  void
+  setInstrumentDefault(); ///< Sets default parameters for current instrument
+  void mappingOptionSelected(const QString &groupType); ///< change ui to display appropriate options
+  void plotRaw();       ///< plot raw data from instrument
+  void pbRunEditing();  //< Called when a user starts to type / edit the runs to load.
+  void pbRunFinding();  //< Called when the FileFinder starts finding the files.
+  void pbRunFinished(); //< Called when the FileFinder has finished finding the files.
+  void plotRawComplete(bool error); //< Called when the Plot Raw algorithmm chain completes
 
-  private:
-    Ui::ISISEnergyTransfer m_uiForm;
+private:
+  Ui::ISISEnergyTransfer m_uiForm;
 
-    QPair<QString, QString> createMapFile(const QString& groupType); ///< create the mapping file with which to group results
-    std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
-
-  };
+  QPair<QString, QString> createMapFile(const QString &groupType); ///< create the mapping file with which to group results
+  std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
+};
 } // namespace CustomInterfaces
 } // namespace Mantid
 
-#endif //MANTIDQTCUSTOMINTERFACES_ISISENERGYTRANSFER_H_
+#endif // MANTIDQTCUSTOMINTERFACES_ISISENERGYTRANSFER_H_

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -69,19 +69,19 @@ bool ISISEnergyTransfer::validate() {
   UserInputValidator uiv;
 
   // Run files input
-  if (!m_uiForm.dsRunFiles->isValid()){
+  if (!m_uiForm.dsRunFiles->isValid()) {
     uiv.addErrorMessage("Run file range is invalid.");
   }
 
   // Calibration file input
   if (m_uiForm.ckUseCalib->isChecked() &&
-      !m_uiForm.dsCalibrationFile->isValid()){
+      !m_uiForm.dsCalibrationFile->isValid()) {
     uiv.addErrorMessage("Calibration file/workspace is invalid.");
   }
 
   // Mapping file
   if ((m_uiForm.cbGroupingOptions->currentText() == "File") &&
-      (!m_uiForm.dsMapFile->isValid())){
+      (!m_uiForm.dsMapFile->isValid())) {
     uiv.addErrorMessage("Mapping file is invalid.");
   }
 
@@ -115,17 +115,17 @@ bool ISISEnergyTransfer::validate() {
   // Spectra Number check
   const int specMin = m_uiForm.spSpectraMin->value();
   const int specMax = m_uiForm.spSpectraMax->value();
-  if(specMin > specMax){
-	uiv.addErrorMessage("Spectra Min must be less than Spectra Max");
+  if (specMin > specMax) {
+    uiv.addErrorMessage("Spectra Min must be less than Spectra Max");
   }
 
   // Background Removal (TOF)
-  if(m_uiForm.ckBackgroundRemoval->isChecked()){
-	  const int start = m_uiForm.spBackgroundStart->value();
-	  const int end = m_uiForm.spBackgroundEnd->value();
-	  if(start > end){
-		  uiv.addErrorMessage("Background Start must be less than Background End");
-	  }
+  if (m_uiForm.ckBackgroundRemoval->isChecked()) {
+    const int start = m_uiForm.spBackgroundStart->value();
+    const int end = m_uiForm.spBackgroundEnd->value();
+    if (start > end) {
+      uiv.addErrorMessage("Background Start must be less than Background End");
+    }
   }
 
   QString error = uiv.generateErrorMessage();
@@ -446,10 +446,10 @@ void ISISEnergyTransfer::plotRaw() {
         "Minimum spectra must be less than or equal to maximum spectra.");
     return;
   }
+  const int startBack = m_uiForm.spBackgroundStart->value();
+  const int endBack = m_uiForm.spBackgroundEnd->value();
 
   if (m_uiForm.ckBackgroundRemoval->isChecked() == true) {
-    int startBack = m_uiForm.spBackgroundStart->value();
-    int endBack = m_uiForm.spBackgroundEnd->value();
     if (startBack > endBack) {
       emit showMessageBox("Background Start must be less than Background End");
       return;
@@ -462,7 +462,7 @@ void ISISEnergyTransfer::plotRaw() {
   QFileInfo rawFileInfo(rawFile);
   std::string name = rawFileInfo.baseName().toStdString();
 
-   IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("Load");
+  IAlgorithm_sptr loadAlg = AlgorithmManager::Instance().create("Load");
   loadAlg->initialize();
   loadAlg->setProperty("Filename", rawFile.toStdString());
   loadAlg->setProperty("OutputWorkspace", name);
@@ -477,7 +477,27 @@ void ISISEnergyTransfer::plotRaw() {
     loadAlg->setProperty("SpectrumMin", detectorMin);
     loadAlg->setProperty("SpectrumMax", detectorMax);
   }
-  m_batchAlgoRunner->addAlgorithm(loadAlg);
+
+  loadAlg->execute();
+
+  if (m_uiForm.ckBackgroundRemoval->isChecked()) {
+    MatrixWorkspace_sptr tempWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+    const int minBack = tempWs->readX(0)[0];
+    const int maxBack = tempWs->readX(0)[tempWs->blocksize()];
+
+    if (startBack < minBack) {
+      emit showMessageBox("The Start of Background Removal is less than the "
+                          "minimum of the data range");
+      return;
+    }
+
+    if (endBack > maxBack) {
+      emit showMessageBox("The End of Background Removal is more than the "
+                          "maximum of the data range");
+      return;
+    }
+  }
 
   // Rebin the workspace to its self to ensure constant binning
   BatchAlgorithmRunner::AlgorithmRuntimeProps inputToRebin;

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -159,8 +159,8 @@ bool ISISEnergyTransfer::validate() {
     if (m_uiForm.ckBackgroundRemoval->isChecked()) {
       MatrixWorkspace_sptr tempWs =
           AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
-      const int minBack = tempWs->readX(0)[0];
-      const int maxBack = tempWs->readX(0)[tempWs->blocksize()];
+      const double minBack = tempWs->readX(0)[0];
+      const double maxBack = tempWs->readX(0)[tempWs->blocksize()];
 
       if (m_uiForm.spBackgroundStart->value() < minBack) {
         uiv.addErrorMessage("The Start of Background Removal is less than the "
@@ -529,8 +529,8 @@ void ISISEnergyTransfer::plotRaw() {
   if (m_uiForm.ckBackgroundRemoval->isChecked()) {
     MatrixWorkspace_sptr tempWs =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
-    const int minBack = tempWs->readX(0)[0];
-    const int maxBack = tempWs->readX(0)[tempWs->blocksize()];
+    const double minBack = tempWs->readX(0)[0];
+    const double maxBack = tempWs->readX(0)[tempWs->blocksize()];
 
     if (startBack < minBack) {
       emit showMessageBox("The Start of Background Removal is less than the "


### PR DESCRIPTION
Fixes #13897 

Added validation to ensure that Start/End values for background removal are within the min/max range of the data.
# To Test
- Open ISIS Energy Transfer (Interfaces >  Indirect > Data Reduction > ISIS Energy Transfer)
- Ensure you are using the Data archive and use the run number 26176 with the instrument IRIS / Graphite / 002
- Run `Plot Time` _Without checking the remove background option._
- Ensure a plot is produced and take note of the range of the ToF 
- Check the remove background option and enter a Start and End time within the data range 
  - Ensure that this produces a similar plot with the specified background removed
- Set the start time outside the range (either side OR both) 
  - Ensure that an warning is produced and the plot is not produced  
