### PR TITLE
Refactor plotting code in MuonAnalysis

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2024,7 +2024,9 @@ void MuonAnalysis::plotSpectrum(const QString& wsName, bool logScale)
     const QMap<QString, QString>& params = getPlotStyleParams(wsName);
 
     // Insert real values
-    pyS.replace("%WSNAME%", wsName);
+    QString safeWSName(wsName);
+    safeWSName.replace("'", "\'");
+    pyS.replace("%WSNAME%", safeWSName);
     pyS.replace("%PREV%", m_currentDataName);
     pyS.replace("%ERRORS%", params["ShowErrors"]);
     pyS.replace("%CONNECT%", params["ConnectType"]);

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1989,35 +1989,31 @@ void MuonAnalysis::plotSpectrum(const QString& wsName, bool logScale)
       hideAllPlotWindows();
     }
 
+    QStringList& s = acquireWindowScript; // To keep short
+    s << "ws = mtd['%WSNAME%']";
+    s << "altName = ws.name() + '-1'";
+
     if ( policy == MuonAnalysisOptionTab::PreviousWindow )
     {
-      QStringList& s = acquireWindowScript; // To keep short
-
-      s << "ew = graph('%WSNAME%-1')";
+      s << "ew = graph(altName)";
       s << "if '%WSNAME%' != '%PREV%' and ew != None:";
       s << "    ew.close()";
 
       s << "pw = graph('%PREV%-1')";
       s << "if pw == None:";
-      s << "  pw = newGraph('%WSNAME%-1', 0)";
-
-      s << "w = plotSpectrum('%WSNAME%', 0, %ERRORS%, %CONNECT%, window = pw, clearWindow = True)";
-      s << "w.setName('%WSNAME%-1')";
-      s << "w.setObjectName('%WSNAME%')";
-      s << "w.show()";
-      s << "w.setFocus()";
+      s << "  pw = newGraph(altName, 0)";
     }
     else if ( policy == MuonAnalysisOptionTab::NewWindow )
     {
-      QStringList& s = acquireWindowScript; // To keep short
-
-      s << "pw = newGraph('%WSNAME%-1', 0)";
-      s << "w = plotSpectrum('%WSNAME%', 0, %ERRORS%, %CONNECT%, window = pw, clearWindow = True)";
-      s << "w.setName('%WSNAME%-1')";
-      s << "w.setObjectName('%WSNAME%')";
-      s << "w.show()";
-      s << "w.setFocus()";
+      s << "pw = newGraph(altName, 0)";
     }
+
+    s << "w = plotSpectrum(ws.name(), 0, %ERRORS%, %CONNECT%, window = pw, "
+      "clearWindow = True)";
+    s << "w.setName(altName)";
+    s << "w.setObjectName(ws.name())";
+    s << "w.show()";
+    s << "w.setFocus()";
 
     QString pyS;
 
@@ -2035,10 +2031,8 @@ void MuonAnalysis::plotSpectrum(const QString& wsName, bool logScale)
 
     // Update titles
     pyS += "l = w.activeLayer()\n"
-           "l.setCurveTitle(0, '%1')\n"
-           "l.setTitle('%2')\n";
-
-    pyS = pyS.arg(wsName).arg(m_title.c_str());
+           "l.setCurveTitle(0, ws.name())\n"
+           "l.setTitle(ws.getTitle())\n";
 
     // Set logarithmic scale if required
     if ( logScale )


### PR DESCRIPTION
Resolves #14460 

Refactored python code to use the workspace's title directly rather
than passing the title in as a string and having to escape the single
quotes. 
