### PR TITLE
Added progress to Scale and SphericalAbsorption Algorithms

### DIFF
--- a/Framework/Algorithms/src/Scale.cpp
+++ b/Framework/Algorithms/src/Scale.cpp
@@ -38,11 +38,16 @@ void Scale::exec() {
 
   auto hasDx = inputWS->hasDx(0);
 
+  Progress progress(this, 0, 1, 2);
+
   // We require a copy of the workspace if the
   auto inPlace = outputWS == inputWS;
   MatrixWorkspace_sptr bufferWS;
 
   if (op == "Multiply") {
+
+    progress.report("Multiplying factor...");
+
     if (outputWS == inputWS) {
       if (hasDx) {
         bufferWS = MatrixWorkspace_sptr(inputWS->clone().release());
@@ -52,6 +57,9 @@ void Scale::exec() {
       outputWS = inputWS * factor;
     }
   } else {
+
+    progress.report("Adding factor...");
+
     if (outputWS == inputWS) {
       if (hasDx) {
         bufferWS = MatrixWorkspace_sptr(inputWS->clone().release());
@@ -61,6 +69,8 @@ void Scale::exec() {
       outputWS = inputWS + factor;
     }
   }
+
+  progress.report();
 
   // If there are any Dx values in the input workspace, then
   // copy them across. We check only the first spectrum.

--- a/Framework/Algorithms/src/SphericalAbsorption.cpp
+++ b/Framework/Algorithms/src/SphericalAbsorption.cpp
@@ -79,6 +79,10 @@ void SphericalAbsorption::exec() {
   correctionFactors->setYUnitLabel("Attenuation factor");
   double m_sphRadius = getProperty("SphericalSampleRadius"); // in cm
 
+  Progress progress(this, 0, 1, 2);
+
+  progress.report("AnvredCorrection");
+
   IAlgorithm_sptr anvred = createChildAlgorithm("AnvredCorrection");
   anvred->setProperty<MatrixWorkspace_sptr>("InputWorkspace", m_inputWS);
   anvred->setProperty<MatrixWorkspace_sptr>("OutputWorkspace",
@@ -89,6 +93,9 @@ void SphericalAbsorption::exec() {
   anvred->setProperty("LinearAbsorptionCoef", m_refAtten);
   anvred->setProperty("Radius", m_sphRadius);
   anvred->executeAsChildAlg();
+
+  progress.report();
+
   // Get back the result
   correctionFactors = anvred->getProperty("OutputWorkspace");
   setProperty("OutputWorkspace", correctionFactors);


### PR DESCRIPTION
Fixes #14296 

Release notes not yet updated.
## Changes

These algorithms now produce basic progress reporting however it is important to note the following:
- The Scale algorithm potentially takes a while to execute for large workspaces due to an addition operation (using the workspace  operator+/+=). The algorithm therefore cannot produce incremental reporting.
- The SphericalAbsorption algorithm calls the AnvredCorrection algorithm. This algorithm is responsible for the majority of the processing time within the algorithm. Although AnvredCorrection contains progress reporting (which works when using this algorithm in isolation), AnvredCorrection does not seem to produce reports as a nested/child algorithm. This might be a separate issue altogether.
## Testing
### Scale

Run this code in the script editor:

_ws = CreateSampleWorkspace(BankPixelWidth=1)_
_print "Every 10th bin value of " + ws.getName()_
_print ws.readY(0)[0: 100 :10]_

_# Add 2 using scale_
_wsOffset = Scale(ws,2,"Add")_
_print "Every 10th bin value of " + wsOffset.getName()_
_print wsOffset.readY(0)[0: 100 :10]_

_# Add 2 using the workspace operator overloads_
_wsOffset2 = ws + 2_
_print "Every 10th bin value of " + wsOffset2.getName()_
_print wsOffset2.readY(0)[0: 100 :10]_
### SphericalAbsorption

Run this code in the script editor:

_ws = CreateSampleWorkspace("Histogram",NumBanks=10,BankPixelWidth=10)_
_ws = ConvertUnits(ws,"Wavelength")_
_ws = Rebin(ws,Params=[1])_
_SetSampleMaterial(ws,ChemicalFormula="V")_

_#restrict the number of wavelength points to speed up the example_
_wsOut = SphericalAbsorption(ws,SphericalSampleRadius=0.2)_

_print "The created workspace has spectra: ", wsOut.readY(0)_
