### PR TITLE
Remove the invisible sliceviewer rebin lock button that is not used

### DIFF
--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -1171,9 +1171,9 @@ void SliceViewer::setRebinNumBins(int xBins, int yBins)
 
 %End
 
-  void setRebinMode(bool mode, bool locked)   throw (std::runtime_error);
+  void setRebinMode(bool mode)   throw (std::runtime_error);
 %Docstring
-void SliceViewer::setRebinMode(bool mode, bool locked)
+void SliceViewer::setRebinMode(bool mode)
 ------------------------------------------------------
     Sets the SliceViewer in dynamic rebin mode.
     In this mode, the current view area (see setXYLimits()) is used as the
@@ -1183,8 +1183,6 @@ void SliceViewer::setRebinMode(bool mode, bool locked)
 
     Args:
         mode :: true for rebinning mode
-        locked :: if true, then the rebinned area is only refreshed manually
-           or when changing rebinning parameters.
 
 %End
 

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -117,7 +117,7 @@ public:
   /// Dynamic Rebinning-related Python bindings
   void setRebinThickness(int dim, double thickness);
   void setRebinNumBins(int xBins, int yBins);
-  void setRebinMode(bool mode, bool locked);
+  void setRebinMode(bool mode);
   void refreshRebin();
 
   /// Methods relating to peaks overlays.

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -188,7 +188,6 @@ public slots:
   void LineMode_toggled(bool);
   void SnapToGrid_toggled(bool);
   void RebinMode_toggled(bool);
-  void RebinLock_toggled(bool);
   void autoRebin_toggled(bool);
 
   // Dynamic rebinning
@@ -333,7 +332,7 @@ private:
 
   /// Synced menu/buttons
   MantidQt::API::SyncedCheckboxes *m_syncLineMode, *m_syncSnapToGrid,
-    *m_syncRebinMode, *m_syncRebinLock, *m_syncAutoRebin;
+    *m_syncRebinMode, *m_syncAutoRebin;
 
   /// Cached double for infinity
   double m_inf;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.ui
@@ -490,47 +490,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QToolButton" name="btnRebinLock">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>45</width>
-              <height>45</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>45</width>
-              <height>45</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Lock the rebinned workspace in place (use the refresh button to refresh)</string>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normaloff>:/SliceViewer/icons/stock-lock.png</normaloff>:/SliceViewer/icons/stock-lock.png</iconset>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>32</width>
-              <height>32</height>
-             </size>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
            <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -998,10 +998,8 @@ void SliceViewer::setRebinNumBins(int xBins, int yBins) {
  * See setRebinThickness() to adjust the thickness in other dimensions.
  *
  * @param mode :: true for rebinning mode
- * @param locked :: if true, then the rebinned area is only refreshed manually
- *        or when changing rebinning parameters.
  */
-void SliceViewer::setRebinMode(bool mode, bool locked) {
+void SliceViewer::setRebinMode(bool mode) {
   // The events associated with these controls will trigger a re-draw
   m_syncRebinMode->toggle(mode);
 }

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -122,8 +122,6 @@ SliceViewer::SliceViewer(QWidget *parent)
 
   // hide unused buttons
   ui.btnZoom->hide();      // hidden for a long time
-  ui.btnRebinLock->hide(); // now replaced by auto rebin mode
-  // ui.btnClearLine->hide();  // turning off line mode now removes line
 
   // ----------- Toolbar button signals ----------------
   QObject::connect(ui.btnResetZoom, SIGNAL(clicked()), this, SLOT(resetZoom()));
@@ -377,13 +375,6 @@ void SliceViewer::initMenus() {
   m_syncRebinMode = new SyncedCheckboxes(action, ui.btnRebinMode, false);
   connect(m_syncRebinMode, SIGNAL(toggled(bool)), this,
           SLOT(RebinMode_toggled(bool)));
-  m_menuView->addAction(action);
-
-  action = new QAction(QPixmap(), "&Lock Rebinned WS", this);
-  m_syncRebinLock = new SyncedCheckboxes(action, ui.btnRebinLock, true);
-  connect(m_syncRebinLock, SIGNAL(toggled(bool)), this,
-          SLOT(RebinLock_toggled(bool)));
-  action->setVisible(false); // hide this action
   m_menuView->addAction(action);
 
   action = new QAction(QPixmap(), "Rebin Current View", this);
@@ -691,7 +682,6 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
 
   // Can't use dynamic rebin mode with a MatrixWorkspace
   m_syncRebinMode->setEnabled(!matrix);
-  m_syncRebinLock->setEnabled(!matrix);
 
   // Go to no normalization by default for MatrixWorkspaces
   if (matrix)
@@ -1014,7 +1004,6 @@ void SliceViewer::setRebinNumBins(int xBins, int yBins) {
 void SliceViewer::setRebinMode(bool mode, bool locked) {
   // The events associated with these controls will trigger a re-draw
   m_syncRebinMode->toggle(mode);
-  m_syncRebinLock->toggle(locked);
 }
 
 //------------------------------------------------------------------------------
@@ -1098,7 +1087,6 @@ void SliceViewer::RebinMode_toggled(bool checked) {
   for (size_t d = 0; d < m_dimWidgets.size(); d++)
     m_dimWidgets[d]->showRebinControls(checked);
   ui.btnRebinRefresh->setEnabled(checked);
-  ui.btnRebinLock->setEnabled(checked);
   m_syncAutoRebin->setEnabled(checked);
   m_actionRefreshRebin->setEnabled(checked);
   m_rebinMode = checked;
@@ -1118,17 +1106,6 @@ void SliceViewer::RebinMode_toggled(bool checked) {
   }
 }
 
-//------------------------------------------------------------------------------
-/** Slot called when locking/unlocking the dynamically rebinned
- * overlaid workspace
- * @param checked :: DO lock the workspace in place
- */
-void SliceViewer::RebinLock_toggled(bool checked) {
-  m_rebinLocked = checked;
-  // Rebin immediately
-  if (!m_rebinLocked && m_rebinMode)
-    this->rebinParamsChanged();
-}
 
 //------------------------------------------------------------------------------
 /// Slot for zooming into

--- a/MantidQt/SliceViewer/test/SliceViewerPythonInterfaceTest.py
+++ b/MantidQt/SliceViewer/test/SliceViewerPythonInterfaceTest.py
@@ -449,7 +449,7 @@ class SliceViewerPythonInterfaceTest(unittest.TestCase):
         sv.setRebinThickness(2, 1.0)
         sv.setRebinNumBins(50, 200)
         sv.refreshRebin()
-        sv.setRebinMode(True, True)
+        sv.setRebinMode(True)
         time.sleep(1)
         self.assertTrue(mtd.doesExist('uniform_rebinned'), 'Dynamically rebinned workspace was created.')
         ws = mtd['uniform_rebinned']


### PR DESCRIPTION
This  is just a cleanup excercise and had no visible impact to the GUI.

The rebin lock button and menu item have been invisible for a release or two.
This just removes them and the code behind them.
## release notes

No visible changes, just code quality
## to test
1. Check that rebinning in the sliceviewer still works as expected

closes #13470
