### PR TITLE
SaveGSASInstrumentFile moved from Algorithms/ to DataHandlers/

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -224,7 +224,6 @@ set ( SRC_FILES
 	src/SampleCorrections/MayersSampleCorrection.cpp
 	src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
 	src/SassenaFFT.cpp
-	src/SaveGSASInstrumentFile.cpp
 	src/Scale.cpp
 	src/ScaleX.cpp
 	src/Segfault.cpp
@@ -503,7 +502,6 @@ set ( INC_FILES
 	inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrection.h
 	inc/MantidAlgorithms/SampleCorrections/MayersSampleCorrectionStrategy.h
 	inc/MantidAlgorithms/SassenaFFT.h
-	inc/MantidAlgorithms/SaveGSASInstrumentFile.h
 	inc/MantidAlgorithms/Scale.h
 	inc/MantidAlgorithms/ScaleX.h
 	inc/MantidAlgorithms/Segfault.h
@@ -776,7 +774,6 @@ set ( TEST_FILES
 	RingProfileTest.h
 	SANSCollimationLengthEstimatorTest.h
 	SassenaFFTTest.h
-	SaveGSASInstrumentFileTest.h
 	ScaleTest.h
 	ScaleXTest.h
 	SetInstrumentParameterTest.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -126,6 +126,7 @@ set ( SRC_FILES
 	src/SaveDspacemap.cpp
 	src/SaveFocusedXYE.cpp
 	src/SaveFullprofResolution.cpp
+	src/SaveGSASInstrumentFile.cpp
 	src/SaveGSS.cpp
 	src/SaveILLCosmosAscii.cpp
 	src/SaveISISNexus.cpp
@@ -278,6 +279,7 @@ set ( INC_FILES
 	inc/MantidDataHandling/SaveDspacemap.h
 	inc/MantidDataHandling/SaveFocusedXYE.h
 	inc/MantidDataHandling/SaveFullprofResolution.h
+	inc/MantidDataHandling/SaveGSASInstrumentFile.h
 	inc/MantidDataHandling/SaveGSS.h
 	inc/MantidDataHandling/SaveILLCosmosAscii.h
 	inc/MantidDataHandling/SaveISISNexus.h
@@ -427,6 +429,7 @@ set ( TEST_FILES
 	SaveDspacemapTest.h
 	SaveFocussedXYETest.h
 	SaveFullprofResolutionTest.h
+	SaveGSASInstrumentFileTest.h
 	SaveGSSTest.h
 	SaveILLCosmosAsciiTest.h
 	SaveIsawDetCalTest.h

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
@@ -84,15 +84,16 @@ private:
       std::map<unsigned int, std::map<std::string, double>> &profilemap);
 
   /// Convert to GSAS instrument file
-  void convertToGSAS(const std::vector<unsigned int> &outputbankids,
-                     const std::string &gsasinstrfilename,
-                     const std::map<unsigned int, std::map<std::string, double>>
-                         &bankprofilemap);
+  void
+  convertToGSAS(const std::vector<unsigned int> &outputbankids,
+                const std::string &gsasinstrfilename,
+                const std::map<unsigned int, std::map<std::string, double>> &
+                    bankprofilemap);
 
   /// Build a data structure for GSAS's tabulated peak profile
   void buildGSASTabulatedProfile(
-      const std::map<unsigned int, std::map<std::string, double>>
-          &bankprofilemap,
+      const std::map<unsigned int, std::map<std::string, double>> &
+          bankprofilemap,
       unsigned int bankid);
 
   /// Write the header of the file
@@ -100,10 +101,10 @@ private:
                       const std::string &prmfilename);
 
   /// Write out .prm/.iparm file
-  void
-  writePRMSingleBank(const std::map<unsigned int, std::map<std::string, double>>
-                         &bankprofilemap,
-                     unsigned int bankid, const std::string &prmfilename);
+  void writePRMSingleBank(
+      const std::map<unsigned int, std::map<std::string, double>> &
+          bankprofilemap,
+      unsigned int bankid, const std::string &prmfilename);
 
   /// Caclualte L2 from DIFFC and L1
   double calL2FromDtt1(double difc, double L1, double twotheta);

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
@@ -7,7 +7,7 @@
 #include "MantidDataObjects/TableWorkspace.h"
 
 namespace Mantid {
-namespace Algorithms {
+namespace DataHandling {
 
 class ChopperConfiguration;
 
@@ -53,7 +53,7 @@ public:
   virtual int version() const { return (1); }
   /// Algorithm's category for identification
   virtual const std::string category() const {
-    return "Diffraction\\DataHandling";
+    return "DataHandling\\Instrument";
   }
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
@@ -53,7 +53,7 @@ public:
   virtual int version() const { return (1); }
   /// Algorithm's category for identification
   virtual const std::string category() const {
-    return "DataHandling\\Instrument";
+    return "Diffraction\\DataHandling";
   }
 
 private:
@@ -84,16 +84,15 @@ private:
       std::map<unsigned int, std::map<std::string, double>> &profilemap);
 
   /// Convert to GSAS instrument file
-  void
-  convertToGSAS(const std::vector<unsigned int> &outputbankids,
-                const std::string &gsasinstrfilename,
-                const std::map<unsigned int, std::map<std::string, double>> &
-                    bankprofilemap);
+  void convertToGSAS(const std::vector<unsigned int> &outputbankids,
+                     const std::string &gsasinstrfilename,
+                     const std::map<unsigned int, std::map<std::string, double>>
+                         &bankprofilemap);
 
   /// Build a data structure for GSAS's tabulated peak profile
   void buildGSASTabulatedProfile(
-      const std::map<unsigned int, std::map<std::string, double>> &
-          bankprofilemap,
+      const std::map<unsigned int, std::map<std::string, double>>
+          &bankprofilemap,
       unsigned int bankid);
 
   /// Write the header of the file
@@ -101,10 +100,10 @@ private:
                       const std::string &prmfilename);
 
   /// Write out .prm/.iparm file
-  void writePRMSingleBank(
-      const std::map<unsigned int, std::map<std::string, double>> &
-          bankprofilemap,
-      unsigned int bankid, const std::string &prmfilename);
+  void
+  writePRMSingleBank(const std::map<unsigned int, std::map<std::string, double>>
+                         &bankprofilemap,
+                     unsigned int bankid, const std::string &prmfilename);
 
   /// Caclualte L2 from DIFFC and L1
   double calL2FromDtt1(double difc, double L1, double twotheta);

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveGSASInstrumentFile.h
@@ -177,7 +177,7 @@ private:
   std::map<unsigned int, double> m_bank_mxtof;
 };
 
-} // namespace Algorithms
+} // namespace DataHandling
 } // namespace Mantid
 
 #endif /* MANTID_ALGORITHMS_SAVEGSASINSTRUMENTFILE_H_ */

--- a/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
@@ -1161,5 +1161,5 @@ double SaveGSASInstrumentFile::erfc(double xx) {
   return y;
 }
 
-} // namespace Algorithms
+} // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
@@ -702,8 +702,8 @@ SaveGSASInstrumentFile::setupNOMConstants(int intfrequency) {
 void SaveGSASInstrumentFile::convertToGSAS(
     const std::vector<unsigned int> &outputbankids,
     const std::string &gsasinstrfilename,
-    const std::map<unsigned int, std::map<std::string, double>> &
-        bankprofilemap) {
+    const std::map<unsigned int, std::map<std::string, double>>
+        &bankprofilemap) {
   // Check
   if (!m_configuration)
     throw runtime_error("Not set up yet!");

--- a/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
@@ -702,8 +702,8 @@ SaveGSASInstrumentFile::setupNOMConstants(int intfrequency) {
 void SaveGSASInstrumentFile::convertToGSAS(
     const std::vector<unsigned int> &outputbankids,
     const std::string &gsasinstrfilename,
-    const std::map<unsigned int, std::map<std::string, double>>
-        &bankprofilemap) {
+    const std::map<unsigned int, std::map<std::string, double>> &
+        bankprofilemap) {
   // Check
   if (!m_configuration)
     throw runtime_error("Not set up yet!");

--- a/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
@@ -1,4 +1,4 @@
-#include "MantidAlgorithms/SaveGSASInstrumentFile.h"
+#include "MantidDataHandling/SaveGSASInstrumentFile.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidKernel/ListValidator.h"
@@ -16,7 +16,7 @@ using namespace Mantid::DataObjects;
 using namespace std;
 
 namespace Mantid {
-namespace Algorithms {
+namespace DataHandling {
 
 DECLARE_ALGORITHM(SaveGSASInstrumentFile)
 

--- a/Framework/DataHandling/test/SaveGSASInstrumentFileTest.h
+++ b/Framework/DataHandling/test/SaveGSASInstrumentFileTest.h
@@ -3,7 +3,7 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAlgorithms/SaveGSASInstrumentFile.h"
+#include "MantidDataHandling/SaveGSASInstrumentFile.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -17,7 +17,7 @@ using namespace Mantid::DataObjects;
 
 using namespace std;
 
-using Mantid::Algorithms::SaveGSASInstrumentFile;
+using Mantid::DataHandling::SaveGSASInstrumentFile;
 
 class SaveGSASInstrumentFileTest : public CxxTest::TestSuite {
 public:


### PR DESCRIPTION
Fixes #14253 

Release notes have not been updated
## Changes

This fix basically involved modifying the CMake files and moving files around in the repository. The namespace of the SaveGSASInstrumentFile was also changed from Mantid::Algorithms to Mantid::DataHandling.
## Testing

Here are a few points to use when testing this issue:
- Check that CMakeLists.txt for Algorithms no longer contains references to SaveGSASInstrumentFile/Test
- Check that CMakeLists.txt for DataHandlers now contains SaveGSASInstrumentFile/Test
- Ensure DataHandlingTest functions for SaveGSASInstrumentFile correctly
