### PR TITLE
Fix engg GUI: algorithms created using fromString

### DIFF
--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -65,8 +65,7 @@ void EnggDiffractionPresenter::cleanup() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A calibration process is currently running, shutting "
-                        "it down immediately..."
-                     << std::endl;
+                        "it down immediately..." << std::endl;
       m_workerThread->wait(10);
     }
     delete m_workerThread;
@@ -167,8 +166,7 @@ void EnggDiffractionPresenter::processCalcCalib() {
     return;
   }
   g_log.notice() << "EnggDiffraction GUI: starting new calibration. This may "
-                    "take a few seconds... "
-                 << std::endl;
+                    "take a few seconds... " << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -285,8 +283,7 @@ void EnggDiffractionPresenter::processRebinTime() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) with a TOF bin into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -312,8 +309,7 @@ void EnggDiffractionPresenter::processRebinMultiperiod() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) by pulse times into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -611,13 +607,11 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   } catch (std::runtime_error &) {
     g_log.error() << "The calibration calculations failed. One of the "
                      "algorithms did not execute correctly. See log messages "
-                     "for details. "
-                  << std::endl;
+                     "for details. " << std::endl;
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
-           "were not valid. See log messages for details. "
-        << std::endl;
+           "were not valid. See log messages for details. " << std::endl;
   }
   // restore normal data search paths
   conf.setDataSearchDirs(tmpDirs);
