### PR TITLE
TOFTOF algorithm to convert tof to energy transfer.

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFConvertTofToDeltaE.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFConvertTofToDeltaE.py
@@ -1,0 +1,170 @@
+from mantid.api import PythonAlgorithm, AlgorithmFactory, WorkspaceProperty, MatrixWorkspaceProperty,\
+    PropertyMode, Progress
+from mantid.kernel import Direction, StringListValidator
+import mantid.simpleapi as api
+import numpy as np
+import scipy as sp
+import mlzutils
+
+
+class TOFTOFConvertTofToDeltaE(PythonAlgorithm):
+    """ Calculate energy transfer using elastic tof
+    """
+    logs_to_check = ['channel_width', 'chopper_ratio', 'chopper_speed', 'Ei', 'wavelength', 'EPP']
+
+    def __init__(self):
+        """
+        Init
+        """
+        PythonAlgorithm.__init__(self)
+
+    def category(self):
+        """ Return category
+        """
+        return "PythonAlgorithms\\MLZ\\TOFTOF;Transforms\\Units;CorrectionFunctions"
+
+    def name(self):
+        """ Return name
+        """
+        return "TOFTOFConvertTofToDeltaE"
+
+    def summary(self):
+        return "Converts X-axis units from TOF to energy transfer dE."
+
+    def PyInit(self):
+        """ Declare properties
+        """
+        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", direction=Direction.Input),
+                             "Input Sample workspace")
+        # Optional but required if choice of tof_elastic from Vanadium ws or file
+        self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", direction=Direction.Input,
+                                                     optional=PropertyMode.Optional),
+                             "Input Vanadium workspace (optional)")
+        self.declareProperty(WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
+                             "Name the workspace that will contain the result")
+        choice_tof = ["Geometry", "FitVanadium", "FitSample"]
+        self.declareProperty("ChoiceElasticTof", "Geometry", StringListValidator(choice_tof))
+        return
+
+    def validateInputs(self):
+        issues = dict()
+
+        choice_tof = self.getProperty("ChoiceElasticTof").value
+        vanaws_name = self.getPropertyValue("VanadiumWorkspace")
+        inws = self.getProperty("InputWorkspace").value
+
+        # instrument must be set, this can be moved to validator
+        # after validators will work for WorkspaceGroups
+        if not inws.getInstrument().getName():
+            issues['InputWorkspace'] = "Instrument must be set."
+
+        # X units must be TOF
+        xunit = inws.getAxis(0).getUnit().unitID()
+        if xunit != 'TOF':
+            issues['InputWorkspace'] = "X axis units must be TOF. "
+
+        # input workspace must have required sample logs
+        err = api.CheckForSampleLogs(inws, ",".join(self.logs_to_check))
+        if err:
+            issues['InputWorkspace'] = err
+
+        # if Vanadium will be used to find EPP, workspace must exist and have required sample logs
+        if choice_tof == 'FitVanadium':
+            if not api.AnalysisDataService.doesExist(vanaws_name):
+                issues['VanadiumWorkspace'] = "Valid Vanadium Workspace must be given for choosen ElasticTof option."
+
+            else:
+                vanaws = api.AnalysisDataService.retrieve(vanaws_name)
+                xunit = vanaws.getAxis(0).getUnit().unitID()
+                if xunit != 'TOF':
+                    issues['VanadiumWorkspace'] = "X axis units must be TOF. "
+                err = api.CheckForSampleLogs(vanaws, ",".join(self.logs_to_check))
+                if err:
+                    issues['VanadiumWorkspace'] = err
+                # required sample logs for sample and vanadium must be identical
+                else:
+                    result = api.CompareSampleLogs([inws.getName(), vanaws_name], self.logs_to_check, 0.01)
+                    if len(result) > 0:
+                        issues['VanadiumWorkspace'] = "Sample logs " + result + " must match for Vanadium and sample workspaces."
+        # if EPP will be taken from sample logs, it must be > 0
+        epp = inws.getRun().getProperty('EPP').value
+        if float(epp) <= 0:
+            issues['InputWorkspace'] = "EPP must be a positive number."
+
+        return issues
+
+    def PyExec(self):
+        """ Main execution body
+        """
+        input_ws = self.getProperty("InputWorkspace").value
+        outws_name = self.getPropertyValue("OutputWorkspace")
+        choice_tof = self.getProperty("ChoiceElasticTof").value
+
+        run = input_ws.getRun()
+        nb_hist = input_ws.getNumberHistograms()
+
+        prog_reporter = Progress(self, start=0.0, end=1.0, nreports=nb_hist + 1)  # extra call below when summing
+
+        # find elastic time channel
+        tof_elastic = np.zeros(nb_hist)
+        channel_width = float(run.getLogData('channel_width').value)
+        # t_el = epp_channel_number*channel_width + xmin
+        t_el_default = float(run.getLogData('EPP').value)*channel_width + input_ws.readX(0)[0]
+
+        if choice_tof == 'Geometry':
+            # tof_elastic from header of raw datafile start guess on peak position
+            tof_elastic.fill(t_el_default)
+
+        if choice_tof == 'FitSample':
+            prog_reporter.report("Fit function")
+            for idx in range(nb_hist):
+                tof_elastic[idx] = mlzutils.do_fit_gaussian(input_ws, idx, self.log())[0]
+
+        if choice_tof == 'FitVanadium':
+            vanaws = self.getProperty("VanadiumWorkspace").value
+            prog_reporter.report("Fit function")
+            for idx in range(nb_hist):
+                tof_elastic[idx] = mlzutils.do_fit_gaussian(vanaws, idx, self.log())[0]
+
+        self.log().debug("Tel = " + str(tof_elastic))
+        clone = self.createChildAlgorithm("CloneWorkspace")
+        clone.setProperty("InputWorkspace", input_ws)
+        clone.setPropertyValue("OutputWorkspace", outws_name)
+        clone.execute()
+        outws = clone.getProperty("OutputWorkspace").value
+        # mask detectors with EPP=0
+        zeros = np.where(tof_elastic == 0)[0]
+        if len(zeros) > 0:
+            self.log().warning("Detectors " + str(zeros) + " have EPP=0 and will be masked.")
+            api.MaskDetectors(outws, DetectorList=zeros)
+            # makes sence to convert units even for masked detectors, take EPP guess for that
+            for idx in zeros:
+                tof_elastic[idx] = t_el_default
+
+        instrument = outws.getInstrument()
+        sample = instrument.getSample()
+        factor = sp.constants.m_n*1e+15/sp.constants.eV
+
+        # calculate new values for dataX and data Y
+        for idx in range(nb_hist):
+            prog_reporter.report("Setting %dth spectrum" % idx)
+            det = instrument.getDetector(outws.getSpectrum(idx).getDetectorIDs()[0])
+            xbins = input_ws.readX(idx)                   # take bin boundaries
+            tof = xbins[:-1] + 0.5*channel_width          # take middle of each bin
+            sdd = det.getDistance(sample)
+            # calculate new I = t^3*I(t)/(factor*sdd^2*dt)
+            dataY = input_ws.readY(idx)*tof**3/(factor*channel_width*sdd*sdd)
+            dataE = input_ws.readE(idx)*tof**3/(factor*channel_width*sdd*sdd)
+            outws.setY(idx, dataY)
+            outws.setE(idx, dataE)
+            # calculate dE = factor*0.5*sdd^2*(1/t_el^2 - 1/t^2)
+            dataX = 0.5*factor*sdd*sdd*(1/tof_elastic[idx]**2 - 1/xbins**2)
+            outws.setX(idx, dataX)
+
+        outws.getAxis(0).setUnit('DeltaE')
+        outws.setDistribution(True)
+
+        self.setProperty("OutputWorkspace", outws)
+
+# Register algorithm with Mantid.
+AlgorithmFactory.subscribe(TOFTOFConvertTofToDeltaE)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -79,6 +79,7 @@ set ( TEST_PY_FILES
   UpdatePeakParameterTableValueTest.py
   SANSSubtractTest.py
   TimeSliceTest.py
+  TOFTOFConvertTofToDeltaETest.py
   TOFTOFCropWorkspaceTest.py
   TOFTOFMergeRunsTest.py
   TOSCABankCorrectionTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFConvertTofToDeltaETest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFConvertTofToDeltaETest.py
@@ -1,0 +1,137 @@
+import unittest
+from mantid.simpleapi import DeleteWorkspace, CreateSampleWorkspace, AddSampleLogMultiple, AddSampleLog, \
+    TOFTOFConvertTofToDeltaE, DeleteLog
+from testhelpers import run_algorithm
+from mantid.api import AnalysisDataService
+import numpy as np
+from scipy.constants import m_n, eV
+
+
+class TOFTOFConvertTofToDeltaETest(unittest.TestCase):
+    def setUp(self):
+        # create sample workspace
+        ws_tof = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction="name=LinearBackground, \
+                                       A0=0.3;name=Gaussian, PeakCentre=6000, Height=5, Sigma=75", NumBanks=2,
+                                       BankPixelWidth=1, XMin=4005.75, XMax=7995.75, BinWidth=10.5,
+                                       BankDistanceFromSample=4.0)
+        # add required sample logs
+        lognames = "channel_width,chopper_ratio,chopper_speed,Ei,wavelength,EPP"
+        logvalues = "10.5,5,14000,2.27,6,190.0"
+        AddSampleLogMultiple(ws_tof, lognames, logvalues)
+        self._input_ws = ws_tof
+
+    def test_basicrun(self):
+        OutputWorkspaceName = "outputws"
+        alg_test = run_algorithm("TOFTOFConvertTofToDeltaE", InputWorkspace=self._input_ws,
+                                 OutputWorkspace=OutputWorkspaceName, ChoiceElasticTof="Geometry")
+        wsoutput = AnalysisDataService.retrieve(OutputWorkspaceName)
+        # execution of algorithm
+        self.assertTrue(alg_test.isExecuted())
+        # unit of output
+        self.assertEqual(wsoutput.getAxis(0).getUnit().unitID(), "DeltaE")
+        # shape of output compared to input
+        self.assertEqual(wsoutput.getNumberHistograms(), self._input_ws.getNumberHistograms())
+        self.assertEqual(wsoutput.blocksize(), self._input_ws.blocksize())
+        DeleteWorkspace(wsoutput)
+
+    def test_defaultsetup(self):
+        OutputWorkspaceName = "outputws"
+        alg_test = run_algorithm("TOFTOFConvertTofToDeltaE", InputWorkspace=self._input_ws,
+                                 OutputWorkspace=OutputWorkspaceName)
+        self.assertTrue(alg_test.isExecuted())
+        self.assertEqual(alg_test.getProperty("ChoiceElasticTof").value, "Geometry")
+        wsoutput = AnalysisDataService.retrieve(OutputWorkspaceName)
+        DeleteWorkspace(wsoutput)
+
+    # Test options to calculate tof elastic
+    def test_calculation_geometry(self):
+        OutputWorkspaceName = "outputws"
+        alg_test = run_algorithm("TOFTOFConvertTofToDeltaE", InputWorkspace=self._input_ws,
+                                 OutputWorkspace=OutputWorkspaceName, ChoiceElasticTof='Geometry')
+        self.assertTrue(alg_test.isExecuted())
+        wsoutput = AnalysisDataService.retrieve(OutputWorkspaceName)
+
+        # create reference data for X axis
+        dataX = np.linspace(4005.75, 7995.75, 381)
+        tel = 190.0*10.5 + 4005.75
+        factor = m_n*1e+15/eV
+        newX = 0.5*factor*16.0*(1/tel**2 - 1/dataX**2)
+        # compare
+        self.assertTrue(np.allclose(newX, wsoutput.readX(0)))           # sdd = 4.0
+        self.assertTrue(np.allclose(4.0*newX, wsoutput.readX(1)))       # sdd = 8.0
+
+        # create reference data for Y axis and compare to the output
+        tof = dataX[:-1] + 5.25
+        newY = self._input_ws.readY(0)*tof**3/(factor*10.5*16.0)
+        self.assertTrue(np.allclose(newY, wsoutput.readY(0)))           # sdd = 4.0
+        self.assertTrue(np.allclose(newY/4.0, wsoutput.readY(1)))       # sdd = 8.0
+
+        DeleteWorkspace(wsoutput)
+
+    def test_calculation_fitsample(self):
+        OutputWorkspaceName = "outputws"
+        alg_test = run_algorithm("TOFTOFConvertTofToDeltaE", InputWorkspace=self._input_ws,
+                                 OutputWorkspace=OutputWorkspaceName, ChoiceElasticTof='FitSample')
+        self.assertTrue(alg_test.isExecuted())
+        wsoutput = AnalysisDataService.retrieve(OutputWorkspaceName)
+
+        # create reference data for X axis
+        dataX = np.linspace(4005.75, 7995.75, 381)
+        tel = 6005.25
+        factor = m_n*1e+15/eV
+        newX = 0.5*factor*16.0*(1/tel**2 - 1/dataX**2)
+        # compare
+        self.assertTrue(np.allclose(newX, wsoutput.readX(0)))           # sdd = 4.0
+        self.assertTrue(np.allclose(4.0*newX, wsoutput.readX(1)))       # sdd = 8.0
+
+        # create reference data for Y axis and compare to the output
+        tof = dataX[:-1] + 5.25
+        newY = self._input_ws.readY(0)*tof**3/(factor*10.5*16.0)
+        self.assertTrue(np.allclose(newY, wsoutput.readY(0)))           # sdd = 4.0
+        self.assertTrue(np.allclose(newY/4.0, wsoutput.readY(1)))       # sdd = 8.0
+
+        DeleteWorkspace(wsoutput)
+
+    def test_calculation_fitvanadium(self):
+        OutputWorkspaceName = "outputws"
+        alg_test = run_algorithm("TOFTOFConvertTofToDeltaE", InputWorkspace=self._input_ws,
+                                 VanadiumWorkspace=self._input_ws, OutputWorkspace=OutputWorkspaceName,
+                                 ChoiceElasticTof='FitVanadium')
+        self.assertTrue(alg_test.isExecuted())
+        wsoutput = AnalysisDataService.retrieve(OutputWorkspaceName)
+
+        # create reference data for X axis
+        dataX = np.linspace(4005.75, 7995.75, 381)
+        tel = 6005.25
+        factor = m_n*1e+15/eV
+        newX = 0.5*factor*16.0*(1/tel**2 - 1/dataX**2)
+        # compare
+        self.assertTrue(np.allclose(newX, wsoutput.readX(0)))           # sdd = 4.0
+        self.assertTrue(np.allclose(4.0*newX, wsoutput.readX(1)))       # sdd = 8.0
+
+        # create reference data for Y axis and compare to the output
+        tof = dataX[:-1] + 5.25
+        newY = self._input_ws.readY(0)*tof**3/(factor*10.5*16.0)
+        self.assertTrue(np.allclose(newY, wsoutput.readY(0)))           # sdd = 4.0
+        self.assertTrue(np.allclose(newY/4.0, wsoutput.readY(1)))       # sdd = 8.0
+
+        DeleteWorkspace(wsoutput)
+
+    def test_invalid_epp(self):
+        AddSampleLog(self._input_ws, LogName='EPP', LogText=str(0), LogType='Number')
+        OutputWorkspaceName = "outputws"
+        self.assertRaises(RuntimeError, TOFTOFConvertTofToDeltaE, InputWorkspace=self._input_ws,
+                          OutputWorkspace=OutputWorkspaceName)
+
+    def test_no_channel_width(self):
+        DeleteLog(self._input_ws, 'channel_width')
+        OutputWorkspaceName = "outputws"
+        self.assertRaises(RuntimeError, TOFTOFConvertTofToDeltaE, InputWorkspace=self._input_ws,
+                          OutputWorkspace=OutputWorkspaceName)
+
+    def cleanUp(self):
+        if self._input_ws is not None:
+            DeleteWorkspace(self._input_ws)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/algorithms/TOFTOFConvertTofToDeltaE-v1.rst
+++ b/docs/source/algorithms/TOFTOFConvertTofToDeltaE-v1.rst
@@ -1,0 +1,124 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+
+Converts X-axis units of the given workspace or group of workspaces from time-of-flight to energy transfer. Conversion is performed in a following way. The new X-axis data (:math:`\Delta E`, meV) are calculated as
+
+:math:`\Delta E = \frac{1}{2} C m_n L^2\cdot\left(\frac{1}{t_{el}^2} - \frac{1}{t^2}\right)`
+
+where :math:`L` is the sample-detector distance, :math:`m_n` is the neutron mass, :math:`t_{el}` is the time-of-flight corresponding to the elastic peak, :math:`t` is the time-of-flight corresponding to the bin boundaries of the X data in the input workspace. Coefficient :math:`C` is related to the unit conversion and calculated as
+
+:math:`C = \frac{10^{12}\cdot 10^3}{1.6\cdot 10^{-19}}`
+
+where :math:`1.6\cdot 10^{-19}` is the coefficient to convert energy from eV to Joule, :math:`10^3` is the coefficient to convert eV to meV and :math:`10^{12}` is the coefficient to convert :math:`\mu\mathrm{sec}^2` to :math:`\mathrm{seconds}^2`.
+
+In contrast to the :ref:`algm-ConvertUnits`, this algorithm calculates the new Y values :math:`I_E(\Delta E)` as 
+
+:math:`I_E (\Delta E) = \frac{t_c^3}{C\cdot m_n\cdot L^2\cdot\Delta t}\cdot I(t)`
+
+where :math:`t_c` is the time-of-flight corresponding to the bin centre in the X data in the input workspace, :math:`\Delta t` is the time channel width, and :math:`I(t)` are the Y data in the given input workspace.
+
+
+This algorithm offers three options for calculation of the elastic peak position :math:`t_{el}`:
+
+    1. **Geometry**: position of the elastic peak will be taken from the *EPP* sample log.
+           
+    2. **FitVanadium**: position of the elastic peak will be determined from the Gaussian fit of the given Vanadium workspace.
+           
+    3. **FitSample**: position of the elastic peak will be determined from the Gaussian fit of the given input workspace.
+
+If position of the elastic peak cannot be determined or :math:`t_{el} = 0` for a particular detector, this detector will be masked in the output workspace and warning will be produced. 
+
+Restrictions on the input workspaces
+###################################
+
+-  The unit of the X-axis must be **Time-of-flight**.
+
+-  Workspace must contain following sample logs: *channel_width*, *chopper_ratio*, *chopper_speed*, *Ei*, *wavelength*, *EPP*.
+
+-  Workpace must have an instrument set.
+
+-  If option *ChoiceElasticTof* is set to **FitVanaduim**:
+
+    1. valid Vanadium workspace must be provided
+
+    2. sample logs  *channel_width*, *chopper_ratio*, *chopper_speed*, *Ei*, *wavelength*, *EPP* must match for both, Vanadium and input workspaces.
+
+
+Usage
+-----
+
+**Example 1: Convert using the default option.**
+
+.. testcode:: ExTOFTOFConvertTofToDeltaE
+    
+    import numpy
+
+    # create workspace with appropriate sample logs
+    ws_tof = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction="name=LinearBackground, \
+                A0=0.3;name=Gaussian, PeakCentre=6000, Height=5, Sigma=75", NumBanks=2, BankPixelWidth=1,
+                XMin=4005.75, XMax=7995.75, BinWidth=10.5, BankDistanceFromSample=4.0)
+
+    lognames="channel_width,chopper_ratio,chopper_speed,Ei,wavelength,EPP"
+    logvalues="10.5,5,14000,2.27,6,190.0"
+    AddSampleLogMultiple(ws_tof, lognames, logvalues)
+
+    ws_dE=TOFTOFConvertTofToDeltaE(ws_tof)
+
+    print "Unit of X-axis before conversion: ", ws_tof.getAxis(0).getUnit().unitID()
+    print "Unit of X-axis after conversion: ",  ws_dE.getAxis(0).getUnit().unitID()
+    print "First 5 X values before conversion: ", ws_tof.readX(0)[:5]
+    print "First 5 X values after conversion: ", numpy.round(ws_dE.readX(0)[:5], 2)
+
+Output:
+
+.. testoutput:: ExTOFTOFConvertTofToDeltaE
+
+    Unit of X-axis before conversion:  TOF
+    Unit of X-axis after conversion:  DeltaE
+    First 5 X values before conversion:  [ 4005.75  4016.25  4026.75  4037.25  4047.75]
+    First 5 X values after conversion:  [-2.89 -2.86 -2.84 -2.81 -2.78]
+
+
+**Example 2: Convert using the FitSample option.**
+
+.. testcode:: Ex2TOFTOFConvertTofToDeltaE
+    
+    import numpy
+
+    # create workspace with appropriate sample logs
+    ws_tof = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction="name=LinearBackground, \
+                A0=0.3;name=Gaussian, PeakCentre=6000, Height=5, Sigma=75", NumBanks=2, BankPixelWidth=1,
+                XMin=4005.75, XMax=7995.75, BinWidth=10.5, BankDistanceFromSample=4.0)
+
+    lognames="channel_width,chopper_ratio,chopper_speed,Ei,wavelength,EPP"
+    logvalues="10.5,5,14000,2.27,6,190.0"
+    AddSampleLogMultiple(ws_tof, lognames, logvalues)
+
+    ws_dE=TOFTOFConvertTofToDeltaE(ws_tof, ChoiceElasticTof='FitSample')
+
+    print "Unit of X-axis before conversion: ", ws_tof.getAxis(0).getUnit().unitID()
+    print "Unit of X-axis after conversion: ",  ws_dE.getAxis(0).getUnit().unitID()
+    print "First 5 X values before conversion: ", ws_tof.readX(0)[:5]
+    print "First 5 X values after conversion: ", numpy.round(ws_dE.readX(0)[:5], 2)
+
+Output:
+
+.. testoutput:: Ex2TOFTOFConvertTofToDeltaE
+
+    Unit of X-axis before conversion:  TOF
+    Unit of X-axis after conversion:  DeltaE
+    First 5 X values before conversion:  [ 4005.75  4016.25  4026.75  4037.25  4047.75]
+    First 5 X values after conversion:  [-2.89 -2.87 -2.84 -2.81 -2.79]
+
+.. categories::
+
+.. sourcelink::


### PR DESCRIPTION
Python algorithm for conversion of the x-axis units from TOF to energy transfer. Developed for TOFTOF@MLZ, but not restricted to this instrument. This algorithm uses the conversion approach different from the ConvertUnits algorithm (see documentation). Can be tested on the sample workspaces.

Please, review the code, tests and documentation. Let me know if I should correct or improve them.

Label: Direct Inelastic
