### PR TITLE
add x error to save and load for Nexus files

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNexusProcessed.h
@@ -165,6 +165,7 @@ private:
   void loadBlock(Mantid::NeXus::NXDataSetTyped<double> &data,
                  Mantid::NeXus::NXDataSetTyped<double> &errors,
                  Mantid::NeXus::NXDataSetTyped<double> &farea, bool hasFArea,
+                 Mantid::NeXus::NXDouble &xErrors, bool hasXErrors,
                  int64_t blocksize, int64_t nchannels, int64_t &hist,
                  API::MatrixWorkspace_sptr local_workspace);
 
@@ -173,12 +174,14 @@ private:
   void loadBlock(Mantid::NeXus::NXDataSetTyped<double> &data,
                  Mantid::NeXus::NXDataSetTyped<double> &errors,
                  Mantid::NeXus::NXDataSetTyped<double> &farea, bool hasFArea,
+                 Mantid::NeXus::NXDouble &xErrors, bool hasXErrors,
                  int64_t blocksize, int64_t nchannels, int64_t &hist,
                  int64_t &wsIndex, API::MatrixWorkspace_sptr local_workspace);
   /// Load a block of data into the workspace
   void loadBlock(Mantid::NeXus::NXDataSetTyped<double> &data,
                  Mantid::NeXus::NXDataSetTyped<double> &errors,
                  Mantid::NeXus::NXDataSetTyped<double> &farea, bool hasFArea,
+                 Mantid::NeXus::NXDouble &xErrors, bool hasXErrors,
                  Mantid::NeXus::NXDouble &xbins, int64_t blocksize,
                  int64_t nchannels, int64_t &hist, int64_t &wsIndex,
                  API::MatrixWorkspace_sptr local_workspace);

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1293,6 +1293,11 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
     fracarea = wksp_cls.openNXDouble("frac_area");
   }
 
+  // Check for x errors; as with fracArea we set it to xbins
+  // although in this case it would never be used.
+  auto hasXErrors = wksp_cls.isValid("xerrors");
+  NXDouble &xErrors = hasXErrors ? wksp_cls.openNXDouble("xerrors") : xbins;
+
   int64_t blocksize(8);
   // const int fullblocks = nspectra / blocksize;
   // size of the workspace
@@ -1325,12 +1330,12 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(hist_index) /
                            static_cast<double>(read_stop),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea, blocksize, nchannels,
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, blocksize, nchannels,
                     hist_index, wsIndex, local_workspace);
         }
         int64_t finalblock = m_spec_max - 1 - read_stop;
         if (finalblock > 0) {
-          loadBlock(data, errors, fracarea, hasFracArea, finalblock, nchannels,
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, finalblock, nchannels,
                     hist_index, wsIndex, local_workspace);
         }
       }
@@ -1344,7 +1349,7 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(specIndex) /
                            static_cast<double>(m_spec_list.size()),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea,
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
                     static_cast<int64_t>(1), nchannels, specIndex, wsIndex,
                     local_workspace);
         }
@@ -1355,12 +1360,12 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                      progressScaler * static_cast<double>(hist_index) /
                          static_cast<double>(read_stop),
                  "Reading workspace data...");
-        loadBlock(data, errors, fracarea, hasFracArea, blocksize, nchannels,
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, blocksize, nchannels,
                   hist_index, wsIndex, local_workspace);
       }
       int64_t finalblock = total_specs - read_stop;
       if (finalblock > 0) {
-        loadBlock(data, errors, fracarea, hasFracArea, finalblock, nchannels,
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, finalblock, nchannels,
                   hist_index, wsIndex, local_workspace);
       }
     }
@@ -1383,12 +1388,12 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(hist_index) /
                            static_cast<double>(read_stop),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea, xbins, blocksize,
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, blocksize,
                     nchannels, hist_index, wsIndex, local_workspace);
         }
         int64_t finalblock = m_spec_max - 1 - read_stop;
         if (finalblock > 0) {
-          loadBlock(data, errors, fracarea, hasFracArea, xbins, finalblock,
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, finalblock,
                     nchannels, hist_index, wsIndex, local_workspace);
         }
       }
@@ -1401,7 +1406,7 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(specIndex) /
                            static_cast<double>(read_stop),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea, xbins, 1, nchannels,
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, 1, nchannels,
                     specIndex, wsIndex, local_workspace);
         }
       }
@@ -1411,12 +1416,12 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                      progressScaler * static_cast<double>(hist_index) /
                          static_cast<double>(read_stop),
                  "Reading workspace data...");
-        loadBlock(data, errors, fracarea, hasFracArea, xbins, blocksize,
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, blocksize,
                   nchannels, hist_index, wsIndex, local_workspace);
       }
       int64_t finalblock = total_specs - read_stop;
       if (finalblock > 0) {
-        loadBlock(data, errors, fracarea, hasFracArea, xbins, finalblock,
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, finalblock,
                   nchannels, hist_index, wsIndex, local_workspace);
       }
     }
