### PR TITLE
Muon Analysis interface - clear data when instrument changed

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysis.h
@@ -317,6 +317,9 @@ private:
   /// Clear tables and front combo box
   void clearTablesAndCombo();
 
+  /// Clear run info and loaded run
+  void clearLoadedRun();
+
   /// Deletes a workspace _or_ a workspace group with the given name, if one exists
   void deleteWorkspaceIfExists(const std::string& wsName);
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -3124,6 +3124,16 @@ void MuonAnalysis::openSequentialFitDialog()
   {
     loadAlg = createLoadAlgorithm();
   }
+  catch (const std::runtime_error &err) {
+    QString message("Error while setting load properties.\n"
+                    "If instrument was changed, properties will have been "
+                    "cleared and should be reset.\n\n"
+                    "Error was: ");
+    message.append(err.what());
+    QMessageBox::critical(this, "Unable to open dialog", message);
+    g_log.error(message.ascii());
+    return;
+  }
   catch(...)
   {
     QMessageBox::critical(this, "Unable to open dialog", "Error while setting load properties");

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -711,6 +711,7 @@ void MuonAnalysis::userSelectInstrument(const QString& prefix)
   {
     runClearGroupingButton();
     m_curInterfaceSetup = prefix;
+    clearLoadedRun();
 
     // save this new choice
     QSettings group;
@@ -1934,6 +1935,16 @@ void MuonAnalysis::clearTablesAndCombo()
   }
 
   m_uiForm.groupDescription->clear();
+}
+
+/**
+ * Clear loaded run, run info and delete loaded workspaces
+ */
+void MuonAnalysis::clearLoadedRun() {
+  m_uiForm.mwRunFiles->clear();
+  m_uiForm.infoBrowser->clear();
+  deleteWorkspaceIfExists(m_workspace_name);
+  deleteWorkspaceIfExists(m_grouped_name);
 }
 
 /**


### PR DESCRIPTION
Resolves #13616 

When the instrument is changed in Muon Analysis, properties are cleared. Give the user a more useful message when "Sequential Fit" fails because of this. Also clear loaded run and run information when instrument is changed.
