### PR TITLE
Fixing ISIS autoconfig script

### DIFF
--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -811,7 +811,7 @@ class MantidConfigDirectInelastic(object):
 if __name__ == "__main__":
 
     if len(sys.argv) != 6:
-        print "usage: Config.py instrument userID cycleID start_date rb_folder"
+        print "usage: Config.py userID instrument RBNumber cycleID start_date"
         exit()
 
     argi  = sys.argv[1:]

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -285,9 +285,13 @@ class MantidConfigDirectInelastic(object):
         # missing file should always be replaced
         if not os.path.isfile(config_file_name):
             return True
-        modification_date = date.fromtimestamp(os.path.getmtime(config_file_name))
+
         start_date = self._user.start_date
-        if modification_date<start_date:
+        unmodified_creation_time = time.mktime(start_date.timetuple())
+        targ_config_time  = os.path.getmtime(config_file_name)
+
+        # Only rewrite configuration if nobody have touched it
+        if unmodified_creation_time  == targ_config_time:
             return True
         else:
             return False
@@ -689,6 +693,12 @@ class MantidConfigDirectInelastic(object):
         fp.close()
         if platform.system() != 'Windows':
             os.system('chown -R {0}:{0} {1}'.format(self._fedid,config_file_name))
+        # Set up configuration for the specific time, which should change only if user 
+        # modified this configuration
+        start_date = self._user.start_date
+        file_time = time.mktime(start_date.timetuple())
+        os.utime(config_file_name,(file_time,file_time))
+
 
 if __name__ == "__main__":
 
@@ -725,7 +735,7 @@ if __name__ == "__main__":
     else:
         sys.path.insert(0,'/opt/Mantid/scripts/Inelastic/Direct/')
         #sys.path.insert(0,'/opt/mantidnightly/scripts/Inelastic/Direct/')
-        WinDebug=False
+
 
         MantidDir = '/opt/Mantid'
         MapMaskDir = '/usr/local/mprogs/InstrumentFiles/'

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -258,7 +258,7 @@ class UserProperties(object):
                     rbf = "RB{0:07}".format(rbf)
                     rb_folder_or_id = os.path.join(base,rbf)
                 except ValueError:
-                    raise RuntimeError("RB Folder {0} should be a string".format(rb_folder_or_id))
+                    raise RuntimeError("RB Folder {0} should be a string containing RB number at the end".format(rb_folder_or_id))
         #end
         if os.path.exists(rb_folder_or_id) and os.path.isdir(rb_folder_or_id):
             rb_exist = True

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -250,7 +250,16 @@ class UserProperties(object):
            rb_folder_or_id = "RB{0:07}".format(rb_folder_or_id)
         if not isinstance(rb_folder_or_id,str):
             raise RuntimeError("RB Folder {0} should be a string".format(rb_folder_or_id))
-
+        else:
+            base,rbf = os.path.split(rb_folder_or_id)
+            if(len(rbf) != 9):
+                try:
+                    rbf = int(rbf)
+                    rbf = "RB{0:07}".format(rbf)
+                    rb_folder_or_id = os.path.join(base,rbf)
+                except ValueError:
+                    raise RuntimeError("RB Folder {0} should be a string".format(rb_folder_or_id))
+        #end
         if os.path.exists(rb_folder_or_id) and os.path.isdir(rb_folder_or_id):
             rb_exist = True
         else:
@@ -613,7 +622,7 @@ class MantidConfigDirectInelastic(object):
             if isinstance(fedIDorUser,UserProperties):
                 theUser = fedIDorUser
             else:
-                raise RuntimeError("self.init_user(val) has to have val of UserProperty type only")
+                raise RuntimeError("self.init_user(val) has to have val of UserProperty type only and got")
         else:
             theUser.userID = fedIDorUser
         #
@@ -805,7 +814,8 @@ if __name__ == "__main__":
         print "usage: Config.py instrument userID cycleID start_date rb_folder"
         exit()
 
-    user = UserProperties(sys.argv[1:])
+    argi  = sys.argv[1:]
+    user = UserProperties(*argi)
 
 
     if platform.system() == 'Windows':
@@ -847,7 +857,8 @@ if __name__ == "__main__":
         print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(user.rb_dir,user.userID)
         exit()
     # Configure user
-    mcf.init_user(user)
+    mcf.init_user(user.userID,user)
     mcf.generate_config()
