### PR TITLE
Added log notices to CompareWorkspaces

### DIFF
--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -132,6 +132,11 @@ void CompareWorkspaces::exec() {
   if (!m_Result) {
     std::string message = m_Messages->cell<std::string>(0, 0);
     g_log.notice() << "The workspaces did not match: " << message << std::endl;
+  } else {
+    std::string ws1 = Workspace_const_sptr(getProperty("Workspace1"))->name();
+    std::string ws2 = Workspace_const_sptr(getProperty("Workspace2"))->name();
+    g_log.notice() << "The workspaces \"" << ws1 << "\" and \"" << ws2
+                   << "\" matched!" << std::endl;
   }
 
   setProperty("Result", m_Result);
@@ -169,6 +174,11 @@ bool CompareWorkspaces::processGroups() {
   } else if (!ws1 || !ws2) {
     recordMismatch(
         "Type mismatch. One workspace is a group, the other is not.");
+  }
+
+  if (m_Result && ws1 && ws2) {
+    g_log.notice() << "All workspaces in workspace groups \"" << ws1->name()
+                   << "\" and \"" << ws2->name() << "\" matched!" << std::endl;
   }
 
   setProperty("Result", m_Result);


### PR DESCRIPTION
Fixes #14619.

No need to update release notes since this is an internal testing algorithm.

CompareWorkspaces algorithm was not providing any indication that workspaces matched when run from the Algorithms dock window. When run from Python, there is a boolean return value to indicate an overall match / mismatch, but this is not accessible when running it from the GUI.

This PR adds a log notice that informs the user that everything matched.
### Testing

Load some workspaces and group workspaces, run the CompareWorkspaces algorithm from the Algorithms dock and compare them with each other. 

When selecting matching workspaces or group workspaces (or just comparing a workspace with itself), you should see a log message (notice level) to indicate a match was detected. That message should, of course, not show up when mismatches are detected.
