### PR TITLE
Ensure Resolution workspace remains after ResNorm run

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -103,11 +103,18 @@ void ResNorm::run() {
   double eMax(m_dblManager->value(m_properties["EMax"]));
 
   QString outputWsName = getWorkspaceBasename(vanWsName) + "_ResNorm";
+  QString resCloneName = "__" + resWsName + "_temp";
+  IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
+  clone->initialize();
+  clone->setProperty("InputWorkspace", resWsName.toStdString());
+  clone->setProperty("OutputWorkspace", resCloneName.toStdString());
+  clone->execute();
+
 
   IAlgorithm_sptr resNorm = AlgorithmManager::Instance().create("ResNorm", 2);
   resNorm->initialize();
   resNorm->setProperty("VanadiumWorkspace", vanWsName.toStdString());
-  resNorm->setProperty("ResolutionWorkspace", resWsName.toStdString());
+  resNorm->setProperty("ResolutionWorkspace", resCloneName.toStdString());
   resNorm->setProperty("EnergyMin", eMin);
   resNorm->setProperty("EnergyMax", eMax);
   resNorm->setProperty("CreateOutput", true);


### PR DESCRIPTION
Fixes #14015

ResNorm can now be run and saved through the interface while having a workspace input for the Resolution.

**Test data can be found in the `\ExternalData\Testing\Data\UnitTest` directory**
# To Test
- Open ResNorm (Interfaces > Indirect > Bayes > ResNorm)
- Vanadium=`irs26173_graphite002_red.nxs`
- Resolution=`irs26173_graphite002_res.nxs`
- Ensure both files have been loaded into the ADS
- Change Resolution from `File` to `Workspace` using the drop down menu in the interface (next to the Resolution input field)
- Ensure that the workspace ending in `_res` is being used
- Check the `Save Result` box 
- Click `Run`
- Ensure that the algorithm runs to completion and produces no errors regarding missing workspaces / saving problems
