### PR TITLE
Fix slow delete of large workspaces on Windows (again)

### DIFF
--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -63,8 +63,8 @@ Workspace2D::~Workspace2D() {
  * @param XLength :: The number of X data points/bin boundaries in each vector
  * (must all be the same)
  *
- * @param YLength :: The number of data/error points in each vector (must all be
- * the same)
+ * @param YLength :: The number of data/error points in each vector
+ * (must all be the same)
 */
 void Workspace2D::init(const std::size_t &NVectors, const std::size_t &XLength,
                        const std::size_t &YLength) {

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -34,8 +34,22 @@ Workspace2D::Workspace2D(const Workspace2D &other)
 
 /// Destructor
 Workspace2D::~Workspace2D() {
-  // Clear out the memory
-  for (size_t i = 0; i < m_noVectors; i++) {
+// On MSVC when you allocate memory in a multithreaded loop, like our cow_ptrs
+// will do, the
+// deallocation time increases by a huge amount if the memory is just
+// naively deallocated in a serial order. This is because when it was
+// allocated in the omp loop then the actual memory ends up being
+// interleaved and then trying to deallocate this serially leads to
+// lots of swapping in and out of memory. See
+// http://social.msdn.microsoft.com/Forums/en-US/2fe4cfc7-ca5c-4665-8026-42e0ba634214/visual-studio-$
+
+#ifdef _MSC_VER
+  PARALLEL_FOR1(this)
+  for (int64_t i = 0; i < static_cast<int64_t>(m_noVectors); i++) {
+#else
+  for (size_t i = 0; i < m_noVectors; ++i) {
+#endif
+    // Clear out the memory
     delete data[i];
   }
 }


### PR DESCRIPTION
To test use:

```
whitebeamfile="MER06398"
LoadRaw(Filename=whitebeamfile,OutputWorkspace="wb_wksp",LoadLogFiles="0")
white_ws = ConvertUnits(InputWorkspace="wb_wksp",OutputWorkspace="wb_wksp", Target= "Energy", AlignBins=0)
```

The data file is in the system test data. Before the fix the delete should be very slow but quite speedy afterwards.

No release note changes required. This is a regression from disabling tcmalloc when moving to VS2015