@@ -1812,6 +1817,8 @@ void LoadNexusProcessed::readBinMasking(
  * @param errors :: The NXDataSet object of error values
  * @param farea :: The NXDataSet object of fraction area values
  * @param hasFArea :: Flag to signal a RebinnedOutput workspace is in use
+ * @param xErrors :: The NXDataSet object of xError values
+ * @param hasXErrors :: Flag to signal the File contains x errors
  * @param blocksize :: The blocksize to use
  * @param nchannels :: The number of channels for the block
  * @param hist :: The workspace index to start reading into
@@ -1820,6 +1827,7 @@ void LoadNexusProcessed::readBinMasking(
 void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
                                    NXDataSetTyped<double> &errors,
                                    NXDataSetTyped<double> &farea, bool hasFArea,
+                                   NXDouble &xErrors, bool hasXErrors,
                                    int64_t blocksize, int64_t nchannels,
                                    int64_t &hist,
                                    API::MatrixWorkspace_sptr local_workspace) {
@@ -1831,6 +1839,9 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
   double *err_end = err_start + nchannels;
   double *farea_start = NULL;
   double *farea_end = NULL;
+  const int64_t nxbins(m_xbins->size());
+  double *xErrors_start = NULL;
+  double *xErrors_end = NULL;
   RebinnedOutput_sptr rb_workspace;
   if (hasFArea) {
     farea.load(static_cast<int>(blocksize), static_cast<int>(hist));
@@ -1838,6 +1849,12 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
     farea_end = farea_start + nchannels;
     rb_workspace = boost::dynamic_pointer_cast<RebinnedOutput>(local_workspace);
   }
+  if (hasXErrors) {
+    xErrors.load(static_cast<int>(blocksize), static_cast<int>(hist));
+    xErrors_start = xErrors();
+    xErrors_end = xErrors_start + nxbins;
+  }
+
   int64_t final(hist + blocksize);
   while (hist < final) {
     MantidVec &Y = local_workspace->dataY(hist);
@@ -1854,6 +1871,13 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
       farea_start += nchannels;
       farea_end += nchannels;
     }
+    if (hasXErrors) {
+      MantidVec &DX = local_workspace->dataDx(hist);
+      DX.assign(xErrors_start, xErrors_end);
+      xErrors_start += nxbins;
+      xErrors_end += nxbins;
+    }
+
     local_workspace->setX(hist, m_xbins);
     ++hist;
   }
@@ -1868,6 +1892,8 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
  * @param errors :: The NXDataSet object of error values
  * @param farea :: The NXDataSet object of fraction area values
  * @param hasFArea :: Flag to signal a RebinnedOutput workspace is in use
+ * @param xErrors :: The NXDataSet object of xError values
+ * @param hasXErrors :: Flag to signal the File contains x errors
  * @param blocksize :: The blocksize to use
  * @param nchannels :: The number of channels for the block
  * @param hist :: The workspace index to start reading into
@@ -1878,6 +1904,7 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
 void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
                                    NXDataSetTyped<double> &errors,
                                    NXDataSetTyped<double> &farea, bool hasFArea,
+                                   NXDouble &xErrors, bool hasXErrors,
                                    int64_t blocksize, int64_t nchannels,
                                    int64_t &hist, int64_t &wsIndex,
                                    API::MatrixWorkspace_sptr local_workspace) {
@@ -1889,6 +1916,9 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
   double *err_end = err_start + nchannels;
   double *farea_start = NULL;
   double *farea_end = NULL;
+  const int64_t nxbins(m_xbins->size());
+  double *xErrors_start = NULL;
+  double *xErrors_end = NULL;
   RebinnedOutput_sptr rb_workspace;
   if (hasFArea) {
     farea.load(static_cast<int>(blocksize), static_cast<int>(hist));
@@ -1896,6 +1926,12 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
     farea_end = farea_start + nchannels;
     rb_workspace = boost::dynamic_pointer_cast<RebinnedOutput>(local_workspace);
   }
+  if (hasXErrors) {
+    xErrors.load(static_cast<int>(blocksize), static_cast<int>(hist));
+    xErrors_start = xErrors();
+    xErrors_end = xErrors_start + nxbins;
+  }
+
   int64_t final(hist + blocksize);
   while (hist < final) {
     MantidVec &Y = local_workspace->dataY(wsIndex);
@@ -1912,6 +1948,12 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
       farea_start += nchannels;
       farea_end += nchannels;
     }
+    if (hasXErrors) {
+      MantidVec &DX = local_workspace->dataDx(wsIndex);
+      DX.assign(xErrors_start, xErrors_end);
+      xErrors_start += nxbins;
+      xErrors_end += nxbins;
+    }
     local_workspace->setX(wsIndex, m_xbins);
     ++hist;
     ++wsIndex;
@@ -1927,6 +1969,8 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
  * @param errors :: The NXDataSet object of error values
  * @param farea :: The NXDataSet object of fraction area values
  * @param hasFArea :: Flag to signal a RebinnedOutput workspace is in use
+ * @param xErrors :: The NXDataSet object of xError values
+ * @param hasXErrors :: Flag to signal the File contains x errors
  * @param xbins :: The xbin NXDataSet
  * @param blocksize :: The blocksize to use
  * @param nchannels :: The number of channels for the block
@@ -1937,6 +1981,7 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
 void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
                                    NXDataSetTyped<double> &errors,
                                    NXDataSetTyped<double> &farea, bool hasFArea,
+                                   NXDouble &xErrors, bool hasXErrors,
                                    NXDouble &xbins, int64_t blocksize,
                                    int64_t nchannels, int64_t &hist,
                                    int64_t &wsIndex,
@@ -1949,6 +1994,8 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
   double *err_end = err_start + nchannels;
   double *farea_start = NULL;
   double *farea_end = NULL;
+  double *xErrors_start = NULL;
+  double *xErrors_end = NULL;
   RebinnedOutput_sptr rb_workspace;
   if (hasFArea) {
     farea.load(static_cast<int>(blocksize), static_cast<int>(hist));
@@ -1961,6 +2008,13 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
   double *xbin_start = xbins();
   double *xbin_end = xbin_start + nxbins;
   int64_t final(hist + blocksize);
+
+  if (hasXErrors) {
+    xErrors.load(static_cast<int>(blocksize), static_cast<int>(hist));
+    xErrors_start = xErrors();
+    xErrors_end = xErrors_start + nxbins;
+  }
+
   while (hist < final) {
     MantidVec &Y = local_workspace->dataY(wsIndex);
     Y.assign(data_start, data_end);
@@ -1975,6 +2029,12 @@ void LoadNexusProcessed::loadBlock(NXDataSetTyped<double> &data,
       F.assign(farea_start, farea_end);
       farea_start += nchannels;
       farea_end += nchannels;
+    }
+    if (hasXErrors) {
+      MantidVec &DX = local_workspace->dataDx(wsIndex);
+      DX.assign(xErrors_start, xErrors_end);
+      xErrors_start += nxbins;
+      xErrors_end += nxbins;
     }
     MantidVec &X = local_workspace->dataX(wsIndex);
     X.assign(xbin_start, xbin_end);

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1296,7 +1296,7 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
   // Check for x errors; as with fracArea we set it to xbins
   // although in this case it would never be used.
   auto hasXErrors = wksp_cls.isValid("xerrors");
-  NXDouble &xErrors = hasXErrors ? wksp_cls.openNXDouble("xerrors") : xbins;
+  auto xErrors = hasXErrors ? wksp_cls.openNXDouble("xerrors") : errors;
 
   int64_t blocksize(8);
   // const int fullblocks = nspectra / blocksize;
@@ -1330,13 +1330,14 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(hist_index) /
                            static_cast<double>(read_stop),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, blocksize, nchannels,
-                    hist_index, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                    blocksize, nchannels, hist_index, wsIndex, local_workspace);
         }
         int64_t finalblock = m_spec_max - 1 - read_stop;
         if (finalblock > 0) {
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, finalblock, nchannels,
-                    hist_index, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                    finalblock, nchannels, hist_index, wsIndex,
+                    local_workspace);
         }
       }
       // if spectrum list property is set read each spectrum separately by
