### PR TITLE
IndirectCorrections ContainerSubtraction Rebinning step

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ApplyPaalmanPings.cpp
@@ -130,7 +130,7 @@ void ApplyPaalmanPings::run() {
       if (!checkWorkspaceBinningMatches(sampleWs, canCloneWs)) {
         QString text =
             "Binning on sample and container does not match."
-            "Would you like to rebin the sample to match the container?";
+            "Would you like to rebin the container to match the sample?";
 
         int result = QMessageBox::question(NULL, tr("Rebin sample?"), tr(text),
                                            QMessageBox::Yes, QMessageBox::No,

--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -100,7 +100,7 @@ void ContainerSubtraction::run() {
     if (!checkWorkspaceBinningMatches(sampleWs, canCloneWs)) {
       QString text =
           "Binning on sample and container does not match."
-          "Would you like to rebin the sample to match the container?";
+          "Would you like to rebin the container to match the sample?";
 
       int result = QMessageBox::question(NULL, tr("Rebin sample?"), tr(text),
                                          QMessageBox::Yes, QMessageBox::No,


### PR DESCRIPTION
Fixes #14469

The Rebinning step is now ensured to run in the correct order to avoid shift and mismatch container data range errors when subtracting.
- Data for this test can be found at : `\\olympic\babylon5\Public\ElliotOram\Corrections\ContainerSubtraction\IN16B`
# To Test
- Open ContainerSubtraction (Interfaces > Indirect > Corrections > ContainerSubtraction) 
- Sample = `125283_silicon_111_red`
- Container = `125188_silicon_111_red`
- Click `Run` - _The default settings in the interface are correct for this test_
- Ensure that the algorithm runs without error and that the mini plot is updated with the container sample and subtracted curves
