### PR TITLE
Indirect absorption container shift

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectAnnulusAbsorption.py
@@ -129,13 +129,13 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
             ConvertUnits(InputWorkspace=self._can_ws_name, OutputWorkspace=can1_wave_ws,
                          Target='Wavelength', EMode='Indirect', EFixed=efixed)
             if self._can_scale != 1.0:
-                logger.information('Scaling can by: ' + str(self._can_scale))
+                logger.information('Scaling container by: ' + str(self._can_scale))
                 Scale(InputWorkspace=can1_wave_ws, OutputWorkspace=can1_wave_ws, Factor=self._can_scale, Operation='Multiply')
             CloneWorkspace(InputWorkspace=can1_wave_ws, OutputWorkspace=can2_wave_ws)
 
             can_thickness_1 = self._sample_inner_radius - self._can_inner_radius
             can_thickness_2 = self._can_outer_radius - self._sample_outer_radius
-            logger.information('Can thickness: %f & %f' % (can_thickness_1, can_thickness_2))
+            logger.information('Container thickness: %f & %f' % (can_thickness_1, can_thickness_2))
 
             if self._use_can_corrections:
                 prog.report('Calculating container corrections')
@@ -205,12 +205,12 @@ class IndirectAnnulusAbsorption(DataProcessorAlgorithm):
                        ('can_outer', self._can_outer_radius)]
 
         if self._can_ws_name is not None:
-            sample_logs.append(('can_filename', self._can_ws_name))
-            sample_logs.append(('can_scale', self._can_scale))
+            sample_logs.append(('container_filename', self._can_ws_name))
+            sample_logs.append(('container_scale', self._can_scale))
             if self._use_can_corrections:
                 sample_log_workspaces.append(self._acc_ws)
-                sample_logs.append(('can_thickness_1', can_thickness_1))
-                sample_logs.append(('can_thickness_2', can_thickness_2))
+                sample_logs.append(('container_thickness_1', can_thickness_1))
+                sample_logs.append(('container_thickness_2', can_thickness_2))
 
         log_names = [item[0] for item in sample_logs]
         log_values = [item[1] for item in sample_logs]

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCylinderAbsorption.py
@@ -121,11 +121,11 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
                 Scale(InputWorkspace=can_wave_ws, OutputWorkspace=can_wave_ws, Factor=self._can_scale, Operation='Multiply')
 
             can_thickness = self._can_radius - self._sample_radius
-            logger.information('Can thickness: ' + str(can_thickness))
+            logger.information('Container thickness: ' + str(can_thickness))
 
             if self._use_can_corrections:
                 # Doing can corrections
-                prog.report('Calculating can corrections')
+                prog.report('Calculating container corrections')
                 Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
                 SetSampleMaterial(can_wave_ws, ChemicalFormula=self._can_chemical_formula, SampleNumberDensity=self._can_number_density)
@@ -147,7 +147,7 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
 
             else:
                 # Doing simple can subtraction
-                prog.report('Calculating can scaling')
+                prog.report('Calculating container scaling')
                 Minus(LHSWorkspace=sample_wave_ws, RHSWorkspace=can_wave_ws, OutputWorkspace=sample_wave_ws)
                 Divide(LHSWorkspace=sample_wave_ws, RHSWorkspace=self._ass_ws, OutputWorkspace=sample_wave_ws)
 
@@ -169,11 +169,11 @@ class IndirectCylinderAbsorption(DataProcessorAlgorithm):
                        ('sample_radius', self._sample_radius)]
 
         if self._can_ws_name is not None:
-            sample_logs.append(('can_filename', self._can_ws_name))
-            sample_logs.append(('can_scale', self._can_scale))
+            sample_logs.append(('container_filename', self._can_ws_name))
+            sample_logs.append(('container_scale', self._can_scale))
             if self._use_can_corrections:
                 sample_log_workspaces.append(self._acc_ws)
-                sample_logs.append(('can_thickness', can_thickness))
+                sample_logs.append(('container_thickness', can_thickness))
 
         log_names = [item[0] for item in sample_logs]
         log_values = [item[1] for item in sample_logs]

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectFlatPlateAbsorption.py
@@ -131,7 +131,7 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
             ConvertUnits(InputWorkspace=self._can_ws_name, OutputWorkspace=can_wave_ws,
                          Target='Wavelength', EMode='Indirect', EFixed=efixed)
             if self._can_scale != 1.0:
-                logger.information('Scaling can by: ' + str(self._can_scale))
+                logger.information('Scaling container by: ' + str(self._can_scale))
                 Scale(InputWorkspace=can_wave_ws, OutputWorkspace=can_wave_ws, Factor=self._can_scale, Operation='Multiply')
 
             if self._use_can_corrections:
@@ -179,12 +179,12 @@ class IndirectFlatPlateAbsorption(DataProcessorAlgorithm):
                        ('element_size', self._element_size)]
 
         if self._can_ws_name is not None:
