### PR TITLE
Ignore binary & .git directories on packaging source tarball

### DIFF
--- a/buildconfig/CMake/CPackLinuxSetup.cmake
+++ b/buildconfig/CMake/CPackLinuxSetup.cmake
@@ -7,6 +7,8 @@ string ( TOLOWER "${CPACK_PACKAGE_NAME}" CPACK_PACKAGE_NAME )
 
 # define the source generators
 set ( CPACK_SOURCE_GENERATOR TGZ )
+set ( CPACK_SOURCE_IGNORE_FILES
+  "${CMAKE_BINARY_DIR};/\\\\.git*;${CPACK_SOURCE_IGNORE_FILES}" )
 
 include (DetermineLinuxDistro)
 


### PR DESCRIPTION
The `build` directory along with the `.git` directory are both now ignored when creating the source tarball.

**Tester**

To generate a source tarball run (on Linux):

```
cmake -DENABLE_CPACK=ON
cpack --config CPackSourceConfig.cmake -D CPACK_PACKAGING_INSTALL_PREFIX= .
```

in the build directory. This will generate a tarball that should be ~40Mb in size and not the ~800Mb it currently is on the `RHEL6` server.

No release not updates required
