### PR TITLE
Make integrateProtonCharge just integrate the proton charge

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -2,14 +2,16 @@
 #define MANTID_API_LOGMANAGER_H_
 
 #include "MantidAPI/DllConfig.h"
-#include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidKernel/Cache.h"
 #include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/Statistics.h"
 #include "MantidKernel/TimeSplitter.h"
-#include "MantidKernel/Matrix.h"
-#include <nexus/NeXusFile.hpp>
 #include <vector>
+
+namespace NeXus {
+	class File;
+}
+
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -9,9 +9,8 @@
 #include <vector>
 
 namespace NeXus {
-	class File;
+class File;
 }
-
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -3,11 +3,13 @@
 
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/LogManager.h"
-#include "MantidGeometry/Instrument/Goniometer.h"
-#include "MantidKernel/Statistics.h"
 #include "MantidKernel/TimeSplitter.h"
-#include <nexus/NeXusFile.hpp>
+#include "MantidGeometry/Instrument/Goniometer.h"
 #include <vector>
+
+namespace NeXus {
+class File;
+}
 
 namespace Mantid {
 
@@ -69,8 +71,10 @@ public:
   void setProtonCharge(const double charge);
   /// Get the proton charge
   double getProtonCharge() const;
-  /// Integrate the proton charge over the whole run time
-  double integrateProtonCharge();
+  /// Integrate the proton charge over the whole run time - default log
+  /// proton_charge
+  void
+  integrateProtonCharge(const std::string &logname = "proton_charge") const;
 
   /// Store the given values as a set of histogram bin boundaries
   void storeHistogramBinBoundaries(const std::vector<double> &energyBins);

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -4,13 +4,11 @@
 #include "MantidAPI/LogManager.h"
 #include "MantidAPI/PropertyNexus.h"
 
-#include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/DateAndTime.h"
 #include "MantidKernel/TimeSplitter.h"
 #include "MantidKernel/TimeSeriesProperty.h"
-#include "MantidKernel/VectorHelper.h"
 
-#include <boost/lexical_cast.hpp>
+#include <nexus/NeXusFile.hpp>
 
 #include <algorithm>
 

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -176,8 +176,9 @@ double Run::getProtonCharge() const {
   if (m_manager.existsProperty(PROTON_CHARGE_LOG_NAME)) {
     charge = m_manager.getProperty(PROTON_CHARGE_LOG_NAME);
   } else {
-    throw Exception::NotFoundError("Proton charge log was not found",
-                                   PROTON_CHARGE_LOG_NAME);
+    g_log.warning() << PROTON_CHARGE_LOG_NAME
+                    << " log was not found. Proton Charge set to 0.0"
+                    << std::endl;
   }
   return charge;
 }

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -23,9 +23,9 @@ namespace {
 const int ADDABLES = 12;
 /// The names of the log entries summed when adding two runs together
 const std::string ADDABLE[ADDABLES] = {
-    "tot_prtn_chrg",   "rawfrm",          "goodfrm",         "dur",
-    "gd_prtn_chrg",    "uA.hour",         "monitor0_counts", "monitor1_counts",
-    "monitor2_counts", "monitor3_counts", "monitor4_counts", "monitor5_counts"};
+    "tot_prtn_chrg", "rawfrm", "goodfrm", "dur", "gd_prtn_chrg", "uA.hour",
+    "monitor0_counts", "monitor1_counts", "monitor2_counts", "monitor3_counts",
+    "monitor4_counts", "monitor5_counts"};
 /// Name of the goniometer log when saved to a NeXus file
 const char *GONIOMETER_LOG_NAME = "goniometer";
 /// Name of the stored histogram bins log when saved to NeXus
@@ -244,8 +244,8 @@ void Run::storeHistogramBinBoundaries(const std::vector<double> &histoBins) {
   if (histoBins.front() >= histoBins.back()) {
     std::ostringstream os;
     os << "Run::storeEnergyBinBoundaries - Inconsistent start & end values "
-          "given, size="
-       << histoBins.size() << ". Cannot interpret values as bin boundaries.";
+          "given, size=" << histoBins.size()
+       << ". Cannot interpret values as bin boundaries.";
     throw std::out_of_range(os.str());
   }
   m_histoBins = histoBins;
@@ -268,15 +268,13 @@ Run::histogramBinBoundaries(const double value) const {
   if (value < m_histoBins.front()) {
     std::ostringstream os;
     os << "Run::histogramBinBoundaries- Value lower than first bin boundary. "
-          "Value= "
-       << value << ", first boundary=" << m_histoBins.front();
+          "Value= " << value << ", first boundary=" << m_histoBins.front();
     throw std::out_of_range(os.str());
   }
   if (value > m_histoBins.back()) {
     std::ostringstream os;
     os << "Run::histogramBinBoundaries- Value greater than last bin boundary. "
-          "Value= "
-       << value << ", last boundary=" << m_histoBins.back();
+          "Value= " << value << ", last boundary=" << m_histoBins.back();
     throw std::out_of_range(os.str());
   }
   const int index = VectorHelper::getBinIndex(m_histoBins, value);

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -176,9 +176,8 @@ double Run::getProtonCharge() const {
   if (m_manager.existsProperty(PROTON_CHARGE_LOG_NAME)) {
     charge = m_manager.getProperty(PROTON_CHARGE_LOG_NAME);
   } else {
-    g_log.warning() << PROTON_CHARGE_LOG_NAME
-                    << " log was not found. Proton Charge set to 0.0"
-                    << std::endl;
+    throw Exception::NotFoundError("Proton charge log was not found",
+                                   PROTON_CHARGE_LOG_NAME);
   }
   return charge;
 }

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -2,13 +2,11 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Run.h"
-#include "MantidAPI/PropertyNexus.h"
-
-#include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/DateAndTime.h"
-#include "MantidKernel/TimeSplitter.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/VectorHelper.h"
+
+#include <nexus/NeXusFile.hpp>
 
 #include <boost/lexical_cast.hpp>
 
@@ -25,9 +23,9 @@ namespace {
 const int ADDABLES = 12;
 /// The names of the log entries summed when adding two runs together
 const std::string ADDABLE[ADDABLES] = {
-    "tot_prtn_chrg", "rawfrm", "goodfrm", "dur", "gd_prtn_chrg", "uA.hour",
-    "monitor0_counts", "monitor1_counts", "monitor2_counts", "monitor3_counts",
-    "monitor4_counts", "monitor5_counts"};
+    "tot_prtn_chrg",   "rawfrm",          "goodfrm",         "dur",
+    "gd_prtn_chrg",    "uA.hour",         "monitor0_counts", "monitor1_counts",
+    "monitor2_counts", "monitor3_counts", "monitor4_counts", "monitor5_counts"};
 /// Name of the goniometer log when saved to a NeXus file
 const char *GONIOMETER_LOG_NAME = "goniometer";
 /// Name of the stored histogram bins log when saved to NeXus
@@ -106,16 +104,16 @@ Run &Run::operator+=(const Run &rhs) {
   // Other properties are added together if they are on the approved list
   for (int i = 0; i < ADDABLES; ++i) {
     if (rhs.m_manager.existsProperty(ADDABLE[i])) {
-      // get a pointer to the property on the right-handside workspace
+      // get a pointer to the property on the right-hand side workspace
       Property *right = rhs.m_manager.getProperty(ADDABLE[i]);
 
-      // now deal with the left-handside
+      // now deal with the left-hand side
       if (m_manager.existsProperty(ADDABLE[i])) {
         Property *left = m_manager.getProperty(ADDABLE[i]);
         left->operator+=(right);
       } else
-        // no property on the left-handside, create one and copy the
-        // right-handside across verbatum
+        // no property on the left-hand side, create one and copy the
+        // right-hand side across verbatim
         m_manager.declareProperty(right->clone(), "");
     }
   }
@@ -171,7 +169,17 @@ void Run::setProtonCharge(const double charge) {
  * @throw Exception::NotFoundError if the proton charge has not been set
  */
 double Run::getProtonCharge() const {
-  double charge = m_manager.getProperty(PROTON_CHARGE_LOG_NAME);
+  double charge = 0.0;
+  if (!m_manager.existsProperty(PROTON_CHARGE_LOG_NAME)) {
+    integrateProtonCharge();
+  }
+  if (m_manager.existsProperty(PROTON_CHARGE_LOG_NAME)) {
+    charge = m_manager.getProperty(PROTON_CHARGE_LOG_NAME);
+  } else {
+    g_log.warning() << PROTON_CHARGE_LOG_NAME
+                    << " log was not found. Proton Charge set to 0.0"
+                    << std::endl;
+  }
   return charge;
 }
 
@@ -180,17 +188,17 @@ double Run::getProtonCharge() const {
  * Calculate the total proton charge by integrating up all the entries in the
  * "proton_charge" time series log. This is then saved in the log entry
  * using setProtonCharge().
- * If "proton_charge" is not found, the value is set to 0.0.
- * @return :: the total charge in microAmp*hours.
+ * If "proton_charge" is not found, the value is not stored
  */
-double Run::integrateProtonCharge() {
+void Run::integrateProtonCharge(const std::string &logname) const {
   Kernel::TimeSeriesProperty<double> *log;
   try {
     log = dynamic_cast<Kernel::TimeSeriesProperty<double> *>(
-        this->getProperty("proton_charge"));
+        this->getProperty(logname));
   } catch (Exception::NotFoundError &) {
-    this->setProtonCharge(0);
-    return 0;
+    g_log.warning(logname + " log was not found. The value of the total proton "
+                            "charge has not been set");
+    return;
   }
 
   if (log) {
@@ -203,14 +211,17 @@ double Run::integrateProtonCharge() {
       const double currentConversion = 1.e-6 / 3600.;
       total *= currentConversion;
     } else if (!unit.empty() && unit != "uAh") {
-      g_log.warning("Proton charge log has units other than uAh or "
+      g_log.warning(logname +
+                    " log has units other than uAh or "
                     "picoCoulombs. The value of the total proton charge has "
                     "been left at the sum of the log values.");
     }
-    this->setProtonCharge(total);
-    return total;
+    const_cast<Run *>(this)->setProtonCharge(total);
   } else {
-    return -1;
+    g_log.warning(
+        logname +
+        " log was not a time series property. The value of the total proton "
+        "charge has not been set");
   }
 }
 
@@ -233,8 +244,8 @@ void Run::storeHistogramBinBoundaries(const std::vector<double> &histoBins) {
   if (histoBins.front() >= histoBins.back()) {
     std::ostringstream os;
     os << "Run::storeEnergyBinBoundaries - Inconsistent start & end values "
-          "given, size=" << histoBins.size()
-       << ". Cannot interpret values as bin boundaries.";
+          "given, size="
+       << histoBins.size() << ". Cannot interpret values as bin boundaries.";
     throw std::out_of_range(os.str());
   }
   m_histoBins = histoBins;
@@ -257,13 +268,15 @@ Run::histogramBinBoundaries(const double value) const {
   if (value < m_histoBins.front()) {
     std::ostringstream os;
     os << "Run::histogramBinBoundaries- Value lower than first bin boundary. "
-          "Value= " << value << ", first boundary=" << m_histoBins.front();
+          "Value= "
+       << value << ", first boundary=" << m_histoBins.front();
     throw std::out_of_range(os.str());
   }
   if (value > m_histoBins.back()) {
     std::ostringstream os;
     os << "Run::histogramBinBoundaries- Value greater than last bin boundary. "
-          "Value= " << value << ", last boundary=" << m_histoBins.back();
+          "Value= "
+       << value << ", last boundary=" << m_histoBins.back();
     throw std::out_of_range(os.str());
   }
   const int index = VectorHelper::getBinIndex(m_histoBins, value);

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -95,7 +95,7 @@ public:
 
   void testGetSetProtonCharge() {
     Run runInfo;
-    TS_ASSERT_THROWS(runInfo.getProtonCharge(), Exception::NotFoundError);
+		TS_ASSERT_EQUALS(runInfo.getProtonCharge(), 0.0);
     TS_ASSERT_THROWS_NOTHING(runInfo.setProtonCharge(10.0));
     TS_ASSERT_EQUALS(runInfo.getProtonCharge(), 10.0);
   }

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -95,7 +95,7 @@ public:
 
   void testGetSetProtonCharge() {
     Run runInfo;
-		TS_ASSERT_EQUALS(runInfo.getProtonCharge(), 0.0);
+    TS_ASSERT_EQUALS(runInfo.getProtonCharge(), 0.0);
     TS_ASSERT_THROWS_NOTHING(runInfo.setProtonCharge(10.0));
     TS_ASSERT_EQUALS(runInfo.getProtonCharge(), 10.0);
   }

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -2327,7 +2327,7 @@ void FilterEventsByLogValuePreNexus::setProtonCharge(
 
   // Add the proton charge entries.
   TimeSeriesProperty<double> *log =
-      new TimeSeriesProperty<double>("m_protonCharge");
+      new TimeSeriesProperty<double>("proton_charge");
   log->setUnits("picoCoulombs");
 
   // Add the time and associated charge to the log
@@ -2335,8 +2335,9 @@ void FilterEventsByLogValuePreNexus::setProtonCharge(
 
   // TODO set the units for the log
   run.addLogData(log);
-  double integ = run.integrateProtonCharge();
-  // run.setProtonCharge(this->m_protonChargeTot); //This is now redundant
+	// Force re-integration
+	run.integrateProtonCharge();
+  double integ = run.getProtonCharge();
   this->g_log.information() << "Total proton charge of " << integ
                             << " microAmp*hours found by integrating.\n";
 

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -2335,8 +2335,8 @@ void FilterEventsByLogValuePreNexus::setProtonCharge(
 
   // TODO set the units for the log
   run.addLogData(log);
-	// Force re-integration
-	run.integrateProtonCharge();
+  // Force re-integration
+  run.integrateProtonCharge();
   double integ = run.getProtonCharge();
   this->g_log.information() << "Total proton charge of " << integ
                             << " microAmp*hours found by integrating.\n";

--- a/Framework/DataHandling/src/LoadEventPreNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus.cpp
@@ -832,8 +832,8 @@ void LoadEventPreNexus::setProtonCharge(
 
   /// TODO set the units for the log
   run.addLogData(log);
-	// Force re-integration
-	run.integrateProtonCharge();
+  // Force re-integration
+  run.integrateProtonCharge();
   double integ = run.getProtonCharge();
   this->g_log.information() << "Total proton charge of " << integ
                             << " microAmp*hours found by integrating.\n";

--- a/Framework/DataHandling/src/LoadEventPreNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus.cpp
@@ -832,8 +832,9 @@ void LoadEventPreNexus::setProtonCharge(
 
   /// TODO set the units for the log
   run.addLogData(log);
-  double integ = run.integrateProtonCharge();
-  // run.setProtonCharge(this->proton_charge_tot); //This is now redundant
+	// Force re-integration
+	run.integrateProtonCharge();
+  double integ = run.getProtonCharge();
   this->g_log.information() << "Total proton charge of " << integ
                             << " microAmp*hours found by integrating.\n";
 }

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -1237,8 +1237,10 @@ void LoadEventPreNexus2::setProtonCharge(
   log->addValues(this->pulsetimes, this->proton_charge);
 
   /// TODO set the units for the log
-  run.addLogData(log);
-  double integ = run.integrateProtonCharge();
+  run.addLogData(log);	
+	// Force re-integration
+	run.integrateProtonCharge();
+  double integ = run.getProtonCharge();
 
   g_log.information() << "Total proton charge of " << integ
                       << " microAmp*hours found by integrating.\n";

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -1237,9 +1237,9 @@ void LoadEventPreNexus2::setProtonCharge(
   log->addValues(this->pulsetimes, this->proton_charge);
 
   /// TODO set the units for the log
-  run.addLogData(log);	
-	// Force re-integration
-	run.integrateProtonCharge();
+  run.addLogData(log);
+  // Force re-integration
+  run.integrateProtonCharge();
   double integ = run.getProtonCharge();
 
   g_log.information() << "Total proton charge of " << integ

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -269,7 +269,7 @@ void LoadNexusLogs::exec() {
       // Try and integrate the proton logs
       try {
         // Use the DAS logs to integrate the proton charge (if any).
-        workspace->mutableRun().integrateProtonCharge();
+        workspace->mutableRun().getProtonCharge();
       } catch (Exception::NotFoundError &) {
         // Ignore not found property error.
       }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -110,6 +110,9 @@ bpl::list keys(Run &self) {
 }
 }
 
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(integrateProtonCharge_Overload,
+                                       integrateProtonCharge, 0, 1)
+
 void export_Run() {
   // Pointer
   register_ptr_to_python<Run *>();
@@ -119,8 +122,11 @@ void export_Run() {
       .def("getProtonCharge", &Run::getProtonCharge, arg("self"),
            "Return the total good proton charge for the run")
 
-      .def("integrateProtonCharge", &Run::integrateProtonCharge, arg("self"),
-           "Return the total good proton charge for the run")
+      .def("integrateProtonCharge", &Run::integrateProtonCharge,
+           integrateProtonCharge_Overload(
+               "Set the total good proton charge for the run, from the proton "
+               "charge log",
+               (arg("self"), arg("logname") = "proton_charge")))
 
       .def("hasProperty", &Run::hasProperty, (arg("self"), arg("name")),
            "Returns True if the given log value is contained within the run")


### PR DESCRIPTION
in all cases call getProtonCharge to get the proton charge

This was just a simplification really, the previous approach was confusing as we had two methods for getting the proton charge.

closes #14323
### release notes

Too minor
### To test
1. Code review and check that al unit tests and system tests passed
