### PR TITLE
Fix Bilby IDF and Loader for Source Position based on Logs

### DIFF
--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -405,6 +405,7 @@ void LoadBBY::exec() {
       createChildAlgorithm("LoadInstrument");
   loadInstrumentAlg->setProperty("Workspace", eventWS);
   loadInstrumentAlg->setPropertyValue("InstrumentName", "BILBY");
+  loadInstrumentAlg->setProperty("RewriteSpectraMap", false);
   loadInstrumentAlg->executeAsChildAlg();
 
   setProperty("OutputWorkspace", eventWS);

--- a/instrument/Bilby_Definition.xml
+++ b/instrument/Bilby_Definition.xml
@@ -26,7 +26,7 @@
   <component name="Source" type="source">
     <location x="0.0" y="0.0" />
     <parameter name="z"> 
-      <logfile id="L1_chopper_value" eq="1*value"/>
+      <logfile id="L1_chopper_value" eq="-1*value"/>
     </parameter>
   </component>
   <type name="source" is="Source" />


### PR DESCRIPTION
Fixes #13997.

**Tester**

See problem description. Repeat this and you should much more reasonable Theta angles. You can also cross-compare with the 3.5 version of Mantid, which had the Theta values set correctly by hard-coding the instrument. See Owen for more details.
