### PR TITLE
Option of using old SplineSmoothing algorithm

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -62,7 +62,7 @@ private:
   void exec();
 
   /// smooth a single spectrum of the workspace
-  void smoothSpectrum(int index, int maxBreaks);
+  void smoothSpectrum(int index);
 
   /// calculate derivatives for a single spectrum
   void calculateSpectrumDerivatives(int index, int order);
@@ -82,7 +82,7 @@ private:
 
   /// choose points to define a spline and smooth the data
   void selectSmoothingPoints(API::MatrixWorkspace_const_sptr inputWorkspace,
-                             size_t row, int maxBreaks);
+                             size_t row);
 
   /// calculate the spline based on the smoothing points chosen
   void calculateSmoothing(API::MatrixWorkspace_const_sptr inputWorkspace,

--- a/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
@@ -74,7 +74,7 @@ void SplineSmoothing::init() {
   auto numOfBreaks = boost::make_shared<BoundedValidator<int>>();
   numOfBreaks->setLower(0);
   declareProperty("MaxNumberOfBreaks", 0, numOfBreaks,
-                  "To set the positions of the break-points, default 10 "
+                  "To set the positions of the break-points, default 0 "
                   "equally spaced real values in interval 0.0 - 1.0");
 }
 

--- a/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
+++ b/Framework/CurveFitting/src/Algorithms/SplineSmoothing.cpp
@@ -73,7 +73,7 @@ void SplineSmoothing::init() {
 
   auto numOfBreaks = boost::make_shared<BoundedValidator<int>>();
   numOfBreaks->setLower(0);
-  declareProperty("MaxNumberOfBreaks", M_START_SMOOTH_POINTS, numOfBreaks,
+  declareProperty("MaxNumberOfBreaks", 0, numOfBreaks,
                   "To set the positions of the break-points, default 10 "
                   "equally spaced real values in interval 0.0 - 1.0");
 }
@@ -87,9 +87,6 @@ void SplineSmoothing::exec() {
   int histNo = static_cast<int>(m_inputWorkspace->getNumberHistograms());
   int order = static_cast<int>(getProperty("DerivOrder"));
 
-  // retrieving number of breaks
-  int maxBreaks = static_cast<int>(getProperty("MaxNumberOfBreaks"));
-
   m_inputWorkspacePointData = convertBinnedData(m_inputWorkspace);
   m_outputWorkspace = setupOutputWorkspace(m_inputWorkspacePointData, histNo);
 
@@ -100,7 +97,7 @@ void SplineSmoothing::exec() {
 
   Progress pgress(this, 0.0, 1.0, histNo);
   for (int i = 0; i < histNo; ++i) {
-    smoothSpectrum(i, maxBreaks);
+    smoothSpectrum(i);
     calculateSpectrumDerivatives(i, order);
     pgress.report();
   }
@@ -115,14 +112,13 @@ void SplineSmoothing::exec() {
 /** Smooth a single spectrum of the input workspace
  *
  * @param index :: index of the spectrum to smooth
- * @param maxBreaks :: the number to set the positions of the break-points
  */
-void SplineSmoothing::smoothSpectrum(int index, int maxBreaks) {
+void SplineSmoothing::smoothSpectrum(int index) {
   m_cspline = boost::make_shared<BSpline>();
   m_cspline->setAttributeValue("Uniform", false);
 
   // choose some smoothing points from input workspace
-  selectSmoothingPoints(m_inputWorkspacePointData, index, maxBreaks);
+  selectSmoothingPoints(m_inputWorkspacePointData, index);
   performAdditionalFitting(m_inputWorkspacePointData, index);
 
   // compare the data set against our spline
@@ -310,25 +306,34 @@ void SplineSmoothing::addSmoothingPoints(const std::set<int> &points,
  *
  * @param inputWorkspace :: The input workspace containing noisy data
  * @param row :: The row of spectra to use
- * @param maxBreaks :: the number to set the positions of the break-points
  */
 void SplineSmoothing::selectSmoothingPoints(
-    MatrixWorkspace_const_sptr inputWorkspace, size_t row, int maxBreaks) {
+    MatrixWorkspace_const_sptr inputWorkspace, size_t row) {
   std::set<int> smoothPts;
   const auto &xs = inputWorkspace->readX(row);
   const auto &ys = inputWorkspace->readY(row);
 
+  // retrieving number of breaks
+  int maxBreaks = static_cast<int>(getProperty("MaxNumberOfBreaks"));
+
   int xSize = static_cast<int>(xs.size());
-  // if retrienved value is default zero
-  if (maxBreaks == 0) {
-    setProperty("MaxNumberOfBreaks", xs.size());
-    maxBreaks = getProperty("MaxNumberOfBreaks");
-  }
-  // number of points to start with
-  int numSmoothPts(maxBreaks);
 
   // evenly space initial points over data set
-  int delta = xSize / numSmoothPts;
+  int delta;
+
+  // if retrieved value is default zero/default
+  bool incBreaks = false;
+
+  if (maxBreaks != 0) {
+    // number of points to start with
+    int numSmoothPts(maxBreaks);
+    delta = xSize / numSmoothPts;
+    // include maxBreaks when != 0
+    incBreaks = true;
+  } else {
+    int numSmoothPts(M_START_SMOOTH_POINTS);
+    delta = xSize / numSmoothPts;
+  }
 
   for (int i = 0; i < xSize; i += delta) {
     smoothPts.insert(i);
@@ -337,9 +342,17 @@ void SplineSmoothing::selectSmoothingPoints(
 
   bool resmooth(true);
   while (resmooth) {
-    // if we're using all points then we can't do anything more.
-    if (smoothPts.size() > (unsigned)(maxBreaks + 2))
-      break;
+
+    if (incBreaks) {
+      if (smoothPts.size() > (unsigned)(maxBreaks + 2)) {
+        break;
+      }
+
+    } else if (!incBreaks) {
+      if (smoothPts.size() >= xs.size() - 1) {
+        break;
+      }
+    }
 
     addSmoothingPoints(smoothPts, xs.data(), ys.data());
     resmooth = false;

--- a/docs/source/algorithms/SplineSmoothing-v1.rst
+++ b/docs/source/algorithms/SplineSmoothing-v1.rst
@@ -18,16 +18,21 @@ derivatives of each of the interpolated points as a side product.
 Setting the DerivOrder property to zero will force the algorithm to
 calculate no derivatives.
 
-The algorithm allows user to include number of breaking points which
-will enable the algorithm to execute functions with large number of
-spikes or noise. With the control of number of breaking points, user
-will be able to execute :ref:`SplineSmoothing <algm-SplineSmoothing-v1>`
-algorithm in small period of time. The lower breaking points number is
-set the faster algorithm will execute the function but it will not
-produce high quality smoothing function. By inserting high number of
-breaking points, a detailed smoothing function can also be produced.
+The algorithm provides user with an option of including number of
+breaking points which will enable the algorithm to execute functions
+with large number of spikes or noise. With the control of number of
+breaking points, user will be able to execute
+:ref:`SplineSmoothing <algm-SplineSmoothing-v1>` algorithm in small
+period of time. The lower breaking points number is set the faster
+algorithm will execute the function but it will not produce high
+quality smoothing function. By inserting high number of breaking points,
+a detailed smoothing function can also be produced. By not providing
+MaxNumberOfBreaks, the alogirthm will assume that user would like to
+execute the maximum number of breaks possible. This comes with a risk
+of alogirthm falling in to a very long loop.
 
-Users are also able to successfully apply the algorithm to a workspace
+By providing MaxNumberOfBreaks as a parameter, the users are also will
+be able to successfully and efficiently apply the algorithm to a workspace
 with multiple spectrums, which would generate an output of workspace
 with multiple spectrums of :ref:`SplineSmoothing <algm-SplineSmoothing-v1>`
 algorithm applied to it. `BSpline <http://www.mantidproject.org/BSpline>`_


### PR DESCRIPTION
Fixes #13869

Most of the workspaces are working better with the new implementation of the SplineSmoothing. However for some workspaces for example: [Stheta.nxs](https://files.slack.com/files-pri/T02J4MMEW-F0CTP03JT/download/stheta.nxs), the old `SplineSmoothing` algorithm seems to work better, hence there is now an option of leaving the default value for `MaxNumberOfBreaks` property _(0)_ and it will use the old algorithm and if any integer `> 0` provided for `MaxNumberOfBreaks` it will implement the updated `SplineSmoothing` algorithm.

**Test 1**
Load File ->  [`Stheta.nxs`](https://files.slack.com/files-pri/T02J4MMEW-F0CTP03JT/download/stheta.nxs)
Execute -> SplineSmoothing
InputWorkspace -> Stheta
OutputWorkspace -> outputSpline
**Make sure** `MaxNumberOfBreaks = 0` _the default value_
Click Right on workspace -> outputSpline
Select `Plot Spectrum...`
This should generate more accurate graph `Stheta.nxs`

**Test 2**
Load File -> `Testing/Data/DocTest/ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs`
Execute -> SplineSmoothing
InputWorkspace -> ENGINX_precalculated_vanadium_run000236516_bank_curves
OutputWorkspace -> outputSpline
**Make sure** `MaxNumberOfBreaks = 20`
Click Right on workspace -> outputSpline
Select `Plot Spectrum...`
Enter Workspace Indices: 0-2 -> `2`
This should plot a smooth accurate graph of `ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs`
