### PR TITLE
 Fix SumRowColumn algorithm

### DIFF
--- a/Framework/Algorithms/src/SumRowColumn.cpp
+++ b/Framework/Algorithms/src/SumRowColumn.cpp
@@ -81,7 +81,7 @@ void SumRowColumn::exec() {
   MatrixWorkspace_sptr outputWS =
       WorkspaceFactory::Instance().create(integratedWS, 1, dim, dim);
   // Remove the unit
-  outputWS->getAxis(0)->unit().reset();
+  outputWS->getAxis(0)->unit().reset(new Mantid::Kernel::Units::Empty);
 
   // Get references to the vectors for the results
   MantidVec &X = outputWS->dataX(0);

--- a/Framework/Algorithms/test/SumRowColumnTest.h
+++ b/Framework/Algorithms/test/SumRowColumnTest.h
@@ -63,7 +63,9 @@ public:
     TS_ASSERT_EQUALS(output->readE(0)[1], 0)
     TS_ASSERT_EQUALS(output->readE(0)[9], 0)
 
-    TS_ASSERT(!output->getAxis(0)->unit())
+    TSM_ASSERT("Should have an empty unit",
+               boost::dynamic_pointer_cast<Mantid::Kernel::Units::Empty>(
+                   output->getAxis(0)->unit()))
   }
 
   void testVertical() {


### PR DESCRIPTION
Fixes #14612

The `SumRowColumn` algorithm reset the unit of the x axis which made the xunit point to `nullptr`. Now it is pointing to a new instance of `Empty` unit.
# For testing:
1. Run

``` python
# Create a workspace with 128*128 spectra each with 5 values (only 128*128 or 192*192 are valid)
ws = CreateSampleWorkspace("Histogram",  NumBanks=1, BankPixelWidth=128, BinWidth=10, Xmax=50)

# Run algorithm with Horizontal orientation
OutputWorkspace = SumRowColumn( ws, "D_H")

print  "Input workspace has",ws.getNPoints(),"points."
print  "Output workspace has",OutputWorkspace.getNPoints(),"points."
```
1. Plot the output workspace
   - Confirm that there is no error
   - Confirm that the x axis has no error
2. Open the output workspace in a Mantid Matrix
   - Confirm that there is no error
   - Confirm that the x axis has no error
