### PR TITLE
Improve handling of multiple files in the recent files list

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -14050,7 +14050,6 @@ void ApplicationWindow::updateRecentFilesList(QString fname) {
       mfp.setValue(recentFiles[i].toStdString());
       const std::vector<std::string> files =
           Mantid::API::MultipleFileProperty::flattenFileNames(mfp());
-      int commaPos = recentFiles[i].find(",", 0);
       if (files.size() == 1) {
         mi->setText("&" + QString::number(i + 1) + " " + recentFiles[i]);
       } else {

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -14051,15 +14051,23 @@ void ApplicationWindow::updateRecentFilesList(QString fname) {
       const std::vector<std::string> files =
           Mantid::API::MultipleFileProperty::flattenFileNames(mfp());
       if (files.size() == 1) {
-        mi->setText("&" + QString::number(i + 1) + " " + recentFiles[i]);
-      } else {
+        std::ostringstream ostr;
+        ostr << "&" << QString::number(i + 1).toStdString() << " " << files[0];
+        mi->setText(QString::fromStdString(ostr.str()));
+      } else if (files.size() > 1) {
         std::ostringstream ostr;
         ostr << "&" << QString::number(i + 1).toStdString() << " " << files[0]
              << " && " << files.size() - 1 << " more";
         mi->setText(QString::fromStdString(ostr.str()));
+      } else {
+        // mfp.setValue strips out any filenames that cannot be resolved.
+        // So if your recent file history contains a file that you have
+        // since deleted or renamed, files will be empty so do not
+        // register this entry and go on to the next one
+        delete (mi);
+        continue;
       }
-    } catch (std::runtime_error &ex) {
-      UNUSED_ARG(ex);
+    } catch (std::runtime_error &) {
       // The file property could not parse the string, use as is
       mi->setText("&" + QString::number(i + 1) + " " + recentFiles[i]);
     }


### PR DESCRIPTION
closes #14246

For multiple files it shows the first and states & x more
![image](https://cloud.githubusercontent.com/assets/1017173/11218849/3b4ead96-8d4f-11e5-9242-644d80240543.png)
### Release Notes

Too minor
### To test
1. Load few few files simulataneously, by selecting more than one while browsing, or using the mutliple file syntax
2. Look at the File->recent files menu
3. Select items and check they reload successfully.
