### PR TITLE
Adding workspace groups to multi-dataset fitting interface.

### DIFF
--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
@@ -24,8 +24,9 @@ AddWorkspaceDialog::AddWorkspaceDialog(QWidget *parent):QDialog(parent),m_maxInd
   auto wsNames = Mantid::API::AnalysisDataService::Instance().getObjectNames();
   for(auto name = wsNames.begin(); name != wsNames.end(); ++name)
   {
-    auto ws = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>( *name );
-    if ( ws )
+    auto mws = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>( *name );
+    auto grp = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::WorkspaceGroup>( *name );
+    if ( mws || grp )
     {
       workspaceNames << QString::fromStdString( *name );
     }
@@ -40,15 +41,24 @@ AddWorkspaceDialog::AddWorkspaceDialog(QWidget *parent):QDialog(parent),m_maxInd
 /// @param wsName :: Name of newly selected workspace.
 void AddWorkspaceDialog::workspaceNameChanged(const QString& wsName)
 {
-  auto ws = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>( wsName.toStdString() );
-  if ( ws )
+  auto stdWsName = wsName.toStdString();
+  auto mws = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>( stdWsName );
+
+  auto grp = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::WorkspaceGroup>( stdWsName );
+  if ( grp && !grp->isEmpty() )
   {
-    int maxValue = static_cast<int>(ws->getNumberHistograms()) - 1;
+    mws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(grp->getItem(0));
+  }
+
+  if ( mws )
+  {
+    int maxValue = static_cast<int>(mws->getNumberHistograms()) - 1;
     if ( maxValue < 0 ) maxValue = 0;
     m_maxIndex = maxValue;
-    if ( m_uiForm.cbAllSpectra->isChecked() )
+    if ( m_uiForm.cbAllSpectra->isChecked() || m_maxIndex == 0 )
     {
-      m_uiForm.leWSIndices->setText(QString("0-%1").arg(m_maxIndex));
+      auto text = m_maxIndex > 0 ? QString("0-%1").arg(m_maxIndex) : "0";
+      m_uiForm.leWSIndices->setText(text);
     }
     else
     {

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFAddWorkspaceDialog.cpp
@@ -2,6 +2,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ArrayBoundedValidator.h"
 

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
@@ -57,7 +57,7 @@ void DataController::addWorkspace()
         auto grp = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::WorkspaceGroup>( wsName.toStdString() );
         if ( grp )
         {
-          for(size_t i = 0; i < grp->getNumberOfEntries(); ++i)
+          for(size_t i = 0; i < static_cast<size_t>(grp->getNumberOfEntries()); ++i)
           {
             mws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(grp->getItem(i));
             if ( mws )

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
@@ -44,14 +44,42 @@ void DataController::addWorkspace()
     if ( wsName.isEmpty() ) return;
     if ( Mantid::API::AnalysisDataService::Instance().doesExist( wsName.toStdString()) )
     {
-      auto ws = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>( wsName.toStdString() );
       auto indices = dialog.workspaceIndices();
-      for(auto i = indices.begin(); i != indices.end(); ++i)
+      std::vector<Mantid::API::MatrixWorkspace_sptr> matrixWorkspaces;
+      auto mws = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::MatrixWorkspace>( wsName.toStdString() );
+      if ( mws )
       {
-        addWorkspaceSpectrum( wsName, *i, *ws );
+        matrixWorkspaces.push_back(mws);
       }
-      emit spectraAdded(static_cast<int>(indices.size()));
-      emit dataTableUpdated();
+      else
+      {
+        auto grp = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::WorkspaceGroup>( wsName.toStdString() );
+        if ( grp )
+        {
+          for(size_t i = 0; i < grp->getNumberOfEntries(); ++i)
+          {
+            mws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(grp->getItem(i));
+            if ( mws )
+            {
+              matrixWorkspaces.push_back(mws);
+            }
+          }
+        }
+      }
+
+      if ( !matrixWorkspaces.empty() )
+      {
+        for(auto iws = matrixWorkspaces.begin(); iws != matrixWorkspaces.end(); ++iws)
+        {
+          auto name = QString::fromStdString((**iws).name());
+          for(auto i = indices.begin(); i != indices.end(); ++i)
+          {
+            addWorkspaceSpectrum( name, *i, **iws );
+          }
+        }
+        emit spectraAdded(static_cast<int>(indices.size() * matrixWorkspaces.size()));
+        emit dataTableUpdated();
+      }
     }
     else
     {

--- a/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
+++ b/MantidQt/CustomInterfaces/src/MultiDatasetFit/MDFDataController.cpp
@@ -4,6 +4,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 
 #include <QTableWidget>
 #include <QMessageBox>


### PR DESCRIPTION
Fixes #13778.

**To test**

Check that both matrix workspaces and workspace groups can be added to the list of datasets.
