### PR TITLE
Engg GUI: move RB number field

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -86,6 +86,7 @@ protected:
   void processResetFocus();
   void processLogMsg();
   void processInstChange();
+  void processRBNumberChange();
   void processShutDown();
 
 protected slots:
@@ -93,6 +94,8 @@ protected slots:
   void focusingFinished();
 
 private:
+  bool validateRBNumber(const std::string &rbn) const;
+
   /// @name Calibration related private methods
   //@{
   void inputChecksBeforeCalibrate(const std::string &newVanNo,

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtGUI.ui
@@ -85,6 +85,16 @@
     <item row="0" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
+       <widget class="QLabel" name="label_RBNumber">
+        <property name="text">
+         <string>RB Number:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="lineEdit_RBNumber"/>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabCalib.ui
@@ -13,35 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label_RBNumber">
-       <property name="text">
-        <string>RB Number:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lineEdit_RBNumber"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>358</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
     <widget class="QGroupBox" name="groupBox_current_calib">
      <property name="title">
       <string>Current calibration:</string>
@@ -144,7 +117,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <spacer name="horizontalSpacer_6">
@@ -233,7 +206,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -99,6 +99,8 @@ public:
                          const std::vector<double> &difc,
                          const std::vector<double> &tzero);
 
+  virtual void enableTabs(bool enable);
+
   virtual void enableCalibrateAndFocusActions(bool enable);
 
   virtual std::string focusingDir() const;
@@ -152,6 +154,8 @@ private slots:
 
   // slots of the general part of the interface
   void instrumentChanged(int idx);
+
+  void RBNumberChanged();
 
   // slots of the focus part of the interface
   void plotRepChanged(int idx);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionPresenter.h
@@ -47,6 +47,7 @@ public:
     ResetFocus,        ///< Re-set / clear all focus inputs and options
     LogMsg,            ///< need to send a message to the Mantid log system
     InstrumentChange,  ///< Instrument selection updated
+    RBNumberChange,    ///< RBNumber filled-in/changed
     ShutDown           ///< closing the interface
   };
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -191,6 +191,16 @@ public:
                                  const std::vector<double> &tzero) = 0;
 
   /**
+   * Enable/disable all the sections or tabs of the interface. To be
+   * used with required parameters, like a valid instrument, a valid
+   * RB number, etc. This should effectively disable/enable all
+   * actions, including calibration, focusing, event mode, etc.
+   *
+   * @param enable true to enable all tabs of the interface
+   */
+  virtual void enableTabs(bool enable) = 0;
+
+  /**
    * Enable/disable calibrate+focus actions. The idea is that actions
    * / buttons like 'calibrate', 'load calibration', or 'focus' can be
    * disabled while a calibration of a focusing is being calculated.

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -96,9 +96,9 @@ public:
   virtual std::vector<std::string> logMsgs() const = 0;
 
   /**
-   * Username entered by the user
+   * RB Number entered by the user
    *
-   * @return username to log in to the compute resource
+   * @return RB number as string as provided by the user
    */
   virtual std::string getRBNumber() const = 0;
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -57,8 +57,7 @@ void EnggDiffractionPresenter::cleanup() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A calibration process is currently running, shutting "
-                        "it down immediately..."
-                     << std::endl;
+                        "it down immediately..." << std::endl;
       m_workerThread->wait(10);
     }
     delete m_workerThread;
