### PR TITLE
Increasing the run time of performance tests for CompactMD

### DIFF
--- a/Framework/MDAlgorithms/test/CompactMDTest.h
+++ b/Framework/MDAlgorithms/test/CompactMDTest.h
@@ -262,10 +262,6 @@ public:
     Mantid::coord_t min[static_cast<int>(numDims)] = {-5, -10, -5, -10};
     Mantid::coord_t max[static_cast<int>(numDims)] = {5, 10, 5, 10};
     const std::string name("test");
-    m_ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(
-        numDims, signal, errorSquared, numBins, min, max, name);
-  }
-  void test_execute_4d() {
     // setting signals like this for variety
     auto iter = m_ws->createIterator();
     do {
@@ -274,21 +270,10 @@ public:
         m_ws->setSignalAt(index, 1.0);
       }
     } while (iter->next());
-    CompactMD alg;
-    alg.setChild(true);
-    alg.setRethrows(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_ws);
-    alg.setProperty("OutputWorkspace", "out");
-    alg.execute();
-    IMDHistoWorkspace_sptr outWS = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outWS);
+    m_ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(
+        numDims, signal, errorSquared, numBins, min, max, name);
   }
-  void test_on_workspace_where_every_bin_has_non_zero_signal() {
-    auto iter = m_ws->createIterator();
-    do {
-      m_ws->setSignalAt(iter->getLinearIndex(), 1.0);
-    } while (iter->next());
+  void test_execute_4d() {
     CompactMD alg;
     alg.setChild(true);
     alg.setRethrows(true);

--- a/Framework/MDAlgorithms/test/CompactMDTest.h
+++ b/Framework/MDAlgorithms/test/CompactMDTest.h
@@ -258,10 +258,12 @@ public:
     const size_t numDims = 4;
     const double signal = 0.0;
     const double errorSquared = 1.2;
-    size_t numBins[static_cast<int>(numDims)] = {5, 10, 5, 10};
+    size_t numBins[static_cast<int>(numDims)] = {10, 20, 10, 20};
     Mantid::coord_t min[static_cast<int>(numDims)] = {-5, -10, -5, -10};
     Mantid::coord_t max[static_cast<int>(numDims)] = {5, 10, 5, 10};
     const std::string name("test");
+    m_ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(
+        numDims, signal, errorSquared, numBins, min, max, name);
     // setting signals like this for variety
     auto iter = m_ws->createIterator();
     do {
@@ -270,8 +272,6 @@ public:
         m_ws->setSignalAt(index, 1.0);
       }
     } while (iter->next());
-    m_ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(
-        numDims, signal, errorSquared, numBins, min, max, name);
   }
   void test_execute_4d() {
     CompactMD alg;

--- a/Framework/MDAlgorithms/test/CompactMDTest.h
+++ b/Framework/MDAlgorithms/test/CompactMDTest.h
@@ -34,9 +34,9 @@ public:
      * Input structure:
      *------------------
      *  -------------
-     *  |   |///|   |
-     *  -------------
-     * -3-2-1 0 1 2 3
+     *  |   |   |///|   |   |
+     *  ---------------------
+     * -5-4-3 2-1 0 1 2 3 4 5
      *---------------------------
      * Expected output structure:
      *----------------------------
@@ -51,13 +51,13 @@ public:
     const size_t numDims = 1;
     const double signal = 0.0;
     const double errorSquared = 1.3;
-    size_t numBins[static_cast<int>(numDims)] = {3};
-    Mantid::coord_t min[static_cast<int>(numDims)] = {-3};
-    Mantid::coord_t max[static_cast<int>(numDims)] = {3};
+    size_t numBins[static_cast<int>(numDims)] = {5};
+    Mantid::coord_t min[static_cast<int>(numDims)] = {-5};
+    Mantid::coord_t max[static_cast<int>(numDims)] = {5};
     const std::string name("test");
     auto inWS = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(
         numDims, signal, errorSquared, numBins, min, max, name);
-    inWS->setSignalAt(1, 1.0); // set middle bin signal to one
+    inWS->setSignalAt(2, 1.0); // set middle bin signal to one
     CompactMD alg;
     alg.setChild(true);
     alg.setRethrows(true);
@@ -258,17 +258,37 @@ public:
     const size_t numDims = 4;
     const double signal = 0.0;
     const double errorSquared = 1.2;
-    size_t numBins[static_cast<int>(numDims)] = {3, 3, 3, 3};
-    Mantid::coord_t min[static_cast<int>(numDims)] = {-3, -3, -3, -3};
-    Mantid::coord_t max[static_cast<int>(numDims)] = {3, 3, 3, 3};
+    size_t numBins[static_cast<int>(numDims)] = {5, 10, 5, 10};
+    Mantid::coord_t min[static_cast<int>(numDims)] = {-5, -10, -5, -10};
+    Mantid::coord_t max[static_cast<int>(numDims)] = {5, 10, 5, 10};
     const std::string name("test");
     m_ws = MDEventsTestHelper::makeFakeMDHistoWorkspaceGeneral(
         numDims, signal, errorSquared, numBins, min, max, name);
   }
   void test_execute_4d() {
-    m_ws->setSignalAt(0, 1.0);
-    m_ws->setSignalAt(5, 1.2);
-    m_ws->setSignalAt(1, 2.3);
+    // setting signals like this for variety
+    auto iter = m_ws->createIterator();
+    do {
+      auto index = iter->getLinearIndex();
+      if (index % 2 == 0) {
+        m_ws->setSignalAt(index, 1.0);
+      }
+    } while (iter->next());
+    CompactMD alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", m_ws);
+    alg.setProperty("OutputWorkspace", "out");
+    alg.execute();
+    IMDHistoWorkspace_sptr outWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outWS);
+  }
+  void test_on_workspace_where_every_bin_has_non_zero_signal() {
+    auto iter = m_ws->createIterator();
+    do {
+      m_ws->setSignalAt(iter->getLinearIndex(), 1.0);
+    } while (iter->next());
     CompactMD alg;
     alg.setChild(true);
     alg.setRethrows(true);


### PR DESCRIPTION
Fixes #14011 

I have adjusted the size of the workspaces used for performance testing and also increased the number of bins that have a non-zero signal. This should increase the time it takes to process the workspaces and the tests are taking ~0.9s to complete on my own machine.

**To Test:**
- Build MDAlgorithmsTest in Release mode
- Create a batch file and run it from the batch script below which will generate an XML file with the time taken to run the tests, in the header.

**Script:**

```
cd "C:\Builds\Mantid\bin\Release"
set PATH=%PATH%;C:\<YOUR SOURCE DIRECTORY HERE>\mantid\Third_Party\lib\win64;C:\<YOUR SOURCE DIRECTORY HERE>\mantid\Third_Party\lib\win64\Python27

MDAlgorithmsTest.exe CompactMDTestPerformance
cmd /K
```

**Release Notes:**

No major changes, no need to update release notes.
