### PR TITLE
Add Python interface for table column plot types

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -143,14 +143,14 @@ void setValue(const Column_sptr column, const int row,
 /**
  * Add a column with a given plot type to the TableWorkspace
  * @param self Reference to TableWorkspace this is called on
- * @param datatype The data type of the column to add
+ * @param type The data type of the column to add
  * @param name The name of the column to add
  * @param plottype The plot type to set on the column
  * @return Boolean true if successful, false otherwise
  */
-bool addColumnPlotType(ITableWorkspace &self, const std::string &datatype,
+bool addColumnPlotType(ITableWorkspace &self, const std::string &type,
                const std::string &name, int plottype) {
-  auto column = self.addColumn(datatype, name);
+  auto column = self.addColumn(type, name);
 
   if (column)
     column->setPlotType(plottype);
@@ -162,15 +162,15 @@ bool addColumnPlotType(ITableWorkspace &self, const std::string &datatype,
  * Add a column to the TableWorkspace (with default plot type)
  * @param self A reference to the TableWorkspace python object that we were
  * called on
- * @param datatype The data type of the column to add
+ * @param type The data type of the column to add
  * @param name The name of the column to add
  * @return A boolean indicating success or failure. Note that this is different
  * to the corresponding C++ method, which returns a pointer to the
  * newly-created column (as the Column class is not exposed to python).
  */
-bool addColumnSimple(ITableWorkspace &self, const std::string &datatype,
+bool addColumnSimple(ITableWorkspace &self, const std::string &type,
                const std::string &name) {
-  return self.addColumn(datatype, name) != 0;
+  return self.addColumn(type, name) != 0;
 }
 
 /**
@@ -442,12 +442,12 @@ void export_ITableWorkspace() {
 
   class_<ITableWorkspace, bases<Workspace>, boost::noncopyable>(
       "ITableWorkspace", iTableWorkspace_docstring.c_str(), no_init)
-      .def("addColumn", &addColumnSimple, (arg("self"), arg("datatype"),
+      .def("addColumn", &addColumnSimple, (arg("self"), arg("type"),
                                            arg("name")),
            "Add a named column with the given type. Recognized types are: "
            "int,float,double,bool,str,V3D,long64")
 
-      .def("addColumn", &addColumnPlotType, (arg("self"), arg("datatype"),
+      .def("addColumn", &addColumnPlotType, (arg("self"), arg("type"),
                                              arg("name"), arg("plottype")),
            "Add a named column with the given datatype "
            "(int,float,double,bool,str,V3D,long64) "

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -149,7 +149,7 @@ void setValue(const Column_sptr column, const int row,
  * @return Boolean true if successful, false otherwise
  */
 bool addColumnPlotType(ITableWorkspace &self, const std::string &type,
-               const std::string &name, int plottype) {
+                       const std::string &name, int plottype) {
   auto column = self.addColumn(type, name);
 
   if (column)
@@ -169,7 +169,7 @@ bool addColumnPlotType(ITableWorkspace &self, const std::string &type,
  * newly-created column (as the Column class is not exposed to python).
  */
 bool addColumnSimple(ITableWorkspace &self, const std::string &type,
-               const std::string &name) {
+                     const std::string &name) {
   return self.addColumn(type, name) != 0;
 }
 
@@ -179,8 +179,7 @@ bool addColumnSimple(ITableWorkspace &self, const std::string &type,
  * @param column Name or index of column
  * @return PlotType: 0=None, 1=X, 2=Y, 3=Z, 4=xErr, 5=yErr, 6=Label
  */
-int getPlotType(ITableWorkspace &self, const bpl::object &column)
-{
+int getPlotType(ITableWorkspace &self, const bpl::object &column) {
   // Find the column
   Mantid::API::Column_const_sptr colptr;
   if (PyString_Check(column.ptr())) {
@@ -198,8 +197,7 @@ int getPlotType(ITableWorkspace &self, const bpl::object &column)
  * @param column Name or index of column
  * @param ptype PlotType: 0=None, 1=X, 2=Y, 3=Z, 4=xErr, 5=yErr, 6=Label
  */
-void setPlotType(ITableWorkspace &self, const bpl::object &column, int ptype)
-{
+void setPlotType(ITableWorkspace &self, const bpl::object &column, int ptype) {
   // Find the column
   Mantid::API::Column_sptr colptr;
   if (PyString_Check(column.ptr())) {
@@ -442,13 +440,13 @@ void export_ITableWorkspace() {
 
   class_<ITableWorkspace, bases<Workspace>, boost::noncopyable>(
       "ITableWorkspace", iTableWorkspace_docstring.c_str(), no_init)
-      .def("addColumn", &addColumnSimple, (arg("self"), arg("type"),
-                                           arg("name")),
+      .def("addColumn", &addColumnSimple,
+           (arg("self"), arg("type"), arg("name")),
            "Add a named column with the given type. Recognized types are: "
            "int,float,double,bool,str,V3D,long64")
 
-      .def("addColumn", &addColumnPlotType, (arg("self"), arg("type"),
-                                             arg("name"), arg("plottype")),
+      .def("addColumn", &addColumnPlotType,
+           (arg("self"), arg("type"), arg("name"), arg("plottype")),
            "Add a named column with the given datatype "
            "(int,float,double,bool,str,V3D,long64) "
            "\nand plottype "
@@ -459,8 +457,8 @@ void export_ITableWorkspace() {
            "Accepts column name or index. \nPossible return values: "
            "(0 = None, 1 = X, 2 = Y, 3 = Z, 4 = xErr, 5 = yErr, 6 = Label).")
 
-      .def("setPlotType", &setPlotType, (arg("self"), arg("column"),
-                                         arg("ptype")),
+      .def("setPlotType", &setPlotType,
+           (arg("self"), arg("column"), arg("ptype")),
            "Set the plot type of given column. "
            "Accepts column name or index. \nPossible type values: "
            "(0 = None, 1 = X, 2 = Y, 3 = Z, 4 = xErr, 5 = yErr, 6 = Label).")

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -140,20 +140,75 @@ void setValue(const Column_sptr column, const int row,
   }
 }
 
-/** Access a cell and return a corresponding Python type
- *  @param self A reference to the TableWorkspace python object that we were
- * called on
- *  @param type The data type of the column to add
- *  @param name The name of the column to add
- *  @return A boolean indicating success or failure. Note that this is different
- * to the
- *          corresponding C++ method, which returns a pointer to the
- * newly-created column
- *          (as the Column class is not exposed to python).
+/**
+ * Add a column with a given plot type to the TableWorkspace
+ * @param self Reference to TableWorkspace this is called on
+ * @param datatype The data type of the column to add
+ * @param name The name of the column to add
+ * @param plottype The plot type to set on the column
+ * @return Boolean true if successful, false otherwise
  */
-bool addColumn(ITableWorkspace &self, const std::string &type,
+bool addColumnPlotType(ITableWorkspace &self, const std::string &datatype,
+               const std::string &name, int plottype) {
+  auto column = self.addColumn(datatype, name);
+
+  if (column)
+    column->setPlotType(plottype);
+
+  return column != 0;
+}
+
+/**
+ * Add a column to the TableWorkspace (with default plot type)
+ * @param self A reference to the TableWorkspace python object that we were
+ * called on
+ * @param datatype The data type of the column to add
+ * @param name The name of the column to add
+ * @return A boolean indicating success or failure. Note that this is different
+ * to the corresponding C++ method, which returns a pointer to the
+ * newly-created column (as the Column class is not exposed to python).
+ */
+bool addColumnSimple(ITableWorkspace &self, const std::string &datatype,
                const std::string &name) {
-  return self.addColumn(type, name) != 0;
+  return self.addColumn(datatype, name) != 0;
+}
+
+/**
+ * Get the plot type of a column given by name or index
+ * @param self Reference to TableWorkspace this is called on
+ * @param column Name or index of column
+ * @return PlotType: 0=None, 1=X, 2=Y, 3=Z, 4=xErr, 5=yErr, 6=Label
+ */
+int getPlotType(ITableWorkspace &self, const bpl::object &column)
+{
+  // Find the column
+  Mantid::API::Column_const_sptr colptr;
+  if (PyString_Check(column.ptr())) {
+    colptr = self.getColumn(extract<std::string>(column)());
+  } else {
+    colptr = self.getColumn(extract<int>(column)());
+  }
+
+  return colptr->getPlotType();
+}
+
+/**
+ * Set the plot type of a column given by name or index
+ * @param self Reference to TableWorkspace this is called on
+ * @param column Name or index of column
+ * @param ptype PlotType: 0=None, 1=X, 2=Y, 3=Z, 4=xErr, 5=yErr, 6=Label
+ */
+void setPlotType(ITableWorkspace &self, const bpl::object &column, int ptype)
+{
+  // Find the column
+  Mantid::API::Column_sptr colptr;
+  if (PyString_Check(column.ptr())) {
+    colptr = self.getColumn(extract<std::string>(column)());
+  } else {
+    colptr = self.getColumn(extract<int>(column)());
+  }
+
+  colptr->setPlotType(ptype);
 }
 
 /**
@@ -387,9 +442,28 @@ void export_ITableWorkspace() {
 
   class_<ITableWorkspace, bases<Workspace>, boost::noncopyable>(
       "ITableWorkspace", iTableWorkspace_docstring.c_str(), no_init)
-      .def("addColumn", &addColumn, (arg("self"), arg("type"), arg("name")),
+      .def("addColumn", &addColumnSimple, (arg("self"), arg("datatype"),
+                                           arg("name")),
            "Add a named column with the given type. Recognized types are: "
            "int,float,double,bool,str,V3D,long64")
+
+      .def("addColumn", &addColumnPlotType, (arg("self"), arg("datatype"),
+                                             arg("name"), arg("plottype")),
+           "Add a named column with the given datatype "
+           "(int,float,double,bool,str,V3D,long64) "
+           "\nand plottype "
+           "(0 = None, 1 = X, 2 = Y, 3 = Z, 4 = xErr, 5 = yErr, 6 = Label).")
+
+      .def("getPlotType", &getPlotType, (arg("self"), arg("column")),
+           "Get the plot type of given column as an integer. "
+           "Accepts column name or index. \nPossible return values: "
+           "(0 = None, 1 = X, 2 = Y, 3 = Z, 4 = xErr, 5 = yErr, 6 = Label).")
+
+      .def("setPlotType", &setPlotType, (arg("self"), arg("column"),
+                                         arg("ptype")),
+           "Set the plot type of given column. "
+           "Accepts column name or index. \nPossible type values: "
+           "(0 = None, 1 = X, 2 = Y, 3 = Z, 4 = xErr, 5 = yErr, 6 = Label).")
 
       .def("removeColumn", &ITableWorkspace::removeColumn,
            (arg("self"), arg("name")), "Remove the named column")

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -175,5 +175,26 @@ class ITableWorkspaceTest(unittest.TestCase):
         self.assertTrue( numpy.array_equal( table.cell(0,0), numpy.array([1,2,3,4,5]) ) )
         self.assertTrue( numpy.array_equal( table.cell(1,0), numpy.array([6,7,8,9,10]) ) )
 
+    def test_set_and_extract_plot_types(self):
+        table = WorkspaceFactory.createTable()
+
+        table.addColumn("int", "index")
+        table.addColumn("int", "value", 3)
+        self.assertEquals(table.columnCount(), 2)
+
+        self.assertEquals(table.getPlotType(0), -1000) # default plot type
+        self.assertEquals(table.getPlotType(1), 3)
+
+        table.setPlotType(0, 1)
+        table.setPlotType("value", 2)
+
+        self.assertEquals(table.getPlotType("index"), 1)
+        self.assertEquals(table.getPlotType("value"), 2)
+
+        table.addRow([1, 2])
+        table.addRow([3, 4])
+        self.assertEquals(table.rowCount(), 2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #13878.

Release notes not yet updated.

Since the TableWorkspace's Column class is not exposed to Python, there was no way to programmatically set or get the plot type of a column from Python. 

Added two functions, `getPlotType` and `setPlotType`, to the ITableWorkspace interface for Python to address this. Both functions accept either an index or a column name as their first parameter to specify a column. The plot type can also be set when adding columns using `addColumn` by making use of a new, optional third parameter.

In all cases, the plot type is taken or given as an integer and it is up to the user to know which integer value maps to which type of column (the mapping is the same as in C++). This is rather awkward, but consistent with the C++ interface, which also only provides plain integers. 

I also considered adding a Column class to the Python interface, but decided against it. It would be more consistent with the C++ interface but, since the rest of column functionality has already been implemented into ITableWorkspace directly, it would introduce internal inconsistency into the Python interface or require modification of existing functionality to make it consistent again (likely breaking code that uses it).
### Testing

Can be tested in the script interpreter window. Sample code:

```
table = CreateEmptyTableWorkspace()
table.addColumn("int", "index") # Old way of adding columns (default plot type)
table.addColumn("int", "value", 3) # New optional plot type parameter
table.getPlotType(0) # Returns -1000 since that is the default "not set" value
table.getPlotType(1) # Returns 3
table.setPlotType(0, 1) # Set plot type to 1 for column with index 0
table.setPlotType("value", 2) # Set plot type to 2 for column with name "value"
table.getPlotType("index") # Returns 1
table.getPlotType("value") # Returns 2
```
