### PR TITLE
Added progress report in algorithms: FFTSmooth and FitPeak

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FFTSmooth2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FFTSmooth2.h
@@ -60,20 +60,12 @@ private:
   void init();
   void exec();
 
-  // Smoothing by truncation.
-  void truncate(int n);
   // Smoothing by zeroing.
-  void zero(int n);
+  void zero(int n, API::MatrixWorkspace_sptr &unfilteredWS,
+            API::MatrixWorkspace_sptr &filteredWS);
   // Smoothing using Butterworth filter of any positive order.
-  void Butterworth(int n, int order);
-
-  /// The input workspace
-  API::MatrixWorkspace_sptr m_inWS;
-  /// Temporary workspace for keeping the unfiltered Fourier transform of the
-  /// imput spectrum
-  API::MatrixWorkspace_sptr m_unfilteredWS;
-  /// Temporary workspace for keeping the filtered spectrum
-  API::MatrixWorkspace_sptr m_filteredWS;
+  void Butterworth(int n, int order, API::MatrixWorkspace_sptr &unfilteredWS,
+                   API::MatrixWorkspace_sptr &filteredWS);
 };
 
 } // namespace Algorithm

--- a/Framework/Algorithms/src/FFTSmooth2.cpp
+++ b/Framework/Algorithms/src/FFTSmooth2.cpp
@@ -79,7 +79,7 @@ void FFTSmooth2::exec() {
   API::MatrixWorkspace_sptr symmWS = API::WorkspaceFactory::Instance().create(
       "Workspace2D", 1, inWS->readX(0).size() + dn, inWS->readY(0).size() + dn);
 
-  Progress progress(this, 0, 1, 4 * (s0 - send));
+  Progress progress(this, 0, 1, 4 * (send - s0));
 
   for (int spec = s0; spec < send; spec++) {
     // Save the starting x value so it can be restored after all transforms.

--- a/Framework/Algorithms/src/FFTSmooth2.cpp
+++ b/Framework/Algorithms/src/FFTSmooth2.cpp
@@ -58,7 +58,7 @@ void FFTSmooth2::init() {
 /** Executes the algorithm
  */
 void FFTSmooth2::exec() {
-  m_inWS = getProperty("InputWorkspace");
+  API::MatrixWorkspace_sptr inWS = getProperty("InputWorkspace");
   /// Will we Allow Any X Bins?
   bool ignoreXBins = getProperty("IgnoreXBins");
 
@@ -68,38 +68,42 @@ void FFTSmooth2::exec() {
   int send = s0 + 1;
   if (getProperty("AllSpectra")) { // Except if AllSpectra
     s0 = 0;
-    send = static_cast<int>(m_inWS->getNumberHistograms());
+    send = static_cast<int>(inWS->getNumberHistograms());
   }
   // Create output
   API::MatrixWorkspace_sptr outWS = API::WorkspaceFactory::Instance().create(
-      m_inWS, send - s0, m_inWS->readX(0).size(), m_inWS->readY(0).size());
+      inWS, send - s0, inWS->readX(0).size(), inWS->readY(0).size());
 
   // Symmetrize the input spectrum
-  int dn = static_cast<int>(m_inWS->readY(0).size());
+  int dn = static_cast<int>(inWS->readY(0).size());
   API::MatrixWorkspace_sptr symmWS = API::WorkspaceFactory::Instance().create(
-      "Workspace2D", 1, m_inWS->readX(0).size() + dn,
-      m_inWS->readY(0).size() + dn);
+      "Workspace2D", 1, inWS->readX(0).size() + dn, inWS->readY(0).size() + dn);
+
+  Progress progress(this, 0, 1, 4 * (s0 - send));
 
   for (int spec = s0; spec < send; spec++) {
     // Save the starting x value so it can be restored after all transforms.
-    double x0 = m_inWS->readX(spec)[0];
+    double x0 = inWS->readX(spec)[0];
 
-    double dx = (m_inWS->readX(spec).back() - m_inWS->readX(spec).front()) /
-                (static_cast<double>(m_inWS->readX(spec).size()) - 1.0);
+    double dx = (inWS->readX(spec).back() - inWS->readX(spec).front()) /
+                (static_cast<double>(inWS->readX(spec).size()) - 1.0);
+
+    progress.report();
     for (int i = 0; i < dn; i++) {
-      symmWS->dataX(0)[dn + i] = m_inWS->readX(spec)[i];
-      symmWS->dataY(0)[dn + i] = m_inWS->readY(spec)[i];
+      symmWS->dataX(0)[dn + i] = inWS->readX(spec)[i];
+      symmWS->dataY(0)[dn + i] = inWS->readY(spec)[i];
 
       symmWS->dataX(0)[dn - i] = x0 - dx * i;
-      symmWS->dataY(0)[dn - i] = m_inWS->readY(spec)[i];
+      symmWS->dataY(0)[dn - i] = inWS->readY(spec)[i];
     }
-    symmWS->dataY(0).front() = m_inWS->readY(spec).back();
+    symmWS->dataY(0).front() = inWS->readY(spec).back();
     symmWS->dataX(0).front() = x0 - dx * dn;
-    if (m_inWS->isHistogramData())
-      symmWS->dataX(0).back() = m_inWS->readX(spec).back();
+    if (inWS->isHistogramData())
+      symmWS->dataX(0).back() = inWS->readX(spec).back();
 
     // setProperty("OutputWorkspace",symmWS); return;
 
+    progress.report("Calculating FFT");
     // Forward Fourier transform
     IAlgorithm_sptr fft = createChildAlgorithm("RealFFT", 0, 0.5);
     fft->setProperty("InputWorkspace", symmWS);
@@ -112,22 +116,13 @@ void FFTSmooth2::exec() {
       throw;
     }
 
-    m_unfilteredWS = fft->getProperty("OutputWorkspace");
+    API::MatrixWorkspace_sptr unfilteredWS =
+        fft->getProperty("OutputWorkspace");
+    API::MatrixWorkspace_sptr filteredWS;
 
     // Apply the filter
     std::string type = getProperty("Filter");
-    // x - value correction doesn't work, so no truncation yet
-    // if (type == "Truncation")
-    //{
-    //  std::string sn = getProperty("Params");
-    //  int n;
-    //  if (sn.empty()) n = 2;
-    //  else
-    //    n = atoi(sn.c_str());
-    //  if (n <= 1) throw std::invalid_argument("Truncation parameter must be an
-    //  integer > 1");
-    //  truncate(n);
-    //}else
+
     if (type == "Zeroing") {
       std::string sn = getProperty("Params");
       int n;
@@ -138,7 +133,10 @@ void FFTSmooth2::exec() {
       if (n <= 1)
         throw std::invalid_argument(
             "Truncation parameter must be an integer > 1");
-      zero(n);
+
+      progress.report("Zero Filter");
+
+      zero(n, unfilteredWS, filteredWS);
     } else if (type == "Butterworth") {
       int n, order;
 
@@ -161,14 +159,15 @@ void FFTSmooth2::exec() {
       if (order < 1)
         throw std::invalid_argument(
             "Butterworth filter order must be an integer >= 1");
-      Butterworth(n, order);
+
+      progress.report("ButterWorth Filter");
+      Butterworth(n, order, unfilteredWS, filteredWS);
     }
 
+    progress.report("Backward Transformation");
     // Backward transform
     fft = createChildAlgorithm("RealFFT", 0.5, 1.);
-    fft->setProperty("InputWorkspace", m_filteredWS);
-    // fft->setProperty("Real",0);
-    // fft->setProperty("Imaginary",1);
+    fft->setProperty("InputWorkspace", filteredWS);
     fft->setProperty("Transform", "Backward");
     fft->setProperty("IgnoreXBins", ignoreXBins);
     try {
@@ -184,32 +183,14 @@ void FFTSmooth2::exec() {
     // probably be used.
     dn = static_cast<int>(tmpWS->blocksize()) / 2;
 
-    // x-value correction is needed if the size of the spectrum is changed (e.g.
-    // after truncation)
-    // but it doesn't work accurately enough, so commented out
-    //// Correct the x values:
-    // x0 -= tmpWS->dataX(0)[dn];
-    // if (tmpWS->isHistogramData())
-    //{// Align centres of the in and out histograms. I am not sure here
-    //  double dX = m_inWS->readX(0)[1] - m_inWS->readX(0)[0];
-    //  double dx = tmpWS->readX(0)[1] - tmpWS->readX(0)[0];
-    //  x0 += dX/2 - dx;
-    //}
-    // outWS->dataX(0).assign(tmpWS->readX(0).begin()+dn,tmpWS->readX(0).end());
-    // outWS->dataY(0).assign(tmpWS->readY(0).begin()+dn,tmpWS->readY(0).end());
-    //
-    // std::transform( outWS->dataX(0).begin(), outWS->dataX(0).end(),
-    // outWS->dataX(0).begin(),
-    //  std::bind2nd(std::plus<double>(), x0) );
-
     if (getProperty("AllSpectra")) {
       outWS->dataX(spec)
-          .assign(m_inWS->readX(spec).begin(), m_inWS->readX(spec).end());
+          .assign(inWS->readX(spec).begin(), inWS->readX(spec).end());
       outWS->dataY(spec)
           .assign(tmpWS->readY(0).begin() + dn, tmpWS->readY(0).end());
     } else {
       outWS->dataX(0)
-          .assign(m_inWS->readX(spec).begin(), m_inWS->readX(spec).end());
+          .assign(inWS->readX(spec).begin(), inWS->readX(spec).end());
       outWS->dataY(0)
           .assign(tmpWS->readY(0).begin() + dn, tmpWS->readY(0).end());
     }
@@ -218,90 +199,32 @@ void FFTSmooth2::exec() {
   setProperty("OutputWorkspace", outWS);
 }
 
-/** Smoothing by truncation.
- *  @param n :: The order of truncation
- */
-void FFTSmooth2::truncate(int n) {
-  int my = static_cast<int>(m_unfilteredWS->readY(0).size());
-  int ny = my / n;
-
-  double f = double(ny) / my;
-
-  if (ny == 0)
-    ny = 1;
-  int nx = m_unfilteredWS->isHistogramData() ? ny + 1 : ny;
-  m_filteredWS =
-      API::WorkspaceFactory::Instance().create(m_unfilteredWS, 2, nx, ny);
-
-  const Mantid::MantidVec &Yr = m_unfilteredWS->readY(0);
-  const Mantid::MantidVec &Yi = m_unfilteredWS->readY(1);
-  const Mantid::MantidVec &X = m_unfilteredWS->readX(0);
-
-  Mantid::MantidVec &yr = m_filteredWS->dataY(0);
-  Mantid::MantidVec &yi = m_filteredWS->dataY(1);
-  Mantid::MantidVec &xr = m_filteredWS->dataX(0);
-  Mantid::MantidVec &xi = m_filteredWS->dataX(1);
-
-  // int odd = ny % 2;
-
-  yr.assign(Yr.begin(), Yr.begin() + ny);
-  yi.assign(Yi.begin(), Yi.begin() + ny);
-  xr.assign(X.begin(), X.begin() + nx);
-  xi.assign(X.begin(), X.begin() + nx);
-
-  std::transform(yr.begin(), yr.end(), yr.begin(),
-                 std::bind2nd(std::multiplies<double>(), f));
-  std::transform(yi.begin(), yi.end(), yi.begin(),
-                 std::bind2nd(std::multiplies<double>(), f));
-
-  // for(int i=0;i<=ny2;i++)
-  //{
-  //  double re = Yr[my2 - i] * f;
-  //  double im = Yi[my2 - i] * f;
-  //  double x = X[my2 - i];
-  //  yr[ny2 - i] = re;
-  //  yi[ny2 - i] = im;
-  //  xr[ny2 - i] = x;
-  //  xi[ny2 - i] = x;
-  //  if (odd || i < ny2)
-  //  {
-  //    yr[ny2 + i] = re;
-  //    if (i > 0) yi[ny2 + i] = -im;
-  //    x = X[my2 + i];
-  //    xr[ny2 + i] = x;
-  //    xi[ny2 + i] = x;
-  //  }
-  //}
-
-  // if (m_filteredWS->isHistogramData())
-  //{
-  //  xr[ny] = X[my2 + ny2 + odd];
-  //  xi[ny] = xr[ny];
-  //}
-}
-
 /** Smoothing by zeroing.
  *  @param n :: The order of truncation
+ *  @param unfilteredWS :: workspace for storing the unfiltered Fourier
+ * transform of the input spectrum
+ *  @param filteredWS :: workspace for storing the filtered spectrum
  */
-void FFTSmooth2::zero(int n) {
-  int mx = static_cast<int>(m_unfilteredWS->readX(0).size());
-  int my = static_cast<int>(m_unfilteredWS->readY(0).size());
+void FFTSmooth2::zero(int n, API::MatrixWorkspace_sptr &unfilteredWS,
+                      API::MatrixWorkspace_sptr &filteredWS) {
+  int mx = static_cast<int>(unfilteredWS->readX(0).size());
+  int my = static_cast<int>(unfilteredWS->readY(0).size());
   int ny = my / n;
 
   if (ny == 0)
     ny = 1;
 
-  m_filteredWS =
-      API::WorkspaceFactory::Instance().create(m_unfilteredWS, 2, mx, my);
+  filteredWS =
+      API::WorkspaceFactory::Instance().create(unfilteredWS, 2, mx, my);
 
-  const Mantid::MantidVec &Yr = m_unfilteredWS->readY(0);
-  const Mantid::MantidVec &Yi = m_unfilteredWS->readY(1);
-  const Mantid::MantidVec &X = m_unfilteredWS->readX(0);
+  const Mantid::MantidVec &Yr = unfilteredWS->readY(0);
+  const Mantid::MantidVec &Yi = unfilteredWS->readY(1);
+  const Mantid::MantidVec &X = unfilteredWS->readX(0);
 
-  Mantid::MantidVec &yr = m_filteredWS->dataY(0);
-  Mantid::MantidVec &yi = m_filteredWS->dataY(1);
-  Mantid::MantidVec &xr = m_filteredWS->dataX(0);
-  Mantid::MantidVec &xi = m_filteredWS->dataX(1);
+  Mantid::MantidVec &yr = filteredWS->dataY(0);
+  Mantid::MantidVec &yi = filteredWS->dataY(1);
+  Mantid::MantidVec &xr = filteredWS->dataX(0);
+  Mantid::MantidVec &xi = filteredWS->dataX(1);
 
   xr.assign(X.begin(), X.end());
   xi.assign(X.begin(), X.end());
@@ -309,11 +232,8 @@ void FFTSmooth2::zero(int n) {
   yi.assign(Yr.size(), 0);
 
   for (int i = 0; i < ny; i++) {
-    // if (abs(my2-i) < ny2)
-    //{
     yr[i] = Yr[i];
     yi[i] = Yi[i];
-    //}
   }
 }
 
@@ -326,26 +246,31 @@ void FFTSmooth2::zero(int n) {
  *               and set to 1 if the truncated value was zero.
  *  @param order :: The order of the Butterworth filter, 1, 2, etc.
  *               This must be a positive integer.
+ *  @param unfilteredWS :: workspace for storing the unfiltered Fourier
+ * transform of the input spectrum
+ *  @param filteredWS :: workspace for storing the filtered spectrum
  */
-void FFTSmooth2::Butterworth(int n, int order) {
-  int mx = static_cast<int>(m_unfilteredWS->readX(0).size());
-  int my = static_cast<int>(m_unfilteredWS->readY(0).size());
+void FFTSmooth2::Butterworth(int n, int order,
+                             API::MatrixWorkspace_sptr &unfilteredWS,
+                             API::MatrixWorkspace_sptr &filteredWS) {
+  int mx = static_cast<int>(unfilteredWS->readX(0).size());
+  int my = static_cast<int>(unfilteredWS->readY(0).size());
   int ny = my / n;
 
   if (ny == 0)
     ny = 1;
 
-  m_filteredWS =
-      API::WorkspaceFactory::Instance().create(m_unfilteredWS, 2, mx, my);
+  filteredWS =
+      API::WorkspaceFactory::Instance().create(unfilteredWS, 2, mx, my);
 
-  const Mantid::MantidVec &Yr = m_unfilteredWS->readY(0);
-  const Mantid::MantidVec &Yi = m_unfilteredWS->readY(1);
-  const Mantid::MantidVec &X = m_unfilteredWS->readX(0);
+  const Mantid::MantidVec &Yr = unfilteredWS->readY(0);
+  const Mantid::MantidVec &Yi = unfilteredWS->readY(1);
+  const Mantid::MantidVec &X = unfilteredWS->readX(0);
 
-  Mantid::MantidVec &yr = m_filteredWS->dataY(0);
-  Mantid::MantidVec &yi = m_filteredWS->dataY(1);
-  Mantid::MantidVec &xr = m_filteredWS->dataX(0);
-  Mantid::MantidVec &xi = m_filteredWS->dataX(1);
+  Mantid::MantidVec &yr = filteredWS->dataY(0);
+  Mantid::MantidVec &yi = filteredWS->dataY(1);
+  Mantid::MantidVec &xr = filteredWS->dataX(0);
+  Mantid::MantidVec &xi = filteredWS->dataX(1);
 
   xr.assign(X.begin(), X.end());
   xi.assign(X.begin(), X.end());

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -1415,8 +1415,7 @@ void FitPeak::createFunctions() {
   if (m_bkgdParameterNames.size() != vec_bkgdparvalues.size()) {
     stringstream errss;
     errss << "Input background properties' arrays are incorrect: # of "
-             "parameter names = "
-          << m_bkgdParameterNames.size()
+             "parameter names = " << m_bkgdParameterNames.size()
           << ", # of parameter values = " << vec_bkgdparvalues.size() << "\n";
     g_log.error(errss.str());
     throw runtime_error(errss.str());
@@ -1453,8 +1452,7 @@ void FitPeak::createFunctions() {
   if (m_peakParameterNames.size() != vec_peakparvalues.size()) {
     stringstream errss;
     errss << "Input peak properties' arrays are incorrect: # of parameter "
-             "names = "
-          << m_peakParameterNames.size()
+             "names = " << m_peakParameterNames.size()
           << ", # of parameter values = " << vec_peakparvalues.size() << "\n";
     throw runtime_error(errss.str());
   }

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -322,6 +322,9 @@ bool FitOneSinglePeak::simpleFit() {
 
   // Fit with different starting values of peak width
   size_t numfits = m_vecFWHM.size();
+
+  Progress progress(this, 0, 1, numfits);
+
   for (size_t i = 0; i < numfits; ++i) {
     // set FWHM
     m_sstream << "[SingleStepFit] FWHM = " << m_vecFWHM[i] << "\n";
@@ -337,6 +340,8 @@ bool FitOneSinglePeak::simpleFit() {
       pop(m_bkupPeakFunc, m_peakFunc);
       pop(m_bkupBkgdFunc, m_bkgdFunc);
     }
+
+    progress.report();
   }
 
   // Retrieve the best result stored
@@ -533,6 +538,8 @@ void FitOneSinglePeak::highBkgdFit() {
   // Store starting setup
   push(m_peakFunc, m_bkupPeakFunc);
 
+  Progress progress(this, 0, 1, m_vecFWHM.size());
+
   // Fit with different starting values of peak width
   for (size_t i = 0; i < m_vecFWHM.size(); ++i) {
     // Restore
@@ -552,6 +559,8 @@ void FitOneSinglePeak::highBkgdFit() {
 
     // Store result
     processNStoreFitResult(rwp, false);
+
+    progress.report();
   }
 
   // Get best fitting peak function and Make a combo fit
@@ -1406,7 +1415,8 @@ void FitPeak::createFunctions() {
   if (m_bkgdParameterNames.size() != vec_bkgdparvalues.size()) {
     stringstream errss;
     errss << "Input background properties' arrays are incorrect: # of "
-             "parameter names = " << m_bkgdParameterNames.size()
+             "parameter names = "
+          << m_bkgdParameterNames.size()
           << ", # of parameter values = " << vec_bkgdparvalues.size() << "\n";
     g_log.error(errss.str());
     throw runtime_error(errss.str());
@@ -1443,7 +1453,8 @@ void FitPeak::createFunctions() {
   if (m_peakParameterNames.size() != vec_peakparvalues.size()) {
     stringstream errss;
     errss << "Input peak properties' arrays are incorrect: # of parameter "
-             "names = " << m_peakParameterNames.size()
+             "names = "
+          << m_peakParameterNames.size()
           << ", # of parameter values = " << vec_peakparvalues.size() << "\n";
     throw runtime_error(errss.str());
   }


### PR DESCRIPTION
Fixes #14295 

The release notes have not been updated.
### Changes

The algorithms FFTSmooth (v2) and FitPeak have been modified to include progress reporting. There was also general code maintenance to remove unused code/unecessary member variables. The other algorithms identified in the original issue did not require progress reporting.
### Testing
## FFTSmooth

Set BankPixelWidth=15, NumBanks=100
http://docs.mantidproject.org/nightly/algorithms/FFTSmooth-v2.html#id7
## FitPeak

http://docs.mantidproject.org/nightly/algorithms/FitPeak-v1.html#id16
