### PR TITLE
ContainerSubtraction shift x changes

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
@@ -46,6 +46,7 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
                              doc='The output corrections workspace.')
 
 
+
     def PyExec(self):
         self._setup()
 
@@ -89,15 +90,17 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
             self._subtract()
             correction_type = 'can_subtraction'
             # Add container filename to log values
+            can_cut = self._can_ws_name.index('_')
+            can_base = self._can_ws_name[:can_cut]
             AddSampleLog(Workspace=self._output_ws_name,
                          LogName='container_filename',
                          LogType='String',
-                         LogText=self._can_ws_name)
+                         LogText=can_base)
 
         # Record the container scale factor
         if self._use_can and self._scale_can:
             AddSampleLog(Workspace=self._output_ws_name,
-                         LogName='apply_corr_can_scale_factor',
+                         LogName='container_scale',
                          LogType='Number',
                          LogText=str(self._can_scale_factor))
 
@@ -108,10 +111,12 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
                      LogText=correction_type)
 
         # Add original sample as log entry
+        sam_cut = self._sample_ws_name.index('_')
+        sam_base = self._sample_ws_name[:sam_cut]
         AddSampleLog(Workspace=self._output_ws_name,
                      LogName='sample_filename',
                      LogType='String',
-                     LogText=self._sample_ws_name)
+                     LogText=sam_base)
 
         self.setPropertyValue('OutputWorkspace', self._output_ws_name)
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ContainerSubtraction.ui
@@ -174,7 +174,7 @@
                       <double>-999.990000000000009</double>
                     </property>
                     <property name="singleStep">
-                      <double>0.100000000000000</double>
+                      <double>0.010000000000000</double>
                     </property>
                     <property name="value">
                       <double>0.000000000000000</double>

--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -300,6 +300,19 @@ void ContainerSubtraction::absCorComplete(bool error) {
   if (save)
     addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
 
+  if (m_uiForm.ckShiftCan->isChecked()) {
+    IAlgorithm_sptr shiftLog =
+        AlgorithmManager::Instance().create("AddSampleLog");
+    shiftLog->initialize();
+
+    shiftLog->setProperty("Workspace", m_pythonExportWsName);
+    shiftLog->setProperty("LogName", "container_shift");
+    shiftLog->setProperty("LogType", "Number");
+    shiftLog->setProperty(
+        "LogText", boost::lexical_cast<std::string>(m_uiForm.spShift->value()));
+    m_batchAlgoRunner->addAlgorithm(shiftLog);
+  }
+
   // Run algorithm queue
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(postProcessComplete(bool)));

--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -94,21 +94,26 @@ void ContainerSubtraction::run() {
   }
 
   // Check for same binning across sample and container
-  if (!checkWorkspaceBinningMatches(sampleWs, canCloneWs)) {
-    QString text = "Binning on sample and container does not match."
-                   "Would you like to rebin the sample to match the container?";
+  if (m_uiForm.ckShiftCan->isChecked()) {
+    addRebinStep(canCloneName, sampleWsName);
+  } else {
+    if (!checkWorkspaceBinningMatches(sampleWs, canCloneWs)) {
+      QString text =
+          "Binning on sample and container does not match."
+          "Would you like to rebin the sample to match the container?";
 
-    int result = QMessageBox::question(NULL, tr("Rebin sample?"), tr(text),
-                                       QMessageBox::Yes, QMessageBox::No,
-                                       QMessageBox::NoButton);
+      int result = QMessageBox::question(NULL, tr("Rebin sample?"), tr(text),
+                                         QMessageBox::Yes, QMessageBox::No,
+                                         QMessageBox::NoButton);
 
-    if (result == QMessageBox::Yes) {
-		addRebinStep(canCloneName, sampleWsName);
-    } else {
-      m_batchAlgoRunner->clearQueue();
-      g_log.error("Cannot apply absorption corrections using a sample and "
-                  "container with different binning.");
-      return;
+      if (result == QMessageBox::Yes) {
+        addRebinStep(canCloneName, sampleWsName);
+      } else {
+        m_batchAlgoRunner->clearQueue();
+        g_log.error("Cannot apply absorption corrections using a sample and "
+                    "container with different binning.");
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #14090 

A few updates have been made to the ContainerSubtraction tab after the changes made to add the Shift X spinner. These include, log changes, interval of spinner and Rebinning request.
# To Test
- Open ContainerSubtraction (Interfaces > Indirect > Corrections > ContainerSubtraction)
- Sample = `irs26176`
- Container = `irs26174`
  - Both are available from `\\olympic\Babylon5\Public\ElliotOram\Corrections\ContainerSubtraction\Base`
- Check the Scaling and Shift options. **Ensure that the input fields are then enabled**
- Change the Shift option with the spinner arrows. **Ensure that the interval of change is +/- 0.01**
- Click Run. **Ensure that no message box is produced asking about Rebinning**
- After the run is complete, check the sample logs and Ensure the following:
  - `container_shift`is present and has the correct value
  - `container_filename` only has the instrument and run number (e.g. `irs26174`)
  - `sample_filename` only has the instrument and run number (e.g. `irs26176`)