-    print "Successfully Configured user: ",user.userID," for instrument: ",user.instrument
+    print "Successfully Configured user: {0} for instrument {1} and RBNum: {2}"\
+           .format(user.userID,user.instrument,user.rb_folder)
 

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -1,5 +1,4 @@
 ﻿import os
-#os.environ["PATH"] = r"c:/Mantid/Code/builds/br_master/bin/Release;"+os.environ["PATH"]
 import unittest
 import shutil
 import datetime

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -123,8 +123,8 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.rbdir,'CYC20144',self.start_date)
         self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.rbdir,'CYCLE201444',self.start_date)
 
-        #self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.start_date,'missing/folder')
-        user.set_user_properties('HET','missing/folder',self.cycle,"19990101")
+        self.assertRaises(RuntimeError,user.set_user_properties,'HET','missing/folder',self.cycle,"19990101")
+        #user.set_user_properties('HET','missing/folder',self.cycle,"19990101")
         # this refers to recent experiment, not the old one
         self.assertTrue(user.rb_dir_exist)
 
@@ -419,7 +419,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
 
 if __name__=="__main__":
-   #test = ISISDirectInelasticConfigTest('test_init_user')
+   #test = ISISDirectInelasticConfigTest('test_UserProperties')
    #test._set_up()
    #test.run()
    #test._tear_down()

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -137,7 +137,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
             shutil.rmtree(rbdir)
 
         self.assertEqual(len(user.instrument),6)
-        self.assertEqual(len(user._instrument),3)
+        self.assertEqual(len(user._instrument),2)
 
         self.assertEqual(user._recent_dateID,id)
         self.assertEqual(user._start_dates['2000-01-12'],datetime.date(2000,01,12))
@@ -150,7 +150,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         if os.path.exists(rbdir):
             shutil.rmtree(rbdir)
 
-        self.assertEqual(len(user._instrument),4)
+        self.assertEqual(len(user._instrument),3)
         id = user._recent_dateID
         self.assertEqual(id,'2016-12-01')
         self.assertEqual(user._instrument[id],'MERLIN')

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -100,7 +100,8 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
     def test_UserProperties(self):
         user = UserProperties(self.userID)
 
-        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+        #set_user_properties(self,instrument,rb_folder_or_id,cycle,start_date):
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
 
         id = user._recent_dateID
         self.assertEqual(user._instrument[id],'MERLIN')
@@ -115,22 +116,28 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         self.assertEqual(user.rb_dir,self.rbdir)
 
 
-        self.assertRaises(RuntimeError,user.set_user_properties,'SANS2D',self.start_date,self.cycle,self.rbdir)
-        self.assertRaises(RuntimeError,user.set_user_properties,'HET','201400000',self.cycle,self.rbdir)
-        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.start_date,'20144',self.rbdir)
-        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.start_date,'CYC20144',self.rbdir)
-        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.start_date,'CYCLE201444',self.rbdir)
-        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.start_date,self.cycle,'missing/folder')
+
+        self.assertRaises(RuntimeError,user.set_user_properties,'SANS2D',self.rbdir,self.cycle,self.start_date)
+        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.rbdir,self.cycle,'201400000')
+        #self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.rbdir,'20144',self.start_date)
+        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.rbdir,'CYC20144',self.start_date)
+        self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.rbdir,'CYCLE201444',self.start_date)
+
+        #self.assertRaises(RuntimeError,user.set_user_properties,'HET',self.start_date,'missing/folder')
+        user.set_user_properties('HET','missing/folder',self.cycle,"19990101")
+        # this refers to recent experiment, not the old one
+        self.assertTrue(user.rb_dir_exist)
+
 
         rbdir = os.path.join(self.userRootDir,'RB1000666')
         if not os.path.exists(rbdir):
             os.makedirs(rbdir)
-        user.set_user_properties('MARI','20000112','CYCLE20001',rbdir)
+        user.set_user_properties('MARI',rbdir,'CYCLE20001','20000112')
         if os.path.exists(rbdir):
             shutil.rmtree(rbdir)
 
         self.assertEqual(len(user.instrument),6)
-        self.assertEqual(len(user._instrument),2)
+        self.assertEqual(len(user._instrument),3)
 
         self.assertEqual(user._recent_dateID,id)
         self.assertEqual(user._start_dates['2000-01-12'],datetime.date(2000,01,12))
@@ -139,11 +146,11 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         rbdir = os.path.join(self.userRootDir,'RB1999666')
         if not os.path.exists(rbdir):
             os.makedirs(rbdir)
