### PR TITLE
Separate concepts CrystalSystem and LatticeSystem

### DIFF
--- a/Framework/API/inc/MantidAPI/ILatticeFunction.h
+++ b/Framework/API/inc/MantidAPI/ILatticeFunction.h
@@ -55,7 +55,7 @@ public:
                                     Jacobian &jacobian);
 
   /// A string that names the crystal system.
-  virtual void setCrystalSystem(const std::string &crystalSystem) = 0;
+  virtual void setLatticeSystem(const std::string &crystalSystem) = 0;
 
   /// Set the function parameters according to the supplied unit cell.
   virtual void setUnitCell(const std::string &unitCellString) = 0;

--- a/Framework/API/inc/MantidAPI/IPawleyFunction.h
+++ b/Framework/API/inc/MantidAPI/IPawleyFunction.h
@@ -44,7 +44,7 @@ public:
   virtual ~IPawleyFunction() {}
 
   /// A string that names the crystal system.
-  virtual void setCrystalSystem(const std::string &crystalSystem) = 0;
+  virtual void setLatticeSystem(const std::string &crystalSystem) = 0;
 
   /// Sets the name of the profile function used for the reflections.
   virtual void setProfileFunction(const std::string &profileFunction) = 0;

--- a/Framework/API/test/ILatticeFunctionTest.h
+++ b/Framework/API/test/ILatticeFunctionTest.h
@@ -90,7 +90,7 @@ private:
 
     MOCK_METHOD2(functionDerivLattice, void(const LatticeDomain &, Jacobian &));
 
-    MOCK_METHOD1(setCrystalSystem, void(const std::string &));
+    MOCK_METHOD1(setLatticeSystem, void(const std::string &));
     MOCK_METHOD1(setUnitCell, void(const std::string &));
     MOCK_METHOD1(setUnitCell, void(const Mantid::Geometry::UnitCell &));
     MOCK_CONST_METHOD0(getUnitCell, Mantid::Geometry::UnitCell());

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -233,11 +233,7 @@ API::ILatticeFunction_sptr
 OptimizeLatticeForCellType::getLatticeFunction(const std::string &cellType,
                                                const UnitCell &cell) const {
   std::ostringstream fun_str;
-  // TODO remove next 3 lines when PointGroup is changed
-  if (cellType == "Rhombohedral")
-    fun_str << "name=LatticeFunction,CrystalSystem=Trigonal";
-  else
-    fun_str << "name=LatticeFunction,CrystalSystem=" << cellType;
+  fun_str << "name=LatticeFunction,LatticeSystem=" << cellType;
 
   API::IFunction_sptr rawFunction =
       API::FunctionFactory::Instance().createInitialized(fun_str.str());

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
@@ -36,7 +36,7 @@ public:
 
   void setAttribute(const std::string &attName, const Attribute &attValue);
 
-  Geometry::PointGroup::CrystalSystem getCrystalSystem() const;
+  Geometry::PointGroup::LatticeSystem getLatticeSystem() const;
   Geometry::UnitCell getUnitCellFromParameters() const;
   void setParametersFromUnitCell(const Geometry::UnitCell &cell);
 
@@ -59,10 +59,10 @@ protected:
   void init();
 
   void setProfileFunction(const std::string &profileFunction);
-  void setCrystalSystem(const std::string &crystalSystem);
+  void setLatticeSystem(const std::string &latticeSystem);
 
-  void createCrystalSystemParameters(
-      Geometry::PointGroup::CrystalSystem crystalSystem);
+  void createLatticeSystemParameters(
+      Geometry::PointGroup::LatticeSystem latticeSystem);
 
   void addLengthConstraint(const std::string &parameterName);
   void addAngleConstraint(const std::string &parameterName);
@@ -70,7 +70,7 @@ protected:
   void setCenterParameterNameFromFunction(
       const API::IPeakFunction_sptr &profileFunction);
 
-  Geometry::PointGroup::CrystalSystem m_crystalSystem;
+  Geometry::PointGroup::LatticeSystem m_latticeSystem;
   std::string m_profileFunctionCenterParameterName;
 };
 
@@ -123,7 +123,7 @@ public:
   setMatrixWorkspace(boost::shared_ptr<const API::MatrixWorkspace> workspace,
                      size_t wi, double startX, double endX);
 
-  void setCrystalSystem(const std::string &crystalSystem);
+  void setLatticeSystem(const std::string &latticeSystem);
   void setProfileFunction(const std::string &profileFunction);
   void setUnitCell(const std::string &unitCellString);
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/LatticeFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/LatticeFunction.h
@@ -51,7 +51,7 @@ public:
   void functionLattice(const API::LatticeDomain &latticeDomain,
                        API::FunctionValues &values) const;
 
-  void setCrystalSystem(const std::string &crystalSystem);
+  void setLatticeSystem(const std::string &crystalSystem);
   void setUnitCell(const std::string &unitCellString);
   void setUnitCell(const Geometry::UnitCell &unitCell);
   Geometry::UnitCell getUnitCell() const;

