### PR TITLE
New IDF for LET

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -287,10 +287,10 @@ class ISISLoadFilesLET(stresstesting.MantidStressTest):
         # Adjust old IDF to new changes. This may change when loader is modified.
         propman.ei_mon2_spec  = [5506,5505,5507]
         propman.spectra_to_monitors_list=[5506,5505,5507]
-        # 
+        #
         ws = PropertyManager.sample_run.get_workspace()
         # apply IDF property, correspondent to this particular time interval
-        allChanges = propman.update_defaults_from_instrument(ws.getInstrument())
+        propman.update_defaults_from_instrument(ws.getInstrument())
         self.assertEqual(int(propman.mon1_norm_spec),40961)
         self.assertEqual(propman.ei_mon1_spec,40966)
 

--- a/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 import os,sys
 import stresstesting
 from mantid.simpleapi import *
@@ -282,20 +282,27 @@ class ISISLoadFilesLET(stresstesting.MantidStressTest):
         # Normalized by monitor-1. -- need monitor1 and ei needs ei_mon1_spec
         # This problem is hopefully fixed in reduction now, but here
         # we have to specify these values manually to guard against
-        # changes in a future
+        # changes in a future. This issue should be now fixed through varions means
         propman.normalise_method='monitor-1'
-        propman.mon1_norm_spec=40961
-        propman.ei_mon1_spec  =40966
+        # Adjust old IDF to new changes. This may change when loader is modified.
+        propman.ei_mon2_spec  = [5506,5505,5507]
+        propman.spectra_to_monitors_list=[5506,5505,5507]
+        # 
+        ws = PropertyManager.sample_run.get_workspace()
+        # apply IDF property, correspondent to this particular time interval
+        allChanges = propman.update_defaults_from_instrument(ws.getInstrument())
+        self.assertEqual(int(propman.mon1_norm_spec),40961)
+        self.assertEqual(propman.ei_mon1_spec,40966)
+
 
         mon_ws = PropertyManager.sample_run.get_monitors_ws()
         self.assertTrue(not mon_ws is None)
-        ws = PropertyManager.sample_run.get_workspace()
 
         self.assertTrue(isinstance(ws,IEventWorkspace))
         self.assertEqual(ws.getNumberHistograms(),40960)
         self.assertTrue(isinstance(mon_ws,Workspace))
         #
-        self.assertEqual(mon_ws.getNumberHistograms(),27)
+        self.assertEqual(mon_ws.getNumberHistograms(),11)
 
         ei_ws = GetAllEi(mon_ws,40966,40967,IgnoreSecondMonitor=True)
         self.assertTrue(isinstance(ei_ws,Workspace))

