### PR TITLE
Use direct array access to manipulate VTK data structures

### DIFF
--- a/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
@@ -142,11 +142,11 @@ void vtkDataSetToNonOrthogonalDataSet::execute() {
     m_boundingBox[5] = infoWs->getZDimension()->getMaximum();
 
     m_numDims = infoWs->getNumDims();
-    // m_coordType = infoWs->getSpecialCoordinateSystem();
-    // if (Kernel::HKL != m_coordType) {
-    //  throw std::invalid_argument(
-    //      "Cannot create non-orthogonal view for non-HKL coordinates");
-    //}
+    m_coordType = infoWs->getSpecialCoordinateSystem();
+    if (Kernel::HKL != m_coordType) {
+      throw std::invalid_argument(
+          "Cannot create non-orthogonal view for non-HKL coordinates");
+    }
     const API::Sample sample = infoWs->getExperimentInfo(0)->sample();
     if (!sample.hasOrientedLattice()) {
       throw std::invalid_argument(

--- a/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
@@ -211,13 +211,13 @@ void vtkDataSetToNonOrthogonalDataSet::execute() {
   this->createSkewInformation(oLatt, wTrans, affMat);
 
   /// Put together the skew matrix for use
-  float skew[9];
+  Mantid::coord_t skew[9];
 
   // Create from the internal skew matrix
   std::size_t index = 0;
   for (std::size_t i = 0; i < m_skewMat.numRows(); i++) {
     for (std::size_t j = 0; j < m_skewMat.numCols(); j++) {
-      skew[index] = m_skewMat[i][j];
+      skew[index] = static_cast<Mantid::coord_t>(m_skewMat[i][j]);
       index++;
     }
   }
@@ -232,13 +232,13 @@ void vtkDataSetToNonOrthogonalDataSet::execute() {
   }
 
   float *end = points->GetPointer(points->GetNumberOfTuples() * 3);
-  for (float *i = points->GetPointer(0); i < end; std::advance(i, 3)) {
-    float v1 = i[0];
-    float v2 = i[1];
-    float v3 = i[2];
-    i[0] = v1 * skew[0] + v2 * skew[1] + v3 * skew[2];
-    i[1] = v1 * skew[3] + v2 * skew[4] + v3 * skew[5];
-    i[2] = v1 * skew[6] + v2 * skew[7] + v3 * skew[8];
+  for (float *it = points->GetPointer(0); it < end; std::advance(it, 3)) {
+    float v1 = it[0];
+    float v2 = it[1];
+    float v3 = it[2];
+    it[0] = v1 * skew[0] + v2 * skew[1] + v3 * skew[2];
+    it[1] = v1 * skew[3] + v2 * skew[4] + v3 * skew[5];
+    it[2] = v1 * skew[6] + v2 * skew[7] + v3 * skew[8];
   }
   this->updateMetaData(data);
 }

--- a/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToNonOrthogonalDataSet.cpp
@@ -226,7 +226,7 @@ void vtkDataSetToNonOrthogonalDataSet::execute() {
   vtkFloatArray *points =
       vtkFloatArray::SafeDownCast(data->GetPoints()->GetData());
   if (points == NULL) {
-    throw std::runtime_error("Failed to cast VtkDataArray to vtkFloatArray.");
+    throw std::runtime_error("Failed to cast vtkDataArray to vtkFloatArray.");
   } else if (points->GetNumberOfComponents() != 3) {
     throw std::runtime_error("points array must have 3 components.");
   }

--- a/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
@@ -97,15 +97,16 @@ vtkDataSetToScaledDataSet::execute(double xScale, double yScale, double zScale,
     throw std::runtime_error("points array must have 3 components.");
   }
 
+  // only cast once;
+  float Scale[3] {static_cast<float>(xScale),static_cast<float>(yScale),static_cast<float>(zScale)};
   vtkIdType numberElements = points->GetNumberOfPoints() * 3;
-
   float *end = oldPointsArray->GetPointer(numberElements);
   float *newPoint = newPointsArray->WritePointer(0, numberElements);
   for (float *oldPoint = oldPointsArray->GetPointer(0); oldPoint < end;
        std::advance(oldPoint, 3), std::advance(newPoint, 3)) {
-    newPoint[0] = xScale * oldPoint[0];
-    newPoint[1] = yScale * oldPoint[1];
-    newPoint[2] = zScale * oldPoint[2];
+    newPoint[0] = Scale[0] * oldPoint[0];
+    newPoint[1] = Scale[1] * oldPoint[1];
+    newPoint[2] = Scale[2] * oldPoint[2];
   }
 
   // Shallow copy the input.

--- a/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
@@ -98,7 +98,10 @@ vtkDataSetToScaledDataSet::execute(double xScale, double yScale, double zScale,
   }
 
   // only cast once;
-  float Scale[3] {static_cast<float>(xScale),static_cast<float>(yScale),static_cast<float>(zScale)};
+  float Scale[3];
+  Scale[0] = static_cast<float>(xScale);
+  Scale[1] = static_cast<float>(yScale);
+  Scale[2] = static_cast<float>(zScale);
   vtkIdType numberElements = points->GetNumberOfPoints() * 3;
   float *end = oldPointsArray->GetPointer(numberElements);
   float *newPoint = newPointsArray->WritePointer(0, numberElements);

--- a/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetToScaledDataSet.cpp
@@ -91,7 +91,7 @@ vtkDataSetToScaledDataSet::execute(double xScale, double yScale, double zScale,
       vtkFloatArray::SafeDownCast(newPoints->GetData());
 
   if (oldPointsArray == NULL || newPointsArray == NULL) {
-    throw std::runtime_error("Failed to cast VtkDataArray to vtkFloatArray.");
+    throw std::runtime_error("Failed to cast vtkDataArray to vtkFloatArray.");
   } else if (oldPointsArray->GetNumberOfComponents() != 3 ||
              newPointsArray->GetNumberOfComponents() != 3) {
     throw std::runtime_error("points array must have 3 components.");

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -144,7 +144,7 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
 
   vtkNew<vtkPoints> points;
 
-  float in[3];
+  float in[2];
 
   const float maxX = m_workspace->getXDimension()->getMaximum();
   const float minX = m_workspace->getXDimension()->getMinimum();
@@ -169,16 +169,16 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   for (int z = 0; z < nPointsZ; z++) {
     // Report progress updates for the last 50%
     progressUpdate.eventRaised(double(z) * progressFactor + progressOffset);
-    in[2] = (minZ +
+    in[1] = (minZ +
              (static_cast<float>(z) * incrementZ)); // Calculate increment in z;
     for (int y = 0; y < nPointsY; y++) {
-      in[1] = (minY + (static_cast<float>(y) *
+      in[0] = (minY + (static_cast<float>(y) *
                        incrementY)); // Calculate increment in y;
       for (int x = 0; x < nPointsX; x++) {
         i[0] = (minX + (static_cast<float>(x) *
                         incrementX)); // Calculate increment in x;
-        i[1] = in[1];
-        i[2] = in[2];
+        i[1] = in[0];
+        i[2] = in[1];
         std::advance(i, 3);
       }
     }

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -162,6 +162,11 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
   const vtkIdType nPointsZ = nBinsZ + 1;
 
   vtkFloatArray *pointsarray = vtkFloatArray::SafeDownCast(points->GetData());
+  if (pointsarray == NULL) {
+    throw std::runtime_error("Failed to cast vtkDataArray to vtkFloatArray.");
+  } else if (pointsarray->GetNumberOfComponents() != 3) {
+    throw std::runtime_error("points array must have 3 components.");
+  }
   float *it = pointsarray->WritePointer(0, nPointsX * nPointsY * nPointsZ * 3);
   // Array with the point IDs (only set where needed)
   progressFactor = 0.5 / static_cast<double>(nPointsZ);

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -144,25 +144,25 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
 
   vtkNew<vtkPoints> points;
 
-  float in[2];
+  Mantid::coord_t in[2];
 
-  const float maxX = m_workspace->getXDimension()->getMaximum();
-  const float minX = m_workspace->getXDimension()->getMinimum();
-  const float maxY = m_workspace->getYDimension()->getMaximum();
-  const float minY = m_workspace->getYDimension()->getMinimum();
-  const float maxZ = m_workspace->getZDimension()->getMaximum();
-  const float minZ = m_workspace->getZDimension()->getMinimum();
+  const coord_t maxX = m_workspace->getXDimension()->getMaximum();
+  const coord_t minX = m_workspace->getXDimension()->getMinimum();
+  const coord_t maxY = m_workspace->getYDimension()->getMaximum();
+  const coord_t minY = m_workspace->getYDimension()->getMinimum();
+  const coord_t maxZ = m_workspace->getZDimension()->getMaximum();
+  const coord_t minZ = m_workspace->getZDimension()->getMinimum();
 
-  const float incrementX = (maxX - minX) / static_cast<float>(nBinsX);
-  const float incrementY = (maxY - minY) / static_cast<float>(nBinsY);
-  const float incrementZ = (maxZ - minZ) / static_cast<float>(nBinsZ);
+  const coord_t incrementX = (maxX - minX) / static_cast<coord_t>(nBinsX);
+  const coord_t incrementY = (maxY - minY) / static_cast<coord_t>(nBinsY);
+  const coord_t incrementZ = (maxZ - minZ) / static_cast<coord_t>(nBinsZ);
 
-  vtkIdType nPointsX = nBinsX + 1;
-  vtkIdType nPointsY = nBinsY + 1;
-  vtkIdType nPointsZ = nBinsZ + 1;
+  const vtkIdType nPointsX = nBinsX + 1;
+  const vtkIdType nPointsY = nBinsY + 1;
+  const vtkIdType nPointsZ = nBinsZ + 1;
 
   vtkFloatArray *pointsarray = vtkFloatArray::SafeDownCast(points->GetData());
-  float *i = pointsarray->WritePointer(0, nPointsX * nPointsY * nPointsZ * 3);
+  float *it = pointsarray->WritePointer(0, nPointsX * nPointsY * nPointsZ * 3);
   // Array with the point IDs (only set where needed)
   progressFactor = 0.5 / static_cast<double>(nPointsZ);
   double progressOffset = 0.5;
@@ -170,16 +170,16 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
     // Report progress updates for the last 50%
     progressUpdate.eventRaised(double(z) * progressFactor + progressOffset);
     in[1] = (minZ +
-             (static_cast<float>(z) * incrementZ)); // Calculate increment in z;
+             (static_cast<coord_t>(z) * incrementZ)); // Calculate increment in z;
     for (int y = 0; y < nPointsY; y++) {
-      in[0] = (minY + (static_cast<float>(y) *
+      in[0] = (minY + (static_cast<coord_t>(y) *
                        incrementY)); // Calculate increment in y;
       for (int x = 0; x < nPointsX; x++) {
-        i[0] = (minX + (static_cast<float>(x) *
+        it[0] = (minX + (static_cast<coord_t>(x) *
                         incrementX)); // Calculate increment in x;
-        i[1] = in[0];
-        i[2] = in[1];
-        std::advance(i, 3);
+        it[1] = in[0];
+        it[2] = in[1];
+        std::advance(it, 3);
       }
     }
   }

--- a/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHistoHexFactory.cpp
@@ -144,38 +144,42 @@ vtkMDHistoHexFactory::create3Dor4D(size_t timestep,
 
   vtkNew<vtkPoints> points;
 
-  Mantid::coord_t in[3];
+  float in[3];
 
-  const coord_t maxX = m_workspace->getXDimension()->getMaximum();
-  const coord_t minX = m_workspace->getXDimension()->getMinimum();
-  const coord_t maxY = m_workspace->getYDimension()->getMaximum();
-  const coord_t minY = m_workspace->getYDimension()->getMinimum();
-  const coord_t maxZ = m_workspace->getZDimension()->getMaximum();
-  const coord_t minZ = m_workspace->getZDimension()->getMinimum();
+  const float maxX = m_workspace->getXDimension()->getMaximum();
+  const float minX = m_workspace->getXDimension()->getMinimum();
+  const float maxY = m_workspace->getYDimension()->getMaximum();
+  const float minY = m_workspace->getYDimension()->getMinimum();
+  const float maxZ = m_workspace->getZDimension()->getMaximum();
+  const float minZ = m_workspace->getZDimension()->getMinimum();
 
-  const coord_t incrementX = (maxX - minX) / static_cast<coord_t>(nBinsX);
-  const coord_t incrementY = (maxY - minY) / static_cast<coord_t>(nBinsY);
-  const coord_t incrementZ = (maxZ - minZ) / static_cast<coord_t>(nBinsZ);
+  const float incrementX = (maxX - minX) / static_cast<float>(nBinsX);
+  const float incrementY = (maxY - minY) / static_cast<float>(nBinsY);
+  const float incrementZ = (maxZ - minZ) / static_cast<float>(nBinsZ);
 
-  const int nPointsX = nBinsX + 1;
-  const int nPointsY = nBinsY + 1;
-  const int nPointsZ = nBinsZ + 1;
+  vtkIdType nPointsX = nBinsX + 1;
+  vtkIdType nPointsY = nBinsY + 1;
+  vtkIdType nPointsZ = nBinsZ + 1;
 
+  vtkFloatArray *pointsarray = vtkFloatArray::SafeDownCast(points->GetData());
+  float *i = pointsarray->WritePointer(0, nPointsX * nPointsY * nPointsZ * 3);
   // Array with the point IDs (only set where needed)
   progressFactor = 0.5 / static_cast<double>(nPointsZ);
   double progressOffset = 0.5;
   for (int z = 0; z < nPointsZ; z++) {
     // Report progress updates for the last 50%
     progressUpdate.eventRaised(double(z) * progressFactor + progressOffset);
-    in[2] = (minZ + (static_cast<coord_t>(z) *
-                     incrementZ)); // Calculate increment in z;
+    in[2] = (minZ +
+             (static_cast<float>(z) * incrementZ)); // Calculate increment in z;
     for (int y = 0; y < nPointsY; y++) {
-      in[1] = (minY + (static_cast<coord_t>(y) *
+      in[1] = (minY + (static_cast<float>(y) *
                        incrementY)); // Calculate increment in y;
       for (int x = 0; x < nPointsX; x++) {
-        in[0] = (minX + (static_cast<coord_t>(x) *
-                         incrementX)); // Calculate increment in x;
-        points->InsertNextPoint(in);
+        i[0] = (minX + (static_cast<float>(x) *
+                        incrementX)); // Calculate increment in x;
+        i[1] = in[1];
+        i[2] = in[2];
+        std::advance(i, 3);
       }
     }
   }


### PR DESCRIPTION
This fixes #14235.

This changes our creation and manipulation of `vtkPoints` objects to use direct array access. This is almost an order or magnitude faster than using the member function `vtkPoints::InsertNextPoint`. I created a [small test repository](https://github.com/quantumsteve/vtkPoints) comparing our current code in Mantid to direct array access. A similar conclusion is documented on the [ParaView wiki](http://www.paraview.org/ParaView/index.php/Data_Array_Strides_and_Iteration)

I'm also including a tiny bug fix for @AndreiSavici which correctly sets the bounding box so that new grid axes are displayed for MDEventWorkspaces and MDHistoWorkspaces.

Release notes: [here](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_6_UI_Changes&diff=25381&oldid=25380) and [here](http://www.mantidproject.org/ReleaseNotes_3_6_UI_Changes#User_Interface).
### testing:

Convince yourself either by
1. reading the article above from the ParaView wiki
2. running the benchmark in quantumsteve/vtkPoints repository.
3. loading an MDEventWorkspace or MDHistoWorkspace in the VSI.

that direct array access is a better way to set and modify vtkPoints objects. Code Review. Check that the Axes Grid can be made visible. 