@@ -107,6 +106,10 @@ void EnggDiffractionPresenter::notify(
     processInstChange();
     break;
 
+  case IEnggDiffractionPresenter::RBNumberChange:
+    processRBNumberChange();
+    break;
+
   case IEnggDiffractionPresenter::ShutDown:
     processShutDown();
     break;
@@ -147,8 +150,7 @@ void EnggDiffractionPresenter::processCalcCalib() {
     return;
   }
   g_log.notice() << "EnggDiffraction GUI: starting new calibration. This may "
-                    "take a few seconds... "
-                 << std::endl;
+                    "take a few seconds... " << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -262,9 +264,24 @@ void EnggDiffractionPresenter::processInstChange() {
   m_view->userError("Fatal error", err);
 }
 
+void EnggDiffractionPresenter::processRBNumberChange() {
+  const std::string rbn = m_view->getRBNumber();
+  m_view->enableTabs(validateRBNumber(rbn));
+}
+
 void EnggDiffractionPresenter::processShutDown() {
   m_view->saveSettings();
   cleanup();
+}
+
+/**
+ * Check if an RB number is valid to work with it (retrieve data,
+ * calibrate, focus, etc.).
+ *
+ * @param rbn RB number as given by the user
+ */
+bool EnggDiffractionPresenter::validateRBNumber(const std::string &rbn) const {
+  return !rbn.empty();
 }
 
 /**
@@ -467,13 +484,11 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   } catch (std::runtime_error &) {
     g_log.error() << "The calibration calculations failed. One of the "
                      "algorithms did not execute correctly. See log messages "
-                     "for details. "
-                  << std::endl;
+                     "for details. " << std::endl;
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
-           "were not valid. See log messages for details. "
-        << std::endl;
+           "were not valid. See log messages for details. " << std::endl;
   }
   // restore normal data search paths
   conf.setDataSearchDirs(tmpDirs);
@@ -851,8 +866,7 @@ void EnggDiffractionPresenter::doFocusRun(
     const std::string &specNos, const std::string &dgFile) {
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: "
-                 << dir << std::endl;
+                    "this directory: " << dir << std::endl;
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -891,8 +905,7 @@ void EnggDiffractionPresenter::doFocusRun(
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what()
-                      << std::endl;
+                             ". Detailed error: " + re.what() << std::endl;
         bankIDs.clear();
         specs.clear();
       }
@@ -908,8 +921,8 @@ void EnggDiffractionPresenter::doFocusRun(
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo + " into: "
-                   << effectiveFilenames[idx] << std::endl;
+                          ") for run " + runNo +
+                          " into: " << effectiveFilenames[idx] << std::endl;
     try {
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
       m_focusFinishedOK = true;
@@ -921,8 +934,7 @@ void EnggDiffractionPresenter::doFocusRun(
     } catch (std::invalid_argument &ia) {
       g_log.error()
           << "The focusing failed. Some input properties were not valid. "
-             "See log messages for details. Error: "
-          << ia.what() << std::endl;
+             "See log messages for details. Error: " << ia.what() << std::endl;
     }
   }
 
@@ -1183,8 +1195,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what())
-                    << std::endl;
+                           std::string(ia.what()) << std::endl;
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1193,8 +1204,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what())
-                    << std::endl;
+                           std::string(re.what()) << std::endl;
       throw;
     }
   } else {

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -96,6 +96,7 @@ void EnggDiffractionViewQtGUI::initLayout() {
   // it will know what compute resources and tools we have available:
   // This view doesn't even know the names of compute resources, etc.
   m_presenter->notify(IEnggDiffractionPresenter::Start);
+  m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
 }
 
 void EnggDiffractionViewQtGUI::doSetupTabCalib() {
@@ -178,7 +179,7 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
-  m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
+  enableTabs(false);
 
   // change instrument
   connect(m_ui.comboBox_instrument, SIGNAL(currentIndexChanged(int)), this,

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -178,6 +178,8 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
 }
 
 void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
+  m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
+
   // change instrument
   connect(m_ui.comboBox_instrument, SIGNAL(currentIndexChanged(int)), this,
           SLOT(instrumentChanged(int)));
@@ -186,13 +188,16 @@ void EnggDiffractionViewQtGUI::doSetupGeneralWidgets() {
   // may remain open and visible after this close
   connect(m_ui.pushButton_close, SIGNAL(released()), this->parent(),
           SLOT(close()));
+
+  connect(m_ui.lineEdit_RBNumber, SIGNAL(editingFinished()), this,
+          SLOT(RBNumberChanged()));
 }
 
 void EnggDiffractionViewQtGUI::readSettings() {
   QSettings qs;
   qs.beginGroup(QString::fromStdString(m_settingsGroup));
 
-  m_uiTabCalib.lineEdit_RBNumber->setText(
+  m_ui.lineEdit_RBNumber->setText(
       qs.value("user-params-RBNumber", "").toString());
 
   m_uiTabCalib.lineEdit_current_vanadium_num->setText(
@@ -277,7 +282,7 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
   QSettings qs;
   qs.beginGroup(QString::fromStdString(m_settingsGroup));
 
-  qs.setValue("user-params-RBNumber", m_uiTabCalib.lineEdit_RBNumber->text());
+  qs.setValue("user-params-RBNumber", m_ui.lineEdit_RBNumber->text());
 
   qs.setValue("user-params-current-vanadium-num",
               m_uiTabCalib.lineEdit_current_vanadium_num->text());
@@ -377,7 +382,7 @@ std::string EnggDiffractionViewQtGUI::askNewCalibrationFilename(
 }
 
 std::string EnggDiffractionViewQtGUI::getRBNumber() const {
-  return m_uiTabCalib.lineEdit_RBNumber->text().toStdString();
+  return m_ui.lineEdit_RBNumber->text().toStdString();
 }
 
 std::string EnggDiffractionViewQtGUI::currentVanadiumNo() const {
@@ -419,7 +424,6 @@ void EnggDiffractionViewQtGUI::newCalibLoaded(const std::string &vanadiumNo,
 
 void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   // calibrate
-  m_uiTabCalib.lineEdit_RBNumber->setEnabled(enable);
   m_uiTabCalib.groupBox_make_new_calib->setEnabled(enable);
   m_uiTabCalib.groupBox_current_calib->setEnabled(enable);
 
@@ -434,6 +438,12 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
   m_uiTabFocus.pushButton_focus_cropped->setEnabled(enable);
   m_uiTabFocus.pushButton_focus_texture->setEnabled(enable);
+}
+
+void EnggDiffractionViewQtGUI::enableTabs(bool enable) {
+  for (int ti = 0; ti < m_ui.tabMain->count(); ++ti) {
+    m_ui.tabMain->setTabEnabled(ti, enable);
+  }
 }
 
 void EnggDiffractionViewQtGUI::plotFocusedSpectrum(const std::string &wsName) {
@@ -740,6 +750,10 @@ void EnggDiffractionViewQtGUI::instrumentChanged(int /*idx*/) {
     return;
   m_currentInst = inst->currentText().toStdString();
   m_presenter->notify(IEnggDiffractionPresenter::InstrumentChange);
+}
+
+void EnggDiffractionViewQtGUI::RBNumberChanged() {
+  m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
 }
 
 void EnggDiffractionViewQtGUI::userSelectInstrument(const QString &prefix) {

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -97,12 +97,14 @@ public:
 
     // will need basic calibration settings from the user
     EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(1)
+        .WillOnce(Return(calibSettings));
 
     const std::string mockFname = "foo.par";
-    EXPECT_CALL(mockView, askExistingCalibFilename()).Times(1).WillOnce(
-        Return(mockFname));
+    EXPECT_CALL(mockView, askExistingCalibFilename())
+        .Times(1)
+        .WillOnce(Return(mockFname));
 
     // should not get to the point where the calibration is calculated
     EXPECT_CALL(mockView, newCalibLoaded(testing::_, testing::_, mockFname))
@@ -121,12 +123,14 @@ public:
 
     // will need basic calibration settings from the user
     EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(1)
+        .WillOnce(Return(calibSettings));
 
     const std::string mockFname = "ENGINX_111111_222222_foo_bar.par";
-    EXPECT_CALL(mockView, askExistingCalibFilename()).Times(1).WillOnce(
-        Return(mockFname));
+    EXPECT_CALL(mockView, askExistingCalibFilename())
+        .Times(1)
+        .WillOnce(Return(mockFname));
     EXPECT_CALL(mockView, newCalibLoaded(testing::_, testing::_, mockFname))
         .Times(1);
 
@@ -175,8 +179,9 @@ public:
     // them
     EnggDiffCalibSettings calibSettings;
 
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(1)
+        .WillOnce(Return(calibSettings));
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(vanNo));
 
