### PR TITLE
Fix Valgrind GeometryTest suppression file.

### DIFF
--- a/tools/Valgrind/GeometryTest.supp
+++ b/tools/Valgrind/GeometryTest.supp
@@ -44,7 +44,8 @@
    fun:_ZN28BRepAlgoAPI_BooleanOperation5BuildEv
    fun:_ZN18BRepAlgoAPI_CommonC1ERK12TopoDS_ShapeS2_
    ...
-   fun:_ZN6Mantid8Geometry19OCGeometryGenerator11AnalyzeRuleEPNS0_4RuleE
+   fun:_ZN6Mantid8Geometry19OCGeometryGenerator13AnalyzeObjectEv
+   ...
 }
 {
    <OpenCascade_conditional_jump_2>
@@ -54,5 +55,6 @@
    fun:_ZN28BRepAlgoAPI_BooleanOperation5BuildEv
    fun:_ZN18BRepAlgoAPI_CommonC1ERK12TopoDS_ShapeS2_
    ...
-   fun:_ZN6Mantid8Geometry19OCGeometryGenerator11AnalyzeRuleEPNS0_4RuleE
+   fun:_ZN6Mantid8Geometry19OCGeometryGenerator13AnalyzeObjectEv
+   ...
 }


### PR DESCRIPTION
This fixes #14170.

Changes in pull request #14034 remove the AnalyzeRule member function from OCGeometryGenerator. I've updated the suppression file to reflect this.

This doesn't alter the binary package and shouldn't be mentioned in the release notes.

Testing: Review changes. Run GeometryTest through valgrind on your local machine and/or monitor the `valgrind_core_packages` on Jenkins.
