### PR TITLE
Rename QLRun to BayesQuasi in all documents

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -13,7 +13,7 @@ if is_supported_f2py_platform():
     QLd     = import_f2py("QLdata")
     Qse     = import_f2py("QLse")
 
-class QLRun(PythonAlgorithm):
+class BayesQuasi(PythonAlgorithm):
 
     _program = None
     _samWS = None
@@ -143,7 +143,7 @@ class QLRun(PythonAlgorithm):
         from IndirectCommon import (CheckXrange, CheckAnalysers, getEfixed, GetThetaQ,
                                     CheckHistZero, CheckHistSame)
 
-        self.log().information('QLRun input')
+        self.log().information('BayesQuasi input')
 
         erange = [self._e_min, self._e_max]
         nbins = [self._sam_bins, self._res_bins]
@@ -358,4 +358,4 @@ class QLRun(PythonAlgorithm):
 
 if is_supported_f2py_platform():
     # Register algorithm with Mantid
-    AlgorithmFactory.subscribe(QLRun)
+    AlgorithmFactory.subscribe(BayesQuasi)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/BayesQuasiTest.py
@@ -4,7 +4,7 @@ from IndirectImport import *
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 
 if is_supported_f2py_platform():
-    class QLRunTest(unittest.TestCase):
+    class BayesQuasiTest(unittest.TestCase):
 
         _res_ws = None
         _sample_ws = None
@@ -13,9 +13,9 @@ if is_supported_f2py_platform():
 
         def setUp(self):
             self._res_ws = Load(Filename='irs26173_graphite002_res.nxs',
-                                OutputWorkspace='__QLRunTest_Resolution')
+                                OutputWorkspace='__BayesQuasiTest_Resolution')
             self._sample_ws = Load(Filename='irs26176_graphite002_red.nxs',
-                                OutputWorkspace='__QLRunTest_Sample')
+                                OutputWorkspace='__BayesQuasiTest_Sample')
             self._num_bins = self._sample_ws.blocksize()
             self._num_hists = self._sample_ws.getNumberHistograms()
 
@@ -24,9 +24,9 @@ if is_supported_f2py_platform():
             """
             Validates that the output workspaces are of the correct type, units and shape.
 
-            @param result Result workspace from QLRun
-            @param prob Probability workspace from QLRun
-            @param group Group workspace of fitted spectra from QLRun
+            @param result Result workspace from BayesQuasi
+            @param prob Probability workspace from BayesQuasi
+            @param group Group workspace of fitted spectra from BayesQuasi
             """
 
             # Test size/shape of result
@@ -58,9 +58,9 @@ if is_supported_f2py_platform():
             Validates that the output workspaces have expected values
             with values from the last known correct version
 
-            @param result Result workspace from QLRun
-            @param prob Probability workspace from QLRun
-            @param group Group workspace of fitted spectra from QLRun
+            @param result Result workspace from BayesQuasi
+            @param prob Probability workspace from BayesQuasi
+            @param group Group workspace of fitted spectra from BayesQuasi
             """
 
             # Test values of result
@@ -91,8 +91,8 @@ if is_supported_f2py_platform():
             Validates that the output workspaces are of the correct type, units and shape.
             with values from the last known correct version
 
-            @param result Result workspace from QLRun
-            @param group Group workspace of fitted spectra from QLRun
+            @param result Result workspace from BayesQuasi
+            @param group Group workspace of fitted spectra from BayesQuasi
             """
 
             # Test size/shape of result
@@ -117,9 +117,9 @@ if is_supported_f2py_platform():
             """
             Validates that the output workspaces have expected values
 
-            @param result Result workspace from QLRun
-            @param prob Probability workspace from QLRun
-            @param group Group workspace of fitted spectra from QLRun
+            @param result Result workspace from BayesQuasi
+            @param prob Probability workspace from BayesQuasi
+            @param group Group workspace of fitted spectra from BayesQuasi
             """
 
             # Test values of result
