### PR TITLE
Fix compilation on rhel 6 with gcc 4 8

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumDetectorMapping.h
+++ b/Framework/API/inc/MantidAPI/SpectrumDetectorMapping.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <set>
 #ifndef Q_MOC_RUN
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #endif
 
 #include "MantidGeometry/IDTypes.h"
@@ -50,7 +50,7 @@ class MatrixWorkspace;
     Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
 class MANTID_API_DLL SpectrumDetectorMapping {
-  typedef boost::unordered_map<specid_t, std::set<detid_t>> sdmap;
+  typedef std::unordered_map<specid_t, std::set<detid_t>> sdmap;
 
 public:
   explicit SpectrumDetectorMapping(const MatrixWorkspace *const workspace,

--- a/Framework/Algorithms/inc/MantidAlgorithms/MaskDetectorsIf.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MaskDetectorsIf.h
@@ -10,7 +10,7 @@
 
 // To be compatible with VSC Express edition that does not have tr1
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 namespace Mantid {
 namespace Algorithms {
@@ -69,7 +69,7 @@ private:
   /// Returns an allowed values statement to insert into decumentation
   std::string allowedValuesStatement(std::vector<std::string> vals);
   // Typedef for det to value map
-  typedef boost::unordered_map<detid_t, bool> udet2valuem;
+  typedef std::unordered_map<detid_t, bool> udet2valuem;
   /// A map of detector numbers to mask boolean
   udet2valuem umap;
   /// Get the properties

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReadGroupsFromFile.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReadGroupsFromFile.h
@@ -5,7 +5,7 @@
 // Includes
 //----------------------------------------------------------------------
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataObjects/Workspace2D.h"
 
@@ -98,7 +98,7 @@ public:
 private:
   /// Map containing the detector entries found in the *.cal file. The key is
   /// the udet number, the value of is a pair of <group,selected>.
-  typedef boost::unordered_map<int, std::pair<int, int>> calmap;
+  typedef std::unordered_map<int, std::pair<int, int>> calmap;
   /// Initialisation code
   void init();
   /// Execution code

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateGammaBackground.h
@@ -3,7 +3,7 @@
 
 #include "MantidAPI/Algorithm.h"
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 namespace Mantid {
 namespace CurveFitting {
@@ -104,7 +104,7 @@ private:
   /// Input TOF data
   API::MatrixWorkspace_const_sptr m_inputWS;
   /// Sorted indices to correct
-  boost::unordered_map<size_t, size_t> m_indices;
+  std::unordered_map<size_t, size_t> m_indices;
   /// Function that defines the mass profile
   std::string m_profileFunction;
   /// The number of peaks in spectrum

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/INearestNeighbours.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/INearestNeighbours.h
@@ -8,7 +8,7 @@
 // Boost graphing
 #ifndef Q_MOC_RUN
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <boost/shared_ptr.hpp>
 #include <boost/scoped_ptr.hpp>
 #endif
@@ -21,7 +21,7 @@ namespace Geometry {
 class Instrument;
 class IComponent;
 
-typedef boost::unordered_map<specid_t, std::set<detid_t>>
+typedef std::unordered_map<specid_t, std::set<detid_t>>
     ISpectrumDetectorMapping;
 
 /**

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/NearestNeighbours.h
@@ -93,7 +93,7 @@ private:
   /// Vertex descriptor object for Graph
   typedef boost::graph_traits<Graph>::vertex_descriptor Vertex;
   /// map object of int to Graph Vertex descriptor
-  typedef boost::unordered_map<specid_t, Vertex> MapIV;
+  typedef std::unordered_map<specid_t, Vertex> MapIV;
 
   /// Construct the graph based on the given number of neighbours and the
   /// current instument and spectra-detector mapping

--- a/Framework/Geometry/test/NearestNeighboursTest.h
+++ b/Framework/Geometry/test/NearestNeighboursTest.h
@@ -27,7 +27,7 @@ class NearestNeighboursTest : public CxxTest::TestSuite {
 public:
   static ISpectrumDetectorMapping
   buildSpectrumDetectorMapping(const specid_t start, const specid_t end) {
-    boost::unordered_map<specid_t, std::set<detid_t>> map;
+    std::unordered_map<specid_t, std::set<detid_t>> map;
     for (specid_t i = start; i <= end; ++i) {
       map[i].insert(i);
     }

--- a/Framework/ICat/CMakeLists.txt
+++ b/Framework/ICat/CMakeLists.txt
@@ -98,7 +98,7 @@ set_property ( TARGET ICat PROPERTY FOLDER "MantidFramework" )
 
 include_directories ( inc )
 
-target_link_libraries ( ICat LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} ${OPENSSL_LIBRARIES} )
+target_link_libraries ( ICat LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} ${OPENSSL_LIBRARIES} ${JSONCPP_LIBRARIES})
 
 # Add the unit tests directory
 add_subdirectory ( test )

--- a/Framework/ICat/src/CatalogAlgorithmHelper.cpp
+++ b/Framework/ICat/src/CatalogAlgorithmHelper.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/assign/list_of.hpp>
 #include <json/reader.h>
+#include <json/value.h>
 
 namespace Mantid {
 namespace ICat {
@@ -27,10 +28,11 @@ const std::string CatalogAlgorithmHelper::getIDSError(
     // Stores the contents of `jsonResponseData` as a json property tree.
     Json::Value json;
     // Convert the stream to a JSON tree.
-    Json::Reader::parse(responseStream, json);
+    Json::Reader json_reader;
+    json_reader.parse(responseStream, json);
     // Return the message returned by the server.
-    return json.get<std::string>("code") + ": " +
-           json.get<std::string>("message");
+    return json.get("code", "UTF-8" ).asString() + ": " +
+      json.get("message", "UTF-8" ).asString();
   }
   // No error occurred, so return an empty string for verification.
   return "";

--- a/Framework/ICat/src/CatalogAlgorithmHelper.cpp
+++ b/Framework/ICat/src/CatalogAlgorithmHelper.cpp
@@ -1,8 +1,7 @@
 #include "MantidICat/CatalogAlgorithmHelper.h"
 
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/assign/list_of.hpp>
+#include <json/reader.h>
 
 namespace Mantid {
 namespace ICat {
@@ -26,9 +25,9 @@ const std::string CatalogAlgorithmHelper::getIDSError(
   // from the server is not in our successHTTPStatus set.
   if (successHTTPStatus.find(HTTPStatus) == successHTTPStatus.end()) {
     // Stores the contents of `jsonResponseData` as a json property tree.
-    boost::property_tree::ptree json;
+    Json::Value json;
     // Convert the stream to a JSON tree.
-    boost::property_tree::read_json(responseStream, json);
+    Json::Reader::parse(responseStream, json);
     // Return the message returned by the server.
     return json.get<std::string>("code") + ": " +
            json.get<std::string>("message");

--- a/Framework/ICat/src/CatalogAlgorithmHelper.cpp
+++ b/Framework/ICat/src/CatalogAlgorithmHelper.cpp
@@ -31,8 +31,8 @@ const std::string CatalogAlgorithmHelper::getIDSError(
     Json::Reader json_reader;
     json_reader.parse(responseStream, json);
     // Return the message returned by the server.
-    return json.get("code", "UTF-8" ).asString() + ": " +
-      json.get("message", "UTF-8" ).asString();
+    return json.get("code", "UTF-8").asString() + ": " +
+           json.get("message", "UTF-8").asString();
   }
   // No error occurred, so return an empty string for verification.
   return "";

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <boost/shared_ptr.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include "MantidKernel/V3D.h"
 #include "MantidKernel/Matrix.h"
 
@@ -53,9 +53,9 @@ namespace MDAlgorithms {
                  <http://doxygen.mantidproject.org>
  */
 
-typedef boost::unordered_map<
+typedef std::unordered_map<
     int64_t, std::vector<std::pair<double, Mantid::Kernel::V3D>>> EventListMap;
-typedef boost::unordered_map<int64_t, Mantid::Kernel::V3D> PeakQMap;
+typedef std::unordered_map<int64_t, Mantid::Kernel::V3D> PeakQMap;
 
 class DLLExport Integrate3DEvents {
 public:

--- a/Framework/ScriptRepository/CMakeLists.txt
+++ b/Framework/ScriptRepository/CMakeLists.txt
@@ -35,6 +35,6 @@ set ( LIBS ${MANTIDLIBS} )
 
 include_directories(inc)
 
-target_link_libraries(ScriptRepository LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${LIBS})
+target_link_libraries(ScriptRepository LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${LIBS} ${JSONCPP_LIBRARIES})
 
 install (TARGETS ScriptRepository ${SYSTEM_PACKAGE_TARGET} DESTINATION ${PLUGINS_DIR} )

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -19,13 +19,16 @@
 namespace Mantid {
 namespace API {
 
-void writeJsonFile(const std::string& filename, Json::Value json, const std::string& error);
+void writeJsonFile(const std::string &filename, Json::Value json,
+                   const std::string &error);
 
-Json::Value readJsonFile(const std::string& filename, const std::string& error);
+Json::Value readJsonFile(const std::string &filename, const std::string &error);
 
-void writeStringFile(const std::string& filename, const std::string& stringToWrite, const std::string& error);
+void writeStringFile(const std::string &filename,
+                     const std::string &stringToWrite,
+                     const std::string &error);
 
-bool fileExists(const std::string& filename);
+bool fileExists(const std::string &filename);
 
 /** Implementation of Mantid::API::ScriptRepository
 

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -19,11 +19,13 @@
 namespace Mantid {
 namespace API {
 
-void write_json_file(std::string filename, Json::Value json, std::string error);
+void writeJsonFile(const std::string& filename, Json::Value json, const std::string& error);
 
-void write_string_file(std::string filename, std::string strToWrite, std::string error);
+Json::Value readJsonFile(const std::string& filename, const std::string& error);
 
-bool file_exists(std::string filename);
+void writeStringFile(const std::string& filename, const std::string& stringToWrite, const std::string& error);
+
+bool fileExists(const std::string& filename);
 
 /** Implementation of Mantid::API::ScriptRepository
 

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -21,6 +21,8 @@ namespace API {
 
 void write_json_file(std::string filename, Json::Value json, std::string error);
 
+void write_string_file(std::string filename, std::string strToWrite, std::string error);
+
 bool file_exists(std::string filename);
 
 /** Implementation of Mantid::API::ScriptRepository

--- a/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
+++ b/Framework/ScriptRepository/inc/MantidScriptRepository/ScriptRepositoryImpl.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/ScriptRepository.h"
 #include "MantidKernel/DateAndTime.h"
 #include <map>
+#include <json/value.h>
 
 #ifdef _WIN32
 #if (IN_MANTID_SCRIPTREPO)
@@ -17,6 +18,10 @@
 
 namespace Mantid {
 namespace API {
+
+void write_json_file(std::string filename, Json::Value json, std::string error);
+
+bool file_exists(std::string filename);
 
 /** Implementation of Mantid::API::ScriptRepository
 

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1427,10 +1427,12 @@ void ScriptRepositoryImpl::parseCentralRepository(Repository &repo) {
     Json::Value pt =
         readJsonFile(filename, "Error reading .repository.json file");
 
-    // This is looping through the member name list rather than using Json::ValueIterator
-    // as a workaround for a bug in the JsonCpp library (Json::ValueIterator is not exported)
+    // This is looping through the member name list rather than using
+    // Json::ValueIterator
+    // as a workaround for a bug in the JsonCpp library (Json::ValueIterator is
+    // not exported)
     Json::Value::Members member_names = pt.getMemberNames();
-    for (unsigned int i=0; i<member_names.size(); ++i) {
+    for (unsigned int i = 0; i < member_names.size(); ++i) {
       std::string filepath = member_names[i];
       if (!isEntryValid(filepath))
         continue;
@@ -1490,9 +1492,14 @@ void ScriptRepositoryImpl::parseDownloadedEntries(Repository &repo) {
 
   try {
     Json::Value pt = readJsonFile(filename, "Error reading .local.json file");
-    for (auto it = pt.begin(); it != pt.end(); it++) {
 
-      std::string filepath = it.key().asString();
+    // This is looping through the member name list rather than using
+    // Json::ValueIterator
+    // as a workaround for a bug in the JsonCpp library (Json::ValueIterator is
+    // not exported)
+    Json::Value::Members member_names = pt.getMemberNames();
+    for (unsigned int i = 0; i < member_names.size(); ++i) {
+      std::string filepath = member_names[i];
       Json::Value entry_json = pt.get(filepath, "");
 
       entry_it = repo.find(filepath);
@@ -1506,8 +1513,10 @@ void ScriptRepositoryImpl::parseDownloadedEntries(Repository &repo) {
               DateAndTime(entry_json.get("downloaded_pubdate", "").asString());
           entry_it->second.downloaded_date =
               DateAndTime(entry_json.get("downloaded_date", "").asString());
+          std::string auto_update =
+              entry_json.get("auto_update", "false").asString();
           entry_it->second.auto_update =
-              entry_json.get("auto_update", false).asBool();
+              (auto_update == "true"); // get().asBool() fails here on OS X
 
         } else {
           // if the entry was not found locally or remotely, this means
@@ -1598,6 +1607,7 @@ void ScriptRepositoryImpl::updateLocalJson(const std::string &path,
         entry.downloaded_pubdate.toFormattedString();
     replace_entry["auto_update"] = ((entry.auto_update) ? "true" : "false");
 
+    // Replace existing entry for this file
     local_json.removeMember(path);
     local_json[path] = replace_entry;
   }

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -89,6 +89,19 @@ void write_json_file(std::string filename, Json::Value json, std::string error)
 }
 
 /**
+Write string to file
+*/
+void write_string_file(std::string filename, std::string strToWrite, std::string error)
+{
+  Poco::FileStream filestream(filename);
+  if (!filestream.good()) {
+    g_log.error() << error;
+  }
+  filestream << strToWrite;
+  filestream.close();
+}
+
+/**
 Test if a file with this filename already exists
 */
 bool file_exists(std::string filename)
@@ -302,8 +315,7 @@ void ScriptRepositoryImpl::install(const std::string &path) {
   // creation of the instance of local_json file
   if (!file_exists(local_json_file))
   {
-    Json::Value pt;
-    write_json_file(local_json_file, pt,
+    write_string_file(local_json_file, "{\n}",
                     "ScriptRepository failed to create local repository");
     g_log.debug() << "ScriptRepository created the local repository information"
     << std::endl;

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -1427,8 +1427,11 @@ void ScriptRepositoryImpl::parseCentralRepository(Repository &repo) {
     Json::Value pt =
         readJsonFile(filename, "Error reading .repository.json file");
 
-    for (auto it = pt.begin(); it != pt.end(); it++) {
-      std::string filepath = it.key().asString();
+    // This is looping through the member name list rather than using Json::ValueIterator
+    // as a workaround for a bug in the JsonCpp library (Json::ValueIterator is not exported)
+    Json::Value::Members member_names = pt.getMemberNames();
+    for (unsigned int i=0; i<member_names.size(); ++i) {
+      std::string filepath = member_names[i];
       if (!isEntryValid(filepath))
         continue;
       Json::Value entry_json = pt.get(filepath, "");

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -49,15 +49,11 @@ using Mantid::Kernel::NetworkProxy;
 #include <Poco/DateTimeFormatter.h>
 
 // from boost
-#include <boost/property_tree/ptree.hpp>
-#include <boost/property_tree/json_parser.hpp>
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 
 #include <json/json.h>
-
-using boost::property_tree::ptree;  // Todo remove once using jsoncpp, plus boost ptree includes
 
 namespace Mantid {
 namespace API {

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -73,8 +73,8 @@ const char *emptyURL =
 /**
 Write json object to file
 */
-void writeJsonFile(const std::string& filename, Json::Value json, const std::string& error)
-{
+void writeJsonFile(const std::string &filename, Json::Value json,
+                   const std::string &error) {
   Poco::FileOutputStream filestream(filename);
   if (!filestream.good()) {
     g_log.error() << error << std::endl;
@@ -87,8 +87,8 @@ void writeJsonFile(const std::string& filename, Json::Value json, const std::str
 /**
 Read json object from file
 */
-Json::Value readJsonFile(const std::string& filename, const std::string& error)
-{
+Json::Value readJsonFile(const std::string &filename,
+                         const std::string &error) {
   Poco::FileInputStream filestream(filename);
   if (!filestream.good()) {
     g_log.error() << error << std::endl;
@@ -102,8 +102,9 @@ Json::Value readJsonFile(const std::string& filename, const std::string& error)
 /**
 Write string to file
 */
-void writeStringFile(const std::string& filename, const std::string& stringToWrite, const std::string& error)
-{
+void writeStringFile(const std::string &filename,
+                     const std::string &stringToWrite,
+                     const std::string &error) {
   Poco::FileStream filestream(filename);
   if (!filestream.good()) {
     g_log.error() << error << std::endl;
@@ -115,8 +116,7 @@ void writeStringFile(const std::string& filename, const std::string& stringToWri
 /**
 Test if a file with this filename already exists
 */
-bool fileExists(const std::string& filename)
-{
+bool fileExists(const std::string &filename) {
   Poco::File test_file(filename);
   if (test_file.exists()) {
     return true;
@@ -324,12 +324,11 @@ void ScriptRepositoryImpl::install(const std::string &path) {
   g_log.debug() << "ScriptRepository downloaded repository information"
                 << std::endl;
   // creation of the instance of local_json file
-  if (!fileExists(local_json_file))
-  {
+  if (!fileExists(local_json_file)) {
     writeStringFile(local_json_file, "{\n}",
                     "ScriptRepository failed to create local repository");
     g_log.debug() << "ScriptRepository created the local repository information"
-    << std::endl;
+                  << std::endl;
   }
 
 #if defined(_WIN32) || defined(_WIN64)
@@ -942,8 +941,9 @@ void ScriptRepositoryImpl::updateRepositoryJson(const std::string &path,
 
   Json::Value repository_json;
   std::string filename =
-  std::string(local_repository).append(".repository.json");
-  repository_json = readJsonFile(filename, "Error reading .repository.json file");
+      std::string(local_repository).append(".repository.json");
+  repository_json =
+      readJsonFile(filename, "Error reading .repository.json file");
 
   if (!repository_json.isMember(path)) {
     // Create Json value for entry
@@ -962,7 +962,8 @@ void ScriptRepositoryImpl::updateRepositoryJson(const std::string &path,
   // set the .repository.json and .local.json not hidden to be able to edit it
   SetFileAttributes(filename.c_str(), FILE_ATTRIBUTE_NORMAL);
 #endif
-  writeJsonFile(filename, repository_json, "Error writing .repository.json file");
+  writeJsonFile(filename, repository_json,
+                "Error writing .repository.json file");
 #if defined(_WIN32) || defined(_WIN64)
   // set the .repository.json and .local.json hidden
   SetFileAttributes(filename.c_str(), FILE_ATTRIBUTE_HIDDEN);
@@ -1095,7 +1096,8 @@ void ScriptRepositoryImpl::remove(const std::string &file_path,
       std::string filename =
           std::string(local_repository).append(".repository.json");
 
-      Json::Value pt = readJsonFile(filename, "Error reading .repository.json file");
+      Json::Value pt =
+          readJsonFile(filename, "Error reading .repository.json file");
       pt.removeMember(relative_path); // remove the entry
 #if defined(_WIN32) || defined(_WIN64)
       // set the .repository.json and .local.json not hidden (to be able to
@@ -1422,9 +1424,10 @@ void ScriptRepositoryImpl::parseCentralRepository(Repository &repo) {
   std::string filename =
       std::string(local_repository).append(".repository.json");
   try {
-    Json::Value pt = readJsonFile(filename, "Error reading .repository.json file");
+    Json::Value pt =
+        readJsonFile(filename, "Error reading .repository.json file");
 
-    for( auto it = pt.begin() ; it != pt.end() ; it++ ) {
+    for (auto it = pt.begin(); it != pt.end(); it++) {
       std::string filepath = it.key().asString();
       if (!isEntryValid(filepath))
         continue;
@@ -1484,7 +1487,7 @@ void ScriptRepositoryImpl::parseDownloadedEntries(Repository &repo) {
 
   try {
     Json::Value pt = readJsonFile(filename, "Error reading .local.json file");
-    for( auto it = pt.begin() ; it != pt.end() ; it++ ) {
+    for (auto it = pt.begin(); it != pt.end(); it++) {
 
       std::string filepath = it.key().asString();
       Json::Value entry_json = pt.get(filepath, "");
@@ -1569,14 +1572,16 @@ void ScriptRepositoryImpl::updateLocalJson(const std::string &path,
                                            const RepositoryEntry &entry) {
 
   std::string filename = std::string(local_repository).append(".local.json");
-  Json::Value local_json = readJsonFile(filename, "Error reading .local.json file");
+  Json::Value local_json =
+      readJsonFile(filename, "Error reading .local.json file");
 
   if (!local_json.isMember(path)) {
 
     // Create new entry
     Json::Value new_entry;
     new_entry["downloaded_date"] = entry.downloaded_date.toFormattedString();
-    new_entry["downloaded_pubdate"] = entry.downloaded_pubdate.toFormattedString();
+    new_entry["downloaded_pubdate"] =
+        entry.downloaded_pubdate.toFormattedString();
 
     // Add new entry to repository json value
     local_json[path] = new_entry;
@@ -1584,8 +1589,10 @@ void ScriptRepositoryImpl::updateLocalJson(const std::string &path,
   } else {
 
     Json::Value replace_entry;
-    replace_entry["downloaded_date"] = entry.downloaded_date.toFormattedString();
-    replace_entry["downloaded_pubdate"] = entry.downloaded_pubdate.toFormattedString();
+    replace_entry["downloaded_date"] =
+        entry.downloaded_date.toFormattedString();
+    replace_entry["downloaded_pubdate"] =
+        entry.downloaded_pubdate.toFormattedString();
     replace_entry["auto_update"] = ((entry.auto_update) ? "true" : "false");
 
     local_json.removeMember(path);


### PR DESCRIPTION
Closes #13729 

Changes required were replacing `boost::unordered_map` with `std::unordered_map` and using `JsonCpp` instead of `boost::property_tree`.

**For tester:**
Extensive changes to the script repository code were required.

The script repository can be tested with the test (sandbox) repository by putting the following lines in your Mantid.user.properties file:
`UploaderWebServer=http://upload.mantidproject.org/scriptrepository/payload/publish_debug`
`ScriptRepository=http://download.mantidproject.org/dev-scriptrepository/`

Having set this, start the script repository with File->Script Repository in MantidPlot and select any empty directory when prompted to create a local repository.

I suggest uploading a file, deleting a file, editing a file locally etc. After each change, hit "Reload" in the repository window and check that the file status makes sense.

Here is the [Windows Installer](http://builds.mantidproject.org/job/pull_requests-win7/3364/artifact/build/mantid-3.5.20151021.1034-win64.exe) package for the build.
