### PR TITLE
Added progress report in algorithms: HFIRLoad, SumNeighbours and DgsReduction

### DIFF
--- a/Framework/Algorithms/src/SumNeighbours.cpp
+++ b/Framework/Algorithms/src/SumNeighbours.cpp
@@ -74,6 +74,10 @@ void SumNeighbours::exec() {
 
   Mantid::API::MatrixWorkspace_sptr outWS;
 
+  Progress progress(this, 0, 1, 2);
+
+  progress.report("Smoothing Neighbours...");
+
   IAlgorithm_sptr smooth = createChildAlgorithm("SmoothNeighbours");
   smooth->setProperty("InputWorkspace", inWS);
   if (rect) {
@@ -87,6 +91,8 @@ void SumNeighbours::exec() {
     smooth->setProperty("SumNumberOfNeighbours", SumX * SumY);
   }
   smooth->executeAsChildAlg();
+
+  progress.report();
   // Get back the result
   outWS = smooth->getProperty("OutputWorkspace");
   // Cast to the matrixOutputWS and save it

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRLoad.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/HFIRLoad.h
@@ -46,9 +46,7 @@ namespace WorkflowAlgorithms {
 class DLLExport HFIRLoad : public API::Algorithm {
 public:
   /// Constructor
-  HFIRLoad() : API::Algorithm(), m_center_x(0), m_center_y(0) {
-    m_output_message = "";
-  }
+  HFIRLoad() : API::Algorithm() {}
   /// Virtual destructor
   virtual ~HFIRLoad() {}
   /// Algorithm's name
@@ -67,12 +65,8 @@ private:
   void init();
   /// Execution code
   void exec();
-  void moveToBeamCenter();
-
-  double m_center_x;
-  double m_center_y;
-  std::string m_output_message;
-  API::MatrixWorkspace_sptr dataWS;
+  void moveToBeamCenter(API::MatrixWorkspace_sptr &dataWS, double &center_x,
+                        double &center_y);
 };
 
 } // namespace Algorithms

--- a/Framework/WorkflowAlgorithms/src/DgsReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/DgsReduction.cpp
@@ -694,6 +694,11 @@ void DgsReduction::exec() {
       this->reductionManager->declareProperty((*iter)->clone());
     }
   }
+
+  Progress progress(this, 0, 1, 7);
+
+  progress.report();
+
   // Determine the default facility
   const FacilityInfo defaultFacility = ConfigService::Instance().getFacility();
 
@@ -727,6 +732,8 @@ void DgsReduction::exec() {
     boost::erase_all(outputWsName, "_spe");
   }
 
+  progress.report("Loading hard mask...");
+
   // Load the hard mask if available
   MatrixWorkspace_sptr hardMaskWS = this->loadHardMask();
   if (hardMaskWS && showIntermedWS) {
@@ -735,6 +742,8 @@ void DgsReduction::exec() {
         "ReductionHardMask", hardMaskName, Direction::Output));
     this->setProperty("ReductionHardMask", hardMaskWS);
   }
