### PR TITLE
Added modification to Indirect ILL Reduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectILLReduction.py
@@ -377,15 +377,24 @@ class IndirectILLReduction(DataProcessorAlgorithm):
         imid = float(npt / 2 + 1)
         gRun = mtd[ws].getRun()
         wave = gRun.getLogData('wavelength').value
-        freq = gRun.getLogData('Doppler.doppler_frequency').value
-        amp = gRun.getLogData('Doppler.doppler_amplitude').value
+        logger.information('Wavelength : %s' % wave)
+        if gRun.hasProperty('Doppler.maximum_delta_energy'):
+            energy = gRun.getLogData('Doppler.maximum_delta_energy').value
+            logger.information('Doppler max energy : %s' % energy)
+        elif gRun.hasProperty('Doppler.doppler_speed'):
+            speed = gRun.getLogData('Doppler.doppler_speed').value
+            amp = gRun.getLogData('Doppler.doppler_amplitude').value
+            logger.information('Doppler speed : %s' % speed)
+            logger.information('Doppler amplitude : %s' % amp)
+            energy = 1.2992581918414711e-4 * speed * amp * 2.0 / wave  # max energy
+        elif gRun.hasProperty('Doppler.doppler_freq'):
+            speed = gRun.getLogData('Doppler.doppler_freq').value
+            amp = gRun.getLogData('Doppler.doppler_amplitude').value
+            logger.information('Doppler freq : %s' % freq)
+            logger.information('Doppler amplitude : %s' % amp)
+            energy = 1.2992581918414711e-4 * freq * amp * 2.0 / wave  # max energy
 
-        logger.information('Wavelength : ' + str(wave))
-        logger.information('Doppler frequency : ' + str(freq))
-        logger.information('Doppler amplitude : ' + str(amp))
-
-        vmax = 1.2992581918414711e-4 * freq * amp * 2.0 / wave  # max energy
-        dele = 2.0 * vmax / npt
+        dele = 2.0 * energy / npt
         formula = '(x-%f)*%f' % (imid, dele)
 
         return formula


### PR DESCRIPTION
Fixes #14177

Spencer's modification to ILL Reduction have been implemented. These should allow for the use of the new `.nxs` files provided by the ILL
# To Test
- Change your default Facility and Instrument to Facility=ILL, Inst=IN16B
  - View > Preferences > Mantid > Instrument
- Open ILL Energy Transfer (Interfaces > Indirect > Data Reduction > ILL Energy Transfer)
- Ensure the settings for the instrument options are:
  - Instrument= `IN16B`
  - Analyser= `silicon`
  - Reflection= `111`
- **Test mirrored**
  - Enter one of the files from `\\olympic\Babylon5\Public\ElliotOram\ILL\EnergyTransfer\Mirrored`
  - Ensure the `Use Mirror Mode` is checked
  - Click `Run`
  - Ensure this produces the following workspaces ending in:
    - `_left`
    - `_raw`
    - `_red`
    - `_right`
  - Test the other file in the `Mirrored` directory, ensure that produces the same workspaces (with run numbers matching the file name)
- **Test non-mirrored**
  - Enter one of the files from `\\olympic\Babylon5\Public\ElliotOram\ILL\EnergyTransfer\nonMirrored`
  - Ensure `Use Mirror mode` is unchecked
  - Click `Run`
  - Ensure this produces the following workspaces ending in:
    - `_raw`
    - `_red`

*\* All the produced workspaces should be in the form: `runNumber_analyser_reflection_` followed by the above suffixes**
