### PR TITLE
Fix SCARFTomoReconstructionTest when facility != ISIS

### DIFF
--- a/Framework/RemoteAlgorithms/src/SCARFTomoReconstruction.cpp
+++ b/Framework/RemoteAlgorithms/src/SCARFTomoReconstruction.cpp
@@ -724,7 +724,7 @@ bool SCARFTomoReconstruction::doPing() {
     }
   } else {
     throw std::runtime_error(
-        "Failed to ping the web service at:" + httpsURL +
+        "Failed to ping the web service at: " + httpsURL +
         ". Please check your parameters, software version, "
         "etc.");
   }

--- a/Framework/RemoteJobManagers/src/SCARFLSFJobManager.cpp
+++ b/Framework/RemoteJobManagers/src/SCARFLSFJobManager.cpp
@@ -133,7 +133,7 @@ bool SCARFLSFJobManager::ping() {
     }
   } else {
     throw std::runtime_error(
-        "Failed to ping the web service at:" + fullURL.toString() +
+        "Failed to ping the web service at: " + fullURL.toString() +
         ". Please check your parameters, software version, "
         "etc.");
   }


### PR DESCRIPTION
Fixes #14317.

**To test**: change your facility to not-ISIS, for example SNS, and run the unit test `SCARFTomoReconstructionTest`. It should now pass. You can change the facility in 
Help->FirstTimeSetup or editing your properties file.

This does not need to go in the release notes.
