### PR TITLE
Fix ipython launch script for Windows

### DIFF
--- a/buildconfig/CMake/Packaging/mantidpython.bat
+++ b/buildconfig/CMake/Packaging/mantidpython.bat
@@ -37,7 +37,7 @@ if "%1"=="--classic" (
 )
 
 :: Start ipython and pass through all arguments to it
-start "Mantid Python" /B /WAIT %_BIN_DIR%\python.exe %_BIN_DIR%\Scripts\ipython.py %*
+start "Mantid Python" /B /WAIT %_BIN_DIR%\python.exe %_BIN_DIR%\Scripts\ipython.cmd %*
 goto TheEnd
 
 :StartPython

--- a/buildconfig/CMake/Packaging/mantidpython.bat
+++ b/buildconfig/CMake/Packaging/mantidpython.bat
@@ -37,7 +37,7 @@ if "%1"=="--classic" (
 )
 
 :: Start ipython and pass through all arguments to it
-start "Mantid Python" /B /WAIT %_BIN_DIR%\python.exe %_BIN_DIR%\Scripts\ipython.cmd %*
+start "Mantid Python" /B /WAIT %_BIN_DIR%\Scripts\ipython.cmd %*
 goto TheEnd
 
 :StartPython


### PR DESCRIPTION
Fixes #14405 

Changed ipython.py back to ipython.cmd

Install from the installer package, the mantidpython.bat launch script is in /bin in the Mantid install directory. Running it from the command line should have the following behaviour:
- ipython should be launched
  `mantidpython.bat`
- ipython help should be displayed
  `mantidpython.bat -h`
- python should be launched
  `mantidpython.bat --classic`
- python help should be displayed
  `mantidpython.bat --classic -h`