@@ -213,8 +218,9 @@ public:
     calibSettings.m_pixelCalibFilename =
         instr + "_" + vanNo + "_" + ceriaNo + ".prm";
     calibSettings.m_templateGSAS_PRM = "fake.prm";
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(2).WillRepeatedly(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(2)
+        .WillRepeatedly(Return(calibSettings));
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(vanNo));
 
@@ -264,8 +270,9 @@ public:
 
     // will need basic calibration settings from the user
     EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(2).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(2)
+        .WillOnce(Return(calibSettings));
 
     // No errors/warnings
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
@@ -280,8 +287,9 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return(""));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(m_ex_enginx_banks));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
@@ -340,13 +348,15 @@ public:
 
     // wrong run number!
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return("999999"));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(m_ex_enginx_banks));
 
     // needs basic calibration settings from the user to start focusing
     EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(1)
+        .WillOnce(Return(calibSettings));
 
     // Should not try to use options for other types of focusing
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
@@ -374,19 +384,23 @@ public:
 
     // an example run available in unit test data:
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return("228061"));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(m_ex_enginx_banks));
 
     // will need basic calibration settings from the user
     EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(1)
+        .WillOnce(Return(calibSettings));
 
     // check automatic plotting
-    EXPECT_CALL(mockView, focusedOutWorkspace()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(mockView, focusedOutWorkspace())
+        .Times(1)
+        .WillOnce(Return(true));
     EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(1);
-	// There are two/three other tests that have the disabled_ prefix so they
-	// normally run
+    // There are two/three other tests that have the disabled_ prefix so they
+    // normally run
 
     // Should not try to use options for other types of focusing
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(0);
@@ -414,8 +428,9 @@ public:
 
     // will need basic calibration settings from the user
     EnggDiffCalibSettings calibSettings;
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(1).WillOnce(
-        Return(calibSettings));
+    EXPECT_CALL(mockView, currentCalibSettings())
+        .Times(1)
+        .WillOnce(Return(calibSettings));
 
     EXPECT_CALL(mockView, focusedOutWorkspace()).Times(0);
     EXPECT_CALL(mockView, plotFocusedSpectrum(testing::_)).Times(0);
@@ -433,10 +448,12 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(Return(""));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(m_ex_enginx_banks));
-    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(1).WillOnce(
-        Return("1"));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs())
+        .Times(1)
+        .WillOnce(Return("1"));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
@@ -461,12 +478,15 @@ public:
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
     // ok run number
