### PR TITLE
Change order of operations to allow RemovePromptPulse to be skipped

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -294,8 +294,8 @@ void AlignAndFocusPowder::exec() {
       }
     }
   }
-  xmin = 0;
-  xmax = 0;
+  xmin = 0.;
+  xmax = 0.;
   if (tmin > 0.) {
     xmin = tmin;
   }

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -417,8 +417,7 @@ void AlignAndFocusPowder::exec() {
   if (removePromptPulseWidth > 0.) {
     g_log.information() << "running RemovePromptPulse(Width="
                         << removePromptPulseWidth << ")\n";
-    API::IAlgorithm_sptr filterPAlg =
-            createChildAlgorithm("RemovePromptPulse");
+    API::IAlgorithm_sptr filterPAlg = createChildAlgorithm("RemovePromptPulse");
     filterPAlg->setProperty("InputWorkspace", m_outputW);
     filterPAlg->setProperty("OutputWorkspace", m_outputW);
     filterPAlg->setProperty("Width", removePromptPulseWidth);

--- a/docs/source/algorithms/AlignAndFocusPowder-v1.rst
+++ b/docs/source/algorithms/AlignAndFocusPowder-v1.rst
@@ -13,9 +13,9 @@ This is a workflow algorithm that does the bulk of the work for time
 focusing diffraction data. This is done by executing several
 sub-algorithms as listed below.
 
-#. :ref:`algm-RemovePromptPulse` (event workspace only)
 #. :ref:`algm-CompressEvents` (event workspace only)
 #. :ref:`algm-CropWorkspace`
+#. :ref:`algm-RemovePromptPulse`
 #. :ref:`algm-MaskDetectors`
 #. :ref:`algm-Rebin` or :ref:`algm-ResampleX` if not d-space binning
 #. :ref:`algm-AlignDetectors`
@@ -51,9 +51,9 @@ and
 You will have to rename :literal:`pg3_mantid_det.cal` manually, as its name in the link above is a list of random characters.
 
 .. code-block:: python
-    
+
     PG3_9830_event = Load('PG3_9830_event.nxs')
-    PG3_9830_event = AlignAndFocusPowder(PG3_9830_event, 
+    PG3_9830_event = AlignAndFocusPowder(PG3_9830_event,
         CalFileName='pg3_mantid_det.cal', Params='100')
 
 

--- a/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
+++ b/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
@@ -52,16 +52,18 @@ digraph AlignAndFocusPowder {
 
   InputWorkspace         -> isEventWorkspace1
 
-  isEventWorkspace1      -> removePromptPulse    [label="Yes"]
-  RemovePromptPulseWidth -> removePromptPulse
-  removePromptPulse      -> compressEvents
+  isEventWorkspace1      -> compressEvents       [label="Yes"]
   CompressTolerance      -> compressEvents
+
   compressEvents         -> cropWorkspace
 
   isEventWorkspace1      -> cropWorkspace        [label="No"]
   CropWaveLengthMin      -> cropWorkspace
+  cropWorkspace          -> removePromptPulse
 
-  cropWorkspace          -> maskDetectors
+  RemovePromptPulseWidth -> removePromptPulse
+
+  removePromptPulse      -> maskDetectors
   MaskWorkspace          -> maskDetectors
   maskDetectors          -> isDspace1
   isDspace1              -> resampleX            [label="Yes"]


### PR DESCRIPTION
**To test:** The tests should all pass and review the code.

In the release notes [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_6_Diffraction&diff=25447&oldid=25395)
