### PR TITLE
Qt Signal showMessageBox no longer redefined in indirect

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CorrectionsTab.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/CorrectionsTab.h
@@ -54,10 +54,6 @@ namespace CustomInterfaces
     /// Loads the tab's settings.
     void loadTabSettings(const QSettings & settings);
 
-  signals:
-		/// Send signal to parent window to show a message box to user
-		void showMessageBox(const QString& message);
-
   protected:
     /// Function to run a string as python code
     void runPythonScript(const QString& pyInput);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayesTab.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectBayesTab.h
@@ -83,10 +83,6 @@ public:
   /// Base methods implemented in derived classes
   virtual void loadSettings(const QSettings &settings) = 0;
 
-signals:
-  /// Send signal to parent window to show a message box to user
-  void showMessageBox(const QString &message);
-
 protected slots:
   /// Slot to update the guides when the range properties change
   virtual void updateProperties(QtProperty *prop, double val) = 0;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectDataAnalysisTab.h
@@ -57,10 +57,6 @@ namespace IDA
     /// Loads the tab's settings.
     void loadTabSettings(const QSettings & settings);
 
-  signals:
-		/// Send signal to parent window to show a message box to user
-		void showMessageBox(const QString& message);
-
   protected:
     /// Function to run a string as python code
     void runPythonScript(const QString& pyInput);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectToolsTab.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectToolsTab.h
@@ -6,64 +6,62 @@
 #include <QSettings>
 #include <QWidget>
 
-namespace MantidQt
-{
-	namespace CustomInterfaces
-	{
-		/**
-			This class defines a abstract base class for the different tabs of the Indirect Foreign interface.
-			Any joint functionality shared between each of the tabs should be implemented here as well as defining
-			shared member functions.
+namespace MantidQt {
+namespace CustomInterfaces {
+/**
+    This class defines a abstract base class for the different tabs of the
+	Indirect Foreign interface.
+    Any joint functionality shared between each of the tabs should be
+	implemented here as well as defining
+    shared member functions.
 
-			@author Samuel Jackson, STFC
+    @author Samuel Jackson, STFC
 
-			Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+    Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory, NScD Oak
+	Ridge National Laboratory & European Spallation Source
 
-			This file is part of Mantid.
+    This file is part of Mantid.
 
-			Mantid is free software; you can redistribute it and/or modify
-			it under the terms of the GNU General Public License as published by
-			the Free Software Foundation; either version 3 of the License, or
-			(at your option) any later version.
+    Mantid is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
 
-			Mantid is distributed in the hope that it will be useful,
-			but WITHOUT ANY WARRANTY; without even the implied warranty of
-			MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-			GNU General Public License for more details.
+    Mantid is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-			You should have received a copy of the GNU General Public License
-			along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-			File change history is stored at: <https://github.com/mantidproject/mantid>
-			Code Documentation is available at: <http://doxygen.mantidproject.org>
-		*/
+    File change history is stored at:
+	<https://github.com/mantidproject/mantid>
+	Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
 
-		class DLLExport IndirectToolsTab : public IndirectTab
-		{
-			Q_OBJECT
+class DLLExport IndirectToolsTab : public IndirectTab {
+  Q_OBJECT
 
-		public:
-			IndirectToolsTab(QWidget * parent = 0);
-			~IndirectToolsTab();
+public:
+  IndirectToolsTab(QWidget *parent = 0);
+  ~IndirectToolsTab();
 
-			/// Base methods implemented in derived classes
-			virtual void loadSettings(const QSettings& settings) = 0;
+  /// Base methods implemented in derived classes
+  virtual void loadSettings(const QSettings &settings) = 0;
 
-		signals:
-			/// Send signal to parent window to execute python script
-			void executePythonScript(const QString& pyInput, bool output);
-			/// Send signal to parent window to show a message box to user
-			void showMessageBox(const QString& message);
+signals:
+  /// Send signal to parent window to execute python script
+  void executePythonScript(const QString &pyInput, bool output);
 
-		protected:
-      virtual void setup() = 0;
-      virtual void run() = 0;
-      virtual bool validate() = 0;
+protected:
+  virtual void setup() = 0;
+  virtual void run() = 0;
+  virtual bool validate() = 0;
 
-			void runPythonScript(const QString& pyInput);
-
-		};
-	} // namespace CustomInterfaces
+  void runPythonScript(const QString &pyInput);
+};
+} // namespace CustomInterfaces
 } // namespace Mantid
 
 #endif


### PR DESCRIPTION
Fixes #14478

showMessageBox signal is no longer being redefined in the child classes tabs in Indirect.
# To Test
- Build Qt-help and ensure that no warnings are produced similar to:

```
QMetaObject::indexOfSignal: signal showMessageBox(QString) from MantidQt::CustomInterfaces::IndirectTab redefined in MantidQt::CustomInterfaces::IndirectBayesTab
```
