### PR TITLE
MuonAnalysis: fix "load current" for non-Windows systems

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h
@@ -54,6 +54,12 @@ MANTIDQT_CUSTOMINTERFACES_DLL bool compareByRunNumber(Workspace_sptr ws1, Worksp
 MANTIDQT_CUSTOMINTERFACES_DLL void groupWorkspaces(const std::string& groupName,
                                                    const std::vector<std::string>& inputWorkspaces);
 
+/// Mounts SMB share if current system is Linux/Mac
+MANTIDQT_CUSTOMINTERFACES_DLL void mountSharedDrive(const std::string &source);
+
+/// Unmounts mounted SMB share if current system is Linux/Mac
+MANTIDQT_CUSTOMINTERFACES_DLL void unmountSharedDrive();
+
 /**
  * A class which deals with auto-saving the widget values. Widgets are registered and then on any
  * change, their value is stored using QSettings.

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/MuonAnalysisHelper.h
@@ -55,7 +55,7 @@ MANTIDQT_CUSTOMINTERFACES_DLL void groupWorkspaces(const std::string& groupName,
                                                    const std::vector<std::string>& inputWorkspaces);
 
 /// Mounts SMB share if current system is Linux/Mac
-MANTIDQT_CUSTOMINTERFACES_DLL void mountSharedDrive(const std::string &source);
+MANTIDQT_CUSTOMINTERFACES_DLL std::string mountSharedDrive(const std::string &source);
 
 /// Unmounts mounted SMB share if current system is Linux/Mac
 MANTIDQT_CUSTOMINTERFACES_DLL void unmountSharedDrive();

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -885,7 +885,7 @@ void MuonAnalysis::runLoadCurrent()
     return;
   }
 
-  if ( instname == "EMU" || instname == "HIFI" || instname == "MUSR" || instname == "CHRONUS")
+  if ( instname == "EMU" || instname == "HIFI" || instname == "MUSR" || instname == "CHRONUS" || instname == "ARGUS")
   {
     QString instDirectory = instname;
     if ( instname == "CHRONUS" )

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -858,40 +858,22 @@ void MuonAnalysis::runLoadCurrent()
 {
   QString instname = m_uiForm.instrSelector->currentText().toUpper();
 
-  // If Argus data then simple
-  if ( instname == "ARGUS" )
-  {
-    QString argusDAE = "\\\\ndw828\\argusdata\\current cycle\\nexus\\argus0000000.nxs";
-    Poco::File l_path( argusDAE.toStdString() );
-    try
-    {
-      if ( !l_path.exists() )
-      {
-        QMessageBox::warning(this,"Mantid - MuonAnalysis",
-          QString("Can't load ARGUS Current data since\n") +
-          argusDAE + QString("\n") +
-          QString("does not seem to exist"));
-        return;
-      }
-    }
-    catch(Poco::Exception&)
-    {
-       QMessageBox::warning(this, "MantidPlot - MuonAnalysis", "Can't read from the selected directory, either the computer you are trying"
-         "\nto access is down or your computer is not currently connected to the network.");
-       return;
-    }
-    m_uiForm.mwRunFiles->setUserInput(argusDAE);
-    m_uiForm.mwRunFiles->setText("CURRENT RUN");
-    return;
-  }
-
-  if ( instname == "EMU" || instname == "HIFI" || instname == "MUSR" || instname == "CHRONUS" || instname == "ARGUS")
-  {
+  if (instname == "EMU" || instname == "HIFI" || instname == "MUSR" ||
+      instname == "CHRONUS" || instname == "ARGUS") {
     QString instDirectory = instname;
     if ( instname == "CHRONUS" )
       instDirectory = "NDW1030";
     std::string autosavePointsTo = "";
-    std::string autosaveFile = "\\\\" + instDirectory.toStdString() + "\\data\\autosave.run";
+    std::string separator = "\\";
+    std::string dataDirectory =
+        "\\\\" + instDirectory.toStdString() + separator + "data";
+
+    // If not Windows, must mount the share and convert the path
+#ifndef _WIN32
+    dataDirectory = mountSharedDrive(dataDirectory);
+    separator = "/";
+#endif
+    std::string autosaveFile = dataDirectory + separator + "autosave.run";
     Poco::File pathAutosave( autosaveFile );
     
     try // check if exists
@@ -911,9 +893,10 @@ void MuonAnalysis::runLoadCurrent()
 
     QString psudoDAE;
     if ( autosavePointsTo.empty() )
-      psudoDAE = "\\\\" + instDirectory + "\\data\\" + instDirectory + "auto_A.tmp";
+      psudoDAE = QString((dataDirectory + separator).c_str()) + instDirectory +
+                 separator.c_str() + "auto_A.tmp";
     else
-      psudoDAE = "\\\\" + instDirectory + "\\data\\" + autosavePointsTo.c_str();
+      psudoDAE = (dataDirectory + separator + autosavePointsTo).c_str();
 
     Poco::File l_path( psudoDAE.toStdString() );
     try

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -869,8 +869,19 @@ void MuonAnalysis::runLoadCurrent()
         "\\\\" + instDirectory.toStdString() + separator + "data";
 
     // If not Windows, must mount the share and convert the path
+    bool mounted = false;
 #ifndef _WIN32
-    dataDirectory = mountSharedDrive(dataDirectory);
+    try {
+      dataDirectory = mountSharedDrive(dataDirectory);
+      mounted = true;
+    } catch (const std::exception &ex) {
+      QMessageBox::warning(
+          this, "MantidPlot - MuonAnalysis",
+          "Can't mount the remote data share, error given was " +
+              QString(ex.what()) +
+              "\nEnsure you have root permissions and are connected to the "
+              "network.");
+    }
     separator = "/";
 #endif
     std::string autosaveFile = dataDirectory + separator + "autosave.run";
@@ -888,6 +899,9 @@ void MuonAnalysis::runLoadCurrent()
     {
        QMessageBox::warning(this, "MantidPlot - MuonAnalysis", "Can't read from the selected directory, either the computer you are trying"
          "\nto access is down or your computer is not currently connected to the network.");
+       if (mounted) {
+         unmountSharedDrive();
+       }
        return;
     }
 
@@ -907,6 +921,9 @@ void MuonAnalysis::runLoadCurrent()
           QString("Can't load ") + "Current data since\n" +
           psudoDAE + QString("\n") +
           QString("does not seem to exist"));
+        if (mounted) {
+          unmountSharedDrive();
+        }
         return;
       }
     }
@@ -916,10 +933,16 @@ void MuonAnalysis::runLoadCurrent()
         QString("Can't load ") + "Current data since\n" +
         psudoDAE + QString("\n") +
         QString("does not seem to exist"));
+      if (mounted) {
+        unmountSharedDrive();
+      }
       return;
     }
     m_uiForm.mwRunFiles->setUserInput(psudoDAE);
     m_uiForm.mwRunFiles->setText("CURRENT RUN");
+    if (mounted) {
+      unmountSharedDrive();
+    }
     return;
   }
 

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -11,7 +11,7 @@
 #include <QLineEdit>
 #include <QCheckBox>
 #include <QComboBox>
-#include <qprocess.h>
+#include <QProcess>
 
 #include <stdexcept>
 #include <boost/scope_exit.hpp>
@@ -541,11 +541,17 @@ void groupWorkspaces(const std::string& groupName, const std::vector<std::string
  * /mnt/currentdata
  * Probably requires root permissions
  * @param source Windows-style path
+ * @returns mount point, or nothing if no mount performed
  */
-void mountSharedDrive(const std::string &source) {
+std::string mountSharedDrive(const std::string &source) {
+  QString mountPoint("");
+#ifndef _WIN32
+  mountPoint = "/mnt/currentdata";
   QString path(source.c_str());
   path.replace("\\", "/");
-  sendCommand(QString("mount -t cifs %1 /mnt/currentdata").arg(path));
+  sendCommand(QString("mount -t cifs %1 %2").arg(path).arg(mountPoint));
+#endif
+  return mountPoint.toStdString();
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysisHelper.cpp
@@ -16,6 +16,25 @@
 #include <stdexcept>
 #include <boost/scope_exit.hpp>
 
+// free functions
+namespace {
+  /**
+  * If current system is Unix-like, run the supplied shell command
+  * @param command Command to run in the shell
+  */
+  void sendCommand(const QString &command) {
+#ifndef _WIN32
+    QString shell("/bin/bash");
+    QString argument = QString("-c \"%1\"").arg(command);
+    QStringList args;
+    args.push_back(argument);
+    QProcess process;
+    process.start(shell, args);
+    process.waitForFinished();
+#endif
+  }
+}
+
 namespace MantidQt
 {
 namespace CustomInterfaces
@@ -564,22 +583,3 @@ void unmountSharedDrive() { sendCommand("umount /mnt/currentdata"); }
 } // namespace MuonAnalysisHelper
 } // namespace CustomInterfaces
 } // namespace Mantid
-
-// free functions
-namespace {
-/**
- * If current system is Unix-like, run the supplied shell command
- * @param command Command to run in the shell
- */
-void sendCommand(const QString &command) {
-#ifndef _WIN32
-  QString shell("/bin/bash");
-  QString argument = QString("-c \"%1\"").arg(command);
-  QStringList args;
-  args.push_back(argument);
-  QProcess process;
-  process.start(shell, args);
-  process.waitForFinished();
-#endif
-}
-}


### PR DESCRIPTION
Resolves #10329 
Pull request is an updated version of #14446 

The "load current" button in Muon Analysis gets the latest data set from the selected (ISIS) instrument. 

This does _not_ use the `\\isis\inst$\Instruments$\NDX...` catalog path that is mounted under `/archive` on Linux/Mac. Rather, the data is on an SMB share named after the machine, e.g. `\\MUSR\data`.

This works fine on Windows but, on Unix-like systems, it is necessary to explicitly mount the shared drives to access the data (and unmount afterwards).

(Tester will need a Linux/Mac machine, access to the ISIS network, and probably root permissions, unless there is a way to access the data using something like `gvfs-mount`?).

Also updated the path for ARGUS instrument - this had a hardcoded special case that appears to no longer apply, so is now treated the same as the other instruments.

Test: open Muon Analysis interface and click the "Load current" button. Dataset should be loaded.