-    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(
-        Return("228061"));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(std::vector<bool>()));
-    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(1).WillOnce(
-        Return("1,5"));
+    EXPECT_CALL(mockView, focusingCroppedRunNo())
+        .Times(1)
+        .WillOnce(Return("228061"));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(std::vector<bool>()));
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs())
+        .Times(1)
+        .WillOnce(Return("1,5"));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
@@ -491,12 +511,15 @@ public:
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
     // ok run number
-    EXPECT_CALL(mockView, focusingCroppedRunNo()).Times(1).WillOnce(
-        Return("228061"));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(m_ex_enginx_banks));
-    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs()).Times(1).WillOnce(
-        Return(""));
+    EXPECT_CALL(mockView, focusingCroppedRunNo())
+        .Times(1)
+        .WillOnce(Return("228061"));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingCroppedSpectrumIDs())
+        .Times(1)
+        .WillOnce(Return(""));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
@@ -522,8 +545,9 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingTextureRunNo()).Times(1).WillOnce(Return(""));
-    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(1).WillOnce(
-        Return(""));
+    EXPECT_CALL(mockView, focusingTextureGroupingFile())
+        .Times(1)
+        .WillOnce(Return(""));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
@@ -547,11 +571,13 @@ public:
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
     // goo run number
-    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(1).WillOnce(
-        Return("228061"));
+    EXPECT_CALL(mockView, focusingTextureRunNo())
+        .Times(1)
+        .WillOnce(Return("228061"));
     EXPECT_CALL(mockView, focusingBanks()).Times(0);
