### PR TITLE
Fix period subtraction in MuonCalculateAsymmetry

### DIFF
--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonCalculateAsymmetry.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/MuonCalculateAsymmetry.h
@@ -49,12 +49,22 @@ private:
   void init();
   void exec();
 
-  /// Converts given workspace according to the OutputType
-  API::MatrixWorkspace_sptr convertWorkspace(API::MatrixWorkspace_sptr ws);
-
-  /// Merges two period workspaces according to PeriodOperation specified
-  API::MatrixWorkspace_sptr mergePeriods(API::MatrixWorkspace_sptr ws1,
-                                         API::MatrixWorkspace_sptr ws2);
+  // Calculates raw counts
+  API::MatrixWorkspace_sptr
+  calculateGroupCounts(const API::MatrixWorkspace_sptr &firstPeriodWS,
+                       const API::MatrixWorkspace_sptr &secondPeriodWS,
+                       int groupIndex, std::string op);
+  // Calculates asymmetry for specified spectrum
+  API::MatrixWorkspace_sptr
+  calculateGroupAsymmetry(const API::MatrixWorkspace_sptr &firstPeriodWS,
+                          const API::MatrixWorkspace_sptr &secondPeriodWS,
+                          int groupIndex, std::string op);
+  // Calculates asymmetry for a pair of spectra
+  API::MatrixWorkspace_sptr
+  calculatePairAsymmetry(const API::MatrixWorkspace_sptr &firstPeriodWS,
+                         const API::MatrixWorkspace_sptr &secondPeriodWS,
+                         int firstPairIndex, int secondPairIndex, double alpha,
+                         std::string op);
 };
 
 } // namespace WorkflowAlgorithms