-            sample_logs.append(('can_filename', self._can_ws_name))
-            sample_logs.append(('can_scale', self._can_scale))
+            sample_logs.append(('container_filename', self._can_ws_name))
+            sample_logs.append(('container_scale', self._can_scale))
             if self._use_can_corrections:
                 sample_log_workspaces.append(self._acc_ws)
-                sample_logs.append(('can_front_thickness', self. _can_front_thickness))
-                sample_logs.append(('can_back_thickness', self. _can_back_thickness))
+                sample_logs.append(('container_front_thickness', self. _can_front_thickness))
+                sample_logs.append(('container_back_thickness', self. _can_back_thickness))
 
         log_names = [item[0] for item in sample_logs]
         log_values = [item[1] for item in sample_logs]

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
@@ -513,21 +513,21 @@
       <string>Container Details</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="3" column="2">
+      <item row="4" column="2">
        <widget class="QLabel" name="lbCanChemicalFormula">
         <property name="text">
          <string>Chemical Formula:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="lbCanNumberDensity">
         <property name="text">
          <string>Number Density:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QDoubleSpinBox" name="spCanNumberDensity">
         <property name="enabled">
          <bool>false</bool>
@@ -546,7 +546,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="3">
+      <item row="4" column="3">
        <widget class="QLineEdit" name="leCanChemicalFormula">
         <property name="enabled">
          <bool>false</bool>
@@ -578,6 +578,32 @@
          <string>Scale:</string>
         </property>
        </widget>
+      </item>
+      <item row="3" column="3">
+        <widget class="QDoubleSpinBox" name="spCanShift">
+          <property name="enabled">
+            <bool>false</bool>
+          </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
+          <property name="singleStep">
+            <double>0.010000000000000</double>
+          </property>
+          <property name="minimum">
+            <double>-999.999999</double>
+          </property>
+          <property name="maximum">
+            <double>999.99999</double>
+          </property>
+        </widget>
+      </item>
+      <item row="3" column="2">
+        <widget class="QCheckBox" name="ckShiftCan">
+          <property name="text">
+            <string>Shift x-values of container by adding:</string>
+          </property>
+        </widget>
       </item>
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="ckUseCanCorrections">
@@ -682,6 +708,8 @@
   <tabstop>ckUseCanCorrections</tabstop>
   <tabstop>ckScaleCan</tabstop>
   <tabstop>spCanScale</tabstop>
+  <tabstop>ckShiftCan</tabstop>
+  <tabstop>spCanShift</tabstop>
   <tabstop>spCanNumberDensity</tabstop>
   <tabstop>leCanChemicalFormula</tabstop>
   <tabstop>ckKeepFactors</tabstop>
@@ -707,20 +735,36 @@
    </hints>
   </connection>
   <connection>