--- a/instrument/LET_Definition_dr1to12.xml
+++ b/instrument/LET_Definition_dr1to12.xml
@@ -1,0 +1,723 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- For help on the notation used to specify an Instrument Definition File 
+     see http://www.mantidproject.org/IDF -->
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
+ name="LET" valid-from   ="2015-11-03 00:00:01"
+               valid-to     ="2999-12-31 23:59:59"
+               last-modified="2015-04-01 11:00:0">
+ 
+   <defaults>
+     <length unit="meter"/>
+     <angle unit="degree"/>
+ <location r="0.0" t="0.0" p="0.0" ang="0.0" axis-x="0.0" axis-y="0.0" axis-z="1.0"/>
+     <reference-frame>
+       <!-- The z-axis is set parallel to and in the direction of the beam. the 
+        y-axis points up and the coordinate system is right handed. -->
+       <along-beam axis="z"/>
+       <pointing-up axis="y"/>
+       <handedness val="right"/>
+       <origin val="beam" /> 
+     </reference-frame>
+     <default-view view="cylindrical_y"/>
+     <!-- Comment "components-are-facing" out if you dont want the
+     components defined in this file to face a position by default -->    
+     <components-are-facing x="0.0" y="0.0" z="0.0" />
+   </defaults>
+   
+   <!-- LIST OF PHYSICAL COMPONENTS (which the instrument consists of) -->
+   <!-- detector components -->
+    <properties>
+   </properties>
+   <component type="monitors" idlist="monitors">
+     <location/>
+   </component>
+<component type="door01" idlist="door01">
+ <location />
+ </component>
+<component type="door02" idlist="door02">
+ <location />
+ </component>
+<component type="door03" idlist="door03">
+ <location />
+ </component>
+<component type="door04" idlist="door04">
+ <location />
+ </component>
+<component type="door05" idlist="door05">
+ <location />
+ </component>
+<component type="door06" idlist="door06">
+ <location />
+ </component>
+<component type="door07" idlist="door07">
+ <location />
+ </component>
+<component type="door08" idlist="door08">
+ <location />
+ </component>
+<component type="door09" idlist="door09">
+ <location />
+ </component>
+<component type="door10" idlist="door10">
+ <location />
+ </component>
+<component type="door11" idlist="door11">
+ <location />
+ </component>
+<component type="door12" idlist="door12">
+ <location />
+ </component>
+ <!-- source and sample-position components -->
+   <component type="undulator">
+     <location z="-25.0"> <facing val="none"/> </location>
+   </component>
+ 
+   <component type="nickel-holder">
+     <location> <facing val="none"/> </location>
+   </component>
+ 
+   <!-- DEFINITION OF TYPES -->
+   <!-- Source types -->
+   <type name="undulator" is="Source">
+     <properties />
+     <cylinder id="some-shape">
+       <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+       <axis x="0.0" y="0.0" z="1.0" /> 
+       <radius val="0.01" />
+       <height val="0.03" />
+     </cylinder> 
+     <algebra val="some-shape" />
+   </type>
+   
+ 
+   <!-- Sample-position types -->
+   <type name="nickel-holder" is="SamplePos">
+     <properties />
+     <sphere id="some-shape">
+       <centre x="0.0"  y="0.0" z="0.0" />
+       <radius val="0.03" />
+     </sphere>
+     <algebra val="some-shape" />
+   </type>
+ 
+   <!-- Detectors types -->
+   <type name="monitors">
+     <component type="monitor">
+       <location r="17.758" t="180.0" p="0.0" name="monitor1" />
+       <location r="17.060" t="180.0" p="0.0" name="monitor2" />
+       <location r="16.558" t="180.0" p="0.0" name="monitor3" />
+       <location r="13.164" t="180.0" p="0.0" name="monitor4" />
+       <location r="9.255" t="180.0" p="0.0" name="monitor5" />
+       <location r="1.333" t="180.0" p="0.0" name="monitor6" />
+       <location r="1.088" t="180.0" p="0.0" name="monitor7" />
+       <location r="1.088" t="180.0" p="0.0" name="monitor8" />
+     </component>
+   </type>
+ 
+<type name="door01">
+ <component type="LETdoor">
+<location  x="  -1.8805    " z="  2.9519    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door02">
+ <component type="LETdoor">
+<location  x="  -1.0525    " z="  3.3380    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door03">
+ <component type="LETdoor">
+<location  x=" -0.15267    " z="  3.4967    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door04">
+ <component type="LETdoor">
+<location  x="0.75754    " z="  3.4170    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door05">
+ <component type="LETdoor">
+<location  x=" 1.6161    " z="  3.1045    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door06">
+ <component type="LETdoor">
+<location  x=" 2.3646    " z="  2.5805    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door07">
+ <component type="LETdoor">
+<location  x=" 2.9519    " z="  1.8805    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door08">
+ <component type="LETdoor">
+<location  x=" 3.3380    " z="  1.0525    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door09">
+ <component type="LETdoor">
+<location  x=" 3.4967    " z=" 0.15267    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door10">
+ <component type="LETdoor">
+<location  x=" 3.4170    " z="-0.75754    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door11">
+ <component type="LETdoor">
+<location  x=" 3.1045    " z=" -1.6161    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+<type name="door12">
+ <component type="LETdoor">
+<location  x=" 2.5805    " z=" -2.3646    "> <facing x="0" y="0" z="0"/> </location>
+ </component>
+ </type>
+ 
+ 
+ <type name="LETdoor">
+ <properties />
+ <component type="LETtube" outline="yes">
+<location  x="   -0.393024    " z="  -0.221369E-01" name="tube1" />
+<location  x="   -0.367765    " z="  -0.193752E-01" name="tube2" />
+<location  x="   -0.342486    " z="  -0.167970E-01" name="tube3" />
+<location  x="   -0.317189    " z="  -0.144023E-01" name="tube4" />
+<location  x="   -0.291876    " z="  -0.121914E-01" name="tube5" />
+<location  x="   -0.266547    " z="  -0.101643E-01" name="tube6" />
+<location  x="   -0.241204    " z="  -0.832121E-02" name="tube7" />
+<location  x="   -0.215848    " z="  -0.666210E-02" name="tube8" />
+<location  x="   -0.190481    " z="  -0.518712E-02" name="tube9" />
+<location  x="   -0.165104    " z="  -0.389635E-02" name="tube10" />
+<location  x="   -0.139718    " z="  -0.278984E-02" name="tube11" />
+<location  x="   -0.114325    " z="  -0.186766E-02" name="tube12" />
+<location  x="   -0.889254E-01" z="  -0.112986E-02" name="tube13" />
+<location  x="   -0.635215E-01" z="  -0.576474E-03" name="tube14" />
+<location  x="   -0.381142E-01" z="  -0.207534E-03" name="tube15" />
+<location  x="   -0.127050E-01" z="  -0.230596E-04" name="tube16" />
+<location  x="  0.127050E-01" z="  -0.230596E-04" name="tube17" />
+<location  x="  0.381142E-01" z="  -0.207534E-03" name="tube18" />
+<location  x="  0.635215E-01" z="  -0.576474E-03" name="tube19" />
+<location  x="  0.889254E-01" z="  -0.112986E-02" name="tube20" />
+<location  x="  0.114325    " z="  -0.186766E-02" name="tube21" />
+<location  x="  0.139718    " z="  -0.278984E-02" name="tube22" />
+<location  x="  0.165104    " z="  -0.389635E-02" name="tube23" />
+<location  x="  0.190481    " z="  -0.518712E-02" name="tube24" />
+<location  x="  0.215848    " z="  -0.666210E-02" name="tube25" />
+<location  x="  0.241204    " z="  -0.832121E-02" name="tube26" />
+<location  x="  0.266547    " z="  -0.101643E-01" name="tube27" />
+<location  x="  0.291876    " z="  -0.121914E-01" name="tube28" />
+<location  x="  0.317189    " z="  -0.144023E-01" name="tube29" />
+<location  x="  0.342486    " z="  -0.167970E-01" name="tube30" />
+<location  x="  0.367765    " z="  -0.193752E-01" name="tube31" />
+<location  x="  0.393024    " z="  -0.221369E-01" name="tube32" />
+ </component>
+ </type>
+ 
+ <type name="LETtube" outline="yes">
+ <component type="pixel">
+   <locations y="-2.00304" y-end="2.00304" n-elements="1024" />
+ </component>
+ </type>
+ 
+ <type name="monitor" is="monitor">
+  <properties/>
+  <cylinder id="some-shape">
+ <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+ <axis x="0.0" y="0.0" z="1.0" />
+ <radius val="0.01" />
+ <height val="0.03" />
+ </cylinder>
+ <algebra val="some-shape" />
+ </type>
+ 
+ <type name="pixel" is="detector">
+ <cylinder id="cyl-approx">
+   <centre-of-bottom-base r="0.0" t="0.0" p="0.0" />
+   <axis x="0.0" y="0.2" z="0.0" />
+  <radius val="   0.127000E-01" />
+  <height val="   0.391602E-02" />
+ </cylinder>
+ <algebra val="cyl-approx" />
+  </type>
+ 
+  <!-- MONITOR ID LISTS -->
+   <idlist idname="monitors">
+     <id start="11" end="81" step="10"/>
+   </idlist>
+ 
+   <!-- DETECTOR ID LISTS -->
+   <idlist idname="door01">
+  <id start="1110001" end="1111024" />
+  <id start="1120001" end="1121024" />
+  <id start="1130001" end="1131024" />
+  <id start="1140001" end="1141024" />
+  <id start="1150001" end="1151024" />
+  <id start="1160001" end="1161024" />
+  <id start="1170001" end="1171024" />
+  <id start="1180001" end="1181024" />
+  <id start="1210001" end="1211024" />
+  <id start="1220001" end="1221024" />
+  <id start="1230001" end="1231024" />
+  <id start="1240001" end="1241024" />
+  <id start="1250001" end="1251024" />
+  <id start="1260001" end="1261024" />
+  <id start="1270001" end="1271024" />
+  <id start="1280001" end="1281024" />
+  <id start="1310001" end="1311024" />
+  <id start="1320001" end="1321024" />
+  <id start="1330001" end="1331024" />
+  <id start="1340001" end="1341024" />
+  <id start="1350001" end="1351024" />
+  <id start="1360001" end="1361024" />
+  <id start="1370001" end="1371024" />
+  <id start="1380001" end="1381024" />
+  <id start="1410001" end="1411024" />
+  <id start="1420001" end="1421024" />
+  <id start="1430001" end="1431024" />
+  <id start="1440001" end="1441024" />
+  <id start="1450001" end="1451024" />
+  <id start="1460001" end="1461024" />
+  <id start="1470001" end="1471024" />
+  <id start="1480001" end="1481024" />
+ </idlist>
+   <idlist idname="door02">
+  <id start="2110001" end="2111024" />
+  <id start="2120001" end="2121024" />
+  <id start="2130001" end="2131024" />
+  <id start="2140001" end="2141024" />
+  <id start="2150001" end="2151024" />
+  <id start="2160001" end="2161024" />
+  <id start="2170001" end="2171024" />
+  <id start="2180001" end="2181024" />
+  <id start="2210001" end="2211024" />
+  <id start="2220001" end="2221024" />
+  <id start="2230001" end="2231024" />
+  <id start="2240001" end="2241024" />
+  <id start="2250001" end="2251024" />
+  <id start="2260001" end="2261024" />
+  <id start="2270001" end="2271024" />
+  <id start="2280001" end="2281024" />
+  <id start="2310001" end="2311024" />
+  <id start="2320001" end="2321024" />
+  <id start="2330001" end="2331024" />
+  <id start="2340001" end="2341024" />
+  <id start="2350001" end="2351024" />
+  <id start="2360001" end="2361024" />
+  <id start="2370001" end="2371024" />
+  <id start="2380001" end="2381024" />
+  <id start="2410001" end="2411024" />
+  <id start="2420001" end="2421024" />
+  <id start="2430001" end="2431024" />
+  <id start="2440001" end="2441024" />
+  <id start="2450001" end="2451024" />
+  <id start="2460001" end="2461024" />
+  <id start="2470001" end="2471024" />
+  <id start="2480001" end="2481024" />
+ </idlist>
+   <idlist idname="door03">
+  <id start="3110001" end="3111024" />
+  <id start="3120001" end="3121024" />
+  <id start="3130001" end="3131024" />
+  <id start="3140001" end="3141024" />
+  <id start="3150001" end="3151024" />
+  <id start="3160001" end="3161024" />
+  <id start="3170001" end="3171024" />
+  <id start="3180001" end="3181024" />
+  <id start="3210001" end="3211024" />
+  <id start="3220001" end="3221024" />
+  <id start="3230001" end="3231024" />
+  <id start="3240001" end="3241024" />
+  <id start="3250001" end="3251024" />
+  <id start="3260001" end="3261024" />
+  <id start="3270001" end="3271024" />
+  <id start="3280001" end="3281024" />
+  <id start="3310001" end="3311024" />
+  <id start="3320001" end="3321024" />
+  <id start="3330001" end="3331024" />
+  <id start="3340001" end="3341024" />
+  <id start="3350001" end="3351024" />
+  <id start="3360001" end="3361024" />
+  <id start="3370001" end="3371024" />
+  <id start="3380001" end="3381024" />
+  <id start="3410001" end="3411024" />
+  <id start="3420001" end="3421024" />
+  <id start="3430001" end="3431024" />
+  <id start="3440001" end="3441024" />
+  <id start="3450001" end="3451024" />
+  <id start="3460001" end="3461024" />
+  <id start="3470001" end="3471024" />
+  <id start="3480001" end="3481024" />
+ </idlist>
+   <idlist idname="door04">
+  <id start="4110001" end="4111024" />
+  <id start="4120001" end="4121024" />
+  <id start="4130001" end="4131024" />
+  <id start="4140001" end="4141024" />
+  <id start="4150001" end="4151024" />
+  <id start="4160001" end="4161024" />
+  <id start="4170001" end="4171024" />
+  <id start="4180001" end="4181024" />
+  <id start="4210001" end="4211024" />
+  <id start="4220001" end="4221024" />
+  <id start="4230001" end="4231024" />
+  <id start="4240001" end="4241024" />
+  <id start="4250001" end="4251024" />
+  <id start="4260001" end="4261024" />
+  <id start="4270001" end="4271024" />
+  <id start="4280001" end="4281024" />
+  <id start="4310001" end="4311024" />
+  <id start="4320001" end="4321024" />
+  <id start="4330001" end="4331024" />
+  <id start="4340001" end="4341024" />
+  <id start="4350001" end="4351024" />
+  <id start="4360001" end="4361024" />
+  <id start="4370001" end="4371024" />
+  <id start="4380001" end="4381024" />
+  <id start="4410001" end="4411024" />
+  <id start="4420001" end="4421024" />
+  <id start="4430001" end="4431024" />
+  <id start="4440001" end="4441024" />
+  <id start="4450001" end="4451024" />
+  <id start="4460001" end="4461024" />
+  <id start="4470001" end="4471024" />
+  <id start="4480001" end="4481024" />
+ </idlist>
+   <idlist idname="door05">
+  <id start="5110001" end="5111024" />
+  <id start="5120001" end="5121024" />
+  <id start="5130001" end="5131024" />
+  <id start="5140001" end="5141024" />
+  <id start="5150001" end="5151024" />
+  <id start="5160001" end="5161024" />
+  <id start="5170001" end="5171024" />
+  <id start="5180001" end="5181024" />
+  <id start="5210001" end="5211024" />
+  <id start="5220001" end="5221024" />
+  <id start="5230001" end="5231024" />
+  <id start="5240001" end="5241024" />
+  <id start="5250001" end="5251024" />
+  <id start="5260001" end="5261024" />
+  <id start="5270001" end="5271024" />
+  <id start="5280001" end="5281024" />
+  <id start="5310001" end="5311024" />
+  <id start="5320001" end="5321024" />
+  <id start="5330001" end="5331024" />
+  <id start="5340001" end="5341024" />
+  <id start="5350001" end="5351024" />
+  <id start="5360001" end="5361024" />
+  <id start="5370001" end="5371024" />
+  <id start="5380001" end="5381024" />
+  <id start="5410001" end="5411024" />
+  <id start="5420001" end="5421024" />
+  <id start="5430001" end="5431024" />
+  <id start="5440001" end="5441024" />
+  <id start="5450001" end="5451024" />
+  <id start="5460001" end="5461024" />
+  <id start="5470001" end="5471024" />
+  <id start="5480001" end="5481024" />
+ </idlist>
+   <idlist idname="door06">
+  <id start="6110001" end="6111024" />
+  <id start="6120001" end="6121024" />
+  <id start="6130001" end="6131024" />
+  <id start="6140001" end="6141024" />
+  <id start="6150001" end="6151024" />
+  <id start="6160001" end="6161024" />
+  <id start="6170001" end="6171024" />
+  <id start="6180001" end="6181024" />
+  <id start="6210001" end="6211024" />
+  <id start="6220001" end="6221024" />
+  <id start="6230001" end="6231024" />
+  <id start="6240001" end="6241024" />
+  <id start="6250001" end="6251024" />
+  <id start="6260001" end="6261024" />
+  <id start="6270001" end="6271024" />
+  <id start="6280001" end="6281024" />
+  <id start="6310001" end="6311024" />
+  <id start="6320001" end="6321024" />
+  <id start="6330001" end="6331024" />
+  <id start="6340001" end="6341024" />
+  <id start="6350001" end="6351024" />
+  <id start="6360001" end="6361024" />
+  <id start="6370001" end="6371024" />
+  <id start="6380001" end="6381024" />
+  <id start="6410001" end="6411024" />
+  <id start="6420001" end="6421024" />
+  <id start="6430001" end="6431024" />
+  <id start="6440001" end="6441024" />
+  <id start="6450001" end="6451024" />
+  <id start="6460001" end="6461024" />
+  <id start="6470001" end="6471024" />
+  <id start="6480001" end="6481024" />
+ </idlist>
+   <idlist idname="door07">
+  <id start="7110001" end="7111024" />
+  <id start="7120001" end="7121024" />
+  <id start="7130001" end="7131024" />
+  <id start="7140001" end="7141024" />
+  <id start="7150001" end="7151024" />
+  <id start="7160001" end="7161024" />
+  <id start="7170001" end="7171024" />
+  <id start="7180001" end="7181024" />
+  <id start="7210001" end="7211024" />
+  <id start="7220001" end="7221024" />
+  <id start="7230001" end="7231024" />
+  <id start="7240001" end="7241024" />
+  <id start="7250001" end="7251024" />
+  <id start="7260001" end="7261024" />
+  <id start="7270001" end="7271024" />
+  <id start="7280001" end="7281024" />
+  <id start="7310001" end="7311024" />
+  <id start="7320001" end="7321024" />
+  <id start="7330001" end="7331024" />
+  <id start="7340001" end="7341024" />
+  <id start="7350001" end="7351024" />
+  <id start="7360001" end="7361024" />
+  <id start="7370001" end="7371024" />
+  <id start="7380001" end="7381024" />
+  <id start="7410001" end="7411024" />
+  <id start="7420001" end="7421024" />
+  <id start="7430001" end="7431024" />
+  <id start="7440001" end="7441024" />
+  <id start="7450001" end="7451024" />
+  <id start="7460001" end="7461024" />
+  <id start="7470001" end="7471024" />
+  <id start="7480001" end="7481024" />
+ </idlist>
+   <idlist idname="door08">
+  <id start="8110001" end="8111024" />
+  <id start="8120001" end="8121024" />
+  <id start="8130001" end="8131024" />
+  <id start="8140001" end="8141024" />
+  <id start="8150001" end="8151024" />
+  <id start="8160001" end="8161024" />
+  <id start="8170001" end="8171024" />
+  <id start="8180001" end="8181024" />
+  <id start="8210001" end="8211024" />
+  <id start="8220001" end="8221024" />
+  <id start="8230001" end="8231024" />
+  <id start="8240001" end="8241024" />
+  <id start="8250001" end="8251024" />
+  <id start="8260001" end="8261024" />
+  <id start="8270001" end="8271024" />
+  <id start="8280001" end="8281024" />
+  <id start="8310001" end="8311024" />
+  <id start="8320001" end="8321024" />
+  <id start="8330001" end="8331024" />
+  <id start="8340001" end="8341024" />
+  <id start="8350001" end="8351024" />
+  <id start="8360001" end="8361024" />
+  <id start="8370001" end="8371024" />
+  <id start="8380001" end="8381024" />
+  <id start="8410001" end="8411024" />
+  <id start="8420001" end="8421024" />
+  <id start="8430001" end="8431024" />
+  <id start="8440001" end="8441024" />
+  <id start="8450001" end="8451024" />
+  <id start="8460001" end="8461024" />
+  <id start="8470001" end="8471024" />
+  <id start="8480001" end="8481024" />
+ </idlist>
+   <idlist idname="door09">
+  <id start="9110001" end="9111024" />
+  <id start="9120001" end="9121024" />
+  <id start="9130001" end="9131024" />
+  <id start="9140001" end="9141024" />
+  <id start="9150001" end="9151024" />
+  <id start="9160001" end="9161024" />
+  <id start="9170001" end="9171024" />
+  <id start="9180001" end="9181024" />
+  <id start="9210001" end="9211024" />
+  <id start="9220001" end="9221024" />
+  <id start="9230001" end="9231024" />
+  <id start="9240001" end="9241024" />
+  <id start="9250001" end="9251024" />
+  <id start="9260001" end="9261024" />
+  <id start="9270001" end="9271024" />
+  <id start="9280001" end="9281024" />
+  <id start="9310001" end="9311024" />
+  <id start="9320001" end="9321024" />
+  <id start="9330001" end="9331024" />
+  <id start="9340001" end="9341024" />
+  <id start="9350001" end="9351024" />
+  <id start="9360001" end="9361024" />
+  <id start="9370001" end="9371024" />
+  <id start="9380001" end="9381024" />
+  <id start="9410001" end="9411024" />
+  <id start="9420001" end="9421024" />
+  <id start="9430001" end="9431024" />
+  <id start="9440001" end="9441024" />
+  <id start="9450001" end="9451024" />
+  <id start="9460001" end="9461024" />
+  <id start="9470001" end="9471024" />
+  <id start="9480001" end="9481024" />
+ </idlist>
+   <idlist idname="door10">
+  <id start="10110001" end="10111024" />
+  <id start="10120001" end="10121024" />
+  <id start="10130001" end="10131024" />
+  <id start="10140001" end="10141024" />
+  <id start="10150001" end="10151024" />
+  <id start="10160001" end="10161024" />
+  <id start="10170001" end="10171024" />
+  <id start="10180001" end="10181024" />
+  <id start="10210001" end="10211024" />
+  <id start="10220001" end="10221024" />
+  <id start="10230001" end="10231024" />
+  <id start="10240001" end="10241024" />
+  <id start="10250001" end="10251024" />
+  <id start="10260001" end="10261024" />
+  <id start="10270001" end="10271024" />
+  <id start="10280001" end="10281024" />
+  <id start="10310001" end="10311024" />
+  <id start="10320001" end="10321024" />
+  <id start="10330001" end="10331024" />
+  <id start="10340001" end="10341024" />
+  <id start="10350001" end="10351024" />
+  <id start="10360001" end="10361024" />
+  <id start="10370001" end="10371024" />
+  <id start="10380001" end="10381024" />
+  <id start="10410001" end="10411024" />
+  <id start="10420001" end="10421024" />
+  <id start="10430001" end="10431024" />
+  <id start="10440001" end="10441024" />
+  <id start="10450001" end="10451024" />
+  <id start="10460001" end="10461024" />
+  <id start="10470001" end="10471024" />
+  <id start="10480001" end="10481024" />
+ </idlist>
+   <idlist idname="door11">
+  <id start="11110001" end="11111024" />
+  <id start="11120001" end="11121024" />
+  <id start="11130001" end="11131024" />
+  <id start="11140001" end="11141024" />
+  <id start="11150001" end="11151024" />
+  <id start="11160001" end="11161024" />
+  <id start="11170001" end="11171024" />
+  <id start="11180001" end="11181024" />
+  <id start="11210001" end="11211024" />
+  <id start="11220001" end="11221024" />
+  <id start="11230001" end="11231024" />
+  <id start="11240001" end="11241024" />
+  <id start="11250001" end="11251024" />
+  <id start="11260001" end="11261024" />
+  <id start="11270001" end="11271024" />
+  <id start="11280001" end="11281024" />
+  <id start="11310001" end="11311024" />
+  <id start="11320001" end="11321024" />
+  <id start="11330001" end="11331024" />
+  <id start="11340001" end="11341024" />
+  <id start="11350001" end="11351024" />
+  <id start="11360001" end="11361024" />
+  <id start="11370001" end="11371024" />
+  <id start="11380001" end="11381024" />
+  <id start="11410001" end="11411024" />
+  <id start="11420001" end="11421024" />
+  <id start="11430001" end="11431024" />
+  <id start="11440001" end="11441024" />
+  <id start="11450001" end="11451024" />
+  <id start="11460001" end="11461024" />
+  <id start="11470001" end="11471024" />
+  <id start="11480001" end="11481024" />
+ </idlist>
+   <idlist idname="door12">
+  <id start="12110001" end="12111024" />
+  <id start="12120001" end="12121024" />
+  <id start="12130001" end="12131024" />
+  <id start="12140001" end="12141024" />
+  <id start="12150001" end="12151024" />
+  <id start="12160001" end="12161024" />
+  <id start="12170001" end="12171024" />
+  <id start="12180001" end="12181024" />
+  <id start="12210001" end="12211024" />
+  <id start="12220001" end="12221024" />
+  <id start="12230001" end="12231024" />
+  <id start="12240001" end="12241024" />
+  <id start="12250001" end="12251024" />
+  <id start="12260001" end="12261024" />
+  <id start="12270001" end="12271024" />
+  <id start="12280001" end="12281024" />
+  <id start="12310001" end="12311024" />
+  <id start="12320001" end="12321024" />
+  <id start="12330001" end="12331024" />
+  <id start="12340001" end="12341024" />
+  <id start="12350001" end="12351024" />
+  <id start="12360001" end="12361024" />
+  <id start="12370001" end="12371024" />
+  <id start="12380001" end="12381024" />
+  <id start="12410001" end="12411024" />
+  <id start="12420001" end="12421024" />
+  <id start="12430001" end="12431024" />
+  <id start="12440001" end="12441024" />
+  <id start="12450001" end="12451024" />
+  <id start="12460001" end="12461024" />
+  <id start="12470001" end="12471024" />
+  <id start="12480001" end="12481024" />
+ </idlist>
+<!-- Chopper position -->
+ <component type="chopper-position">
+    <location z="-1.5"/>
+    <!--description is="The component provides sample-choper distance, used
+    to estimate chopper delay time and Tobyfit resolution calculations."/-->
+    <parameter name="initial_phase">    
+        <value val="-0."/>
+        <description is="The initial rotation phase of the disk used to caluclate the time
+        for neutrons arriving at the chopper according to the formula time = delay + initial_phase/Speed"/>    
+    </parameter>
+    <parameter name="ChopperDelayLog" type="string">
+        <value val="Chopper5_Disk2_phase"/>    
+    </parameter>
+    <parameter name="ChopperSpeedLog" type="string">
+        <value val="Chopper5_Disk2_speed"/>    
+    </parameter>
+    <parameter name="FilterBaseLog" type="string">
+        <value val="good_uah_log"/>    
+    </parameter>
+    <!-- if the log above should be used as it is or 
+    one should calculate its derivative -->
+    <parameter name="filter_with_derivative" type="bool">
+        <value val="True"/>    
+    </parameter>    
+
+  </component>
+  <type name="chopper-position" is="ChopperPos"></type>  
+  
+  
+  <!-- DETECTOR PARAMETERS -->
+  <component-link name="monitors">
+   <parameter name="DelayTime">
+      <value units="microseconds" val="0"/>
+   </parameter>
+  </component-link>
+
+  <!-- Set the same across the rest of the instrument -->
+  <component-link name = "LET">
+    <parameter name="TubePressure">
+      <value units="atm" val="10.0"/>
+    </parameter>
+    <parameter name="TubeThickness">
+      <value units="metre" val="0.0008"/>
+    </parameter>
+    <parameter name="DelayTime">
+      <value units="microseconds" val="-5.3"/>
+    </parameter>
+  </component-link>
+
+
+
+ </instrument>
+