-        user.set_user_properties('MERLIN','20161201','CYCLE20163',rbdir)
+        user.set_user_properties('MERLIN',rbdir,'CYCLE20163','20161201')
         if os.path.exists(rbdir):
             shutil.rmtree(rbdir)
 
-        self.assertEqual(len(user._instrument),3)
+        self.assertEqual(len(user._instrument),4)
         id = user._recent_dateID
         self.assertEqual(id,'2016-12-01')
         self.assertEqual(user._instrument[id],'MERLIN')
@@ -165,7 +172,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         self.assertRaises(RuntimeError,MantidConfigDirectInelastic,MantidDir,HomeRootDir,self.UserScriptRepoDir,'MissingMapMaskDir')
 
         user = UserProperties(self.userID)
-        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
 
         # clear up the previous
         if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
@@ -190,12 +197,12 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         reduction_file = os.path.join(mcf._user.rb_dir,targ_file)
         self.assertTrue(os.path.isfile(reduction_file))
 
-        self.assertFalse(mcf.config_need_replacing(config_file))
+        self.assertTrue(mcf.config_need_replacing(config_file))
         start_date = user.start_date
         date_in_apast=datetime.date(start_date.year,start_date.month,start_date.day-1)
-        time_in_a_past = time.mktime(date_in_apast.timetuple())
-        os.utime(config_file,(time_in_a_past,time_in_a_past))
-        self.assertTrue(mcf.config_need_replacing(config_file))
+        time_user_touched = time.mktime(date_in_apast.timetuple())
+        os.utime(config_file,(time_user_touched,time_user_touched))
+        self.assertFalse(mcf.config_need_replacing(config_file))
         # clear up
         if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
             shutil.rmtree(os.path.join(self.userRootDir,'.mantid'))
@@ -209,7 +216,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         mcf = MantidConfigDirectInelastic(MantidDir,HomeRootDir,self.UserScriptRepoDir,self.MapMaskDir)
 
         user = UserProperties(self.userID)
-        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
 
 
         rbnum2='RB1999000'
@@ -218,13 +225,13 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         rbdir2 = os.path.join(targetDir,self.userID,rbnum2)
         if not os.path.exists(rbdir2):
             os.makedirs(rbdir2)
-        user.set_user_properties('MARI','20000124','CYCLE20001',rbdir2)
+        user.set_user_properties('MARI',rbdir2,'CYCLE20001','20000124')
 
         rbnum3='RB1204000'
         rbdir3 = os.path.join(targetDir,self.userID,rbnum3)
         if not os.path.exists(rbdir3):
             os.makedirs(rbdir3)
-        user.set_user_properties('MAPS','20041207','CYCLE20044',rbdir3)
+        user.set_user_properties('MAPS',rbdir3,'CYCLE20044','20041207')
 
         # clear up the previous
         if os.path.exists(os.path.join(self.userRootDir,'.mantid')):
@@ -243,12 +250,12 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.userRootDir,'.mantid')))
         self.assertTrue(os.path.exists(config_file))
 
-        self.assertFalse(mcf.config_need_replacing(config_file))
+        self.assertTrue(mcf.config_need_replacing(config_file))
         start_date = user.start_date
         date_in_apast=datetime.date(start_date.year,start_date.month,start_date.day-1)
         time_in_a_past = time.mktime(date_in_apast.timetuple())
         os.utime(config_file,(time_in_a_past,time_in_a_past))
-        self.assertTrue(mcf.config_need_replacing(config_file))
+        self.assertFalse(mcf.config_need_replacing(config_file))
         #--------------------------------------------------------------------
         user1ID = 'tuf299966'
         user1RootDir = os.path.join(self.get_save_dir(),user1ID)
@@ -256,7 +263,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
             os.makedirs(user1RootDir)
         #
         user1 = UserProperties(user1ID)
-        user1.set_user_properties('MARI','20990124','CYCLE20991',rbdir2)
+        user1.set_user_properties('MARI',rbdir2,'CYCLE20991','20990124')
 
         mcf.init_user(user1)
         source_file = self.makeFakeSourceReductionFile(mcf)
@@ -300,12 +307,12 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
     def test_replace_user_variables(self):
         user = UserProperties("wkc26243")
-        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
 
         targ_string = user.replace_variables('$instrument$ReductionScript$cycleID$.py')
         self.assertEqual(self.instrument+'ReductionScript2015_1.py',targ_string)
         self.assertEqual(user.GID,'1310168')
