### PR TITLE
Store CrystalStructure in Sample

### DIFF
--- a/Framework/API/inc/MantidAPI/Sample.h
+++ b/Framework/API/inc/MantidAPI/Sample.h
@@ -107,7 +107,8 @@ public:
   /** @name Access the sample's crystal structure */
   //@{
   const Geometry::CrystalStructure &getCrystalStructure() const;
-  void setCrystalStructure(const Geometry::CrystalStructure &newCrystalStructure);
+  void
+  setCrystalStructure(const Geometry::CrystalStructure &newCrystalStructure);
   bool hasCrystalStructure() const;
   void clearCrystalStructure();
   //@}

--- a/Framework/API/inc/MantidAPI/Sample.h
+++ b/Framework/API/inc/MantidAPI/Sample.h
@@ -15,6 +15,7 @@ namespace Mantid {
 //------------------------------------------------------------------------------
 namespace Geometry {
 class OrientedLattice;
+class CrystalStructure;
 }
 
 namespace API {
@@ -103,6 +104,14 @@ public:
   bool hasOrientedLattice() const;
   //@}
 
+  /** @name Access the sample's crystal structure */
+  //@{
+  const Geometry::CrystalStructure &getCrystalStructure() const;
+  void setCrystalStructure(const Geometry::CrystalStructure &newCrystalStructure);
+  bool hasCrystalStructure() const;
+  void clearCrystalStructure();
+  //@}
+
   // Required for SANS work until we define a proper
   // sample object from the raw file information
   /**@name Legacy functions */
@@ -136,6 +145,9 @@ private:
   boost::shared_ptr<SampleEnvironment> m_environment;
   /// Pointer to the OrientedLattice of the sample, NULL if not set.
   Geometry::OrientedLattice *m_lattice;
+
+  /// CrystalStructure of the sample
+  std::unique_ptr<Geometry::CrystalStructure> m_crystalStructure;
 
   /// Vector of child samples
   std::vector<boost::shared_ptr<Sample>> m_samples;

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -4,6 +4,7 @@
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SampleEnvironment.h"
 #include "MantidGeometry/IComponent.h"
+#include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidKernel/Strings.h"
@@ -22,8 +23,9 @@ using Geometry::ShapeFactory;
  * Default constructor. Required for cow_ptr.
  */
 Sample::Sample()
-    : m_name(), m_shape(), m_environment(), m_lattice(NULL), m_samples(),
-      m_geom_id(0), m_thick(0.0), m_height(0.0), m_width(0.0) {}
+    : m_name(), m_shape(), m_environment(), m_lattice(NULL),
+      m_crystalStructure(), m_samples(), m_geom_id(0), m_thick(0.0),
+      m_height(0.0), m_width(0.0) {}
 
 /**
  * Copy constructor
@@ -31,11 +33,16 @@ Sample::Sample()
  */
 Sample::Sample(const Sample &copy)
     : m_name(copy.m_name), m_shape(copy.m_shape),
-      m_environment(copy.m_environment), m_lattice(NULL),
+      m_environment(copy.m_environment), m_lattice(NULL), m_crystalStructure(),
       m_samples(copy.m_samples), m_geom_id(copy.m_geom_id),
       m_thick(copy.m_thick), m_height(copy.m_height), m_width(copy.m_width) {
   if (copy.m_lattice)
     m_lattice = new OrientedLattice(copy.getOrientedLattice());
+
+  if (copy.hasCrystalStructure()) {
+    m_crystalStructure.reset(
+        new Geometry::CrystalStructure(copy.getCrystalStructure()));
+  }
 }
 
 /// Destructor
@@ -63,6 +70,12 @@ Sample &Sample::operator=(const Sample &rhs) {
     m_lattice = new OrientedLattice(rhs.getOrientedLattice());
   else
     m_lattice = NULL;
+
+  m_crystalStructure.reset();
+  if (rhs.hasCrystalStructure()) {
+    m_crystalStructure.reset(
+        new Geometry::CrystalStructure(rhs.getCrystalStructure()));
+  }
 
   return *this;
 }
@@ -160,6 +173,29 @@ void Sample::setOrientedLattice(OrientedLattice *latt) {
 
 /** @return true if the sample has an OrientedLattice  */
 bool Sample::hasOrientedLattice() const { return (m_lattice != NULL); }
+
+const Geometry::CrystalStructure &Sample::getCrystalStructure() const {
+  if (!hasCrystalStructure()) {
+    throw std::runtime_error(
+        "Sample::getCrystalStructure - No CrystalStructure has been defined.");
+  }
+
+  return *m_crystalStructure;
+}
+
+/// Resets the internal pointer to the new CrystalStructure (it's copied).
+void Sample::setCrystalStructure(
+    const Geometry::CrystalStructure &newCrystalStructure) {
+  m_crystalStructure.reset(new Geometry::CrystalStructure(newCrystalStructure));
+}
+
+/// Returns true if the sample actually holds a CrystalStructure.
+bool Sample::hasCrystalStructure() const {
+  return m_crystalStructure.operator bool();
+}
+
+/// Destroys the internally stored CrystalStructure-object.
+void Sample::clearCrystalStructure() { m_crystalStructure.reset(); }
 
 /**
  * Set the geometry flag that is specfied in the raw file within the SPB_STRUCT

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -191,7 +191,13 @@ void Sample::setCrystalStructure(
 
 /// Returns true if the sample actually holds a CrystalStructure.
 bool Sample::hasCrystalStructure() const {
-  return m_crystalStructure.operator bool();
+  // Conversion to bool seems to be a problem in VS2012, so this is a bit more
+  // verbose than it should be.
+  if (m_crystalStructure) {
+    return true;
+  }
+
+  return false;
 }
 
 /// Destroys the internally stored CrystalStructure-object.

--- a/Framework/API/test/SampleTest.h
+++ b/Framework/API/test/SampleTest.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/SampleEnvironment.h"
+#include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/Exception.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
@@ -197,6 +198,57 @@ public:
     TS_ASSERT(!sampleB.hasOrientedLattice())
     TS_ASSERT_THROWS(sampleB.getOrientedLattice(), std::runtime_error &)
     delete latticeA;
+  }
+
+  void test_setCrystalStructure() {
+    Sample sample;
+    TS_ASSERT(!sample.hasCrystalStructure());
+    TS_ASSERT_THROWS(sample.getCrystalStructure(), std::runtime_error);
+
+    CrystalStructure structure("3 4 5 90 90 90", "C m m m",
+                               "Fe 0.12 0.23 0.121");
+
+    TS_ASSERT_THROWS_NOTHING(sample.setCrystalStructure(structure));
+    TS_ASSERT(sample.hasCrystalStructure());
+    CrystalStructure fromSample = sample.getCrystalStructure();
+
+    TS_ASSERT(fromSample.spaceGroup());
+    TS_ASSERT_EQUALS(fromSample.spaceGroup()->hmSymbol(), "C m m m");
+  }
+
+  void test_clearCrystalStructure() {
+    Sample sample;
+    TS_ASSERT(!sample.hasCrystalStructure());
+    TS_ASSERT_THROWS(sample.getCrystalStructure(), std::runtime_error);
+
+    CrystalStructure structure("3 4 5 90 90 90", "C m m m",
+                               "Fe 0.12 0.23 0.121");
+    sample.setCrystalStructure(structure);
+    TS_ASSERT(sample.hasCrystalStructure());
+
+    TS_ASSERT_THROWS_NOTHING(sample.clearCrystalStructure());
+    TS_ASSERT(!sample.hasCrystalStructure());
+  }
+
+  void test_crystalStructureCopyConstructorAndAssignment() {
+      Sample sampleA;
+
+      CrystalStructure structure("3 4 5 90 90 90", "C m m m",
+                                 "Fe 0.12 0.23 0.121");
+      sampleA.setCrystalStructure(structure);
+      TS_ASSERT(sampleA.hasCrystalStructure());
+
+      Sample sampleB = sampleA;
+      TS_ASSERT(sampleB.hasCrystalStructure());
+
+      CrystalStructure fromA = sampleA.getCrystalStructure();
+      CrystalStructure fromB = sampleB.getCrystalStructure();
+      TS_ASSERT_EQUALS(fromA.spaceGroup()->hmSymbol(), fromB.spaceGroup()->hmSymbol());
+
+      Sample sampleC(sampleA);
+
+      CrystalStructure fromC = sampleC.getCrystalStructure();
+      TS_ASSERT_EQUALS(fromA.spaceGroup()->hmSymbol(), fromC.spaceGroup()->hmSymbol());
   }
 
   void test_Material_Returns_The_Correct_Value() {

--- a/Framework/API/test/SampleTest.h
+++ b/Framework/API/test/SampleTest.h
@@ -231,24 +231,26 @@ public:
   }
 
   void test_crystalStructureCopyConstructorAndAssignment() {
-      Sample sampleA;
+    Sample sampleA;
 
-      CrystalStructure structure("3 4 5 90 90 90", "C m m m",
-                                 "Fe 0.12 0.23 0.121");
-      sampleA.setCrystalStructure(structure);
-      TS_ASSERT(sampleA.hasCrystalStructure());
+    CrystalStructure structure("3 4 5 90 90 90", "C m m m",
+                               "Fe 0.12 0.23 0.121");
+    sampleA.setCrystalStructure(structure);
+    TS_ASSERT(sampleA.hasCrystalStructure());
 
-      Sample sampleB = sampleA;
-      TS_ASSERT(sampleB.hasCrystalStructure());
+    Sample sampleB = sampleA;
+    TS_ASSERT(sampleB.hasCrystalStructure());
 
-      CrystalStructure fromA = sampleA.getCrystalStructure();
-      CrystalStructure fromB = sampleB.getCrystalStructure();
-      TS_ASSERT_EQUALS(fromA.spaceGroup()->hmSymbol(), fromB.spaceGroup()->hmSymbol());
+    CrystalStructure fromA = sampleA.getCrystalStructure();
+    CrystalStructure fromB = sampleB.getCrystalStructure();
+    TS_ASSERT_EQUALS(fromA.spaceGroup()->hmSymbol(),
+                     fromB.spaceGroup()->hmSymbol());
 
-      Sample sampleC(sampleA);
+    Sample sampleC(sampleA);
 
-      CrystalStructure fromC = sampleC.getCrystalStructure();
-      TS_ASSERT_EQUALS(fromA.spaceGroup()->hmSymbol(), fromC.spaceGroup()->hmSymbol());
+    CrystalStructure fromC = sampleC.getCrystalStructure();
+    TS_ASSERT_EQUALS(fromA.spaceGroup()->hmSymbol(),
+                     fromC.spaceGroup()->hmSymbol());
   }
 
   void test_Material_Returns_The_Correct_Value() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -1,5 +1,6 @@
 #include "MantidAPI/Sample.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidKernel/Material.h"
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
@@ -25,6 +26,17 @@ void export_Sample() {
       .def("hasOrientedLattice", &Sample::hasOrientedLattice, arg("self"),
            "Returns True if this sample has an oriented lattice, false "
            "otherwise")
+      .def("getCrystalStructure", &Sample::getCrystalStructure, arg("self"),
+           return_value_policy<reference_existing_object>(),
+           "Get the crystal structure for this sample")
+      .def("hasCrystalStructure", &Sample::hasCrystalStructure, arg("self"),
+           "Returns True if this sample has a crystal structure, false "
+           "otherwise")
+      .def("setCrystalStructure", &Sample::setCrystalStructure, arg("self"),
+           arg("crystalStructure"),
+           "Assign a crystal structure object to the sample.")
+      .def("clearCrystalStructure", &Sample::clearCrystalStructure, arg("self"),
+           "Removes the internally stored crystal structure.")
       .def("size", &Sample::size, arg("self"),
            "Return the number of samples contained within this sample")
       // Required for ISIS SANS reduction until the full sample geometry is

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -1,6 +1,7 @@
 import unittest
 from mantid.api import Sample
 from mantid.simpleapi import CreateWorkspace
+from mantid.geometry import CrystalStructure
 
 class SampleTest(unittest.TestCase):
 
@@ -16,6 +17,36 @@ class SampleTest(unittest.TestCase):
         self.assertEquals(sample.getHeight(), 10.2)
         sample.setWidth(5.9)
         self.assertEquals(sample.getWidth(), 5.9)
+
+    def test_crystal_structure_handling(self):
+        sample = self._ws.sample()
+
+        self.assertEquals(sample.hasCrystalStructure(), False)
+        self.assertRaises(RuntimeError, sample.getCrystalStructure)
+
+        cs = CrystalStructure('5.43 5.43 5.43',
+                              'F d -3 m',
+                              'Si 0 0 0 1.0 0.01')
+
+        sample.setCrystalStructure(cs)
+
+        self.assertEquals(sample.hasCrystalStructure(), True)
+
+        cs_from_sample = sample.getCrystalStructure()
+
+        self.assertEquals(cs.getSpaceGroup().getHMSymbol(), cs_from_sample.getSpaceGroup().getHMSymbol())
+        self.assertEquals(cs.getUnitCell().a(), cs_from_sample.getUnitCell().a())
+        self.assertEquals(len(cs.getScatterers()), len(cs_from_sample.getScatterers()))
+        self.assertEquals(cs.getScatterers()[0], cs_from_sample.getScatterers()[0])
+
+
+        sample.clearCrystalStructure()
+
+        self.assertEquals(sample.hasCrystalStructure(), False)
+        self.assertRaises(RuntimeError, sample.getCrystalStructure)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This addresses #13905.

Sample now holds a CrystalStructure. I have not included it in the Nexus reading/writing of Sample yet, because it's still unclear how exactly the scatterers would be stored (ongoing discussion with Tobias Richter). However I do not think that this is urgent, because typically this information would come from a CIF-file and added to sample after loading the raw data into a workspace. This will be addressed in #11268, which is also the reason for exposing Sample::setCrystalStructure to Python - this way it's possible to use either a C++ or Python library for CIF-parsing.

**Testing information**
Code review. I marked it Core because Sample is present in all workspaces and it would be good to make sure nothing has been overlooked.
