### PR TITLE
Fix SpecularReflectionPositionCorrection Bug

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionAlgorithm.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpecularReflectionAlgorithm.h
@@ -2,7 +2,7 @@
 #define MANTID_ALGORITHMS_SPECULARREFLECTIONALGORITHM_H_
 
 #include "MantidKernel/System.h"
-#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/IComponent.h"
 
@@ -34,7 +34,8 @@ namespace Algorithms {
  File change history is stored at: <https://github.com/mantidproject/mantid>
  Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport SpecularReflectionAlgorithm : public Mantid::API::Algorithm {
+class DLLExport SpecularReflectionAlgorithm
+    : public Mantid::API::DataProcessorAlgorithm {
 protected:
   /// Constructor
   SpecularReflectionAlgorithm();

--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
@@ -23,10 +23,10 @@ const std::string pointDetectorAnalysis = "PointDetectorAnalysis";
  * @return : Parent component.
  */
 IComponent_const_sptr
-getRootComponent(IComponent_const_sptr &currentComponent) {
+getParentComponent(IComponent_const_sptr &currentComponent) {
   if (IComponent_const_sptr parent = currentComponent->getParent()) {
     if (!dynamic_cast<Instrument *>(const_cast<IComponent *>(parent.get()))) {
-      return getRootComponent(parent);
+      currentComponent = parent;
     }
   }
   return currentComponent;
@@ -173,7 +173,7 @@ void SpecularReflectionPositionCorrect::moveDetectors(
         this->createChildAlgorithm("MoveInstrumentComponent");
     moveComponentAlg->initialize();
     moveComponentAlg->setProperty("Workspace", toCorrect);
-    IComponent_const_sptr root = getRootComponent(detector);
+    IComponent_const_sptr root = getParentComponent(detector);
     const std::string componentName = root->getName();
     moveComponentAlg->setProperty("ComponentName", componentName);
     moveComponentAlg->setProperty("RelativePosition", false);


### PR DESCRIPTION
Fixes #14309

**Tester**
See original issue for how to reproduce the issue. After this fix, there should only be a vertical shift (Y) in the detector position, and no beam direction (Z) shift at all.