-        
+
     def test_parse_file_description(self):
 
         this_file = os.path.realpath(__file__)
@@ -319,7 +326,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         
         user = UserProperties(self.userID)
-        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
         mcf.init_user(user)
 
         # test old defaults, deployed if no User_files_description are defined
@@ -368,7 +375,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         
         user = UserProperties(self.userID)
-        user.set_user_properties(self.instrument,self.start_date,self.cycle,self.rbdir)
+        user.set_user_properties(self.instrument,self.rbdir,self.cycle,self.start_date)
 
         mcf.init_user(self.userID,user)
         user1 = mcf._user
@@ -380,9 +387,41 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         self.assertRaises(RuntimeError,mcf.init_user,'bla_bla_bla')
 
+    def test_various_user_constructors(self):
+        
+        user = UserProperties('tusxxx MARI RB1040506 153 150821')
+        sus = str(user)
+        self.assertEqual(sus,'tusxxx MARI RB1040506 2015_3 2015-08-21')
+
+        user1 = UserProperties(sus)
+        sus1  = str(user1)
+        self.assertEqual(sus,sus1)
+
+        user2 = UserProperties('tusxxx','MARI','RB1040506','2015_3','20150821')
+        sus2  = str(user2)
+        self.assertEqual(sus,sus2)
+
+        user2.rb_dir = 'bla_bla_bla'
+        self.assertFalse(user2.rb_dir_exist)
+
+
+        user3 = UserProperties(self.userID,self.instrument,self.rbdir,self.cycle, self.start_date)
+        self.assertTrue(user3.rb_dir_exist)
+
+        rb_folder = user3.rb_dir
+        base,rb = os.path.split(rb_folder)
+        user3.rb_dir = base
+        self.assertTrue(user3.rb_dir_exist)
+        rb_folder1 = user3.rb_dir
+        self.assertEqual(rb_folder,rb_folder1)
 
 
 
 
 if __name__=="__main__":
-    unittest.main()
+   #test = ISISDirectInelasticConfigTest('test_init_user')
+   #test._set_up()
+   #test.run()
+   #test._tear_down()
+
+   unittest.main()

--- a/scripts/test/MariReduction.py
+++ b/scripts/test/MariReduction.py
@@ -1,7 +1,5 @@
 """ Sample MARI reduction scrip used in testing ReductionWrapper """
 import os
-#os.environ["PATH"] =\
-#r"c:/Mantid/Code/builds/br_10881/bin/Release;"+os.environ["PATH"]
 
 from Direct.ReductionWrapper import *
 try:

--- a/scripts/test/User_files_description_test.xml
+++ b/scripts/test/User_files_description_test.xml
@@ -21,7 +21,7 @@
   -->    
   <file_to_copy file_name="Test_reduction_file.py" copy_as="Test_reduction_file_$cycleID$.py">
     <replace var  ="Test_reduction_file" by_var="$instrument$Test_reduction_file_$cycleID$"/>
-    <replace var  ="AAAA" by_var="BBB"/>  
+    <replace var  ="AAAA" by_var="BBB"/>
   </file_to_copy>
 
 </user_files_description>

--- a/scripts/test/User_files_description_test.xml
+++ b/scripts/test/User_files_description_test.xml
@@ -18,7 +18,7 @@
 
  <!--Advanced file copying 
     Variables have to be either strings or strings with variables, described above
-  -->    
+  -->
   <file_to_copy file_name="Test_reduction_file.py" copy_as="Test_reduction_file_$cycleID$.py">
     <replace var  ="Test_reduction_file" by_var="$instrument$Test_reduction_file_$cycleID$"/>
     <replace var  ="AAAA" by_var="BBB"/>


### PR DESCRIPTION
The work is divided into two parts where one is here and another -- deals with ISIS administrative script, which runs this one. That part is outside Mantid. 

The essence of this ticket appears to modify ISIS configuration script to run from command line. I did this not very nicely, but the thing works.  Script expected to run from command line for testing purposes only in very specific situation, on ISIS isiscompute services, so tester probably should not bother recreating such configuration on his/her machine, though he can see what is necessary by looking through **name**=='**main**'  part of the script.  It is also runs as part of ISIS administrative script and it works, so no doubt that the issue have been fixed. 

Test by code review. 

As the changes are largely administrative, user should not care, so no release notes.
