### PR TITLE
Updated version of numpy for is_supported_f2py_platform

### DIFF
--- a/scripts/Inelastic/IndirectImport.py
+++ b/scripts/Inelastic/IndirectImport.py
@@ -69,7 +69,7 @@ def is_supported_f2py_platform():
     @returns True if we are currently on a platform that supports the F2Py
     libraries, else False.
     """
-    if _os_env().startswith("Windows") and _numpy_ver() == "1.6.2" and "python_d" not in sys.executable:
+    if _os_env().startswith("Windows") and _numpy_ver() == "1.9.3" and "python_d" not in sys.executable:
         return True
     return False
 


### PR DESCRIPTION
Fixes #14472

BayesQuasi should now be registered as a Mantid Algorithm.
# To Test
- Open BayesQuasi (Interfaces > Indirect > Bayes > Quasi) 
- Input = `irs26176_graphite002_red.nxs`
- Resolution = `irs26173_graphite002_res.nxs` 
- Click `Run`
- Ensure the algorithm runs to completion without error
