### PR TITLE
ConvFit sample log update

### DIFF
--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -301,7 +301,7 @@ void ConvolutionFitSequential::exec() {
 
   // Create Sample Log
   auto sampleLogStrings = std::map<std::string, std::string>();
-  sampleLogStrings["sam_workspace"] = inputWs->getName();
+  sampleLogStrings["sample_filename"] = inputWs->getName();
   sampleLogStrings["convolve_members"] = (convolve == 1) ? "true" : "false";
   sampleLogStrings["fit_program"] = "ConvFit";
   sampleLogStrings["background"] = backType;

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -219,9 +219,9 @@ void ConvFit::setup() {
 }
 
 /**
- * Handles the initial set up and running of the ConvolutionFitSequential
- * algorithm
- */
+* Handles the initial set up and running of the ConvolutionFitSequential
+* algorithm
+*/
 void ConvFit::run() {
   if (m_cfInputWS == NULL) {
     g_log.error("No workspace loaded");
@@ -297,10 +297,10 @@ void ConvFit::run() {
 }
 
 /**
- * Handles completion of the ConvolutionFitSequential algorithm.
- *
- * @param error True if the algorithm was stopped due to error, false otherwise
- */
+* Handles completion of the ConvolutionFitSequential algorithm.
+*
+* @param error True if the algorithm was stopped due to error, false otherwise
+*/
 void ConvFit::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(algorithmComplete(bool)));
@@ -343,6 +343,29 @@ void ConvFit::algorithmComplete(bool error) {
     }
   }
 
+  // Obtain WorkspaceGroup from ADS
+  std::string groupName = m_baseName.toStdString() + "_Workspaces";
+  WorkspaceGroup_sptr groupWs =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
+
+  // Log for Resolution to result Ws
+  auto resLog = AlgorithmManager::Instance().create("AddSampleLog");
+  resLog->setProperty("Workspace", resultWs->getName());
+  resLog->setProperty("LogName", "resolution_filename");
+  resLog->setProperty("LogText",
+                      m_uiForm.dsResInput->getCurrentDataName().toStdString());
+  resLog->setProperty("LogType", "String");
+  m_batchAlgoRunner->addAlgorithm(resLog);
+
+  // Log for resolution to group Ws
+  auto resLogGrp = AlgorithmManager::Instance().create("AddSampleLog");
+  resLogGrp->setProperty("Workspace", groupWs->getName());
+  resLogGrp->setProperty("LogName", "resolution_filename");
+  resLogGrp->setProperty(
+      "LogText", m_uiForm.dsResInput->getCurrentDataName().toStdString());
+  resLogGrp->setProperty("LogType", "String");
+  m_batchAlgoRunner->addAlgorithm(resLogGrp);
+
   // Handle Temperature logs
   if (m_uiForm.ckTempCorrection->isChecked()) {
     QString temperature = m_uiForm.leTempCorrection->text();
@@ -352,32 +375,37 @@ void ConvFit::algorithmComplete(bool error) {
     }
 
     if (temp != 0.0) {
-      // Obtain WorkspaceGroup from ADS
-      std::string groupName = m_baseName.toStdString() + "_Workspaces";
-      WorkspaceGroup_sptr groupWs =
-          AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
+      // Log for temp value in result Ws
+      auto valMtx = AlgorithmManager::Instance().create("AddSampleLog");
+      valMtx->setProperty("Workspace", resultWs->getName());
+      valMtx->setProperty("LogName", "temperature_value");
+      valMtx->setProperty("LogText", temperature.toStdString());
+      valMtx->setProperty("LogType", "Number");
+      m_batchAlgoRunner->addAlgorithm(valMtx);
 
-      auto addSample = AlgorithmManager::Instance().create("AddSampleLog");
-      addSample->setProperty("Workspace", resultWs);
-      addSample->setProperty("LogName", "temperature_value");
-      addSample->setProperty("LogText", temperature.toStdString());
-      addSample->setProperty("LogType", "Number");
-      addSample->execute();
-      addSample->setProperty("Workspace", resultWs);
-      addSample->setProperty("LogName", "temperature_correction");
-      addSample->setProperty("LogText", "true");
-      addSample->setProperty("LogType", "String");
-      addSample->execute();
-      addSample->setProperty("Workspace", groupWs);
-      addSample->setProperty("LogName", "temperature_value");
-      addSample->setProperty("LogText", temperature.toStdString());
-      addSample->setProperty("LogType", "Number");
-      addSample->execute();
-      addSample->setProperty("Workspace", groupWs);
-      addSample->setProperty("LogName", "temperature_correction");
-      addSample->setProperty("LogText", "true");
-      addSample->setProperty("LogType", "String");
-      addSample->execute();
+      // Log for temp bool in result Ws
+      auto corrMtx = AlgorithmManager::Instance().create("AddSampleLog");
+      corrMtx->setProperty("Workspace", resultWs->getName());
+      corrMtx->setProperty("LogName", "temperature_correction");
+      corrMtx->setProperty("LogText", "true");
+      corrMtx->setProperty("LogType", "String");
+      m_batchAlgoRunner->addAlgorithm(corrMtx);
+
+      // Log for temp value in group Ws
+      auto valGrp = AlgorithmManager::Instance().create("AddSampleLog");
+      valGrp->setProperty("Workspace", groupWs->getName());
+      valGrp->setProperty("LogName", "temperature_value");
+      valGrp->setProperty("LogText", temperature.toStdString());
+      valGrp->setProperty("LogType", "Number");
+      m_batchAlgoRunner->addAlgorithm(valGrp);
+
+      // Log for temp bool in group Ws
+      auto corrGrp = AlgorithmManager::Instance().create("AddSampleLog");
+      corrGrp->setProperty("Workspace", groupWs->getName());
+      corrGrp->setProperty("LogName", "temperature_correction");
+      corrGrp->setProperty("LogText", "true");
+      corrGrp->setProperty("LogType", "String");
+      m_batchAlgoRunner->addAlgorithm(corrGrp);
     }
   }
   m_batchAlgoRunner->executeBatchAsync();
@@ -385,9 +413,9 @@ void ConvFit::algorithmComplete(bool error) {
 }
 
 /**
- * Validates the user's inputs in the ConvFit tab.
- * @return If the validation was successful
- */
+* Validates the user's inputs in the ConvFit tab.
+* @return If the validation was successful
+*/
 bool ConvFit::validate() {
   UserInputValidator uiv;
 
@@ -405,6 +433,13 @@ bool ConvFit::validate() {
       !m_blnManager->value(m_properties["UseDeltaFunc"]))
     uiv.addErrorMessage("No fit function has been selected.");
 
+  if (m_uiForm.ckTempCorrection->isChecked()) {
+    if (m_uiForm.leTempCorrection->text().compare("") == 0) {
+      uiv.addErrorMessage("Temperature correction has been checked in the "
+                          "interface, but no value has been given.");
+    }
+  }
+
   QString error = uiv.generateErrorMessage();
   showMessageBox(error);
 
@@ -412,21 +447,21 @@ bool ConvFit::validate() {
 }
 
 /**
- * Reads in settings files
- * @param settings The name of the QSettings object to retrieve data from
- */
+* Reads in settings files
+* @param settings The name of the QSettings object to retrieve data from
+*/
 void ConvFit::loadSettings(const QSettings &settings) {
   m_uiForm.dsSampleInput->readSettings(settings.group());
   m_uiForm.dsResInput->readSettings(settings.group());
 }
 
 /**
- * Called when new data has been loaded by the data selector.
- *
- * Configures ranges for spin boxes before raw plot is done.
- *
- * @param wsName Name of new workspace loaded
- */
+* Called when new data has been loaded by the data selector.
+*
+* Configures ranges for spin boxes before raw plot is done.
+*
+* @param wsName Name of new workspace loaded
+*/
 void ConvFit::newDataLoaded(const QString wsName) {
   m_cfInputWSName = wsName;
   m_cfInputWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
@@ -449,13 +484,13 @@ void ConvFit::newDataLoaded(const QString wsName) {
 }
 
 /**
- * Create a resolution workspace with the same number of histograms as in the
- * sample.
- *
- * Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as
- * they need
- * to have the WorkspaceIndex attribute set.
- */
+* Create a resolution workspace with the same number of histograms as in the
+* sample.
+*
+* Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as
+* they need
+* to have the WorkspaceIndex attribute set.
+*/
 void ConvFit::extendResolutionWorkspace() {
   if (m_cfInputWS && m_uiForm.dsResInput->isValid()) {
     const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
@@ -488,14 +523,14 @@ namespace {
 ////////////////////////////
 
 /**
- * Takes an index and a name, and constructs a single level parameter name
- * for use with function ties, etc.
- *
- * @param index :: the index of the function in the first level.
- * @param name  :: the name of the parameter inside the function.
- *
- * @returns the constructed function parameter name.
- */
+* Takes an index and a name, and constructs a single level parameter name
+* for use with function ties, etc.
+*
+* @param index :: the index of the function in the first level.
+* @param name  :: the name of the parameter inside the function.
+*
+* @returns the constructed function parameter name.
+*/
 std::string createParName(size_t index, const std::string &name = "") {
   std::stringstream prefix;
   prefix << "f" << index << "." << name;
@@ -503,15 +538,15 @@ std::string createParName(size_t index, const std::string &name = "") {
 }
 
 /**
- * Takes an index, a sub index and a name, and constructs a double level
- * (nested) parameter name for use with function ties, etc.
- *
- * @param index    :: the index of the function in the first level.
- * @param subIndex :: the index of the function in the second level.
- * @param name     :: the name of the parameter inside the function.
- *
- * @returns the constructed function parameter name.
- */
+* Takes an index, a sub index and a name, and constructs a double level
+* (nested) parameter name for use with function ties, etc.
+*
+* @param index    :: the index of the function in the first level.
+* @param subIndex :: the index of the function in the second level.
+* @param name     :: the name of the parameter inside the function.
+*
+* @returns the constructed function parameter name.
+*/
 std::string createParName(size_t index, size_t subIndex,
                           const std::string &name = "") {
   std::stringstream prefix;
@@ -521,40 +556,39 @@ std::string createParName(size_t index, size_t subIndex,
 }
 
 /**
- * Creates a function to carry out the fitting in the "ConvFit" tab.  The
- * function consists of various sub functions, with the following structure:
- *
- * Composite
- *  |
- *  +- LinearBackground
- *  +- Convolution
- *      |
- *      +- Resolution
- *      +- Model (AT LEAST one delta function or one/two lorentzians.)
- *          |
- *          +- DeltaFunction(yes/no)
- *				+- ProductFunction
- *					|
- *					+- Lorentzian 1(yes/no)
- *					+- Temperature Correction(yes/no)
- *				+- ProductFunction
- *					|
- *					+- Lorentzian 2(yes/no)
- *					+- Temperature Correction(yes/no)
- *				+- ProductFunction
- *					|
- *					+- InelasticDiffSphere(yes/no)
- *					+- Temperature Correction(yes/no)
- *				+- ProductFunction
- *					|
- *					+-
- *InelasticDiffRotDiscreteCircle(yes/no)
- *					+- Temperature Correction(yes/no)
- *
- * @param tieCentres :: whether to tie centres of the two lorentzians.
- *
- * @returns the composite fitting function.
- */
+* Creates a function to carry out the fitting in the "ConvFit" tab.  The
+* function consists of various sub functions, with the following structure:
+*
+* Composite
+*  |
+*  +- LinearBackground
+*  +- Convolution
+*      |
+*      +- Resolution
+*      +- Model (AT LEAST one delta function or one/two lorentzians.)
+*          |
+*          +- DeltaFunction(yes/no)
+*				+- ProductFunction
+*					|
+*					+- Lorentzian 1(yes/no)
+*					+- Temperature Correction(yes/no)
+*				+- ProductFunction
+*					|
+*					+- Lorentzian 2(yes/no)
+*					+- Temperature Correction(yes/no)
+*				+- ProductFunction
+*					|
+*					+- InelasticDiffSphere(yes/no)
+*					+- Temperature Correction(yes/no)
+*				+- ProductFunction
+*					|
+*					+- InelasticDiffRotDisCircle(yes/no)
+*					+- Temperature Correction(yes/no)
+*
+* @param tieCentres :: whether to tie centres of the two lorentzians.
+*
+* @returns the composite fitting function.
+*/
 CompositeFunction_sptr ConvFit::createFunction(bool tieCentres) {
   auto conv = boost::dynamic_pointer_cast<CompositeFunction>(
       FunctionFactory::Instance().createFunction("Convolution"));
@@ -692,8 +726,8 @@ CompositeFunction_sptr ConvFit::createFunction(bool tieCentres) {
 }
 
 /**
- * Creates the correction for the temperature
- */
+* Creates the correction for the temperature
+*/
 void ConvFit::createTemperatureCorrection(CompositeFunction_sptr product) {
   // create temperature correction function to multiply with the lorentzians
   IFunction_sptr tempFunc;
@@ -714,12 +748,12 @@ void ConvFit::createTemperatureCorrection(CompositeFunction_sptr product) {
 }
 
 /**
- * Obtains the instrument resolution from the provided workspace
- * @param workspaceName The name of the workspaces which holds the instrument
- * resolution
- * @return The resolution of the instrument. returns 0 if no resolution data
- * could be found
- */
+* Obtains the instrument resolution from the provided workspace
+* @param workspaceName The name of the workspaces which holds the instrument
+* resolution
+* @return The resolution of the instrument. returns 0 if no resolution data
+* could be found
+*/
 double ConvFit::getInstrumentResolution(std::string workspaceName) {
   using namespace Mantid::API;
 
@@ -780,10 +814,10 @@ double ConvFit::getInstrumentResolution(std::string workspaceName) {
 }
 
 /**
- * Intialises the property values for any of the fit type
- * @param propName The name of the property group
- * @return The popuated property group representing a fit type
- */
+* Intialises the property values for any of the fit type
+* @param propName The name of the property group
+* @return The popuated property group representing a fit type
+*/
 QtProperty *ConvFit::createFitType(const QString &propName) {
   QtProperty *fitTypeGroup = m_grpManager->addProperty(propName);
   QString cbName = propName;
@@ -808,13 +842,13 @@ QtProperty *ConvFit::createFitType(const QString &propName) {
 }
 
 /**
- * Populates the properties of a function with given values
- * @param func The function currently being added to the composite
- * @param comp A composite function of the previously called functions
- * @param group The QtProperty representing the fit type
- * @param pref The index of the functions eg. (f0.f1)
- * @param tie Bool to state if parameters are to be tied together
- */
+* Populates the properties of a function with given values
+* @param func The function currently being added to the composite
+* @param comp A composite function of the previously called functions
+* @param group The QtProperty representing the fit type
+* @param pref The index of the functions eg. (f0.f1)
+* @param tie Bool to state if parameters are to be tied together
+*/
 void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp,
                                QtProperty *group, const std::string &pref,
                                bool tie) {
@@ -841,14 +875,14 @@ void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp,
 }
 
 /**
- * Generate a string to describe the fit type selected by the user.
- * Used when naming the resultant workspaces.
- *
- * Assertions used to guard against any future changes that dont take
- * workspace naming into account.
- *
- * @returns the generated QString.
- */
+* Generate a string to describe the fit type selected by the user.
+* Used when naming the resultant workspaces.
+*
+* Assertions used to guard against any future changes that dont take
+* workspace naming into account.
+*
+* @returns the generated QString.
+*/
 QString ConvFit::fitTypeString() const {
   QString fitType("");
 
@@ -861,14 +895,14 @@ QString ConvFit::fitTypeString() const {
 }
 
 /**
- * Generate a string to describe the background selected by the user.
- * Used when naming the resultant workspaces.
- *
- * Assertions used to guard against any future changes that dont take
- * workspace naming into account.
- *
- * @returns the generated QString.
- */
+* Generate a string to describe the background selected by the user.
+* Used when naming the resultant workspaces.
+*
+* Assertions used to guard against any future changes that dont take
+* workspace naming into account.
+*
+* @returns the generated QString.
+*/
 QString ConvFit::backgroundString() const {
   switch (m_uiForm.cbBackground->currentIndex()) {
   case 0:
@@ -883,11 +917,11 @@ QString ConvFit::backgroundString() const {
 }
 
 /**
- * Generates a string that defines the fitting minimizer based on the user
- * options.
- *
- * @return Minimizer as a string
- */
+* Generates a string that defines the fitting minimizer based on the user
+* options.
+*
+* @return Minimizer as a string
+*/
 QString ConvFit::minimizerString(QString outputName) const {
   QString minimizer = "Levenberg-Marquardt";
 
@@ -916,9 +950,9 @@ QString ConvFit::minimizerString(QString outputName) const {
 }
 
 /**
- * Changes property tree and plot appearance based on Fit Type
- * @param index A reference to the Fit Type (0-9)
- */
+* Changes property tree and plot appearance based on Fit Type
+* @param index A reference to the Fit Type (0-9)
+*/
 void ConvFit::typeSelection(int index) {
 
   auto hwhmRangeSelector = m_uiForm.ppPlot->getRangeSelector("ConvFitHWHM");
@@ -942,9 +976,9 @@ void ConvFit::typeSelection(int index) {
 }
 
 /**
- * Add/Remove sub property 'BGA1' from background based on Background type
- * @param index A reference to the Background type
- */
+* Add/Remove sub property 'BGA1' from background based on Background type
+* @param index A reference to the Background type
+*/
 void ConvFit::bgTypeSelection(int index) {
   if (index == 2) {
     m_properties["LinearBackground"]->addSubProperty(m_properties["BGA1"]);
@@ -954,8 +988,8 @@ void ConvFit::bgTypeSelection(int index) {
 }
 
 /**
- * Updates the plot in the gui window
- */
+* Updates the plot in the gui window
+*/
 void ConvFit::updatePlot() {
   using Mantid::Kernel::Exception::NotFoundError;
 
@@ -1013,8 +1047,8 @@ void ConvFit::updatePlot() {
 }
 
 /**
- * Updates the guess for the plot
- */
+* Updates the guess for the plot
+*/
 void ConvFit::plotGuess() {
   m_uiForm.ppPlot->removeSpectrum("Guess");
 
@@ -1080,8 +1114,8 @@ void ConvFit::plotGuess() {
 }
 
 /**
- * Fits a single spectrum to the plot
- */
+* Fits a single spectrum to the plot
+*/
 void ConvFit::singleFit() {
   if (!validate())
     return;
@@ -1138,10 +1172,10 @@ void ConvFit::singleFit() {
 }
 
 /**
- * Handle completion of the fit algorithm for single fit.
- *
- * @param error If the fit algorithm failed
- */
+* Handle completion of the fit algorithm for single fit.
+*
+* @param error If the fit algorithm failed
+*/
 void ConvFit::singleFitComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(singleFitComplete(bool)));
@@ -1203,8 +1237,10 @@ void ConvFit::singleFitComplete(bool error) {
       key += "f0.";
     }
 
-    m_dblManager->setValue(m_properties["DeltaHeight"], parameters[key + "Height"]);
-	m_dblManager->setValue(m_properties["DeltaCentre"], parameters[key + "Centre"]);
+    m_dblManager->setValue(m_properties["DeltaHeight"],
+                           parameters[key + "Height"]);
+    m_dblManager->setValue(m_properties["DeltaCentre"],
+                           parameters[key + "Centre"]);
     funcIndex++;
   }
 
@@ -1255,23 +1291,23 @@ void ConvFit::singleFitComplete(bool error) {
 }
 
 /**
- * Handles the user entering a new minimum spectrum index.
- *
- * Prevents the user entering an overlapping spectra range.
- *
- * @param value Minimum spectrum index
- */
+* Handles the user entering a new minimum spectrum index.
+*
+* Prevents the user entering an overlapping spectra range.
+*
+* @param value Minimum spectrum index
+*/
 void ConvFit::specMinChanged(int value) {
   m_uiForm.spSpectraMax->setMinimum(value);
 }
 
 /**
- * Handles the user entering a new maximum spectrum index.
- *
- * Prevents the user entering an overlapping spectra range.
- *
- * @param value Maximum spectrum index
- */
+* Handles the user entering a new maximum spectrum index.
+*
+* Prevents the user entering an overlapping spectra range.
+*
+* @param value Maximum spectrum index
+*/
 void ConvFit::specMaxChanged(int value) {
   m_uiForm.spSpectraMin->setMaximum(value);
 }
@@ -1445,9 +1481,9 @@ void ConvFit::showTieCheckbox(QString fitType) {
 }
 
 /**
- * Gets a list of parameters for a given fit function.
- * @return List fo parameters
- */
+* Gets a list of parameters for a given fit function.
+* @return List fo parameters
+*/
 QStringList ConvFit::getFunctionParameters(QString functionName) {
   QStringList parameters;
   if (functionName.compare("Two Lorentzians") == 0) {
@@ -1479,9 +1515,9 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
 }
 
 /**
- * Handles a new fit function being selected.
- * @param functionName Name of new fit function
- */
+* Handles a new fit function being selected.
+* @param functionName Name of new fit function
+*/
 void ConvFit::fitFunctionSelected(const QString &functionName) {
   double oneLValues[3] = {0.0, 0.0, 0.0};
   bool previouslyOneL = false;
@@ -1589,8 +1625,8 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
 }
 
 /**
- * Populates the plot combobox
- */
+* Populates the plot combobox
+*/
 void ConvFit::updatePlotOptions() {
   m_uiForm.cbPlotType->clear();
 
@@ -1624,11 +1660,11 @@ void ConvFit::updatePlotOptions() {
 }
 
 /**
- * Converts the user input for function into short hand for use in the workspace
- * naming
- * @param original - The original user input to the function
- * @return The short hand of the users input
- */
+* Converts the user input for function into short hand for use in the workspace
+* naming
+* @param original - The original user input to the function
+* @return The short hand of the users input
+*/
 QString ConvFit::convertFuncToShort(const QString &original) {
   QString result = "";
   if (m_uiForm.cbFitType->currentIndex() != 0) {
@@ -1650,11 +1686,11 @@ QString ConvFit::convertFuncToShort(const QString &original) {
 }
 
 /**
- * Converts the user input for background into short hand for use in the
- * workspace naming
- * @param original - The original user input to the function
- * @return The short hand of the users input
- */
+* Converts the user input for background into short hand for use in the
+* workspace naming
+* @param original - The original user input to the function
+* @return The short hand of the users input
+*/
 QString ConvFit::convertBackToShort(const std::string &original) {
   QString result = QString::fromStdString(original.substr(0, 3));
   auto pos = original.find(" ");


### PR DESCRIPTION
Fixes #14267

The output workspace from ConvFit should now contain `sample_filename` and `resolution_filename`

**Data for testing is available from `/ExternalData/Testing/Data/UnitTest/`**
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Sample = `irs26176_graphite002_red.nxs`
- Resolution = `irs26173_graphite002_res.nxs`
- Change Fit Type to `One Lorentzian`
- Check `Temp. Correction` and enter a value into the corresponding input field
- Click `Run`
- Ensure that the OutputWorkspace (ending in `_Result`) contains sample_filename, resolution_filename, temperature_correction and temperature_value.
- Ensure that the workspaces in the group workspace (workspace ending in `_Workspaces`) also has these entries in the log (It is probably only necessary to check one or two of these workspaces)
