### PR TITLE
ConvFit delta peak centre option

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -119,8 +119,10 @@ void ConvFit::setup() {
   m_properties["DeltaFunction"] = m_grpManager->addProperty("Delta Function");
   m_properties["UseDeltaFunc"] = m_blnManager->addProperty("Use");
   m_properties["DeltaHeight"] = m_dblManager->addProperty("Height");
+  m_properties["DeltaCentre"] = m_dblManager->addProperty("Centre");
   m_dblManager->setDecimals(m_properties["DeltaHeight"], NUM_DECIMALS);
   m_properties["DeltaFunction"]->addSubProperty(m_properties["UseDeltaFunc"]);
+  m_dblManager->setDecimals(m_properties["DeltaCentre"], NUM_DECIMALS);
   m_cfTree->addProperty(m_properties["DeltaFunction"]);
 
   // Fit functions
@@ -1103,7 +1105,8 @@ void ConvFit::singleFit() {
       runPythonCode(
           QString(
               "from IndirectCommon import getWSprefix\nprint getWSprefix('") +
-          m_cfInputWSName + QString("')\n")).trimmed();
+          m_cfInputWSName + QString("')\n"))
+          .trimmed();
   m_singleFitOutputName +=
       QString("conv_") + fitType + bgType + m_uiForm.spPlotSpectrum->text();
   int maxIterations =
@@ -1333,9 +1336,14 @@ void ConvFit::checkBoxUpdate(QtProperty *prop, bool checked) {
       m_properties["DeltaFunction"]->addSubProperty(
           m_properties["DeltaHeight"]);
       m_dblManager->setValue(m_properties["DeltaHeight"], 1.0000);
+      m_properties["DeltaFunction"]->addSubProperty(
+          m_properties["DeltaCentre"]);
+      m_dblManager->setValue(m_properties["DeltaCentre"], 0.0000);
     } else {
       m_properties["DeltaFunction"]->removeSubProperty(
           m_properties["DeltaHeight"]);
+      m_properties["DeltaFunction"]->removeSubProperty(
+          m_properties["DeltaCentre"]);
     }
   } else if (prop == m_properties["UseFABADA"]) {
     if (checked) {

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1203,9 +1203,8 @@ void ConvFit::singleFitComplete(bool error) {
       key += "f0.";
     }
 
-    key += "Height";
-
-    m_dblManager->setValue(m_properties["DeltaHeight"], parameters[key]);
+    m_dblManager->setValue(m_properties["DeltaHeight"], parameters[key + "Height"]);
+	m_dblManager->setValue(m_properties["DeltaCentre"], parameters[key + "Centre"]);
     funcIndex++;
   }
 


### PR DESCRIPTION
Fixes #14211

ConvFit now allows for a shift in the centre of the Delta function
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Load in data _(available from `\ExternalData\Testing\Data\UnitTest\`)_:
  - Sample=`irs26176_graphite002_red.nxs`
  - Resolution=`irs26173_graphite002_res.nxs`
- Change Fit Type to `One Lorentzian`
- Check the `Use` option under `Delta Function` in the parameter tree (bottom left table)
- Ensure options for `Height` (default=1.000000) and `Centre` (default=0.000000) are displayed
- Click `Fit single Spectrum` 
- Ensure the values for Delta (Height, Centre) and One Lorentzian (Amplitude, PeakCentre, FWHM) are all updated and the plot has updated.
- Click `Run` 
- Ensure that the run is successful and updates the mini plot with reasonable Sample, Fit and Diff curves (black, red, blue respectively)
