### PR TITLE
Minor changeto prevent double call to setEnabled

### DIFF
--- a/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
@@ -139,10 +139,11 @@ void ColorMapWidget::setupColorBarScaling(const MantidColorMap& colorMap)
   }
   m_scaleOptions->blockSignals(true);
   m_scaleOptions->setCurrentIndex(m_scaleOptions->findData(type));
-  m_dspnN->setEnabled(false);
   if (m_scaleOptions->findData(type) == 2) {
     m_dspnN->setEnabled(true);
-  }
+  } else {
+		m_dspnN->setEnabled(false);
+	}
   m_scaleOptions->blockSignals(false);
 }
 

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
@@ -34,7 +34,6 @@ class InstrumentWindowRenderTab;
 class QPushButton;
 class QDialog;
 class QSlider;
-class QSpinBox;
 class QTabWidget;
 class QLineEdit;
 class QLabel;


### PR DESCRIPTION
This resolves a bug where the spin box for the scale power would appear disabled when just clicking the up or down spinbox arrows.

fixes #14050
### release notes

This fixes a bug before it was released, so nothing to say
### to test
1. start mantid, load some data, bring up the instrument view
2. On the Render tab by the colour scale there is a scale type listbox and a double spinbox labelled.
3. Play with these, paying attention to when the spinbox is enabled and disabled.
   1. It should be disabled unless the scale is set to power
   2. It should not change state just by clicking the up and down arrows of the spin box.
