### PR TITLE
Catch potential errors on startup of Mantid

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -255,10 +255,27 @@ ConfigServiceImpl::ConfigServiceImpl()
   Poco::Path path(appDataDir);
   path.pushDirectory("instrument");
   Poco::File file(path);
-  // createdirectories will fail gracefully if it is already present
-  file.createDirectories();
+  // createDirectories will fail gracefully if it is already present - but will
+  // throw an error if it cannot create the directory
+  try {
+    file.createDirectories();
+  } catch (Poco::FileException &fe) {
+    g_log.error()
+        << "Cannot create the local instrument cache directory ["
+        << path.toString()
+        << "]. Mantid will not be able to update instrument definitions.\n"
+        << fe.what() << std::endl;
+  }
   Poco::File vtpDir(getVTPFileDirectory());
-  vtpDir.createDirectories();
+  try {
+    vtpDir.createDirectories();
+  } catch (Poco::FileException &fe) {
+    g_log.error()
+        << "Cannot create the local instrument geometry cache directory ["
+        << path.toString()
+        << "]. Mantid will be slower at viewing complex instruments.\n"
+        << fe.what() << std::endl;
+  }
   // must update the cache of instrument paths
   cacheInstrumentPaths();
 }


### PR DESCRIPTION
if .mantid or %appdata% directory permissions do not allow writing
closes #14404
### Release Notes

Too minor and internal
### To test (Linux)
1. To reproduce, remove the folder `rm -r ~/.mantid/instrument`, then create as non writable `mkdir -m 555 ~/.mantid/instrument`, then start Mantid.
2. It should start sucessfully, but have error messages on the console.
