### PR TITLE
Clone first object, then move second and final object.

### DIFF
--- a/Framework/Geometry/src/Objects/Rules.cpp
+++ b/Framework/Geometry/src/Objects/Rules.cpp
@@ -238,7 +238,7 @@ int Rule::makeCNFcopy(std::unique_ptr<Rule> &TopRule)
           // gamma->clone()
           std::unique_ptr<Rule> tmp1 =
               Mantid::Kernel::make_unique<Intersection>(std::move(alpha),
-                                                        std::move(gamma));
+                                                        gamma->clone());
           std::unique_ptr<Rule> tmp2 =
               Mantid::Kernel::make_unique<Intersection>(std::move(beta),
                                                         std::move(gamma));
@@ -358,7 +358,7 @@ int Rule::makeCNF(std::unique_ptr<Rule> &TopRule)
           // gamma->clone()
           std::unique_ptr<Rule> tmp1 =
               Mantid::Kernel::make_unique<Intersection>(std::move(alpha),
-                                                        std::move(gamma));
+                                                        gamma->clone());
           std::unique_ptr<Rule> tmp2 =
               Mantid::Kernel::make_unique<Intersection>(std::move(beta),
                                                         std::move(gamma));


### PR DESCRIPTION
This fixes a bug introduced in pull request #14403. 

I accidentally moved an object twice instead of cloning it the first time and moving the object the second (and final) time.

no release notes.

testing: code review.
