### PR TITLE
Fix for ConvertToReflectometryQ NaN issue

### DIFF
--- a/Framework/DataObjects/CMakeLists.txt
+++ b/Framework/DataObjects/CMakeLists.txt
@@ -170,6 +170,7 @@ set ( TEST_FILES
 	PeaksWorkspaceTest.h
 	RebinnedOutputTest.h
 	RefAxisTest.h
+        ReflectometryTransformTest.h
 	SkippingPolicyTest.h
 	SpecialWorkspace2DTest.h
 	SplittersWorkspaceTest.h

--- a/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
@@ -18,7 +18,16 @@ namespace DataObjects {
 class CalculateReflectometry;
 class TableWorkspace;
 
-/** ReflectometryMDTransform : Abstract type for reflectometry transforms to
+/**
+Simple container for porting detector angular information
+ */
+struct MANTID_DATAOBJECTS_DLL DetectorAngularCache {
+  std::vector<double> thetaWidths;
+  std::vector<double> thetas;
+  std::vector<double> detectorHeights;
+};
+
+/** ReflectometryMDTransform : Base type for reflectometry transforms to
  MDWorkspaces. This is a Strategy Design Pattern.
 
  @date 2012-05-29
@@ -44,7 +53,7 @@ class TableWorkspace;
  File change history is stored at: <https://github.com/mantidproject/mantid>
  Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
-class DLLExport ReflectometryTransform {
+class MANTID_DATAOBJECTS_DLL ReflectometryTransform {
 
 protected:
   const size_t m_d0NumBins;
@@ -67,9 +76,6 @@ protected:
   boost::shared_ptr<DataObjects::MDEventWorkspace2Lean>
   createMDWorkspace(Geometry::IMDDimension_sptr, Geometry::IMDDimension_sptr,
                     API::BoxController_sptr boxController) const;
-
-  void
-  initAngularCaches(const API::MatrixWorkspace_const_sptr &workspace) const;
 
 public:
   // Execute the strategy to produce a transformed, output MDWorkspace
@@ -101,9 +107,9 @@ public:
 
 /// Create a new x-axis for the output workspace
 MANTID_DATAOBJECTS_DLL MantidVec
-createXAxis(Mantid::API::MatrixWorkspace *const ws, const double gradQx,
-            const double cxToUnit, const size_t nBins,
-            const std::string &caption, const std::string &units);
+    createXAxis(Mantid::API::MatrixWorkspace *const ws, const double gradQx,
+                const double cxToUnit, const size_t nBins,
+                const std::string &caption, const std::string &units);
 
 /// Create a new y(vertical)-axis for the output workspace
 MANTID_DATAOBJECTS_DLL void
@@ -111,6 +117,10 @@ createVerticalAxis(Mantid::API::MatrixWorkspace *const ws,
                    const MantidVec &xAxisVec, const double gradQz,
                    const double cyToUnit, const size_t nBins,
                    const std::string &caption, const std::string &units);
+
+/// Create angular caches.
+MANTID_DATAOBJECTS_DLL DetectorAngularCache
+    initAngularCaches(const Mantid::API::MatrixWorkspace *const workspace);
 
 // Helper typedef for scoped pointer of this type.
 typedef boost::shared_ptr<ReflectometryTransform> ReflectometryTransform_sptr;

--- a/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/ReflectometryTransform.h
@@ -107,9 +107,9 @@ public:
 
 /// Create a new x-axis for the output workspace
 MANTID_DATAOBJECTS_DLL MantidVec
-    createXAxis(Mantid::API::MatrixWorkspace *const ws, const double gradQx,
-                const double cxToUnit, const size_t nBins,
-                const std::string &caption, const std::string &units);
+createXAxis(Mantid::API::MatrixWorkspace *const ws, const double gradQx,
+            const double cxToUnit, const size_t nBins,
+            const std::string &caption, const std::string &units);
 
 /// Create a new y(vertical)-axis for the output workspace
 MANTID_DATAOBJECTS_DLL void
@@ -120,7 +120,7 @@ createVerticalAxis(Mantid::API::MatrixWorkspace *const ws,
 
 /// Create angular caches.
 MANTID_DATAOBJECTS_DLL DetectorAngularCache
-    initAngularCaches(const Mantid::API::MatrixWorkspace *const workspace);
+initAngularCaches(const Mantid::API::MatrixWorkspace *const workspace);
 
 // Helper typedef for scoped pointer of this type.
 typedef boost::shared_ptr<ReflectometryTransform> ReflectometryTransform_sptr;

--- a/Framework/DataObjects/test/ReflectometryTransformTest.h
+++ b/Framework/DataObjects/test/ReflectometryTransformTest.h
@@ -1,0 +1,96 @@
+#ifndef MANTID_DATAOBJECTS_REFLECTOMETRYTRANSFORTEST_H_
+#define MANTID_DATAOBJECTS_REFLECTOMETRYTRANSFORTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidDataObjects/ReflectometryTransform.h"
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
+using namespace Mantid::Geometry;
+using namespace Mantid::DataObjects;
+
+class ReflectometryTransformTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ReflectometryTransformTest *createSuite() {
+    return new ReflectometryTransformTest();
+  }
+  static void destroySuite(ReflectometryTransformTest *suite) { delete suite; }
+
+  void test_cache_calculation_when_y_is_up() {
+
+    // Creates a detector with dimensions x=0.02, y=0.04, z=0.06
+    auto reflWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+
+    // Get the existing instrument
+    Instrument_sptr inst =
+        boost::const_pointer_cast<Instrument>(reflWS->getInstrument());
+    // Replace the reference frame
+    inst->setReferenceFrame(boost::make_shared<ReferenceFrame>(
+        Y /*up*/, X /*along beam*/, Left, "0,0,0"));
+    // Reset the instrument on the ws
+    reflWS->setInstrument(inst);
+
+    auto detPos = reflWS->getDetector(0)->getPos();
+    auto samplePos = inst->getSample()->getPos();
+    auto l2 = detPos.distance(samplePos);
+
+    DetectorAngularCache cache = initAngularCaches(reflWS.get());
+
+    TS_ASSERT_DELTA(0.04, cache.detectorHeights[0], 1e-6);
+
+    auto calculatedThetaW =
+        2.0 * std::fabs(std::atan((cache.detectorHeights[0] / 2) / l2)) *
+        180.0 / M_PI;
+
+    TSM_ASSERT_DELTA(
+        "Calculated theta width should agree with detector height calculation",
+        cache.thetaWidths[0], calculatedThetaW, 1e-6)
+  }
+
+  void test_cache_calculation_when_x_is_up() {
+
+    // Creates a detector with dimensions x=0.02, y=0.04, z=0.06
+    auto reflWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+
+    // Get the existing instrument
+    Instrument_sptr inst =
+        boost::const_pointer_cast<Instrument>(reflWS->getInstrument());
+    // Replace the reference frame
+    inst->setReferenceFrame(boost::make_shared<ReferenceFrame>(
+        X /*up*/, Y /*along beam*/, Left, "0,0,0"));
+    // Reset the instrument on the ws
+    reflWS->setInstrument(inst);
+
+    DetectorAngularCache cache = initAngularCaches(reflWS.get());
+
+    TS_ASSERT_DELTA(0.02, cache.detectorHeights[0], 1e6);
+  }
+
+  void test_cache_calculation_when_z_is_up() {
+
+    // Creates a detector with dimensions x=0.02, y=0.04, z=0.06
+    auto reflWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithReflectometryInstrument();
+
+    // Get the existing instrument
+    Instrument_sptr inst =
+        boost::const_pointer_cast<Instrument>(reflWS->getInstrument());
+    // Replace the reference frame
+    inst->setReferenceFrame(boost::make_shared<ReferenceFrame>(
+        Z /*up*/, X /*along beam*/, Left, "0,0,0"));
+    // Reset the instrument on the ws
+    reflWS->setInstrument(inst);
+
+    DetectorAngularCache cache = initAngularCaches(reflWS.get());
+
+    TS_ASSERT_DELTA(0.06, cache.detectorHeights[0], 1e6);
+  }
+};
+
+#endif /* MANTID_DATAOBJECTS_REFLECTOMETRYTRANSFORTEST_H_ */

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -519,7 +519,7 @@ MatrixWorkspace_sptr
 create2DWorkspaceWithReflectometryInstrument(double startX) {
   Instrument_sptr instrument = boost::make_shared<Instrument>();
   instrument->setReferenceFrame(
-      boost::make_shared<ReferenceFrame>(Y, X, Left, "0,0,0"));
+      boost::make_shared<ReferenceFrame>(Y /*up*/, X /*along*/, Left, "0,0,0"));
 
   ObjComponent *source = new ObjComponent("source");
   source->setPos(V3D(0, 0, 0));
@@ -536,7 +536,10 @@ create2DWorkspaceWithReflectometryInstrument(double startX) {
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
-  Detector *det = new Detector("point-detector", 2, NULL);
+  // Where 0.01 is half detector width etc.
+  Detector *det = new Detector(
+      "point-detector", 2,
+      ComponentCreationHelper::createCuboid(0.01, 0.02, 0.03), NULL);
   det->setPos(20, (20 - sample->getPos().X()), 0);
   instrument->add(det);
   instrument->markAsDetector(det);


### PR DESCRIPTION
Fixes #14342. 

**Tester**
@raquelalvarezbanos. Rerun the OFFSPEC example, and check the map is clear of Nans. Look at the vertex dump plot in matplotlib and you should see that the empty regions are gone. Run the POLREF example and do the same.
