### PR TITLE
Refactor MD axis validation for SetMDFrame and TransposeMD

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -43,6 +43,7 @@ set ( SRC_FILES
 	src/LogFilter.cpp
 	src/LogParser.cpp
 	src/Logger.cpp
+	src/MDAxisValidator.cpp
 	src/MDUnit.cpp
 	src/MDUnitFactory.cpp
 	src/MagneticFormFactorTable.cpp
@@ -184,6 +185,7 @@ set ( INC_FILES
 	inc/MantidKernel/LogFilter.h
 	inc/MantidKernel/LogParser.h
 	inc/MantidKernel/Logger.h
+	inc/MantidKernel/MDAxisValidator.h
 	inc/MantidKernel/MDUnit.h
 	inc/MantidKernel/MDUnitFactory.h
 	inc/MantidKernel/MRUList.h
@@ -322,6 +324,7 @@ set ( TEST_FILES
 	LogFilterTest.h
 	LogParserTest.h
 	LoggerTest.h
+	MDAxisValidatorTest.h
 	MDUnitFactoryTest.h
 	MDUnitTest.h
 	MRUListTest.h

--- a/Framework/Kernel/inc/MantidKernel/MDAxisValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/MDAxisValidator.h
@@ -1,0 +1,59 @@
+#ifndef MANTID_KERNEL_MDAXISVALIDATOR_H_
+#define MANTID_KERNEL_MDAXISVALIDATOR_H_
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidKernel/DllConfig.h"
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Mantid {
+namespace Kernel {
+
+/** @class MDAxisValidator MDAxisValidator.h Kernel/MDAxisValidator.h
+
+    MDAxisValidator is a class that checks the number of MD axes match the
+    number of workspace dimensions,
+    refactoring out the common validation code from several MD algorithms
+    into a common class.
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_KERNEL_DLL MDAxisValidator {
+public:
+  MDAxisValidator(const std::vector<int> &axes, const size_t nDimensions,
+                  const bool checkIfEmpty);
+  virtual ~MDAxisValidator();
+  virtual std::map<std::string, std::string> validate() const;
+
+private:
+  std::vector<int> m_axes;
+  size_t m_wsDimensions;
+  bool m_emptyCheck;
+};
+
+} // namespace Kernel
+} // namespace Mantid
+
+#endif /* MANTID_KERNEL_MDAXISVALIDATOR_H_ */

--- a/Framework/Kernel/inc/MantidKernel/MDAxisValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/MDAxisValidator.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/Kernel/src/MDAxisValidator.cpp
+++ b/Framework/Kernel/src/MDAxisValidator.cpp
@@ -53,7 +53,8 @@ std::map<std::string, std::string> MDAxisValidator::validate() const {
   // workspace
   if (!m_axes.empty()) {
     auto it = std::max_element(m_axes.begin(), m_axes.end());
-    if (*it >= m_wsDimensions) {
+    size_t largest = static_cast<size_t>(*it);
+    if (largest >= m_wsDimensions) {
       invalidProperties.insert(
           std::make_pair("Axes", "One of the axis indexes specified indexes a "
                                  "dimension outside the real dimension range"));

--- a/Framework/Kernel/src/MDAxisValidator.cpp
+++ b/Framework/Kernel/src/MDAxisValidator.cpp
@@ -1,0 +1,66 @@
+#include "MantidKernel/MDAxisValidator.h"
+
+namespace Mantid {
+namespace Kernel {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ *  @param axes Vector containing MD axes to validate
+ *  @param nDimensions Number of dimensions of input workspace for algorithm
+ *  @param checkIfEmpty Whether validator will check if the axes vector is empty
+ */
+MDAxisValidator::MDAxisValidator(const std::vector<int> &axes,
+                                 const size_t nDimensions, const bool checkIfEmpty)
+    : m_wsDimensions(nDimensions), m_emptyCheck(checkIfEmpty) {
+  for (auto iter = axes.begin(); iter != axes.end(); iter++) {
+    m_axes.push_back(*iter);
+  }
+}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+MDAxisValidator::~MDAxisValidator() {}
+
+/**
+ * @brief Checks the MD axes given against the given number of dimensions of the
+ * input workspace.
+ *
+ * @returns A map with validation warnings, to be used in an algorithm's
+ * validateInputs()
+ */
+std::map<std::string, std::string> MDAxisValidator::validate() const {
+  std::map<std::string, std::string> invalidProperties;
+
+  // Empty check if required
+  // (Some algorithms have special handling for an empty axes vector, e.g.
+  // TransposeMD, so don't need an error here).
+  if (m_emptyCheck) {
+    if (m_axes.empty()) {
+      invalidProperties.insert(
+          std::make_pair("Axes", "No index was specified."));
+    }
+  }
+
+  // Make sure that there are fewer axes specified than exist on the workspace
+  if (m_axes.size() > m_wsDimensions) {
+    invalidProperties.insert(std::make_pair(
+        "Axes", "More axes specified than dimensions available in the input"));
+  }
+
+  // Ensure that the axes selection is within the number of dimensions of the
+  // workspace
+  if (!m_axes.empty()) {
+    auto it = std::max_element(m_axes.begin(), m_axes.end());
+    if (*it >= m_wsDimensions) {
+      invalidProperties.insert(
+          std::make_pair("Axes", "One of the axis indexes specified indexes a "
+                                 "dimension outside the real dimension range"));
+    }
+  }
+
+  return invalidProperties;
+}
+
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/Kernel/src/MDAxisValidator.cpp
+++ b/Framework/Kernel/src/MDAxisValidator.cpp
@@ -10,7 +10,8 @@ namespace Kernel {
  *  @param checkIfEmpty Whether validator will check if the axes vector is empty
  */
 MDAxisValidator::MDAxisValidator(const std::vector<int> &axes,
-                                 const size_t nDimensions, const bool checkIfEmpty)
+                                 const size_t nDimensions,
+                                 const bool checkIfEmpty)
     : m_wsDimensions(nDimensions), m_emptyCheck(checkIfEmpty) {
   for (auto iter = axes.begin(); iter != axes.end(); iter++) {
     m_axes.push_back(*iter);

--- a/Framework/Kernel/test/MDAxisValidatorTest.h
+++ b/Framework/Kernel/test/MDAxisValidatorTest.h
@@ -1,0 +1,100 @@
+#ifndef MANTID_KERNEL_MDAXISVALIDATORTEST_H_
+#define MANTID_KERNEL_MDAXISVALIDATORTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidKernel/MDAxisValidator.h"
+#include <map>
+#include <string>
+#include <vector>
+#include "boost/shared_ptr.hpp"
+#include "boost/make_shared.hpp"
+
+using Mantid::Kernel::MDAxisValidator;
+typedef boost::shared_ptr<MDAxisValidator> MDAxisValidator_sptr;
+
+class MDAxisValidatorTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static MDAxisValidatorTest *createSuite() {
+    return new MDAxisValidatorTest();
+  }
+  static void destroySuite(MDAxisValidatorTest *suite) { delete suite; }
+
+  /**
+   * Tests the class on valid input - output of validate should be empty
+   */
+  void testMDAxisValidator_Valid() {
+    MDAxisValidator_sptr checker = createValidator(4, 5, true);
+    auto errors = checker->validate();
+    TS_ASSERT_EQUALS(errors.size(), 0);
+  }
+
+  /**
+   * Tests the error given for an empty axes vector (if check turned on)
+   */
+  void testMDAxisValidator_Empty() {
+    MDAxisValidator_sptr checker = createValidator(0, 3, true);
+    auto errors = checker->validate();
+    TS_ASSERT_EQUALS(errors.size(), 1);
+  }
+
+  /**
+    * Tests no error given for an empty axes vector (if check turned off)
+    */
+  void testMDAxisValidator_EmptyNoCheck() {
+    MDAxisValidator_sptr checker = createValidator(0, 3, false);
+    auto errors = checker->validate();
+    TS_ASSERT_EQUALS(errors.size(), 0);
+  }
+
+  /**
+   * Tests the error given when number of axes is greater than number of
+   * dimensions in the workspace
+   */
+  void testMDAxisValidator_TooManyAxes() {
+    MDAxisValidator_sptr checker = createValidator(5, 4, true);
+    auto errors = checker->validate();
+    TS_ASSERT_EQUALS(errors.size(), 1);
+  }
+
+  /**
+   * Tests the error given when one of the axes given is out of the range of
+   * dimensions in the workspace
+   */
+  void testMDAxisValidator_BadDimensionIndexed() {
+    int nAxes = 3;
+    std::vector<int> axes;
+    for (int i = 0; i < nAxes - 1; i++) {
+      axes.push_back(i);
+    }
+    axes.push_back(99); // a dimension out of the real dimension range
+    MDAxisValidator checker(axes, nAxes, true);
+    auto errors = checker.validate();
+    TS_ASSERT_EQUALS(errors.size(), 1);
+  }
+
+private:
+  /**
+   * @brief Utility function to create an MDAxisValidator to test
+   *
+   * @param nAxes number of MD axes
+   * @param nDimensions number of workspace dimensions
+   * @param checkIfEmpty Whether the MDAxisValidator should check if the axes
+   * vector is empty
+   * @returns A shared pointer to an MDAxisValidator with the given properties
+   */
+  MDAxisValidator_sptr createValidator(int nAxes, int nDimensions,
+                                       bool checkIfEmpty) const {
+    std::vector<int> axes;
+    for (int i = 0; i < nAxes; i++) {
+      axes.push_back(i);
+    }
+    auto checker =
+        boost::make_shared<MDAxisValidator>(axes, nDimensions, checkIfEmpty);
+    return checker;
+  }
+};
+
+#endif /* MANTID_KERNEL_MDAXISVALIDATORTEST_H_ */

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/TransposeMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/TransposeMD.h
@@ -3,6 +3,7 @@
 
 #include "MantidMDAlgorithms/DllConfig.h"
 #include "MantidAPI/Algorithm.h"
+#include "MantidKernel/MDAxisValidator.h"
 namespace Mantid {
 namespace MDAlgorithms {
 

--- a/Framework/MDAlgorithms/src/TransposeMD.cpp
+++ b/Framework/MDAlgorithms/src/TransposeMD.cpp
@@ -94,14 +94,11 @@ void TransposeMD::exec() {
   std::vector<size_t> axes(axesInts.begin(), axesInts.end());
   Property *axesProperty = this->getProperty("Axes");
   if (!axesProperty->isDefault()) {
-    if (axes.size() > nDimsInput) {
-      throw std::invalid_argument(
-          "More axis specified than dimensions are avaiable in the input");
-    }
-    auto it = std::max_element(axes.begin(), axes.end());
-    if (*it > nDimsInput) {
-      throw std::invalid_argument("One of the axis indexes specified indexes a "
-                                  "dimension outside the real dimension range");
+    Kernel::MDAxisValidator checker(axesInts, nDimsInput, false);
+    auto axisErrors = checker.validate();
+    if (!axisErrors.empty()) {
+      std::string error = axisErrors.begin()->second;
+      throw std::invalid_argument(error.c_str());
     }
     nDimsOutput = axes.size();
   } else {


### PR DESCRIPTION
Resolves #14275 

Created an MDAxisValidator class to handle the common validation code for MD axes in these two algorithms. Used this class to replace existing validation code.
