### PR TITLE
Attempt to remove touch screen warnings 

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -745,10 +745,6 @@ void MantidUI::showVatesSimpleInterface()
       MantidQt::API::VatesViewerInterface *vsui = interfaceManager.createVatesSimpleGui();
       if (vsui)
       {     
-        //reset the qt error redirection that Paraview puts in place
-        // this may not be necessary if we move to qt5
-        qInstallMsgHandler(0);
-
         connect(m_appWindow, SIGNAL(shutting_down()),
           vsui, SLOT(shutdown()));
         connect(vsui, SIGNAL(requestClose()), m_vatesSubWindow, SLOT(close()));
@@ -774,7 +770,11 @@ void MantidUI::showVatesSimpleInterface()
   }
   catch (...)
   {
-  }
+  }     
+  //reset the qt error redirection that Paraview puts in place
+  // this may not be necessary if we move to qt5
+  qInstallMsgHandler(0);
+
 }
 
 void MantidUI::showSpectrumViewer()

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -740,6 +740,10 @@ void MantidUI::showVatesSimpleInterface()
       m_vatesSubWindow->setWindowIcon(icon);
       connect(m_appWindow, SIGNAL(shutting_down()), m_vatesSubWindow, SLOT(close()));
 
+      //reset the qt error redirection that Paraview puts in place
+      // this may not be necessary if we move to qt5
+      qInstallMsgHandler(0);
+
       MantidQt::API::InterfaceManager interfaceManager;
       MantidQt::API::VatesViewerInterface *vsui = interfaceManager.createVatesSimpleGui();
       if (vsui)

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -740,14 +740,15 @@ void MantidUI::showVatesSimpleInterface()
       m_vatesSubWindow->setWindowIcon(icon);
       connect(m_appWindow, SIGNAL(shutting_down()), m_vatesSubWindow, SLOT(close()));
 
-      //reset the qt error redirection that Paraview puts in place
-      // this may not be necessary if we move to qt5
-      qInstallMsgHandler(0);
-
+ 
       MantidQt::API::InterfaceManager interfaceManager;
       MantidQt::API::VatesViewerInterface *vsui = interfaceManager.createVatesSimpleGui();
       if (vsui)
-      {
+      {     
+        //reset the qt error redirection that Paraview puts in place
+        // this may not be necessary if we move to qt5
+        qInstallMsgHandler(0);
+
         connect(m_appWindow, SIGNAL(shutting_down()),
           vsui, SLOT(shutdown()));
         connect(vsui, SIGNAL(requestClose()), m_vatesSubWindow, SLOT(close()));


### PR DESCRIPTION
closes #14009
### Release Notes

Too minor an issue, only affects touch screen PC's
### To test

Needs a touch screen PC So I've assigned it to Michael Wedel who is the only other person I know that has a touch screen laptop.
1. Start up Mantidplot 
2. Run this script (or create any MD workspace) 

``` python
SXD23767 = Load(Filename='SXD23767.raw', LoadMonitors='Exclude')
SXDNaClQLab=ConvertToMD( InputWorkspace=SXD23767, QDimensions="Q3D",
                    dEAnalysisMode="Elastic", QConversionScales="Q in A^-1",
                LorentzCorrection='1', MinValues=[-15,-15,-15], MaxValues=[15,15,15],
                    SplitInto='2', SplitThreshold='50',MaxRecursionDepth='14' )
```

The file mentioned is here https://sourceforge.net/projects/mantid/files/Sample%20Data/TrainingCourseData.zip/download
1. right click on the workspace to create a sliceviewer
2. Mouse over the menus and click a couple, verify you do not get any warnings in a new window (see the issue for a screenshot).
3. Open a VSI instance (then just leave the window alone and ignore it)
4. Return to the sliceviewer
5. Mouse over the menus and click a couple, verify you do not get any warnings in a new window (see the issue for a screenshot).
6. If there is no warnings window then all is good with the world.
