### PR TITLE
Add StaticKuboToyabeTimesStretchExp fitting function

### DIFF
--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -91,6 +91,7 @@ set ( SRC_FILES
 	src/Functions/StaticKuboToyabe.cpp
 	src/Functions/StaticKuboToyabeTimesExpDecay.cpp
 	src/Functions/StaticKuboToyabeTimesGausDecay.cpp
+	src/Functions/StaticKuboToyabeTimesStretchExp.cpp
 	src/Functions/StretchExp.cpp
 	src/Functions/StretchExpMuon.cpp
 	src/Functions/TabulatedFunction.cpp
@@ -214,6 +215,7 @@ set ( INC_FILES
 	inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
 	inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
 	inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
+	inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
 	inc/MantidCurveFitting/Functions/StretchExp.h
 	inc/MantidCurveFitting/Functions/StretchExpMuon.h
 	inc/MantidCurveFitting/Functions/TabulatedFunction.h
@@ -334,6 +336,7 @@ set ( TEST_FILES
 	Functions/StaticKuboToyabeTest.h
 	Functions/StaticKuboToyabeTimesExpDecayTest.h
 	Functions/StaticKuboToyabeTimesGausDecayTest.h
+	Functions/StaticKuboToyabeTimesStretchExpTest.h
 	Functions/StretchExpMuonTest.h
 	Functions/StretchExpTest.h
 	Functions/TabulatedFunctionTest.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
@@ -1,0 +1,59 @@
+#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXP_H_
+#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXP_H_
+
+#include "MantidAPI/ParamFunction.h"
+#include "MantidAPI/IFunction1D.h"
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+
+/**
+StaticKuboToyabeTimesStretchExp fitting function
+
+Represents multiplication of two other fitting functions: StaticKuboToyabe and
+Stretched Exponential Decay.
+
+@author Lamar Moore
+@date 13/11/2015
+
+Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
+
+This file is part of Mantid.
+
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+File change history is stored at: <https://github.com/mantidproject/mantid>
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport StaticKuboToyabeTimesStretchExp : public API::ParamFunction,
+                                                  public API::IFunction1D {
+public:
+  std::string name() const { return "StaticKuboToyabeTimesStretchExp"; }
+
+  virtual const std::string category() const { return "Muon"; }
+
+protected:
+  virtual void function1D(double *out, const double *xValues,
+                          const size_t nData) const;
+
+  virtual void init();
+};
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid
+
+#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXP_H_ */

--- a/Framework/CurveFitting/src/Functions/StaticKuboToyabeTimesStretchExp.cpp
+++ b/Framework/CurveFitting/src/Functions/StaticKuboToyabeTimesStretchExp.cpp
@@ -35,7 +35,7 @@ void StaticKuboToyabeTimesStretchExp::function1D(double *out,
   for (size_t i = 0; i < nData; i++) {
     double x = xValues[i];
     double DXSquared = pow(D * x, 2);
-    double stretchExp = pow(exp(-L * x), B);
+    double stretchExp = exp(-pow(L * x, B));
     out[i] = A * (exp(-DXSquared / 2) * (1 - DXSquared) * C1 + C2) * stretchExp;
   }
 }

--- a/Framework/CurveFitting/src/Functions/StaticKuboToyabeTimesStretchExp.cpp
+++ b/Framework/CurveFitting/src/Functions/StaticKuboToyabeTimesStretchExp.cpp
@@ -1,0 +1,45 @@
+#include "MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h"
+#include "MantidAPI/FunctionFactory.h"
+#include <cmath>
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+
+using namespace CurveFitting;
+
+using namespace Kernel;
+
+using namespace API;
+
+DECLARE_FUNCTION(StaticKuboToyabeTimesStretchExp)
+
+void StaticKuboToyabeTimesStretchExp::init() {
+  declareParameter("A", 0.2, "Amplitude at time 0");
+  declareParameter("Delta", 0.2, "StaticKuboToyabe decay rate");
+  declareParameter("Lambda", 0.2, "Exponential decay rate");
+  declareParameter("Beta", 0.2, "Stretching Exponent");
+}
+
+void StaticKuboToyabeTimesStretchExp::function1D(double *out,
+                                                 const double *xValues,
+                                                 const size_t nData) const {
+  const double A = getParameter("A");
+  const double D = getParameter("Delta");
+  const double L = getParameter("Lambda");
+  const double B = getParameter("Beta");
+
+  const double C1 = 2.0 / 3;
+  const double C2 = 1.0 / 3;
+
+  for (size_t i = 0; i < nData; i++) {
+    double x = xValues[i];
+    double DXSquared = pow(D * x, 2);
+    double stretchExp = pow(exp(-L * x), B);
+    out[i] = A * (exp(-DXSquared / 2) * (1 - DXSquared) * C1 + C2) * stretchExp;
+  }
+}
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
@@ -1,0 +1,122 @@
+#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXPTEST_H_
+#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXPTEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidCurveFitting/Algorithms/Fit.h"
+#include "MantidDataObjects/Workspace2D.h"
+
+using Mantid::CurveFitting::Functions::StaticKuboToyabeTimesStretchExp;
+
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+using namespace Mantid::CurveFitting;
+using namespace Mantid::CurveFitting::Functions;
+using namespace Mantid::CurveFitting::Algorithms;
+using namespace Mantid::DataObjects;
+
+class StaticKuboToyabeTimesStretchExpTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static StaticKuboToyabeTimesStretchExpTest *createSuite() {
+    return new StaticKuboToyabeTimesStretchExpTest();
+  }
+  static void destroySuite(StaticKuboToyabeTimesStretchExpTest *suite) {
+    delete suite;
+  }
+
+  void getMockData(Mantid::MantidVec &y, Mantid::MantidVec &e) {
+    // Calculated with A = 0.24, Delta = 0.16, Lambda = 0.1 and Beta = 0.1 on
+    // an Excel spreadsheet
+    y[0] = 0.24;
+    y[1] = 0.231593592;
+    y[2] = 0.212161973;
+    y[3] = 0.184129727;
+	y[4] = 0.150815346;
+    y[5] = 0.115884651;
+    y[6] = 0.082792865;
+    y[7] = 0.054321822;
+    y[8] = 0.03228742;
+    y[9] = 0.017447284;
+    y[10] = 0.009592987;
+    y[11] = 0.007776424;
+    y[12] = 0.010602737;
+    y[13] = 0.016523386;
+    y[14] = 0.024078397;
+
+    for (int i = 0; i < 15; i++)
+      e[i] = 1.0;
+  }
+
+  StaticKuboToyabeTimesStretchExpTest() : fn() {}
+
+  void test_Initialize() { TS_ASSERT_THROWS_NOTHING(fn.initialize()); }
+
+  void test_Name() {
+    TS_ASSERT_EQUALS(fn.name(), "StaticKuboToyabeTimesStretchExp");
+  }
+
+  void test_Params() {
+    TS_ASSERT_DELTA(fn.getParameter("A"), 0.2, 0.0001);
+    TS_ASSERT_DELTA(fn.getParameter("Delta"), 0.2, 0.0001);
+    TS_ASSERT_DELTA(fn.getParameter("Lambda"), 0.2, 0.0001);
+    TS_ASSERT_DELTA(fn.getParameter("Beta"), 0.2, 0.0001)
+  }
+
+  void test_Category() {
+    const std::vector<std::string> categories = fn.categories();
+    TS_ASSERT(categories.size() == 1);
+    TS_ASSERT(categories[0] == "Muon");
+  }
+
+  void test_AgainstMockData() {
+    Algorithms::Fit alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize());
+    TS_ASSERT(alg2.isInitialized());
+
+    // create mock data to test against
+    std::string wsName = "SKTTimesStretchExpMockData";
+    Workspace_sptr ws =
+        WorkspaceFactory::Instance().create("Workspace2D", 1, 15, 15);
+    Workspace2D_sptr ws2D = boost::dynamic_pointer_cast<Workspace2D>(ws);
+
+    for (int i = 0; i < 15; i++)
+      ws2D->dataX(0)[i] = i;
+
+    getMockData(ws2D->dataY(0), ws2D->dataE(0));
+
+    // put this workspace in the data service
+    TS_ASSERT_THROWS_NOTHING(
+        AnalysisDataService::Instance().addOrReplace(wsName, ws2D));
+
+    alg2.setPropertyValue("Function", fn.asString());
+
+    // Set which spectrum to fit against and initial starting values
+    alg2.setPropertyValue("InputWorkspace", wsName);
+    alg2.setPropertyValue("WorkspaceIndex", "0");
+    alg2.setPropertyValue("StartX", "0");
+    alg2.setPropertyValue("EndX", "14");
+
+    TS_ASSERT_THROWS_NOTHING(TS_ASSERT(alg2.execute()))
+
+    TS_ASSERT(alg2.isExecuted());
+
+    double dummy = alg2.getProperty("OutputChi2overDoF");
+    TS_ASSERT_DELTA(dummy, 0.0001, 0.0001);
+
+    IFunction_sptr out = alg2.getProperty("Function");
+    TS_ASSERT_DELTA(out->getParameter("A"), 0.24, 0.0001);
+    TS_ASSERT_DELTA(out->getParameter("Delta"), 0.16, 0.001);
+    TS_ASSERT_DELTA(out->getParameter("Lambda"), 0.1, 0.001);
+    TS_ASSERT_DELTA(out->getParameter("Beta"), 0.1, 0.001);
+
+    AnalysisDataService::Instance().remove(wsName);
+  }
+
+  StaticKuboToyabeTimesStretchExp fn;
+};
+
+#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXPTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
@@ -29,25 +29,28 @@ public:
   }
 
   void getMockData(Mantid::MantidVec &y, Mantid::MantidVec &e) {
-    // Calculated with A = 0.24, Delta = 0.16, Lambda = 0.1 and Beta = 0.1 on
+    // Calculated with A = 0.24, Delta = 0.06, Lambda = 0.63 and Beta = 0.63 on
     // an Excel spreadsheet
     y[0] = 0.24;
-    y[1] = 0.231593592;
-    y[2] = 0.212161973;
-    y[3] = 0.184129727;
-	y[4] = 0.150815346;
-    y[5] = 0.115884651;
-    y[6] = 0.082792865;
-    y[7] = 0.054321822;
-    y[8] = 0.03228742;
-    y[9] = 0.017447284;
-    y[10] = 0.009592987;
-    y[11] = 0.007776424;
-    y[12] = 0.010602737;
-    y[13] = 0.016523386;
-    y[14] = 0.024078397;
+    y[1] = 0.113248409;
+    y[2] = 0.074402367;
+    y[3] = 0.052183632;
+    y[4] = 0.037812471;
+    y[5] = 0.027927981;
+    y[6] = 0.020873965;
+    y[7] = 0.015717258;
+    y[8] = 0.011885418;
+    y[9] = 0.009005914;
+    y[10] = 0.006825573;
+    y[11] = 0.005166593;
+    y[12] = 0.003900885;
+    y[13] = 0.002934321;
+    y[14] = 0.002196637;
+    y[15] = 0.001634742;
+    y[16] = 0.001208136;
+    y[17] = 0.000885707;
 
-    for (int i = 0; i < 15; i++)
+    for (int i = 0; i < 18; i++)
       e[i] = 1.0;
   }
 
