### PR TITLE
ApplyPaalmanPings Container Shift

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
@@ -56,7 +56,8 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
             logger.information('Not using container')
 
         # Apply container scale factor if needed
-        prog_container = Progress(self, start=0.0, end=0.2, nreports=1)
+        prog_container = Progress(self, start=0.0, end=0.2, nreports=2)
+        prog_container.report('Starting algorithm')
         if self._use_can:
             if self._scale_can:
                 # Use temp workspace so we don't modify original data
@@ -72,25 +73,27 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
                                OutputWorkspace=self._scaled_container)
 
 
-        prog_corr = Progress(self, start=0.2, end=0.6, nreports=1)
+        prog_corr = Progress(self, start=0.2, end=0.6, nreports=2)
         if self._use_corrections:
+            prog_corr.report('Preprocessing corrections')
             self._pre_process_corrections()
 
             if self._use_can:
                 # Use container factors
+                prog_corr.report('Correcting sample and can')
                 self._correct_sample_can()
                 correction_type = 'sample_and_can_corrections'
-                prog_corr.report('Correcting sample and can')
             else:
                 # Use sample factor only
                 self._correct_sample()
                 correction_type = 'sample_corrections_only'
                 # Add corrections filename to log values
+                prog_corr.report('Correcting sample')
                 AddSampleLog(Workspace=self._output_ws_name,
                              LogName='corrections_filename',
                              LogType='String',
                              LogText=self._corrections_ws_name)
-                prog_corr.report('Correcting sample')
+
 
         else:
             # Do simple subtraction
@@ -99,45 +102,47 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
             # Add container filename to log values
             can_cut = self._can_ws_name.index('_')
             can_base = self._can_ws_name[:can_cut]
+            prog_corr.report('Adding container filename')
             AddSampleLog(Workspace=self._output_ws_name,
                          LogName='container_filename',
                          LogType='String',
                          LogText=can_base)
-            prog_corr.report('Adding container filename')
 
         prog_wrkflow = Progress(self, 0.6, 1.0, nreports=4)
         # Record the container scale factor
         if self._use_can and self._scale_can:
+            prog_wrkflow.report('Adding container scaling')
             AddSampleLog(Workspace=self._output_ws_name,
                          LogName='container_scale',
                          LogType='Number',
                          LogText=str(self._can_scale_factor))
-        prog_wrkflow.report('Adding container scaling')
 
         # Record the type of corrections applied
+        prog_wrkflow.report('Adding correction type')
         AddSampleLog(Workspace=self._output_ws_name,
                      LogName='corrections_type',
                      LogType='String',
                      LogText=correction_type)
-        prog_wrkflow.report('Adding correction type')
 
         # Add original sample as log entry
         sam_cut = self._sample_ws_name.index('_')
         sam_base = self._sample_ws_name[:sam_cut]
+        prog_wrkflow.report('Adding sample filename')
         AddSampleLog(Workspace=self._output_ws_name,
                      LogName='sample_filename',
                      LogType='String',
                      LogText=sam_base)
-        prog_wrkflow.report('Adding sample filename')
 
         self.setPropertyValue('OutputWorkspace', self._output_ws_name)
 
         # Remove temporary workspaces
+        prog_wrkflow.report('Deleting Workspaces')
         if self._corrections in mtd:
             DeleteWorkspace(self._corrections)
         if self._scaled_container in mtd:
             DeleteWorkspace(self._scaled_container)
-        prog_wrkflow.report('Deleting Workspaces')
+        prog_wrkflow.report('Algorithm Complete')
+
 
 
     def validateInputs(self):

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -60,7 +60,7 @@
             <item row="1" column="0">
               <widget class="QCheckBox" name="ckUseCan">
                 <property name="text">
-                  <string>Use Can:</string>
+                  <string>Use Container:</string>
                 </property>
               </widget>
             </item>
@@ -163,7 +163,7 @@
                   <bool>false</bool>
                 </property>
                 <property name="text">
-                  <string>Scale Can by factor:</string>
+                  <string>Scale Container by factor:</string>
                 </property>
                 <property name="checked">
                   <bool>false</bool>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -191,19 +191,6 @@
                     </property>
                   </widget>
                 </item>
-                <item>
-                  <spacer name="horizontalSpacer">
-                    <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>40</width>
-                        <height>20</height>
-                      </size>
-                    </property>
-                  </spacer>
-                </item>
               </layout>
             </item>
             <item row="4" column="0">
@@ -229,6 +216,9 @@
                     <property name="decimals">
                       <number>5</number>
                     </property>
+                    <property name="minimum">
+                      <double>-999.990000000000009</double>
+                    </property>
                     <property name="maximum">
                       <double>999.990000000000009</double>
                     </property>
@@ -239,19 +229,6 @@
                       <double>0.000000000000000</double>
                     </property>
                   </widget>
-                </item>
-                <item>
-                  <spacer name="horizontalSpacer">
-                    <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>40</width>
-                        <height>20</height>
-                      </size>
-                    </property>
-                  </spacer>
                 </item>
               </layout>
             </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -233,10 +233,10 @@
                       <double>999.990000000000009</double>
                     </property>
                     <property name="singleStep">
-                      <double>0.100000000000000</double>
+                      <double>0.010000000000000</double>
                     </property>
                     <property name="value">
