### PR TITLE
Fix link error in calculate transmission

### DIFF
--- a/docs/source/algorithms/CalculateTransmission-v1.rst
+++ b/docs/source/algorithms/CalculateTransmission-v1.rst
@@ -37,7 +37,7 @@ the data to be corrected.
 ChildAlgorithms used
 ####################
 
-Uses the algorithm `Fit <algm-Fit>`_ to fit to the calculated
+Uses the algorithm :ref:`Fit <algm-Fit>` to fit to the calculated
 transmission fraction.
 
 .. categories::


### PR DESCRIPTION
Fixes #14496 

In the help pages for `CalculateTranmission`, go to the bottom and pres the link to the  `Fit` pages. Make sure that it works.
