### PR TITLE
Changed default value for bin width in TFXA parameter file

### DIFF
--- a/instrument/TFXA_Parameters.xml
+++ b/instrument/TFXA_Parameters.xml
@@ -43,7 +43,7 @@
     </parameter>
 
     <parameter name="rebin-default" type="string">
-      <value val="3,-0.005,500" />
+      <value val="3,0.005,500" />
     </parameter>
 
     <!-- This is actually spectrum index, NOT spectrum number -->


### PR DESCRIPTION
Fixes #14520

Changed bin width in parameter file for TFXA to be positive
# To Test
- Code Review should show the value is changed
- You can also check in the ISIS Energy Transfer interface (Interfaces > Indirect > Data Reduction > Energy Transfer) - Change the instrument to `TFXA` in the drop down menu and ensure that the bin width is +0.005 

_You may get a validation error when switching between instruments in Indirect Data Reduction. This is being dealt with in a separate issue_
