### PR TITLE
Disable static linking to libstdc++ on RHEL6

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -123,9 +123,9 @@ fi
 ###############################################################################
 # RHEL6 setup steps - nodes must have a "rhel6" label set (in lowercase)
 ###############################################################################
+DIST_FLAGS="-DSTATIC_LIBSTDCXX=OFF"
 if [[ ${NODE_LABELS} == *rhel6* ]]; then
   SCL_ON_RHEL6="scl enable mantidlibs34 devtoolset-2"
-  DIST_FLAGS="-DSTATIC_LIBSTDCXX=ON"
   ON_RHEL6=true
 else
   SCL_ON_RHEL6="eval"


### PR DESCRIPTION
**Tester**

Build Mantid on RHEL6 with the `devtoolset-2` & `-DSTATIC_LIBSTDCXX=OFF`. When built run

```
bin/launch_mantidplot.sh
```

and `MantidPlot` should start cleanly. Note: This will fix the [master doctests](http://builds.mantidproject.org/job/master_doctests/label=rhel6-build/) job.

Internal change so no release notes updated.
