### PR TITLE
Fix dx error in can subtraction

### DIFF
--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-lines
+﻿#pylint: disable=too-many-lines
 #pylint: disable=invalid-name
 #########################################################
 # This module contains utility functions common to the
@@ -1167,7 +1167,7 @@ def correct_q_resolution_for_can(original_workspace, can_workspace, subtracted_w
     @param subtracted_workspace: the subtracted workspace
     '''
     dummy1 = can_workspace
-    if original_workspace.getNumberHistograms() == 1:
+    if original_workspace.getNumberHistograms() == 1 and original_workspace.hasDx(0):
         subtracted_workspace.setDx(0, original_workspace.dataDx(0))
 
 def correct_q_resolution_for_merged(count_ws_front, count_ws_rear,

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1,4 +1,4 @@
-
+﻿
 import unittest
 # Need to import mantid before we import SANSUtility
 import mantid
@@ -1046,6 +1046,26 @@ class TestGetCorrectQResolution(unittest.TestCase):
         provide_workspace_with_x_errors(orig_name, True, 2)
         provide_workspace_with_x_errors(can_name, True, 2)
         provide_workspace_with_x_errors(result_name, False, 2)
+        orig = mtd[orig_name]
+        can = mtd[can_name]
+        result = mtd[result_name]
+        # Act
+        su.correct_q_resolution_for_can(orig, can, result)
+        # Assert
+        self.assertFalse(result.hasDx(0))
+        # Clean up
+        DeleteWorkspace(orig)
+        DeleteWorkspace(can)
+        DeleteWorkspace(result)
+
+    def test_error_is_not_passed_on_when_did_not_exist_beforehand(self):
+        # Arrange
+        orig_name = "orig"
+        can_name = "can"
+        result_name = "result"
+        provide_workspace_with_x_errors(orig_name, False, 1)
+        provide_workspace_with_x_errors(can_name, False, 1)
+        provide_workspace_with_x_errors(result_name, False, 1)
         orig = mtd[orig_name]
         can = mtd[can_name]
         result = mtd[result_name]


### PR DESCRIPTION
Fixes  #14372 
# For testing

Please find the data here: \olympic\Babylon5\Scratch\Anton\Testing\RKH_QError_Issue

The instrument is : SANS2DTUBES
The user file is:USER_SANS2D_153E_2p4_4m_M3_Mears_12mm_changer.txt
Make sure that the data is in  the path.
Make sure that the data archive is enabled
1. Switch to batch mode on the first tab
2. Load the file batch_Nov_15av2.csv into the batch mode section
3. In the save section select the RKH format
4. Press 1D reduce
   - Confirm that the file which was saved out (.txt) does only contain three columns and not a fourth with zeros
