### PR TITLE
Display empty values in Workspace History dialog rather than actual numeric values

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyHistory.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHistory.h
@@ -70,7 +70,8 @@ public:
   unsigned int direction() const { return m_direction; };
   /// print contents of object
   void printSelf(std::ostream &, const int indent = 0) const;
-  /// get whether algorithm parameter was left as default EMPTY_INT,LONG,DBL const
+  /// get whether algorithm parameter was left as default EMPTY_INT,LONG,DBL
+  /// const
   bool isEmptyDefault() const;
 
   /// this is required for boost.python

--- a/Framework/Kernel/inc/MantidKernel/PropertyHistory.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHistory.h
@@ -4,10 +4,11 @@
 //----------------------------------------------------------------------
 // Includes
 //----------------------------------------------------------------------
-#include "MantidKernel/DllConfig.h"
+#include "MantidKernel/EmptyValues.h"
 #include <string>
 #include <vector>
 #include <boost/shared_ptr.hpp>
+#include <boost/lexical_cast.hpp>
 
 namespace Mantid {
 namespace Kernel {
@@ -69,6 +70,8 @@ public:
   unsigned int direction() const { return m_direction; };
   /// print contents of object
   void printSelf(std::ostream &, const int indent = 0) const;
+  /// get whether algorithm parameter was left as default EMPTY_INT,LONG,DBL const
+  bool isEmptyDefault() const;
 
   /// this is required for boost.python
   bool operator==(const PropertyHistory &other) const {

--- a/Framework/Kernel/src/PropertyHistory.cpp
+++ b/Framework/Kernel/src/PropertyHistory.cpp
@@ -73,5 +73,39 @@ std::ostream &operator<<(std::ostream &os, const PropertyHistory &AP) {
   return os;
 }
 
+/** Returns whether algorithm parameter was left as default EMPTY_INT,LONG,DBL
+ *  @returns True if param was unset and value = EMPTY_XXX, else false
+ */
+bool PropertyHistory::isEmptyDefault() const {
+  bool emptyDefault = false;
+
+  // Static lists to be initialised on first call
+  static std::vector<std::string> numberTypes, emptyValues;
+  // Type strings corresponding to numbers
+  if (numberTypes.empty()) {
+    numberTypes.push_back(getUnmangledTypeName(typeid(int)));
+    numberTypes.push_back(getUnmangledTypeName(typeid(int64_t)));
+    numberTypes.push_back(getUnmangledTypeName(typeid(double)));
+  }
+  // Empty values
+  if (emptyValues.empty()) {
+    emptyValues.push_back(boost::lexical_cast<std::string>(EMPTY_INT()));
+    emptyValues.push_back(boost::lexical_cast<std::string>(EMPTY_DBL()));
+    emptyValues.push_back(boost::lexical_cast<std::string>(EMPTY_LONG()));
+  }
+
+  // If default, input, number type and matches empty value then return true
+  if (m_isDefault && m_direction != Direction::Output) {
+    if (std::find(numberTypes.begin(), numberTypes.end(), m_type) !=
+        numberTypes.end()) {
+      if (std::find(emptyValues.begin(), emptyValues.end(), m_value) !=
+          emptyValues.end()) {
+        emptyDefault = true;
+      }
+    }
+  }
+  return emptyDefault;
+}
+
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/test/PropertyHistoryTest.h
+++ b/Framework/Kernel/test/PropertyHistoryTest.h
@@ -67,10 +67,10 @@ public:
     TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
   }
 
-/**
-  * Test the isEmptyDefault method returns false if the parameter type is not
-  * "number"
-  */
+  /**
+    * Test the isEmptyDefault method returns false if the parameter type is not
+    * "number"
+    */
   void testIsEmptyDefault_WrongType() {
     PropertyHistory prop("arg",
                          boost::lexical_cast<std::string>(Mantid::EMPTY_INT()),
@@ -78,16 +78,15 @@ public:
     TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
   }
 
-/**
-  * Test the isEmptyDefault method returns false if the value is not EMPTY_XXX
-  */
+  /**
+    * Test the isEmptyDefault method returns false if the value is not EMPTY_XXX
+    */
   void testIsEmptyDefault_NotEmpty() {
     PropertyHistory prop(
         "arg", boost::lexical_cast<std::string>(Mantid::EMPTY_INT() - 1),
         "number", true, Direction::Input);
     TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
   }
-
 };
 
 #endif /* PROPERTYHISTORYTEST_H_*/

--- a/Framework/Kernel/test/PropertyHistoryTest.h
+++ b/Framework/Kernel/test/PropertyHistoryTest.h
@@ -5,6 +5,7 @@
 #include "MantidKernel/PropertyHistory.h"
 #include "MantidKernel/Property.h"
 #include <sstream>
+#include <boost/lexical_cast.hpp>
 
 using namespace Mantid::Kernel;
 
@@ -24,6 +25,69 @@ public:
     TS_ASSERT_THROWS_NOTHING(output << AP);
     TS_ASSERT_EQUALS(output.str(), correctOutput);
   }
+
+  /**
+   * Test the isEmptyDefault method returns true for unset default-value
+   * properties
+   * with EMPTY_INT, EMPTY_DBL, EMPTY_LONG
+   */
+  void testIsEmptyDefault_True() {
+    PropertyHistory intProp(
+        "arg1_param", boost::lexical_cast<std::string>(Mantid::EMPTY_INT()),
+        "number", true, Direction::Input);
+    PropertyHistory dblProp(
+        "arg2_param", boost::lexical_cast<std::string>(Mantid::EMPTY_DBL()),
+        "number", true, Direction::Input);
+    PropertyHistory longProp(
+        "arg3_param", boost::lexical_cast<std::string>(Mantid::EMPTY_LONG()),
+        "number", true, Direction::Input);
+    TS_ASSERT_EQUALS(intProp.isEmptyDefault(), true);
+    TS_ASSERT_EQUALS(dblProp.isEmptyDefault(), true);
+    TS_ASSERT_EQUALS(longProp.isEmptyDefault(), true);
+  }
+
+  /**
+   * Test the isEmptyDefault method returns false for an output parameter
+   */
+  void testIsEmptyDefault_WrongDirection() {
+    PropertyHistory prop("arg",
+                         boost::lexical_cast<std::string>(Mantid::EMPTY_INT()),
+                         "number", true, Direction::Output);
+    TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
+  }
+
+  /**
+    * Test the isEmptyDefault method returns false if the value of EMPTY_INT is
+    * not the default
+    */
+  void testIsEmptyDefault_NotDefault() {
+    PropertyHistory prop("arg",
+                         boost::lexical_cast<std::string>(Mantid::EMPTY_INT()),
+                         "number", false, Direction::Input);
+    TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
+  }
+
+/**
+  * Test the isEmptyDefault method returns false if the parameter type is not
+  * "number"
+  */
+  void testIsEmptyDefault_WrongType() {
+    PropertyHistory prop("arg",
+                         boost::lexical_cast<std::string>(Mantid::EMPTY_INT()),
+                         "something", true, Direction::Input);
+    TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
+  }
+
+/**
+  * Test the isEmptyDefault method returns false if the value is not EMPTY_XXX
+  */
+  void testIsEmptyDefault_NotEmpty() {
+    PropertyHistory prop(
+        "arg", boost::lexical_cast<std::string>(Mantid::EMPTY_INT() - 1),
+        "number", true, Direction::Input);
+    TS_ASSERT_EQUALS(prop.isEmptyDefault(), false);
+  }
+
 };
 
 #endif /* PROPERTYHISTORYTEST_H_*/

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -467,8 +467,18 @@ const PropertyHistories& AlgHistoryProperties:: getAlgProperties()
 {
   return m_Histprop;
 }