@@ -1360,13 +1361,13 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                      progressScaler * static_cast<double>(hist_index) /
                          static_cast<double>(read_stop),
                  "Reading workspace data...");
-        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, blocksize, nchannels,
-                  hist_index, wsIndex, local_workspace);
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                  blocksize, nchannels, hist_index, wsIndex, local_workspace);
       }
       int64_t finalblock = total_specs - read_stop;
       if (finalblock > 0) {
-        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, finalblock, nchannels,
-                  hist_index, wsIndex, local_workspace);
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                  finalblock, nchannels, hist_index, wsIndex, local_workspace);
       }
     }
 
@@ -1388,13 +1389,15 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(hist_index) /
                            static_cast<double>(read_stop),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, blocksize,
-                    nchannels, hist_index, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                    xbins, blocksize, nchannels, hist_index, wsIndex,
+                    local_workspace);
         }
         int64_t finalblock = m_spec_max - 1 - read_stop;
         if (finalblock > 0) {
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, finalblock,
-                    nchannels, hist_index, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                    xbins, finalblock, nchannels, hist_index, wsIndex,
+                    local_workspace);
         }
       }
       //
@@ -1406,8 +1409,8 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                        progressScaler * static_cast<double>(specIndex) /
                            static_cast<double>(read_stop),
                    "Reading workspace data...");
-          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, 1, nchannels,
-                    specIndex, wsIndex, local_workspace);
+          loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                    xbins, 1, nchannels, specIndex, wsIndex, local_workspace);
         }
       }
     } else {
@@ -1416,13 +1419,15 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
                      progressScaler * static_cast<double>(hist_index) /
                          static_cast<double>(read_stop),
                  "Reading workspace data...");
