### PR TITLE
Added Progress Tracking to SofQWMoments

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMoments.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMoments.py
@@ -2,7 +2,7 @@
 # Algorithm to start Bayes programs
 from mantid.simpleapi import *
 from mantid.api import DataProcessorAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, \
-                       WorkspaceGroupProperty
+                       WorkspaceGroupProperty, Progress
 from mantid.kernel import Direction
 from mantid import logger
 
@@ -40,6 +40,8 @@ class SofQWMoments(DataProcessorAlgorithm):
     def PyExec(self):
         from IndirectCommon import CheckHistZero, CheckElimits, getDefaultWorkingDirectory
 
+        workflow_prog = Progress(self, start=0.0, end=1.0, nreports=20)
+        workflow_prog.report('Setting up algorithm')
         sample_workspace = self.getPropertyValue('Sample')
         output_workspace = self.getPropertyValue('OutputWorkspace')
         factor = self.getProperty('Scale').value
@@ -50,6 +52,7 @@ class SofQWMoments(DataProcessorAlgorithm):
         Plot = self.getProperty('Plot').value
         Save = self.getProperty('Save').value
 
+        workflow_prog.report('Validating input')
         num_spectra,num_w = CheckHistZero(sample_workspace)
 
         logger.information('Sample %s has %d Q values & %d w values' % (sample_workspace, num_spectra, num_w))
@@ -57,6 +60,7 @@ class SofQWMoments(DataProcessorAlgorithm):
         x_data = np.asarray(mtd[sample_workspace].readX(0))
         CheckElimits(erange,x_data)
 
+        workflow_prog.report('Cropping Workspace')
         samWS = '__temp_sqw_moments_cropped'
         CropWorkspace(InputWorkspace=sample_workspace, OutputWorkspace=samWS,
                       XMin=erange[0], XMax=erange[1])
@@ -64,12 +68,15 @@ class SofQWMoments(DataProcessorAlgorithm):
         logger.information('Energy range is %f to %f' % (erange[0], erange[1]))
 
         if factor > 0.0:
+            workflow_prog.report('Scaling Workspace by factor %f' % factor)
             Scale(InputWorkspace=samWS, OutputWorkspace=samWS, Factor=factor, Operation='Multiply')
             logger.information('y(q,w) scaled by %f' % factor)
 
         #calculate delta x
+        workflow_prog.report('Converting to point data')
         ConvertToPointData(InputWorkspace=samWS, OutputWorkspace=samWS)
         x_data = np.asarray(mtd[samWS].readX(0))
+        workflow_prog.report('Creating temporary data workspace')
         x_workspace = CreateWorkspace(OutputWorkspace="__temp_sqw_moments_x",
                                       DataX=x_data, DataY=x_data, UnitX="DeltaE")
 
@@ -80,21 +87,26 @@ class SofQWMoments(DataProcessorAlgorithm):
         moments_3 = output_workspace + '_M3'
         moments_4 = output_workspace + '_M4'
 
+        workflow_prog.report('Multiplying Workspaces by moments')
         Multiply(x_workspace, samWS, OutputWorkspace=moments_1)
         Multiply(x_workspace, moments_1, OutputWorkspace=moments_2)
         Multiply(x_workspace, moments_2, OutputWorkspace=moments_3)
         Multiply(x_workspace, moments_3, OutputWorkspace=moments_4)
         DeleteWorkspace(moments_3)
 
+        workflow_prog.report('Converting to Histogram')
         ConvertToHistogram(InputWorkspace=samWS, OutputWorkspace=samWS)
+        workflow_prog.report('Intergrating result')
         Integration(samWS, OutputWorkspace=moments_0)
 
         moments = [moments_1, moments_2, moments_4]
         for moment_ws in moments:
+            workflow_prog.report('Processing workspace %s' % moment_ws)
             ConvertToHistogram(InputWorkspace=moment_ws, OutputWorkspace=moment_ws)
             Integration(moment_ws, OutputWorkspace=moment_ws)
             Divide(moment_ws, moments_0, OutputWorkspace=moment_ws)
 
+        workflow_prog.report('Deleting Workspaces')
         DeleteWorkspace(samWS)
         DeleteWorkspace(x_workspace)
 
@@ -102,12 +114,14 @@ class SofQWMoments(DataProcessorAlgorithm):
         extensions = ['_M0', '_M1', '_M2', '_M4']
         for ext in extensions:
             ws_name = output_workspace+ext
+            workflow_prog.report('Processing Workspace %s' % ext)
             Transpose(InputWorkspace=ws_name, OutputWorkspace=ws_name)
             ConvertToHistogram(InputWorkspace=ws_name, OutputWorkspace=ws_name)
             ConvertUnits(InputWorkspace=ws_name, OutputWorkspace=ws_name,
                          Target='MomentumTransfer', EMode='Indirect')
 
             CopyLogs(InputWorkspace=sample_workspace, OutputWorkspace=ws_name)
+            workflow_prog.report('Adding Sample logs to %s' % ws_name)
             AddSampleLog(Workspace=ws_name, LogName="energy_min",
                          LogType="Number", LogText=str(emin))
             AddSampleLog(Workspace=ws_name, LogName="energy_max",
@@ -116,19 +130,23 @@ class SofQWMoments(DataProcessorAlgorithm):
                          LogType="Number", LogText=str(factor))
 
         # Group output workspace
+        workflow_prog.report('Grouping OutputWorkspace')
         group_workspaces = ','.join([output_workspace+ext for ext in extensions])
         GroupWorkspaces(InputWorkspaces=group_workspaces, OutputWorkspace=output_workspace)
 
         if Save:
+            workflow_prog.report('Saving Workspace')
             workdir = getDefaultWorkingDirectory()
             opath = os.path.join(workdir,output_workspace+'.nxs')
             SaveNexusProcessed(InputWorkspace=output_workspace, Filename=opath)
             logger.information('Output file : ' + opath)
 
         if Plot:
+            workflow_prog.report('Plotting Workspace')
             self._plot_moments(output_workspace)
 
         self.setProperty("OutputWorkspace", output_workspace)
+        workflow_prog.report('Algorithm complete')
 
 
     def _plot_moments(self, inputWS):


### PR DESCRIPTION
Fixes #14221

SofQWMoments (also known as S(Q,w) Moments) now has progress tracking with labels.
# To Test
- Open Moments (Interfaces > Indirect > Data Reduction > Moments) 
- Load in the input file `iris26176_graphite002_sqw.nxs` available from `\\olympic\Babylon5\Public\ElliotOram\DataReduction\Moments`
  - The algorithm will actually run when you load the file but if you click `Run` it will run the algorithm.
- Click `Run`
- Ensure that the progress tracking runs for the duration of the algorithm and has labels describing the processes taking.
