### PR TITLE
OptionalBool property widget

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -258,6 +258,23 @@ inline void addingOperator(boost::shared_ptr<T> &,
   throw Exception::NotImplementedError(
       "PropertyWithValue.h: += operator not implemented for boost::shared_ptr");
 }
+
+template <typename T>
+inline std::vector<std::string>
+determineAllowedValues(const T &, const IValidator &validator) {
+  return validator.allowedValues();
+}
+
+template <>
+inline std::vector<std::string> determineAllowedValues(const OptionalBool &,
+                                                       const IValidator &) {
+  auto enumMap = OptionalBool::enumToStrMap();
+  std::vector<std::string> values;
+  for (auto it = enumMap.begin(); it != enumMap.end(); ++it) {
+    values.push_back(it->second);
+  }
+  return values;
+}
 }
 //------------------------------------------------------------------------------------------------
 // Now the PropertyWithValue class itself
@@ -496,7 +513,7 @@ public:
    * an empty vector.
    */
   virtual std::vector<std::string> allowedValues() const {
-    return m_validator->allowedValues();
+    return determineAllowedValues(m_value, *m_validator);
   }
 
   /**

--- a/Framework/Kernel/test/PropertyWithValueTest.h
+++ b/Framework/Kernel/test/PropertyWithValueTest.h
@@ -377,6 +377,7 @@ public:
     TS_ASSERT(dProp->allowedValues().empty());
     TS_ASSERT(sProp->allowedValues().empty());
     TS_ASSERT(lProp->allowedValues().empty());
+    TS_ASSERT(!bProp->allowedValues().empty())
     // Tests using a ListValidator are below
   }
 
@@ -676,10 +677,22 @@ public:
   void test_optional_bool_to_setValue() {
 
     std::string input = OptionalBool::StrTrue;
-
     PropertyWithValue<OptionalBool> property("myproperty", OptionalBool::Unset,
                                              Direction::Input);
     property.setValue(input);
+  }
+
+  void test_optional_bool_allowed_values() {
+    PropertyWithValue<OptionalBool> property("myproperty", OptionalBool::Unset,
+                                             Direction::Input);
+
+    auto values = property.allowedValues();
+    auto possibilities = OptionalBool::strToEmumMap();
+    TSM_ASSERT_EQUALS("3 states allowed", possibilities.size(), values.size());
+    for (auto it = values.begin(); it != values.end(); ++it) {
+      TSM_ASSERT("value not a known state",
+                 possibilities.find(*it) != possibilities.end());
+    }
   }
 
 private:


### PR DESCRIPTION
Fixes #14421

**Tester**
Repeat steps in issue description. You should have a dropdown for the optionalbool now.
