### PR TITLE
Refs #14160 fix edgePixel for corelli

### DIFF
--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -93,7 +93,7 @@ void OptimizeLatticeForCellType::exec() {
   runWS.push_back(ws);
 
   if (perRun) {
-    std::vector<std::pair<std::string, bool> > criteria;
+    std::vector<std::pair<std::string, bool>> criteria;
     // Sort by run number
     criteria.push_back(std::pair<std::string, bool>("runnumber", true));
     ws->sort(criteria);
@@ -131,8 +131,7 @@ void OptimizeLatticeForCellType::exec() {
     IAlgorithm_sptr fit_alg;
     try {
       fit_alg = createChildAlgorithm("Fit", -1, -1, false);
-    }
-    catch (Exception::NotFoundError &) {
+    } catch (Exception::NotFoundError &) {
       g_log.error("Can't locate Fit algorithm");
       throw;
     }
@@ -156,8 +155,7 @@ void OptimizeLatticeForCellType::exec() {
     try {
       ub_alg =
           createChildAlgorithm("FindUBUsingLatticeParameters", -1, -1, false);
-    }
-    catch (Exception::NotFoundError &) {
+    } catch (Exception::NotFoundError &) {
       g_log.error("Can't locate FindUBUsingLatticeParameters algorithm");
       throw;
     }
@@ -208,9 +206,9 @@ void OptimizeLatticeForCellType::exec() {
                                                runWS[i_run]->getName() +
                                                ".integrate");
       savePks_alg->executeAsChildAlg();
-      g_log.notice() << "See output file: " << outputdir + "ls" +
-                                                   runWS[i_run]->getName() +
-                                                   ".integrate"
+      g_log.notice() << "See output file: "
+                     << outputdir + "ls" + runWS[i_run]->getName() +
+                            ".integrate"
                      << "\n";
       // Save UB
       Mantid::API::IAlgorithm_sptr saveUB_alg =


### PR DESCRIPTION
Fixes #14160 . Remove .txt extension from file for testing
[MAP_300K.peaks.txt](https://github.com/mantidproject/mantid/files/22845/MAP_300K.peaks.txt)

To test

``` python
ws=LoadIsawPeaks("MAP_300K.peaks")
FindUBUsingIndexedPeaks(ws, Tolerance=0.12)
print "Before Optimization:"
print ws.sample().getOrientedLattice().getUB()
OptimizeLatticeForCellType(ws,CellType="Tetragonal")
print "\nAfter Optimization:"
print ws.sample().getOrientedLattice().getUB()
OptimizeLatticeForCellType(ws,CellType="Tetragonal",EdgePixels=1)
print "\nAfter Optimization with edge peaks removed:"
print ws.sample().getOrientedLattice().getUB()

```
