### PR TITLE
Make CompactMD return the workspace if it is populated only by zero signal values

### DIFF
--- a/Framework/MDAlgorithms/test/CompactMDTest.h
+++ b/Framework/MDAlgorithms/test/CompactMDTest.h
@@ -233,7 +233,7 @@ public:
     alg.initialize();
     alg.setProperty("InputWorkspace", inWS);
     alg.setProperty("OutputWorkspace", "out");
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error &);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
   }
 };
 


### PR DESCRIPTION
Previously for CompactMD, if the calculated `min`/`max` extents for PBins were the same or `min > max`.The workspace was rejected and an exception was thrown by IntegrateMDHistoWorkspace. Now, when finding the `min`/`max` extents of a dimension, if `min >= max` for a particular dimension then the original Minimum and Maximum for that dimension will be substituted instead.
## To Test:
- Load an MDHistoWorkspace with all zero signal values into CompactMD (script below)
- Notice that no error is produced from using this workspace
- Check that the input workspace has the same extents in each dimension as the output from CompactMD

**starter script for zero-filled MDHistoWorkspace**
Feel free to play around with the creation of this workspace but signal values must be kept as 0 for all bins.

``` python
in_ws_for_compactMD = CreateMDHistoWorkspace(SignalInput='0,0,0,0', ErrorInput='1,1,1,1', Dimensionality=1, Extents='2,3', NumberOfBins='4', Names='test', Units='unitA', OutputWorkspace='in_ws')

compact_output = CompactMD(in_ws_for_compactMD)

```

Fixes #14032 