-void AlgHistoryProperties::displayAlgHistoryProperties()
-{
+
+/**
+ * @brief Populates the Algorithm History display
+ * with property names, values, directions and whether their values were the
+ * defaults.
+ *
+ * If a value was unset and its default value is EMPTY_INT, EMPTY_DBL
+ * or EMPTY_LONG, display an empty space to the user rather than the
+ * internal numeric representation of an empty value.
+ *
+ */
+void AlgHistoryProperties::displayAlgHistoryProperties() {
   QStringList propList;
   std::string sProperty;
   for ( std::vector<PropertyHistory_sptr>::const_iterator pIter = m_Histprop.begin();
@@ -476,12 +486,17 @@ void AlgHistoryProperties::displayAlgHistoryProperties()
   {
     sProperty=(*pIter)->name();
     propList.append(sProperty.c_str());
-    sProperty=(*pIter)->value();
+
+    sProperty = (*pIter)->value();
+    bool bisDefault = (*pIter)->isDefault();
+    if (bisDefault == true) {
+      if ((*pIter)->isEmptyDefault()) {
+        sProperty = ""; // replace EMPTY_XXX with empty string
+      }
+    }
     propList.append(sProperty.c_str());
 
-    bool bisDefault=(*pIter)->isDefault();
     bisDefault? (sProperty="Yes"):(sProperty="No");
-
     propList.append(sProperty.c_str());
     int nDirection=(*pIter)->direction();
     switch(nDirection)


### PR DESCRIPTION
Resolves #14207 

If a property is not set for an algorithm and its default value is set
to be an EMPTY_INT/DBL/LONG, do not show the internal representation of this value to the user in the Workspace History dialog. Instead, show an empty property.

Add a method to PropertyHistory to test if property is set to an EMPTY_XXX default value. Use this test in AlgorithmHistoryWindow. Add tests for this new method.
