### PR TITLE
Better text for SCD interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MantidEV.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/MantidEV.ui
@@ -250,7 +250,7 @@
                    <item>
                     <widget class="QLabel" name="MinMagQ_lbl">
                      <property name="text">
-                      <string>Min |Q| to Map to MD</string>
+                      <string>Qmin to Map to MD</string>
                      </property>
                     </widget>
                    </item>
@@ -282,7 +282,7 @@
                       </size>
                      </property>
                      <property name="toolTip">
-                      <string>Specify value to use as bound on |Qx|, |Qy| and |Qz|</string>
+                      <string>Specify value to use as lower bound of Qx, Qy and Qz. Default is -Qmax</string>
                      </property>
                     </widget>
                    </item>
@@ -293,7 +293,7 @@
                    <item>
                     <widget class="QLabel" name="MaxMagQ_lbl">
                      <property name="text">
-                      <string>Max |Q| to Map to MD</string>
+                      <string>Qmax to Map to MD</string>
                      </property>
                     </widget>
                    </item>
@@ -325,7 +325,7 @@
                       </size>
                      </property>
                      <property name="toolTip">
-                      <string>Specify value to use as bound on |Qx|, |Qy| and |Qz|</string>
+                      <string>Specify value to use as upper bound of Qx, Qy and Qz</string>
                      </property>
                     </widget>
                    </item>


### PR DESCRIPTION
Fixes #14315 

For testing go to Interfaces/Diffraction/SCD Event Data Reduction.  Look at text for Convert to MD and the tips when you put the cursor in the boxes.  If you run the Convert to MD for TOPAZ_3132_event.nxs in system tests, you can use SliceViewer to check the limits.
