### PR TITLE
Changed ordering of plot options in Bayes Quasi interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Quasi.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Quasi.ui
@@ -340,11 +340,6 @@
           </item>
           <item>
            <property name="text">
-            <string>All</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
             <string>Amplitude</string>
            </property>
           </item>
@@ -362,6 +357,11 @@
            <property name="text">
             <string>Prob</string>
            </property>
+          </item>
+           <item>
+            <property name="text">
+             <string>All</string>
+            </property>
           </item>
          </widget>
         </item>


### PR DESCRIPTION
Fixes #13973

Changed the ordering of the plot options in the interface for Bayes Quasi
# To Test
- Open Quasi (Interface > Indirect > Bayes > Quasi)
- Ensure that the plot options in the interface (bottom left) now read in the following order:
  - None
  - Amplitude
  - FWHM
  - Fit
  - Prob
  - All
