### PR TITLE
Include BinWidth in QResolution calculation

### DIFF
--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -235,8 +235,12 @@ void Q1D2::exec() {
           EOutTo2[bin] += (*EIn) * (*EIn);
           normError2[bin] += *normETo2s;
           if (useQResolution) {
-            auto QBin = (QOut[bin + 1] - QOut[bin]) / std::sqrt(12.);
-            qResolutionOut[bin] += (*YIn) * (*QResIn) * QBin;
+            auto QBin = (QOut[bin + 1] - QOut[bin]);
+            // Here we need to take into account the Bin width and the count
+            // weigthing. The
+            // formula should be YIN* sqrt(QResIn^2 + (QBin/sqrt(12))^2)
+            qResolutionOut[bin] +=
+                (*YIn) * std::sqrt((*QResIn) * (*QResIn) + QBin * QBin / 12.0);
           }
         }
       }

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -376,7 +376,7 @@ void Q1D2::calculateNormalization(const size_t wavStart, const size_t specInd,
   // use that the normalization array ends at the start of the error array
   for (MantidVec::iterator n = norm, e = normETo2; n != normETo2; ++n, ++e) {
     *n = detectorAdj;
-    *e = detAdjErr * detAdjErr;
+    *e = detAdjErr *detAdjErr;
   }
 
   if (binNorms && binNormEs) {
@@ -583,7 +583,7 @@ void Q1D2::convertWavetoQ(const size_t specInd, const bool doGravity,
       // different for each bin with each detector
       const double sinTheta = grav.calcSinTheta(lambda);
       // Now we're ready to go to Q
-      *Qs = FOUR_PI * sinTheta / lambda;
+      *Qs = FOUR_PI *sinTheta / lambda;
     }
   } else {
     // Calculate the Q values for the current spectrum, using Q =

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -235,7 +235,8 @@ void Q1D2::exec() {
           EOutTo2[bin] += (*EIn) * (*EIn);
           normError2[bin] += *normETo2s;
           if (useQResolution) {
-            qResolutionOut[bin] += (*YIn) * (*QResIn);
+            auto QBin = (QOut[bin + 1] - QOut[bin])/std::sqrt(12.);
+            qResolutionOut[bin] += (*YIn) * (*QResIn) * QBin;
           }
         }
       }

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -235,7 +235,7 @@ void Q1D2::exec() {
           EOutTo2[bin] += (*EIn) * (*EIn);
           normError2[bin] += *normETo2s;
           if (useQResolution) {
-            auto QBin = (QOut[bin + 1] - QOut[bin])/std::sqrt(12.);
+            auto QBin = (QOut[bin + 1] - QOut[bin]) / std::sqrt(12.);
             qResolutionOut[bin] += (*YIn) * (*QResIn) * QBin;
           }
         }
@@ -372,7 +372,7 @@ void Q1D2::calculateNormalization(const size_t wavStart, const size_t specInd,
   // use that the normalization array ends at the start of the error array
   for (MantidVec::iterator n = norm, e = normETo2; n != normETo2; ++n, ++e) {
     *n = detectorAdj;
-    *e = detAdjErr *detAdjErr;
+    *e = detAdjErr * detAdjErr;
   }
 
   if (binNorms && binNormEs) {
@@ -579,7 +579,7 @@ void Q1D2::convertWavetoQ(const size_t specInd, const bool doGravity,
       // different for each bin with each detector
       const double sinTheta = grav.calcSinTheta(lambda);
       // Now we're ready to go to Q
-      *Qs = FOUR_PI *sinTheta / lambda;
+      *Qs = FOUR_PI * sinTheta / lambda;
     }
   } else {
     // Calculate the Q values for the current spectrum, using Q =

--- a/Framework/Algorithms/test/Q1D2Test.h
+++ b/Framework/Algorithms/test/Q1D2Test.h
@@ -430,11 +430,13 @@ public:
                 outputWS + "_sumOfCounts")))
 
     TSM_ASSERT("Should have the x error flag set", result->hasDx(0));
-    // That output will be SUM_i(Yin_i*QRES_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i)) for each q
+    // That output will be
+    // SUM_i(Yin_i*QRES_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i)) for each q
     // value
     // In our test workspace we set QRes_in_1 to 1, this means that all DX
     // values should be SUM_i(Y_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i))
-    // which is either 0.1/sqrt(12) or 0. It can be 0 if no data falls into this bin. We
+    // which is either 0.1/sqrt(12) or 0. It can be 0 if no data falls into this
+    // bin. We
     // make sure that there is at least one bin
     // with a count of 1
     auto &dataDX = result->dataDx(0);
@@ -445,7 +447,8 @@ public:
       // our value with 0.1/sqrt(12). Hence it is enough for us to confirm
       // that the values lie in an interval around this value
       auto isZeroValue = *it == 0.0;
