### PR TITLE
Engg::Enabled Multi-Run Focusing for Focus Tab with Two Different Focusing Modes

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
@@ -47,12 +47,12 @@ public:
 
   /// for focusing
   EnggDiffWorker(EnggDiffractionPresenter *pres, const std::string &outDir,
-                 const std::vector<std::string> &outFilenames,
-                 const std::string &runNo, const std::vector<bool> &banks,
-                 const std::string &specIDs, const std::string &dgFile)
-      : m_pres(pres), m_outFilenames(outFilenames), m_outCalibFilename(),
-        m_runNo(runNo), m_outDir(outDir), m_banks(banks), m_specIDs(specIDs),
-        m_dgFile(dgFile), m_bin(.0), m_nperiods(0) {}
+                 const std::vector<std::string> &runNo,
+                 const std::vector<bool> &banks, const std::string &specIDs,
+                 const std::string &dgFile)
+      : m_pres(pres), m_outCalibFilename(), m_multiRunNo(runNo),
+        m_outDir(outDir), m_banks(banks), m_specIDs(specIDs), m_dgFile(dgFile),
+        m_bin(.0), m_nperiods(0) {}
 
   // for rebinning (ToF)
   EnggDiffWorker(EnggDiffractionPresenter *pres, const std::string &runNo,
@@ -82,8 +82,12 @@ private slots:
    * signal.
    */
   void focus() {
-    m_pres->doFocusRun(m_outDir, m_outFilenames, m_runNo, m_banks, m_specIDs,
-                       m_dgFile);
+
+    for (size_t i = 0; i < m_multiRunNo.size(); ++i) {
+
+      auto runNo = m_multiRunNo[i];
+      m_pres->doFocusRun(m_outDir, runNo, m_banks, m_specIDs, m_dgFile);
+    }
     emit finished();
   }
 
@@ -108,6 +112,9 @@ private:
   const std::string m_outCalibFilename, m_vanNo, m_ceriaNo;
   /// sample run to process
   const std::string m_runNo;
+
+  const std::vector<std::string> m_multiRunNo;
+
   /// Output directory
   const std::string m_outDir;
   /// instrument banks: do focus/don't

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresWorker.h
@@ -112,7 +112,7 @@ private:
   const std::string m_outCalibFilename, m_vanNo, m_ceriaNo;
   /// sample run to process
   const std::string m_runNo;
-
+  // sample multi-run to process
   const std::vector<std::string> m_multiRunNo;
 
   /// Output directory

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -67,13 +67,16 @@ public:
                         const std::string &vanNo, const std::string &ceriaNo);
 
   /// the focusing hard work that a worker / thread will run
-  void doFocusRun(const std::string &dir,
-                  const std::vector<std::string> &outFilenames,
-                  const std::string &runNo, const std::vector<bool> &banks,
-                  const std::string &specNos, const std::string &dgFile);
+  void doFocusRun(const std::string &dir, const std::string &runNo,
+                  const std::vector<bool> &banks, const std::string &specNos,
+                  const std::string &dgFile);
 
-  /// checks if its a valid run number
+  /// checks if its a valid run number returns string
   std::string isValidRunNumber(std::vector<std::string> dir);
