### PR TITLE
Introduce constructor taking std::intializer_list into FileProperty

### DIFF
--- a/Framework/API/inc/MantidAPI/FileProperty.h
+++ b/Framework/API/inc/MantidAPI/FileProperty.h
@@ -53,7 +53,7 @@ public:
   };
 
   /// Constructor taking a list of extensions as a vector
-  FileProperty(const std::string &name, const std::string &default_value,
+  FileProperty(const std::string &name, const std::string &defaultValue,
                unsigned int action, const std::vector<std::string> &exts =
                                         std::vector<std::string>(),
                unsigned int direction = Kernel::Direction::Input);
@@ -92,8 +92,6 @@ public:
 private:
   /// Returns a string depending on whether an empty value is valid
   std::string isEmptyValueValid() const;
-  /// Setup based on the default extension
-  void setUp(const std::string &defExt);
   /// Do the allowed values match the facility preference extensions for run
   /// files
   bool extsMatchRunFiles();

--- a/Framework/API/inc/MantidAPI/FileProperty.h
+++ b/Framework/API/inc/MantidAPI/FileProperty.h
@@ -52,13 +52,18 @@ public:
         5 ///< to specify a directory that does not have to exist
   };
 
-  /// Constructor
+  /// Constructor taking a list of extensions as a vector
   FileProperty(const std::string &name, const std::string &default_value,
                unsigned int action, const std::vector<std::string> &exts =
                                         std::vector<std::string>(),
                unsigned int direction = Kernel::Direction::Input);
+  /// Constructor taking a single extension as a string
   FileProperty(const std::string &name, const std::string &default_value,
                unsigned int action, const std::string &ext,
+               unsigned int direction = Kernel::Direction::Input);
+  /// Constructor taking a list of extensions as an initializer_list
+  FileProperty(const std::string &name, const std::string &default_value,
+               unsigned int action, std::initializer_list<std::string> exts,
                unsigned int direction = Kernel::Direction::Input);
 
   /// 'Virtual copy constructor

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -113,8 +113,7 @@ FileProperty::FileProperty(const std::string &name,
                            std::initializer_list<std::string> exts,
                            unsigned int direction)
     : FileProperty(name, default_value, action,
-                   std::vector<std::string>(std::move(exts)),
-                   direction) {}
+                   std::vector<std::string>(std::move(exts)), direction) {}
 
 /**
  * Check if this is a load property

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -2,6 +2,7 @@
 // Includes
 //-----------------------------------------------------------------
 #include "MantidAPI/FileProperty.h"
+
 #include "MantidAPI/FileFinder.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DirectoryValidator.h"
@@ -9,10 +10,11 @@
 #include "MantidKernel/FileValidator.h"
 #include "MantidKernel/Strings.h"
 
-#include <Poco/Path.h>
 #include <Poco/File.h>
-#include <cctype>
+#include <Poco/Path.h>
+
 #include <algorithm>
+#include <cctype>
 
 namespace Mantid {
 
@@ -87,6 +89,23 @@ FileProperty::FileProperty(const std::string &name,
       m_oldLoadPropValue(""), m_oldLoadFoundFile("") {
   setUp(ext);
 }
+
+/**
+ * Constructor
+ * @param name ::          The name of the property
+ * @param default_value :: A default value for the property
+ * @param exts ::          The braced-list of allowed extensions
+ * @param action ::        An enum indicating whether this should be a load/save
+ * property
+ * @param direction ::     An optional direction (default=Input)
+ */
+FileProperty::FileProperty(const std::string &name,
+                           const std::string &default_value,
+                           unsigned int action,
+                           std::initializer_list<std::string> exts,
+                           unsigned int direction)
+    : FileProperty(name, default_value, action,
+                   std::vector<std::string>(std::move(exts)), direction) {}
 
 /**
  * Check if this is a load property

--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -64,13 +64,13 @@ void addExtension(const std::string &extension,
 //-----------------------------------------------------------------
 /**
  * Constructor
- * @param name ::          The name of the property
- * @param default_value :: A default value for the property
- * @param exts ::          The allowed extensions, the front entry in the vector
- * will be the default extension
- * @param action ::        An enum indicating whether this should be a load/save
+ * @param name The name of the property
+ * @param defaultValue A default value for the property
+ * @param action Inndicate whether this should be a load/save
  * property
- * @param direction ::     An optional direction (default=Input)
+ * @param exts The allowed extensions. The front entry in the vector
+ * will be the default extension
+ * @param direction An optional direction (default=Input)
  */
 FileProperty::FileProperty(const std::string &name,
                            const std::string &defaultValue, unsigned int action,

--- a/Framework/API/test/FilePropertyTest.h
+++ b/Framework/API/test/FilePropertyTest.h
@@ -3,14 +3,15 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidAPI/FileProperty.h"
 #include "MantidAPI/FileFinder.h"
+#include "MantidAPI/FileProperty.h"
 #include "MantidKernel/ConfigService.h"
-#include <Poco/Path.h>
 #include <Poco/File.h>
 #include <fstream>
 
-using namespace Mantid::Kernel;
+using Mantid::API::FileProperty;
+using Mantid::API::FileFinder;
+using Mantid::Kernel::ConfigService;
 
 class FilePropertyTest : public CxxTest::TestSuite {
 public:
@@ -56,101 +57,80 @@ public:
   }
 
   void testLoadPropertyWithEmptyValueIsInvalid() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::Load);
