### PR TITLE
Update arguments for cppcheck version 1.71

### DIFF
--- a/buildconfig/CMake/FindCppcheck.cmake
+++ b/buildconfig/CMake/FindCppcheck.cmake
@@ -61,12 +61,14 @@ if(CPPCHECK_EXECUTABLE)
 endif()
 
 mark_as_advanced(CPPCHECK_EXECUTABLE)
-if (${CPPCHECK_VERSION} VERSION_LESS 1.71)
-  set ( CPPCHECK_ARGS --enable=all --inline-suppr
-                      --suppressions ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
-else()
-  set ( CPPCHECK_ARGS --enable=all --inline-suppr
-                      --suppressions-list=${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
+if(CPPCHECK_EXECUTABLE)
+  if (${CPPCHECK_VERSION} VERSION_LESS 1.71)
+    set ( CPPCHECK_ARGS --enable=all --inline-suppr
+                        --suppressions ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
+  else()
+    set ( CPPCHECK_ARGS --enable=all --inline-suppr
+                        --suppressions-list=${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
+  endif()
 endif()
 set ( CPPCHECK_NUM_THREADS 0 CACHE STRING "Number of threads to use when running cppcheck" )
 set ( CPPCHECK_GENERATE_XML OFF CACHE BOOL "Generate xml output files from cppcheck" )

--- a/buildconfig/CMake/FindCppcheck.cmake
+++ b/buildconfig/CMake/FindCppcheck.cmake
@@ -61,8 +61,13 @@ if(CPPCHECK_EXECUTABLE)
 endif()
 
 mark_as_advanced(CPPCHECK_EXECUTABLE)
-set ( CPPCHECK_ARGS --enable=all --inline-suppr 
-                    --suppressions ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
+if (${CPPCHECK_VERSION} VERSION_LESS 1.71)
+  set ( CPPCHECK_ARGS --enable=all --inline-suppr
+                      --suppressions ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
+else()
+  set ( CPPCHECK_ARGS --enable=all --inline-suppr
+                      --suppressions-list=${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/CppCheck_Suppressions.txt )
+endif()
 set ( CPPCHECK_NUM_THREADS 0 CACHE STRING "Number of threads to use when running cppcheck" )
 set ( CPPCHECK_GENERATE_XML OFF CACHE BOOL "Generate xml output files from cppcheck" )
 


### PR DESCRIPTION
Using cppcheck 1.71 with mantid gives the following error:

```
cppcheck: '--suppressions' has been removed, use '--suppressions-list=<file>' instead.
```

This PR changes the `CPPCHECK_ARGS` iff 1.71 or later is installed.

no release notes.

testing: Verify below that cppcheck still runs correctly on the build servers. After merging, check that the [cppcheck-1.71 build](http://builds.mantidproject.org/view/Static%20Analysis/job/cppcheck-1.71/) works. 