--- a/Framework/CurveFitting/src/Algorithms/PawleyFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PawleyFit.cpp
@@ -199,21 +199,21 @@ void PawleyFit::init() {
   declareProperty("StartX", 0.0, "Lower border of fitted data range.");
   declareProperty("EndX", 0.0, "Upper border of fitted data range.");
 
-  std::vector<std::string> crystalSystems;
-  crystalSystems.push_back("Cubic");
-  crystalSystems.push_back("Tetragonal");
-  crystalSystems.push_back("Hexagonal");
-  crystalSystems.push_back("Trigonal");
-  crystalSystems.push_back("Orthorhombic");
-  crystalSystems.push_back("Monoclinic");
-  crystalSystems.push_back("Triclinic");
+  std::vector<std::string> latticeSystems;
+  latticeSystems.push_back("Cubic");
+  latticeSystems.push_back("Tetragonal");
+  latticeSystems.push_back("Hexagonal");
+  latticeSystems.push_back("Rhombohedral");
+  latticeSystems.push_back("Orthorhombic");
+  latticeSystems.push_back("Monoclinic");
+  latticeSystems.push_back("Triclinic");
 
-  auto crystalSystemValidator =
-      boost::make_shared<StringListValidator>(crystalSystems);
+  auto latticeSystemValidator =
+      boost::make_shared<StringListValidator>(latticeSystems);
 
-  declareProperty("CrystalSystem", crystalSystems.back(),
-                  crystalSystemValidator,
-                  "Crystal system to use for refinement.");
+  declareProperty("LatticeSystem", latticeSystems.back(),
+                  latticeSystemValidator,
+                  "Lattice system to use for refinement.");
 
   declareProperty("InitialCell", "1.0 1.0 1.0 90.0 90.0 90.0",
                   "Specification of initial unit cell, given as 'a, b, c, "
@@ -282,9 +282,9 @@ void PawleyFit::exec() {
   g_log.information() << "  Selected profile function: " << profileFunction
                       << std::endl;
 
-  std::string crystalSystem = getProperty("CrystalSystem");
-  pawleyFn->setCrystalSystem(crystalSystem);
-  g_log.information() << "  Selected crystal system: " << crystalSystem
+  std::string latticeSystem = getProperty("LatticeSystem");
+  pawleyFn->setLatticeSystem(latticeSystem);
+  g_log.information() << "  Selected crystal system: " << latticeSystem
                       << std::endl;
 
   pawleyFn->setUnitCell(getProperty("InitialCell"));

--- a/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
@@ -28,22 +28,22 @@ using namespace Kernel;
 
 /// Constructor
 PawleyParameterFunction::PawleyParameterFunction()
-    : ParamFunction(), m_crystalSystem(PointGroup::CrystalSystem::Triclinic),
+    : ParamFunction(), m_latticeSystem(PointGroup::LatticeSystem::Triclinic),
       m_profileFunctionCenterParameterName() {}
 
 /**
  * @brief Sets the supplied attribute value
  *
  * The function calls ParamFunction::setAttribute, but performs additional
- * actions for CrystalSystem and ProfileFunction.
+ * actions for latticeSystem and ProfileFunction.
  *
  * @param attName :: Name of the attribute
  * @param attValue :: Value of the attribute
  */
 void PawleyParameterFunction::setAttribute(const std::string &attName,
                                            const Attribute &attValue) {
-  if (attName == "CrystalSystem") {
-    setCrystalSystem(attValue.asString());
+  if (attName == "LatticeSystem") {
+    setLatticeSystem(attValue.asString());
   } else if (attName == "ProfileFunction") {
     setProfileFunction(attValue.asString());
   }
@@ -52,35 +52,35 @@ void PawleyParameterFunction::setAttribute(const std::string &attName,
 }
 
 /// Returns the crystal system
-PointGroup::CrystalSystem PawleyParameterFunction::getCrystalSystem() const {
-  return m_crystalSystem;
+PointGroup::LatticeSystem PawleyParameterFunction::getLatticeSystem() const {
+  return m_latticeSystem;
 }
 
 /// Returns a UnitCell object constructed from the function's parameters.
 UnitCell PawleyParameterFunction::getUnitCellFromParameters() const {
-  switch (m_crystalSystem) {
-  case PointGroup::CrystalSystem::Cubic: {
+  switch (m_latticeSystem) {
+  case PointGroup::LatticeSystem::Cubic: {
     double a = getParameter("a");
     double aErr = getError(0);
     UnitCell uc(a, a, a);
     uc.setError(aErr, aErr, aErr, 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::CrystalSystem::Tetragonal: {
+  case PointGroup::LatticeSystem::Tetragonal: {
     double a = getParameter("a");
     double aErr = getError(0);
     UnitCell uc(a, a, getParameter("c"));
     uc.setError(aErr, aErr, getError(1), 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::CrystalSystem::Hexagonal: {
+  case PointGroup::LatticeSystem::Hexagonal: {
     double a = getParameter("a");
     double aErr = getError(0);
     UnitCell uc(a, a, getParameter("c"), 90, 90, 120);
     uc.setError(aErr, aErr, getError(1), 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::CrystalSystem::Trigonal: {
+  case PointGroup::LatticeSystem::Rhombohedral: {
     double a = getParameter("a");
     double alpha = getParameter("Alpha");
     double aErr = getError(0);
@@ -89,18 +89,18 @@ UnitCell PawleyParameterFunction::getUnitCellFromParameters() const {
     uc.setError(aErr, aErr, aErr, alphaErr, alphaErr, alphaErr);
     return uc;
   }
-  case PointGroup::CrystalSystem::Orthorhombic: {
+  case PointGroup::LatticeSystem::Orthorhombic: {
     UnitCell uc(getParameter("a"), getParameter("b"), getParameter("c"));
     uc.setError(getError(0), getError(1), getError(2), 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::CrystalSystem::Monoclinic: {
+  case PointGroup::LatticeSystem::Monoclinic: {
     UnitCell uc(getParameter("a"), getParameter("b"), getParameter("c"), 90,
                 getParameter("Beta"), 90);
     uc.setError(getError(0), getError(1), getError(2), 0.0, getError(3), 0.0);
     return uc;
   }
-  case PointGroup::CrystalSystem::Triclinic: {
+  case PointGroup::LatticeSystem::Triclinic: {
     UnitCell uc(getParameter("a"), getParameter("b"), getParameter("c"),
                 getParameter("Alpha"), getParameter("Beta"),
                 getParameter("Gamma"));
@@ -163,10 +163,10 @@ void PawleyParameterFunction::functionDeriv(const FunctionDomain &domain,
 
 /// Declares attributes and generates parameters based on the defaults.
 void PawleyParameterFunction::init() {
-  declareAttribute("CrystalSystem", IFunction::Attribute("Triclinic"));
+  declareAttribute("LatticeSystem", IFunction::Attribute("Triclinic"));
   declareAttribute("ProfileFunction", IFunction::Attribute("Gaussian"));
 
-  setCrystalSystem("Triclinic");
+  setLatticeSystem("Triclinic");
   setProfileFunction("Gaussian");
 }
 
@@ -193,44 +193,44 @@ void PawleyParameterFunction::setProfileFunction(
 }
 
 /**
- * Assigns the crystal system
+ * Assigns the lattice system
  *
- * This method takes the name of a crystal system (case insensitive) and stores
+ * This method takes the name of a lattice system (case insensitive) and stores
  * it. Furthermore it creates the necessary parameters, which means that after
  * calling this function, PawleyParameterFunction potentially exposes a
  * different number of parameters. The parameters are constrained to physically
  * meaningful values (angles between 0 and 180 degrees, cell edges above 0).
  *
- * @param crystalSystem :: Crystal system, case insensitive.
+ * @param latticeSystem :: Crystal system, case insensitive.
  */
-void PawleyParameterFunction::setCrystalSystem(
-    const std::string &crystalSystem) {
-  m_crystalSystem = Geometry::getCrystalSystemFromString(crystalSystem);
+void PawleyParameterFunction::setLatticeSystem(
+    const std::string &latticeSystem) {
+  m_latticeSystem = Geometry::getLatticeSystemFromString(latticeSystem);
 
-  createCrystalSystemParameters(m_crystalSystem);
+  createLatticeSystemParameters(m_latticeSystem);
 }
 
 /// This method clears all parameters and declares parameters according to the
 /// supplied crystal system.
-void PawleyParameterFunction::createCrystalSystemParameters(
-    PointGroup::CrystalSystem crystalSystem) {
+void PawleyParameterFunction::createLatticeSystemParameters(
+    PointGroup::LatticeSystem latticeSystem) {
 
   clearAllParameters();
-  switch (crystalSystem) {
-  case PointGroup::CrystalSystem::Cubic:
+  switch (latticeSystem) {
+  case PointGroup::LatticeSystem::Cubic:
     declareParameter("a", 1.0);
     addLengthConstraint("a");
     break;
 
-  case PointGroup::CrystalSystem::Hexagonal:
-  case PointGroup::CrystalSystem::Tetragonal:
+  case PointGroup::LatticeSystem::Hexagonal:
+  case PointGroup::LatticeSystem::Tetragonal:
     declareParameter("a", 1.0);
     declareParameter("c", 1.0);
     addLengthConstraint("a");
     addLengthConstraint("c");
     break;
 
-  case PointGroup::CrystalSystem::Orthorhombic:
+  case PointGroup::LatticeSystem::Orthorhombic:
     declareParameter("a", 1.0);
     declareParameter("b", 1.0);
     declareParameter("c", 1.0);
@@ -239,7 +239,7 @@ void PawleyParameterFunction::createCrystalSystemParameters(
     addLengthConstraint("c");
     break;
 
-  case PointGroup::CrystalSystem::Monoclinic:
+  case PointGroup::LatticeSystem::Monoclinic:
     declareParameter("a", 1.0);
     declareParameter("b", 1.0);
     declareParameter("c", 1.0);
@@ -251,7 +251,7 @@ void PawleyParameterFunction::createCrystalSystemParameters(
     addAngleConstraint("Beta");
     break;
 
-  case PointGroup::CrystalSystem::Trigonal:
+  case PointGroup::LatticeSystem::Rhombohedral:
     declareParameter("a", 1.0);
     declareParameter("Alpha", 90.0);
     addLengthConstraint("a");
@@ -346,8 +346,8 @@ void PawleyFunction::setMatrixWorkspace(
 
 /// Sets the crystal system on the internal parameter function and updates the
 /// exposed parameters
-void PawleyFunction::setCrystalSystem(const std::string &crystalSystem) {
-  m_pawleyParameterFunction->setAttributeValue("CrystalSystem", crystalSystem);
+void PawleyFunction::setLatticeSystem(const std::string &latticeSystem) {
+  m_pawleyParameterFunction->setAttributeValue("LatticeSystem", latticeSystem);
   m_compositeFunction->checkFunction();
 }
 

--- a/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/PawleyFunction.cpp
@@ -28,7 +28,7 @@ using namespace Kernel;
 
 /// Constructor
 PawleyParameterFunction::PawleyParameterFunction()
-    : ParamFunction(), m_crystalSystem(PointGroup::Triclinic),
+    : ParamFunction(), m_crystalSystem(PointGroup::CrystalSystem::Triclinic),
       m_profileFunctionCenterParameterName() {}
 
 /**
@@ -59,28 +59,28 @@ PointGroup::CrystalSystem PawleyParameterFunction::getCrystalSystem() const {
 /// Returns a UnitCell object constructed from the function's parameters.
 UnitCell PawleyParameterFunction::getUnitCellFromParameters() const {
   switch (m_crystalSystem) {
-  case PointGroup::Cubic: {
+  case PointGroup::CrystalSystem::Cubic: {
     double a = getParameter("a");
     double aErr = getError(0);
     UnitCell uc(a, a, a);
     uc.setError(aErr, aErr, aErr, 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::Tetragonal: {
+  case PointGroup::CrystalSystem::Tetragonal: {
     double a = getParameter("a");
     double aErr = getError(0);
     UnitCell uc(a, a, getParameter("c"));
     uc.setError(aErr, aErr, getError(1), 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::Hexagonal: {
+  case PointGroup::CrystalSystem::Hexagonal: {
     double a = getParameter("a");
     double aErr = getError(0);
     UnitCell uc(a, a, getParameter("c"), 90, 90, 120);
     uc.setError(aErr, aErr, getError(1), 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::Trigonal: {
+  case PointGroup::CrystalSystem::Trigonal: {
     double a = getParameter("a");
     double alpha = getParameter("Alpha");
     double aErr = getError(0);
@@ -89,18 +89,18 @@ UnitCell PawleyParameterFunction::getUnitCellFromParameters() const {
     uc.setError(aErr, aErr, aErr, alphaErr, alphaErr, alphaErr);
     return uc;
   }
-  case PointGroup::Orthorhombic: {
+  case PointGroup::CrystalSystem::Orthorhombic: {
     UnitCell uc(getParameter("a"), getParameter("b"), getParameter("c"));
     uc.setError(getError(0), getError(1), getError(2), 0.0, 0.0, 0.0);
     return uc;
   }
-  case PointGroup::Monoclinic: {
+  case PointGroup::CrystalSystem::Monoclinic: {
     UnitCell uc(getParameter("a"), getParameter("b"), getParameter("c"), 90,
                 getParameter("Beta"), 90);
     uc.setError(getError(0), getError(1), getError(2), 0.0, getError(3), 0.0);
     return uc;
   }
-  case PointGroup::Triclinic: {
+  case PointGroup::CrystalSystem::Triclinic: {
     UnitCell uc(getParameter("a"), getParameter("b"), getParameter("c"),
                 getParameter("Alpha"), getParameter("Beta"),
                 getParameter("Gamma"));
@@ -217,20 +217,20 @@ void PawleyParameterFunction::createCrystalSystemParameters(
 
   clearAllParameters();
   switch (crystalSystem) {
-  case PointGroup::Cubic:
+  case PointGroup::CrystalSystem::Cubic:
     declareParameter("a", 1.0);
     addLengthConstraint("a");
     break;
 
-  case PointGroup::Hexagonal:
-  case PointGroup::Tetragonal:
+  case PointGroup::CrystalSystem::Hexagonal:
+  case PointGroup::CrystalSystem::Tetragonal:
     declareParameter("a", 1.0);
     declareParameter("c", 1.0);
     addLengthConstraint("a");
     addLengthConstraint("c");
     break;
 
-  case PointGroup::Orthorhombic:
+  case PointGroup::CrystalSystem::Orthorhombic:
     declareParameter("a", 1.0);
     declareParameter("b", 1.0);
     declareParameter("c", 1.0);
@@ -239,7 +239,7 @@ void PawleyParameterFunction::createCrystalSystemParameters(
     addLengthConstraint("c");
     break;
 
-  case PointGroup::Monoclinic:
+  case PointGroup::CrystalSystem::Monoclinic:
     declareParameter("a", 1.0);
     declareParameter("b", 1.0);
     declareParameter("c", 1.0);
@@ -251,7 +251,7 @@ void PawleyParameterFunction::createCrystalSystemParameters(
     addAngleConstraint("Beta");
     break;
 
-  case PointGroup::Trigonal:
+  case PointGroup::CrystalSystem::Trigonal:
     declareParameter("a", 1.0);
     declareParameter("Alpha", 90.0);
     addLengthConstraint("a");

--- a/Framework/CurveFitting/src/LatticeFunction.cpp
+++ b/Framework/CurveFitting/src/LatticeFunction.cpp
@@ -27,10 +27,10 @@ void LatticeFunction::functionLattice(const LatticeDomain &latticeDomain,
 
 /// Assigns the crystal system to the internally stored function. Number of
 /// parameters may change after this function call.
-void LatticeFunction::setCrystalSystem(const std::string &crystalSystem) {
+void LatticeFunction::setLatticeSystem(const std::string &crystalSystem) {
   throwIfNoFunctionSet();
 
-  m_cellParameters->setAttributeValue("CrystalSystem", crystalSystem);
+  m_cellParameters->setAttributeValue("LatticeSystem", crystalSystem);
 }
 
 /// Sets the unit cell parameters from a string that can be parsed by

--- a/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
@@ -52,7 +52,7 @@ public:
     IAlgorithm_sptr pFit = AlgorithmManager::Instance().create("PawleyFit");
     pFit->setProperty("InputWorkspace", ws);
     pFit->setProperty("WorkspaceIndex", 0);
-    pFit->setProperty("CrystalSystem", "Hexagonal");
+    pFit->setProperty("LatticeSystem", "Hexagonal");
     pFit->setProperty("InitialCell", "2.444 2.441 3.937 90 90 120");
     pFit->setProperty("PeakTable", hkls);
     pFit->setProperty("OutputWorkspace", "HCP_output");
@@ -101,7 +101,7 @@ public:
     IAlgorithm_sptr pFit = AlgorithmManager::Instance().create("PawleyFit");
     pFit->setProperty("InputWorkspace", ws);
     pFit->setProperty("WorkspaceIndex", 0);
-    pFit->setProperty("CrystalSystem", "Orthorhombic");
+    pFit->setProperty("LatticeSystem", "Orthorhombic");
     pFit->setProperty("InitialCell", "2.44 3.13 4.07 90 90 90");
     pFit->setProperty("PeakTable", hkls);
     pFit->setProperty("EnableChebyshevBackground", true);

--- a/Framework/CurveFitting/test/Functions/PawleyFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/PawleyFunctionTest.h
@@ -23,100 +23,100 @@ public:
   static PawleyFunctionTest *createSuite() { return new PawleyFunctionTest(); }
   static void destroySuite(PawleyFunctionTest *suite) { delete suite; }
 
-  void testCrystalSystem() {
+  void testLatticeSystem() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    TS_ASSERT(fn.hasAttribute("CrystalSystem"));
+    TS_ASSERT(fn.hasAttribute("LatticeSystem"));
 
     // Cubic, check case insensitivity
-    TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("CrystalSystem", "cubic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::CrystalSystem::Cubic);
-    TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("CrystalSystem", "Cubic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::CrystalSystem::Cubic);
-    TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("CrystalSystem", "CUBIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::CrystalSystem::Cubic);
+    TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("LatticeSystem", "cubic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(), PointGroup::LatticeSystem::Cubic);
+    TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("LatticeSystem", "Cubic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(), PointGroup::LatticeSystem::Cubic);
+    TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("LatticeSystem", "CUBIC"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(), PointGroup::LatticeSystem::Cubic);
 
     // Tetragonal
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "tetragonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Tetragonal);
+        fn.setAttributeValue("LatticeSystem", "tetragonal"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Tetragonal);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "Tetragonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Tetragonal);
+        fn.setAttributeValue("LatticeSystem", "Tetragonal"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Tetragonal);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "TETRAGONAL"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Tetragonal);
+        fn.setAttributeValue("LatticeSystem", "TETRAGONAL"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Tetragonal);
 
     // Hexagonal
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "hexagonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Hexagonal);
+        fn.setAttributeValue("LatticeSystem", "hexagonal"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Hexagonal);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "Hexagonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Hexagonal);
+        fn.setAttributeValue("LatticeSystem", "Hexagonal"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Hexagonal);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "HEXAGONAL"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Hexagonal);
+        fn.setAttributeValue("LatticeSystem", "HEXAGONAL"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Hexagonal);
 
     // Orthorhombic
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "orthorhombic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Orthorhombic);
+        fn.setAttributeValue("LatticeSystem", "orthorhombic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Orthorhombic);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "Orthorhombic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Orthorhombic);
+        fn.setAttributeValue("LatticeSystem", "Orthorhombic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Orthorhombic);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "ORTHORHOMBIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Orthorhombic);
+        fn.setAttributeValue("LatticeSystem", "ORTHORHOMBIC"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Orthorhombic);
 
     // Monoclinic
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "monoclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Monoclinic);
+        fn.setAttributeValue("LatticeSystem", "monoclinic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Monoclinic);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "Monoclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Monoclinic);
+        fn.setAttributeValue("LatticeSystem", "Monoclinic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Monoclinic);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "MONOCLINIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Monoclinic);
+        fn.setAttributeValue("LatticeSystem", "MONOCLINIC"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Monoclinic);
 
     // Triclinic
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "triclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Triclinic);
+        fn.setAttributeValue("LatticeSystem", "triclinic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Triclinic);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "Triclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Triclinic);
+        fn.setAttributeValue("LatticeSystem", "Triclinic"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Triclinic);
     TS_ASSERT_THROWS_NOTHING(
-        fn.setAttributeValue("CrystalSystem", "TRICLINIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
-                     PointGroup::CrystalSystem::Triclinic);
+        fn.setAttributeValue("LatticeSystem", "TRICLINIC"));
+    TS_ASSERT_EQUALS(fn.getLatticeSystem(),
+                     PointGroup::LatticeSystem::Triclinic);
 
     // invalid string
-    TS_ASSERT_THROWS(fn.setAttributeValue("CrystalSystem", "invalid"),
+    TS_ASSERT_THROWS(fn.setAttributeValue("LatticeSystem", "invalid"),
                      std::invalid_argument);
   }
 
-  void testCrystalSystemConstraintsCubic() {
+  void testLatticeSystemConstraintsCubic() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Cubic");
+    fn.setAttributeValue("LatticeSystem", "Cubic");
 
     TS_ASSERT_EQUALS(fn.nParams(), 2);
 
@@ -133,11 +133,11 @@ public:
     cellParametersAre(cell, 3.0, 3.0, 3.0, 90.0, 90.0, 90.0);
   }
 
-  void testCrystalSystemConstraintsTetragonal() {
+  void testLatticeSystemConstraintsTetragonal() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Tetragonal");
+    fn.setAttributeValue("LatticeSystem", "Tetragonal");
 
     TS_ASSERT_EQUALS(fn.nParams(), 3);
 
@@ -155,11 +155,11 @@ public:
     cellParametersAre(cell, 3.0, 3.0, 5.0, 90.0, 90.0, 90.0);
   }
 
-  void testCrystalSystemConstraintsHexagonal() {
+  void testLatticeSystemConstraintsHexagonal() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Hexagonal");
+    fn.setAttributeValue("LatticeSystem", "Hexagonal");
 
     TS_ASSERT_EQUALS(fn.nParams(), 3);
 
@@ -177,11 +177,11 @@ public:
     cellParametersAre(cell, 3.0, 3.0, 5.0, 90.0, 90.0, 120.0);
   }
 
-  void testCrystalSystemConstraintsTrigonal() {
+  void testLatticeSystemConstraintsRhombohedral() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Trigonal");
+    fn.setAttributeValue("LatticeSystem", "Rhombohedral");
 
     TS_ASSERT_EQUALS(fn.nParams(), 3);
 
@@ -199,11 +199,11 @@ public:
     cellParametersAre(cell, 3.0, 3.0, 3.0, 101.0, 101.0, 101.0);
   }
 
-  void testCrystalSystemConstraintsOrthorhombic() {
+  void testLatticeSystemConstraintsOrthorhombic() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Orthorhombic");
+    fn.setAttributeValue("LatticeSystem", "Orthorhombic");
 
     TS_ASSERT_EQUALS(fn.nParams(), 4);
 
@@ -222,11 +222,11 @@ public:
     cellParametersAre(cell, 3.0, 4.0, 5.0, 90.0, 90.0, 90.0);
   }
 
-  void testCrystalSystemConstraintsMonoclinic() {
+  void testLatticeSystemConstraintsMonoclinic() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Monoclinic");
+    fn.setAttributeValue("LatticeSystem", "Monoclinic");
 
     TS_ASSERT_EQUALS(fn.nParams(), 5);
 
@@ -246,11 +246,11 @@ public:
     cellParametersAre(cell, 3.0, 4.0, 5.0, 90.0, 101.0, 90.0);
   }
 
-  void testCrystalSystemConstraintsTriclinic() {
+  void testLatticeSystemConstraintsTriclinic() {
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Triclinic");
+    fn.setAttributeValue("LatticeSystem", "Triclinic");
 
     TS_ASSERT_EQUALS(fn.nParams(), 7);
 
@@ -275,7 +275,7 @@ public:
     PawleyParameterFunction fn;
     fn.initialize();
 
-    fn.setAttributeValue("CrystalSystem", "Triclinic");
+    fn.setAttributeValue("LatticeSystem", "Triclinic");
 
     UnitCell cell(3., 4., 5., 101., 111., 103.);
 
@@ -288,7 +288,7 @@ public:
     TS_ASSERT_EQUALS(fn.getParameter("Beta"), 111.0);
     TS_ASSERT_EQUALS(fn.getParameter("Gamma"), 103.0);
 
-    fn.setAttributeValue("CrystalSystem", "Cubic");
+    fn.setAttributeValue("LatticeSystem", "Cubic");
 
     cell.seta(5.43);
     TS_ASSERT_THROWS_NOTHING(fn.setParametersFromUnitCell(cell));
@@ -323,13 +323,13 @@ public:
     TS_ASSERT_EQUALS(fn.nParams(), 7);
   }
 
-  void testPawleyFunctionSetCrystalSystem() {
+  void testPawleyFunctionSetLatticeSystem() {
     PawleyFunction fn;
     fn.initialize();
 
     TS_ASSERT_EQUALS(fn.nParams(), 7);
 
-    fn.setCrystalSystem("Cubic");
+    fn.setLatticeSystem("Cubic");
 
     TS_ASSERT_EQUALS(fn.nParams(), 2);
   }
@@ -439,7 +439,7 @@ public:
 
     PawleyFunction_sptr pawleyFn = boost::make_shared<PawleyFunction>();
     pawleyFn->initialize();
-    pawleyFn->setCrystalSystem("Cubic");
+    pawleyFn->setLatticeSystem("Cubic");
     pawleyFn->addPeak(V3D(1, 1, 1), 0.0065, 35.0);
     pawleyFn->addPeak(V3D(2, 2, 0), 0.0045, 110.0);
     pawleyFn->setUnitCell("5.4295 5.4295 5.4295");
@@ -475,7 +475,7 @@ public:
 
     PawleyFunction_sptr pawleyFn = boost::make_shared<PawleyFunction>();
     pawleyFn->initialize();
-    pawleyFn->setCrystalSystem("Cubic");
+    pawleyFn->setLatticeSystem("Cubic");
     pawleyFn->addPeak(V3D(1, 1, 1), 0.0065, 35.0);
     pawleyFn->addPeak(V3D(2, 2, 0), 0.0045, 115.0);
     pawleyFn->addPeak(V3D(3, 1, 1), 0.0035, 115.0);

--- a/Framework/CurveFitting/test/Functions/PawleyFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/PawleyFunctionTest.h
@@ -31,66 +31,81 @@ public:
 
     // Cubic, check case insensitivity
     TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("CrystalSystem", "cubic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Cubic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::CrystalSystem::Cubic);
     TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("CrystalSystem", "Cubic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Cubic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::CrystalSystem::Cubic);
     TS_ASSERT_THROWS_NOTHING(fn.setAttributeValue("CrystalSystem", "CUBIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Cubic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::CrystalSystem::Cubic);
 
     // Tetragonal
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "tetragonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Tetragonal);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Tetragonal);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "Tetragonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Tetragonal);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Tetragonal);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "TETRAGONAL"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Tetragonal);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Tetragonal);
 
     // Hexagonal
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "hexagonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Hexagonal);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Hexagonal);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "Hexagonal"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Hexagonal);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Hexagonal);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "HEXAGONAL"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Hexagonal);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Hexagonal);
 
     // Orthorhombic
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "orthorhombic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Orthorhombic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Orthorhombic);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "Orthorhombic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Orthorhombic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Orthorhombic);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "ORTHORHOMBIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Orthorhombic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Orthorhombic);
 
     // Monoclinic
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "monoclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Monoclinic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Monoclinic);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "Monoclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Monoclinic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Monoclinic);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "MONOCLINIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Monoclinic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Monoclinic);
 
     // Triclinic
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "triclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Triclinic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Triclinic);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "Triclinic"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Triclinic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Triclinic);
     TS_ASSERT_THROWS_NOTHING(
         fn.setAttributeValue("CrystalSystem", "TRICLINIC"));
-    TS_ASSERT_EQUALS(fn.getCrystalSystem(), PointGroup::Triclinic);
+    TS_ASSERT_EQUALS(fn.getCrystalSystem(),
+                     PointGroup::CrystalSystem::Triclinic);
 
     // invalid string
     TS_ASSERT_THROWS(fn.setAttributeValue("CrystalSystem", "invalid"),

--- a/Framework/CurveFitting/test/LatticeFunctionTest.h
+++ b/Framework/CurveFitting/test/LatticeFunctionTest.h
@@ -27,22 +27,22 @@ public:
   }
   static void destroySuite(LatticeFunctionTest *suite) { delete suite; }
 
-  void testSetCrystalSystem() {
+  void testSetLatticeSystem() {
     LatticeFunction fn;
     fn.initialize();
 
-    TS_ASSERT_THROWS_NOTHING(fn.setCrystalSystem("Cubic"));
-    TS_ASSERT_THROWS_NOTHING(fn.setCrystalSystem("Tetragonal"));
-    TS_ASSERT_THROWS_NOTHING(fn.setCrystalSystem("triclinic"));
+    TS_ASSERT_THROWS_NOTHING(fn.setLatticeSystem("Cubic"));
+    TS_ASSERT_THROWS_NOTHING(fn.setLatticeSystem("Tetragonal"));
+    TS_ASSERT_THROWS_NOTHING(fn.setLatticeSystem("triclinic"));
 
-    TS_ASSERT_THROWS(fn.setCrystalSystem("DoesNotExist"),
+    TS_ASSERT_THROWS(fn.setLatticeSystem("DoesNotExist"),
                      std::invalid_argument);
 
-    fn.setCrystalSystem("Cubic");
+    fn.setLatticeSystem("Cubic");
     // a and ZeroShift
     TS_ASSERT_EQUALS(fn.nParams(), 2);
 
-    fn.setCrystalSystem("Hexagonal");
+    fn.setLatticeSystem("Hexagonal");
     // a, c and ZeroShift
     TS_ASSERT_EQUALS(fn.nParams(), 3);
 
@@ -100,7 +100,7 @@ public:
     fn.initialize();
 
     // Al2O3, from PoldiCreatePeaksFromCell system test.
-    fn.setCrystalSystem("Hexagonal");
+    fn.setLatticeSystem("Hexagonal");
     fn.setParameter("a", 4.7605);
     fn.setParameter("c", 12.9956);
 
@@ -138,7 +138,7 @@ public:
 
     IFunction_sptr fn =
         FunctionFactory::Instance().createFunction("LatticeFunction");
-    fn->setAttributeValue("CrystalSystem", "Cubic");
+    fn->setAttributeValue("LatticeSystem", "Cubic");
     fn->addTies("ZeroShift=0.0");
     fn->setParameter("a", 5);
 

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
@@ -105,7 +105,7 @@ getLatticeSystemFromString(const std::string &latticeSystem);
 /// when GCC 4.4 is not used anymore.
 struct MANTID_GEOMETRY_DLL CrystalSystemComparator {
   bool operator()(const PointGroup::CrystalSystem &lhs,
-                  const PointGroup::CrystalSystem &rhs);
+                  const PointGroup::CrystalSystem &rhs) const;
 };
 
 typedef std::multimap<PointGroup::CrystalSystem, PointGroup_sptr,

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
@@ -24,7 +24,7 @@ namespace Geometry {
  */
 class MANTID_GEOMETRY_DLL PointGroup : public Group {
 public:
-  enum CrystalSystem {
+  enum class CrystalSystem {
     Triclinic,
     Monoclinic,
     Orthorhombic,

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
@@ -34,6 +34,16 @@ public:
     Cubic
   };
 
+  enum class LatticeSystem {
+    Triclinic,
+    Monoclinic,
+    Orthorhombic,
+    Tetragonal,
+    Hexagonal,
+    Rhombohedral,
+    Cubic
+  };
+
   PointGroup(const std::string &symbolHM, const Group &group,
              const std::string &description = "");
 
@@ -47,6 +57,7 @@ public:
   std::string getSymbol() const;
 
   CrystalSystem crystalSystem() const { return m_crystalSystem; }
+  LatticeSystem latticeSystem() const { return m_latticeSystem; }
 
   /// Return true if the hkls are in same group
   bool isEquivalent(const Kernel::V3D &hkl, const Kernel::V3D &hkl2) const;
@@ -60,10 +71,13 @@ protected:
   std::vector<Kernel::V3D> getEquivalentSet(const Kernel::V3D &hkl) const;
 
   CrystalSystem getCrystalSystemFromGroup() const;
+  LatticeSystem getLatticeSystemFromCrystalSystemAndGroup(
+      const CrystalSystem &crystalSystem) const;
 
   std::string m_symbolHM;
   std::string m_name;
   CrystalSystem m_crystalSystem;
+  LatticeSystem m_latticeSystem;
 };
 
 /// Shared pointer to a PointGroup
@@ -82,6 +96,14 @@ getCrystalSystemAsString(const PointGroup::CrystalSystem &crystalSystem);
 MANTID_GEOMETRY_DLL
 PointGroup::CrystalSystem
 getCrystalSystemFromString(const std::string &crystalSystem);
+
+MANTID_GEOMETRY_DLL
+std::string
+getLatticeSystemAsString(const PointGroup::LatticeSystem &latticeSystem);
+
+MANTID_GEOMETRY_DLL
+PointGroup::LatticeSystem
+getLatticeSystemFromString(const std::string &latticeSystem);
 
 } // namespace Mantid
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PointGroup.h
@@ -85,10 +85,6 @@ typedef boost::shared_ptr<PointGroup> PointGroup_sptr;
 
 MANTID_GEOMETRY_DLL std::vector<PointGroup_sptr> getAllPointGroups();
 
-typedef std::multimap<PointGroup::CrystalSystem, PointGroup_sptr>
-    PointGroupCrystalSystemMap;
-MANTID_GEOMETRY_DLL PointGroupCrystalSystemMap getPointGroupsByCrystalSystem();
-
 MANTID_GEOMETRY_DLL
 std::string
 getCrystalSystemAsString(const PointGroup::CrystalSystem &crystalSystem);
@@ -104,6 +100,18 @@ getLatticeSystemAsString(const PointGroup::LatticeSystem &latticeSystem);
 MANTID_GEOMETRY_DLL
 PointGroup::LatticeSystem
 getLatticeSystemFromString(const std::string &latticeSystem);
+
+/// This is necessary to make the map work with older compilers. Can be removed
+/// when GCC 4.4 is not used anymore.
+struct MANTID_GEOMETRY_DLL CrystalSystemComparator {
+  bool operator()(const PointGroup::CrystalSystem &lhs,
+                  const PointGroup::CrystalSystem &rhs);
+};
+
+typedef std::multimap<PointGroup::CrystalSystem, PointGroup_sptr,
+                      CrystalSystemComparator> PointGroupCrystalSystemMap;
+
+MANTID_GEOMETRY_DLL PointGroupCrystalSystemMap getPointGroupsByCrystalSystem();
 
 } // namespace Mantid
 } // namespace Geometry

--- a/Framework/Geometry/src/Crystal/PointGroup.cpp
+++ b/Framework/Geometry/src/Crystal/PointGroup.cpp
@@ -327,5 +327,10 @@ getLatticeSystemFromString(const std::string &latticeSystem) {
   }
 }
 
+bool CrystalSystemComparator::operator()(const PointGroup::CrystalSystem &lhs,
+                                         const PointGroup::CrystalSystem &rhs) {
+  return static_cast<int>(lhs) < static_cast<int>(rhs);
+}
+
 } // namespace Mantid
 } // namespace Geometry

--- a/Framework/Geometry/src/Crystal/PointGroup.cpp
+++ b/Framework/Geometry/src/Crystal/PointGroup.cpp
@@ -117,6 +117,17 @@ std::vector<V3D> PointGroup::getEquivalentSet(const Kernel::V3D &hkl) const {
   return equivalents;
 }
 
+/**
+ * Returns the CrystalSystem determined from symmetry elements
+ *
+ * This method determines the crystal system of the point group. It makes
+ * use of the fact that each crystal system has a characteristic set of
+ * symmetry elements. The requirement for the cubic system is for example
+ * that four 3-fold axes are present, whereas one 3-fold axis indicates
+ * that the group belongs to the trigonal system.
+ *
+ * @return Crystal system that the point group belongs to.
+ */
 PointGroup::CrystalSystem PointGroup::getCrystalSystemFromGroup() const {
   std::map<std::string, std::set<V3D>> symbolMap;
 
@@ -161,6 +172,17 @@ PointGroup::CrystalSystem PointGroup::getCrystalSystemFromGroup() const {
   return CrystalSystem::Triclinic;
 }
 
+/**
+ * Returns the LatticeSystem of the point group, using the crystal system
+ *
+ * This function uses the crystal system argument and the coordinate system
+ * stored in Group to determine the lattice system. For all crystal systems
+ * except trigonal there is a 1:1 correspondence, but for trigonal groups
+ * the lattice system can be either rhombohedral or hexagonal.
+ *
+ * @param crystalSystem :: CrystalSystem of the point group.
+ * @return LatticeSystem the point group belongs to.
+ */
 PointGroup::LatticeSystem PointGroup::getLatticeSystemFromCrystalSystemAndGroup(
     const CrystalSystem &crystalSystem) const {
   switch (crystalSystem) {
@@ -199,6 +221,7 @@ std::vector<PointGroup_sptr> getAllPointGroups() {
   return out;
 }
 
+/// Returns a multimap with crystal system as key and point groups as values.
 PointGroupCrystalSystemMap getPointGroupsByCrystalSystem() {
   PointGroupCrystalSystemMap map;
 
@@ -231,6 +254,8 @@ getCrystalSystemAsString(const PointGroup::CrystalSystem &crystalSystem) {
   }
 }
 
+/// Returns the crystal system enum that corresponds to the supplied string or
+/// throws an invalid_argument exception.
 PointGroup::CrystalSystem
 getCrystalSystemFromString(const std::string &crystalSystem) {
   std::string crystalSystemLC = boost::algorithm::to_lower_copy(crystalSystem);
@@ -255,6 +280,7 @@ getCrystalSystemFromString(const std::string &crystalSystem) {
   }
 }
 
+/// Returns the supplied LatticeSystem as a string.
 std::string
 getLatticeSystemAsString(const PointGroup::LatticeSystem &latticeSystem) {
   switch (latticeSystem) {
@@ -275,6 +301,8 @@ getLatticeSystemAsString(const PointGroup::LatticeSystem &latticeSystem) {
   }
 }
 
+/// Returns the lattice system enum that corresponds to the supplied string or
+/// throws an invalid_argument exception.PointGroup::LatticeSystem
 PointGroup::LatticeSystem
 getLatticeSystemFromString(const std::string &latticeSystem) {
   std::string latticeSystemLC = boost::algorithm::to_lower_copy(latticeSystem);

--- a/Framework/Geometry/src/Crystal/PointGroup.cpp
+++ b/Framework/Geometry/src/Crystal/PointGroup.cpp
@@ -57,11 +57,13 @@ PointGroup::PointGroup(const std::string &symbolHM, const Group &group,
     : Group(group), m_symbolHM(symbolHM),
       m_name(symbolHM + " (" + description + ")") {
   m_crystalSystem = getCrystalSystemFromGroup();
+  m_latticeSystem = getLatticeSystemFromCrystalSystemAndGroup(m_crystalSystem);
 }
 
 PointGroup::PointGroup(const PointGroup &other)
     : Group(other), m_symbolHM(other.m_symbolHM), m_name(other.m_name),
-      m_crystalSystem(other.m_crystalSystem) {}
+      m_crystalSystem(other.m_crystalSystem),
+      m_latticeSystem(other.m_latticeSystem) {}
 
 PointGroup &PointGroup::operator=(const PointGroup &other) {
   Group::operator=(other);
@@ -69,6 +71,7 @@ PointGroup &PointGroup::operator=(const PointGroup &other) {
   m_symbolHM = other.m_symbolHM;
   m_name = other.m_name;
   m_crystalSystem = other.m_crystalSystem;
+  m_latticeSystem = other.m_latticeSystem;
 
   return *this;
 }
@@ -158,6 +161,31 @@ PointGroup::CrystalSystem PointGroup::getCrystalSystemFromGroup() const {
   return CrystalSystem::Triclinic;
 }
 
+PointGroup::LatticeSystem PointGroup::getLatticeSystemFromCrystalSystemAndGroup(
+    const CrystalSystem &crystalSystem) const {
+  switch (crystalSystem) {
+  case CrystalSystem::Cubic:
+    return LatticeSystem::Cubic;
+  case CrystalSystem::Hexagonal:
+    return LatticeSystem::Hexagonal;
+  case CrystalSystem::Tetragonal:
+    return LatticeSystem::Tetragonal;
+  case CrystalSystem::Orthorhombic:
+    return LatticeSystem::Orthorhombic;
+  case CrystalSystem::Monoclinic:
+    return LatticeSystem::Monoclinic;
+  case CrystalSystem::Triclinic:
+    return LatticeSystem::Triclinic;
+  default: {
+    if (getCoordinateSystem() == Group::Hexagonal) {
+      return LatticeSystem::Hexagonal;
+    }
+
+    return LatticeSystem::Rhombohedral;
+  }
+  }
+}
+
 /** @return a vector with all possible PointGroup objects */
 std::vector<PointGroup_sptr> getAllPointGroups() {
   std::vector<std::string> allSymbols =
@@ -224,6 +252,50 @@ getCrystalSystemFromString(const std::string &crystalSystem) {
   } else {
     throw std::invalid_argument("Not a valid crystal system: '" +
                                 crystalSystem + "'.");
+  }
+}
+
+std::string
+getLatticeSystemAsString(const PointGroup::LatticeSystem &latticeSystem) {
+  switch (latticeSystem) {
+  case PointGroup::LatticeSystem::Cubic:
+    return "Cubic";
+  case PointGroup::LatticeSystem::Tetragonal:
+    return "Tetragonal";
+  case PointGroup::LatticeSystem::Hexagonal:
+    return "Hexagonal";
+  case PointGroup::LatticeSystem::Rhombohedral:
+    return "Rhombohedral";
+  case PointGroup::LatticeSystem::Orthorhombic:
+    return "Orthorhombic";
+  case PointGroup::LatticeSystem::Monoclinic:
+    return "Monoclinic";
+  default:
+    return "Triclinic";
+  }
+}
+
+PointGroup::LatticeSystem
+getLatticeSystemFromString(const std::string &latticeSystem) {
+  std::string latticeSystemLC = boost::algorithm::to_lower_copy(latticeSystem);
+
+  if (latticeSystemLC == "cubic") {
+    return PointGroup::LatticeSystem::Cubic;
+  } else if (latticeSystemLC == "tetragonal") {
+    return PointGroup::LatticeSystem::Tetragonal;
+  } else if (latticeSystemLC == "hexagonal") {
+    return PointGroup::LatticeSystem::Hexagonal;
+  } else if (latticeSystemLC == "rhombohedral") {
+    return PointGroup::LatticeSystem::Rhombohedral;
+  } else if (latticeSystemLC == "orthorhombic") {
+    return PointGroup::LatticeSystem::Orthorhombic;
+  } else if (latticeSystemLC == "monoclinic") {
+    return PointGroup::LatticeSystem::Monoclinic;
+  } else if (latticeSystemLC == "triclinic") {
+    return PointGroup::LatticeSystem::Triclinic;
+  } else {
+    throw std::invalid_argument("Not a valid lattice system: '" +
+                                latticeSystem + "'.");
   }
 }
 

--- a/Framework/Geometry/src/Crystal/PointGroup.cpp
+++ b/Framework/Geometry/src/Crystal/PointGroup.cpp
@@ -327,8 +327,9 @@ getLatticeSystemFromString(const std::string &latticeSystem) {
   }
 }
 
-bool CrystalSystemComparator::operator()(const PointGroup::CrystalSystem &lhs,
-                                         const PointGroup::CrystalSystem &rhs) {
+bool CrystalSystemComparator::
+operator()(const PointGroup::CrystalSystem &lhs,
+           const PointGroup::CrystalSystem &rhs) const {
   return static_cast<int>(lhs) < static_cast<int>(rhs);
 }
 

--- a/Framework/Geometry/src/Crystal/PointGroup.cpp
+++ b/Framework/Geometry/src/Crystal/PointGroup.cpp
@@ -131,31 +131,31 @@ PointGroup::CrystalSystem PointGroup::getCrystalSystemFromGroup() const {
   }
 
   if (symbolMap["3"].size() == 4) {
-    return Cubic;
+    return CrystalSystem::Cubic;
   }
 
   if (symbolMap["6"].size() == 1 || symbolMap["-6"].size() == 1) {
-    return Hexagonal;
+    return CrystalSystem::Hexagonal;
   }
 
   if (symbolMap["3"].size() == 1) {
-    return Trigonal;
+    return CrystalSystem::Trigonal;
   }
 
   if (symbolMap["4"].size() == 1 || symbolMap["-4"].size() == 1) {
-    return Tetragonal;
+    return CrystalSystem::Tetragonal;
   }
 
   if (symbolMap["2"].size() == 3 ||
       (symbolMap["2"].size() == 1 && symbolMap["m"].size() == 2)) {
-    return Orthorhombic;
+    return CrystalSystem::Orthorhombic;
   }
 
   if (symbolMap["2"].size() == 1 || symbolMap["m"].size() == 1) {
-    return Monoclinic;
+    return CrystalSystem::Monoclinic;
   }
 
-  return Triclinic;
+  return CrystalSystem::Triclinic;
 }
 
 /** @return a vector with all possible PointGroup objects */
@@ -186,17 +186,17 @@ PointGroupCrystalSystemMap getPointGroupsByCrystalSystem() {
 std::string
 getCrystalSystemAsString(const PointGroup::CrystalSystem &crystalSystem) {
   switch (crystalSystem) {
-  case PointGroup::Cubic:
+  case PointGroup::CrystalSystem::Cubic:
     return "Cubic";
-  case PointGroup::Tetragonal:
+  case PointGroup::CrystalSystem::Tetragonal:
     return "Tetragonal";
-  case PointGroup::Hexagonal:
+  case PointGroup::CrystalSystem::Hexagonal:
     return "Hexagonal";
-  case PointGroup::Trigonal:
+  case PointGroup::CrystalSystem::Trigonal:
     return "Trigonal";
-  case PointGroup::Orthorhombic:
+  case PointGroup::CrystalSystem::Orthorhombic:
     return "Orthorhombic";
-  case PointGroup::Monoclinic:
+  case PointGroup::CrystalSystem::Monoclinic:
     return "Monoclinic";
   default:
     return "Triclinic";
@@ -208,19 +208,19 @@ getCrystalSystemFromString(const std::string &crystalSystem) {
   std::string crystalSystemLC = boost::algorithm::to_lower_copy(crystalSystem);
 
   if (crystalSystemLC == "cubic") {
-    return PointGroup::Cubic;
+    return PointGroup::CrystalSystem::Cubic;
   } else if (crystalSystemLC == "tetragonal") {
-    return PointGroup::Tetragonal;
+    return PointGroup::CrystalSystem::Tetragonal;
   } else if (crystalSystemLC == "hexagonal") {
-    return PointGroup::Hexagonal;
+    return PointGroup::CrystalSystem::Hexagonal;
   } else if (crystalSystemLC == "trigonal") {
-    return PointGroup::Trigonal;
+    return PointGroup::CrystalSystem::Trigonal;
   } else if (crystalSystemLC == "orthorhombic") {
-    return PointGroup::Orthorhombic;
+    return PointGroup::CrystalSystem::Orthorhombic;
   } else if (crystalSystemLC == "monoclinic") {
-    return PointGroup::Monoclinic;
+    return PointGroup::CrystalSystem::Monoclinic;
   } else if (crystalSystemLC == "triclinic") {
-    return PointGroup::Triclinic;
+    return PointGroup::CrystalSystem::Triclinic;
   } else {
     throw std::invalid_argument("Not a valid crystal system: '" +
                                 crystalSystem + "'.");

--- a/Framework/Geometry/src/Crystal/PointGroupFactory.cpp
+++ b/Framework/Geometry/src/Crystal/PointGroupFactory.cpp
@@ -33,7 +33,7 @@ PointGroup_sptr PointGroupFactoryImpl::createPointGroupFromSpaceGroup(
     PointGroup_sptr pointGroup = createPointGroup(pointGroupSymbol);
 
     // If the crystal system is trigonal, we need to do more.
-    if (pointGroup->crystalSystem() == PointGroup::Trigonal) {
+    if (pointGroup->crystalSystem() == PointGroup::CrystalSystem::Trigonal) {
       throw std::invalid_argument(
           "Trigonal space groups need to be processed differently.");
     }

--- a/Framework/Geometry/test/PointGroupFactoryTest.h
+++ b/Framework/Geometry/test/PointGroupFactoryTest.h
@@ -67,14 +67,14 @@ public:
   void testGetAllPointGroupSymbolsCrystalSystems() {
     std::vector<std::string> cubic =
         PointGroupFactory::Instance().getPointGroupSymbols(
-            PointGroup::Monoclinic);
+            PointGroup::CrystalSystem::Monoclinic);
 
     TS_ASSERT_DIFFERS(findString(cubic, "monoclinicA"), cubic.end());
     TS_ASSERT_DIFFERS(findString(cubic, "monoclinicB"), cubic.end());
 
     std::vector<std::string> triclinic =
         PointGroupFactory::Instance().getPointGroupSymbols(
-            PointGroup::Triclinic);
+            PointGroup::CrystalSystem::Triclinic);
     TS_ASSERT_DIFFERS(findString(triclinic, "triclinic"), triclinic.end());
   }
 

--- a/Framework/Geometry/test/PointGroupTest.h
+++ b/Framework/Geometry/test/PointGroupTest.h
@@ -367,6 +367,55 @@ public:
                      PointGroup::CrystalSystem::Triclinic);
   }
 
+  void testLatticeSystemNames() {
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Cubic"),
+                     PointGroup::LatticeSystem::Cubic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("cubic"),
+                     PointGroup::LatticeSystem::Cubic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("CUBIC"),
+                     PointGroup::LatticeSystem::Cubic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("CuBiC"),
+                     PointGroup::LatticeSystem::Cubic);
+
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Tetragonal"),
+                     PointGroup::LatticeSystem::Tetragonal);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Hexagonal"),
+                     PointGroup::LatticeSystem::Hexagonal);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Rhombohedral"),
+                     PointGroup::LatticeSystem::Rhombohedral);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Orthorhombic"),
+                     PointGroup::LatticeSystem::Orthorhombic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Monoclinic"),
+                     PointGroup::LatticeSystem::Monoclinic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString("Triclinic"),
+                     PointGroup::LatticeSystem::Triclinic);
+
+    TS_ASSERT_THROWS(getLatticeSystemFromString("DoesNotExist"),
+                     std::invalid_argument);
+
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Cubic)),
+                     PointGroup::LatticeSystem::Cubic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Tetragonal)),
+                     PointGroup::LatticeSystem::Tetragonal);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Hexagonal)),
+                     PointGroup::LatticeSystem::Hexagonal);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Rhombohedral)),
+                     PointGroup::LatticeSystem::Rhombohedral);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Orthorhombic)),
+                     PointGroup::LatticeSystem::Orthorhombic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Monoclinic)),
+                     PointGroup::LatticeSystem::Monoclinic);
+    TS_ASSERT_EQUALS(getLatticeSystemFromString(getLatticeSystemAsString(
+                         PointGroup::LatticeSystem::Triclinic)),
+                     PointGroup::LatticeSystem::Triclinic);
+  }
+
 private:
   void checkPointGroupPerformance(const PointGroup_sptr &pointGroup) {
     V3D equiv[] = {

--- a/Framework/Geometry/test/PointGroupTest.h
+++ b/Framework/Geometry/test/PointGroupTest.h
@@ -230,58 +230,58 @@ public:
 
   void testCrystalSystems() {
     std::map<std::string, PointGroup::CrystalSystem> crystalSystemsMap;
-    crystalSystemsMap["1"] = PointGroup::Triclinic;
-    crystalSystemsMap["-1"] = PointGroup::Triclinic;
+    crystalSystemsMap["1"] = PointGroup::CrystalSystem::Triclinic;
+    crystalSystemsMap["-1"] = PointGroup::CrystalSystem::Triclinic;
 
-    crystalSystemsMap["2"] = PointGroup::Monoclinic;
-    crystalSystemsMap["m"] = PointGroup::Monoclinic;
-    crystalSystemsMap["2/m"] = PointGroup::Monoclinic;
-    crystalSystemsMap["112/m"] = PointGroup::Monoclinic;
+    crystalSystemsMap["2"] = PointGroup::CrystalSystem::Monoclinic;
+    crystalSystemsMap["m"] = PointGroup::CrystalSystem::Monoclinic;
+    crystalSystemsMap["2/m"] = PointGroup::CrystalSystem::Monoclinic;
+    crystalSystemsMap["112/m"] = PointGroup::CrystalSystem::Monoclinic;
 
-    crystalSystemsMap["222"] = PointGroup::Orthorhombic;
-    crystalSystemsMap["mm2"] = PointGroup::Orthorhombic;
-    crystalSystemsMap["mmm"] = PointGroup::Orthorhombic;
+    crystalSystemsMap["222"] = PointGroup::CrystalSystem::Orthorhombic;
+    crystalSystemsMap["mm2"] = PointGroup::CrystalSystem::Orthorhombic;
+    crystalSystemsMap["mmm"] = PointGroup::CrystalSystem::Orthorhombic;
 
-    crystalSystemsMap["4"] = PointGroup::Tetragonal;
-    crystalSystemsMap["-4"] = PointGroup::Tetragonal;
-    crystalSystemsMap["4/m"] = PointGroup::Tetragonal;
-    crystalSystemsMap["422"] = PointGroup::Tetragonal;
-    crystalSystemsMap["4mm"] = PointGroup::Tetragonal;
-    crystalSystemsMap["-42m"] = PointGroup::Tetragonal;
-    crystalSystemsMap["-4m2"] = PointGroup::Tetragonal;
-    crystalSystemsMap["4/mmm"] = PointGroup::Tetragonal;
+    crystalSystemsMap["4"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["-4"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["4/m"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["422"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["4mm"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["-42m"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["-4m2"] = PointGroup::CrystalSystem::Tetragonal;
+    crystalSystemsMap["4/mmm"] = PointGroup::CrystalSystem::Tetragonal;
 
-    crystalSystemsMap["3"] = PointGroup::Trigonal;
-    crystalSystemsMap["-3"] = PointGroup::Trigonal;
-    crystalSystemsMap["321"] = PointGroup::Trigonal;
-    crystalSystemsMap["32"] = PointGroup::Trigonal;
-    crystalSystemsMap["312"] = PointGroup::Trigonal;
-    crystalSystemsMap["3m1"] = PointGroup::Trigonal;
-    crystalSystemsMap["3m"] = PointGroup::Trigonal;
-    crystalSystemsMap["31m"] = PointGroup::Trigonal;
-    crystalSystemsMap["-3m1"] = PointGroup::Trigonal;
-    crystalSystemsMap["-3m"] = PointGroup::Trigonal;
-    crystalSystemsMap["-31m"] = PointGroup::Trigonal;
-    crystalSystemsMap["3 r"] = PointGroup::Trigonal;
-    crystalSystemsMap["-3 r"] = PointGroup::Trigonal;
-    crystalSystemsMap["32 r"] = PointGroup::Trigonal;
-    crystalSystemsMap["3m r"] = PointGroup::Trigonal;
-    crystalSystemsMap["-3m r"] = PointGroup::Trigonal;
+    crystalSystemsMap["3"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["-3"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["321"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["32"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["312"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["3m1"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["3m"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["31m"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["-3m1"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["-3m"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["-31m"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["3 r"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["-3 r"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["32 r"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["3m r"] = PointGroup::CrystalSystem::Trigonal;
+    crystalSystemsMap["-3m r"] = PointGroup::CrystalSystem::Trigonal;
 
-    crystalSystemsMap["6"] = PointGroup::Hexagonal;
-    crystalSystemsMap["-6"] = PointGroup::Hexagonal;
-    crystalSystemsMap["6/m"] = PointGroup::Hexagonal;
-    crystalSystemsMap["622"] = PointGroup::Hexagonal;
-    crystalSystemsMap["6mm"] = PointGroup::Hexagonal;
-    crystalSystemsMap["-62m"] = PointGroup::Hexagonal;
-    crystalSystemsMap["-6m2"] = PointGroup::Hexagonal;
-    crystalSystemsMap["6/mmm"] = PointGroup::Hexagonal;
+    crystalSystemsMap["6"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["-6"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["6/m"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["622"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["6mm"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["-62m"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["-6m2"] = PointGroup::CrystalSystem::Hexagonal;
+    crystalSystemsMap["6/mmm"] = PointGroup::CrystalSystem::Hexagonal;
 
-    crystalSystemsMap["23"] = PointGroup::Cubic;
-    crystalSystemsMap["m-3"] = PointGroup::Cubic;
-    crystalSystemsMap["432"] = PointGroup::Cubic;
-    crystalSystemsMap["-43m"] = PointGroup::Cubic;
-    crystalSystemsMap["m-3m"] = PointGroup::Cubic;
+    crystalSystemsMap["23"] = PointGroup::CrystalSystem::Cubic;
+    crystalSystemsMap["m-3"] = PointGroup::CrystalSystem::Cubic;
+    crystalSystemsMap["432"] = PointGroup::CrystalSystem::Cubic;
+    crystalSystemsMap["-43m"] = PointGroup::CrystalSystem::Cubic;
+    crystalSystemsMap["m-3m"] = PointGroup::CrystalSystem::Cubic;
 
     std::vector<PointGroup_sptr> pointgroups = getAllPointGroups();
 
@@ -299,17 +299,18 @@ public:
 
     TS_ASSERT_EQUALS(pointgroups.size(), pgMap.size());
 
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Triclinic), 2);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Triclinic), 2);
 
     // 2/m with axis b and c, so one more
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Monoclinic), 3 + 1);
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Orthorhombic), 3);
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Tetragonal), 8);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Monoclinic), 3 + 1);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Orthorhombic), 3);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Tetragonal), 8);
 
     // 5 with rhombohedral axes and 8 with hexagonal and 3 for defaults
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Trigonal), 5 + 8 + 3);
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Hexagonal), 8);
-    TS_ASSERT_EQUALS(pgMap.count(PointGroup::Cubic), 5);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Trigonal),
+                     5 + 8 + 3);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Hexagonal), 8);
+    TS_ASSERT_EQUALS(pgMap.count(PointGroup::CrystalSystem::Cubic), 5);
   }
 
   void testPerformance() {
@@ -318,48 +319,52 @@ public:
   }
 
   void testCrystalSystemNames() {
-    TS_ASSERT_EQUALS(getCrystalSystemFromString("Cubic"), PointGroup::Cubic);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString("cubic"), PointGroup::Cubic);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString("CUBIC"), PointGroup::Cubic);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString("CuBiC"), PointGroup::Cubic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString("Cubic"),
+                     PointGroup::CrystalSystem::Cubic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString("cubic"),
+                     PointGroup::CrystalSystem::Cubic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString("CUBIC"),
+                     PointGroup::CrystalSystem::Cubic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString("CuBiC"),
+                     PointGroup::CrystalSystem::Cubic);
 
     TS_ASSERT_EQUALS(getCrystalSystemFromString("Tetragonal"),
-                     PointGroup::Tetragonal);
+                     PointGroup::CrystalSystem::Tetragonal);
     TS_ASSERT_EQUALS(getCrystalSystemFromString("Hexagonal"),
-                     PointGroup::Hexagonal);
+                     PointGroup::CrystalSystem::Hexagonal);
     TS_ASSERT_EQUALS(getCrystalSystemFromString("Trigonal"),
-                     PointGroup::Trigonal);
+                     PointGroup::CrystalSystem::Trigonal);
     TS_ASSERT_EQUALS(getCrystalSystemFromString("Orthorhombic"),
-                     PointGroup::Orthorhombic);
+                     PointGroup::CrystalSystem::Orthorhombic);
     TS_ASSERT_EQUALS(getCrystalSystemFromString("Monoclinic"),
-                     PointGroup::Monoclinic);
+                     PointGroup::CrystalSystem::Monoclinic);
     TS_ASSERT_EQUALS(getCrystalSystemFromString("Triclinic"),
-                     PointGroup::Triclinic);
+                     PointGroup::CrystalSystem::Triclinic);
 
     TS_ASSERT_THROWS(getCrystalSystemFromString("DoesNotExist"),
                      std::invalid_argument);
 
-    TS_ASSERT_EQUALS(
-        getCrystalSystemFromString(getCrystalSystemAsString(PointGroup::Cubic)),
-        PointGroup::Cubic);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString(
-                         getCrystalSystemAsString(PointGroup::Tetragonal)),
-                     PointGroup::Tetragonal);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString(
-                         getCrystalSystemAsString(PointGroup::Hexagonal)),
-                     PointGroup::Hexagonal);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString(
-                         getCrystalSystemAsString(PointGroup::Trigonal)),
-                     PointGroup::Trigonal);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString(
-                         getCrystalSystemAsString(PointGroup::Orthorhombic)),
-                     PointGroup::Orthorhombic);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString(
-                         getCrystalSystemAsString(PointGroup::Monoclinic)),
-                     PointGroup::Monoclinic);
-    TS_ASSERT_EQUALS(getCrystalSystemFromString(
-                         getCrystalSystemAsString(PointGroup::Triclinic)),
-                     PointGroup::Triclinic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Cubic)),
+                     PointGroup::CrystalSystem::Cubic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Tetragonal)),
+                     PointGroup::CrystalSystem::Tetragonal);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Hexagonal)),
+                     PointGroup::CrystalSystem::Hexagonal);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Trigonal)),
+                     PointGroup::CrystalSystem::Trigonal);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Orthorhombic)),
+                     PointGroup::CrystalSystem::Orthorhombic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Monoclinic)),
+                     PointGroup::CrystalSystem::Monoclinic);
+    TS_ASSERT_EQUALS(getCrystalSystemFromString(getCrystalSystemAsString(
+                         PointGroup::CrystalSystem::Triclinic)),
+                     PointGroup::CrystalSystem::Triclinic);
   }
 
 private:

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -54,10 +54,20 @@ void export_PointGroup() {
       .value("Trigonal", PointGroup::CrystalSystem::Trigonal)
       .value("Cubic", PointGroup::CrystalSystem::Cubic);
 
+  enum_<PointGroup::LatticeSystem>("LatticeSystem")
+      .value("Triclinic", PointGroup::LatticeSystem::Triclinic)
+      .value("Monoclinic", PointGroup::LatticeSystem::Monoclinic)
+      .value("Orthorhombic", PointGroup::LatticeSystem::Orthorhombic)
+      .value("Tetragonal", PointGroup::LatticeSystem::Tetragonal)
+      .value("Hexagonal", PointGroup::LatticeSystem::Hexagonal)
+      .value("Rhombohedral", PointGroup::LatticeSystem::Rhombohedral)
+      .value("Cubic", PointGroup::LatticeSystem::Cubic);
+
   class_<PointGroup, boost::noncopyable, bases<Group>>("PointGroup", no_init)
       .def("getName", &PointGroup::getName, arg("self"))
       .def("getHMSymbol", &PointGroup::getSymbol, arg("self"))
       .def("getCrystalSystem", &PointGroup::crystalSystem, arg("self"))
+      .def("getLatticeSystem", &PointGroup::latticeSystem, arg("self"))
       .def("isEquivalent", &isEquivalent,
            (arg("self"), arg("hkl1"), arg("hkl2")),
            "Check whether the two HKLs are symmetrically equivalent.")

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -46,13 +46,13 @@ void export_PointGroup() {
       class_<PointGroup, boost::noncopyable>("PointGroup", no_init);
 
   enum_<PointGroup::CrystalSystem>("CrystalSystem")
-      .value("Triclinic", PointGroup::Triclinic)
-      .value("Monoclinic", PointGroup::Monoclinic)
-      .value("Orthorhombic", PointGroup::Orthorhombic)
-      .value("Tetragonal", PointGroup::Tetragonal)
-      .value("Hexagonal", PointGroup::Hexagonal)
-      .value("Trigonal", PointGroup::Trigonal)
-      .value("Cubic", PointGroup::Cubic);
+      .value("Triclinic", PointGroup::CrystalSystem::Triclinic)
+      .value("Monoclinic", PointGroup::CrystalSystem::Monoclinic)
+      .value("Orthorhombic", PointGroup::CrystalSystem::Orthorhombic)
+      .value("Tetragonal", PointGroup::CrystalSystem::Tetragonal)
+      .value("Hexagonal", PointGroup::CrystalSystem::Hexagonal)
+      .value("Trigonal", PointGroup::CrystalSystem::Trigonal)
+      .value("Cubic", PointGroup::CrystalSystem::Cubic);
 
   class_<PointGroup, boost::noncopyable, bases<Group>>("PointGroup", no_init)
       .def("getName", &PointGroup::getName, arg("self"))

--- a/Framework/PythonInterface/test/python/mantid/geometry/PointGroupTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/PointGroupTest.py
@@ -1,9 +1,10 @@
+# pylint: disable=invalid-name,too-many-public-methods
 import unittest
 from mantid.geometry import PointGroup, PointGroupFactory
 from mantid.kernel import V3D
 
-class PointGroupTest(unittest.TestCase):
 
+class PointGroupTest(unittest.TestCase):
     def test_creation(self):
         self.assertRaises(ValueError, PointGroupFactory.createPointGroup, "none")
 
@@ -42,6 +43,14 @@ class PointGroupTest(unittest.TestCase):
 
         pg = PointGroupFactory.createPointGroup("m-3m")
         self.assertEquals(pg.getReflectionFamily(hkl1), pg.getReflectionFamily(hkl2))
+
+    def test_getLatticeSystem(self):
+        pg_rhombohedral = PointGroupFactory.createPointGroup("3m r")
+        pg_hexagonal = PointGroupFactory.createPointGroup("3m")
+
+        self.assertEquals(pg_rhombohedral.getLatticeSystem(), PointGroup.LatticeSystem.Rhombohedral)
+        self.assertEquals(pg_hexagonal.getLatticeSystem(), PointGroup.LatticeSystem.Hexagonal)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
+++ b/Framework/SINQ/inc/MantidSINQ/PoldiFitPeaks2D.h
@@ -105,12 +105,12 @@ protected:
   getFunctionPawley(std::string profileFunctionName,
                     const PoldiPeakCollection_sptr &peakCollection);
 
-  std::string getCrystalSystemFromPointGroup(
+  std::string getLatticeSystemFromPointGroup(
       const Geometry::PointGroup_sptr &pointGroup) const;
 
   std::string
   getRefinedStartingCell(const std::string &initialCell,
-                         const std::string &crystalSystem,
+                         const std::string &latticeSystem,
                          const PoldiPeakCollection_sptr &peakCollection);
 
   std::string getUserSpecifiedTies(const API::IFunction_sptr &poldiFn);

--- a/Framework/SINQ/src/PoldiCreatePeaksFromCell.cpp
+++ b/Framework/SINQ/src/PoldiCreatePeaksFromCell.cpp
@@ -139,22 +139,22 @@ UnitCell PoldiCreatePeaksFromCell::getConstrainedUnitCell(
     const UnitCell &unitCell, const PointGroup::CrystalSystem &crystalSystem,
     const Group::CoordinateSystem &coordinateSystem) const {
   switch (crystalSystem) {
-  case PointGroup::Cubic:
+  case PointGroup::CrystalSystem::Cubic:
     return UnitCell(unitCell.a(), unitCell.a(), unitCell.a());
-  case PointGroup::Tetragonal:
+  case PointGroup::CrystalSystem::Tetragonal:
     return UnitCell(unitCell.a(), unitCell.a(), unitCell.c());
-  case PointGroup::Orthorhombic:
+  case PointGroup::CrystalSystem::Orthorhombic:
     return UnitCell(unitCell.a(), unitCell.b(), unitCell.c());
-  case PointGroup::Monoclinic:
+  case PointGroup::CrystalSystem::Monoclinic:
     return UnitCell(unitCell.a(), unitCell.b(), unitCell.c(), 90.0,
                     unitCell.beta(), 90.0);
-  case PointGroup::Trigonal:
+  case PointGroup::CrystalSystem::Trigonal:
     if (coordinateSystem == Group::Orthogonal) {
       return UnitCell(unitCell.a(), unitCell.a(), unitCell.a(),
                       unitCell.alpha(), unitCell.alpha(), unitCell.alpha());
     }
   // fall through to hexagonal.
-  case PointGroup::Hexagonal:
+  case PointGroup::CrystalSystem::Hexagonal:
     return UnitCell(unitCell.a(), unitCell.a(), unitCell.c(), 90.0, 90.0,
                     120.0);
   default:

--- a/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -593,10 +593,10 @@ std::string PoldiFitPeaks2D::getCrystalSystemFromPointGroup(
 
   PointGroup::CrystalSystem crystalSystem = pointGroup->crystalSystem();
 
-  if (crystalSystem == PointGroup::Trigonal) {
+  if (crystalSystem == PointGroup::CrystalSystem::Trigonal) {
     if (pointGroup->getCoordinateSystem() ==
         Group::CoordinateSystem::Hexagonal) {
-      return getCrystalSystemAsString(PointGroup::Hexagonal);
+      return getCrystalSystemAsString(PointGroup::CrystalSystem::Hexagonal);
     }
   }
 

--- a/Framework/SINQ/src/PoldiFitPeaks2D.cpp
+++ b/Framework/SINQ/src/PoldiFitPeaks2D.cpp
@@ -546,13 +546,13 @@ Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionPawley(
                                 "peaks do not have point group.");
   }
 
-  std::string crystalSystem = getCrystalSystemFromPointGroup(pointGroup);
-  pawleyFunction->setCrystalSystem(crystalSystem);
+  std::string latticeSystem = getLatticeSystemFromPointGroup(pointGroup);
+  pawleyFunction->setLatticeSystem(latticeSystem);
 
   UnitCell cell = peakCollection->unitCell();
   // Extract unit cell from peak collection
   pawleyFunction->setUnitCell(getRefinedStartingCell(
-      unitCellToStr(cell), crystalSystem, peakCollection));
+      unitCellToStr(cell), latticeSystem, peakCollection));
 
   IPeakFunction_sptr pFun = boost::dynamic_pointer_cast<IPeakFunction>(
       FunctionFactory::Instance().createFunction(profileFunctionName));
@@ -575,32 +575,21 @@ Poldi2DFunction_sptr PoldiFitPeaks2D::getFunctionPawley(
 }
 
 /**
- * Returns the crystal system for the specified point group
+ * Returns the lattice system for the specified point group
  *
- * This function simply uses Geometry::getCrystalSystemAsString(), except when
- * the crystal system is trigonal but the point group uses hexagonal axes. In
- * that case this function returns the string for PointGroup::Hexagonal.
+ * This function simply uses Geometry::getLatticeSystemAsString().
  *
  * @param pointGroup :: The point group for which to find the crystal system
  * @return The crystal system for the point group
  */
-std::string PoldiFitPeaks2D::getCrystalSystemFromPointGroup(
+std::string PoldiFitPeaks2D::getLatticeSystemFromPointGroup(
     const PointGroup_sptr &pointGroup) const {
   if (!pointGroup) {
     throw std::invalid_argument(
-        "Cannot return crystal system for null PointGroup.");
+        "Cannot return lattice system for null PointGroup.");
   }
 
-  PointGroup::CrystalSystem crystalSystem = pointGroup->crystalSystem();
-
-  if (crystalSystem == PointGroup::CrystalSystem::Trigonal) {
-    if (pointGroup->getCoordinateSystem() ==
-        Group::CoordinateSystem::Hexagonal) {
-      return getCrystalSystemAsString(PointGroup::CrystalSystem::Hexagonal);
-    }
-  }
-
-  return getCrystalSystemAsString(crystalSystem);
+  return Geometry::getLatticeSystemAsString(pointGroup->latticeSystem());
 }
 
 /**
@@ -618,7 +607,7 @@ std::string PoldiFitPeaks2D::getCrystalSystemFromPointGroup(
  * @return String for refined unit cell
  */
 std::string PoldiFitPeaks2D::getRefinedStartingCell(
-    const std::string &initialCell, const std::string &crystalSystem,
+    const std::string &initialCell, const std::string &latticeSystem,
     const PoldiPeakCollection_sptr &peakCollection) {
 
   Geometry::UnitCell cell = Geometry::strToUnitCell(initialCell);
@@ -627,7 +616,7 @@ std::string PoldiFitPeaks2D::getRefinedStartingCell(
       boost::dynamic_pointer_cast<ILatticeFunction>(
           FunctionFactory::Instance().createFunction("LatticeFunction"));
 
-  latticeFunction->setCrystalSystem(crystalSystem);
+  latticeFunction->setLatticeSystem(latticeSystem);
   latticeFunction->fix(latticeFunction->parameterIndex("ZeroShift"));
   latticeFunction->setUnitCell(cell);
 

--- a/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
+++ b/Framework/SINQ/test/PoldiCreatePeaksFromCellTest.h
@@ -142,37 +142,38 @@ public:
     UnitCell rawCell(2.0, 3.0, 4.0, 91.0, 92.0, 93.0);
 
     checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Cubic), 2.0, 2.0, 2.0,
-        90.0, 90.0, 90.0, "Cubic");
+        alg.getConstrainedUnitCell(rawCell, PointGroup::CrystalSystem::Cubic),
+        2.0, 2.0, 2.0, 90.0, 90.0, 90.0, "Cubic");
+
+    checkUnitCellParameters(alg.getConstrainedUnitCell(
+                                rawCell, PointGroup::CrystalSystem::Tetragonal),
+                            2.0, 2.0, 4.0, 90.0, 90.0, 90.0, "Tetragonal");
 
     checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Tetragonal), 2.0, 2.0,
-        4.0, 90.0, 90.0, 90.0, "Tetragonal");
+        alg.getConstrainedUnitCell(rawCell,
+                                   PointGroup::CrystalSystem::Orthorhombic),
+        2.0, 3.0, 4.0, 90.0, 90.0, 90.0, "Orthorhombic");
+
+    checkUnitCellParameters(alg.getConstrainedUnitCell(
+                                rawCell, PointGroup::CrystalSystem::Monoclinic),
+                            2.0, 3.0, 4.0, 90.0, 92.0, 90.0, "Monoclinic");
+
+    checkUnitCellParameters(alg.getConstrainedUnitCell(
+                                rawCell, PointGroup::CrystalSystem::Triclinic),
+                            2.0, 3.0, 4.0, 91.0, 92.0, 93.0, "Triclinic");
+
+    checkUnitCellParameters(alg.getConstrainedUnitCell(
+                                rawCell, PointGroup::CrystalSystem::Hexagonal),
+                            2.0, 2.0, 4.0, 90.0, 90.0, 120.0, "Hexagonal");
+
+    checkUnitCellParameters(alg.getConstrainedUnitCell(
+                                rawCell, PointGroup::CrystalSystem::Trigonal),
+                            2.0, 2.0, 2.0, 91.0, 91.0, 91.0, "Trigonal");
 
     checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Orthorhombic), 2.0, 3.0,
