### PR TITLE
SliceView: Disable/centre slider for integrated dimensions 

### DIFF
--- a/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
+++ b/MantidQt/SliceViewer/src/DimensionSliceWidget.cpp
@@ -112,7 +112,8 @@ void DimensionSliceWidget::setShownDim(int dim)
   ui.btnY->setChecked( m_shownDim == 1 );
   ui.btnX->blockSignals(false);
   ui.btnY->blockSignals(false);
-  bool slicing = m_shownDim == -1;
+  /// Slice if dimension is not X or Y AND is not integrated
+  bool slicing = (m_shownDim == -1 && !m_dim->getIsIntegrated());
   ui.horizontalSlider->setVisible( slicing );
   ui.doubleSpinBox->setVisible( slicing );
   ui.lblUnits->setVisible( slicing );


### PR DESCRIPTION
Resolves #13512 

For integrated dimensions (number of bins = 1), don't display the slider as it doesn't make sense to do so - there is only one bin. 

The slice point is shown as 0 by default (or minimum, if 0 not in bin range), and is arbitrary as the whole range is in the same bin.