+
+  progress.report("Loading grouping file...");
   // Load the grouping file if available
   MatrixWorkspace_sptr groupingWS = this->loadGroupingFile("");
   if (groupingWS && showIntermedWS) {
@@ -802,6 +811,7 @@ void DgsReduction::exec() {
     detVanWS.reset();
   }
 
+  progress.report("Converting to energy transfer...");
   IAlgorithm_sptr etConv =
       this->createChildAlgorithm("DgsConvertToEnergyTransfer");
   etConv->setProperty("InputWorkspace", sampleWS);
@@ -830,6 +840,8 @@ void DgsReduction::exec() {
   }
 
   Workspace_sptr absSampleWS = this->loadInputData("AbsUnitsSample", false);
+
+  progress.report("Absolute units reduction...");
 
   // Perform absolute normalisation if necessary
   if (absSampleWS) {
@@ -884,6 +896,8 @@ void DgsReduction::exec() {
     }
   }
 
+  progress.report();
+
   // Convert from DeltaE to powder S(Q,W)
   const bool doPowderConvert = this->getProperty("DoPowderDataConversion");
   if (doPowderConvert) {
@@ -918,6 +932,8 @@ void DgsReduction::exec() {
       saveNxs->executeAsChildAlg();
     }
   }
+
+  progress.report();
 
   this->setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/WorkflowAlgorithms/src/HFIRLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/HFIRLoad.cpp
@@ -151,8 +151,7 @@ void HFIRLoad::exec() {
     // reduced data set
     // as a sensitivity data set.
     g_log.warning() << "Unable to load file as a SPICE file. Trying to load as "
-                       "a Nexus file."
-                    << std::endl;
+                       "a Nexus file." << std::endl;
     loadAlg = createChildAlgorithm("Load", 0, 0.2);
     loadAlg->setProperty("Filename", fileName);
     loadAlg->executeAsChildAlg();

--- a/Framework/WorkflowAlgorithms/src/HFIRLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/HFIRLoad.cpp
@@ -60,7 +60,8 @@ void HFIRLoad::init() {
 }
 
 /// Move the detector according to the beam center
-void HFIRLoad::moveToBeamCenter() {
+void HFIRLoad::moveToBeamCenter(API::MatrixWorkspace_sptr &dataWS,
+                                double &center_x, double &center_y) {
   double default_ctr_x_pix = 0.0;
   double default_ctr_y_pix = 0.0;
   double default_ctr_x = 0.0;
@@ -72,20 +73,20 @@ void HFIRLoad::moveToBeamCenter() {
 
   // Check that we have a beam center defined, otherwise set the
   // default beam center
-  if (isEmpty(m_center_x) || isEmpty(m_center_y)) {
-    m_center_x = default_ctr_x_pix;
-    m_center_y = default_ctr_y_pix;
+  if (isEmpty(center_x) || isEmpty(center_y)) {
+    center_x = default_ctr_x_pix;
+    center_y = default_ctr_y_pix;
     g_log.information() << "Setting beam center to ["
-                        << Poco::NumberFormatter::format(m_center_x, 1) << ", "
-                        << Poco::NumberFormatter::format(m_center_y, 1) << "]"
+                        << Poco::NumberFormatter::format(center_x, 1) << ", "
+                        << Poco::NumberFormatter::format(center_y, 1) << "]"
                         << std::endl;
     return;
   }
 
   double beam_ctr_x = 0.0;
   double beam_ctr_y = 0.0;
-  HFIRInstrument::getCoordinateFromPixel(m_center_x, m_center_y, dataWS,
-                                         beam_ctr_x, beam_ctr_y);
+  HFIRInstrument::getCoordinateFromPixel(center_x, center_y, dataWS, beam_ctr_x,
+                                         beam_ctr_y);
 
   IAlgorithm_sptr mvAlg =
       createChildAlgorithm("MoveInstrumentComponent", 0.5, 0.50);
@@ -95,8 +96,8 @@ void HFIRLoad::moveToBeamCenter() {
   mvAlg->setProperty("Y", default_ctr_y - beam_ctr_y);
   mvAlg->setProperty("RelativePosition", true);
   mvAlg->executeAsChildAlg();
-  g_log.information() << "Moving beam center to " << m_center_x << " "
-                      << m_center_y << std::endl;
+  g_log.information() << "Moving beam center to " << center_x << " " << center_y
+                      << std::endl;
 }
 
 void HFIRLoad::exec() {
@@ -112,6 +113,10 @@ void HFIRLoad::exec() {
                                                         reductionManager);
   }
 
+  Progress progress(this, 0, 1, 5);
+
+  progress.report();
+
   // If the load algorithm isn't in the reduction properties, add it
   if (!reductionManager->existsProperty("LoadAlgorithm")) {
     AlgorithmProperty *algProp = new AlgorithmProperty("LoadAlgorithm");
@@ -122,9 +127,11 @@ void HFIRLoad::exec() {
   const std::string fileName = getPropertyValue("Filename");
 
   // Output log
-  m_output_message = "";
+  std::string output_message = "";
   const double wavelength_input = getProperty("Wavelength");
   const double wavelength_spread_input = getProperty("WavelengthSpread");
+
+  progress.report("LoadSpice2D...");
 
   IAlgorithm_sptr loadAlg = createChildAlgorithm("LoadSpice2D", 0, 0.2);
   loadAlg->setProperty("Filename", fileName);
@@ -144,7 +151,8 @@ void HFIRLoad::exec() {
     // reduced data set
     // as a sensitivity data set.
     g_log.warning() << "Unable to load file as a SPICE file. Trying to load as "
-                       "a Nexus file." << std::endl;
+                       "a Nexus file."
+                    << std::endl;
     loadAlg = createChildAlgorithm("Load", 0, 0.2);
     loadAlg->setProperty("Filename", fileName);
     loadAlg->executeAsChildAlg();
@@ -158,7 +166,8 @@ void HFIRLoad::exec() {
     return;
   }
   Workspace_sptr dataWS_tmp = loadAlg->getProperty("OutputWorkspace");
-  dataWS = boost::dynamic_pointer_cast<MatrixWorkspace>(dataWS_tmp);
+  API::MatrixWorkspace_sptr dataWS =
+      boost::dynamic_pointer_cast<MatrixWorkspace>(dataWS_tmp);
 
   // Get the sample-detector distance
   double sdd = 0.0;
@@ -185,6 +194,8 @@ void HFIRLoad::exec() {
   }
   dataWS->mutableRun().addProperty("sample_detector_distance", sdd, "mm", true);
 
+  progress.report("MoveInstrumentComponent...");
+
   // Move the detector to its correct position
   IAlgorithm_sptr mvAlg =
       createChildAlgorithm("MoveInstrumentComponent", 0.2, 0.4);
@@ -194,8 +205,8 @@ void HFIRLoad::exec() {
   mvAlg->setProperty("RelativePosition", false);
   mvAlg->executeAsChildAlg();
   g_log.information() << "Moving detector to " << sdd / 1000.0 << std::endl;
-  m_output_message += "   Detector position: " +
-                      Poco::NumberFormatter::format(sdd / 1000.0, 3) + " m\n";
+  output_message += "   Detector position: " +
+                    Poco::NumberFormatter::format(sdd / 1000.0, 3) + " m\n";
 
   // Compute beam diameter at the detector
   double src_to_sample = 0.0;
@@ -204,16 +215,16 @@ void HFIRLoad::exec() {
     src_to_sample = HFIRInstrument::getSourceToSampleDistance(dataWS);
     dataWS->mutableRun().addProperty("source-sample-distance", src_to_sample,
                                      "mm", true);
-    m_output_message +=
-        "   Computed SSD from number of guides: " +
-        Poco::NumberFormatter::format(src_to_sample / 1000.0, 3) + " \n";
+    output_message += "   Computed SSD from number of guides: " +
+                      Poco::NumberFormatter::format(src_to_sample / 1000.0, 3) +
+                      " \n";
   } catch (...) {
     Mantid::Kernel::Property *prop =
         dataWS->run().getProperty("source-sample-distance");
     Mantid::Kernel::PropertyWithValue<double> *dp =
         dynamic_cast<Mantid::Kernel::PropertyWithValue<double> *>(prop);
     src_to_sample = *dp;
-    m_output_message +=
+    output_message +=
         "   Could not compute SSD from number of guides, taking: " +
         Poco::NumberFormatter::format(src_to_sample / 1000.0, 3) + " \n";
   };
@@ -243,56 +254,60 @@ void HFIRLoad::exec() {
       sdd / src_to_sample * (source_apert + sample_apert) + sample_apert;
   dataWS->mutableRun().addProperty("beam-diameter", beam_diameter, "mm", true);
 
+  progress.report("Move to center beam...");
+
+  double center_x = 0;
+  double center_y = 0;
+
   // Move the beam center to its proper position
   const bool noBeamCenter = getProperty("NoBeamCenter");
   if (!noBeamCenter) {
-    m_center_x = getProperty("BeamCenterX");
-    m_center_y = getProperty("BeamCenterY");
-    if (isEmpty(m_center_x) && isEmpty(m_center_y)) {
+    center_x = getProperty("BeamCenterX");
+    center_y = getProperty("BeamCenterY");
+    if (isEmpty(center_x) && isEmpty(center_y)) {
       if (reductionManager->existsProperty("LatestBeamCenterX") &&
           reductionManager->existsProperty("LatestBeamCenterY")) {
-        m_center_x = reductionManager->getProperty("LatestBeamCenterX");
-        m_center_y = reductionManager->getProperty("LatestBeamCenterY");
+        center_x = reductionManager->getProperty("LatestBeamCenterX");
+        center_y = reductionManager->getProperty("LatestBeamCenterY");
       }
     }
-    moveToBeamCenter();
+
+    moveToBeamCenter(dataWS, center_x, center_y);
+
+    progress.report();
 
     // Add beam center to reduction properties, as the last beam center position
     // that was used.
     // This will give us our default position next time.
     if (!reductionManager->existsProperty("LatestBeamCenterX"))
       reductionManager->declareProperty(
-          new PropertyWithValue<double>("LatestBeamCenterX", m_center_x));
+          new PropertyWithValue<double>("LatestBeamCenterX", center_x));
     else
-      reductionManager->setProperty("LatestBeamCenterX", m_center_x);
+      reductionManager->setProperty("LatestBeamCenterX", center_x);
     if (!reductionManager->existsProperty("LatestBeamCenterY"))
       reductionManager->declareProperty(
-          new PropertyWithValue<double>("LatestBeamCenterY", m_center_y));
+          new PropertyWithValue<double>("LatestBeamCenterY", center_y));
     else
-      reductionManager->setProperty("LatestBeamCenterY", m_center_y);
+      reductionManager->setProperty("LatestBeamCenterY", center_y);
 
-    dataWS->mutableRun().addProperty("beam_center_x", m_center_x, "pixel",
-                                     true);
-    dataWS->mutableRun().addProperty("beam_center_y", m_center_y, "pixel",
-                                     true);
-    m_output_message += "   Beam center: " +
-                        Poco::NumberFormatter::format(m_center_x, 1) + ", " +
-                        Poco::NumberFormatter::format(m_center_y, 1) + "\n";
+    dataWS->mutableRun().addProperty("beam_center_x", center_x, "pixel", true);
+    dataWS->mutableRun().addProperty("beam_center_y", center_y, "pixel", true);
+    output_message += "   Beam center: " +
+                      Poco::NumberFormatter::format(center_x, 1) + ", " +
+                      Poco::NumberFormatter::format(center_y, 1) + "\n";
   } else {
-    HFIRInstrument::getDefaultBeamCenter(dataWS, m_center_x, m_center_y);
+    HFIRInstrument::getDefaultBeamCenter(dataWS, center_x, center_y);
 
-    dataWS->mutableRun().addProperty("beam_center_x", m_center_x, "pixel",
-                                     true);
-    dataWS->mutableRun().addProperty("beam_center_y", m_center_y, "pixel",
-                                     true);
-    m_output_message += "   Default beam center: " +
-                        Poco::NumberFormatter::format(m_center_x, 1) + ", " +
-                        Poco::NumberFormatter::format(m_center_y, 1) + "\n";
+    dataWS->mutableRun().addProperty("beam_center_x", center_x, "pixel", true);
+    dataWS->mutableRun().addProperty("beam_center_y", center_y, "pixel", true);
+    output_message += "   Default beam center: " +
+                      Poco::NumberFormatter::format(center_x, 1) + ", " +
+                      Poco::NumberFormatter::format(center_y, 1) + "\n";
   }
 
   setProperty<MatrixWorkspace_sptr>(
       "OutputWorkspace", boost::dynamic_pointer_cast<MatrixWorkspace>(dataWS));
-  setPropertyValue("OutputMessage", m_output_message);
+  setPropertyValue("OutputMessage", output_message);
 }
 
 } // namespace WorkflowAlgorithms


### PR DESCRIPTION
Fixes #14297 

The release notes have not been updated
## Changes

HFIRLoad, SumNeighbours and DgsReduction now report progress while running the algorithm. There was also a bit of code maintenance in HFIRLoad. HFIRSANSNormalise did not require progress reporting since it executes very quickly.
## Testing
### HFIRLoad

http://docs.mantidproject.org/nightly/algorithms/HFIRLoad-v1.html#id4
### SumNeighbours

_ws = CreateSampleWorkspace(BankPixelWidth=25,NumBanks=100)_
_print "ws has %i spectra to begin with" % ws.getNumberHistograms()_
_wsOut = SumNeighbours(ws,5,5)_

_print "wsOut has only %i spectra after beimng summed into 5x5 blocks" % *_wsOut.getNumberHistograms()*
### DgsReduction

http://docs.mantidproject.org/nightly/algorithms/DgsReduction-v1.html#id5