-      auto isCloseToZeroPoint1DividedByRootTwelve = (*it > 0.0288674) && (*it < 0.0288676);
+      auto isCloseToZeroPoint1DividedByRootTwelve =
+          (*it > 0.0288674) && (*it < 0.0288676);
 
       if (isCloseToZeroPoint1DividedByRootTwelve) {
         counter++;

--- a/Framework/Algorithms/test/Q1D2Test.h
+++ b/Framework/Algorithms/test/Q1D2Test.h
@@ -409,7 +409,7 @@ public:
     Q1D.setProperty("WavelengthAdj", m_wavNorm);
     Q1D.setProperty("PixelAdj", m_pixel);
     Q1D.setPropertyValue("OutputWorkspace", outputWS);
-    Q1D.setPropertyValue("OutputBinning", "0.1,0.1,1.0");
+    Q1D.setPropertyValue("OutputBinning", "0.5,0.5,10.0");
     Q1D.setProperty("QResolution", qResolution);
     Q1D.setProperty("OutputParts", true);
 
@@ -431,31 +431,31 @@ public:
 
     TSM_ASSERT("Should have the x error flag set", result->hasDx(0));
     // That output will be
-    // SUM_i(Yin_i*QRES_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i)) for each q
+    // SUM_i(Yin_i*sqrt(QRES_in_i^2 + *QBinWidth^2/sqrt(12)^2))/(SUM_i(Y_in_i))
+    // for each q
     // value
     // In our test workspace we set QRes_in_1 to 1, this means that all DX
-    // values should be SUM_i(Y_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i))
-    // which is either 0.1/sqrt(12) or 0. It can be 0 if no data falls into this
-    // bin. We
-    // make sure that there is at least one bin
-    // with a count of 1
+    // values should be SUM_i(Y_in_i*sqrt((1+ QBinWidth^2/12)/(SUM_i(Y_in_i))
+    // which is either sqrt(1 + 0.5^2/12) or 0. It can be 0 if no data falls
+    // into this
+    // bin. We make sure that there is at least one bin with a count
+    // of sqrt(1 + 0.5^2/12) ~ 1.01036297108
     auto &dataDX = result->dataDx(0);
     unsigned int counter = 0;
     for (auto it = dataDX.begin(); it != dataDX.end(); ++it) {
 
       // Since we are dealing with a float it can be difficult to compare
-      // our value with 0.1/sqrt(12). Hence it is enough for us to confirm
+      // our value with sqrt(1 + 0.5^2/12). Hence it is enough for us to confirm
       // that the values lie in an interval around this value
       auto isZeroValue = *it == 0.0;
       auto isCloseToZeroPoint1DividedByRootTwelve =
-          (*it > 0.0288674) && (*it < 0.0288676);
-
+          (*it > 1.01035) && (*it < 1.01037);
       if (isCloseToZeroPoint1DividedByRootTwelve) {
         counter++;
       }
 
-      // Make sure that the value is either 1 or 0
-      TSM_ASSERT("The DX value should be either 0.1/sqrt(12) or 0",
+      // Make sure that the value is either sqrt(1 + 0.5^2/12) or 0
+      TSM_ASSERT("The DX value should be either sqrt(1 + 0.5^2/12) or 0",
                  isCloseToZeroPoint1DividedByRootTwelve || isZeroValue);
     }
     TSM_ASSERT("There should be at least one bin which is not 0", counter > 0);

--- a/Framework/Algorithms/test/Q1D2Test.h
+++ b/Framework/Algorithms/test/Q1D2Test.h
@@ -394,7 +394,7 @@ public:
     // Arrange
     Mantid::API::MatrixWorkspace_sptr qResolution, alteredInput;
     const double value1 = 1;
-    const double value2 = 2;
+    const double value2 = 1;
     createQResolutionWorkspace(qResolution, alteredInput, m_inputWS, value1,
                                value2);
 
@@ -409,7 +409,7 @@ public:
     Q1D.setProperty("WavelengthAdj", m_wavNorm);
     Q1D.setProperty("PixelAdj", m_pixel);
     Q1D.setPropertyValue("OutputWorkspace", outputWS);
-    Q1D.setPropertyValue("OutputBinning", "0.1,-0.02,0.5");
+    Q1D.setPropertyValue("OutputBinning", "0.1,0.1,1.0");
     Q1D.setProperty("QResolution", qResolution);
     Q1D.setProperty("OutputParts", true);
 
@@ -430,22 +430,30 @@ public:
                 outputWS + "_sumOfCounts")))
 
     TSM_ASSERT("Should have the x error flag set", result->hasDx(0));
-    // That output will be SUM_i(Yin_i*QRES_in_i)/(SUM_i(Y_in_i)) for each q
+    // That output will be SUM_i(Yin_i*QRES_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i)) for each q
     // value
     // In our test workspace we set QRes_in_1 to 1, this means that all DX
