### PR TITLE
Fix catalog HTTP downloads

### DIFF
--- a/Framework/ICat/src/CatalogAlgorithmHelper.cpp
+++ b/Framework/ICat/src/CatalogAlgorithmHelper.cpp
@@ -6,6 +6,9 @@
 
 namespace Mantid {
 namespace ICat {
+
+using Poco::Net::HTTPResponse;
+
 /**
  * Obtain the error message returned by the IDS.
  * @param HTTPStatus     :: The HTTPStatus returned by the IDS.
@@ -14,28 +17,33 @@ namespace ICat {
  * @returns An appropriate error message for the user if it exists. Otherwise an
  * empty string.
  */
-const std::string CatalogAlgorithmHelper::getIDSError(
-    Poco::Net::HTTPResponse::HTTPStatus &HTTPStatus,
-    std::istream &responseStream) {
-  std::set<Poco::Net::HTTPResponse::HTTPStatus> successHTTPStatus =
-      boost::assign::list_of(Poco::Net::HTTPResponse::HTTPStatus::HTTP_OK)(
-          Poco::Net::HTTPResponse::HTTPStatus::HTTP_CREATED)(
-          Poco::Net::HTTPResponse::HTTPStatus::HTTP_ACCEPTED);
+const std::string
+CatalogAlgorithmHelper::getIDSError(HTTPResponse::HTTPStatus &HTTPStatus,
+                                    std::istream &responseStream) {
+  std::set<HTTPResponse::HTTPStatus> successHTTPStatus = {
+      HTTPResponse::HTTP_OK, HTTPResponse::HTTP_CREATED,
+      HTTPResponse::HTTP_ACCEPTED};
 
-  // Cancel the algorithm and output message if status returned
-  // from the server is not in our successHTTPStatus set.
+  // HTTP Status is not one of the positive statuses
   if (successHTTPStatus.find(HTTPStatus) == successHTTPStatus.end()) {
-    // Stores the contents of `jsonResponseData` as a json property tree.
+    // Attempt to parse response as json stream
     Json::Value json;
-    // Convert the stream to a JSON tree.
     Json::Reader json_reader;
-    json_reader.parse(responseStream, json);
-    // Return the message returned by the server.
-    return json.get("code", "UTF-8").asString() + ": " +
-           json.get("message", "UTF-8").asString();
+    auto json_valid = json_reader.parse(responseStream, json);
+
+    // Error messages from IDS are returned as json
+    if (json_valid) {
+      return json.get("code", "UNKNOWN").asString() + ": " +
+             json.get("message", "Unknown Error").asString();
+    } else {
+      // Sometimes the HTTP server can throw an error (which is plain HTML)
+      return "HTTP Error: " + std::to_string(HTTPStatus);
+    }
   }
+
   // No error occurred, so return an empty string for verification.
   return "";
 }
-}
-}
+
+} // namespace ICat
+} // namespace Mantid

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -12,7 +12,7 @@
 
   <catalog name="ICat4Catalog">
     <soapendpoint url="https://icatisis.esc.rl.ac.uk/ICATService/ICAT"></soapendpoint>
-    <externaldownload url="https://isisicatds.stfc.ac.uk/idsbeta/"></externaldownload>
+    <externaldownload url="https://isisicatds.stfc.ac.uk/ids/"></externaldownload>
     <filelocation>
       <prefix regex="\\\\isis\\inst\$"></prefix>
       <windows replacement=""></windows>


### PR DESCRIPTION
Fixes #14537.

Release notes not yet updated.

HTTP downloads of data files from the ICAT service were failing because our Facilities config file contained an old URL that no longer works (`https://isisicatds.stfc.ac.uk/idsbeta/` as opposed to `https://isisicatds.stfc.ac.uk/ids/`). Updated it to the new URL.

Also adjusted error handling code to display a more reasonable error message when HTTP errors such as this occur. Previously it was only handling the json errors dispatched by the service that is running on the server, but not HTTP errors dispatched by the server itself.
### Testing

This is easiest to test on Linux or Mac, since Windows will just access the file via samba share rather than HTTP.

To test downloading: Log into the Catalog, find any datafile and attempt to download it.

To test error message: Without this PR, just try to download a data file. With this PR, first edit `instrument/Facilities.xml` (line 15) to change the `url` property of the `<externaldownload ...>` tag to something invalid (for example, `https://isisicatds.stfc.ac.uk/idsbeta/`).