--- a/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
@@ -235,18 +235,28 @@ MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupAsymmetry(
         alg->execute();
         MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
 
+        // GroupIndex as vector
+        // Necessary if we want RemoveExpDecay to fit only the requested
+        // spectrum
+        std::vector<int> spec(1, groupIndex);
+
         // Remove decay
         IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
         asym->setProperty("InputWorkspace",sumWS);
+        asym->setProperty("Spectra", spec);
         asym->execute();
         tempWS = asym->getProperty("OutputWorkspace");
 
       } else if (op == "-") {
 
+        // GroupIndex as vector
+        std::vector<int> spec(1, groupIndex);
+
         // Remove decay (first period ws)
         IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
         asym->initialize();
         asym->setProperty("InputWorkspace",firstPeriodWS);
+        asym->setProperty("Spectra", spec);
         asym->execute();
         MatrixWorkspace_sptr asymFirstPeriod = asym->getProperty("OutputWorkspace");
 
@@ -254,6 +264,7 @@ MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupAsymmetry(
         asym = createChildAlgorithm("RemoveExpDecay");
         asym->initialize();
         asym->setProperty("InputWorkspace", secondPeriodWS);
+        asym->setProperty("Spectra", spec);
         asym->execute();
         MatrixWorkspace_sptr asymSecondPeriod = asym->getProperty("OutputWorkspace");
 

--- a/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
@@ -107,19 +107,20 @@ void MuonCalculateAsymmetry::exec() {
   MatrixWorkspace_sptr firstPeriodWS = getProperty("FirstPeriodWorkspace");
   MatrixWorkspace_sptr secondPeriodWS = getProperty("SecondPeriodWorkspace");
 
-  MatrixWorkspace_sptr convertedWS;
+  MatrixWorkspace_sptr firstConverted = convertWorkspace(firstPeriodWS);
 
   if (secondPeriodWS) {
     // Two periods
-    MatrixWorkspace_sptr mergedWS = mergePeriods(firstPeriodWS, secondPeriodWS);
-    convertedWS = convertWorkspace(mergedWS);
+    MatrixWorkspace_sptr secondConverted = convertWorkspace(secondPeriodWS);
+
+    setProperty("OutputWorkspace",
+                mergePeriods(firstConverted, secondConverted));
 
   } else {
     // Single period only
-    convertedWS = convertWorkspace(firstPeriodWS);
+    setProperty("OutputWorkspace", firstConverted);
   }
 
-  setProperty("OutputWorkspace", convertedWS);
 }
 
 /**

--- a/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
@@ -107,126 +107,272 @@ void MuonCalculateAsymmetry::exec() {
   MatrixWorkspace_sptr firstPeriodWS = getProperty("FirstPeriodWorkspace");
   MatrixWorkspace_sptr secondPeriodWS = getProperty("SecondPeriodWorkspace");
 
-  MatrixWorkspace_sptr firstConverted = convertWorkspace(firstPeriodWS);
-
-  if (secondPeriodWS) {
-    // Two periods
-    MatrixWorkspace_sptr secondConverted = convertWorkspace(secondPeriodWS);
-
-    setProperty("OutputWorkspace",
-                mergePeriods(firstConverted, secondConverted));
-
-  } else {
-    // Single period only
-    setProperty("OutputWorkspace", firstConverted);
-  }
-
-}
-
-/**
- * Converts given workspace according to the OutputType.
- * @param ws :: Workspace to convert
- * @return Converted workspace
- */
-MatrixWorkspace_sptr
-MuonCalculateAsymmetry::convertWorkspace(MatrixWorkspace_sptr ws) {
+  // The type of calculation
   const std::string type = getPropertyValue("OutputType");
 
-  if (type == "GroupCounts" || type == "GroupAsymmetry") {
-    int groupIndex = getProperty("GroupIndex");
+  // The group index
+  int groupIndex = getProperty("GroupIndex");
 
-    if (groupIndex == EMPTY_INT())
-      throw std::runtime_error("GroupIndex is not specified");
+  // The type of period operation (+ or -)
+  std::string op = getProperty("PeriodOperation");
 
-    // Yank out the counts of requested group
-    IAlgorithm_sptr alg = createChildAlgorithm("ExtractSingleSpectrum");
-    alg->initialize();
-    alg->setProperty("InputWorkspace", ws);
-    alg->setProperty("WorkspaceIndex", groupIndex);
-    alg->execute();
+  if (type == "GroupCounts") {
 
-    MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+    auto outWS =
+        calculateGroupCounts(firstPeriodWS, secondPeriodWS, groupIndex, op);
 
-    if (type == "GroupAsymmetry") {
-      // GroupAsymmetry - counts with ExpDecay removed and normalized
+    setProperty("OutputWorkspace", outWS);
 
-      IAlgorithm_sptr alg = createChildAlgorithm("RemoveExpDecay");
-      alg->initialize();
-      alg->setProperty("InputWorkspace", outWS);
-      alg->execute();
+  } else if (type == "GroupAsymmetry") {
 
-      outWS = alg->getProperty("OutputWorkspace");
-    }
+    auto outWS =
+        calculateGroupAsymmetry(firstPeriodWS, secondPeriodWS, groupIndex, op);
 
-    return outWS;
+    setProperty("OutputWorkspace", outWS);
+
   } else if (type == "PairAsymmetry") {
-    // PairAsymmetry - result of AsymmetryCalc algorithm
 
     int pairFirstIndex = getProperty("PairFirstIndex");
     int pairSecondIndex = getProperty("PairSecondIndex");
-
-    if (pairFirstIndex == EMPTY_INT() || pairSecondIndex == EMPTY_INT())
-      throw std::invalid_argument("Both pair indices should be specified");
-
     double alpha = getProperty("Alpha");
 
-    // We get pair groups as their workspace indices, but AsymmetryCalc wants
-    // spectra numbers,
-    // so need to convert
-    specid_t spectraNo1 = ws->getSpectrum(pairFirstIndex)->getSpectrumNo();
-    specid_t spectraNo2 = ws->getSpectrum(pairSecondIndex)->getSpectrumNo();
+    auto outWS =
+        calculatePairAsymmetry(firstPeriodWS, secondPeriodWS, pairFirstIndex,
+                               pairSecondIndex, alpha, op);
 
-    if (spectraNo1 == -1 || spectraNo2 == -1 || spectraNo1 == spectraNo2)
-      throw std::invalid_argument(
-          "Spectra numbers of the input workspace are not set properly");
+    setProperty("OutputWorkspace", outWS);
 
-    IAlgorithm_sptr alg = createChildAlgorithm("AsymmetryCalc");
-    alg->setProperty("InputWorkspace", ws);
-    // As strings, cause otherwise would need to create arrays with single
-    // elements
-    alg->setPropertyValue("ForwardSpectra",
-                          boost::lexical_cast<std::string>(spectraNo1));
-    alg->setPropertyValue("BackwardSpectra",
-                          boost::lexical_cast<std::string>(spectraNo2));
-    alg->setProperty("Alpha", alpha);
+  } else {
+
+    throw std::invalid_argument("Specified OutputType is not supported");
+  }
+}
+
+/**
+* Calculates raw counts according to period operation
+* @param firstPeriodWS :: [input] First period workspace
+* @param secondPeriodWS :: [input] Second period workspace
+* @param groupIndex :: [input] Index of the workspace to extract counts from
+* @param op :: [input] Period operation (+ or -)
+*/
+MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupCounts(
+    const MatrixWorkspace_sptr &firstPeriodWS,
+    const MatrixWorkspace_sptr &secondPeriodWS, int groupIndex,
+    std::string op) {
+
+  if (secondPeriodWS) {
+    // Two periods supplied
+
+    MatrixWorkspace_sptr tempWS;
+
+    if (op == "+") {
+
+      IAlgorithm_sptr alg = createChildAlgorithm("Plus");
+      alg->initialize();
+      alg->setProperty("LHSWorkspace", firstPeriodWS);
+      alg->setProperty("RHSWorkspace", secondPeriodWS);
+      alg->execute();
+      tempWS = alg->getProperty("OutputWorkspace");
+
+    } else if (op == "-") {
+
+      IAlgorithm_sptr alg = createChildAlgorithm("Minus");
+      alg->initialize();
+      alg->setProperty("LHSWorkspace", firstPeriodWS);
+      alg->setProperty("RHSWorkspace", secondPeriodWS);
+      alg->execute();
+      tempWS = alg->getProperty("OutputWorkspace");
+    }
+
+    IAlgorithm_sptr alg = createChildAlgorithm("ExtractSingleSpectrum");
+    alg->initialize();
+    alg->setProperty("InputWorkspace", tempWS);
+    alg->setProperty("WorkspaceIndex", groupIndex);
     alg->execute();
+    MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
 
+    return outWS;
+
+  } else {
+    // Only one period supplied
+
+    IAlgorithm_sptr alg = createChildAlgorithm("ExtractSingleSpectrum");
+    alg->initialize();
+    alg->setProperty("InputWorkspace", firstPeriodWS);
+    alg->setProperty("WorkspaceIndex", groupIndex);
+    alg->execute();
     MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
 
     return outWS;
   }
-
-  throw std::invalid_argument("Specified OutputType is not supported");
 }
 
 /**
- * Merges two period workspaces according to PeriodOperation specified.
- * @param ws1 :: First period workspace
- * @param ws2 :: Second period workspace
- * @return Merged workspace
- */
-MatrixWorkspace_sptr
-MuonCalculateAsymmetry::mergePeriods(MatrixWorkspace_sptr ws1,
-                                     MatrixWorkspace_sptr ws2) {
-  std::string op = getProperty("PeriodOperation");
+* Calculates single-spectrum asymmetry according to period operation
+* @param firstPeriodWS :: [input] First period workspace
+* @param secondPeriodWS :: [input] Second period workspace
+* @param groupIndex :: [input] Workspace index for which to calculate asymmetry
+* @param op :: [input] Period operation (+ or -)
+*/
+MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupAsymmetry(
+    const MatrixWorkspace_sptr &firstPeriodWS,
+    const MatrixWorkspace_sptr &secondPeriodWS, int groupIndex,
+    std::string op) {
 
-  std::string algorithmName;
+  // The output workspace
+  MatrixWorkspace_sptr tempWS;
 
-  if (op == "+") {
-    algorithmName = "Plus";
-  } else if (op == "-") {
-    algorithmName = "Minus";
+  if (secondPeriodWS) {
+    // Two period workspaces where supplied
+
+      if (op == "+") {
+
+        // Sum
+        IAlgorithm_sptr alg = createChildAlgorithm("Plus");
+        alg->initialize();
+        alg->setProperty("LHSWorkspace", firstPeriodWS);
+        alg->setProperty("RHSWorkspace", secondPeriodWS);
+        alg->execute();
+        MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
+
+        // Remove decay
+        IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
+        asym->setProperty("InputWorkspace",sumWS);
+        asym->execute();
+        tempWS = asym->getProperty("OutputWorkspace");
+
+      } else if (op == "-") {
+
+        // Remove decay (first period ws)
+        IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
+        asym->initialize();
+        asym->setProperty("InputWorkspace",firstPeriodWS);
+        asym->execute();
+        MatrixWorkspace_sptr asymFirstPeriod = asym->getProperty("OutputWorkspace");
+
+        // Remove decay (second period ws)
+        asym = createChildAlgorithm("RemoveExpDecay");
+        asym->initialize();
+        asym->setProperty("InputWorkspace", secondPeriodWS);
+        asym->execute();
+        MatrixWorkspace_sptr asymSecondPeriod = asym->getProperty("OutputWorkspace");
+
+        // Now subtract
+        IAlgorithm_sptr alg = createChildAlgorithm("Minus");
+        alg->initialize();
+        alg->setProperty("LHSWorkspace", asymFirstPeriod);
+        alg->setProperty("RHSWorkspace", asymSecondPeriod);
+        alg->execute();
+        tempWS = alg->getProperty("OutputWorkspace");
+
+      }
+    } else {
+      // Only one period was supplied
+
+      IAlgorithm_sptr alg = createChildAlgorithm("RemoveExpDecay");
+      alg->initialize();
+      alg->setProperty("InputWorkspace", firstPeriodWS);
+      alg->execute();
+      tempWS = alg->getProperty("OutputWorkspace");
+    }
+
+    // Extract the requested spectrum
+    IAlgorithm_sptr alg = createChildAlgorithm("ExtractSingleSpectrum");
+    alg->initialize();
+    alg->setProperty("InputWorkspace", tempWS);
+    alg->setProperty("WorkspaceIndex", groupIndex);
+    alg->execute();
+    MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+    return outWS;
+}
+
+/**
+* Calculates pair asymmetry according to period operation
+* @param firstPeriodWS :: [input] First period workspace
+* @param secondPeriodWS :: [input] Second period workspace
+* @param groupIndex :: [input] Workspace index for which to calculate asymmetry
+* @param op :: [input] Period operation (+ or -)
+*/
+MatrixWorkspace_sptr MuonCalculateAsymmetry::calculatePairAsymmetry(
+    const MatrixWorkspace_sptr &firstPeriodWS,
+    const MatrixWorkspace_sptr &secondPeriodWS, int firstPairIndex,
+    int secondPairIndex, double alpha, std::string op) {
+
+  // Pair indices as vectors
+  std::vector<int> fwd(1, firstPairIndex + 1);
+  std::vector<int> bwd(1, secondPairIndex + 1);
+
+  if (secondPeriodWS) {
+
+    MatrixWorkspace_sptr outWS;
+
+    if (op == "+") {
+
+        // Sum
+        IAlgorithm_sptr alg = createChildAlgorithm("Plus");
+        alg->initialize();
+        alg->setProperty("LHSWorkspace", firstPeriodWS);
+        alg->setProperty("RHSWorkspace", secondPeriodWS);
+        alg->execute();
+        MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
+
+        // Asymmetry calculation
+        alg = createChildAlgorithm("AsymmetryCalc");
+        alg->setProperty("InputWorkspace", sumWS);
+        alg->setProperty("ForwardSpectra", fwd);
+        alg->setProperty("BackwardSpectra", bwd);
+        alg->setProperty("Alpha", alpha);
+        alg->execute();
+        outWS = alg->getProperty("OutputWorkspace");
+
+    } else if (op == "-") {
+
+        std::vector<int> fwd(1, firstPairIndex + 1);
+        std::vector<int> bwd(1, secondPairIndex + 1);
+
+        // First period asymmetry
+        IAlgorithm_sptr alg = createChildAlgorithm("AsymmetryCalc");
+        alg->setProperty("InputWorkspace", firstPeriodWS);
+        alg->setProperty("ForwardSpectra", fwd);
+        alg->setProperty("BackwardSpectra", bwd);
+        alg->setProperty("Alpha", alpha);
+        alg->execute();
+        MatrixWorkspace_sptr asymFirstPeriod =
+            alg->getProperty("OutputWorkspace");
+
+        // Second period asymmetry
+        alg = createChildAlgorithm("AsymmetryCalc");
+        alg->setProperty("InputWorkspace", secondPeriodWS);
+        alg->setProperty("ForwardSpectra", fwd);
+        alg->setProperty("BackwardSpectra", bwd);
+        alg->setProperty("Alpha", alpha);
+        alg->execute();
+        MatrixWorkspace_sptr asymSecondPeriod =
+            alg->getProperty("OutputWorkspace");
+
+        // Now subtract
+        alg = createChildAlgorithm("Minus");
+        alg->initialize();
+        alg->setProperty("LHSWorkspace", asymFirstPeriod);
+        alg->setProperty("RHSWorkspace", asymSecondPeriod);
+        alg->execute();
+        outWS = alg->getProperty("OutputWorkspace");
+    }
+
+    return outWS;
+
+  } else {
+
+    IAlgorithm_sptr alg = createChildAlgorithm("AsymmetryCalc");
+    alg->setProperty("InputWorkspace", firstPeriodWS);
+    alg->setProperty("ForwardSpectra", fwd);
+    alg->setProperty("BackwardSpectra", bwd);
+    alg->setProperty("Alpha", alpha);
+    alg->execute();
+    MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+
+    return outWS;
   }
-
-  IAlgorithm_sptr alg = createChildAlgorithm(algorithmName);
-  alg->initialize();
-  alg->setProperty("LHSWorkspace", ws1);
-  alg->setProperty("RHSWorkspace", ws2);
-  alg->execute();
-
-  MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
-
-  return outWS;
 }
 } // namespace WorkflowAlgorithms
 } // namespace Mantid

--- a/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
@@ -304,6 +304,7 @@ MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupAsymmetry(
 * @param secondPeriodWS :: [input] Second period workspace
 * @param firstPairIndex :: [input] Workspace index for the forward group
 * @param secondPairIndex :: [input] Workspace index for the backward group
+* @param alpha :: [input] The balance parameter
 * @param op :: [input] Period operation (+ or -)
 */
 MatrixWorkspace_sptr MuonCalculateAsymmetry::calculatePairAsymmetry(

--- a/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
@@ -225,76 +225,77 @@ MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupAsymmetry(
   if (secondPeriodWS) {
     // Two period workspaces where supplied
 
-      if (op == "+") {
+    if (op == "+") {
 
-        // Sum
-        IAlgorithm_sptr alg = createChildAlgorithm("Plus");
-        alg->initialize();
-        alg->setProperty("LHSWorkspace", firstPeriodWS);
-        alg->setProperty("RHSWorkspace", secondPeriodWS);
-        alg->execute();
-        MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
-
-        // GroupIndex as vector
-        // Necessary if we want RemoveExpDecay to fit only the requested
-        // spectrum
-        std::vector<int> spec(1, groupIndex);
-
-        // Remove decay
-        IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
-        asym->setProperty("InputWorkspace",sumWS);
-        asym->setProperty("Spectra", spec);
-        asym->execute();
-        tempWS = asym->getProperty("OutputWorkspace");
-
-      } else if (op == "-") {
-
-        // GroupIndex as vector
-        std::vector<int> spec(1, groupIndex);
-
-        // Remove decay (first period ws)
-        IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
-        asym->initialize();
-        asym->setProperty("InputWorkspace",firstPeriodWS);
-        asym->setProperty("Spectra", spec);
-        asym->execute();
-        MatrixWorkspace_sptr asymFirstPeriod = asym->getProperty("OutputWorkspace");
-
-        // Remove decay (second period ws)
-        asym = createChildAlgorithm("RemoveExpDecay");
-        asym->initialize();
-        asym->setProperty("InputWorkspace", secondPeriodWS);
-        asym->setProperty("Spectra", spec);
-        asym->execute();
-        MatrixWorkspace_sptr asymSecondPeriod = asym->getProperty("OutputWorkspace");
-
-        // Now subtract
-        IAlgorithm_sptr alg = createChildAlgorithm("Minus");
-        alg->initialize();
-        alg->setProperty("LHSWorkspace", asymFirstPeriod);
-        alg->setProperty("RHSWorkspace", asymSecondPeriod);
-        alg->execute();
-        tempWS = alg->getProperty("OutputWorkspace");
-
-      }
-    } else {
-      // Only one period was supplied
-
-      IAlgorithm_sptr alg = createChildAlgorithm("RemoveExpDecay");
+      // Sum
+      IAlgorithm_sptr alg = createChildAlgorithm("Plus");
       alg->initialize();
-      alg->setProperty("InputWorkspace", firstPeriodWS);
+      alg->setProperty("LHSWorkspace", firstPeriodWS);
+      alg->setProperty("RHSWorkspace", secondPeriodWS);
+      alg->execute();
+      MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
+
+      // GroupIndex as vector
+      // Necessary if we want RemoveExpDecay to fit only the requested
+      // spectrum
+      std::vector<int> spec(1, groupIndex);
+
+      // Remove decay
+      IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
+      asym->setProperty("InputWorkspace", sumWS);
+      asym->setProperty("Spectra", spec);
+      asym->execute();
+      tempWS = asym->getProperty("OutputWorkspace");
+
+    } else if (op == "-") {
+
+      // GroupIndex as vector
+      std::vector<int> spec(1, groupIndex);
+
+      // Remove decay (first period ws)
+      IAlgorithm_sptr asym = createChildAlgorithm("RemoveExpDecay");
+      asym->initialize();
+      asym->setProperty("InputWorkspace", firstPeriodWS);
+      asym->setProperty("Spectra", spec);
+      asym->execute();
+      MatrixWorkspace_sptr asymFirstPeriod =
+          asym->getProperty("OutputWorkspace");
+
+      // Remove decay (second period ws)
+      asym = createChildAlgorithm("RemoveExpDecay");
+      asym->initialize();
+      asym->setProperty("InputWorkspace", secondPeriodWS);
+      asym->setProperty("Spectra", spec);
+      asym->execute();
+      MatrixWorkspace_sptr asymSecondPeriod =
+          asym->getProperty("OutputWorkspace");
+
+      // Now subtract
+      IAlgorithm_sptr alg = createChildAlgorithm("Minus");
+      alg->initialize();
+      alg->setProperty("LHSWorkspace", asymFirstPeriod);
+      alg->setProperty("RHSWorkspace", asymSecondPeriod);
       alg->execute();
       tempWS = alg->getProperty("OutputWorkspace");
     }
+  } else {
+    // Only one period was supplied
 
-    // Extract the requested spectrum
-    IAlgorithm_sptr alg = createChildAlgorithm("ExtractSingleSpectrum");
+    IAlgorithm_sptr alg = createChildAlgorithm("RemoveExpDecay");
     alg->initialize();
-    alg->setProperty("InputWorkspace", tempWS);
-    alg->setProperty("WorkspaceIndex", groupIndex);
+    alg->setProperty("InputWorkspace", firstPeriodWS);
     alg->execute();
-    MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
-    return outWS;
+    tempWS = alg->getProperty("OutputWorkspace");
+  }
+
+  // Extract the requested spectrum
+  IAlgorithm_sptr alg = createChildAlgorithm("ExtractSingleSpectrum");
+  alg->initialize();
+  alg->setProperty("InputWorkspace", tempWS);
+  alg->setProperty("WorkspaceIndex", groupIndex);
+  alg->execute();
+  MatrixWorkspace_sptr outWS = alg->getProperty("OutputWorkspace");
+  return outWS;
 }
 
 /**
@@ -319,55 +320,55 @@ MatrixWorkspace_sptr MuonCalculateAsymmetry::calculatePairAsymmetry(
 
     if (op == "+") {
 
-        // Sum
-        IAlgorithm_sptr alg = createChildAlgorithm("Plus");
-        alg->initialize();
-        alg->setProperty("LHSWorkspace", firstPeriodWS);
-        alg->setProperty("RHSWorkspace", secondPeriodWS);
-        alg->execute();
-        MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
+      // Sum
+      IAlgorithm_sptr alg = createChildAlgorithm("Plus");
+      alg->initialize();
+      alg->setProperty("LHSWorkspace", firstPeriodWS);
+      alg->setProperty("RHSWorkspace", secondPeriodWS);
+      alg->execute();
+      MatrixWorkspace_sptr sumWS = alg->getProperty("OutputWorkspace");
 
-        // Asymmetry calculation
-        alg = createChildAlgorithm("AsymmetryCalc");
-        alg->setProperty("InputWorkspace", sumWS);
-        alg->setProperty("ForwardSpectra", fwd);
-        alg->setProperty("BackwardSpectra", bwd);
-        alg->setProperty("Alpha", alpha);
-        alg->execute();
-        outWS = alg->getProperty("OutputWorkspace");
+      // Asymmetry calculation
+      alg = createChildAlgorithm("AsymmetryCalc");
+      alg->setProperty("InputWorkspace", sumWS);
+      alg->setProperty("ForwardSpectra", fwd);
+      alg->setProperty("BackwardSpectra", bwd);
+      alg->setProperty("Alpha", alpha);
+      alg->execute();
+      outWS = alg->getProperty("OutputWorkspace");
 
     } else if (op == "-") {
 
-        std::vector<int> fwd(1, firstPairIndex + 1);
-        std::vector<int> bwd(1, secondPairIndex + 1);
+      std::vector<int> fwd(1, firstPairIndex + 1);
+      std::vector<int> bwd(1, secondPairIndex + 1);
 
-        // First period asymmetry
-        IAlgorithm_sptr alg = createChildAlgorithm("AsymmetryCalc");
-        alg->setProperty("InputWorkspace", firstPeriodWS);
-        alg->setProperty("ForwardSpectra", fwd);
-        alg->setProperty("BackwardSpectra", bwd);
-        alg->setProperty("Alpha", alpha);
-        alg->execute();
-        MatrixWorkspace_sptr asymFirstPeriod =
-            alg->getProperty("OutputWorkspace");
+      // First period asymmetry
+      IAlgorithm_sptr alg = createChildAlgorithm("AsymmetryCalc");
+      alg->setProperty("InputWorkspace", firstPeriodWS);
+      alg->setProperty("ForwardSpectra", fwd);
+      alg->setProperty("BackwardSpectra", bwd);
+      alg->setProperty("Alpha", alpha);
+      alg->execute();
+      MatrixWorkspace_sptr asymFirstPeriod =
+          alg->getProperty("OutputWorkspace");
 
-        // Second period asymmetry
-        alg = createChildAlgorithm("AsymmetryCalc");
-        alg->setProperty("InputWorkspace", secondPeriodWS);
-        alg->setProperty("ForwardSpectra", fwd);
-        alg->setProperty("BackwardSpectra", bwd);
-        alg->setProperty("Alpha", alpha);
-        alg->execute();
-        MatrixWorkspace_sptr asymSecondPeriod =
-            alg->getProperty("OutputWorkspace");
+      // Second period asymmetry
+      alg = createChildAlgorithm("AsymmetryCalc");
+      alg->setProperty("InputWorkspace", secondPeriodWS);
+      alg->setProperty("ForwardSpectra", fwd);
+      alg->setProperty("BackwardSpectra", bwd);
+      alg->setProperty("Alpha", alpha);
+      alg->execute();
+      MatrixWorkspace_sptr asymSecondPeriod =
+          alg->getProperty("OutputWorkspace");
 
-        // Now subtract
-        alg = createChildAlgorithm("Minus");
-        alg->initialize();
-        alg->setProperty("LHSWorkspace", asymFirstPeriod);
-        alg->setProperty("RHSWorkspace", asymSecondPeriod);
-        alg->execute();
-        outWS = alg->getProperty("OutputWorkspace");
+      // Now subtract
+      alg = createChildAlgorithm("Minus");
+      alg->initialize();
+      alg->setProperty("LHSWorkspace", asymFirstPeriod);
+      alg->setProperty("RHSWorkspace", asymSecondPeriod);
+      alg->execute();
+      outWS = alg->getProperty("OutputWorkspace");
     }
 
     return outWS;

--- a/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonCalculateAsymmetry.cpp
@@ -302,7 +302,8 @@ MatrixWorkspace_sptr MuonCalculateAsymmetry::calculateGroupAsymmetry(
 * Calculates pair asymmetry according to period operation
 * @param firstPeriodWS :: [input] First period workspace
 * @param secondPeriodWS :: [input] Second period workspace
-* @param groupIndex :: [input] Workspace index for which to calculate asymmetry
+* @param firstPairIndex :: [input] Workspace index for the forward group
+* @param secondPairIndex :: [input] Workspace index for the backward group
 * @param op :: [input] Period operation (+ or -)
 */
 MatrixWorkspace_sptr MuonCalculateAsymmetry::calculatePairAsymmetry(

--- a/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
@@ -346,7 +346,7 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
-    void test_pairAsymmetry_twoPeriods_minus() {
+  void test_pairAsymmetry_twoPeriods_minus() {
     // Name of the output workspace.
     const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
 

--- a/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
@@ -318,6 +318,7 @@ public:
     alg.setProperty("FirstPeriodWorkspace", inWS);
     alg.setProperty("SecondPeriodWorkspace", inWSSecond);
     alg.setProperty("OutputType", "PairAsymmetry");
+    alg.setProperty("PeriodOperation", "-");
     alg.setProperty("PairFirstIndex", 2);
     alg.setProperty("PairSecondIndex", 0);
     alg.setPropertyValue("OutputWorkspace", outWSName);
@@ -333,9 +334,9 @@ public:
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(ws->blocksize(), 3);
 
-      TS_ASSERT_DELTA(ws->readY(0)[0], 1.1785, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[1], 0.9750, 0.0001);
-      TS_ASSERT_DELTA(ws->readY(0)[2], 0.8333, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[0], -0.3214, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], -0.2250, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], -0.1666, 0.0001);
 
       TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
       TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);

--- a/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
@@ -171,7 +171,7 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
-  void test_groupAsymmetry() {
+  void test_groupAsymmetry_singlePeriod() {
     // Name of the output workspace.
     const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
 
@@ -213,7 +213,56 @@ public:
     AnalysisDataService::Instance().remove(outWSName);
   }
 
-  void test_pairAsymmetry() {
+  void test_groupAsymmetry_twoPeriods_minus() {
+    // Name of the output workspace.
+    const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
+
+    MatrixWorkspace_sptr inWS = createWorkspace(3);
+    MatrixWorkspace_sptr inWSSecond = createWorkspace();
+
+    MuonCalculateAsymmetry alg;
+    alg.initialize();
+    alg.setProperty("FirstPeriodWorkspace", inWS);
+    alg.setProperty("SecondPeriodWorkspace", inWSSecond);
+    alg.setProperty("PeriodOperation", "-");
+    alg.setProperty("OutputType", "GroupAsymmetry");
+    alg.setProperty("GroupIndex", 2);
+    alg.setPropertyValue("OutputWorkspace", outWSName);
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    auto ws =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWSName);
+    TS_ASSERT(ws);
+
+    if (ws) {
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
+      TS_ASSERT_EQUALS(ws->blocksize(), 3);
+
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
+
+      TS_ASSERT_DELTA(ws->readY(0)[0], 0.0030, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], -0.0455, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], -0.1511, 0.0001);
+
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.1066, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1885, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.3295, 0.0001);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_groupAsymmetry_twoPeriods_plus() {
+
+    // TODO: write test once plus operation is fixed
+  }
+
+  void test_pairAsymmetry_singlePeriod() {
     // Name of the output workspace.
     const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
 
@@ -255,6 +304,55 @@ public:
 
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(outWSName);
+  }
+
+    void test_pairAsymmetry_twoPeriods_minus() {
+    // Name of the output workspace.
+    const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
+
+    MatrixWorkspace_sptr inWS = createWorkspace(3);
+    MatrixWorkspace_sptr inWSSecond = createWorkspace();
+
+    MuonCalculateAsymmetry alg;
+    alg.initialize();
+    alg.setProperty("FirstPeriodWorkspace", inWS);
+    alg.setProperty("SecondPeriodWorkspace", inWSSecond);
+    alg.setProperty("OutputType", "PairAsymmetry");
+    alg.setProperty("PairFirstIndex", 2);
+    alg.setProperty("PairSecondIndex", 0);
+    alg.setPropertyValue("OutputWorkspace", outWSName);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    auto ws =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWSName);
+    TS_ASSERT(ws);
+
+    if (ws) {
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
+      TS_ASSERT_EQUALS(ws->blocksize(), 3);
+
+      TS_ASSERT_DELTA(ws->readY(0)[0], 1.1785, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], 0.9750, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], 0.8333, 0.0001);
+
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
+
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.5290, 0.001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.4552, 0.001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.4073, 0.001);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
+  }
+
+  void test_pairAsymmetry_twoPeriods_plus() {
+
+    // TODO: write unit test for "+" operation once it is fixed
   }
 
 private:

--- a/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
@@ -259,7 +259,47 @@ public:
 
   void test_groupAsymmetry_twoPeriods_plus() {
 
-    // TODO: write test once plus operation is fixed
+    // Name of the output workspace.
+    const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
+
+    MatrixWorkspace_sptr inWS = createWorkspace(3);
+    MatrixWorkspace_sptr inWSSecond = createWorkspace();
+
+    MuonCalculateAsymmetry alg;
+    alg.initialize();
+    alg.setProperty("FirstPeriodWorkspace", inWS);
+    alg.setProperty("SecondPeriodWorkspace", inWSSecond);
+    alg.setProperty("PeriodOperation", "+");
+    alg.setProperty("OutputType", "GroupAsymmetry");
+    alg.setProperty("GroupIndex", 1);
+    alg.setPropertyValue("OutputWorkspace", outWSName);
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    auto ws =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWSName);
+    TS_ASSERT(ws);
+
+    if (ws) {
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
+      TS_ASSERT_EQUALS(ws->blocksize(), 3);
+
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2);
+      TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
+
+      TS_ASSERT_DELTA(ws->readY(0)[0], -0.2529, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], 0.3918, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], 1.5316, 0.0001);
+
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.0547, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.1010, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.1825, 0.0001);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
   }
 
   void test_pairAsymmetry_singlePeriod() {
@@ -354,7 +394,48 @@ public:
 
   void test_pairAsymmetry_twoPeriods_plus() {
 
-    // TODO: write unit test for "+" operation once it is fixed
+    // Name of the output workspace.
+    const std::string outWSName = outputWorkspaceName("GroupAsymmetry");
+
+    MatrixWorkspace_sptr inWS = createWorkspace(3);
+    MatrixWorkspace_sptr inWSSecond = createWorkspace();
+
+    MuonCalculateAsymmetry alg;
+    alg.initialize();
+    alg.setProperty("FirstPeriodWorkspace", inWS);
+    alg.setProperty("SecondPeriodWorkspace", inWSSecond);
+    alg.setProperty("PeriodOperation", "+");
+    alg.setProperty("OutputType", "PairAsymmetry");
+    alg.setProperty("PairFirstIndex", 0);
+    alg.setProperty("PairSecondIndex", 2);
+    alg.setPropertyValue("OutputWorkspace", outWSName);
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service.
+    auto ws =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outWSName);
+    TS_ASSERT(ws);
+
+    if (ws) {
+      TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
+      TS_ASSERT_EQUALS(ws->blocksize(), 3);
+
+      TS_ASSERT_EQUALS(ws->readX(0)[0], 1.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[1], 2.5);
+      TS_ASSERT_EQUALS(ws->readX(0)[2], 3);
+
+      TS_ASSERT_DELTA(ws->readY(0)[0], -0.5454, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[1], -0.4615, 0.0001);
+      TS_ASSERT_DELTA(ws->readY(0)[2], -0.4000, 0.0001);
+
+      TS_ASSERT_DELTA(ws->readE(0)[0], 0.2428, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[1], 0.2159, 0.0001);
+      TS_ASSERT_DELTA(ws->readE(0)[2], 0.1966, 0.0001);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(outWSName);
   }
 
 private:

--- a/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
+++ b/Framework/WorkflowAlgorithms/test/MuonCalculateAsymmetryTest.h
@@ -317,6 +317,7 @@ public:
     alg.initialize();
     alg.setProperty("FirstPeriodWorkspace", inWS);
     alg.setProperty("SecondPeriodWorkspace", inWSSecond);
+    alg.setProperty("PeriodOperation", "-");
     alg.setProperty("OutputType", "PairAsymmetry");
     alg.setProperty("PeriodOperation", "-");
     alg.setProperty("PairFirstIndex", 2);

--- a/Testing/SystemTests/tests/analysis/reference/MuonLoad_MUSR00015192.nxs.md5
+++ b/Testing/SystemTests/tests/analysis/reference/MuonLoad_MUSR00015192.nxs.md5
@@ -1,1 +1,1 @@
-f9f8aee9e15f495f43a9846da7adad3e
+75b425bdf72f1d82bb78e0c71a7fe2ca

--- a/docs/source/algorithms/MuonCalculateAsymmetry-v1.rst
+++ b/docs/source/algorithms/MuonCalculateAsymmetry-v1.rst
@@ -57,7 +57,7 @@ Output:
 .. testcode:: ExGroupAsymmetryMultiperiod
 
    y1 = [100,50,10]
-   y2 = [ 50,25, 5]
+   y2 = [150,20,1]
    x = [1,2,3]
 
    input1 = CreateWorkspace(x, y1)
@@ -75,7 +75,7 @@ Output:
 
 .. testoutput:: ExGroupAsymmetryMultiperiod
 
-   Output: [ 0.1524242  -0.0916425  -0.71360777]
+   Output: [-0.28634067  0.60594273  0.26255546]
 
 .. categories::
 


### PR DESCRIPTION
Fixes #13952 

MuonCalculateAsymmetry is used in the MuonAnalysis interface. It is a workflow algorithm that can take two input workspaces and combine them to calculate the asymmetry. There are two possible operations on the input workspaces: period addition (+) and period subtraction (-). In the first case, the input workspaces must be summed first and then the asymmetry must be calculated. In the latter case, the asymmetry must be calculated first and then the workspaces must be subtracted.

Before #13102, the period addition (+) was not working as expected, as the asymmetry was calculated before adding the counts. When fixing this, I broke the period subtraction (-), as I was not aware that the two operations are not equivalent. This PR is to fix the "-" operation I broke in #13102.

**For tester**:

There are two things to test here: period addition and period subtraction.
- Period subtraction: I've restored the previous reference file used in MuonLoad system test. Everything is OK if this test passes.
- Period addition: 
  - Open Interfaces > Muon > Muon Analysis. Load "HIFI00084447.nxs" (can be found here \HIFI\Data).
  - A graph will appear, make sure this corresponds to period 1 and that "None" is selected as the second period. Plot type should be "Asymmetry" and "Dead Time Correction" (section "Instrument") should be set to "From Data File". Go to "Data Analysis" and add FlatBackground + ExpDecayMuon. Fit the data (fitting range [0.11, 12.67])and write down the fitting results (A0, A and Lambda values).
  - Go back to "Home" tab and select period 3 (again "None" should be the second period). Repeat the fit and write down the fitting results.
- Now go back to "Home" tab and select period 3 + 1. Go to "Data Analysis" and fit the data. The fit parameters should all be the average of those found in the individual period fits.

As an example, my fitting results are:

> Period 1:              A=0.109808(0.016461)    Lambda=0.078193(0.015791)       A0=0.052417(0.016830)
> Period 3:              A=0.128165(0.022629)    Lambda= 0.065989(0.015012)     A0= 0.033689(0.023000)
> Period 1+3:         A= 0.117273(0.013306)  Lambda= 0.072781(0.010908)     A0= 0.044780(0.013567)

you should get similar results.

**Release notes**: http://www.mantidproject.org/index.php?title=Release_Notes_3_6_MuonAnalysis&diff=25401&oldid=25396
