### PR TITLE
ConvFit Added Diff data to Mini plot 

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -993,8 +993,14 @@ void ConvFit::updatePlot() {
       return;
     MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
         outputGroup->getItem(specNo));
-    if (ws)
+    if (ws) {
       m_uiForm.ppPlot->addSpectrum("Fit", ws, 1, Qt::red);
+      m_uiForm.ppPlot->addSpectrum("Diff", ws, 2, Qt::blue);
+	  if(m_uiForm.ckPlotGuess->isChecked()){
+		  m_uiForm.ppPlot->removeSpectrum("Guess");
+		  m_uiForm.ckPlotGuess->setChecked(false);
+	  }
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #13976

The Mini plot in the interface should now show the Diff data after a fit is run. Furthermore, if Plot guess was being used, it should be removed after a fit.
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Load a suitable Sample and Resolution File which should contain in it's name:
  - `irs26176_graphite002_red.nxs` for the sample
  - `irs26173_graphite002_res.nxs` for the resolution
    - Available from the external data folder
  - **Please avoid using files with additional extension in the filename e.g. `_diffspec` These files will not run in ConvFit validation for this will most likely be implemented for 3.6**
- Select a fit Type and or Delta Function 
- Check the plot Guess check box
- Run the algorithm (Click `run`)
- Ensure the mini plot has:
  - The sample (black)
  - The Fit (Red)
  - The Diff (Blue)
- Ensure that the guess (Green) is not there
