### PR TITLE
ISIS Reduction does not change instrument

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init
+﻿#pylint: disable=no-init
 import stresstesting
 from mantid.simpleapi import *
 from mantid.api import Workspace
@@ -120,7 +120,7 @@ class MARIReductionFromFileCache(ISISDirectInelasticReduction):
       """
         self._counter+=1
         if self._counter == 2:
-            source =  FileFinder.findRuns('11001')[0]
+            source =  FileFinder.findRuns('MAR11001')[0]
             targ_path = config['defaultsave.directory']
             targ_file = os.path.join(targ_path,'MAR11002.nxs')
             shutil.copy2(source ,targ_file )
@@ -128,7 +128,7 @@ class MARIReductionFromFileCache(ISISDirectInelasticReduction):
         if self._counter>= 3:
             if os.path.exists(self._file_to_clear):
                 os.remove(self._file_to_clear)
-            source =  FileFinder.findRuns('11001')[0]
+            source =  FileFinder.findRuns('MAR11001')[0]
             targ_path = config['defaultsave.directory']
             targ_file = os.path.join(targ_path,'MAR11002.raw')
             shutil.copy2(source ,targ_file )

--- a/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
@@ -310,7 +310,7 @@ class MARIReductionWaitAndSum(ISISDirectInelasticReduction):
       """
         self._counter+=1
         if self._counter>= 3:
-            source =  FileFinder.findRuns('11015')[0]
+            source =  FileFinder.findRuns('MAR11015')[0]
             targ_path = config['defaultsave.directory']
             targ_file = os.path.join(targ_path,'MAR11002.raw')
             shutil.copy2(source ,targ_file )

--- a/Testing/SystemTests/tests/analysis/ISIS_LETReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_LETReduction.py
@@ -1,7 +1,5 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 """ Sample LET reduction script """
-#os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
-
 
 from Direct.ReductionWrapper import *
 try:
