### PR TITLE
IDR Progress Tracking

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -138,14 +138,19 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                                              plot_reduction)
 
         self._setup()
+        load_prog = Progress(self, start=0.0, end=0.10, nreports=2)
+        load_prog.report('loading files')
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                self._ipf_filename,
                                                                self._spectra_range[0],
                                                                self._spectra_range[1],
                                                                self._sum_files,
                                                                self._load_logs)
+        load_prog.report('files loaded')
 
+        process_prog = Progress(self, start=0.1, end=0.9, nreports=len(self._workspace_names))
         for c_ws_name in self._workspace_names:
+            process_prog.report('processing workspace' + c_ws_name)
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)
 
             # Get list of workspaces
@@ -263,13 +268,17 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         # Rename output workspaces
         output_workspace_names = [rename_reduction(ws_name, self._sum_files) for ws_name in self._workspace_names]
 
+        summary_prog = Progress(self, start=0.9, end=1.0, nreports=4)
+
         # Save result workspaces
         if self._save_formats is not None:
+            summary_prog.report('saving')
             save_reduction(output_workspace_names,
                            self._save_formats,
                            self._output_x_units)
 
         # Group result workspaces
+        summary_prog.report('grouping workspaces')
         GroupWorkspaces(InputWorkspaces=output_workspace_names,
                         OutputWorkspace=self._output_ws)
 
@@ -277,8 +286,10 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         # Plot result workspaces
         if self._plot_type != 'None':
+            summary_prog.report('Plotting')
             for ws_name in mtd[self._output_ws].getNames():
                 plot_reduction(ws_name, self._plot_type)
+        summary_prog.report('Algorithm complete')
 
 
     def validateInputs(self):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -282,7 +282,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         GroupWorkspaces(InputWorkspaces=output_workspace_names,
                         OutputWorkspace=self._output_ws)
 
-        self.setProperty('OutputWorkspace', self._output_ws)
+        self.setProperty('OutputWorkspace', mtd[self._output_ws])
 
         # Plot result workspaces
         if self._plot_type != 'None':

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -87,9 +87,10 @@ class IndirectCalibration(DataProcessorAlgorithm):
         from IndirectCommon import get_run_number
 
         self._setup()
-
         runs = []
         self._run_numbers = []
+        load_prog = Progress(self, start=0.0, end=0.30, nreports=len(self._input_files))
+        i = 0
         for in_file in self._input_files:
             (_, filename) = os.path.split(in_file)
             (root, _) = os.path.splitext(filename)
@@ -104,34 +105,45 @@ class IndirectCalibration(DataProcessorAlgorithm):
                 self._run_numbers.append(get_run_number(root))
             except (RuntimeError,ValueError) as exc:
                 logger.error('Could not load raw file "%s": %s' % (in_file, str(exc)))
+            load_prog.report('Loading file: ' + str(i))
+            i += 1
 
         calib_ws_name = 'calibration'
+        merge_prog = Progress(self, start=0.30, end=0.40, nreports=2)
         if len(runs) > 1:
             MergeRuns(InputWorkspaces=",".join(runs),
                       OutputWorkspace=calib_ws_name)
+            merge_prog.report('Workspaces merged')
             factor = 1.0 / len(runs)
             Scale(InputWorkspace=calib_ws_name,
                   OutputWorkspace=calib_ws_name,
                   Factor=factor)
+            merge_prog.report('Scaling complete')
         else:
             calib_ws_name = runs[0]
+            merge_prog.report()
 
+        workflow_prog = Progress(self, start=0.40, end=0.90, nreports=10)
+        workflow_prog.report('Calculating flat background')
         CalculateFlatBackground(InputWorkspace=calib_ws_name,
                                 OutputWorkspace=calib_ws_name,
                                 StartX=self._back_range[0],
                                 EndX=self._back_range[1],
                                 Mode='Mean')
 
+        workflow_prog.report('Masking detectors')
         number_historgrams = mtd[calib_ws_name].getNumberHistograms()
         ws_mask, num_zero_spectra = FindDetectorsOutsideLimits(InputWorkspace=calib_ws_name,
                                                                OutputWorkspace='__temp_ws_mask')
         DeleteWorkspace(ws_mask)
 
+        workflow_prog.report('Integrating calibration file')
         Integration(InputWorkspace=calib_ws_name,
                     OutputWorkspace=calib_ws_name,
                     RangeLower=self._peak_range[0],
                     RangeUpper=self._peak_range[1])
 
