### PR TITLE
Engg::Plots focused workspace for cropped and texture

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -182,7 +182,7 @@ private:
                               Mantid::API::MatrixWorkspace_sptr &vanCurvesWS);
 
   // plots workspace according to the user selection
-  void plotFocusedWorkspace(std::string outWSName, std::string bank);
+  void plotFocusedWorkspace(std::string outWSName, int bank);
 
   // algorithms to save the generated workspace
   void saveGSS(std::string inputWorkspace, std::string bank, std::string runNo);
@@ -216,6 +216,9 @@ private:
 
   /// Counter for the cropped output files
   static int g_croppedCounter;
+
+  /// counter for the plotting workspace
+  static int g_plottingCounter;
 
   /// Associated view for this presenter (MVP pattern)
   IEnggDiffractionView *const m_view;

--- a/docs/source/interfaces/Engineering_Diffraction.rst
+++ b/docs/source/interfaces/Engineering_Diffraction.rst
@@ -108,7 +108,13 @@ Plots: will replace the previous graph and plot a new graph on top.
 One Window - Waterfall: will plot all the generated focused
 workspace graphs in one window which can be useful while comparing
 various graphs. The Multiple Windows: will plot graph in
-separate windows.
+separate windows. However, user may also change the Plot Data
+Representation drop-down box while a run is being carried out. This
+will update the interface and plot workspace according to the new
+given input. For example, if a user has selected One Window -
+Replacing Plots and then decides to change it to One Window -
+Waterfall during a run, the interface will carry on by plotting
+Waterfall within the same window.
 
 The user also has an option of generated GSS, XYE and OpenGenie
 formatted file by clicking the Output Files checkbox. This will


### PR DESCRIPTION
Fixes #14126

**To Test**

> Go to `Interface/Diffraction/Engineering Diffraction`

To use the focus tab: first you need to calibrate, following the steps
explained in #13370 (you need a few files too). If you've done it
before the GUI will remember the last settings. 

**Test 1**
Once you have done that, then go to the focus tab, and under Focus Cropped:
- make sure `Plot Focused Workspace` is checked
- enter run number: 
  
  > you can try 228061 (the file ENGINX00228061.nxs is available from the unit test data)
  > and/or 213855 (the file ENGINX00213855.nxs is available from the doc test data), or other ENGINX runs from the archive.
- Type in range of id: e.g. `100-200`
- Click `Focus` underneath

> Should plot the `engggui_focusing_output_ws_cropped`

**Test 2**
Once you have done that, then go to the focus tab, and under Focus Texture:
- make sure `Plot Focused Workspace` is checked
- Select from `Plot Data Representation` combo-box 
- enter run number: 
- Create a text file with an extension of .csv and paste following data inside it

```
1, 100-200
2, 300-400
3, 500-900
```
- Browse the created file for `Detector Grouping File:`
- Click Focus underneath 

> Should plot the plot 3 separate workspaces according to the selection of `Plot Data Representation` combo-box.
