### PR TITLE
Make HFIR 4Circle Reduction UI Scrollable

### DIFF
--- a/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
@@ -10,6 +10,7 @@ import csv
 import time
 
 from PyQt4 import QtCore, QtGui
+from mantidqtpython import MantidQt
 
 import reduce4circleControl as r4c
 import guiutility as gutil
@@ -37,6 +38,10 @@ class MainWindow(QtGui.QMainWindow):
         # UI Window (from Qt Designer)
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
+
+        # Make UI scrollable
+        self._scrollbars = MantidQt.API.WidgetScrollbarDecorator(self)
+        self._scrollbars.setEnabled(True) # Must follow after setupUi(self)!
 
         # Mantid configuration
         self._instrument = str(self.ui.comboBox_instrument.currentText())


### PR DESCRIPTION
Fixes #14452.

This change adds scrollbars to the HFIR 4Circle Reduction interface to improve usability on low resolution screens. Since the interface cannot be resized to a width of less than 1097 pixels, it was too large for 1024x768 resolution screens. Now, scrollbars will appear when necessary to allow full use of the interface regardless of screen resolution.

This change is part of making all dialogs usable on smaller screens (see issue linked in #14452).
### Testing

Open `Interfaces -> Diffraction -> HFIR 4Circle Reduction` window and try resizing it. Scrollbars should appear or disappear as necessary.

Ideally this should be tested with the screen resolution set to 1024x768. The dialog should appear with a reasonable size and the horizontal scrollbar already visible in this case. 

Keep an eye out for any widgets not resizing correctly.
