### PR TITLE
Fix PredictPeaks doctest error on RHEL6

### DIFF
--- a/docs/source/algorithms/PredictPeaks-v1.rst
+++ b/docs/source/algorithms/PredictPeaks-v1.rst
@@ -62,7 +62,7 @@ which can currently be achieved as in the following example:
     maxIntensity = np.max(intensities)
     relativeIntensities = intensities / maxIntensity
 
-    print 'Maximum intensity: {:.2f}'.format(maxIntensity)
+    print 'Maximum intensity: {0:.2f}'.format(maxIntensity)
     print 'Peaks with relative intensity < 1%:', len([x for x in relativeIntensities if x < 0.01])
 
     absences = [i for i, x in enumerate(intensities) if x < 1e-9]


### PR DESCRIPTION
There is no issue for this as the change is very small. Other doctests using the `{}` to format strings have the number explicitly set. In https://docs.python.org/2.6/library/string.html the `field_name` is mandatory, so I think this should fix the problem. Unfortunately I don't have Python 2.6 available right now.
