### PR TITLE
Fix a bug in SpecularReflectionPositionCorrect

### DIFF
--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
@@ -229,7 +229,7 @@ void SpecularReflectionPositionCorrect::correctPosition(
 
   double upOffset =
       (beamOffset *
-       std::tan(twoThetaInRad)); // We only correct vertical position
+       std::tan(0.5*twoThetaInRad)); // We only correct vertical position
 
   // Apply the movements.
   moveDetectors(toCorrect, detector, sample, upOffset, acrossOffset,

--- a/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionPositionCorrect.cpp
@@ -229,7 +229,7 @@ void SpecularReflectionPositionCorrect::correctPosition(
 
   double upOffset =
       (beamOffset *
-       std::tan(0.5*twoThetaInRad)); // We only correct vertical position
+       std::tan(0.5 * twoThetaInRad)); // We only correct vertical position
 
   // Apply the movements.
   moveDetectors(toCorrect, detector, sample, upOffset, acrossOffset,

--- a/Framework/Algorithms/test/SpecularReflectionPositionCorrectTest.h
+++ b/Framework/Algorithms/test/SpecularReflectionPositionCorrectTest.h
@@ -155,7 +155,7 @@ public:
     alg.initialize();
     alg.setProperty("InputWorkspace", toConvert);
     alg.setPropertyValue("OutputWorkspace", "test_out");
-    alg.setProperty("TwoThetaIn", 2*currentThetaInDeg);
+    alg.setProperty("TwoThetaIn", 2 * currentThetaInDeg);
     alg.execute();
     MatrixWorkspace_sptr corrected = alg.getProperty("OutputWorkspace");
 
@@ -197,7 +197,7 @@ public:
     alg.setPropertyValue("OutputWorkspace", "test_out");
     if (!detectorFindProperty.empty())
       alg.setProperty(detectorFindProperty, stringValue);
-    alg.setProperty("TwoThetaIn", 2*thetaInDegrees);
+    alg.setProperty("TwoThetaIn", 2 * thetaInDegrees);
     alg.execute();
     MatrixWorkspace_sptr corrected = alg.getProperty("OutputWorkspace");
 

--- a/Framework/Algorithms/test/SpecularReflectionPositionCorrectTest.h
+++ b/Framework/Algorithms/test/SpecularReflectionPositionCorrectTest.h
@@ -155,7 +155,7 @@ public:
     alg.initialize();
     alg.setProperty("InputWorkspace", toConvert);
     alg.setPropertyValue("OutputWorkspace", "test_out");
-    alg.setProperty("TwoThetaIn", currentThetaInDeg);
+    alg.setProperty("TwoThetaIn", 2*currentThetaInDeg);
     alg.execute();
     MatrixWorkspace_sptr corrected = alg.getProperty("OutputWorkspace");
 
@@ -197,7 +197,7 @@ public:
     alg.setPropertyValue("OutputWorkspace", "test_out");
     if (!detectorFindProperty.empty())
       alg.setProperty(detectorFindProperty, stringValue);
-    alg.setProperty("TwoThetaIn", thetaInDegrees);
+    alg.setProperty("TwoThetaIn", 2*thetaInDegrees);
     alg.execute();
     MatrixWorkspace_sptr corrected = alg.getProperty("OutputWorkspace");
 

--- a/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAuto.py
+++ b/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAuto.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init,invalid-name
+﻿#pylint: disable=no-init,invalid-name
 """
 This system test verifies that OFFSPEC data is processed correctly by
 ReflectometryReductionOneAuto
@@ -16,15 +16,15 @@ class OFFSPECReflRedOneAuto(stresstesting.MantidStressTest):
 
         #Process using ReflectometryReductionOneAuto
         ivq_75, __, __ = ReflectometryReductionOneAuto(offspec75,
-                                                       ThetaIn=0.35,
+                                                       ThetaIn=0.70,#2*th
                                                        FirstTransmissionRun=offspec85)
 
         ivq_76, __, __ = ReflectometryReductionOneAuto(offspec76,
-                                                       ThetaIn=1.00,
+                                                       ThetaIn=2.00,#2*th
                                                        FirstTransmissionRun=offspec85)
 
         ivq_78, __, __ = ReflectometryReductionOneAuto(offspec78,
-                                                       ThetaIn=1.70,
+                                                       ThetaIn=3.40,#2*th
                                                        FirstTransmissionRun=offspec85)
 
         ivq_75_76, __ = Stitch1D(ivq_75, ivq_76, Params="1e-3")

--- a/Testing/SystemTests/tests/analysis/RROAutoFunctionalityTests.py
+++ b/Testing/SystemTests/tests/analysis/RROAutoFunctionalityTests.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 import stresstesting
 from algorithm_decorator import make_decorator
 from mantid.simpleapi import *
@@ -134,7 +134,7 @@ class RROAutoFunctionalityTest(stresstesting.MantidStressTest):
         alg.set_ProcessingInstructions("73") # Fictional values
         alg.set_CorrectDetectorPositions(True)
         alg.set_RegionOfDirectBeam("28, 29") # Fictional values
-        alg.set_ThetaIn(0.49 / 2) # Fictional values
+        alg.set_ThetaIn(0.49) # Fictional values
 
         out_ws_q, out_ws_lam, theta =  alg.execute()
 

--- a/docs/source/algorithms/SpecularReflectionPositionCorrect-v1.rst
+++ b/docs/source/algorithms/SpecularReflectionPositionCorrect-v1.rst
@@ -54,7 +54,7 @@ Output:
 
 .. testoutput:: SpecularReflectionPositionCorrectExample 
  
-   [0,1,1]
+   [0,0.414214,1]
 
 .. categories::
 


### PR DESCRIPTION
Fixes #14371 

To test: Please, review the code changes. `SpecularReflectionPositionCorrect()` takes `TwoThetaIn` as input and it uses this value to calculate the Y shift, but it should use just `Theta`. The following script:

```
import sys
sys.path.append(r'C:\Users\dsl37522\Desktop\Routines')
import Sanity as s

r=s.Runs()
dref=s.OurLoad(r[36265,36266,36267,36268])
#MoveInstrumentComponent(dref,'DetectorBench',Y=0.0404)
dtrans=s.OurLoad(r[36252])

Transo=CreateTransmissionWorkspaceAuto(dtrans,AnalysisMode="MultiDetectorAnalysis",ProcessingInstructions="380-428",WavelengthMin=2.0)
IvsQ2o, IvsLam2o, thetaOut=ReflectometryReductionOneAuto(dref,AnalysisMode="MultiDetectorAnalysis",ProcessingInstructions="390-450", FirstTransmissionRun=Transo, ThetaIn="0.64",WavelengthMin=2.0,CorrectionAlgorithm='None',StrictSpectrumChecking=False,CorrectDetectorPositions=True)#,NormalizeByIntegratedMonitors=False
IvsQo, IvsLamo, thetaOut=ReflectometryReductionOneAuto(dref,AnalysisMode="MultiDetectorAnalysis",ProcessingInstructions=','.join(map(str, range(250, 558))), FirstTransmissionRun=Transo, ThetaIn="0.64",WavelengthMin=2.0,CorrectionAlgorithm='None',StrictSpectrumChecking=False,CorrectDetectorPositions=True)#,NormalizeByIntegratedMonitors=False
TvLo = ConvertSpectrumAxis(IvsLamo,'SignedTheta')
ConvertToReflectometryQ(TvLo,IncidentTheta=0.64,DumpVertexes=True,OverrideIncidentTheta=True, OutputWorkspace="QxQz",OutputVertexes="Qtableo",Extents=[-5e-4,3e-4,0.008,0.08],NumberBinsQz=500,NumberBinsQx=500,Method='NormalisedPolygon',OutputAsMDWorkspace=False)
```

should produce a QxQz map identical to the first map in #14371.

Release notes: http://www.mantidproject.org/index.php?title=Release_Notes_3_6_Reflectometry&diff=25535&oldid=25512