@@ -80,10 +83,10 @@ public:
     // create mock data to test against
     std::string wsName = "SKTTimesStretchExpMockData";
     Workspace_sptr ws =
-        WorkspaceFactory::Instance().create("Workspace2D", 1, 15, 15);
+        WorkspaceFactory::Instance().create("Workspace2D", 1, 18, 18);
     Workspace2D_sptr ws2D = boost::dynamic_pointer_cast<Workspace2D>(ws);
 
-    for (int i = 0; i < 15; i++)
+    for (int i = 0; i < 18; i++)
       ws2D->dataX(0)[i] = i;
 
     getMockData(ws2D->dataY(0), ws2D->dataE(0));
@@ -98,7 +101,7 @@ public:
     alg2.setPropertyValue("InputWorkspace", wsName);
     alg2.setPropertyValue("WorkspaceIndex", "0");
     alg2.setPropertyValue("StartX", "0");
-    alg2.setPropertyValue("EndX", "14");
+    alg2.setPropertyValue("EndX", "17");
 
     TS_ASSERT_THROWS_NOTHING(TS_ASSERT(alg2.execute()))
 
@@ -109,9 +112,9 @@ public:
 
     IFunction_sptr out = alg2.getProperty("Function");
     TS_ASSERT_DELTA(out->getParameter("A"), 0.24, 0.0001);