-                      <double>1.000000000000000</double>
+                      <double>0.000000000000000</double>
                     </property>
                   </widget>
                 </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ApplyPaalmanPings.ui
@@ -64,7 +64,7 @@
                 </property>
               </widget>
             </item>
-            <item row="4" column="0">
+            <item row="5" column="0">
               <widget class="QCheckBox" name="ckUseCorrections">
                 <property name="text">
                   <string>Use Corrections:</string>
@@ -90,7 +90,7 @@
                 </item>
               </widget>
             </item>
-            <item row="4" column="1">
+            <item row="5" column="1">
               <widget class="MantidQt::MantidWidgets::DataSelector" name="dsCorrections" native="true">
                 <property name="enabled">
                   <bool>false</bool>
@@ -174,6 +174,55 @@
               <layout class="QHBoxLayout" name="loScaleFactor">
                 <item>
                   <widget class="QDoubleSpinBox" name="spCanScale">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
+                    <property name="decimals">
+                      <number>5</number>
+                    </property>
+                    <property name="maximum">
+                      <double>999.990000000000009</double>
+                    </property>
+                    <property name="singleStep">
+                      <double>0.100000000000000</double>
+                    </property>
+                    <property name="value">
+                      <double>1.000000000000000</double>
+                    </property>
+                  </widget>
+                </item>
+                <item>
+                  <spacer name="horizontalSpacer">
+                    <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                      <size>
+                        <width>40</width>
+                        <height>20</height>
+                      </size>
+                    </property>
+                  </spacer>
+                </item>
+              </layout>
+            </item>
+            <item row="4" column="0">
+              <widget class="QCheckBox" name="ckShiftCan">
+                <property name="enabled">
+                  <bool>false</bool>
+                </property>
+                <property name="text">
+                  <string>Shift x-values of container by adding:</string>
+                </property>
+                <property name="checked">
+                  <bool>false</bool>
+                </property>
+              </widget>
+            </item>
+            <item row="4" column="1">
+              <layout class="QHBoxLayout" name="loShiftFactor">
+                <item>
+                  <widget class="QDoubleSpinBox" name="spCanShift">
                     <property name="enabled">
                       <bool>false</bool>
                     </property>
@@ -359,9 +408,41 @@
       </hints>
     </connection>
     <connection>
+      <sender>ckUseCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>ckShiftCan</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>50</x>
+          <y>111</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>61</x>
+          <y>142</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
       <sender>ckScaleCan</sender>
       <signal>toggled(bool)</signal>
       <receiver>spCanScale</receiver>
+      <slot>setEnabled(bool)</slot>
+      <hints>
+        <hint type="sourcelabel">
+          <x>133</x>
+          <y>143</y>
+        </hint>
+        <hint type="destinationlabel">
+          <x>251</x>
+          <y>147</y>
+        </hint>
+      </hints>
+    </connection>
+    <connection>
+      <sender>ckShiftCan</sender>
+      <signal>toggled(bool)</signal>
+      <receiver>spCanShift</receiver>
       <slot>setEnabled(bool)</slot>
       <hints>
         <hint type="sourcelabel">

--- a/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -338,7 +338,7 @@ void ApplyPaalmanPings::absCorComplete(bool error) {
     shiftLog->setProperty("LogName", "container_shift");
     shiftLog->setProperty("LogType", "Number");
     shiftLog->setProperty(
-        "LogText", boost::lexical_cast<std::string>(m_uiForm.spShift->value()));
+        "LogText", boost::lexical_cast<std::string>(m_uiForm.spCanShift->value()));
     m_batchAlgoRunner->addAlgorithm(shiftLog);
   }
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -329,6 +329,19 @@ void ApplyPaalmanPings::absCorComplete(bool error) {
   if (save)
     addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
 
+  if (m_uiForm.ckShiftCan->isChecked()) {
+    IAlgorithm_sptr shiftLog =
+        AlgorithmManager::Instance().create("AddSampleLog");
+    shiftLog->initialize();
+
+    shiftLog->setProperty("Workspace", m_pythonExportWsName);
+    shiftLog->setProperty("LogName", "container_shift");
+    shiftLog->setProperty("LogType", "Number");
+    shiftLog->setProperty(
+        "LogText", boost::lexical_cast<std::string>(m_uiForm.spShift->value()));
+    m_batchAlgoRunner->addAlgorithm(shiftLog);
+  }
+
   // Run algorithm queue
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(postProcessComplete(bool)));


### PR DESCRIPTION
Fixes #14244 

An option to allow shifting the container has been added to ApplyPaalmanPings. This is very similar to the change made in ContainerSubtraction.

**The files for testing this interface can be found at: `\\olympic\Babylon5\Public\ElliotOram\Corrections\correction_set`**
# To Test
- Open ApplyPaalmanPings (Interfaces > Indirect > Corrections > ApplyPaalmanPings)
- Input=`irs26176_graphite002_red.nxs`
- Check the `Use Container` option and enter the Can file as `irs26174_graphite002_red.nxs`
- Check the `Scale Container by factor` option and alter the value (~±0.2)
- Check the `Shift x-values of container by adding` option and alter the value (~±0.2)
- Click `Run`
- Ensure the mini plot is updated and looks correct for the alterations
- Check the sample logs of the workspace that was created (`irs26176_graphite002_subtracted_26174_red`)
- Ensure that the logs container:
  - container_filename
  - container_scale
  - container_shift
  - sample_filename
