### PR TITLE
i(Q,t)Fit Plot Options Ordering

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IqtFit.ui
@@ -267,11 +267,6 @@
         </item>
         <item>
          <property name="text">
-          <string>All</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
           <string>Intensity</string>
          </property>
         </item>
@@ -284,6 +279,11 @@
          <property name="text">
           <string>Beta</string>
          </property>
+        </item>
+        <item>
+          <property name="text">
+            <string>All</string>
+          </property>
         </item>
        </widget>
       </item>

--- a/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IqtFit.cpp
@@ -400,33 +400,40 @@ void IqtFit::typeSelection(int index) {
   case 0:
     m_ffTree->addProperty(m_properties["Exponential1"]);
 
-    // remove option to plot beta
-    m_uiForm.cbPlotType->removeItem(4);
+    // remove option to plot beta and add all
+	m_uiForm.cbPlotType->removeItem(4);
+    m_uiForm.cbPlotType->removeItem(3);
+	m_uiForm.cbPlotType->addItem("All");
     break;
   case 1:
     m_ffTree->addProperty(m_properties["Exponential1"]);
     m_ffTree->addProperty(m_properties["Exponential2"]);
 
-    // remove option to plot beta
-    m_uiForm.cbPlotType->removeItem(4);
+    // remove option to plot beta and add all
+	m_uiForm.cbPlotType->removeItem(4);
+	m_uiForm.cbPlotType->removeItem(3);
+
+	m_uiForm.cbPlotType->addItem("All");
     break;
   case 2:
     m_ffTree->addProperty(m_properties["StretchedExp"]);
 
-    // add option to plot beta
-    if (m_uiForm.cbPlotType->count() == 4) {
-      m_uiForm.cbPlotType->addItem("Beta");
-    }
+	// add option to plot beta and all
+	m_uiForm.cbPlotType->removeItem(4);
+	m_uiForm.cbPlotType->removeItem(3);
+	m_uiForm.cbPlotType->addItem("Beta");
+	m_uiForm.cbPlotType->addItem("All");
 
     break;
   case 3:
     m_ffTree->addProperty(m_properties["Exponential1"]);
     m_ffTree->addProperty(m_properties["StretchedExp"]);
 
-    // add option to plot beta
-    if (m_uiForm.cbPlotType->count() == 4) {
-      m_uiForm.cbPlotType->addItem("Beta");
-    }
+    // add option to plot beta and all
+	m_uiForm.cbPlotType->removeItem(4);
+	m_uiForm.cbPlotType->removeItem(3);
+	m_uiForm.cbPlotType->addItem("Beta");
+	m_uiForm.cbPlotType->addItem("All");
 
     break;
   }


### PR DESCRIPTION
Fixes #14398 

The plot options for `I(Q,t)Fit` are now in the correct order starting with `None`, then any other plot options then ending in `All`

**Plot Options A**
- None
- Intensity
- Tau
- All

**Plot Options B**
- None
- Intensity 
- Tau
- Beta
- All
# To Test
- Open `I(Q,t)Fit` (Interfaces > Indirect > Data Analysis > `I(Q,t)Fit`)
- Check the current plot options are= **Plot Options A**
- Change the Fit Type to `2 Exponentials` 
  - Ensure the plot options are = **Plot Options A**
- Ensure fit type `1 Stretched Exponential` = **Plot Options B**
- Ensure fit type `1 Stretched Exponential and 1 Exponential` = **Plot Options B**
