### PR TITLE
Fixed number type problem with AddSampleLog algorithm

### DIFF
--- a/Framework/Algorithms/src/AddSampleLog.cpp
+++ b/Framework/Algorithms/src/AddSampleLog.cpp
@@ -44,8 +44,8 @@ void AddSampleLog::init() {
   typeOptions.push_back("");
   declareProperty("NumberType", "",
                   boost::make_shared<StringListValidator>(typeOptions),
-                  "Force LogText to be interpreted as a number of type \"int\" "
-                  "or \"double\".");
+                  "Force LogText to be interpreted as a number of type 'int' "
+                  "or 'double'.");
 }
 
 void AddSampleLog::exec() {

--- a/Framework/Algorithms/src/AddSampleLog.cpp
+++ b/Framework/Algorithms/src/AddSampleLog.cpp
@@ -37,6 +37,13 @@ void AddSampleLog::init() {
                   boost::make_shared<StringListValidator>(propOptions),
                   "The type that the log data will be.");
   declareProperty("LogUnit", "", "The units of the log");
+
+  std::vector<std::string> typeOptions;
+  typeOptions.push_back("Int");
+  typeOptions.push_back("Double");
+  declareProperty("NumberType", "String",
+                  boost::make_shared<StringListValidator>(typeOptions),
+                  "Force LogText to be interpreted as a number of type \"int\" or \"double\".");
 }
 
 void AddSampleLog::exec() {
@@ -51,6 +58,11 @@ void AddSampleLog::exec() {
   std::string propValue = getProperty("LogText");
   std::string propUnit = getProperty("LogUnit");
   std::string propType = getPropertyValue("LogType");
+  std::string propNumberType = getPropertyValue("NumberType");
+
+  if (!propNumberType.empty() && (propType != "Number")) {
+    throw std::invalid_argument("You may only use NumberType property if LogType is \"Number\"");
+  }
 
   // Remove any existing log
   if (theRun.hasProperty(propName)) {

--- a/Framework/Algorithms/test/AddSampleLogTest.h
+++ b/Framework/Algorithms/test/AddSampleLogTest.h
@@ -105,11 +105,11 @@ public:
   }
 
   template <typename T>
-  void ExecuteAlgorithm(MatrixWorkspace_sptr testWS, std::string LogName,
-                        std::string LogType, std::string LogText,
-                        T expectedValue, bool fails = false,
-                        std::string LogUnit = "", std::string NumberType = "",
-                        bool throws = false) {
+  void
+  ExecuteAlgorithm(MatrixWorkspace_sptr testWS, std::string LogName,
+                   std::string LogType, std::string LogText, T expectedValue,
+                   bool fails = false, std::string LogUnit = "",
+                   std::string NumberType = "AutoDetect", bool throws = false) {
     // add the workspace to the ADS
     AnalysisDataService::Instance().addOrReplace("AddSampleLogTest_Temporary",
                                                  testWS);

--- a/Framework/Algorithms/test/AddSampleLogTest.h
+++ b/Framework/Algorithms/test/AddSampleLogTest.h
@@ -84,11 +84,32 @@ public:
                      "stringUnit");
   }
 
+  void test_number_type() {
+    MatrixWorkspace_sptr ws =
+        WorkspaceCreationHelper::Create2DWorkspace(10, 10);
+    ws->mutableRun().setStartAndEndTime(DateAndTime("2013-12-18T13:40:00"),
+                                        DateAndTime("2013-12-18T13:42:00"));
+    ExecuteAlgorithm(ws, "My Name", "Number Series", "1.234", 1.234, false,
+                     "myUnit", "Double");
+    ExecuteAlgorithm(ws, "My New Name", "Number", "963", 963, false,
+                     "differentUnit", "Int");
+    // Can force '963' to be interpreted as a double
+    ExecuteAlgorithm(ws, "My New Name", "Number", "963", 963.0, false,
+                     "differentUnit", "Double");
+    // Should throw error as NumberType defined for a String
+    ExecuteAlgorithm(ws, "My Name", "String", "My Value", 0.0, true,
+                     "stringUnit", "Double", true);
+    // Should throw error trying to interpret '1.234' as Int
+    ExecuteAlgorithm(ws, "My Name", "Number Series", "1.234", 1.234, true,
+                     "myUnit", "Int", true);
+  }
+
   template <typename T>
   void ExecuteAlgorithm(MatrixWorkspace_sptr testWS, std::string LogName,
                         std::string LogType, std::string LogText,
                         T expectedValue, bool fails = false,
-                        std::string LogUnit = "") {
+                        std::string LogUnit = "", std::string NumberType = "",
+                        bool throws = false) {
     // add the workspace to the ADS
     AnalysisDataService::Instance().addOrReplace("AddSampleLogTest_Temporary",
                                                  testWS);
@@ -96,6 +117,8 @@ public:
     // execute algorithm
     AddSampleLog alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    if (throws)
+      alg.setRethrows(true);
     TS_ASSERT(alg.isInitialized())
 
     alg.setPropertyValue("Workspace", "AddSampleLogTest_Temporary");
@@ -103,6 +126,11 @@ public:
     alg.setPropertyValue("LogText", LogText);
     alg.setPropertyValue("LogUnit", LogUnit);
     alg.setPropertyValue("LogType", LogType);
+    alg.setPropertyValue("NumberType", NumberType);
+    if (throws) {
+      TS_ASSERT_THROWS_ANYTHING(alg.execute())
+      return;
+    }
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     if (fails) {
       TS_ASSERT(!alg.isExecuted())

--- a/docs/source/algorithms/AddSampleLog-v1.rst
+++ b/docs/source/algorithms/AddSampleLog-v1.rst
@@ -24,7 +24,10 @@ otherwise. This applies to both the Number & Number Series options.
 The algorithm can be forced to create a log of integer or floating point 
 type by using the optional NumberType property as 'Int' or 'Double'. For 
 example, with NumberType='Double' the log for LogText='12' would be 
-created as a floating point (double) rather than an integer.
+created as a floating point (double) rather than an integer. NumberType defaults
+to 'AutoDetect' which decides whether to use integer or floating point based
+on the format of the string, e.g. LogText='12' would create an integer type 
+log and LogText='12.0' would create a floating point type log.
 
 To add logs that vary over time (Time Series Logs) use :ref:`algm-AddTimeSeriesLog`.
 

--- a/docs/source/algorithms/AddSampleLog-v1.rst
+++ b/docs/source/algorithms/AddSampleLog-v1.rst
@@ -21,6 +21,11 @@ If the LogText contains a numeric value, the created log will be of
 integer type if an integer is passed and floating point (double)
 otherwise. This applies to both the Number & Number Series options.
 
+The algorithm can be forced to create a log of integer or floating point 
+type by using the optional NumberType property as 'Int' or 'Double'. For 
+example, with NumberType='Double' the log for LogText='12' would be 
+created as a floating point (double) rather than an integer.
+
 To add logs that vary over time (Time Series Logs) use :ref:`algm-AddTimeSeriesLog`.
 
 Usage


### PR DESCRIPTION
Closes #14178 

The problem and solution are described in the issue.
Added property "NumberType" which may be "Double" or "Int". Covered new functionality with tests and updated the documentation for the algorithm.

**For Tester:**

You can test using the following python. For the first workspace the NumberType property is not used and LogText="12" is stored as an integer, "12" should be printed. For the second workspace the NumberType property is "Double" and LogText="12" is stored as a double, "12.0" should be printed.

``` python

sample_ws_1 = CreateSampleWorkspace()
AddSampleLog(Workspace=sample_ws_1, LogName="LogName", LogText="12", LogType="Number")
print sample_ws_1.getRun().getProperty("LogName").value

sample_ws_2 = CreateSampleWorkspace()
AddSampleLog(Workspace=sample_ws_2, LogName="LogName", LogText="12", LogType="Number", NumberType="Double")
print sample_ws_2.getRun().getProperty("LogName").value

```
