### PR TITLE
Fix "List Data" causing MantidPlot crash

### DIFF
--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -302,7 +302,8 @@ bool MDHistoWorkspaceIterator::valid() const { return (m_pos < m_max); }
 /// @return true if you can continue iterating
 bool MDHistoWorkspaceIterator::next() {
   if (m_function) {
-    bool allIncremented = false;
+    bool allIncremented;
+
     do {
       m_pos++;
       allIncremented =
@@ -311,31 +312,20 @@ bool MDHistoWorkspaceIterator::next() {
       for (size_t d = 0; d < m_nd; d++) {
         m_center[d] =
             m_origin[d] + (coord_t(m_index[d]) + 0.5f) * m_binWidth[d];
-        //          std::cout << m_center[d] << ",";
       }
-      //        std::cout<<std::endl;
-      // Keep incrementing until you are in the implicit function
-    } while (!allIncremented && !m_function->isPointContained(m_center) &&
-             m_pos < m_max);
+      // Keep incrementing until you are in the implicit function and not masked
+    } while (m_pos < m_max &&
+             ((!allIncremented && !m_function->isPointContained(m_center)) ||
+              m_skippingPolicy->keepGoing()));
   } else {
-    ++m_pos;
+    // Keep moving to next position if the current position is masked and
+    // still valid.
+    do {
+      m_pos++;
+    } while (m_skippingPolicy->keepGoing() && m_pos < m_max);
   }
-  bool ret = m_pos < m_max;
 
-  if (ret) {
-    // Avoid recursion in while loop as m_function does not need to be checked
-    // if skipping_policy is true anyway
-    // This also avoids high recursion depth causing stack overflow, which would
-    // otherwise be a problem for large masked regions
-    // Keep moving to next position if the current position is masked and still
-    // valid.
-    while (m_skippingPolicy->keepGoing()) { //(m_ws->getIsMaskedAt(m_pos)) {
-      ++m_pos;
-      ret = m_pos < m_max;
-      if (!ret)
-        break;
-    }
-  }
+  bool ret = m_pos < m_max;
   // Go through every point;
   return ret;
 }

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -321,10 +321,17 @@ bool MDHistoWorkspaceIterator::next() {
     ++m_pos;
   }
   bool ret = m_pos < m_max;
