### PR TITLE
Algorithms which may have required progress: LoadEventsAndCompress, MuonLoad

### DIFF
--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -43,16 +43,12 @@ public:
 
 protected:
   API::ITableWorkspace_sptr determineChunk(const std::string &filename);
-  API::MatrixWorkspace_sptr loadChunk(const size_t rowIndex);
-  API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr wksp);
+  API::MatrixWorkspace_sptr loadChunk(const size_t rowIndex, API::ITableWorkspace_sptr &chunkingTable);
+  API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr &wksp, double filterBadPulses);
 
 private:
   void init();
   void exec();
-
-  std::string m_filename;
-  double m_filterBadPulses;
-  API::ITableWorkspace_sptr m_chunkingTable;
 };
 
 } // namespace WorkflowAlgorithms

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -42,9 +42,11 @@ public:
   virtual const std::string summary() const;
 
 protected:
-  virtual API::ITableWorkspace_sptr determineChunk(const std::string &filename) override;
+  virtual API::ITableWorkspace_sptr
+  determineChunk(const std::string &filename) override;
   virtual API::MatrixWorkspace_sptr loadChunk(const size_t rowIndex) override;
-  API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr &wksp, double filterBadPulses);
+  API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr &wksp,
+                                         double filterBadPulses);
 
 private:
   void init();

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -42,13 +42,15 @@ public:
   virtual const std::string summary() const;
 
 protected:
-  API::ITableWorkspace_sptr determineChunk(const std::string &filename);
-  API::MatrixWorkspace_sptr loadChunk(const size_t rowIndex, API::ITableWorkspace_sptr &chunkingTable);
+  virtual API::ITableWorkspace_sptr determineChunk(const std::string &filename) override;
+  virtual API::MatrixWorkspace_sptr loadChunk(const size_t rowIndex) override;
   API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr &wksp, double filterBadPulses);
 
 private:
   void init();
   void exec();
+
+  API::ITableWorkspace_sptr m_chunkingTable;
 };
 
 } // namespace WorkflowAlgorithms

