### PR TITLE
RemoveBins: Fix bug if wsindex > 0

### DIFF
--- a/Framework/Algorithms/src/RemoveBins.cpp
+++ b/Framework/Algorithms/src/RemoveBins.cpp
@@ -146,7 +146,7 @@ void RemoveBins::exec() {
     }
 
     // Calculate the bin indices corresponding to the X range, if necessary
-    if (recalcRange || !i) {
+    if (recalcRange || singleSpectrum || !i) {
       start = this->findIndex(startX, X);
       end = this->findIndex(endX, X);
     }

--- a/Framework/Algorithms/test/RemoveBinsTest.h
+++ b/Framework/Algorithms/test/RemoveBinsTest.h
@@ -157,7 +157,7 @@ public:
   void testSingleSpectrumNotWS0() {
     RemoveBins rb;
     Workspace2D_sptr inputWS = makeDummyWorkspace2D();
-		std::string outputWSName = "output44";
+    std::string outputWSName = "output44";
     TS_ASSERT_THROWS_NOTHING(rb.initialize())
     TS_ASSERT(rb.isInitialized())
     rb.setPropertyValue("InputWorkspace", inputWS->getName());
@@ -169,7 +169,8 @@ public:
     TS_ASSERT(rb.execute())
 
     MatrixWorkspace_const_sptr outputWS =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputWSName);
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            outputWSName);
     TS_ASSERT_EQUALS(inputWS->readX(1), outputWS->readX(1))
     TS_ASSERT_EQUALS(inputWS->readX(0), outputWS->readX(0))
     TS_ASSERT_EQUALS(inputWS->readY(0), outputWS->readY(0))
@@ -211,7 +212,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->dataX(0).size(), 1994);
   }
 
-	Workspace2D_sptr makeDummyWorkspace2D() {
+  Workspace2D_sptr makeDummyWorkspace2D() {
     Workspace2D_sptr testWorkspace(new Workspace2D);
 
     testWorkspace->setTitle("input2D");
@@ -244,7 +245,7 @@ public:
 
     AnalysisDataService::Instance().addOrReplace("input2D", testWorkspace);
 
-		return testWorkspace;
+    return testWorkspace;
   }
 
 private:

--- a/Framework/Algorithms/test/RemoveBinsTest.h
+++ b/Framework/Algorithms/test/RemoveBinsTest.h
@@ -154,6 +154,34 @@ public:
     AnalysisDataService::Instance().remove("output4");
   }
 
+  void testSingleSpectrumNotWS0() {
+    RemoveBins rb;
+    Workspace2D_sptr inputWS = makeDummyWorkspace2D();
+		std::string outputWSName = "output44";
+    TS_ASSERT_THROWS_NOTHING(rb.initialize())
+    TS_ASSERT(rb.isInitialized())
+    rb.setPropertyValue("InputWorkspace", inputWS->getName());
+    rb.setPropertyValue("OutputWorkspace", outputWSName);
+    rb.setPropertyValue("XMin", "0");
+    rb.setPropertyValue("XMax", "40");
+    rb.setPropertyValue("WorkspaceIndex", "1");
+
+    TS_ASSERT(rb.execute())
+
+    MatrixWorkspace_const_sptr outputWS =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(outputWSName);
+    TS_ASSERT_EQUALS(inputWS->readX(1), outputWS->readX(1))
+    TS_ASSERT_EQUALS(inputWS->readX(0), outputWS->readX(0))
+    TS_ASSERT_EQUALS(inputWS->readY(0), outputWS->readY(0))
+    TS_ASSERT_EQUALS(inputWS->readE(0), outputWS->readE(0))
+    for (int i = 0; i < 4; ++i) {
+      TS_ASSERT_EQUALS(outputWS->readY(1)[i], 0.0)
+      TS_ASSERT_EQUALS(outputWS->readE(1)[i], 0.0)
+    }
+
+    AnalysisDataService::Instance().remove(outputWSName);
+  }
+
   void xtestRealData() {
     Mantid::DataHandling::LoadMuonNexus2 loader;
     loader.initialize();
@@ -183,7 +211,7 @@ public:
     TS_ASSERT_EQUALS(outputWS->dataX(0).size(), 1994);
   }
 
-  void makeDummyWorkspace2D() {
+	Workspace2D_sptr makeDummyWorkspace2D() {
     Workspace2D_sptr testWorkspace(new Workspace2D);
 
     testWorkspace->setTitle("input2D");
@@ -214,7 +242,9 @@ public:
     testWorkspace->getAxis(0)->unit() =
         Mantid::Kernel::UnitFactory::Instance().create("TOF");
 
-    AnalysisDataService::Instance().add("input2D", testWorkspace);
+    AnalysisDataService::Instance().addOrReplace("input2D", testWorkspace);
+
+		return testWorkspace;
   }
 
 private:


### PR DESCRIPTION
Previously RemoveBins contained a bug that if you specified a wsIndex, but it was >0 then the algorithm did nothing.
- now fixed, and unit test added

closes #13612 
### Release Notes

http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Improved
### To test
1. unit tests pass
2. 

``` python
w=CreateSampleWorkspace()
w=RemoveBins(w, XMin=0, XMax=2000, WorkspaceIndex=0)
x=w.readX(0)
y=w.readY(0)
print "this should be 2000.0", min([ x[i] for i in range(0,len(y)) if y[i]>0 ])


w=RemoveBins(w, XMin=0, XMax=2000, WorkspaceIndex=1)
x=w.readX(1)
y=w.readY(1)
print "this should be 2000.0", min([ x[i] for i in range(0,len(y)) if y[i]>0 ])
```
