### PR TITLE
Get Left, Right, Up, Down workspaces for 0 iterations

### DIFF
--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -1156,7 +1156,15 @@ def FindBeamCentre(rlow, rupp, MaxIter = 10, xstart = None, ystart = None, toler
                                           coord1_scale_factor,
                                           coord2_scale_factor)
 
-    # If we have 0 iterations then we should return here
+    # this function moves the detector to the beam center positions defined above and
+    # returns an estimate of where the beam center is relative to the new center
+    resCoord1_old, resCoord2_old = centre.SeekCentre(centre_reduction, [COORD1NEW, COORD2NEW])
+    centre_reduction = copy.deepcopy(ReductionSingleton().reference())
+    LimitsR(str(float(rlow)), str(float(rupp)), quiet=True, reducer=centre_reduction)
+    beam_center_logger.report_status(0, original[0], original[1], resCoord1_old, resCoord2_old)
+
+    # If we have 0 iterations then we should return here. At this point the
+    # Left/Right/Up/Down workspaces have been already created by the SeekCentre function.
     if MaxIter <= 0:
         zero_iterations_msg = ("You have selected 0 iterations. The beam centre" +
                                "will be positioned at (" + str(xstart) + ", " + str(ystart) +")")
@@ -1165,12 +1173,6 @@ def FindBeamCentre(rlow, rupp, MaxIter = 10, xstart = None, ystart = None, toler
 
     beam_center_logger.report_init(COORD1NEW, COORD2NEW)
 
-    # this function moves the detector to the beam center positions defined above and
-    # returns an estimate of where the beam center is relative to the new center
-    resCoord1_old, resCoord2_old = centre.SeekCentre(centre_reduction, [COORD1NEW, COORD2NEW])
-    centre_reduction = copy.deepcopy(ReductionSingleton().reference())
-    LimitsR(str(float(rlow)), str(float(rupp)), quiet=True, reducer=centre_reduction)
-    beam_center_logger.report_status(0, original[0], original[1], resCoord1_old, resCoord2_old)
     # take first trial step
     COORD1NEW, COORD2NEW = centre_positioner.increment_position(COORD1NEW, COORD2NEW)
     graph_handle = None


### PR DESCRIPTION
Fixes #14270 
# For testing

The relevant files for testing can be found here: \olympic\Babylon5\Scratch\Anton\Testing\14270_Beam_Centre_Finder_Fix

**Test that for 0 iterations the left, right, up and down workspaes are crated**
1. Make sure that the files are in your Mantid path
2. In the ISIS SANS GUI set the instrument to LARMOR
3. Load the user file USER_LARMORTEAM_152L_a2_6x8mm_r5889.txt
4. Load as Sample the file LARMOR00005889.nxs
5. Go to the Geometry Tab and set 0 for Max. iterations
6. Make a note of the values for RearX and RearY

![beamcentrepng](https://cloud.githubusercontent.com/assets/8955784/10942089/5bf28890-8306-11e5-860e-aa9968b747d6.PNG)
1. Press Run
   - Confirm that once everything is calculated teh RearX and RearY values have not changed
   - Confirm that the workspaces Left, Right, Up and Down are being loaded