-    // values should be SUM_i(Y_in_i)/(SUM_i(Y_in_i))
-    // which is either 1 or 0. It can be 0 if no data falls into this bin. We
+    // values should be SUM_i(Y_in_i*QBinWidth/sqrt(12))/(SUM_i(Y_in_i))
+    // which is either 0.1/sqrt(12) or 0. It can be 0 if no data falls into this bin. We
     // make sure that there is at least one bin
     // with a count of 1
     auto &dataDX = result->dataDx(0);
     unsigned int counter = 0;
     for (auto it = dataDX.begin(); it != dataDX.end(); ++it) {
-      if (*it == 1.0) {
+
+      // Since we are dealing with a float it can be difficult to compare
+      // our value with 0.1/sqrt(12). Hence it is enough for us to confirm
+      // that the values lie in an interval around this value
+      auto isZeroValue = *it == 0.0;
+      auto isCloseToZeroPoint1DividedByRootTwelve = (*it > 0.0288674) && (*it < 0.0288676);
+
+      if (isCloseToZeroPoint1DividedByRootTwelve) {
         counter++;
       }
+
       // Make sure that the value is either 1 or 0
-      TSM_ASSERT("The DX value should be either 1 or 0",
-                 (*it == 1.0) || (*it == 0.0));
+      TSM_ASSERT("The DX value should be either 0.1/sqrt(12) or 0",
+                 isCloseToZeroPoint1DividedByRootTwelve || isZeroValue);
     }
     TSM_ASSERT("There should be at least one bin which is not 0", counter > 0);
 

--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -981,6 +981,9 @@ bool SANSRunWindow::loadUserFile() {
   // Set the beam finder specific settings
   setBeamFinderDetails();
   // get the scale factor1 for the beam centre to scale it correctly
+  dbl_param =
+      runReduceScriptFunction(
+          "print i.ReductionSingleton().get_beam_center('rear')[0]").toDouble();
   double dbl_paramsf =
       runReduceScriptFunction(
           "print i.ReductionSingleton().get_beam_center_scale_factor1()")

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -1441,7 +1441,19 @@ def AddRuns(runs, instrument ='sans2d', saveAsEvent=False, binning = "Monitors",
     Method to expose the add_runs functionality for custom scripting.
     @param runs: a list with the requested run numbers
     @param instrument: the name of the selected instrument
-    @param binning: the where to get the binnings from. This can either be "Monitors
+    @param saveAsEvent: when adding event-type data, then this can be stored as event-type data
+    @param binning: where to get the binnings from. This is relevant when adding Event-type data.
+                    The property can be set to "Monitors" in order to emulate the binning of the monitors or to a
+                    string list with the same format that is used for the Rebin algorithm. This property is ignored
+                    when saving as event data.
+    @param isOverlay: sets if the the overlay mechanism should be used when the saveAsEvent flag is set
+    @param time_shifts: provides additional time shifts if the isOverlay flag is specified. The time shifts are specifed
+                        in a string list. Either time_shifts is not used or a list with times in secomds. Note that there
+                        has to be one entry fewer than the number of workspaces to add.
+    @param defType: the file type
+    @param rawTypes: the raw types
+    @param lowMem: if the lowMem option should be used
+    @returns a success message
     '''
     # Need at least two runs to work
     if len(runs) < 1:
@@ -1451,15 +1463,15 @@ def AddRuns(runs, instrument ='sans2d', saveAsEvent=False, binning = "Monitors",
     if time_shifts is None:
         time_shifts = []
 
-    add_runs(runs = runs,
-             inst = instrument,
-             defType = defType,
-             rawTypes = rawTypes,
-             lowMem = lowMem,
-             binning = binning,
-             saveAsEvent=saveAsEvent,
-             isOverlay = isOverlay,
-             time_shifts = time_shifts)
+    return add_runs(runs = runs,
+                    inst = instrument,
+                    defType = defType,
+                    rawTypes = rawTypes,
+                    lowMem = lowMem,
+                    binning = binning,
+                    saveAsEvent=saveAsEvent,
+                    isOverlay = isOverlay,
+                    time_shifts = time_shifts)
 
 
 


### PR DESCRIPTION
Fixes  #14241 
# For testing
1. Make sure the new unit test passses
2. Code reivew

A Windows installer can be found here: \olympic\Babylon5\Scratch\Anton\Testing\14248_SANS_BugFixes

**Test that operations run normally**
1. Make sure that the test files are in the Mantid Path
2. Set the instrument to be SANS2DTUBES
3. Load the user file USER_FILE_QRESOLUTION_CIRCULAR.txt
4. Go to the Geometry tab
   - Confirm that the entry for Rear_X is 108.1
5. Load SANS2D000028793.nxs as the sample file
6. Press Reduce 1D
   - Confirm that no errors are produced
