### PR TITLE
Added alias PermuteMD for algorithm TransposeMD

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/TransposeMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/TransposeMD.h
@@ -40,6 +40,8 @@ public:
   virtual const std::string category() const;
   virtual const std::string summary() const;
 
+  virtual const std::string alias() const { return "PermuteMD"; }
+
 private:
   void init();
   void exec();


### PR DESCRIPTION
Closes #14008 

Added "PermuteMD" as an alias for algorithm "TransposeMD", this will aid users switching from using Horace to Mantid.

**For Tester**
Typing "PermuteMD" into the algorithm search in MantidPlot should give "PermuteMD [TransposeMD]" as a result.