@@ -703,7 +697,8 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
 
   const std::string instStr = m_view->currentInstrument();
   try {
-    auto load = Algorithm::fromString("Load");
+    auto load =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
     load->initialize();
     load->setPropertyValue("Filename", instStr + ceriaNo);
     const std::string ceriaWSName = "engggui_calibration_sample_ws";
@@ -728,7 +723,8 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
   difc.resize(numBanks);
   tzero.resize(numBanks);
   for (size_t i = 0; i < difc.size(); i++) {
-    auto alg = Algorithm::fromString("EnggCalibrate");
+    auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+        "EnggCalibrate");
     try {
       alg->initialize();
       alg->setProperty("InputWorkspace", ceriaWS);
@@ -999,8 +995,7 @@ void EnggDiffractionPresenter::doFocusRun(
     const std::string &specNos, const std::string &dgFile) {
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: "
-                 << dir << std::endl;
+                    "this directory: " << dir << std::endl;
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1039,8 +1034,7 @@ void EnggDiffractionPresenter::doFocusRun(
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what()
-                      << std::endl;
+                             ". Detailed error: " + re.what() << std::endl;
         bankIDs.clear();
         specs.clear();
       }
@@ -1056,8 +1050,8 @@ void EnggDiffractionPresenter::doFocusRun(
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo + " into: "
-                   << effectiveFilenames[idx] << std::endl;
+                          ") for run " + runNo +
+                          " into: " << effectiveFilenames[idx] << std::endl;
     try {
       m_focusFinishedOK = false;
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1070,8 +1064,7 @@ void EnggDiffractionPresenter::doFocusRun(
     } catch (std::invalid_argument &ia) {
       g_log.error()
           << "The focusing failed. Some input properties were not valid. "
-             "See log messages for details. Error: "
-          << ia.what() << std::endl;
+             "See log messages for details. Error: " << ia.what() << std::endl;
     }
   }
 
@@ -1192,7 +1185,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   const std::string inWSName = "engggui_focusing_input_ws";
   const std::string instStr = m_view->currentInstrument();
   try {
-    auto load = Algorithm::fromString("Load");
+    auto load =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
     load->initialize();
     load->setPropertyValue("Filename", instStr + runNo);
     load->setPropertyValue("OutputWorkspace", inWSName);
@@ -1235,7 +1229,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
     specNumsOpenGenie = specNos;
   }
   try {
-    auto alg = Algorithm::fromString("EnggFocus");
+    auto alg =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged("EnggFocus");
     alg->initialize();
     alg->setProperty("InputWorkspace", inWSName);
     alg->setProperty("OutputWorkspace", outWSName);
@@ -1269,7 +1264,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   try {
     g_log.debug() << "Going to save focused output into nexus file: "
                   << fullFilename << std::endl;
-    auto alg = Algorithm::fromString("SaveNexus");
+    auto alg =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged("SaveNexus");
     alg->initialize();
     alg->setPropertyValue("InputWorkspace", outWSName);
     alg->setPropertyValue("Filename", fullFilename);
@@ -1346,8 +1342,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what())
-                    << std::endl;
+                           std::string(ia.what()) << std::endl;
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1356,15 +1351,14 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what())
-                    << std::endl;
+                           std::string(re.what()) << std::endl;
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run "
-                   << vanNo << ". Re-using these files: " << preIntegFilename
-                   << ", and " << preCurvesFilename << std::endl;
+                      "Vanadium run " << vanNo
+                   << ". Re-using these files: " << preIntegFilename << ", and "
+                   << preCurvesFilename << std::endl;
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS);
@@ -1454,7 +1448,8 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
     ITableWorkspace_sptr &vanIntegWS, MatrixWorkspace_sptr &vanCurvesWS) {
   AnalysisDataServiceImpl &ADS = Mantid::API::AnalysisDataService::Instance();
 
-  auto alg = Algorithm::fromString("LoadNexus");
+  auto alg =
+      Mantid::API::AlgorithmManager::Instance().createUnmanaged("LoadNexus");
   alg->initialize();
   alg->setPropertyValue("Filename", preIntegFilename);
   std::string integWSName = g_vanIntegrationWSName;
@@ -1463,7 +1458,8 @@ void EnggDiffractionPresenter::loadVanadiumPrecalcWorkspaces(
   // alg->getProperty("OutputWorkspace");
   vanIntegWS = ADS.retrieveWS<ITableWorkspace>(integWSName);
 
-  auto algCurves = Algorithm::fromString("LoadNexus");
+  auto algCurves =
+      Mantid::API::AlgorithmManager::Instance().createUnmanaged("LoadNexus");
   algCurves->initialize();
   algCurves->setPropertyValue("Filename", preCurvesFilename);
   std::string curvesWSName = "engggui_vanadium_curves_ws";
@@ -1489,7 +1485,7 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
     const std::string &vanNo, ITableWorkspace_sptr &vanIntegWS,
     MatrixWorkspace_sptr &vanCurvesWS) {
 
-  auto load = Algorithm::fromString("Load");
+  auto load = Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
   load->initialize();
   load->setPropertyValue("Filename",
                          vanNo); // TODO more specific build Vanadium filename
@@ -1501,7 +1497,8 @@ void EnggDiffractionPresenter::calcVanadiumWorkspaces(
   // TODO?: maybe use setChild() and then
   // load->getProperty("OutputWorkspace");
 
-  auto alg = Algorithm::fromString("EnggVanadiumCorrections");
+  auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+      "EnggVanadiumCorrections");
   alg->initialize();
   alg->setProperty("VanadiumWorkspace", vanWS);
   std::string integName = g_vanIntegrationWSName;
@@ -1528,7 +1525,8 @@ EnggDiffractionPresenter::loadToPreproc(const std::string runNo) {
   Workspace_sptr inWS;
 
   try {
-    auto load = Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
+    auto load =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
     load->initialize();
     load->setPropertyValue("Filename", runNo);
     const std::string inWSName = "engggui_preproc_input_ws";
@@ -1565,7 +1563,8 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
 
   const std::string rebinName = "Rebin";
   try {
-    auto alg = Algorithm::fromString(rebinName);
+    auto alg =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged(rebinName);
     alg->initialize();
     alg->setPropertyValue("InputWorkspace", inWS->name());
     alg->setPropertyValue("OutputWorkspace", outWSName);
@@ -1575,15 +1574,14 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() + "."
-                  << std::endl;
+                         rebinName + ". Error description: " + ia.what() +
+                         "." << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "."
-                  << std::endl;
+                         re.what() + "." << std::endl;
     return;
   }
 
@@ -1668,7 +1666,8 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
 
   const std::string rebinName = "RebinByPulseTimes";
   try {
-    auto alg = Algorithm::fromString(rebinName);
+    auto alg =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged(rebinName);
     alg->initialize();
     alg->setPropertyValue("InputWorkspace", inWS->name());
     alg->setPropertyValue("OutputWorkspace", outWSName);
@@ -1678,15 +1677,14 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() + "."
-                  << std::endl;
+                         rebinName + ". Error description: " + ia.what() +
+                         "." << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "."
-                  << std::endl;
+                         re.what() + "." << std::endl;
     return;
   }
 
@@ -1740,8 +1738,7 @@ void EnggDiffractionPresenter::rebinningFinished() {
         << std::endl;
   } else {
     g_log.notice() << "Pre-processing (re-binning) finished - the output "
-                      "workspace is ready."
-                   << std::endl;
+                      "workspace is ready." << std::endl;
   }
   if (m_workerThread) {
     delete m_workerThread;
@@ -1802,7 +1799,8 @@ void EnggDiffractionPresenter::saveFocusedXYE(const std::string inputWorkspace,
   try {
     g_log.debug() << "Going to save focused output into OpenGenie file: "
                   << fullFilename << std::endl;
-    auto alg = Algorithm::fromString("SaveFocusedXYE");
+    auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+        "SaveFocusedXYE");
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWorkspace);
     std::string filename(saveDir.toString());
@@ -1846,7 +1844,8 @@ void EnggDiffractionPresenter::saveGSS(const std::string inputWorkspace,
   try {
     g_log.debug() << "Going to save focused output into OpenGenie file: "
                   << fullFilename << std::endl;
-    auto alg = Algorithm::fromString("SaveGSS");
+    auto alg =
+        Mantid::API::AlgorithmManager::Instance().createUnmanaged("SaveGSS");
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWorkspace);
     std::string filename(saveDir.toString());
@@ -1893,7 +1892,8 @@ void EnggDiffractionPresenter::saveOpenGenie(const std::string inputWorkspace,
   try {
     g_log.debug() << "Going to save focused output into OpenGenie file: "
                   << fullFilename << std::endl;
-    auto alg = Algorithm::fromString("SaveOpenGenieAscii");
+    auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+        "SaveOpenGenieAscii");
     alg->initialize();
     alg->setProperty("InputWorkspace", inputWorkspace);
     std::string filename(saveDir.toString());

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1,7 +1,5 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidQtAPI/AlgorithmInputHistory.h"
-#include "MantidQtAPI/AlgorithmRunner.h"
 #include "MantidQtAPI/PythonRunner.h"
 // #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionModel.h"
 #include "MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h"

--- a/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
@@ -286,7 +286,8 @@ void TomographyIfaceViewQtGUI::menuSaveClicked() {
                                         m_currPlugins);
     std::string csvWorkspaceNames = m_currPlugins->name();
 
-    auto alg = Algorithm::fromString("SaveTomoConfig");
+    auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+        "SaveTomoConfig");
     alg->initialize();
     alg->setPropertyValue("Filename", m_currentParamPath);
     alg->setPropertyValue("InputWorkspaces", csvWorkspaceNames);
@@ -476,8 +477,8 @@ TomographyIfaceViewQtGUI::pluginParamValString(const Json::Value &jsonVal,
   return s;
 }
 
-void
-TomographyIfaceViewQtGUI::createPluginTreeEntries(ITableWorkspace_sptr table) {
+void TomographyIfaceViewQtGUI::createPluginTreeEntries(
+    ITableWorkspace_sptr table) {
   for (size_t i = 0; i < table->rowCount(); ++i) {
     TableRow r = table->getRow(i);
     createPluginTreeEntry(r);

--- a/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/SavuConfigDialog.cpp
@@ -1,6 +1,5 @@
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/ITableWorkspace.h"
-#include "MantidQtAPI/AlgorithmInputHistory.h"
-#include "MantidQtAPI/AlgorithmRunner.h"
 #include "MantidQtCustomInterfaces/Tomography/TomographyIfaceViewQtGUI.h"
 
 #include <boost/lexical_cast.hpp>

--- a/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceModel.cpp
@@ -217,7 +217,8 @@ bool TomographyIfaceModel::facilitySupported() {
 bool TomographyIfaceModel::doPing(const std::string &compRes) {
   // This actually does more than a simple ping. Ping and check that a
   // transaction can be created succesfully
-  auto alg = Algorithm::fromString("StartRemoteTransaction");
+  auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+      "StartRemoteTransaction");
   alg->initialize();
   alg->setProperty("ComputeResource", compRes);
   std::string tid;
@@ -246,7 +247,8 @@ bool TomographyIfaceModel::doPing(const std::string &compRes) {
 void TomographyIfaceModel::doLogin(const std::string &compRes,
                                    const std::string &user,
                                    const std::string &pw) {
-  auto alg = Algorithm::fromString("Authenticate");
+  auto alg =
+      Mantid::API::AlgorithmManager::Instance().createUnmanaged("Authenticate");
   alg->initialize();
   alg->setPropertyValue("UserName", user);
   alg->setPropertyValue("ComputeResource", compRes);
@@ -265,7 +267,8 @@ void TomographyIfaceModel::doLogin(const std::string &compRes,
 
 void TomographyIfaceModel::doLogout(const std::string &compRes,
                                     const std::string &username) {
-  auto alg = Algorithm::fromString("Logout");
+  auto alg =
+      Mantid::API::AlgorithmManager::Instance().createUnmanaged("Logout");
   alg->initialize();
   alg->setProperty("ComputeResource", compRes);
   alg->setProperty("UserName", username);
@@ -285,7 +288,8 @@ void TomographyIfaceModel::doQueryJobStatus(const std::string &compRes,
                                             std::vector<std::string> &names,
                                             std::vector<std::string> &status,
                                             std::vector<std::string> &cmds) {
-  auto alg = Algorithm::fromString("QueryAllRemoteJobs");
+  auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+      "QueryAllRemoteJobs");
   alg->initialize();
   alg->setPropertyValue("ComputeResource", compRes);
   try {
@@ -304,8 +308,8 @@ void TomographyIfaceModel::doQueryJobStatus(const std::string &compRes,
 /**
  * Handle the job submission request relies on a submit algorithm.
  */
-void
-TomographyIfaceModel::doSubmitReconstructionJob(const std::string &compRes) {
+void TomographyIfaceModel::doSubmitReconstructionJob(
+    const std::string &compRes) {
   std::string run, opt;
   try {
     makeRunnableWithOptions(compRes, run, opt);
@@ -317,7 +321,8 @@ TomographyIfaceModel::doSubmitReconstructionJob(const std::string &compRes) {
   }
 
   // with SCARF we use one (pseudo)-transaction for every submission
-  auto transAlg = Algorithm::fromString("StartRemoteTransaction");
+  auto transAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+      "StartRemoteTransaction");
   transAlg->initialize();
   transAlg->setProperty("ComputeResource", compRes);
   std::string tid;
@@ -330,7 +335,8 @@ TomographyIfaceModel::doSubmitReconstructionJob(const std::string &compRes) {
                              std::string(e.what()));
   }
 
-  auto submitAlg = Algorithm::fromString("SubmitRemoteJob");
+  auto submitAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+      "SubmitRemoteJob");
   submitAlg->initialize();
   submitAlg->setProperty("ComputeResource", compRes);
   submitAlg->setProperty("TaskName", "Mantid tomographic reconstruction job");
@@ -350,7 +356,8 @@ void TomographyIfaceModel::doCancelJobs(const std::string &compRes,
                                         const std::vector<std::string> &ids) {
   for (size_t i = 0; i < ids.size(); i++) {
     const std::string id = ids[i];
-    auto algJob = Algorithm::fromString("AbortRemoteJob");
+    auto algJob = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+        "AbortRemoteJob");
     algJob->initialize();
     algJob->setPropertyValue("ComputeResource", compRes);
     algJob->setPropertyValue("JobID", id);
@@ -570,7 +577,6 @@ WorkspaceGroup_sptr
 TomographyIfaceModel::loadFITSImage(const std::string &path) {
   // get fits file into workspace and retrieve it from the ADS
   auto alg = AlgorithmManager::Instance().createUnmanaged("LoadFITS");
-  //Algorithm::fromString("LoadFITS");
   alg->initialize();
   alg->setPropertyValue("Filename", path);
   std::string wsName = "__fits_ws_tomography_gui";

--- a/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
@@ -369,7 +369,8 @@ void TomographyIfaceViewQtGUI::saveSettings() const {
 void TomographyIfaceViewQtGUI::loadSavuTomoConfig(
     std::string &filePath, Mantid::API::ITableWorkspace_sptr &currentPlugins) {
   // try to load tomo reconstruction parametereization file
-  auto alg = Algorithm::fromString("LoadSavuTomoConfig");
+  auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+      "LoadSavuTomoConfig");
   alg->initialize();
   alg->setPropertyValue("Filename", filePath);
   alg->setPropertyValue("OutputWorkspace", createUniqueNameHidden());
@@ -845,7 +846,7 @@ void TomographyIfaceViewQtGUI::showImage(const MatrixWorkspace_sptr &ws) {
   QImage rawImg(QSize(static_cast<int>(width), static_cast<int>(height)),
                 QImage::Format_RGB32);
   const double max_min = max - min;
-  const double scaleFactor = 255.0/max_min;
+  const double scaleFactor = 255.0 / max_min;
   for (size_t yi = 0; yi < width; ++yi) {
     for (size_t xi = 0; xi < width; ++xi) {
       const double &v = ws->readY(yi)[xi];

--- a/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/Tomography/TomographyIfaceViewQtGUI.cpp
@@ -1,7 +1,8 @@
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidQtAPI/AlgorithmInputHistory.h"
-#include "MantidQtAPI/AlgorithmRunner.h"
+
 #include "MantidQtAPI/HelpWindow.h"
 #include "MantidQtCustomInterfaces/Tomography/ImageROIViewQtWidget.h"
 #include "MantidQtCustomInterfaces/Tomography/TomographyIfaceViewQtGUI.h"


### PR DESCRIPTION
Fixes #14416.

**To test**: with the typical EnggGUI settings from other pull requests, run a few example focus or calibration and see that it works well. Code review (changes here are mechanical, just replace `fromString()` which is now more cumbersome to use with `createUnmanaged()`).

This has been broken in master for 1.5 days since the changes to algorithm serialization were merged.
I also fixed similar issues in another custom GUI for tomography.
