### PR TITLE
LoadVesuvio reduced calls to FileFinder

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -363,7 +363,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 out_name, out_mon = SUMMED_WS + 'tmp', SUMMED_MON + 'tmp'
 
             # Load data
-            file = FileFinder.findRuns(run)
+            file = FileFinder.findRuns(run)[0]
             ms.LoadRaw(Filename=file,
                        SpectrumList=spectra,
                        OutputWorkspace=out_name,

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -363,12 +363,13 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 out_name, out_mon = SUMMED_WS + 'tmp', SUMMED_MON + 'tmp'
 
             # Load data
-            ms.LoadRaw(Filename=run,
+            file = FileFinder.findRuns(run)
+            ms.LoadRaw(Filename=file,
                        SpectrumList=spectra,
                        OutputWorkspace=out_name,
                        LoadMonitors='Exclude',
                        EnableLogging=_LOGGING_)
-            ms.LoadRaw(Filename=run,
+            ms.LoadRaw(Filename=file,
                        SpectrumList=self._mon_spectra,
                        OutputWorkspace=out_mon,
                        EnableLogging=_LOGGING_)

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -363,13 +363,13 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 out_name, out_mon = SUMMED_WS + 'tmp', SUMMED_MON + 'tmp'
 
             # Load data
-            file = FileFinder.findRuns(run)[0]
-            ms.LoadRaw(Filename=file,
+            raw_filepath = FileFinder.findRuns(run)[0]
+            ms.LoadRaw(Filename=raw_filepath,
                        SpectrumList=spectra,
                        OutputWorkspace=out_name,
                        LoadMonitors='Exclude',
                        EnableLogging=_LOGGING_)
-            ms.LoadRaw(Filename=file,
+            ms.LoadRaw(Filename=raw_filepath,
                        SpectrumList=self._mon_spectra,
                        OutputWorkspace=out_mon,
                        EnableLogging=_LOGGING_)


### PR DESCRIPTION
Fixes #14212

There is now one less use of the FileFinder in the LoadVesuvio algorithm.

**Note to tester:**
- The instrumentParFile is called IP0005.par and is available from `\\olympic\Babylon5\Public\ElliotOram\Vesuvio`
# To Test
- Open `Manage user Directories` Window and check the `Search Data Archive` option
- Open the LoadVesuvio input dialog via the algorithms browser.
- Enter the following inputs:
  - Filename = 17414-17420
  - SpectrumList = 3
  - Mode = SingleDifference
  - InstrumentParFile = _Previously mentioned file available from babylon5_ - If you can't find the file in file browser, ensure the file browser is searching for `.par` files. It defaults to looking for `.dat` files. 
  - Check SumSpectra
  - OutputWorkspace = outWs
- Ensure that a MatrixWorkspace is produced called OutWs it should have the following:
  - 1190 bins
  - 1 histogram
  - plot = 
    ![image](https://cloud.githubusercontent.com/assets/13132128/10880927/d506da94-8156-11e5-906a-045171f6f832.png)