-    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(1).WillOnce(
-        Return(""));
+    EXPECT_CALL(mockView, focusingTextureGroupingFile())
+        .Times(1)
+        .WillOnce(Return(""));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
@@ -574,11 +600,13 @@ public:
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
     // goo run number
-    EXPECT_CALL(mockView, focusingTextureRunNo()).Times(1).WillOnce(
-        Return("228061"));
+    EXPECT_CALL(mockView, focusingTextureRunNo())
+        .Times(1)
+        .WillOnce(Return("228061"));
     // non empty but absurd csv file of detector groups
-    EXPECT_CALL(mockView, focusingTextureGroupingFile()).Times(1).WillOnce(
-        Return("i_dont_exist_dont_look_for_me.csv"));
+    EXPECT_CALL(mockView, focusingTextureGroupingFile())
+        .Times(1)
+        .WillOnce(Return("i_dont_exist_dont_look_for_me.csv"));
 
     // should not try to use these ones
     EXPECT_CALL(mockView, focusingRunNo()).Times(0);
@@ -621,8 +649,9 @@ public:
 
     // empty run number!
     EXPECT_CALL(mockView, focusingRunNo()).Times(1).WillOnce(Return(""));
-    EXPECT_CALL(mockView, focusingBanks()).Times(1).WillOnce(
-        Return(m_ex_enginx_banks));
+    EXPECT_CALL(mockView, focusingBanks())
+        .Times(1)
+        .WillOnce(Return(m_ex_enginx_banks));
 
     // should not get that far that it tries to get these parameters
     EXPECT_CALL(mockView, currentInstrument()).Times(0);
@@ -648,6 +677,36 @@ public:
     EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffractionPresenter::LogMsg);
+  }
+
+  void test_RBNumberChange_ok() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // as if the user has set an empty RB Number that looks correct
+    EXPECT_CALL(mockView, getRBNumber()).Times(1).WillOnce(Return("RB000xxxx"));
+    EXPECT_CALL(mockView, enableTabs(true)).Times(1);
+
+    // no errors/ warnings
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffractionPresenter::RBNumberChange);
+  }
+
+  void test_RBNumberChange_empty() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
+
+    // as if the user has set an empty RB Number
+    EXPECT_CALL(mockView, getRBNumber()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(mockView, enableTabs(false)).Times(1);
+
+    // no errors/ warnings
+    EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
+
+    pres.notify(IEnggDiffractionPresenter::RBNumberChange);
   }
 
   void test_instChange() {

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -74,6 +74,9 @@ public:
                void(const std::string &, const std::vector<double> &,
                     const std::vector<double> &));
 
+  // virtual void enableTabs(bool enable);
+  MOCK_METHOD1(enableTabs, void(bool));
+
   // virtual void enableCalibrateAndFocusActions(bool enable);
   MOCK_METHOD1(enableCalibrateAndFocusActions, void(bool));
 
@@ -124,8 +127,6 @@ public:
 
   // virtual void plotReplacingWindow
   MOCK_METHOD1(plotReplacingWindow, void(const std::string &wsName));
-
-
 };
 
 #endif // MANTID_CUSTOMINTERFACES_ENGGDIFFRACTIONVIEWMOCK_H


### PR DESCRIPTION
Fixes #14109.

**To test**: 
- Check that the RB number is now visible on top, not only for calibration. 
- If it's empty all the tabs should be disabled / you should not be allowed to do anything
- It should be remembered from previous sessions, as usual
