### PR TITLE
Fix -Winconsistent-missing-override warnings from Xcode 7.1

### DIFF
--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -36,10 +36,10 @@ public:
   LoadEventAndCompress();
   virtual ~LoadEventAndCompress();
 
-  virtual const std::string name() const;
-  virtual int version() const;
-  virtual const std::string category() const;
-  virtual const std::string summary() const;
+  virtual const std::string name() const override;
+  virtual int version() const override;
+  virtual const std::string category() const override;
+  virtual const std::string summary() const override;
 
 protected:
   virtual API::ITableWorkspace_sptr
@@ -49,8 +49,8 @@ protected:
                                          double filterBadPulses);
 
 private:
-  void init();
-  void exec();
+  virtual void init() override;
+  virtual void exec() override;
 
   API::ITableWorkspace_sptr m_chunkingTable;
 };

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -34,7 +34,7 @@ namespace WorkflowAlgorithms {
 class DLLExport LoadEventAndCompress : public API::DataProcessorAlgorithm {
 public:
   LoadEventAndCompress();
-  virtual ~LoadEventAndCompress();
+  virtual ~LoadEventAndCompress() override;
 
   virtual const std::string name() const override;
   virtual int version() const override;


### PR DESCRIPTION
This fixes new warnings generated by Xcode 7.1.

no release notes.

testing: code review
