### PR TITLE
Fix bug in ConvertToReflectometryQ

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/CalculateReflectometryQxQz.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/CalculateReflectometryQxQz.h
@@ -80,6 +80,12 @@ public:
                                  calculateDim1(lamUpper));
 
     Mantid::Geometry::Quadrilateral quad(ll, lr, ur, ul);
+
+    while ((quad.at(0).X() > quad.at(3).X()) ||
+           (quad.at(0).Y() > quad.at(1).Y())) {
+      quad.shiftVertexesClockwise();
+    }
+
     return quad;
   }
 };

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -20,7 +20,8 @@ namespace FractionalRebinning {
 
 /**
  * Find the possible region of intersection on the output workspace for the
- * given polygon. The given polygon must have a CLOCKWISE winding.
+ * given polygon. The given polygon must have a CLOCKWISE winding and the
+ * first vertex must be the "lowest left" point.
  * @param outputWS A pointer to the output workspace
  * @param verticalAxis A vector containing the output vertical axis edges
  * @param inputQ The input polygon (Polygon winding must be clockwise)

--- a/Framework/Geometry/inc/MantidGeometry/Math/Quadrilateral.h
+++ b/Framework/Geometry/inc/MantidGeometry/Math/Quadrilateral.h
@@ -73,6 +73,8 @@ public:
   virtual double maxY() const;
   /// Return a new Polygon based on the current Quadrilateral
   virtual ConvexPolygon toPoly() const;
+  /// Shifts the vertexes in a clockwise manner
+  virtual void shiftVertexesClockwise();
 
 private:
   /// Lower left

--- a/Framework/Geometry/src/Math/Quadrilateral.cpp
+++ b/Framework/Geometry/src/Math/Quadrilateral.cpp
@@ -156,5 +156,16 @@ ConvexPolygon Quadrilateral::toPoly() const {
   return ConvexPolygon(points);
 }
 
+/// Shifts the vertexes in a clockwise manner
+void Quadrilateral::shiftVertexesClockwise() {
+
+  V2D temp = m_lowerLeft;
+
+  m_lowerLeft = m_upperLeft;
+  m_upperLeft = m_upperRight;
+  m_upperRight = m_lowerRight;
+  m_lowerRight = temp;
+}
+
 } // namespace Mantid
 } // namespace Geometry

--- a/Framework/Geometry/test/QuadrilateralTest.h
+++ b/Framework/Geometry/test/QuadrilateralTest.h
@@ -85,6 +85,22 @@ public:
     TS_ASSERT(!smallRectangle.contains(largeRectangle));
   }
 
+  void test_clockwise_rotation() {
+    Quadrilateral quad(V2D(0.0, 0.0), V2D(1.0, 3.0), V2D(4.0, 4.0),
+                       V2D(4.0, 1.0));
+
+    quad.shiftVertexesClockwise();
+
+    TS_ASSERT_EQUALS(quad.at(0).X(), 4.0);
+    TS_ASSERT_EQUALS(quad.at(0).Y(), 1.0);
+    TS_ASSERT_EQUALS(quad.at(1).X(), 4.0);
+    TS_ASSERT_EQUALS(quad.at(1).Y(), 4.0);
+    TS_ASSERT_EQUALS(quad.at(2).X(), 1.0);
+    TS_ASSERT_EQUALS(quad.at(2).Y(), 3.0);
+    TS_ASSERT_EQUALS(quad.at(3).X(), 0.0);
+    TS_ASSERT_EQUALS(quad.at(3).Y(), 0.0);
+  }
+
 private:
   Quadrilateral makeRectangle() {
     return Quadrilateral(V2D(), V2D(2.0, 0.0), V2D(2.0, 1.5), V2D(0.0, 1.5));


### PR DESCRIPTION
Fixes #14279

To test: code review. Run the first example in the algorithm's documentation, you should get something similar to the following graph:

![reflectometryresults](https://cloud.githubusercontent.com/assets/8956985/10945460/77b6285c-8315-11e5-8d7e-1d38e9228c8c.png)

Release notes: http://www.mantidproject.org/index.php?title=Release_Notes_3_6_Reflectometry&diff=25512&oldid=25467
