### PR TITLE
Fix unitialized variables issue with HKLGenerator::const_iterator

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/HKLGenerator.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/HKLGenerator.h
@@ -113,8 +113,7 @@ public:
       : public boost::iterator_facade<const_iterator, const Kernel::V3D &,
                                       boost::forward_traversal_tag> {
   public:
-    /// Default constructor, requirement from boost::iterator_facade
-    const_iterator() {}
+    const_iterator();
 
     explicit const_iterator(const Kernel::V3D &current);
 

--- a/Framework/Geometry/src/Crystal/HKLGenerator.cpp
+++ b/Framework/Geometry/src/Crystal/HKLGenerator.cpp
@@ -61,7 +61,7 @@ V3D HKLGenerator::getEndHKL() const {
 
 /// Default constructor, requirement from boost::iterator_facade
 HKLGenerator::const_iterator::const_iterator()
-    : m_h(0), m_k(0), m_l(0), m_hkl(0), m_hMin(0), m_hMax(0), m_kMin(0),
+    : m_h(0), m_k(0), m_l(0), m_hkl(V3D(0, 0, 0)), m_hMin(0), m_hMax(0), m_kMin(0),
       m_kMax(0), m_lMin(0), m_lMax(0) {}
 
 /// Return an iterator with min = max = current.

--- a/Framework/Geometry/src/Crystal/HKLGenerator.cpp
+++ b/Framework/Geometry/src/Crystal/HKLGenerator.cpp
@@ -61,8 +61,8 @@ V3D HKLGenerator::getEndHKL() const {
 
 /// Default constructor, requirement from boost::iterator_facade
 HKLGenerator::const_iterator::const_iterator()
-    : m_h(0), m_k(0), m_l(0), m_hkl(V3D(0, 0, 0)), m_hMin(0), m_hMax(0), m_kMin(0),
-      m_kMax(0), m_lMin(0), m_lMax(0) {}
+    : m_h(0), m_k(0), m_l(0), m_hkl(V3D(0, 0, 0)), m_hMin(0), m_hMax(0),
+      m_kMin(0), m_kMax(0), m_lMin(0), m_lMax(0) {}
 
 /// Return an iterator with min = max = current.
 HKLGenerator::const_iterator::const_iterator(const V3D &current)

--- a/Framework/Geometry/src/Crystal/HKLGenerator.cpp
+++ b/Framework/Geometry/src/Crystal/HKLGenerator.cpp
@@ -59,6 +59,11 @@ V3D HKLGenerator::getEndHKL() const {
   return V3D(m_hklMax.X() + 1, m_hklMin.Y(), m_hklMin.Z());
 }
 
+/// Default constructor, requirement from boost::iterator_facade
+HKLGenerator::const_iterator::const_iterator()
+    : m_h(0), m_k(0), m_l(0), m_hkl(0), m_hMin(0), m_hMax(0), m_kMin(0),
+      m_kMax(0), m_lMin(0), m_lMax(0) {}
+
 /// Return an iterator with min = max = current.
 HKLGenerator::const_iterator::const_iterator(const V3D &current)
     : m_h(static_cast<int>(current.X())), m_k(static_cast<int>(current.Y())),


### PR DESCRIPTION
This fixes #14023.

The default constructor of HKLGenerator::const_iterator did not initialize the member variables properly, which was exposed in the unit test. This should fix it.

**Testing information**
Code review should be enough. I ran the test in valgrind before and after the change to make sure the problem is really gone, if you like you can do the same.
