### PR TITLE
EnggDiffraction::fixes red symbol displayed when run number given

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
@@ -108,7 +108,7 @@
        <widget class="QComboBox" name="comboBox_instrument">
         <item>
          <property name="text">
-          <string>ENGIN-X</string>
+          <string>ENGINX</string>
          </property>
         </item>
        </widget>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -198,8 +198,11 @@ private:
   /// instrument selected (ENGIN-X, etc.)
   std::string m_currentInst;
 
-  /// the instrument selection has changed (slot)
-  void userSelectInstrument();
+  /// User select instrument
+  void userSelectInstrument(const QString &prefix);
+
+  /// setting the instrument prefix ahead of the run number
+  void setPrefix(std::string prefix);
 
   // plot data representation type selected
   int static m_currentType;
@@ -227,7 +230,6 @@ private:
 
   /// presenter as in the model-view-presenter
   boost::scoped_ptr<IEnggDiffractionPresenter> m_presenter;
-
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -198,6 +198,9 @@ private:
   /// instrument selected (ENGIN-X, etc.)
   std::string m_currentInst;
 
+  /// the instrument selection has changed (slot)
+  void userSelectInstrument();
+
   // plot data representation type selected
   int static m_currentType;
 
@@ -224,6 +227,7 @@ private:
 
   /// presenter as in the model-view-presenter
   boost::scoped_ptr<IEnggDiffractionPresenter> m_presenter;
