### PR TITLE
Changing when tcmalloc reports large memory allocation.

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidplot.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.sh.in
@@ -20,7 +20,22 @@ else
     TCM_RELEASE=${TCMALLOC_RELEASE_RATE}
 fi
 
+# Define when to report large memory allocation
+if [ -z "${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}" ]; then
+    # total available memory
+    TCM_REPORT=$(grep MemTotal /proc/meminfo --color=never | awk '{print $2}')
+    # half of available memory
+    TCM_REPORT=$(echo "1024*${TCM_REPORT}/2" | bc)
+    # minimum is 1GB
+    if [[ ${TCM_REPORT} < 1073741824 ]]; then
+        TCM_REPORT=1073741824
+    fi
+else
+    TCM_REPORT=${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}
+fi
+
 # Launch
 LD_PRELOAD=${LOCAL_PRELOAD} TCMALLOC_RELEASE_RATE=${TCM_RELEASE} \
+    TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=${TCM_REPORT} \
     LD_LIBRARY_PATH=${LOCAL_LDPATH} QT_API=pyqt \
     @WRAPPER_PREFIX@$INSTALLDIR/@MANTIDPLOT_EXEC@ $*@WRAPPER_POSTFIX@

--- a/buildconfig/CMake/Packaging/mantidpython.in
+++ b/buildconfig/CMake/Packaging/mantidpython.in
@@ -21,6 +21,20 @@ else
     TCM_RELEASE=${TCMALLOC_RELEASE_RATE}
 fi
 
+# Define when to report large memory allocation
+if [ -z "${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}" ]; then
+    # total available memory
+    TCM_REPORT=$(grep MemTotal /proc/meminfo --color=never | awk '{print $2}')
+    # half of available memory
+    TCM_REPORT=$(echo "1024*${TCM_REPORT}/2" | bc)
+    # minimum is 1GB
+    if [[ ${TCM_REPORT} < 1073741824 ]]; then
+        TCM_REPORT=1073741824
+    fi
+else
+    TCM_REPORT=${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}
+fi
+
 # Define paraview information
 PV_PLUGIN_PATH="${INSTALLDIR}/pvplugins/pvplugins"
 
@@ -37,6 +51,7 @@ fi
 
 # Launch ipython or python
 LD_PRELOAD=${LOCAL_PRELOAD} TCMALLOC_RELEASE_RATE=${TCM_RELEASE} \
+    TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=${TCM_REPORT} \
     LD_LIBRARY_PATH=${LOCAL_LDPATH} QT_API=pyqt \
     PV_PLUGIN_PATH=${PV_PLUGIN_PATH} \
     PYTHONPATH=${LOCAL_PYTHONPATH} \


### PR DESCRIPTION
**To test:** Try to both `launch_mantidplot.sh` and `mantidpython`. The only noticeable difference is that you will no longer see warnings for large memory allocations.

This does not need to be in the release notes.