@@ -20,6 +18,8 @@ def find_binning_range(energy,ebin):
     """
 
     InstrName =  config['default.instrument'][0:3]
+    if not InstrName in ['MER','LET']:
+        InstrName = 'LET'
     if InstrName.find('LET')>-1:
         ls  =25
         lm2 =23.5

--- a/Testing/SystemTests/tests/analysis/ISIS_MariReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_MariReduction.py
@@ -186,7 +186,7 @@ class ReduceMARIMon2Norm(ReductionWrapper):
       # MARI calibration uses one of data files defined on instrument.  Here
       # vanadium run is used for calibration
       # TODO: Why not workspace?, check it
-        prop['det_cal_file'] = "11060"
+        prop['det_cal_file'] = "MAR11060.raw"
         prop['save_format'] = []
         return prop
       #
@@ -301,12 +301,12 @@ class ReduceMARIMonitorsSeparate(ReductionWrapper):
 if __name__ == "__main__":
 
     data_root = r'd:\Data\MantidDevArea\Datastore\DataCopies'
-    data_dir = os.path.join(data_root,r'Testing\Data\SystemTest')
-    ref_data_dir = os.path.join(data_root,r'Testing\SystemTests\tests\analysis\reference')
-    result_dir = r'd:/Data/Mantid_Testing/14_12_15'
-    config.setDataSearchDirs('{0};{1};{2}'.format(data_dir,ref_data_dir,result_dir))
+    #data_dir = os.path.join(data_root,r'Testing\Data\SystemTest')
+    #ref_data_dir = os.path.join(data_root,r'Testing\SystemTests\tests\analysis\reference')
+    #result_dir = r'd:/Data/Mantid_Testing/14_12_15'
+    #config.setDataSearchDirs('{0};{1};{2}'.format(data_dir,ref_data_dir,result_dir))
     #config.appendDataSearchDir('d:/Data/Mantid_GIT/Test/AutoTestData')
-    config['defaultsave.directory'] = result_dir # folder to save resulting spe/nxspe files.  Defaults are in
+    #config['defaultsave.directory'] = result_dir # folder to save resulting spe/nxspe files.  Defaults are in
 
     # execute stuff from Mantid
     #rd = ReduceMARIFromFile()

--- a/Testing/SystemTests/tests/analysis/ISIS_MariReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_MariReduction.py
@@ -309,8 +309,8 @@ if __name__ == "__main__":
     #config['defaultsave.directory'] = result_dir # folder to save resulting spe/nxspe files.  Defaults are in
 
     # execute stuff from Mantid
-    #rd = ReduceMARIFromFile()
-    rd= ReduceMARIMon2Norm()
+    rd = ReduceMARIFromFile()
+    #rd= ReduceMARIMon2Norm()
     #rd = ReduceMARIMonitorsSeparate()
     #rd = ReduceMARIFromWorkspace()
     rd.def_advanced_properties()

--- a/scripts/Inelastic/Direct/NonIDF_Properties.py
+++ b/scripts/Inelastic/Direct/NonIDF_Properties.py
@@ -171,7 +171,7 @@ class NonIDF_Properties(object):
 
             elif isinstance(Instrument,str): # instrument name defined
                 new_name,full_name,facility_ = prop_helpers.check_instrument_name(None,Instrument)
-                idf_dir = config.getString('instrumentDefinitgeton.directory')
+                #idf_dir = config.getString('instrumentDefinitgeton.directory')
                 idf_file = api.ExperimentInfo.getInstrumentFilename(full_name)
                 tmp_ws_name = '__empty_' + full_name
                 if not mtd.doesExist(tmp_ws_name):

--- a/scripts/Inelastic/Direct/NonIDF_Properties.py
+++ b/scripts/Inelastic/Direct/NonIDF_Properties.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 from Direct.PropertiesDescriptors import *
 from Direct.RunDescriptor import RunDescriptor,RunDescriptorDependent
 
@@ -165,13 +165,13 @@ class NonIDF_Properties(object):
                 except KeyError: # the instrument pointer is not found in any facility but we have it after all
                     new_name = instr_name
                     full_name = instr_name
-                    facility_ = 'TEST'
+                    facility_ = config.getFacility('TEST_LIVE')
                 #end
 
 
             elif isinstance(Instrument,str): # instrument name defined
                 new_name,full_name,facility_ = prop_helpers.check_instrument_name(None,Instrument)
-                idf_dir = config.getString('instrumentDefinition.directory')
+                idf_dir = config.getString('instrumentDefinitgeton.directory')
                 idf_file = api.ExperimentInfo.getInstrumentFilename(full_name)
                 tmp_ws_name = '__empty_' + full_name
                 if not mtd.doesExist(tmp_ws_name):

--- a/scripts/Inelastic/Direct/PropertiesDescriptors.py
+++ b/scripts/Inelastic/Direct/PropertiesDescriptors.py
@@ -6,7 +6,9 @@
 
 import os
 from mantid.simpleapi import *
+#pylint: disable=unused-import
 from mantid.kernel import funcreturns
+#pylint: disable=unused-import
 from mantid import api,geometry,config
 import numpy as np
 
@@ -564,7 +566,7 @@ class DetCalFile(PropDescriptor):
         if isinstance(self._det_cal_file,api.Workspace):
         # nothing to do.  Workspace used for calibration
             return (True,'Workspace {0} used for detectors calibration'.format(self._det_cal_file.name()))
- 
+
         dcf_val = self._det_cal_file
         if isinstance(dcf_val,str): # it may be string representation of runN
             try:
@@ -607,7 +609,7 @@ class MapMaskFile(PropDescriptor):
         if not doc_string is None:
             self.__doc__ = doc_string
 
-    def __get__(self,instance,type=None):
+    def __get__(self,instance,class_type=None):
         if instance is None:
             return self
 
@@ -619,7 +621,7 @@ class MapMaskFile(PropDescriptor):
             if not fileExtension:
                 value = value + self._file_ext
         self._file_name = value
-
+#pylint: disable=unused-argument
     def find_file(self,instance,**kwargs):
         """ Method to find file, correspondent to
            current MapMaskFile file hint
@@ -1174,6 +1176,7 @@ class MonoCorrectionFactor(PropDescriptor):
         self._cor_factor = value
     #
         if value is None:
+#pylint: disable=W0212
             self._mono_run_prop._in_cash = False # enable monovan run validation if any
     #
     def set_val_to_cash(self,instance,value):