-        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, blocksize,
-                  nchannels, hist_index, wsIndex, local_workspace);
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                  xbins, blocksize, nchannels, hist_index, wsIndex,
+                  local_workspace);
       }
       int64_t finalblock = total_specs - read_stop;
       if (finalblock > 0) {
-        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors, xbins, finalblock,
-                  nchannels, hist_index, wsIndex, local_workspace);
+        loadBlock(data, errors, fracarea, hasFracArea, xErrors, hasXErrors,
+                  xbins, finalblock, nchannels, hist_index, wsIndex,
+                  local_workspace);
       }
     }
   }

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -1061,6 +1061,63 @@ public:
     Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
   }
 
+  void test_SaveAndLoadOnHistogramWSwithXErrors() {
+    // Test SaveNexusProcessed/LoadNexusProcessed on a histogram workspace with x errors
+
+    // Create histogram workspace with two spectra and 4 points
+    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
+    std::vector<double> dx1 = boost::assign::list_of(3)(2)(1);
+    std::vector<double> y1 = boost::assign::list_of(1)(2);
+    std::vector<double> x2 = boost::assign::list_of(1)(2)(3);
+    std::vector<double> dx2 = boost::assign::list_of(3)(2)(1);
+    std::vector<double> y2 = boost::assign::list_of(1)(2);
+    MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
+        "Workspace2D", 2, x1.size(), y1.size());
+    inputWs->dataX(0) = x1;
+    inputWs->dataX(1) = x2;
+    inputWs->dataY(0) = y1;
+    inputWs->dataY(1) = y2;
+    inputWs->dataDx(0) = dx1;
+    inputWs->dataDx(1) = dx2;
+
+    // Save workspace
+    IAlgorithm_sptr save =
+        AlgorithmManager::Instance().create("SaveNexusProcessed");
+    save->initialize();
+    TS_ASSERT(save->isInitialized());
+    TS_ASSERT_THROWS_NOTHING(save->setProperty("InputWorkspace", inputWs));
+    TS_ASSERT_THROWS_NOTHING(save->setPropertyValue(
+        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
+    TS_ASSERT_THROWS_NOTHING(save->execute());
+
+    // Load workspace
+    IAlgorithm_sptr load =
+        AlgorithmManager::Instance().create("LoadNexusProcessed");
+    load->initialize();
+    TS_ASSERT(load->isInitialized());
+    TS_ASSERT_THROWS_NOTHING(load->setPropertyValue(
+        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
+    TS_ASSERT_THROWS_NOTHING(
+        load->setPropertyValue("OutputWorkspace", "output"));
+    TS_ASSERT_THROWS_NOTHING(load->execute());
+
+    // Check spectra in loaded workspace
+    MatrixWorkspace_sptr outputWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
+    TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
+    TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
+    TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
+    TS_ASSERT_EQUALS(inputWs->readY(1), outputWs->readY(1));
+    TS_ASSERT_EQUALS(inputWs->readE(0), outputWs->readE(0));
+    TS_ASSERT_EQUALS(inputWs->readE(1), outputWs->readE(1));
+    TS_ASSERT_EQUALS(inputWs->readDx(0), outputWs->readDx(0));
+    TS_ASSERT_EQUALS(inputWs->readDx(1), outputWs->readDx(1));
+
+    // Remove workspace and saved nexus file
+    AnalysisDataService::Instance().remove("output");
+    Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
+  }
+
   void test_SaveAndLoadOnPointLikeWS() {
     // Test SaveNexusProcessed/LoadNexusProcessed on a point-like workspace
 

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -1010,163 +1010,16 @@ public:
     }
   }
 
-  void test_SaveAndLoadOnHistogramWS() {
-    // Test SaveNexusProcessed/LoadNexusProcessed on a histogram workspace
-
-    // Create histogram workspace with two spectra and 4 points
-    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> y1 = boost::assign::list_of(1)(2);
-    std::vector<double> x2 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> y2 = boost::assign::list_of(1)(2);
-    MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
-        "Workspace2D", 2, x1.size(), y1.size());
-    inputWs->dataX(0) = x1;
-    inputWs->dataX(1) = x2;
-    inputWs->dataY(0) = y1;
-    inputWs->dataY(1) = y2;
-
-    // Save workspace
-    IAlgorithm_sptr save =
-        AlgorithmManager::Instance().create("SaveNexusProcessed");
-    save->initialize();
-    TS_ASSERT(save->isInitialized());
-    TS_ASSERT_THROWS_NOTHING(save->setProperty("InputWorkspace", inputWs));
-    TS_ASSERT_THROWS_NOTHING(save->setPropertyValue(
-        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
-    TS_ASSERT_THROWS_NOTHING(save->execute());
-
-    // Load workspace
-    IAlgorithm_sptr load =
-        AlgorithmManager::Instance().create("LoadNexusProcessed");
-    load->initialize();
-    TS_ASSERT(load->isInitialized());
-    TS_ASSERT_THROWS_NOTHING(load->setPropertyValue(
-        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
-    TS_ASSERT_THROWS_NOTHING(
-        load->setPropertyValue("OutputWorkspace", "output"));
-    TS_ASSERT_THROWS_NOTHING(load->execute());
-
-    // Check spectra in loaded workspace
-    MatrixWorkspace_sptr outputWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
-    TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
-    TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
-    TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
-    TS_ASSERT_EQUALS(inputWs->readY(1), outputWs->readY(1));
-    TS_ASSERT_EQUALS(inputWs->readE(0), outputWs->readE(0));
-    TS_ASSERT_EQUALS(inputWs->readE(1), outputWs->readE(1));
-
-    // Remove workspace and saved nexus file
-    AnalysisDataService::Instance().remove("output");
-    Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
-  }
+  void test_SaveAndLoadOnHistogramWS() { doTestLoadAndSaveHistogramWS(false); }
 
   void test_SaveAndLoadOnHistogramWSwithXErrors() {
-    // Test SaveNexusProcessed/LoadNexusProcessed on a histogram workspace with x errors
-
-    // Create histogram workspace with two spectra and 4 points
-    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> dx1 = boost::assign::list_of(3)(2)(1);
-    std::vector<double> y1 = boost::assign::list_of(1)(2);
-    std::vector<double> x2 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> dx2 = boost::assign::list_of(3)(2)(1);
-    std::vector<double> y2 = boost::assign::list_of(1)(2);
-    MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
-        "Workspace2D", 2, x1.size(), y1.size());
-    inputWs->dataX(0) = x1;
-    inputWs->dataX(1) = x2;
-    inputWs->dataY(0) = y1;
-    inputWs->dataY(1) = y2;
-    inputWs->dataDx(0) = dx1;
-    inputWs->dataDx(1) = dx2;
-
-    // Save workspace
-    IAlgorithm_sptr save =
-        AlgorithmManager::Instance().create("SaveNexusProcessed");
-    save->initialize();
-    TS_ASSERT(save->isInitialized());
-    TS_ASSERT_THROWS_NOTHING(save->setProperty("InputWorkspace", inputWs));
-    TS_ASSERT_THROWS_NOTHING(save->setPropertyValue(
-        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
-    TS_ASSERT_THROWS_NOTHING(save->execute());
-
-    // Load workspace
-    IAlgorithm_sptr load =
-        AlgorithmManager::Instance().create("LoadNexusProcessed");
-    load->initialize();
-    TS_ASSERT(load->isInitialized());
-    TS_ASSERT_THROWS_NOTHING(load->setPropertyValue(
-        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
-    TS_ASSERT_THROWS_NOTHING(
-        load->setPropertyValue("OutputWorkspace", "output"));
-    TS_ASSERT_THROWS_NOTHING(load->execute());
-
-    // Check spectra in loaded workspace
-    MatrixWorkspace_sptr outputWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
-    TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
-    TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
-    TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
-    TS_ASSERT_EQUALS(inputWs->readY(1), outputWs->readY(1));
-    TS_ASSERT_EQUALS(inputWs->readE(0), outputWs->readE(0));
-    TS_ASSERT_EQUALS(inputWs->readE(1), outputWs->readE(1));
-    TS_ASSERT_EQUALS(inputWs->readDx(0), outputWs->readDx(0));
-    TS_ASSERT_EQUALS(inputWs->readDx(1), outputWs->readDx(1));
-
-    // Remove workspace and saved nexus file
-    AnalysisDataService::Instance().remove("output");
-    Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
+    doTestLoadAndSaveHistogramWS(true);
   }
 
-  void test_SaveAndLoadOnPointLikeWS() {
-    // Test SaveNexusProcessed/LoadNexusProcessed on a point-like workspace
+  void test_SaveAndLoadOnPointLikeWS() { doTestLoadAndSavePointWS(false); }
 
-    // Create histogram workspace with two spectra and 4 points
-    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> y1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> x2 = boost::assign::list_of(10)(20)(30);
-    std::vector<double> y2 = boost::assign::list_of(10)(20)(30);
-    MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
-        "Workspace2D", 2, x1.size(), y1.size());
-    inputWs->dataX(0) = x1;
-    inputWs->dataX(1) = x2;
-    inputWs->dataY(0) = y1;
-    inputWs->dataY(1) = y2;
-
-    // Save workspace
-    IAlgorithm_sptr save =
-        AlgorithmManager::Instance().create("SaveNexusProcessed");
-    save->initialize();
-    TS_ASSERT(save->isInitialized());
-    TS_ASSERT_THROWS_NOTHING(save->setProperty("InputWorkspace", inputWs));
-    TS_ASSERT_THROWS_NOTHING(save->setPropertyValue(
-        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
-    TS_ASSERT_THROWS_NOTHING(save->execute());
-
-    // Load workspace
-    IAlgorithm_sptr load =
-        AlgorithmManager::Instance().create("LoadNexusProcessed");
-    load->initialize();
-    TS_ASSERT(load->isInitialized());
-    TS_ASSERT_THROWS_NOTHING(load->setPropertyValue(
-        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
-    TS_ASSERT_THROWS_NOTHING(
-        load->setPropertyValue("OutputWorkspace", "output"));
-    TS_ASSERT_THROWS_NOTHING(load->execute());
-
-    // Check spectra in loaded workspace
-    MatrixWorkspace_sptr outputWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
-    TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
-    TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
-    TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
-    TS_ASSERT_EQUALS(inputWs->readY(1), outputWs->readY(1));
-    TS_ASSERT_EQUALS(inputWs->readE(0), outputWs->readE(0));
-    TS_ASSERT_EQUALS(inputWs->readE(1), outputWs->readE(1));
-
-    // Remove workspace and saved nexus file
-    AnalysisDataService::Instance().remove("output");
-    Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
+  void test_SaveAndLoadOnPointLikeWSWithXErrors() {
+    doTestLoadAndSavePointWS(true);
   }
 
   void do_load_multiperiod_workspace(bool fast) {
@@ -1315,6 +1168,131 @@ private:
     if (!m_savedTmpEventFile.empty() &&
         Poco::File(m_savedTmpEventFile).exists())
       Poco::File(m_savedTmpEventFile).remove();
+  }
+
+  void doTestLoadAndSaveHistogramWS(bool useXErrors = false) {
+    // Test SaveNexusProcessed/LoadNexusProcessed on a histogram workspace with
+    // x errors
+
+    // Create histogram workspace with two spectra and 4 points
+    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
+    std::vector<double> dx1 = boost::assign::list_of(3)(2)(1);
+    std::vector<double> y1 = boost::assign::list_of(1)(2);
+    std::vector<double> x2 = boost::assign::list_of(1)(2)(3);
+    std::vector<double> dx2 = boost::assign::list_of(3)(2)(1);
+    std::vector<double> y2 = boost::assign::list_of(1)(2);
+    MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
+        "Workspace2D", 2, x1.size(), y1.size());
+    inputWs->dataX(0) = x1;
+    inputWs->dataX(1) = x2;
+    inputWs->dataY(0) = y1;
+    inputWs->dataY(1) = y2;
+    if (useXErrors) {
+      inputWs->dataDx(0) = dx1;
+      inputWs->dataDx(1) = dx2;
+    }
+
+    // Save workspace
+    IAlgorithm_sptr save =
+        AlgorithmManager::Instance().create("SaveNexusProcessed");
+    save->initialize();
+    TS_ASSERT(save->isInitialized());
+    TS_ASSERT_THROWS_NOTHING(save->setProperty("InputWorkspace", inputWs));
+    TS_ASSERT_THROWS_NOTHING(save->setPropertyValue(
+        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
+    TS_ASSERT_THROWS_NOTHING(save->execute());
+
+    // Load workspace
+    IAlgorithm_sptr load =
+        AlgorithmManager::Instance().create("LoadNexusProcessed");
+    load->initialize();
+    TS_ASSERT(load->isInitialized());
+    TS_ASSERT_THROWS_NOTHING(load->setPropertyValue(
+        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
+    TS_ASSERT_THROWS_NOTHING(
+        load->setPropertyValue("OutputWorkspace", "output"));
+    TS_ASSERT_THROWS_NOTHING(load->execute());
+
+    // Check spectra in loaded workspace
+    MatrixWorkspace_sptr outputWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
+    TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
+    TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
+    TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
+    TS_ASSERT_EQUALS(inputWs->readY(1), outputWs->readY(1));
+    TS_ASSERT_EQUALS(inputWs->readE(0), outputWs->readE(0));
+    TS_ASSERT_EQUALS(inputWs->readE(1), outputWs->readE(1));
+    if (useXErrors) {
+      TSM_ASSERT("Should have an x error", outputWs->hasDx(0));
+      TS_ASSERT_EQUALS(inputWs->readDx(0), outputWs->readDx(0));
+      TS_ASSERT_EQUALS(inputWs->readDx(1), outputWs->readDx(1));
+    }
+
+    // Remove workspace and saved nexus file
+    AnalysisDataService::Instance().remove("output");
+    Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
+  }
+
+  void doTestLoadAndSavePointWS(bool useXErrors = false) {
+    // Test SaveNexusProcessed/LoadNexusProcessed on a point-like workspace
+
+    // Create histogram workspace with two spectra and 4 points
+    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
+    std::vector<double> dx1 = boost::assign::list_of(3)(2)(1);
+    std::vector<double> y1 = boost::assign::list_of(1)(2)(3);
+    std::vector<double> x2 = boost::assign::list_of(10)(20)(30);
+    std::vector<double> dx2 = boost::assign::list_of(30)(22)(10);
+    std::vector<double> y2 = boost::assign::list_of(10)(20)(30);
+    MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
+        "Workspace2D", 2, x1.size(), y1.size());
+    inputWs->dataX(0) = x1;
+    inputWs->dataX(1) = x2;
+    inputWs->dataY(0) = y1;
+    inputWs->dataY(1) = y2;
+    if (useXErrors) {
+      inputWs->dataDx(0) = dx1;
+      inputWs->dataDx(1) = dx2;
+    }
+
+    // Save workspace
+    IAlgorithm_sptr save =
+        AlgorithmManager::Instance().create("SaveNexusProcessed");
+    save->initialize();
+    TS_ASSERT(save->isInitialized());
+    TS_ASSERT_THROWS_NOTHING(save->setProperty("InputWorkspace", inputWs));
+    TS_ASSERT_THROWS_NOTHING(save->setPropertyValue(
+        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
+    TS_ASSERT_THROWS_NOTHING(save->execute());
+
+    // Load workspace
+    IAlgorithm_sptr load =
+        AlgorithmManager::Instance().create("LoadNexusProcessed");
+    load->initialize();
+    TS_ASSERT(load->isInitialized());
+    TS_ASSERT_THROWS_NOTHING(load->setPropertyValue(
+        "Filename", "TestSaveAndLoadNexusProcessed.nxs"));
+    TS_ASSERT_THROWS_NOTHING(
+        load->setPropertyValue("OutputWorkspace", "output"));
+    TS_ASSERT_THROWS_NOTHING(load->execute());
+
+    // Check spectra in loaded workspace
+    MatrixWorkspace_sptr outputWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
+    TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
+    TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
+    TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
+    TS_ASSERT_EQUALS(inputWs->readY(1), outputWs->readY(1));
+    TS_ASSERT_EQUALS(inputWs->readE(0), outputWs->readE(0));
+    TS_ASSERT_EQUALS(inputWs->readE(1), outputWs->readE(1));
+    if (useXErrors) {
+      TSM_ASSERT("Should have an x error", outputWs->hasDx(0));
+      TS_ASSERT_EQUALS(inputWs->readDx(0), outputWs->readDx(0));
+      TS_ASSERT_EQUALS(inputWs->readDx(1), outputWs->readDx(1));
+    }
+
+    // Remove workspace and saved nexus file
+    AnalysisDataService::Instance().remove("output");
+    Poco::File("TestSaveAndLoadNexusProcessed.nxs").remove();
   }
 
   std::string testFile, output_ws;

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -375,6 +375,23 @@ int NexusFileIO::writeNexusProcessedData2D(
                 start, asize);
       start[0]++;
     }
+
+    // Potentially x error
+    if (localworkspace->hasDx(0)) {
+      name = "xerrors";
+      NXcompmakedata(fileID, name.c_str(), NX_FLOAT64, 2, dims_array,
+                     m_nexuscompression, asize);
+      NXopendata(fileID, name.c_str());
+      start[0] = 0;
+      for (size_t i = 0; i < nSpect; i++) {
+        int s = spec[i];
+        NXputslab(fileID, reinterpret_cast<void *>(const_cast<double *>(
+                              &(localworkspace->readDx(s)[0]))),
+                  start, asize);
+        start[0]++;
+      }
+    }
+
     if (m_progress != 0)
       m_progress->reportIncrement(1, "Writing data");
 

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -376,22 +376,6 @@ int NexusFileIO::writeNexusProcessedData2D(
       start[0]++;
     }
 
-    // Potentially x error
-    if (localworkspace->hasDx(0)) {
-      name = "xerrors";
-      NXcompmakedata(fileID, name.c_str(), NX_FLOAT64, 2, dims_array,
-                     m_nexuscompression, asize);
-      NXopendata(fileID, name.c_str());
-      start[0] = 0;
-      for (size_t i = 0; i < nSpect; i++) {
-        int s = spec[i];
-        NXputslab(fileID, reinterpret_cast<void *>(const_cast<double *>(
-                              &(localworkspace->readDx(s)[0]))),
-                  start, asize);
-        start[0]++;
-      }
-    }
-
     if (m_progress != 0)
       m_progress->reportIncrement(1, "Writing data");
 
@@ -425,6 +409,7 @@ int NexusFileIO::writeNexusProcessedData2D(
     NXopendata(fileID, "axis1");
     NXputdata(fileID, reinterpret_cast<void *>(const_cast<double *>(
                           &(localworkspace->readX(0)[0]))));
+
   } else {
     dims_array[0] = static_cast<int>(nSpect);
     dims_array[1] = static_cast<int>(localworkspace->readX(0).size());
@@ -439,6 +424,26 @@ int NexusFileIO::writeNexusProcessedData2D(
       start[0]++;
     }
   }
+
+  // Potentially x error
+  if (localworkspace->hasDx(0)) {
+    dims_array[0] = static_cast<int>(nSpect);
+    dims_array[1] = static_cast<int>(localworkspace->readX(0).size());
+    std::string dxErrorName = "xerrors";
+    NXcompmakedata(fileID, dxErrorName.c_str(), NX_FLOAT64, 2, dims_array,
+                    m_nexuscompression, asize);
+    NXopendata(fileID, dxErrorName.c_str());
+    start[0] = 0;
+    asize[1] = dims_array[1];
+    for (size_t i = 0; i < nSpect; i++) {
+      int s = spec[i];
+      NXputslab(fileID, reinterpret_cast<void *>(const_cast<double *>(
+                            &(localworkspace->readDx(s)[0]))),
+                start, asize);
+      start[0]++;
+    }
+  }
+
   std::string dist = (localworkspace->isDistribution()) ? "1" : "0";
   NXputattr(fileID, "distribution",
             reinterpret_cast<void *>(const_cast<char *>(dist.c_str())), 2,

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -399,6 +399,25 @@ int NexusFileIO::writeNexusProcessedData2D(
         m_progress->reportIncrement(1, "Writing data");
     }
 
+    // Potentially x error
+    if (localworkspace->hasDx(0)) {
+      dims_array[0] = static_cast<int>(nSpect);
+      dims_array[1] = static_cast<int>(localworkspace->readX(0).size());
+      std::string dxErrorName = "xerrors";
+      NXcompmakedata(fileID, dxErrorName.c_str(), NX_FLOAT64, 2, dims_array,
+                     m_nexuscompression, asize);
+      NXopendata(fileID, dxErrorName.c_str());
+      start[0] = 0;
+      asize[1] = dims_array[1];
+      for (size_t i = 0; i < nSpect; i++) {
+        int s = spec[i];
+        NXputslab(fileID, reinterpret_cast<void *>(const_cast<double *>(
+                              &(localworkspace->readDx(s)[0]))),
+                  start, asize);
+        start[0]++;
+      }
+    }
+
     NXclosedata(fileID);
   }
 
@@ -420,25 +439,6 @@ int NexusFileIO::writeNexusProcessedData2D(
     for (size_t i = 0; i < nSpect; i++) {
       NXputslab(fileID, reinterpret_cast<void *>(const_cast<double *>(
                             &(localworkspace->readX(i)[0]))),
-                start, asize);
-      start[0]++;
-    }
-  }
-
-  // Potentially x error
-  if (localworkspace->hasDx(0)) {
-    dims_array[0] = static_cast<int>(nSpect);
-    dims_array[1] = static_cast<int>(localworkspace->readX(0).size());
-    std::string dxErrorName = "xerrors";
-    NXcompmakedata(fileID, dxErrorName.c_str(), NX_FLOAT64, 2, dims_array,
-                   m_nexuscompression, asize);
-    NXopendata(fileID, dxErrorName.c_str());
-    start[0] = 0;
-    asize[1] = dims_array[1];
-    for (size_t i = 0; i < nSpect; i++) {
-      int s = spec[i];
-      NXputslab(fileID, reinterpret_cast<void *>(const_cast<double *>(
-                            &(localworkspace->readDx(s)[0]))),
                 start, asize);
       start[0]++;
     }

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -431,7 +431,7 @@ int NexusFileIO::writeNexusProcessedData2D(
     dims_array[1] = static_cast<int>(localworkspace->readX(0).size());
     std::string dxErrorName = "xerrors";
     NXcompmakedata(fileID, dxErrorName.c_str(), NX_FLOAT64, 2, dims_array,
-                    m_nexuscompression, asize);
+                   m_nexuscompression, asize);
     NXopendata(fileID, dxErrorName.c_str());
     start[0] = 0;
     asize[1] = dims_array[1];


### PR DESCRIPTION
Fixes #13458 
# For Testing

You can create sample workspaces with the scripts below:
**HistoWorkspace**

``` python
# Create workspace
dataX = [1,2,3,4,5,6,1,2,3,4,5,6]
dataY = [1.,1.,1.,1.,1.,2.,2.,2.,2.,2.]
dataE = [3.,3.,3.,3.,3.,3.,3.,3.,3.,3.]
ws_dx = CreateWorkspace(dataX, dataY, dataE, NSpec=2, UnitX="MomentumTransfer")

# Create DX values
dataDX1 = [5.,5.,5.,5.,5., 5.]
dataDX2 = [4.,4.,4.,4.,4., 4.]
DX = [dataDX1, dataDX2]

# Populate the the workspace with the DX values
for spec in range(0, ws_dx.getNumberHistograms()):
    DX_values_for_spectrum = DX[spec]
    dx = ws_dx.dataDx(spec)
    for index in range(0, len(dx)):
        dx[index] = DX_values_for_spectrum[index]
```

**PointWorkspace**

``` python
# Create workspace
dataX = [1,2,3,4,5,1,2,3,4,5]
dataY = [1.,1.,1.,1.,1.,2.,2.,2.,2.,2.]
dataE = [3.,3.,3.,3.,3.,3.,3.,3.,3.,3.]
ws_dx = CreateWorkspace(dataX, dataY, dataE, NSpec=2, UnitX="MomentumTransfer")

# Create DX values
dataDX1 = [5.,5.,5.,5.,5.]
dataDX2 = [4.,4.,4.,4.,4.]
DX = [dataDX1, dataDX2]

# Populate the the workspace with the DX values
for spec in range(0, ws_dx.getNumberHistograms()):
    DX_values_for_spectrum = DX[spec]
    dx = ws_dx.dataDx(spec)
    for index in range(0, len(dx)):
        dx[index] = DX_values_for_spectrum[index]
```
1. For each case create the sample workspace
2. Use SaveNexus to save out the workspace
   - Open the workspace with HDFView and confirm that an entry **xerrors** under the **workspace** group is present.
3. Load the file back in again. Open the data using the Mantid Matrix (double clicking on it should do)
   - Confirm that the x errors have been loaded and that they have the correct value 
# Release Notes

See [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_6_SANS&diff=25446&oldid=25415)
