### PR TITLE
Coverity issues - OPJ

### DIFF
--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -29,12 +29,13 @@
 
 // Disable various warnings as this is not our code
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
-#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#define GCC_VERSION                                                            \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #pragma GCC diagnostic ignored "-Wreorder"
 #pragma GCC diagnostic ignored "-Wformat"
 // This option seems to have disappeared in 4.4.4, but came back in 4.5.x?!?!?
 #if GCC_VERSION < 40404 || GCC_VERSION > 40500
-  #pragma GCC diagnostic ignored "-Wunused-result"
+#pragma GCC diagnostic ignored "-Wunused-result"
 #endif
 #pragma GCC diagnostic ignored "-Wunused"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -43,11 +44,11 @@
 #endif
 
 #ifdef _WIN32
-  #pragma warning( disable: 4800 )
+#pragma warning(disable : 4800)
 #endif
 
 #ifdef __INTEL_COMPILER
-  #pragma warning disable 181
+#pragma warning disable 181
 #endif
 
 #include <stdio.h>
@@ -61,135 +62,134 @@
 using std::vector;
 using std::string;
 
-const char* colTypeNames[] = {"X", "Y", "Z", "XErr", "YErr", "Label", "None"};
+const char *colTypeNames[] = {"X", "Y", "Z", "XErr", "YErr", "Label", "None"};
 #define MAX_LEVEL 20
-#define ERROR_MSG "Please send the OPJ file and the opjfile.log to the author of liborigin!\n"
+#define ERROR_MSG                                                              \
+  "Please send the OPJ file and the opjfile.log to the author of liborigin!\n"
 
-#define SwapBytes(x) ByteSwap((unsigned char *) &x,sizeof(x))
+#define SwapBytes(x) ByteSwap((unsigned char *)&x, sizeof(x))
 
