### PR TITLE
Add check for successful MatrixWorkspace cast in ValidateInputs for PhaseQuad

### DIFF
--- a/Framework/Algorithms/src/PhaseQuadMuon.cpp
+++ b/Framework/Algorithms/src/PhaseQuadMuon.cpp
@@ -5,6 +5,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidKernel/PhysicalConstants.h"
+#include "MantidAPI/MatrixWorkspaceValidator.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -18,7 +19,6 @@ DECLARE_ALGORITHM(PhaseQuadMuon)
  *
  */
 void PhaseQuadMuon::init() {
-
   declareProperty(new API::WorkspaceProperty<API::MatrixWorkspace>(
                       "InputWorkspace", "", Direction::Input),
                   "Name of the input workspace containing the spectra");
@@ -72,9 +72,18 @@ std::map<std::string, std::string> PhaseQuadMuon::validateInputs() {
   // Check that input ws and table ws have compatible dimensions
   API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
   API::ITableWorkspace_const_sptr tabWS = getProperty("PhaseTable");
-
+  if (!inputWS) {
+    result["InputWorkspace"] = "InputWorkspace is of Incorrect type. Please "
+                               "provide a MatrixWorkspace as the "
+                               "InputWorkspace";
+    return result;
+  }
   size_t nspec = inputWS->getNumberHistograms();
   size_t ndet = tabWS->rowCount();
+
+  if (tabWS->columnCount() == 0) {
+    result["PhaseTable"] = "Please provide a non-empty PhaseTable.";
+  }
 
   if (nspec != ndet) {
     result["PhaseTable"] = "PhaseTable must have one row per spectrum";


### PR DESCRIPTION
**To Test:**
- Load MUSR00015189.nxs into mantid (can be found at \\ISIS\inst$)
  - Create an empty Table workspace
  - Run PhaseQuad algorithm with `MUSR00015189` as the InputWorkspace and the empty Table workspace as the PhaseTable.
- A red star should appear next to InputWorkspace warning about Incorrect type
- See that mantid does not crash.
- A quick code review would also be helpful to see if this could be handled in a better way.

Fixes #14507
