### PR TITLE
Find correct QMin and QMax values for stitching plots in Reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -794,7 +794,6 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                             if self.tableMain.item(row, self.scale_col).text():
                                 Scale(InputWorkspace=wksp[i], OutputWorkspace=wksp[i], Factor=1 / float(self.tableMain.item(row, self.scale_col).text()))
                             if self.__checked_row_stiched(row):
-                                print 'iterator i has a value of : ', i, '\n'
                                 if len(runno) == 1:
                                     logger.notice("Nothing to combine for processing row : " + str(row))
                                 else:
@@ -813,16 +812,13 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                                     Qmax = max(w2.readX(0))
                                     if len(self.tableMain.item(row, i * 5 + 3).text()) > 0:
                                         Qmin = float(self.tableMain.item(row, i * 5 + 3).text())
-                                        if (Qmin < _overallQMin) :
-                                            print 'QMin Changed.'
-                                            _overallQMin = Qmin
-
                                     if len(self.tableMain.item(row, i * 5 + 4).text()) > 0:
                                         Qmax = float(self.tableMain.item(row, i * 5 + 4).text())
-                                        if (Qmax > _overallQMax):
-                                            print 'QMax Changed.'
-                                            _overallQMax = Qmax
-                                
+                                    if Qmax > _overallQMax:
+                                        _overallQMax = Qmax
+                                    if Qmin < _overallQMin :
+                                        _overallQMin = Qmin
+
                                     wcomb = combineDataMulti(wksp, outputwksp, overlapLow, overlapHigh, _overallQMin, _overallQMax, -dqq, 1, keep=True)
 
 

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -5,7 +5,6 @@ import refl_save
 import refl_choose_col
 import refl_options
 import csv
-import string
 import os
 import re
 from operator import itemgetter
@@ -819,7 +818,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                                     if Qmin < _overallQMin :
                                         _overallQMin = Qmin
 
-                                    wcomb = combineDataMulti(wksp, outputwksp, overlapLow, overlapHigh, _overallQMin, _overallQMax, -dqq, 1, keep=True)
+                                    _wcomb = combineDataMulti(wksp, outputwksp, overlapLow, overlapHigh, _overallQMin, _overallQMax, -dqq, 1, keep=True)
 
 
                         # Enable the plot button

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -672,6 +672,8 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         Process has been pressed, check what has been selected then pass the selection (or whole table) to quick
         """
 #--------- If "Process" button pressed, convert raw files to IvsLam and IvsQ and combine if checkbox ticked -------------
+        _overallQMin = float("inf")
+        _overallQMax = float("-inf")
         try:
             willProcess = True
             rows = self.tableMain.selectionModel().selectedRows()
@@ -760,7 +762,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
 
                         # Populate runlist
                         first_wq = None
-                        for i in range(len(runno)):
+                        for i in range(0,len(runno)):
                             theta, qmin, qmax, wlam, wq = self._do_run(runno[i], row, i)
                             if not first_wq:
                                 first_wq = wq # Cache the first Q workspace
@@ -791,32 +793,37 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                             #Scale each run
                             if self.tableMain.item(row, self.scale_col).text():
                                 Scale(InputWorkspace=wksp[i], OutputWorkspace=wksp[i], Factor=1 / float(self.tableMain.item(row, self.scale_col).text()))
-
-                        if self.__checked_row_stiched(row):
-                            if len(runno) == 1:
-                                logger.notice("Nothing to combine for processing row : " + str(row))
-                            else:
-                                w1 = getWorkspace(wksp[0])
-                                w2 = getWorkspace(wksp[-1])
-                                if len(runno) == 2:
-                                    outputwksp = runno[0] + '_' + runno[1][3:5]
+                            if self.__checked_row_stiched(row):
+                                print 'iterator i has a value of : ', i, '\n'
+                                if len(runno) == 1:
+                                    logger.notice("Nothing to combine for processing row : " + str(row))
                                 else:
-                                    outputwksp = runno[0] + '_' + runno[-1][3:5]
-                                begoverlap = w2.readX(0)[0]
-                                # get Qmax
-                                if self.tableMain.item(row, i * 5 + 4).text() == '':
-                                    overlapHigh = 0.3 * max(w1.readX(0))
+                                    w1 = getWorkspace(wksp[0])
+                                    w2 = getWorkspace(wksp[-1])
+                                    if len(runno) == 2:
+                                        outputwksp = runno[0] + '_' + runno[1][3:5]
+                                    else:
+                                        outputwksp = runno[0] + '_' + runno[-1][3:5]
+                                    begoverlap = w2.readX(0)[0]
+                                    # get Qmax
+                                    if self.tableMain.item(row, i * 5 + 4).text() == '':
+                                        overlapHigh = 0.3 * max(w1.readX(0))
 
-                                Qmin = min(w1.readX(0))
-                                Qmax = max(w2.readX(0))
+                                    Qmin = min(w1.readX(0))
+                                    Qmax = max(w2.readX(0))
+                                    if len(self.tableMain.item(row, i * 5 + 3).text()) > 0:
+                                        Qmin = float(self.tableMain.item(row, i * 5 + 3).text())
+                                        if (Qmin < _overallQMin) :
+                                            print 'QMin Changed.'
+                                            _overallQMin = Qmin
 
-                                if len(self.tableMain.item(row, i * 5 + 3).text()) > 0:
-                                    Qmin = float(self.tableMain.item(row, i * 5 + 3).text())
-
-                                if len(self.tableMain.item(row, i * 5 + 4).text()) > 0:
-                                    Qmax = float(self.tableMain.item(row, i * 5 + 4).text())
-
-                                wcomb = combineDataMulti(wksp, outputwksp, overlapLow, overlapHigh, Qmin, Qmax, -dqq, 1, keep=True)
+                                    if len(self.tableMain.item(row, i * 5 + 4).text()) > 0:
+                                        Qmax = float(self.tableMain.item(row, i * 5 + 4).text())
+                                        if (Qmax > _overallQMax):
+                                            print 'QMax Changed.'
+                                            _overallQMax = Qmax
+                                
+                                    wcomb = combineDataMulti(wksp, outputwksp, overlapLow, overlapHigh, _overallQMin, _overallQMax, -dqq, 1, keep=True)
 
 
                         # Enable the plot button


### PR DESCRIPTION
Fixes #14058

Previously the values for QMin and QMax were extracted from the table using an offset to find the correct column for QMin and QMax values. The iterative part of the offset was never being increased as the code for calculating the extents was outside of the for loop that the iterator was associated with.
