### PR TITLE
Remove make_unique workaround for MSVC 2012.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/make_unique.h
+++ b/Framework/Kernel/inc/MantidKernel/make_unique.h
@@ -18,7 +18,7 @@ namespace Kernel {
 
 using std::make_unique;
 
-#else // C++11
+#else  // C++11
 
 template <class T> struct _Unique_if {
   typedef std::unique_ptr<T> _Single_object;

--- a/Framework/Kernel/inc/MantidKernel/make_unique.h
+++ b/Framework/Kernel/inc/MantidKernel/make_unique.h
@@ -38,8 +38,6 @@ typename _Unique_if<T>::_Unknown_bound make_unique(size_t n) {
   return std::unique_ptr<T>(new U[n]());
 }
 
-#if !defined(_MSC_VER) || _MSC_VER > 1700
-
 template <class T, class... Args>
 inline typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
   return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
@@ -47,69 +45,7 @@ inline typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
 
 template <class T, class... Args>
 inline typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
-#else
-// workaround for MSVC 2012
-
-template <class T> inline typename _Unique_if<T>::_Single_object make_unique() {
-  return std::unique_ptr<T>(new T());
-}
-
-template <class T, class Arg1>
-inline typename _Unique_if<T>::_Single_object make_unique(Arg1 param1) {
-  return std::unique_ptr<T>(new T(std::forward<Arg1>(param1)));
-}
-
-template <class T, class Arg1, class Arg2>
-inline typename _Unique_if<T>::_Single_object make_unique(Arg1 param1,
-                                                          Arg2 param2) {
-  return std::unique_ptr<T>(
-      new T(std::forward<Arg1>(param1), std::forward<Arg2>(param2)));
-}
-
-template <class T, class Arg1, class Arg2, class Arg3>
-inline typename _Unique_if<T>::_Single_object
-make_unique(Arg1 param1, Arg2 param2, Arg3 param3) {
-  return std::unique_ptr<T>(new T(std::forward<Arg1>(param1),
-                                  std::forward<Arg2>(param2),
-                                  std::forward<Arg3>(param3)));
-}
-
-template <class T, class Arg1, class Arg2, class Arg3, class Arg4>
-inline typename _Unique_if<T>::_Single_object
-make_unique(Arg1 param1, Arg2 param2, Arg3 param3, Arg4 param4) {
-  return std::unique_ptr<T>(
-      new T(std::forward<Arg1>(param1), std::forward<Arg2>(param2),
-            std::forward<Arg3>(param3), std::forward<Arg4>(param4)));
-}
-
-template <class T, class Arg1, class Arg2, class Arg3, class Arg4, class Arg5>
-inline typename _Unique_if<T>::_Single_object
-make_unique(Arg1 param1, Arg2 param2, Arg3 param3, Arg4 param4, Arg5 param5) {
-  return std::unique_ptr<T>(
-      new T(std::forward<Arg1>(param1), std::forward<Arg2>(param2),
-            std::forward<Arg3>(param3), std::forward<Arg4>(param4),
-            std::forward<Arg5>(param5)));
-}
-
-template <class T>
-inline typename _Unique_if<T>::_Known_bound make_unique() = delete;
-template <class T, class Arg1>
-inline typename _Unique_if<T>::_Known_bound make_unique(Arg1 param1) = delete;
-template <class T, class Arg1, class Arg2>
-inline typename _Unique_if<T>::_Known_bound make_unique(Arg1 param1,
-                                                        Arg2 param2) = delete;
-template <class T, class Arg1, class Arg2, class Arg3>
-inline typename _Unique_if<T>::_Known_bound
-make_unique(Arg1 param1, Arg2 param2, Arg3 param3) = delete;
-template <class T, class Arg1, class Arg2, class Arg3, class Arg4>
-inline typename _Unique_if<T>::_Known_bound
-make_unique(Arg1 param1, Arg2 param2, Arg3 param3, Arg4 param4) = delete;
-template <class T, class Arg1, class Arg2, class Arg3, class Arg4, class Arg5>
-inline typename _Unique_if<T>::_Known_bound
-make_unique(Arg1 param1, Arg2 param2, Arg3 param3, Arg4 param4,
-            Arg5 param5) = delete;
-#endif // MSVC
 #endif // __cplusplus == 201402L
 }
 }
-#endif
+#endif // Mantid_make_unique_h

--- a/Framework/Kernel/inc/MantidKernel/make_unique.h
+++ b/Framework/Kernel/inc/MantidKernel/make_unique.h
@@ -46,6 +46,6 @@ inline typename _Unique_if<T>::_Single_object make_unique(Args &&... args) {
 template <class T, class... Args>
 inline typename _Unique_if<T>::_Known_bound make_unique(Args &&...) = delete;
 #endif // __cplusplus == 201402L
-}
-}
+} // namespace Kernel
+} // namespace Mantid
 #endif // Mantid_make_unique_h


### PR DESCRIPTION
This removes a workaround for MSVC 2012, which doesn't support variadic templates. Since we no longer support building Mantid with MSVC 2012, this is no longer necessary.

no release notes

testing: Verify build servers still pass.
