### PR TITLE
LoadFITS: use fixed size 8 bytes word in fast load loop

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadFITS.h
@@ -191,6 +191,12 @@ private:
   static const std::string g_ROTATION_NAME;
   static const std::string g_IMAGE_KEY_NAME;
   static const std::string g_HEADER_MAP_NAME;
+
+  // Bits per pixel
+  // This must be consistent with how the BITPIX header entries are processed
+  static const size_t g_maxBitDepth;
+  // max. bytes per pixel, for buffers
+  static const size_t g_maxBytesPP;
 };
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -43,6 +43,10 @@ const std::string LoadFITS::g_IMAGE_KEY_NAME = "ImageKeyName";
 const std::string LoadFITS::g_HEADER_MAP_NAME = "HeaderMapFile";
 const std::string LoadFITS::g_defaultImgType = "SAMPLE";
 
+// Bits/bytes per pixel. Values fixed in the FITS standard
+const size_t LoadFITS::g_maxBitDepth = 64;
+const size_t LoadFITS::g_maxBytesPP = g_maxBitDepth / 8;
+
 /**
  * Constructor. Just initialize everything to prevent issues.
  */
@@ -175,9 +179,9 @@ void LoadFITS::doLoadHeaders(const std::vector<std::string> &paths,
           e.what());
     }
 
-    // Get and convert specific standard header values which will are
-    // needed to know how to load the data: BITPIX, NAXIS, NAXISi (where i =
-    // 1..NAXIS, e.g. NAXIS2 for two axis).
+    // Get and convert specific MANDATORY standard header values which
+    // will are needed to know how to load the data: BITPIX, NAXIS,
+    // NAXISi (where i = 1..NAXIS, e.g. NAXIS2 for two axis).
     try {
       std::string tmpBitPix = headers[i].headerKeys[m_headerBitDepthKey];
       if (boost::contains(tmpBitPix, "-")) {
@@ -194,12 +198,15 @@ void LoadFITS::doLoadHeaders(const std::vector<std::string> &paths,
             "Coult not interpret the entry number of bits per pixel (" +
             m_headerBitDepthKey + ") as an integer. Error: " + e.what());
       }
-      // Check that the files use bit depths of either 8, 16 or 32
+      // Check that the files use valid BITPIX values
+      // http://archive.stsci.edu/fits/fits_standard/node39.html#SECTION00941000000000000000
       if (headers[i].bitsPerPixel != 8 && headers[i].bitsPerPixel != 16 &&
           headers[i].bitsPerPixel != 32 && headers[i].bitsPerPixel != 64)
+        // this implicitly includes when 'headers[i].bitsPerPixel > g_maxBitDepth'
         throw std::runtime_error(
             "This algorithm only supports 8, 16, 32 or 64 "
-            "bits per pixel. The header of file '" +
+            "bits per pixel as allowed in the FITS standard. The header of "
+            "file '" +
             paths[i] + "' says that its bit depth is: " +
             boost::lexical_cast<std::string>(headers[i].bitsPerPixel));
     } catch (std::exception &e) {
@@ -816,22 +823,22 @@ void LoadFITS::readDataToWorkspace(const FITSInfo &fileInfo, double cmpp,
       uint8_t const *const buffer8Start = buffer8 + start;
       // Reverse byte order of current value. Make sure we allocate enough
       // enough space to hold the size
-      boost::scoped_array<uint8_t> byteValue(new uint8_t[bytespp]);
-      std::reverse_copy(buffer8Start, buffer8Start + bytespp, byteValue.get());
+      uint8_t byteValue[g_maxBytesPP];
+      std::reverse_copy(buffer8Start, buffer8Start + bytespp, byteValue);
 
       double val = 0;
       if (fileInfo.bitsPerPixel == 8) {
-        val = toDouble<uint8_t>(byteValue.get());
+        val = toDouble<uint8_t>(byteValue);
       } else if (fileInfo.bitsPerPixel == 16) {
-        val = toDouble<uint16_t>(byteValue.get());
+        val = toDouble<uint16_t>(byteValue);
       } else if (fileInfo.bitsPerPixel == 32 && !fileInfo.isFloat) {
-        val = toDouble<uint32_t>(byteValue.get());
+        val = toDouble<uint32_t>(byteValue);
       } else if (fileInfo.bitsPerPixel == 64 && !fileInfo.isFloat) {
-        val = toDouble<uint32_t>(byteValue.get());
+        val = toDouble<uint32_t>(byteValue);
       } else if (fileInfo.bitsPerPixel == 32 && fileInfo.isFloat) {
-        val = toDouble<float>(byteValue.get());
+        val = toDouble<float>(byteValue);
       } else if (fileInfo.bitsPerPixel == 64 && fileInfo.isFloat) {
-        val = toDouble<double>(byteValue.get());
+        val = toDouble<double>(byteValue);
       }
 
       val = fileInfo.scale * val - fileInfo.offset;

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -202,7 +202,8 @@ void LoadFITS::doLoadHeaders(const std::vector<std::string> &paths,
       // http://archive.stsci.edu/fits/fits_standard/node39.html#SECTION00941000000000000000
       if (headers[i].bitsPerPixel != 8 && headers[i].bitsPerPixel != 16 &&
           headers[i].bitsPerPixel != 32 && headers[i].bitsPerPixel != 64)
-        // this implicitly includes when 'headers[i].bitsPerPixel > g_maxBitDepth'
+        // this implicitly includes when 'headers[i].bitsPerPixel >
+        // g_maxBitDepth'
         throw std::runtime_error(
             "This algorithm only supports 8, 16, 32 or 64 "
             "bits per pixel as allowed in the FITS standard. The header of "


### PR DESCRIPTION
Fixes #14361.

**To test**: code review.

The `new` operation that was introduced in the loop that reads the image pixels has turned out to be very slow (in comparison to the operations done for every pixel). I double-checked the FITS standard and confirmed that the pixel bit depth is between 8 and 64 bits. Also in practice I'm not aware of any datasets using more than that. 

The solution in this branch is to use a small good old array on the stack. An alternative solution would be to use `new` with `scoped_array` but outside the loop, allocating one small array for every thread. This requires using `PARALLEL_GET_MAX_THREADS` for the initial allocation and then taking the thread-specific buffer with `PARALLEL_THREAD_NUMBER`. This seems to work well but I'm not sure how common is that in Mantid algorithms.

I did a few performance checks and these show that a new (or std::vector) are too much overhead, having really bad worst case when running this many times for large input chunks.

Comparisons of alternative LoadFITS loops. Load times in seconds:

```
GCC 4.9.2 on debian

A stack of 1350 images (512x512)
with new:          [8.84, 18.5]
with std::vector:  [8.76, 16.3]
with array:        [2.60, 2.75]

A stack of 144 images (512x512)
with new:          [1.45, 1.52]
with std::vector:  [1.44, 1.52]
with array:        [0.44, 0.47]
```

```
MSVC 2012

A stack of 144 images (512x512)
with new:          [1.38, 1.51]
with std::vector:  [1.82, 2.09]
with array:        [0.99, 1.09]
```

```
GCC 4.9.2 on debian

With scoped_arrays outside the loops, [0.45, 0.49] ~= same time as using the threads' stacks
```

(the ranges come from 7 repetions, after a couple of initial runs to cache the files (for the small stack case)).

Not related to this issue/branch, but still interesting to note: I'm puzzled by why MSVC (in Release mode) is so slower than GCC . It normally produces fast code for this type of loops. Maybe the OMP threads are underperforming.

TODO: quick check again with MSVC 2015 just to see if there's any big difference - to be added in a comment below.
