### PR TITLE
Make workspaces produced by GetNegMuMuonicXRD plottable

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/GetNegMuMuonicXRD.py
+++ b/Framework/PythonInterface/plugins/algorithms/GetNegMuMuonicXRD.py
@@ -28,15 +28,20 @@ class GetNegMuMuonicXRD(PythonAlgorithm):
                             doc='The output workspace will always be a GroupWorkspaces '
                                 'that will have the workspaces of each'
                                   ' muonicXR workspace created')
+        #We sort the lists of x-values from the dictionary here
+        #so that mantid can plot the workspaces it produces.
+        for key in self.muonic_xr:
+            value = self.muonic_xr.get(key)
+            self.muonic_xr[key] = sorted(value)
 
     def get_muonic_xr(self, element):
         #retrieve peak values from dictionary Muonic_XR
         peak_values = self.muonic_xr[element]
         return peak_values
-        
+
     def validateInput(self):
         issues = dict()
-        
+
         elements = self.getProperty('Elements').value()
         if elements == "":
             issues["Elements"] = 'No elements have been selected from the periodic table'
@@ -46,7 +51,7 @@ class GetNegMuMuonicXRD(PythonAlgorithm):
         outputworkspace_str = self.getProperty('OutputWorkspace').value()
         if outputworkspace_str == "":
             issues['OutputWorkspace'] = 'No output workspace name has been specified'
-            
+
         return issues
 
     def create_muonic_xr_ws(self, element, y_pos):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GetNegMuMuonicXRDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GetNegMuMuonicXRDTest.py
@@ -11,6 +11,8 @@ class GetNegMuMuonicXRDTest(unittest.TestCase):
 
     #TESTING FOR ONE WORKSPACE IN GROUP WORKSPACE
     def test_muonic_xrd_single_ws_in_group(self):
+        self.au_muonic_xr.sort()
+        self.as_muonic_xr.sort()
         #Setting up the work space manually
         au_peak_values = self.au_muonic_xr
         y_position = -0.001 #same as default used by GetNegMuMuonic
@@ -42,18 +44,18 @@ class GetNegMuMuonicXRDTest(unittest.TestCase):
         #check length of XValues is the same
         self.assertEqual(len(au_muon_ws.readX(0)), len(neg_mu_xr_ws.readX(0)))
         #check all the XValues are the same
-        
-        #For RHEL6 (running an older version of python) this assert is not yet implemented: 
+
+        #For RHEL6 (running an older version of python) this assert is not yet implemented:
         #self.assertItemsEqual(au_muon_ws.readX(0),neg_mu_xr_ws.readX(0))
         #INSTEAD we will use a simple for loop
         for x_value in range(len(au_muon_ws.readX(0))):
             self.assertEqual(au_muon_ws.readX(0)[x_value], neg_mu_xr_ws.readX(0)[x_value])
-        
+
         #check length of YValues is the same
         self.assertEqual(len(au_muon_ws.readY(0)), len(neg_mu_xr_ws.readY(0)))
         #check all the YValues are the same
-        
-        #For RHEL6 (running an older version of python) this assert is not yet implemented: 
+
+        #For RHEL6 (running an older version of python) this assert is not yet implemented:
         #self.assertItemsEqual(au_muon_ws.readY(0),neg_mu_xr_ws.readY(0))
         #INSTEAD we will use a simple for loop
         for y_value in range(len(au_muon_ws.readY(0))):
@@ -61,6 +63,8 @@ class GetNegMuMuonicXRDTest(unittest.TestCase):
 
     #TESTING FOR MORE THAN ONE WORKSPACE IN GROUP WORKSPACE
     def test_muonic_xrd_more_than_one_ws_in_group(self):
+        self.au_muonic_xr.sort()
+        self.as_muonic_xr.sort()
         y_position = 0.2
         #Setting up au_muonic workspace
         au_peak_values = self.au_muonic_xr
@@ -102,8 +106,8 @@ class GetNegMuMuonicXRDTest(unittest.TestCase):
         self.assertEqual(len(grouped_muon_ws[1].readX(0)), len(group_muonic_xr_ws[1].readX(0)))
 
         #Compare X values read from each workspace in grouped workspace
-        
-        #For RHEL6 (running an older version of python) this assert is not yet implemented: 
+
+        #For RHEL6 (running an older version of python) this assert is not yet implemented:
         #self.assertItemsEqual(grouped_muon_ws[0].readX(0), group_muonic_xr_ws[0].readX(0))
         #self.assertItemsEqual(grouped_muon_ws[1].readX(0), group_muonic_xr_ws[1].readX(0))
         #INSTEAD we will use a simple for loop
@@ -116,8 +120,8 @@ class GetNegMuMuonicXRDTest(unittest.TestCase):
         self.assertEqual(len(grouped_muon_ws[1].readY(0)), len(group_muonic_xr_ws[1].readY(0)))
 
         #Compare Y values read from each workspace in grouped workspace
-        
-        #For RHEL6 (running an older version of python) this assert is not yet implemented: 
+
+        #For RHEL6 (running an older version of python) this assert is not yet implemented:
         #self.assertItemsEqual(grouped_muon_ws[0].readY(0), group_muonic_xr_ws[0].readY(0))
         #self.assertItemsEqual(grouped_muon_ws[1].readY(0), group_muonic_xr_ws[1].readY(0))
         #INSTEAD we will use a simple for loop


### PR DESCRIPTION
The x-values featured in the dictionary for the GetNegMuMuonicXRD algorithm needed to be sorted in ascending order so that they could be plotted.

**To Test**:
- Load `GetNegMuMuonicXRD`
- Choose any element
- select a value for `Y-shift`
- enter a name for the output workspace
- Run the algorithm
- `Right click` -> `Plot Spectrum` for each workspace in the output group workspace
- See that they actually plot

**Release Notes**: //todo

Fixes #14347
