### PR TITLE
Added progress reporting to EVSDiffractionReduction algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/EVSDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/EVSDiffractionReduction.py
@@ -97,10 +97,10 @@ class EVSDiffractionReduction(DataProcessorAlgorithm):
         load_opts = dict()
         load_opts['Mode'] = 'FoilOut'
         load_opts['InstrumentParFile'] = self._par_filename
-        
+
         prog_reporter = Progress(self, start=0.0, end=1.0, nreports=1)
-        
-        prog_reporter.report("Loading Files");
+
+        prog_reporter.report("Loading Files")
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,
@@ -111,7 +111,7 @@ class EVSDiffractionReduction(DataProcessorAlgorithm):
 
 
         prog_reporter.resetNumSteps(self._workspace_names.__len__(), 0.0, 1.0)
-        
+
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/EVSDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/EVSDiffractionReduction.py
@@ -97,6 +97,10 @@ class EVSDiffractionReduction(DataProcessorAlgorithm):
         load_opts = dict()
         load_opts['Mode'] = 'FoilOut'
         load_opts['InstrumentParFile'] = self._par_filename
+        
+        prog_reporter = Progress(self, start=0.0, end=1.0, nreports=1)
+        
+        prog_reporter.report("Loading Files");
 
         self._workspace_names, self._chopped_data = load_files(self._data_files,
                                                                ipf_filename=self._ipf_filename,
@@ -105,6 +109,9 @@ class EVSDiffractionReduction(DataProcessorAlgorithm):
                                                                sum_files=self._sum_files,
                                                                load_opts=load_opts)
 
+
+        prog_reporter.resetNumSteps(self._workspace_names.__len__(), 0.0, 1.0)
+        
         for c_ws_name in self._workspace_names:
             is_multi_frame = isinstance(mtd[c_ws_name], WorkspaceGroup)
 
@@ -157,8 +164,11 @@ class EVSDiffractionReduction(DataProcessorAlgorithm):
                               masked_detectors,
                               self._grouping_method)
 
+
             if is_multi_frame:
                 fold_chopped(c_ws_name)
+
+            prog_reporter.report()
 
         # Rename output workspaces
         output_workspace_names = [rename_reduction(ws_name, self._sum_files) for ws_name in self._workspace_names]


### PR DESCRIPTION
Fixes #13992 

Release notes have not been updated
## Changes

The EVSDiffractionReduction python algorithm now includes progress updated. Progress updating is minimal since the part of the algorithm which takes up most time is file loading which does not itself produce progress reporting. 
## Testing

Code review and run the following script:

_EVSDiffractionReduction(InputFiles='EVS15289.raw',_
                        _OutputWorkspace='DiffractionReductions',_
                        _InstrumentParFile='IP0005.dat')_

_ws = mtd['DiffractionReductions'].getItem(0)_

_print 'Workspace name: %s' % ws.getName()_
_print 'Number of spectra: %d' % ws.getNumberHistograms()_
_print 'Number of bins: %s' % ws.blocksize()_
