### PR TITLE
ResNorm should allow for old and new naming conventions to be used

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -8,6 +8,7 @@ from mantid.simpleapi import *
 
 class ResNorm(PythonAlgorithm):
 
+    _res_clone = None
     _res_ws = None
     _van_ws = None
     _e_min = None
@@ -92,6 +93,10 @@ class ResNorm(PythonAlgorithm):
 
     def PyExec(self):
         from IndirectCommon import getWSprefix
+
+        res_clone_name = '__' + self._res_ws
+        res_clone_ws= CloneWorkspace(InputWorkspace=self._res_ws, OutputWorkspace=res_clone_name)
+
         if self._create_output:
             self._out_ws_table = self.getPropertyValue('OutputWorkspaceTable')
 
@@ -147,6 +152,10 @@ class ResNorm(PythonAlgorithm):
         if self._create_output:
             self.setProperty('OutputWorkspaceTable', fit_params)
 
+        prog_process.report('Add or replace Resolution workspace')
+        res_name = res_clone_name[2:]
+        RenameWorkspace(InputWorkspace=res_clone_name,OutputWorkspace=res_name)
+        mtd.addOrReplace(res_name, res_clone_ws)
 
     def _process_res_ws(self, num_hist):
         """

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -92,8 +92,6 @@ class ResNorm(PythonAlgorithm):
 
 
     def PyExec(self):
-        from IndirectCommon import getWSprefix
-
         res_clone_name = '__' + self._res_ws
         res_clone_ws= CloneWorkspace(InputWorkspace=self._res_ws, OutputWorkspace=res_clone_name)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -119,7 +119,8 @@ class ResNorm(PythonAlgorithm):
             input_str += '%s,i%d;' % (padded_res_ws, idx)
             prog_namer.report('Generating PlotPeak input string')
 
-        out_name = getWSprefix(self._res_ws) + 'ResNorm_Fit'
+        base_name = padded_res_ws.getName()
+        out_name = '%sResNorm_Fit' % (base_name[:-3])
         function = 'name=TabulatedFunction,Workspace=%s,Scaling=1,Shift=0,XScaling=1,ties=(Shift=0)' % self._van_ws
 
         plot_peaks = self.createChildAlgorithm(name='PlotPeakByLogValue', startProgress=0.02, endProgress=0.94, enableLogging=True)

--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -103,14 +103,12 @@ bool ResNorm::validate() {
 void ResNorm::run() {
   QString vanWsName(m_uiForm.dsVanadium->getCurrentDataName());
   QString resWsName(m_uiForm.dsResolution->getCurrentDataName());
-  std::string vanIn = vanWsName.toStdString();
-  std::string resIn = resWsName.toStdString();
 
   double eMin(m_dblManager->value(m_properties["EMin"]));
   double eMax(m_dblManager->value(m_properties["EMax"]));
 
-  QString outputWsName = getWorkspaceBasename(vanWsName) + "_ResNorm";
-  std::string outname = outputWsName.toStdString();
+  QString outputWsName = getWorkspaceBasename(resWsName) + "_ResNorm";
+
 
   IAlgorithm_sptr resNorm = AlgorithmManager::Instance().create("ResNorm", 2);
   resNorm->initialize();
@@ -142,7 +140,7 @@ void ResNorm::handleAlgorithmComplete(bool error) {
   if (error)
     return;
 
-  QString outputBase = (m_uiForm.dsVanadium->getCurrentDataName()).toLower();
+  QString outputBase = (m_uiForm.dsResolution->getCurrentDataName()).toLower();
   const int indexCut = outputBase.lastIndexOf("_");
   outputBase = outputBase.left(indexCut);
   outputBase += "_ResNorm";

--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -103,23 +103,19 @@ bool ResNorm::validate() {
 void ResNorm::run() {
   QString vanWsName(m_uiForm.dsVanadium->getCurrentDataName());
   QString resWsName(m_uiForm.dsResolution->getCurrentDataName());
+  std::string vanIn = vanWsName.toStdString();
+  std::string resIn = resWsName.toStdString();
 
   double eMin(m_dblManager->value(m_properties["EMin"]));
   double eMax(m_dblManager->value(m_properties["EMax"]));
 
   QString outputWsName = getWorkspaceBasename(vanWsName) + "_ResNorm";
-  QString resCloneName = "__" + resWsName + "_temp";
-  IAlgorithm_sptr clone = AlgorithmManager::Instance().create("CloneWorkspace");
-  clone->initialize();
-  clone->setProperty("InputWorkspace", resWsName.toStdString());
-  clone->setProperty("OutputWorkspace", resCloneName.toStdString());
-  clone->execute();
-
+  std::string outname = outputWsName.toStdString();
 
   IAlgorithm_sptr resNorm = AlgorithmManager::Instance().create("ResNorm", 2);
   resNorm->initialize();
   resNorm->setProperty("VanadiumWorkspace", vanWsName.toStdString());
-  resNorm->setProperty("ResolutionWorkspace", resCloneName.toStdString());
+  resNorm->setProperty("ResolutionWorkspace", resWsName.toStdString());
   resNorm->setProperty("EnergyMin", eMin);
   resNorm->setProperty("EnergyMax", eMax);
   resNorm->setProperty("CreateOutput", true);
@@ -134,7 +130,6 @@ void ResNorm::run() {
 
   m_pythonExportWsName = outputWsName.toStdString();
   m_batchAlgoRunner->executeBatchAsync();
-
 
 }
 


### PR DESCRIPTION
Fixes #14604 

ResNorm can now deal with both the old and new style naming conventions

**Files for this test can be found at: `\\olympic\babylon5\Public\ElliotOram\Bayes\ResNorm`**
# To Test
- Open ResNorm (Interfaces > Indirect > Bayes > ResNorm) 
- Test the following inputs with each other
  - Vanadium = `irs26173_graphite002_red.nxs` OR `iris26173_graphite002_red.nxs`
  - Resolution = `irs26173_graphite002_res.nxs` OR `iris26173_graphite002_res.nxs`
- To run the algorithm click `Run`
  - For the purpose of the test is advisable to close the interface and clear the ADS of workspaces after each run to verify that the correct workspaces are being selected for plotting each time.
- Ensure that in every combination the algorithm runs without producing any errors
- Ensure that once the algorithm has run that the mini plot has the Resolution, Vanadium and Fit displayed.
