### PR TITLE
13957 remove q settings dependence from refl main view presenter

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QtReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/QtReflMainView.h
@@ -64,6 +64,10 @@ namespace MantidQt
       virtual void showAlgorithmDialog(const std::string& algorithm);
       virtual std::string requestNotebookPath();
 
+      //Settings
+      virtual void saveSettings(const std::map<std::string,QVariant>& options);
+      virtual void loadSettings(std::map<std::string,QVariant>& options);
+
       //Plotting
       virtual void plotWorkspaces(const std::set<std::string>& workspaces);
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/ReflMainView.h
@@ -59,6 +59,10 @@ namespace MantidQt
       virtual void showAlgorithmDialog(const std::string& algorithm) = 0;
       virtual std::string requestNotebookPath() = 0;
 
+      //Settings
+      virtual void saveSettings(const std::map<std::string,QVariant>& options) = 0;
+      virtual void loadSettings(std::map<std::string,QVariant>& options) = 0;
+
       //Plotting
       virtual void plotWorkspaces(const std::set<std::string>& workspaces) = 0;
 

--- a/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
@@ -453,8 +453,9 @@ namespace MantidQt
 
     /**
      Save settings
+     @param options : map of user options to save
      */
-    void saveSettings(const std::map<std::string,QVariant>& options)
+    void QtReflMainView::saveSettings(const std::map<std::string,QVariant>& options)
     {
       QSettings settings;
       settings.beginGroup(ReflSettingsGroup);
@@ -463,10 +464,11 @@ namespace MantidQt
       settings.endGroup();
     }
 
-    /*
+    /**
      Load settings
+     @param options : map of user options to load into
      */
-    void loadSettings(std::map<std::string,QVariant>& options)
+    void QtReflMainView::loadSettings(std::map<std::string,QVariant>& options)
     {
       QSettings settings;
       settings.beginGroup(ReflSettingsGroup);

--- a/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/QtReflMainView.cpp
@@ -8,6 +8,12 @@
 #include <qinputdialog.h>
 #include <qmessagebox.h>
 
+
+namespace
+{
+  const QString ReflSettingsGroup = "Mantid/CustomInterfaces/ISISReflectometry";
+}
+
 namespace MantidQt
 {
   namespace CustomInterfaces
@@ -443,6 +449,31 @@ namespace MantidQt
                                                        "IPython Notebook files (*.ipynb);;All files (*.*)",
                                                        new QString("IPython Notebook files (*.ipynb)"));
       return qfilename.toStdString();
+    }
+
+    /**
+     Save settings
+     */
+    void saveSettings(const std::map<std::string,QVariant>& options)
+    {
+      QSettings settings;
+      settings.beginGroup(ReflSettingsGroup);
+      for(auto it = options.begin(); it != options.end(); ++it)
+        settings.setValue(QString::fromStdString(it->first), it->second);
+      settings.endGroup();
+    }
+
+    /*
+     Load settings
+     */
+    void loadSettings(std::map<std::string,QVariant>& options)
+    {
+      QSettings settings;
+      settings.beginGroup(ReflSettingsGroup);
+      QStringList keys = settings.childKeys();
+      for(auto it = keys.begin(); it != keys.end(); ++it)
+        options[it->toStdString()] = settings.value(*it);
+      settings.endGroup();
     }
 
     /**

--- a/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -24,8 +24,6 @@
 #include <fstream>
 #include <sstream>
 
-#include <QSettings>
-
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -35,7 +33,6 @@ using namespace MantidQt::MantidWidgets;
 
 namespace
 {
-  const QString ReflSettingsGroup = "Mantid/CustomInterfaces/ISISReflectometry";
 
   void validateModel(ITableWorkspace_sptr model)
   {
@@ -1510,11 +1507,7 @@ namespace MantidQt
         m_options[it->first] = it->second;
 
       //Save any changes to disk
-      QSettings settings;
-      settings.beginGroup(ReflSettingsGroup);
-      for(auto it = m_options.begin(); it != m_options.end(); ++it)
-        settings.setValue(QString::fromStdString(it->first), it->second);
-      settings.endGroup();
+      m_view->saveSettings(m_options);
     }
 
     /** Load options from disk if possible, or set to defaults */
@@ -1536,12 +1529,7 @@ namespace MantidQt
       m_options["RoundDQQPrecision"] = 3;
 
       //Load saved values from disk
-      QSettings settings;
-      settings.beginGroup(ReflSettingsGroup);
-      QStringList keys = settings.childKeys();
-      for(auto it = keys.begin(); it != keys.end(); ++it)
-        m_options[it->toStdString()] = settings.value(*it);
-      settings.endGroup();
+      m_view->loadSettings(m_options);
     }
   }
 }

--- a/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/ReflMainViewPresenter.cpp
@@ -25,7 +25,6 @@
 #include <sstream>
 
 #include <QSettings>
-#include <QFileDialog>
 
 
 using namespace Mantid::API;

--- a/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -57,6 +57,8 @@ public:
   virtual void setProgress(int) {};
   virtual void setTableList(const std::set<std::string>&) {};
   virtual void setInstrumentList(const std::vector<std::string>&, const std::string&) {};
+  virtual void saveSettings(const std::map<std::string,QVariant>&) {};
+  virtual void loadSettings(std::map<std::string,QVariant>&) {};
   virtual std::string getProcessInstrument() const {return "FAKE";}
   virtual boost::shared_ptr<IReflPresenter> getPresenter() const {return boost::shared_ptr<IReflPresenter>();}
 };


### PR DESCRIPTION
Fixes #13957 

Dependence of the reflectometry interface presenter on QSettings has been removed in order not to have hard coupling between the user interface and the controlling/presenter code.

Tester:
I suggest opening the interface (Interfaces->Reflectometry->ISIS Reflectometry (Polref)), changing the settings (Reflectometry->Options...). Then restart MantidPlot and ensure that the settings are as you left them.