+        workflow_prog.report('Summing Spectra')
         temp_sum = SumSpectra(InputWorkspace=calib_ws_name,
                               OutputWorkspace='__temp_sum')
         total = temp_sum.readY(0)[0]
@@ -140,6 +152,7 @@ class IndirectCalibration(DataProcessorAlgorithm):
         if self._intensity_scale is None:
             self._intensity_scale = 1 / (total / (number_historgrams - num_zero_spectra))
 
+        workflow_prog.report('Scaling calibration')
         Scale(InputWorkspace=calib_ws_name,
               OutputWorkspace=self._out_ws,
               Factor=self._intensity_scale,
@@ -149,6 +162,7 @@ class IndirectCalibration(DataProcessorAlgorithm):
         if len(runs) > 1:
             for run in runs:
                 DeleteWorkspace(Workspace=run)
+                workflow_prog.report('Deleting workspaces')
 
         self._add_logs()
         self.setProperty('OutputWorkspace', self._out_ws)
@@ -186,9 +200,11 @@ class IndirectCalibration(DataProcessorAlgorithm):
         if self._intensity_scale is not None:
             sample_logs.append(('calib_scale_factor', self._intensity_scale))
 
-        AddSampleLogMultiple(Workspace=self._out_ws,
-                             LogNames=[log[0] for log in sample_logs],
-                             LogValues=[log[1] for log in sample_logs])
+        log_alg = self.createChildAlgorithm(name='AddSampleLogMultiple', startProgress=0.9,
+                                            endProgress=1.0, enableLogging=True)
+        log_alg.setProperty('Workspace', self._out_ws)
+        log_alg.setProperty('LogNames', [log[0] for log in sample_logs])
+        log_alg.setProperty('LogValues', [log[1] for log in sample_logs])
 
 
 # Register algorithm with Mantid

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
@@ -59,22 +59,29 @@ class IndirectResolution(DataProcessorAlgorithm):
     def PyExec(self):
         self._setup()
 
-        ISISIndirectEnergyTransfer(Instrument=self._instrument,
-                                   Analyser=self._analyser,
-                                   Reflection=self._reflection,
-                                   GroupingMethod='All',
-                                   SumFiles=True,
-                                   InputFiles=self._input_files,
-                                   SpectraRange=self._detector_range,
-                                   OutputWorkspace='__et_ws_group')
+        iet_alg = self.createChildAlgorithm(name='ISISIndirectEnergyTransfer', startProgress=0.0,
+                                            endProgress=0.7, enableLogging=True)
+        iet_alg.setProperty('Instrument', self._instrument)
+        iet_alg.setProperty('Analyser', self._analyser)
+        iet_alg.setProperty('Reflection', self._reflection)
+        iet_alg.setProperty('GroupingMethod', 'All')
+        iet_alg.setProperty('SumFiles', True)
+        iet_alg.setProperty('InputFiles', self._input_files)
+        iet_alg.setProperty('SpectraRange', self._detector_range)
+        iet_alg.execute()
+        
+        group_ws = iet_alg.getProperty('OutputWorkspace').value
+        icon_ws = group_ws.getItem(0).getName()
 
-        icon_ws = mtd['__et_ws_group'].getItem(0).getName()
-
+        workflow_prog = Progress(self, start=0.7, end=0.9, nreports=4)
+        
         if self._scale_factor != 1.0:
+            workflow_prog.report('Scaling Workspace')
             Scale(InputWorkspace=icon_ws,
                   OutputWorkspace=icon_ws,
                   Factor=self._scale_factor)
 
+        workflow_prog.report('Calculating flat background')
         CalculateFlatBackground(InputWorkspace=icon_ws,
                                 OutputWorkspace=self._out_ws,
                                 StartX=self._background[0],
@@ -82,10 +89,12 @@ class IndirectResolution(DataProcessorAlgorithm):
                                 Mode='Mean',
                                 OutputMode='Subtract Background')
 
+        workflow_prog.report('Rebinning Workspace')
         Rebin(InputWorkspace=self._out_ws,
               OutputWorkspace=self._out_ws,
               Params=self._rebin_string)
 
+        workflow_prog.report('Completing Post Processing')
         self._post_process()
         self.setProperty('OutputWorkspace', self._out_ws)
 
@@ -125,9 +134,11 @@ class IndirectResolution(DataProcessorAlgorithm):
             sample_logs.append(('rebin_width', rebin_params[1]))
             sample_logs.append(('rebin_high', rebin_params[2]))
 
-        AddSampleLogMultiple(Workspace=self._out_ws,
-                             LogNames=[log[0] for log in sample_logs],
-                             LogValues=[log[1] for log in sample_logs])
+        log_alg = self.createChildAlgorithm(name='AddSampleLogMultiple', startProgress=0.9,
+                                            endProgress=1.0, enableLogging=True)
+        log_alg.setProperty('Workspace', self._out_ws)
+        log_alg.setProperty('LogNames', [log[0] for log in sample_logs])
+        log_alg.setProperty('LogValues',[log[1] for log in sample_logs])
 
         self.setProperty('OutputWorkspace', self._out_ws)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectResolution.py
@@ -69,12 +69,12 @@ class IndirectResolution(DataProcessorAlgorithm):
         iet_alg.setProperty('InputFiles', self._input_files)
         iet_alg.setProperty('SpectraRange', self._detector_range)
         iet_alg.execute()
-        
+
         group_ws = iet_alg.getProperty('OutputWorkspace').value
         icon_ws = group_ws.getItem(0).getName()
 
         workflow_prog = Progress(self, start=0.7, end=0.9, nreports=4)
-        
+
         if self._scale_factor != 1.0:
             workflow_prog.report('Scaling Workspace')
             Scale(InputWorkspace=icon_ws,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -141,7 +141,7 @@ class TimeSlice(PythonAlgorithm):
             Transpose(InputWorkspace=slice_file, OutputWorkspace=slice_file)
             unit = mtd[slice_file].getAxis(0).setUnit("Label")
             unit.setLabel("Spectrum Number", "")
-            
+
             workflow_prog.report('Deleting Workspace')
             out_ws_list.append(slice_file)
             DeleteWorkspace(raw_file)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -126,24 +126,31 @@ class TimeSlice(PythonAlgorithm):
 
         # CheckXrange(xRange, 'Time')
         out_ws_list = []
-
+        i = 0
+        workflow_prog = Progress(self, start=0.0, end=0.96, nreports=len(self._raw_files)*3)
         for index, filename in enumerate(self._raw_files):
+            workflow_prog.report('Reading file: ' + str(i))
             raw_file = self._read_raw_file(filename)
 
             # Only need to process the calib file once
             if index == 0 and self._calib_ws is not None:
                 self._process_calib(raw_file)
 
+            workflow_prog.report('Transposing Workspace: ' + str(i))
             slice_file = self._process_raw_file(raw_file)
             Transpose(InputWorkspace=slice_file, OutputWorkspace=slice_file)
             unit = mtd[slice_file].getAxis(0).setUnit("Label")
             unit.setLabel("Spectrum Number", "")
-
+            
+            workflow_prog.report('Deleting Workspace')
             out_ws_list.append(slice_file)
             DeleteWorkspace(raw_file)
 
         all_workspaces = ','.join(out_ws_list)
+        final_prog = Progress(self, start=0.96, end=1.0, nreports=2)
+        final_prog.report('Grouping result')
         GroupWorkspaces(InputWorkspaces=all_workspaces, OutputWorkspace=self._out_ws_group)
+        final_prog.report('setting result')
         self.setProperty('OutputWorkspace', self._out_ws_group)
 
 


### PR DESCRIPTION
Fixes #13974 

These progress tracking changes cover the bulk of the indirect Tab including:
- Energy Transfer
- Calibration
- Diagnostics
# To Test (General)
- Ensure that you facility is set to ISIS before testing
- The default instrument to use is IRIS / Graphite / 002
- Run numbers are available from the data archive 
  - I suggest using a range to make it easier to see the progress tracking I used 26173-26176
# To Test (ISIS Energy Transfer)
- Open ISIS Energy Transfer (Interfaces > Indirect > Data Reduction > ISIS Energy Transfer)
- Enter run numbers _(see general)_
- Click `Run` after the files have been found.
- Observe the progress tracking in the bottom right
- This will pause on loading files for a while because the underlying script is not an algorithm (this will be changed in the future)
# To Test (ISIS Calibration)
- Open ISIS Calibration (Interfaces > Indirect > Data Reduction > ISIS Calibration)
- Enter run numbers _(see general)_
- Check the `Create RES File` box in Create Resolution
- Click `Run` after the files have been found.
- Ensure progress tracking runs twice (once for Calib, once for res)
- This will pause on loading files for a while because the underlying script is not an algorithm (this will be changed in the future)
# To Test (ISIS Diagnostics)
- Open ISIS Diagnostics (Interfaces > Indirect > Data Reduction > ISIS Diagnostics)
- Enter run numbers _(see general)_
- Ensure progress tracking takes place while the plot in loaded in the interface
- Click `Run` after the files have been found.
- Ensure progress tracking runs in bottom right
