### PR TITLE
ResNorm Improve algorithm tracking

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -109,7 +109,7 @@ class ResNorm(PythonAlgorithm):
         input_str = ''
         for idx in range(num_hist):
             input_str += '%s,i%d;' % (padded_res_ws, idx)
-            prog_namer.report()
+            prog_namer.report('Generating PlotPeak input string')
 
         out_name = getWSprefix(self._res_ws) + 'ResNorm_Fit'
         function = 'name=TabulatedFunction,Workspace=%s,Scaling=1,Shift=0,XScaling=1,ties=(Shift=0)' % self._van_ws
@@ -131,7 +131,7 @@ class ResNorm(PythonAlgorithm):
         prog_process = Progress(self, start=0.94, end=1.0, nreports=3)
         for param_name, output_name in params.items():
             result_workspaces.append(self._process_fit_params(fit_params, param_name, v_values, v_unit, output_name))
-            prog_process.report()
+            prog_process.report('Processing Fit data')
 
         GroupWorkspaces(InputWorkspaces=result_workspaces,
                         OutputWorkspace=self._out_ws)
@@ -140,7 +140,7 @@ class ResNorm(PythonAlgorithm):
 
         DeleteWorkspace(van_ws)
         DeleteWorkspace(padded_res_ws)
-        prog_process.report()
+        prog_process.report('Deleting workspaces')
         if not self._create_output:
             DeleteWorkspace(fit_params)
         

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -108,14 +108,17 @@ class ResNorm(PythonAlgorithm):
         out_name = getWSprefix(self._res_ws) + 'ResNorm_Fit'
         function = 'name=TabulatedFunction,Workspace=%s,Scaling=1,Shift=0,XScaling=1,ties=(Shift=0)' % self._van_ws
 
-        fit_params = PlotPeakByLogValue(Input=input_str,
-                                        OutputWorkspace=out_name,
-                                        Function=function,
-                                        FitType='Individual',
-                                        PassWSIndexToFunction=True,
-                                        CreateOutput=self._create_output,
-                                        StartX=self._e_min,
-                                        EndX=self._e_max)
+        plot_peaks = self.createChildAlgorithm(name='PlotPeakByLogValue', startProgress=0.02, endProgress=0.94, enableLogging=True)
+        plot_peaks.setProperty('Input', input_str)
+        plot_peaks.setProperty('OutputWorkspace', out_name)
+        plot_peaks.setProperty('Function', function)
+        plot_peaks.setProperty('FitType', 'Individual')
+        plot_peaks.setProperty('PassWSIndexToFunction', True)
+        plot_peaks.setProperty('CreateOutput', self._create_output)
+        plot_peaks.setProperty('StartX', self._e_min)
+        plot_peaks.setProperty('EndX', self._e_max)
+        plot_peaks.execute()
+        fit_params = plot_peaks.getProperty('OutputWorkspace').value
 
         params = {'XScaling':'Stretch', 'Scaling':'Intensity'}
         result_workspaces = []
@@ -133,7 +136,7 @@ class ResNorm(PythonAlgorithm):
         prog_process.report()
         if not self._create_output:
             DeleteWorkspace(fit_params)
-
+        
 
     def _process_res_ws(self, num_hist):
         """

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -1,6 +1,7 @@
 #pylint: disable=no-init
 from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty,
-                        WorkspaceGroup, WorkspaceGroupProperty, Progress)
+                        WorkspaceGroup, WorkspaceGroupProperty, ITableWorkspaceProperty,
+                        Progress)
 from mantid.kernel import Direction
 from mantid.simpleapi import *
 
@@ -13,6 +14,7 @@ class ResNorm(PythonAlgorithm):
     _e_max = None
     _create_output = None
     _out_ws = None
+    _out_ws_table = None
 
 
     def category(self):
@@ -52,6 +54,9 @@ class ResNorm(PythonAlgorithm):
         self.declareProperty(WorkspaceGroupProperty('OutputWorkspace', '',
                                                     direction=Direction.Output),
                              doc='Fitted parameter output')
+        self.declareProperty(ITableWorkspaceProperty('OutputWorkspaceTable', '',
+                                                    direction=Direction.Output),
+                             doc='Table workspace of fit parameters')
 
 
     def validateInputs(self):
@@ -81,6 +86,7 @@ class ResNorm(PythonAlgorithm):
         self._e_max = self.getProperty('EnergyMax').value
         self._create_output = self.getProperty('CreateOutput').value
         self._out_ws = self.getPropertyValue('OutputWorkspace')
+        self._out_ws_table = self.getPropertyValue('OutputWorkspaceTable')
 
 
     def PyExec(self):
@@ -130,6 +136,7 @@ class ResNorm(PythonAlgorithm):
         GroupWorkspaces(InputWorkspaces=result_workspaces,
                         OutputWorkspace=self._out_ws)
         self.setProperty('OutputWorkspace', self._out_ws)
+        self.setProperty('OutputWorkspaceTable', fit_params)
 
         DeleteWorkspace(van_ws)
         DeleteWorkspace(padded_res_ws)

--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -112,6 +112,7 @@ void ResNorm::run() {
   resNorm->setProperty("EnergyMax", eMax);
   resNorm->setProperty("CreateOutput", true);
   resNorm->setProperty("OutputWorkspace", outputWsName.toStdString());
+  resNorm->setProperty("OutputWorkspaceTable", (outputWsName + "_Fit").toStdString());
   m_batchAlgoRunner->addAlgorithm(resNorm);
 
   // Handle saving


### PR DESCRIPTION
Fixes #13985

ResNorm should now not only tracking the progress of the child algorithm PlotPeakByLogValue, but it should also display the current tasks in ResNorm that are taking place.
# To Test
- Open ResNorm (Interfaces > Indirect > Bayes > ResNorm)
- From the system test data Load in:
  - `irs26173_red` file for Vanadium
  - `irs26173_res` file for Resolution
- Run the ResNorm algorithm 
- Ensure that the progress tracking bar updates smoothly without large jumps.
- Ensure that the progress tracking bar has labels for the current process _(Note that this is only for the beginning and end 2%-94% is not labelled as it is governed by a child algorithm that will be updated in a separate issue)_
- Ensure that the following workspaces are produced: _(these are all prefixed by the file name)_
  - _ResNorm
  - _ResNorm_Fit
  - _ResNorm_Fit_NormalisedCovarianceMatrices
  - _ResNorm_Fit_Parameters
  - _ResNorm_Fit_Workspaces 
- Ensure that algorithm can be re-Run without loading new data (This is a legacy issue that is worth checking due to small changes in the algorithm workflow)