-    TS_ASSERT_DELTA(out->getParameter("Delta"), 0.16, 0.001);
-    TS_ASSERT_DELTA(out->getParameter("Lambda"), 0.1, 0.001);
-    TS_ASSERT_DELTA(out->getParameter("Beta"), 0.1, 0.001);
+    TS_ASSERT_DELTA(out->getParameter("Delta"), 0.06, 0.001);
+    TS_ASSERT_DELTA(out->getParameter("Lambda"), 0.63, 0.001);
+    TS_ASSERT_LESS_THAN(out->getParameter("Beta"), 1.00);
 
     AnalysisDataService::Instance().remove(wsName);
   }

--- a/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
+++ b/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
@@ -1,0 +1,24 @@
+.. _func-StaticKuboToyabeTimesStretchExp:
+
+=============================
+StaticKuboToyabeTimesStretchExp
+=============================
+
+.. index:: StaticKuboToyabeTimesStretchExp
+
+Description
+-----------
+
+Fitting function for use by Muon scientists defined by:
+
+.. math::
+
+   \mbox{A}\times ( \exp(-{Delta}^2 \times {x}^2 / 2 ) \times ( 1 - ( {Delta}^2 \times {x}^2 ) ) \times  \frac 2 3 + \frac 1 3 ) \times \{exp(-{Lambda} \times {x})}^beta
+
+.. attributes::
+
+.. properties::
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
+++ b/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
@@ -13,7 +13,7 @@ Fitting function for use by Muon scientists defined by:
 
 .. math::
 
