### PR TITLE
Disables cropped and texture widget by default

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/EnggDiffraction/EnggDiffractionQtTabFocus.ui
@@ -152,9 +152,18 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_cropped">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>Focus Cropped</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
       <item row="0" column="0">
@@ -259,9 +268,18 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="groupBox_texture">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
      <property name="title">
       <string>Focus Texture</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -264,6 +264,12 @@ void EnggDiffractionViewQtGUI::readSettings() {
       qs.value("user-params-focus-texture-detector-grouping-file", "")
           .toString());
 
+  m_uiTabFocus.groupBox_cropped->setChecked(
+	  qs.value("user-params-focus-cropped-group-checkbox", true).toBool());
+
+  m_uiTabFocus.groupBox_texture->setChecked(
+	  qs.value("user-params-focus-texture-group-checkbox", true).toBool());
+
   m_uiTabFocus.checkBox_FocusedWS->setChecked(
       qs.value("user-params-focus-plot-ws", true).toBool());
 
@@ -351,6 +357,12 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabFocus.lineEdit_texture_run_num->getText());
   qs.setValue("user-params-focus-texture-detector-grouping-file",
               m_uiTabFocus.lineEdit_texture_grouping_file->text());
+
+  qs.setValue("user-params-focus-cropped-group-checkbox",
+	  m_uiTabFocus.groupBox_cropped->isChecked());
+
+  qs.setValue("user-params-focus-texture-group-checkbox",
+	  m_uiTabFocus.groupBox_texture->isChecked());
 
   qs.setValue("value", m_uiTabFocus.checkBox_FocusedWS->isChecked());
 

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -265,10 +265,10 @@ void EnggDiffractionViewQtGUI::readSettings() {
           .toString());
 
   m_uiTabFocus.groupBox_cropped->setChecked(
-	  qs.value("user-params-focus-cropped-group-checkbox", true).toBool());
+	  qs.value("user-params-focus-cropped-group-checkbox", false).toBool());
 
   m_uiTabFocus.groupBox_texture->setChecked(
-	  qs.value("user-params-focus-texture-group-checkbox", true).toBool());
+	  qs.value("user-params-focus-texture-group-checkbox", false).toBool());
 
   m_uiTabFocus.checkBox_FocusedWS->setChecked(
       qs.value("user-params-focus-plot-ws", true).toBool());
@@ -572,6 +572,9 @@ void EnggDiffractionViewQtGUI::resetFocus() {
 
   m_uiTabFocus.lineEdit_cropped_run_num->setText("");
   m_uiTabFocus.lineEdit_cropped_spec_ids->setText("");
+
+  m_uiTabFocus.groupBox_cropped->setChecked(false);
+  m_uiTabFocus.groupBox_texture->setChecked(false);
 
   m_uiTabFocus.lineEdit_texture_run_num->setText("");
   m_uiTabFocus.lineEdit_texture_grouping_file->setText("");


### PR DESCRIPTION
fixes #14592 

`Interface/Diffraction/Engineering Diffraction/Focus`
Makes the cropped and texture group greyed out by default, the `cropped` and `texture` group can be enabled via group check-box. Also remembers the settings from previous session with all the focus settings.