+
+  /// checks if its a valid run number inside vector and returns a vector;
+  /// used for mutli-run focusing
+  std::vector<std::string> isValidMultiRunNumber(std::vector<std::string> dir);
 
   /// pre-processing re-binning with Rebin, for a worker/thread
   void doRebinningTime(const std::string &runNo, double bin,
@@ -137,15 +140,16 @@ private:
   /// @name Focusing related private methods
   //@{
   /// this may also need to be mocked up in tests
-  void startFocusing(const std::string &runNo, const std::vector<bool> &banks,
+  void startFocusing(const std::vector<std::string> &runNo,
+                     const std::vector<bool> &banks,
                      const std::string &specNos = "",
                      const std::string &dgFile = "");
 
-  virtual void startAsyncFocusWorker(
-	  const std::string &dir, const std::vector<std::string> &outFilenames,
-	  const std::string &runNo, const std::vector<bool> &banks,
-	  const std::string &specNos, const std::string &dgFile);
-
+  virtual void startAsyncFocusWorker(const std::string &dir,
+                                     const std::vector<std::string> &runNo,
+                                     const std::vector<bool> &banks,
+                                     const std::string &specNos,
+                                     const std::string &dgFile);
 
   void inputChecksBeforeFocusBasic(const std::string &runNo,
                                    const std::vector<bool> &banks);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -140,24 +140,26 @@ private:
   /// @name Focusing related private methods
   //@{
   /// this may also need to be mocked up in tests
-  void startFocusing(const std::vector<std::string> &runNo,
+  void startFocusing(const std::vector<std::string> &multi_runNo,
                      const std::vector<bool> &banks,
                      const std::string &specNos = "",
                      const std::string &dgFile = "");
 
-  virtual void startAsyncFocusWorker(const std::string &dir,
-                                     const std::vector<std::string> &runNo,
-                                     const std::vector<bool> &banks,
-                                     const std::string &specNos,
-                                     const std::string &dgFile);
+  virtual void
+  startAsyncFocusWorker(const std::string &dir,
+                        const std::vector<std::string> &multi_RunNo,
+                        const std::vector<bool> &banks,
+                        const std::string &specNos, const std::string &dgFile);
 
   void inputChecksBeforeFocusBasic(const std::vector<std::string> &multi_RunNo,
                                    const std::vector<bool> &banks);
-  void inputChecksBeforeFocusCropped(const std::vector<std::string> &multi_RunNo,
-                                     const std::vector<bool> &banks,
-                                     const std::string &specNos);
-  void inputChecksBeforeFocusTexture(const std::vector<std::string> &multi_RunNo,
-                                     const std::string &dgfile);
+  void
+  inputChecksBeforeFocusCropped(const std::vector<std::string> &multi_RunNo,
+                                const std::vector<bool> &banks,
+                                const std::string &specNos);
+  void
+  inputChecksBeforeFocusTexture(const std::vector<std::string> &multi_RunNo,
+                                const std::string &dgfile);
   void inputChecksBeforeFocus();
   void inputChecksBanks(const std::vector<bool> &banks);
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -151,12 +151,12 @@ private:
                                      const std::string &specNos,
                                      const std::string &dgFile);
 
-  void inputChecksBeforeFocusBasic(const std::string &runNo,
+  void inputChecksBeforeFocusBasic(const std::vector<std::string> &multi_RunNo,
                                    const std::vector<bool> &banks);
-  void inputChecksBeforeFocusCropped(const std::string &runNo,
+  void inputChecksBeforeFocusCropped(const std::vector<std::string> &multi_RunNo,
                                      const std::vector<bool> &banks,
                                      const std::string &specNos);
-  void inputChecksBeforeFocusTexture(const std::string &runNo,
+  void inputChecksBeforeFocusTexture(const std::vector<std::string> &multi_RunNo,
                                      const std::string &dgfile);
   void inputChecksBeforeFocus();
   void inputChecksBanks(const std::vector<bool> &banks);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>614</width>
-    <height>551</height>
+    <width>616</width>
+    <height>630</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,76 +20,71 @@
       <string>Focus run</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <item row="1" column="1" rowspan="2">
+       <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QLabel" name="label_banks_sel">
-              <property name="text">
-               <string>Banks:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>298</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>18</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
+         <widget class="QCheckBox" name="checkBox_focus_bank1">
+          <property name="text">
+           <string>1</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
         </item>
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
-          <item>
-           <widget class="QCheckBox" name="checkBox_focus_bank1">
-            <property name="text">
-             <string>1</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="checkBox_focus_bank2">
-            <property name="text">
-             <string>2</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QCheckBox" name="checkBox_focus_bank2">
+          <property name="text">
+           <string>2</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="label_banks_sel">
+          <property name="text">
+           <string>Banks:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>298</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>
       <item row="2" column="0">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Maximum</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>18</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <spacer name="horizontalSpacer_3">
@@ -113,7 +108,7 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="0">
+      <item row="0" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label_run_num">
@@ -372,10 +367,13 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>28</height>
       </size>
      </property>
     </spacer>
@@ -391,7 +389,7 @@
      <property name="title">
       <string>Output</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_6">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_20">
         <item>
@@ -507,6 +505,80 @@
            </size>
           </property>
          </spacer>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <spacer name="horizontalSpacer_22">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>58</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QLabel" name="mutli_run_lbl">
+          <property name="text">
+           <string>Mutiple Runs Focus Mode:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="comboBox_Multi_Runs">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>210</width>
+            <height>10</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>175</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="sizeIncrement">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::LeftToRight</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>Focus Individual Run Files Seperately</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Focus Sum Of Files</string>
+           </property>
+          </item>
+         </widget>
         </item>
        </layout>
       </item>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -550,7 +550,7 @@
           <property name="maximumSize">
            <size>
             <width>175</width>
-            <height>16777215</height>
+            <height>20</height>
            </size>
           </property>
           <property name="sizeIncrement">

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -140,6 +140,8 @@ public:
 
   int currentPlotType() const { return m_currentType; }
 
+  int currentMultiRunMode() const { return m_currentRunMode; }
+
 private slots:
   /// for buttons, do calibrate, focus, event->histo rebin, and similar
   void loadCalibrationClicked();
@@ -170,6 +172,9 @@ private slots:
 
   // slots of the focus part of the interface
   void plotRepChanged(int idx);
+
+  // slot of the multi-run mode for focus
+  void multiRunModeChanged(int idx);
 
   // slots of plot spectrum check box status
   void plotFocusStatus();
@@ -214,7 +219,7 @@ private:
 
   /// converts QList to a vector
   std::vector<std::string> qListToVector(QStringList list,
-	  bool validator) const;
+                                         bool validator) const;
 
   /// instrument selected (ENGIN-X, etc.)
   std::string m_currentInst;
@@ -227,6 +232,9 @@ private:
 
   // plot data representation type selected
   int static m_currentType;
+
+  // multi-run focus mode type selected
+  int static m_currentRunMode;
 
   /// current calibration produced in the 'Calibration' tab
   std::string m_currentCalibFilename;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/IEnggDiffractionView.h
@@ -125,6 +125,13 @@ public:
   virtual int currentPlotType() const = 0;
 
   /**
+  * Selected multi-run focus mode
+  *
+  * @return return integer to the presenter
+  */
+  virtual int currentMultiRunMode() const = 0;
+
+  /**
    * The Vanadium run number used in the current calibration
    *
    * @return Vanadium run number, as a string

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -185,20 +185,20 @@ void EnggDiffractionPresenter::processFocusBasic() {
 
   int focusMode = m_view->currentMultiRunMode();
 
-  if (focusMode == 0) {
-	  g_log.debug() << " focus mode selected Individual Run Files Separately " << std::endl;
-	  try {
-		  inputChecksBeforeFocusBasic(multi_RunNo, banks);
-	  }
-	  catch (std::invalid_argument &ia) {
-		  m_view->userWarning("Error in the inputs required to focus a run",
-			  ia.what());
-		  return;
-	  }
-	  startFocusing(multi_RunNo, banks, "", "");
+  try {
+    inputChecksBeforeFocusBasic(multi_RunNo, banks);
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning("Error in the inputs required to focus a run",
+                        ia.what());
+    return;
   }
-  else if (focusMode == 1) {
-	  g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
+
+  if (focusMode == 0) {
+    g_log.debug() << " focus mode selected Individual Run Files Separately "
+                  << std::endl;
+    startFocusing(multi_RunNo, banks, "", "");
+  } else if (focusMode == 1) {
+    g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
   }
 }
 
@@ -210,21 +210,20 @@ void EnggDiffractionPresenter::processFocusCropped() {
 
   int focusMode = m_view->currentMultiRunMode();
 
-  if (focusMode == 0) {
-	  g_log.debug() << " focus mode selected Individual Run Files Separately " << std::endl;
-	  try {
-		  inputChecksBeforeFocusCropped(multi_RunNo, banks, specNos);
-	  }
-	  catch (std::invalid_argument &ia) {
-		  m_view->userWarning(
-			  "Error in the inputs required to focus a run (in cropped mode)",
-			  ia.what());
-		  return;
-	  }
-	  startFocusing(multi_RunNo, banks, specNos, "");
+  try {
+    inputChecksBeforeFocusCropped(multi_RunNo, banks, specNos);
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning(
+        "Error in the inputs required to focus a run (in cropped mode)",
+        ia.what());
+    return;
   }
-  else if (focusMode == 1) {
-		  g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
+  if (focusMode == 0) {
+    g_log.debug() << " focus mode selected Individual Run Files Separately "
+                  << std::endl;
+    startFocusing(multi_RunNo, banks, specNos, "");
+  } else if (focusMode == 1) {
+    g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
   }
 }
 
@@ -235,21 +234,20 @@ void EnggDiffractionPresenter::processFocusTexture() {
 
   int focusMode = m_view->currentMultiRunMode();
 
-  if (focusMode == 0) {
-	  g_log.debug() << " focus mode selected Individual Run Files Separately " << std::endl;
-	  try {
-		  inputChecksBeforeFocusTexture(multi_RunNo, dgFile);
-	  }
-	  catch (std::invalid_argument &ia) {
-		  m_view->userWarning(
-			  "Error in the inputs required to focus a run (in texture mode)",
-			  ia.what());
-		  return;
-	  }
-	  startFocusing(multi_RunNo, std::vector<bool>(), "", dgFile);
+  try {
+    inputChecksBeforeFocusTexture(multi_RunNo, dgFile);
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning(
+        "Error in the inputs required to focus a run (in texture mode)",
+        ia.what());
+    return;
   }
-  else if (focusMode == 1) {
-	  g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
+  if (focusMode == 0) {
+    g_log.debug() << " focus mode selected Individual Run Files Separately "
+                  << std::endl;
+    startFocusing(multi_RunNo, std::vector<bool>(), "", dgFile);
+  } else if (focusMode == 1) {
+    g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
   }
 }
 
@@ -868,7 +866,7 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
  * inputChecksBeforeFocus() which is called from this method). Use
  * always before running 'Focus'
  *
- * @param runNo run number to focus
+ * @param multi_RunNo vector of run number to focus
  * @param banks which banks to consider in the focusing
  *
  * @throws std::invalid_argument with an informative message.
@@ -892,7 +890,7 @@ void EnggDiffractionPresenter::inputChecksBeforeFocusBasic(
  * inputChecksBeforeFocus() which is called from this method). Use
  * always before running 'FocusCropped'
  *
- * @param runNo run number to focus
+ * @param multi_RunNo vector of run number to focus
  * @param banks which banks to consider in the focusing
  * @param specNos list of spectra (as usual csv list of spectra in Mantid)
  *
@@ -922,7 +920,7 @@ void EnggDiffractionPresenter::inputChecksBeforeFocusCropped(
  * inputChecksBeforeFocus() which is called from this method). Use
  * always before running 'FocusCropped'
  *
- * @param runNo run number to focus
+ * @param multi_RunNo vector of run number to focus
  * @param dgFile file with detector grouping info
  *
  * @throws std::invalid_argument with an informative message.
@@ -1033,21 +1031,20 @@ std::vector<std::string> EnggDiffractionPresenter::outputFocusTextureFilenames(
  * Q_OBJECT.
  *
  * @param dir directory (full path) for the focused output files
- * @param outFilenames full names for the output focused runs
- * @param runNo input run number
+ * @param multi_RunNo input vector of run number
  * @param banks instrument bank to focus
  * @param specNos list of spectra (as usual csv list of spectra in Mantid)
  * @param dgFile detector grouping file name
  */
 void EnggDiffractionPresenter::startAsyncFocusWorker(
-    const std::string &dir, const std::vector<std::string> &runNo,
+    const std::string &dir, const std::vector<std::string> &multi_RunNo,
     const std::vector<bool> &banks, const std::string &specNos,
     const std::string &dgFile) {
 
   delete m_workerThread;
   m_workerThread = new QThread(this);
   EnggDiffWorker *worker =
-      new EnggDiffWorker(this, dir, runNo, banks, specNos, dgFile);
+      new EnggDiffWorker(this, dir, multi_RunNo, banks, specNos, dgFile);
   worker->moveToThread(m_workerThread);
   connect(m_workerThread, SIGNAL(started()), worker, SLOT(focus()));
   connect(worker, SIGNAL(finished()), this, SLOT(focusingFinished()));
@@ -1064,7 +1061,6 @@ void EnggDiffractionPresenter::startAsyncFocusWorker(
  * push or similar from the user.
  *
  * @param dir directory (full path) for the output focused files
- * @param outFilenames names for the output focused files (one per bank)
  * @param runNo input run number
  *
  * @param specNos list of spectra to use when focusing. Not empty

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -257,7 +257,7 @@ void EnggDiffractionPresenter::processFocusTexture() {
  * respective specific processFocus methods (for normal, cropped,
  * texture, etc. focusing).
  *
- * @param runNo run/file number to focus
+ * @param multi_RunNo vector of run/file number to focus
  * @param banks banks to include in the focusing, processed one at a time
  *
  * @param specNos list of spectra to use when focusing. If not empty
@@ -267,7 +267,7 @@ void EnggDiffractionPresenter::processFocusTexture() {
  * not empty, this implies focusing in texture mode.
  */
 void EnggDiffractionPresenter::startFocusing(
-    const std::vector<std::string> &runNo, const std::vector<bool> &banks,
+    const std::vector<std::string> &multi_RunNo, const std::vector<bool> &banks,
     const std::string &specNos, const std::string &dgFile) {
 
   std::string optMsg = "";
@@ -286,7 +286,7 @@ void EnggDiffractionPresenter::startFocusing(
   // doFocusRun(focusDir, outFilenames, runNo, banks, specNos, dgFile)
   // focusingFinished()
 
-  startAsyncFocusWorker(focusDir, runNo, banks, specNos, dgFile);
+  startAsyncFocusWorker(focusDir, multi_RunNo, banks, specNos, dgFile);
 }
 
 void EnggDiffractionPresenter::processResetFocus() { m_view->resetFocus(); }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -63,7 +63,8 @@ void EnggDiffractionPresenter::cleanup() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A calibration process is currently running, shutting "
-                        "it down immediately..." << std::endl;
+                        "it down immediately..."
+                     << std::endl;
       m_workerThread->wait(10);
     }
     delete m_workerThread;
@@ -164,7 +165,8 @@ void EnggDiffractionPresenter::processCalcCalib() {
     return;
   }
   g_log.notice() << "EnggDiffraction GUI: starting new calibration. This may "
-                    "take a few seconds... " << std::endl;
+                    "take a few seconds... "
+                 << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -176,51 +178,66 @@ void EnggDiffractionPresenter::processCalcCalib() {
 }
 
 void EnggDiffractionPresenter::processFocusBasic() {
-  const std::string runNo = isValidRunNumber(m_view->focusingRunNo());
+  const std::vector<std::string> multi_RunNo =
+      isValidMultiRunNumber(m_view->focusingRunNo());
   const std::vector<bool> banks = m_view->focusingBanks();
 
-  try {
-    inputChecksBeforeFocusBasic(runNo, banks);
-  } catch (std::invalid_argument &ia) {
-    m_view->userWarning("Error in the inputs required to focus a run",
-                        ia.what());
-    return;
-  }
+  std::string runNo;
 
-  startFocusing(runNo, banks, "", "");
+  for (int i = 0; i < multi_RunNo.size(); ++i) {
+    runNo = multi_RunNo[i];
+    try {
+      inputChecksBeforeFocusBasic(runNo, banks);
+    } catch (std::invalid_argument &ia) {
+      m_view->userWarning("Error in the inputs required to focus a run",
+                          ia.what());
+      return;
+    }
+  }
+  startFocusing(multi_RunNo, banks, "", "");
 }
 
 void EnggDiffractionPresenter::processFocusCropped() {
-  const std::string runNo = isValidRunNumber(m_view->focusingCroppedRunNo());
+  const std::vector<std::string> multi_RunNo =
+      isValidMultiRunNumber(m_view->focusingRunNo());
   const std::vector<bool> banks = m_view->focusingBanks();
   const std::string specNos = m_view->focusingCroppedSpectrumIDs();
 
-  try {
-    inputChecksBeforeFocusCropped(runNo, banks, specNos);
-  } catch (std::invalid_argument &ia) {
-    m_view->userWarning(
-        "Error in the inputs required to focus a run (in cropped mode)",
-        ia.what());
-    return;
+  std::string runNo;
+  for (int i = 0; i < multi_RunNo.size(); ++i) {
+    runNo = multi_RunNo[i];
+    try {
+      inputChecksBeforeFocusCropped(runNo, banks, specNos);
+    } catch (std::invalid_argument &ia) {
+      m_view->userWarning(
+          "Error in the inputs required to focus a run (in cropped mode)",
+          ia.what());
+      return;
+    }
   }
 
-  startFocusing(runNo, banks, specNos, "");
+  startFocusing(multi_RunNo, banks, specNos, "");
 }
 
 void EnggDiffractionPresenter::processFocusTexture() {
-  const std::string runNo = isValidRunNumber(m_view->focusingTextureRunNo());
+  const std::vector<std::string> multi_RunNo =
+      isValidMultiRunNumber(m_view->focusingRunNo());
   const std::string dgFile = m_view->focusingTextureGroupingFile();
 
-  try {
-    inputChecksBeforeFocusTexture(runNo, dgFile);
-  } catch (std::invalid_argument &ia) {
-    m_view->userWarning(
-        "Error in the inputs required to focus a run (in texture mode)",
-        ia.what());
-    return;
+  std::string runNo;
+  for (int i = 0; i < multi_RunNo.size(); ++i) {
+    runNo = multi_RunNo[i];
+    try {
+      inputChecksBeforeFocusTexture(runNo, dgFile);
+    } catch (std::invalid_argument &ia) {
+      m_view->userWarning(
+          "Error in the inputs required to focus a run (in texture mode)",
+          ia.what());
+      return;
+    }
   }
 
-  startFocusing(runNo, std::vector<bool>(), "", dgFile);
+  startFocusing(multi_RunNo, std::vector<bool>(), "", dgFile);
 }
 
 /**
@@ -238,10 +255,9 @@ void EnggDiffractionPresenter::processFocusTexture() {
  * @param dgFile detector grouping file to define banks (texture). If
  * not empty, this implies focusing in texture mode.
  */
-void EnggDiffractionPresenter::startFocusing(const std::string &runNo,
-                                             const std::vector<bool> &banks,
-                                             const std::string &specNos,
-                                             const std::string &dgFile) {
+void EnggDiffractionPresenter::startFocusing(
+    const std::vector<std::string> &runNo, const std::vector<bool> &banks,
+    const std::string &specNos, const std::string &dgFile) {
 
   std::string optMsg = "";
   if (!specNos.empty()) {
@@ -253,14 +269,13 @@ void EnggDiffractionPresenter::startFocusing(const std::string &runNo,
                  << ". This may take some seconds... " << std::endl;
 
   const std::string focusDir = m_view->focusingDir();
-  const std::vector<std::string> outFilenames =
-      outputFocusFilenames(runNo, banks);
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
   // doFocusRun(focusDir, outFilenames, runNo, banks, specNos, dgFile)
   // focusingFinished()
-  startAsyncFocusWorker(focusDir, outFilenames, runNo, banks, specNos, dgFile);
+
+  startAsyncFocusWorker(focusDir, runNo, banks, specNos, dgFile);
 }
 
 void EnggDiffractionPresenter::processResetFocus() { m_view->resetFocus(); }
@@ -281,7 +296,8 @@ void EnggDiffractionPresenter::processRebinTime() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) with a TOF bin into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... " << std::endl;
+                                    "may take some seconds... "
+                 << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -307,7 +323,8 @@ void EnggDiffractionPresenter::processRebinMultiperiod() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) by pulse times into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... " << std::endl;
+                                    "may take some seconds... "
+                 << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -404,6 +421,65 @@ EnggDiffractionPresenter::isValidRunNumber(std::vector<std::string> dir) {
   g_log.debug() << "run number is: " << run_number << std::endl;
 
   return run_number;
+}
+
+/**
+* Checks if the provided run number is valid and if a direcotory is provided
+*
+* @param dir takes the input/directory of the user
+*
+* @return vector of string multi_run_number, 6 character string of a run number
+*/
+std::vector<std::string>
+EnggDiffractionPresenter::isValidMultiRunNumber(std::vector<std::string> dir) {
+
+  std::vector<std::string> run_vec = dir;
+  std::string run_number;
+  std::vector<std::string> multi_run_number;
+
+  // if empty string
+  size_t i = 0;
+  if (!dir.empty() && dir.at(i) != "") {
+
+    auto p = run_vec.begin();
+    int i = 0;
+    while (p != run_vec.end()) {
+      run_number = *p;
+      p++;
+      i++;
+
+      try {
+        if (Poco::File(run_number).exists()) {
+          Poco::Path inputDir = run_number;
+          run_number = "";
+          // get file name name via poco::path
+
+          std::string filename = inputDir.getFileName();
+
+          // convert to int or assign it to size_t
+          for (size_t i = 0; i < filename.size(); i++) {
+            char *str = &filename[i];
+            if (std::isdigit(*str)) {
+              run_number += filename[i];
+            }
+          }
+          run_number.erase(0, run_number.find_first_not_of('0'));
+        }
+      } catch (std::runtime_error &re) {
+        throw std::invalid_argument("Error browsing selected file: " +
+                                    static_cast<std::string>(re.what()));
+      } catch (...) {
+        throw std::invalid_argument("Error browsing selected file: ");
+      }
+
+      multi_run_number.push_back(run_number);
+    }
+  }
+
+  g_log.debug() << "run number selected for multi-run: " << run_number
+                << std::endl;
+
+  return multi_run_number;
 }
 
 /**
@@ -605,11 +681,13 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   } catch (std::runtime_error &) {
     g_log.error() << "The calibration calculations failed. One of the "
                      "algorithms did not execute correctly. See log messages "
-                     "for details. " << std::endl;
+                     "for details. "
+                  << std::endl;
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
-           "were not valid. See log messages for details. " << std::endl;
+           "were not valid. See log messages for details. "
+        << std::endl;
   }
   // restore normal data search paths
   conf.setDataSearchDirs(tmpDirs);
@@ -906,13 +984,11 @@ std::vector<std::string>
 EnggDiffractionPresenter::outputFocusFilenames(const std::string &runNo,
                                                const std::vector<bool> &banks) {
   const std::string instStr = m_view->currentInstrument();
-
   std::vector<std::string> res;
   for (size_t b = 1; b <= banks.size(); b++) {
     res.push_back(instStr + "_" + runNo + "_focused_bank_" +
                   boost::lexical_cast<std::string>(b) + ".nxs");
   }
-
   return res;
 }
 
@@ -950,16 +1026,15 @@ std::vector<std::string> EnggDiffractionPresenter::outputFocusTextureFilenames(
  * @param dgFile detector grouping file name
  */
 void EnggDiffractionPresenter::startAsyncFocusWorker(
-    const std::string &dir, const std::vector<std::string> &outFilenames,
-    const std::string &runNo, const std::vector<bool> &banks,
-    const std::string &specNos, const std::string &dgFile) {
+    const std::string &dir, const std::vector<std::string> &runNo,
+    const std::vector<bool> &banks, const std::string &specNos,
+    const std::string &dgFile) {
 
   delete m_workerThread;
   m_workerThread = new QThread(this);
-  EnggDiffWorker *worker = new EnggDiffWorker(this, dir, outFilenames, runNo,
-                                              banks, specNos, dgFile);
+  EnggDiffWorker *worker =
+      new EnggDiffWorker(this, dir, runNo, banks, specNos, dgFile);
   worker->moveToThread(m_workerThread);
-
   connect(m_workerThread, SIGNAL(started()), worker, SLOT(focus()));
   connect(worker, SIGNAL(finished()), this, SLOT(focusingFinished()));
   // early delete of thread and worker
@@ -987,13 +1062,15 @@ void EnggDiffractionPresenter::startAsyncFocusWorker(
  * @param banks for every bank, (true/false) to consider it or not for
  * the focusing
  */
-void EnggDiffractionPresenter::doFocusRun(
-    const std::string &dir, const std::vector<std::string> &outFilenames,
-    const std::string &runNo, const std::vector<bool> &banks,
-    const std::string &specNos, const std::string &dgFile) {
+void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
+                                          const std::string &runNo,
+                                          const std::vector<bool> &banks,
+                                          const std::string &specNos,
+                                          const std::string &dgFile) {
 
   g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                    "this directory: " << dir << std::endl;
+                    "this directory: "
+                 << dir << std::endl;
 
   // TODO: this is almost 100% common with doNewCalibrate() - refactor
   EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1014,25 +1091,29 @@ void EnggDiffractionPresenter::doFocusRun(
   std::vector<std::string> effectiveFilenames;
   std::vector<std::string> specs;
   if (!specNos.empty()) {
+    // Cropped focusing
     // just to iterate once, but there's no real bank here
     bankIDs.push_back(0);
     specs.push_back(specNos); // one spectrum IDs list given by the user
     effectiveFilenames.push_back(outputFocusCroppedFilename(runNo));
   } else {
     if (dgFile.empty()) {
+      // Basic/normal focusing
       for (size_t bidx = 0; bidx < banks.size(); bidx++) {
         if (banks[bidx]) {
           bankIDs.push_back(bidx + 1);
           specs.push_back("");
-          effectiveFilenames.push_back(outFilenames[bidx]);
+          effectiveFilenames = outputFocusFilenames(runNo, banks);
         }
       }
     } else {
+      // texture focusing
       try {
         loadDetectorGroupingCSV(dgFile, bankIDs, specs);
       } catch (std::runtime_error &re) {
         g_log.error() << "Error loading detector grouping file: " + dgFile +
-                             ". Detailed error: " + re.what() << std::endl;
+                             ". Detailed error: " + re.what()
+                      << std::endl;
         bankIDs.clear();
         specs.clear();
       }
@@ -1048,8 +1129,8 @@ void EnggDiffractionPresenter::doFocusRun(
         fpath.append(effectiveFilenames[idx]).toString();
     g_log.notice() << "Generating new focused file (bank " +
                           boost::lexical_cast<std::string>(bankIDs[idx]) +
-                          ") for run " + runNo +
-                          " into: " << effectiveFilenames[idx] << std::endl;
+                          ") for run " + runNo + " into: "
+                   << effectiveFilenames[idx] << std::endl;
     try {
       m_focusFinishedOK = false;
       doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1062,7 +1143,8 @@ void EnggDiffractionPresenter::doFocusRun(
     } catch (std::invalid_argument &ia) {
       g_log.error()
           << "The focusing failed. Some input properties were not valid. "
-             "See log messages for details. Error: " << ia.what() << std::endl;
+             "See log messages for details. Error: "
+          << ia.what() << std::endl;
     }
   }
 
@@ -1340,7 +1422,8 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what()) << std::endl;
+                           std::string(ia.what())
+                    << std::endl;
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1349,14 +1432,15 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what()) << std::endl;
+                           std::string(re.what())
+                    << std::endl;
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run " << vanNo
-                   << ". Re-using these files: " << preIntegFilename << ", and "
-                   << preCurvesFilename << std::endl;
+                      "Vanadium run "
+                   << vanNo << ". Re-using these files: " << preIntegFilename
+                   << ", and " << preCurvesFilename << std::endl;
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS);
@@ -1537,7 +1621,8 @@ EnggDiffractionPresenter::loadToPreproc(const std::string runNo) {
   } catch (std::runtime_error &re) {
     g_log.error()
         << "Error while loading run data to pre-process. "
-           "Could not run the algorithm Load succesfully for the run number: " +
+           "Could not run the algorithm Load succesfully for the run "
+           "number: " +
                runNo + "). Error description: " + re.what() +
                " Please check also the previous log messages for details.";
     throw;
@@ -1572,14 +1657,15 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() +
-                         "." << std::endl;
+                         rebinName + ". Error description: " + ia.what() + "."
+                  << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "." << std::endl;
+                         re.what() + "."
+                  << std::endl;
     return;
   }
 
@@ -1675,14 +1761,15 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() +
-                         "." << std::endl;
+                         rebinName + ". Error description: " + ia.what() + "."
+                  << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "." << std::endl;
+                         re.what() + "."
+                  << std::endl;
     return;
   }
 
@@ -1736,7 +1823,8 @@ void EnggDiffractionPresenter::rebinningFinished() {
         << std::endl;
   } else {
     g_log.notice() << "Pre-processing (re-binning) finished - the output "
-                      "workspace is ready." << std::endl;
+                      "workspace is ready."
+                   << std::endl;
   }
   if (m_workerThread) {
     delete m_workerThread;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -28,8 +28,9 @@ Mantid::Kernel::Logger g_log("EngineeringDiffractionGUI");
 const std::string EnggDiffractionPresenter::g_enginxStr = "ENGINX";
 
 const std::string EnggDiffractionPresenter::g_runNumberErrorStr =
-    " cannot be empty, must be an integer number, a valid ENGINX run number or "
-    "a valid directory.";
+    " cannot be empty, must be an integer number, valid ENGINX run number/s "
+    "or "
+    "valid directory/directories.";
 
 // discouraged at the moment
 const bool EnggDiffractionPresenter::g_askUserCalibFilename = false;
@@ -182,17 +183,12 @@ void EnggDiffractionPresenter::processFocusBasic() {
       isValidMultiRunNumber(m_view->focusingRunNo());
   const std::vector<bool> banks = m_view->focusingBanks();
 
-  std::string runNo;
-
-  for (int i = 0; i < multi_RunNo.size(); ++i) {
-    runNo = multi_RunNo[i];
-    try {
-      inputChecksBeforeFocusBasic(runNo, banks);
-    } catch (std::invalid_argument &ia) {
-      m_view->userWarning("Error in the inputs required to focus a run",
-                          ia.what());
-      return;
-    }
+  try {
+    inputChecksBeforeFocusBasic(multi_RunNo, banks);
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning("Error in the inputs required to focus a run",
+                        ia.what());
+    return;
   }
   startFocusing(multi_RunNo, banks, "", "");
 }
@@ -203,19 +199,14 @@ void EnggDiffractionPresenter::processFocusCropped() {
   const std::vector<bool> banks = m_view->focusingBanks();
   const std::string specNos = m_view->focusingCroppedSpectrumIDs();
 
-  std::string runNo;
-  for (int i = 0; i < multi_RunNo.size(); ++i) {
-    runNo = multi_RunNo[i];
-    try {
-      inputChecksBeforeFocusCropped(runNo, banks, specNos);
-    } catch (std::invalid_argument &ia) {
-      m_view->userWarning(
-          "Error in the inputs required to focus a run (in cropped mode)",
-          ia.what());
-      return;
-    }
+  try {
+    inputChecksBeforeFocusCropped(multi_RunNo, banks, specNos);
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning(
+        "Error in the inputs required to focus a run (in cropped mode)",
+        ia.what());
+    return;
   }
-
   startFocusing(multi_RunNo, banks, specNos, "");
 }
 
@@ -224,19 +215,14 @@ void EnggDiffractionPresenter::processFocusTexture() {
       isValidMultiRunNumber(m_view->focusingTextureRunNo());
   const std::string dgFile = m_view->focusingTextureGroupingFile();
 
-  std::string runNo;
-  for (int i = 0; i < multi_RunNo.size(); ++i) {
-    runNo = multi_RunNo[i];
-    try {
-      inputChecksBeforeFocusTexture(runNo, dgFile);
-    } catch (std::invalid_argument &ia) {
-      m_view->userWarning(
-          "Error in the inputs required to focus a run (in texture mode)",
-          ia.what());
-      return;
-    }
+  try {
+    inputChecksBeforeFocusTexture(multi_RunNo, dgFile);
+  } catch (std::invalid_argument &ia) {
+    m_view->userWarning(
+        "Error in the inputs required to focus a run (in texture mode)",
+        ia.what());
+    return;
   }
-
   startFocusing(multi_RunNo, std::vector<bool>(), "", dgFile);
 }
 
@@ -861,8 +847,9 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
  * @throws std::invalid_argument with an informative message.
  */
 void EnggDiffractionPresenter::inputChecksBeforeFocusBasic(
-    const std::string &runNo, const std::vector<bool> &banks) {
-  if (runNo.empty()) {
+    const std::vector<std::string> &multi_RunNo,
+    const std::vector<bool> &banks) {
+  if (multi_RunNo.size() == 0) {
     const std::string msg = "The sample run number" + g_runNumberErrorStr;
     throw std::invalid_argument(msg);
   }
@@ -885,9 +872,9 @@ void EnggDiffractionPresenter::inputChecksBeforeFocusBasic(
  * @throws std::invalid_argument with an informative message.
  */
 void EnggDiffractionPresenter::inputChecksBeforeFocusCropped(
-    const std::string &runNo, const std::vector<bool> &banks,
+    const std::vector<std::string> &multi_RunNo, const std::vector<bool> &banks,
     const std::string &specNos) {
-  if (runNo.empty()) {
+  if (multi_RunNo.size() == 0) {
     throw std::invalid_argument("To focus cropped the sample run number" +
                                 g_runNumberErrorStr);
   }
@@ -914,8 +901,8 @@ void EnggDiffractionPresenter::inputChecksBeforeFocusCropped(
  * @throws std::invalid_argument with an informative message.
  */
 void EnggDiffractionPresenter::inputChecksBeforeFocusTexture(
-    const std::string &runNo, const std::string &dgFile) {
-  if (runNo.empty()) {
+    const std::vector<std::string> &multi_RunNo, const std::string &dgFile) {
+  if (multi_RunNo.size() == 0) {
     throw std::invalid_argument("To focus texture banks the sample run number" +
                                 g_runNumberErrorStr);
   }

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -183,14 +183,23 @@ void EnggDiffractionPresenter::processFocusBasic() {
       isValidMultiRunNumber(m_view->focusingRunNo());
   const std::vector<bool> banks = m_view->focusingBanks();
 
-  try {
-    inputChecksBeforeFocusBasic(multi_RunNo, banks);
-  } catch (std::invalid_argument &ia) {
-    m_view->userWarning("Error in the inputs required to focus a run",
-                        ia.what());
-    return;
+  int focusMode = m_view->currentMultiRunMode();
+
+  if (focusMode == 0) {
+	  g_log.debug() << " focus mode selected Individual Run Files Separately " << std::endl;
+	  try {
+		  inputChecksBeforeFocusBasic(multi_RunNo, banks);
+	  }
+	  catch (std::invalid_argument &ia) {
+		  m_view->userWarning("Error in the inputs required to focus a run",
+			  ia.what());
+		  return;
+	  }
+	  startFocusing(multi_RunNo, banks, "", "");
   }
-  startFocusing(multi_RunNo, banks, "", "");
+  else if (focusMode == 1) {
+	  g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
+  }
 }
 
 void EnggDiffractionPresenter::processFocusCropped() {
@@ -199,15 +208,24 @@ void EnggDiffractionPresenter::processFocusCropped() {
   const std::vector<bool> banks = m_view->focusingBanks();
   const std::string specNos = m_view->focusingCroppedSpectrumIDs();
 
-  try {
-    inputChecksBeforeFocusCropped(multi_RunNo, banks, specNos);
-  } catch (std::invalid_argument &ia) {
-    m_view->userWarning(
-        "Error in the inputs required to focus a run (in cropped mode)",
-        ia.what());
-    return;
+  int focusMode = m_view->currentMultiRunMode();
+
+  if (focusMode == 0) {
+	  g_log.debug() << " focus mode selected Individual Run Files Separately " << std::endl;
+	  try {
+		  inputChecksBeforeFocusCropped(multi_RunNo, banks, specNos);
+	  }
+	  catch (std::invalid_argument &ia) {
+		  m_view->userWarning(
+			  "Error in the inputs required to focus a run (in cropped mode)",
+			  ia.what());
+		  return;
+	  }
+	  startFocusing(multi_RunNo, banks, specNos, "");
   }
-  startFocusing(multi_RunNo, banks, specNos, "");
+  else if (focusMode == 1) {
+		  g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
+  }
 }
 
 void EnggDiffractionPresenter::processFocusTexture() {
@@ -215,15 +233,24 @@ void EnggDiffractionPresenter::processFocusTexture() {
       isValidMultiRunNumber(m_view->focusingTextureRunNo());
   const std::string dgFile = m_view->focusingTextureGroupingFile();
 
-  try {
-    inputChecksBeforeFocusTexture(multi_RunNo, dgFile);
-  } catch (std::invalid_argument &ia) {
-    m_view->userWarning(
-        "Error in the inputs required to focus a run (in texture mode)",
-        ia.what());
-    return;
+  int focusMode = m_view->currentMultiRunMode();
+
+  if (focusMode == 0) {
+	  g_log.debug() << " focus mode selected Individual Run Files Separately " << std::endl;
+	  try {
+		  inputChecksBeforeFocusTexture(multi_RunNo, dgFile);
+	  }
+	  catch (std::invalid_argument &ia) {
+		  m_view->userWarning(
+			  "Error in the inputs required to focus a run (in texture mode)",
+			  ia.what());
+		  return;
+	  }
+	  startFocusing(multi_RunNo, std::vector<bool>(), "", dgFile);
   }
-  startFocusing(multi_RunNo, std::vector<bool>(), "", dgFile);
+  else if (focusMode == 1) {
+	  g_log.debug() << " focus mode selected Focus Sum Of Files " << std::endl;
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -199,7 +199,7 @@ void EnggDiffractionPresenter::processFocusBasic() {
 
 void EnggDiffractionPresenter::processFocusCropped() {
   const std::vector<std::string> multi_RunNo =
-      isValidMultiRunNumber(m_view->focusingRunNo());
+      isValidMultiRunNumber(m_view->focusingCroppedRunNo());
   const std::vector<bool> banks = m_view->focusingBanks();
   const std::string specNos = m_view->focusingCroppedSpectrumIDs();
 
@@ -221,7 +221,7 @@ void EnggDiffractionPresenter::processFocusCropped() {
 
 void EnggDiffractionPresenter::processFocusTexture() {
   const std::vector<std::string> multi_RunNo =
-      isValidMultiRunNumber(m_view->focusingRunNo());
+      isValidMultiRunNumber(m_view->focusingTextureRunNo());
   const std::string dgFile = m_view->focusingTextureGroupingFile();
 
   std::string runNo;

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -27,6 +27,7 @@ DECLARE_SUBWINDOW(EnggDiffractionViewQtGUI)
 
 const double EnggDiffractionViewQtGUI::g_defaultRebinWidth = -0.0005;
 int EnggDiffractionViewQtGUI::m_currentType = 0;
+int EnggDiffractionViewQtGUI::m_currentRunMode = 0;
 
 const std::string EnggDiffractionViewQtGUI::g_iparmExtStr =
     "GSAS instrument parameters, IPARM file: PRM, PAR, IPAR, IPARAM "
@@ -146,6 +147,9 @@ void EnggDiffractionViewQtGUI::doSetupTabFocus() {
   connect(m_uiTabFocus.comboBox_PlotData, SIGNAL(currentIndexChanged(int)),
           this, SLOT(plotRepChanged(int)));
 
+  connect(m_uiTabFocus.comboBox_Multi_Runs, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(multiRunModeChanged(int)));
+
   connect(m_uiTabFocus.checkBox_FocusedWS, SIGNAL(clicked()), this,
           SLOT(plotFocusStatus()));
 }
@@ -264,6 +268,8 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("user-params-focus-plot-ws", true).toBool());
 
   m_uiTabFocus.comboBox_PlotData->setCurrentIndex(0);
+
+  m_uiTabFocus.comboBox_Multi_Runs->setCurrentIndex(0);
 
   // pre-processing (re-binning)
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setUserInput(
@@ -477,6 +483,7 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
   m_uiTabFocus.checkBox_FocusedWS->setEnabled(enable);
   m_uiTabFocus.checkBox_SaveOutputFiles->setEnabled(enable);
+  m_uiTabFocus.comboBox_Multi_Runs->setEnabled(enable);
 
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
   m_uiTabFocus.pushButton_focus_cropped->setEnabled(enable);
@@ -823,6 +830,13 @@ void EnggDiffractionViewQtGUI::plotFocusStatus() {
   } else {
     m_uiTabFocus.comboBox_PlotData->setEnabled(false);
   }
+}
+
+void EnggDiffractionViewQtGUI::multiRunModeChanged(int /*idx*/) {
+  QComboBox *plotType = m_uiTabFocus.comboBox_Multi_Runs;
+  if (!plotType)
+    return;
+  m_currentRunMode = plotType->currentIndex();
 }
 
 void EnggDiffractionViewQtGUI::plotRepChanged(int /*idx*/) {

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -31,12 +31,16 @@ private:
   }
 
   void startAsyncFocusWorker(const std::string &dir,
-                             const std::string &runNo,
+                             const std::vector<std::string> &multi_RunNo,
                              const std::vector<bool> &banks,
                              const std::string &specNos,
                              const std::string &dgFile) {
     std::cerr << "focus run " << std::endl;
+
+    std::string runNo = multi_RunNo[0];
+
     doFocusRun(dir, runNo, banks, specNos, dgFile);
+
     focusingFinished();
   }
 

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionPresenterTest.h
@@ -31,13 +31,12 @@ private:
   }
 
   void startAsyncFocusWorker(const std::string &dir,
-                             const std::vector<std::string> &outFilenames,
                              const std::string &runNo,
                              const std::vector<bool> &banks,
                              const std::string &specNos,
                              const std::string &dgFile) {
     std::cerr << "focus run " << std::endl;
-    doFocusRun(dir, outFilenames, runNo, banks, specNos, dgFile);
+    doFocusRun(dir, runNo, banks, specNos, dgFile);
     focusingFinished();
   }
 

--- a/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
+++ b/MantidQt/CustomInterfaces/test/EnggDiffractionViewMock.h
@@ -50,8 +50,11 @@ public:
   // virtual std::string currentCalibFile() const;
   MOCK_CONST_METHOD0(currentCalibFile, std::string());
 
-  // std::string currentPlotType
+  // int currentPlotType
   MOCK_CONST_METHOD0(currentPlotType, int());
+
+  // int currentMultiRunMode
+  MOCK_CONST_METHOD0(currentMultiRunMode, int());
 
   // virtual std::vector<std::string> newVanadiumNo() const;
   MOCK_CONST_METHOD0(newVanadiumNo, std::vector<std::string>());


### PR DESCRIPTION
fixes #13784 
- Enables the focusing tab to take multiple files and also option of utilising two different type of focusing
- Presenter test has also been updated

_Note That_
- The `Plot Data Representation` is not compatible with the multi-run focusing yet
- `Focus Sum Of Files` will not be functioning on this branch

**To Test**
`Interface/Diffraction/Engineering Diffraction`
_Get initial settings from [here](https://github.com/mantidproject/mantid/pull/13501)_

Provide any of three focusing text field with a multiple run number for example `228061-228063`
You can find `ENGINX` inside the system & unit test data
One or various files can be renamed to `228061`, `228062` and `228061`
Make sure that the directory where files are found is mentioned in the Mantid `manage directory`.
Click Focus and you should end up with with saved files save by its own `run number` and `bank number` 

_Things to look-out for:_
Focusing should only carry out when `Focus Individual Run Files Separately` is selected 
Output files have been all generated & saved when `Output Files` is ticked
All of them `Plot Focused Workspace` for each separate run number, even though `Replacing Plot` and `Waterfall` isn't how it should be
