### PR TITLE
ISIS Data Reduction Naming convention on raw files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TimeSlice.py
@@ -244,7 +244,8 @@ class TimeSlice(PythonAlgorithm):
 
         # Construct output workspace name
         run = mtd[raw_file].getRun().getLogData('run_number').value
-        slice_file = raw_file[:3].lower() + run + self._output_ws_name_suffix
+        inst = mtd[raw_file].getInstrument().getName()
+        slice_file = inst.lower() + run + self._output_ws_name_suffix
 
         if self._background_range is None:
             Integration(InputWorkspace=raw_file,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EVSDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EVSDiffractionReductionTest.py
@@ -17,7 +17,7 @@ class EVDDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'EVS15289_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'vesuvio15289_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectDiffractionReductionTest.py
@@ -19,7 +19,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
@@ -39,7 +39,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
@@ -63,8 +63,8 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 2)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_diffspec_red')
-        self.assertEqual(wks.getNames()[1], 'IRS26173_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
+        self.assertEqual(wks.getNames()[1], 'iris26173_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
@@ -84,7 +84,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_multi_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_multi_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
@@ -107,7 +107,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
@@ -127,7 +127,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')
@@ -148,7 +148,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_diffspec_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_diffspec_red')
 
         red_ws = wks[0]
         self.assertEqual(red_ws.getAxis(0).getUnit().unitID(), 'dSpacing')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectEnergyTransferTest.py
@@ -37,7 +37,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          SpectraRange=[3, 53])
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
@@ -56,7 +56,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          SpectraRange=[35, 40])
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 6)
@@ -75,7 +75,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          GroupingMethod='All')
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 1)
@@ -94,7 +94,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          GroupingMethod='Individual')
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
@@ -113,7 +113,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          BackgroundRange=[70000, 75000])
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
 
     def test_reduction_with_output_unit(self):
@@ -129,7 +129,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          UnitX='DeltaE_inWavenumber')
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
@@ -150,7 +150,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          DetailedBalance='300')
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
@@ -171,7 +171,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          MapFile='osi_002_14Groups.map')
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'OSI97919_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'osiris97919_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 14)
@@ -191,7 +191,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          CalibrationWorkspace=_generate_calibration_workspace('IRIS'))
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
@@ -211,7 +211,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          CalibrationWorkspace=_generate_calibration_workspace('IRIS'))
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 6)
@@ -230,8 +230,8 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 2)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
-        self.assertEqual(wks.getNames()[1], 'IRS26173_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
+        self.assertEqual(wks.getNames()[1], 'iris26173_graphite002_red')
 
 
     def test_sum_files(self):
@@ -248,7 +248,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
         self.assertEqual(len(wks), 1)
-        self.assertEqual(wks.getNames()[0], 'IRS26176_multi_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_multi_graphite002_red')
 
         red_ws = wks[0]
         self.assertTrue('multi_run_numbers' in red_ws.getRun())
@@ -301,7 +301,7 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
                                          Efixed=1.9)
 
         self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
-        self.assertEqual(wks.getNames()[0], 'IRS26176_graphite002_red')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
 
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TimeSliceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TimeSliceTest.py
@@ -16,7 +16,7 @@ class TimeSliceTest(unittest.TestCase):
                   OutputWorkspace='SliceTestOut')
 
         self.assertTrue(mtd.doesExist('SliceTestOut'))
-        self.assertTrue(mtd.doesExist('irs26173_slice'))
+        self.assertTrue(mtd.doesExist('iris26173_slice'))
 
 
     def test_suffix(self):
@@ -31,7 +31,7 @@ class TimeSliceTest(unittest.TestCase):
                   OutputNameSuffix='_graphite002_slice',
                   OutputWorkspace='SliceTestOut')
 
-        self.assertTrue(mtd.doesExist('irs26173_graphite002_slice'))
+        self.assertTrue(mtd.doesExist('iris26173_graphite002_slice'))
 
 
     def test_validation_peak_range_order(self):

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -152,8 +152,7 @@ namespace CustomInterfaces
   {
   }
 