+
 };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -100,9 +100,9 @@ void EnggDiffractionViewQtGUI::doSetupTabCalib() {
   // CalibrationParameters or similar class/structure
   const std::string vanadiumRun = "236516";
   const std::string ceriaRun = "241391";
-  m_uiTabCalib.lineEdit_new_vanadium_num->setText(
+  m_uiTabCalib.lineEdit_new_vanadium_num->setUserInput(
       QString::fromStdString(vanadiumRun));
-  m_uiTabCalib.lineEdit_new_ceria_num->setText(
+  m_uiTabCalib.lineEdit_new_ceria_num->setUserInput(
       QString::fromStdString(ceriaRun));
 
   // push button signals/slots
@@ -178,6 +178,11 @@ void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
   connect(m_ui.comboBox_instrument, SIGNAL(currentIndexChanged(int)), this,
           SLOT(instrumentChanged(int)));
 
+  // signal/slot connections to respond to changes in instrument selection combo
+  // boxes
+  connect(m_ui.comboBox_instrument, SIGNAL(instrumentChanged(int)), this,
+          SLOT(userSelectInstrument()));
+
   connect(m_ui.pushButton_help, SIGNAL(released()), this, SLOT(openHelpWin()));
   // note connection to the parent window, otherwise an empty frame window
   // may remain open and visible after this close
@@ -212,7 +217,7 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("user-params-new-ceria-num", "").toString());
 
   // user params - focusing
-  m_uiTabFocus.lineEdit_run_num->setText(
+  m_uiTabFocus.lineEdit_run_num->setUserInput(
       qs.value("user-params-focus-runno", "").toString());
 
   qs.beginReadArray("user-params-focus-bank_i");
@@ -224,13 +229,13 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("value", true).toBool());
   qs.endArray();
 
-  m_uiTabFocus.lineEdit_cropped_run_num->setText(
+  m_uiTabFocus.lineEdit_cropped_run_num->setUserInput(
       qs.value("user-params-focus-cropped-runno", "").toString());
 
   m_uiTabFocus.lineEdit_cropped_spec_ids->setText(
       qs.value("user-params-focus-cropped-spectrum-nos", "").toString());
 
-  m_uiTabFocus.lineEdit_texture_run_num->setText(
+  m_uiTabFocus.lineEdit_texture_run_num->setUserInput(
       qs.value("user-params-focus-texture-runno", "").toString());
 
   m_uiTabFocus.lineEdit_texture_grouping_file->setText(
@@ -735,9 +740,19 @@ void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {
   QComboBox *inst = m_ui.comboBox_instrument;
   if (!inst)
     return;
-
   m_currentInst = inst->currentText().toStdString();
   m_presenter->notify(IEnggDiffractionPresenter::InstrumentChange);
+}
+
+void EnggDiffractionViewQtGUI::userSelectInstrument() {
+  // Set file browsing to current instrument
+  auto prefix = QString::fromStdString(m_currentInst);
+  m_uiTabFocus.lineEdit_run_num->setInstrumentOverride(prefix);
+  m_uiTabFocus.lineEdit_texture_run_num->setInstrumentOverride(prefix);
+  m_uiTabFocus.lineEdit_cropped_run_num->setInstrumentOverride(prefix);
+
+  m_uiTabCalib.lineEdit_new_ceria_num->setInstrumentOverride(prefix);
+  m_uiTabCalib.lineEdit_new_vanadium_num->setInstrumentOverride(prefix);
 }
 
 void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -76,6 +76,9 @@ void EnggDiffractionViewQtGUI::initLayout() {
   m_uiTabSettings.setupUi(wSettings);
   m_ui.tabMain->addTab(wSettings, QString("Settings"));
 
+  QComboBox *inst = m_ui.comboBox_instrument;
+  m_currentInst = inst->currentText().toStdString();
+  setPrefix(m_currentInst);
   readSettings();
 
   // basic UI setup, connect signals, etc.
@@ -177,12 +180,6 @@ void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
   // change instrument
   connect(m_ui.comboBox_instrument, SIGNAL(currentIndexChanged(int)), this,
           SLOT(instrumentChanged(int)));
-
-  // signal/slot connections to respond to changes in instrument selection combo
-  // boxes
-  connect(m_ui.comboBox_instrument, SIGNAL(instrumentChanged(int)), this,
-          SLOT(userSelectInstrument()));
-
   connect(m_ui.pushButton_help, SIGNAL(released()), this, SLOT(openHelpWin()));
   // note connection to the parent window, otherwise an empty frame window
   // may remain open and visible after this close
@@ -744,15 +741,21 @@ void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {
   m_presenter->notify(IEnggDiffractionPresenter::InstrumentChange);
 }
 
-void EnggDiffractionViewQtGUI::userSelectInstrument() {
+void EnggDiffractionViewQtGUI::userSelectInstrument(const QString &prefix) {
   // Set file browsing to current instrument
-  auto prefix = QString::fromStdString(m_currentInst);
-  m_uiTabFocus.lineEdit_run_num->setInstrumentOverride(prefix);
-  m_uiTabFocus.lineEdit_texture_run_num->setInstrumentOverride(prefix);
-  m_uiTabFocus.lineEdit_cropped_run_num->setInstrumentOverride(prefix);
+  setPrefix(prefix.toStdString());
+}
 
-  m_uiTabCalib.lineEdit_new_ceria_num->setInstrumentOverride(prefix);
-  m_uiTabCalib.lineEdit_new_vanadium_num->setInstrumentOverride(prefix);
+void EnggDiffractionViewQtGUI::setPrefix(std::string prefix) {
+  QString prefixInput = QString::fromStdString(prefix);
+  // focus tab
+  m_uiTabFocus.lineEdit_run_num->setInstrumentOverride(prefixInput);
+  m_uiTabFocus.lineEdit_texture_run_num->setInstrumentOverride(prefixInput);
+  m_uiTabFocus.lineEdit_cropped_run_num->setInstrumentOverride(prefixInput);
+
+  // calibration tab
+  m_uiTabCalib.lineEdit_new_ceria_num->setInstrumentOverride(prefixInput);
+  m_uiTabCalib.lineEdit_new_vanadium_num->setInstrumentOverride(prefixInput);
 }
 
 void EnggDiffractionViewQtGUI::closeEvent(QCloseEvent *event) {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -55,7 +55,7 @@ const std::string EnggDiffractionViewQtGUI::m_settingsGroup =
  * @param parent Parent window (most likely the Mantid main app window).
  */
 EnggDiffractionViewQtGUI::EnggDiffractionViewQtGUI(QWidget *parent)
-    : UserSubWindow(parent), IEnggDiffractionView(), m_currentInst("ENGIN-X"),
+    : UserSubWindow(parent), IEnggDiffractionView(), m_currentInst("ENGINX"),
       m_currentCalibFilename(""), m_presenter(NULL) {}
 
 EnggDiffractionViewQtGUI::~EnggDiffractionViewQtGUI() {}
@@ -78,6 +78,7 @@ void EnggDiffractionViewQtGUI::initLayout() {
 
   QComboBox *inst = m_ui.comboBox_instrument;
   m_currentInst = inst->currentText().toStdString();
+
   setPrefix(m_currentInst);
   readSettings();
 


### PR DESCRIPTION
Fixes #14006

Go to: `Interface/Diffraction/Engineering Diffraction`

When a EnginX specific run number is given to `Calibration/Vanadium #:` or  `Calibration/Calibration sample #:` or any `Run #:` under `Focus` tab, it should not display red `*` symbol next to the text-box.
Make sure the file is within the path provided to `Manage User Directories` or  `Engineering Diffraction Analysis/Settings` and `Search Data Archive` is **not** checked 