--- a/instrument/LET_Definition_dr2to12.xml
+++ b/instrument/LET_Definition_dr2to12.xml
@@ -5,8 +5,8 @@
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
  name="LET" valid-from   ="2014-09-01 00:00:01"
-               valid-to     ="2015-12-31 23:59:59"
-               last-modified="2015-03-09 18:30:0">
+               valid-to     ="2015-11-02 23:59:59"
+               last-modified="2015-11-04 14:20:0">
  
    <defaults>
      <length unit="meter"/>

--- a/instrument/LET_Parameters_dr1to12.xml
+++ b/instrument/LET_Parameters_dr1to12.xml
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<parameter-file instrument = "LET" valid-from = "2015-11-03T00:00:00">
+
+<component-link name = "LET">
+
+<!-- files properties : -->
+
+<!-- Specify that the detector positions should be taken from the data file (Not used TODO!) -->
+<parameter name="det-pos-source" type="string">
+  <value val="datafile"/>
+</parameter>
+
+<!-- The file which defines proper (calibrated) detector positions 
+     if None - it is undefined -->
+<parameter name="det_cal_file" type="string">
+   <value val="det_corrected_cycle153.dat"/>
+</parameter>
+
+<!-- The file which defines detectors to spectra mapping; File extension has to be specified here but filepath not
+     if None - one2one map is used  -->
+<parameter name="map_file" type="string">
+   <value val="LET_one2one_153.map"/>
+</parameter>
+
+<!-- Prefered extension of the data files obtained from DAE, e.g. what to prefer if two 
+     files with the same name and different extension are found
+ -->
+<parameter name="data_file_ext" type="string">
+   <value val=".nxs"/>
+</parameter>
+<!-- The name of the hard mask file to use together with diag masking -->
+<parameter name="hard_mask_file" type="string">
+    <value val="hard.msk"/>
+</parameter>
+<!-- The map file used when calculating absolute units conversion integrals 
+     This map usually groups together large areas of detectors to obtain proper vanadium statistics  -->
+<parameter name="monovan_mapfile" type="string">
+   <value val="LET_rings_153.map"/>
+</parameter>
+
+
+
+
+<!-- RunNumber to use for diag instead of the input run number if none - use input run 
+     if yes, will probably change from command line-->
+<parameter name="mask_run" type="string">
+   <value val="None"/>
+</parameter>
+
+<!-- Energy conversion mode direct/indirect/elastic (the one the reducer understands) -->
+<parameter name="deltaE-mode" type="string">
+  <value val="direct"/>
+</parameter>
+
+<!-- normalise_method normalization. To compare different runs with different length one uses normalization by some flux-dependent parameter
+     Available values are: none (-largely meaningless), monitor-1,monitor-2, current 
+     the acceptable values are defined in DirectEnergyConversion initialization routine as recognized by direct energy conversion normalize method
+     these three are currently disabled/unknown:  uamph peak-->
+<parameter name="normalise_method" type="string">
+    <value val="monitor-1"/>
+</parameter>
+
+<!-- Monitor used to estimate total current on the sample  while normalizing by monitor 1.  -->
+<parameter name="norm-mon1-spec">
+  <value val="98305"/>
+</parameter>
+  
+
+<!-- Time interval used for integration to estimate current on the sample 
+    This interval is usually taken around the monitor peak-->
+<parameter name="norm-mon1-min">
+  <value val="10000"/>
+</parameter>
+<parameter name="norm-mon1-max">
+  <value val="12000"/>
+</parameter>
+<parameter name="norm_mon_integration_range"  type="string">
+  <value val="norm-mon1-min:norm-mon1-max"/>
+</parameter>
+
+<!-- Monitor after chopper used to estimate total current on the sample, if normalization is done on monitor 2  -->
+<parameter name="norm-mon2-spec"  type="int">
+    <value val="98310"/>
+</parameter>
+
+<!-- Relative energy range (wrt. to the incident energy) in which monitor 2 signal is present and the integration to 
+     calculate monitor-2 current occurs   -->
+<parameter name="mon2_norm_energy_range" type = "string">
+    <value val="0.8,1.2"/>
+</parameter>
+
+<!-- Usually one wants to avoid loading monitors together with data except in special cases. One of this cases is 
+     MARI which monitors numbers are in the beginning of the spectra. If one loads them separately, 
+     spectra numbers change and ISIS hard masks (msk) prepared for workspace with monitors become invalid. 
+     This parameter is actual until Mantid Masking change.
+  -->
+<parameter name="load_monitors_with_workspace"  type="bool">
+<value val="False"/>
+</parameter>
+
+<!-- -->
+<parameter name="ei-mon1-spec"  type="string">
+  <value val="98310"/>
+  <description is="First spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
+</parameter>
+<!-- -->
+<parameter name="ei-mon2-spec"  type="string">
+  <value val="21889,21886,21887,21888,21890,22142,22143,22144,22145,22146,21630,21631,21632,21633,21634,22400,22401"/>
+  <description is="Second spectra number (monitor's spectra number) to use when measuring incident energy,
+     or comma separated list of such numbers.
+     Should be spectra with well defined energy peak or monitor's spectra.
+     If list of numbers is provided, the final spectrum is the sum of the spectra with the numbers provided.
+     It is important to have the detectors for these spectra to be located at the same distance from the source,
+     as the position of the combined detector will be defined by the position of the first spectra's detector."/>
+</parameter>
+<!-- -->
+<parameter name="ei_mon_spectra"  type="string">
+  <value val="ei-mon1-spec:ei-mon2-spec"/>
+  <description is="List of spectra, used to calculate incident energy of beam in inelastic experiments by GetEi algorithm.
+  It is complex property, dependent on two other properties, namely ei-mon1-spec and ei-mon2-spec, which define spectrum or
+  spectra lists for each of two monitors, used in GetEi calculations"/>
+</parameter>
+
+<!-- -->
+<parameter name="spectra_to_monitors_list"  type="string">
+  <value val="21889,21886,21887,21888,21890,22142,22143,22144,22145,22146,21630,21631,21632,21633,21634,22400,22401"/>
+  <description is="If you use some detectors as monitors and work in event mode,
+    one needs to specify the comma separated list of these detectors as the value of this property
+    to copy detectors spectra to monitors spectra collected in histogram mode.
+    If no such monitors are used, None (or text string 'None' in IDF) has to be specified as the value.
+    This is also necessary in Histogram mode if you want to use some detectors as monitors and 
+    load_monitors_with_workspace is set to False necessary if monitors are measured with different time channels"/>
+</parameter>
+
+<!-- -->
+<parameter name="multirep_tof_specta_list"  type="string">
+    <value val="1,128"/>
+    <description is="List of two spectra corresponding to the detectors which are closest and furthest from the sample.
+    These detectors locations are used to identify TOF range, contributing into each energy range
+    in multirep mode"/>
+</parameter>
+
+
+<!-- by default getEi looks for peaks within (1+-0.1)*TOF_GUES range where TOF_GUES is evaluated on the basis of ei guess.
+    If the peaks are very narrow, or there are a lot of them very close to each other, 
+    this value can be reduced. For example, such situation happens on MARI for very high incident energies Ei=1800.
+ -->
+<parameter name="ei_mon_peak_search_range">
+   <value val="0.1"/>
+</parameter>
+
+
+<parameter name="scale-factor">
+  <value val="1.7016e8"/>
+</parameter>
+
+<parameter name="wb-scale-factor">
+  <value val="1000"/>
+</parameter>
+
+<!-- Remove the count rate seen in the regions of the histograms defined as the background regions -->
+<parameter name="check_background"  type="bool">
+   <value val="False"/>
+</parameter>
+
+<!--  detector_van_range- integratin in E(mev) for detector(white beam) vanadium data [20,100] -->
+<parameter name="wb-integr-min">
+  <value val="0.5"/>
+</parameter>
+<parameter name="wb-integr-max">
+  <value val="200"/>
+</parameter>
+<parameter name="wb_integr_range"   type="string">
+    <value val="wb-integr-min:wb-integr-max"/>
+</parameter>
+
+
+<!-- integration range for background tests  (in TOF) - composite property 
+  Used in test to reject high backgound (FlatBackground) and in High Background tests integration in Diagnostics
+  if diag_background_test_range is not set -->
+<parameter name="bkgd-range-min"> 
+  <value val="90000"/>
+</parameter>
+<parameter name="bkgd-range-max">
+  <value val="95000"/>
+</parameter>
+<parameter name="background_range"  type="string">
+      <value val="bkgd-range-min:bkgd-range-max"/>
+</parameter>
+
+<!-- ******************************** DIAGNOSTICS DEFAILTS **************************************** -->
+
+<!-- Perform diag by bank. These are the spectrum numbers -->
+<parameter name="diag_spectra" type="string">
+  <value val="None"/>
+</parameter>
+
+<!-- Absolute lo threshold for vanadium diag (tiny) -->
+<parameter name="diag_tiny">
+  <value val="1e-10"/>
+</parameter>
+
+<!-- Absolute hi threshold for vanadium diag (large) -->
+<parameter name="diag_huge">
+  <value val="1e10"/>
+</parameter>
+
+<!-- Setting diag to reject zero backgrounds; If true then zeroes in (vanadium) data are masked as fail  -->
+<parameter name="diag_samp_zero"  type="bool">
+  <value val="False"/>
+</parameter>
+
+<!-- Fraction of median to consider counting low for the white beam diag (diag_van_median_rate_limit_hi sv_lo)-->
+<parameter name="diag_samp_lo">
+  <value val="0.0"/>
+</parameter>
+<!-- Fraction of median to consider counting high for the white beam diag (sv_hi)-->
+<parameter name="diag_samp_hi">
+  <value val="1.5"/>
+</parameter>
+
+<!-- Error criterion as a multiple of error bar for background (sv_sig) 
+  i.e. to fail the test, the magnitude of the
+  difference with respect to the median value must also exceed this number of error bars (default=3.3)
+-->  
+<parameter name="diag_samp_sig">
+  <value val="3.3"/>
+</parameter>
+
+<!-- Lower bound defining outliers as fraction of median value (v_out_lo)-->
+<parameter name="diag_van_out_lo">
+  <value val="0.01"/>
+</parameter>
+
+<!-- Upper bound defining outliers as fraction of median value (v_out_hi) -->
+<parameter name="diag_van_out_hi">
+  <value val="100."/>
+</parameter>
+
+<!-- Fraction of median to consider counting low for the white beam diag (vv_lo)  vanlo=0.1  -->
+<parameter name="diag_van_lo">
+  <value val="0.1"/>
+</parameter>
+
+<!-- Fraction of median to consider counting high for the white beam diag (vv_hi) vanhi=1.5 -->
+<parameter name="diag_van_hi">
+  <value val="2.0"/>
+</parameter>
+
+<!-- Error criterion as a multiple of error bar     van_sig  "
+    i.e. to fail the test, the magnitude of the difference with respect to the median value must also exceed this number of error bars (default=0.0)
+-->
+<parameter name="diag_van_sig">
+  <value val="0.0"/>
+</parameter>
+
+<!-- Variation for ratio test with second white beam -->
+<parameter name="diag_variation">
+  <value val="1.1"/>
+</parameter>
+<!-- The range used in diagnostics and rejecting high background.
+  If none, the diag background range uses background ranges from background_range. Has to be directly set otherwise -->
+<parameter name="diag_background_test_range"  type="string" >
+    <value val="None"/>
+</parameter>
+
+<!--  -->
+<!--  Bleeding corrections   -->
+
+<!--  the number of pixels ignored within the bleed test diagnostic -->
+<parameter name="diag_bleed_pixels">
+    <value val="80"/>
+</parameter>
+<!--  the maximum framerate allowed in a tube -->
+<parameter name="diag_bleed_maxrate">
+    <value val="0.01"/>
+</parameter>
+<!-- True if the bleed tests should be run use_bleeding-->
+<parameter name="diag_bleed_test"  type="bool">
+    <value val="False"/>
+</parameter>
+
+<!-- **************************************** DIAGNOSTICS DEFAILTS END ****************************************    -->
+
+
+<!-- **************************************** ABSOLUTE UNITS CORRECTION DEFAULTS ********************************  -->
+<!-- Absolute units conversion average -->
+<parameter name="monovan_lo_bound">
+  <value val="0.01"/>
+</parameter>
+
+<parameter name="monovan_hi_bound">
+  <value val="100"/>
+</parameter>
+
+<!-- This property is the part of the composite definition for abs_units_van_range: 
+ It specifies the relative to incident energy lower integration limit for monochromatic vanadium in the mono-vanadium integration -->
+<parameter name="monovan_lo_frac">
+  <value val="-0.8"/>
+</parameter>
+
+<!-- This property is the part of the composite definition for abs_units_van_range:
+ It specifies the the lower limit of energy range in the monochromatic-vanadium integration 
+ Used only if abs_units_van_range is set to val="monovan_lo_value,monovan_hi_value"-->
+<parameter name="monovan_lo_value">
+  <value val="-40."/>
+</parameter>
+
+<!-- This property is the part of the composite definition for abs_units_van_range
+ It specifies the relative to incident energy higher integration limit for monochromatic vanadium in the mono-vanadium integration -->
+<parameter name="monovan_hi_frac">
+  <value val="0.8"/>
+</parameter>
+<!-- This property is the part of the composite definition for abs_units_van_range
+ It specifies the the higher limit of energy range in the monochromatic-vanadium integration 
+ Used only if abs_units_van_range is set to val="monovan_lo_value,monovan_hi_value"-->
+<parameter name="monovan_hi_value">
+  <value val="40."/>
+</parameter>
+
+<!-- energy range for integration calculating absolute units correction vanadium data. 
+     if None, range is calculated from monovan_hi_frac/monovan_lo_frac 
+     - providing the fractions of the incident energy      
+     if one wants to specify the energy values here it has to be defined in the form:
+    <value val="monovan_lo_value,monovan_hi_value"/>      -->    
+<parameter name="abs_units_van_range"  type="string">
+  <value val="None"/>
+</parameter>
+<!-- Sample mass used in absolute units normalization and should usually be changed by user-->
+<parameter name="sample_mass">
+  <value val="1"/>
+</parameter>
+<!-- Sample rmm used in absolute units normalization should usually be changed by user -->
+<parameter name="sample_rmm">
+  <value val="1"/>
+</parameter>
+<!-- Vanaduim mass used in absolute units normalization and is usually instrument specific (changes rarely) -->
+<parameter name="vanadium-mass">
+  <value val="8.47"/>
+</parameter>
+<!-- if this value set to true, modo-vanadium run is not analyzed and masks obtained for arbitrary units are used for mono-vanadium -->
+<parameter name="use_sam_msk_on_monovan" type = "bool">
+  <value val="False"/>
+</parameter>
+
+<!-- if this value is provided (not None) it is string reperesentation of the number used instead of calculating mono-vanadium based normalization factor 
+   one does not need to provide mono-vanadium run if this value is provided as it will be used instead
+  -->
+<parameter name="mono_correction_factor" type="string">
+  <value val="None"/>
+</parameter>
+  
+<!-- **************************************** ABSOLUTE UNITS CORRECTION DEFAULTS END ****************************  -->
+
+<!-- if defined to true, fix incident energy to this value and do not calculate the energy from the run -->
+<parameter name="fixei"  type="bool">
+    <value val="False"/>
+</parameter>
+
+<!--  ****************************************  Workflow control **************************** -->
+
+<!-- This parameter controls the format of output data written by reducer. 
+    Three values are currently supported, namely .spe, .nxspe, and nexus (mantid workspace) (.nxs)
+     Three possible values for this are defined inin DirectEnergyConversion init routine as recognized by save method 
+     If None is there, no internal script saving occurs and one needs to use external save operations -->  
+<parameter name="save_format" type="string">
+   <value val="None"/>
+</parameter>
+
+<!-- If one wants to sum runs. By default no, as in addition to the key word one has to provide list of input run-numbers
+     but presence of this key here allows to propagate this key-word to the reducer   -->
+<parameter name="sum_runs"  type="bool">
+   <value val="False"/>
+</parameter>
+
+<!-- # Run Detector Efficiency Correction -->
+<parameter name="apply_detector_eff"  type="bool">
+   <value val="True"/>
+</parameter>
+<!-- # Multiply result by ki/kf value -->
+<parameter name="apply_kikf_correction"  type="bool">
+   <value val="True"/>
+</parameter>
+
+<!-- The if true, use only hard mask file specified above and do not run diagnostics procedures -->
+<parameter name="use_hard_mask_only" type="bool">
+    <value val="False"/>
+</parameter>
+
+<!-- Parameter specifies if one wants to run diagnostics (which include applying hard mask file) or not-->
+<parameter name="run_diagnostics" type="bool">
+    <value val="True"/>
+</parameter>
+
+
+<!-- If this parameter is set to true, dgreduce will try to load mask from the mask file
+     correspondent to the run if finds it and uses this mask as hard mask only (does not run diagnostics). 
+     If such file has not been found, it will run diagnostics and save the masks into mask file for reuse 
+     Hard Mask file, provided separately or as additional hard mask file is ignored in this case -->
+<parameter name="save_and_reuse_masks"  type="bool">
+   <value val="False"/>
+</parameter>
+
+<!-- The semicolon separated list of possible log names, containing information on crystl rotation.
+     First found log will be used togethere with motor_offset to identify crystal rotation 
+     (psi in Horace) -->
+<parameter name="motor_log_names"  type="string">
+   <value val="CCR_ROT;Rot"/>
+</parameter>
+<!-- Initial value used to identify crytsal rotation angle psi=motor_offset+wccr.timeAverageValue()  -->
+<parameter name="motor_offset">
+   <value val="None"/>
+</parameter>
+
+
+<!-- List of the words which can be used as a command line arguments to define reducer keywords
+     the form is reducer_keword1=synonim1=synonim2=synonim3;reducer_keword1=synonim1a, so, 
+     the reducer keywords are the leftmost values of the keyword assignments below
+     Each keyword met in command line or file above are converted into reducer keyword as below
+-->  
+<parameter name="synonims" type="string">
+   <value val="normalise_method=norm_method;
+       fix_ei=fixei;
+       sum_runs=sum;
+       wb_integr_range=detector_van_range;
+       motor_log_names = motor_name;       
+       van_mass=vanadium-mass;
+       check_background = background;
+       mon1_norm_spec=norm-mon1-spec;
+       mon2_norm_spec=norm-mon2-spec;       
+       scale_factor=scale-factor;
+       wb_scale_factor=wb-scale-factor;
+       monovan_integr_range=abs_units_van_range;
+       monovan_lo_value = monovan-integr-min;
+       monovan_hi_value = monovan-integr-max;       
+       bkgd_range = background_range;
+       background_test_range = diag_background_test_range;
+       hard_mask_file=hard_mask;
+       van_out_lo = diag_van_median_rate_limit_lo=diag_van_out_lo;
+       van_out_hi = diag_van_median_rate_limit_hi=diag_van_out_hi;
+       van_lo     = diag_van_median_sigma_lo=diag_van_lo;
+       van_hi     = diag_van_median_sigma_hi=diag_van_hi;
+       van_sig    = diag_van_median_sigma=diag_van_sig;
+       tiny       = diag_tiny;
+       huge       = diag_huge=large;
+       samp_zero  = diag_remove_zero=diag_samp_zero;
+       samp_lo    = diag_samp_median_sigma_lo=diag_samp_lo;
+       samp_hi    = diag_samp_median_sigma_hi=diag_samp_hi;
+       samp_sig   = diag_samp_median_sigma=diag_samp_sig;
+       variation  = diag_variation;
+       bleed_test = bleed = diag_bleed_test;
+       bleed_maxrate = diag_bleed_maxrate;
+       bleed_pixels  = diag_bleed_pixels;
+       deltaE_mode =  deltaE-mode;
+       ei-mon1-spec=ei_mon1_spec;
+       ei-mon2-spec = test_ei2_mon_spectra=ei_mon2_spec;
+       ei_mon_spectra=test_mon_spectra_composite"
+    />
+</parameter>
+ 
+  <!-- -->
+</component-link>
+
+</parameter-file>


### PR DESCRIPTION
LET got last door so IDF-s have to be modified for reduction to work properly. Its nothing to test here -- as soon as system tests ensure that no typos appear in the files, it should just be merged to master to allow Mantid in instruments to update itself and use recent IDF -- High priority to allow users to deploy it in forthcoming experiments, but no release notes are needed as its obvious.

If the light of the changes I had to modify the system test which was always verifying the aspects of latest  IDF rather then the IDF corresponding to the loaded file. This have been fixed and pretty minor.
