### PR TITLE
Added RewriteSpectraMap property to LoadInst call in IDRTab

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReductionTab.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectDataReductionTab.cpp
@@ -174,6 +174,7 @@ namespace CustomInterfaces
     loadInstAlg->initialize();
     loadInstAlg->setProperty("Workspace", energyWs);
     loadInstAlg->setProperty("InstrumentName", instName.toStdString());
+    loadInstAlg->setProperty("RewriteSpectraMap", OptionalBool(true));
     loadInstAlg->execute();
     energyWs = loadInstAlg->getProperty("Workspace");
 


### PR DESCRIPTION
Fixes #14464

The Indirect Data Reduction Tab should now open without error the qthelp package should also build without errors.
# To Test (Interface)
- Open Indirect Data Reduction(Interfaces > Indirect > Data Reduction) 
- Ensure the interface loads (this may take a few seconds) successfully
# To Test (Documentation)
- Build the docs-qthelp package
- Ensure this builds without error
