### PR TITLE
Fix default dimension names from CreateMD being incompatible with MaskMD

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
@@ -20,34 +20,34 @@ parseDimensionNames(const std::string &names_string);
 std::vector<std::string> MANTID_MDALGORITHMS_DLL
 removeBracketedNames(const std::string &names_string);
 
-    /** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
-      exisitng MDWorkspace. Operates on a MDWorkspace in-situ.
+/** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
+  exisitng MDWorkspace. Operates on a MDWorkspace in-situ.
 
-      @date 2012-03-01
+  @date 2012-03-01
 
-      Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
-      National Laboratory & European Spallation Source
+  Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
 
-      This file is part of Mantid.
+  This file is part of Mantid.
 
-      Mantid is free software; you can redistribute it and/or modify
-      it under the terms of the GNU General Public License as published by
-      the Free Software Foundation; either version 3 of the License, or
-      (at your option) any later version.
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
 
-      Mantid is distributed in the hope that it will be useful,
-      but WITHOUT ANY WARRANTY; without even the implied warranty of
-      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-      GNU General Public License for more details.
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-      You should have received a copy of the GNU General Public License
-      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-      File change history is stored at:
-      <https://github.com/mantidproject/mantid>
-      Code Documentation is available at: <http://doxygen.mantidproject.org>
-    */
-    class MANTID_MDALGORITHMS_DLL MaskMD : public API::Algorithm {
+  File change history is stored at:
+  <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_MDALGORITHMS_DLL MaskMD : public API::Algorithm {
 public:
   MaskMD();
   virtual ~MaskMD();

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
@@ -3,9 +3,17 @@
 
 #include "MantidKernel/System.h"
 #include "MantidAPI/Algorithm.h"
+#include "MantidMDAlgorithms/DllConfig.h"
+#include <boost/regex.hpp>
 
 namespace Mantid {
 namespace MDAlgorithms {
+
+std::vector<std::string> MANTID_MDALGORITHMS_DLL
+splitByCommas(const std::string &input_string);
+
+std::vector<std::string> MANTID_MDALGORITHMS_DLL
+findNamesInBrackets(const std::string &names_string, boost::regex re);
 
 /** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
   exisitng MDWorkspace. Operates on a MDWorkspace in-situ.
@@ -33,7 +41,7 @@ namespace MDAlgorithms {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class DLLExport MaskMD : public API::Algorithm {
+class MANTID_MDALGORITHMS_DLL MaskMD : public API::Algorithm {
 public:
   MaskMD();
   virtual ~MaskMD();
@@ -50,6 +58,8 @@ public:
 private:
   void init();
   void exec();
+
+  std::vector<std::string> parseDimensionNames(std::string &names_string);
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
@@ -15,6 +15,9 @@ splitByCommas(const std::string &input_string);
 std::vector<std::string> MANTID_MDALGORITHMS_DLL
 findNamesInBrackets(const std::string &names_string, boost::regex re);
 
+std::vector<std::string> MANTID_MDALGORITHMS_DLL
+parseDimensionNames(const std::string &names_string);
+
 /** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
   exisitng MDWorkspace. Operates on a MDWorkspace in-situ.
 
@@ -58,8 +61,6 @@ public:
 private:
   void init();
   void exec();
-
-  std::vector<std::string> parseDimensionNames(std::string &names_string);
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
@@ -4,47 +4,50 @@
 #include "MantidKernel/System.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidMDAlgorithms/DllConfig.h"
-#include <boost/regex.hpp>
 
 namespace Mantid {
 namespace MDAlgorithms {
 
 std::vector<std::string> MANTID_MDALGORITHMS_DLL
-splitByCommas(const std::string &input_string);
+splitByCommas(const std::string &names_string);
 
 std::vector<std::string> MANTID_MDALGORITHMS_DLL
-findNamesInBrackets(const std::string &names_string, boost::regex re);
+findNamesInBrackets(const std::string &names_string);
 
 std::vector<std::string> MANTID_MDALGORITHMS_DLL
 parseDimensionNames(const std::string &names_string);
 
-/** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
-  exisitng MDWorkspace. Operates on a MDWorkspace in-situ.
+std::vector<std::string> MANTID_MDALGORITHMS_DLL
+removeBracketedNames(const std::string &names_string);
 
-  @date 2012-03-01
+    /** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
+      exisitng MDWorkspace. Operates on a MDWorkspace in-situ.
 
-  Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
-  National Laboratory & European Spallation Source
+      @date 2012-03-01
 
-  This file is part of Mantid.
+      Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+      National Laboratory & European Spallation Source
 
-  Mantid is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 3 of the License, or
-  (at your option) any later version.
+      This file is part of Mantid.
 
-  Mantid is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+      Mantid is free software; you can redistribute it and/or modify
+      it under the terms of the GNU General Public License as published by
+      the Free Software Foundation; either version 3 of the License, or
+      (at your option) any later version.
 
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+      Mantid is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU General Public License for more details.
 
-  File change history is stored at: <https://github.com/mantidproject/mantid>
-  Code Documentation is available at: <http://doxygen.mantidproject.org>
-*/
-class MANTID_MDALGORITHMS_DLL MaskMD : public API::Algorithm {
+      You should have received a copy of the GNU General Public License
+      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+      File change history is stored at:
+      <https://github.com/mantidproject/mantid>
+      Code Documentation is available at: <http://doxygen.mantidproject.org>
+    */
+    class MANTID_MDALGORITHMS_DLL MaskMD : public API::Algorithm {
 public:
   MaskMD();
   virtual ~MaskMD();

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -47,7 +47,8 @@ std::vector<std::string> findNamesInBrackets(const std::string &names_string) {
 
 std::vector<std::string> removeBracketedNames(const std::string &names_string) {
   regex re(REGEX_STR);
-  const std::string names_string_reduced = regex_replace(names_string, re, "[]");
+  const std::string names_string_reduced =
+      regex_replace(names_string, re, "[]");
 
   std::vector<std::string> remainder_split =
       splitByCommas(names_string_reduced);

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -17,6 +17,10 @@ namespace MDAlgorithms {
 
 static const std::string REGEX_STR = "\\[[^\\[\\]]*\\]";
 
+/*
+ * Split the input string on commas and trim leading and trailing whitespace
+ * from the results
+ */
 std::vector<std::string> splitByCommas(const std::string &names_string) {
   std::vector<std::string> names_split_by_commas;
   boost::split(names_split_by_commas, names_string, boost::is_any_of(","));
@@ -28,6 +32,10 @@ std::vector<std::string> splitByCommas(const std::string &names_string) {
   return names_split_by_commas;
 }
 
+/*
+ * Return a vector of only those names from the input string which are within
+ * brackets
+ */
 std::vector<std::string> findNamesInBrackets(const std::string &names_string) {
   std::vector<std::string> names_result;
 
@@ -45,6 +53,10 @@ std::vector<std::string> findNamesInBrackets(const std::string &names_string) {
   return names_result;
 }
 
+/*
+ * Return a vector of names from the string, but with names in brackets reduced
+ * to '[]'
+ */
 std::vector<std::string> removeBracketedNames(const std::string &names_string) {
   regex re(REGEX_STR);
   const std::string names_string_reduced =

--- a/Framework/MDAlgorithms/test/MaskMDTest.h
+++ b/Framework/MDAlgorithms/test/MaskMDTest.h
@@ -59,6 +59,62 @@ public:
   static MaskMDTest *createSuite() { return new MaskMDTest(); }
   static void destroySuite(MaskMDTest *suite) { delete suite; }
 
+  void test_split_by_commas() {
+    std::string test_string = "a, b,c ,d,e ";
+    std::vector<std::string> split_test_string = splitByCommas(test_string);
+
+    // String should be split on commas and whitespace trimmed off to result in:
+    TS_ASSERT_EQUALS(split_test_string[0], "a");
+    TS_ASSERT_EQUALS(split_test_string[1], "b");
+    TS_ASSERT_EQUALS(split_test_string[2], "c");
+    TS_ASSERT_EQUALS(split_test_string[3], "d");
+    TS_ASSERT_EQUALS(split_test_string[4], "e");
+  }
+
+  void test_find_names_in_brackets() {
+    std::string test_string = "[a,b,c], [d,e], f, g";
+    std::vector<std::string> names_in_brackets =
+        findNamesInBrackets(test_string);
+
+    TS_ASSERT_EQUALS(names_in_brackets[0], "[a,b,c]");
+    TS_ASSERT_EQUALS(names_in_brackets[1], "[d,e]");
+    TS_ASSERT_EQUALS(names_in_brackets.size(), 2);
+  }
+
+  void test_parse_dimension_names() {
+    // These are default dimension names from CreateMD
+    std::string test_string = "[H,0,0],[0,K,0],[0,0,L],DeltaE";
+    std::vector<std::string> names_result = parseDimensionNames(test_string);
+
+    TS_ASSERT_EQUALS(names_result[0], "[H,0,0]");
+    TS_ASSERT_EQUALS(names_result[1], "[0,K,0]");
+    TS_ASSERT_EQUALS(names_result[2], "[0,0,L]");
+    TS_ASSERT_EQUALS(names_result[3], "DeltaE");
+  }
+
+  void test_remove_bracketed_names() {
+    std::string test_string = "[a,b] , c, [d,e], f";
+    std::vector<std::string> names_result = removeBracketedNames(test_string);
+
+    TS_ASSERT_EQUALS(names_result[0], "[]");
+    TS_ASSERT_EQUALS(names_result[1], "c");
+    TS_ASSERT_EQUALS(names_result[2], "[]");
+    TS_ASSERT_EQUALS(names_result[3], "f");
+  }
+
+  void test_parse_dimension_names_retains_order() {
+
+    std::string test_string = "[a,b],c,[d,e],f";
+    std::vector<std::string> names_result = parseDimensionNames(test_string);
+
+    // Check that order in the vector is the same as order in the original
+    // string
+    TS_ASSERT_EQUALS(names_result[0], "[a,b]");
+    TS_ASSERT_EQUALS(names_result[1], "c");
+    TS_ASSERT_EQUALS(names_result[2], "[d,e]");
+    TS_ASSERT_EQUALS(names_result[3], "f");
+  }
+
   void test_Init() {
     MaskMD alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())


### PR DESCRIPTION
Fixes #14368

A three dimensional workspace created with CreateMD has the dimension names "[H,0,0]", "[0,K,0]", "[0,0,L]" and "DeltaE". Specifying dimensions to mask with MaskMD is done by passing a list of dimension names. This list is split on commas, therefore entering Dimensions="[H,0,0], [0,K,0],[0,0,L],DeltaE" results in getProperty returning a list of 10 dimension names and MaskMD throws an error.

Ideally this would be solved by changing ArrayProperty and allowing an algorithm to use a setting to allow "sub-lists" in brackets. An issue has been created to do this #14413. In the meantime MaskMD has been changed to get the list string with getPropertyValue and carry out it's own parsing for dimension names.

Unit tests cover the changes.

**For Tester:**

Please review the code.
The following code can be used to test the changes. Previously this code would return an error claiming that too many dimension names were specified. Now it should run successfully.

``` python

input_runs = list()
psi = list()
gs = list()
gl = list()
for i in range(1, 5):
    current_ws = CreateSimulationWorkspace(Instrument='MAR', BinParams=[-3,1,3], UnitX='DeltaE', OutputWorkspace='input_ws_' + str(i))
    input_runs.append(current_ws.name())
    psi.append(float(5 * i))
    gl.append(0.0)
    gs.append(0.0)

# Convert and merge
new_merged = CreateMD(input_runs, Emode='Direct', Alatt=[1.4165, 1.4165,1.4165], Angdeg=[ 90, 90, 90], u=[1, 0, 0,], v=[0,1,0], Psi=psi, Gl=gl, Gs=gs, EFix=3.0)

# Show dimensionality and dimension names
ndims = new_merged.getNumDims()
for i in range(ndims):
    dim = new_merged.getDimension(i)
    print dim.getName()

MaskMD(new_merged, Dimensions="[H,0,0],[0,K,0],[0,0,L],DeltaE", Extents=[-1,1,-1,1,-1,1,-1,1])

```
