### PR TITLE
Make sample workspace a histogram in SeqDomainSpectrumCreatorTest

### DIFF
--- a/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
@@ -256,7 +256,7 @@ public:
   void testCreateOutputWorkspaceWithDistributionAsInput() {
     // Arrange
     MatrixWorkspace_sptr matrixWs =
-        WorkspaceCreationHelper::Create2DWorkspace123(4, 12);
+        WorkspaceCreationHelper::Create2DWorkspace123(4, 12, true);
     Mantid::API::WorkspaceHelpers::makeDistribution(matrixWs);
 
     TestableSeqDomainSpectrumCreator creator(NULL, "");


### PR DESCRIPTION
Fixes #14427 

To test:

Run the unit test SeqDomainSpectrumCreatorTest in debug mode and confirm that it does not fail any longer.