-    doPropertyTraitTests(*fp, true, false, false);
-    std::string msg = fp->setValue("");
+    FileProperty fp("Filename", "", FileProperty::Load);
+    doPropertyTraitTests(fp, true, false, false);
+    std::string msg = fp.setValue("");
     TS_ASSERT_DIFFERS("", msg);
-    delete fp;
   }
 
   void testLoadPropertyNoExtension() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::Load);
-    doPropertyTraitTests(*fp, true, false, false);
-    doExtensionCheck(*fp, "", "LOQ48127.raw", "48098.Q");
-    delete fp;
+    FileProperty fp("Filename", "", FileProperty::Load);
+    doPropertyTraitTests(fp, true, false, false);
+    doExtensionCheck(fp, "", "LOQ48127.raw", "48098.Q");
   }
 
   void testLoadPropertyWithExtensionAsVector() {
     std::vector<std::string> exts(1, ".raw");
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::Load, exts);
-    doPropertyTraitTests(*fp, true, false, false);
-    doExtensionCheck(*fp, ".raw", "LOQ48127.raw", "48098.Q");
-    delete fp;
+    FileProperty fp("Filename", "", FileProperty::Load, exts);
+    doPropertyTraitTests(fp, true, false, false);
+    doExtensionCheck(fp, ".raw", "LOQ48127.raw", "48098.Q");
   }
-  
+
   void testLoadPropertyWithExtensionAsString() {
     std::string ext(".raw");
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::Load, ext);
-    doPropertyTraitTests(*fp, true, false, false);
-    doExtensionCheck(*fp, ".raw", "LOQ48127.raw", "48098.Q");
-    delete fp;
+    FileProperty fp("Filename", "", FileProperty::Load, ext);
+    doPropertyTraitTests(fp, true, false, false);
+    doExtensionCheck(fp, ".raw", "LOQ48127.raw", "48098.Q");
   }
 
-
   void testLoadPropertyWithExtensionAsInitializerList() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-          "Filename", "", Mantid::API::FileProperty::Load, {".raw"});
-    doPropertyTraitTests(*fp, true, false, false);
-    doExtensionCheck(*fp, ".raw", "LOQ48127.raw", "48098.Q");
-    delete fp;
+    FileProperty fp("Filename", "", FileProperty::Load, {".raw"});
+    doPropertyTraitTests(fp, true, false, false);
+    doExtensionCheck(fp, ".raw", "LOQ48127.raw", "48098.Q");
   }
 
   void testOptionalLoadProperty() {
     std::vector<std::string> exts(1, "raw");
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::OptionalLoad, exts);
-    doPropertyTraitTests(*fp, true, false, true);
+    FileProperty fp("Filename", "", FileProperty::OptionalLoad, exts);
+    doPropertyTraitTests(fp, true, false, true);
 
-    std::string msg = fp->setValue("LOQ48127.raw");
+    std::string msg = fp.setValue("LOQ48127.raw");
     TS_ASSERT_EQUALS(msg, "");
     // I'm using part of the file's path to check that the property really has
     // found the file, with OptionalLoad the property returns valid whether it
     // finds the file or not
-    TS_ASSERT(fp->value().find("UnitTest") != std::string::npos);
+    TS_ASSERT(fp.value().find("UnitTest") != std::string::npos);
     // do this in parts making no assumptions about the identity of the slash
     // that separates directories
-    TS_ASSERT(fp->value().find("Test") != std::string::npos);
+    TS_ASSERT(fp.value().find("Test") != std::string::npos);
 
-    msg = fp->setValue("LOQ48127.raw");
+    msg = fp.setValue("LOQ48127.raw");
     TS_ASSERT_EQUALS(msg, "");
 
-    msg = fp->setValue("");
+    msg = fp.setValue("");
     TS_ASSERT_EQUALS(msg, "");
-    TS_ASSERT_EQUALS(fp->value(), "");
-
-    delete fp;
+    TS_ASSERT_EQUALS(fp.value(), "");
   }
 
   void testSaveProperty() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::Save);
-    doPropertyTraitTests(*fp, false, true, false);
+    FileProperty fp("Filename", "", FileProperty::Save);
+    doPropertyTraitTests(fp, false, true, false);
     // Test for some random file name as this doesn't need to exist here
-    std::string msg = fp->setValue("filepropertytest.sav");
+    std::string msg = fp.setValue("filepropertytest.sav");
     TS_ASSERT_EQUALS(msg, "");
-
-    delete fp;
   }
 
   void testOptionalSaveProperty() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "Filename", "", Mantid::API::FileProperty::OptionalSave);
