### PR TITLE
Indirect Corrections output workspace naming convention

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -122,13 +122,29 @@ void ContainerSubtraction::run() {
   int sampleNameCutIndex = sampleWsName.lastIndexOf("_");
   if (sampleNameCutIndex == -1)
     sampleNameCutIndex = sampleWsName.length();
-  int containerNameCutIndex = containerWsName.indexOf("_");
-  if (containerNameCutIndex == -1)
-    containerNameCutIndex = containerWsName.length();
 
-  const QString outputWsName = sampleWsName.left(sampleNameCutIndex) +
-                               "_Subtract_" +
-                               containerWsName.left(containerNameCutIndex);
+  MatrixWorkspace_sptr containerWs =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+          containerWsName.toStdString());
+  std::string runNum = "";
+  int containerNameCutIndex = 0;
+  if(containerWs->run().hasProperty("run_number")){
+	runNum = containerWs->run().getProperty("run_number")->value();
+  }else{
+	containerNameCutIndex = containerWsName.indexOf("_");
+	if (containerNameCutIndex == -1)
+		containerNameCutIndex = containerWsName.length();
+  }
+
+  QString outputWsName = sampleWsName.left(sampleNameCutIndex) + "_Subtract_";
+  if (runNum.compare("") != 0) {
+	  outputWsName += QString::fromStdString(runNum);
+  } else {
+    auto canCut = containerWsName.left(containerNameCutIndex);
+    outputWsName += canCut;
+  }
+
+  outputWsName += "_red";
 
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -128,20 +128,19 @@ void ContainerSubtraction::run() {
           containerWsName.toStdString());
   std::string runNum = "";
   int containerNameCutIndex = 0;
-  if(containerWs->run().hasProperty("run_number")){
-	runNum = containerWs->run().getProperty("run_number")->value();
-  }else{
-	containerNameCutIndex = containerWsName.indexOf("_");
-	if (containerNameCutIndex == -1)
-		containerNameCutIndex = containerWsName.length();
+  if (containerWs->run().hasProperty("run_number")) {
+    runNum = containerWs->run().getProperty("run_number")->value();
+  } else {
+    containerNameCutIndex = containerWsName.indexOf("_");
+    if (containerNameCutIndex == -1)
+      containerNameCutIndex = containerWsName.length();
   }
 
   QString outputWsName = sampleWsName.left(sampleNameCutIndex) + "_Subtract_";
   if (runNum.compare("") != 0) {
-	  outputWsName += QString::fromStdString(runNum);
+    outputWsName += QString::fromStdString(runNum);
   } else {
-    auto canCut = containerWsName.left(containerNameCutIndex);
-    outputWsName += canCut;
+    outputWsName += containerWsName.left(containerNameCutIndex);
   }
 
   outputWsName += "_red";


### PR DESCRIPTION
Fixes #14144 

The naming convention of files produced in the ContainerSubtraction and ApplyPaalmanPings tabs have been updated.

**All files are available from `\\olympic\Babylon5\Public\ElliotOram\Corrections\correction_set`**
# To Test (ContainerSubtraction)
- Open ContainerSubtraction (Interfaces > Indirect > Corrections > ContainerSubtraction)
- Add the Sample (`IRS26176`) and the Container (`IRS26174`)
- Run
- Ensure output workspace is called `IRS26176_graphite002_Subtract_26174_red`
# To Test (ApplyPaalmanPings)
- Open ApplyPaalmanPings (Interfaces > Indirect > Corrections > ContainerSubtraction)
- Add Input file (`IRS26176`), 
- Ensure Geometry is set to Flat Plate (to match the corrections file
- Check `Use Can` and add the Can file (`IRS26174`)
- Check `Use Corrections` and add the Correction file (File ending in flt_abs.nxs)
- Run with `Use Can` **and** `Use Corrections`:
  - OutputWorkspace = `IRS26176_graphite002_flt_Corrected_26174_red`
- Run with **ONLY** `Use Can` (uncheck `Use Corrections`):
  - OutputWorkspace = `IRS26176_grpahite002_Subtract_26174_red`
- Run with **ONLY** `Use Corrections` (uncheck `Use Can`):
  - OutputWorkspace = `IRS26176_graphite002_flt_Corrected_red`
- It should not be possible to run without either and you should be stopped by validation.
