### PR TITLE
Statically link to libstdc++ on RHEL6

### DIFF
--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -89,6 +89,16 @@ else()
   endif()
 endif()
 
+if( CMAKE_COMPILER_IS_GNUCXX )
+  # Define an option to statically link libstdc++
+  option( STATIC_LIBSTDCXX "If ON then statically link with the C++ standard library" OFF )
+  if( STATIC_LIBSTDCXX )
+    set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static-libgcc" )
+    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++" )
+    set( CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "${CMAKE_SHARED_LIBRARY_LINK_C_FLAGS} -static-libgcc" )
+    set( CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "${CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS} -static-libgcc -static-libstdc++" )
+  endif()
+endif()
 
 # Cleanup
 set ( GNUFLAGS )

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -125,6 +125,7 @@ fi
 ###############################################################################
 if [[ ${NODE_LABELS} == *rhel6* ]]; then
   SCL_ON_RHEL6="scl enable mantidlibs34 devtoolset-2"
+  DIST_FLAGS="-DSTATIC_LIBSTDCXX=ON"
   ON_RHEL6=true
 else
   SCL_ON_RHEL6="eval"
@@ -183,7 +184,7 @@ rm -f *.dmg *.rpm *.deb *.tar.gz
 ###############################################################################
 # CMake configuration
 ###############################################################################
-$SCL_ON_RHEL6 "cmake -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON ${PACKAGINGVARS} .."
+$SCL_ON_RHEL6 "cmake -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} -DENABLE_CPACK=ON -DMAKE_VATES=ON -DParaView_DIR=${PARAVIEW_DIR} -DMANTID_DATA_STORE=${MANTID_DATA_STORE} -DDOCS_HTML=ON ${DIST_FLAGS} ${PACKAGINGVARS} .."
 
 ###############################################################################
 # Coverity build should exit early


### PR DESCRIPTION
A new CMake option has been added to statically link to `libstdc++`. It is now enabled by default on RHEL6.

To check locally run:

```
cmake -DSTATIC_LIBSTDCXX=ON .
ninja Kernel -v  
```

Check the output contains `-static-libgcc`. The following command should also produce no output:

```
readelf -d bin/libMantidKernel.so | grep stdc++
```

No release note updates are necessary.