-    doPropertyTraitTests(*fp, false, true, true);
+    FileProperty fp("Filename", "", FileProperty::OptionalSave);
+    doPropertyTraitTests(fp, false, true, true);
     // Test for some random file name as this doesn't need to exist here
-    std::string msg = fp->setValue("filepropertytest.sav");
+    std::string msg = fp.setValue("filepropertytest.sav");
     TS_ASSERT_EQUALS(msg, "");
-
-    delete fp;
   }
 
   void testThatRunNumberReturnsFileWithCorrectPrefix() {
-    Mantid::API::FileProperty fp("Filename", "",
-                                 Mantid::API::FileProperty::Load,
-                                 std::vector<std::string>(1, ".raw"));
+    FileProperty fp("Filename", "", FileProperty::Load,
+                    std::vector<std::string>(1, ".raw"));
     std::string error = fp.setValue("48127");
     TS_ASSERT_EQUALS(error, "");
     TS_ASSERT_DIFFERS(fp.value().find("LOQ48127"), std::string::npos);
@@ -170,28 +150,22 @@ public:
   }
 
   void testOptionalDirectory() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "SavePath", "", Mantid::API::FileProperty::OptionalDirectory);
+    FileProperty fp("SavePath", "", FileProperty::OptionalDirectory);
     // Check type
-    TS_ASSERT_EQUALS(fp->isDirectoryProperty(), true);
+    TS_ASSERT_EQUALS(fp.isDirectoryProperty(), true);
 
     // Test for some random directory that does not need to exist
-    std::string msg = fp->setValue("my_nonexistent_folder");
+    std::string msg = fp.setValue("my_nonexistent_folder");
     TS_ASSERT_EQUALS(msg, "");
-
-    delete fp;
   }
 
   void testDirectoryFailsIfNonExistent() {
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "SavePath", "", Mantid::API::FileProperty::Directory);
+    FileProperty fp("SavePath", "", FileProperty::Directory);
     // This will fail because this folder does not exist
     std::string TestDir("my_nonexistent_folder");
-    std::string msg = fp->setValue(TestDir);
+    std::string msg = fp.setValue(TestDir);
     // It gives an error message starting "Directory "X" not found".
     TS_ASSERT_EQUALS(msg.substr(0, 3), "Dir");
-
-    delete fp;
   }
 
   void testDirectoryPasses() {
@@ -200,23 +174,19 @@ public:
     Poco::File dir(TestDir);
     dir.createDirectory();
 
-    Mantid::API::FileProperty *fp = new Mantid::API::FileProperty(
-        "SavePath", "", Mantid::API::FileProperty::Directory);
-    TS_ASSERT_EQUALS(fp->isDirectoryProperty(), true);
+    FileProperty fp("SavePath", "", FileProperty::Directory);
+    TS_ASSERT_EQUALS(fp.isDirectoryProperty(), true);
 
     // The directory exists, so no failure
-    std::string msg = fp->setValue(TestDir);
+    std::string msg = fp.setValue(TestDir);
     TS_ASSERT_EQUALS(msg, "");
 
-    delete fp;
     dir.remove(); // clean up your folder
   }
 
 private:
-  
-  void doPropertyTraitTests(const Mantid::API::FileProperty &fileProp,
-                            const bool loadProp, const bool saveProp,
-                            const bool validByDefault) {
+  void doPropertyTraitTests(const FileProperty &fileProp, const bool loadProp,
+                            const bool saveProp, const bool validByDefault) {
     // Check type
     TS_ASSERT_EQUALS(fileProp.isLoadProperty(), loadProp);
     TS_ASSERT_EQUALS(fileProp.isSaveProperty(), saveProp);
@@ -226,11 +196,9 @@ private:
       TS_ASSERT_DIFFERS(fileProp.isValid(), "");
     }
   }
-  
-  void doExtensionCheck(Mantid::API::FileProperty &fileProp,
-                        const std::string &defaultExt,
-                        const std::string & match,
-                        const std::string & nomatch) {
+
+  void doExtensionCheck(FileProperty &fileProp, const std::string &defaultExt,
+                        const std::string &match, const std::string &nomatch) {
     TS_ASSERT_EQUALS(fileProp.getDefaultExt(), defaultExt);
     // Filename as given
     std::string msg = fileProp.setValue(match);
@@ -244,7 +212,6 @@ private:
     msg = fileProp.setValue(nomatch);
     TS_ASSERT_EQUALS(msg, "");
   }
-  
 };
 
 #endif


### PR DESCRIPTION
Fixes #14584

Most usages of FileProperty in algorithms pass in a fixed list of extensions. This change allows the following code:

``` c++
FileProperty("Filename", "", FileProperty.Load, {".nxs", ".raw"})
```

rather than the old-style

``` c++
std::vector<std::string> exts(2);
exts[0] = ".nxs"
exts[1] = ".raw"
FileProperty("Filename", "", FileProperty.Load, exts)
```

**Tester**
A code review should suffice along with confirming all tests work.

No release note updates required
