### PR TITLE
Extend LoadLogPropertyTable to be able to parse SNS files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadLogPropertyTable.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadLogPropertyTable.py
@@ -56,7 +56,7 @@ class LoadLogPropertyTable(PythonAlgorithm):
             for tt in v.times:
                 times2.append((datetime.datetime(*(time.strptime(str(tt),"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds())
         except:
-            #print "probably not a time series"
+            # print "probably not a time series"
             pass
         if name[0:8]=="Beamlog_" and (name.find("Counts")>0 or name.find("Frames")>0):
             i=bisect.bisect_right(times2,2) # allowance for "slow" clearing of DAE
@@ -70,46 +70,36 @@ class LoadLogPropertyTable(PythonAlgorithm):
     #pylint: disable=too-many-branches
     def PyExec(self):
 
-        file1=self.getProperty("FirstFile").value
-        file9=self.getProperty("LastFile").value
-        i1=file1.rindex('.')
-        j1=i1-1
-        while file1[j1-1].isdigit():
-            j1=j1-1
-        firstnum=int(file1[j1:i1])
-        i9=file9.rindex('.')
-        j9=i9-1
-        while file9[j9-1].isdigit():
-            j9=j9-1
-        lastnum=int(file9[j9:i9])
-        if file1[:j9] != file9[:j9]:
+        firstFileName=self.getProperty("FirstFile").value
+        lastFileName=self.getProperty("LastFile").value
+
+        firstRunNum, firstFileFirstDigit,firstFileLastDigit = self.getRunNumber(firstFileName)
+        lastRunNum, lastFileFirstDigit,LastFileLastDigit = self.getRunNumber(lastFileName)
+
+        if firstFileName[:lastFileFirstDigit] != lastFileName[:lastFileFirstDigit]:
             raise Exception("Files from different directories or instruments")
-        if file1[i1:] != file9[i9:]:
+        if firstFileName[firstFileName.rindex('.')] != lastFileName[firstFileName.rindex('.')]:
             raise Exception("Files of different types")
-        if i1-j1 != i9-j9:
+        if firstFileLastDigit-firstFileFirstDigit != LastFileLastDigit-lastFileFirstDigit:
             raise Exception("File numbering error")
-        if lastnum < firstnum:
+        if lastRunNum < firstRunNum:
             raise Exception("Run numbers must increase")
 
         # table. Rows=runs, columns=logs (col 0 = run number)
         collist=self.getProperty("LogNames").value
-        ows=WorkspaceFactory.createTable()
-        ows.addColumn("int","RunNumber")
+        wsOutput=WorkspaceFactory.createTable()
+        wsOutput.addColumn("int","RunNumber")
 
         # loop and load files. Absolute numbers for now.
-        for ff in range(firstnum,lastnum+1):
-            thispath=file1[:j1]+str(ff).zfill(i1-j1)+file1[i1:]
-            returnTuple=None
-            try:
-                returnTuple=Load(Filename=thispath,OutputWorkspace="__CopyLogsTmp",SpectrumMin=1, SpectrumMax=1)
-            except (ValueError,RuntimeError):
-                continue
+        for loopRunNum in range(firstRunNum,lastRunNum+1):
+            # create a file path for intervening files, based from the 1st filename
+            thispath=firstFileName[:firstFileFirstDigit] + \
+                     str(loopRunNum).zfill(firstFileLastDigit-firstFileFirstDigit) + \
+                     firstFileName[firstFileLastDigit:]
 
-            #check if the return type is atuple
-            if type(returnTuple) == tuple:
-                loadedWs=returnTuple[0]
-            else:
-                loadedWs = returnTuple
+            loadedWs = self.loadMetaData(thispath)
+            if loadedWs is None:
+                continue
 
             #check if the ws is a group
             ws = loadedWs
@@ -117,27 +107,64 @@ class LoadLogPropertyTable(PythonAlgorithm):
                 ws=ws[0]
 
             begin=datetime.datetime(*(time.strptime(ws.getRun().getProperty("run_start").value,"%Y-%m-%dT%H:%M:%S")[0:6])) # start of day
-            vallist=[ff]
-            for cc in collist:
+            vallist=[loopRunNum]
+            for col in collist:
                 try:
-                    (cv,leftover,lval)=self.getGeneralLogValue(ws,cc,begin)
+                    (colValue, leftover, lval)=self.getGeneralLogValue(ws, col, begin)
                 except ValueError:
-                    #this is a failure to find the named log
-                    DeleteWorkspace(loadedWs)
+                    # this is a failure to find the named log
                     raise
-                vallist.append(cv)
-                if ff==firstnum:
-                    if isinstance(cv, numbers.Number):
-                        ows.addColumn("double",cc)
+                vallist.append(colValue)
+                if loopRunNum==firstRunNum:
+                    if isinstance(colValue, numbers.Number):
+                        wsOutput.addColumn("double",col)
                     else:
-                        ows.addColumn("str",cc)
-                if leftover and ff>firstnum:
-                    if lval>ows.cell(cc,ff-firstnum-1):
-                        ows.setCell(cc,ff-firstnum-1,lval)
-            ows.addRow(vallist)
-            DeleteWorkspace(loadedWs)
+                        wsOutput.addColumn("str",col)
+                if leftover and loopRunNum>firstRunNum:
+                    if lval>wsOutput.cell(col,loopRunNum-firstRunNum-1):
+                        wsOutput.setCell(col,loopRunNum-firstRunNum-1, lval)
+            wsOutput.addRow(vallist)
 
+        self.setProperty("OutputWorkspace",wsOutput)
 
-        self.setProperty("OutputWorkspace",ows)
+    def loadMetaData(self, thispath):
+        loadedWs = None
+        try:
+            loadAlg = self.createChildAlgorithm('Load')
+            #set Filename first
+            loadAlg.setProperty('Filename', thispath)
+            loadAlg.setProperty('OutputWorkspace', '__CopyLogsTmp')
+            try:
+                #try to set MetaDataOnly
+                loadAlg.setProperty('MetaDataOnly', True)
+            except:
+                #If that fails set SpectrumMin and SpectrumMax
+                loadAlg.setProperty('SpectrumMin', 1)
+                loadAlg.setProperty('SpectrumMax', 1)
+            loadAlg.execute()
+
+            outWSPropName = 'OutputWorkspace'
+            try:
+                loadedWs = loadAlg.getProperty(outWSPropName).value
+            except RuntimeError:
+                raise RuntimeError("No output workspace for " + thispath)
+        except (ValueError,RuntimeError):
+            return None
+
+        return loadedWs
+
+    def getRunNumber(self, fileName):
+        # Find last . and step back until you find a digit
+        lastDigitIndex = fileName.rindex('.')
+        while (not fileName[lastDigitIndex - 1].isdigit()):
+            lastDigitIndex -= 1
+
+        # Keep going back until you find the start of the number sequence
+        firstDigitIndex = lastDigitIndex - 1
+        while fileName[firstDigitIndex - 1].isdigit():
+            firstDigitIndex -= 1
+        runNumber = int(fileName[firstDigitIndex:lastDigitIndex])
+        return runNumber, firstDigitIndex, lastDigitIndex
+
 
 AlgorithmFactory.subscribe(LoadLogPropertyTable())

--- a/Framework/PythonInterface/plugins/algorithms/LoadLogPropertyTable.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadLogPropertyTable.py
@@ -55,7 +55,7 @@ class LoadLogPropertyTable(PythonAlgorithm):
                 v=v.unfiltered()
             for tt in v.times:
                 times2.append((datetime.datetime(*(time.strptime(str(tt),"%Y-%m-%dT%H:%M:%S")[0:6]))-begin).total_seconds())
-        except:
+        except StandardError:
             # print "probably not a time series"
             pass
         if name[0:8]=="Beamlog_" and (name.find("Counts")>0 or name.find("Frames")>0):
@@ -137,7 +137,7 @@ class LoadLogPropertyTable(PythonAlgorithm):
             try:
                 #try to set MetaDataOnly
                 loadAlg.setProperty('MetaDataOnly', True)
-            except:
+            except (ValueError,RuntimeError):
                 #If that fails set SpectrumMin and SpectrumMax
                 loadAlg.setProperty('SpectrumMin', 1)
                 loadAlg.setProperty('SpectrumMax', 1)
@@ -156,7 +156,7 @@ class LoadLogPropertyTable(PythonAlgorithm):
     def getRunNumber(self, fileName):
         # Find last . and step back until you find a digit
         lastDigitIndex = fileName.rindex('.')
-        while (not fileName[lastDigitIndex - 1].isdigit()):
+        while not fileName[lastDigitIndex - 1].isdigit():
             lastDigitIndex -= 1
 
         # Keep going back until you find the start of the number sequence

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadLogPropertyTableTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadLogPropertyTableTest.py
@@ -103,6 +103,27 @@ class LoadLogPropertyTableTest(unittest.TestCase):
 
         return
 
+    def test_LoadValidSNSFiles(self):
+        outputWorskapceName = "LoadLogPropertyTableTest_Test5"
+
+        alg_test = run_algorithm("LoadLogPropertyTable", FirstFile = "BSS_11841_event.nxs",
+                LastFile = "BSS_11841_event.nxs", LogNames="duration", OutputWorkspace = outputWorskapceName)
+
+        self.assertTrue(alg_test.isExecuted())
+
+        #Verify some values
+        tablews = AnalysisDataService.retrieve(outputWorskapceName)
+        self.assertEqual(1, tablews.rowCount())
+        self.assertEqual(2, tablews.columnCount())
+
+        self.assertEqual(14, tablews.cell(0,1))
+        self.assertEqual(11841, tablews.cell(0,0))
+
+        run_algorithm("DeleteWorkspace", Workspace = outputWorskapceName)
+
+        return
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This allows it to handle filenames like CNCS_1234_event.nxs
Also it can now handle event files which it could not previously
Also a fair bit of refactoring to improve code readability
And a new unit test that proves it all works

Closes #7971
### Release Notes

http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Improved
### To test

``` python
LoadLogPropertyTable(FirstFile='BSS_11841_event.nxs', LastFile='BSS_11841_event.nxs', LogNames='duration', OutputWorkspace='output')
```

Should output a table workspace with 1 row
11841, 14
