### PR TITLE
Update doctest runner for better compatability across sphinx versions

### DIFF
--- a/docs/runsphinx.py.in
+++ b/docs/runsphinx.py.in
@@ -58,6 +58,7 @@ def main(sysarg):
     output_dir = pathjoin(SPHINX_BUILD_DIR, BUILDER)
     doctree_dir = pathjoin(SPHINX_BUILD_DIR, "doctrees")
     argv = [sys.executable,
+            "-N",
             "-b", BUILDER,
             "-d", doctree_dir,
             "-c", CONF_DIR,

--- a/docs/runsphinx.py.in
+++ b/docs/runsphinx.py.in
@@ -72,7 +72,7 @@ def main(sysarg):
                                 % opts.testinclude)
 
     # Run
-    import sphinx
+    import sphinx.cmdline
     # IPython monkey patches the RegexLexer.get_tokens_unprocessed method and
     # causes Sphinx to fall over. We need to put it back while processing
     # the documentation
@@ -84,7 +84,7 @@ def main(sysarg):
     except AttributeError:
         pass
     try:
-        return_value = sphinx.main(argv)
+        return_value = sphinx.cmdline.main(argv)
     finally:
         from IPython.qt.console import pygments_highlighter
         RegexLexer.get_tokens_unprocessed = pygments_highlighter.get_tokens_unprocessed


### PR DESCRIPTION
Internal change for running the documentation checks.

The new Windows libraries contain a newer Sphinx version that has a refactored `Sphinx.main` method. It now calls `sys.exit` directly whereas we would like to get the return value, perform some cleanup and then call `sys.exit` ourselves.

These changes call the `sphinx.cmdline.main` method directly and are compatible with Sphinx >= 1.2, which is required by check in the cmake files.
