### PR TITLE
Instrument view crash.

### DIFF
--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentActor.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentActor.cpp
@@ -387,16 +387,20 @@ Mantid::detid_t InstrumentActor::getDetID(size_t pickID)const
 Mantid::Geometry::ComponentID InstrumentActor::getComponentID(size_t pickID) const
 {
   size_t ndet = m_detIDs.size();
+  auto compID = Mantid::Geometry::ComponentID();
   if ( pickID < ndet )
   {
     auto det = getDetector( m_detIDs[pickID] );
-    return det->getComponentID();
+    if (det)
+    {
+      compID = det->getComponentID();
+    }
   }
   else if (pickID < ndet + m_nonDetIDs.size())
   {
-    return m_nonDetIDs[pickID - ndet];
+    compID = m_nonDetIDs[pickID - ndet];
   }
-  return Mantid::Geometry::ComponentID();
+  return compID;
 }
 
 /** Retrieve the workspace index corresponding to a particular detector


### PR DESCRIPTION
Fixes #14215.

**To test**
1. Open any HYSPEC file in the instrument view in 3D.
2. Go to Pick tab.
3. Pick any of the three monitors (cuboids on the negative blue axis).
4. Mantid shouldn't crash.
