### PR TITLE
Fix null termination character issue when loading

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1684,7 +1684,7 @@ void LoadNexusProcessed::loadNonSpectraAxis(
   } else if (axis->isText()) {
     NXChar axisData = data.openNXChar("axis2");
     axisData.load();
-    std::string axisLabels = axisData();
+    std::string axisLabels(axisData(), axisData.dim0());
     // Use boost::tokenizer to split up the input
     boost::char_separator<char> sep("\n");
     boost::tokenizer<boost::char_separator<char>> tokenizer(axisLabels, sep);


### PR DESCRIPTION
Fixes  #14327 
# For testing

Make sure that the system tests pass

Run the script below and make sure to insert the correct paths. one is to the system test data and the other is needed to save and reload a temporary file. The prints should all state Success

``` python
WS_PREFIX="fit"

def do_fit_with_quadratic_background():
    """
    Run the Vesuvio fit without background. If k_is_free is False then it is fixed to f0.Width*sqrt(2)/12
    """
    function_str = \
        "composite=ComptonScatteringCountRate,NumDeriv=1,IntensityConstraints=\"Matrix(1|3)0|-1|3\";"\
        "name=GramCharlierComptonProfile,Mass=1.007940,HermiteCoeffs=1 0 1;"\
        "name=GaussianComptonProfile,Mass=27.000000;"\
        "name=GaussianComptonProfile,Mass=91.000000;name=Polynomial,n=2,A0=0,A1=0,A2=0"
    # Run fit
    _do_fit(function_str, k_is_free=False)
def do_fit_no_background(k_is_free):
    """
    Run the Vesuvio fit without background. If k_is_free is False then it is fixed to f0.Width*sqrt(2)/12
    """
    function_str = \
        "composite=ComptonScatteringCountRate,NumDeriv=1,IntensityConstraints=\"Matrix(1|3)0|-1|3\";"\
        "name=GramCharlierComptonProfile,Mass=1.007940,HermiteCoeffs=1 0 1;"\
        "name=GaussianComptonProfile,Mass=27.000000;"\
        "name=GaussianComptonProfile,Mass=91.000000"
    # Run fit
    _do_fit(function_str, k_is_free)

def _do_fit(function_str, k_is_free):
    """
    Run the Vesuvio . If k_is_free is False then it is fixed to f0.Width*sqrt(2)/12

    """
    LoadVesuvio(Filename='14188-14190',OutputWorkspace='raw_ws',SpectrumList='135',Mode='SingleDifference',
                InstrumentParFile=r'IP0005.dat')
    CropWorkspace(InputWorkspace='raw_ws',OutputWorkspace='raw_ws',XMin=50,XMax=562)
    # Convert to seconds
    ScaleX(InputWorkspace='raw_ws',OutputWorkspace='raw_ws',Operation='Multiply',Factor=1e-06)

    if k_is_free:
        ties_str = "f1.Width=10.000000,f2.Width=25.000000"
    else:
        ties_str = "f1.Width=10.000000,f2.Width=25.000000,f0.FSECoeff=f0.Width*sqrt(2)/12"

    constraints_str = "2.000000 < f0.Width < 7.000000"

    Fit(InputWorkspace='raw_ws',Function=function_str,Ties=ties_str,Constraints=constraints_str,
        Output=WS_PREFIX, CreateOutput=True,OutputCompositeMembers=True,MaxIterations=5000,
        Minimizer="Levenberg-Marquardt,AbsError=1e-08,RelError=1e-08")
    # Convert to microseconds
    ScaleX(InputWorkspace=WS_PREFIX + '_Workspace',OutputWorkspace=WS_PREFIX + '_Workspace',Operation='Multiply',Factor=1e06)


do_fit_with_quadratic_background()


# Check current reference
ws_ref = LoadNexusProcessed(Filename="C:/BuildStore/M-build_V2/ExternalData/Testing/SystemTests/tests/analysis/reference/VesuvioFittingWithQuadraticBackgroundTest_V3.nxs")
print CheckWorkspacesMatch(Workspace1=ws_ref, Workspace2="fit_Workspace", Tolerance="0.01",CheckSpectraMap=False)


# Save and reload fit_Workspace
SaveNexusProcessed(InputWorkspace ='fit_Workspace', Filename="C:/Users/xsd05043/Desktop/temp_bug.nxs")
reloaded_ws = LoadNexusProcessed(Filename="C:/Users/xsd05043/Desktop/temp_bug.nxs")
print CheckWorkspacesMatch(Workspace1=reloaded_ws, Workspace2="fit_Workspace", Tolerance="0.01",CheckSpectraMap=False)

# Sanity check
print CheckWorkspacesMatch(Workspace1="fit_Workspace", Workspace2="fit_Workspace", Tolerance="0.01",CheckSpectraMap=False)

```
