### PR TITLE
GetComponentByName: Alter search order slightly and add test

### DIFF
--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -455,16 +455,22 @@ int RectangularDetector::maxDetectorID() {
 boost::shared_ptr<const IComponent>
 RectangularDetector::getComponentByName(const std::string &cname,
                                         int nlevels) const {
+	// exact matches
+	if (cname== this->getName())
+		return boost::shared_ptr<const IComponent>(this);
+
   // cache the detector's name as all the other names are longer
-  const std::string NAME = this->getName();
+  // The extra ( is because all children of this have that as the next character
+  // and this prevents Bank11 matching Bank 1
+	const std::string MEMBER_NAME = this->getName() +"(";
 
   // if the component name is too short, just return
-  if (cname.length() <= NAME.length())
+  if (cname.length() <= MEMBER_NAME.length())
     return boost::shared_ptr<const IComponent>();
 
   // check that the searched for name starts with the detector's
   // name as they are generated
-  if (cname.substr(0, NAME.length()).compare(NAME) == 0) {
+  if (cname.substr(0, MEMBER_NAME.length()).compare(MEMBER_NAME) == 0) {
     return CompAssembly::getComponentByName(cname, nlevels);
   } else {
     return boost::shared_ptr<const IComponent>();

--- a/Framework/Geometry/src/Instrument/RectangularDetector.cpp
+++ b/Framework/Geometry/src/Instrument/RectangularDetector.cpp
@@ -455,14 +455,14 @@ int RectangularDetector::maxDetectorID() {
 boost::shared_ptr<const IComponent>
 RectangularDetector::getComponentByName(const std::string &cname,
                                         int nlevels) const {
-	// exact matches
-	if (cname== this->getName())
-		return boost::shared_ptr<const IComponent>(this);
+  // exact matches
+  if (cname == this->getName())
+    return boost::shared_ptr<const IComponent>(this);
 
   // cache the detector's name as all the other names are longer
   // The extra ( is because all children of this have that as the next character
   // and this prevents Bank11 matching Bank 1
-	const std::string MEMBER_NAME = this->getName() +"(";
+  const std::string MEMBER_NAME = this->getName() + "(";
 
   // if the component name is too short, just return
   if (cname.length() <= MEMBER_NAME.length())

--- a/Framework/Geometry/test/CompAssemblyTest.h
+++ b/Framework/Geometry/test/CompAssemblyTest.h
@@ -509,13 +509,13 @@ public:
         "bank 11(1,1)");
     TS_ASSERT_EQUALS(
         inst->getComponentByName(
-                "inst/detectors/Rectangle bank 4/Rectangle bank 4(3,5)")
+                  "inst/detectors/Rectangle bank 4/Rectangle bank 4(3,5)")
             ->getFullName(),
         "inst/detectors/Rectangle bank 4/Rectangle bank 4(x=3)/Rectangle bank "
         "4(3,5)");
-		TS_ASSERT_EQUALS(
-			inst->getComponentByName("Rectangle bank 11")->getFullName(),
-			"inst/detectors/Rectangle bank 11");
+    TS_ASSERT_EQUALS(
+        inst->getComponentByName("Rectangle bank 11")->getFullName(),
+        "inst/detectors/Rectangle bank 11");
 
     delete (inst);
   }

--- a/Framework/Geometry/test/CompAssemblyTest.h
+++ b/Framework/Geometry/test/CompAssemblyTest.h
@@ -513,6 +513,9 @@ public:
             ->getFullName(),
         "inst/detectors/Rectangle bank 4/Rectangle bank 4(x=3)/Rectangle bank "
         "4(3,5)");
+		TS_ASSERT_EQUALS(
+			inst->getComponentByName("Rectangle bank 11")->getFullName(),
+			"inst/detectors/Rectangle bank 11");
 
     delete (inst);
   }

--- a/Framework/Geometry/test/CompAssemblyTest.h
+++ b/Framework/Geometry/test/CompAssemblyTest.h
@@ -8,6 +8,7 @@
 #include "MantidKernel/V3D.h"
 #include "MantidKernel/Quat.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
+#include "MantidGeometry/Instrument/RectangularDetector.h"
 
 using namespace Mantid::Geometry;
 using Mantid::Kernel::V3D;
@@ -445,6 +446,75 @@ public:
     TS_ASSERT_DELTA(bbox.yMax(), 1.5, 1e-08);
     TS_ASSERT_DELTA(bbox.zMin(), -0.5, 1e-08);
     TS_ASSERT_DELTA(bbox.zMax(), 0.5, 1e-08);
+  }
+
+  void test_get_component_by_name_with_rect_detectors() {
+
+    CompAssembly *inst = new CompAssembly("inst");
+    CompAssembly *monitors = new CompAssembly("monitors", inst);
+    for (size_t i = 0; i < 5; i++) {
+      std::ostringstream sstr;
+      sstr << "monitor " << i;
+      Component *monitor = new Component(sstr.str());
+      monitors->add(monitor);
+    }
+    CompAssembly *detectors = new CompAssembly("detectors", inst);
+    CompAssembly *bank1 = new CompAssembly("bank 1", detectors);
+    CompAssembly *bank2 = new CompAssembly("bank 11", detectors);
+    CompAssembly *bank3 = new CompAssembly("bank 111", detectors);
+
+    // add some rectangular detectors
+    boost::shared_ptr<Object> cuboidShape =
+        ComponentCreationHelper::createCuboid(0.5);
+
+    for (size_t i = 0; i < 15; i++) {
+      std::ostringstream sstr;
+      sstr << "Rectangle bank " << i;
+      RectangularDetector *det = new RectangularDetector(sstr.str(), detectors);
+
+      // Initialize with these parameters
+      det->initialize(cuboidShape, 100, -50.0, 1.0, 200, -100.0, 1.0, 1000000,
+                      true, 1000);
+    }
+
+    // and a couple more assemblies
+    CompAssembly *bank4 = new CompAssembly("bank 12", detectors);
+    CompAssembly *bank5 = new CompAssembly("bank 121", detectors);
+
+    TS_ASSERT_EQUALS(inst->getComponentByName("bank 1")->getFullName(),
+                     bank1->getFullName());
+    TS_ASSERT_EQUALS(
+        inst->getComponentByName("inst/detectors/bank 1")->getFullName(),
+        bank1->getFullName());
+    TS_ASSERT_EQUALS(inst->getComponentByName("monitor 2")->getFullName(),
+                     "inst/monitors/monitor 2");
+    TS_ASSERT_EQUALS(
+        inst->getComponentByName("Rectangle bank 2")->getFullName(),
+        "inst/detectors/Rectangle bank 2");
+    TS_ASSERT_EQUALS(inst->getComponentByName("bank 12")->getFullName(),
+                     bank4->getFullName());
+    TS_ASSERT_EQUALS(inst->getComponentByName("bank 121")->getFullName(),
+                     bank5->getFullName());
+    TS_ASSERT_EQUALS(inst->getComponentByName("bank 11")->getFullName(),
+                     bank2->getFullName());
+    TS_ASSERT_EQUALS(inst->getComponentByName("bank 111")->getFullName(),
+                     bank3->getFullName());
+    TS_ASSERT_EQUALS(
+        inst->getComponentByName("Rectangle bank 1(1,1)")->getFullName(),
+        "inst/detectors/Rectangle bank 1/Rectangle bank 1(x=1)/Rectangle bank "
+        "1(1,1)");
+    TS_ASSERT_EQUALS(
+        inst->getComponentByName("Rectangle bank 11(1,1)")->getFullName(),
+        "inst/detectors/Rectangle bank 11/Rectangle bank 11(x=1)/Rectangle "
+        "bank 11(1,1)");
+    TS_ASSERT_EQUALS(
+        inst->getComponentByName(
+                "inst/detectors/Rectangle bank 4/Rectangle bank 4(3,5)")
+            ->getFullName(),
+        "inst/detectors/Rectangle bank 4/Rectangle bank 4(x=3)/Rectangle bank "
+        "4(3,5)");
+
+    delete (inst);
   }
 };
 


### PR DESCRIPTION
It now remains searching broadly across a
component assembly until all children names are checked.
Then it will dive deep into a Rectangular deteector if needed.

This means it should check the name of Bank 11 before checking the contents of Bank 1.

closes #14003
### Release Notes

This might give a general performance boost to any instrument with lots of rectangular detectors, but that is probably not worth mentioning.
### To test
1. Most importantly the unit and system tests must pass
2. Code review
