### PR TITLE
Added default fold parameter to IRIS/OSIRIS definition

### DIFF
--- a/instrument/IRIS_Parameters.xml
+++ b/instrument/IRIS_Parameters.xml
@@ -38,6 +38,9 @@
 <parameter name="save-ascii-choice" type="string">
     <value val="false" />
 </parameter>
+<parameter name="fold-frames-choice" type="string">
+    <value val="false" />
+</parameter>
 
 <!-- Reduction workflow parameters under this line -->
 <!-- This is actually spectrum index, NOT spectrum number -->

--- a/instrument/OSIRIS_Parameters.xml
+++ b/instrument/OSIRIS_Parameters.xml
@@ -30,6 +30,9 @@
 <parameter name="save-ascii-choice" type="string">
     <value val="false" />
 </parameter>
+<parameter name="fold-frames-choice" type="string">
+    <value val="false" />
+</parameter>
 
 <!-- Reduction workflow parameters under this line -->
 <!-- This is actually spectrum index, NOT spectrum number -->


### PR DESCRIPTION
Fixes #13744 

`Fold Multiple Frames` should no longer be checked by default for IRIS and OSIRIS
# To Test
- Change your default Facility and Instrument to Facility=ISIS, Inst=IRIS
  - View > Preferences > Mantid > Instrument
- Open ISIS Energy Transfer (Interfaces > Indirect > Data Reduction >  ISIS Energy Transfer)
- In the Output section of the interface there is an option called `Fold Multiple Frames` ensure this box is checked/unchecked for the following instruments _(Instruments can be changes via the instrument drop down in the top left of the interface)_
- IRIS = **Unchecked**
- OSIRIS = **Unchecked**
- TOSCA = **Checked**

**Note to tester - The interface may produce a dialogue box stating that the Run file range is invalid. This is a known issue and is being fixed separately**
