### PR TITLE
13828 fix instrument position in reflectometry reduction

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -110,9 +110,8 @@ void ReflectometryReductionOneAuto::init() {
                   "I0 monitor workspace index");
   declareProperty(new PropertyWithValue<std::string>("ProcessingInstructions",
                                                      "", Direction::Input),
-                  "Processing commands to select and add spectrum to make a "
-                  "detector workspace. See [[PeformIndexOperations]] for "
-                  "syntax.");
+                  "Grouping pattern of workspace indices to yield only the"
+                  " detectors of interest. See GroupDetectors for syntax.");
   declareProperty("WavelengthMin", Mantid::EMPTY_DBL(),
                   "Wavelength Min in angstroms", Direction::Input);
   declareProperty("WavelengthMax", Mantid::EMPTY_DBL(),

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v1.rst
@@ -13,13 +13,19 @@ Facade over :ref:`algm-ReflectometryReductionOne`.
 
 Pulls numeric parameters out of the instrument parameters where possible. You can override any of these automatically applied defaults by providing your own value for the input.
 
+See :ref:`algm-ReflectometryReductionOne` for more information on the wrapped algorithm.
+
+ProcessingInstructions
+######################
+
 If ProcessingInstructions is not set its value is inferred from other properties:
 
 * If AnalysisMode = PointDetectorAnalaysis and PointDetectorStart = PointDetectorStop then the spectrum specified by PointDetectorStart is used.
 * If AnalysisMode = PointDetectorAnalaysis and PointDetectorStart ≠ PointDetectorStop then the sum of the spectra from PointDetectorStart to PointDetectorStop is used.
 * If AnalysisMode = MultiDetectorAnalaysis then all of the spectra from MultiDetectorStart onwards are used.
 
-See :ref:`algm-ReflectometryReductionOne` for more information on the wrapped algorithm.
+Note, the ProcessingInstructions are workspace indicies, not detector IDs. The first few workspaces may correspond to monitors, rather than detectors of interest.
+For the syntax of this property, see :ref:`algm-GroupDetectors`.
 
 Workflow for WorkspaceGroups
 ############################


### PR DESCRIPTION
Closes #13828 

Small changes to documentation for the ReflectometryReductionOneAuto algorithm to clarify that the ProcessingInstructions property corresponds to workspace indices.

For Tester:
Please read the changes and check they make sense.
