### PR TITLE
Make parsing of first line in Batch Mode silent in ISIS SANS 

### DIFF
--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -3081,7 +3081,7 @@ void SANSRunWindow::handleInstrumentChange() {
       m_uiForm.front_beam_x, m_uiForm.front_beam_y, m_uiForm.front_radio};
   bool loq_selected = (instClass == "LOQ()");
   for (int i = 0; i < 3; i++)
-    front_center_widgets[i]->setEnabled(loq_selected);
+    front_center_widgets[i]->setEnabled(true);
   // Set the label of the radio buttons according to the
   // beamline usage:
   // REAR/FRONT -> SANS2D

--- a/scripts/SANS/SANSBatchMode.py
+++ b/scripts/SANS/SANSBatchMode.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 #
 # SANSBatchMode.py
 #
@@ -101,6 +101,9 @@ def addRunToStore(parts, run_store):
         @param parts: the parts of a CSV line
         @param run_store: Append info about CSV line
     """
+    if "MANTID_BATCH_FILE" in parts:
+        return 0
+
     # Check logical structure of line
     nparts = len(parts)
     if nparts not in ALLOWED_NUM_ENTRIES:


### PR DESCRIPTION
Fixes #14443 
# For testing

Please find the relevant files here: \olympic\Babylon5\Scratch\Anton\Testing\14443_StephensFix

The user file is: USER_LOQ_151D_Xpress_6mm.txt

**Test in batch mode**
1. Set the instrument to LOQ
2. Load the user file
3. Switch to batch mode ( on the first tab)
4. Load the batch mode file: batch_sk_test_corrected
5. Press 1DReduce
   - Confirm that there are no warnings regarding skipping entries

**Test that font detector is not grey out in Beam Centre Finder**

1.Swith the instrument to SANS2DTUBES (there will be an error because the User file does not match, but that is ok)
2. Go to the Geometry tab
- Confirm that the entry for the FRONT detector on the Beam Centre Finder is not grey out.
