### PR TITLE
Removed using statements from CalculcateDIFC header

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateDIFC.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateDIFC.h
@@ -4,17 +4,6 @@
 #include "MantidKernel/System.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
-#include "MantidDataObjects/SpecialWorkspace2D.h"
-#include "MantidGeometry/IDetector.h"
-
-using Mantid::API::MatrixWorkspace;
-using Mantid::API::WorkspaceProperty;
-using Mantid::DataObjects::OffsetsWorkspace;
-using Mantid::DataObjects::OffsetsWorkspace_sptr;
-using Mantid::DataObjects::SpecialWorkspace2D;
-using Mantid::DataObjects::SpecialWorkspace2D_sptr;
-using Mantid::Geometry::Instrument_const_sptr;
-using Mantid::Kernel::Direction;
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/CalculateDIFC.cpp
+++ b/Framework/Algorithms/src/CalculateDIFC.cpp
@@ -5,6 +5,15 @@
 namespace Mantid {
 namespace Algorithms {
 
+using Mantid::API::MatrixWorkspace;
+using Mantid::API::WorkspaceProperty;
+using Mantid::DataObjects::OffsetsWorkspace;
+using Mantid::DataObjects::OffsetsWorkspace_sptr;
+using Mantid::DataObjects::SpecialWorkspace2D;
+using Mantid::DataObjects::SpecialWorkspace2D_sptr;
+using Mantid::Geometry::Instrument_const_sptr;
+using Mantid::Kernel::Direction;
+
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(CalculateDIFC)
 


### PR DESCRIPTION
Fixes #14408 

This change fixes an error where using statements were placed in CalculateDIFC.h as opposed to CalculateDIFC.cpp.
