### PR TITLE
Make log level for beam centre finder independent of general log level

### DIFF
--- a/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
+++ b/MantidQt/CustomInterfaces/src/SANSRunWindow.cpp
@@ -40,6 +40,7 @@
 #include <QUrl>
 
 #include <Poco/StringTokenizer.h>
+#include <Poco/Message.h>
 
 #include <boost/lexical_cast.hpp>
 
@@ -2662,6 +2663,15 @@ QString SANSRunWindow::getInstrumentClass() const {
   return instrum + "()";
 }
 void SANSRunWindow::handleRunFindCentre() {
+  // Set the log level of to at least notice:
+  const auto initialLogLevel = g_centreFinderLog.getLevel();
+  auto noticeLevelAsInt = static_cast<int>(Poco::Message::PRIO_NOTICE);
+  auto hasToBeSwapped = initialLogLevel < noticeLevelAsInt ? true : false;
+  if (hasToBeSwapped) {
+    // Set to a notice setting
+    g_centreFinderLog.setLevel(noticeLevelAsInt);
+  }
+
   QLineEdit *beam_x;
   QLineEdit *beam_y;
 
@@ -2832,6 +2842,11 @@ void SANSRunWindow::handleRunFindCentre() {
                               "ReductionSingleton())").trimmed();
 
   g_centreFinderLog.notice() << result.toStdString() << "\n";
+
+  // Set the centre logger back to the initial log level
+  if (hasToBeSwapped) {
+    g_centreFinderLog.setLevel(initialLogLevel);
+  }
 
   // Reenable stuff
   setProcessingState(Ready);


### PR DESCRIPTION
Fixes #10891 
# For testing

Find the relevant files here: \olympic\Babylon5\Scratch\Anton\Testing\14506_improve_log_level
The user file is:USER_LARMORTEAM_152L_a2_6x8mm_r5889.txt
1. In Mantid set the log level to warning or error
2. Open the iSIS SANS GUI and set the instrument to LARMOR
3. Load the user file.
   3.5 Load the data set LARMOR0000588.nxs as the sample 
4. Set the log level in the Mantid UI to error or warning
5. Go to the Geometry tab, we focus here on the Beam Centre Finder
6. Set MaxItr to 0 (!)
7. Press Run
   - Confirm that there is an output on the console on the geometry tab
   - After everything has completed confirm that the log level is still the same, ie warning or error
