### PR TITLE
Added progress report in algorithms: CreatePeaksWorkspace, CreatePSDBleedMask

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CreatePSDBleedMask.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreatePSDBleedMask.h
@@ -67,18 +67,11 @@ private:
 
   /// Process a tube
   bool performBleedTest(const std::vector<int> &tubeIndices,
-                        API::MatrixWorkspace_const_sptr inputWS);
+                        API::MatrixWorkspace_const_sptr inputWS, double maxRate,
+                        int numIgnoredPixels);
   /// Mask a tube with the given workspace indices
   void maskTube(const std::vector<int> &tubeIndices,
                 API::MatrixWorkspace_sptr workspace);
-
-  /// Maximum allowed rate
-  double m_maxRate;
-  /// Number of ignored pixels
-  int m_numIgnoredPixels;
-  /// Is the input a distribution or raw counts. If true then bin width division
-  /// is necessary when calculating the rate
-  bool m_isRawCounts;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
+++ b/Framework/Algorithms/src/CreatePeaksWorkspace.cpp
@@ -52,11 +52,14 @@ void CreatePeaksWorkspace::exec() {
   int NumberOfPeaks = getProperty("NumberOfPeaks");
 
   if (instWS) {
+    Progress progress(this, 0, 1, NumberOfPeaks);
+
     out->setInstrument(instWS->getInstrument());
     // Create some default peaks
     for (int i = 0; i < NumberOfPeaks; i++) {
       out->addPeak(Peak(out->getInstrument(),
                         out->getInstrument()->getDetectorIDs(true)[0], 1.0));
+      progress.report();
     }
   }
 }


### PR DESCRIPTION
Fixes #14294 

The release notes have not been updated.
## Changes

The algorithms CreatePeaksWorkspace and CreatePSDBleedMask are now reporting progress. The other algorithms listed in the original issue execute very quickly and therefore do not need progress reports.
## Testing
### CreatePeaksWorkspace

Test in script editor:

_sampleWs = CreateSampleWorkspace(BankPixelWidth=50, NumBanks=100)_
_ws = CreatePeaksWorkspace(InstrumentWorkspace=sampleWs,NumberOfPeaks=3)_
_print "Created a %s with %i rows" % (ws.id(), ws.rowCount())_
### CreatePSDBleedMask

Test in script editor:

_import numpy as np_

_ws=CreateSampleWorkspace(BankPixelWidth=20, NumBanks=100)_
_AddSampleLog(ws,"goodfrm","10","Number")_
_noisyY =  np.array(ws.readY(0))_
_noisyY[0]=1e20_
_ws.setY(50,noisyY)_
_(wsOut, numFailures) = CreatePSDBleedMask(ws,MaxTubeFramerate=10,_ _NIgnoredCentralPixels=2)_

_print "%i spectra have been masked in wsOut" % numFailures_