-        4.0, 90.0, 90.0, 90.0, "Orthorhombic");
-
-    checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Monoclinic), 2.0, 3.0,
-        4.0, 90.0, 92.0, 90.0, "Monoclinic");
-
-    checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Triclinic), 2.0, 3.0,
-        4.0, 91.0, 92.0, 93.0, "Triclinic");
-
-    checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Hexagonal), 2.0, 2.0,
-        4.0, 90.0, 90.0, 120.0, "Hexagonal");
-
-    checkUnitCellParameters(
-        alg.getConstrainedUnitCell(rawCell, PointGroup::Trigonal), 2.0, 2.0,
-        2.0, 91.0, 91.0, 91.0, "Trigonal");
-
-    checkUnitCellParameters(alg.getConstrainedUnitCell(rawCell,
-                                                       PointGroup::Trigonal,
-                                                       Group::Hexagonal),
-                            2.0, 2.0, 4.0, 90.0, 90.0, 120.0, "Trigonal");
+        alg.getConstrainedUnitCell(rawCell, PointGroup::CrystalSystem::Trigonal,
+                                   Group::Hexagonal),
+        2.0, 2.0, 4.0, 90.0, 90.0, 120.0, "Trigonal");
   }
 
 private:

--- a/Framework/SINQ/test/PoldiFitPeaks2DTest.h
+++ b/Framework/SINQ/test/PoldiFitPeaks2DTest.h
@@ -437,33 +437,34 @@ public:
     TestablePoldiFitPeaks2D alg;
 
     auto pgCubic = PointGroupFactory::Instance().createPointGroup("m-3m");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgCubic), "Cubic");
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgCubic), "Cubic");
 
     auto pgTetra = PointGroupFactory::Instance().createPointGroup("4/mmm");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTetra), "Tetragonal");
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgTetra), "Tetragonal");
 
     auto pgOrtho = PointGroupFactory::Instance().createPointGroup("mmm");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgOrtho),
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgOrtho),
                      "Orthorhombic");
 
     auto pgMono = PointGroupFactory::Instance().createPointGroup("2/m");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgMono), "Monoclinic");
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgMono), "Monoclinic");
 
     auto pgTric = PointGroupFactory::Instance().createPointGroup("-1");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTric), "Triclinic");
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgTric), "Triclinic");
 
     auto pgHex = PointGroupFactory::Instance().createPointGroup("6/mmm");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgHex), "Hexagonal");
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgHex), "Hexagonal");
 
     auto pgTrigRh = PointGroupFactory::Instance().createPointGroup("-3m r");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTrigRh), "Trigonal");
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgTrigRh),
+                     "Rhombohedral");
 
     auto pgTrigHex = PointGroupFactory::Instance().createPointGroup("-3m");
