### PR TITLE
Give more appropriate run number in stitched workspace names for SURF in Reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -799,9 +799,9 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                                     w1 = getWorkspace(wksp[0])
                                     w2 = getWorkspace(wksp[-1])
                                     if len(runno) == 2:
-                                        outputwksp = runno[0] + '_' + runno[1][3:5]
+                                        outputwksp = runno[0] + '_' + runno[1][3:]
                                     else:
-                                        outputwksp = runno[0] + '_' + runno[-1][3:5]
+                                        outputwksp = runno[0] + '_' + runno[-1][3:]
                                     begoverlap = w2.readX(0)[0]
                                     # get Qmax
                                     if self.tableMain.item(row, i * 5 + 4).text() == '':
@@ -906,9 +906,9 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         # Create and plot stitched outputs
         if self.__checked_row_stiched(row):
             if len(runno) == 2:
-                outputwksp = runno[0] + '_' + runno[1][3:5]
+                outputwksp = runno[0] + '_' + runno[1][3:]
             else:
-                outputwksp = runno[0] + '_' + runno[2][3:5]
+                outputwksp = runno[0] + '_' + runno[2][3:]
             if not getWorkspace(outputwksp, report_error=False):
                 # Stitching has not been done as part of processing, so we need to do it here.
                 wcomb = combineDataMulti(wkspBinned, outputwksp, overlapLow, overlapHigh, Qmin, Qmax, -dqq, 1, keep=True)


### PR DESCRIPTION
Fixes #13757

The workspace names for stitched workspaces consisted of the first run number of the stitched workspace and then the last two digits of the last workspace to be stitched.

For example:
stitching run `12345` and `12346` would result in a workspace name of `12345_46`.

For instruments that have been around a long time and have therefore accumulated a lot of runs (SURF), the numbers were shortened to the format above. `1234567` and `1234568` would become `1234567_68` which may cause some confusion. 

Now that the specific indexes used to fill in the suffix of the workspace name have not been limited, we should see that stitching `1234567` and `1234568` will be `1234567_568` 
## To Test:

**INTER**
- Load [INTER table](https://slack-files.com/T02J4MMEW-F0D0K3GSH-2a9900c4f2) into ISIS Reflectometry GUI (`interfaces>Reflectometry>ISISReflectometry`)
- Stitch runs together by ticking the `Stitch` checkbox
- Press `Process`
- Observe the output workspace names, there should be one with the format `<firstRunNumber>_<LastTwoDigitsOfSecondRunNumber>`

**SURF**
- Load [SURF table](https://slack-files.com/T02J4MMEW-F0D0KMN23-03b3ef0866) into ISIS Reflectometry GUI (`interfaces>Reflectometry>ISISReflectometry`)
- Stitch runs together by ticking the `Stitch` checkbox
- Press `Process`
- Observe the output workspace names, there should be one with the format `<firstRunNumber>_<LastThreeDigitsOfSecondRunNumber>`
## Release Notes:

TODO
