### PR TITLE
Re #14333 Fix deprecation warning in simpleapi.py

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -825,7 +825,7 @@ def _create_algorithm_function(algorithm, version, _algm_object):
                 # Check for missing mandatory parameters
                 _check_mandatory_args(algorithm, _algm_object, e, *args, **kwargs)
             else:
-                raise RuntimeError(str(e))
+                raise
         return _gather_returns(algorithm, lhs, algm)
 
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -825,7 +825,7 @@ def _create_algorithm_function(algorithm, version, _algm_object):
                 # Check for missing mandatory parameters
                 _check_mandatory_args(algorithm, _algm_object, e, *args, **kwargs)
             else:
-                raise RuntimeError(e.message)
+                raise RuntimeError(str(e))
         return _gather_returns(algorithm, lhs, algm)
 
 


### PR DESCRIPTION
BaseException.message has been deprecated since python 2.6. Whenever an error is thrown, the Mantid logs show a warning. This fixes it. Fixes #14333 
