### PR TITLE
Improve performance on LoadIsawPeaks algorithm

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -8,7 +8,8 @@
 namespace Mantid {
 namespace Crystal {
 
-/** LoadIsawPeaks : Load an ISAW-style .peaks file
+/**
+ * Load an ISAW-style .peaks or .integrate file
  * into a PeaksWorkspace
  *
  * @author Janik Zikovsky, SNS
@@ -17,18 +18,24 @@ namespace Crystal {
 class DLLExport LoadIsawPeaks
     : public API::IFileLoader<Kernel::FileDescriptor> {
 public:
-  LoadIsawPeaks();
-  virtual ~LoadIsawPeaks();
+  LoadIsawPeaks() = default;
+  virtual ~LoadIsawPeaks() = default;
 
   /// Algorithm's name for identification
-  virtual const std::string name() const { return "LoadIsawPeaks"; };
+  virtual const std::string name() const {
+    return "LoadIsawPeaks";
+  }
+
   /// Summary of algorithms purpose
   virtual const std::string summary() const {
     return "Load an ISAW-style .peaks file into a PeaksWorkspace.";
   }
 
   /// Algorithm's version for identification
-  virtual int version() const { return 1; };
+  virtual int version() const {
+    return 1;
+  }
+
   /// Algorithm's category for identification
   virtual const std::string category() const {
     return "Crystal;DataHandling\\Isaw";
@@ -40,16 +47,20 @@ public:
 private:
   /// Initialise the properties
   void init();
+
   /// Run the algorithm
   void exec();
 
+  /// Reads calibration/detector section and returns first word of next line
   std::string ApplyCalibInfo(std::ifstream &in, std::string startChar,
                              Geometry::Instrument_const_sptr instr_old,
                              Geometry::Instrument_const_sptr instr, double &T0);
 
+  /// Reads first line of peaks file and returns first word of next line
   std::string readHeader(Mantid::DataObjects::PeaksWorkspace_sptr outWS,
                          std::ifstream &in, double &T0);
 
+  /// Read a single peak from peaks file
   DataObjects::Peak readPeak(DataObjects::PeaksWorkspace_sptr outWS,
                              std::string &lastStr, std::ifstream &in,
                              int &seqNum, std::string bankName);
@@ -57,12 +68,17 @@ private:
   int findPixelID(Geometry::Instrument_const_sptr inst, std::string bankName,
                   int col, int row);
 
+  /// Read the header of a peak block section, returns first word of next line
   std::string readPeakBlockHeader(std::string lastStr, std::ifstream &in,
                                   int &run, int &detName, double &chi,
                                   double &phi, double &omega, double &monCount);
 
+  /// Append peaks from given file to given workspace
   void appendFile(Mantid::DataObjects::PeaksWorkspace_sptr outWS,
                   std::string filename);
+
+  /// Compare number of peaks in given file to given workspace
+  /// Throws std::length_error on mismatch
   void checkNumberPeaks(Mantid::DataObjects::PeaksWorkspace_sptr outWS,
                         std::string filename);
 

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -18,13 +18,11 @@ namespace Crystal {
 class DLLExport LoadIsawPeaks
     : public API::IFileLoader<Kernel::FileDescriptor> {
 public:
-  LoadIsawPeaks() = default;
-  virtual ~LoadIsawPeaks() = default;
+  LoadIsawPeaks();
+  virtual ~LoadIsawPeaks();
 
   /// Algorithm's name for identification
-  virtual const std::string name() const {
-    return "LoadIsawPeaks";
-  }
+  virtual const std::string name() const { return "LoadIsawPeaks"; }
 
   /// Summary of algorithms purpose
   virtual const std::string summary() const {
@@ -32,9 +30,7 @@ public:
   }
 
   /// Algorithm's version for identification
-  virtual int version() const {
-    return 1;
-  }
+  virtual int version() const { return 1; }
 
   /// Algorithm's category for identification
   virtual const std::string category() const {
@@ -86,8 +82,9 @@ private:
   std::map<std::string, boost::shared_ptr<const Geometry::IComponent>> m_banks;
 
   /// Retrieve cached bank (or load and cache for next time)
-  boost::shared_ptr<const Geometry::IComponent> getCachedBankByName(std::string bankname, const boost::shared_ptr<const Geometry::Instrument>& inst);
-
+  boost::shared_ptr<const Geometry::IComponent> getCachedBankByName(
+      std::string bankname,
+      const boost::shared_ptr<const Geometry::Instrument> &inst);
 };
 
 } // namespace Mantid

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -65,6 +65,13 @@ private:
                   std::string filename);
   void checkNumberPeaks(Mantid::DataObjects::PeaksWorkspace_sptr outWS,
                         std::string filename);
+
+  /// Local cache of bank IComponents used in file
+  std::map<std::string, boost::shared_ptr<const Geometry::IComponent>> m_banks;
+
+  /// Retrieve cached bank (or load and cache for next time)
+  boost::shared_ptr<const Geometry::IComponent> getCachedBankByName(std::string bankname, const boost::shared_ptr<const Geometry::Instrument>& inst);
+
 };
 
 } // namespace Mantid

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -36,8 +36,6 @@ public:
 
   /// Returns a confidence value that this algorithm can load a file
   virtual int confidence(Kernel::FileDescriptor &descriptor) const;
-  int findPixelID(Geometry::Instrument_const_sptr inst, std::string bankName,
-                  int col, int row);
 
 private:
   /// Initialise the properties
@@ -51,6 +49,17 @@ private:
 
   std::string readHeader(Mantid::DataObjects::PeaksWorkspace_sptr outWS,
                          std::ifstream &in, double &T0);
+
+  DataObjects::Peak readPeak(DataObjects::PeaksWorkspace_sptr outWS,
+                             std::string &lastStr, std::ifstream &in,
+                             int &seqNum, std::string bankName);
+
+  int findPixelID(Geometry::Instrument_const_sptr inst, std::string bankName,
+                  int col, int row);
+
+  std::string readPeakBlockHeader(std::string lastStr, std::ifstream &in,
+                                  int &run, int &detName, double &chi,
+                                  double &phi, double &omega, double &monCount);
 
   void appendFile(Mantid::DataObjects::PeaksWorkspace_sptr outWS,
                   std::string filename);

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -19,6 +19,15 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+LoadIsawPeaks::LoadIsawPeaks() {}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+LoadIsawPeaks::~LoadIsawPeaks() {}
 
 //----------------------------------------------------------------------------------------------
 /**
@@ -68,8 +77,7 @@ int LoadIsawPeaks::confidence(Kernel::FileDescriptor &descriptor) const {
       getWord(in, false);
     readToEndOfLine(in, true);
     confidence = 95;
-  }
-  catch (std::exception &) {
+  } catch (std::exception &) {
   }
 
   return confidence;
@@ -322,8 +330,9 @@ std::string LoadIsawPeaks::readHeader(PeaksWorkspace_sptr outWS,
  * @return the Peak the Peak object created
  */
 DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
-                                   std::string &lastStr, std::ifstream &in,
-                                   int &seqNum, std::string bankName) {
+                                          std::string &lastStr,
+                                          std::ifstream &in, int &seqNum,
+                                          std::string bankName) {
   double h;
   double k;
   double l;
@@ -391,8 +400,8 @@ DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
   if (!inst)
     throw std::runtime_error("No instrument in PeaksWorkspace!");
 
-  int pixelID = findPixelID(inst, bankName, static_cast<int>(col),
-                              static_cast<int>(row));
+  int pixelID =
+      findPixelID(inst, bankName, static_cast<int>(col), static_cast<int>(row));
 
   // Create the peak object
   Peak peak(outWS->getInstrument(), pixelID, wl);
@@ -446,9 +455,11 @@ int LoadIsawPeaks::findPixelID(Instrument_const_sptr inst, std::string bankName,
 
 //-----------------------------------------------------------------------------------------------
 /** Read the header of each peak block section */
-std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr, std::ifstream &in,
-                                int &run, int &detName, double &chi,
-                                double &phi, double &omega, double &monCount) {
+std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr,
+                                               std::ifstream &in, int &run,
+                                               int &detName, double &chi,
+                                               double &phi, double &omega,
+                                               double &monCount) {
   std::string s = lastStr;
 
   if (s.length() < 1 && in.good()) // blank line
@@ -615,14 +626,17 @@ void LoadIsawPeaks::checkNumberPeaks(PeaksWorkspace_sptr outWS,
  * work for caching any component without modification.
  *
  * @param bankname :: the name of the requested bank
- * @param inst :: the instrument from which to load the bank if it is not yet cached
- * @return A shared pointer to the request bank (empty shared pointer if not found)
+ * @param inst :: the instrument from which to load the bank if it is not yet
+ *cached
+ * @return A shared pointer to the request bank (empty shared pointer if not
+ *found)
  */
-boost::shared_ptr<const IComponent> LoadIsawPeaks::getCachedBankByName(std::string bankname, const boost::shared_ptr<const Geometry::Instrument>& inst)
-{
-    if (m_banks.count(bankname) == 0)
-        m_banks[bankname] = inst->getComponentByName(bankname);
-    return m_banks[bankname];
+boost::shared_ptr<const IComponent> LoadIsawPeaks::getCachedBankByName(
+    std::string bankname,
+    const boost::shared_ptr<const Geometry::Instrument> &inst) {
+  if (m_banks.count(bankname) == 0)
+    m_banks[bankname] = inst->getComponentByName(bankname);
+  return m_banks[bankname];
 }
 
 } // namespace Mantid

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -318,7 +318,7 @@ std::string LoadIsawPeaks::readHeader(PeaksWorkspace_sptr outWS,
  * @param bankName :: the bank number from the ISAW file.
  * @return the Peak the Peak object created
  */
-Mantid::DataObjects::Peak readPeak(PeaksWorkspace_sptr outWS,
+DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
                                    std::string &lastStr, std::ifstream &in,
                                    int &seqNum, std::string bankName) {
   double h;
@@ -387,8 +387,8 @@ Mantid::DataObjects::Peak readPeak(PeaksWorkspace_sptr outWS,
   Instrument_const_sptr inst = outWS->getInstrument();
   if (!inst)
     throw std::runtime_error("No instrument in PeaksWorkspace!");
-  LoadIsawPeaks u;
-  int pixelID = u.findPixelID(inst, bankName, static_cast<int>(col),
+
+  int pixelID = findPixelID(inst, bankName, static_cast<int>(col),
                               static_cast<int>(row));
 
   // Create the peak object
@@ -441,7 +441,7 @@ int LoadIsawPeaks::findPixelID(Instrument_const_sptr inst, std::string bankName,
 
 //-----------------------------------------------------------------------------------------------
 /** Read the header of each peak block section */
-std::string readPeakBlockHeader(std::string lastStr, std::ifstream &in,
+std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr, std::ifstream &in,
                                 int &run, int &detName, double &chi,
                                 double &phi, double &omega, double &monCount) {
   std::string s = lastStr;

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -897,7 +897,7 @@ std::string getWord(std::istream &in, bool consumeEOL) {
     nextch = static_cast<char>(in.get());
 
     // Handle CRLF and LFCR on Unix by consuming both
-    if (nextch == '\n' || nextch == '\n') {
+    if (nextch == '\n' || nextch == '\r') {
       if ((nextch == '\n' && in.peek() == '\r') ||
           (nextch == '\r' && in.peek() == '\n')) {
         in.ignore();

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -875,13 +875,18 @@ std::string getWord(std::istream &in, bool consumeEOL) {
 
   // Return an empty string on EOL; optionally consume it
   if (nextch == '\n' || nextch == '\r') {
-    if (!consumeEOL)
+    if (!consumeEOL) {
       in.unget();
+    } else if ((nextch == '\n' && in.peek() == '\r') ||
+               (nextch == '\r' && in.peek() == '\n')) {
+      // Handle CRLF and LFCR on Unix by consuming both
+      in.ignore();
+    }
 
     return ret;
   }
-  else { // Non-EOL and non-space character
-      in.unget(); // Put it back on stream
+  else {      // Non-EOL and non-space character
+    in.unget(); // Put it back on stream
   }
 
   // Get next word if stream is still valid
@@ -890,9 +895,18 @@ std::string getWord(std::istream &in, bool consumeEOL) {
 
   // Optionally consume EOL character
   if (consumeEOL) {
-    nextch = static_cast<char>(in.peek());
-    if ((nextch == '\n') || (nextch == '\r'))
-      in.ignore();
+    nextch = static_cast<char>(in.get());
+
+    // Handle CRLF and LFCR on Unix by consuming both
+    if (nextch == '\n' || nextch == '\n') {
+      if ((nextch == '\n' && in.peek() == '\r') ||
+          (nextch == '\r' && in.peek() == '\n')) {
+        in.ignore();
+      }
+    }
+    else {
+      in.unget();
+    }
   }
 
   return ret;

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -865,34 +865,37 @@ int setValues(const std::string &Line, const std::vector<int> &Index,
  * @return a string with the word read in
  */
 std::string getWord(std::istream &in, bool consumeEOL) {
-  std::string s;
-  char c = 0;
-  if (in.good())
-    for (c = static_cast<char>(in.get()); c == ' ' && in.good();
-         c = static_cast<char>(in.get())) {
-    }
-  else
-    return std::string();
+  std::string ret;
+  char nextch = 0;
 
-  if (c == '\n') {
+  // Skip leading spaces
+  do {
+    nextch = static_cast<char>(in.get());
+  } while (nextch == ' ');
+
+  // Return an empty string on EOL; optionally consume it
+  if (nextch == '\n' || nextch == '\r') {
     if (!consumeEOL)
-      in.putback(c);
+      in.unget();
 
-    return std::string();
+    return ret;
+  }
+  else { // Non-EOL and non-space character
+      in.unget(); // Put it back on stream
   }
 
-  s.push_back(c);
-
+  // Get next word if stream is still valid
   if (in.good())
-    for (c = static_cast<char>(in.get());
-         in.good() && c != ' ' && c != '\n' && c != '\r';
-         c = static_cast<char>(in.get()))
-      s.push_back(c);
+    in >> ret;
 
-  if (((c == '\n') || (c == '\r')) && !consumeEOL)
-    in.putback(c);
+  // Optionally consume EOL character
+  if (consumeEOL) {
+    nextch = static_cast<char>(in.peek());
+    if ((nextch == '\n') || (nextch == '\r'))
+      in.ignore();
+  }
 
-  return s;
+  return ret;
 }
 
 //-----------------------------------------------------------------------------------------------

--- a/Framework/Kernel/src/Strings.cpp
+++ b/Framework/Kernel/src/Strings.cpp
@@ -884,8 +884,7 @@ std::string getWord(std::istream &in, bool consumeEOL) {
     }
 
     return ret;
-  }
-  else {      // Non-EOL and non-space character
+  } else {      // Non-EOL and non-space character
     in.unget(); // Put it back on stream
   }
 
@@ -903,8 +902,7 @@ std::string getWord(std::istream &in, bool consumeEOL) {
           (nextch == '\r' && in.peek() == '\n')) {
         in.ignore();
       }
-    }
-    else {
+    } else {
       in.unget();
     }
   }


### PR DESCRIPTION
Fixes #13632.

The [release notes](http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes) have been updated.

Identified CompAssembly::getComponentByName() as the cause for slow performance on some files. 

When a file has many peaks that use detector banks with IDs >= 10, an issue with getComponentByName() will cause considerably slow loading times.

Issue mainly addressed by keeping a local cache of pointers to banks to minimize the number of times getComponentByName() needs to be called.
