### PR TITLE
ConvFit Plot is correct for current spectra in mini plot

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -77,6 +77,9 @@ private:
   QStringList m_fitStrings;
   QString m_previousFit;
   QString m_baseName;
+  int m_runMin;
+  int m_runMax;
+
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -35,6 +35,8 @@ ConvFit::ConvFit(QWidget *parent)
 void ConvFit::setup() {
   // Create Property Managers
   m_stringManager = new QtStringPropertyManager();
+  m_runMin = 0;
+  m_runMax = 0;
 
   // Initialise fitTypeStrings
   m_fitStrings = QStringList() << ""
@@ -237,6 +239,8 @@ void ConvFit::run() {
   std::string function = std::string(func->asString());
   std::string stX = m_properties["StartX"]->valueText().toStdString();
   std::string enX = m_properties["EndX"]->valueText().toStdString();
+  m_runMin = m_uiForm.spSpectraMin->value();
+  m_runMax = m_uiForm.spSpectraMax->value();
   std::string specMin = m_uiForm.spSpectraMin->text().toStdString();
   std::string specMax = m_uiForm.spSpectraMax->text().toStdString();
   int maxIterations =
@@ -984,22 +988,23 @@ void ConvFit::updatePlot() {
   }
 
   // If there is a result plot then plot it
-  std::string groupName =  m_baseName.toStdString() + "_Workspaces";
+  std::string groupName = m_baseName.toStdString() + "_Workspaces";
   if (AnalysisDataService::Instance().doesExist(groupName)) {
     WorkspaceGroup_sptr outputGroup =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            groupName);
-    if (specNo >= static_cast<int>(outputGroup->size()))
+        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
+    if (specNo - m_runMin >= static_cast<int>(outputGroup->size()))
       return;
-    MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
-        outputGroup->getItem(specNo));
-    if (ws) {
-      m_uiForm.ppPlot->addSpectrum("Fit", ws, 1, Qt::red);
-      m_uiForm.ppPlot->addSpectrum("Diff", ws, 2, Qt::blue);
-	  if(m_uiForm.ckPlotGuess->isChecked()){
-		  m_uiForm.ppPlot->removeSpectrum("Guess");
-		  m_uiForm.ckPlotGuess->setChecked(false);
-	  }
+    if ((specNo - m_runMin) >= 0) {
+      MatrixWorkspace_sptr ws = boost::dynamic_pointer_cast<MatrixWorkspace>(
+		  outputGroup->getItem(specNo- m_runMin));
+      if (ws) {
+        m_uiForm.ppPlot->addSpectrum("Fit", ws, 1, Qt::red);
+        m_uiForm.ppPlot->addSpectrum("Diff", ws, 2, Qt::blue);
+        if (m_uiForm.ckPlotGuess->isChecked()) {
+          m_uiForm.ppPlot->removeSpectrum("Guess");
+          m_uiForm.ckPlotGuess->setChecked(false);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #13977

The spectra number for plotting in the mini plot in ConvFit should now correctly map to the actual workspace in the group. Previously this only appeared to work as normally the run was for the full spectra.
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Load in:
  - `irs26176_graphite002_red.nxs` for the sample
  - `irs26173_graphite002_res.nxs` for the resolution
    - Available from the external data folder
  - **Please avoid using files with additional extension in the filename e.g. `_diffspec` These files will not run in ConvFit validation for this will most likely be implemented for 3.6**
- Change the Spectra Range to not be the full range e.g min > 0, max < 50
- Run ConvFit
- Ensure the mini plot only shows data for those spectra in the fit range
- Ensure that the plots look correct for each spectra 
