### PR TITLE
Cleanup OS X packaging

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -58,6 +58,7 @@ library_filenames = ["libboost_regex-mt.dylib",
                      "libmxml.dylib",
                      "libhdf5.dylib",
                      "libhdf5_hl.dylib",
+                     "libhdf5_cpp.dylib",
                      "libmfhdf.dylib",
                      "libdf.dylib",
                      "libsz.dylib",
@@ -160,42 +161,10 @@ end
 `macdeployqt ../MantidPlot.app #{Qt_Executables}`
 
 #Fix remaining QT-related linking issues.
-`install_name_tool -id @rpath/libqsqlite.dylib Contents/Frameworks/plugins/sqldrivers/libqsqlite.dylib`
-`install_name_tool -id @rpath/libqsqlite.dylib Contents/PlugIns/sqldrivers/libqsqlite.dylib`
-`install_name_tool -id @rpath/libqtaccessiblecompatwidgets.dylib Contents/PlugIns/accessible/libqtaccessiblecompatwidgets.dylib`
-`install_name_tool -id @rpath/libqtaccessiblewidgets.dylib Contents/PlugIns/accessible/libqtaccessiblewidgets.dylib`
-`install_name_tool -id @rpath/libqcorewlanbearer.dylib Contents/PlugIns/bearer/libqcorewlanbearer.dylib`
-`install_name_tool -id @rpath/libqgenericbearer.dylib  Contents/PlugIns/bearer/libqgenericbearer.dylib`
-`install_name_tool -id @rpath/libqsvgicon.dylib Contents/PlugIns/iconengines/libqsvgicon.dylib`
-
-#change id of all Qt4 imageformats libraries
-qt4_patterns = ["**/imageformats/*.dylib"]
-qt4_patterns.each do |pattern|
-  Dir[pattern].each do |library|
-    basename =  File.basename(library)
-    `chmod +w Contents/Frameworks/plugins/imageformats/#{basename}`
-    `install_name_tool -id @rpath/#{basename} Contents/Frameworks/plugins/imageformats/#{basename}`
-  end
-end
-
-#change id of all Qt4 imageformats libraries
-qt4_patterns = ["**/imageformats/*.dylib"]
-qt4_patterns.each do |pattern|
-  Dir[pattern].each do |library|
-    basename =  File.basename(library)
-    `chmod +w Contents/PlugIns/imageformats/#{basename}`
-    `install_name_tool -id @rpath/#{basename} Contents/PlugIns/imageformats/#{basename}`
-  end
-end
-
-#change id of all Qt4 codecs libraries
-qt4_patterns = ["**/codecs/*.dylib"]
-qt4_patterns.each do |pattern|
-  Dir[pattern].each do |library|
-    basename =  File.basename(library)
-    `chmod +w Contents/PlugIns/codecs/#{basename}`
-    `install_name_tool -id @rpath/#{basename} Contents/PlugIns/codecs/#{basename}`
-  end
+Dir["Contents/PlugIns/**/*.dylib"].each do |library|
+  basename =  File.basename(library)
+  `chmod +w #{library}`
+  `install_name_tool -id @rpath/#{basename} #{library}`
 end
 
 #change id of all PyQt4 libraries

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -11,25 +11,20 @@ execute_process(
 # Strip off any /CR or /LF
 string(STRIP ${OSX_VERSION} OSX_VERSION)
 
-if (OSX_VERSION VERSION_LESS 10.6)
-  message (FATAL_ERROR "The minimum supported version of Mac OS X is 10.6 (Snow Leopard).")
-endif()
-
-if (OSX_VERSION VERSION_GREATER 10.6 OR OSX_VERSION VERSION_EQUAL 10.6)
-  set ( OSX_CODENAME "Snow Leopard" )
-endif()
-
-if (OSX_VERSION VERSION_GREATER 10.7 OR OSX_VERSION VERSION_EQUAL 10.7)
-  set ( OSX_CODENAME "Lion")
-endif()
-
-if (OSX_VERSION VERSION_GREATER 10.8 OR OSX_VERSION VERSION_EQUAL 10.8)
-  set ( OSX_CODENAME "Mountain Lion")
+if (OSX_VERSION VERSION_LESS 10.9)
+  message (FATAL_ERROR "The minimum supported version of Mac OS X is 10.9 (Mavericks).")
 endif()
 
 if (OSX_VERSION VERSION_GREATER 10.9 OR OSX_VERSION VERSION_EQUAL 10.9)
   set ( OSX_CODENAME "Mavericks")
+endif()
 
+if (OSX_VERSION VERSION_GREATER 10.10 OR OSX_VERSION VERSION_EQUAL 10.10)
+  set ( OSX_CODENAME "Yosemite")
+endif()
+
+if (OSX_VERSION VERSION_GREATER 10.11 OR OSX_VERSION VERSION_EQUAL 10.11)
+  set ( OSX_CODENAME "El Capitan")
 endif()
 
 # Export variables globally
@@ -37,23 +32,6 @@ set(OSX_VERSION ${OSX_VERSION} CACHE INTERNAL "")
 set(OSX_CODENAME ${OSX_CODENAME} CACHE INTERNAL "")
 
 message (STATUS "Operating System: Mac OS X ${OSX_VERSION} (${OSX_CODENAME})")
-
-###########################################################################
-# Set include and library directories so that CMake finds Third_Party
-###########################################################################
-
-# Only use Third_Party for OS X older than Mavericks (10.9)
-if (OSX_VERSION VERSION_LESS 10.9)
-  message ( STATUS "Using Third_Party.")
-
-  set ( CMAKE_INCLUDE_PATH "${THIRD_PARTY}/include" )
-  set ( BOOST_INCLUDEDIR "${THIRD_PARTY}/include" )
-
-  set ( CMAKE_LIBRARY_PATH "${THIRD_PARTY}/lib/mac64" )
-  set ( BOOST_LIBRARYDIR  "${THIRD_PARTY}/lib/mac64" )
-else()
-  message ( STATUS "OS X Mavericks - Not using Mantid Third_Party libraries.")
-endif()
 
 # Enable the use of the -isystem flag to mark headers in Third_Party as system headers
 set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
@@ -210,11 +188,7 @@ if (OSX_VERSION VERSION_LESS 10.9)
   endforeach( PYPACKAGE )
 endif ()
 
-install ( DIRECTORY ${QT_PLUGINS_DIR}/imageformats DESTINATION MantidPlot.app/Contents/Frameworks/plugins )
-install ( DIRECTORY ${QT_PLUGINS_DIR}/sqldrivers DESTINATION MantidPlot.app/Contents/Frameworks/plugins )
-
 install ( FILES ${CMAKE_SOURCE_DIR}/images/MantidPlot.icns
-                ${CMAKE_SOURCE_DIR}/installers/MacInstaller/qt.conf
           DESTINATION MantidPlot.app/Contents/Resources/
 )
 

--- a/installers/MacInstaller/qt.conf
+++ b/installers/MacInstaller/qt.conf
@@ -1,2 +1,0 @@
-[Paths]
-Plugins = Frameworks/plugins


### PR DESCRIPTION
This cleans up changes to the OS X package made hastily on a Friday evening in pull request #14340. 

The largest change is to use the `PlugIns` directory now installed by `macdeployqt`. In addition, I'm copying over `libhdf5_cpp.dylib` and updating its linking in the script instead of having it done by `macdeployqt`. Lastly, I did some cleanup to remove references to `ThirdParty` and old versions of OS X that we no longer support.

no release notes.

testing: code review. 
