### PR TITLE
IndirectCorrections chemical formula validation

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/AbsorptionCorrections.cpp
@@ -1,3 +1,4 @@
+#include "MantidKernel/Material.h"
 #include "MantidKernel/Unit.h"
 
 #include "MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.h"
@@ -237,6 +238,22 @@ bool AbsorptionCorrections::validate() {
                                m_uiForm.leSampleChemicalFormula))
     uiv.checkFieldIsValid("Sample Chamical Formula",
                           m_uiForm.leSampleChemicalFormula);
+  const auto sampleChem =
+      m_uiForm.leSampleChemicalFormula->text().toStdString();
+  const auto containerChem =
+      m_uiForm.leCanChemicalFormula->text().toStdString();
+  try {
+    Mantid::Kernel::Material::parseChemicalFormula(sampleChem);
+  } catch (std::runtime_error &ex) {
+    UNUSED_ARG(ex);
+    uiv.addErrorMessage("Chemical Formula for Sample was not recognised.");
+  }
+  try {
+    Mantid::Kernel::Material::parseChemicalFormula(containerChem);
+  } catch (std::runtime_error &ex) {
+    UNUSED_ARG(ex);
+    uiv.addErrorMessage("Chemical Formula for Container was not recognised.");
+  }
 
   bool useCan = m_uiForm.ckUseCan->isChecked();
   if (useCan) {

--- a/MantidQt/CustomInterfaces/src/Indirect/CalculatePaalmanPings.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/CalculatePaalmanPings.cpp
@@ -157,6 +157,25 @@ bool CalculatePaalmanPings::doValidation(bool silent) {
 
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
 
+  const auto sampleChem =
+	  m_uiForm.leSampleChemicalFormula->text().toStdString();
+  const auto containerChem =
+	  m_uiForm.leCanChemicalFormula->text().toStdString();
+  try {
+	  Mantid::Kernel::Material::parseChemicalFormula(sampleChem);
+  }
+  catch (std::runtime_error &ex) {
+	  UNUSED_ARG(ex);
+	  uiv.addErrorMessage("Chemical Formula for Sample was not recognised.");
+  }
+  try {
+	  Mantid::Kernel::Material::parseChemicalFormula(containerChem);
+  }
+  catch (std::runtime_error &ex) {
+	  UNUSED_ARG(ex);
+	  uiv.addErrorMessage("Chemical Formula for Container was not recognised.");
+  }
+
   // Validate chemical formula
   if (uiv.checkFieldIsNotEmpty("Sample Chemical Formula",
                                m_uiForm.leSampleChemicalFormula,


### PR DESCRIPTION
Fixes #14569

Chemical Formula inputs in the corrections tab are now checked to ensure that the formula is valid before processing.
# To Test
- Open Absorption (Interfaces > Indirect > Corrections > Absorption)
- See https://github.com/mantidproject/mantid/pull/14558 for input parameters (no need to add the shift this time)
- sample chemical = H2-O 
- container chemical = V
- Try these and ensure validation passes and the algorithm runs correctly
- Ensure that validation fails when you try to use invalid chemical formula 
- Also test the validation in CalulcatePaalmanPings (Interfaces > Indirect > Corrections > ApplyPaalmanPings) 
- The input parameters are similar to `Absorption` 
  - Sample angle = 45
- Test this interface again with valid/non-valid chemical formula
