### PR TITLE
Allow ResNorm2 to work at any facility

### DIFF
--- a/scripts/Inelastic/IndirectCommon.py
+++ b/scripts/Inelastic/IndirectCommon.py
@@ -61,9 +61,13 @@ def getInstrRun(ws_name):
 
     instrument = mtd[ws_name].getInstrument().getName()
     if instrument != '':
-        facility = config.getFacility()
-        instrument = facility.instrument(instrument).filePrefix(int(run_number))
-        instrument = instrument.lower()
+        for facility in config.getFacilities():
+            try:
+                instrument = facility.instrument(instrument).filePrefix(int(run_number))
+                instrument = instrument.lower()
+                break
+            except RuntimeError:
+                continue
 
     return instrument, run_number
 


### PR DESCRIPTION
Fixes the failing test when tests are run at a facility other than ISIS.

To test:
- Set facility to SNS
- Run `ResNorm2Test`
