### PR TITLE
ContainerSubtraction Ensure input files are correct before further validation

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -189,39 +189,43 @@ bool ContainerSubtraction::validate() {
   UserInputValidator uiv;
 
   // Check valid inputs
-  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
-  uiv.checkDataSelectorIsValid("Container", m_uiForm.dsContainer);
+  const bool samValid = uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+  const bool canValid = uiv.checkDataSelectorIsValid("Container", m_uiForm.dsContainer);
 
-  // Get Workspaces
-  MatrixWorkspace_sptr sampleWs =
-      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-          m_uiForm.dsSample->getCurrentDataName().toStdString());
-  MatrixWorkspace_sptr containerWs =
-      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-          m_uiForm.dsContainer->getCurrentDataName().toStdString());
+  if (samValid && canValid) {
+    // Get Workspaces
+    MatrixWorkspace_sptr sampleWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            m_uiForm.dsSample->getCurrentDataName().toStdString());
+    MatrixWorkspace_sptr containerWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            m_uiForm.dsContainer->getCurrentDataName().toStdString());
 
-  // Check Sample is of same type as container
-  QString sample = m_uiForm.dsSample->getCurrentDataName();
-  QString sampleType = sample.right(sample.length() - sample.lastIndexOf("_"));
-  QString container = m_uiForm.dsContainer->getCurrentDataName();
-  QString containerType =
-      container.right(sample.length() - container.lastIndexOf("_"));
+    // Check Sample is of same type as container
+    QString sample = m_uiForm.dsSample->getCurrentDataName();
+    QString sampleType =
+        sample.right(sample.length() - sample.lastIndexOf("_"));
+    QString container = m_uiForm.dsContainer->getCurrentDataName();
+    QString containerType =
+        container.right(sample.length() - container.lastIndexOf("_"));
 
-  g_log.debug() << "Sample type is: " << sampleType.toStdString() << std::endl;
-  g_log.debug() << "Container type is: " << containerType.toStdString()
-                << std::endl;
+    g_log.debug() << "Sample type is: " << sampleType.toStdString()
+                  << std::endl;
+    g_log.debug() << "Container type is: " << containerType.toStdString()
+                  << std::endl;
 
-  if (containerType != sampleType)
-    uiv.addErrorMessage(
-        "Sample and can workspaces must contain the same type of data.");
+    if (containerType != sampleType)
+      uiv.addErrorMessage(
+          "Sample and can workspaces must contain the same type of data.");
 
-  // Check sample has the same number of Histograms as the contianer
-  const size_t sampleHist = sampleWs->getNumberHistograms();
-  const size_t containerHist = containerWs->getNumberHistograms();
+    // Check sample has the same number of Histograms as the contianer
+    const size_t sampleHist = sampleWs->getNumberHistograms();
+    const size_t containerHist = containerWs->getNumberHistograms();
 
-  if (sampleHist != containerHist) {
-    uiv.addErrorMessage(
-        " Sample and Container do not have a matching number of Histograms.");
+    if (sampleHist != containerHist) {
+      uiv.addErrorMessage(
+          " Sample and Container do not have a matching number of Histograms.");
+    }
   }
 
   // Show errors if there are any


### PR DESCRIPTION
Fixes #14528

ContainerSubtraction should no longer crash no longer attempt to access the ADS when invalid data files are used.
# To Test
- Open ContainerSubtraction (Interfaces > Indirect > Corrections > ContainerSubtraction)
- Click `Run`
- Ensure that the interface does not try to access the ADS in the validation step.
