### PR TITLE
Fix is already in use warnings generated by Qt.

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui
@@ -3479,7 +3479,7 @@ p, li { white-space: pre-wrap; }
                </widget>
               </item>
               <item row="1" column="3">
-               <layout class="QHBoxLayout" name="horizontalLayout_24">
+               <layout class="QHBoxLayout" name="horizontalLayout_241">
                 <item>
                  <widget class="QCheckBox" name="left_right_checkbox">
                   <property name="text">
@@ -3503,7 +3503,7 @@ p, li { white-space: pre-wrap; }
                </layout>
               </item>
               <item row="0" column="3">
-               <widget class="QLabel" name="label_16">
+               <widget class="QLabel" name="label_161">
                 <property name="text">
                  <string>Find Beam Centre for:</string>
                 </property>
@@ -4353,7 +4353,7 @@ p, li { white-space: pre-wrap; }
          </widget>
         </item>
         <item row="12" column="2">
-         <layout class="QHBoxLayout" name="horizontalLayout_241">
+         <layout class="QHBoxLayout" name="horizontalLayout_2411">
           <item>
            <widget class="QLabel" name="binning_label">
             <property name="minimumSize">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImageSelectCoRAndRegions.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImageSelectCoRAndRegions.ui
@@ -154,7 +154,7 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="layoutWidget">
+      <widget class="QWidget" name="layoutWidget1">
        <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,1">
         <property name="sizeConstraint">
          <enum>QLayout::SetMaximumSize</enum>


### PR DESCRIPTION
After performing a clean build, I found a number of warnings from the Qt. 

```
[1931/3184] Generating ui_SANSRunWindow.h
mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui: Warning: The name 'horizontalLayout_24' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_241'.

mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui: Warning: The name 'label_16' (QLabel) is already in use, defaulting to 'label_161'.

mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/SANSRunWindow.ui: Warning: The name 'horizontalLayout_241' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_2411'.

[1979/3184] Generating ui_ImageSelectCoRAndRegions.h
mantid/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Tomography/ImageSelectCoRAndRegions.ui: Warning: The name 'layoutWidget' (QWidget) is already in use, defaulting to 'layoutWidget1'.
```

This pull request changes names to what Qt suggests.

No release notes.

Testing: code review.
