### PR TITLE
Indirect Data Analysis ConvFit ILL File input issue

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -463,6 +463,7 @@ void ConvFit::loadSettings(const QSettings &settings) {
 * @param wsName Name of new workspace loaded
 */
 void ConvFit::newDataLoaded(const QString wsName) {
+  std::string name = wsName.toStdString();
   m_cfInputWSName = wsName;
   m_cfInputWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
       m_cfInputWSName.toStdString());
@@ -1523,8 +1524,9 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
 * @param functionName Name of new fit function
 */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
-  double oneLValues[3] = {0.0, 0.0, 0.0};
+  double oneLValues[3] = {0.0, 0.0, 0.0}; //previous values for one lorentzian fit
   bool previouslyOneL = false;
+  // If the previosu fit was One Lorentzian and the new fit is Two Lorentzian preserve the values of One Lorentzian Fit
   if (m_previousFit.compare("One Lorentzian") == 0 &&
       m_uiForm.cbFitType->currentText().compare("Two Lorentzians") == 0) {
     previouslyOneL = true;
@@ -1572,10 +1574,11 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[name] = m_dblManager->addProperty(*it);
 
         if (QString(*it).compare("FWHM") == 0) {
+		  double resolution = getInstrumentResolution(m_cfInputWS->getName());
           if (previouslyOneL && count < 3) {
             m_dblManager->setValue(m_properties[name], oneLValues[2]);
           } else {
-            m_dblManager->setValue(m_properties[name], 0.0175);
+            m_dblManager->setValue(m_properties[name], resolution);
           }
         } else if (QString(*it).compare("Amplitude") == 0) {
           if (previouslyOneL && count < 3) {
@@ -1612,7 +1615,8 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[name] = m_dblManager->addProperty(*it);
 
         if (QString(*it).compare("FWHM") == 0) {
-          m_dblManager->setValue(m_properties[name], 0.0175);
+	      double resolution = getInstrumentResolution(m_cfInputWS->getName());
+          m_dblManager->setValue(m_properties[name], resolution);
         } else if (QString(*it).compare("Amplitude") == 0 ||
                    QString(*it).compare("Intensity") == 0) {
           m_dblManager->setValue(m_properties[name], 1.0);

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1018,6 +1018,8 @@ void ConvFit::updatePlot() {
     m_uiForm.ppPlot->getRangeSelector("ConvFitRange")
         ->setRange(range.first, range.second);
     m_uiForm.ckPlotGuess->setChecked(plotGuess);
+	m_dblManager->setValue(m_properties["StartX"], range.first);
+	m_dblManager->setValue(m_properties["EndX"], range.second);
   } catch (std::invalid_argument &exc) {
     showMessageBox(exc.what());
   }
@@ -1524,9 +1526,11 @@ QStringList ConvFit::getFunctionParameters(QString functionName) {
 * @param functionName Name of new fit function
 */
 void ConvFit::fitFunctionSelected(const QString &functionName) {
-  double oneLValues[3] = {0.0, 0.0, 0.0}; //previous values for one lorentzian fit
+  double oneLValues[3] = {0.0, 0.0,
+                          0.0}; // previous values for one lorentzian fit
   bool previouslyOneL = false;
-  // If the previosu fit was One Lorentzian and the new fit is Two Lorentzian preserve the values of One Lorentzian Fit
+  // If the previosu fit was One Lorentzian and the new fit is Two Lorentzian
+  // preserve the values of One Lorentzian Fit
   if (m_previousFit.compare("One Lorentzian") == 0 &&
       m_uiForm.cbFitType->currentText().compare("Two Lorentzians") == 0) {
     previouslyOneL = true;
@@ -1574,7 +1578,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[name] = m_dblManager->addProperty(*it);
 
         if (QString(*it).compare("FWHM") == 0) {
-		  double resolution = getInstrumentResolution(m_cfInputWS->getName());
+          double resolution = getInstrumentResolution(m_cfInputWS->getName());
           if (previouslyOneL && count < 3) {
             m_dblManager->setValue(m_properties[name], oneLValues[2]);
           } else {
@@ -1615,7 +1619,7 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[name] = m_dblManager->addProperty(*it);
 
         if (QString(*it).compare("FWHM") == 0) {
-	      double resolution = getInstrumentResolution(m_cfInputWS->getName());
+          double resolution = getInstrumentResolution(m_cfInputWS->getName());
           m_dblManager->setValue(m_properties[name], resolution);
         } else if (QString(*it).compare("Amplitude") == 0 ||
                    QString(*it).compare("Intensity") == 0) {

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -776,9 +776,10 @@ double ConvFit::getInstrumentResolution(std::string workspaceName) {
 
     // If the analyser component is not already in the data file then load it
     // from the parameter file
-    if (inst->getComponentByName(analyser)
-            ->getNumberParameter("resolution")
-            .size() == 0) {
+    if (inst->getComponentByName(analyser) == NULL ||
+        inst->getComponentByName(analyser)
+                ->getNumberParameter("resolution")
+                .size() == 0) {
       std::string reflection = inst->getStringParameter("reflection")[0];
 
       IAlgorithm_sptr loadParamFile =
@@ -800,9 +801,12 @@ double ConvFit::getInstrumentResolution(std::string workspaceName) {
                  .retrieveWS<MatrixWorkspace>(workspaceName)
                  ->getInstrument();
     }
-
-    resolution =
-        inst->getComponentByName(analyser)->getNumberParameter("resolution")[0];
+    if (inst->getComponentByName(analyser) != NULL) {
+      resolution = inst->getComponentByName(analyser)
+                       ->getNumberParameter("resolution")[0];
+    } else {
+      resolution = inst->getNumberParameter("resolution")[0];
+    }
   } catch (Mantid::Kernel::Exception::NotFoundError &e) {
     UNUSED_ARG(e);
 

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -463,7 +463,6 @@ void ConvFit::loadSettings(const QSettings &settings) {
 * @param wsName Name of new workspace loaded
 */
 void ConvFit::newDataLoaded(const QString wsName) {
-  std::string name = wsName.toStdString();
   m_cfInputWSName = wsName;
   m_cfInputWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
       m_cfInputWSName.toStdString());

--- a/instrument/IN16B_Definition.xml
+++ b/instrument/IN16B_Definition.xml
@@ -3,9 +3,12 @@
 <instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
-name="IN16B" valid-from="1900-01-31 23:59:59"
-valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
+            name="IN16B" 
+            valid-from="1900-01-31 23:59:59"
+            valid-to="2100-01-31 23:59:59"
+            last-modified="2014-03-21 13:10:51">
   <!-- Author: raoul@ill.fr -->
+
   <defaults>
     <length unit="meter" />
     <angle unit="degree" />
@@ -17,12 +20,16 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
       <handedness val="right" />
     </reference-frame>
   </defaults>
+
   <!--Moderator -->
+
   <component type="moderator">
     <location z="-36.41" />
   </component>
   <type name="moderator" is="Source"></type>
+
   <!--MONITORS-->
+
   <component type="monitors" idlist="monitors">
     <location />
   </component>
@@ -31,7 +38,9 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
       <location z="0.0181" name="monitor1" />
     </component>
   </type>
+
   <!-- Sample position -->
+
   <component type="sample-position">
     <location y="0.0" x="0.0" z="0.0" />
   </component>
@@ -39,17 +48,23 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
   <idlist idname="detectors">
     <id start="1" end="2048" />
   </idlist>
+
   <!-- Detector list def -->
+
   <component type="detectors" idlist="detectors">
     <location />
   </component>
+
   <!-- Detector Banks -->
+
   <type name="detectors">
     <component type="bank_uniq">
       <location />
     </component>
   </type>
+
   <!-- Definition of the unique existent bank (made of tubes) -->
+
   <type name="bank_uniq">
     <component type="standard_tube">
       <location r="3.935600" t="128.000000" name="tube_1" />
@@ -70,7 +85,9 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
       <location r="3.935600" t="-13.700000" name="tube_16" />
     </component>
   </type>
+
   <!-- Definition of standard_tube -->
+
   <type name="standard_tube" outline="yes">
     <component type="standard_pixel">
       <location y="-0.150000" />
@@ -206,18 +223,24 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
   <idlist idname="single_detectors">
     <id start="2049" end="2056" />
   </idlist>
+
   <!-- Detector list def -->
+
   <component type="single_detectors" idlist="single_detectors">
     <location />
     <!--location x="0.0" y="0.0" z="0.0" rot="0.0" axis-x="1.0" axis-y="0.0" axis-z="0.0"/-->
   </component>
+
   <!-- Detector Banks -->
+
   <type name="single_detectors">
     <component type="bank_single_detectors">
       <location />
     </component>
   </type>
+
   <!-- Definition of the bank_single_detectors -->
+
   <type name="bank_single_detectors">
     <component type="single_tube">
       <location r="4.100000" t="10.000000" p="0.0" rot="100.000000" axis-x="0.0" axis-y="1.0" axis-z="0.0" name="single_tube_1" />
@@ -230,7 +253,9 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
       <location r="4.100000" t="120.000000" p="0.0" rot="210.000000" axis-x="0.0" axis-y="1.0" axis-z="0.0" name="single_tube_8" />
     </component>
   </type>
+
   <!-- Definition of single_tube -->
+
   <type name="single_tube" outline="yes">
     <component type="single_pixel">
       <location />
@@ -247,7 +272,9 @@ valid-to="2100-01-31 23:59:59" last-modified="2014-03-21 13:10:51">
     </cylinder>
     <algebra val="cyl-approx" />
   </type>
+
   <!--MONITOR IDs-->
+
   <idlist idname="monitors">
     <id val="0" />
   </idlist>


### PR DESCRIPTION
Fixes #14485 

Added a way to access the resolution from the ILL IN16B IDF. Also ensured that resolution and fitting range update automatically based on the resolution and data range of the input file.
# To Test
- Open ConvFit(Interfaces > Indirect > Data Analysis > ConvFit)
- Check the following files load without error and the resolution and `Fitting Range` in both the parameter table (bottom left) and mini plot are as stated below.
  - _In this case, the resolution is the same as the `FWHM`this can be found by changing the `Fit Type` to `One Lorentzian` in the drop down menu and then looking for `FWHM` under `One Lorentzian` in the Parameter table_
- Sample=`irs26176_graphite002_red.nxs` (from `\ExternalData\Testing\Data\SystemTest\`)
  - Resolution(FWHM) = 0.0175
  - StartX = -0.547608
  - EndX = 0.543217
- Sample=`osi92762_graphite002_red.nxs` (from `\ExternalData\Testing\Data\SystemTest\`)
  - Resolution(FWHM) = 0.0245
  - StartX = -0.927690
  - EndX = 2.148071
- Sample=`125878_silicon_111_red.nxs` (from `\\olympic\babylon5\Public\ElliotOram\DataAnalysis\ConvFit\ILL`)
  - Resolution(FWHM) = 0.0003
  - StartX = -0.029013
  - EndX = 0.028785
