### PR TITLE
Verify macdeployqt created Qt PlugIns folder.

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -160,11 +160,16 @@ if( "@MAKE_VATES@" == "ON" )
 end
 `macdeployqt ../MantidPlot.app #{Qt_Executables}`
 
-#Fix remaining QT-related linking issues.
-Dir["Contents/PlugIns/**/*.dylib"].each do |library|
-  basename =  File.basename(library)
-  `chmod +w #{library}`
-  `install_name_tool -id @rpath/#{basename} #{library}`
+if Dir.exist?("Contents/PlugIns")
+  #Fix remaining QT-related linking issues.
+  Dir["Contents/PlugIns/**/*.dylib"].each do |library|
+    basename =  File.basename(library)
+    `chmod +w #{library}`
+    `install_name_tool -id @rpath/#{basename} #{library}`
+  end
+else
+  p "Contents/PlugIns not created by macdeployqt."
+  exit 1
 end
 
 #change id of all PyQt4 libraries


### PR DESCRIPTION
This Fixes #14607.

We changed from manually copying Qt plugins since they are now being copied by macdeployqt (see #14340 and #14358). This pull request adds a check to verify that the directory `Contents/PlugIns` is created and if not fails noisily.

no release notes.

testing: code review.