-   <sender>ckScaleCan</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spCanScale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>156</x>
-     <y>91</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>436</x>
-     <y>92</y>
-    </hint>
-   </hints>
+    <sender>ckScaleCan</sender>
+    <signal>toggled(bool)</signal>
+    <receiver>spCanScale</receiver>
+    <slot>setEnabled(bool)</slot>
+    <hints>
+      <hint type="sourcelabel">
+        <x>156</x>
+        <y>91</y>
+      </hint>
+      <hint type="destinationlabel">
+        <x>436</x>
+        <y>92</y>
+     </hint>
+    </hints>
+  </connection>
+  <connection>
+    <sender>ckShiftCan</sender>
+    <signal>toggled(bool)</signal>
+    <receiver>spCanShift</receiver>
+    <slot>setEnabled(bool)</slot>
+    <hints>
+     <hint type="sourcelabel">
+        <x>156</x>
+        <y>91</y>
+     </hint>
+     <hint type="destinationlabel">
+       <x>436</x>
+       <y>92</y>
+      </hint>
+     </hints>
   </connection>
   <connection>
    <sender>ckUseCan</sender>

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -64,7 +64,7 @@ void AbsorptionCorrections::run() {
     clone->setProperty("OutputWorkspace", shiftedCanName);
     clone->execute();
 
-    MatrixWorkspace_sptr shiftedCan = clone->getProperty("OuputWorkspace");
+    MatrixWorkspace_sptr shiftedCan = clone->getProperty("OutputWorkspace");
 
     IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
     scaleX->initialize();
@@ -77,7 +77,7 @@ void AbsorptionCorrections::run() {
         AlgorithmManager::Instance().create("RebinToWorkspace");
     rebin->initialize();
     rebin->setProperty("WorkspaceToRebin", shiftedCan);
-    rebin->setProperty("WorkspaceToMatch", sampleWsName);
+    rebin->setProperty("WorkspaceToMatch", sampleWsName.toStdString());
     rebin->setProperty("OutputWorkspace", shiftedCanName);
     rebin->execute();
 

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -61,14 +61,32 @@ namespace CustomInterfaces
     // Can details
     bool useCan = m_uiForm.ckUseCan->isChecked();
     if (useCan) {
-      std::string canWsName = m_uiForm.dsCanInput->getCurrentDataName().toStdString();
-	  std::string shiftedCanName = canWsName + "_shifted";
+      std::string canWsName =
+          m_uiForm.dsCanInput->getCurrentDataName().toStdString();
+      std::string shiftedCanName = canWsName + "_shifted";
       IAlgorithm_sptr clone =
           AlgorithmManager::Instance().create("CloneWorkspace");
       clone->initialize();
-	  clone->setProperty("InputWorkspace", canWsName);
-	  clone->setProperty("OutputWorkspace", shiftedCanName);
-	  clone->execute();
+      clone->setProperty("InputWorkspace", canWsName);
+      clone->setProperty("OutputWorkspace", shiftedCanName);
+      clone->execute();
+
+      MatrixWorkspace_sptr shiftedCan = clone->getProperty("OuputWorkspace");
+
+      IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
+      scaleX->initialize();
+      scaleX->setProperty("InputWorkspace", shiftedCan);
+      scaleX->setProperty("OutputWorkspace", shiftedCanName);
+      scaleX->setProperty("Factor", m_uiForm.spCanShift->value());
+      scaleX->setProperty("Operation", "Add");
+      scaleX->execute();
+      IAlgorithm_sptr rebin =
+          AlgorithmManager::Instance().create("RebinToWorkspace");
+      rebin->initialize();
+      rebin->setProperty("WorkspaceToRebin", shiftedCan);
+      rebin->setProperty("WorkspaceToMatch", sampleWsName);
+      rebin->setProperty("OutputWorkspace", shiftedCanName);
+      rebin->execute();
 
       absCorAlgo->setProperty("CanWorkspace", shiftedCanName);
 

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -275,6 +275,17 @@ void AbsorptionCorrections::algorithmComplete(bool error) {
     emit showMessageBox(
         "Could not run absorption corrections.\nSee Results Log for details.");
   }
+  if (m_uiForm.ckShiftCan->isChecked()) {
+    IAlgorithm_sptr shiftLog =
+        AlgorithmManager::Instance().create("AddSampleLog");
+    shiftLog->initialize();
+    shiftLog->setProperty("Workspace", m_pythonExportWsName);
+    shiftLog->setProperty("LogName", "container_shift");
+    shiftLog->setProperty("logType", "Number");
+    shiftLog->setProperty("LogText", boost::lexical_cast<std::string>(
+                                         m_uiForm.spCanShift->value()));
+    shiftLog->execute();
+  }
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -7,294 +7,273 @@
 
 using namespace Mantid::API;
 
-namespace
-{
-  Mantid::Kernel::Logger g_log("AbsorptionCorrections");
+namespace {
+Mantid::Kernel::Logger g_log("AbsorptionCorrections");
 }
 
-namespace MantidQt
-{
-namespace CustomInterfaces
-{
-  AbsorptionCorrections::AbsorptionCorrections(QWidget * parent) :
-    CorrectionsTab(parent)
-  {
-    m_uiForm.setupUi(parent);
+namespace MantidQt {
+namespace CustomInterfaces {
+AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
+    : CorrectionsTab(parent) {
+  m_uiForm.setupUi(parent);
 
-    QRegExp regex("[A-Za-z0-9\\-\\(\\)]*");
-    QValidator *formulaValidator = new QRegExpValidator(regex, this);
-    m_uiForm.leSampleChemicalFormula->setValidator(formulaValidator);
-    m_uiForm.leCanChemicalFormula->setValidator(formulaValidator);
+  QRegExp regex("[A-Za-z0-9\\-\\(\\)]*");
+  QValidator *formulaValidator = new QRegExpValidator(regex, this);
+  m_uiForm.leSampleChemicalFormula->setValidator(formulaValidator);
+  m_uiForm.leCanChemicalFormula->setValidator(formulaValidator);
 
-    // Handle algorithm completion
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)),
-            this, SLOT(algorithmComplete(bool)));
+  // Handle algorithm completion
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+          SLOT(algorithmComplete(bool)));
+}
+
+void AbsorptionCorrections::setup() {}
+
+void AbsorptionCorrections::run() {
+  // Get correct corrections algorithm
+  QString sampleShape = m_uiForm.cbShape->currentText().replace(" ", "");
+  QString algorithmName = "Indirect" + sampleShape + "Absorption";
+
+  IAlgorithm_sptr absCorAlgo =
+      AlgorithmManager::Instance().create(algorithmName.toStdString());
+  absCorAlgo->initialize();
+
+  // Sample details
+  QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
+  absCorAlgo->setProperty("SampleWorkspace", sampleWsName.toStdString());
+
+  double sampleNumberDensity = m_uiForm.spSampleNumberDensity->value();
+  absCorAlgo->setProperty("SampleNumberDensity", sampleNumberDensity);
+
+  QString sampleChemicalFormula = m_uiForm.leSampleChemicalFormula->text();
+  absCorAlgo->setProperty("SampleChemicalFormula",
+                          sampleChemicalFormula.toStdString());
+
+  addShapeSpecificSampleOptions(absCorAlgo, sampleShape);
+
+  // Can details
+  bool useCan = m_uiForm.ckUseCan->isChecked();
+  if (useCan) {
+    std::string canWsName =
+        m_uiForm.dsCanInput->getCurrentDataName().toStdString();
+    std::string shiftedCanName = canWsName + "_shifted";
+    IAlgorithm_sptr clone =
+        AlgorithmManager::Instance().create("CloneWorkspace");
+    clone->initialize();
+    clone->setProperty("InputWorkspace", canWsName);
+    clone->setProperty("OutputWorkspace", shiftedCanName);
+    clone->execute();
+
+    MatrixWorkspace_sptr shiftedCan = clone->getProperty("OuputWorkspace");
+
+    IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
+    scaleX->initialize();
+    scaleX->setProperty("InputWorkspace", shiftedCan);
+    scaleX->setProperty("OutputWorkspace", shiftedCanName);
+    scaleX->setProperty("Factor", m_uiForm.spCanShift->value());
+    scaleX->setProperty("Operation", "Add");
+    scaleX->execute();
+    IAlgorithm_sptr rebin =
+        AlgorithmManager::Instance().create("RebinToWorkspace");
+    rebin->initialize();
+    rebin->setProperty("WorkspaceToRebin", shiftedCan);
+    rebin->setProperty("WorkspaceToMatch", sampleWsName);
+    rebin->setProperty("OutputWorkspace", shiftedCanName);
+    rebin->execute();
+
+    absCorAlgo->setProperty("CanWorkspace", shiftedCanName);
+
+    bool useCanCorrections = m_uiForm.ckUseCanCorrections->isChecked();
+    absCorAlgo->setProperty("UseCanCorrections", useCanCorrections);
+
+    if (useCanCorrections) {
+      double canNumberDensity = m_uiForm.spCanNumberDensity->value();
+      absCorAlgo->setProperty("CanNumberDensity", canNumberDensity);
+
+      QString canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
+      absCorAlgo->setProperty("CanChemicalFormula",
+                              canChemicalFormula.toStdString());
+    }
+
+    addShapeSpecificCanOptions(absCorAlgo, sampleShape);
   }
 
+  bool plot = m_uiForm.ckPlot->isChecked();
+  absCorAlgo->setProperty("Plot", plot);
 
-  void AbsorptionCorrections::setup()
-  {
+  // Generate workspace names
+  int nameCutIndex = sampleWsName.lastIndexOf("_");
+  if (nameCutIndex == -1)
+    nameCutIndex = sampleWsName.length();
+
+  QString outputBaseName = sampleWsName.left(nameCutIndex);
+
+  QString outputWsName = outputBaseName + "_" + sampleShape + "_Corrected";
+  absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
+
+  // Set the correction workspace to keep the factors if desired
+  bool keepCorrectionFactors = m_uiForm.ckKeepFactors->isChecked();
+  QString outputFactorsWsName = outputBaseName + "_" + sampleShape + "_Factors";
+  if (keepCorrectionFactors)
+    absCorAlgo->setProperty("CorrectionsWorkspace",
+                            outputFactorsWsName.toStdString());
+
+  // Add correction algorithm to batch
+  m_batchAlgoRunner->addAlgorithm(absCorAlgo);
+
+  // Add save algorithms if needed
+  bool save = m_uiForm.ckSave->isChecked();
+  if (save) {
+    addSaveWorkspace(outputWsName);
+    if (keepCorrectionFactors)
+      addSaveWorkspace(outputFactorsWsName);
   }
 
+  // Run algorithm batch
+  m_batchAlgoRunner->executeBatchAsync();
 
-  void AbsorptionCorrections::run()
-  {
-    // Get correct corrections algorithm
-    QString sampleShape = m_uiForm.cbShape->currentText().replace(" ", "");
-    QString algorithmName = "Indirect" + sampleShape + "Absorption";
+  // Set the result workspace for Python script export
+  m_pythonExportWsName = outputWsName.toStdString();
+}
 
-    IAlgorithm_sptr absCorAlgo = AlgorithmManager::Instance().create(algorithmName.toStdString());
-    absCorAlgo->initialize();
+/**
+ * Configures the SaveNexusProcessed algorithm to save a workspace in the
+ * default
+ * save directory and adds the algorithm to the batch queue.
+ *
+ * @param wsName Name of workspace to save
+ */
+void AbsorptionCorrections::addSaveWorkspace(QString wsName) {
+  QString filename = wsName + ".nxs";
 
-    // Sample details
-    QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
-    absCorAlgo->setProperty("SampleWorkspace", sampleWsName.toStdString());
+  // Setup the input workspace property
+  API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
+  saveProps["InputWorkspace"] = wsName.toStdString();
 
-    double sampleNumberDensity = m_uiForm.spSampleNumberDensity->value();
-    absCorAlgo->setProperty("SampleNumberDensity", sampleNumberDensity);
+  // Setup the algorithm
+  IAlgorithm_sptr saveAlgo =
+      AlgorithmManager::Instance().create("SaveNexusProcessed");
+  saveAlgo->initialize();
+  saveAlgo->setProperty("Filename", filename.toStdString());
 
-    QString sampleChemicalFormula = m_uiForm.leSampleChemicalFormula->text();
-    absCorAlgo->setProperty("SampleChemicalFormula", sampleChemicalFormula.toStdString());
+  // Add the save algorithm to the batch
+  m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+}
 
-    addShapeSpecificSampleOptions(absCorAlgo, sampleShape);
+/**
+ * Sets algorithm properties specific to the sample for a given shape.
+ *
+ * @param alg Algorithm to set properties of
+ * @param shape Sample shape
+ */
+void AbsorptionCorrections::addShapeSpecificSampleOptions(IAlgorithm_sptr alg,
+                                                          QString shape) {
+  if (shape == "FlatPlate") {
+    double sampleHeight = m_uiForm.spFlatSampleHeight->value();
+    alg->setProperty("SampleHeight", sampleHeight);
 
-    // Can details
-    bool useCan = m_uiForm.ckUseCan->isChecked();
-    if (useCan) {
-      std::string canWsName =
-          m_uiForm.dsCanInput->getCurrentDataName().toStdString();
-      std::string shiftedCanName = canWsName + "_shifted";
-      IAlgorithm_sptr clone =
-          AlgorithmManager::Instance().create("CloneWorkspace");
-      clone->initialize();
-      clone->setProperty("InputWorkspace", canWsName);
-      clone->setProperty("OutputWorkspace", shiftedCanName);
-      clone->execute();
+    double sampleWidth = m_uiForm.spFlatSampleWidth->value();
+    alg->setProperty("SampleWidth", sampleWidth);
 
-      MatrixWorkspace_sptr shiftedCan = clone->getProperty("OuputWorkspace");
+    double sampleThickness = m_uiForm.spFlatSampleThickness->value();
+    alg->setProperty("SampleThickness", sampleThickness);
 
-      IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
-      scaleX->initialize();
-      scaleX->setProperty("InputWorkspace", shiftedCan);
-      scaleX->setProperty("OutputWorkspace", shiftedCanName);
-      scaleX->setProperty("Factor", m_uiForm.spCanShift->value());
-      scaleX->setProperty("Operation", "Add");
-      scaleX->execute();
-      IAlgorithm_sptr rebin =
-          AlgorithmManager::Instance().create("RebinToWorkspace");
-      rebin->initialize();
-      rebin->setProperty("WorkspaceToRebin", shiftedCan);
-      rebin->setProperty("WorkspaceToMatch", sampleWsName);
-      rebin->setProperty("OutputWorkspace", shiftedCanName);
-      rebin->execute();
+    double elementSize = m_uiForm.spFlatElementSize->value();
+    alg->setProperty("ElementSize", elementSize);
+  } else if (shape == "Annulus") {
+    double sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
+    alg->setProperty("SampleInnerRadius", sampleInnerRadius);
 
-      absCorAlgo->setProperty("CanWorkspace", shiftedCanName);
+    double sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
+    alg->setProperty("SampleOuterRadius", sampleOuterRadius);
 
-      bool useCanCorrections = m_uiForm.ckUseCanCorrections->isChecked();
-      absCorAlgo->setProperty("UseCanCorrections", useCanCorrections);
+    double canInnerRadius = m_uiForm.spAnnCanInnerRadius->value();
+    alg->setProperty("CanInnerRadius", canInnerRadius);
 
-      if (useCanCorrections) {
-        double canNumberDensity = m_uiForm.spCanNumberDensity->value();
-        absCorAlgo->setProperty("CanNumberDensity", canNumberDensity);
+    double canOuterRadius = m_uiForm.spAnnCanOuterRadius->value();
+    alg->setProperty("CanOuterRadius", canOuterRadius);
 
-        QString canChemicalFormula = m_uiForm.leCanChemicalFormula->text();
-        absCorAlgo->setProperty("CanChemicalFormula", canChemicalFormula.toStdString());
-      }
+    long events = static_cast<long>(m_uiForm.spAnnEvents->value());
+    alg->setProperty("Events", events);
+  } else if (shape == "Cylinder") {
+    double sampleRadius = m_uiForm.spCylSampleRadius->value();
+    alg->setProperty("SampleRadius", sampleRadius);
 
-      addShapeSpecificCanOptions(absCorAlgo, sampleShape);
-    }
-
-    bool plot = m_uiForm.ckPlot->isChecked();
-    absCorAlgo->setProperty("Plot", plot);
-
-    // Generate workspace names
-    int nameCutIndex = sampleWsName.lastIndexOf("_");
-    if(nameCutIndex == -1)
-      nameCutIndex = sampleWsName.length();
-
-    QString outputBaseName = sampleWsName.left(nameCutIndex);
-
-    QString outputWsName = outputBaseName + "_" + sampleShape + "_Corrected";
-    absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
-
-    // Set the correction workspace to keep the factors if desired
-    bool keepCorrectionFactors = m_uiForm.ckKeepFactors->isChecked();
-    QString outputFactorsWsName = outputBaseName + "_" + sampleShape + "_Factors";
-    if(keepCorrectionFactors)
-      absCorAlgo->setProperty("CorrectionsWorkspace", outputFactorsWsName.toStdString());
-
-    // Add correction algorithm to batch
-    m_batchAlgoRunner->addAlgorithm(absCorAlgo);
-
-    // Add save algorithms if needed
-    bool save = m_uiForm.ckSave->isChecked();
-    if(save)
-    {
-      addSaveWorkspace(outputWsName);
-      if(keepCorrectionFactors)
-        addSaveWorkspace(outputFactorsWsName);
-    }
-
-    // Run algorithm batch
-    m_batchAlgoRunner->executeBatchAsync();
-
-    // Set the result workspace for Python script export
-    m_pythonExportWsName = outputWsName.toStdString();
+    long events = static_cast<long>(m_uiForm.spCylEvents->value());
+    alg->setProperty("Events", events);
   }
+}
 
+/**
+ * Sets algorithm properties specific to the can for a given shape.
+ *
+ * All options for Annulus are added in addShapeSpecificSampleOptions.
+ *
+ * @param alg Algorithm to set properties of
+ * @param shape Sample shape
+ */
+void AbsorptionCorrections::addShapeSpecificCanOptions(IAlgorithm_sptr alg,
+                                                       QString shape) {
+  if (shape == "FlatPlate") {
+    double canFrontThickness = m_uiForm.spFlatCanFrontThickness->value();
+    alg->setProperty("CanFrontThickness", canFrontThickness);
 
-  /**
-   * Configures the SaveNexusProcessed algorithm to save a workspace in the default
-   * save directory and adds the algorithm to the batch queue.
-   *
-   * @param wsName Name of workspace to save
-   */
-  void AbsorptionCorrections::addSaveWorkspace(QString wsName)
-  {
-    QString filename = wsName + ".nxs";
-
-    // Setup the input workspace property
-    API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
-    saveProps["InputWorkspace"] = wsName.toStdString();
-
-    // Setup the algorithm
-    IAlgorithm_sptr saveAlgo = AlgorithmManager::Instance().create("SaveNexusProcessed");
-    saveAlgo->initialize();
-    saveAlgo->setProperty("Filename", filename.toStdString());
-
-    // Add the save algorithm to the batch
-    m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+    double canBackThickness = m_uiForm.spFlatCanBackThickness->value();
+    alg->setProperty("CanBackThickness", canBackThickness);
+  } else if (shape == "Cylinder") {
+    double canRadius = m_uiForm.spCylCanRadius->value();
+    alg->setProperty("CanRadius", canRadius);
   }
+}
 
+bool AbsorptionCorrections::validate() {
+  UserInputValidator uiv;
 
-  /**
-   * Sets algorithm properties specific to the sample for a given shape.
-   *
-   * @param alg Algorithm to set properties of
-   * @param shape Sample shape
-   */
-  void AbsorptionCorrections::addShapeSpecificSampleOptions(IAlgorithm_sptr alg, QString shape)
-  {
-    if(shape == "FlatPlate")
-    {
-      double sampleHeight = m_uiForm.spFlatSampleHeight->value();
-      alg->setProperty("SampleHeight", sampleHeight);
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSampleInput);
 
-      double sampleWidth = m_uiForm.spFlatSampleWidth->value();
-      alg->setProperty("SampleWidth", sampleWidth);
+  if (uiv.checkFieldIsNotEmpty("Sample Chemical Formula",
+                               m_uiForm.leSampleChemicalFormula))
+    uiv.checkFieldIsValid("Sample Chamical Formula",
+                          m_uiForm.leSampleChemicalFormula);
 
-      double sampleThickness = m_uiForm.spFlatSampleThickness->value();
-      alg->setProperty("SampleThickness", sampleThickness);
+  bool useCan = m_uiForm.ckUseCan->isChecked();
+  if (useCan) {
+    uiv.checkDataSelectorIsValid("Container", m_uiForm.dsCanInput);
 
-      double elementSize = m_uiForm.spFlatElementSize->value();
-      alg->setProperty("ElementSize", elementSize);
-    }
-    else if(shape == "Annulus")
-    {
-      double sampleInnerRadius = m_uiForm.spAnnSampleInnerRadius->value();
-      alg->setProperty("SampleInnerRadius", sampleInnerRadius);
-
-      double sampleOuterRadius = m_uiForm.spAnnSampleOuterRadius->value();
-      alg->setProperty("SampleOuterRadius", sampleOuterRadius);
-
-      double canInnerRadius = m_uiForm.spAnnCanInnerRadius->value();
-      alg->setProperty("CanInnerRadius", canInnerRadius);
-
-      double canOuterRadius = m_uiForm.spAnnCanOuterRadius->value();
-      alg->setProperty("CanOuterRadius", canOuterRadius);
-
-      long events = static_cast<long>(m_uiForm.spAnnEvents->value());
-      alg->setProperty("Events", events);
-    }
-    else if(shape == "Cylinder")
-    {
-      double sampleRadius = m_uiForm.spCylSampleRadius->value();
-      alg->setProperty("SampleRadius", sampleRadius);
-
-      long events = static_cast<long>(m_uiForm.spCylEvents->value());
-      alg->setProperty("Events", events);
+    bool useCanCorrections = m_uiForm.ckUseCanCorrections->isChecked();
+    if (useCanCorrections) {
+      if (uiv.checkFieldIsNotEmpty("Container Chamical Formula",
+                                   m_uiForm.leCanChemicalFormula))
+        uiv.checkFieldIsValid("Container Chamical Formula",
+                              m_uiForm.leCanChemicalFormula);
     }
   }
 
-
-  /**
-   * Sets algorithm properties specific to the can for a given shape.
-   *
-   * All options for Annulus are added in addShapeSpecificSampleOptions.
-   *
-   * @param alg Algorithm to set properties of
-   * @param shape Sample shape
-   */
-  void AbsorptionCorrections::addShapeSpecificCanOptions(IAlgorithm_sptr alg, QString shape)
-  {
-    if(shape == "FlatPlate")
-    {
-      double canFrontThickness = m_uiForm.spFlatCanFrontThickness->value();
-      alg->setProperty("CanFrontThickness", canFrontThickness);
-
-      double canBackThickness = m_uiForm.spFlatCanBackThickness->value();
-      alg->setProperty("CanBackThickness", canBackThickness);
-    }
-    else if(shape == "Cylinder")
-    {
-      double canRadius = m_uiForm.spCylCanRadius->value();
-      alg->setProperty("CanRadius", canRadius);
-    }
+  // Give error for failed validation
+  if (!uiv.isAllInputValid()) {
+    QString error = uiv.generateErrorMessage();
+    showMessageBox(error);
   }
 
+  return uiv.isAllInputValid();
+}
 
-  bool AbsorptionCorrections::validate()
-  {
-    UserInputValidator uiv;
+void AbsorptionCorrections::loadSettings(const QSettings &settings) {
+  m_uiForm.dsSampleInput->readSettings(settings.group());
+  m_uiForm.dsCanInput->readSettings(settings.group());
+}
 
-    uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSampleInput);
-
-    if(uiv.checkFieldIsNotEmpty("Sample Chemical Formula", m_uiForm.leSampleChemicalFormula))
-      uiv.checkFieldIsValid("Sample Chamical Formula", m_uiForm.leSampleChemicalFormula);
-
-    bool useCan = m_uiForm.ckUseCan->isChecked();
-    if(useCan)
-    {
-      uiv.checkDataSelectorIsValid("Container", m_uiForm.dsCanInput);
-
-      bool useCanCorrections = m_uiForm.ckUseCanCorrections->isChecked();
-      if(useCanCorrections)
-      {
-        if(uiv.checkFieldIsNotEmpty("Container Chamical Formula", m_uiForm.leCanChemicalFormula))
-          uiv.checkFieldIsValid("Container Chamical Formula", m_uiForm.leCanChemicalFormula);
-      }
-    }
-
-    // Give error for failed validation
-    if(!uiv.isAllInputValid())
-    {
-      QString error = uiv.generateErrorMessage();
-      showMessageBox(error);
-    }
-
-    return uiv.isAllInputValid();
+/**
+ * Handle completion of the absorption correction algorithm.
+ *
+ * @param error True if algorithm has failed.
+ */
+void AbsorptionCorrections::algorithmComplete(bool error) {
+  if (error) {
+    emit showMessageBox(
+        "Could not run absorption corrections.\nSee Results Log for details.");
   }
-
-
-  void AbsorptionCorrections::loadSettings(const QSettings & settings)
-  {
-    m_uiForm.dsSampleInput->readSettings(settings.group());
-    m_uiForm.dsCanInput->readSettings(settings.group());
-  }
-
-
-  /**
-   * Handle completion of the absorption correction algorithm.
-   *
-   * @param error True if algorithm has failed.
-   */
-  void AbsorptionCorrections::algorithmComplete(bool error)
-  {
-    if(error)
-    {
-      emit showMessageBox("Could not run absorption corrections.\nSee Results Log for details.");
-    }
-  }
+}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -64,7 +64,9 @@ void AbsorptionCorrections::run() {
     clone->setProperty("OutputWorkspace", shiftedCanName);
     clone->execute();
 
-    MatrixWorkspace_sptr shiftedCan = clone->getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr shiftedCan =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            shiftedCanName);
 
     IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
     scaleX->initialize();
@@ -108,7 +110,7 @@ void AbsorptionCorrections::run() {
 
   QString outputBaseName = sampleWsName.left(nameCutIndex);
 
-  QString outputWsName = outputBaseName + "_" + sampleShape + "_Corrected";
+  QString outputWsName = outputBaseName + "_" + sampleShape + "_red";
   absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
 
   // Set the correction workspace to keep the factors if desired

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -67,22 +67,22 @@ void AbsorptionCorrections::run() {
     MatrixWorkspace_sptr shiftedCan =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             shiftedCanName);
-
-    IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
-    scaleX->initialize();
-    scaleX->setProperty("InputWorkspace", shiftedCan);
-    scaleX->setProperty("OutputWorkspace", shiftedCanName);
-    scaleX->setProperty("Factor", m_uiForm.spCanShift->value());
-    scaleX->setProperty("Operation", "Add");
-    scaleX->execute();
-    IAlgorithm_sptr rebin =
-        AlgorithmManager::Instance().create("RebinToWorkspace");
-    rebin->initialize();
-    rebin->setProperty("WorkspaceToRebin", shiftedCan);
-    rebin->setProperty("WorkspaceToMatch", sampleWsName.toStdString());
-    rebin->setProperty("OutputWorkspace", shiftedCanName);
-    rebin->execute();
-
+    if (m_uiForm.ckShiftCan->isChecked()) {
+      IAlgorithm_sptr scaleX = AlgorithmManager::Instance().create("ScaleX");
+      scaleX->initialize();
+      scaleX->setProperty("InputWorkspace", shiftedCan);
+      scaleX->setProperty("OutputWorkspace", shiftedCanName);
+      scaleX->setProperty("Factor", m_uiForm.spCanShift->value());
+      scaleX->setProperty("Operation", "Add");
+      scaleX->execute();
+      IAlgorithm_sptr rebin =
+          AlgorithmManager::Instance().create("RebinToWorkspace");
+      rebin->initialize();
+      rebin->setProperty("WorkspaceToRebin", shiftedCan);
+      rebin->setProperty("WorkspaceToMatch", sampleWsName.toStdString());
+      rebin->setProperty("OutputWorkspace", shiftedCanName);
+      rebin->execute();
+    }
     absCorAlgo->setProperty("CanWorkspace", shiftedCanName);
 
     bool useCanCorrections = m_uiForm.ckUseCanCorrections->isChecked();

--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -60,16 +60,22 @@ namespace CustomInterfaces
 
     // Can details
     bool useCan = m_uiForm.ckUseCan->isChecked();
-    if(useCan)
-    {
-      QString canWsName = m_uiForm.dsCanInput->getCurrentDataName();
-      absCorAlgo->setProperty("CanWorkspace", canWsName.toStdString());
+    if (useCan) {
+      std::string canWsName = m_uiForm.dsCanInput->getCurrentDataName().toStdString();
+	  std::string shiftedCanName = canWsName + "_shifted";
+      IAlgorithm_sptr clone =
+          AlgorithmManager::Instance().create("CloneWorkspace");
+      clone->initialize();
+	  clone->setProperty("InputWorkspace", canWsName);
+	  clone->setProperty("OutputWorkspace", shiftedCanName);
+	  clone->execute();
+
+      absCorAlgo->setProperty("CanWorkspace", shiftedCanName);
 
       bool useCanCorrections = m_uiForm.ckUseCanCorrections->isChecked();
       absCorAlgo->setProperty("UseCanCorrections", useCanCorrections);
 
-      if(useCanCorrections)
-      {
+      if (useCanCorrections) {
         double canNumberDensity = m_uiForm.spCanNumberDensity->value();
         absCorAlgo->setProperty("CanNumberDensity", canNumberDensity);
 


### PR DESCRIPTION
Fixes #14243 

Indirect Corrections Absorption interface should now have an option to add a shift to the container before running the absorption corrections.

**Files can be obtained from `\\olympic\Babylon5\Public\ElliotOram\Corrections\Absorption`**
# To Test
- Open Absorption (Interfaces > Indirect > Corrections > Absorption)
- Sample Input = `irs26176_graphite002_red.nxs`
- Check the `Use Container`option, Container = `irs26174_graphite002_red.nxs`
- Shape details:
  - Shape = `FlatPlate`
  - Set all the value to 0.1
- Sample details:
  - NumberDensity = 0.1
  - Chemical Formula = `H2-O`
- Container details;
  - Check the `Use Container`, `Scale` and `Shift x-values of container by adding` options
  - Scale = 1.0
  - Shift = 0.3
  - NumberDensity = 0.1
  - Chemical Formula = `V`
- Click `Run`
- Ensure a workspace is created called `irs26176_graphite002_FlatPlate_red`
- Rename this workspace and then Run the algorithm again through the interface with the same input parameters expect uncheck the Shift option.
- Ensure you now have the renamed workspace and a workspace called `irs26176_graphite002_FlatPlate_red` in the ADS
- Plot these two workspaces together for one of the spectra you should see something like the following:
  ![image](https://cloud.githubusercontent.com/assets/13132128/11363552/6ccfced4-9292-11e5-93fe-10a738f1ddfb.png)
- Look that the sample logs for the renamed workspace and ensure that the following values are present and correct:
  - `container_shift`
  - `container_scale`
  - `container_filename`
  - _There are other `container_` values these have not been changed so should be correct_