@@ -1327,6 +1330,7 @@ class RotationAngle(PropDescriptor):
                 working_ws = mtd[external_ws]
 
         value = None
+#pylint: disable=W0212
         log_names = self._motor_log._log_names
         for name in log_names:
             try:
@@ -1340,6 +1344,7 @@ class RotationAngle(PropDescriptor):
         """Independent method to read rotation angle from workspace and
          previously set log and offset parameters
         """
+#pylint: disable=W0212
         offset = self._mot_offset._offset
         if offset is None:
             return np.NaN

--- a/scripts/Inelastic/Direct/PropertyManager.py
+++ b/scripts/Inelastic/Direct/PropertyManager.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 from Direct.NonIDF_Properties import *
 
 from collections import OrderedDict,Iterable
@@ -572,7 +572,7 @@ class PropertyManager(NonIDF_Properties):
         file_errors={}
         for prop_name in file_prop_names:
             theProp = getattr(PropertyManager,prop_name)
-            ok,file = theProp.find_file(be_quet=True)
+            ok,file = theProp.find_file(self,be_quet=True)
             if not ok:
                 file_errors[prop_name]=file
 

--- a/scripts/Inelastic/Direct/ReductionHelpers.py
+++ b/scripts/Inelastic/Direct/ReductionHelpers.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 from mantid import config
 import os
 
@@ -320,7 +320,7 @@ def check_instrument_name(old_name,new_name):
     new_name = short_name
     facility = str(config.getFacility())
 
-    config['default.instrument'] = full_name
+    #config['default.instrument'] = full_name
     return (new_name,full_name,facility)
 
 def parse_single_name(filename):

--- a/scripts/Inelastic/Direct/ReductionHelpers.py
+++ b/scripts/Inelastic/Direct/ReductionHelpers.py
@@ -285,12 +285,12 @@ def check_instrument_name(old_name,new_name):
 
     if new_name is None:
         if not old_name is None:
-            return (None,None,config.getFacility(),True)
+            return (None,None,config.getFacility())
         else:
             raise KeyError("No instrument name is defined")
 
     if old_name == new_name:
-        return
+        return (None,None,None)
 
     # Instrument name might be a prefix, query Mantid for the full name
     short_name=''

--- a/scripts/Inelastic/Direct/ReductionHelpers.py
+++ b/scripts/Inelastic/Direct/ReductionHelpers.py
@@ -285,7 +285,7 @@ def check_instrument_name(old_name,new_name):
 
     if new_name is None:
         if not old_name is None:
-            return (None,None,str(config.getFacility()))
+            return (None,None,config.getFacility(),True)
         else:
             raise KeyError("No instrument name is defined")
 
@@ -299,12 +299,12 @@ def check_instrument_name(old_name,new_name):
         instrument = config.getFacility().instrument(new_name)
         short_name = instrument.shortName()
         full_name = instrument.name()
+        facility = config.getFacility()
     except RuntimeError:
         # it is possible to have wrong facility:
         facilities = config.getFacilities()
-        old_facility = str(config.getFacility())
         for facility in facilities:
-            config.setString('default.facility',facility.name())
+            #config.setString('default.facility',facility.name())
             try :
                 instrument = facility.instrument(new_name)
                 short_name = instrument.shortName()
@@ -313,12 +313,11 @@ def check_instrument_name(old_name,new_name):
                     break
             except:
                 pass
+        #config.setString('default.facility',old_facility)
         if len(short_name)==0 :
-            config.setString('default.facility',old_facility)
             raise KeyError(" Can not find/set-up the instrument: "+new_name+' in any supported facility')
 
     new_name = short_name
-    facility = str(config.getFacility())
 
     #config['default.instrument'] = full_name
     return (new_name,full_name,facility)

--- a/scripts/Inelastic/Direct/ReductionWrapper.py
+++ b/scripts/Inelastic/Direct/ReductionWrapper.py
@@ -379,14 +379,14 @@ class ReductionWrapper(object):
         timeToWait = self._wait_for_file
         wait_counter=0
         if timeToWait > 0:
-            Found,input_file = PropertyManager.sample_run.find_file(be_quet=True)
+            Found,input_file = PropertyManager.sample_run.find_file(PropertyManager,be_quet=True)
             while not Found:
                 file_hint,fext = PropertyManager.sample_run.file_hint()
                 self.reducer.prop_man.log("*** Waiting {0} sec for file {1} to appear on the data search path"\
                     .format(timeToWait,file_hint),'notice')
 
                 self._run_pause(timeToWait)
-                Found,input_file = PropertyManager.sample_run.find_file(file_hint=file_hint,be_quet=True)
+                Found,input_file = PropertyManager.sample_run.find_file(PropertyManager,file_hint=file_hint,be_quet=True)
                 if Found:
                     file,found_ext=os.path.splitext(input_file)
                     if found_ext != fext:

--- a/scripts/Inelastic/Direct/ReductionWrapper.py
+++ b/scripts/Inelastic/Direct/ReductionWrapper.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 from mantid.simpleapi import *
 from mantid import config,api
 from mantid.kernel import funcreturns
@@ -379,14 +379,14 @@ class ReductionWrapper(object):
         timeToWait = self._wait_for_file
         wait_counter=0
         if timeToWait > 0:
-            Found,input_file = PropertyManager.sample_run.find_file(PropertyManager,be_quet=True)
+            Found,input_file = PropertyManager.sample_run.find_file(self.reducer.prop_man,be_quet=True)
             while not Found:
                 file_hint,fext = PropertyManager.sample_run.file_hint()
                 self.reducer.prop_man.log("*** Waiting {0} sec for file {1} to appear on the data search path"\
                     .format(timeToWait,file_hint),'notice')
 
                 self._run_pause(timeToWait)
-                Found,input_file = PropertyManager.sample_run.find_file(PropertyManager,file_hint=file_hint,be_quet=True)
+                Found,input_file = PropertyManager.sample_run.find_file(self.reducer.prop_man,file_hint=file_hint,be_quet=True)
                 if Found:
                     file,found_ext=os.path.splitext(input_file)
                     if found_ext != fext:

--- a/scripts/Inelastic/Direct/RunDescriptor.py
+++ b/scripts/Inelastic/Direct/RunDescriptor.py
@@ -1364,6 +1364,7 @@ class RunDescriptor(PropDescriptor):
 #-------------------------------------------------------------------------------------------------------------------------------
 #-------------------------------------------------------------------------------------------------------------------------------
 #-------------------------------------------------------------------------------------------------------------------------------
