### PR TITLE
Fix buffer over-read in MasMDTest/ MaskMD validateInputs

### DIFF
--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -318,12 +318,13 @@ std::map<std::string, std::string> MaskMD::validateInputs() {
     validation_output["Extents"] = messageStream.str();
   }
   // Check extent value provided.
-  for (size_t i = 0; i < nDimensionIds; ++i) {
+  for (size_t i = 0; (i < nDimensionIds) && ((i * 2 + 1) < extents.size());
+       ++i) {
     double min = extents[i * 2];
     double max = extents[(i * 2) + 1];
     if (min > max) {
       messageStream << "Cannot have minimum extents " << min
-                    << " larger than maximum extents " << max;
+                    << " larger than maximum extents " << max << ". ";
       validation_output["Extents"] = messageStream.str();
     }
   }


### PR DESCRIPTION
Fixes #14505.

Small buffer overread that MSVC 2015 catches (sometimes) in debug mode.

**To test:** unit and all other tests should pass.

This fixes the half of #14505 about MaskMDTest. ConvertEventsToMDTest didn't fail in the debug build last night and it doesn't want to fail on my machine either, not even after a few hundred repetitions. So
that other half may have gone away.
