### PR TITLE
Added save path validation to BayesQuasi

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -124,6 +124,23 @@ void Quasi::run() {
   // Using 1/0 instead of True/False for compatibility with underlying Fortran
   // code
   // in some places
+
+  auto saveDirectory = Mantid::Kernel::ConfigService::Instance().getString(
+      "defaultsave.directory");
+  if (saveDirectory.compare("") == 0) {
+    QString textMessage = "BayesQuasi requires a default save directory and "
+                          "one is not currently set."
+                          " If run, the algorithm will default to saving files "
+                          "to the current working directory."
+                          " Would you still like to run the algorithm?";
+    int result = QMessageBox::question(NULL, tr("Save Directory"),
+                                       tr(textMessage), QMessageBox::Yes,
+                                       QMessageBox::No, QMessageBox::NoButton);
+    if (result == QMessageBox::No) {
+      return;
+    }
+  }
+
   bool save = false;
   bool elasticPeak = false;
   bool sequence = false;


### PR DESCRIPTION
Fixes #14194

BayesQuasi will now check with the user that they are happy to have the algorithm save files to the current working directory (cwd) if no default save path is set.
# Note to tester
- If you are building the source code, ensure that you do the following:
  - **You are testing on windows** 
  - **Build in release Mode**
  - **Add `<path to mantid repo>\Third_Party\lib\win64\mingw` to your PATH variable**
# To Test
- Open BayesQuasi ( Interfaces > Indirect > Bayes > Quasi)
- Files for testing this algorithm are available from `ExternalData\Testing\Data\UnitTest\`
  - Input = `irs26173_graphite002_red.nxs`
  - Resolution = `irs26173_graphite002_res.nxs`
- **Test 1**
  - Run the algorithm with your Default Save Directory set 
    - To set this, go to `Manage Directories` (bottom right of the interface). This can then be set with the bottom option in the `Manage User Directory` window.
  - Ensure the algorithm runs without issue
- **Test 2**
  - Clear the default save directory and try to run the algorithm again.
  - Ensure a message box is displayed with a yes/no option.
  - Ensure that if you click yes, the algorithm runs without issue
  - Ensure that if you click no, the algorithm is not run
