### PR TITLE
Clear code in load nexus algorithm confidence

### DIFF
--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -63,7 +63,7 @@ LoadISISNexus2::LoadISISNexus2()
 */
 int LoadISISNexus2::confidence(Kernel::NexusDescriptor &descriptor) const {
   if (descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) {
-    // Could be an Event Nexus file or a TOFRaw file, 
+    // Could be an Event Nexus file or a TOFRaw file,
     // so confidence is less than 80.
     return 75;
   }

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -63,8 +63,8 @@ LoadISISNexus2::LoadISISNexus2()
 */
 int LoadISISNexus2::confidence(Kernel::NexusDescriptor &descriptor) const {
   if (descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) {
-    // Could be an Event Nexus file or a TOFRaw file,
-    // so confidence is less than 80.
+    // It also could be an Event Nexus file or a TOFRaw file,
+    // so confidence is set to less than 80.
     return 75;
   }
   return 0;

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -62,8 +62,11 @@ LoadISISNexus2::LoadISISNexus2()
 * be used
 */
 int LoadISISNexus2::confidence(Kernel::NexusDescriptor &descriptor) const {
-  if (descriptor.pathOfTypeExists("/raw_data_1", "NXentry"))
-    return 80;
+  if (descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) {
+    // Could be an Event Nexus file or a TOFRaw file, 
+    // so confidence is less than 80.
+    return 75;
+  }
   return 0;
 }
 

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -65,8 +65,8 @@ int LoadTOFRawNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
   int confidence(0);
   if (descriptor.pathOfTypeExists("/entry", "NXentry") ||
       descriptor.pathOfTypeExists("/entry-state0", "NXentry")) {
-	// descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) is also valid,
-	// but is currently taken to be ISIS Nexus, till issue #14614 is fixed.
+    // descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) is also valid,
+    // but is currently taken to be ISIS Nexus, till issue #14614 is fixed.
     const bool hasEventData = descriptor.classTypeExists("NXevent_data");
     const bool hasData = descriptor.classTypeExists("NXdata");
     if (hasData && hasEventData)

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -64,8 +64,9 @@ void LoadTOFRawNexus::init() {
 int LoadTOFRawNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
   int confidence(0);
   if (descriptor.pathOfTypeExists("/entry", "NXentry") ||
-      descriptor.pathOfTypeExists("/entry-state0", "NXentry") ||
-      descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) {
+      descriptor.pathOfTypeExists("/entry-state0", "NXentry")) {
+	// descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) is also valid,
+	// but is currently taken to be ISIS Nexus, till issue #14614 is fixed.
     const bool hasEventData = descriptor.classTypeExists("NXevent_data");
     const bool hasData = descriptor.classTypeExists("NXdata");
     if (hasData && hasEventData)


### PR DESCRIPTION
Fixes #14577 .

To test check that Load works for various nexus files. Also when reviewing the code, look at the confidence functions of other algorithms that load Nexus (but have not been modified), particularly LoadEventNexus and loadTOFRawNexus. Also check references to issues in comments added.

No release notes needed