+
   if (ret) {
-    // Keep calling next if the current position is masked and still valid.
-    while (m_skippingPolicy->keepGoing()) {
-      ret = this->next();
+    // Avoid recursion in while loop as m_function does not need to be checked
+    // if skipping_policy is true anyway
+    // This also avoids high recursion depth causing stack overflow, which would
+    // otherwise be a problem for large masked regions
+    // Keep moving to next position if the current position is masked and still
+    // valid.
+    while (m_skippingPolicy->keepGoing()) { //(m_ws->getIsMaskedAt(m_pos)) {
+      ++m_pos;
+      ret = m_pos < m_max;
       if (!ret)
         break;
     }

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -311,9 +311,7 @@ bool MDHistoWorkspaceIterator::next() {
       for (size_t d = 0; d < m_nd; d++) {
         m_center[d] =
             m_origin[d] + (coord_t(m_index[d]) + 0.5f) * m_binWidth[d];
-        //          std::cout << m_center[d] << ",";
       }
-      //        std::cout<<std::endl;
       // Keep incrementing until you are in the implicit function
     } while (!allIncremented && !m_function->isPointContained(m_center) &&
              m_pos < m_max);
@@ -324,12 +322,12 @@ bool MDHistoWorkspaceIterator::next() {
 
   if (ret) {
     // Avoid recursion in while loop as m_function does not need to be checked
-    // if skipping_policy is true anyway
-    // This also avoids high recursion depth causing stack overflow, which would
-    // otherwise be a problem for large masked regions
+    // if skipping_policy is true
+    // This also avoids high recursion depth causing stack overflow for large 
+	// masked regions
     // Keep moving to next position if the current position is masked and still
     // valid.
-    while (m_skippingPolicy->keepGoing()) { //(m_ws->getIsMaskedAt(m_pos)) {
+    while (m_skippingPolicy->keepGoing()) {
       ++m_pos;
       ret = m_pos < m_max;
       if (!ret)

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -98,7 +98,7 @@ public:
     }
   }
 
-  void test_skip_mask_and_function() {
+  void test_edge_of_masked_region_falls_outside_implicit_function_bounds() {
 
     std::vector<coord_t> normal_vector;
     std::vector<coord_t> bound_vector;

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -98,6 +98,48 @@ public:
     }
   }
 
+  void test_skip_mask_and_function() {
+
+    std::vector<coord_t> normal_vector;
+    std::vector<coord_t> bound_vector;
+    normal_vector.push_back(1.);
+    bound_vector.push_back(3.);
+
+    MDImplicitFunction *function = new MDImplicitFunction();
+    function->addPlane(MDPlane(normal_vector, bound_vector));
+
+    Mantid::Geometry::GeneralFrame frame(
+        Mantid::Geometry::GeneralFrame::GeneralFrameDistance, "m");
+    WritableHistoWorkspace *ws =
+        new WritableHistoWorkspace(MDHistoDimension_sptr(
+            new MDHistoDimension("x", "x", frame, 0.0, 10, 11)));
+
+    ws->setMaskValueAt(0, true);  // Masked
+    ws->setMaskValueAt(1, true);  // Masked
+    ws->setMaskValueAt(2, false); // NOT MASKED, EXCLUDED BY FUNCTION
+    ws->setMaskValueAt(3, true);  // Masked
+    ws->setMaskValueAt(4, true);  // Masked
+    ws->setMaskValueAt(5, false); // NOT MASKED
+    ws->setMaskValueAt(6, true);  // Masked
+    ws->setMaskValueAt(7, false); // NOT MASKED
+    ws->setMaskValueAt(8, true);  // Masked
+
+    Mantid::DataObjects::MDHistoWorkspace_sptr ws_sptr(ws);
+
+    MDHistoWorkspaceIterator *histoIt =
+        new MDHistoWorkspaceIterator(ws, function);
+
+    TSM_ASSERT_EQUALS("The first index hit should be 5 since that is the first "
+                      "unmasked and inside function",
+                      5, histoIt->getLinearIndex());
+    histoIt->next();
+    TSM_ASSERT_EQUALS("The next index hit should be 7 since that is the next "
+                      "unmasked and inside function",
+                      7, histoIt->getLinearIndex());
+
+    delete histoIt;
+  }
+
   void test_iterator_1D() { do_test_iterator(1, 10); }
 
   void test_iterator_2D() { do_test_iterator(2, 100); }
@@ -267,8 +309,8 @@ public:
         2, histoIt->getLinearIndex());
     histoIt->next();
     TSM_ASSERT_EQUALS(
-        "The first index hit should be 2 since that is the first unmasked one",
-        5, histoIt->getLinearIndex());
+        "The next index hit should be 5 since that is the next unmasked one", 5,
+        histoIt->getLinearIndex());
 
     delete histoIt;
   }


### PR DESCRIPTION
Fixes #14367 

For large masked regions of MDHistoWorkspaces choosing "List Data" when right clicking on the workspace causes MantidPlot to crash. This was caused by stack overflow due to high recursion depth in the `MDHistoWorkspaceIterator`. It has been fixed by refactoring `MDHistoWorkspaceIterator::next()` to avoid recursion. Test coverage was improved in the process; the case of using an implicit function and a mask on the same workspace is now covered.

**To Test:**
Selecting "List Data" when right clicking on workspace "wsBinned", created with the following code, would previously crash MantidPlot. The observed behaviour was that MantidPlot would instantly cease running and disappear. "List Data" should now not cause the crash, and a table of data with a single row should appear.

``` python

ws = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='4')
FakeMDEventData(ws, PeakParams='10,1,1,1,0.1', RandomizeSignal='1')
wsBinned = BinMD(ws,AlignedDim0='h,-2,2,64',AlignedDim1='k,-2,2,64',AlignedDim2='l,-2,2,64')
MaskMD(Workspace=wsBinned,Dimensions="h,k,l",Extents="-2,2,-2,2,-2,2")

```
