### PR TITLE
Set units instead of unit label

### DIFF
--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -194,7 +194,7 @@ void SaveCanSAS1D2::createSASTransElement(std::string &sasTrans,
   std::stringstream trans;
 
   trans << "\n\t\t<SAStransmission_spectrum name=\"" << name << "\">";
-  std::string t_unit = m_ws->YUnitLabel();
+  std::string t_unit = m_ws->YUnit();
   std::string lambda_unit = m_ws->getAxis(0)->unit()->label();
   if (t_unit.empty())
     t_unit = "none";


### PR DESCRIPTION
Fixes #14282 
# For Testing

Find the test data here: \olympic\Babylon5\Scratch\Anton\Testing\14327_fix_axis_bug

Make sure that the test data is in your Mantid search directories
1. Set the instrument to SANS2DTUBES
2. Load the User file user_file_M3_old.txt
3. The files are:
   
   ```
       Scattering        Transmission    Direct
   ```
   
   SAMPLE    23785-add             23775           23774

CAN          23784-add              23774           23774
1. Press load
2. Press 1D Reduce
3. Check CanSAS in the Save area and press Save Result
4. Open the newly saved xml file in a text editor.
5. Go to the <SAStransmission_spectrum name="sample"> section
   - Confirm that the unit is none, i.e. .... </Lambda><T unit="none">