-int strcmp_i(const char *s1, const char *s2) { //compare two strings ignoring case
+int strcmp_i(const char *s1,
+             const char *s2) { // compare two strings ignoring case
 #ifdef _WINDOWS
-  return _stricmp(s1,s2);
+  return _stricmp(s1, s2);
 #else
-  return strcasecmp(s1,s2);
+  return strcasecmp(s1, s2);
 #endif
 }
 
 // for standard calls like 'int retval = fseek(f, 0x7, SEEK_SET);'
-#define CHECKED_FSEEK(debug, fd, offset, whence)                                                \
-  {                                                                                             \
-    int retval = fseek(fd, offset, whence);                                                     \
-    if (retval < 0) {                                                                           \
-      char *posStr = NULL;                                                                      \
-      if (SEEK_SET == whence)                                                                   \
-        posStr = "beginning of the file";                                                       \
-      else if (SEEK_CUR == whence)                                                              \
-        posStr = "current position of the file";                                                \
-      else if (SEEK_END == whence)                                                              \
-        posStr = "end of the file";                                                             \
-                                                                                                \
-      fprintf(debug, " WARNING : could not move to position %d from the %s\n", offset, posStr); \
-   }                                                                                            \
- }
-
-// for standard calls like 'int retval = fread(&objectcount, 4, 1, f);'
-#define CHECKED_FREAD(debug, ptr, size, nmemb, stream)                                         \
-  {                                                                                            \
-    int retval = fread(ptr, size, nmemb, stream);                                              \
-    if (size*nmemb != retval) {                                                                \
-      fprintf(debug, " WARNING : could not read %d bytes from file, read: %d bytes\n",         \
-              size*nmemb);                                                                     \
-    }                                                                                          \
+#define CHECKED_FSEEK(debug, fd, offset, whence)                               \
+  {                                                                            \
+    int retval = fseek(fd, offset, whence);                                    \
+    if (retval < 0) {                                                          \
+      char *posStr = NULL;                                                     \
+      if (SEEK_SET == whence)                                                  \
+        posStr = "beginning of the file";                                      \
+      else if (SEEK_CUR == whence)                                             \
+        posStr = "current position of the file";                               \
+      else if (SEEK_END == whence)                                             \
+        posStr = "end of the file";                                            \
+                                                                               \
+      fprintf(debug, " WARNING : could not move to position %d from the %s\n", \
+              offset, posStr);                                                 \
+    }                                                                          \
   }
 
-void OPJFile::ByteSwap(unsigned char * b, int n) {
+// for standard calls like 'int retval = fread(&objectcount, 4, 1, f);'
+#define CHECKED_FREAD(debug, ptr, size, nmemb, stream)                         \
+  {                                                                            \
+    int retval = fread(ptr, size, nmemb, stream);                              \
+    if (size * nmemb != retval) {                                              \
+      fprintf(                                                                 \
+          debug,                                                               \
+          " WARNING : could not read %d bytes from file, read: %d bytes\n",    \
+          size *nmemb);                                                        \
+    }                                                                          \
+  }
+
+void OPJFile::ByteSwap(unsigned char *b, int n) {
   int i = 0;
-  int j = n-1;
-  while (i<j) {
+  int j = n - 1;
+  while (i < j) {
     std::swap(b[i], b[j]);
     i++, j--;
   }
 }
 
-OPJFile::OPJFile(const char *filename)
-  : filename(filename)
-{
-  version=0;
-  dataIndex=0;
-  objectIndex=0;
+OPJFile::OPJFile(const char *filename) : filename(filename) {
+  version = 0;
+  dataIndex = 0;
+  objectIndex = 0;
 }
 
 int OPJFile::compareSpreadnames(char *sname) const {
-  for(unsigned int i=0;i<SPREADSHEET.size();i++)
-    if (0==strcmp_i(SPREADSHEET[i].name.c_str(),sname))
+  for (unsigned int i = 0; i < SPREADSHEET.size(); i++)
+    if (0 == strcmp_i(SPREADSHEET[i].name.c_str(), sname))
       return i;
   return -1;
 }
 
 int OPJFile::compareExcelnames(char *sname) const {
-  for(unsigned int i=0;i<EXCEL.size();i++)
-    if (0==strcmp_i(EXCEL[i].name.c_str(),sname))
+  for (unsigned int i = 0; i < EXCEL.size(); i++)
+    if (0 == strcmp_i(EXCEL[i].name.c_str(), sname))
       return i;
   return -1;
 }
 
-
 int OPJFile::compareColumnnames(int spread, char *sname) const {
-  for(unsigned int i=0;i<SPREADSHEET[spread].column.size();i++)
+  for (unsigned int i = 0; i < SPREADSHEET[spread].column.size(); i++)
     if (SPREADSHEET[spread].column[i].name == sname)
       return i;
   return -1;
 }
-int OPJFile::compareExcelColumnnames(int iexcel, int isheet, char *sname) const {
-  for(unsigned int i=0;i<EXCEL[iexcel].sheet[isheet].column.size();i++)
+int OPJFile::compareExcelColumnnames(int iexcel, int isheet,
+                                     char *sname) const {
+  for (unsigned int i = 0; i < EXCEL[iexcel].sheet[isheet].column.size(); i++)
     if (EXCEL[iexcel].sheet[isheet].column[i].name == sname)
       return i;
   return -1;
 }
 
 int OPJFile::compareMatrixnames(char *sname) const {
-  for(unsigned int i=0;i<MATRIX.size();i++)
-    if (0==strcmp_i(MATRIX[i].name.c_str(),sname))
+  for (unsigned int i = 0; i < MATRIX.size(); i++)
+    if (0 == strcmp_i(MATRIX[i].name.c_str(), sname))
       return i;
   return -1;
 }
 
 int OPJFile::compareFunctionnames(const char *sname) const {
-  for(unsigned int i=0;i<FUNCTION.size();i++)
-    if (0==strcmp_i(FUNCTION[i].name.c_str(),sname))
+  for (unsigned int i = 0; i < FUNCTION.size(); i++)
+    if (0 == strcmp_i(FUNCTION[i].name.c_str(), sname))
       return i;
   return -1;
 }
 
 vector<string> OPJFile::findDataByIndex(int index) const {
   vector<string> str;
-  for(unsigned int spread=0;spread<SPREADSHEET.size();spread++)
-    for(unsigned int i=0;i<SPREADSHEET[spread].column.size();i++)
-      if (SPREADSHEET[spread].column[i].index == index)
-      {
+  for (unsigned int spread = 0; spread < SPREADSHEET.size(); spread++)
+    for (unsigned int i = 0; i < SPREADSHEET[spread].column.size(); i++)
+      if (SPREADSHEET[spread].column[i].index == index) {
         str.push_back(SPREADSHEET[spread].column[i].name);
         str.push_back("T_" + SPREADSHEET[spread].name);
         return str;
       }
-  for(unsigned int i=0;i<MATRIX.size();i++)
-    if (MATRIX[i].index == index)
-    {
+  for (unsigned int i = 0; i < MATRIX.size(); i++)
+    if (MATRIX[i].index == index) {
       str.push_back(MATRIX[i].name);
       str.push_back("M_" + MATRIX[i].name);
       return str;
     }
-  for(unsigned int i=0;i<EXCEL.size();i++)
-    for(unsigned int j=0;j<EXCEL[i].sheet.size();j++)
-      for(unsigned int k=0;k<EXCEL[i].sheet[j].column.size();k++)
-        if (EXCEL[i].sheet[j].column[k].index == index)
-        {
+  for (unsigned int i = 0; i < EXCEL.size(); i++)
+    for (unsigned int j = 0; j < EXCEL[i].sheet.size(); j++)
+      for (unsigned int k = 0; k < EXCEL[i].sheet[j].column.size(); k++)
+        if (EXCEL[i].sheet[j].column[k].index == index) {
           str.push_back(EXCEL[i].sheet[j].column[k].name);
           str.push_back("E_" + EXCEL[i].name);
           return str;
         }
-  for(unsigned int i=0;i<FUNCTION.size();i++)
-    if (FUNCTION[i].index == index)
-    {
+  for (unsigned int i = 0; i < FUNCTION.size(); i++)
+    if (FUNCTION[i].index == index) {
       str.push_back(FUNCTION[i].name);
       str.push_back("F_" + FUNCTION[i].name);
       return str;
@@ -198,62 +198,58 @@ vector<string> OPJFile::findDataByIndex(int index) const {
 }
 
 string OPJFile::findObjectByIndex(int index) {
-  for(unsigned int i=0;i<SPREADSHEET.size();i++)
-    if (SPREADSHEET[i].objectID == index)
-    {
+  for (unsigned int i = 0; i < SPREADSHEET.size(); i++)
+    if (SPREADSHEET[i].objectID == index) {
       return SPREADSHEET[i].name;
     }
 
-  for(unsigned int i=0;i<MATRIX.size();i++)
-    if (MATRIX[i].objectID == index)
-    {
+  for (unsigned int i = 0; i < MATRIX.size(); i++)
+    if (MATRIX[i].objectID == index) {
       return MATRIX[i].name;
     }
 
-  for(unsigned int i=0;i<EXCEL.size();i++)
-    if (EXCEL[i].objectID == index)
-    {
+  for (unsigned int i = 0; i < EXCEL.size(); i++)
+    if (EXCEL[i].objectID == index) {
       return EXCEL[i].name;
     }
 
-  for(unsigned int i=0;i<GRAPH.size();i++)
-    if (GRAPH[i].objectID == index)
-    {
+  for (unsigned int i = 0; i < GRAPH.size(); i++)
+    if (GRAPH[i].objectID == index) {
       return GRAPH[i].name;
     }
 
   return "";
 }
 
-void OPJFile::convertSpreadToExcel(int spread)
-{
-  //add new Excel sheet
-  EXCEL.push_back(excel(SPREADSHEET[spread].name, SPREADSHEET[spread].label, SPREADSHEET[spread].maxRows, SPREADSHEET[spread].bHidden, SPREADSHEET[spread].bLoose));
-  for (unsigned int i=0; i<SPREADSHEET[spread].column.size(); ++i)
-  {
-    string name=SPREADSHEET[spread].column[i].name;
-    int pos=static_cast<int>(name.find_last_of("@"));
-    string col=name;
-    unsigned int index=0;
-    if(pos!=-1)
-    {
-      col=name.substr(0, pos);
-      index=atoi(name.substr(pos+1).c_str())-1;
+void OPJFile::convertSpreadToExcel(int spread) {
+  // add new Excel sheet
+  EXCEL.push_back(excel(SPREADSHEET[spread].name, SPREADSHEET[spread].label,
+                        SPREADSHEET[spread].maxRows,
+                        SPREADSHEET[spread].bHidden,
+                        SPREADSHEET[spread].bLoose));
+  for (unsigned int i = 0; i < SPREADSHEET[spread].column.size(); ++i) {
+    string name = SPREADSHEET[spread].column[i].name;
+    int pos = static_cast<int>(name.find_last_of("@"));
+    string col = name;
+    unsigned int index = 0;
+    if (pos != -1) {
+      col = name.substr(0, pos);
+      index = atoi(name.substr(pos + 1).c_str()) - 1;
     }
 
-    if(EXCEL.back().sheet.size()<=index)
-      EXCEL.back().sheet.resize(index+1);
-    SPREADSHEET[spread].column[i].name=col;
+    if (EXCEL.back().sheet.size() <= index)
+      EXCEL.back().sheet.resize(index + 1);
+    SPREADSHEET[spread].column[i].name = col;
     EXCEL.back().sheet[index].column.push_back(SPREADSHEET[spread].column[i]);
   }
-  SPREADSHEET.erase(SPREADSHEET.begin()+spread);
+  SPREADSHEET.erase(SPREADSHEET.begin() + spread);
 }
 // set default name for columns starting from spreadsheet spread
 void OPJFile::setColName(int spread) {
-  for(unsigned int j=spread;j<SPREADSHEET.size();j++) {
-    SPREADSHEET[j].column[0].type=X;
-    for (unsigned int k=1;k<SPREADSHEET[j].column.size();k++)
-      SPREADSHEET[j].column[k].type=Y;
+  for (unsigned int j = spread; j < SPREADSHEET.size(); j++) {
+    SPREADSHEET[j].column[0].type = X;
+    for (unsigned int k = 1; k < SPREADSHEET[j].column.size(); k++)
+      SPREADSHEET[j].column[k].type = Y;
   }
 }
 
@@ -266,412 +262,443 @@ filepre +
 /* parse file "filename" completely and save values */
 int OPJFile::Parse() {
   FILE *f;
-  if((f=fopen(filename,"rb")) == NULL ) {
-    printf("Could not open %s!\n",filename);
+  if ((f = fopen(filename, "rb")) == NULL) {
+    printf("Could not open %s!\n", filename);
     return -1;
   }
 
   char vers[5];
-  vers[4]=0;
+  vers[4] = 0;
 
   // get version
-  int retval = fseek(f,0x7,SEEK_SET);
+  int retval = fseek(f, 0x7, SEEK_SET);
   if (retval < 0) {
-    printf(" WARNING : could not move to position %d from the beginning of the file\n", 0x7);
+    printf(" WARNING : could not move to position %d from the beginning of the "
+           "file\n",
+           0x7);
     return -1;
   }
 
-  retval = fread(&vers,4,1,f);
+  retval = fread(&vers, 4, 1, f);
   if (4 != retval) {
-    printf(" WARNING : could not read four bytes with the version information, read: %d bytes\n", retval);
+    printf(" WARNING : could not read four bytes with the version information, "
+           "read: %d bytes\n",
+           retval);
     return -1;
   }
 
   fclose(f);
   version = atoi(vers);
 
-  if(version >= 2766 && version <= 2769)  // 7.5
+  if (version >= 2766 && version <= 2769) // 7.5
     return ParseFormatNew();
   else
     return ParseFormatOld();
 }
 
-
 int OPJFile::ParseFormatOld() {
   int i;
   FILE *f, *debug;
-  if((f=fopen(filename,"rb")) == NULL ) {
-    printf("Could not open %s!\n",filename);
+  if ((f = fopen(filename, "rb")) == NULL) {
+    printf("Could not open %s!\n", filename);
     return -1;
   }
 
-  if((debug=fopen("opjfile.log","w")) == NULL ) {
+  if ((debug = fopen("opjfile.log", "w")) == NULL) {
     printf("Could not open log file!\n");
-    fclose(f); //f is still open, so close it before returning
+    fclose(f); // f is still open, so close it before returning
     return -1;
   }
 
-  ////////////////////////////// check version from header ///////////////////////////////
+  ////////////////////////////// check version from header
+  //////////////////////////////////
   char vers[5];
-  vers[4]=0;
+  vers[4] = 0;
 
   // get version
   // fseek(f,0x7,SEEK_SET);
   CHECKED_FSEEK(debug, f, 0x7, SEEK_SET);
-  CHECKED_FREAD(debug, &vers,4,1,f);
+  CHECKED_FREAD(debug, &vers, 4, 1, f);
   version = atoi(vers);
-  fprintf(debug," [version = %d]\n",version);
+  fprintf(debug, " [version = %d]\n", version);
 
   // translate version
-  if(version >= 130 && version <= 140)    // 4.1
-    version=410;
-  else if(version == 210)   // 5.0
-    version=500;
-  else if(version == 2625)  // 6.0
-    version=600;
-  else if(version == 2627)  // 6.0 SR1
-    version=601;
-  else if(version == 2630 )   // 6.0 SR4
-    version=604;
-  else if(version == 2635 )   // 6.1
-    version=610;
-  else if(version == 2656)  // 7.0
-    version=700;
-  else if(version == 2672)  // 7.0 SR3
-    version=703;
+  if (version >= 130 && version <= 140) // 4.1
+    version = 410;
+  else if (version == 210) // 5.0
+    version = 500;
+  else if (version == 2625) // 6.0
+    version = 600;
+  else if (version == 2627) // 6.0 SR1
+    version = 601;
+  else if (version == 2630) // 6.0 SR4
+    version = 604;
+  else if (version == 2635) // 6.1
+    version = 610;
+  else if (version == 2656) // 7.0
+    version = 700;
+  else if (version == 2672) // 7.0 SR3
+    version = 703;
   else {
-    fprintf(debug,"Found unknown project version %d\n",version);
-    fprintf(debug,"Please contact the author of opj2dat\n");
+    fprintf(debug, "Found unknown project version %d\n", version);
+    fprintf(debug, "Please contact the author of opj2dat\n");
   }
-  fprintf(debug,"Found project version %.2f\n",version/100.0);
+  fprintf(debug, "Found project version %.2f\n", version / 100.0);
 
-  unsigned char c=0;  // tmp char
+  unsigned char c = 0; // tmp char
 
-  fprintf(debug,"HEADER :\n");
-  for(i=0;i<0x16;i++) { // skip header + 5 Bytes ("27")
-    CHECKED_FREAD(debug, &c,1,1,f);
-    fprintf(debug,"%.2X ",c);
-    if(!((i+1)%16)) fprintf(debug,"\n");
+  fprintf(debug, "HEADER :\n");
+  for (i = 0; i < 0x16; i++) { // skip header + 5 Bytes ("27")
+    CHECKED_FREAD(debug, &c, 1, 1, f);
+    fprintf(debug, "%.2X ", c);
+    if (!((i + 1) % 16))
+      fprintf(debug, "\n");
   }
-  fprintf(debug,"\n");
+  fprintf(debug, "\n");
 
-  do{
-    CHECKED_FREAD(debug, &c,1,1,f);
+  do {
+    CHECKED_FREAD(debug, &c, 1, 1, f);
   } while (c != '\n');
-  fprintf(debug," [file header @ 0x%X]\n", (unsigned int) ftell(f));
+  fprintf(debug, " [file header @ 0x%X]\n", (unsigned int)ftell(f));
 
-  /////////////////// find column ///////////////////////////////////////////////////////////
-  if(version>410)
-    for(i=0;i<5;i++)  // skip "0"
-      CHECKED_FREAD(debug, &c,1,1,f);
+  /////////////////// find column
+  //////////////////////////////////////////////////////////////
+  if (version > 410)
+    for (i = 0; i < 5; i++) // skip "0"
+      CHECKED_FREAD(debug, &c, 1, 1, f);
 
   int col_found;
-  CHECKED_FREAD(debug, &col_found,4,1,f);
-  if(IsBigEndian()) SwapBytes(col_found);
+  CHECKED_FREAD(debug, &col_found, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(col_found);
 
-  CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
-  fprintf(debug," [column found = %d/0x%X @ 0x%X]\n",col_found,col_found,(unsigned int) ftell(f));
+  CHECKED_FREAD(debug, &c, 1, 1, f); // skip '\n'
+  fprintf(debug, " [column found = %d/0x%X @ 0x%X]\n", col_found, col_found,
+          (unsigned int)ftell(f));
 
-  int current_col=1, nr=0, nbytes=0;
+  int current_col = 1, nr = 0, nbytes = 0;
   double a;
   char name[25], valuesize;
-  while(col_found > 0 && col_found < 0x84) {  // should be 0x72, 0x73 or 0x83
-    //////////////////////////////// COLUMN HEADER /////////////////////////////////////////////
-    fprintf(debug,"COLUMN HEADER :\n");
-    for(i=0;i < 0x3D;i++) { // skip 0x3C chars to value size
-      CHECKED_FREAD(debug, &c,1,1,f);
-      //if(i>21 && i<27) {
-      fprintf(debug,"%.2X ",c);
-      if(!((i+1)%16)) fprintf(debug,"\n");
+  while (col_found > 0 && col_found < 0x84) { // should be 0x72, 0x73 or 0x83
+    //////////////////////////////// COLUMN HEADER
+    ////////////////////////////////////////////////
+    fprintf(debug, "COLUMN HEADER :\n");
+    for (i = 0; i < 0x3D; i++) { // skip 0x3C chars to value size
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      // if(i>21 && i<27) {
+      fprintf(debug, "%.2X ", c);
+      if (!((i + 1) % 16))
+        fprintf(debug, "\n");
       //}
     }
-    fprintf(debug,"\n");
+    fprintf(debug, "\n");
 
-    CHECKED_FREAD(debug, &valuesize,1,1,f);
-    fprintf(debug," [valuesize = %d @ 0x%X]\n",valuesize,(unsigned int) ftell(f)-1);
-    if(valuesize <= 0) {
-      fprintf(debug," WARNING : found strange valuesize of %d\n",valuesize);
-      valuesize=10;
+    CHECKED_FREAD(debug, &valuesize, 1, 1, f);
+    fprintf(debug, " [valuesize = %d @ 0x%X]\n", valuesize,
+            (unsigned int)ftell(f) - 1);
+    if (valuesize <= 0) {
+      fprintf(debug, " WARNING : found strange valuesize of %d\n", valuesize);
+      valuesize = 10;
     }
 
-    fprintf(debug,"SKIP :\n");
-    for(i=0;i<0x1A;i++) { // skip to name
-      CHECKED_FREAD(debug, &c,1,1,f);
-      fprintf(debug,"%.2X ",c);
-      if(!((i+1)%16)) fprintf(debug,"\n");
+    fprintf(debug, "SKIP :\n");
+    for (i = 0; i < 0x1A; i++) { // skip to name
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      fprintf(debug, "%.2X ", c);
+      if (!((i + 1) % 16))
+        fprintf(debug, "\n");
     }
-    fprintf(debug,"\n");
+    fprintf(debug, "\n");
 
     // read name
-    fprintf(debug," [Spreadsheet @ 0x%X]\n",(unsigned int) ftell(f));
+    fprintf(debug, " [Spreadsheet @ 0x%X]\n", (unsigned int)ftell(f));
     fflush(debug);
-    CHECKED_FREAD(debug, &name,25,1,f);
-    //char* sname = new char[26];
+    CHECKED_FREAD(debug, &name, 25, 1, f);
+    // char* sname = new char[26];
     char sname[26];
-    sprintf(sname,"%s",strtok(name,"_")); // spreadsheet name
-    char* cname = strtok(NULL,"_"); // column name
-    while(char* tmpstr = strtok(NULL,"_")) {  // get multiple-"_" title correct
-      strcat(sname,"_");
-      strcat(sname,cname);
-      strcpy(cname,tmpstr);
+    sprintf(sname, "%s", strtok(name, "_"));   // spreadsheet name
+    char *cname = strtok(NULL, "_");           // column name
+    while (char *tmpstr = strtok(NULL, "_")) { // get multiple-"_" title correct
+      strcat(sname, "_");
+      strcat(sname, cname);
+      strcpy(cname, tmpstr);
     }
-    int spread=0;
-    if(SPREADSHEET.size() == 0 || compareSpreadnames(sname) == -1) {
-      fprintf(debug,"NEW SPREADSHEET\n");
-      current_col=1;
+    int spread = 0;
+    if (SPREADSHEET.size() == 0 || compareSpreadnames(sname) == -1) {
+      fprintf(debug, "NEW SPREADSHEET\n");
+      current_col = 1;
       SPREADSHEET.push_back(spreadSheet(sname));
-      spread=static_cast<int>(SPREADSHEET.size())-1;
-      SPREADSHEET.back().maxRows=0;
-    }
-    else {
+      spread = static_cast<int>(SPREADSHEET.size()) - 1;
+      SPREADSHEET.back().maxRows = 0;
+    } else {
 
-      spread=compareSpreadnames(sname);
+      spread = compareSpreadnames(sname);
 
-      current_col=static_cast<int>(SPREADSHEET[spread].column.size());
+      current_col = static_cast<int>(SPREADSHEET[spread].column.size());
 
-      if(!current_col)
-        current_col=1;
+      if (!current_col)
+        current_col = 1;
       current_col++;
     }
-    fprintf(debug,"SPREADSHEET = %s COLUMN %d NAME = %s (@0x%X)\n",
-      sname, current_col, cname, (unsigned int) ftell(f));
+    fprintf(debug, "SPREADSHEET = %s COLUMN %d NAME = %s (@0x%X)\n", sname,
+            current_col, cname, (unsigned int)ftell(f));
     fflush(debug);
 
-    if(cname == 0) {
-      fprintf(debug,"NO COLUMN NAME FOUND! Must be a matrix or function.\n");
-      ////////////////////////////// READ MATRIX or FUNCTION ////////////////////////////////////
-      fprintf(debug,"Reading MATRIX.\n");
+    if (cname == 0) {
+      fprintf(debug, "NO COLUMN NAME FOUND! Must be a matrix or function.\n");
+      ////////////////////////////// READ MATRIX or FUNCTION
+      ///////////////////////////////////////
+      fprintf(debug, "Reading MATRIX.\n");
       fflush(debug);
 
-      fprintf(debug," [position @ 0x%X]\n",(unsigned int) ftell(f));
+      fprintf(debug, " [position @ 0x%X]\n", (unsigned int)ftell(f));
       // TODO
-      fprintf(debug," SIGNATURE : ");
-      for(i=0;i<2;i++) {  // skip header
-        CHECKED_FREAD(debug, &c,1,1,f);
-        fprintf(debug,"%.2X ",c);
+      fprintf(debug, " SIGNATURE : ");
+      for (i = 0; i < 2; i++) { // skip header
+        CHECKED_FREAD(debug, &c, 1, 1, f);
+        fprintf(debug, "%.2X ", c);
       }
       fflush(debug);
 
-      do{ // skip until '\n'
-        CHECKED_FREAD(debug, &c,1,1,f);
+      do { // skip until '\n'
+        CHECKED_FREAD(debug, &c, 1, 1, f);
         // fprintf(debug,"%.2X ",c);
       } while (c != '\n');
-      fprintf(debug,"\n");
+      fprintf(debug, "\n");
       fflush(debug);
 
       // read size
       int size;
-      CHECKED_FREAD(debug, &size,4,1,f);
-      CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
+      CHECKED_FREAD(debug, &size, 4, 1, f);
+      CHECKED_FREAD(debug, &c, 1, 1, f); // skip '\n'
       // TODO : use entry size : double, float, ...
       size /= 8;
-      fprintf(debug," SIZE = %d\n",size);
+      fprintf(debug, " SIZE = %d\n", size);
       fflush(debug);
 
       // catch exception
-      if(size>10000)
-        size=1000;
+      if (size > 10000)
+        size = 1000;
 
-      fprintf(debug,"VALUES :\n");
-      SPREADSHEET[SPREADSHEET.size()-1].maxRows=1;
+      fprintf(debug, "VALUES :\n");
+      SPREADSHEET[SPREADSHEET.size() - 1].maxRows = 1;
 
-      double value=0;
-      for(i=0;i<size;i++) { // read data
+      double value = 0;
+      for (i = 0; i < size; i++) { // read data
         string stmp;
-        if(i<26)
-          stmp=char(i+0x41);
-        else if(i<26*26) {
-          stmp = char(0x40+i/26);
-                                        stmp[1] = i%26+0x41;
+        if (i < 26)
+          stmp = char(i + 0x41);
+        else if (i < 26 * 26) {
+          stmp = char(0x40 + i / 26);
+          stmp[1] = i % 26 + 0x41;
+        } else {
+          stmp = char(0x40 + i / 26 / 26);
+          stmp[1] = char(i / 26 % 26 + 0x41);
+          stmp[2] = char(i % 26 + 0x41);
         }
-        else {
-          stmp = char(0x40+i/26/26);
-          stmp[1] = char(i/26%26+0x41);
-          stmp[2] = char(i%26+0x41);
-        }
-        SPREADSHEET[SPREADSHEET.size()-1].column.push_back(stmp);
-        CHECKED_FREAD(debug, &value,8,1,f);
-        SPREADSHEET[SPREADSHEET.size()-1].column[i].odata.push_back(originData(value));
+        SPREADSHEET[SPREADSHEET.size() - 1].column.push_back(stmp);
+        CHECKED_FREAD(debug, &value, 8, 1, f);
+        SPREADSHEET[SPREADSHEET.size() - 1].column[i].odata.push_back(
+            originData(value));
 
-        fprintf(debug,"%g ",value);
+        fprintf(debug, "%g ", value);
       }
-      fprintf(debug,"\n");
+      fprintf(debug, "\n");
       fflush(debug);
 
-    }
-    else {  // worksheet
+    } else { // worksheet
       SPREADSHEET[spread].column.push_back(spreadColumn(cname));
 
-      ////////////////////////////// SIZE of column /////////////////////////////////////////////
-      do{ // skip until '\n'
-        CHECKED_FREAD(debug, &c,1,1,f);
+      ////////////////////////////// SIZE of column
+      ////////////////////////////////////////////////
+      do { // skip until '\n'
+        CHECKED_FREAD(debug, &c, 1, 1, f);
       } while (c != '\n');
 
-      CHECKED_FREAD(debug, &nbytes,4,1,f);
-      if(IsBigEndian()) SwapBytes(nbytes);
-      if(fmod(nbytes,(double)valuesize)>0)
-        fprintf(debug,"WARNING: data section could not be read correct\n");
+      CHECKED_FREAD(debug, &nbytes, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(nbytes);
+      if (fmod(nbytes, (double)valuesize) > 0)
+        fprintf(debug, "WARNING: data section could not be read correct\n");
       nr = nbytes / valuesize;
-      fprintf(debug," [number of rows = %d (%d Bytes) @ 0x%X]\n",nr,nbytes,(unsigned int) ftell(f));
+      fprintf(debug, " [number of rows = %d (%d Bytes) @ 0x%X]\n", nr, nbytes,
+              (unsigned int)ftell(f));
       fflush(debug);
 
-      SPREADSHEET[spread].maxRows<nr?SPREADSHEET[spread].maxRows=nr:0;
+      SPREADSHEET[spread].maxRows < nr ? SPREADSHEET[spread].maxRows = nr : 0;
 
-      ////////////////////////////////////// DATA ////////////////////////////////////////////////
-      CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
-      if(valuesize != 8 && valuesize <= 16) { // skip 0 0
-        CHECKED_FREAD(debug, &c,1,1,f);
-        CHECKED_FREAD(debug, &c,1,1,f);
+      ////////////////////////////////////// DATA
+      ///////////////////////////////////////////////////
+      CHECKED_FREAD(debug, &c, 1, 1, f);       // skip '\n'
+      if (valuesize != 8 && valuesize <= 16) { // skip 0 0
+        CHECKED_FREAD(debug, &c, 1, 1, f);
+        CHECKED_FREAD(debug, &c, 1, 1, f);
       }
-      fprintf(debug," [data @ 0x%X]\n",(unsigned int) ftell(f));
+      fprintf(debug, " [data @ 0x%X]\n", (unsigned int)ftell(f));
       fflush(debug);
 
-      for (i=0;i<nr;i++) {
-        if(valuesize <= 16) { // value
-          CHECKED_FREAD(debug, &a,valuesize,1,f);
-          if(IsBigEndian()) SwapBytes(a);
-          fprintf(debug,"%g ",a);
-          SPREADSHEET[spread].column[(current_col-1)].odata.push_back(originData(a));
-        }
-        else {      // label
-          char *stmp = new char[valuesize+1];
-          CHECKED_FREAD(debug, stmp,valuesize,1,f);
-          fprintf(debug,"%s ",stmp);
-          SPREADSHEET[spread].column[(current_col-1)].odata.push_back(originData(stmp));
-          delete [] stmp;
+      for (i = 0; i < nr; i++) {
+        if (valuesize <= 16) { // value
+          CHECKED_FREAD(debug, &a, valuesize, 1, f);
+          if (IsBigEndian())
+            SwapBytes(a);
+          fprintf(debug, "%g ", a);
+          SPREADSHEET[spread].column[(current_col - 1)].odata.push_back(
+              originData(a));
+        } else { // label
+          char *stmp = new char[valuesize + 1];
+          CHECKED_FREAD(debug, stmp, valuesize, 1, f);
+          fprintf(debug, "%s ", stmp);
+          SPREADSHEET[spread].column[(current_col - 1)].odata.push_back(
+              originData(stmp));
+          delete[] stmp;
         }
       }
     } // else
     //    fprintf(debug," [now @ 0x%X]\n",ftell(f));
-    fprintf(debug,"\n");
+    fprintf(debug, "\n");
     fflush(debug);
 
-    for(i=0;i<4;i++)  // skip "0"
-      CHECKED_FREAD(debug, &c,1,1,f);
-    if(valuesize == 8 || valuesize > 16) {  // skip 0 0
-      CHECKED_FREAD(debug, &c,1,1,f);
-      CHECKED_FREAD(debug, &c,1,1,f);
+    for (i = 0; i < 4; i++) // skip "0"
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+    if (valuesize == 8 || valuesize > 16) { // skip 0 0
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      CHECKED_FREAD(debug, &c, 1, 1, f);
     }
-    CHECKED_FREAD(debug, &col_found,4,1,f);
-    if(IsBigEndian()) SwapBytes(col_found);
-    CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
-    fprintf(debug," [column found = %d/0x%X (@ 0x%X)]\n",col_found,col_found,(unsigned int) ftell(f)-5);
+    CHECKED_FREAD(debug, &col_found, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(col_found);
+    CHECKED_FREAD(debug, &c, 1, 1, f); // skip '\n'
+    fprintf(debug, " [column found = %d/0x%X (@ 0x%X)]\n", col_found, col_found,
+            (unsigned int)ftell(f) - 5);
     fflush(debug);
   }
 
   ////////////////////// HEADER SECTION //////////////////////////////////////
   // TODO : use new method ('\n')
 
-  int POS = int(ftell(f)-11);
-  fprintf(debug,"\nHEADER SECTION\n");
-  fprintf(debug," nr_spreads = %zu\n",SPREADSHEET.size());
-  fprintf(debug," [position @ 0x%X]\n",POS);
+  int POS = int(ftell(f) - 11);
+  fprintf(debug, "\nHEADER SECTION\n");
+  fprintf(debug, " nr_spreads = %zu\n", SPREADSHEET.size());
+  fprintf(debug, " [position @ 0x%X]\n", POS);
   fflush(debug);
 
-///////////////////// SPREADSHEET INFOS ////////////////////////////////////
-  int LAYER=0;
+  ///////////////////// SPREADSHEET INFOS ////////////////////////////////////
+  int LAYER = 0;
   int COL_JUMP = 0x1ED;
-  for(unsigned int i=0; i < SPREADSHEET.size(); i++) {
-  fprintf(debug,"   reading Spreadsheet %d/%zd properties\n",i+1,SPREADSHEET.size());
-  fflush(debug);
-  if(i > 0) {
-    if (version == 700 )
-      POS += 0x2530 + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;
-    else if (version == 610 )
-      POS += 0x25A4 + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;
-    else if (version == 604 )
-      POS += 0x25A0 + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;
-    else if (version == 601 )
-      POS += 0x2560 + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;  // ?
-    else if (version == 600 )
-      POS += 0x2560 + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;
-    else if (version == 500 )
-      POS += 0x92C + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;
-    else if (version == 410 )
-      POS += 0x7FB + static_cast<int>(SPREADSHEET[i-1].column.size())*COL_JUMP;
-  }
-
-  fprintf(debug,"     reading Header\n");
-  fflush(debug);
-  // HEADER
-  // check header
-  int ORIGIN = 0x55;
-  if(version == 500)
-    ORIGIN = 0x58;
-  CHECKED_FSEEK(debug, f,POS + ORIGIN,SEEK_SET); // check for 'O'RIGIN
-  char c;
-  CHECKED_FREAD(debug, &c,1,1,f);
-  int jump=0;
-  if( c == 'O')
-    fprintf(debug,"     \"ORIGIN\" found ! (@ 0x%X)\n",POS+ORIGIN);
-  while( c != 'O' && jump < MAX_LEVEL) {  // no inf loop
-    fprintf(debug,"   TRY %d  \"O\"RIGIN not found ! : %c (@ 0x%X)",jump+1,c,POS+ORIGIN);
-    fprintf(debug,"     POS=0x%X | ORIGIN = 0x%X\n",POS,ORIGIN);
+  for (unsigned int i = 0; i < SPREADSHEET.size(); i++) {
+    fprintf(debug, "   reading Spreadsheet %d/%zd properties\n", i + 1,
+            SPREADSHEET.size());
     fflush(debug);
-    POS+=0x1F2;
-    CHECKED_FSEEK(debug, f,POS + ORIGIN,SEEK_SET);
-    CHECKED_FREAD(debug, &c,1,1,f);
-    jump++;
-  }
+    if (i > 0) {
+      if (version == 700)
+        POS += 0x2530 +
+               static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP;
+      else if (version == 610)
+        POS += 0x25A4 +
+               static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP;
+      else if (version == 604)
+        POS += 0x25A0 +
+               static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP;
+      else if (version == 601)
+        POS +=
+            0x2560 +
+            static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP; // ?
+      else if (version == 600)
+        POS += 0x2560 +
+               static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP;
+      else if (version == 500)
+        POS += 0x92C +
+               static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP;
+      else if (version == 410)
+        POS += 0x7FB +
+               static_cast<int>(SPREADSHEET[i - 1].column.size()) * COL_JUMP;
+    }
 
-  int spread=i;
-  if(jump == MAX_LEVEL){
-    fprintf(debug,"   Spreadsheet SECTION not found !   (@ 0x%X)\n",POS-10*0x1F2+0x55);
-    // setColName(spread);
-    fclose(f);
-    fclose(debug);
-    return -5;
-  }
-
-  fprintf(debug,"     [Spreadsheet SECTION (@ 0x%X)]\n",POS);
-  fflush(debug);
-
-  // check spreadsheet name
-  CHECKED_FSEEK(debug, f,POS + 0x12,SEEK_SET);
-  CHECKED_FREAD(debug, &name,25,1,f);
-
-  spread=compareSpreadnames(name);
-  if(spread == -1)
-    spread=i;
-
-  fprintf(debug,"     SPREADSHEET %d NAME : %s  (@ 0x%X) has %zu columns\n",
-    spread+1,name,POS + 0x12,SPREADSHEET[spread].column.size());
-  fflush(debug);
-
-  int ATYPE=0;
-  LAYER = POS;
-  if (version == 700)
-    ATYPE = 0x2E4;
-  else if (version == 610)
-    ATYPE = 0x358;
-  else if (version == 604)
-    ATYPE = 0x354;
-  else if (version == 601)
-    ATYPE = 0x500;  // ?
-  else if (version == 600)
-    ATYPE = 0x314;
-  else if (version == 500) {
-    COL_JUMP=0x5D;
-    ATYPE = 0x300;
-  }
-  else if (version == 410) {
-    COL_JUMP = 0x58;
-    ATYPE = 0x229;
-  }
-  fflush(debug);
-
-  /////////////// COLUMN Types ///////////////////////////////////////////
-  fprintf(debug,"     Spreadsheet has %zu columns\n",SPREADSHEET[spread].column.size());
-  for (unsigned int j=0;j<SPREADSHEET[spread].column.size();j++) {
-    fprintf(debug,"     reading COLUMN %d/%zd type\n",j+1,SPREADSHEET[spread].column.size());
+    fprintf(debug, "     reading Header\n");
     fflush(debug);
-    CHECKED_FSEEK(debug, f,LAYER+ATYPE+j*COL_JUMP, SEEK_SET);
-    CHECKED_FREAD(debug, &name,25,1,f);
+    // HEADER
+    // check header
+    int ORIGIN = 0x55;
+    if (version == 500)
+      ORIGIN = 0x58;
+    CHECKED_FSEEK(debug, f, POS + ORIGIN, SEEK_SET); // check for 'O'RIGIN
+    char c;
+    CHECKED_FREAD(debug, &c, 1, 1, f);
+    int jump = 0;
+    if (c == 'O')
+      fprintf(debug, "     \"ORIGIN\" found ! (@ 0x%X)\n", POS + ORIGIN);
+    while (c != 'O' && jump < MAX_LEVEL) { // no inf loop
+      fprintf(debug, "   TRY %d  \"O\"RIGIN not found ! : %c (@ 0x%X)",
+              jump + 1, c, POS + ORIGIN);
+      fprintf(debug, "     POS=0x%X | ORIGIN = 0x%X\n", POS, ORIGIN);
+      fflush(debug);
+      POS += 0x1F2;
+      CHECKED_FSEEK(debug, f, POS + ORIGIN, SEEK_SET);
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      jump++;
+    }
 
-    CHECKED_FSEEK(debug, f,LAYER+ATYPE+j*COL_JUMP-1, SEEK_SET);
-    CHECKED_FREAD(debug, &c,1,1,f);
-    ColumnType type;
-    switch(c) {
+    int spread = i;
+    if (jump == MAX_LEVEL) {
+      fprintf(debug, "   Spreadsheet SECTION not found !   (@ 0x%X)\n",
+              POS - 10 * 0x1F2 + 0x55);
+      // setColName(spread);
+      fclose(f);
+      fclose(debug);
+      return -5;
+    }
+
+    fprintf(debug, "     [Spreadsheet SECTION (@ 0x%X)]\n", POS);
+    fflush(debug);
+
+    // check spreadsheet name
+    CHECKED_FSEEK(debug, f, POS + 0x12, SEEK_SET);
+    CHECKED_FREAD(debug, &name, 25, 1, f);
+
+    spread = compareSpreadnames(name);
+    if (spread == -1)
+      spread = i;
+
+    fprintf(debug, "     SPREADSHEET %d NAME : %s  (@ 0x%X) has %zu columns\n",
+            spread + 1, name, POS + 0x12, SPREADSHEET[spread].column.size());
+    fflush(debug);
+
+    int ATYPE = 0;
+    LAYER = POS;
+    if (version == 700)
+      ATYPE = 0x2E4;
+    else if (version == 610)
+      ATYPE = 0x358;
+    else if (version == 604)
+      ATYPE = 0x354;
+    else if (version == 601)
+      ATYPE = 0x500; // ?
+    else if (version == 600)
+      ATYPE = 0x314;
+    else if (version == 500) {
+      COL_JUMP = 0x5D;
+      ATYPE = 0x300;
+    } else if (version == 410) {
+      COL_JUMP = 0x58;
+      ATYPE = 0x229;
+    }
+    fflush(debug);
+
+    /////////////// COLUMN Types ///////////////////////////////////////////
+    fprintf(debug, "     Spreadsheet has %zu columns\n",
+            SPREADSHEET[spread].column.size());
+    for (unsigned int j = 0; j < SPREADSHEET[spread].column.size(); j++) {
+      fprintf(debug, "     reading COLUMN %d/%zd type\n", j + 1,
+              SPREADSHEET[spread].column.size());
+      fflush(debug);
+      CHECKED_FSEEK(debug, f, LAYER + ATYPE + j * COL_JUMP, SEEK_SET);
+      CHECKED_FREAD(debug, &name, 25, 1, f);
+
+      CHECKED_FSEEK(debug, f, LAYER + ATYPE + j * COL_JUMP - 1, SEEK_SET);
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      ColumnType type;
+      switch (c) {
       case 3:
         type = X;
         break;
@@ -693,758 +720,1056 @@ int OPJFile::ParseFormatOld() {
       default:
         type = NONE;
         break;
+      }
+
+      SPREADSHEET[spread].column[j].type = type;
+
+      fprintf(debug, "       COLUMN \"%s\" type = %s (@ 0x%X)\n",
+              SPREADSHEET[spread].column[j].name.c_str(), colTypeNames[type],
+              LAYER + ATYPE + j * COL_JUMP);
+      fflush(debug);
+
+      // check column name
+      int max_length = 11; // only first 11 chars are saved here !
+      int name_length =
+          static_cast<int>(SPREADSHEET[spread].column[j].name.length());
+      int length = (name_length < max_length) ? name_length : max_length;
+
+      if (SPREADSHEET[spread].column[j].name.substr(0, length) == name) {
+        fprintf(debug, "       TEST : column name = \"%s\". OK!\n",
+                SPREADSHEET[spread].column[j].name.c_str());
+      } else {
+        fprintf(debug,
+                "       TEST : COLUMN %d name mismatch (\"%s\" != \"%s\")\n",
+                j + 1, name, SPREADSHEET[spread].column[j].name.c_str());
+        // fprintf(debug,"ERROR : column name mismatch! Continue
+        // anyway.\n"ERROR_MSG);
+      }
+      fflush(debug);
     }
-
-    SPREADSHEET[spread].column[j].type=type;
-
-    fprintf(debug,"       COLUMN \"%s\" type = %s (@ 0x%X)\n",
-      SPREADSHEET[spread].column[j].name.c_str(),colTypeNames[type],LAYER+ATYPE+j*COL_JUMP);
-    fflush(debug);
-
-    // check column name
-    int max_length=11;  // only first 11 chars are saved here !
-    int name_length = static_cast<int>(SPREADSHEET[spread].column[j].name.length());
-                    int length = (name_length < max_length) ? name_length : max_length;
-
-    if(SPREADSHEET[spread].column[j].name.substr(0,length) == name) {
-      fprintf(debug,"       TEST : column name = \"%s\". OK!\n",
-        SPREADSHEET[spread].column[j].name.c_str());
-    }
-    else {
-      fprintf(debug,"       TEST : COLUMN %d name mismatch (\"%s\" != \"%s\")\n",
-        j+1,name,SPREADSHEET[spread].column[j].name.c_str());
-      //fprintf(debug,"ERROR : column name mismatch! Continue anyway.\n"ERROR_MSG);
-    }
+    fprintf(debug, "   Done with spreadsheet %d\n", spread);
     fflush(debug);
   }
-    fprintf(debug,"   Done with spreadsheet %d\n",spread);
-    fflush(debug);
-  }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
   // TODO : GRAPHS
 
-  fprintf(debug,"Done parsing\n");
+  fprintf(debug, "Done parsing\n");
   fclose(debug);
   fclose(f);
 
   return 0;
 }
 
-
 int OPJFile::ParseFormatNew() {
   int i;
   FILE *f, *debug;
-  if((f=fopen(filename,"rb")) == NULL ) {
-    printf("Could not open %s!\n",filename);
+  if ((f = fopen(filename, "rb")) == NULL) {
+    printf("Could not open %s!\n", filename);
     return -1;
   }
 
-  if((debug=fopen("opjfile.log","w")) == NULL ) {
+  if ((debug = fopen("opjfile.log", "w")) == NULL) {
     printf("Could not open log file!\n");
     fclose(f);
     return -1;
   }
 
-////////////////////////////// check version from header ///////////////////////////////
+  ////////////////////////////// check version from header
+  //////////////////////////////////
   char vers[5];
-  vers[4]=0;
+  vers[4] = 0;
 
   // get file size
   int file_size = 0;
   {
-    CHECKED_FSEEK(debug, f, 0 , SEEK_END);
+    CHECKED_FSEEK(debug, f, 0, SEEK_END);
     file_size = ftell(f);
     CHECKED_FSEEK(debug, f, 0, SEEK_SET);
   }
 
   // get version
-  CHECKED_FSEEK(debug, f,0x7,SEEK_SET);
-  CHECKED_FREAD(debug, &vers,4,1,f);
+  CHECKED_FSEEK(debug, f, 0x7, SEEK_SET);
+  CHECKED_FREAD(debug, &vers, 4, 1, f);
   version = atoi(vers);
-  fprintf(debug," [version = %d]\n",version);
+  fprintf(debug, " [version = %d]\n", version);
 
   // translate version
-  if(version >= 130 && version <= 140)    // 4.1
-    version=410;
-  else if(version == 210)   // 5.0
-    version=500;
-  else if(version == 2625)  // 6.0
-    version=600;
-  else if(version == 2627)  // 6.0 SR1
-    version=601;
-  else if(version == 2630 )   // 6.0 SR4
-    version=604;
-  else if(version == 2635 )   // 6.1
-    version=610;
-  else if(version == 2656)  // 7.0
-    version=700;
-  else if(version == 2672)  // 7.0 SR3
-    version=703;
-  else if(version >= 2766 && version <= 2769)   // 7.5
-    version=750;
+  if (version >= 130 && version <= 140) // 4.1
+    version = 410;
+  else if (version == 210) // 5.0
+    version = 500;
+  else if (version == 2625) // 6.0
+    version = 600;
+  else if (version == 2627) // 6.0 SR1
+    version = 601;
+  else if (version == 2630) // 6.0 SR4
+    version = 604;
+  else if (version == 2635) // 6.1
+    version = 610;
+  else if (version == 2656) // 7.0
+    version = 700;
+  else if (version == 2672) // 7.0 SR3
+    version = 703;
+  else if (version >= 2766 && version <= 2769) // 7.5
+    version = 750;
   else {
-    fprintf(debug,"Found unknown project version %d\n",version);
-    fprintf(debug,"Please contact the author of opj2dat\n");
+    fprintf(debug, "Found unknown project version %d\n", version);
+    fprintf(debug, "Please contact the author of opj2dat\n");
   }
-  fprintf(debug,"Found project version %.2f\n",version/100.0);
+  fprintf(debug, "Found project version %.2f\n", version / 100.0);
 
-  unsigned char c=0;  // tmp char
+  unsigned char c = 0; // tmp char
 
-  fprintf(debug,"HEADER :\n");
-  for(i=0;i<0x16;i++) { // skip header + 5 Bytes ("27")
-    CHECKED_FREAD(debug, &c,1,1,f);
-    fprintf(debug,"%.2X ",c);
-    if(!((i+1)%16)) fprintf(debug,"\n");
+  fprintf(debug, "HEADER :\n");
+  for (i = 0; i < 0x16; i++) { // skip header + 5 Bytes ("27")
+    CHECKED_FREAD(debug, &c, 1, 1, f);
+    fprintf(debug, "%.2X ", c);
+    if (!((i + 1) % 16))
+      fprintf(debug, "\n");
   }
-  fprintf(debug,"\n");
+  fprintf(debug, "\n");
 
-  do{
-    CHECKED_FREAD(debug, &c,1,1,f);
+  do {
+    CHECKED_FREAD(debug, &c, 1, 1, f);
   } while (c != '\n');
-  fprintf(debug," [file header @ 0x%X]\n", (unsigned int) ftell(f));
+  fprintf(debug, " [file header @ 0x%X]\n", (unsigned int)ftell(f));
 
-/////////////////// find column ///////////////////////////////////////////////////////////
-  if(version>410)
-    for(i=0;i<5;i++)  // skip "0"
-      CHECKED_FREAD(debug, &c,1,1,f);
+  /////////////////// find column
+  //////////////////////////////////////////////////////////////
+  if (version > 410)
+    for (i = 0; i < 5; i++) // skip "0"
+      CHECKED_FREAD(debug, &c, 1, 1, f);
 
   int col_found;
-  CHECKED_FREAD(debug, &col_found,4,1,f);
-  if(IsBigEndian()) SwapBytes(col_found);
+  CHECKED_FREAD(debug, &col_found, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(col_found);
 
-  CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
-  fprintf(debug," [column found = %d/0x%X @ 0x%X]\n",col_found,col_found,(unsigned int) ftell(f));
-  int colpos=int(ftell(f));
+  CHECKED_FREAD(debug, &c, 1, 1, f); // skip '\n'
+  fprintf(debug, " [column found = %d/0x%X @ 0x%X]\n", col_found, col_found,
+          (unsigned int)ftell(f));
+  int colpos = int(ftell(f));
 
-  int current_col=1, nr=0, nbytes=0;
+  int current_col = 1, nr = 0, nbytes = 0;
   double a;
   char name[25], valuesize;
-  while(col_found > 0 && col_found < 0x84) {  // should be 0x72, 0x73 or 0x83
-//////////////////////////////// COLUMN HEADER /////////////////////////////////////////////
+  while (col_found > 0 && col_found < 0x84) { // should be 0x72, 0x73 or 0x83
+    //////////////////////////////// COLUMN HEADER
+    ////////////////////////////////////////////////
     short data_type;
     char data_type_u;
-    int oldpos=int(ftell(f));
-    CHECKED_FSEEK(debug, f,oldpos+0x16,SEEK_SET);
-    CHECKED_FREAD(debug, &data_type,2,1,f);
-    if(IsBigEndian()) SwapBytes(data_type);
-    CHECKED_FSEEK(debug, f,oldpos+0x3F,SEEK_SET);
-    CHECKED_FREAD(debug, &data_type_u,1,1,f);
-    CHECKED_FSEEK(debug, f,oldpos,SEEK_SET);
+    int oldpos = int(ftell(f));
+    CHECKED_FSEEK(debug, f, oldpos + 0x16, SEEK_SET);
+    CHECKED_FREAD(debug, &data_type, 2, 1, f);
+    if (IsBigEndian())
+      SwapBytes(data_type);
+    CHECKED_FSEEK(debug, f, oldpos + 0x3F, SEEK_SET);
+    CHECKED_FREAD(debug, &data_type_u, 1, 1, f);
+    CHECKED_FSEEK(debug, f, oldpos, SEEK_SET);
 
-    fprintf(debug,"COLUMN HEADER :\n");
-    for(i=0;i < 0x3D;i++) { // skip 0x3C chars to value size
-      CHECKED_FREAD(debug, &c,1,1,f);
-      //if(i>21 && i<27) {
-        fprintf(debug,"%.2X ",c);
-        if(!((i+1)%16)) fprintf(debug,"\n");
+    fprintf(debug, "COLUMN HEADER :\n");
+    for (i = 0; i < 0x3D; i++) { // skip 0x3C chars to value size
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      // if(i>21 && i<27) {
+      fprintf(debug, "%.2X ", c);
+      if (!((i + 1) % 16))
+        fprintf(debug, "\n");
       //}
     }
-    fprintf(debug,"\n");
+    fprintf(debug, "\n");
 
-    CHECKED_FREAD(debug, &valuesize,1,1,f);
-    fprintf(debug," [valuesize = %d @ 0x%X]\n",valuesize,(unsigned int) ftell(f)-1);
-    if(valuesize <= 0) {
-      fprintf(debug," WARNING : found strange valuesize of %d\n",valuesize);
-      valuesize=10;
+    CHECKED_FREAD(debug, &valuesize, 1, 1, f);
+    fprintf(debug, " [valuesize = %d @ 0x%X]\n", valuesize,
+            (unsigned int)ftell(f) - 1);
+    if (valuesize <= 0) {
+      fprintf(debug, " WARNING : found strange valuesize of %d\n", valuesize);
+      valuesize = 10;
     }
 
-    fprintf(debug,"SKIP :\n");
-    for(i=0;i<0x1A;i++) { // skip to name
-      CHECKED_FREAD(debug, &c,1,1,f);
-      fprintf(debug,"%.2X ",c);
-      if(!((i+1)%16)) fprintf(debug,"\n");
+    fprintf(debug, "SKIP :\n");
+    for (i = 0; i < 0x1A; i++) { // skip to name
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      fprintf(debug, "%.2X ", c);
+      if (!((i + 1) % 16))
+        fprintf(debug, "\n");
     }
-    fprintf(debug,"\n");
+    fprintf(debug, "\n");
 
     // read name
-    fprintf(debug," [Spreadsheet @ 0x%X]\n",(unsigned int) ftell(f));
+    fprintf(debug, " [Spreadsheet @ 0x%X]\n", (unsigned int)ftell(f));
     fflush(debug);
-    CHECKED_FREAD(debug, &name,25,1,f);
-    //char* sname = new char[26];
+    CHECKED_FREAD(debug, &name, 25, 1, f);
+    // char* sname = new char[26];
     char sname[26];
-    sprintf(sname,"%s",strtok(name,"_")); // spreadsheet name
-    char* cname = strtok(NULL,"_"); // column name
-    while(char* tmpstr = strtok(NULL,"_")) {  // get multiple-"_" title correct
-      strcat(sname,"_");
-      strcat(sname,cname);
-      strcpy(cname,tmpstr);
+    sprintf(sname, "%s", strtok(name, "_"));   // spreadsheet name
+    char *cname = strtok(NULL, "_");           // column name
+    while (char *tmpstr = strtok(NULL, "_")) { // get multiple-"_" title correct
+      strcat(sname, "_");
+      strcat(sname, cname);
+      strcpy(cname, tmpstr);
     }
-    int spread=0;
-    if(cname == 0) {
-      fprintf(debug,"NO COLUMN NAME FOUND! Must be a matrix or function.\n");
-////////////////////////////// READ MATRIX or FUNCTION ////////////////////////////////////
+    int spread = 0;
+    if (cname == 0) {
+      fprintf(debug, "NO COLUMN NAME FOUND! Must be a matrix or function.\n");
+      ////////////////////////////// READ MATRIX or FUNCTION
+      ///////////////////////////////////////
 
-      fprintf(debug," [position @ 0x%X]\n",(unsigned int) ftell(f));
+      fprintf(debug, " [position @ 0x%X]\n", (unsigned int)ftell(f));
       // TODO
       short signature;
-      CHECKED_FREAD(debug, &signature,2,1,f);
-      if(IsBigEndian()) SwapBytes(signature);
-      fprintf(debug," SIGNATURE : ");
-      fprintf(debug,"%.2X ",signature);
+      CHECKED_FREAD(debug, &signature, 2, 1, f);
+      if (IsBigEndian())
+        SwapBytes(signature);
+      fprintf(debug, " SIGNATURE : ");
+      fprintf(debug, "%.2X ", signature);
       fflush(debug);
 
-      do{ // skip until '\n'
-        CHECKED_FREAD(debug, &c,1,1,f);
+      do { // skip until '\n'
+        CHECKED_FREAD(debug, &c, 1, 1, f);
         // fprintf(debug,"%.2X ",c);
       } while (c != '\n');
-      fprintf(debug,"\n");
+      fprintf(debug, "\n");
       fflush(debug);
 
       // read size
       int size;
-      CHECKED_FREAD(debug, &size,4,1,f);
-      if(IsBigEndian()) SwapBytes(size);
-      CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
+      CHECKED_FREAD(debug, &size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(size);
+      CHECKED_FREAD(debug, &c, 1, 1, f); // skip '\n'
       // TODO : use entry size : double, float, ...
       size /= valuesize;
-      fprintf(debug," SIZE = %d\n",size);
+      fprintf(debug, " SIZE = %d\n", size);
       fflush(debug);
 
       // catch exception
       /*if(size>10000)
         size=1000;*/
-      switch(signature)
-      {
+      switch (signature) {
       case 0x50CA:
       case 0x70CA:
       case 0x50F2:
       case 0x50E2:
-        fprintf(debug,"NEW MATRIX\n");
+        fprintf(debug, "NEW MATRIX\n");
         MATRIX.push_back(matrix(sname, dataIndex));
         dataIndex++;
 
-        fprintf(debug,"VALUES :\n");
+        fprintf(debug, "VALUES :\n");
 
-        switch(data_type)
-        {
-        case 0x6001://double
-          for(i=0;i<size;i++) {
+        switch (data_type) {
+        case 0x6001: // double
+          for (i = 0; i < size; i++) {
             double value;
-            CHECKED_FREAD(debug, &value,valuesize,1,f);
-            if(IsBigEndian()) SwapBytes(value);
+            CHECKED_FREAD(debug, &value, valuesize, 1, f);
+            if (IsBigEndian())
+              SwapBytes(value);
             MATRIX.back().data.push_back((double)value);
-            fprintf(debug,"%g ",MATRIX.back().data.back());
+            fprintf(debug, "%g ", MATRIX.back().data.back());
           }
           break;
-        case 0x6003://float
-          for(i=0;i<size;i++) {
+        case 0x6003: // float
+          for (i = 0; i < size; i++) {
             float value;
-            CHECKED_FREAD(debug, &value,valuesize,1,f);
-            if(IsBigEndian()) SwapBytes(value);
+            CHECKED_FREAD(debug, &value, valuesize, 1, f);
+            if (IsBigEndian())
+              SwapBytes(value);
             MATRIX.back().data.push_back((double)value);
-            fprintf(debug,"%g ",MATRIX.back().data.back());
+            fprintf(debug, "%g ", MATRIX.back().data.back());
           }
           break;
-        case 0x6801://int
-          if(data_type_u==8)//unsigned
-            for(i=0;i<size;i++) {
+        case 0x6801: // int
+          if (data_type_u == 8) // unsigned
+            for (i = 0; i < size; i++) {
               unsigned int value;
-              CHECKED_FREAD(debug, &value,valuesize,1,f);
-              if(IsBigEndian()) SwapBytes(value);
+              CHECKED_FREAD(debug, &value, valuesize, 1, f);
+              if (IsBigEndian())
+                SwapBytes(value);
               MATRIX.back().data.push_back((double)value);
-              fprintf(debug,"%g ",MATRIX.back().data.back());
+              fprintf(debug, "%g ", MATRIX.back().data.back());
             }
           else
-            for(i=0;i<size;i++) {
+            for (i = 0; i < size; i++) {
               int value;
-              CHECKED_FREAD(debug, &value,valuesize,1,f);
-              if(IsBigEndian()) SwapBytes(value);
+              CHECKED_FREAD(debug, &value, valuesize, 1, f);
+              if (IsBigEndian())
+                SwapBytes(value);
               MATRIX.back().data.push_back((double)value);
-              fprintf(debug,"%g ",MATRIX.back().data.back());
+              fprintf(debug, "%g ", MATRIX.back().data.back());
             }
           break;
-        case 0x6803://short
-          if(data_type_u==8)//unsigned
-            for(i=0;i<size;i++) {
+        case 0x6803: // short
+          if (data_type_u == 8) // unsigned
+            for (i = 0; i < size; i++) {
               unsigned short value;
-              CHECKED_FREAD(debug, &value,valuesize,1,f);
-              if(IsBigEndian()) SwapBytes(value);
+              CHECKED_FREAD(debug, &value, valuesize, 1, f);
+              if (IsBigEndian())
+                SwapBytes(value);
               MATRIX.back().data.push_back((double)value);
-              fprintf(debug,"%g ",MATRIX.back().data.back());
+              fprintf(debug, "%g ", MATRIX.back().data.back());
             }
           else
-            for(i=0;i<size;i++) {
+            for (i = 0; i < size; i++) {
               short value;
-              CHECKED_FREAD(debug, &value,valuesize,1,f);
-              if(IsBigEndian()) SwapBytes(value);
+              CHECKED_FREAD(debug, &value, valuesize, 1, f);
+              if (IsBigEndian())
+                SwapBytes(value);
               MATRIX.back().data.push_back((double)value);
-              fprintf(debug,"%g ",MATRIX.back().data.back());
+              fprintf(debug, "%g ", MATRIX.back().data.back());
             }
           break;
-        case 0x6821://char
-          if(data_type_u==8)//unsigned
-            for(i=0;i<size;i++) {
+        case 0x6821: // char
+          if (data_type_u == 8) // unsigned
+            for (i = 0; i < size; i++) {
               unsigned char value;
-              CHECKED_FREAD(debug, &value,valuesize,1,f);
-              if(IsBigEndian()) SwapBytes(value);
+              CHECKED_FREAD(debug, &value, valuesize, 1, f);
+              if (IsBigEndian())
+                SwapBytes(value);
               MATRIX.back().data.push_back((double)value);
-              fprintf(debug,"%g ",MATRIX.back().data.back());
+              fprintf(debug, "%g ", MATRIX.back().data.back());
             }
           else
-            for(i=0;i<size;i++) {
+            for (i = 0; i < size; i++) {
               char value;
-              CHECKED_FREAD(debug, &value,valuesize,1,f);
-              if(IsBigEndian()) SwapBytes(value);
+              CHECKED_FREAD(debug, &value, valuesize, 1, f);
+              if (IsBigEndian())
+                SwapBytes(value);
               MATRIX.back().data.push_back((double)value);
-              fprintf(debug,"%g ",MATRIX.back().data.back());
+              fprintf(debug, "%g ", MATRIX.back().data.back());
             }
           break;
         default:
-          fprintf(debug,"UNKNOWN MATRIX DATATYPE: %.2X SKIP DATA\n", data_type);
-          CHECKED_FSEEK(debug, f, valuesize*size, SEEK_CUR);
+          fprintf(debug, "UNKNOWN MATRIX DATATYPE: %.2X SKIP DATA\n",
+                  data_type);
+          CHECKED_FSEEK(debug, f, valuesize * size, SEEK_CUR);
           MATRIX.pop_back();
         }
 
         break;
       case 0x10C8:
-        fprintf(debug,"NEW FUNCTION\n");
+        fprintf(debug, "NEW FUNCTION\n");
         FUNCTION.push_back(function(sname, dataIndex));
         dataIndex++;
 
         char *cmd;
-        cmd=new char[valuesize+1];
-        cmd[size_t(valuesize)]='\0';
-        CHECKED_FREAD(debug, cmd,valuesize,1,f);
-        FUNCTION.back().formula=cmd;
+        cmd = new char[valuesize + 1];
+        cmd[size_t(valuesize)] = '\0';
+        CHECKED_FREAD(debug, cmd, valuesize, 1, f);
+        FUNCTION.back().formula = cmd;
         int oldpos;
-        oldpos=int(ftell(f));
+        oldpos = int(ftell(f));
         short t;
-        CHECKED_FSEEK(debug, f,colpos+0xA,SEEK_SET);
-        CHECKED_FREAD(debug, &t,2,1,f);
-        if(IsBigEndian()) SwapBytes(t);
-        if(t==0x1194)
-          FUNCTION.back().type=1;
+        CHECKED_FSEEK(debug, f, colpos + 0xA, SEEK_SET);
+        CHECKED_FREAD(debug, &t, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(t);
+        if (t == 0x1194)
+          FUNCTION.back().type = 1;
         int N;
-        CHECKED_FSEEK(debug, f,colpos+0x21,SEEK_SET);
-        CHECKED_FREAD(debug, &N,4,1,f);
-        if(IsBigEndian()) SwapBytes(N);
-        FUNCTION.back().points=N;
+        CHECKED_FSEEK(debug, f, colpos + 0x21, SEEK_SET);
+        CHECKED_FREAD(debug, &N, 4, 1, f);
+        if (IsBigEndian())
+          SwapBytes(N);
+        FUNCTION.back().points = N;
         double d;
-        CHECKED_FREAD(debug, &d,8,1,f);
-        if(IsBigEndian()) SwapBytes(d);
-        FUNCTION.back().begin=d;
-        CHECKED_FREAD(debug, &d,8,1,f);
-        if(IsBigEndian()) SwapBytes(d);
-        FUNCTION.back().end=FUNCTION.back().begin+d*(FUNCTION.back().points-1);
-        fprintf(debug,"FUNCTION %s : %s \n", FUNCTION.back().name.c_str(), FUNCTION.back().formula.c_str());
-        fprintf(debug," interval %g : %g, number of points %d \n", FUNCTION.back().begin, FUNCTION.back().end, FUNCTION.back().points);
-        CHECKED_FSEEK(debug, f,oldpos,SEEK_SET);
+        CHECKED_FREAD(debug, &d, 8, 1, f);
+        if (IsBigEndian())
+          SwapBytes(d);
+        FUNCTION.back().begin = d;
+        CHECKED_FREAD(debug, &d, 8, 1, f);
+        if (IsBigEndian())
+          SwapBytes(d);
+        FUNCTION.back().end =
+            FUNCTION.back().begin + d * (FUNCTION.back().points - 1);
+        fprintf(debug, "FUNCTION %s : %s \n", FUNCTION.back().name.c_str(),
+                FUNCTION.back().formula.c_str());
+        fprintf(debug, " interval %g : %g, number of points %d \n",
+                FUNCTION.back().begin, FUNCTION.back().end,
+                FUNCTION.back().points);
+        CHECKED_FSEEK(debug, f, oldpos, SEEK_SET);
 
-        delete [] cmd;
+        delete[] cmd;
         break;
       default:
-        fprintf(debug,"UNKNOWN SIGNATURE: %.2X SKIP DATA\n", signature);
-        CHECKED_FSEEK(debug, f, valuesize*size, SEEK_CUR);
-        if(valuesize != 8 && valuesize <= 16)
+        fprintf(debug, "UNKNOWN SIGNATURE: %.2X SKIP DATA\n", signature);
+        CHECKED_FSEEK(debug, f, valuesize * size, SEEK_CUR);
+        if (valuesize != 8 && valuesize <= 16)
           CHECKED_FSEEK(debug, f, 2, SEEK_CUR);
       }
 
-      fprintf(debug,"\n");
+      fprintf(debug, "\n");
       fflush(debug);
-    }
-    else {  // worksheet
-      if(SPREADSHEET.size() == 0 || compareSpreadnames(sname) == -1) {
-        fprintf(debug,"NEW SPREADSHEET\n");
-        current_col=1;
+    } else { // worksheet
+      if (SPREADSHEET.size() == 0 || compareSpreadnames(sname) == -1) {
+        fprintf(debug, "NEW SPREADSHEET\n");
+        current_col = 1;
         SPREADSHEET.push_back(spreadSheet(sname));
-        spread=static_cast<int>(SPREADSHEET.size())-1;
-        SPREADSHEET.back().maxRows=0;
-      }
-      else {
+        spread = static_cast<int>(SPREADSHEET.size()) - 1;
+        SPREADSHEET.back().maxRows = 0;
+      } else {
 
-        spread=compareSpreadnames(sname);
+        spread = compareSpreadnames(sname);
 
-        current_col=static_cast<int>(SPREADSHEET[spread].column.size());
+        current_col = static_cast<int>(SPREADSHEET[spread].column.size());
 
-        if(!current_col)
-          current_col=1;
+        if (!current_col)
+          current_col = 1;
         current_col++;
       }
-      fprintf(debug,"SPREADSHEET = %s COLUMN NAME = %s (%d) (@0x%X)\n",
-        sname, cname,current_col,(unsigned int) ftell(f));
+      fprintf(debug, "SPREADSHEET = %s COLUMN NAME = %s (%d) (@0x%X)\n", sname,
+              cname, current_col, (unsigned int)ftell(f));
       fflush(debug);
       SPREADSHEET[spread].column.push_back(spreadColumn(cname, dataIndex));
-      int sheetpos=static_cast<int>(SPREADSHEET[spread].column.back().name.find_last_of("@"));
-      if(!SPREADSHEET[spread].bMultisheet && sheetpos!=-1)
-        if(atoi(string(cname).substr(sheetpos+1).c_str())>1)
-        {
-          SPREADSHEET[spread].bMultisheet=true;
-          fprintf(debug,"SPREADSHEET \"%s\" IS MULTISHEET \n", sname);
+      int sheetpos = static_cast<int>(
+          SPREADSHEET[spread].column.back().name.find_last_of("@"));
+      if (!SPREADSHEET[spread].bMultisheet && sheetpos != -1)
+        if (atoi(string(cname).substr(sheetpos + 1).c_str()) > 1) {
+          SPREADSHEET[spread].bMultisheet = true;
+          fprintf(debug, "SPREADSHEET \"%s\" IS MULTISHEET \n", sname);
         }
       dataIndex++;
 
-////////////////////////////// SIZE of column /////////////////////////////////////////////
-      do{ // skip until '\n'
-        CHECKED_FREAD(debug, &c,1,1,f);
+      ////////////////////////////// SIZE of column
+      ////////////////////////////////////////////////
+      do { // skip until '\n'
+        CHECKED_FREAD(debug, &c, 1, 1, f);
       } while (c != '\n');
 
-      CHECKED_FREAD(debug, &nbytes,4,1,f);
-      if(IsBigEndian()) SwapBytes(nbytes);
-      if(fmod(nbytes,(double)valuesize)>0)
-        fprintf(debug,"WARNING: data section could not be read correct\n");
+      CHECKED_FREAD(debug, &nbytes, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(nbytes);
+      if (fmod(nbytes, (double)valuesize) > 0)
+        fprintf(debug, "WARNING: data section could not be read correct\n");
       nr = nbytes / valuesize;
-      fprintf(debug," [number of rows = %d (%d Bytes) @ 0x%X]\n",nr,nbytes,(unsigned int) ftell(f));
+      fprintf(debug, " [number of rows = %d (%d Bytes) @ 0x%X]\n", nr, nbytes,
+              (unsigned int)ftell(f));
       fflush(debug);
 
-      SPREADSHEET[spread].maxRows<nr?SPREADSHEET[spread].maxRows=nr:0;
+      SPREADSHEET[spread].maxRows < nr ? SPREADSHEET[spread].maxRows = nr : 0;
 
-////////////////////////////////////// DATA ////////////////////////////////////////////////
-      CHECKED_FREAD(debug, &c,1,1,f);  // skip '\n'
+      ////////////////////////////////////// DATA
+      ///////////////////////////////////////////////////
+      CHECKED_FREAD(debug, &c, 1, 1, f); // skip '\n'
       /*if(valuesize != 8 && valuesize <= 16 && nbytes>0) { // skip 0 0
         CHECKED_FREAD(debug, &c,1,1,f);
         CHECKED_FREAD(debug, &c,1,1,f);
       }*/
-      fprintf(debug," [data @ 0x%X]\n",(unsigned int) ftell(f));
+      fprintf(debug, " [data @ 0x%X]\n", (unsigned int)ftell(f));
       fflush(debug);
 
-      for (i=0;i<nr;i++) {
-        if(valuesize <= 8) {  // Numeric, Time, Date, Month, Day
-          CHECKED_FREAD(debug, &a,valuesize,1,f);
-          if(IsBigEndian()) SwapBytes(a);
-          fprintf(debug,"%g ",a);
-          SPREADSHEET[spread].column[(current_col-1)].odata.push_back(originData(a));
-        }
-        else if((data_type&0x100)==0x100) // Text&Numeric
+      for (i = 0; i < nr; i++) {
+        if (valuesize <= 8) { // Numeric, Time, Date, Month, Day
+          CHECKED_FREAD(debug, &a, valuesize, 1, f);
+          if (IsBigEndian())
+            SwapBytes(a);
+          fprintf(debug, "%g ", a);
+          SPREADSHEET[spread].column[(current_col - 1)].odata.push_back(
+              originData(a));
+        } else if ((data_type & 0x100) == 0x100) // Text&Numeric
         {
-          CHECKED_FREAD(debug, &c,1,1,f);
-          CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-          if(c==0) //value
+          CHECKED_FREAD(debug, &c, 1, 1, f);
+          CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+          if (c == 0) // value
           {
-            //CHECKED_FREAD(debug, &a,valuesize-2,1,f);
-            CHECKED_FREAD(debug, &a,8,1,f);
-            if(IsBigEndian()) SwapBytes(a);
-            fprintf(debug,"%g ",a);
-            SPREADSHEET[spread].column[(current_col-1)].odata.push_back(originData(a));
-            CHECKED_FSEEK(debug, f,valuesize-10,SEEK_CUR);
-          }
-          else //text
+            // CHECKED_FREAD(debug, &a,valuesize-2,1,f);
+            CHECKED_FREAD(debug, &a, 8, 1, f);
+            if (IsBigEndian())
+              SwapBytes(a);
+            fprintf(debug, "%g ", a);
+            SPREADSHEET[spread].column[(current_col - 1)].odata.push_back(
+                originData(a));
+            CHECKED_FSEEK(debug, f, valuesize - 10, SEEK_CUR);
+          } else // text
           {
-            char *stmp = new char[valuesize-1];
-            CHECKED_FREAD(debug, stmp,valuesize-2,1,f);
-            if(strchr(stmp,0x0E)) // try find non-printable symbol - garbage test
-              stmp[0]='\0';
-            SPREADSHEET[spread].column[(current_col-1)].odata.push_back(originData(stmp));
-            fprintf(debug,"%s ",stmp);
-            delete [] stmp;
+            char *stmp = new char[valuesize - 1];
+            CHECKED_FREAD(debug, stmp, valuesize - 2, 1, f);
+            if (strchr(stmp,
+                       0x0E)) // try find non-printable symbol - garbage test
+              stmp[0] = '\0';
+            SPREADSHEET[spread].column[(current_col - 1)].odata.push_back(
+                originData(stmp));
+            fprintf(debug, "%s ", stmp);
+            delete[] stmp;
           }
-        }
-        else //Text
+        } else // Text
         {
-          char *stmp = new char[valuesize+1];
-          CHECKED_FREAD(debug, stmp,valuesize,1,f);
-          if(strchr(stmp,0x0E)) // try find non-printable symbol - garbage test
-            stmp[0]='\0';
-          SPREADSHEET[spread].column[(current_col-1)].odata.push_back(originData(stmp));
-          fprintf(debug,"%s ",stmp);
-          delete [] stmp;
+          char *stmp = new char[valuesize + 1];
+          CHECKED_FREAD(debug, stmp, valuesize, 1, f);
+          if (strchr(stmp,
+                     0x0E)) // try find non-printable symbol - garbage test
+            stmp[0] = '\0';
+          SPREADSHEET[spread].column[(current_col - 1)].odata.push_back(
+              originData(stmp));
+          fprintf(debug, "%s ", stmp);
+          delete[] stmp;
         }
       }
 
     } // else
 
-    fprintf(debug,"\n");
+    fprintf(debug, "\n");
     fflush(debug);
 
-    if(nbytes>0||cname==0)
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
+    if (nbytes > 0 || cname == 0)
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
 
     int tailsize;
-    CHECKED_FREAD(debug, &tailsize,4,1,f);
-    if(IsBigEndian()) SwapBytes(tailsize);
-    CHECKED_FSEEK(debug, f,1+tailsize+(tailsize>0?1:0),SEEK_CUR); //skip tail
-    //fseek(f,5+((nbytes>0||cname==0)?1:0),SEEK_CUR);
-    CHECKED_FREAD(debug, &col_found,4,1,f);
-    if(IsBigEndian()) SwapBytes(col_found);
-    CHECKED_FSEEK(debug, f,1,SEEK_CUR);  // skip '\n'
-    fprintf(debug," [column found = %d/0x%X (@ 0x%X)]\n",col_found,col_found,(unsigned int) ftell(f)-5);
-    colpos=int(ftell(f));
+    CHECKED_FREAD(debug, &tailsize, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(tailsize);
+    CHECKED_FSEEK(debug, f, 1 + tailsize + (tailsize > 0 ? 1 : 0),
+                  SEEK_CUR); // skip tail
+    // fseek(f,5+((nbytes>0||cname==0)?1:0),SEEK_CUR);
+    CHECKED_FREAD(debug, &col_found, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(col_found);
+    CHECKED_FSEEK(debug, f, 1, SEEK_CUR); // skip '\n'
+    fprintf(debug, " [column found = %d/0x%X (@ 0x%X)]\n", col_found, col_found,
+            (unsigned int)ftell(f) - 5);
+    colpos = int(ftell(f));
     fflush(debug);
   }
 
-////////////////////////////////////////////////////////////////////////////
-  for(unsigned int i=0; i<SPREADSHEET.size(); ++i)
-    if(SPREADSHEET[i].bMultisheet)
-    {
-      fprintf(debug,"   CONVERT SPREADSHEET \"%s\" to EXCEL\n", SPREADSHEET[i].name.c_str());
+  ////////////////////////////////////////////////////////////////////////////
+  for (unsigned int i = 0; i < SPREADSHEET.size(); ++i)
+    if (SPREADSHEET[i].bMultisheet) {
+      fprintf(debug, "   CONVERT SPREADSHEET \"%s\" to EXCEL\n",
+              SPREADSHEET[i].name.c_str());
       fflush(debug);
       convertSpreadToExcel(i);
       i--;
     }
-////////////////////////////////////////////////////////////////////////////
-////////////////////// HEADER SECTION //////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////
+  ////////////////////// HEADER SECTION //////////////////////////////////////
 
-  int POS = int(ftell(f)-11);
-  fprintf(debug,"\nHEADER SECTION\n");
-  fprintf(debug," nr_spreads = %zu\n",SPREADSHEET.size());
-  fprintf(debug," [position @ 0x%X]\n",POS);
+  int POS = int(ftell(f) - 11);
+  fprintf(debug, "\nHEADER SECTION\n");
+  fprintf(debug, " nr_spreads = %zu\n", SPREADSHEET.size());
+  fprintf(debug, " [position @ 0x%X]\n", POS);
   fflush(debug);
 
-//////////////////////// OBJECT INFOS //////////////////////////////////////
-  POS+=0xB;
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
-  while(1) {
+  //////////////////////// OBJECT INFOS //////////////////////////////////////
+  POS += 0xB;
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
+  while (1) {
 
-    fprintf(debug,"     reading Header\n");
+    fprintf(debug, "     reading Header\n");
     fflush(debug);
     // HEADER
     // check header
-    POS=int(ftell(f));
+    POS = int(ftell(f));
     int headersize;
-    CHECKED_FREAD(debug, &headersize,4,1,f);
-    if(IsBigEndian()) SwapBytes(headersize);
-    if(headersize==0)
+    CHECKED_FREAD(debug, &headersize, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(headersize);
+    if (headersize == 0)
       break;
     char object_type[10];
     char object_name[25];
-    CHECKED_FSEEK(debug, f,POS + 0x7,SEEK_SET);
-    CHECKED_FREAD(debug, &object_name,25,1,f);
-    CHECKED_FSEEK(debug, f,POS + 0x4A,SEEK_SET);
-    CHECKED_FREAD(debug, &object_type,10,1,f);
+    CHECKED_FSEEK(debug, f, POS + 0x7, SEEK_SET);
+    CHECKED_FREAD(debug, &object_name, 25, 1, f);
+    CHECKED_FSEEK(debug, f, POS + 0x4A, SEEK_SET);
+    CHECKED_FREAD(debug, &object_type, 10, 1, f);
 
-    CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+    CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 
-    if(compareSpreadnames(object_name)!=-1)
+    if (compareSpreadnames(object_name) != -1)
       readSpreadInfo(f, file_size, debug);
-    else if(compareMatrixnames(object_name)!=-1)
+    else if (compareMatrixnames(object_name) != -1)
       readMatrixInfo(f, file_size, debug);
-    else if(compareExcelnames(object_name)!=-1)
+    else if (compareExcelnames(object_name) != -1)
       readExcelInfo(f, file_size, debug);
     else
       readGraphInfo(f, file_size, debug);
   }
 
-
-
-  CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-  fprintf(debug,"Some Origin params @ 0x%X:\n", (unsigned int)ftell(f));
-  CHECKED_FREAD(debug, &c,1,1,f);
-  while(c!=0)
-  {
-    fprintf(debug,"   ");
-    while(c!='\n'){
-      fprintf(debug,"%c",c);
-      CHECKED_FREAD(debug, &c,1,1,f);
+  CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+  fprintf(debug, "Some Origin params @ 0x%X:\n", (unsigned int)ftell(f));
+  CHECKED_FREAD(debug, &c, 1, 1, f);
+  while (c != 0) {
+    fprintf(debug, "   ");
+    while (c != '\n') {
+      fprintf(debug, "%c", c);
+      CHECKED_FREAD(debug, &c, 1, 1, f);
     }
     double parvalue;
-    CHECKED_FREAD(debug, &parvalue,8,1,f);
-    if(IsBigEndian()) SwapBytes(parvalue);
-    fprintf(debug,": %g\n", parvalue);
-    CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-    CHECKED_FREAD(debug, &c,1,1,f);
+    CHECKED_FREAD(debug, &parvalue, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(parvalue);
+    fprintf(debug, ": %g\n", parvalue);
+    CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+    CHECKED_FREAD(debug, &c, 1, 1, f);
   }
-  CHECKED_FSEEK(debug, f,1+5,SEEK_CUR);
-  while(1)
-  {
-    //fseek(f,5+0x40+1,SEEK_CUR);
+  CHECKED_FSEEK(debug, f, 1 + 5, SEEK_CUR);
+  while (1) {
+    // fseek(f,5+0x40+1,SEEK_CUR);
     int size;
-    CHECKED_FREAD(debug, &size,4,1,f);
-    if(IsBigEndian()) SwapBytes(size);
-    if(size!=0x40)
+    CHECKED_FREAD(debug, &size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(size);
+    if (size != 0x40)
       break;
 
     double creation_date, modification_date;
 
-    CHECKED_FSEEK(debug, f,1+0x20,SEEK_CUR);
-    CHECKED_FREAD(debug, &creation_date,8,1,f);
-    if(IsBigEndian()) SwapBytes(creation_date);
+    CHECKED_FSEEK(debug, f, 1 + 0x20, SEEK_CUR);
+    CHECKED_FREAD(debug, &creation_date, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(creation_date);
 
-    CHECKED_FREAD(debug, &modification_date,8,1,f);
-    if(IsBigEndian()) SwapBytes(modification_date);
+    CHECKED_FREAD(debug, &modification_date, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(modification_date);
 
-    CHECKED_FSEEK(debug, f,0x10-4,SEEK_CUR);
+    CHECKED_FSEEK(debug, f, 0x10 - 4, SEEK_CUR);
     unsigned char labellen;
-    CHECKED_FREAD(debug, &labellen,1,1,f);
+    CHECKED_FREAD(debug, &labellen, 1, 1, f);
 
-    CHECKED_FSEEK(debug, f,4,SEEK_CUR);
-    CHECKED_FREAD(debug, &size,4,1,f);
-    if(IsBigEndian()) SwapBytes(size);
-    CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-    char *stmp = new char[size+1];
-    CHECKED_FREAD(debug, stmp,size,1,f);
-    if(0==strcmp(stmp,"ResultsLog"))
-    {
-      delete [] stmp;
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-      CHECKED_FREAD(debug, &size,4,1,f);
-      if(IsBigEndian()) SwapBytes(size);
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-      stmp = new char[size+1];
-      CHECKED_FREAD(debug, stmp,size,1,f);
-      resultsLog=stmp;
-      fprintf(debug,"Results Log: %s\n", resultsLog.c_str());
-      delete [] stmp;
+    CHECKED_FSEEK(debug, f, 4, SEEK_CUR);
+    CHECKED_FREAD(debug, &size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(size);
+    CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+    char *stmp = new char[size + 1];
+    CHECKED_FREAD(debug, stmp, size, 1, f);
+    if (0 == strcmp(stmp, "ResultsLog")) {
+      delete[] stmp;
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+      CHECKED_FREAD(debug, &size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(size);
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+      stmp = new char[size + 1];
+      CHECKED_FREAD(debug, stmp, size, 1, f);
+      resultsLog = stmp;
+      fprintf(debug, "Results Log: %s\n", resultsLog.c_str());
+      delete[] stmp;
       break;
-    }
-    else
-    {
+    } else {
       NOTE.push_back(note(stmp));
-      NOTE.back().objectID=objectIndex;
-      NOTE.back().creation_date=creation_date;
-      NOTE.back().modification_date=modification_date;
+      NOTE.back().objectID = objectIndex;
+      NOTE.back().creation_date = creation_date;
+      NOTE.back().modification_date = modification_date;
       objectIndex++;
-      delete [] stmp;
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-      CHECKED_FREAD(debug, &size,4,1,f);
-      if(IsBigEndian()) SwapBytes(size);
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
-      if(labellen>1)
-      {
+      delete[] stmp;
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+      CHECKED_FREAD(debug, &size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(size);
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
+      if (labellen > 1) {
         stmp = new char[labellen];
-        stmp[labellen-1]='\0';
-        CHECKED_FREAD(debug, stmp,labellen-1,1,f);
-        NOTE.back().label=stmp;
-        delete [] stmp;
-        CHECKED_FSEEK(debug, f,1,SEEK_CUR);
+        stmp[labellen - 1] = '\0';
+        CHECKED_FREAD(debug, stmp, labellen - 1, 1, f);
+        NOTE.back().label = stmp;
+        delete[] stmp;
+        CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
       }
-      stmp = new char[size-labellen+1];
-      CHECKED_FREAD(debug, stmp,size-labellen,1,f);
-      NOTE.back().text=stmp;
-      fprintf(debug,"NOTE %zu NAME: %s\n", NOTE.size(), NOTE.back().name.c_str());
-      fprintf(debug,"NOTE %zu LABEL: %s\n", NOTE.size(), NOTE.back().label.c_str());
-      fprintf(debug,"NOTE %zu TEXT:\n%s\n", NOTE.size(), NOTE.back().text.c_str());
-      delete [] stmp;
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
+      stmp = new char[size - labellen + 1];
+      CHECKED_FREAD(debug, stmp, size - labellen, 1, f);
+      NOTE.back().text = stmp;
+      fprintf(debug, "NOTE %zu NAME: %s\n", NOTE.size(),
+              NOTE.back().name.c_str());
+      fprintf(debug, "NOTE %zu LABEL: %s\n", NOTE.size(),
+              NOTE.back().label.c_str());
+      fprintf(debug, "NOTE %zu TEXT:\n%s\n", NOTE.size(),
+              NOTE.back().text.c_str());
+      delete[] stmp;
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
     }
   }
 
-  CHECKED_FSEEK(debug, f,1+4*5+0x10+1,SEEK_CUR);
-  try
-  {
+  CHECKED_FSEEK(debug, f, 1 + 4 * 5 + 0x10 + 1, SEEK_CUR);
+  try {
     readProjectTree(f, debug);
+  } catch (...) {
   }
-  catch(...)
-  {}
-  fprintf(debug,"Done parsing\n");
+  fprintf(debug, "Done parsing\n");
   fclose(debug);
 
   return 0;
 }
 
-void OPJFile::readSpreadInfo(FILE *f, int file_size, FILE *debug)
-{
-  int POS=int(ftell(f));
+void OPJFile::readSpreadInfo(FILE *f, int file_size, FILE *debug) {
+  int POS = int(ftell(f));
 
   int headersize;
-  CHECKED_FREAD(debug, &headersize,4,1,f);
-  if(IsBigEndian()) SwapBytes(headersize);
+  CHECKED_FREAD(debug, &headersize, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(headersize);
 
-  POS+=5;
+  POS += 5;
 
-  fprintf(debug,"     [Spreadsheet SECTION (@ 0x%X)]\n",POS);
+  fprintf(debug, "     [Spreadsheet SECTION (@ 0x%X)]\n", POS);
   fflush(debug);
 
   // check spreadsheet name
   char name[25];
-  CHECKED_FSEEK(debug, f,POS + 0x2,SEEK_SET);
-  CHECKED_FREAD(debug, &name,25,1,f);
+  CHECKED_FSEEK(debug, f, POS + 0x2, SEEK_SET);
+  CHECKED_FREAD(debug, &name, 25, 1, f);
 
-  int spread=compareSpreadnames(name);
-  SPREADSHEET[spread].name=name;
+  int spread = compareSpreadnames(name);
+  SPREADSHEET[spread].name = name;
   readWindowProperties(SPREADSHEET[spread], f, debug, POS, headersize);
-  SPREADSHEET[spread].bLoose=false;
+  SPREADSHEET[spread].bLoose = false;
   char c = 0;
 
   int LAYER = POS;
   {
     // LAYER section
-    LAYER += headersize + 0x1 + 0x5/* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
-    //now structure is next : section_header_size=0x6F(4 bytes) + '\n' + section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' + section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' + section_body_2 + '\n'
-    //possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage etc
-    //section name(column name in formula case) starts with 0x46 position
-    while(1)
-    {
+    LAYER += headersize + 0x1 + 0x5 /* length of block = 0x12D + '\n'*/ +
+             0x12D + 0x1;
+    // now structure is next : section_header_size=0x6F(4 bytes) + '\n' +
+    // section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' +
+    // section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' +
+    // section_body_2 + '\n'
+    // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
+    // etc
+    // section name(column name in formula case) starts with 0x46 position
+    while (1) {
       int sec_size;
-    //section_header_size=0x6F(4 bytes) + '\n'
-      LAYER+=0x5;
+      // section_header_size=0x6F(4 bytes) + '\n'
+      LAYER += 0x5;
 
-    //section_header
-      CHECKED_FSEEK(debug, f,LAYER+0x46,SEEK_SET);
+      // section_header
+      CHECKED_FSEEK(debug, f, LAYER + 0x46, SEEK_SET);
       char sec_name[42];
-      CHECKED_FREAD(debug, &sec_name,41,1,f);
-      sec_name[41]='\0';
+      CHECKED_FREAD(debug, &sec_name, 41, 1, f);
+      sec_name[41] = '\0';
 
-      fprintf(debug,"       DEBUG SECTION NAME: %s (@ 0x%X)\n", sec_name, LAYER+0x46);
+      fprintf(debug, "       DEBUG SECTION NAME: %s (@ 0x%X)\n", sec_name,
+              LAYER + 0x46);
       fflush(debug);
 
-    //section_body_1_size
-      LAYER+=0x6F+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_1_size
+      LAYER += 0x6F + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
       if (INT_MAX == sec_size) {
         // this would end in an overflow and it's obviously wrong
-        fprintf(debug, "Error: while reading spread info, found section size: %d\n", sec_size);
+        fprintf(debug,
+                "Error: while reading spread info, found section size: %d\n",
+                sec_size);
         fflush(debug);
       }
 
       if (file_size < sec_size) {
-        fprintf(debug, "Error in readSpread: found section size (%d) bigger than total file size: %d\n", sec_size, file_size);
+        fprintf(debug, "Error in readSpread: found section size (%d) bigger "
+                       "than total file size: %d\n",
+                sec_size, file_size);
         fflush(debug);
         return;
       }
 
-    //section_body_1
-      LAYER+=0x5;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      //check if it is a formula
-      int col_index=compareColumnnames(spread,sec_name);
-      if(col_index!=-1)
-      {
-        char *stmp=new char[sec_size+1];
+      // section_body_1
+      LAYER += 0x5;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      // check if it is a formula
+      int col_index = compareColumnnames(spread, sec_name);
+      if (col_index != -1) {
+        char *stmp = new char[sec_size + 1];
         if (!stmp)
           break;
 
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, stmp,sec_size,1,f);
-        SPREADSHEET[spread].column[col_index].command=stmp;
-        delete [] stmp;
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, stmp, sec_size, 1, f);
+        SPREADSHEET[spread].column[col_index].command = stmp;
+        delete[] stmp;
       }
 
-    //section_body_2_size
-      LAYER+=sec_size+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_2_size
+      LAYER += sec_size + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
-    //section_body_2
-      LAYER+=0x5;
+      // section_body_2
+      LAYER += 0x5;
 
-    //close section 00 00 00 00 0A
-      LAYER+=sec_size+(sec_size>0?0x1:0)+0x5;
+      // close section 00 00 00 00 0A
+      LAYER += sec_size + (sec_size > 0 ? 0x1 : 0) + 0x5;
 
-      if(0==strcmp(sec_name,"__LayerInfoStorage"))
+      if (0 == strcmp(sec_name, "__LayerInfoStorage"))
         break;
-
     }
-    LAYER+=0x5;
-
+    LAYER += 0x5;
   }
 
   fflush(debug);
 
   /////////////// COLUMN Types ///////////////////////////////////////////
-  fprintf(debug,"     Spreadsheet has %zu columns\n",SPREADSHEET[spread].column.size());
+  fprintf(debug, "     Spreadsheet has %zu columns\n",
+          SPREADSHEET[spread].column.size());
 
-  while(1)
-  {
-    LAYER+=0x5;
-    CHECKED_FSEEK(debug, f,LAYER+0x12, SEEK_SET);
-    CHECKED_FREAD(debug, &name,12,1,f);
+  while (1) {
+    LAYER += 0x5;
+    CHECKED_FSEEK(debug, f, LAYER + 0x12, SEEK_SET);
+    CHECKED_FREAD(debug, &name, 12, 1, f);
 
-    CHECKED_FSEEK(debug, f,LAYER+0x11, SEEK_SET);
-    CHECKED_FREAD(debug, &c,1,1,f);
-    short width=0;
-    CHECKED_FSEEK(debug, f,LAYER+0x4A, SEEK_SET);
-    CHECKED_FREAD(debug, &width,2,1,f);
-    if(IsBigEndian()) SwapBytes(width);
-    int col_index=compareColumnnames(spread,name);
-    if(col_index!=-1)
-    {
+    CHECKED_FSEEK(debug, f, LAYER + 0x11, SEEK_SET);
+    CHECKED_FREAD(debug, &c, 1, 1, f);
+    short width = 0;
+    CHECKED_FSEEK(debug, f, LAYER + 0x4A, SEEK_SET);
+    CHECKED_FREAD(debug, &width, 2, 1, f);
+    if (IsBigEndian())
+      SwapBytes(width);
+    int col_index = compareColumnnames(spread, name);
+    if (col_index != -1) {
       ColumnType type;
-      switch(c) {
+      switch (c) {
+      case 3:
+        type = X;
+        break;
+      case 0:
+        type = Y;
+        break;
+      case 5:
+        type = Z;
+        break;
+      case 6:
+        type = XErr;
+        break;
+      case 2:
+        type = YErr;
+        break;
+      case 4:
+        type = Label;
+        break;
+      default:
+        type = NONE;
+        break;
+      }
+      SPREADSHEET[spread].column[col_index].type = type;
+      width /= 0xA;
+      if (width == 0)
+        width = 8;
+      SPREADSHEET[spread].column[col_index].width = width;
+      CHECKED_FSEEK(debug, f, LAYER + 0x1E, SEEK_SET);
+      unsigned char c1, c2;
+      CHECKED_FREAD(debug, &c1, 1, 1, f);
+      CHECKED_FREAD(debug, &c2, 1, 1, f);
+      switch (c1) {
+      case 0x00: // Numeric    - Dec1000
+      case 0x09: // Text&Numeric - Dec1000
+      case 0x10: // Numeric    - Scientific
+      case 0x19: // Text&Numeric - Scientific
+      case 0x20: // Numeric    - Engeneering
+      case 0x29: // Text&Numeric - Engeneering
+      case 0x30: // Numeric    - Dec1,000
+      case 0x39: // Text&Numeric - Dec1,000
+        SPREADSHEET[spread].column[col_index].value_type =
+            (c1 % 0x10 == 0x9) ? 6 : 0;
+        SPREADSHEET[spread].column[col_index].value_type_specification =
+            c1 / 0x10;
+        if (c2 >= 0x80) {
+          SPREADSHEET[spread].column[col_index].significant_digits = c2 - 0x80;
+          SPREADSHEET[spread].column[col_index].numeric_display_type = 2;
+        } else if (c2 > 0) {
+          SPREADSHEET[spread].column[col_index].decimal_places = c2 - 0x03;
+          SPREADSHEET[spread].column[col_index].numeric_display_type = 1;
+        }
+        break;
+      case 0x02: // Time
+        SPREADSHEET[spread].column[col_index].value_type = 3;
+        SPREADSHEET[spread].column[col_index].value_type_specification =
+            c2 - 0x80;
+        break;
+      case 0x03: // Date
+        SPREADSHEET[spread].column[col_index].value_type = 2;
+        SPREADSHEET[spread].column[col_index].value_type_specification =
+            c2 - 0x80;
+        break;
+      case 0x31: // Text
+        SPREADSHEET[spread].column[col_index].value_type = 1;
+        break;
+      case 0x4: // Month
+      case 0x34:
+        SPREADSHEET[spread].column[col_index].value_type = 4;
+        SPREADSHEET[spread].column[col_index].value_type_specification = c2;
+        break;
+      case 0x5: // Day
+      case 0x35:
+        SPREADSHEET[spread].column[col_index].value_type = 5;
+        SPREADSHEET[spread].column[col_index].value_type_specification = c2;
+        break;
+      default: // Text
+        SPREADSHEET[spread].column[col_index].value_type = 1;
+        break;
+      }
+      fprintf(debug, "       COLUMN \"%s\" type = %s(%d) (@ 0x%X)\n",
+              SPREADSHEET[spread].column[col_index].name.c_str(),
+              colTypeNames[type], c, LAYER + 0x11);
+      fflush(debug);
+    }
+    LAYER += 0x1E7 + 0x1;
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    int comm_size = 0;
+    CHECKED_FREAD(debug, &comm_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(comm_size);
+    LAYER += 0x5;
+    if (comm_size > 0) {
+      char *comment = new char[comm_size + 1];
+      comment[comm_size] = '\0';
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, comment, comm_size, 1, f);
+      if (col_index != -1)
+        SPREADSHEET[spread].column[col_index].comment = comment;
+      LAYER += comm_size + 0x1;
+      delete[] comment;
+    }
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    int ntmp;
+    CHECKED_FREAD(debug, &ntmp, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(ntmp);
+    if (ntmp != 0x1E7)
+      break;
+  }
+  fprintf(debug, "   Done with spreadsheet %d\n", spread);
+  fflush(debug);
+
+  POS = LAYER + 0x5 * 0x6 + 0x1ED * 0x12;
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
+}
+
+void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug) {
+  int POS = int(ftell(f));
+
+  int headersize;
+  CHECKED_FREAD(debug, &headersize, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(headersize);
+
+  POS += 5;
+
+  fprintf(debug, "     [EXCEL SECTION (@ 0x%X)]\n", POS);
+  fflush(debug);
+
+  // check spreadsheet name
+  char name[25];
+  CHECKED_FSEEK(debug, f, POS + 0x2, SEEK_SET);
+  CHECKED_FREAD(debug, &name, 25, 1, f);
+
+  int iexcel = compareExcelnames(name);
+  EXCEL[iexcel].name = name;
+  readWindowProperties(EXCEL[iexcel], f, debug, POS, headersize);
+  EXCEL[iexcel].bLoose = false;
+  char c = 0;
+
+  int LAYER = POS;
+  LAYER += headersize + 0x1;
+  int sec_size;
+  int isheet = 0;
+  while (1) // multisheet loop
+  {
+    // LAYER section
+    LAYER += 0x5 /* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
+    // now structure is next : section_header_size=0x6F(4 bytes) + '\n' +
+    // section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' +
+    // section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' +
+    // section_body_2 + '\n'
+    // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
+    // etc
+    // section name(column name in formula case) starts with 0x46 position
+    while (1) {
+      // section_header_size=0x6F(4 bytes) + '\n'
+      LAYER += 0x5;
+
+      // section_header
+      CHECKED_FSEEK(debug, f, LAYER + 0x46, SEEK_SET);
+      char sec_name[42];
+      CHECKED_FREAD(debug, &sec_name, 41, 1, f);
+      sec_name[41] = '\0';
+
+      fprintf(debug, "       DEBUG SECTION NAME: %s (@ 0x%X)\n", sec_name,
+              LAYER + 0x46);
+      fflush(debug);
+
+      // section_body_1_size
+      LAYER += 0x6F + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
+
+      if (INT_MAX == sec_size) {
+        // this would end in an overflow for new[] below and it's obviously
+        // wrong
+        fprintf(debug,
+                "Error: while reading Excel info, found section size: %d\n",
+                sec_size);
+        fflush(debug);
+      }
+
+      if (file_size < sec_size) {
+        fprintf(debug, "Error in readExcel: found section size (%d) bigger "
+                       "than total file size: %d\n",
+                sec_size, file_size);
+        fflush(debug);
+        return;
+      }
+
+      // section_body_1
+      LAYER += 0x5;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      // check if it is a formula
+      int col_index = compareExcelColumnnames(iexcel, isheet, sec_name);
+      if (col_index != -1) {
+        char *stmp = new char[sec_size + 1];
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, stmp, sec_size, 1, f);
+        EXCEL[iexcel].sheet[isheet].column[col_index].command = stmp;
+        delete[] stmp;
+      }
+
+      // section_body_2_size
+      LAYER += sec_size + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
+
+      // section_body_2
+      LAYER += 0x5;
+
+      // close section 00 00 00 00 0A
+      LAYER += sec_size + (sec_size > 0 ? 0x1 : 0) + 0x5;
+
+      if (0 == strcmp(sec_name, "__LayerInfoStorage"))
+        break;
+    }
+    LAYER += 0x5;
+
+    fflush(debug);
+
+    /////////////// COLUMN Types ///////////////////////////////////////////
+    fprintf(debug, "     Excel sheet %d has %zu columns\n", isheet,
+            EXCEL[iexcel].sheet[isheet].column.size());
+
+    while (1) {
+      LAYER += 0x5;
+      CHECKED_FSEEK(debug, f, LAYER + 0x12, SEEK_SET);
+      CHECKED_FREAD(debug, &name, 12, 1, f);
+
+      CHECKED_FSEEK(debug, f, LAYER + 0x11, SEEK_SET);
+      CHECKED_FREAD(debug, &c, 1, 1, f);
+      short width = 0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x4A, SEEK_SET);
+      CHECKED_FREAD(debug, &width, 2, 1, f);
+      if (IsBigEndian())
+        SwapBytes(width);
+      // char col_name[30];
+      // sprintf(col_name, "%s@%d", name, isheet);
+      int col_index = compareExcelColumnnames(iexcel, isheet, name);
+      if (col_index != -1) {
+        ColumnType type;
+        switch (c) {
         case 3:
           type = X;
           break;
@@ -1466,255 +1791,17 @@ void OPJFile::readSpreadInfo(FILE *f, int file_size, FILE *debug)
         default:
           type = NONE;
           break;
-      }
-      SPREADSHEET[spread].column[col_index].type=type;
-      width/=0xA;
-      if(width==0)
-        width=8;
-      SPREADSHEET[spread].column[col_index].width=width;
-      CHECKED_FSEEK(debug, f,LAYER+0x1E, SEEK_SET);
-      unsigned char c1,c2;
-      CHECKED_FREAD(debug, &c1,1,1,f);
-      CHECKED_FREAD(debug, &c2,1,1,f);
-      switch(c1)
-      {
-      case 0x00: // Numeric    - Dec1000
-      case 0x09: // Text&Numeric - Dec1000
-      case 0x10: // Numeric    - Scientific
-      case 0x19: // Text&Numeric - Scientific
-      case 0x20: // Numeric    - Engeneering
-      case 0x29: // Text&Numeric - Engeneering
-      case 0x30: // Numeric    - Dec1,000
-      case 0x39: // Text&Numeric - Dec1,000
-        SPREADSHEET[spread].column[col_index].value_type=(c1%0x10==0x9)?6:0;
-        SPREADSHEET[spread].column[col_index].value_type_specification=c1/0x10;
-        if(c2>=0x80)
-        {
-          SPREADSHEET[spread].column[col_index].significant_digits=c2-0x80;
-          SPREADSHEET[spread].column[col_index].numeric_display_type=2;
         }
-        else if(c2>0)
-        {
-          SPREADSHEET[spread].column[col_index].decimal_places=c2-0x03;
-          SPREADSHEET[spread].column[col_index].numeric_display_type=1;
-        }
-        break;
-      case 0x02: // Time
-        SPREADSHEET[spread].column[col_index].value_type=3;
-        SPREADSHEET[spread].column[col_index].value_type_specification=c2-0x80;
-        break;
-      case 0x03: // Date
-        SPREADSHEET[spread].column[col_index].value_type=2;
-        SPREADSHEET[spread].column[col_index].value_type_specification=c2-0x80;
-        break;
-      case 0x31: // Text
-        SPREADSHEET[spread].column[col_index].value_type=1;
-        break;
-      case 0x4: // Month
-      case 0x34:
-        SPREADSHEET[spread].column[col_index].value_type=4;
-        SPREADSHEET[spread].column[col_index].value_type_specification=c2;
-        break;
-      case 0x5: // Day
-      case 0x35:
-        SPREADSHEET[spread].column[col_index].value_type=5;
-        SPREADSHEET[spread].column[col_index].value_type_specification=c2;
-        break;
-      default: // Text
-        SPREADSHEET[spread].column[col_index].value_type=1;
-        break;
-      }
-      fprintf(debug,"       COLUMN \"%s\" type = %s(%d) (@ 0x%X)\n",
-        SPREADSHEET[spread].column[col_index].name.c_str(),colTypeNames[type],c,LAYER+0x11);
-      fflush(debug);
-    }
-    LAYER+=0x1E7+0x1;
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    int comm_size=0;
-    CHECKED_FREAD(debug, &comm_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(comm_size);
-    LAYER+=0x5;
-    if(comm_size>0)
-    {
-      char* comment=new char[comm_size+1];
-      comment[comm_size]='\0';
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, comment,comm_size,1,f);
-      if(col_index!=-1)
-        SPREADSHEET[spread].column[col_index].comment=comment;
-      LAYER+=comm_size+0x1;
-      delete [] comment;
-    }
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    int ntmp;
-    CHECKED_FREAD(debug, &ntmp,4,1,f);
-    if(IsBigEndian()) SwapBytes(ntmp);
-    if(ntmp!=0x1E7)
-      break;
-  }
-  fprintf(debug,"   Done with spreadsheet %d\n",spread);
-  fflush(debug);
-
-  POS = LAYER+0x5*0x6+0x1ED*0x12;
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
-}
-
-void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug)
-{
-  int POS=int(ftell(f));
-
-  int headersize;
-  CHECKED_FREAD(debug, &headersize,4,1,f);
-  if(IsBigEndian()) SwapBytes(headersize);
-
-  POS+=5;
-
-  fprintf(debug,"     [EXCEL SECTION (@ 0x%X)]\n",POS);
-  fflush(debug);
-
-  // check spreadsheet name
-  char name[25];
-  CHECKED_FSEEK(debug, f,POS + 0x2,SEEK_SET);
-  CHECKED_FREAD(debug, &name,25,1,f);
-
-  int iexcel=compareExcelnames(name);
-  EXCEL[iexcel].name=name;
-  readWindowProperties(EXCEL[iexcel], f, debug, POS, headersize);
-  EXCEL[iexcel].bLoose=false;
-  char c = 0;
-
-  int LAYER = POS;
-  LAYER += headersize + 0x1;
-  int sec_size;
-  int isheet=0;
-  while(1)// multisheet loop
-  {
-    // LAYER section
-    LAYER += 0x5/* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
-    //now structure is next : section_header_size=0x6F(4 bytes) + '\n' + section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' + section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' + section_body_2 + '\n'
-    //possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage etc
-    //section name(column name in formula case) starts with 0x46 position
-    while(1)
-    {
-    //section_header_size=0x6F(4 bytes) + '\n'
-      LAYER+=0x5;
-
-    //section_header
-      CHECKED_FSEEK(debug, f,LAYER+0x46,SEEK_SET);
-      char sec_name[42];
-      CHECKED_FREAD(debug, &sec_name,41,1,f);
-      sec_name[41]='\0';
-
-      fprintf(debug,"       DEBUG SECTION NAME: %s (@ 0x%X)\n", sec_name, LAYER+0x46);
-      fflush(debug);
-
-    //section_body_1_size
-      LAYER+=0x6F+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
-
-      if (INT_MAX == sec_size) {
-        // this would end in an overflow for new[] below and it's obviously wrong
-        fprintf(debug, "Error: while reading Excel info, found section size: %d\n", sec_size);
-        fflush(debug);
-      }
-
-      if (file_size < sec_size) {
-        fprintf(debug, "Error in readExcel: found section size (%d) bigger than total file size: %d\n", sec_size, file_size);
-        fflush(debug);
-        return;
-    }
-
-    //section_body_1
-      LAYER+=0x5;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      //check if it is a formula
-      int col_index=compareExcelColumnnames(iexcel, isheet, sec_name);
-      if(col_index!=-1)
-      {
-        char *stmp=new char[sec_size+1];
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, stmp,sec_size,1,f);
-        EXCEL[iexcel].sheet[isheet].column[col_index].command=stmp;
-        delete [] stmp;
-      }
-
-    //section_body_2_size
-      LAYER+=sec_size+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
-
-    //section_body_2
-      LAYER+=0x5;
-
-    //close section 00 00 00 00 0A
-      LAYER+=sec_size+(sec_size>0?0x1:0)+0x5;
-
-      if(0==strcmp(sec_name,"__LayerInfoStorage"))
-        break;
-
-    }
-    LAYER+=0x5;
-
-    fflush(debug);
-
-    /////////////// COLUMN Types ///////////////////////////////////////////
-    fprintf(debug,"     Excel sheet %d has %zu columns\n",isheet,EXCEL[iexcel].sheet[isheet].column.size());
-
-    while(1)
-    {
-      LAYER+=0x5;
-      CHECKED_FSEEK(debug, f,LAYER+0x12, SEEK_SET);
-      CHECKED_FREAD(debug, &name,12,1,f);
-
-      CHECKED_FSEEK(debug, f,LAYER+0x11, SEEK_SET);
-      CHECKED_FREAD(debug, &c,1,1,f);
-      short width=0;
-      CHECKED_FSEEK(debug, f,LAYER+0x4A, SEEK_SET);
-      CHECKED_FREAD(debug, &width,2,1,f);
-      if(IsBigEndian()) SwapBytes(width);
-      //char col_name[30];
-      //sprintf(col_name, "%s@%d", name, isheet);
-      int col_index=compareExcelColumnnames(iexcel, isheet, name);
-      if(col_index!=-1)
-      {
-        ColumnType type;
-        switch(c) {
-          case 3:
-            type = X;
-            break;
-          case 0:
-            type = Y;
-            break;
-          case 5:
-            type = Z;
-            break;
-          case 6:
-            type = XErr;
-            break;
-          case 2:
-            type = YErr;
-            break;
-          case 4:
-            type = Label;
-            break;
-          default:
-            type = NONE;
-            break;
-        }
-        EXCEL[iexcel].sheet[isheet].column[col_index].type=type;
-        width/=0xA;
-        if(width==0)
-          width=8;
-        EXCEL[iexcel].sheet[isheet].column[col_index].width=width;
-        CHECKED_FSEEK(debug, f,LAYER+0x1E, SEEK_SET);
-        unsigned char c1,c2;
-        CHECKED_FREAD(debug, &c1,1,1,f);
-        CHECKED_FREAD(debug, &c2,1,1,f);
-        switch(c1)
-        {
+        EXCEL[iexcel].sheet[isheet].column[col_index].type = type;
+        width /= 0xA;
+        if (width == 0)
+          width = 8;
+        EXCEL[iexcel].sheet[isheet].column[col_index].width = width;
+        CHECKED_FSEEK(debug, f, LAYER + 0x1E, SEEK_SET);
+        unsigned char c1, c2;
+        CHECKED_FREAD(debug, &c1, 1, 1, f);
+        CHECKED_FREAD(debug, &c2, 1, 1, f);
+        switch (c1) {
         case 0x00: // Numeric    - Dec1000
         case 0x09: // Text&Numeric - Dec1000
         case 0x10: // Numeric    - Scientific
@@ -1723,115 +1810,134 @@ void OPJFile::readExcelInfo(FILE *f, int file_size, FILE *debug)
         case 0x29: // Text&Numeric - Engeneering
         case 0x30: // Numeric    - Dec1,000
         case 0x39: // Text&Numeric - Dec1,000
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=(c1%0x10==0x9)?6:0;
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type_specification=c1/0x10;
-          if(c2>=0x80)
-          {
-            EXCEL[iexcel].sheet[isheet].column[col_index].significant_digits=c2-0x80;
-            EXCEL[iexcel].sheet[isheet].column[col_index].numeric_display_type=2;
-          }
-          else if(c2>0)
-          {
-            EXCEL[iexcel].sheet[isheet].column[col_index].decimal_places=c2-0x03;
-            EXCEL[iexcel].sheet[isheet].column[col_index].numeric_display_type=1;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type =
+              (c1 % 0x10 == 0x9) ? 6 : 0;
+          EXCEL[iexcel]
+              .sheet[isheet]
+              .column[col_index]
+              .value_type_specification = c1 / 0x10;
+          if (c2 >= 0x80) {
+            EXCEL[iexcel].sheet[isheet].column[col_index].significant_digits =
+                c2 - 0x80;
+            EXCEL[iexcel].sheet[isheet].column[col_index].numeric_display_type =
+                2;
+          } else if (c2 > 0) {
+            EXCEL[iexcel].sheet[isheet].column[col_index].decimal_places =
+                c2 - 0x03;
+            EXCEL[iexcel].sheet[isheet].column[col_index].numeric_display_type =
+                1;
           }
           break;
         case 0x02: // Time
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=3;
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type_specification=c2-0x80;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type = 3;
+          EXCEL[iexcel]
+              .sheet[isheet]
+              .column[col_index]
+              .value_type_specification = c2 - 0x80;
           break;
         case 0x03: // Date
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=2;
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type_specification=c2-0x80;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type = 2;
+          EXCEL[iexcel]
+              .sheet[isheet]
+              .column[col_index]
+              .value_type_specification = c2 - 0x80;
           break;
         case 0x31: // Text
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=1;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type = 1;
           break;
         case 0x4: // Month
         case 0x34:
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=4;
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type_specification=c2;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type = 4;
+          EXCEL[iexcel]
+              .sheet[isheet]
+              .column[col_index]
+              .value_type_specification = c2;
           break;
         case 0x5: // Day
         case 0x35:
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=5;
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type_specification=c2;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type = 5;
+          EXCEL[iexcel]
+              .sheet[isheet]
+              .column[col_index]
+              .value_type_specification = c2;
           break;
         default: // Text
-          EXCEL[iexcel].sheet[isheet].column[col_index].value_type=1;
+          EXCEL[iexcel].sheet[isheet].column[col_index].value_type = 1;
           break;
         }
-        fprintf(debug,"       COLUMN \"%s\" type = %s(%d) (@ 0x%X)\n",
-          EXCEL[iexcel].sheet[isheet].column[col_index].name.c_str(),colTypeNames[type],c,LAYER+0x11);
+        fprintf(debug, "       COLUMN \"%s\" type = %s(%d) (@ 0x%X)\n",
+                EXCEL[iexcel].sheet[isheet].column[col_index].name.c_str(),
+                colTypeNames[type], c, LAYER + 0x11);
         fflush(debug);
       }
-      LAYER+=0x1E7+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      int comm_size=0;
-      CHECKED_FREAD(debug, &comm_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(comm_size);
-      LAYER+=0x5;
-      if(comm_size>0)
-      {
-        char* comment=new char[comm_size+1];
-        comment[comm_size]='\0';
-        CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-        CHECKED_FREAD(debug, comment,comm_size,1,f);
-        if(col_index!=-1)
-          EXCEL[iexcel].sheet[isheet].column[col_index].comment=comment;
-        LAYER+=comm_size+0x1;
-        delete [] comment;
+      LAYER += 0x1E7 + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      int comm_size = 0;
+      CHECKED_FREAD(debug, &comm_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(comm_size);
+      LAYER += 0x5;
+      if (comm_size > 0) {
+        char *comment = new char[comm_size + 1];
+        comment[comm_size] = '\0';
+        CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+        CHECKED_FREAD(debug, comment, comm_size, 1, f);
+        if (col_index != -1)
+          EXCEL[iexcel].sheet[isheet].column[col_index].comment = comment;
+        LAYER += comm_size + 0x1;
+        delete[] comment;
       }
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
       int ntmp;
-      CHECKED_FREAD(debug, &ntmp,4,1,f);
-      if(IsBigEndian()) SwapBytes(ntmp);
-      if(ntmp!=0x1E7)
+      CHECKED_FREAD(debug, &ntmp, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(ntmp);
+      if (ntmp != 0x1E7)
         break;
     }
-    fprintf(debug,"   Done with excel %d\n", iexcel);
+    fprintf(debug, "   Done with excel %d\n", iexcel);
     fflush(debug);
 
-    //POS = LAYER+0x5*0x6+0x1ED*0x12;
-    LAYER+=0x5*0x5+0x1ED*0x12;
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    CHECKED_FREAD(debug, &sec_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(sec_size);
-    if(sec_size==0)
+    // POS = LAYER+0x5*0x6+0x1ED*0x12;
+    LAYER += 0x5 * 0x5 + 0x1ED * 0x12;
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(sec_size);
+    if (sec_size == 0)
       break;
     isheet++;
   }
-  POS = LAYER+0x5;
+  POS = LAYER + 0x5;
 
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 }
 
-void OPJFile::readMatrixInfo(FILE *f, int file_size, FILE *debug)
-{
-  int POS=int(ftell(f));
+void OPJFile::readMatrixInfo(FILE *f, int file_size, FILE *debug) {
+  int POS = int(ftell(f));
 
   int headersize;
-  CHECKED_FREAD(debug, &headersize,4,1,f);
-  if(IsBigEndian()) SwapBytes(headersize);
-  POS+=5;
+  CHECKED_FREAD(debug, &headersize, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(headersize);
+  POS += 5;
 
-  fprintf(debug,"     [Matrix SECTION (@ 0x%X)]\n",POS);
+  fprintf(debug, "     [Matrix SECTION (@ 0x%X)]\n", POS);
   fflush(debug);
 
   // check spreadsheet name
   char name[25];
-  CHECKED_FSEEK(debug, f,POS + 0x2,SEEK_SET);
-  CHECKED_FREAD(debug, &name,25,1,f);
+  CHECKED_FSEEK(debug, f, POS + 0x2, SEEK_SET);
+  CHECKED_FREAD(debug, &name, 25, 1, f);
 
-  int idx=compareMatrixnames(name);
-  MATRIX[idx].name=name;
+  int idx = compareMatrixnames(name);
+  MATRIX[idx].name = name;
   readWindowProperties(MATRIX[idx], f, debug, POS, headersize);
 
   unsigned char h = 0;
-  CHECKED_FSEEK(debug, f,POS+0x87,SEEK_SET);
-  CHECKED_FREAD(debug, &h,1,1,f);
-  switch(h)
-  {
+  CHECKED_FSEEK(debug, f, POS + 0x87, SEEK_SET);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
+  switch (h) {
   case 1:
     MATRIX[idx].view = matrix::ImageView;
     break;
@@ -1844,1133 +1950,1209 @@ void OPJFile::readMatrixInfo(FILE *f, int file_size, FILE *debug)
   LAYER += headersize + 0x1;
   int sec_size;
   // LAYER section
-  LAYER +=0x5;
-  CHECKED_FSEEK(debug, f,LAYER+0x2B,SEEK_SET);
-  short w=0;
-  CHECKED_FREAD(debug, &w,2,1,f);
-  if(IsBigEndian()) SwapBytes(w);
-  MATRIX[idx].nr_cols=w;
-  CHECKED_FSEEK(debug, f,LAYER+0x52,SEEK_SET);
-  CHECKED_FREAD(debug, &w,2,1,f);
-  if(IsBigEndian()) SwapBytes(w);
-  MATRIX[idx].nr_rows=w;
+  LAYER += 0x5;
+  CHECKED_FSEEK(debug, f, LAYER + 0x2B, SEEK_SET);
+  short w = 0;
+  CHECKED_FREAD(debug, &w, 2, 1, f);
+  if (IsBigEndian())
+    SwapBytes(w);
+  MATRIX[idx].nr_cols = w;
+  CHECKED_FSEEK(debug, f, LAYER + 0x52, SEEK_SET);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
+  if (IsBigEndian())
+    SwapBytes(w);
+  MATRIX[idx].nr_rows = w;
 
-  LAYER +=0x12D + 0x1;
-  //now structure is next : section_header_size=0x6F(4 bytes) + '\n' + section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' + section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' + section_body_2 + '\n'
-  //possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
-  //section name(column name in formula case) starts with 0x46 position
-  while(1)
-  {
-  //section_header_size=0x6F(4 bytes) + '\n'
-    LAYER+=0x5;
+  LAYER += 0x12D + 0x1;
+  // now structure is next : section_header_size=0x6F(4 bytes) + '\n' +
+  // section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' +
+  // section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' +
+  // section_body_2 + '\n'
+  // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
+  // section name(column name in formula case) starts with 0x46 position
+  while (1) {
+    // section_header_size=0x6F(4 bytes) + '\n'
+    LAYER += 0x5;
 
-  //section_header
-    CHECKED_FSEEK(debug, f,LAYER+0x46,SEEK_SET);
+    // section_header
+    CHECKED_FSEEK(debug, f, LAYER + 0x46, SEEK_SET);
     char sec_name[42];
-    sec_name[41]='\0';
-    CHECKED_FREAD(debug, &sec_name,41,1,f);
+    sec_name[41] = '\0';
+    CHECKED_FREAD(debug, &sec_name, 41, 1, f);
 
-  //section_body_1_size
-    LAYER+=0x6F+0x1;
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    CHECKED_FREAD(debug, &sec_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(sec_size);
+    // section_body_1_size
+    LAYER += 0x6F + 0x1;
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(sec_size);
 
     if (INT_MAX == sec_size) {
       // this would end in an overflow for new[] below and it's obviously wrong
-      fprintf(debug, "Error: while reading matrix info, found section size: %d\n", sec_size);
+      fprintf(debug,
+              "Error: while reading matrix info, found section size: %d\n",
+              sec_size);
       fflush(debug);
     }
 
     if (file_size < sec_size) {
-        fprintf(debug, "Error in readMatrix: found section size (%d) bigger than total file size: %d\n", sec_size, file_size);
-        fflush(debug);
-        return;
+      fprintf(debug, "Error in readMatrix: found section size (%d) bigger than "
+                     "total file size: %d\n",
+              sec_size, file_size);
+      fflush(debug);
+      return;
     }
 
-    //section_body_1
-    LAYER+=0x5;
-    //check if it is a formula
-    if(0==strcmp(sec_name,"MV"))
-    {
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      char *stmp=new char[sec_size+1];
-      stmp[sec_size]='\0';
-      CHECKED_FREAD(debug, stmp,sec_size,1,f);
-      MATRIX[idx].command=stmp;
-      delete [] stmp;
+    // section_body_1
+    LAYER += 0x5;
+    // check if it is a formula
+    if (0 == strcmp(sec_name, "MV")) {
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      char *stmp = new char[sec_size + 1];
+      stmp[sec_size] = '\0';
+      CHECKED_FREAD(debug, stmp, sec_size, 1, f);
+      MATRIX[idx].command = stmp;
+      delete[] stmp;
     }
 
-  //section_body_2_size
-    LAYER+=sec_size+0x1;
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    CHECKED_FREAD(debug, &sec_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(sec_size);
+    // section_body_2_size
+    LAYER += sec_size + 0x1;
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(sec_size);
 
-  //section_body_2
-    LAYER+=0x5;
+    // section_body_2
+    LAYER += 0x5;
 
-  //close section 00 00 00 00 0A
-    LAYER+=sec_size+(sec_size>0?0x1:0)+0x5;
+    // close section 00 00 00 00 0A
+    LAYER += sec_size + (sec_size > 0 ? 0x1 : 0) + 0x5;
 
-    if(0==strcmp(sec_name,"__LayerInfoStorage"))
+    if (0 == strcmp(sec_name, "__LayerInfoStorage"))
       break;
-
   }
-  LAYER+=0x5;
+  LAYER += 0x5;
 
-  while(1)
-  {
-    LAYER+=0x5;
+  while (1) {
+    LAYER += 0x5;
 
-    short width=0;
-    CHECKED_FSEEK(debug, f,LAYER+0x2B, SEEK_SET);
-    CHECKED_FREAD(debug, &width,2,1,f);
-    if(IsBigEndian()) SwapBytes(width);
-    width=short((width-55)/0xA);
-    if(width==0)
-      width=8;
-    MATRIX[idx].width=width;
-    CHECKED_FSEEK(debug, f,LAYER+0x1E, SEEK_SET);
-    unsigned char c1,c2;
-    CHECKED_FREAD(debug, &c1,1,1,f);
-    CHECKED_FREAD(debug, &c2,1,1,f);
+    short width = 0;
+    CHECKED_FSEEK(debug, f, LAYER + 0x2B, SEEK_SET);
+    CHECKED_FREAD(debug, &width, 2, 1, f);
+    if (IsBigEndian())
+      SwapBytes(width);
+    width = short((width - 55) / 0xA);
+    if (width == 0)
+      width = 8;
+    MATRIX[idx].width = width;
+    CHECKED_FSEEK(debug, f, LAYER + 0x1E, SEEK_SET);
+    unsigned char c1, c2;
+    CHECKED_FREAD(debug, &c1, 1, 1, f);
+    CHECKED_FREAD(debug, &c2, 1, 1, f);
 
-    MATRIX[idx].value_type_specification=c1/0x10;
-    if(c2>=0x80)
-    {
-      MATRIX[idx].significant_digits=c2-0x80;
-      MATRIX[idx].numeric_display_type=2;
-    }
-    else if(c2>0)
-    {
-      MATRIX[idx].decimal_places=c2-0x03;
-      MATRIX[idx].numeric_display_type=1;
+    MATRIX[idx].value_type_specification = c1 / 0x10;
+    if (c2 >= 0x80) {
+      MATRIX[idx].significant_digits = c2 - 0x80;
+      MATRIX[idx].numeric_display_type = 2;
+    } else if (c2 > 0) {
+      MATRIX[idx].decimal_places = c2 - 0x03;
+      MATRIX[idx].numeric_display_type = 1;
     }
 
-    LAYER+=0x1E7+0x1;
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    int comm_size=0;
-    CHECKED_FREAD(debug, &comm_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(comm_size);
-    LAYER+=0x5;
-    if(comm_size>0)
-    {
-      LAYER+=comm_size+0x1;
+    LAYER += 0x1E7 + 0x1;
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    int comm_size = 0;
+    CHECKED_FREAD(debug, &comm_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(comm_size);
+    LAYER += 0x5;
+    if (comm_size > 0) {
+      LAYER += comm_size + 0x1;
     }
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
     int ntmp;
-    CHECKED_FREAD(debug, &ntmp,4,1,f);
-    if(IsBigEndian()) SwapBytes(ntmp);
-    if(ntmp!=0x1E7)
+    CHECKED_FREAD(debug, &ntmp, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(ntmp);
+    if (ntmp != 0x1E7)
       break;
   }
 
-  LAYER+=0x5*0x5+0x1ED*0x12;
-  POS = LAYER+0x5;
+  LAYER += 0x5 * 0x5 + 0x1ED * 0x12;
+  POS = LAYER + 0x5;
 
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 }
 
-
-void OPJFile::readGraphInfo(FILE *f, int file_size, FILE *debug)
-{
-  int POS=int(ftell(f));
+void OPJFile::readGraphInfo(FILE *f, int file_size, FILE *debug) {
+  int POS = int(ftell(f));
 
   int headersize;
-  CHECKED_FREAD(debug, &headersize,4,1,f);
-  if(IsBigEndian()) SwapBytes(headersize);
-  POS+=5;
+  CHECKED_FREAD(debug, &headersize, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(headersize);
+  POS += 5;
 
-  fprintf(debug,"     [Graph SECTION (@ 0x%X)]\n",POS);
+  fprintf(debug, "     [Graph SECTION (@ 0x%X)]\n", POS);
   fflush(debug);
 
   char name[25];
-  CHECKED_FSEEK(debug, f,POS + 0x2,SEEK_SET);
-  CHECKED_FREAD(debug, &name,25,1,f);
+  CHECKED_FSEEK(debug, f, POS + 0x2, SEEK_SET);
+  CHECKED_FREAD(debug, &name, 25, 1, f);
 
   GRAPH.push_back(graph(name));
   readWindowProperties(GRAPH.back(), f, debug, POS, headersize);
-        //char c = 0;
+  // char c = 0;
 
   unsigned short graph_width;
-  CHECKED_FSEEK(debug, f,POS + 0x23,SEEK_SET);
-  CHECKED_FREAD(debug, &graph_width,2,1,f);
-  if(IsBigEndian()) SwapBytes(graph_width);
+  CHECKED_FSEEK(debug, f, POS + 0x23, SEEK_SET);
+  CHECKED_FREAD(debug, &graph_width, 2, 1, f);
+  if (IsBigEndian())
+    SwapBytes(graph_width);
   GRAPH.back().width = graph_width;
 
   unsigned short graph_height;
-  CHECKED_FREAD(debug, &graph_height,2,1,f);
-  if(IsBigEndian()) SwapBytes(graph_height);
+  CHECKED_FREAD(debug, &graph_height, 2, 1, f);
+  if (IsBigEndian())
+    SwapBytes(graph_height);
   GRAPH.back().height = graph_height;
 
   int LAYER = POS;
   LAYER += headersize + 0x1;
   int sec_size;
-  while(1)// multilayer loop
+  while (1) // multilayer loop
   {
     GRAPH.back().layer.push_back(graphLayer());
     // LAYER section
-    LAYER +=0x5;
-    double range=0.0;
-    unsigned char m=0;
-    CHECKED_FSEEK(debug, f, LAYER+0xF, SEEK_SET);
-    CHECKED_FREAD(debug, &range,8,1,f);
-    if(IsBigEndian()) SwapBytes(range);
-    GRAPH.back().layer.back().xAxis.min=range;
-    CHECKED_FREAD(debug, &range,8,1,f);
-    if(IsBigEndian()) SwapBytes(range);
-    GRAPH.back().layer.back().xAxis.max=range;
-    CHECKED_FREAD(debug, &range,8,1,f);
-    if(IsBigEndian()) SwapBytes(range);
-    GRAPH.back().layer.back().xAxis.step=range;
-    CHECKED_FSEEK(debug, f, LAYER+0x2B, SEEK_SET);
-    CHECKED_FREAD(debug, &m,1,1,f);
-    GRAPH.back().layer.back().xAxis.majorTicks=m;
-    CHECKED_FSEEK(debug, f, LAYER+0x37, SEEK_SET);
-    CHECKED_FREAD(debug, &m,1,1,f);
-    GRAPH.back().layer.back().xAxis.minorTicks=m;
-    CHECKED_FREAD(debug, &m,1,1,f);
-    GRAPH.back().layer.back().xAxis.scale=m;
+    LAYER += 0x5;
+    double range = 0.0;
+    unsigned char m = 0;
+    CHECKED_FSEEK(debug, f, LAYER + 0xF, SEEK_SET);
+    CHECKED_FREAD(debug, &range, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(range);
+    GRAPH.back().layer.back().xAxis.min = range;
+    CHECKED_FREAD(debug, &range, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(range);
+    GRAPH.back().layer.back().xAxis.max = range;
+    CHECKED_FREAD(debug, &range, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(range);
+    GRAPH.back().layer.back().xAxis.step = range;
+    CHECKED_FSEEK(debug, f, LAYER + 0x2B, SEEK_SET);
+    CHECKED_FREAD(debug, &m, 1, 1, f);
+    GRAPH.back().layer.back().xAxis.majorTicks = m;
+    CHECKED_FSEEK(debug, f, LAYER + 0x37, SEEK_SET);
+    CHECKED_FREAD(debug, &m, 1, 1, f);
+    GRAPH.back().layer.back().xAxis.minorTicks = m;
+    CHECKED_FREAD(debug, &m, 1, 1, f);
+    GRAPH.back().layer.back().xAxis.scale = m;
 
-    CHECKED_FSEEK(debug, f, LAYER+0x3A, SEEK_SET);
-    CHECKED_FREAD(debug, &range,8,1,f);
-    if(IsBigEndian()) SwapBytes(range);
-    GRAPH.back().layer.back().yAxis.min=range;
-    CHECKED_FREAD(debug, &range,8,1,f);
-    if(IsBigEndian()) SwapBytes(range);
-    GRAPH.back().layer.back().yAxis.max=range;
-    CHECKED_FREAD(debug, &range,8,1,f);
-    if(IsBigEndian()) SwapBytes(range);
-    GRAPH.back().layer.back().yAxis.step=range;
-    CHECKED_FSEEK(debug, f, LAYER+0x56, SEEK_SET);
-    CHECKED_FREAD(debug, &m,1,1,f);
-    GRAPH.back().layer.back().yAxis.majorTicks=m;
-    CHECKED_FSEEK(debug, f, LAYER+0x62, SEEK_SET);
-    CHECKED_FREAD(debug, &m,1,1,f);
-    GRAPH.back().layer.back().yAxis.minorTicks=m;
-    CHECKED_FREAD(debug, &m,1,1,f);
-    GRAPH.back().layer.back().yAxis.scale=m;
+    CHECKED_FSEEK(debug, f, LAYER + 0x3A, SEEK_SET);
+    CHECKED_FREAD(debug, &range, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(range);
+    GRAPH.back().layer.back().yAxis.min = range;
+    CHECKED_FREAD(debug, &range, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(range);
+    GRAPH.back().layer.back().yAxis.max = range;
+    CHECKED_FREAD(debug, &range, 8, 1, f);
+    if (IsBigEndian())
+      SwapBytes(range);
+    GRAPH.back().layer.back().yAxis.step = range;
+    CHECKED_FSEEK(debug, f, LAYER + 0x56, SEEK_SET);
+    CHECKED_FREAD(debug, &m, 1, 1, f);
+    GRAPH.back().layer.back().yAxis.majorTicks = m;
+    CHECKED_FSEEK(debug, f, LAYER + 0x62, SEEK_SET);
+    CHECKED_FREAD(debug, &m, 1, 1, f);
+    GRAPH.back().layer.back().yAxis.minorTicks = m;
+    CHECKED_FREAD(debug, &m, 1, 1, f);
+    GRAPH.back().layer.back().yAxis.scale = m;
 
     rect r;
-    CHECKED_FSEEK(debug, f, LAYER+0x71, SEEK_SET);
-    CHECKED_FREAD(debug, &r,sizeof(rect),1,f);
-    if(IsBigEndian()) SwapBytes(r);
-    GRAPH.back().layer.back().clientRect=r;
+    CHECKED_FSEEK(debug, f, LAYER + 0x71, SEEK_SET);
+    CHECKED_FREAD(debug, &r, sizeof(rect), 1, f);
+    if (IsBigEndian())
+      SwapBytes(r);
+    GRAPH.back().layer.back().clientRect = r;
 
     LAYER += 0x12D + 0x1;
-    //now structure is next : section_header_size=0x6F(4 bytes) + '\n' + section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' + section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' + section_body_2 + '\n'
-    //possible sections: axes, legend, __BC02, _202, _231, _232, __LayerInfoStorage etc
-    //section name starts with 0x46 position
-    while(1)
-    {
-    //section_header_size=0x6F(4 bytes) + '\n'
-      LAYER+=0x5;
+    // now structure is next : section_header_size=0x6F(4 bytes) + '\n' +
+    // section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' +
+    // section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' +
+    // section_body_2 + '\n'
+    // possible sections: axes, legend, __BC02, _202, _231, _232,
+    // __LayerInfoStorage etc
+    // section name starts with 0x46 position
+    while (1) {
+      // section_header_size=0x6F(4 bytes) + '\n'
+      LAYER += 0x5;
 
-    //section_header
-      CHECKED_FSEEK(debug, f,LAYER+0x46,SEEK_SET);
+      // section_header
+      CHECKED_FSEEK(debug, f, LAYER + 0x46, SEEK_SET);
       char sec_name[42];
-      sec_name[41]='\0';
-      CHECKED_FREAD(debug, &sec_name,41,1,f);
+      sec_name[41] = '\0';
+      CHECKED_FREAD(debug, &sec_name, 41, 1, f);
 
-      CHECKED_FSEEK(debug, f, LAYER+0x3, SEEK_SET);
-      CHECKED_FREAD(debug, &r,sizeof(rect),1,f);
-      if(IsBigEndian()) SwapBytes(r);
+      CHECKED_FSEEK(debug, f, LAYER + 0x3, SEEK_SET);
+      CHECKED_FREAD(debug, &r, sizeof(rect), 1, f);
+      if (IsBigEndian())
+        SwapBytes(r);
 
-      unsigned char attach=0;
-      CHECKED_FSEEK(debug, f,LAYER+0x28,SEEK_SET);
-      CHECKED_FREAD(debug, &attach,1,1,f);
+      unsigned char attach = 0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x28, SEEK_SET);
+      CHECKED_FREAD(debug, &attach, 1, 1, f);
 
-      unsigned char border=0;
-      CHECKED_FSEEK(debug, f, LAYER+0x29, SEEK_SET);
-      CHECKED_FREAD(debug, &border,1,1,f);
+      unsigned char border = 0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x29, SEEK_SET);
+      CHECKED_FREAD(debug, &border, 1, 1, f);
 
-      unsigned char color=0;
-      CHECKED_FSEEK(debug, f,LAYER+0x33,SEEK_SET);
-      CHECKED_FREAD(debug, &color,1,1,f);
+      unsigned char color = 0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x33, SEEK_SET);
+      CHECKED_FREAD(debug, &color, 1, 1, f);
 
-    //section_body_1_size
-      LAYER+=0x6F+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_1_size
+      LAYER += 0x6F + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
-    //section_body_1
-      LAYER+=0x5;
-      int size=sec_size;
+      // section_body_1
+      LAYER += 0x5;
+      int size = sec_size;
 
-      unsigned char type=0;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &type,1,1,f);
+      unsigned char type = 0;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &type, 1, 1, f);
 
-      //text properties
-      short rotation=0;
-      CHECKED_FSEEK(debug, f,LAYER+2,SEEK_SET);
-      CHECKED_FREAD(debug, &rotation,2,1,f);
-      if(IsBigEndian()) SwapBytes(rotation);
+      // text properties
+      short rotation = 0;
+      CHECKED_FSEEK(debug, f, LAYER + 2, SEEK_SET);
+      CHECKED_FREAD(debug, &rotation, 2, 1, f);
+      if (IsBigEndian())
+        SwapBytes(rotation);
 
-      unsigned char fontsize=0;
-      CHECKED_FREAD(debug, &fontsize,1,1,f);
+      unsigned char fontsize = 0;
+      CHECKED_FREAD(debug, &fontsize, 1, 1, f);
 
-      unsigned char tab=0;
-      CHECKED_FSEEK(debug, f,LAYER+0xA,SEEK_SET);
-      CHECKED_FREAD(debug, &tab,1,1,f);
+      unsigned char tab = 0;
+      CHECKED_FSEEK(debug, f, LAYER + 0xA, SEEK_SET);
+      CHECKED_FREAD(debug, &tab, 1, 1, f);
 
-      //line properties
+      // line properties
       unsigned char line_style = 0;
       double width = 0.0;
       lineVertex begin, end;
       unsigned int w = 0;
 
-      CHECKED_FSEEK(debug, f,LAYER+0x12,SEEK_SET);
-      CHECKED_FREAD(debug, &line_style,1,1,f);
+      CHECKED_FSEEK(debug, f, LAYER + 0x12, SEEK_SET);
+      CHECKED_FREAD(debug, &line_style, 1, 1, f);
 
-      CHECKED_FSEEK(debug, f,LAYER+0x13,SEEK_SET);
-      CHECKED_FREAD(debug, &w,2,1,f);
-      if(IsBigEndian()) SwapBytes(w);
-      width = (double)w/500.0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x13, SEEK_SET);
+      CHECKED_FREAD(debug, &w, 2, 1, f);
+      if (IsBigEndian())
+        SwapBytes(w);
+      width = (double)w / 500.0;
 
-      CHECKED_FSEEK(debug, f,LAYER+0x20,SEEK_SET);
-      CHECKED_FREAD(debug, &begin.x,8,1,f);
-      if(IsBigEndian()) SwapBytes(begin.x);
+      CHECKED_FSEEK(debug, f, LAYER + 0x20, SEEK_SET);
+      CHECKED_FREAD(debug, &begin.x, 8, 1, f);
+      if (IsBigEndian())
+        SwapBytes(begin.x);
 
-      CHECKED_FREAD(debug, &end.x,8,1,f);
-      if(IsBigEndian()) SwapBytes(end.x);
+      CHECKED_FREAD(debug, &end.x, 8, 1, f);
+      if (IsBigEndian())
+        SwapBytes(end.x);
 
-      CHECKED_FSEEK(debug, f,LAYER+0x40,SEEK_SET);
-      CHECKED_FREAD(debug, &begin.y,8,1,f);
-      if(IsBigEndian()) SwapBytes(begin.y);
+      CHECKED_FSEEK(debug, f, LAYER + 0x40, SEEK_SET);
+      CHECKED_FREAD(debug, &begin.y, 8, 1, f);
+      if (IsBigEndian())
+        SwapBytes(begin.y);
 
-      CHECKED_FREAD(debug, &end.y,8,1,f);
-      if(IsBigEndian()) SwapBytes(end.y);
+      CHECKED_FREAD(debug, &end.y, 8, 1, f);
+      if (IsBigEndian())
+        SwapBytes(end.y);
 
-      CHECKED_FSEEK(debug, f,LAYER+0x60,SEEK_SET);
-      CHECKED_FREAD(debug, &begin.shape_type,1,1,f);
+      CHECKED_FSEEK(debug, f, LAYER + 0x60, SEEK_SET);
+      CHECKED_FREAD(debug, &begin.shape_type, 1, 1, f);
 
-      CHECKED_FSEEK(debug, f,LAYER+0x64,SEEK_SET);
-      CHECKED_FREAD(debug, &w,4,1,f);
-      if(IsBigEndian()) SwapBytes(w);
-      begin.shape_width = (double)w/500.0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x64, SEEK_SET);
+      CHECKED_FREAD(debug, &w, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(w);
+      begin.shape_width = (double)w / 500.0;
 
-      CHECKED_FREAD(debug, &w,4,1,f);
-      if(IsBigEndian()) SwapBytes(w);
-      begin.shape_length = (double)w/500.0;
+      CHECKED_FREAD(debug, &w, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(w);
+      begin.shape_length = (double)w / 500.0;
 
-      CHECKED_FSEEK(debug, f,LAYER+0x6C,SEEK_SET);
-      CHECKED_FREAD(debug, &end.shape_type,1,1,f);
+      CHECKED_FSEEK(debug, f, LAYER + 0x6C, SEEK_SET);
+      CHECKED_FREAD(debug, &end.shape_type, 1, 1, f);
 
-      CHECKED_FSEEK(debug, f,LAYER+0x70,SEEK_SET);
-      CHECKED_FREAD(debug, &w,4,1,f);
-      if(IsBigEndian()) SwapBytes(w);
-      end.shape_width = (double)w/500.0;
+      CHECKED_FSEEK(debug, f, LAYER + 0x70, SEEK_SET);
+      CHECKED_FREAD(debug, &w, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(w);
+      end.shape_width = (double)w / 500.0;
 
-      CHECKED_FREAD(debug, &w,4,1,f);
-      if(IsBigEndian()) SwapBytes(w);
-      end.shape_length = (double)w/500.0;
+      CHECKED_FREAD(debug, &w, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(w);
+      end.shape_length = (double)w / 500.0;
 
       // bitmap properties
       short bitmap_width = 0;
-      CHECKED_FSEEK(debug, f,LAYER+0x1,SEEK_SET);
-      CHECKED_FREAD(debug, &bitmap_width,2,1,f);
-      if(IsBigEndian()) SwapBytes(bitmap_width);
+      CHECKED_FSEEK(debug, f, LAYER + 0x1, SEEK_SET);
+      CHECKED_FREAD(debug, &bitmap_width, 2, 1, f);
+      if (IsBigEndian())
+        SwapBytes(bitmap_width);
 
       short bitmap_height = 0;
-      CHECKED_FREAD(debug, &bitmap_height,2,1,f);
-      if(IsBigEndian()) SwapBytes(bitmap_height);
+      CHECKED_FREAD(debug, &bitmap_height, 2, 1, f);
+      if (IsBigEndian())
+        SwapBytes(bitmap_height);
 
       double bitmap_left = 0.0;
-      CHECKED_FSEEK(debug, f,LAYER+0x13,SEEK_SET);
-      CHECKED_FREAD(debug, &bitmap_left,8,1,f);
-      if(IsBigEndian()) SwapBytes(bitmap_left);
+      CHECKED_FSEEK(debug, f, LAYER + 0x13, SEEK_SET);
+      CHECKED_FREAD(debug, &bitmap_left, 8, 1, f);
+      if (IsBigEndian())
+        SwapBytes(bitmap_left);
 
       double bitmap_top = 0.0;
-      CHECKED_FSEEK(debug, f,LAYER+0x1B,SEEK_SET);
-      CHECKED_FREAD(debug, &bitmap_top,8,1,f);
-      if(IsBigEndian()) SwapBytes(bitmap_top);
+      CHECKED_FSEEK(debug, f, LAYER + 0x1B, SEEK_SET);
+      CHECKED_FREAD(debug, &bitmap_top, 8, 1, f);
+      if (IsBigEndian())
+        SwapBytes(bitmap_top);
 
-    //section_body_2_size
-      LAYER+=sec_size+0x1;
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_2_size
+      LAYER += sec_size + 0x1;
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
       if (file_size < sec_size) {
-        fprintf(debug, "Error in readGraph: found section size (%d) bigger than total file size: %d\n", sec_size, file_size);
+        fprintf(debug, "Error in readGraph: found section size (%d) bigger "
+                       "than total file size: %d\n",
+                sec_size, file_size);
         fflush(debug);
         return;
-    }
+      }
 
-    //section_body_2
-      LAYER+=0x5;
-      //check if it is a axis or legend
-      CHECKED_FSEEK(debug, f,1,SEEK_CUR);
+      // section_body_2
+      LAYER += 0x5;
+      // check if it is a axis or legend
+      CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
       char stmp[255];
-      if(0==strcmp(sec_name,"XB"))
-      {
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, &stmp,sec_size,1,f);
+      if (0 == strcmp(sec_name, "XB")) {
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, &stmp, sec_size, 1, f);
         GRAPH.back().layer.back().xAxis.pos = Bottom;
-        GRAPH.back().layer.back().xAxis.label = text(stmp, r, color, fontsize, rotation/10, tab, (border >= 0x80 ? border-0x80 : None), attach);
-      }
-      else if(0==strcmp(sec_name,"XT"))
-      {
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, &stmp,sec_size,1,f);
-        GRAPH.back().layer.back().xAxis.pos=Top;
-        GRAPH.back().layer.back().xAxis.label = text(stmp, r, color, fontsize, rotation/10, tab, (border >= 0x80 ? border-0x80 : None), attach);
-      }
-      else if(0==strcmp(sec_name,"YL"))
-      {
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, &stmp,sec_size,1,f);
+        GRAPH.back().layer.back().xAxis.label =
+            text(stmp, r, color, fontsize, rotation / 10, tab,
+                 (border >= 0x80 ? border - 0x80 : None), attach);
+      } else if (0 == strcmp(sec_name, "XT")) {
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, &stmp, sec_size, 1, f);
+        GRAPH.back().layer.back().xAxis.pos = Top;
+        GRAPH.back().layer.back().xAxis.label =
+            text(stmp, r, color, fontsize, rotation / 10, tab,
+                 (border >= 0x80 ? border - 0x80 : None), attach);
+      } else if (0 == strcmp(sec_name, "YL")) {
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, &stmp, sec_size, 1, f);
         GRAPH.back().layer.back().yAxis.pos = Left;
-        GRAPH.back().layer.back().yAxis.label = text(stmp, r, color, fontsize, rotation/10, tab, (border >= 0x80 ? border-0x80 : None), attach);
-      }
-      else if(0==strcmp(sec_name,"YR"))
-      {
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, &stmp,sec_size,1,f);
+        GRAPH.back().layer.back().yAxis.label =
+            text(stmp, r, color, fontsize, rotation / 10, tab,
+                 (border >= 0x80 ? border - 0x80 : None), attach);
+      } else if (0 == strcmp(sec_name, "YR")) {
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, &stmp, sec_size, 1, f);
         GRAPH.back().layer.back().yAxis.pos = Right;
-        GRAPH.back().layer.back().yAxis.label = text(stmp, r, color, fontsize, rotation/10, tab, (border >= 0x80 ? border-0x80 : None), attach);
-      }
-      else if(0==strcmp(sec_name,"Legend"))
-      {
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, &stmp,sec_size,1,f);
-        GRAPH.back().layer.back().legend = text(stmp, r, color, fontsize, rotation/10, tab, (border >= 0x80 ? border-0x80 : None), attach);
-      }
-      else if(0==strcmp(sec_name,"__BCO2")) // histogram
+        GRAPH.back().layer.back().yAxis.label =
+            text(stmp, r, color, fontsize, rotation / 10, tab,
+                 (border >= 0x80 ? border - 0x80 : None), attach);
+      } else if (0 == strcmp(sec_name, "Legend")) {
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, &stmp, sec_size, 1, f);
+        GRAPH.back().layer.back().legend =
+            text(stmp, r, color, fontsize, rotation / 10, tab,
+                 (border >= 0x80 ? border - 0x80 : None), attach);
+      } else if (0 == strcmp(sec_name, "__BCO2")) // histogram
       {
         double d;
-        CHECKED_FSEEK(debug, f,LAYER+0x10,SEEK_SET);
-        CHECKED_FREAD(debug, &d,8,1,f);
-        if(IsBigEndian()) SwapBytes(d);
-        GRAPH.back().layer.back().histogram_bin=d;
-        CHECKED_FSEEK(debug, f,LAYER+0x20,SEEK_SET);
-        CHECKED_FREAD(debug, &d,8,1,f);
-        if(IsBigEndian()) SwapBytes(d);
-        GRAPH.back().layer.back().histogram_end=d;
-        CHECKED_FSEEK(debug, f,LAYER+0x28,SEEK_SET);
-        CHECKED_FREAD(debug, &d,8,1,f);
-        if(IsBigEndian()) SwapBytes(d);
-        GRAPH.back().layer.back().histogram_begin=d;
-      }
-      else if(size==0x3E) // text
+        CHECKED_FSEEK(debug, f, LAYER + 0x10, SEEK_SET);
+        CHECKED_FREAD(debug, &d, 8, 1, f);
+        if (IsBigEndian())
+          SwapBytes(d);
+        GRAPH.back().layer.back().histogram_bin = d;
+        CHECKED_FSEEK(debug, f, LAYER + 0x20, SEEK_SET);
+        CHECKED_FREAD(debug, &d, 8, 1, f);
+        if (IsBigEndian())
+          SwapBytes(d);
+        GRAPH.back().layer.back().histogram_end = d;
+        CHECKED_FSEEK(debug, f, LAYER + 0x28, SEEK_SET);
+        CHECKED_FREAD(debug, &d, 8, 1, f);
+        if (IsBigEndian())
+          SwapBytes(d);
+        GRAPH.back().layer.back().histogram_begin = d;
+      } else if (size == 0x3E) // text
       {
-        stmp[sec_size]='\0';
-        CHECKED_FREAD(debug, &stmp,sec_size,1,f);
+        stmp[sec_size] = '\0';
+        CHECKED_FREAD(debug, &stmp, sec_size, 1, f);
         GRAPH.back().layer.back().texts.push_back(text(stmp));
-        GRAPH.back().layer.back().texts.back().color=color;
-        GRAPH.back().layer.back().texts.back().clientRect=r;
-        GRAPH.back().layer.back().texts.back().tab=tab;
-        GRAPH.back().layer.back().texts.back().fontsize=fontsize;
-        GRAPH.back().layer.back().texts.back().rotation=rotation/10;
-        GRAPH.back().layer.back().texts.back().attach=attach;
-        if(border>=0x80)
-          GRAPH.back().layer.back().texts.back().border_type=border-0x80;
+        GRAPH.back().layer.back().texts.back().color = color;
+        GRAPH.back().layer.back().texts.back().clientRect = r;
+        GRAPH.back().layer.back().texts.back().tab = tab;
+        GRAPH.back().layer.back().texts.back().fontsize = fontsize;
+        GRAPH.back().layer.back().texts.back().rotation = rotation / 10;
+        GRAPH.back().layer.back().texts.back().attach = attach;
+        if (border >= 0x80)
+          GRAPH.back().layer.back().texts.back().border_type = border - 0x80;
         else
-          GRAPH.back().layer.back().texts.back().border_type=None;
-      }
-      else if(size==0x78 && type==2) // line
+          GRAPH.back().layer.back().texts.back().border_type = None;
+      } else if (size == 0x78 && type == 2) // line
       {
         GRAPH.back().layer.back().lines.push_back(line());
-        GRAPH.back().layer.back().lines.back().color=color;
-        GRAPH.back().layer.back().lines.back().clientRect=r;
-        GRAPH.back().layer.back().lines.back().attach=attach;
-        GRAPH.back().layer.back().lines.back().width=width;
-        GRAPH.back().layer.back().lines.back().line_style=line_style;
-        GRAPH.back().layer.back().lines.back().begin=begin;
-        GRAPH.back().layer.back().lines.back().end=end;
-      }
-      else if(size==0x28 && type==4) // bitmap
+        GRAPH.back().layer.back().lines.back().color = color;
+        GRAPH.back().layer.back().lines.back().clientRect = r;
+        GRAPH.back().layer.back().lines.back().attach = attach;
+        GRAPH.back().layer.back().lines.back().width = width;
+        GRAPH.back().layer.back().lines.back().line_style = line_style;
+        GRAPH.back().layer.back().lines.back().begin = begin;
+        GRAPH.back().layer.back().lines.back().end = end;
+      } else if (size == 0x28 && type == 4) // bitmap
       {
-        unsigned long filesize=sec_size+14;
+        unsigned long filesize = sec_size + 14;
         GRAPH.back().layer.back().bitmaps.push_back(bitmap());
-        GRAPH.back().layer.back().bitmaps.back().left=bitmap_left;
-        GRAPH.back().layer.back().bitmaps.back().top=bitmap_top;
-        GRAPH.back().layer.back().bitmaps.back().width=
-          (GRAPH.back().layer.back().xAxis.max - GRAPH.back().layer.back().xAxis.min)*bitmap_width/10000;
-        GRAPH.back().layer.back().bitmaps.back().height=
-          (GRAPH.back().layer.back().yAxis.max - GRAPH.back().layer.back().yAxis.min)*bitmap_height/10000;
-        GRAPH.back().layer.back().bitmaps.back().attach=attach;
-        GRAPH.back().layer.back().bitmaps.back().size=filesize;
-        GRAPH.back().layer.back().bitmaps.back().data=new unsigned char[filesize];
-        unsigned char *data=GRAPH.back().layer.back().bitmaps.back().data;
-        //add Bitmap header
+        GRAPH.back().layer.back().bitmaps.back().left = bitmap_left;
+        GRAPH.back().layer.back().bitmaps.back().top = bitmap_top;
+        GRAPH.back().layer.back().bitmaps.back().width =
+            (GRAPH.back().layer.back().xAxis.max -
+             GRAPH.back().layer.back().xAxis.min) *
+            bitmap_width / 10000;
+        GRAPH.back().layer.back().bitmaps.back().height =
+            (GRAPH.back().layer.back().yAxis.max -
+             GRAPH.back().layer.back().yAxis.min) *
+            bitmap_height / 10000;
+        GRAPH.back().layer.back().bitmaps.back().attach = attach;
+        GRAPH.back().layer.back().bitmaps.back().size = filesize;
+        GRAPH.back().layer.back().bitmaps.back().data =
+            new unsigned char[filesize];
+        unsigned char *data = GRAPH.back().layer.back().bitmaps.back().data;
+        // add Bitmap header
         memcpy(data, "BM", 2);
-        data+=2;
+        data += 2;
         memcpy(data, &filesize, 4);
-        data+=4;
-        unsigned int d=0;
+        data += 4;
+        unsigned int d = 0;
         memcpy(data, &d, 4);
-        data+=4;
-        d=0x36;
+        data += 4;
+        d = 0x36;
         memcpy(data, &d, 4);
-        data+=4;
-        CHECKED_FREAD(debug, data,sec_size,1,f);
+        data += 4;
+        CHECKED_FREAD(debug, data, sec_size, 1, f);
       }
 
-    //close section 00 00 00 00 0A
-      LAYER+=sec_size+(sec_size>0?0x1:0);
+      // close section 00 00 00 00 0A
+      LAYER += sec_size + (sec_size > 0 ? 0x1 : 0);
 
-    //section_body_3_size
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_3_size
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
-    //section_body_3
-      LAYER+=0x5;
+      // section_body_3
+      LAYER += 0x5;
 
-    //close section 00 00 00 00 0A
-      LAYER+=sec_size+(sec_size>0?0x1:0);
+      // close section 00 00 00 00 0A
+      LAYER += sec_size + (sec_size > 0 ? 0x1 : 0);
 
-      if(0==strcmp(sec_name,"__LayerInfoStorage"))
+      if (0 == strcmp(sec_name, "__LayerInfoStorage"))
         break;
-
     }
-    LAYER+=0x5;
+    LAYER += 0x5;
     unsigned char h;
     short w;
 
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    CHECKED_FREAD(debug, &sec_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(sec_size);
-    if(sec_size==0x1E7)//check layer is not empty
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(sec_size);
+    if (sec_size == 0x1E7) // check layer is not empty
     {
-      while(1)
-      {
-        LAYER+=0x5;
+      while (1) {
+        LAYER += 0x5;
 
         graphCurve curve;
 
         vector<string> col;
-        CHECKED_FSEEK(debug, f,LAYER+0x4,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        col=findDataByIndex(w-1);
+        CHECKED_FSEEK(debug, f, LAYER + 0x4, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        col = findDataByIndex(w - 1);
         short nColY = w;
-        if(col.size()>0)
-        {
-          fprintf(debug,"     GRAPH %zu layer %zu curve %zu Y : %s.%s\n",GRAPH.size(),GRAPH.back().layer.size(),GRAPH.back().layer.back().curve.size(),col[1].c_str(),col[0].c_str());
+        if (col.size() > 0) {
+          fprintf(debug, "     GRAPH %zu layer %zu curve %zu Y : %s.%s\n",
+                  GRAPH.size(), GRAPH.back().layer.size(),
+                  GRAPH.back().layer.back().curve.size(), col[1].c_str(),
+                  col[0].c_str());
           fflush(debug);
-          curve.yColName=col[0];
-          curve.dataName=col[1];
+          curve.yColName = col[0];
+          curve.dataName = col[1];
         }
 
-        CHECKED_FSEEK(debug, f,LAYER+0x23,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        col=findDataByIndex(w-1);
-        if(col.size()>0)
-        {
-          fprintf(debug,"     GRAPH %zu layer %zu curve %zu X : %s.%s\n",GRAPH.size(),GRAPH.back().layer.size(),GRAPH.back().layer.back().curve.size(),col[1].c_str(),col[0].c_str());
+        CHECKED_FSEEK(debug, f, LAYER + 0x23, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        col = findDataByIndex(w - 1);
+        if (col.size() > 0) {
+          fprintf(debug, "     GRAPH %zu layer %zu curve %zu X : %s.%s\n",
+                  GRAPH.size(), GRAPH.back().layer.size(),
+                  GRAPH.back().layer.back().curve.size(), col[1].c_str(),
+                  col[0].c_str());
           fflush(debug);
-          curve.xColName=col[0];
-          if(curve.dataName!=col[1])
-            fprintf(debug,"     GRAPH %zu X and Y from different tables\n",GRAPH.size());
+          curve.xColName = col[0];
+          if (curve.dataName != col[1])
+            fprintf(debug, "     GRAPH %zu X and Y from different tables\n",
+                    GRAPH.size());
         }
 
-        CHECKED_FSEEK(debug, f,LAYER+0x4C,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.type=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x4C, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.type = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x11,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.line_connect=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x11, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.line_connect = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x12,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.line_style=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x12, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.line_style = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x15,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        curve.line_width=(double)w/500.0;
+        CHECKED_FSEEK(debug, f, LAYER + 0x15, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        curve.line_width = (double)w / 500.0;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x19,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        curve.symbol_size=(double)w/500.0;
+        CHECKED_FSEEK(debug, f, LAYER + 0x19, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        curve.symbol_size = (double)w / 500.0;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x1C,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea=(h==2?true:false);
+        CHECKED_FSEEK(debug, f, LAYER + 0x1C, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea = (h == 2 ? true : false);
 
-        CHECKED_FSEEK(debug, f,LAYER+0x1E,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_type=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x1E, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_type = h;
 
-        //vector
-        if(curve.type == FlowVector || curve.type == Vector)
-        {
-          CHECKED_FSEEK(debug, f,LAYER+0x56,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.vector.multiplier,4,1,f);
-          if(IsBigEndian()) SwapBytes(curve.vector.multiplier);
+        // vector
+        if (curve.type == FlowVector || curve.type == Vector) {
+          CHECKED_FSEEK(debug, f, LAYER + 0x56, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.vector.multiplier, 4, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.vector.multiplier);
 
-          CHECKED_FSEEK(debug, f,LAYER+0x5E,SEEK_SET);
-          CHECKED_FREAD(debug, &h,1,1,f);
-          col=findDataByIndex(nColY - 1 + h - 0x64);
-          if(col.size()>0)
-          {
+          CHECKED_FSEEK(debug, f, LAYER + 0x5E, SEEK_SET);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          col = findDataByIndex(nColY - 1 + h - 0x64);
+          if (col.size() > 0) {
             curve.vector.endXColName = col[0];
           }
 
-          CHECKED_FSEEK(debug, f,LAYER+0x62,SEEK_SET);
-          CHECKED_FREAD(debug, &h,1,1,f);
-          col=findDataByIndex(nColY - 1 + h - 0x64);
-          if(col.size()>0)
-          {
+          CHECKED_FSEEK(debug, f, LAYER + 0x62, SEEK_SET);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          col = findDataByIndex(nColY - 1 + h - 0x64);
+          if (col.size() > 0) {
             curve.vector.endYColName = col[0];
           }
 
-          CHECKED_FSEEK(debug, f,LAYER+0x18,SEEK_SET);
-          CHECKED_FREAD(debug, &h,1,1,f);
-          if(h >= 0x64)
-          {
-            col=findDataByIndex(nColY - 1 + h - 0x64);
-            if(col.size()>0)
+          CHECKED_FSEEK(debug, f, LAYER + 0x18, SEEK_SET);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          if (h >= 0x64) {
+            col = findDataByIndex(nColY - 1 + h - 0x64);
+            if (col.size() > 0)
               curve.vector.angleColName = col[0];
-          }
-          else if(h <= 0x08)
-          {
-            curve.vector.const_angle = 45*h;
+          } else if (h <= 0x08) {
+            curve.vector.const_angle = 45 * h;
           }
 
-          CHECKED_FSEEK(debug, f,LAYER+0x19,SEEK_SET);
-          CHECKED_FREAD(debug, &h,1,1,f);
-          if(h >= 0x64)
-          {
-            col=findDataByIndex(nColY - 1 + h - 0x64);
-            if(col.size()>0)
+          CHECKED_FSEEK(debug, f, LAYER + 0x19, SEEK_SET);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          if (h >= 0x64) {
+            col = findDataByIndex(nColY - 1 + h - 0x64);
+            if (col.size() > 0)
               curve.vector.magnitudeColName = col[0];
-          }
-          else
-          {
+          } else {
             curve.vector.const_magnitude = static_cast<int>(curve.symbol_size);
           }
 
-          CHECKED_FSEEK(debug, f,LAYER+0x66,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.vector.arrow_lenght,2,1,f);
-          if(IsBigEndian()) SwapBytes(curve.vector.arrow_lenght);
+          CHECKED_FSEEK(debug, f, LAYER + 0x66, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.vector.arrow_lenght, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.vector.arrow_lenght);
 
-          CHECKED_FREAD(debug, &curve.vector.arrow_angle,1,1,f);
+          CHECKED_FREAD(debug, &curve.vector.arrow_angle, 1, 1, f);
 
-          CHECKED_FREAD(debug, &h,1,1,f);
-          curve.vector.arrow_closed = !(h&0x1);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          curve.vector.arrow_closed = !(h & 0x1);
 
-          CHECKED_FREAD(debug, &w,2,1,f);
-          if(IsBigEndian()) SwapBytes(w);
-          curve.vector.width=(double)w/500.0;
+          CHECKED_FREAD(debug, &w, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(w);
+          curve.vector.width = (double)w / 500.0;
 
-          CHECKED_FSEEK(debug, f,LAYER+0x142,SEEK_SET);
-          CHECKED_FREAD(debug, &h,1,1,f);
-          switch(h)
-          {
+          CHECKED_FSEEK(debug, f, LAYER + 0x142, SEEK_SET);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          switch (h) {
           case 2:
             curve.vector.position = Midpoint;
             break;
           case 4:
             curve.vector.position = Head;
-              break;
+            break;
           default:
             curve.vector.position = Tail;
-              break;
+            break;
           }
-          
         }
 
-        //pie
-        if(curve.type == Pie)
-        {
-          CHECKED_FSEEK(debug, f,LAYER+0x92,SEEK_SET);
-          CHECKED_FREAD(debug, &h,1,1,f);
-          curve.pie.format_percentages = (h&0x01);
-          curve.pie.format_values = (h&0x02);
-          curve.pie.position_associate = (h&0x08);
-          curve.pie.clockwise_rotation = (h&0x20);
-          curve.pie.format_categories = (h&0x80);
+        // pie
+        if (curve.type == Pie) {
+          CHECKED_FSEEK(debug, f, LAYER + 0x92, SEEK_SET);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
+          curve.pie.format_percentages = (h & 0x01);
+          curve.pie.format_values = (h & 0x02);
+          curve.pie.position_associate = (h & 0x08);
+          curve.pie.clockwise_rotation = (h & 0x20);
+          curve.pie.format_categories = (h & 0x80);
 
-          CHECKED_FREAD(debug, &h,1,1,f);
+          CHECKED_FREAD(debug, &h, 1, 1, f);
           curve.pie.format_automatic = h;
 
-          CHECKED_FREAD(debug, &curve.pie.distance,2,1,f);
-          if(IsBigEndian()) SwapBytes(curve.pie.distance);
+          CHECKED_FREAD(debug, &curve.pie.distance, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.pie.distance);
 
-          CHECKED_FREAD(debug, &curve.pie.view_angle,1,1,f);
+          CHECKED_FREAD(debug, &curve.pie.view_angle, 1, 1, f);
 
-          CHECKED_FSEEK(debug, f,LAYER+0x98,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.pie.thickness,1,1,f);
+          CHECKED_FSEEK(debug, f, LAYER + 0x98, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.pie.thickness, 1, 1, f);
 
-          CHECKED_FSEEK(debug, f,LAYER+0x9A,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.pie.rotation,2,1,f);
-          if(IsBigEndian()) SwapBytes(curve.pie.rotation);
+          CHECKED_FSEEK(debug, f, LAYER + 0x9A, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.pie.rotation, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.pie.rotation);
 
-          CHECKED_FSEEK(debug, f,LAYER+0x9E,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.pie.displacement,2,1,f);
-          if(IsBigEndian()) SwapBytes(curve.pie.displacement);
+          CHECKED_FSEEK(debug, f, LAYER + 0x9E, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.pie.displacement, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.pie.displacement);
 
-          CHECKED_FSEEK(debug, f,LAYER+0xA0,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.pie.radius,2,1,f);
-          if(IsBigEndian()) SwapBytes(curve.pie.radius);
+          CHECKED_FSEEK(debug, f, LAYER + 0xA0, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.pie.radius, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.pie.radius);
 
-          CHECKED_FSEEK(debug, f,LAYER+0xA2,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.pie.horizontal_offset,2,1,f);
-          if(IsBigEndian()) SwapBytes(curve.pie.horizontal_offset);
+          CHECKED_FSEEK(debug, f, LAYER + 0xA2, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.pie.horizontal_offset, 2, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.pie.horizontal_offset);
 
-          CHECKED_FSEEK(debug, f,LAYER+0xA6,SEEK_SET);
-          CHECKED_FREAD(debug, &curve.pie.displaced_sections,4,1,f);
-          if(IsBigEndian()) SwapBytes(curve.pie.displaced_sections);
+          CHECKED_FSEEK(debug, f, LAYER + 0xA6, SEEK_SET);
+          CHECKED_FREAD(debug, &curve.pie.displaced_sections, 4, 1, f);
+          if (IsBigEndian())
+            SwapBytes(curve.pie.displaced_sections);
         }
-        
-        CHECKED_FSEEK(debug, f,LAYER+0xC2,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_color=h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xC3,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_first_color=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0xC2, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xCE,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_pattern=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0xC3, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_first_color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xCA,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_pattern_color=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0xCE, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_pattern = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xC6,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        curve.fillarea_pattern_width=(double)w/500.0;
+        CHECKED_FSEEK(debug, f, LAYER + 0xCA, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_pattern_color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xCF,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_pattern_border_style=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0xC6, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        curve.fillarea_pattern_width = (double)w / 500.0;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xD2,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.fillarea_pattern_border_color=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0xCF, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_pattern_border_style = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0xD0,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        curve.fillarea_pattern_border_width=(double)w/500.0;
+        CHECKED_FSEEK(debug, f, LAYER + 0xD2, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.fillarea_pattern_border_color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x16A,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.line_color=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0xD0, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        curve.fillarea_pattern_border_width = (double)w / 500.0;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x17,SEEK_SET);
-        CHECKED_FREAD(debug, &w,2,1,f);
-        if(IsBigEndian()) SwapBytes(w);
-        curve.symbol_type=w;
+        CHECKED_FSEEK(debug, f, LAYER + 0x16A, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.line_color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x12E,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.symbol_fill_color=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x17, SEEK_SET);
+        CHECKED_FREAD(debug, &w, 2, 1, f);
+        if (IsBigEndian())
+          SwapBytes(w);
+        curve.symbol_type = w;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x132,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.symbol_color=h;
-        curve.vector.color=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x12E, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.symbol_fill_color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x136,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.symbol_thickness=(h==255?1:h);
+        CHECKED_FSEEK(debug, f, LAYER + 0x132, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.symbol_color = h;
+        curve.vector.color = h;
 
-        CHECKED_FSEEK(debug, f,LAYER+0x137,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        curve.point_offset=h;
+        CHECKED_FSEEK(debug, f, LAYER + 0x136, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.symbol_thickness = (h == 255 ? 1 : h);
+
+        CHECKED_FSEEK(debug, f, LAYER + 0x137, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        curve.point_offset = h;
 
         GRAPH.back().layer.back().curve.push_back(curve);
 
-        LAYER+=0x1E7+0x1;
-        CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-        int comm_size=0;
-        CHECKED_FREAD(debug, &comm_size,4,1,f);
-        if(IsBigEndian()) SwapBytes(comm_size);
-        LAYER+=0x5;
-        if(comm_size>0)
-        {
-          LAYER+=comm_size+0x1;
+        LAYER += 0x1E7 + 0x1;
+        CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+        int comm_size = 0;
+        CHECKED_FREAD(debug, &comm_size, 4, 1, f);
+        if (IsBigEndian())
+          SwapBytes(comm_size);
+        LAYER += 0x5;
+        if (comm_size > 0) {
+          LAYER += comm_size + 0x1;
         }
-        CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
+        CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
         int ntmp;
-        CHECKED_FREAD(debug, &ntmp,4,1,f);
-        if(IsBigEndian()) SwapBytes(ntmp);
-        if(ntmp!=0x1E7)
+        CHECKED_FREAD(debug, &ntmp, 4, 1, f);
+        if (IsBigEndian())
+          SwapBytes(ntmp);
+        if (ntmp != 0x1E7)
           break;
       }
-
     }
-    //LAYER+=0x5*0x5+0x1ED*0x12;
-    //LAYER+=2*0x5;
+    // LAYER+=0x5*0x5+0x1ED*0x12;
+    // LAYER+=2*0x5;
 
-    LAYER+=0x5;
-    //read axis breaks
-    while(1)
-    {
-      CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(debug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
-      if(sec_size == 0x2D)
-      {
-        LAYER+=0x5;
-        CHECKED_FSEEK(debug, f,LAYER+2,SEEK_SET);
-        CHECKED_FREAD(debug, &h,1,1,f);
-        if(h==2)
-        {
-          GRAPH.back().layer.back().xAxisBreak.minor_ticks_before = (unsigned char)(GRAPH.back().layer.back().xAxis.minorTicks);
-          GRAPH.back().layer.back().xAxisBreak.scale_increment_before = GRAPH.back().layer.back().xAxis.step;
-          readGraphAxisBreakInfo(GRAPH.back().layer.back().xAxisBreak, f, debug, LAYER);
+    LAYER += 0x5;
+    // read axis breaks
+    while (1) {
+      CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
+      if (sec_size == 0x2D) {
+        LAYER += 0x5;
+        CHECKED_FSEEK(debug, f, LAYER + 2, SEEK_SET);
+        CHECKED_FREAD(debug, &h, 1, 1, f);
+        if (h == 2) {
+          GRAPH.back().layer.back().xAxisBreak.minor_ticks_before =
+              (unsigned char)(GRAPH.back().layer.back().xAxis.minorTicks);
+          GRAPH.back().layer.back().xAxisBreak.scale_increment_before =
+              GRAPH.back().layer.back().xAxis.step;
+          readGraphAxisBreakInfo(GRAPH.back().layer.back().xAxisBreak, f, debug,
+                                 LAYER);
+        } else if (h == 4) {
+          GRAPH.back().layer.back().yAxisBreak.minor_ticks_before =
+              (unsigned char)(GRAPH.back().layer.back().yAxis.minorTicks);
+          GRAPH.back().layer.back().yAxisBreak.scale_increment_before =
+              GRAPH.back().layer.back().yAxis.step;
+          readGraphAxisBreakInfo(GRAPH.back().layer.back().yAxisBreak, f, debug,
+                                 LAYER);
         }
-        else if(h==4)
-        {
-          GRAPH.back().layer.back().yAxisBreak.minor_ticks_before = (unsigned char)(GRAPH.back().layer.back().yAxis.minorTicks);
-          GRAPH.back().layer.back().yAxisBreak.scale_increment_before = GRAPH.back().layer.back().yAxis.step;
-          readGraphAxisBreakInfo(GRAPH.back().layer.back().yAxisBreak, f, debug, LAYER);
-        }
-        LAYER+=0x2D + 0x1;
-      }
-      else
+        LAYER += 0x2D + 0x1;
+      } else
         break;
     }
-    LAYER+=0x5;
-    
+    LAYER += 0x5;
 
-    LAYER+=0x5;
-    readGraphGridInfo(GRAPH.back().layer.back().xAxis.minorGrid, f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphGridInfo(GRAPH.back().layer.back().xAxis.minorGrid, f, debug,
+                      LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphGridInfo(GRAPH.back().layer.back().xAxis.majorGrid, f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphGridInfo(GRAPH.back().layer.back().xAxis.majorGrid, f, debug,
+                      LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().xAxis.tickAxis[0], debug, f, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().xAxis.tickAxis[0],
+                                debug, f, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisFormatInfo(GRAPH.back().layer.back().xAxis.formatAxis[0], f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisFormatInfo(GRAPH.back().layer.back().xAxis.formatAxis[0], f,
+                            debug, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().xAxis.tickAxis[1], debug, f, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().xAxis.tickAxis[1],
+                                debug, f, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisFormatInfo(GRAPH.back().layer.back().xAxis.formatAxis[1], debug, f, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisFormatInfo(GRAPH.back().layer.back().xAxis.formatAxis[1],
+                            debug, f, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
+    LAYER += 0x5;
 
+    LAYER += 0x5;
+    readGraphGridInfo(GRAPH.back().layer.back().yAxis.minorGrid, f, debug,
+                      LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphGridInfo(GRAPH.back().layer.back().yAxis.minorGrid, f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphGridInfo(GRAPH.back().layer.back().yAxis.majorGrid, f, debug,
+                      LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphGridInfo(GRAPH.back().layer.back().yAxis.majorGrid, f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().yAxis.tickAxis[0], f,
+                                debug, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().yAxis.tickAxis[0], f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisFormatInfo(GRAPH.back().layer.back().yAxis.formatAxis[0], f,
+                            debug, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisFormatInfo(GRAPH.back().layer.back().yAxis.formatAxis[0], f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().yAxis.tickAxis[1], f,
+                                debug, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisTickLabelsInfo(GRAPH.back().layer.back().yAxis.tickAxis[1], f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x5;
+    readGraphAxisFormatInfo(GRAPH.back().layer.back().yAxis.formatAxis[1], f,
+                            debug, LAYER);
+    LAYER += 0x1E7 + 1;
 
-    LAYER+=0x5;
-    readGraphAxisFormatInfo(GRAPH.back().layer.back().yAxis.formatAxis[1], f, debug, LAYER);
-    LAYER+=0x1E7+1;
+    LAYER += 0x2 * 0x5 + 0x1ED * 0x6;
 
-    LAYER+=0x2*0x5+0x1ED*0x6;
-
-    CHECKED_FSEEK(debug, f,LAYER,SEEK_SET);
-    CHECKED_FREAD(debug, &sec_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(sec_size);
-    if(sec_size==0)
+    CHECKED_FSEEK(debug, f, LAYER, SEEK_SET);
+    CHECKED_FREAD(debug, &sec_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(sec_size);
+    if (sec_size == 0)
       break;
   }
-  POS = LAYER+0x5;
+  POS = LAYER + 0x5;
 
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 }
 
-void OPJFile::skipObjectInfo(FILE *f, FILE *fdebug)
-{
-  int POS=int(ftell(f));
+void OPJFile::skipObjectInfo(FILE *f, FILE *fdebug) {
+  int POS = int(ftell(f));
 
   int headersize;
-  CHECKED_FREAD(fdebug, &headersize,4,1,f);
-  if(IsBigEndian()) SwapBytes(headersize);
-  POS+=5;
+  CHECKED_FREAD(fdebug, &headersize, 4, 1, f);
+  if (IsBigEndian())
+    SwapBytes(headersize);
+  POS += 5;
 
   int LAYER = POS;
   LAYER += headersize + 0x1;
   int sec_size;
-  while(1)// multilayer loop
+  while (1) // multilayer loop
   {
     // LAYER section
-    LAYER +=0x5/* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
-    //now structure is next : section_header_size=0x6F(4 bytes) + '\n' + section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' + section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' + section_body_2 + '\n'
-    //possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
-    //section name(column name in formula case) starts with 0x46 position
-    while(1)
-    {
-    //section_header_size=0x6F(4 bytes) + '\n'
-      LAYER+=0x5;
+    LAYER += 0x5 /* length of block = 0x12D + '\n'*/ + 0x12D + 0x1;
+    // now structure is next : section_header_size=0x6F(4 bytes) + '\n' +
+    // section_header(0x6F bytes) + section_body_1_size(4 bytes) + '\n' +
+    // section_body_1 + section_body_2_size(maybe=0)(4 bytes) + '\n' +
+    // section_body_2 + '\n'
+    // possible sections: column formulas, __WIPR, __WIOTN, __LayerInfoStorage
+    // section name(column name in formula case) starts with 0x46 position
+    while (1) {
+      // section_header_size=0x6F(4 bytes) + '\n'
+      LAYER += 0x5;
 
-    //section_header
-      CHECKED_FSEEK(fdebug, f,LAYER+0x46,SEEK_SET);
+      // section_header
+      CHECKED_FSEEK(fdebug, f, LAYER + 0x46, SEEK_SET);
       char sec_name[42];
-      sec_name[41]='\0';
-      CHECKED_FREAD(fdebug, &sec_name,41,1,f);
+      sec_name[41] = '\0';
+      CHECKED_FREAD(fdebug, &sec_name, 41, 1, f);
 
-    //section_body_1_size
-      LAYER+=0x6F+0x1;
-      CHECKED_FSEEK(fdebug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(fdebug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_1_size
+      LAYER += 0x6F + 0x1;
+      CHECKED_FSEEK(fdebug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(fdebug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
-    //section_body_1
-      LAYER+=0x5;
+      // section_body_1
+      LAYER += 0x5;
 
-    //section_body_2_size
-      LAYER+=sec_size+0x1;
-      CHECKED_FSEEK(fdebug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(fdebug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_2_size
+      LAYER += sec_size + 0x1;
+      CHECKED_FSEEK(fdebug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(fdebug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
-    //section_body_2
-      LAYER+=0x5;
+      // section_body_2
+      LAYER += 0x5;
 
-    //close section 00 00 00 00 0A
-      LAYER+=sec_size+(sec_size>0?0x1:0);
+      // close section 00 00 00 00 0A
+      LAYER += sec_size + (sec_size > 0 ? 0x1 : 0);
 
-    //section_body_3_size
-      CHECKED_FSEEK(fdebug, f,LAYER,SEEK_SET);
-      CHECKED_FREAD(fdebug, &sec_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(sec_size);
+      // section_body_3_size
+      CHECKED_FSEEK(fdebug, f, LAYER, SEEK_SET);
+      CHECKED_FREAD(fdebug, &sec_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(sec_size);
 
-    //section_body_3
-      LAYER+=0x5;
+      // section_body_3
+      LAYER += 0x5;
 
-    //close section 00 00 00 00 0A
-      LAYER+=sec_size+(sec_size>0?0x1:0);
+      // close section 00 00 00 00 0A
+      LAYER += sec_size + (sec_size > 0 ? 0x1 : 0);
 
-      if(0==strcmp(sec_name,"__LayerInfoStorage"))
+      if (0 == strcmp(sec_name, "__LayerInfoStorage"))
         break;
-
     }
-    LAYER+=0x5;
+    LAYER += 0x5;
 
-    while(1)
-    {
-      LAYER+=0x5;
+    while (1) {
+      LAYER += 0x5;
 
-      LAYER+=0x1E7+0x1;
-      CHECKED_FSEEK(fdebug, f,LAYER,SEEK_SET);
-      int comm_size=0;
-      CHECKED_FREAD(fdebug, &comm_size,4,1,f);
-      if(IsBigEndian()) SwapBytes(comm_size);
-      LAYER+=0x5;
-      if(comm_size>0)
-      {
-        LAYER+=comm_size+0x1;
+      LAYER += 0x1E7 + 0x1;
+      CHECKED_FSEEK(fdebug, f, LAYER, SEEK_SET);
+      int comm_size = 0;
+      CHECKED_FREAD(fdebug, &comm_size, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(comm_size);
+      LAYER += 0x5;
+      if (comm_size > 0) {
+        LAYER += comm_size + 0x1;
       }
-      CHECKED_FSEEK(fdebug, f,LAYER,SEEK_SET);
+      CHECKED_FSEEK(fdebug, f, LAYER, SEEK_SET);
       int ntmp;
-      CHECKED_FREAD(fdebug, &ntmp,4,1,f);
-      if(IsBigEndian()) SwapBytes(ntmp);
-      if(ntmp!=0x1E7)
+      CHECKED_FREAD(fdebug, &ntmp, 4, 1, f);
+      if (IsBigEndian())
+        SwapBytes(ntmp);
+      if (ntmp != 0x1E7)
         break;
     }
 
-    LAYER+=0x5*0x5+0x1ED*0x12;
-    CHECKED_FSEEK(fdebug, f,LAYER,SEEK_SET);
-    CHECKED_FREAD(fdebug, &sec_size,4,1,f);
-    if(IsBigEndian()) SwapBytes(sec_size);
-    if(sec_size==0)
+    LAYER += 0x5 * 0x5 + 0x1ED * 0x12;
+    CHECKED_FSEEK(fdebug, f, LAYER, SEEK_SET);
+    CHECKED_FREAD(fdebug, &sec_size, 4, 1, f);
+    if (IsBigEndian())
+      SwapBytes(sec_size);
+    if (sec_size == 0)
       break;
   }
-  POS = LAYER+0x5;
+  POS = LAYER + 0x5;
 
-  CHECKED_FSEEK(fdebug, f,POS,SEEK_SET);
+  CHECKED_FSEEK(fdebug, f, POS, SEEK_SET);
 }
 
-void OPJFile::readGraphGridInfo(graphGrid &grid, FILE *f, FILE *debug, int pos)
-{
+void OPJFile::readGraphGridInfo(graphGrid &grid, FILE *f, FILE *debug,
+                                int pos) {
   unsigned char h;
   short w;
-  CHECKED_FSEEK(debug, f,pos+0x26,SEEK_SET);
-  CHECKED_FREAD(debug, &h,1,1,f);
-  grid.hidden=(h==0);
+  CHECKED_FSEEK(debug, f, pos + 0x26, SEEK_SET);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
+  grid.hidden = (h == 0);
 
-  CHECKED_FSEEK(debug, f,pos+0xF,SEEK_SET);
-  CHECKED_FREAD(debug, &h,1,1,f);
-  grid.color=h;
+  CHECKED_FSEEK(debug, f, pos + 0xF, SEEK_SET);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
+  grid.color = h;
 
+  CHECKED_FSEEK(debug, f, pos + 0x12, SEEK_SET);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
+  grid.style = h;
 
-  CHECKED_FSEEK(debug, f,pos+0x12,SEEK_SET);
-  CHECKED_FREAD(debug, &h,1,1,f);
-  grid.style=h;
-
-  CHECKED_FSEEK(debug, f,pos+0x15,SEEK_SET);
-  CHECKED_FREAD(debug, &w,2,1,f);
-  if(IsBigEndian()) SwapBytes(w);
-  grid.width=(double)w/500.0;
+  CHECKED_FSEEK(debug, f, pos + 0x15, SEEK_SET);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
+  if (IsBigEndian())
+    SwapBytes(w);
+  grid.width = (double)w / 500.0;
 }
 
-void OPJFile::readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *f, FILE *debug, int pos)
-{
-  axis_break.show=true;
+void OPJFile::readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *f,
+                                     FILE *debug, int pos) {
+  axis_break.show = true;
 
-  CHECKED_FSEEK(debug, f,pos+0x0B,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x0B, SEEK_SET);
 
-  CHECKED_FREAD(debug, &axis_break.from,8,1,f);
+  CHECKED_FREAD(debug, &axis_break.from, 8, 1, f);
 
-  if(IsBigEndian()) SwapBytes(axis_break.from);
-  
-  CHECKED_FREAD(debug, &axis_break.to,8,1,f);
+  if (IsBigEndian())
+    SwapBytes(axis_break.from);
 
-  if(IsBigEndian()) SwapBytes(axis_break.to);
+  CHECKED_FREAD(debug, &axis_break.to, 8, 1, f);
 
-  CHECKED_FREAD(debug, &axis_break.scale_increment_after,8,1,f);
+  if (IsBigEndian())
+    SwapBytes(axis_break.to);
 
-  if(IsBigEndian()) SwapBytes(axis_break.scale_increment_after);
+  CHECKED_FREAD(debug, &axis_break.scale_increment_after, 8, 1, f);
 
-  double position=0.0;
-  CHECKED_FREAD(debug, &position,8,1,f);
+  if (IsBigEndian())
+    SwapBytes(axis_break.scale_increment_after);
 
-  if(IsBigEndian()) SwapBytes(position);
-  axis_break.position=(int)position;
+  double position = 0.0;
+  CHECKED_FREAD(debug, &position, 8, 1, f);
+
+  if (IsBigEndian())
+    SwapBytes(position);
+  axis_break.position = (int)position;
 
   unsigned char h;
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  axis_break.log10=(h==1);
+  axis_break.log10 = (h == 1);
 
-  CHECKED_FREAD(debug, &axis_break.minor_ticks_after,1,1,f);
+  CHECKED_FREAD(debug, &axis_break.minor_ticks_after, 1, 1, f);
 }
 
-void OPJFile::readGraphAxisFormatInfo(graphAxisFormat &format, FILE *f, FILE *debug, int pos)
-{
+void OPJFile::readGraphAxisFormatInfo(graphAxisFormat &format, FILE *f,
+                                      FILE *debug, int pos) {
   unsigned char h;
   short w;
   double p;
-  CHECKED_FSEEK(debug, f,pos+0x26,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x26, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  format.hidden=(h==0);
+  format.hidden = (h == 0);
 
-  CHECKED_FSEEK(debug, f,pos+0xF,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0xF, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  format.color=h;
+  format.color = h;
 
-  CHECKED_FSEEK(debug, f,pos+0x4A,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x4A, SEEK_SET);
 
-  CHECKED_FREAD(debug, &w,2,1,f);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
 
-  if(IsBigEndian()) SwapBytes(w);
-  format.majorTickLength=(double)w/10.0;
+  if (IsBigEndian())
+    SwapBytes(w);
+  format.majorTickLength = (double)w / 10.0;
 
-  CHECKED_FSEEK(debug, f,pos+0x15,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x15, SEEK_SET);
 
-  CHECKED_FREAD(debug, &w,2,1,f);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
 
-  if(IsBigEndian()) SwapBytes(w);
-  format.thickness=(double)w/500.0;
+  if (IsBigEndian())
+    SwapBytes(w);
+  format.thickness = (double)w / 500.0;
 
-  CHECKED_FSEEK(debug, f,pos+0x25,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x25, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  format.minorTicksType=(h>>6);
-  format.majorTicksType=((h>>4)&3);
-  format.axisPosition=(h&0xF);
-  switch(format.axisPosition)
-  {
-    case 1:
-      CHECKED_FSEEK(debug, f,pos+0x37,SEEK_SET);
+  format.minorTicksType = (h >> 6);
+  format.majorTicksType = ((h >> 4) & 3);
+  format.axisPosition = (h & 0xF);
+  switch (format.axisPosition) {
+  case 1:
+    CHECKED_FSEEK(debug, f, pos + 0x37, SEEK_SET);
 
-      CHECKED_FREAD(debug, &h,1,1,f);
+    CHECKED_FREAD(debug, &h, 1, 1, f);
 
-      format.axisPositionValue=(double)h;
-      break;
-    case 2:
-      CHECKED_FSEEK(debug, f,pos+0x2F,SEEK_SET);
+    format.axisPositionValue = (double)h;
+    break;
+  case 2:
+    CHECKED_FSEEK(debug, f, pos + 0x2F, SEEK_SET);
 
-      CHECKED_FREAD(debug, &p,8,1,f);
+    CHECKED_FREAD(debug, &p, 8, 1, f);
 
-      if(IsBigEndian()) SwapBytes(p);
-      format.axisPositionValue=p;
-      break;
+    if (IsBigEndian())
+      SwapBytes(p);
+    format.axisPositionValue = p;
+    break;
   }
 }
 
-void OPJFile::readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *f, FILE *debug, int pos) {
+void OPJFile::readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *f,
+                                          FILE *debug, int pos) {
   unsigned char h;
   unsigned char h1;
   short w;
-  CHECKED_FSEEK(debug, f,pos+0x26,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x26, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  tick.hidden=(h==0);
+  tick.hidden = (h == 0);
 
-  CHECKED_FSEEK(debug, f,pos+0xF,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0xF, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  tick.color=h;
+  tick.color = h;
 
-  CHECKED_FSEEK(debug, f,pos+0x13,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x13, SEEK_SET);
 
-  CHECKED_FREAD(debug, &w,2,1,f);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
 
-  if(IsBigEndian()) SwapBytes(w);
-  tick.rotation=w/10;
+  if (IsBigEndian())
+    SwapBytes(w);
+  tick.rotation = w / 10;
 
-  CHECKED_FSEEK(debug, f,pos+0x15,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x15, SEEK_SET);
 
-  CHECKED_FREAD(debug, &w,2,1,f);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
 
-  if(IsBigEndian()) SwapBytes(w);
-  tick.fontsize=w;
+  if (IsBigEndian())
+    SwapBytes(w);
+  tick.fontsize = w;
 
-  CHECKED_FSEEK(debug, f,pos+0x1A,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x1A, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  tick.fontbold=(h&0x8);
+  tick.fontbold = (h & 0x8);
 
-  CHECKED_FSEEK(debug, f,pos+0x23,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x23, SEEK_SET);
 
-  CHECKED_FREAD(debug, &w,2,1,f);
+  CHECKED_FREAD(debug, &w, 2, 1, f);
 
-  if(IsBigEndian()) SwapBytes(w);
+  if (IsBigEndian())
+    SwapBytes(w);
 
-  CHECKED_FSEEK(debug, f,pos+0x25,SEEK_SET);
+  CHECKED_FSEEK(debug, f, pos + 0x25, SEEK_SET);
 
-  CHECKED_FREAD(debug, &h,1,1,f);
+  CHECKED_FREAD(debug, &h, 1, 1, f);
 
-  CHECKED_FREAD(debug, &h1,1,1,f);
+  CHECKED_FREAD(debug, &h1, 1, 1, f);
 
-  tick.value_type=(h&0xF);
+  tick.value_type = (h & 0xF);
 
   vector<string> col;
-  switch(tick.value_type)
-  {
-  case 0: //Numeric
+  switch (tick.value_type) {
+  case 0: // Numeric
 
     /*switch((h>>4))
     {
@@ -2986,15 +3168,12 @@ void OPJFile::readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *f, FILE *de
       default:
         tick.value_type_specification=0;
     }*/
-    if((h>>4)>7)
-    {
-      tick.value_type_specification=(h>>4)-8;
-      tick.decimal_places=h1-0x40;
-    }
-    else
-    {
-      tick.value_type_specification=(h>>4);
-      tick.decimal_places=-1;
+    if ((h >> 4) > 7) {
+      tick.value_type_specification = (h >> 4) - 8;
+      tick.decimal_places = h1 - 0x40;
+    } else {
+      tick.value_type_specification = (h >> 4);
+      tick.decimal_places = -1;
     }
 
     break;
@@ -3003,49 +3182,46 @@ void OPJFile::readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *f, FILE *de
   case 4: // Month
   case 5: // Day
   case 6: // Column heading
-    tick.value_type_specification=h1-0x40;
+    tick.value_type_specification = h1 - 0x40;
     break;
-  case 1: // Text
-  case 7: // Tick-indexed dataset
+  case 1:  // Text
+  case 7:  // Tick-indexed dataset
   case 10: // Categorical
-    col=findDataByIndex(w-1);
-    if(col.size()>0)
-    {
-      tick.colName=col[0];
-      tick.dataName=col[1];
+    col = findDataByIndex(w - 1);
+    if (col.size() > 0) {
+      tick.colName = col[0];
+      tick.dataName = col[1];
     }
     break;
   default: // Numeric Decimal 1.000
-    tick.value_type=Numeric;
-    tick.value_type_specification=0;
+    tick.value_type = Numeric;
+    tick.value_type_specification = 0;
     break;
   }
 }
 
-void OPJFile::readProjectTree(FILE *f, FILE *debug)
-{
+void OPJFile::readProjectTree(FILE *f, FILE *debug) {
   readProjectTreeFolder(f, debug, projectTree.begin());
 
-  fprintf(debug,"Origin project Tree\n");
-  tree<projectNode>::iterator sib2=projectTree.begin(projectTree.begin());
-    tree<projectNode>::iterator end2=projectTree.end(projectTree.begin());
-    while(sib2!=end2)
-  {
-        for(int i=0; i<projectTree.depth(sib2)-1; ++i)
-      fprintf(debug," ");
-    fprintf(debug,"%s\n",(*sib2).name.c_str());
-        ++sib2;
-    }
+  fprintf(debug, "Origin project Tree\n");
+  tree<projectNode>::iterator sib2 = projectTree.begin(projectTree.begin());
+  tree<projectNode>::iterator end2 = projectTree.end(projectTree.begin());
+  while (sib2 != end2) {
+    for (int i = 0; i < projectTree.depth(sib2) - 1; ++i)
+      fprintf(debug, " ");
+    fprintf(debug, "%s\n", (*sib2).name.c_str());
+    ++sib2;
+  }
   fflush(debug);
 }
 
-void OPJFile::readProjectTreeFolder(FILE *f, FILE *debug, tree<projectNode>::iterator parent)
-{
-  int POS=int(ftell(f));
+void OPJFile::readProjectTreeFolder(FILE *f, FILE *debug,
+                                    tree<projectNode>::iterator parent) {
+  int POS = int(ftell(f));
 
   int file_size = 0;
   {
-    int rv = fseek(f, 0 , SEEK_END);
+    int rv = fseek(f, 0, SEEK_END);
     if (rv < 0)
       fprintf(debug, "Error: could not move to the end of the file\n");
     file_size = ftell(f);
@@ -3056,164 +3232,170 @@ void OPJFile::readProjectTreeFolder(FILE *f, FILE *debug, tree<projectNode>::ite
 
   double creation_date, modification_date;
 
-  POS+=5;
-  CHECKED_FSEEK(debug, f,POS+0x10,SEEK_SET);
+  POS += 5;
+  CHECKED_FSEEK(debug, f, POS + 0x10, SEEK_SET);
 
-  CHECKED_FREAD(debug, &creation_date,8,1,f);
+  CHECKED_FREAD(debug, &creation_date, 8, 1, f);
 
-  if(IsBigEndian()) SwapBytes(creation_date);
+  if (IsBigEndian())
+    SwapBytes(creation_date);
 
-  CHECKED_FREAD(debug, &modification_date,8,1,f);
+  CHECKED_FREAD(debug, &modification_date, 8, 1, f);
 
-  if(IsBigEndian()) SwapBytes(modification_date);
+  if (IsBigEndian())
+    SwapBytes(modification_date);
 
-  POS+=0x20+1+5;
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
-
+  POS += 0x20 + 1 + 5;
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 
   int namesize;
-  CHECKED_FREAD(debug, &namesize,4,1,f);
+  CHECKED_FREAD(debug, &namesize, 4, 1, f);
 
-  if(IsBigEndian()) SwapBytes(namesize);
+  if (IsBigEndian())
+    SwapBytes(namesize);
 
   if (INT_MAX == namesize) {
     // this would cause an overflow and it's anyway obviously wrong
-    fprintf(debug, "Error: while reading project tree folder, found project/folder name size: %d\n", namesize);
+    fprintf(debug, "Error: while reading project tree folder, found "
+                   "project/folder name size: %d\n",
+            namesize);
     fflush(debug);
   }
 
   // read folder name
-  char* name=new char[namesize+1];
-  name[namesize]='\0';
+  char *name = new char[namesize + 1];
+  name[namesize] = '\0';
 
-  POS+=5;
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+  POS += 5;
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 
-  CHECKED_FREAD(debug, name,namesize,1,f);
+  CHECKED_FREAD(debug, name, namesize, 1, f);
 
-  tree<projectNode>::iterator current_folder=projectTree.append_child(parent, projectNode(name, 1, creation_date, modification_date));
-  POS+=namesize+1+5+5;
+  tree<projectNode>::iterator current_folder = projectTree.append_child(
+      parent, projectNode(name, 1, creation_date, modification_date));
+  POS += namesize + 1 + 5 + 5;
 
   int objectcount;
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 
-  CHECKED_FREAD(debug, &objectcount,4,1,f);
+  CHECKED_FREAD(debug, &objectcount, 4, 1, f);
 
-  if(IsBigEndian()) SwapBytes(objectcount);
-  POS+=5+5;
+  if (IsBigEndian())
+    SwapBytes(objectcount);
+  POS += 5 + 5;
 
   // there cannot be more objects than bytes
   if (objectcount > file_size)
     objectcount = 0;
 
-  for(int i=0; i<objectcount; ++i)
-  {
-    POS+=5;
+  for (int i = 0; i < objectcount; ++i) {
+    POS += 5;
     char c;
-    CHECKED_FSEEK(debug, f,POS+0x2,SEEK_SET);
+    CHECKED_FSEEK(debug, f, POS + 0x2, SEEK_SET);
 
-    CHECKED_FREAD(debug, &c,1,1,f);
+    CHECKED_FREAD(debug, &c, 1, 1, f);
 
     int objectID;
-    CHECKED_FSEEK(debug, f,POS+0x4,SEEK_SET);
+    CHECKED_FSEEK(debug, f, POS + 0x4, SEEK_SET);
 
-    CHECKED_FREAD(debug, &objectID,4,1,f);
+    CHECKED_FREAD(debug, &objectID, 4, 1, f);
 
-    if(IsBigEndian()) SwapBytes(objectID);
-    if(c==0x10)
-    {
-      projectTree.append_child(current_folder, projectNode(NOTE[objectID].name, 0));
-    }
-    else
-      projectTree.append_child(current_folder, projectNode(findObjectByIndex(objectID), 0));
-    POS+=8+1+5+5;
+    if (IsBigEndian())
+      SwapBytes(objectID);
+    if (c == 0x10) {
+      projectTree.append_child(current_folder,
+                               projectNode(NOTE[objectID].name, 0));
+    } else
+      projectTree.append_child(current_folder,
+                               projectNode(findObjectByIndex(objectID), 0));
+    POS += 8 + 1 + 5 + 5;
   }
 
-  CHECKED_FSEEK(debug, f,POS,SEEK_SET);
+  CHECKED_FSEEK(debug, f, POS, SEEK_SET);
 
-  CHECKED_FREAD(debug, &objectcount,4,1,f);
+  CHECKED_FREAD(debug, &objectcount, 4, 1, f);
 
-  if(IsBigEndian()) SwapBytes(objectcount);
-  CHECKED_FSEEK(debug, f,1,SEEK_CUR);
+  if (IsBigEndian())
+    SwapBytes(objectcount);
+  CHECKED_FSEEK(debug, f, 1, SEEK_CUR);
 
-  for(int i=0; i<objectcount; ++i)
+  for (int i = 0; i < objectcount; ++i)
     readProjectTreeFolder(f, debug, current_folder);
-  
-  delete [] name;
+
+  delete[] name;
 }
 
-void OPJFile::readWindowProperties(originWindow& window, FILE *f, FILE *debug, int POS, int headersize)
-{
-  window.objectID=objectIndex;
+void OPJFile::readWindowProperties(originWindow &window, FILE *f, FILE *debug,
+                                   int POS, int headersize) {
+  window.objectID = objectIndex;
   objectIndex++;
 
-  CHECKED_FSEEK(debug, f,POS + 0x1B,SEEK_SET);
-  CHECKED_FREAD(debug, &window.clientRect,8,1,f);
-  if(IsBigEndian()) SwapBytes(window.clientRect);
+  CHECKED_FSEEK(debug, f, POS + 0x1B, SEEK_SET);
+  CHECKED_FREAD(debug, &window.clientRect, 8, 1, f);
+  if (IsBigEndian())
+    SwapBytes(window.clientRect);
 
   char c;
-  CHECKED_FSEEK(debug, f,POS + 0x32,SEEK_SET);
-  CHECKED_FREAD(debug, &c,1,1,f);
+  CHECKED_FSEEK(debug, f, POS + 0x32, SEEK_SET);
+  CHECKED_FREAD(debug, &c, 1, 1, f);
 
-  if(c&0x01)
+  if (c & 0x01)
     window.state = originWindow::Minimized;
-  else if(c&0x02)
+  else if (c & 0x02)
     window.state = originWindow::Maximized;
 
-  CHECKED_FSEEK(debug, f,POS + 0x69,SEEK_SET);
-  CHECKED_FREAD(debug, &c,1,1,f);
+  CHECKED_FSEEK(debug, f, POS + 0x69, SEEK_SET);
+  CHECKED_FREAD(debug, &c, 1, 1, f);
 
-  if(c&0x01)
+  if (c & 0x01)
     window.title = originWindow::Label;
-  else if(c&0x02)
+  else if (c & 0x02)
     window.title = originWindow::Name;
   else
     window.title = originWindow::Both;
 
-  window.bHidden = (c&0x08);
-  if(window.bHidden)
-  {
-    fprintf(debug,"     WINDOW %d NAME : %s is hidden\n", objectIndex, window.name.c_str());
+  window.bHidden = (c & 0x08);
+  if (window.bHidden) {
+    fprintf(debug, "     WINDOW %d NAME : %s is hidden\n", objectIndex,
+            window.name.c_str());
     fflush(debug);
   }
 
-  CHECKED_FSEEK(debug, f,POS + 0x73,SEEK_SET);
-  CHECKED_FREAD(debug, &window.creation_date,8,1,f);
-  if(IsBigEndian()) SwapBytes(window.creation_date);
+  CHECKED_FSEEK(debug, f, POS + 0x73, SEEK_SET);
+  CHECKED_FREAD(debug, &window.creation_date, 8, 1, f);
+  if (IsBigEndian())
+    SwapBytes(window.creation_date);
 
-  CHECKED_FREAD(debug, &window.modification_date,8,1,f);
-  if(IsBigEndian()) SwapBytes(window.modification_date);
-  
-  if(headersize > 0xC3)
-  {
+  CHECKED_FREAD(debug, &window.modification_date, 8, 1, f);
+  if (IsBigEndian())
+    SwapBytes(window.modification_date);
+
+  if (headersize > 0xC3) {
     int labellen = 0;
-    CHECKED_FSEEK(debug, f,POS + 0xC3,SEEK_SET);
-    CHECKED_FREAD(debug, &c,1,1,f);
-    while (c != '@')
-    {
-      CHECKED_FREAD(debug, &c,1,1,f);
+    CHECKED_FSEEK(debug, f, POS + 0xC3, SEEK_SET);
+    CHECKED_FREAD(debug, &c, 1, 1, f);
+    while (c != '@') {
+      CHECKED_FREAD(debug, &c, 1, 1, f);
       labellen++;
     }
-    if(labellen > 0)
-    {
-      char *label=new char[labellen+1];
-      label[labellen]='\0';
-      CHECKED_FSEEK(debug, f,POS + 0xC3,SEEK_SET);
-      CHECKED_FREAD(debug, label,labellen,1,f);
-      window.label=label;
-      delete [] label;
-    }
-    else
-      window.label="";
-    fprintf(debug,"     WINDOW %d LABEL: %s\n", objectIndex, window.label.c_str());
+    if (labellen > 0) {
+      char *label = new char[labellen + 1];
+      label[labellen] = '\0';
+      CHECKED_FSEEK(debug, f, POS + 0xC3, SEEK_SET);
+      CHECKED_FREAD(debug, label, labellen, 1, f);
+      window.label = label;
+      delete[] label;
+    } else
+      window.label = "";
+    fprintf(debug, "     WINDOW %d LABEL: %s\n", objectIndex,
+            window.label.c_str());
     fflush(debug);
   }
 }
-bool OPJFile::IsBigEndian()
-{
-   short word = 0x4321;
-   if((*(char *)& word) != 0x21 )
-     return true;
-   else
-     return false;
+bool OPJFile::IsBigEndian() {
+  short word = 0x4321;
+  if ((*(char *)&word) != 0x21)
+    return true;
+  else
+    return false;
 }

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -96,8 +96,7 @@ int strcmp_i(const char *s1,
     }                                                                          \
   }
 
-// for standard calls like 'int retval = fread(&objectcount, 4, 1, f);'
-// Note: using size_t because of MSVC which takes and returns size_t
+// for standard calls like 'size_t retval = fread(&objectcount, 4, 1, f);'
 #define CHECKED_FREAD(debug, ptr, size, nmemb, stream)                         \
   {                                                                            \
     size_t retval = fread(ptr, size, nmemb, stream);                           \
@@ -280,8 +279,8 @@ int OPJFile::Parse() {
     return -1;
   }
 
-  retval = fread(&vers, 4, 1, f);
-  if (4 != retval) {
+  size_t readval = fread(&vers, 4, 1, f);
+  if (4 != readval) {
     printf(" WARNING : could not read four bytes with the version information, "
            "read: %d bytes\n",
            retval);

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -83,7 +83,7 @@ int strcmp_i(const char *s1,
   {                                                                            \
     int retval = fseek(fd, offset, whence);                                    \
     if (retval < 0) {                                                          \
-      char *posStr = NULL;                                                     \
+      std::string posStr = "";                                                 \
       if (SEEK_SET == whence)                                                  \
         posStr = "beginning of the file";                                      \
       else if (SEEK_CUR == whence)                                             \
@@ -92,15 +92,16 @@ int strcmp_i(const char *s1,
         posStr = "end of the file";                                            \
                                                                                \
       fprintf(debug, " WARNING : could not move to position %d from the %s\n", \
-              offset, posStr);                                                 \
+              offset, posStr.c_str());                                         \
     }                                                                          \
   }
 
 // for standard calls like 'int retval = fread(&objectcount, 4, 1, f);'
+// Note: using size_t because of MSVC which takes and returns size_t
 #define CHECKED_FREAD(debug, ptr, size, nmemb, stream)                         \
   {                                                                            \
-    int retval = fread(ptr, size, nmemb, stream);                              \
-    if (size * nmemb != retval) {                                              \
+    size_t retval = fread(ptr, size, nmemb, stream);                           \
+    if (static_cast<size_t>(size * nmemb) != retval) {                         \
       fprintf(                                                                 \
           debug,                                                               \
           " WARNING : could not read %d bytes from file, read: %d bytes\n",    \

--- a/MantidPlot/src/origin/OPJFile.h
+++ b/MantidPlot/src/origin/OPJFile.h
@@ -782,14 +782,14 @@ private:
 	int compareFunctionnames(const char *sname) const;				//!< returns matching function index
 	std::vector<std::string> findDataByIndex(int index) const;
 	std::string findObjectByIndex(int index);
-	void readSpreadInfo(FILE *fopj, int file_size, FILE *fdebug);
+        void readSpreadInfo(FILE *fopj, int file_size, FILE *fdebug);
 	void readExcelInfo(FILE *f, int file_size, FILE *debug);
 	void readMatrixInfo(FILE *fopj, int file_size, FILE *fdebug);
 	void readGraphInfo(FILE *fopj, int file_size, FILE *fdebug);
-	void readGraphGridInfo(graphGrid &grid, FILE *fopj, int pos);
-	void readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *fopj, int pos);
-	void readGraphAxisFormatInfo(graphAxisFormat &format, FILE *fopj, int pos);
-	void readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *fopj, int pos);
+	void readGraphGridInfo(graphGrid &grid, FILE *fopj, FILE *debug, int pos);
+	void readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *fopj, FILE *debug, int pos);
+	void readGraphAxisFormatInfo(graphAxisFormat &format, FILE *fopj, FILE *debug, int pos);
+	void readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *fopj, FILE *debug, int pos);
 	void readProjectTree(FILE *f, FILE *debug);
 	void readProjectTreeFolder(FILE *f, FILE *debug, tree<projectNode>::iterator parent);
 	void readWindowProperties(originWindow& window, FILE *f, FILE *debug, int POS, int headersize);

--- a/MantidPlot/src/origin/OPJFile.h
+++ b/MantidPlot/src/origin/OPJFile.h
@@ -782,10 +782,10 @@ private:
 	int compareFunctionnames(const char *sname) const;				//!< returns matching function index
 	std::vector<std::string> findDataByIndex(int index) const;
 	std::string findObjectByIndex(int index);
-	void readSpreadInfo(FILE *fopj, FILE *fdebug);
-	void readExcelInfo(FILE *f, FILE *debug);
-	void readMatrixInfo(FILE *fopj, FILE *fdebug);
-	void readGraphInfo(FILE *fopj, FILE *fdebug);
+	void readSpreadInfo(FILE *fopj, int file_size, FILE *fdebug);
+	void readExcelInfo(FILE *f, int file_size, FILE *debug);
+	void readMatrixInfo(FILE *fopj, int file_size, FILE *fdebug);
+	void readGraphInfo(FILE *fopj, int file_size, FILE *fdebug);
 	void readGraphGridInfo(graphGrid &grid, FILE *fopj, int pos);
 	void readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *fopj, int pos);
 	void readGraphAxisFormatInfo(graphAxisFormat &format, FILE *fopj, int pos);

--- a/MantidPlot/src/origin/OPJFile.h
+++ b/MantidPlot/src/origin/OPJFile.h
@@ -40,774 +40,1006 @@
 #include <vector>
 #include "tree.hh"
 
-// Russell Taylor, 23/07/10: Remove evil import - caused clash with std::tr1::function
-//using namespace std;
+// Russell Taylor, 23/07/10: Remove evil import - caused clash with
+// std::tr1::function
+// using namespace std;
 
 struct rect {
-	short left;
-	short top;
-	short right;
-	short bottom;
-	int height() const
-	{
-		return bottom-top;
-	};
-	int width() const
-	{
-		return right-left;
-	};
-    rect() : left(0), top(0), right(0), bottom(0)
-	{
-	}
-	rect(short width, short height)
-		:	left(0)
-		,	top(0)
-		,	right(width)
-		,	bottom(height)
-	{
-	}
+  short left;
+  short top;
+  short right;
+  short bottom;
+  int height() const { return bottom - top; };
+  int width() const { return right - left; };
+  rect() : left(0), top(0), right(0), bottom(0) {}
+  rect(short width, short height)
+      : left(0), top(0), right(width), bottom(height) {}
 };
 
 struct originWindow {
-	enum State {Normal, Minimized, Maximized};
-	enum Title {Name, Label, Both};
+  enum State { Normal, Minimized, Maximized };
+  enum Title { Name, Label, Both };
 
-	std::string name;
-	std::string label;
-	int objectID;
-	bool bHidden;
-	State state;
-	Title title;
-	rect clientRect;
-	double creation_date;	  // Julian date/time
-	double modification_date; // Julian date/time
+  std::string name;
+  std::string label;
+  int objectID;
+  bool bHidden;
+  State state;
+  Title title;
+  rect clientRect;
+  double creation_date;     // Julian date/time
+  double modification_date; // Julian date/time
 
-	originWindow(std::string _name="", std::string _label="", bool _bHidden=false)
-	:	name(_name)
-	,	label(_label)
-	,	objectID(0)
-	,	bHidden(_bHidden)
-	,	state(Normal)
-	,	title(Both)
-	,	creation_date(0.0)
-	,	modification_date(0.0)
-	{};
+  originWindow(std::string _name = "", std::string _label = "",
+               bool _bHidden = false)
+      : name(_name), label(_label), objectID(0), bHidden(_bHidden),
+        state(Normal), title(Both), creation_date(0.0),
+        modification_date(0.0){};
 };
 struct originData {
-	int type; // 0 - double, 1 - string
-	double d;
-	std::string s;
-	originData(double _d)
-	:	type(0)
-	,	d(_d)
-	,	s("")
-	{};
-	originData(char* _s)
-	:	type(1)
-	,	d(1.0e-307)
-	,	s(_s)
-	{};
+  int type; // 0 - double, 1 - string
+  double d;
+  std::string s;
+  originData(double _d) : type(0), d(_d), s(""){};
+  originData(char *_s) : type(1), d(1.0e-307), s(_s){};
 };
 
-enum ColumnType {X, Y, Z, XErr, YErr, Label, NONE};
+enum ColumnType { X, Y, Z, XErr, YErr, Label, NONE };
 
 struct spreadColumn {
-	std::string name;
-	ColumnType type;
-	int value_type;//Numeric = 0, Text = 1, Date = 2, Time = 3, Month = 4, Day = 5, Text&Numeric = 6
-	int value_type_specification; //see above
-	int significant_digits;
-	int decimal_places;
-	int numeric_display_type;//Default Decimal Digits=0, Decimal Places=1, Significant Digits=2
-	std::string command;
-	std::string comment;
-	int width;
-	int index;
-	std::vector <originData> odata;
-	spreadColumn(std::string _name="", int _index=0)
-	:	name(_name)
-    ,   type(NONE)
-	,	value_type(0)
-	,	value_type_specification(0)
-	,	significant_digits(6)
-	,	decimal_places(6)
-	,	numeric_display_type(0)
-	,	command("")
-	,	comment("")
-	,	width(8)
-	,	index(_index)
-	{};
+  std::string name;
+  ColumnType type;
+  int value_type; // Numeric = 0, Text = 1, Date = 2, Time = 3, Month = 4, Day =
+                  // 5, Text&Numeric = 6
+  int value_type_specification; // see above
+  int significant_digits;
+  int decimal_places;
+  int numeric_display_type; // Default Decimal Digits=0, Decimal Places=1,
+                            // Significant Digits=2
+  std::string command;
+  std::string comment;
+  int width;
+  int index;
+  std::vector<originData> odata;
+  spreadColumn(std::string _name = "", int _index = 0)
+      : name(_name), type(NONE), value_type(0), value_type_specification(0),
+        significant_digits(6), decimal_places(6), numeric_display_type(0),
+        command(""), comment(""), width(8), index(_index){};
 };
 
 struct spreadSheet : public originWindow {
-	int maxRows;
-	bool bLoose;
-	bool bMultisheet;
-	std::vector <spreadColumn> column;
-	spreadSheet(std::string _name="")
-        :	originWindow(_name)
-        ,	maxRows(0)
-	,	bLoose(true)
-	,	bMultisheet(false)
-	,	column()          
-        {};
+  int maxRows;
+  bool bLoose;
+  bool bMultisheet;
+  std::vector<spreadColumn> column;
+  spreadSheet(std::string _name = "")
+      : originWindow(_name), maxRows(0), bLoose(true), bMultisheet(false),
+        column(){};
 };
 
 struct excel : public originWindow {
-	int maxRows;
-	bool bLoose;
-	std::vector <spreadSheet> sheet;
-	excel(std::string _name="", std::string _label="", int _maxRows=0, bool _bHidden=false, bool _bLoose=true)
-	:	originWindow(_name, _label, _bHidden)
-	,	maxRows(_maxRows)
-	,	bLoose(_bLoose)
-	{
-	};
+  int maxRows;
+  bool bLoose;
+  std::vector<spreadSheet> sheet;
+  excel(std::string _name = "", std::string _label = "", int _maxRows = 0,
+        bool _bHidden = false, bool _bLoose = true)
+      : originWindow(_name, _label, _bHidden), maxRows(_maxRows),
+        bLoose(_bLoose){};
 };
 
 struct matrix : public originWindow {
-	enum ViewType {DataView, ImageView};
-	enum HeaderViewType {ColumnRow, XY};
-	int nr_rows;
-	int nr_cols;
-	int value_type_specification;
-	int significant_digits;
-	int decimal_places;
-	int numeric_display_type;//Default Decimal Digits=0, Decimal Places=1, Significant Digits=2
-	std::string command;
-	int width;
-	int index;
-	ViewType view;
-	HeaderViewType header;
-	std::vector <double> data;
-	matrix(std::string _name="", int _index=0)
-        :	originWindow(_name)
-        ,       nr_rows(0)
-        ,       nr_cols(0)
-	,	value_type_specification(0)
-	,	significant_digits(6)
-	,	decimal_places(6)
-	,	numeric_display_type(0)
-	,	command("")
-	,	width(8)
-	,	index(_index)
-	,	view(DataView)
-	,	header(ColumnRow)
-	{};
+  enum ViewType { DataView, ImageView };
+  enum HeaderViewType { ColumnRow, XY };
+  int nr_rows;
+  int nr_cols;
+  int value_type_specification;
+  int significant_digits;
+  int decimal_places;
+  int numeric_display_type; // Default Decimal Digits=0, Decimal Places=1,
+                            // Significant Digits=2
+  std::string command;
+  int width;
+  int index;
+  ViewType view;
+  HeaderViewType header;
+  std::vector<double> data;
+  matrix(std::string _name = "", int _index = 0)
+      : originWindow(_name), nr_rows(0), nr_cols(0),
+        value_type_specification(0), significant_digits(6), decimal_places(6),
+        numeric_display_type(0), command(""), width(8), index(_index),
+        view(DataView), header(ColumnRow){};
 };
 
 struct function {
-	std::string name;
-	int type;//Normal = 0, Polar = 1
-	std::string formula;
-	double begin;
-	double end;
-	int points;
-	int index;
-	function(std::string _name="", int _index=0)
-	:	name(_name)
-	,	type(0)
-	,	formula("")
-	,	begin(0.0)
-	,	end(0.0)
-	,	points(0)
-	,	index(_index)
-	{};
+  std::string name;
+  int type; // Normal = 0, Polar = 1
+  std::string formula;
+  double begin;
+  double end;
+  int points;
+  int index;
+  function(std::string _name = "", int _index = 0)
+      : name(_name), type(0), formula(""), begin(0.0), end(0.0), points(0),
+        index(_index){};
 };
-
 
 struct text {
-	std::string txt;
-	rect clientRect;
-	int color;
-	int fontsize;
-	int rotation;
-	int tab;
-	int border_type;
-	int attach;
+  std::string txt;
+  rect clientRect;
+  int color;
+  int fontsize;
+  int rotation;
+  int tab;
+  int border_type;
+  int attach;
 
-	text(const std::string& _txt="")
-		:	txt(_txt)
-		,	clientRect()
-                ,	color(0)
-                ,	fontsize(0)
-                ,	rotation(0)
-                ,	tab(0)
-                ,	border_type(0)
-                ,	attach(0)
-        {};
+  text(const std::string &_txt = "")
+      : txt(_txt), clientRect(), color(0), fontsize(0), rotation(0), tab(0),
+        border_type(0), attach(0){};
 
-	text(const std::string& _txt, const rect& _clientRect, int _color, int _fontsize, int _rotation, int _tab, int _border_type, int _attach)
-		:	txt(_txt)
-		,	clientRect(_clientRect)
-		,	color(_color)
-		,	fontsize(_fontsize)
-		,	rotation(_rotation)
-		,	tab(_tab)
-		,	border_type(_border_type)
-		,	attach(_attach)
-	{};
+  text(const std::string &_txt, const rect &_clientRect, int _color,
+       int _fontsize, int _rotation, int _tab, int _border_type, int _attach)
+      : txt(_txt), clientRect(_clientRect), color(_color), fontsize(_fontsize),
+        rotation(_rotation), tab(_tab), border_type(_border_type),
+        attach(_attach){};
 };
 
-struct pieProperties
-{
-	unsigned char view_angle;
-	unsigned char thickness;
-	bool clockwise_rotation;
-	short rotation;
-	unsigned short radius;
-	unsigned short horizontal_offset;
-	unsigned long displaced_sections; // maximum - 32 sections
-	unsigned short displacement;
-	
-	//labels
-	bool format_automatic;
-	bool format_values;
-	bool format_percentages;
-	bool format_categories;
-	bool position_associate;
-	unsigned short distance;
+struct pieProperties {
+  unsigned char view_angle;
+  unsigned char thickness;
+  bool clockwise_rotation;
+  short rotation;
+  unsigned short radius;
+  unsigned short horizontal_offset;
+  unsigned long displaced_sections; // maximum - 32 sections
+  unsigned short displacement;
 
-	pieProperties()
-	:	view_angle(0)
-	,	thickness(0)
-	,	clockwise_rotation(false)
-	,	rotation(0)
-	,	radius(0)
-	,	horizontal_offset(0)
-	,	displaced_sections(0)
-	,	displacement(0)
-	,	format_automatic(false)
-	,	format_values(false)
-	,	format_percentages(false)
-	,	format_categories(false)
-	,	position_associate(false)
-	,	distance(0)
-        {};
+  // labels
+  bool format_automatic;
+  bool format_values;
+  bool format_percentages;
+  bool format_categories;
+  bool position_associate;
+  unsigned short distance;
+
+  pieProperties()
+      : view_angle(0), thickness(0), clockwise_rotation(false), rotation(0),
+        radius(0), horizontal_offset(0), displaced_sections(0), displacement(0),
+        format_automatic(false), format_values(false),
+        format_percentages(false), format_categories(false),
+        position_associate(false), distance(0){};
 };
 
-struct vectorProperties
-{
-	int color;
-	double width;
-	unsigned short arrow_lenght;
-	unsigned char arrow_angle;
-	bool arrow_closed;
-	std::string endXColName;
-	std::string endYColName;
+struct vectorProperties {
+  int color;
+  double width;
+  unsigned short arrow_lenght;
+  unsigned char arrow_angle;
+  bool arrow_closed;
+  std::string endXColName;
+  std::string endYColName;
 
-	int position;
-	std::string angleColName;
-	std::string magnitudeColName;
-	float multiplier;
-	int const_angle;
-	int const_magnitude;
+  int position;
+  std::string angleColName;
+  std::string magnitudeColName;
+  float multiplier;
+  int const_angle;
+  int const_magnitude;
 
-	vectorProperties()
-        :	color(0)
-        ,	width(0.0)
-        ,	arrow_lenght(0)
-        ,	arrow_angle(0)
-        ,	arrow_closed(false)
-        ,	endXColName()
-        ,	endYColName()
-        ,	position(0)
-        ,	angleColName()
-        ,	magnitudeColName(0)
-        ,	multiplier(1.0)
-        ,	const_angle(0)
-        ,	const_magnitude(0)
-	{};
+  vectorProperties()
+      : color(0), width(0.0), arrow_lenght(0), arrow_angle(0),
+        arrow_closed(false), endXColName(), endYColName(), position(0),
+        angleColName(), magnitudeColName(0), multiplier(1.0), const_angle(0),
+        const_magnitude(0){};
 };
 
 struct graphCurve {
-	int type;
-	std::string dataName;
-	std::string xColName;
-	std::string yColName;
-	int line_color;
-	int line_style;
-	int line_connect;
-	double line_width;
+  int type;
+  std::string dataName;
+  std::string xColName;
+  std::string yColName;
+  int line_color;
+  int line_style;
+  int line_connect;
+  double line_width;
 
-	bool fillarea;
-	int fillarea_type;
-	int fillarea_pattern;
-	int fillarea_color;
-	int fillarea_first_color;
-	int fillarea_pattern_color;
-	double fillarea_pattern_width;
-	int fillarea_pattern_border_style;
-	int fillarea_pattern_border_color;
-	double fillarea_pattern_border_width;
+  bool fillarea;
+  int fillarea_type;
+  int fillarea_pattern;
+  int fillarea_color;
+  int fillarea_first_color;
+  int fillarea_pattern_color;
+  double fillarea_pattern_width;
+  int fillarea_pattern_border_style;
+  int fillarea_pattern_border_color;
+  double fillarea_pattern_border_width;
 
-	int symbol_type;
-	int symbol_color;
-	int symbol_fill_color;
-	double symbol_size;
-	int symbol_thickness;
-	int point_offset;
+  int symbol_type;
+  int symbol_color;
+  int symbol_fill_color;
+  double symbol_size;
+  int symbol_thickness;
+  int point_offset;
 
-	//pie
-	pieProperties pie;
+  // pie
+  pieProperties pie;
 
-	//vector
-	vectorProperties vector;
+  // vector
+  vectorProperties vector;
 };
 
-enum AxisPosition {Left = 0, Bottom = 1, Right = 2, Top = 3};
+enum AxisPosition { Left = 0, Bottom = 1, Right = 2, Top = 3 };
 
 struct graphAxisBreak {
-	bool show;
+  bool show;
 
-	bool log10;
-	double from;
-	double to;
-	int position;
+  bool log10;
+  double from;
+  double to;
+  int position;
 
-	double scale_increment_before;
-	double scale_increment_after;
+  double scale_increment_before;
+  double scale_increment_after;
 
-	unsigned char minor_ticks_before;
-	unsigned char minor_ticks_after;
+  unsigned char minor_ticks_before;
+  unsigned char minor_ticks_after;
 
-	graphAxisBreak()
-	:   show(false)
-          , log10(false)
-          , from(0.0)
-          , to(0.0)
-          , position(0)
-          , scale_increment_before(0)
-          , scale_increment_after(0)
-          , minor_ticks_before(0)
-          , minor_ticks_after(0)
-	{
-	}
+  graphAxisBreak()
+      : show(false), log10(false), from(0.0), to(0.0), position(0),
+        scale_increment_before(0), scale_increment_after(0),
+        minor_ticks_before(0), minor_ticks_after(0) {}
 };
 
 struct graphGrid {
-	bool hidden;
-	int color;
-	int style;
-	double width;
+  bool hidden;
+  int color;
+  int style;
+  double width;
 };
 
 struct graphAxisFormat {
-	bool hidden;
-	int color;
-	double thickness;
-	double majorTickLength;
-	int majorTicksType;
-	int minorTicksType;
-	int axisPosition;
-	double axisPositionValue;
+  bool hidden;
+  int color;
+  double thickness;
+  double majorTickLength;
+  int majorTicksType;
+  int minorTicksType;
+  int axisPosition;
+  double axisPositionValue;
 };
 
 struct graphAxisTick {
-	bool hidden;
-	int color;
-	int value_type;//Numeric = 0, Text = 1, Date = 2, Time = 3, Month = 4, Day = 5, Text&Numeric = 6
-	int value_type_specification; 
-	int decimal_places;
-	int fontsize;
-	bool fontbold;
-	std::string dataName;
-	std::string colName;
-	int rotation;
+  bool hidden;
+  int color;
+  int value_type; // Numeric = 0, Text = 1, Date = 2, Time = 3, Month = 4, Day =
+                  // 5, Text&Numeric = 6
+  int value_type_specification;
+  int decimal_places;
+  int fontsize;
+  bool fontbold;
+  std::string dataName;
+  std::string colName;
+  int rotation;
 };
 
 struct graphAxis {
-	int pos;
-	text label;
-	double min;
-	double max;
-	double step;
-	int majorTicks;
-	int minorTicks;
-	int scale;
-	graphGrid majorGrid;
-	graphGrid minorGrid;
-	graphAxisFormat formatAxis[2];
-	graphAxisTick tickAxis[2]; //bottom-top, left-right
+  int pos;
+  text label;
+  double min;
+  double max;
+  double step;
+  int majorTicks;
+  int minorTicks;
+  int scale;
+  graphGrid majorGrid;
+  graphGrid minorGrid;
+  graphAxisFormat formatAxis[2];
+  graphAxisTick tickAxis[2]; // bottom-top, left-right
 };
 
 struct rectangle {
-	rect clientRect;
-	int attach;
+  rect clientRect;
+  int attach;
 };
 
 struct circle {
-	rect clientRect;
-	int attach;
+  rect clientRect;
+  int attach;
 };
 
 struct lineVertex {
-	int shape_type;
-	double shape_width;
-	double shape_length;
-	double x;
-	double y;
-	lineVertex()
-	:	shape_type(0)
-	,	shape_width(0.0)
-	,	shape_length(0.0)
-	,	x(0.0)
-	,	y(0.0)
-	{}
+  int shape_type;
+  double shape_width;
+  double shape_length;
+  double x;
+  double y;
+  lineVertex()
+      : shape_type(0), shape_width(0.0), shape_length(0.0), x(0.0), y(0.0) {}
 };
 
 struct line {
-	rect clientRect;
-	int color;
-	int attach;
-	double width;
-	int line_style;
-	lineVertex begin;
-	lineVertex end;
+  rect clientRect;
+  int color;
+  int attach;
+  double width;
+  int line_style;
+  lineVertex begin;
+  lineVertex end;
 };
 
 struct bitmap {
-	rect clientRect;
-	int attach;
-	unsigned long size;
-	unsigned char* data;
-	double left;
-	double top;
-	double width;
-	double height;
+  rect clientRect;
+  int attach;
+  unsigned long size;
+  unsigned char *data;
+  double left;
+  double top;
+  double width;
+  double height;
 };
 
 struct metafile {
-	rect clientRect;
-	int attach;
+  rect clientRect;
+  int attach;
 };
 
 struct graphLayer {
-	rect clientRect;
-	text legend;
-	graphAxis xAxis;
-	graphAxis yAxis;
+  rect clientRect;
+  text legend;
+  graphAxis xAxis;
+  graphAxis yAxis;
 
-	graphAxisBreak xAxisBreak;
-	graphAxisBreak yAxisBreak;
+  graphAxisBreak xAxisBreak;
+  graphAxisBreak yAxisBreak;
 
-	double histogram_bin;
-	double histogram_begin;
-	double histogram_end;
+  double histogram_bin;
+  double histogram_begin;
+  double histogram_end;
 
-	std::vector<text> texts;
-	std::vector<line> lines;
-	std::vector<bitmap> bitmaps;
-	std::vector<graphCurve> curve;
+  std::vector<text> texts;
+  std::vector<line> lines;
+  std::vector<bitmap> bitmaps;
+  std::vector<graphCurve> curve;
 };
 
 struct graphLayerRange {
-	double min;
-	double max;
-	double step;
+  double min;
+  double max;
+  double step;
 
-	graphLayerRange(double _min=0.0, double _max=0.0, double _step=0.0)
-	{
-		min=_min;
-		max=_max;
-		step=_step;
-	};
+  graphLayerRange(double _min = 0.0, double _max = 0.0, double _step = 0.0) {
+    min = _min;
+    max = _max;
+    step = _step;
+  };
 };
 
 struct graph : public originWindow {
-	std::vector<graphLayer> layer;
-	unsigned short width;
-	unsigned short height;
+  std::vector<graphLayer> layer;
+  unsigned short width;
+  unsigned short height;
 
-	graph(std::string _name="")
-	:	originWindow(_name)
-        ,	width(0)
-        ,	height(0)
-        {};
+  graph(std::string _name = "") : originWindow(_name), width(0), height(0){};
 };
 
 struct note : public originWindow {
-	std::string text;
-	note(std::string _name="")
-	:	originWindow(_name)
-	{};
+  std::string text;
+  note(std::string _name = "") : originWindow(_name){};
 };
 
 struct projectNode {
-	int type; // 0 - object, 1 - folder
-	std::string name;
-	double creation_date;	  // Julian date/time
-	double modification_date; // Julian date/time
+  int type; // 0 - object, 1 - folder
+  std::string name;
+  double creation_date;     // Julian date/time
+  double modification_date; // Julian date/time
 
-	projectNode(std::string _name="", int _type=0, double _creation_date=0.0, double _modification_date=0.0)
-	:	type(_type)
-	,	name(_name)
-	,	creation_date(_creation_date)
-	,	modification_date(_modification_date)
-	{};
+  projectNode(std::string _name = "", int _type = 0,
+              double _creation_date = 0.0, double _modification_date = 0.0)
+      : type(_type), name(_name), creation_date(_creation_date),
+        modification_date(_modification_date){};
 };
 
-class OPJFile
-{
+class OPJFile {
 public:
-	OPJFile(const char* filename);
-	~OPJFile()
-	{
-		for(unsigned int g=0; g<GRAPH.size(); ++g)
-			for(unsigned int l=0; l<GRAPH[g].layer.size(); ++l)
-				for(unsigned int b=0; b<GRAPH[g].layer[l].bitmaps.size(); ++b)
-					if(GRAPH[g].layer[l].bitmaps[b].size > 0)
-						delete GRAPH[g].layer[l].bitmaps[b].data;
-	}
-	int Parse();
-	double Version() const { return version/100.0; }		//!< get version of project file
+  OPJFile(const char *filename);
+  ~OPJFile() {
+    for (unsigned int g = 0; g < GRAPH.size(); ++g)
+      for (unsigned int l = 0; l < GRAPH[g].layer.size(); ++l)
+        for (unsigned int b = 0; b < GRAPH[g].layer[l].bitmaps.size(); ++b)
+          if (GRAPH[g].layer[l].bitmaps[b].size > 0)
+            delete GRAPH[g].layer[l].bitmaps[b].data;
+  }
+  int Parse();
+  double Version() const {
+    return version / 100.0;
+  } //!< get version of project file
 
-	const tree<projectNode>* project() const { return &projectTree; }
-	//spreadsheet properties
-	int numSpreads() const { return static_cast<int>(SPREADSHEET.size()); }			//!< get number of spreadsheets
-	const char *spreadName(int s) const { return SPREADSHEET[s].name.c_str(); }	//!< get name of spreadsheet s
-	bool spreadHidden(int s) const { return SPREADSHEET[s].bHidden; }	//!< is spreadsheet s hidden
-	bool spreadLoose(int s) const { return SPREADSHEET[s].bLoose; }	//!< is spreadsheet s loose
-	rect spreadWindowRect(int s) const { return SPREADSHEET[s].clientRect; }		//!< get window rectangle of spreadsheet s
-	const char *spreadLabel(int s) const { return SPREADSHEET[s].label.c_str(); }	//!< get label of spreadsheet s
-	double spreadCreationDate(int s) const { return SPREADSHEET[s].creation_date; }	//!< get creation date of spreadsheet s
-	double spreadModificationDate(int s) const { return SPREADSHEET[s].modification_date; }	//!< get modification date of spreadsheet s
-	originWindow::State spreadState(int s) const { return SPREADSHEET[s].state; }	//!< get window state of spreadsheet s
-	originWindow::Title spreadTitle(int s) const { return SPREADSHEET[s].title; }	//!< get window state of spreadsheet s
-	int numCols(int s) const { return static_cast<int>(SPREADSHEET[s].column.size()); }		//!< get number of columns of spreadsheet s
-	int numRows(int s,int c) const { return static_cast<int>(SPREADSHEET[s].column[c].odata.size()); }	//!< get number of rows of column c of spreadsheet s
-	int maxRows(int s) const { return SPREADSHEET[s].maxRows; }		//!< get maximum number of rows of spreadsheet s
+  const tree<projectNode> *project() const { return &projectTree; }
+  // spreadsheet properties
+  int numSpreads() const {
+    return static_cast<int>(SPREADSHEET.size());
+  } //!< get number of spreadsheets
+  const char *spreadName(int s) const {
+    return SPREADSHEET[s].name.c_str();
+  } //!< get name of spreadsheet s
+  bool spreadHidden(int s) const {
+    return SPREADSHEET[s].bHidden;
+  } //!< is spreadsheet s hidden
+  bool spreadLoose(int s) const {
+    return SPREADSHEET[s].bLoose;
+  } //!< is spreadsheet s loose
+  rect spreadWindowRect(int s) const {
+    return SPREADSHEET[s].clientRect;
+  } //!< get window rectangle of spreadsheet s
+  const char *spreadLabel(int s) const {
+    return SPREADSHEET[s].label.c_str();
+  } //!< get label of spreadsheet s
+  double spreadCreationDate(int s) const {
+    return SPREADSHEET[s].creation_date;
+  } //!< get creation date of spreadsheet s
+  double spreadModificationDate(int s) const {
+    return SPREADSHEET[s].modification_date;
+  } //!< get modification date of spreadsheet s
+  originWindow::State spreadState(int s) const {
+    return SPREADSHEET[s].state;
+  } //!< get window state of spreadsheet s
+  originWindow::Title spreadTitle(int s) const {
+    return SPREADSHEET[s].title;
+  } //!< get window state of spreadsheet s
+  int numCols(int s) const {
+    return static_cast<int>(SPREADSHEET[s].column.size());
+  } //!< get number of columns of spreadsheet s
+  int numRows(int s, int c) const {
+    return static_cast<int>(SPREADSHEET[s].column[c].odata.size());
+  } //!< get number of rows of column c of spreadsheet s
+  int maxRows(int s) const {
+    return SPREADSHEET[s].maxRows;
+  } //!< get maximum number of rows of spreadsheet s
 
-	//spreadsheet's column properties
-	const char *colName(int s, int c) const { return SPREADSHEET[s].column[c].name.c_str(); }	//!< get name of column c of spreadsheet s
-	ColumnType colType(int s, int c) const { return SPREADSHEET[s].column[c].type; }	//!< get type of column c of spreadsheet s
-	const char *colCommand(int s, int c) const { return SPREADSHEET[s].column[c].command.c_str(); }	//!< get command of column c of spreadsheet s
-	const char *colComment(int s, int c) const { return SPREADSHEET[s].column[c].comment.c_str(); }	//!< get comment of column c of spreadsheet s
-	int colValueType(int s, int c) const { return SPREADSHEET[s].column[c].value_type; }	//!< get value type of column c of spreadsheet s
-	int colValueTypeSpec(int s, int c) const { return SPREADSHEET[s].column[c].value_type_specification; }	//!< get value type specification of column c of spreadsheet s
-	int colSignificantDigits(int s, int c) const { return SPREADSHEET[s].column[c].significant_digits; }	//!< get significant digits of column c of spreadsheet s
-	int colDecPlaces(int s, int c) const { return SPREADSHEET[s].column[c].decimal_places; }	//!< get decimal places of column c of spreadsheet s
-	int colNumDisplayType(int s, int c) const { return SPREADSHEET[s].column[c].numeric_display_type; }	//!< get numeric display type of column c of spreadsheet s
-	int colWidth(int s, int c) const { return SPREADSHEET[s].column[c].width; }	//!< get width of column c of spreadsheet s
-	void* oData(int s, int c, int r, bool alwaysDouble=false) const {
-		if(alwaysDouble)
-			return (void*)const_cast<double*>(&SPREADSHEET[s].column[c].odata[r].d);
-		if(SPREADSHEET[s].column[c].odata[r].type==0)
-			return (void*)const_cast<double*>(&SPREADSHEET[s].column[c].odata[r].d);
-		else
-			return (void*)const_cast<char*>(SPREADSHEET[s].column[c].odata[r].s.c_str());
-	}	//!< get data of column c/row r of spreadsheet s
+  // spreadsheet's column properties
+  const char *colName(int s, int c) const {
+    return SPREADSHEET[s].column[c].name.c_str();
+  } //!< get name of column c of spreadsheet s
+  ColumnType colType(int s, int c) const {
+    return SPREADSHEET[s].column[c].type;
+  } //!< get type of column c of spreadsheet s
+  const char *colCommand(int s, int c) const {
+    return SPREADSHEET[s].column[c].command.c_str();
+  } //!< get command of column c of spreadsheet s
+  const char *colComment(int s, int c) const {
+    return SPREADSHEET[s].column[c].comment.c_str();
+  } //!< get comment of column c of spreadsheet s
+  int colValueType(int s, int c) const {
+    return SPREADSHEET[s].column[c].value_type;
+  } //!< get value type of column c of spreadsheet s
+  int colValueTypeSpec(int s, int c) const {
+    return SPREADSHEET[s].column[c].value_type_specification;
+  } //!< get value type specification of column c of spreadsheet s
+  int colSignificantDigits(int s, int c) const {
+    return SPREADSHEET[s].column[c].significant_digits;
+  } //!< get significant digits of column c of spreadsheet s
+  int colDecPlaces(int s, int c) const {
+    return SPREADSHEET[s].column[c].decimal_places;
+  } //!< get decimal places of column c of spreadsheet s
+  int colNumDisplayType(int s, int c) const {
+    return SPREADSHEET[s].column[c].numeric_display_type;
+  } //!< get numeric display type of column c of spreadsheet s
+  int colWidth(int s, int c) const {
+    return SPREADSHEET[s].column[c].width;
+  } //!< get width of column c of spreadsheet s
+  void *oData(int s, int c, int r, bool alwaysDouble = false) const {
+    if (alwaysDouble)
+      return (void *)const_cast<double *>(&SPREADSHEET[s].column[c].odata[r].d);
+    if (SPREADSHEET[s].column[c].odata[r].type == 0)
+      return (void *)const_cast<double *>(&SPREADSHEET[s].column[c].odata[r].d);
+    else
+      return (void *)const_cast<char *>(
+          SPREADSHEET[s].column[c].odata[r].s.c_str());
+  } //!< get data of column c/row r of spreadsheet s
 
-	//matrix properties
-	int numMatrices() const { return static_cast<int>(MATRIX.size()); }			//!< get number of matrices
-	const char *matrixName(int m) const { return MATRIX[m].name.c_str(); }	//!< get name of matrix m
-	bool matrixHidden(int m) const { return MATRIX[m].bHidden; }	//!< is matrix m hidden
-	rect matrixWindowRect(int m) const { return MATRIX[m].clientRect; }		//!< get window rectangle of matrix m
-	const char *matrixLabel(int m) const { return MATRIX[m].label.c_str(); }	//!< get label of matrix m
-	double matrixCreationDate(int m) const { return MATRIX[m].creation_date; }	//!< get creation date of matrix m
-	double matrixModificationDate(int m) const { return MATRIX[m].modification_date; }	//!< get modification date of matrix m
-	originWindow::State matrixState(int m) const { return MATRIX[m].state; }	//!< get window state of matrix m
-	originWindow::Title matrixTitle(int m) const { return MATRIX[m].title; }	//!< get window state of matrix m
-	int numMatrixCols(int m) const { return MATRIX[m].nr_cols; }		//!< get number of columns of matrix m
-	int numMatrixRows(int m) const { return MATRIX[m].nr_rows; }	//!< get number of rows of matrix m
-	const char *matrixFormula(int m) const { return MATRIX[m].command.c_str(); }	//!< get formula of matrix m
-	int matrixValueTypeSpec(int m) const { return MATRIX[m].value_type_specification; }	//!< get value type specification of matrix m
-	int matrixSignificantDigits(int m) const { return MATRIX[m].significant_digits; }	//!< get significant digits of matrix m
-	int matrixDecPlaces(int m) const { return MATRIX[m].decimal_places; }	//!< get decimal places of matrix m
-	int matrixNumDisplayType(int m) const { return MATRIX[m].numeric_display_type; }	//!< get numeric display type of matrix m
-	int matrixWidth(int m) const { return MATRIX[m].width; }	//!< get width of matrix m
-	matrix::ViewType matrixViewType(int m) const { return MATRIX[m].view; }	//!< get view type of matrix m
-	matrix::HeaderViewType matrixHeaderViewType(int m) const { return MATRIX[m].header; }	//!< get header view type of matrix m
-	double matrixData(int m, int c, int r) const { return MATRIX[m].data[r*MATRIX[m].nr_cols+c]; }	//!< get data of row r of column c of matrix m
-	std::vector<double> matrixData(int m) const { return MATRIX[m].data; }	//!< get data of matrix m
+  // matrix properties
+  int numMatrices() const {
+    return static_cast<int>(MATRIX.size());
+  } //!< get number of matrices
+  const char *matrixName(int m) const {
+    return MATRIX[m].name.c_str();
+  } //!< get name of matrix m
+  bool matrixHidden(int m) const {
+    return MATRIX[m].bHidden;
+  } //!< is matrix m hidden
+  rect matrixWindowRect(int m) const {
+    return MATRIX[m].clientRect;
+  } //!< get window rectangle of matrix m
+  const char *matrixLabel(int m) const {
+    return MATRIX[m].label.c_str();
+  } //!< get label of matrix m
+  double matrixCreationDate(int m) const {
+    return MATRIX[m].creation_date;
+  } //!< get creation date of matrix m
+  double matrixModificationDate(int m) const {
+    return MATRIX[m].modification_date;
+  } //!< get modification date of matrix m
+  originWindow::State matrixState(int m) const {
+    return MATRIX[m].state;
+  } //!< get window state of matrix m
+  originWindow::Title matrixTitle(int m) const {
+    return MATRIX[m].title;
+  } //!< get window state of matrix m
+  int numMatrixCols(int m) const {
+    return MATRIX[m].nr_cols;
+  } //!< get number of columns of matrix m
+  int numMatrixRows(int m) const {
+    return MATRIX[m].nr_rows;
+  } //!< get number of rows of matrix m
+  const char *matrixFormula(int m) const {
+    return MATRIX[m].command.c_str();
+  } //!< get formula of matrix m
+  int matrixValueTypeSpec(int m) const {
+    return MATRIX[m].value_type_specification;
+  } //!< get value type specification of matrix m
+  int matrixSignificantDigits(int m) const {
+    return MATRIX[m].significant_digits;
+  } //!< get significant digits of matrix m
+  int matrixDecPlaces(int m) const {
+    return MATRIX[m].decimal_places;
+  } //!< get decimal places of matrix m
+  int matrixNumDisplayType(int m) const {
+    return MATRIX[m].numeric_display_type;
+  } //!< get numeric display type of matrix m
+  int matrixWidth(int m) const {
+    return MATRIX[m].width;
+  } //!< get width of matrix m
+  matrix::ViewType matrixViewType(int m) const {
+    return MATRIX[m].view;
+  } //!< get view type of matrix m
+  matrix::HeaderViewType matrixHeaderViewType(int m) const {
+    return MATRIX[m].header;
+  } //!< get header view type of matrix m
+  double matrixData(int m, int c, int r) const {
+    return MATRIX[m].data[r * MATRIX[m].nr_cols + c];
+  } //!< get data of row r of column c of matrix m
+  std::vector<double> matrixData(int m) const {
+    return MATRIX[m].data;
+  } //!< get data of matrix m
 
-	//function properties
-	int numFunctions() const { return static_cast<int>(FUNCTION.size()); }			//!< get number of functions
-	int functionIndex(const char* s) const { return compareFunctionnames(s); }	//!< get name of function s
-	const char *functionName(int s) const { return FUNCTION[s].name.c_str(); }	//!< get name of function s
-	int functionType(int s) const { return FUNCTION[s].type; }		//!< get type of function s
-	double functionBegin(int s) const { return FUNCTION[s].begin; }	//!< get begin of interval of function s
-	double functionEnd(int s) const { return FUNCTION[s].end; }	//!< get end of interval of function s
-	int functionPoints(int s) const { return FUNCTION[s].points; }	//!< get number of points in interval of function s
-	const char *functionFormula(int s) const { return FUNCTION[s].formula.c_str(); }	//!< get formula of function s
+  // function properties
+  int numFunctions() const {
+    return static_cast<int>(FUNCTION.size());
+  } //!< get number of functions
+  int functionIndex(const char *s) const {
+    return compareFunctionnames(s);
+  } //!< get name of function s
+  const char *functionName(int s) const {
+    return FUNCTION[s].name.c_str();
+  } //!< get name of function s
+  int functionType(int s) const {
+    return FUNCTION[s].type;
+  } //!< get type of function s
+  double functionBegin(int s) const {
+    return FUNCTION[s].begin;
+  } //!< get begin of interval of function s
+  double functionEnd(int s) const {
+    return FUNCTION[s].end;
+  } //!< get end of interval of function s
+  int functionPoints(int s) const {
+    return FUNCTION[s].points;
+  } //!< get number of points in interval of function s
+  const char *functionFormula(int s) const {
+    return FUNCTION[s].formula.c_str();
+  } //!< get formula of function s
 
-	//graph properties
-	enum Color {Black=0, Red=1, Green=2, Blue=3, Cyan=4, Magenta=5, Yellow=6, DarkYellow=7, Navy=8,
-		Purple=9, Wine=10, Olive=11, DarkCyan=12, Royal=13, Orange=14, Violet=15, Pink=16, White=17,
-		LightGray=18, Gray=19, LTYellow=20, LTCyan=21, LTMagenta=22, DarkGray=23, Custom=255};
+  // graph properties
+  enum Color {
+    Black = 0,
+    Red = 1,
+    Green = 2,
+    Blue = 3,
+    Cyan = 4,
+    Magenta = 5,
+    Yellow = 6,
+    DarkYellow = 7,
+    Navy = 8,
+    Purple = 9,
+    Wine = 10,
+    Olive = 11,
+    DarkCyan = 12,
+    Royal = 13,
+    Orange = 14,
+    Violet = 15,
+    Pink = 16,
+    White = 17,
+    LightGray = 18,
+    Gray = 19,
+    LTYellow = 20,
+    LTCyan = 21,
+    LTMagenta = 22,
+    DarkGray = 23,
+    Custom = 255
+  };
 
-	enum Plot {Line=200, Scatter=201, LineSymbol=202, Column=203, Area=204, HiLoClose=205, Box=206,
-		ColumnFloat=207, Vector=208, PlotDot=209, Wall3D=210, Ribbon3D=211, Bar3D=212, ColumnStack=213,
-		AreaStack=214, Bar=215, BarStack=216, FlowVector=218, Histogram=219, MatrixImage=220, Pie=225,
-		Contour=226, Unknown=230, ErrorBar=231, TextPlot=232, XErrorBar=233, SurfaceColorMap=236,
-		SurfaceColorFill=237, SurfaceWireframe=238, SurfaceBars=239, Line3D=240, Text3D=241, Mesh3D=242,
-		XYZTriangular=245, LineSeries=246, YErrorBar=254, XYErrorBar=255, GraphScatter3D=0x8AF0,
-		GraphTrajectory3D=0x8AF1, Polar=0x00020000, SmithChart=0x00040000, FillArea=0x00800000};
+  enum Plot {
+    Line = 200,
+    Scatter = 201,
+    LineSymbol = 202,
+    Column = 203,
+    Area = 204,
+    HiLoClose = 205,
+    Box = 206,
+    ColumnFloat = 207,
+    Vector = 208,
+    PlotDot = 209,
+    Wall3D = 210,
+    Ribbon3D = 211,
+    Bar3D = 212,
+    ColumnStack = 213,
+    AreaStack = 214,
+    Bar = 215,
+    BarStack = 216,
+    FlowVector = 218,
+    Histogram = 219,
+    MatrixImage = 220,
+    Pie = 225,
+    Contour = 226,
+    Unknown = 230,
+    ErrorBar = 231,
+    TextPlot = 232,
+    XErrorBar = 233,
+    SurfaceColorMap = 236,
+    SurfaceColorFill = 237,
+    SurfaceWireframe = 238,
+    SurfaceBars = 239,
+    Line3D = 240,
+    Text3D = 241,
+    Mesh3D = 242,
+    XYZTriangular = 245,
+    LineSeries = 246,
+    YErrorBar = 254,
+    XYErrorBar = 255,
+    GraphScatter3D = 0x8AF0,
+    GraphTrajectory3D = 0x8AF1,
+    Polar = 0x00020000,
+    SmithChart = 0x00040000,
+    FillArea = 0x00800000
+  };
 
-	enum LineStyle {Solid=0, Dash=1, Dot=2, DashDot=3, DashDotDot=4, ShortDash=5, ShortDot=6, ShortDashDot=7};
+  enum LineStyle {
+    Solid = 0,
+    Dash = 1,
+    Dot = 2,
+    DashDot = 3,
+    DashDotDot = 4,
+    ShortDash = 5,
+    ShortDot = 6,
+    ShortDashDot = 7
+  };
 
-	enum LineConnect {NoLine=0, Straight=1, TwoPointSegment=2, ThreePointSegment=3, BSpline=8, Spline=9, StepHorizontal=11, StepVertical=12, StepHCenter=13, StepVCenter=14, Bezier=15};
+  enum LineConnect {
+    NoLine = 0,
+    Straight = 1,
+    TwoPointSegment = 2,
+    ThreePointSegment = 3,
+    BSpline = 8,
+    Spline = 9,
+    StepHorizontal = 11,
+    StepVertical = 12,
+    StepHCenter = 13,
+    StepVCenter = 14,
+    Bezier = 15
+  };
 
-	enum Scale {Linear=0, Log10=1, Probability=2, Probit=3, Reciprocal=4, OffsetReciprocal=5, Logit=6, Ln=7, Log2=8};
+  enum Scale {
+    Linear = 0,
+    Log10 = 1,
+    Probability = 2,
+    Probit = 3,
+    Reciprocal = 4,
+    OffsetReciprocal = 5,
+    Logit = 6,
+    Ln = 7,
+    Log2 = 8
+  };
 
-	enum ValueType {Numeric=0, Text=1, Time=2, Date=3,  Month=4, Day=5, ColumnHeading=6, TickIndexedDataset=7, TextNumeric=9, Categorical=10};
-	
-	enum BorderType {BlackLine=0, Shadow=1, DarkMarble=2, WhiteOut=3, BlackOut=4, None=-1};
+  enum ValueType {
+    Numeric = 0,
+    Text = 1,
+    Time = 2,
+    Date = 3,
+    Month = 4,
+    Day = 5,
+    ColumnHeading = 6,
+    TickIndexedDataset = 7,
+    TextNumeric = 9,
+    Categorical = 10
+  };
 
-	enum Attach {Frame=0, Page=1, Scale=2};
+  enum BorderType {
+    BlackLine = 0,
+    Shadow = 1,
+    DarkMarble = 2,
+    WhiteOut = 3,
+    BlackOut = 4,
+    None = -1
+  };
 
-	enum VectorPosition {Tail, Midpoint, Head};
+  enum Attach { Frame = 0, Page = 1, Scale = 2 };
 
-	int numGraphs() const { return static_cast<int>(GRAPH.size()); }			//!< get number of graphs
-	const char *graphName(int s) const { return GRAPH[s].name.c_str(); }	//!< get name of graph s
-	const char *graphLabel(int s) const { return GRAPH[s].label.c_str(); }	//!< get name of graph s
-	double graphCreationDate(int s) const { return GRAPH[s].creation_date; }	//!< get creation date of graph s
-	double graphModificationDate(int s) const { return GRAPH[s].modification_date; }	//!< get modification date of graph s
-	originWindow::State graphState(int s) const { return GRAPH[s].state; }	//!< get window state of graph s
-	originWindow::Title graphTitle(int s) const { return GRAPH[s].title; }	//!< get window state of graph s
-	bool graphHidden(int s) const { return GRAPH[s].bHidden; }	//!< is graph s hidden
-	rect graphRect(int s) const { return rect(GRAPH[s].width, GRAPH[s].height); }		//!< get rectangle of graph s
-	rect graphWindowRect(int s) const { return GRAPH[s].clientRect; }		//!< get window rectangle of graph s
-	int numLayers(int s) const { return static_cast<int>(GRAPH[s].layer.size()); }			//!< get number of layers of graph s
-	rect layerRect(int s, int l) const { return GRAPH[s].layer[l].clientRect; }		//!< get rectangle of layer l of graph s
-	text layerXAxisTitle(int s, int l) const { return GRAPH[s].layer[l].xAxis.label; }		//!< get label of X-axis of layer l of graph s
-	text layerYAxisTitle(int s, int l) const { return GRAPH[s].layer[l].yAxis.label; }		//!< get label of Y-axis of layer l of graph s
-	text layerLegend(int s, int l) const { return GRAPH[s].layer[l].legend; }		//!< get legend of layer l of graph s
-	std::vector<text> layerTexts(int s, int l) const { return GRAPH[s].layer[l].texts; } //!< get texts of layer l of graph s
-	std::vector<line> layerLines(int s, int l) const { return GRAPH[s].layer[l].lines; } //!< get lines of layer l of graph s
-	std::vector<bitmap> layerBitmaps(int s, int l) const { return GRAPH[s].layer[l].bitmaps; } //!< get bitmaps of layer l of graph s
-	graphAxisBreak layerXBreak(int s, int l) const { return GRAPH[s].layer[l].xAxisBreak; } //!< get break of horizontal axis of layer l of graph s
-	graphAxisBreak layerYBreak(int s, int l) const { return GRAPH[s].layer[l].yAxisBreak; } //!< get break of vertical axis of layer l of graph s
-	graphLayerRange layerXRange(int s, int l) const {
-		return graphLayerRange(GRAPH[s].layer[l].xAxis.min, GRAPH[s].layer[l].xAxis.max, GRAPH[s].layer[l].xAxis.step);
-	} //!< get X-range of layer l of graph s
-	graphLayerRange layerYRange(int s, int l) const {
-		return graphLayerRange(GRAPH[s].layer[l].yAxis.min, GRAPH[s].layer[l].yAxis.max, GRAPH[s].layer[l].yAxis.step);
-	} //!< get Y-range of layer l of graph s
-	std::vector<int> layerXTicks(int s, int l) const {
-		std::vector<int> tick;
-		tick.push_back(GRAPH[s].layer[l].xAxis.majorTicks);
-		tick.push_back(GRAPH[s].layer[l].xAxis.minorTicks);
-		return tick;
-	} //!< get X-axis ticks of layer l of graph s
-	std::vector<int> layerYTicks(int s, int l) const {
-		std::vector<int> tick;
-		tick.push_back(GRAPH[s].layer[l].yAxis.majorTicks);
-		tick.push_back(GRAPH[s].layer[l].yAxis.minorTicks);
-		return tick;
-	} //!< get Y-axis ticks of layer l of graph s
-	std::vector<graphGrid> layerGrid(int s, int l) const {
-		std::vector<graphGrid> grid;
-		grid.push_back(GRAPH[s].layer[l].xAxis.majorGrid);
-		grid.push_back(GRAPH[s].layer[l].xAxis.minorGrid);
-		grid.push_back(GRAPH[s].layer[l].yAxis.majorGrid);
-		grid.push_back(GRAPH[s].layer[l].yAxis.minorGrid);
-		return grid;
-	} //!< get grid of layer l of graph s
-	std::vector<graphAxisFormat> layerAxisFormat(int s, int l) const {
-		std::vector<graphAxisFormat> format;
-		format.push_back(GRAPH[s].layer[l].yAxis.formatAxis[0]); //bottom
-		format.push_back(GRAPH[s].layer[l].yAxis.formatAxis[1]); //top
-		format.push_back(GRAPH[s].layer[l].xAxis.formatAxis[0]); //left
-		format.push_back(GRAPH[s].layer[l].xAxis.formatAxis[1]); //right
-		return format;
-	} //!< get title and format of axes of layer l of graph s
-	std::vector<graphAxisTick> layerAxisTickLabels(int s, int l) const {
-		std::vector<graphAxisTick> tick;
-		tick.push_back(GRAPH[s].layer[l].yAxis.tickAxis[0]); //bottom
-		tick.push_back(GRAPH[s].layer[l].yAxis.tickAxis[1]); //top
-		tick.push_back(GRAPH[s].layer[l].xAxis.tickAxis[0]); //left
-		tick.push_back(GRAPH[s].layer[l].xAxis.tickAxis[1]); //right
-		return tick;
-	} //!< get tick labels of axes of layer l of graph s
-	std::vector<double> layerHistogram(int s, int l) const {
-		std::vector<double> range;
-		range.push_back(GRAPH[s].layer[l].histogram_bin);
-		range.push_back(GRAPH[s].layer[l].histogram_begin);
-		range.push_back(GRAPH[s].layer[l].histogram_end);
-		return range;
-	} //!< get histogram bin of layer l of graph s
-	int layerXScale(int s, int l) const { return GRAPH[s].layer[l].xAxis.scale; }		//!< get scale of X-axis of layer l of graph s
-	int layerYScale(int s, int l) const { return GRAPH[s].layer[l].yAxis.scale; }		//!< get scale of Y-axis of layer l of graph s
-	int numCurves(int s, int l) const { return static_cast<int>(GRAPH[s].layer[l].curve.size()); }			//!< get number of curves of layer l of graph s
-	const char *curveDataName(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].dataName.c_str(); }	//!< get data source name of curve c of layer l of graph s
-	const char *curveXColName(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].xColName.c_str(); }	//!< get X-column name of curve c of layer l of graph s
-	const char *curveYColName(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].yColName.c_str(); }	//!< get Y-column name of curve c of layer l of graph s
-	int curveType(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].type; }	//!< get type of curve c of layer l of graph s
-	int curveLineStyle(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].line_style; }	//!< get line style of curve c of layer l of graph s
-	int curveLineColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].line_color; }	//!< get line color of curve c of layer l of graph s
-	int curveLineConnect(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].line_connect; }	//!< get line connect of curve c of layer l of graph s
-	double curveLineWidth(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].line_width; }	//!< get line width of curve c of layer l of graph s
+  enum VectorPosition { Tail, Midpoint, Head };
 
-	bool curveIsFilledArea(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea; }	//!< get is filled area of curve c of layer l of graph s
-	int curveFillAreaColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_color; }	//!< get area fillcolor of curve c of layer l of graph s
-	int curveFillAreaFirstColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_first_color; }	//!< get area first fillcolor of curve c of layer l of graph s
-	int curveFillPattern(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_pattern; }	//!< get fill pattern of curve c of layer l of graph s
-	int curveFillPatternColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_pattern_color; }	//!< get fill pattern color of curve c of layer l of graph s
-	double curveFillPatternWidth(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_pattern_width; }	//!< get fill pattern line width of curve c of layer l of graph s
-	int curveFillPatternBorderStyle(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_pattern_border_style; }	//!< get fill pattern border style of curve c of layer l of graph s
-	int curveFillPatternBorderColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_pattern_border_color; }	//!< get fill pattern border color of curve c of layer l of graph s
-	double curveFillPatternBorderWidth(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].fillarea_pattern_border_width; }	//!< get fill pattern border line width of curve c of layer l of graph s
+  int numGraphs() const {
+    return static_cast<int>(GRAPH.size());
+  } //!< get number of graphs
+  const char *graphName(int s) const {
+    return GRAPH[s].name.c_str();
+  } //!< get name of graph s
+  const char *graphLabel(int s) const {
+    return GRAPH[s].label.c_str();
+  } //!< get name of graph s
+  double graphCreationDate(int s) const {
+    return GRAPH[s].creation_date;
+  } //!< get creation date of graph s
+  double graphModificationDate(int s) const {
+    return GRAPH[s].modification_date;
+  } //!< get modification date of graph s
+  originWindow::State graphState(int s) const {
+    return GRAPH[s].state;
+  } //!< get window state of graph s
+  originWindow::Title graphTitle(int s) const {
+    return GRAPH[s].title;
+  } //!< get window state of graph s
+  bool graphHidden(int s) const {
+    return GRAPH[s].bHidden;
+  } //!< is graph s hidden
+  rect graphRect(int s) const {
+    return rect(GRAPH[s].width, GRAPH[s].height);
+  } //!< get rectangle of graph s
+  rect graphWindowRect(int s) const {
+    return GRAPH[s].clientRect;
+  } //!< get window rectangle of graph s
+  int numLayers(int s) const {
+    return static_cast<int>(GRAPH[s].layer.size());
+  } //!< get number of layers of graph s
+  rect layerRect(int s, int l) const {
+    return GRAPH[s].layer[l].clientRect;
+  } //!< get rectangle of layer l of graph s
+  text layerXAxisTitle(int s, int l) const {
+    return GRAPH[s].layer[l].xAxis.label;
+  } //!< get label of X-axis of layer l of graph s
+  text layerYAxisTitle(int s, int l) const {
+    return GRAPH[s].layer[l].yAxis.label;
+  } //!< get label of Y-axis of layer l of graph s
+  text layerLegend(int s, int l) const {
+    return GRAPH[s].layer[l].legend;
+  } //!< get legend of layer l of graph s
+  std::vector<text> layerTexts(int s, int l) const {
+    return GRAPH[s].layer[l].texts;
+  } //!< get texts of layer l of graph s
+  std::vector<line> layerLines(int s, int l) const {
+    return GRAPH[s].layer[l].lines;
+  } //!< get lines of layer l of graph s
+  std::vector<bitmap> layerBitmaps(int s, int l) const {
+    return GRAPH[s].layer[l].bitmaps;
+  } //!< get bitmaps of layer l of graph s
+  graphAxisBreak layerXBreak(int s, int l) const {
+    return GRAPH[s].layer[l].xAxisBreak;
+  } //!< get break of horizontal axis of layer l of graph s
+  graphAxisBreak layerYBreak(int s, int l) const {
+    return GRAPH[s].layer[l].yAxisBreak;
+  } //!< get break of vertical axis of layer l of graph s
+  graphLayerRange layerXRange(int s, int l) const {
+    return graphLayerRange(GRAPH[s].layer[l].xAxis.min,
+                           GRAPH[s].layer[l].xAxis.max,
+                           GRAPH[s].layer[l].xAxis.step);
+  } //!< get X-range of layer l of graph s
+  graphLayerRange layerYRange(int s, int l) const {
+    return graphLayerRange(GRAPH[s].layer[l].yAxis.min,
+                           GRAPH[s].layer[l].yAxis.max,
+                           GRAPH[s].layer[l].yAxis.step);
+  } //!< get Y-range of layer l of graph s
+  std::vector<int> layerXTicks(int s, int l) const {
+    std::vector<int> tick;
+    tick.push_back(GRAPH[s].layer[l].xAxis.majorTicks);
+    tick.push_back(GRAPH[s].layer[l].xAxis.minorTicks);
+    return tick;
+  } //!< get X-axis ticks of layer l of graph s
+  std::vector<int> layerYTicks(int s, int l) const {
+    std::vector<int> tick;
+    tick.push_back(GRAPH[s].layer[l].yAxis.majorTicks);
+    tick.push_back(GRAPH[s].layer[l].yAxis.minorTicks);
+    return tick;
+  } //!< get Y-axis ticks of layer l of graph s
+  std::vector<graphGrid> layerGrid(int s, int l) const {
+    std::vector<graphGrid> grid;
+    grid.push_back(GRAPH[s].layer[l].xAxis.majorGrid);
+    grid.push_back(GRAPH[s].layer[l].xAxis.minorGrid);
+    grid.push_back(GRAPH[s].layer[l].yAxis.majorGrid);
+    grid.push_back(GRAPH[s].layer[l].yAxis.minorGrid);
+    return grid;
+  } //!< get grid of layer l of graph s
+  std::vector<graphAxisFormat> layerAxisFormat(int s, int l) const {
+    std::vector<graphAxisFormat> format;
+    format.push_back(GRAPH[s].layer[l].yAxis.formatAxis[0]); // bottom
+    format.push_back(GRAPH[s].layer[l].yAxis.formatAxis[1]); // top
+    format.push_back(GRAPH[s].layer[l].xAxis.formatAxis[0]); // left
+    format.push_back(GRAPH[s].layer[l].xAxis.formatAxis[1]); // right
+    return format;
+  } //!< get title and format of axes of layer l of graph s
+  std::vector<graphAxisTick> layerAxisTickLabels(int s, int l) const {
+    std::vector<graphAxisTick> tick;
+    tick.push_back(GRAPH[s].layer[l].yAxis.tickAxis[0]); // bottom
+    tick.push_back(GRAPH[s].layer[l].yAxis.tickAxis[1]); // top
+    tick.push_back(GRAPH[s].layer[l].xAxis.tickAxis[0]); // left
+    tick.push_back(GRAPH[s].layer[l].xAxis.tickAxis[1]); // right
+    return tick;
+  } //!< get tick labels of axes of layer l of graph s
+  std::vector<double> layerHistogram(int s, int l) const {
+    std::vector<double> range;
+    range.push_back(GRAPH[s].layer[l].histogram_bin);
+    range.push_back(GRAPH[s].layer[l].histogram_begin);
+    range.push_back(GRAPH[s].layer[l].histogram_end);
+    return range;
+  } //!< get histogram bin of layer l of graph s
+  int layerXScale(int s, int l) const {
+    return GRAPH[s].layer[l].xAxis.scale;
+  } //!< get scale of X-axis of layer l of graph s
+  int layerYScale(int s, int l) const {
+    return GRAPH[s].layer[l].yAxis.scale;
+  } //!< get scale of Y-axis of layer l of graph s
+  int numCurves(int s, int l) const {
+    return static_cast<int>(GRAPH[s].layer[l].curve.size());
+  } //!< get number of curves of layer l of graph s
+  const char *curveDataName(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].dataName.c_str();
+  } //!< get data source name of curve c of layer l of graph s
+  const char *curveXColName(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].xColName.c_str();
+  } //!< get X-column name of curve c of layer l of graph s
+  const char *curveYColName(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].yColName.c_str();
+  } //!< get Y-column name of curve c of layer l of graph s
+  int curveType(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].type;
+  } //!< get type of curve c of layer l of graph s
+  int curveLineStyle(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].line_style;
+  } //!< get line style of curve c of layer l of graph s
+  int curveLineColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].line_color;
+  } //!< get line color of curve c of layer l of graph s
+  int curveLineConnect(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].line_connect;
+  } //!< get line connect of curve c of layer l of graph s
+  double curveLineWidth(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].line_width;
+  } //!< get line width of curve c of layer l of graph s
 
-	int curveSymbolType(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].symbol_type; }	//!< get symbol type of curve c of layer l of graph s
-	int curveSymbolColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].symbol_color; }	//!< get symbol color of curve c of layer l of graph s
-	int curveSymbolFillColor(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].symbol_fill_color; }	//!< get symbol fill color of curve c of layer l of graph s
-	double curveSymbolSize(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].symbol_size; }	//!< get symbol size of curve c of layer l of graph s
-	int curveSymbolThickness(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].symbol_thickness; }	//!< get symbol thickness of curve c of layer l of graph s
+  bool curveIsFilledArea(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea;
+  } //!< get is filled area of curve c of layer l of graph s
+  int curveFillAreaColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_color;
+  } //!< get area fillcolor of curve c of layer l of graph s
+  int curveFillAreaFirstColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_first_color;
+  } //!< get area first fillcolor of curve c of layer l of graph s
+  int curveFillPattern(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_pattern;
+  } //!< get fill pattern of curve c of layer l of graph s
+  int curveFillPatternColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_pattern_color;
+  } //!< get fill pattern color of curve c of layer l of graph s
+  double curveFillPatternWidth(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_pattern_width;
+  } //!< get fill pattern line width of curve c of layer l of graph s
+  int curveFillPatternBorderStyle(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_pattern_border_style;
+  } //!< get fill pattern border style of curve c of layer l of graph s
+  int curveFillPatternBorderColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_pattern_border_color;
+  } //!< get fill pattern border color of curve c of layer l of graph s
+  double curveFillPatternBorderWidth(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].fillarea_pattern_border_width;
+  } //!< get fill pattern border line width of curve c of layer l of graph s
 
-	pieProperties curvePieProperties(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].pie; }	//!< get pie properties of curve c of layer l of graph s
-	vectorProperties curveVectorProperties(int s, int l, int c) const { return GRAPH[s].layer[l].curve[c].vector; }	//!< get vector properties of curve c of layer l of graph s
+  int curveSymbolType(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].symbol_type;
+  } //!< get symbol type of curve c of layer l of graph s
+  int curveSymbolColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].symbol_color;
+  } //!< get symbol color of curve c of layer l of graph s
+  int curveSymbolFillColor(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].symbol_fill_color;
+  } //!< get symbol fill color of curve c of layer l of graph s
+  double curveSymbolSize(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].symbol_size;
+  } //!< get symbol size of curve c of layer l of graph s
+  int curveSymbolThickness(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].symbol_thickness;
+  } //!< get symbol thickness of curve c of layer l of graph s
 
-	int numNotes() const { return static_cast<int>(NOTE.size()); }			//!< get number of notes
-	const char *noteName(int n) const { return NOTE[n].name.c_str(); }	//!< get name of note n
-	const char *noteLabel(int n) const { return NOTE[n].label.c_str(); }	//!< get label of note n
-	const char *noteText(int n) const { return NOTE[n].text.c_str(); }	//!< get text of note n
-	double noteCreationDate(int n) const { return NOTE[n].creation_date; }	//!< get creation date of note n
-	double noteModificationDate(int n) const { return NOTE[n].modification_date; }	//!< get modification date of note n
-	originWindow::State noteState(int n) const { return NOTE[n].state; }	//!< get window state of note n
-	originWindow::Title noteTitle(int n) const { return NOTE[n].title; }	//!< get window state of note n
+  pieProperties curvePieProperties(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].pie;
+  } //!< get pie properties of curve c of layer l of graph s
+  vectorProperties curveVectorProperties(int s, int l, int c) const {
+    return GRAPH[s].layer[l].curve[c].vector;
+  } //!< get vector properties of curve c of layer l of graph s
 
-	const char* resultsLogString() const { return resultsLog.c_str();}		//!< get Results Log
+  int numNotes() const {
+    return static_cast<int>(NOTE.size());
+  } //!< get number of notes
+  const char *noteName(int n) const {
+    return NOTE[n].name.c_str();
+  } //!< get name of note n
+  const char *noteLabel(int n) const {
+    return NOTE[n].label.c_str();
+  } //!< get label of note n
+  const char *noteText(int n) const {
+    return NOTE[n].text.c_str();
+  } //!< get text of note n
+  double noteCreationDate(int n) const {
+    return NOTE[n].creation_date;
+  } //!< get creation date of note n
+  double noteModificationDate(int n) const {
+    return NOTE[n].modification_date;
+  } //!< get modification date of note n
+  originWindow::State noteState(int n) const {
+    return NOTE[n].state;
+  } //!< get window state of note n
+  originWindow::Title noteTitle(int n) const {
+    return NOTE[n].title;
+  } //!< get window state of note n
+
+  const char *resultsLogString() const {
+    return resultsLog.c_str();
+  } //!< get Results Log
 
 private:
-	bool IsBigEndian();
-	void ByteSwap(unsigned char * b, int n);
-	int ParseFormatOld();
-	int ParseFormatNew();
-	int compareSpreadnames(char *sname) const;				//!< returns matching spread index
-	int compareExcelnames(char *sname) const;				//!< returns matching excel index
-	int compareColumnnames(int spread, char *sname) const;	//!< returns matching column index
-	int compareExcelColumnnames(int excel, int sheet, char *sname) const;  //!< returns matching column index
-	int compareMatrixnames(char *sname) const;				//!< returns matching matrix index
-	int compareFunctionnames(const char *sname) const;				//!< returns matching function index
-	std::vector<std::string> findDataByIndex(int index) const;
-	std::string findObjectByIndex(int index);
-        void readSpreadInfo(FILE *fopj, int file_size, FILE *fdebug);
-	void readExcelInfo(FILE *f, int file_size, FILE *debug);
-	void readMatrixInfo(FILE *fopj, int file_size, FILE *fdebug);
-	void readGraphInfo(FILE *fopj, int file_size, FILE *fdebug);
-	void readGraphGridInfo(graphGrid &grid, FILE *fopj, FILE *debug, int pos);
-	void readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *fopj, FILE *debug, int pos);
-	void readGraphAxisFormatInfo(graphAxisFormat &format, FILE *fopj, FILE *debug, int pos);
-	void readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *fopj, FILE *debug, int pos);
-	void readProjectTree(FILE *f, FILE *debug);
-	void readProjectTreeFolder(FILE *f, FILE *debug, tree<projectNode>::iterator parent);
-	void readWindowProperties(originWindow& window, FILE *f, FILE *debug, int POS, int headersize);
-	void skipObjectInfo(FILE *fopj, FILE *fdebug);
-	void setColName(int spread);		//!< set default column name starting from spreadsheet spread
-	void convertSpreadToExcel(int spread);
-	const char* filename;			//!< project file name
-	int version;				//!< project version
-	int dataIndex;
-	int objectIndex;
-	std::string resultsLog;
-	std::vector <spreadSheet> SPREADSHEET;
-	std::vector <matrix> MATRIX;
-	std::vector <excel> EXCEL;
-	std::vector <function> FUNCTION;
-	std::vector <graph> GRAPH;
-	std::vector <note> NOTE;
-	tree <projectNode> projectTree;
+  bool IsBigEndian();
+  void ByteSwap(unsigned char *b, int n);
+  int ParseFormatOld();
+  int ParseFormatNew();
+  int compareSpreadnames(char *sname) const; //!< returns matching spread index
+  int compareExcelnames(char *sname) const;  //!< returns matching excel index
+  int compareColumnnames(int spread,
+                         char *sname) const; //!< returns matching column index
+  int compareExcelColumnnames(int excel, int sheet, char *sname)
+      const;                                 //!< returns matching column index
+  int compareMatrixnames(char *sname) const; //!< returns matching matrix index
+  int compareFunctionnames(
+      const char *sname) const; //!< returns matching function index
+  std::vector<std::string> findDataByIndex(int index) const;
+  std::string findObjectByIndex(int index);
+  void readSpreadInfo(FILE *fopj, int file_size, FILE *fdebug);
+  void readExcelInfo(FILE *f, int file_size, FILE *debug);
+  void readMatrixInfo(FILE *fopj, int file_size, FILE *fdebug);
+  void readGraphInfo(FILE *fopj, int file_size, FILE *fdebug);
+  void readGraphGridInfo(graphGrid &grid, FILE *fopj, FILE *debug, int pos);
+  void readGraphAxisBreakInfo(graphAxisBreak &axis_break, FILE *fopj,
+                              FILE *debug, int pos);
+  void readGraphAxisFormatInfo(graphAxisFormat &format, FILE *fopj, FILE *debug,
+                               int pos);
+  void readGraphAxisTickLabelsInfo(graphAxisTick &tick, FILE *fopj, FILE *debug,
+                                   int pos);
+  void readProjectTree(FILE *f, FILE *debug);
+  void readProjectTreeFolder(FILE *f, FILE *debug,
+                             tree<projectNode>::iterator parent);
+  void readWindowProperties(originWindow &window, FILE *f, FILE *debug, int POS,
+                            int headersize);
+  void skipObjectInfo(FILE *fopj, FILE *fdebug);
+  void setColName(
+      int spread); //!< set default column name starting from spreadsheet spread
+  void convertSpreadToExcel(int spread);
+  const char *filename; //!< project file name
+  int version;          //!< project version
+  int dataIndex;
+  int objectIndex;
+  std::string resultsLog;
+  std::vector<spreadSheet> SPREADSHEET;
+  std::vector<matrix> MATRIX;
+  std::vector<excel> EXCEL;
+  std::vector<function> FUNCTION;
+  std::vector<graph> GRAPH;
+  std::vector<note> NOTE;
+  tree<projectNode> projectTree;
 };
 
 #endif // OPJFILE_H


### PR DESCRIPTION
Fixes #14028.

**to test**: check that code changes are sensible. To get rid of tens of errors (unchecked return values from fseek/fread) I replaced calls to both functions with macros that do a basic error check and print a debug warning message if there's an error. This is to make as least intrusive changes as possible. Only for the first two first fields I added a return in case of error.

This might be difficult to check manually. I do not know of anyone using these Origin project files in Mantid. I got a few examples from OriginLab which in principle load correctly but Mantid/qti simply says that there's nothing to show from these projects. I'd guess that this supports only old OPJ files or a very limited subset of them.

If these OPJ are really never used/tested probably it should be considered to drop/disable them.

Note: the third commit just clang-formats these couple of files. The first two commits contain the real changes.