+#pylint: disable=too-many-public-methods
 class RunDescriptorDependent(RunDescriptor):
     """Simple RunDescriptor class dependent on another RunDescriptor,
        providing the host descriptor if current descriptor value is not defined
@@ -1463,18 +1464,18 @@ class RunDescriptorDependent(RunDescriptor):
             return super(RunDescriptorDependent,self).get_ws_clone(clone_name)
         else:
             return self._host.get_ws_clone(clone_name)
-
+#pylint: disable=too-many-arguments
     def chop_ws_part(self,origin,tof_range,rebin,chunk_num,n_chunks):
         if self._has_own_value:
             return super(RunDescriptorDependent,self).chop_ws_part(origin,tof_range,rebin,chunk_num,n_chunks)
         else:
             return self._host.chop_ws_part(origin,tof_range,rebin,chunk_num,n_chunks)
 
-    def get_monitors_ws(self,monitor_ID=None):
+    def get_monitors_ws(self,monitor_ID=None,otherWS=None):
         if self._has_own_value:
-            return super(RunDescriptorDependent,self).get_monitors_ws(monitor_ID)
+            return super(RunDescriptorDependent,self).get_monitors_ws(monitor_ID,otherWS)
         else:
-            return self._host.get_monitors_ws(monitor_ID)
+            return self._host.get_monitors_ws(monitor_ID,otherWS)
 
     def is_existing_ws(self):
         if self._has_own_value:
@@ -1487,19 +1488,20 @@ class RunDescriptorDependent(RunDescriptor):
             return super(RunDescriptorDependent,self).file_hint(run_num_str,filePath,fileExt,**kwargs)
         else:
             return self._host.file_hint(run_num_str,filePath,fileExt,**kwargs)
-
+#pylint: disable=too-many-arguments
     def find_file(self,propman,inst_name=None,run_num=None,filePath=None,fileExt=None,**kwargs):
         if self._has_own_value:
             return super(RunDescriptorDependent,self).find_file(propman,inst_name,run_num,filePath,fileExt,**kwargs)
         else:
             return self._host.find_file(propman,inst_name,run_num,filePath,fileExt,**kwargs)
-
+#pylint: disable=too-many-arguments
     def load_file(self,inst_name,ws_name,run_number=None,load_mon_with_workspace=False,filePath=None,fileExt=None,**kwargs):
         if self._has_own_value:
-            return super(RunDescriptorDependent,self).load_file(inst_name,ws_name,run_number,load_mon_with_workspace,filePath,fileExt,**kwargs)
+            return super(RunDescriptorDependent,self).load_file(inst_name,ws_name,run_number,load_mon_with_workspace,\
+                         filePath,fileExt,**kwargs)
         else:
             return self._host.load_file(inst_name,ws_name,run_number,load_mon_with_workspace,filePath,fileExt,**kwargs)
-
+#pylint: disable=too-many-arguments
     def load_run(self,inst_name, calibration=None, force=False, mon_load_option=False,use_ws_calibration=True,\
                  filePath=None,fileExt=None,**kwargs):
         if self._has_own_value:
@@ -1547,9 +1549,10 @@ def build_run_file_name(run_num,inst,file_path='',fext=''):
     if isinstance(run_num,str):
         run_num_str = run_num
     else:
-       fac = RunDescriptor._holder.facility
-       zero_padding    = fac.instrument(inst).zeroPadding(run_num)
-       run_num_str = str(run_num).zfill(zero_padding)
+#pylint: disable=W0212
+        fac = RunDescriptor._holder.facility
+        zero_padding    = fac.instrument(inst).zeroPadding(run_num)
+        run_num_str = str(run_num).zfill(zero_padding)
 
     fname = '{0}{1}{2}'.format(inst,run_num_str,fext)
     if not file_path is None:

--- a/scripts/test/RunDescriptorTest.py
+++ b/scripts/test/RunDescriptorTest.py
@@ -1,4 +1,4 @@
-import os,sys,inspect
+﻿import os,sys,inspect
 #os.environ["PATH"] =r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
 from mantid.simpleapi import *
 from mantid import api
@@ -86,7 +86,7 @@ class RunDescriptorTest(unittest.TestCase):
         propman  = self.prop_man
         propman.sample_run = 11001
 
-        ok,file=PropertyManager.sample_run.find_file()
+        ok,file=PropertyManager.sample_run.find_file(propman)
         self.assertTrue(ok)
         self.assertTrue(len(file)>0)
 
@@ -115,10 +115,10 @@ class RunDescriptorTest(unittest.TestCase):
         propman.sample_run = 101111
         PropertyManager.sample_run.set_file_ext('nxs')
 
-        ok,file=PropertyManager.sample_run.find_file()
+        ok,file=PropertyManager.sample_run.find_file(propman)
         self.assertEqual(testFile1,os.path.normpath(file))
         PropertyManager.sample_run.set_file_ext('.raw')
-        ok,file=PropertyManager.sample_run.find_file()
+        ok,file=PropertyManager.sample_run.find_file(propman)
         self.assertEqual(testFile2,os.path.normpath(file))
 
         os.remove(testFile1)
@@ -567,11 +567,6 @@ class RunDescriptorTest(unittest.TestCase):
 
         propman.sample_run = None
         DeleteWorkspace(a_wksp)
-
-
-
-
-
 
 
 


### PR DESCRIPTION
Resolves #11946

Its easy to test this ticket -- just change facility to e.g. SNS with any instrument and run a ISIS_Direct inelastic system test from Mantid. (e.g. Mantid\Testing\SystemTests\tests\analysis\ISIS_MariReduction.py -- the fastest one, either it passes or not on tester's machine (will fail if you do not have all files necessary for it to run) ) Before the changes after trying MARIReduction you will see facility changed to ISIS and instrument to MARI (for MARIReduction or appropriate for other ISIS direct instrument) No modification to default facility or instrument should happen after this change.

Changes to code is not so easy to follow as there were number of places where reduction was implicitly relying on default facility and instrument. The fact that system and unit tests pass give me confidence that I've identified and fixed all such places.

As the changes are entirely internal, I do not think any release note is necessary.
