### PR TITLE
Updating Mantid.properties.template

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,7 +288,7 @@ if ( ENABLE_CPACK )
                                      "libmuparser0debian1,"
                                      "ipython-qtconsole (>= 1.1),python-matplotlib,python-scipy,"
                                      "libpocofoundation9,libpocoutil9,libpoconet9,libpoconetssl9,libpococrypto9,libpocoxml9")
-        elseif( "${UNIX_CODENAME}" STREQUAL "trusty" OR "${UNIX_CODENAME}" STREQUAL "utopic" OR "${UNIX_CODENAME}" STREQUAL "vivid")
+        elseif( "${UNIX_CODENAME}" STREQUAL "trusty" OR "${UNIX_CODENAME}" STREQUAL "utopic" OR "${UNIX_CODENAME}" STREQUAL "vivid" OR "${UNIX_CODENAME}" STREQUAL "wily")
           list ( APPEND DEPENDS_LIST ",libqscintilla2-11,"
                                      "liboce-foundation8,liboce-modeling8,"
                                      "libmuparser2,"

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -541,6 +541,7 @@ else ()
   set ( CONSOLEPATTERN "%s-[%p] %t" )
 endif ()
 
+set ( CONSOLECHANNELCLASS "ConsoleChannel" )
 configure_file ( ../Properties/Mantid.properties.template
                  ${CMAKE_CURRENT_BINARY_DIR}/Mantid.properties
 )
@@ -615,6 +616,7 @@ else ()
   set ( PV_PLUGINS ${MANTID_ROOT}/${PVPLUGINS_SUBDIR} )
 endif ()
 
+set ( CONSOLECHANNELCLASS "StdoutChannel" )
 configure_file ( ../Properties/Mantid.properties.template
                  ${CMAKE_CURRENT_BINARY_DIR}/Mantid.properties.install
 )

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -171,7 +171,7 @@ logging.channels.fileFilterChannel.channel= fileChannel
 logging.channels.fileFilterChannel.level= information
 
 # output to the console - primarily for console based apps
-logging.channels.consoleChannel.class = ConsoleChannel
+logging.channels.consoleChannel.class = StdoutChannel
 logging.channels.consoleChannel.formatter = f1
 
 # output to a file (For error capturing and debugging)

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -171,7 +171,7 @@ logging.channels.fileFilterChannel.channel= fileChannel
 logging.channels.fileFilterChannel.level= information
 
 # output to the console - primarily for console based apps
-logging.channels.consoleChannel.class = StdoutChannel
+logging.channels.consoleChannel.class = @CONSOLECHANNELCLASS@
 logging.channels.consoleChannel.formatter = f1
 
 # output to a file (For error capturing and debugging)


### PR DESCRIPTION
Fixes #14260
To test: make sure the tests are passing. Writing to the stdout would mess up the xml files from ctest, so the console class is set to StdoutChannel only for the install packages. Check if the Mantid properties is  StdoutChannel in the install package.. No need for release notes
