### PR TITLE
Update TOFSANSResolutionByPixel documentation.

### DIFF
--- a/docs/source/algorithms/TOFSANSResolutionByPixel-v1.rst
+++ b/docs/source/algorithms/TOFSANSResolutionByPixel-v1.rst
@@ -29,7 +29,7 @@ by wavelength steps set elsewhere in Mantid which should be at least as large as
 equivalent time bins used in the original histogram data collection. For event mode data 
 :math:`\Delta \lambda` is in theory very small, but in practice a histogram in 
 time has to be generated (perhaps using monitor time bins or specifically set 
-“event time bins”), before a rebinning into user provided wavelength steps in InputWorkspace. 
+event-time-bins), before a rebinning into user provided wavelength steps in InputWorkspace. 
 Again the latter steps should be the largest.
 
 Q values needed here are calculated in the same way as for Q1D, including correction 

--- a/docs/source/algorithms/TOFSANSResolutionByPixel-v1.rst
+++ b/docs/source/algorithms/TOFSANSResolutionByPixel-v1.rst
@@ -21,15 +21,20 @@ and
 
 .. math:: (\sigma_{\lambda})^2 = (\Delta \lambda )^2 / 12 + (\sigma_{moderator})^2
 
-where :math:`\sigma_{\lambda}` is the overall wavelength std from TOF binning
-and moderator, :math:`\Delta \lambda` is taken from the binning of the InputWorkspace 
-and the :math:`\sigma_{moderator}` is the wavelenght spread from the moderator.
+where :math:`\sigma_{\lambda}` is the overall effective standard deviation in wavelength. 
+:math:`\Delta \lambda` values are found from the wavelength binning of the InputWorkspace, 
+:math:`\sigma_{moderator}` is the moderator time spread (the variation in time for the moderator 
+to emit neutrons of a given wavelength). Note that :math:`\Delta \lambda` may be imposed 
+by wavelength steps set elsewhere in Mantid which should be at least as large as the 
+equivalent time bins used in the original histogram data collection. For event mode data 
+:math:`\Delta \lambda` is in theory very small, but in practice a histogram in 
+time has to be generated (perhaps using monitor time bins or specifically set 
+“event time bins”), before a rebinning into user provided wavelength steps in InputWorkspace. 
+Again the latter steps should be the largest.
 
-where :math:`\sigma_{\lambda}` is the effective standard deviation, and :math:`\Delta \lambda`,
-originating from the TOF binning of the InputWorkspace, is the (rectangular)
-width, of the moderator wavelength distribution. :math:`\sigma_{moderator}` is the
-moderator time spread (the variation in time for the moderator to emit neutrons
-of a given wavelength).
+Q values needed here are calculated in the same way as for Q1D, including correction 
+for gravity for which detector coordinates are assumed centred at zero wavelength.
+
 
 :math:`\sigma_Q` is returned as the y-values of the InputWorkspace, and the 
 remaining variables in the main equation above are related to parameters of this
@@ -53,6 +58,12 @@ use :math:`R = \sqrt{( H^2 +W^2)/6 }`. Note that we are assuming isotropically a
 scalar :math:`Q`, and making some small angle approximations. Results on higher angle detectors
 may not be accurate. For data reduction sliced in different directions on the detector
 (e.g. GISANS) adjust the calling parameters to suit the collimation in that direction.
+
+Note that :math:`\Delta` is the full width of a rectangular distribution in radius or wavelength, 
+for which the standard deviation is :math:`\sigma=\Delta/\sqrt{12}`. For a Gaussian distribution 
+the FWHM (full width at half maximum) is :math:`\sqrt{8\ln{2}}\sigma=2.35482\sigma`. For an exponential decay 
+:math:`e^{-t/\tau}`, the standard deviation (and the mean) is :math:`\tau`. For non-rectangular 
+distributions these equations allow the equivalent :math:`\Delta` to be entered as :math:`\Delta=\sqrt{12}\sigma`.
 
 This version of the algorithm neglects wavelength-dependent detector detection depth effects.
 


### PR DESCRIPTION
Fixes #14148 

This is an update to the `TOFSANSResolutionByPixel` documentation.
# For Testing

Grab an installer and check that the algorithm documentation for `TOFSANSResolutionByPixel` looks ok. The last Jenkins Windows intaller can be found here: \olympic\Babylon5\Scratch\Anton\Testing\14148_Update_documentation
