### PR TITLE
Renamed output of apply/calculate paalmanpings tabs

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -178,14 +178,10 @@ void ApplyPaalmanPings::run() {
   }
   QString outputWsName =
       sampleWsName.left(nameCutIndex) + +"_" + correctionType + "_Corrected";
-
-  if (useCan) {
-    auto containerWsName = m_uiForm.dsContainer->getCurrentDataName();
-    int cutIndex = containerWsName.indexOf("_");
-    if (cutIndex == -1) {
-      cutIndex = containerWsName.length();
-    }
-	outputWsName += "_Subtract_" + containerWsName.left(cutIndex);
+  if(m_uiForm.ckUseCan->isChecked()){
+    QString canWsName = m_uiForm.dsContainer->getCurrentDataName();
+	auto canCut = canWsName.indexOf("_");
+	outputWsName += "_" + canWsName.left(canCut);
   }
 
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());

--- a/MantidQt/CustomInterfaces/src/Indirect/CalculatePaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/CalculatePaalmanPings.cpp
@@ -124,14 +124,6 @@ void CalculatePaalmanPings::run() {
 
   QString outputWsName =
       sampleWsName.left(nameCutIndex) + "_" + correctionType + "_abs";
-  if (useCan) {
-    auto containerWsName = m_uiForm.dsContainer->getCurrentDataName();
-    int cutIndex = containerWsName.indexOf("_");
-    if (cutIndex == -1) {
-      cutIndex = containerWsName.length();
-    }
-    outputWsName += "_Subtract_" + containerWsName.left(cutIndex);
-  }
 
   absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
 


### PR DESCRIPTION
Fixes #13972

The output of these tabs have now been renamed
# To Test (Calc)
- Open CalculatePaalmanPings(Interfaces > Indirect > Corrections > CalculatePaalmanPings
- Sample = `irs26176`
- Container = `irs26174`
  - Theses files are available from `\\olympic\Babylon5\Public\ElliotOram\Corrections\correction_set`
- Set The following options in the interface:
  - Use can (and add container file mentioned above)
  - Sample Thickness = 0.3
  - Sample angle = 45
  - Container Front Thickness = 0.1
  - Container Back Thickness = 0.1
  - Sample Details:
    - Number Density = 0.1
    - Chemical Formula = H2-O
  - Can Details:
    - Number Density = 0.1
    - Chemical Formula = V
- Run this and ensure the output is:
  -  IRS26176_graphite002_flt_abs
# To Test (Apply)
- Switch to the ApplyPaalmanPings
  - Sample =  26176
  - Container = 26174
  - Correction = file produced from CalculatePaalmanPings (`IRS26176_graphite002_flt_abs`)
- Run this with these inputs and Ensure the file produced is:
  - IRS26176_graphite002_Corrected_IRS26174