-    TS_ASSERT_EQUALS(alg.getCrystalSystemFromPointGroup(pgTrigHex),
+    TS_ASSERT_EQUALS(alg.getLatticeSystemFromPointGroup(pgTrigHex),
                      "Hexagonal");
 
     PointGroup_sptr invalid;
-    TS_ASSERT_THROWS(alg.getCrystalSystemFromPointGroup(invalid),
+    TS_ASSERT_THROWS(alg.getLatticeSystemFromPointGroup(invalid),
                      std::invalid_argument);
   }
 

--- a/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
+++ b/Framework/SINQ/test/PoldiSpectrumPawleyFunctionTest.h
@@ -30,7 +30,7 @@ public:
   MOCK_CONST_METHOD2(function, void(const FunctionDomain &, FunctionValues &));
 
   // IPawleyFunction interface
-  MOCK_METHOD1(setCrystalSystem, void(const std::string &));
+  MOCK_METHOD1(setLatticeSystem, void(const std::string &));
   MOCK_METHOD1(setProfileFunction, void(const std::string &));
   MOCK_METHOD1(setUnitCell, void(const std::string &));
 
@@ -132,7 +132,7 @@ public:
 
     IPawleyFunction_sptr pFn = fn.getPawleyFunction();
     pFn->setProfileFunction("Gaussian");
-    pFn->setCrystalSystem("Cubic");
+    pFn->setLatticeSystem("Cubic");
     // Only the first figure matters, because of cubic
     pFn->setUnitCell("5.43122617238802162554 5.431 5.431 90 90 90");
     pFn->addPeak(V3D(4, 2, 2), 0.0027446316797104233, 679.59369981039407842726);

--- a/docs/source/algorithms/PawleyFit-v1.rst
+++ b/docs/source/algorithms/PawleyFit-v1.rst
@@ -51,7 +51,7 @@ For the usage example there is a calculated, theoretical diffraction pattern (in
 
     # Run the actual fit with lattice parameters that are slightly off
     si_fitted, si_cell, si_params, chi_square = PawleyFit(si_spectrum,
-                          CrystalSystem='Cubic',
+                          LatticeSystem='Cubic',
                           InitialCell='5.436 5.436 5.436',
                           PeakTable=si_peaks_indexed)
 

--- a/docs/source/fitfunctions/LatticeFunction.rst
+++ b/docs/source/fitfunctions/LatticeFunction.rst
@@ -14,7 +14,7 @@ been used to assign indices. LatticeFunction can be used to achieve that task wi
 work with a PeaksWorkspace or with a TableWorkspace that contains two columns named `HKL` and `d` (see
 :ref:`algm-PawleyFit` for specification of the table).
 
-After setting the `CrystalSystem` attribute to one of the seven crystal systems, the function exposes the
+After setting the `LatticeSystem` attribute to one of the seven lattice systems, the function exposes the
 corresponding lattice parameters, as well as a `ZeroShift`. In most cases it's recommended to fix this additional
 parameter as this is often taken care of in earlier steps of the data reduction.
 
@@ -38,7 +38,7 @@ used to generate Bragg reflections that are expected for the crystal structure o
                 LatticeSpacingMin=0.7)
 
     # Fit a cubic cell, starting parameter is 5
-    Fit(Function="name=LatticeFunction,CrystalSystem=Cubic,a=5",
+    Fit(Function="name=LatticeFunction,LatticeSystem=Cubic,a=5",
         InputWorkspace=peaks_Si,
         Ties="ZeroShift=0.0",
         CreateOutput=True,

--- a/docs/source/fitfunctions/PawleyFunction.rst
+++ b/docs/source/fitfunctions/PawleyFunction.rst
@@ -11,7 +11,7 @@ Description
 
 The basic principle of fitting unit cell parameters to a complete powder diffraction pattern has been described by Pawley. Instead allowing each peak to have a freely selectable position, these positions are calculated as a result from the unit cell parameters. All other parameters of the peaks are refined independently. The implementation of the function differs from the method described in the paper in some points, for example the number of parameters can not change during the refinement (no reflections will be added or removed).
 
-Since the function requires special setup (assignment of HKLs, selection of crystal system and profile function), there is an algorithm that can perform a Pawley-type fit with different input data. Please see the documentation of :ref:`algm-PawleyFit` for details on how to use it.
+Since the function requires special setup (assignment of HKLs, selection of lattice system and profile function), there is an algorithm that can perform a Pawley-type fit with different input data. Please see the documentation of :ref:`algm-PawleyFit` for details on how to use it.
 
 .. attributes::
 


### PR DESCRIPTION
This fixes #14121.

The IUCr reference dictionary has a good explanation for the problem. Quote from http://reference.iucr.org/dictionary/Lattice_system:

_"Note that the adjective trigonal refers to a crystal system, not to a lattice system. Rhombohedral crystals belong to the trigonal crystal system, but trigonal crystals may belong to the rhombohedral or to the hexagonal lattice system."_

With the modifications to PointGroup, these terminology problems are now fixed. By using strongly typed enums confusion between the two can be avoided. Some algorithms/functions had to be fixed because the AttributeName in PawleyParameterFunction was also changed to LatticeSystem. External scripts using LatticeFunction are affected, but I think the use of that should be very limited. It should however go into the release notes.

**Testing information**
Code review. Tests should still pass.
