### PR TITLE
Make FirstTimeSetup window slightly smaller

### DIFF
--- a/MantidPlot/src/Mantid/FirstTimeSetup.ui
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>990</width>
-    <height>730</height>
+    <height>712</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,13 +19,13 @@
   <property name="minimumSize">
    <size>
     <width>990</width>
-    <height>730</height>
+    <height>712</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>990</width>
-    <height>730</height>
+    <height>712</height>
    </size>
   </property>
   <property name="font">


### PR DESCRIPTION
Fixes #14445.

Release notes not yet updated.

This change adjusts the height of the FirstTimeSetup window from 730 to 712 pixels to help ensure it is fully visible at low screen resolutions. 

This change is part of making all dialogs usable on smaller screens (see issue linked in #14445).
### Testing

Set screen resolution to 1024x768 or 1366x768. Open `Help -> First Time Setup` window and ensure it is fully visible and all widgets are laid out in a reasonable manner.

Ideally this should be tested on all supported operating systems to ensure that any differences in widget sizes, taskbar height, fonts, etc don't cause any issues.
