### PR TITLE
Fix "List Data" causing MantidPlot to crash

### DIFF
--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -321,10 +321,17 @@ bool MDHistoWorkspaceIterator::next() {
     ++m_pos;
   }
   bool ret = m_pos < m_max;
+
   if (ret) {
-    // Keep calling next if the current position is masked and still valid.
-    while (m_skippingPolicy->keepGoing()) {
-      ret = this->next();
+    // Avoid recursion in while loop as m_function does not need to be checked
+    // if skipping_policy is true anyway
+    // This also avoids high recursion depth causing stack overflow, which would
+    // otherwise be a problem for large masked regions
+    // Keep moving to next position if the current position is masked and still
+    // valid.
+    while (m_skippingPolicy->keepGoing()) { //(m_ws->getIsMaskedAt(m_pos)) {
+      ++m_pos;
+      ret = m_pos < m_max;
       if (!ret)
         break;
     }

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -311,9 +311,7 @@ bool MDHistoWorkspaceIterator::next() {
       for (size_t d = 0; d < m_nd; d++) {
         m_center[d] =
             m_origin[d] + (coord_t(m_index[d]) + 0.5f) * m_binWidth[d];
-        //          std::cout << m_center[d] << ",";
       }
-      //        std::cout<<std::endl;
       // Keep incrementing until you are in the implicit function
     } while (!allIncremented && !m_function->isPointContained(m_center) &&
              m_pos < m_max);
@@ -324,12 +322,12 @@ bool MDHistoWorkspaceIterator::next() {
 
   if (ret) {
     // Avoid recursion in while loop as m_function does not need to be checked
-    // if skipping_policy is true anyway
-    // This also avoids high recursion depth causing stack overflow, which would
-    // otherwise be a problem for large masked regions
+    // if skipping_policy is true
+    // This also avoids high recursion depth causing stack overflow for large 
+	// masked regions
     // Keep moving to next position if the current position is masked and still
     // valid.
-    while (m_skippingPolicy->keepGoing()) { //(m_ws->getIsMaskedAt(m_pos)) {
+    while (m_skippingPolicy->keepGoing()) {
       ++m_pos;
       ret = m_pos < m_max;
       if (!ret)


### PR DESCRIPTION
Fixes #14367 

Occurred with an MDHistoWorkspace that had a mask applied. Right clicking on workspace and selecting "List Data" caused MantidPlot to crash every time if the masked region spanned at least 2^18 bins. The crash was a seg fault and MantidPlot would instantly stop running and disappear.

The problem was high recursion depth causing stack overflow in the MDHistoWorkspaceIterator. The iterator's next() function was calling itself to skip over masked bins.

A comment in the code will hopefully avoid the change getting reverted as the recursion method seems like the obvious thing to do there.

**For Tester:**
Please check the code. Running the python below and selecting "List Data" when right-clicking on the `wsBinned` workspace in MantidPlot would previously cause a crash, it now should not.

``` python

ws = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='4')
FakeMDEventData(ws, PeakParams='10,1,1,1,0.1', RandomizeSignal='1')
wsBinned = BinMD(ws,AlignedDim0='h,-2,2,64',AlignedDim1='k,-2,2,64',AlignedDim2='l,-2,2,64')
MaskMD(Workspace=wsBinned,Dimensions="h,k,l",Extents="-2,2,-2,2,-2,2")
```
