### PR TITLE
Ensure GeometryCache is read when Instrument is loaded

### DIFF
--- a/Framework/Geometry/src/Objects/Object.cpp
+++ b/Framework/Geometry/src/Objects/Object.cpp
@@ -1878,6 +1878,7 @@ void Object::setVtkGeometryCacheWriter(
 void Object::setVtkGeometryCacheReader(
     boost::shared_ptr<vtkGeometryCacheReader> reader) {
   vtkCacheReader = reader;
+  updateGeometryHandler();
 }
 
 /**


### PR DESCRIPTION
Fixes #14582 and #8011.

On Linux, the interface freezes when trying to Show Instrument for the first time during a Mantid session because it is calculating a vertex mesh for the instrument. However, these calculations are already done and cached when a new or modified instrument is loaded for the first time.

This change ensures the cache is read and loaded at the point when the IDF is read, rather than recalculating it when attempting to render the instrument for the first time. This allows the instrument window to show up almost instantly.

It is unclear why this issue does not occur on Windows. Without the line of code added by this change, the XML in the cache file will be parsed into a DOM tree, but the actual geometry information in it will not be read while loading the instrument (even though comments and log outputs indicate that this is the point at which it should be read). 

Perhaps, on Windows, `updateGeometryHandler()` is being called indirectly somewhere else. But I cannot see where or why behaviour between the OSes would deviate like this. Investigating the usual suspects (`#define`s and directory paths) did not pan out. There is an `initDraw()` function (present in both `Object` and `ObjComponent`) that would also cause the cache to be read. But it is only ever called by CreateSampleShapeDialog and never by the InstrumentWindow (or anywhere else, for that matter).

In any case, judging by code comments, log output, and the `setVtkGeometryCacheWriter()` function above `setVtkGeometryCacheReader()`, the call to `updateGeometryHandler()` that is added by this PR does belong here and should produce the expected behaviour in all situations.
### Testing

Should be tested on Linux, Windows and OSX since deviating behaviour was observed.

Load an Instrument using `LoadEmptyInstrument` algorithm (or any Workspace that uses an Instrument), right-click the workspace and select "Show Instrument" option.

Before this change there is a delay when showing an instrument for the first time after starting Mantid on Linux (perhaps OSX as well?). With this change, the instrument shows almost instantly. The length of the delay depends on the instrument. OSIRIS has a very noticeable delay. POLARIS is even longer.

Instrument suggestions to load with `LoadEmptyInstrument`:

```
mantid/instrument/OSIRIS_Definition.xml
mantid/instrument/POLARIS_Definition_121.xml   (Warning: can take a few minutes)
```

You can also use `File -> Clear All Memory` to "reset" and see the delay again with the same instrument without having to restart Mantid.