@@ -138,9 +138,9 @@ if is_supported_f2py_platform():
 
         def test_QLr_Run(self):
             """
-            Test Lorentzian fit for QLRun
+            Test Lorentzian fit for BayesQuasi
             """
-            fit_group, result, prob= QLRun(Program='QL',
+            fit_group, result, prob= BayesQuasi(Program='QL',
                                               SampleWorkspace=self._sample_ws,
                                               ResolutionWorkspace=self._res_ws,
                                               MinRange=-0.547607,
@@ -161,9 +161,9 @@ if is_supported_f2py_platform():
 
         def test_QSe_Run(self):
             """
-            Test Stretched Exponential fit for QLRun
+            Test Stretched Exponential fit for BayesQuasi
             """
-            fit_group, result = QLRun(Program='QSe',
+            fit_group, result = BayesQuasi(Program='QSe',
                                       SampleWorkspace=self._sample_ws,
                                       ResolutionWorkspace=self._res_ws,
                                       MinRange=-0.547607,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -5,6 +5,7 @@
 set ( TEST_PY_FILES
   AddSampleLogMultipleTest.py
   ApplyPaalmanPingsCorrectionTest.py
+  BayesQuasiTest.py
   CalculateSampleTransmissionTest.py
   CheckForSampleLogsTest.py
   ConjoinSpectraTest.py
@@ -59,7 +60,6 @@ set ( TEST_PY_FILES
   MSDFitTest.py
   MuscatSofQWTest.py
   OSIRISDiffractionReductionTest.py
-  QLRunTest.py
   ResNorm2Test.py
   RetrieveRunInfoTest.py
   SANSWideAngleCorrectionTest.py

--- a/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -180,7 +180,7 @@ void Quasi::run() {
   }
   std::string plot = m_uiForm.cbPlot->currentText().toStdString();
 
-  IAlgorithm_sptr runAlg = AlgorithmManager::Instance().create("QLRun");
+  IAlgorithm_sptr runAlg = AlgorithmManager::Instance().create("BayesQuasi");
   runAlg->initialize();
   runAlg->setProperty("Program", program);
   runAlg->setProperty("SampleWorkspace", sampleName);

--- a/docs/source/algorithms/BayesQuasi-v1.rst
+++ b/docs/source/algorithms/BayesQuasi-v1.rst
@@ -23,9 +23,9 @@ exp[-2\pi(\sigma k)\beta]. This, in the energy to time FT transformation, is \ps
 Usage
 -----
 
-**Example - QLRun**
+**Example - BayesQuasi**
 
-.. testcode:: QLRunExample
+.. testcode:: BayesQuasiExample
 
     # Check OS support for F2Py
     from IndirectImport import is_supported_f2py_platform
@@ -34,8 +34,8 @@ Usage
         sampleWs = Load('irs26176_graphite002_red.nxs')
         resWs = Load('irs26173_graphite002_red.nxs')
 
-        # Run QLRun algorithm
-        fit_ws, result_ws, prob_ws = QLRun(Program='QL', SampleWorkspace=sampleWs, ResolutionWorkspace=resWs,
+        # Run BayesQuasi algorithm
+        fit_ws, result_ws, prob_ws = BayesQuasi(Program='QL', SampleWorkspace=sampleWs, ResolutionWorkspace=resWs,
                                             MinRange=-0.547607, MaxRange=0.543216, SampleBins=1, ResolutionBins=1,
                                             Elastic=False, Background='Sloping', FixedWidth=False, UseResNorm=False,
                                             WidthFile='', Loop=True, Save=False, Plot='None')


### PR DESCRIPTION
Fixes #13969

All documents that featured QLRuns should now use the new algorithm name BayesQuasi
# To Test
- Open Quasi (Interfaces > Indirect > Bayes > Quasi) 
- Sample = `irs26176_red`
- Resolution = `irs26173_res`
  - Both are available in the `External data` directory
- Run the algorithm **Ensure it still work / does not produce an error**
- Ensure the documentation is up-to-date and correct
- Ensure the test still runs correctly 