-  void ISISCalibration::run()
-  {
+  void ISISCalibration::run() {
     // Get properties
     QStringList filenameList = m_uiForm.leRunNo->getFilenames();
     QString filenames = filenameList.join(",");
@@ -161,13 +160,21 @@ namespace CustomInterfaces
     QString firstFileNumber("");
     auto cutIndexDash = userInFiles.indexOf("-");
     auto cutIndexComma = userInFiles.indexOf(",");
+
     if (cutIndexDash == -1 && cutIndexComma == -1) {
       firstFileNumber = userInFiles;
     } else {
-      if (cutIndexDash < cutIndexComma) {
+      if (cutIndexDash != -1) {
         firstFileNumber = userInFiles.left(cutIndexDash);
       } else {
         firstFileNumber = userInFiles.left(cutIndexComma);
+      }
+      if (cutIndexDash != -1 && cutIndexComma != -1) {
+        if (cutIndexDash < cutIndexComma) {
+          firstFileNumber = userInFiles.left(cutIndexDash);
+        } else {
+          firstFileNumber = userInFiles.left(cutIndexComma);
+        }
       }
     }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -155,20 +155,20 @@ namespace CustomInterfaces
   void ISISCalibration::run()
   {
     // Get properties
-    QString firstFile = m_uiForm.leRunNo->getFirstFilename();
     QStringList filenameList = m_uiForm.leRunNo->getFilenames();
     QString filenames = filenameList.join(",");
     QString userInFiles = m_uiForm.leRunNo->getText();
     QString firstFileNumber("");
-    auto cutIndex = userInFiles.lastIndexOf("-");
-    if (cutIndex == -1) {
-      cutIndex = userInFiles.lastIndexOf(",");
-      if (cutIndex == -1) {
-        firstFileNumber = userInFiles;
-      }
-
+    auto cutIndexDash = userInFiles.indexOf("-");
+    auto cutIndexComma = userInFiles.indexOf(",");
+    if (cutIndexDash == -1 && cutIndexComma == -1) {
+      firstFileNumber = userInFiles;
     } else {
-      firstFileNumber = userInFiles.left(cutIndex);
+      if (cutIndexDash < cutIndexComma) {
+        firstFileNumber = userInFiles.left(cutIndexDash);
+      } else {
+        firstFileNumber = userInFiles.left(cutIndexComma);
+      }
     }
 
     auto instDetails = getInstrumentDetails();
@@ -180,7 +180,6 @@ namespace CustomInterfaces
     QString backgroundRange = m_properties["CalBackMin"]->valueText() + "," +
                               m_properties["CalBackMax"]->valueText();
 
-    // QFileInfo firstFileInfo(firstFile);
     QString outputWorkspaceNameStem =
         getInstrumentConfiguration()->getInstrumentName() + firstFileNumber +
         QString::fromStdString("_") +

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISCalibration.cpp
@@ -158,16 +158,36 @@ namespace CustomInterfaces
     QString firstFile = m_uiForm.leRunNo->getFirstFilename();
     QStringList filenameList = m_uiForm.leRunNo->getFilenames();
     QString filenames = filenameList.join(",");
+    QString userInFiles = m_uiForm.leRunNo->getText();
+    QString firstFileNumber("");
+    auto cutIndex = userInFiles.lastIndexOf("-");
+    if (cutIndex == -1) {
+      cutIndex = userInFiles.lastIndexOf(",");
+      if (cutIndex == -1) {
+        firstFileNumber = userInFiles;
+      }
+
+    } else {
+      firstFileNumber = userInFiles.left(cutIndex);
+    }
 
     auto instDetails = getInstrumentDetails();
-    QString instDetectorRange = instDetails["spectra-min"] + "," + instDetails["spectra-max"];
+    QString instDetectorRange =
+        instDetails["spectra-min"] + "," + instDetails["spectra-max"];
 
-    QString peakRange = m_properties["CalPeakMin"]->valueText() + "," + m_properties["CalPeakMax"]->valueText();
-    QString backgroundRange = m_properties["CalBackMin"]->valueText() + "," + m_properties["CalBackMax"]->valueText();
+    QString peakRange = m_properties["CalPeakMin"]->valueText() + "," +
+                        m_properties["CalPeakMax"]->valueText();
+    QString backgroundRange = m_properties["CalBackMin"]->valueText() + "," +
+                              m_properties["CalBackMax"]->valueText();
 
-    QFileInfo firstFileInfo(firstFile);
-    QString outputWorkspaceNameStem = firstFileInfo.baseName() + "_" + getInstrumentConfiguration()->getAnalyserName()
-                                      + getInstrumentConfiguration()->getReflectionName();
+    // QFileInfo firstFileInfo(firstFile);
+    QString outputWorkspaceNameStem =
+        getInstrumentConfiguration()->getInstrumentName() + firstFileNumber +
+        QString::fromStdString("_") +
+        getInstrumentConfiguration()->getAnalyserName() +
+        getInstrumentConfiguration()->getReflectionName();
+
+        outputWorkspaceNameStem = outputWorkspaceNameStem.toLower();
 
     m_outputCalibrationName = outputWorkspaceNameStem;
     if(filenameList.size() > 1)
@@ -443,7 +463,7 @@ namespace CustomInterfaces
     {
       g_log.warning("No result workspaces, cannot plot energy preview.");
       return;
-    }
+	}
 
     MatrixWorkspace_sptr energyWs = boost::dynamic_pointer_cast<MatrixWorkspace>(reductionOutputGroup->getItem(0));
     if(!energyWs)

--- a/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISDiagnostics.cpp
@@ -405,7 +405,7 @@ void ISISDiagnostics::updatePreviewPlot() {
   if (!m_uiForm.dsInputFiles->isValid())
     return;
 
-  QString suffix = getInstrumentConfiguration()->getAnalyserName() +
+  QString suffix = "_" + getInstrumentConfiguration()->getAnalyserName() +
                    getInstrumentConfiguration()->getReflectionName() + "_slice";
   QString filenames = m_uiForm.dsInputFiles->getFilenames().join(",");
 

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -610,7 +610,7 @@ class ISISIndirectInelasticDiagnostics(ISISIndirectInelasticBase):
                   SpectraRange=self.spectra)
 
         # Construct the result ws name.
-        Load(File=self.rawfiles[0]
+        Load(Filename=self.rawfiles[0],
              OutputWorkspace='__temp')
         resultWs = mtd['__temp']
         inst_name = resultWs.getInstrument().getFullName().lower()

--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -610,7 +610,12 @@ class ISISIndirectInelasticDiagnostics(ISISIndirectInelasticBase):
                   SpectraRange=self.spectra)
 
         # Construct the result ws name.
-        self.result_names = [os.path.splitext(self.rawfiles[0])[0] + self.suffix]
+        Load(File=self.rawfiles[0]
+             OutputWorkspace='__temp')
+        resultWs = mtd['__temp']
+        inst_name = resultWs.getInstrument().getFullName().lower()
+        run_number = resultWs.run().getProperty('run_number').value
+        self.result_names = [inst_name + run_number + self.suffix]
 
     def _validate_properties(self):
         '''Check the object properties are in an expected state to continue'''

--- a/docs/source/algorithms/EVSDiffractionReduction-v1.rst
+++ b/docs/source/algorithms/EVSDiffractionReduction-v1.rst
@@ -35,7 +35,7 @@ Output:
 
 .. testoutput:: ExEVSDiffractionReductionSimple
 
-    Workspace name: EVS15289_diffspec_red
+    Workspace name: vesuvio15289_diffspec_red
     Number of spectra: 1
     Number of bins: 3875
 

--- a/docs/source/algorithms/ISISIndirectDiffractionReduction-v1.rst
+++ b/docs/source/algorithms/ISISIndirectDiffractionReduction-v1.rst
@@ -40,7 +40,7 @@ Output:
 
 .. testoutput:: ExISISIndirectDiffractionReductionSimple
 
-    Workspace name: IRS21360_diffspec_red
+    Workspace name: iris21360_diffspec_red
     Number of spectra: 1
     Number of bins: 1934
 

--- a/docs/source/algorithms/ISISIndirectEnergyTransfer-v1.rst
+++ b/docs/source/algorithms/ISISIndirectEnergyTransfer-v1.rst
@@ -42,7 +42,7 @@ Output:
 
 .. testoutput:: ExIRISReduction
 
-   IRS21360_graphite002_red
+   iris21360_graphite002_red
 
 .. categories::
 

--- a/docs/source/algorithms/TimeSlice-v1.rst
+++ b/docs/source/algorithms/TimeSlice-v1.rst
@@ -47,7 +47,7 @@ Output:
 
 .. testoutput:: ExTimeSliceSimple
 
-    ['irs26173_slice']
+    ['iris26173_slice']
 
 .. categories::
 

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -565,13 +565,7 @@ def rename_reduction(workspace_name, multiple_files):
     logger.information('Run number for workspace %s is %s' % (workspace_name, run_number))
 
     inst_name = instrument.getName()
-    for facility in config.getFacilities():
-        try:
-            short_inst_name = facility.instrument(inst_name).shortName()
-            break
-        except _:
-            pass
-    logger.information('Short name for instrument %s is %s' % (inst_name, short_inst_name))
+    inst_name = inst_name.lower()
 
     # Get run title
     if is_multi_frame:
@@ -591,12 +585,12 @@ def rename_reduction(workspace_name, multiple_files):
     elif convention == 'RunTitle':
         valid = "-_.() %s%s" % (string.ascii_letters, string.digits)
         formatted_title = ''.join([c for c in run_title if c in valid])
-        new_name = '%s%s%s-%s' % (short_inst_name.lower(), run_number, multi_run_marker, formatted_title)
+        new_name = '%s%s%s-%s' % (inst_name.lower(), run_number, multi_run_marker, formatted_title)
 
     elif convention == 'AnalyserReflection':
         analyser = instrument.getStringParameter('analyser')[0]
         reflection = instrument.getStringParameter('reflection')[0]
-        new_name = '%s%s%s_%s%s_red' % (short_inst_name.upper(), run_number, multi_run_marker,
+        new_name = '%s%s%s_%s%s_red' % (inst_name.lower(), run_number, multi_run_marker,
                                         analyser, reflection)
 
     else:


### PR DESCRIPTION
Fixes #13975

Now when loading files in the ISIS Data Reduction interfaces the names will be of the form:
`[**full instrument name**] + [run number] + _ + [analyser] + [reflection] + _red`
_This should all be lower case and any leading zeros should be removed_
# To Test
- Open Indirect Data Reduction (Interfaces > Indirect > Data Reduction)
- Any file numbers can be checked, but I suggest using 26173-26176 from the data archive 
  - These files are IRIS / Graphite / 002 (Ensure these details are set in the Interface
- Load these files in by run number/ run number range in:
  - ISIS Energy Transfer
  - ISIS Calibration
  - ISIS Diagnostics
- Ensure in each case any files produced are in the format above
  - Some files may have different suffixes (in these cases ensure they are lower case and sensible)
