### PR TITLE
Add input validation and progress reporting to MaskMD

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
@@ -64,6 +64,7 @@ public:
 private:
   void init();
   void exec();
+  virtual std::map<std::string, std::string> validateInputs();
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -206,7 +206,7 @@ void MaskMD::exec() {
   std::vector<double> extents = getProperty("Extents");
 
   // Dimension names may contain brackets with commas (i.e. [H,0,0])
-  // so getProperty would return an incorrect vector of names
+  // so getProperty would return an incorrect vector of names;
   // instead get the string and parse it here
   std::vector<std::string> dimensions = parseDimensionNames(dimensions_string);
   // Report what dimension names were found
@@ -224,7 +224,14 @@ void MaskMD::exec() {
   if (bClearExistingMasks) {
     ws->clearMDMasking();
   }
+  this->interruption_point();
+  this->progress(0.0);
 
+  // Explicitly cast nGroups and group to double to avoid compiler warnings
+  // we don't care about loss of precision as we are only using the cast values
+  // for reporting algorithm progress
+  const double nGroups_double = static_cast<double>(nGroups);
+  double group_double;
   // Loop over all groups
   for (size_t group = 0; group < nGroups; ++group) {
     std::vector<InputArgument> arguments(nDims);
@@ -257,7 +264,11 @@ void MaskMD::exec() {
 
     // Add new masking.
     ws->setMDMasking(new MDBoxImplicitFunction(mins, maxs));
+    this->interruption_point();
+    group_double = static_cast<double>(group);
+    this->progress(group_double / nGroups_double);
   }
+  this->progress(1.0); // Ensure algorithm progress is reported as complete
 }
 
 std::map<std::string, std::string> MaskMD::validateInputs() {

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -231,7 +231,6 @@ void MaskMD::exec() {
   // loss of precision does not matter as we are only using the result
   // for reporting algorithm progress
   const double nGroups_double = static_cast<double>(nGroups);
-  double group_double;
   // Loop over all groups
   for (size_t group = 0; group < nGroups; ++group) {
     std::vector<InputArgument> arguments(nDims);
@@ -265,7 +264,7 @@ void MaskMD::exec() {
     // Add new masking.
     ws->setMDMasking(new MDBoxImplicitFunction(mins, maxs));
     this->interruption_point();
-    group_double = static_cast<double>(group);
+    double group_double = static_cast<double>(group);
     this->progress(group_double / nGroups_double);
   }
   this->progress(1.0); // Ensure algorithm progress is reported as complete

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -282,10 +282,23 @@ std::map<std::string, std::string> MaskMD::validateInputs() {
 
   std::vector<std::string> dimensions = parseDimensionNames(dimensions_string);
 
+  std::stringstream messageStream;
+
+  // Check named dimensions can be found in workspace
+  for (auto dimension_name : dimensions) {
+    try {
+      tryFetchDimensionIndex(ws, dimension_name);
+    } catch (std::runtime_error) {
+      messageStream << "Dimension '" << dimension_name << "' not found. ";
+    }
+  }
+  if (messageStream.rdbuf()->in_avail() != 0) {
+    validation_output["Dimensions"] = messageStream.str();
+    messageStream.str(std::string());
+  }
+
   size_t nDims = ws->getNumDims();
   size_t nDimensionIds = dimensions.size();
-
-  std::stringstream messageStream;
 
   // Check cardinality on names/ids
   if (nDimensionIds % nDims != 0) {

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -228,7 +228,7 @@ void MaskMD::exec() {
   this->progress(0.0);
 
   // Explicitly cast nGroups and group to double to avoid compiler warnings
-  // we don't care about loss of precision as we are only using the cast values
+  // loss of precision does not matter as we are only using the result
   // for reporting algorithm progress
   const double nGroups_double = static_cast<double>(nGroups);
   double group_double;

--- a/Framework/MDAlgorithms/test/MaskMDTest.h
+++ b/Framework/MDAlgorithms/test/MaskMDTest.h
@@ -149,7 +149,7 @@ public:
     alg.setPropertyValue(
         "Dimensions", "Axis0, Axis1"); // wrong number of dimenion ids provided.
     alg.setPropertyValue("Extents", "0,10,0,10,0,10");
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error); // fail validators
+    TS_ASSERT_THROWS_ANYTHING(alg.execute()); // fail input validators
   }
 
   void test_throw_if_extent_cardinality_wrong() {
@@ -163,7 +163,7 @@ public:
     alg.setPropertyValue("Dimensions", "Axis0, Axis1, Axis2");
     alg.setPropertyValue("Extents", "0,10"); // wrong number of extents
                                              // provided.
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error); // fail validators
+    TS_ASSERT_THROWS_ANYTHING(alg.execute()); // fail input validators
   }
 
   void test_throw_if_min_greater_than_max_anywhere() {
@@ -176,7 +176,7 @@ public:
     alg.setPropertyValue("Workspace", wsName);
     alg.setPropertyValue("Dimensions", "Axis0, Axis1, Axis2");
     alg.setPropertyValue("Extents", "0,-10,0,-10,0,-10");
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error); // fail validators
+    TS_ASSERT_THROWS_ANYTHING(alg.execute()); // fail input validators
   }
 
   void test_fall_back_to_dimension_names() {

--- a/Framework/MDAlgorithms/test/MaskMDTest.h
+++ b/Framework/MDAlgorithms/test/MaskMDTest.h
@@ -5,6 +5,7 @@
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 
 #include <cxxtest/TestSuite.h>
+#include <stdexcept>
 
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -148,7 +149,7 @@ public:
     alg.setPropertyValue(
         "Dimensions", "Axis0, Axis1"); // wrong number of dimenion ids provided.
     alg.setPropertyValue("Extents", "0,10,0,10,0,10");
-    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument);
+    TS_ASSERT_THROWS(alg.execute(), std::runtime_error); // fail validators
   }
 
   void test_throw_if_extent_cardinality_wrong() {
@@ -162,7 +163,7 @@ public:
     alg.setPropertyValue("Dimensions", "Axis0, Axis1, Axis2");
     alg.setPropertyValue("Extents", "0,10"); // wrong number of extents
                                              // provided.
-    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument);
+    TS_ASSERT_THROWS(alg.execute(), std::runtime_error); // fail validators
   }
 
   void test_throw_if_min_greater_than_max_anywhere() {
@@ -175,7 +176,7 @@ public:
     alg.setPropertyValue("Workspace", wsName);
     alg.setPropertyValue("Dimensions", "Axis0, Axis1, Axis2");
     alg.setPropertyValue("Extents", "0,-10,0,-10,0,-10");
-    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument);
+    TS_ASSERT_THROWS(alg.execute(), std::runtime_error); // fail validators
   }
 
   void test_fall_back_to_dimension_names() {

--- a/Framework/MDAlgorithms/test/MaskMDTest.h
+++ b/Framework/MDAlgorithms/test/MaskMDTest.h
@@ -161,8 +161,8 @@ public:
     alg.initialize();
     alg.setPropertyValue("Workspace", wsName);
     alg.setPropertyValue("Dimensions", "Axis0, Axis1, Axis2");
-    alg.setPropertyValue("Extents", "0,10"); // wrong number of extents
-                                             // provided.
+    alg.setPropertyValue("Extents", "0,10");  // wrong number of extents
+                                              // provided.
     TS_ASSERT_THROWS_ANYTHING(alg.execute()); // fail input validators
   }
 


### PR DESCRIPTION
Closes #14423 

Added input validation, interruption points and progress reporting to MaskMD.

**For Tester**

You can use the following python to create a workspace. If you then access the "MaskMD input dialog" through the Algorithms GUI you can check the validators work.
It run successfully with these inputs:
Workspace=ws
Dimensions=h,k,l
Extents=-1,1-1,1,-1,1

To make it fail to run, and thus check the validators, you could try giving a different number of arguments to Dimensions and Extents or different dimension names. You should see useful error messages after clicking "Run".

``` python

ws = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='4')
FakeMDEventData(ws, PeakParams='10,1,1,1,0.1', RandomizeSignal='1')
ws = BinMD(ws,AlignedDim0='h,-2,2,4',AlignedDim1='k,-2,2,4',AlignedDim2='l,-2,2,4')

```