-   \mbox{A}\times ( \exp(-{Delta}^2 \times {x}^2 / 2 ) \times ( 1 - ( {Delta}^2 \times {x}^2 ) ) \times  \frac 2 3 + \frac 1 3 ) \times \{exp(-{Lambda} \times {x})}^beta
+   \mbox{A}\times ( \exp(-{Delta}^2 \times {x}^2 / 2 ) \times ( 1 - ( {Delta}^2 \times {x}^2 ) ) \times  \frac 2 3 + \frac 1 3 ) \times \{exp(-{{Lambda} \times {x}}^{Beta})}
 
 .. attributes::
 

--- a/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
+++ b/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
@@ -1,8 +1,8 @@
 .. _func-StaticKuboToyabeTimesStretchExp:
 
-=============================
+=================================
 StaticKuboToyabeTimesStretchExp
-=============================
+=================================
 
 .. index:: StaticKuboToyabeTimesStretchExp
 


### PR DESCRIPTION
Fixes #13745 

It would be a good idea for someone to update the release notes as I currently do not have access to this feature.
### Changes

Implemented the fit function StaticKuboToyabeTimesStretchExponentional which takes the form
### Testing

Contact me for the files provided by Devashibhai Adroja. It would be good to compare this with a product function which uses the StaticKuboToyabe and the StretchExp functions.
