### PR TITLE
Change debug logs in Fit / CostFuncLeastSquares (to fix doc test of GetDetSetOffset on win7-debug)

### DIFF
--- a/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncLeastSquares.cpp
@@ -404,36 +404,39 @@ void CostFuncLeastSquares::getParameters(GSLVector &params) const {
 void CostFuncLeastSquares::calActiveCovarianceMatrix(GSLMatrix &covar,
                                                      double epsrel) {
   UNUSED_ARG(epsrel);
+
   if (m_hessian.isEmpty()) {
     valDerivHessian();
   }
+
   if (g_log.is(Kernel::Logger::Priority::PRIO_DEBUG)) {
-    g_log.debug() << "== Hessian (H) ==\n";
-    std::ios::fmtflags prevState = g_log.debug().flags();
-    g_log.debug() << std::left << std::fixed;
+    std::ostringstream osHess;
+    osHess << "== Hessian (H) ==\n";
+    osHess << std::left << std::fixed;
     for (size_t i = 0; i < m_hessian.size1(); ++i) {
       for (size_t j = 0; j < m_hessian.size2(); ++j) {
-        g_log.debug() << std::setw(10);
-        g_log.debug() << m_hessian.get(i, j) << "  ";
+        osHess << std::setw(10);
+        osHess << m_hessian.get(i, j) << "  ";
       }
-      g_log.debug() << "\n";
+      osHess << "\n";
     }
-    g_log.debug().flags(prevState);
+    g_log.debug() << osHess.str();
   }
+
   covar = m_hessian;
   covar.invert();
   if (g_log.is(Kernel::Logger::Priority::PRIO_DEBUG)) {
-    g_log.debug() << "== Covariance matrix (H^-1) ==\n";
-    std::ios::fmtflags prevState = g_log.debug().flags();
-    g_log.debug() << std::left << std::fixed;
+    std::ostringstream osCovar;
+    osCovar << "== Covariance matrix (H^-1) ==\n";
+    osCovar << std::left << std::fixed;
     for (size_t i = 0; i < covar.size1(); ++i) {
       for (size_t j = 0; j < covar.size2(); ++j) {
-        g_log.debug() << std::setw(10);
-        g_log.debug() << covar.get(i, j) << "  ";
+        osCovar << std::setw(10);
+        osCovar << covar.get(i, j) << "  ";
       }
-      g_log.debug() << "\n";
+      osCovar << "\n";
     }
-    g_log.debug().flags(prevState);
+    g_log.debug() << osCovar.str();
   }
 }
 


### PR DESCRIPTION
Fixes #14467.

The doc test of GetDetOffsetsMultiPeaks was getting stuck on windows (debug build) >95% of times because of a data race condition in stream manipulators when writing debug messages concurrently.

**To test:**
- The doctest GetDetOffsetsMultiPeaks should work (finish) in a windows debug build.
- Check that if you set 'debug' logging level you still see the very verbose output from the underlying Fit runs, including the Hessian  and covariance matrices.

Note that the output messages from different parallel fits (especially the matrices) can be mixed-up. Individual lines should be consistent but the lines of multi-line messages coming from different threads
will be scrambled occasionally (that may produce a mix of Hessian/covariance matrices that you'll have to decipher).