--- a/Framework/WorkflowAlgorithms/src/LoadEventAndCompress.cpp
+++ b/Framework/WorkflowAlgorithms/src/LoadEventAndCompress.cpp
@@ -174,10 +174,12 @@ MatrixWorkspace_sptr LoadEventAndCompress::loadChunk(const size_t rowIndex) {
 /**
  * Process a chunk in-place
  *
+ * @param filterBadPulses
  * @param wksp
  */
 API::MatrixWorkspace_sptr
-LoadEventAndCompress::processChunk(API::MatrixWorkspace_sptr &wksp, double filterBadPulses) {
+LoadEventAndCompress::processChunk(API::MatrixWorkspace_sptr &wksp,
+                                   double filterBadPulses) {
   EventWorkspace_sptr eventWS =
       boost::dynamic_pointer_cast<EventWorkspace>(wksp);
 
@@ -234,7 +236,7 @@ void LoadEventAndCompress::exec() {
     plusAlg->executeAsChildAlg();
     resultWS = plusAlg->getProperty("OutputWorkspace");
 
-	progress.report();
+    progress.report();
   }
   Workspace_sptr total = assemble(resultWS);
 

--- a/Framework/WorkflowAlgorithms/src/LoadEventAndCompress.cpp
+++ b/Framework/WorkflowAlgorithms/src/LoadEventAndCompress.cpp
@@ -23,7 +23,7 @@ DECLARE_ALGORITHM(LoadEventAndCompress)
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-LoadEventAndCompress::LoadEventAndCompress() : m_filterBadPulses(EMPTY_DBL()) {}
+LoadEventAndCompress::LoadEventAndCompress() {}
 
 //----------------------------------------------------------------------------------------------
 /** Destructor
@@ -131,10 +131,10 @@ LoadEventAndCompress::determineChunk(const std::string &filename) {
 }
 
 /// @see DataProcessorAlgorithm::loadChunk(const size_t)
-MatrixWorkspace_sptr LoadEventAndCompress::loadChunk(const size_t rowIndex) {
+MatrixWorkspace_sptr LoadEventAndCompress::loadChunk(const size_t rowIndex, API::ITableWorkspace_sptr &chunkingTable) {
   g_log.debug() << "loadChunk(" << rowIndex << ")\n";
 
-  double rowCount = static_cast<double>(m_chunkingTable->rowCount());
+  double rowCount = static_cast<double>(chunkingTable->rowCount());
   double progStart = static_cast<double>(rowIndex) / rowCount;
   double progStop = static_cast<double>(rowIndex + 1) / rowCount;
 
@@ -160,9 +160,9 @@ MatrixWorkspace_sptr LoadEventAndCompress::loadChunk(const size_t rowIndex) {
 
   // set chunking information
   if (rowCount > 0.) {
-    const std::vector<string> COL_NAMES = m_chunkingTable->getColumnNames();
+    const std::vector<string> COL_NAMES = chunkingTable->getColumnNames();
     for (auto name = COL_NAMES.begin(); name != COL_NAMES.end(); ++name) {
-      alg->setProperty(*name, m_chunkingTable->getRef<int>(*name, rowIndex));
+      alg->setProperty(*name, chunkingTable->getRef<int>(*name, rowIndex));
     }
   }
 
@@ -177,15 +177,15 @@ MatrixWorkspace_sptr LoadEventAndCompress::loadChunk(const size_t rowIndex) {
  * @param wksp
  */
 API::MatrixWorkspace_sptr
-LoadEventAndCompress::processChunk(API::MatrixWorkspace_sptr wksp) {
+LoadEventAndCompress::processChunk(API::MatrixWorkspace_sptr &wksp, double filterPulses) {
   EventWorkspace_sptr eventWS =
       boost::dynamic_pointer_cast<EventWorkspace>(wksp);
 
-  if (m_filterBadPulses > 0.) {
+  if (filterPulses > 0.) {
     auto filterBadPulses = createChildAlgorithm("FilterBadPulses");
     filterBadPulses->setProperty("InputWorkspace", eventWS);
     filterBadPulses->setProperty("OutputWorkspace", eventWS);
-    filterBadPulses->setProperty("LowerCutoff", m_filterBadPulses);
+    filterBadPulses->setProperty("LowerCutoff", filterPulses);
     filterBadPulses->executeAsChildAlg();
     eventWS = filterBadPulses->getProperty("OutputWorkspace");
   }
@@ -205,20 +205,29 @@ LoadEventAndCompress::processChunk(API::MatrixWorkspace_sptr wksp) {
 /** Execute the algorithm.
  */
 void LoadEventAndCompress::exec() {
-  m_filename = getPropertyValue("Filename");
-  m_filterBadPulses = getProperty("FilterBadPulses");
+  std::string filename = getPropertyValue("Filename");
+  double filterBadPulses;
+  filterBadPulses = EMPTY_DBL();
+  filterBadPulses = getProperty("FilterBadPulses");
 
-  m_chunkingTable = determineChunk(m_filename);
+  API::ITableWorkspace_sptr chunkingTable = determineChunk(filename);
+
+  Progress progress(this, 0, 1, 2);
 
   // first run is free
-  MatrixWorkspace_sptr resultWS = loadChunk(0);
-  resultWS = processChunk(resultWS);
+  progress.report("Loading Chunk");
+  MatrixWorkspace_sptr resultWS = loadChunk(0, chunkingTable);
+  progress.report("Process Chunk");
+  resultWS = processChunk(resultWS, filterBadPulses);
 
   // load the other chunks
-  const size_t numRows = m_chunkingTable->rowCount();
+  const size_t numRows = chunkingTable->rowCount();
+
+  progress.resetNumSteps(numRows, 0, 1);
+
   for (size_t i = 1; i < numRows; ++i) {
-    MatrixWorkspace_sptr temp = loadChunk(i);
-    temp = processChunk(temp);
+    MatrixWorkspace_sptr temp = loadChunk(i, chunkingTable);
+    temp = processChunk(temp, filterBadPulses);
     auto plusAlg = createChildAlgorithm("Plus");
     plusAlg->setProperty("LHSWorkspace", resultWS);
     plusAlg->setProperty("RHSWorkspace", temp);
@@ -226,6 +235,8 @@ void LoadEventAndCompress::exec() {
     plusAlg->setProperty("ClearRHSWorkspace", true);
     plusAlg->executeAsChildAlg();
     resultWS = plusAlg->getProperty("OutputWorkspace");
+
+	progress.report();
   }
   Workspace_sptr total = assemble(resultWS);
 

--- a/Framework/WorkflowAlgorithms/src/MuonLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/MuonLoad.cpp
@@ -110,6 +110,8 @@ void MuonLoad::init() {
  * Execute the algorithm.
  */
 void MuonLoad::exec() {
+  Progress progress(this, 0, 1, 6);
+
   const std::string filename = getProperty("Filename");
 
   // Whether Dead Time Correction should be applied
@@ -129,11 +131,14 @@ void MuonLoad::exec() {
   if (autoGroup) // Load grouping as well, if needed
     load->setProperty("DetectorGroupingTable", "__NotUsed");
 
+  progress.report();
   load->execute();
 
   Workspace_sptr loadedWS = load->getProperty("OutputWorkspace");
 
   MatrixWorkspace_sptr firstPeriodWS, secondPeriodWS;
+
+  progress.report();
 
   // Deal with single-period workspace
   if (auto ws = boost::dynamic_pointer_cast<MatrixWorkspace>(loadedWS)) {
@@ -157,6 +162,7 @@ void MuonLoad::exec() {
     throw std::runtime_error("Loaded workspace is of invalid type");
   }
 
+  progress.report();
   // Deal with dead time correction (if required)
   if (applyDtc) {
     TableWorkspace_sptr deadTimes = getProperty("CustomDeadTimeTable");
@@ -188,6 +194,7 @@ void MuonLoad::exec() {
 
   TableWorkspace_sptr grouping;
 
+  progress.report();
   if (autoGroup) {
     Workspace_sptr loadedGrouping = load->getProperty("DetectorGroupingTable");
 
@@ -206,6 +213,8 @@ void MuonLoad::exec() {
   } else {
     grouping = getProperty("DetectorGroupingTable");
   }
+
+  progress.report();
 
   // Deal with grouping
   firstPeriodWS = groupWorkspace(firstPeriodWS, grouping);
@@ -243,6 +252,8 @@ void MuonLoad::exec() {
   calcAssym->setProperty("Alpha", static_cast<double>(getProperty("Alpha")));
   calcAssym->setProperty("GroupIndex",
                          static_cast<int>(getProperty("GroupIndex")));
+
+  progress.report();
 
   calcAssym->execute();
 


### PR DESCRIPTION
Fixes #14299 

The release notes have not been updated.

The LoadEventsAndCompress and MuonLoad algorithms now report progress.

**NB** _The algorithm ProcessIndirectFitParameters from the original issue did not require progress reporting._
## Testing
### LoadEventsAndCompress

http://docs.mantidproject.org/nightly/algorithms/LoadEventAndCompress-v1.html#id6
### MuonLoad

This solution is quite crude as there is no loop which represents the algorithm processing. Progress report calls were placed in areas where considerable processing occurs.

http://docs.mantidproject.org/nightly/algorithms/MuonLoad-v1.html#id6
