### PR TITLE
Fix path issue in the pylint report

### DIFF
--- a/tools/Pylint/run_pylint.py
+++ b/tools/Pylint/run_pylint.py
@@ -292,7 +292,7 @@ def run_checks(targets, serializer, options):
         targetpath = os.path.join(options.basedir, target)
         pkg_init = os.path.join(targetpath, "__init__.py")
         if os.path.isfile(targetpath) or os.path.isfile(pkg_init):
-            overall_stats.add(target, exec_pylint_on_importable(targetpath, serializer, options))
+            overall_stats.add(targetpath, exec_pylint_on_importable(targetpath, serializer, options))
         else:
             overall_stats.update(exec_pylint_on_all(targetpath, serializer, options, excludes))
     ##


### PR DESCRIPTION
**To test:** If Andrei is happy, then it is fixed. For other people, look in `workspace/build/pylint.log` and see that there isn't a path `docs/sphinxext/mantiddoc` rather than pointing at the actual python scripts.

This does not need to be in the release notes.
