### PR TITLE
Table addRow now accepts tuples and numpy arrays in Python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -105,12 +105,12 @@ void setValue(const Column_sptr column, const int row,
   }
 
   // Special case: Boost has issues with NumPy ints, so use Python API instead
-  if (typeID == typeid(int) && PyArray_IsIntegerScalar(value.ptr())) {
+  if (typeID == typeid(int)&&PyArray_IsIntegerScalar(value.ptr())) {
     column->cell<int>(row) = static_cast<int>(PyInt_AsLong(value.ptr()));
     return;
   }
 
-  // Macros for all other types
+// Macros for all other types
 #define SET_CELL(R, _, T)                                                      \
   else if (typeID == typeid(T)) {                                              \
     column->cell<T>(row) = bpl::extract<T>(value)();                           \

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -203,13 +203,15 @@ PyObject *row(ITableWorkspace &self, int row) {
 }
 
 /**
- * Adds a new row in the table, where the items are given in a
- * dictionary object mapping {column name:value}
+ * Adds a new row in the table, where the items are given in a dictionary
+ * object mapping {column name:value}. It must contain a key-value entry for
+ * every column in the row, otherwise the insert will fail.
+ *
  * @param self :: A reference to the ITableWorkspace object
- * @param rowItems :: A dictionary defining the items in the row. It must
- * be the same length as the number of columns or the insert will fail
+ * @param rowItems :: A dictionary defining the items in the row
  */
 void addRowFromDict(ITableWorkspace &self, const bpl::dict &rowItems) {
+  // rowItems must contain an entry for every column
   bpl::ssize_t nitems = boost::python::len(rowItems);
   if (nitems != static_cast<bpl::ssize_t>(self.columnCount())) {
     throw std::invalid_argument(
@@ -217,38 +219,59 @@ void addRowFromDict(ITableWorkspace &self, const bpl::dict &rowItems) {
         "Expected: " +
         boost::lexical_cast<std::string>(self.columnCount()));
   }
+
+  // Add a new row to populate with values
   const int rowIndex = static_cast<int>(self.rowCount());
-  TableRow newRow = self.appendRow();
-  boost::python::object iter = rowItems.iteritems();
-  while (true) {
-    bpl::object keyValue;
-    try {
-      keyValue = iter.attr("next")();
-    } catch (bpl::error_already_set &) {
-      PyErr_Clear(); // Clear the raised StopIteration exception
-      break;
+  self.appendRow();
+
+  // Declared in this scope so we can access them in catch block
+  Column_sptr column;   // Column in table
+  bpl::object value;    // Value from dictionary
+
+  try {
+    // Retrieve and set the value for each column
+    auto columns = self.getColumnNames();
+    for (auto iter = columns.begin(); iter != columns.end(); ++iter) {
+      column = self.getColumn(*iter);
+      value = rowItems[*iter];
+      setValue(column, rowIndex, value);
     }
-    const std::string columnName =
-        boost::python::extract<std::string>(keyValue[0]);
-    const Column_sptr column = self.getColumn(columnName);
-    try {
-      setValue(column, rowIndex, keyValue[1]);
-    } catch (bpl::error_already_set &) {
-      std::ostringstream os;
-      os << "Incorrect type passed for \"" << columnName << "\"";
-      throw std::invalid_argument(os.str());
+  } catch (bpl::error_already_set &) {
+    // One of the columns wasn't found in the dictionary
+    if (PyErr_ExceptionMatches(PyExc_KeyError)) {
+      std::ostringstream msg;
+      msg << "Missing key-value entry for column ";
+      msg << "<" << column->name() << ">";
+      PyErr_SetString(PyExc_KeyError, msg.str().c_str());
     }
+
+    // Wrong type of data for one of the columns
+    if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+      std::ostringstream msg;
+      msg << "Wrong datatype <";
+      msg << std::string(bpl::extract<std::string>(
+               value.attr("__class__").attr("__name__")));
+      msg << "> for column <" << column->name() << "> ";
+      msg << "(expected <" << column->type() << ">)";
+      PyErr_SetString(PyExc_TypeError, msg.str().c_str());
+    }
+
+    // Remove the new row since populating it has failed
+    self.removeRow(rowIndex);
+    throw;
   }
 }
 
 /**
- * Adds a new row in the table, where the items are given in a
- * dictionary object mapping {column name:value}
+ * Adds a new row in the table, where the items are given in an ordered python
+ * sequence type (list, tuple, numpy array, etc). It must be the same length as
+ * the number of columns or the insert will fail.
+ *
  * @param self :: A reference to the ITableWorkspace object
- * @param rowItems :: A dictionary defining the items in the row. It must
- * be the same length as the number of columns or the insert will fail
+ * @param rowItems :: A sequence containing the column values in the row
  */
-void addRowFromList(ITableWorkspace &self, const bpl::list &rowItems) {
+void addRowFromSequence(ITableWorkspace &self, const bpl::object &rowItems) {
+  // rowItems must contain an entry for every column
   bpl::ssize_t nitems = boost::python::len(rowItems);
   if (nitems != static_cast<bpl::ssize_t>(self.columnCount())) {
     throw std::invalid_argument(
@@ -256,16 +279,33 @@ void addRowFromList(ITableWorkspace &self, const bpl::list &rowItems) {
         "Expected: " +
         boost::lexical_cast<std::string>(self.columnCount()));
   }
+
+  // Add a new row to populate with values
   const int rowIndex = static_cast<int>(self.rowCount());
-  TableRow newRow = self.appendRow();
+  self.appendRow();
+
+  // Loop over sequence and set each column value in same order
   for (bpl::ssize_t i = 0; i < nitems; ++i) {
-    const Column_sptr column = self.getColumn(i);
+    auto column = self.getColumn(i);
+    auto value = rowItems[i];
+
     try {
-      setValue(column, rowIndex, rowItems[i]);
+      setValue(column, rowIndex, value);
     } catch (bpl::error_already_set &) {
-      std::ostringstream os;
-      os << "Incorrect type passed for item \"" << i << "\" in list";
-      throw std::invalid_argument(os.str());
+      // Wrong type of data for one of the columns
+      if (PyErr_ExceptionMatches(PyExc_TypeError)) {
+        std::ostringstream msg;
+        msg << "Wrong datatype <";
+        msg << std::string(bpl::extract<std::string>(
+                 value.attr("__class__").attr("__name__")));
+        msg << "> for column <" << column->name() << "> ";
+        msg << "(expected <" << column->type() << ">)";
+        PyErr_SetString(PyExc_TypeError, msg.str().c_str());
+      }
+
+      // Remove the new row since populating it has failed
+      self.removeRow(rowIndex);
+      throw;
     }
   }
 }
@@ -372,13 +412,15 @@ void export_ITableWorkspace() {
       .def("row", &row, (arg("self"), arg("row")),
            "Return all values of a specific row as a dict")
 
-      .def("addRow", &addRowFromDict, (arg("self"), arg("row_items_dict")),
-           "Appends a row with the values from the dictionary")
-
-      .def("addRow", &addRowFromList, (arg("self"), arg("row_items_list")),
-           "Appends a row with the values from the given list. "
+      // FromSequence must come first since it takes an object parameter
+      // Otherwise, FromDict will never be called as object accepts anything
+      .def("addRow", &addRowFromSequence, (arg("self"), arg("row_items_seq")),
+           "Appends a row with the values from the given sequence. "
            "It it assumed that the items are in the correct order for the "
            "defined columns")
+
+      .def("addRow", &addRowFromDict, (arg("self"), arg("row_items_dict")),
+           "Appends a row with the values from the dictionary")
 
       .def("cell", &cell, (arg("self"), arg("value"), arg("row_or_column")),
            "Return the given cell. If the first argument is a "

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -225,8 +225,8 @@ void addRowFromDict(ITableWorkspace &self, const bpl::dict &rowItems) {
   self.appendRow();
 
   // Declared in this scope so we can access them in catch block
-  Column_sptr column;   // Column in table
-  bpl::object value;    // Value from dictionary
+  Column_sptr column; // Column in table
+  bpl::object value;  // Value from dictionary
 
   try {
     // Retrieve and set the value for each column
@@ -249,8 +249,8 @@ void addRowFromDict(ITableWorkspace &self, const bpl::dict &rowItems) {
     if (PyErr_ExceptionMatches(PyExc_TypeError)) {
       std::ostringstream msg;
       msg << "Wrong datatype <";
-      msg << std::string(bpl::extract<std::string>(
-               value.attr("__class__").attr("__name__")));
+      msg << std::string(
+          bpl::extract<std::string>(value.attr("__class__").attr("__name__")));
       msg << "> for column <" << column->name() << "> ";
       msg << "(expected <" << column->type() << ">)";
       PyErr_SetString(PyExc_TypeError, msg.str().c_str());
@@ -297,7 +297,7 @@ void addRowFromSequence(ITableWorkspace &self, const bpl::object &rowItems) {
         std::ostringstream msg;
         msg << "Wrong datatype <";
         msg << std::string(bpl::extract<std::string>(
-                 value.attr("__class__").attr("__name__")));
+            value.attr("__class__").attr("__name__")));
         msg << "> for column <" << column->name() << "> ";
         msg << "(expected <" << column->type() << ">)";
         PyErr_SetString(PyExc_TypeError, msg.str().c_str());

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -82,7 +82,7 @@ class ITableWorkspaceTest(unittest.TestCase):
         self.assertEquals(insertedrow, nextrow)
 
         incorrect_type = {'index':1, 'value':10}
-        self.assertRaises(ValueError, table.addRow, incorrect_type)
+        self.assertRaises(TypeError, table.addRow, incorrect_type)
 
 
     def test_adding_table_data_using_list(self):

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -129,10 +129,17 @@ class ITableWorkspaceTest(unittest.TestCase):
         self.assertEquals(table.columnCount(), 2)
 
         nextrow = {'index': 1, 'value': 10}
-        values = numpy.array(nextrow.values())
-        table.addRow(values)
+        values32 = numpy.array(nextrow.values()).astype(numpy.int32)
+        values64 = numpy.array(nextrow.values()).astype(numpy.int64)
+
+        table.addRow(values32)
         self.assertEquals(len(table), 1)
         insertedrow = table.row(0)
+        self.assertEquals(insertedrow, nextrow)
+
+        table.addRow(values64)
+        self.assertEquals(len(table), 2)
+        insertedrow = table.row(1)
         self.assertEquals(insertedrow, nextrow)
 
         incorrect_type = numpy.array(['1', '10'])

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -84,6 +84,8 @@ class ITableWorkspaceTest(unittest.TestCase):
         incorrect_type = {'index':1, 'value':10}
         self.assertRaises(TypeError, table.addRow, incorrect_type)
 
+        incorrect_key = {'notindex': 2, 'notvalue': '20'}
+        self.assertRaises(KeyError, table.addRow, incorrect_key)
 
     def test_adding_table_data_using_list(self):
         table = WorkspaceFactory.createTable()
@@ -94,12 +96,47 @@ class ITableWorkspaceTest(unittest.TestCase):
 
         nextrow = {'index':1, 'value':'10'}
         values = nextrow.values()
-        table.addRow(nextrow)
+        table.addRow(values)
         self.assertEquals(len(table), 1)
         insertedrow = table.row(0)
         self.assertEquals(insertedrow, nextrow)
+
+        incorrect_type = [1, 10]
+        self.assertRaises(TypeError, table.addRow, incorrect_type)
+
+    def test_adding_table_data_using_tuple(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="int",name="index")
+        self.assertEquals(table.columnCount(), 1)
+        table.addColumn(type="str",name="value")
+        self.assertEquals(table.columnCount(), 2)
+
+        nextrow = {'index':1, 'value':'10'}
+        values = tuple(nextrow.values())
+        table.addRow(values)
+        self.assertEquals(len(table), 1)
         insertedrow = table.row(0)
         self.assertEquals(insertedrow, nextrow)
+
+        incorrect_type = (1, 10)
+        self.assertRaises(TypeError, table.addRow, incorrect_type)
+
+    def test_adding_table_data_using_numpy(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="int",name="index")
+        self.assertEquals(table.columnCount(), 1)
+        table.addColumn(type="int",name="value")
+        self.assertEquals(table.columnCount(), 2)
+
+        nextrow = {'index': 1, 'value': 10}
+        values = numpy.array(nextrow.values())
+        table.addRow(values)
+        self.assertEquals(len(table), 1)
+        insertedrow = table.row(0)
+        self.assertEquals(insertedrow, nextrow)
+
+        incorrect_type = numpy.array(['1', '10'])
+        self.assertRaises(TypeError, table.addRow, incorrect_type)
 
     def test_set_and_extract_boolean_columns(self):
         table = WorkspaceFactory.createTable()


### PR DESCRIPTION
Fixes #13879.

[Release notes](http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Python) have been updated.

Python Interface for TableWorkspace.addRow() modified to accept anything that behaves like a Python sequence. This includes tuples and numpy arrays (as long as all table columns have a type that is compatible with the numpy array datatype). Previously only accepted lists and dictionaries.

Expanded error handling a bit to provide more descriptive messages when an exception is thrown.

Added unit tests to test tuple and numpy support in PythonInterfaceAPI_ITableWorkspaceTest.
### Testing

Can be tested in the script interpreter window. Note that numpy arrays are homogeneous and will only work on tables with matching column datatypes.
#### Sample code

import numpy
ws = WorkspaceFactory.createTable()
ws.addColumn('int', 'id')
ws.addColumn('int', 'value')
ws.addRow({'id': 1, 'value': 123})
ws.addRow([2, 234])
ws.addRow((3, 345))
ws.addRow(numpy.array([4, 456]))
for row in ws: print row
