### PR TITLE
IDA  progress tracking

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -326,7 +326,8 @@ void PlotPeakByLogValue::exec() {
       row << chi2;
 
       Prog += dProg;
-      progress(Prog);
+	  std::string current = boost::lexical_cast<std::string>(i);
+	  progress(Prog, ("Fitting Workspace: (" + current + ") - "));
       interruption_point();
 
       if (individual) {

--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -326,8 +326,8 @@ void PlotPeakByLogValue::exec() {
       row << chi2;
 
       Prog += dProg;
-	  std::string current = boost::lexical_cast<std::string>(i);
-	  progress(Prog, ("Fitting Workspace: (" + current + ") - "));
+      std::string current = boost::lexical_cast<std::string>(i);
+      progress(Prog, ("Fitting Workspace: (" + current + ") - "));
       interruption_point();
 
       if (individual) {

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -194,7 +194,7 @@ void ConvolutionFitSequential::exec() {
     std::string nextWs = tempFitWsName + ",i";
     nextWs += boost::lexical_cast<std::string>(i);
     plotPeakInput += nextWs + ";";
-    plotPeakStringProg.report();
+    plotPeakStringProg.report("Constructing PlotPeak name");
   }
 
   // passWSIndex
@@ -227,12 +227,12 @@ void ConvolutionFitSequential::exec() {
   deleter->setProperty("WorkSpace",
                        outputWsName + "_NormalisedCovarianceMatrices");
   deleter->executeAsChildAlg();
-  deleteProgress.report();
+  deleteProgress.report("Deleting PlotPeak Output");
 
   deleter = createChildAlgorithm("DeleteWorkspace");
   deleter->setProperty("WorkSpace", outputWsName + "_Parameters");
   deleter->executeAsChildAlg();
-  deleteProgress.report();
+  deleteProgress.report("Deleting PlotPeak Output");
 
   std::string paramTableName = outputWsName + "_Parameters";
   AnalysisDataService::Instance().add(paramTableName, outputWs);
@@ -251,7 +251,7 @@ void ConvolutionFitSequential::exec() {
     }
     for (size_t i = 0; i < func->nParams(); i++) {
       paramNames.push_back(func->parameterName(i));
-      workflowProg.report();
+      workflowProg.report("Finding parameters to process");
     }
     if (funcName.compare("Lorentzian") == 0) {
       // remove peak centre
@@ -268,7 +268,7 @@ void ConvolutionFitSequential::exec() {
     calculateEISF(outputWs);
   }
 
-  // Construct comma separated list for ProcessIndirectFirParameters
+  // Construct comma separated list for ProcessIndirectFitParameters
   std::string paramNamesList = "";
   const size_t maxNames = paramNames.size();
   for (size_t i = 0; i < maxNames; i++) {
@@ -276,7 +276,7 @@ void ConvolutionFitSequential::exec() {
     if (i != (maxNames - 1)) {
       paramNamesList += ",";
     }
-    workflowProg.report();
+    workflowProg.report("Constructing indirectFitParams input");
   }
 
   // Run ProcessIndirectFitParameters
@@ -319,7 +319,7 @@ void ConvolutionFitSequential::exec() {
     logAdder->setProperty("LogText", it->second);
     logAdder->setProperty("LogType", "String");
     logAdder->executeAsChildAlg();
-    logAdderProg.report();
+    logAdderProg.report("Add text logs");
   }
 
   // Add Numeric Logs
@@ -329,7 +329,7 @@ void ConvolutionFitSequential::exec() {
     logAdder->setProperty("LogText", it->second);
     logAdder->setProperty("LogType", "Number");
     logAdder->executeAsChildAlg();
-    logAdderProg.report();
+    logAdderProg.report("Adding Numerical logs");
   }
   // Copy Logs to GroupWorkspace
   logCopier = createChildAlgorithm("CopyLogs", 0.97, 0.98, true);
@@ -352,7 +352,7 @@ void ConvolutionFitSequential::exec() {
     outName += "_Workspace";
     renamer->setProperty("OutputWorkspace", outName);
     renamer->executeAsChildAlg();
-    renamerProg.report();
+    renamerProg.report("Renaming group workspaces");
   }
 
   AnalysisDataService::Instance().addOrReplace(resultWsName, resultWs);

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -93,7 +93,9 @@ void ProcessIndirectFitParameters::exec() {
   // ignoring their function index and output them to a workspace
   auto workspaceNames = std::vector<std::vector<std::string>>();
   const size_t totalNames = parameterNames.size();
+  Progress tblSearchProg = Progress(this, 0.0, 0.5, totalNames * 2);
   for (size_t i = 0; i < totalNames; i++) {
+	tblSearchProg.report("Splitting table into relevant columns");
     auto const allColumnNames = inputWs->getColumnNames();
     auto columns = searchForFitParams(parameterNames.at(i), allColumnNames);
     auto errColumns =
@@ -107,7 +109,7 @@ void ProcessIndirectFitParameters::exec() {
     auto convertToMatrix =
         createChildAlgorithm("ConvertTableToMatrixWorkspace", -1, -1, true);
     convertToMatrix->setAlwaysStoreInADS(true);
-
+	tblSearchProg.report("Converting Column to Matrix");
     for (size_t j = 0; j < min; j++) {
       convertToMatrix->setProperty("InputWorkspace", inputWs);
       convertToMatrix->setProperty("ColumnX", xColumn);
@@ -120,9 +122,11 @@ void ProcessIndirectFitParameters::exec() {
     workspaceNames.push_back(paramWorkspaces);
   }
 
+  Progress workflowProg = Progress(this, 0.5, 1.0, 10);
   // Transpose list of workspaces, ignoring unequal length of lists
   // this handles the case where a parameter occurs only once in the whole
   // workspace
+  workflowProg.report("Reordering workspace vector");
   workspaceNames = reorder2DVector(workspaceNames);
 
   // Join all the parameters for each peak into a single workspace per peak
@@ -134,6 +138,7 @@ void ProcessIndirectFitParameters::exec() {
   for (size_t j = 0; j < wsMax; j++) {
     std::string tempPeakWs = workspaceNames.at(j).at(0);
     const size_t paramMax = workspaceNames.at(j).size();
+	workflowProg.report("Conjoining matrix workspaces");
     for (size_t k = 1; k < paramMax; k++) {
       auto paramWs = workspaceNames.at(j).at(k);
       conjoin->setProperty("InputWorkspace1", tempPeakWs);
@@ -147,6 +152,7 @@ void ProcessIndirectFitParameters::exec() {
   // Join all peaks into a single workspace
   std::string tempWorkspace = tempWorkspaces.at(0);
   for (auto it = tempWorkspaces.begin() + 1; it != tempWorkspaces.end(); ++it) {
+	workflowProg.report("Joining peak workspaces");
     conjoin->setProperty("InputWorkspace1", tempWorkspace);
     conjoin->setProperty("InputWorkspace2", *it);
     conjoin->executeAsChildAlg();
@@ -154,6 +160,7 @@ void ProcessIndirectFitParameters::exec() {
   }
 
   // Rename the workspace to the specified outputName
+  workflowProg.report("Renaming Workspace");
   auto renamer = createChildAlgorithm("RenameWorkspace", -1, -1, true);
   renamer->setProperty("InputWorkspace", tempWorkspace);
   renamer->setProperty("OutputWorkspace", outputWsName);
@@ -162,6 +169,7 @@ void ProcessIndirectFitParameters::exec() {
   auto outputWs = boost::dynamic_pointer_cast<MatrixWorkspace>(renameWs);
 
   // Replace axis on workspaces with text axis
+  workflowProg.report("Converting text axis");
   auto axis = new TextAxis(outputWs->getNumberHistograms());
   size_t offset = 0;
   for (size_t j = 0; j < workspaceNames.size(); j++) {
@@ -173,6 +181,7 @@ void ProcessIndirectFitParameters::exec() {
   }
   outputWs->replaceAxis(1, axis);
 
+  workflowProg.report("Setting unit");
   // Set units for the xAxis
   if (xUnit.compare("") != 0) {
     outputWs->getAxis(0)->setUnit(xUnit);

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -95,7 +95,7 @@ void ProcessIndirectFitParameters::exec() {
   const size_t totalNames = parameterNames.size();
   Progress tblSearchProg = Progress(this, 0.0, 0.5, totalNames * 2);
   for (size_t i = 0; i < totalNames; i++) {
-	tblSearchProg.report("Splitting table into relevant columns");
+    tblSearchProg.report("Splitting table into relevant columns");
     auto const allColumnNames = inputWs->getColumnNames();
     auto columns = searchForFitParams(parameterNames.at(i), allColumnNames);
     auto errColumns =
@@ -109,7 +109,7 @@ void ProcessIndirectFitParameters::exec() {
     auto convertToMatrix =
         createChildAlgorithm("ConvertTableToMatrixWorkspace", -1, -1, true);
     convertToMatrix->setAlwaysStoreInADS(true);
-	tblSearchProg.report("Converting Column to Matrix");
+    tblSearchProg.report("Converting Column to Matrix");
     for (size_t j = 0; j < min; j++) {
       convertToMatrix->setProperty("InputWorkspace", inputWs);
       convertToMatrix->setProperty("ColumnX", xColumn);
@@ -138,7 +138,7 @@ void ProcessIndirectFitParameters::exec() {
   for (size_t j = 0; j < wsMax; j++) {
     std::string tempPeakWs = workspaceNames.at(j).at(0);
     const size_t paramMax = workspaceNames.at(j).size();
-	workflowProg.report("Conjoining matrix workspaces");
+    workflowProg.report("Conjoining matrix workspaces");
     for (size_t k = 1; k < paramMax; k++) {
       auto paramWs = workspaceNames.at(j).at(k);
       conjoin->setProperty("InputWorkspace1", tempPeakWs);
@@ -152,7 +152,7 @@ void ProcessIndirectFitParameters::exec() {
   // Join all peaks into a single workspace
   std::string tempWorkspace = tempWorkspaces.at(0);
   for (auto it = tempWorkspaces.begin() + 1; it != tempWorkspaces.end(); ++it) {
-	workflowProg.report("Joining peak workspaces");
+    workflowProg.report("Joining peak workspaces");
     conjoin->setProperty("InputWorkspace1", tempWorkspace);
     conjoin->setProperty("InputWorkspace2", *it);
     conjoin->executeAsChildAlg();


### PR DESCRIPTION
Fixes #13982

Indirect Data Analysis tab should now have progress tracking in:
- Iqt
- ConvFit
# To Test (General)
- For testing these, the relevant files are:
  - Sample=`irs26176_graphite002_red.nxs`
  - Resolution=`irs26173_graphite002_res.nxs`
  - These are both available from the External Data folder
# To Test (ConvFit)
- Open ConvFit (Interfaces > Indirect > Data Analysis >  ConvFit)
- Add the sample and resolution files
- Change the fit type to Two Lorentzian in the drop down menu (one of the longer algorithm - easier to see progress tracking)
- Click `Run`
- Ensure progress tracking runs smoothly in the bottom right corner with labels
# To Test (Iqt)
- Open Iqt (Interfaces > Indirect > Data Analysis > Iqt)
- Add the sample and resolution files
- Click `Run`
- Ensure progress tracking runs smoothly in the bottom right corner with labels
