### PR TITLE
Add RewriteSpectraMap property to LoadInstrument in SNSLiveEventDataListener

### DIFF
--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -1250,6 +1250,7 @@ void SNSLiveEventDataListener::initWorkspacePart2() {
   loadInst->setProperty("InstrumentXML", m_instrumentXML);
   loadInst->setProperty("InstrumentName", m_instrumentName);
   loadInst->setProperty("Workspace", m_eventBuffer);
+  loadInst->setProperty("RewriteSpectraMap", OptionalBool(false));
 
   loadInst->execute();
 

--- a/Framework/LiveData/src/TOPAZLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/TOPAZLiveEventDataListener.cpp
@@ -489,6 +489,7 @@ void TOPAZLiveEventDataListener::initWorkspace() {
   //  loadInst->setProperty("InstrumentXML", m_instrumentXML);
   loadInst->setProperty("InstrumentName", "TOPAZ");
   loadInst->setProperty("Workspace", m_eventBuffer);
+  loadInst->setProperty("RewriteSpectraMap", OptionalBool(false));
 
   loadInst->execute();
 


### PR DESCRIPTION
StartLiveData currently fails at SNS with the warning `Property "REWRITESPECTRAMAP" is not set to a valid value: "A value must be entered for this parameter".`

**To Test (SNS Only):**
See if you can now connect to any of the live data streams. Check an ADARA one (e.g CORELLI) and TOPAZ.
