### PR TITLE
Remove redundant bounding boxes from instruments

### DIFF
--- a/instrument/CORELLI_Definition.xml
+++ b/instrument/CORELLI_Definition.xml
@@ -744,14 +744,6 @@
       <right-back-top-point x="-0.291933129728" y="0.239703150615" z="0.0"/>
     </hexahedron>
     <algebra val="body : hole0 : hole1 : hole2 : hole3 : hole4 : hole5 : hole6 : hole7 : hole8 : hole9 : hole10 : hole11 : hole12 : hole13 : hole14 : hole15 : hole16 : hole17 : hole18 : hole19 : hole20 : hole21 : hole22 : hole23 : hole24 : hole25 : hole26 : hole27 : hole28 : hole29 : hole30 : hole31 : hole32 : hole33 : hole34 : hole35 : hole36 : hole37 : hole38 : hole39 : hole40 : hole41 : hole42 : hole43 : hole44 : hole45 : hole46 : hole47 : hole48 : hole49 : hole50 : hole51 : hole52 : hole53 : hole54 : hole55 : hole56 : hole57 : hole58 : hole59 : hole60 : hole61 : hole62 : hole63"/>
-    <bounding-box>
-      <x-min val="-0.58"/>
-      <x-max val="0.02"/>
-      <y-min val="-0.3"/>
-      <y-max val="0.3"/>
-      <z-min val="0.0"/>
-      <z-max val="0.02"/>
-    </bounding-box>
   </type>
   <component-link name="correlation-chopper">
     <parameter name="sequence" type="string">

--- a/instrument/GEM_Definition.xml
+++ b/instrument/GEM_Definition.xml
@@ -346,183 +346,138 @@
 
 <type name="arc_B1s_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2985"/><outer-radius val="0.3035"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0127"/><x-max val="0.0025"/><y-min val="-0.0786"/><y-max val="0.0786"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3044"/><outer-radius val="0.3094"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0129"/><x-max val="0.0025"/><y-min val="-0.0801"/><y-max val="0.0801"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3084"/><outer-radius val="0.3134"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0130"/><x-max val="0.0025"/><y-min val="-0.0811"/><y-max val="0.0811"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3143"/><outer-radius val="0.3193"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0132"/><x-max val="0.0025"/><y-min val="-0.0827"/><y-max val="0.0827"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3183"/><outer-radius val="0.3233"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0133"/><x-max val="0.0025"/><y-min val="-0.0837"/><y-max val="0.0837"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3243"/><outer-radius val="0.3293"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0135"/><x-max val="0.0025"/><y-min val="-0.0852"/><y-max val="0.0852"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3281"/><outer-radius val="0.3331"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0137"/><x-max val="0.0025"/><y-min val="-0.0862"/><y-max val="0.0862"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3342"/><outer-radius val="0.3392"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0139"/><x-max val="0.0025"/><y-min val="-0.0878"/><y-max val="0.0878"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3380"/><outer-radius val="0.3430"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0140"/><x-max val="0.0025"/><y-min val="-0.0888"/><y-max val="0.0888"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3441"/><outer-radius val="0.3491"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0142"/><x-max val="0.0025"/><y-min val="-0.0903"/><y-max val="0.0903"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3479"/><outer-radius val="0.3529"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.0913"/><y-max val="0.0913"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3539"/><outer-radius val="0.3589"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.0929"/><y-max val="0.0929"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3577"/><outer-radius val="0.3627"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.0939"/><y-max val="0.0939"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3638"/><outer-radius val="0.3688"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.0955"/><y-max val="0.0955"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3676"/><outer-radius val="0.3726"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.0964"/><y-max val="0.0964"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3737"/><outer-radius val="0.3787"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.0980"/><y-max val="0.0980"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3774"/><outer-radius val="0.3824"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0154"/><x-max val="0.0025"/><y-min val="-0.0990"/><y-max val="0.0990"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3836"/><outer-radius val="0.3886"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.1006"/><y-max val="0.1006"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3872"/><outer-radius val="0.3922"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.1015"/><y-max val="0.1015"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3934"/><outer-radius val="0.3984"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0159"/><x-max val="0.0025"/><y-min val="-0.1031"/><y-max val="0.1031"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_20" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3971"/><outer-radius val="0.4021"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0160"/><x-max val="0.0025"/><y-min val="-0.1041"/><y-max val="0.1041"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_21" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4033"/><outer-radius val="0.4083"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0162"/><x-max val="0.0025"/><y-min val="-0.1057"/><y-max val="0.1057"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_22" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4069"/><outer-radius val="0.4119"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0164"/><x-max val="0.0025"/><y-min val="-0.1066"/><y-max val="0.1066"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_23" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4131"/><outer-radius val="0.4181"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0166"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_24" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4167"/><outer-radius val="0.4217"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0167"/><x-max val="0.0025"/><y-min val="-0.1091"/><y-max val="0.1091"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_25" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4230"/><outer-radius val="0.4280"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0169"/><x-max val="0.0025"/><y-min val="-0.1108"/><y-max val="0.1108"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_26" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4265"/><outer-radius val="0.4315"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0170"/><x-max val="0.0025"/><y-min val="-0.1117"/><y-max val="0.1117"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_27" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4328"/><outer-radius val="0.4378"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0172"/><x-max val="0.0025"/><y-min val="-0.1133"/><y-max val="0.1133"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_28" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4363"/><outer-radius val="0.4413"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0174"/><x-max val="0.0025"/><y-min val="-0.1142"/><y-max val="0.1142"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_29" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4426"/><outer-radius val="0.4476"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.1159"/><y-max val="0.1159"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_30" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4461"/><outer-radius val="0.4511"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0177"/><x-max val="0.0025"/><y-min val="-0.1168"/><y-max val="0.1168"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_31" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4525"/><outer-radius val="0.4575"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.1184"/><y-max val="0.1184"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_32" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4559"/><outer-radius val="0.4609"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0180"/><x-max val="0.0025"/><y-min val="-0.1193"/><y-max val="0.1193"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_33" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4623"/><outer-radius val="0.4673"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0183"/><x-max val="0.0025"/><y-min val="-0.1209"/><y-max val="0.1209"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_34" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4656"/><outer-radius val="0.4706"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.1218"/><y-max val="0.1218"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_35" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4721"/><outer-radius val="0.4771"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0186"/><x-max val="0.0025"/><y-min val="-0.1235"/><y-max val="0.1235"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_36" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4754"/><outer-radius val="0.4804"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0187"/><x-max val="0.0025"/><y-min val="-0.1243"/><y-max val="0.1243"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_37" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4819"/><outer-radius val="0.4869"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.1260"/><y-max val="0.1260"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_38" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4852"/><outer-radius val="0.4902"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0190"/><x-max val="0.0025"/><y-min val="-0.1269"/><y-max val="0.1269"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_39" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4917"/><outer-radius val="0.4967"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0193"/><x-max val="0.0025"/><y-min val="-0.1285"/><y-max val="0.1285"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_40" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4949"/><outer-radius val="0.4999"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0194"/><x-max val="0.0025"/><y-min val="-0.1294"/><y-max val="0.1294"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_41" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5014"/><outer-radius val="0.5064"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0196"/><x-max val="0.0025"/><y-min val="-0.1311"/><y-max val="0.1311"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_42" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5047"/><outer-radius val="0.5097"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0197"/><x-max val="0.0025"/><y-min val="-0.1319"/><y-max val="0.1319"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_43" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5112"/><outer-radius val="0.5162"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0199"/><x-max val="0.0025"/><y-min val="-0.1336"/><y-max val="0.1336"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1s_44" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5144"/><outer-radius val="0.5194"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0200"/><x-max val="0.0025"/><y-min val="-0.1344"/><y-max val="0.1344"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
 
@@ -592,243 +547,183 @@
 
 <type name="arc_B1l_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2250"/><outer-radius val="0.2300"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0102"/><x-max val="0.0025"/><y-min val="-0.0595"/><y-max val="0.0595"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2300"/><outer-radius val="0.2350"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0103"/><x-max val="0.0025"/><y-min val="-0.0608"/><y-max val="0.0608"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2349"/><outer-radius val="0.2399"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0105"/><x-max val="0.0025"/><y-min val="-0.0621"/><y-max val="0.0621"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2399"/><outer-radius val="0.2449"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0107"/><x-max val="0.0025"/><y-min val="-0.0634"/><y-max val="0.0634"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2449"/><outer-radius val="0.2499"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0108"/><x-max val="0.0025"/><y-min val="-0.0647"/><y-max val="0.0647"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2499"/><outer-radius val="0.2549"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0110"/><x-max val="0.0025"/><y-min val="-0.0660"/><y-max val="0.0660"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2548"/><outer-radius val="0.2598"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0112"/><x-max val="0.0025"/><y-min val="-0.0673"/><y-max val="0.0673"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2598"/><outer-radius val="0.2648"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0114"/><x-max val="0.0025"/><y-min val="-0.0685"/><y-max val="0.0685"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2648"/><outer-radius val="0.2698"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0115"/><x-max val="0.0025"/><y-min val="-0.0698"/><y-max val="0.0698"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2697"/><outer-radius val="0.2747"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0117"/><x-max val="0.0025"/><y-min val="-0.0711"/><y-max val="0.0711"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2747"/><outer-radius val="0.2797"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0119"/><x-max val="0.0025"/><y-min val="-0.0724"/><y-max val="0.0724"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2797"/><outer-radius val="0.2847"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0120"/><x-max val="0.0025"/><y-min val="-0.0737"/><y-max val="0.0737"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2846"/><outer-radius val="0.2896"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0122"/><x-max val="0.0025"/><y-min val="-0.0750"/><y-max val="0.0750"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2896"/><outer-radius val="0.2946"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0124"/><x-max val="0.0025"/><y-min val="-0.0763"/><y-max val="0.0763"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2946"/><outer-radius val="0.2996"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0125"/><x-max val="0.0025"/><y-min val="-0.0775"/><y-max val="0.0775"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2995"/><outer-radius val="0.3045"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0127"/><x-max val="0.0025"/><y-min val="-0.0788"/><y-max val="0.0788"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3045"/><outer-radius val="0.3095"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0129"/><x-max val="0.0025"/><y-min val="-0.0801"/><y-max val="0.0801"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3094"/><outer-radius val="0.3144"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0130"/><x-max val="0.0025"/><y-min val="-0.0814"/><y-max val="0.0814"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3144"/><outer-radius val="0.3194"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0132"/><x-max val="0.0025"/><y-min val="-0.0827"/><y-max val="0.0827"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3194"/><outer-radius val="0.3244"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0134"/><x-max val="0.0025"/><y-min val="-0.0840"/><y-max val="0.0840"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_20" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3243"/><outer-radius val="0.3293"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0136"/><x-max val="0.0025"/><y-min val="-0.0852"/><y-max val="0.0852"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_21" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3293"/><outer-radius val="0.3343"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0137"/><x-max val="0.0025"/><y-min val="-0.0865"/><y-max val="0.0865"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_22" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3342"/><outer-radius val="0.3392"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0139"/><x-max val="0.0025"/><y-min val="-0.0878"/><y-max val="0.0878"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_23" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3392"/><outer-radius val="0.3442"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.0891"/><y-max val="0.0891"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_24" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3441"/><outer-radius val="0.3491"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0142"/><x-max val="0.0025"/><y-min val="-0.0904"/><y-max val="0.0904"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_25" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3491"/><outer-radius val="0.3541"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.0916"/><y-max val="0.0916"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_26" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3540"/><outer-radius val="0.3590"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.0929"/><y-max val="0.0929"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_27" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3590"/><outer-radius val="0.3640"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.0942"/><y-max val="0.0942"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_28" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3639"/><outer-radius val="0.3689"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.0955"/><y-max val="0.0955"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_29" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3688"/><outer-radius val="0.3738"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0151"/><x-max val="0.0025"/><y-min val="-0.0968"/><y-max val="0.0968"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_30" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3738"/><outer-radius val="0.3788"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.0980"/><y-max val="0.0980"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_31" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3787"/><outer-radius val="0.3837"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0154"/><x-max val="0.0025"/><y-min val="-0.0993"/><y-max val="0.0993"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_32" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3836"/><outer-radius val="0.3886"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.1006"/><y-max val="0.1006"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_33" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3886"/><outer-radius val="0.3936"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.1019"/><y-max val="0.1019"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_34" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3935"/><outer-radius val="0.3985"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0159"/><x-max val="0.0025"/><y-min val="-0.1031"/><y-max val="0.1031"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_35" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3984"/><outer-radius val="0.4034"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0161"/><x-max val="0.0025"/><y-min val="-0.1044"/><y-max val="0.1044"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_36" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4034"/><outer-radius val="0.4084"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0162"/><x-max val="0.0025"/><y-min val="-0.1057"/><y-max val="0.1057"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_37" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4083"/><outer-radius val="0.4133"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0164"/><x-max val="0.0025"/><y-min val="-0.1070"/><y-max val="0.1070"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_38" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4132"/><outer-radius val="0.4182"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0166"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_39" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4181"/><outer-radius val="0.4231"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0167"/><x-max val="0.0025"/><y-min val="-0.1095"/><y-max val="0.1095"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_40" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4231"/><outer-radius val="0.4281"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0169"/><x-max val="0.0025"/><y-min val="-0.1108"/><y-max val="0.1108"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_41" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4280"/><outer-radius val="0.4330"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0171"/><x-max val="0.0025"/><y-min val="-0.1121"/><y-max val="0.1121"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_42" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4329"/><outer-radius val="0.4379"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.1133"/><y-max val="0.1133"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_43" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4378"/><outer-radius val="0.4428"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0174"/><x-max val="0.0025"/><y-min val="-0.1146"/><y-max val="0.1146"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_44" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4427"/><outer-radius val="0.4477"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.1159"/><y-max val="0.1159"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_45" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4476"/><outer-radius val="0.4526"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.1172"/><y-max val="0.1172"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_46" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4525"/><outer-radius val="0.4575"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.1184"/><y-max val="0.1184"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_47" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4575"/><outer-radius val="0.4625"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0181"/><x-max val="0.0025"/><y-min val="-0.1197"/><y-max val="0.1197"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_48" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4624"/><outer-radius val="0.4674"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0183"/><x-max val="0.0025"/><y-min val="-0.1210"/><y-max val="0.1210"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_49" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4673"/><outer-radius val="0.4723"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.1222"/><y-max val="0.1222"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_50" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4722"/><outer-radius val="0.4772"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0186"/><x-max val="0.0025"/><y-min val="-0.1235"/><y-max val="0.1235"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_51" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4771"/><outer-radius val="0.4821"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0188"/><x-max val="0.0025"/><y-min val="-0.1248"/><y-max val="0.1248"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_52" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4820"/><outer-radius val="0.4870"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.1260"/><y-max val="0.1260"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_53" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4869"/><outer-radius val="0.4919"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0191"/><x-max val="0.0025"/><y-min val="-0.1273"/><y-max val="0.1273"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_54" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4917"/><outer-radius val="0.4967"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0193"/><x-max val="0.0025"/><y-min val="-0.1286"/><y-max val="0.1286"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_55" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4966"/><outer-radius val="0.5016"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0194"/><x-max val="0.0025"/><y-min val="-0.1298"/><y-max val="0.1298"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_56" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5015"/><outer-radius val="0.5065"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0196"/><x-max val="0.0025"/><y-min val="-0.1311"/><y-max val="0.1311"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_57" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5064"/><outer-radius val="0.5114"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0198"/><x-max val="0.0025"/><y-min val="-0.1324"/><y-max val="0.1324"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_58" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5113"/><outer-radius val="0.5163"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0199"/><x-max val="0.0025"/><y-min val="-0.1336"/><y-max val="0.1336"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B1l_59" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5162"/><outer-radius val="0.5212"/><depth val="0.001"/><arc val="30.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0201"/><x-max val="0.0025"/><y-min val="-0.1349"/><y-max val="0.1349"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
 
@@ -1631,323 +1526,243 @@
 
 <type name="arc_B6a1_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1755"/><outer-radius val="0.1805"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0069"/><x-max val="0.0025"/><y-min val="-0.0402"/><y-max val="0.0402"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1786"/><outer-radius val="0.1836"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0070"/><x-max val="0.0025"/><y-min val="-0.0409"/><y-max val="0.0409"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1852"/><outer-radius val="0.1902"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0071"/><x-max val="0.0025"/><y-min val="-0.0423"/><y-max val="0.0423"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1884"/><outer-radius val="0.1934"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0072"/><x-max val="0.0025"/><y-min val="-0.0430"/><y-max val="0.0430"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1950"/><outer-radius val="0.2000"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0074"/><x-max val="0.0025"/><y-min val="-0.0445"/><y-max val="0.0445"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1982"/><outer-radius val="0.2032"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0075"/><x-max val="0.0025"/><y-min val="-0.0452"/><y-max val="0.0452"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2047"/><outer-radius val="0.2097"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0076"/><x-max val="0.0025"/><y-min val="-0.0467"/><y-max val="0.0467"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2080"/><outer-radius val="0.2130"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0077"/><x-max val="0.0025"/><y-min val="-0.0474"/><y-max val="0.0474"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2145"/><outer-radius val="0.2195"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0079"/><x-max val="0.0025"/><y-min val="-0.0488"/><y-max val="0.0488"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2177"/><outer-radius val="0.2227"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0080"/><x-max val="0.0025"/><y-min val="-0.0496"/><y-max val="0.0496"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2243"/><outer-radius val="0.2293"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0081"/><x-max val="0.0025"/><y-min val="-0.0510"/><y-max val="0.0510"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2275"/><outer-radius val="0.2325"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0082"/><x-max val="0.0025"/><y-min val="-0.0517"/><y-max val="0.0517"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2340"/><outer-radius val="0.2390"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0084"/><x-max val="0.0025"/><y-min val="-0.0532"/><y-max val="0.0532"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2373"/><outer-radius val="0.2423"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0084"/><x-max val="0.0025"/><y-min val="-0.0539"/><y-max val="0.0539"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2438"/><outer-radius val="0.2488"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0086"/><x-max val="0.0025"/><y-min val="-0.0554"/><y-max val="0.0554"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2470"/><outer-radius val="0.2520"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0087"/><x-max val="0.0025"/><y-min val="-0.0561"/><y-max val="0.0561"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2536"/><outer-radius val="0.2586"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0089"/><x-max val="0.0025"/><y-min val="-0.0575"/><y-max val="0.0575"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2568"/><outer-radius val="0.2618"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0089"/><x-max val="0.0025"/><y-min val="-0.0583"/><y-max val="0.0583"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2633"/><outer-radius val="0.2683"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0091"/><x-max val="0.0025"/><y-min val="-0.0597"/><y-max val="0.0597"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a1_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2665"/><outer-radius val="0.2715"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0092"/><x-max val="0.0025"/><y-min val="-0.0604"/><y-max val="0.0604"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3134"/><outer-radius val="0.3184"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0104"/><x-max val="0.0025"/><y-min val="-0.0708"/><y-max val="0.0708"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3157"/><outer-radius val="0.3207"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0104"/><x-max val="0.0025"/><y-min val="-0.0714"/><y-max val="0.0714"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3229"/><outer-radius val="0.3279"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0106"/><x-max val="0.0025"/><y-min val="-0.0730"/><y-max val="0.0730"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3252"/><outer-radius val="0.3302"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0107"/><x-max val="0.0025"/><y-min val="-0.0735"/><y-max val="0.0735"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3324"/><outer-radius val="0.3374"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0108"/><x-max val="0.0025"/><y-min val="-0.0751"/><y-max val="0.0751"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3346"/><outer-radius val="0.3396"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0109"/><x-max val="0.0025"/><y-min val="-0.0756"/><y-max val="0.0756"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3418"/><outer-radius val="0.3468"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0111"/><x-max val="0.0025"/><y-min val="-0.0772"/><y-max val="0.0772"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3441"/><outer-radius val="0.3491"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0111"/><x-max val="0.0025"/><y-min val="-0.0777"/><y-max val="0.0777"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3513"/><outer-radius val="0.3563"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0113"/><x-max val="0.0025"/><y-min val="-0.0793"/><y-max val="0.0793"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3536"/><outer-radius val="0.3586"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0114"/><x-max val="0.0025"/><y-min val="-0.0798"/><y-max val="0.0798"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3608"/><outer-radius val="0.3658"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0115"/><x-max val="0.0025"/><y-min val="-0.0814"/><y-max val="0.0814"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3631"/><outer-radius val="0.3681"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0116"/><x-max val="0.0025"/><y-min val="-0.0819"/><y-max val="0.0819"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3703"/><outer-radius val="0.3753"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0118"/><x-max val="0.0025"/><y-min val="-0.0835"/><y-max val="0.0835"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3726"/><outer-radius val="0.3776"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0118"/><x-max val="0.0025"/><y-min val="-0.0840"/><y-max val="0.0840"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3798"/><outer-radius val="0.3848"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0120"/><x-max val="0.0025"/><y-min val="-0.0856"/><y-max val="0.0856"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3820"/><outer-radius val="0.3870"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0121"/><x-max val="0.0025"/><y-min val="-0.0861"/><y-max val="0.0861"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3892"/><outer-radius val="0.3942"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0123"/><x-max val="0.0025"/><y-min val="-0.0877"/><y-max val="0.0877"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3915"/><outer-radius val="0.3965"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0123"/><x-max val="0.0025"/><y-min val="-0.0882"/><y-max val="0.0882"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3987"/><outer-radius val="0.4037"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0125"/><x-max val="0.0025"/><y-min val="-0.0898"/><y-max val="0.0898"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a2_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4010"/><outer-radius val="0.4060"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0126"/><x-max val="0.0025"/><y-min val="-0.0903"/><y-max val="0.0903"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4531"/><outer-radius val="0.4581"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0139"/><x-max val="0.0025"/><y-min val="-0.1019"/><y-max val="0.1019"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4546"/><outer-radius val="0.4596"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0139"/><x-max val="0.0025"/><y-min val="-0.1023"/><y-max val="0.1023"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4622"/><outer-radius val="0.4672"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.1040"/><y-max val="0.1040"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4638"/><outer-radius val="0.4688"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.1043"/><y-max val="0.1043"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4714"/><outer-radius val="0.4764"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0143"/><x-max val="0.0025"/><y-min val="-0.1060"/><y-max val="0.1060"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4729"/><outer-radius val="0.4779"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.1063"/><y-max val="0.1063"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4806"/><outer-radius val="0.4856"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0145"/><x-max val="0.0025"/><y-min val="-0.1081"/><y-max val="0.1081"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4821"/><outer-radius val="0.4871"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.1084"/><y-max val="0.1084"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4898"/><outer-radius val="0.4948"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0148"/><x-max val="0.0025"/><y-min val="-0.1101"/><y-max val="0.1101"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4913"/><outer-radius val="0.4963"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0148"/><x-max val="0.0025"/><y-min val="-0.1104"/><y-max val="0.1104"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4989"/><outer-radius val="0.5039"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.1121"/><y-max val="0.1121"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5004"/><outer-radius val="0.5054"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.1125"/><y-max val="0.1125"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5081"/><outer-radius val="0.5131"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.1142"/><y-max val="0.1142"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5096"/><outer-radius val="0.5146"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.1145"/><y-max val="0.1145"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5173"/><outer-radius val="0.5223"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0155"/><x-max val="0.0025"/><y-min val="-0.1162"/><y-max val="0.1162"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5188"/><outer-radius val="0.5238"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0155"/><x-max val="0.0025"/><y-min val="-0.1166"/><y-max val="0.1166"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5264"/><outer-radius val="0.5314"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.1183"/><y-max val="0.1183"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5280"/><outer-radius val="0.5330"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.1186"/><y-max val="0.1186"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5356"/><outer-radius val="0.5406"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0159"/><x-max val="0.0025"/><y-min val="-0.1203"/><y-max val="0.1203"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a3_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.5371"/><outer-radius val="0.5421"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0160"/><x-max val="0.0025"/><y-min val="-0.1206"/><y-max val="0.1206"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6086"/><outer-radius val="0.6136"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.1365"/><y-max val="0.1365"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6094"/><outer-radius val="0.6144"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.1367"/><y-max val="0.1367"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6174"/><outer-radius val="0.6224"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0180"/><x-max val="0.0025"/><y-min val="-0.1385"/><y-max val="0.1385"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6182"/><outer-radius val="0.6232"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0180"/><x-max val="0.0025"/><y-min val="-0.1387"/><y-max val="0.1387"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6262"/><outer-radius val="0.6312"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.1405"/><y-max val="0.1405"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6270"/><outer-radius val="0.6320"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.1406"/><y-max val="0.1406"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6351"/><outer-radius val="0.6401"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.1424"/><y-max val="0.1424"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6359"/><outer-radius val="0.6409"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.1426"/><y-max val="0.1426"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6439"/><outer-radius val="0.6489"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0186"/><x-max val="0.0025"/><y-min val="-0.1444"/><y-max val="0.1444"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6447"/><outer-radius val="0.6497"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0187"/><x-max val="0.0025"/><y-min val="-0.1446"/><y-max val="0.1446"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6527"/><outer-radius val="0.6577"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.1464"/><y-max val="0.1464"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6535"/><outer-radius val="0.6585"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.1465"/><y-max val="0.1465"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6615"/><outer-radius val="0.6665"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0191"/><x-max val="0.0025"/><y-min val="-0.1483"/><y-max val="0.1483"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6623"/><outer-radius val="0.6673"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0191"/><x-max val="0.0025"/><y-min val="-0.1485"/><y-max val="0.1485"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6704"/><outer-radius val="0.6754"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0193"/><x-max val="0.0025"/><y-min val="-0.1503"/><y-max val="0.1503"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6712"/><outer-radius val="0.6762"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0193"/><x-max val="0.0025"/><y-min val="-0.1505"/><y-max val="0.1505"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6792"/><outer-radius val="0.6842"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0195"/><x-max val="0.0025"/><y-min val="-0.1522"/><y-max val="0.1522"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6800"/><outer-radius val="0.6850"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0195"/><x-max val="0.0025"/><y-min val="-0.1524"/><y-max val="0.1524"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6880"/><outer-radius val="0.6930"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0198"/><x-max val="0.0025"/><y-min val="-0.1542"/><y-max val="0.1542"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6a4_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.6888"/><outer-radius val="0.6938"/><depth val="0.01"/><arc val="25.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0198"/><x-max val="0.0025"/><y-min val="-0.1544"/><y-max val="0.1544"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
 
@@ -1997,163 +1812,123 @@
   
 <type name="arc_B6b1_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.7838"/><outer-radius val="0.7888"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.1370"/><y-max val="0.1370"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.7839"/><outer-radius val="0.7889"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.1370"/><y-max val="0.1370"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.7922"/><outer-radius val="0.7972"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0145"/><x-max val="0.0025"/><y-min val="-0.1384"/><y-max val="0.1384"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.7923"/><outer-radius val="0.7973"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0145"/><x-max val="0.0025"/><y-min val="-0.1385"/><y-max val="0.1385"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8007"/><outer-radius val="0.8057"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.1399"/><y-max val="0.1399"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8008"/><outer-radius val="0.8058"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.1399"/><y-max val="0.1399"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8091"/><outer-radius val="0.8141"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0148"/><x-max val="0.0025"/><y-min val="-0.1414"/><y-max val="0.1414"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8093"/><outer-radius val="0.8143"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0148"/><x-max val="0.0025"/><y-min val="-0.1414"/><y-max val="0.1414"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8176"/><outer-radius val="0.8226"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.1428"/><y-max val="0.1428"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8177"/><outer-radius val="0.8227"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.1429"/><y-max val="0.1429"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8261"/><outer-radius val="0.8311"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.1443"/><y-max val="0.1443"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8262"/><outer-radius val="0.8312"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0151"/><x-max val="0.0025"/><y-min val="-0.1443"/><y-max val="0.1443"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8345"/><outer-radius val="0.8395"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.1458"/><y-max val="0.1458"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8347"/><outer-radius val="0.8397"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.1458"/><y-max val="0.1458"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8430"/><outer-radius val="0.8480"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.1473"/><y-max val="0.1473"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8431"/><outer-radius val="0.8481"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.1473"/><y-max val="0.1473"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.7964"/><outer-radius val="0.8014"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.1392"/><y-max val="0.1392"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8516"/><outer-radius val="0.8566"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0154"/><x-max val="0.0025"/><y-min val="-0.1487"/><y-max val="0.1487"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8599"/><outer-radius val="0.8649"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.1502"/><y-max val="0.1502"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b1_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.8600"/><outer-radius val="0.8650"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.1502"/><y-max val="0.1502"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9752"/><outer-radius val="0.9802"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.1702"/><y-max val="0.1702"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9748"/><outer-radius val="0.9798"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.1701"/><y-max val="0.1701"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9833"/><outer-radius val="0.9883"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0174"/><x-max val="0.0025"/><y-min val="-0.1716"/><y-max val="0.1716"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9829"/><outer-radius val="0.9879"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0174"/><x-max val="0.0025"/><y-min val="-0.1715"/><y-max val="0.1715"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9914"/><outer-radius val="0.9964"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.1730"/><y-max val="0.1730"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9910"/><outer-radius val="0.9960"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.1730"/><y-max val="0.1730"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9996"/><outer-radius val="1.0046"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0177"/><x-max val="0.0025"/><y-min val="-0.1744"/><y-max val="0.1744"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.9991"/><outer-radius val="1.0041"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0177"/><x-max val="0.0025"/><y-min val="-0.1744"/><y-max val="0.1744"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0077"/><outer-radius val="1.0127"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.1758"/><y-max val="0.1758"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0072"/><outer-radius val="1.0122"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.1758"/><y-max val="0.1758"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0158"/><outer-radius val="1.0208"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.1773"/><y-max val="0.1773"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0153"/><outer-radius val="1.0203"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.1772"/><y-max val="0.1772"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0239"/><outer-radius val="1.0289"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0181"/><x-max val="0.0025"/><y-min val="-0.1787"/><y-max val="0.1787"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0234"/><outer-radius val="1.0284"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0180"/><x-max val="0.0025"/><y-min val="-0.1786"/><y-max val="0.1786"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0320"/><outer-radius val="1.0370"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.1801"/><y-max val="0.1801"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0315"/><outer-radius val="1.0365"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.1800"/><y-max val="0.1800"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0401"/><outer-radius val="1.0451"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0183"/><x-max val="0.0025"/><y-min val="-0.1815"/><y-max val="0.1815"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0397"/><outer-radius val="1.0447"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0183"/><x-max val="0.0025"/><y-min val="-0.1814"/><y-max val="0.1814"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0482"/><outer-radius val="1.0532"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.1829"/><y-max val="0.1829"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc_B6b2_19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="1.0478"/><outer-radius val="1.0528"/><depth val="0.01"/><arc val="20.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.1828"/><y-max val="0.1828"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
   

--- a/instrument/HIFI_Definition.xml
+++ b/instrument/HIFI_Definition.xml
@@ -219,16 +219,7 @@
       <left-back-top-point x="0.005" y="0.037" z="-0.0104"  />
       <right-back-top-point x="0.005" y="0.037" z="0.0104"  />
     </hexahedron>
-    <algebra val="shape" /> 
-
-    <bounding-box>
-      <x-min val="0.0"/>
-      <x-max val="0.005"/>
-      <y-min val="-0.037"/>
-      <y-max val="0.037"/>
-      <z-min val="-0.0104"/>
-      <z-max val="0.0104"/>
-    </bounding-box>
+    <algebra val="shape" />
     
   </type>  
  

--- a/instrument/HRPD_Definition.xml
+++ b/instrument/HRPD_Definition.xml
@@ -414,515 +414,387 @@
 
 <type name="arc0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0596"/><outer-radius val="0.0646"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0070"/><x-max val="0.0025"/><y-min val="-0.0247"/><y-max val="0.0247"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0615"/><outer-radius val="0.0665"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0072"/><x-max val="0.0025"/><y-min val="-0.0255"/><y-max val="0.0255"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0635"/><outer-radius val="0.0685"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0073"/><x-max val="0.0025"/><y-min val="-0.0262"/><y-max val="0.0262"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0654"/><outer-radius val="0.0704"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0075"/><x-max val="0.0025"/><y-min val="-0.0270"/><y-max val="0.0270"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0674"/><outer-radius val="0.0724"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0076"/><x-max val="0.0025"/><y-min val="-0.0277"/><y-max val="0.0277"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0693"/><outer-radius val="0.0743"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0078"/><x-max val="0.0025"/><y-min val="-0.0284"/><y-max val="0.0284"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0713"/><outer-radius val="0.0763"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0079"/><x-max val="0.0025"/><y-min val="-0.0292"/><y-max val="0.0292"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0732"/><outer-radius val="0.0782"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0081"/><x-max val="0.0025"/><y-min val="-0.0299"/><y-max val="0.0299"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0752"/><outer-radius val="0.0802"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0082"/><x-max val="0.0025"/><y-min val="-0.0307"/><y-max val="0.0307"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0771"/><outer-radius val="0.0821"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0084"/><x-max val="0.0025"/><y-min val="-0.0314"/><y-max val="0.0314"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0791"/><outer-radius val="0.0841"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0085"/><x-max val="0.0025"/><y-min val="-0.0322"/><y-max val="0.0322"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0810"/><outer-radius val="0.0860"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0087"/><x-max val="0.0025"/><y-min val="-0.0329"/><y-max val="0.0329"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0830"/><outer-radius val="0.0880"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0088"/><x-max val="0.0025"/><y-min val="-0.0337"/><y-max val="0.0337"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0849"/><outer-radius val="0.0899"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0090"/><x-max val="0.0025"/><y-min val="-0.0344"/><y-max val="0.0344"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0869"/><outer-radius val="0.0919"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0091"/><x-max val="0.0025"/><y-min val="-0.0352"/><y-max val="0.0352"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0888"/><outer-radius val="0.0938"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0093"/><x-max val="0.0025"/><y-min val="-0.0359"/><y-max val="0.0359"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0908"/><outer-radius val="0.0958"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0094"/><x-max val="0.0025"/><y-min val="-0.0367"/><y-max val="0.0367"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0927"/><outer-radius val="0.0977"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0096"/><x-max val="0.0025"/><y-min val="-0.0374"/><y-max val="0.0374"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0947"/><outer-radius val="0.0997"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0097"/><x-max val="0.0025"/><y-min val="-0.0381"/><y-max val="0.0381"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0966"/><outer-radius val="0.1016"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0099"/><x-max val="0.0025"/><y-min val="-0.0389"/><y-max val="0.0389"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc20" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0986"/><outer-radius val="0.1036"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0100"/><x-max val="0.0025"/><y-min val="-0.0396"/><y-max val="0.0396"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc21" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1005"/><outer-radius val="0.1055"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0102"/><x-max val="0.0025"/><y-min val="-0.0404"/><y-max val="0.0404"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc22" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1024"/><outer-radius val="0.1074"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0103"/><x-max val="0.0025"/><y-min val="-0.0411"/><y-max val="0.0411"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc23" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1044"/><outer-radius val="0.1094"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0104"/><x-max val="0.0025"/><y-min val="-0.0419"/><y-max val="0.0419"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc24" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1063"/><outer-radius val="0.1113"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0106"/><x-max val="0.0025"/><y-min val="-0.0426"/><y-max val="0.0426"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc25" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1083"/><outer-radius val="0.1133"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0107"/><x-max val="0.0025"/><y-min val="-0.0433"/><y-max val="0.0433"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc26" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1102"/><outer-radius val="0.1152"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0109"/><x-max val="0.0025"/><y-min val="-0.0441"/><y-max val="0.0441"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc27" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1122"/><outer-radius val="0.1172"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0110"/><x-max val="0.0025"/><y-min val="-0.0448"/><y-max val="0.0448"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc28" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1141"/><outer-radius val="0.1191"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0112"/><x-max val="0.0025"/><y-min val="-0.0456"/><y-max val="0.0456"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc29" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1160"/><outer-radius val="0.1210"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0113"/><x-max val="0.0025"/><y-min val="-0.0463"/><y-max val="0.0463"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc30" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1180"/><outer-radius val="0.1230"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0115"/><x-max val="0.0025"/><y-min val="-0.0471"/><y-max val="0.0471"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc31" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1199"/><outer-radius val="0.1249"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0116"/><x-max val="0.0025"/><y-min val="-0.0478"/><y-max val="0.0478"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc32" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1218"/><outer-radius val="0.1268"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0118"/><x-max val="0.0025"/><y-min val="-0.0485"/><y-max val="0.0485"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc33" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1238"/><outer-radius val="0.1288"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0119"/><x-max val="0.0025"/><y-min val="-0.0493"/><y-max val="0.0493"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc34" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1257"/><outer-radius val="0.1307"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0121"/><x-max val="0.0025"/><y-min val="-0.0500"/><y-max val="0.0500"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc35" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1277"/><outer-radius val="0.1327"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0122"/><x-max val="0.0025"/><y-min val="-0.0508"/><y-max val="0.0508"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc36" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1296"/><outer-radius val="0.1346"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0124"/><x-max val="0.0025"/><y-min val="-0.0515"/><y-max val="0.0515"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc37" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1315"/><outer-radius val="0.1365"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0125"/><x-max val="0.0025"/><y-min val="-0.0522"/><y-max val="0.0522"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc38" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1335"/><outer-radius val="0.1385"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0127"/><x-max val="0.0025"/><y-min val="-0.0530"/><y-max val="0.0530"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc39" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1354"/><outer-radius val="0.1404"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0128"/><x-max val="0.0025"/><y-min val="-0.0537"/><y-max val="0.0537"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc40" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1373"/><outer-radius val="0.1423"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0130"/><x-max val="0.0025"/><y-min val="-0.0545"/><y-max val="0.0545"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc41" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1393"/><outer-radius val="0.1443"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0131"/><x-max val="0.0025"/><y-min val="-0.0552"/><y-max val="0.0552"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc42" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1412"/><outer-radius val="0.1462"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0132"/><x-max val="0.0025"/><y-min val="-0.0559"/><y-max val="0.0559"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc43" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1431"/><outer-radius val="0.1481"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0134"/><x-max val="0.0025"/><y-min val="-0.0567"/><y-max val="0.0567"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc44" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1451"/><outer-radius val="0.1501"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0135"/><x-max val="0.0025"/><y-min val="-0.0574"/><y-max val="0.0574"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc45" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1470"/><outer-radius val="0.1520"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0137"/><x-max val="0.0025"/><y-min val="-0.0582"/><y-max val="0.0582"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc46" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1489"/><outer-radius val="0.1539"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0138"/><x-max val="0.0025"/><y-min val="-0.0589"/><y-max val="0.0589"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc47" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1508"/><outer-radius val="0.1558"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0140"/><x-max val="0.0025"/><y-min val="-0.0596"/><y-max val="0.0596"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc48" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1528"/><outer-radius val="0.1578"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.0604"/><y-max val="0.0604"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc49" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1547"/><outer-radius val="0.1597"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0143"/><x-max val="0.0025"/><y-min val="-0.0611"/><y-max val="0.0611"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc50" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1566"/><outer-radius val="0.1616"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.0618"/><y-max val="0.0618"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc51" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1585"/><outer-radius val="0.1635"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.0626"/><y-max val="0.0626"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc52" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1605"/><outer-radius val="0.1655"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.0633"/><y-max val="0.0633"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc53" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1624"/><outer-radius val="0.1674"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.0641"/><y-max val="0.0641"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc54" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1643"/><outer-radius val="0.1693"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.0648"/><y-max val="0.0648"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc55" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1662"/><outer-radius val="0.1712"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.0655"/><y-max val="0.0655"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc56" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1682"/><outer-radius val="0.1732"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.0663"/><y-max val="0.0663"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc57" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1701"/><outer-radius val="0.1751"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0154"/><x-max val="0.0025"/><y-min val="-0.0670"/><y-max val="0.0670"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc58" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1720"/><outer-radius val="0.1770"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.0677"/><y-max val="0.0677"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc59" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1739"/><outer-radius val="0.1789"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.0685"/><y-max val="0.0685"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc60" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1758"/><outer-radius val="0.1808"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0159"/><x-max val="0.0025"/><y-min val="-0.0692"/><y-max val="0.0692"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc61" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1778"/><outer-radius val="0.1828"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0160"/><x-max val="0.0025"/><y-min val="-0.0699"/><y-max val="0.0699"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc62" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1797"/><outer-radius val="0.1847"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0162"/><x-max val="0.0025"/><y-min val="-0.0707"/><y-max val="0.0707"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc63" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1816"/><outer-radius val="0.1866"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0163"/><x-max val="0.0025"/><y-min val="-0.0714"/><y-max val="0.0714"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc64" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1835"/><outer-radius val="0.1885"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0165"/><x-max val="0.0025"/><y-min val="-0.0721"/><y-max val="0.0721"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc65" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1854"/><outer-radius val="0.1904"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0166"/><x-max val="0.0025"/><y-min val="-0.0729"/><y-max val="0.0729"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc66" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1873"/><outer-radius val="0.1923"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0168"/><x-max val="0.0025"/><y-min val="-0.0736"/><y-max val="0.0736"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc67" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1892"/><outer-radius val="0.1942"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0169"/><x-max val="0.0025"/><y-min val="-0.0743"/><y-max val="0.0743"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc68" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1911"/><outer-radius val="0.1961"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0171"/><x-max val="0.0025"/><y-min val="-0.0751"/><y-max val="0.0751"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc69" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1931"/><outer-radius val="0.1981"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0172"/><x-max val="0.0025"/><y-min val="-0.0758"/><y-max val="0.0758"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc70" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1950"/><outer-radius val="0.2000"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.0765"/><y-max val="0.0765"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc71" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1969"/><outer-radius val="0.2019"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0175"/><x-max val="0.0025"/><y-min val="-0.0773"/><y-max val="0.0773"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc72" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1988"/><outer-radius val="0.2038"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.0780"/><y-max val="0.0780"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc73" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2007"/><outer-radius val="0.2057"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.0787"/><y-max val="0.0787"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc74" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2026"/><outer-radius val="0.2076"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.0794"/><y-max val="0.0794"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc75" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2045"/><outer-radius val="0.2095"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0181"/><x-max val="0.0025"/><y-min val="-0.0802"/><y-max val="0.0802"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc76" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2064"/><outer-radius val="0.2114"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.0809"/><y-max val="0.0809"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc77" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2083"/><outer-radius val="0.2133"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.0816"/><y-max val="0.0816"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc78" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2102"/><outer-radius val="0.2152"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0185"/><x-max val="0.0025"/><y-min val="-0.0824"/><y-max val="0.0824"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc79" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2121"/><outer-radius val="0.2171"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0186"/><x-max val="0.0025"/><y-min val="-0.0831"/><y-max val="0.0831"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc80" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2140"/><outer-radius val="0.2190"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0188"/><x-max val="0.0025"/><y-min val="-0.0838"/><y-max val="0.0838"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc81" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2159"/><outer-radius val="0.2209"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.0845"/><y-max val="0.0845"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc82" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2178"/><outer-radius val="0.2228"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0191"/><x-max val="0.0025"/><y-min val="-0.0853"/><y-max val="0.0853"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc83" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2197"/><outer-radius val="0.2247"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0192"/><x-max val="0.0025"/><y-min val="-0.0860"/><y-max val="0.0860"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc84" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2216"/><outer-radius val="0.2266"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0194"/><x-max val="0.0025"/><y-min val="-0.0867"/><y-max val="0.0867"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc85" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2235"/><outer-radius val="0.2285"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0195"/><x-max val="0.0025"/><y-min val="-0.0874"/><y-max val="0.0874"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc86" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2254"/><outer-radius val="0.2304"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0197"/><x-max val="0.0025"/><y-min val="-0.0882"/><y-max val="0.0882"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc87" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2273"/><outer-radius val="0.2323"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0198"/><x-max val="0.0025"/><y-min val="-0.0889"/><y-max val="0.0889"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc88" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2292"/><outer-radius val="0.2342"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0199"/><x-max val="0.0025"/><y-min val="-0.0896"/><y-max val="0.0896"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc89" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2310"/><outer-radius val="0.2360"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0201"/><x-max val="0.0025"/><y-min val="-0.0903"/><y-max val="0.0903"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc90" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2329"/><outer-radius val="0.2379"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0202"/><x-max val="0.0025"/><y-min val="-0.0911"/><y-max val="0.0911"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc91" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2348"/><outer-radius val="0.2398"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0204"/><x-max val="0.0025"/><y-min val="-0.0918"/><y-max val="0.0918"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc92" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2367"/><outer-radius val="0.2417"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0205"/><x-max val="0.0025"/><y-min val="-0.0925"/><y-max val="0.0925"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc93" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2386"/><outer-radius val="0.2436"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0207"/><x-max val="0.0025"/><y-min val="-0.0932"/><y-max val="0.0932"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc94" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2405"/><outer-radius val="0.2455"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0208"/><x-max val="0.0025"/><y-min val="-0.0939"/><y-max val="0.0939"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc95" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2424"/><outer-radius val="0.2474"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0209"/><x-max val="0.0025"/><y-min val="-0.0947"/><y-max val="0.0947"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc96" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2442"/><outer-radius val="0.2492"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0211"/><x-max val="0.0025"/><y-min val="-0.0954"/><y-max val="0.0954"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc97" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2461"/><outer-radius val="0.2511"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0212"/><x-max val="0.0025"/><y-min val="-0.0961"/><y-max val="0.0961"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc98" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2480"/><outer-radius val="0.2530"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0214"/><x-max val="0.0025"/><y-min val="-0.0968"/><y-max val="0.0968"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc99" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2499"/><outer-radius val="0.2549"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0215"/><x-max val="0.0025"/><y-min val="-0.0975"/><y-max val="0.0975"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc100" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2517"/><outer-radius val="0.2567"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0217"/><x-max val="0.0025"/><y-min val="-0.0982"/><y-max val="0.0982"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc101" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2536"/><outer-radius val="0.2586"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0218"/><x-max val="0.0025"/><y-min val="-0.0990"/><y-max val="0.0990"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc102" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2555"/><outer-radius val="0.2605"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0219"/><x-max val="0.0025"/><y-min val="-0.0997"/><y-max val="0.0997"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc103" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2574"/><outer-radius val="0.2624"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0221"/><x-max val="0.0025"/><y-min val="-0.1004"/><y-max val="0.1004"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc104" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2592"/><outer-radius val="0.2642"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0222"/><x-max val="0.0025"/><y-min val="-0.1011"/><y-max val="0.1011"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc105" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2611"/><outer-radius val="0.2661"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0224"/><x-max val="0.0025"/><y-min val="-0.1018"/><y-max val="0.1018"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc106" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2630"/><outer-radius val="0.2680"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0225"/><x-max val="0.0025"/><y-min val="-0.1025"/><y-max val="0.1025"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc107" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2648"/><outer-radius val="0.2698"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0227"/><x-max val="0.0025"/><y-min val="-0.1033"/><y-max val="0.1033"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc108" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2667"/><outer-radius val="0.2717"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0228"/><x-max val="0.0025"/><y-min val="-0.1040"/><y-max val="0.1040"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc109" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2686"/><outer-radius val="0.2736"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0229"/><x-max val="0.0025"/><y-min val="-0.1047"/><y-max val="0.1047"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc110" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2704"/><outer-radius val="0.2754"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0231"/><x-max val="0.0025"/><y-min val="-0.1054"/><y-max val="0.1054"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc111" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2723"/><outer-radius val="0.2773"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0232"/><x-max val="0.0025"/><y-min val="-0.1061"/><y-max val="0.1061"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc112" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2741"/><outer-radius val="0.2791"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0234"/><x-max val="0.0025"/><y-min val="-0.1068"/><y-max val="0.1068"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc113" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2760"/><outer-radius val="0.2810"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0235"/><x-max val="0.0025"/><y-min val="-0.1075"/><y-max val="0.1075"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc114" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2779"/><outer-radius val="0.2829"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0237"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc115" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2797"/><outer-radius val="0.2847"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0238"/><x-max val="0.0025"/><y-min val="-0.1090"/><y-max val="0.1090"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc116" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2816"/><outer-radius val="0.2866"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0239"/><x-max val="0.0025"/><y-min val="-0.1097"/><y-max val="0.1097"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc117" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2834"/><outer-radius val="0.2884"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0241"/><x-max val="0.0025"/><y-min val="-0.1104"/><y-max val="0.1104"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc118" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2853"/><outer-radius val="0.2903"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0242"/><x-max val="0.0025"/><y-min val="-0.1111"/><y-max val="0.1111"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc119" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2871"/><outer-radius val="0.2921"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0244"/><x-max val="0.0025"/><y-min val="-0.1118"/><y-max val="0.1118"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc120" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2890"/><outer-radius val="0.2940"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0245"/><x-max val="0.0025"/><y-min val="-0.1125"/><y-max val="0.1125"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc121" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2908"/><outer-radius val="0.2958"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0246"/><x-max val="0.0025"/><y-min val="-0.1132"/><y-max val="0.1132"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc122" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2927"/><outer-radius val="0.2977"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0248"/><x-max val="0.0025"/><y-min val="-0.1139"/><y-max val="0.1139"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc123" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2945"/><outer-radius val="0.2995"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0249"/><x-max val="0.0025"/><y-min val="-0.1146"/><y-max val="0.1146"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc124" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2964"/><outer-radius val="0.3014"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0251"/><x-max val="0.0025"/><y-min val="-0.1153"/><y-max val="0.1153"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc125" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2982"/><outer-radius val="0.3032"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0252"/><x-max val="0.0025"/><y-min val="-0.1160"/><y-max val="0.1160"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc126" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3001"/><outer-radius val="0.3051"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0253"/><x-max val="0.0025"/><y-min val="-0.1167"/><y-max val="0.1167"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc127" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3019"/><outer-radius val="0.3069"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0255"/><x-max val="0.0025"/><y-min val="-0.1174"/><y-max val="0.1174"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
 

--- a/instrument/IDFs_for_UNIT_TESTING/HRPD_for_UNIT_TESTING.xml
+++ b/instrument/IDFs_for_UNIT_TESTING/HRPD_for_UNIT_TESTING.xml
@@ -433,515 +433,387 @@
 
 <type name="arc0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0596"/><outer-radius val="0.0646"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0070"/><x-max val="0.0025"/><y-min val="-0.0247"/><y-max val="0.0247"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0615"/><outer-radius val="0.0665"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0072"/><x-max val="0.0025"/><y-min val="-0.0255"/><y-max val="0.0255"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0635"/><outer-radius val="0.0685"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0073"/><x-max val="0.0025"/><y-min val="-0.0262"/><y-max val="0.0262"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0654"/><outer-radius val="0.0704"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0075"/><x-max val="0.0025"/><y-min val="-0.0270"/><y-max val="0.0270"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0674"/><outer-radius val="0.0724"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0076"/><x-max val="0.0025"/><y-min val="-0.0277"/><y-max val="0.0277"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0693"/><outer-radius val="0.0743"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0078"/><x-max val="0.0025"/><y-min val="-0.0284"/><y-max val="0.0284"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0713"/><outer-radius val="0.0763"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0079"/><x-max val="0.0025"/><y-min val="-0.0292"/><y-max val="0.0292"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0732"/><outer-radius val="0.0782"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0081"/><x-max val="0.0025"/><y-min val="-0.0299"/><y-max val="0.0299"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0752"/><outer-radius val="0.0802"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0082"/><x-max val="0.0025"/><y-min val="-0.0307"/><y-max val="0.0307"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0771"/><outer-radius val="0.0821"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0084"/><x-max val="0.0025"/><y-min val="-0.0314"/><y-max val="0.0314"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0791"/><outer-radius val="0.0841"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0085"/><x-max val="0.0025"/><y-min val="-0.0322"/><y-max val="0.0322"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0810"/><outer-radius val="0.0860"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0087"/><x-max val="0.0025"/><y-min val="-0.0329"/><y-max val="0.0329"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0830"/><outer-radius val="0.0880"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0088"/><x-max val="0.0025"/><y-min val="-0.0337"/><y-max val="0.0337"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0849"/><outer-radius val="0.0899"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0090"/><x-max val="0.0025"/><y-min val="-0.0344"/><y-max val="0.0344"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0869"/><outer-radius val="0.0919"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0091"/><x-max val="0.0025"/><y-min val="-0.0352"/><y-max val="0.0352"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0888"/><outer-radius val="0.0938"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0093"/><x-max val="0.0025"/><y-min val="-0.0359"/><y-max val="0.0359"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0908"/><outer-radius val="0.0958"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0094"/><x-max val="0.0025"/><y-min val="-0.0367"/><y-max val="0.0367"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0927"/><outer-radius val="0.0977"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0096"/><x-max val="0.0025"/><y-min val="-0.0374"/><y-max val="0.0374"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0947"/><outer-radius val="0.0997"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0097"/><x-max val="0.0025"/><y-min val="-0.0381"/><y-max val="0.0381"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0966"/><outer-radius val="0.1016"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0099"/><x-max val="0.0025"/><y-min val="-0.0389"/><y-max val="0.0389"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc20" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0986"/><outer-radius val="0.1036"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0100"/><x-max val="0.0025"/><y-min val="-0.0396"/><y-max val="0.0396"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc21" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1005"/><outer-radius val="0.1055"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0102"/><x-max val="0.0025"/><y-min val="-0.0404"/><y-max val="0.0404"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc22" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1024"/><outer-radius val="0.1074"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0103"/><x-max val="0.0025"/><y-min val="-0.0411"/><y-max val="0.0411"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc23" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1044"/><outer-radius val="0.1094"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0104"/><x-max val="0.0025"/><y-min val="-0.0419"/><y-max val="0.0419"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc24" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1063"/><outer-radius val="0.1113"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0106"/><x-max val="0.0025"/><y-min val="-0.0426"/><y-max val="0.0426"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc25" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1083"/><outer-radius val="0.1133"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0107"/><x-max val="0.0025"/><y-min val="-0.0433"/><y-max val="0.0433"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc26" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1102"/><outer-radius val="0.1152"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0109"/><x-max val="0.0025"/><y-min val="-0.0441"/><y-max val="0.0441"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc27" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1122"/><outer-radius val="0.1172"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0110"/><x-max val="0.0025"/><y-min val="-0.0448"/><y-max val="0.0448"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc28" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1141"/><outer-radius val="0.1191"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0112"/><x-max val="0.0025"/><y-min val="-0.0456"/><y-max val="0.0456"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc29" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1160"/><outer-radius val="0.1210"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0113"/><x-max val="0.0025"/><y-min val="-0.0463"/><y-max val="0.0463"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc30" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1180"/><outer-radius val="0.1230"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0115"/><x-max val="0.0025"/><y-min val="-0.0471"/><y-max val="0.0471"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc31" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1199"/><outer-radius val="0.1249"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0116"/><x-max val="0.0025"/><y-min val="-0.0478"/><y-max val="0.0478"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc32" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1218"/><outer-radius val="0.1268"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0118"/><x-max val="0.0025"/><y-min val="-0.0485"/><y-max val="0.0485"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc33" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1238"/><outer-radius val="0.1288"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0119"/><x-max val="0.0025"/><y-min val="-0.0493"/><y-max val="0.0493"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc34" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1257"/><outer-radius val="0.1307"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0121"/><x-max val="0.0025"/><y-min val="-0.0500"/><y-max val="0.0500"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc35" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1277"/><outer-radius val="0.1327"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0122"/><x-max val="0.0025"/><y-min val="-0.0508"/><y-max val="0.0508"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc36" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1296"/><outer-radius val="0.1346"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0124"/><x-max val="0.0025"/><y-min val="-0.0515"/><y-max val="0.0515"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc37" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1315"/><outer-radius val="0.1365"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0125"/><x-max val="0.0025"/><y-min val="-0.0522"/><y-max val="0.0522"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc38" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1335"/><outer-radius val="0.1385"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0127"/><x-max val="0.0025"/><y-min val="-0.0530"/><y-max val="0.0530"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc39" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1354"/><outer-radius val="0.1404"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0128"/><x-max val="0.0025"/><y-min val="-0.0537"/><y-max val="0.0537"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc40" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1373"/><outer-radius val="0.1423"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0130"/><x-max val="0.0025"/><y-min val="-0.0545"/><y-max val="0.0545"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc41" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1393"/><outer-radius val="0.1443"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0131"/><x-max val="0.0025"/><y-min val="-0.0552"/><y-max val="0.0552"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc42" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1412"/><outer-radius val="0.1462"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0132"/><x-max val="0.0025"/><y-min val="-0.0559"/><y-max val="0.0559"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc43" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1431"/><outer-radius val="0.1481"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0134"/><x-max val="0.0025"/><y-min val="-0.0567"/><y-max val="0.0567"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc44" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1451"/><outer-radius val="0.1501"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0135"/><x-max val="0.0025"/><y-min val="-0.0574"/><y-max val="0.0574"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc45" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1470"/><outer-radius val="0.1520"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0137"/><x-max val="0.0025"/><y-min val="-0.0582"/><y-max val="0.0582"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc46" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1489"/><outer-radius val="0.1539"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0138"/><x-max val="0.0025"/><y-min val="-0.0589"/><y-max val="0.0589"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc47" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1508"/><outer-radius val="0.1558"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0140"/><x-max val="0.0025"/><y-min val="-0.0596"/><y-max val="0.0596"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc48" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1528"/><outer-radius val="0.1578"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.0604"/><y-max val="0.0604"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc49" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1547"/><outer-radius val="0.1597"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0143"/><x-max val="0.0025"/><y-min val="-0.0611"/><y-max val="0.0611"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc50" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1566"/><outer-radius val="0.1616"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.0618"/><y-max val="0.0618"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc51" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1585"/><outer-radius val="0.1635"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.0626"/><y-max val="0.0626"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc52" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1605"/><outer-radius val="0.1655"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.0633"/><y-max val="0.0633"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc53" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1624"/><outer-radius val="0.1674"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.0641"/><y-max val="0.0641"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc54" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1643"/><outer-radius val="0.1693"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.0648"/><y-max val="0.0648"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc55" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1662"/><outer-radius val="0.1712"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.0655"/><y-max val="0.0655"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc56" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1682"/><outer-radius val="0.1732"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.0663"/><y-max val="0.0663"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc57" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1701"/><outer-radius val="0.1751"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0154"/><x-max val="0.0025"/><y-min val="-0.0670"/><y-max val="0.0670"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc58" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1720"/><outer-radius val="0.1770"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.0677"/><y-max val="0.0677"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc59" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1739"/><outer-radius val="0.1789"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.0685"/><y-max val="0.0685"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc60" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1758"/><outer-radius val="0.1808"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0159"/><x-max val="0.0025"/><y-min val="-0.0692"/><y-max val="0.0692"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc61" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1778"/><outer-radius val="0.1828"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0160"/><x-max val="0.0025"/><y-min val="-0.0699"/><y-max val="0.0699"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc62" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1797"/><outer-radius val="0.1847"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0162"/><x-max val="0.0025"/><y-min val="-0.0707"/><y-max val="0.0707"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc63" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1816"/><outer-radius val="0.1866"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0163"/><x-max val="0.0025"/><y-min val="-0.0714"/><y-max val="0.0714"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc64" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1835"/><outer-radius val="0.1885"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0165"/><x-max val="0.0025"/><y-min val="-0.0721"/><y-max val="0.0721"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc65" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1854"/><outer-radius val="0.1904"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0166"/><x-max val="0.0025"/><y-min val="-0.0729"/><y-max val="0.0729"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc66" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1873"/><outer-radius val="0.1923"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0168"/><x-max val="0.0025"/><y-min val="-0.0736"/><y-max val="0.0736"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc67" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1892"/><outer-radius val="0.1942"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0169"/><x-max val="0.0025"/><y-min val="-0.0743"/><y-max val="0.0743"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc68" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1911"/><outer-radius val="0.1961"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0171"/><x-max val="0.0025"/><y-min val="-0.0751"/><y-max val="0.0751"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc69" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1931"/><outer-radius val="0.1981"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0172"/><x-max val="0.0025"/><y-min val="-0.0758"/><y-max val="0.0758"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc70" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1950"/><outer-radius val="0.2000"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.0765"/><y-max val="0.0765"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc71" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1969"/><outer-radius val="0.2019"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0175"/><x-max val="0.0025"/><y-min val="-0.0773"/><y-max val="0.0773"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc72" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1988"/><outer-radius val="0.2038"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.0780"/><y-max val="0.0780"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc73" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2007"/><outer-radius val="0.2057"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.0787"/><y-max val="0.0787"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc74" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2026"/><outer-radius val="0.2076"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.0794"/><y-max val="0.0794"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc75" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2045"/><outer-radius val="0.2095"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0181"/><x-max val="0.0025"/><y-min val="-0.0802"/><y-max val="0.0802"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc76" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2064"/><outer-radius val="0.2114"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.0809"/><y-max val="0.0809"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc77" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2083"/><outer-radius val="0.2133"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.0816"/><y-max val="0.0816"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc78" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2102"/><outer-radius val="0.2152"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0185"/><x-max val="0.0025"/><y-min val="-0.0824"/><y-max val="0.0824"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc79" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2121"/><outer-radius val="0.2171"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0186"/><x-max val="0.0025"/><y-min val="-0.0831"/><y-max val="0.0831"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc80" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2140"/><outer-radius val="0.2190"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0188"/><x-max val="0.0025"/><y-min val="-0.0838"/><y-max val="0.0838"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc81" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2159"/><outer-radius val="0.2209"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.0845"/><y-max val="0.0845"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc82" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2178"/><outer-radius val="0.2228"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0191"/><x-max val="0.0025"/><y-min val="-0.0853"/><y-max val="0.0853"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc83" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2197"/><outer-radius val="0.2247"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0192"/><x-max val="0.0025"/><y-min val="-0.0860"/><y-max val="0.0860"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc84" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2216"/><outer-radius val="0.2266"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0194"/><x-max val="0.0025"/><y-min val="-0.0867"/><y-max val="0.0867"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc85" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2235"/><outer-radius val="0.2285"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0195"/><x-max val="0.0025"/><y-min val="-0.0874"/><y-max val="0.0874"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc86" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2254"/><outer-radius val="0.2304"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0197"/><x-max val="0.0025"/><y-min val="-0.0882"/><y-max val="0.0882"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc87" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2273"/><outer-radius val="0.2323"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0198"/><x-max val="0.0025"/><y-min val="-0.0889"/><y-max val="0.0889"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc88" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2292"/><outer-radius val="0.2342"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0199"/><x-max val="0.0025"/><y-min val="-0.0896"/><y-max val="0.0896"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc89" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2310"/><outer-radius val="0.2360"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0201"/><x-max val="0.0025"/><y-min val="-0.0903"/><y-max val="0.0903"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc90" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2329"/><outer-radius val="0.2379"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0202"/><x-max val="0.0025"/><y-min val="-0.0911"/><y-max val="0.0911"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc91" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2348"/><outer-radius val="0.2398"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0204"/><x-max val="0.0025"/><y-min val="-0.0918"/><y-max val="0.0918"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc92" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2367"/><outer-radius val="0.2417"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0205"/><x-max val="0.0025"/><y-min val="-0.0925"/><y-max val="0.0925"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc93" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2386"/><outer-radius val="0.2436"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0207"/><x-max val="0.0025"/><y-min val="-0.0932"/><y-max val="0.0932"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc94" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2405"/><outer-radius val="0.2455"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0208"/><x-max val="0.0025"/><y-min val="-0.0939"/><y-max val="0.0939"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc95" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2424"/><outer-radius val="0.2474"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0209"/><x-max val="0.0025"/><y-min val="-0.0947"/><y-max val="0.0947"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc96" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2442"/><outer-radius val="0.2492"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0211"/><x-max val="0.0025"/><y-min val="-0.0954"/><y-max val="0.0954"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc97" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2461"/><outer-radius val="0.2511"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0212"/><x-max val="0.0025"/><y-min val="-0.0961"/><y-max val="0.0961"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc98" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2480"/><outer-radius val="0.2530"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0214"/><x-max val="0.0025"/><y-min val="-0.0968"/><y-max val="0.0968"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc99" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2499"/><outer-radius val="0.2549"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0215"/><x-max val="0.0025"/><y-min val="-0.0975"/><y-max val="0.0975"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc100" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2517"/><outer-radius val="0.2567"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0217"/><x-max val="0.0025"/><y-min val="-0.0982"/><y-max val="0.0982"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc101" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2536"/><outer-radius val="0.2586"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0218"/><x-max val="0.0025"/><y-min val="-0.0990"/><y-max val="0.0990"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc102" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2555"/><outer-radius val="0.2605"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0219"/><x-max val="0.0025"/><y-min val="-0.0997"/><y-max val="0.0997"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc103" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2574"/><outer-radius val="0.2624"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0221"/><x-max val="0.0025"/><y-min val="-0.1004"/><y-max val="0.1004"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc104" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2592"/><outer-radius val="0.2642"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0222"/><x-max val="0.0025"/><y-min val="-0.1011"/><y-max val="0.1011"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc105" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2611"/><outer-radius val="0.2661"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0224"/><x-max val="0.0025"/><y-min val="-0.1018"/><y-max val="0.1018"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc106" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2630"/><outer-radius val="0.2680"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0225"/><x-max val="0.0025"/><y-min val="-0.1025"/><y-max val="0.1025"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc107" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2648"/><outer-radius val="0.2698"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0227"/><x-max val="0.0025"/><y-min val="-0.1033"/><y-max val="0.1033"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc108" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2667"/><outer-radius val="0.2717"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0228"/><x-max val="0.0025"/><y-min val="-0.1040"/><y-max val="0.1040"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc109" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2686"/><outer-radius val="0.2736"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0229"/><x-max val="0.0025"/><y-min val="-0.1047"/><y-max val="0.1047"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc110" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2704"/><outer-radius val="0.2754"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0231"/><x-max val="0.0025"/><y-min val="-0.1054"/><y-max val="0.1054"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc111" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2723"/><outer-radius val="0.2773"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0232"/><x-max val="0.0025"/><y-min val="-0.1061"/><y-max val="0.1061"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc112" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2741"/><outer-radius val="0.2791"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0234"/><x-max val="0.0025"/><y-min val="-0.1068"/><y-max val="0.1068"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc113" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2760"/><outer-radius val="0.2810"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0235"/><x-max val="0.0025"/><y-min val="-0.1075"/><y-max val="0.1075"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc114" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2779"/><outer-radius val="0.2829"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0237"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc115" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2797"/><outer-radius val="0.2847"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0238"/><x-max val="0.0025"/><y-min val="-0.1090"/><y-max val="0.1090"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc116" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2816"/><outer-radius val="0.2866"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0239"/><x-max val="0.0025"/><y-min val="-0.1097"/><y-max val="0.1097"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc117" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2834"/><outer-radius val="0.2884"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0241"/><x-max val="0.0025"/><y-min val="-0.1104"/><y-max val="0.1104"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc118" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2853"/><outer-radius val="0.2903"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0242"/><x-max val="0.0025"/><y-min val="-0.1111"/><y-max val="0.1111"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc119" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2871"/><outer-radius val="0.2921"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0244"/><x-max val="0.0025"/><y-min val="-0.1118"/><y-max val="0.1118"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc120" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2890"/><outer-radius val="0.2940"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0245"/><x-max val="0.0025"/><y-min val="-0.1125"/><y-max val="0.1125"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc121" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2908"/><outer-radius val="0.2958"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0246"/><x-max val="0.0025"/><y-min val="-0.1132"/><y-max val="0.1132"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc122" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2927"/><outer-radius val="0.2977"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0248"/><x-max val="0.0025"/><y-min val="-0.1139"/><y-max val="0.1139"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc123" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2945"/><outer-radius val="0.2995"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0249"/><x-max val="0.0025"/><y-min val="-0.1146"/><y-max val="0.1146"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc124" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2964"/><outer-radius val="0.3014"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0251"/><x-max val="0.0025"/><y-min val="-0.1153"/><y-max val="0.1153"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc125" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2982"/><outer-radius val="0.3032"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0252"/><x-max val="0.0025"/><y-min val="-0.1160"/><y-max val="0.1160"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc126" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3001"/><outer-radius val="0.3051"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0253"/><x-max val="0.0025"/><y-min val="-0.1167"/><y-max val="0.1167"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc127" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3019"/><outer-radius val="0.3069"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0255"/><x-max val="0.0025"/><y-min val="-0.1174"/><y-max val="0.1174"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
 

--- a/instrument/IDFs_for_UNIT_TESTING/HRPD_for_UNIT_TESTING2.xml
+++ b/instrument/IDFs_for_UNIT_TESTING/HRPD_for_UNIT_TESTING2.xml
@@ -430,515 +430,387 @@
 
 <type name="arc0" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0596"/><outer-radius val="0.0646"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0070"/><x-max val="0.0025"/><y-min val="-0.0247"/><y-max val="0.0247"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc1" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0615"/><outer-radius val="0.0665"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0072"/><x-max val="0.0025"/><y-min val="-0.0255"/><y-max val="0.0255"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc2" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0635"/><outer-radius val="0.0685"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0073"/><x-max val="0.0025"/><y-min val="-0.0262"/><y-max val="0.0262"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc3" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0654"/><outer-radius val="0.0704"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0075"/><x-max val="0.0025"/><y-min val="-0.0270"/><y-max val="0.0270"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc4" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0674"/><outer-radius val="0.0724"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0076"/><x-max val="0.0025"/><y-min val="-0.0277"/><y-max val="0.0277"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc5" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0693"/><outer-radius val="0.0743"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0078"/><x-max val="0.0025"/><y-min val="-0.0284"/><y-max val="0.0284"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc6" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0713"/><outer-radius val="0.0763"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0079"/><x-max val="0.0025"/><y-min val="-0.0292"/><y-max val="0.0292"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc7" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0732"/><outer-radius val="0.0782"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0081"/><x-max val="0.0025"/><y-min val="-0.0299"/><y-max val="0.0299"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc8" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0752"/><outer-radius val="0.0802"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0082"/><x-max val="0.0025"/><y-min val="-0.0307"/><y-max val="0.0307"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc9" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0771"/><outer-radius val="0.0821"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0084"/><x-max val="0.0025"/><y-min val="-0.0314"/><y-max val="0.0314"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc10" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0791"/><outer-radius val="0.0841"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0085"/><x-max val="0.0025"/><y-min val="-0.0322"/><y-max val="0.0322"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc11" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0810"/><outer-radius val="0.0860"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0087"/><x-max val="0.0025"/><y-min val="-0.0329"/><y-max val="0.0329"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc12" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0830"/><outer-radius val="0.0880"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0088"/><x-max val="0.0025"/><y-min val="-0.0337"/><y-max val="0.0337"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc13" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0849"/><outer-radius val="0.0899"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0090"/><x-max val="0.0025"/><y-min val="-0.0344"/><y-max val="0.0344"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc14" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0869"/><outer-radius val="0.0919"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0091"/><x-max val="0.0025"/><y-min val="-0.0352"/><y-max val="0.0352"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc15" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0888"/><outer-radius val="0.0938"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0093"/><x-max val="0.0025"/><y-min val="-0.0359"/><y-max val="0.0359"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc16" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0908"/><outer-radius val="0.0958"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0094"/><x-max val="0.0025"/><y-min val="-0.0367"/><y-max val="0.0367"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc17" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0927"/><outer-radius val="0.0977"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0096"/><x-max val="0.0025"/><y-min val="-0.0374"/><y-max val="0.0374"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc18" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0947"/><outer-radius val="0.0997"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0097"/><x-max val="0.0025"/><y-min val="-0.0381"/><y-max val="0.0381"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc19" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0966"/><outer-radius val="0.1016"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0099"/><x-max val="0.0025"/><y-min val="-0.0389"/><y-max val="0.0389"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc20" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.0986"/><outer-radius val="0.1036"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0100"/><x-max val="0.0025"/><y-min val="-0.0396"/><y-max val="0.0396"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc21" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1005"/><outer-radius val="0.1055"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0102"/><x-max val="0.0025"/><y-min val="-0.0404"/><y-max val="0.0404"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc22" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1024"/><outer-radius val="0.1074"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0103"/><x-max val="0.0025"/><y-min val="-0.0411"/><y-max val="0.0411"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc23" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1044"/><outer-radius val="0.1094"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0104"/><x-max val="0.0025"/><y-min val="-0.0419"/><y-max val="0.0419"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc24" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1063"/><outer-radius val="0.1113"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0106"/><x-max val="0.0025"/><y-min val="-0.0426"/><y-max val="0.0426"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc25" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1083"/><outer-radius val="0.1133"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0107"/><x-max val="0.0025"/><y-min val="-0.0433"/><y-max val="0.0433"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc26" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1102"/><outer-radius val="0.1152"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0109"/><x-max val="0.0025"/><y-min val="-0.0441"/><y-max val="0.0441"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc27" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1122"/><outer-radius val="0.1172"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0110"/><x-max val="0.0025"/><y-min val="-0.0448"/><y-max val="0.0448"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc28" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1141"/><outer-radius val="0.1191"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0112"/><x-max val="0.0025"/><y-min val="-0.0456"/><y-max val="0.0456"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc29" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1160"/><outer-radius val="0.1210"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0113"/><x-max val="0.0025"/><y-min val="-0.0463"/><y-max val="0.0463"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc30" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1180"/><outer-radius val="0.1230"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0115"/><x-max val="0.0025"/><y-min val="-0.0471"/><y-max val="0.0471"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc31" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1199"/><outer-radius val="0.1249"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0116"/><x-max val="0.0025"/><y-min val="-0.0478"/><y-max val="0.0478"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc32" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1218"/><outer-radius val="0.1268"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0118"/><x-max val="0.0025"/><y-min val="-0.0485"/><y-max val="0.0485"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc33" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1238"/><outer-radius val="0.1288"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0119"/><x-max val="0.0025"/><y-min val="-0.0493"/><y-max val="0.0493"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc34" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1257"/><outer-radius val="0.1307"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0121"/><x-max val="0.0025"/><y-min val="-0.0500"/><y-max val="0.0500"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc35" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1277"/><outer-radius val="0.1327"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0122"/><x-max val="0.0025"/><y-min val="-0.0508"/><y-max val="0.0508"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc36" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1296"/><outer-radius val="0.1346"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0124"/><x-max val="0.0025"/><y-min val="-0.0515"/><y-max val="0.0515"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc37" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1315"/><outer-radius val="0.1365"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0125"/><x-max val="0.0025"/><y-min val="-0.0522"/><y-max val="0.0522"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc38" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1335"/><outer-radius val="0.1385"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0127"/><x-max val="0.0025"/><y-min val="-0.0530"/><y-max val="0.0530"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc39" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1354"/><outer-radius val="0.1404"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0128"/><x-max val="0.0025"/><y-min val="-0.0537"/><y-max val="0.0537"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc40" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1373"/><outer-radius val="0.1423"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0130"/><x-max val="0.0025"/><y-min val="-0.0545"/><y-max val="0.0545"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc41" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1393"/><outer-radius val="0.1443"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0131"/><x-max val="0.0025"/><y-min val="-0.0552"/><y-max val="0.0552"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc42" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1412"/><outer-radius val="0.1462"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0132"/><x-max val="0.0025"/><y-min val="-0.0559"/><y-max val="0.0559"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc43" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1431"/><outer-radius val="0.1481"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0134"/><x-max val="0.0025"/><y-min val="-0.0567"/><y-max val="0.0567"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc44" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1451"/><outer-radius val="0.1501"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0135"/><x-max val="0.0025"/><y-min val="-0.0574"/><y-max val="0.0574"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc45" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1470"/><outer-radius val="0.1520"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0137"/><x-max val="0.0025"/><y-min val="-0.0582"/><y-max val="0.0582"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc46" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1489"/><outer-radius val="0.1539"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0138"/><x-max val="0.0025"/><y-min val="-0.0589"/><y-max val="0.0589"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc47" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1508"/><outer-radius val="0.1558"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0140"/><x-max val="0.0025"/><y-min val="-0.0596"/><y-max val="0.0596"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc48" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1528"/><outer-radius val="0.1578"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.0604"/><y-max val="0.0604"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc49" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1547"/><outer-radius val="0.1597"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0143"/><x-max val="0.0025"/><y-min val="-0.0611"/><y-max val="0.0611"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc50" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1566"/><outer-radius val="0.1616"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0144"/><x-max val="0.0025"/><y-min val="-0.0618"/><y-max val="0.0618"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc51" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1585"/><outer-radius val="0.1635"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0146"/><x-max val="0.0025"/><y-min val="-0.0626"/><y-max val="0.0626"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc52" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1605"/><outer-radius val="0.1655"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0147"/><x-max val="0.0025"/><y-min val="-0.0633"/><y-max val="0.0633"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc53" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1624"/><outer-radius val="0.1674"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.0641"/><y-max val="0.0641"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc54" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1643"/><outer-radius val="0.1693"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0150"/><x-max val="0.0025"/><y-min val="-0.0648"/><y-max val="0.0648"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc55" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1662"/><outer-radius val="0.1712"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0152"/><x-max val="0.0025"/><y-min val="-0.0655"/><y-max val="0.0655"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc56" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1682"/><outer-radius val="0.1732"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.0663"/><y-max val="0.0663"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc57" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1701"/><outer-radius val="0.1751"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0154"/><x-max val="0.0025"/><y-min val="-0.0670"/><y-max val="0.0670"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc58" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1720"/><outer-radius val="0.1770"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0156"/><x-max val="0.0025"/><y-min val="-0.0677"/><y-max val="0.0677"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc59" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1739"/><outer-radius val="0.1789"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.0685"/><y-max val="0.0685"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc60" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1758"/><outer-radius val="0.1808"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0159"/><x-max val="0.0025"/><y-min val="-0.0692"/><y-max val="0.0692"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc61" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1778"/><outer-radius val="0.1828"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0160"/><x-max val="0.0025"/><y-min val="-0.0699"/><y-max val="0.0699"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc62" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1797"/><outer-radius val="0.1847"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0162"/><x-max val="0.0025"/><y-min val="-0.0707"/><y-max val="0.0707"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc63" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1816"/><outer-radius val="0.1866"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0163"/><x-max val="0.0025"/><y-min val="-0.0714"/><y-max val="0.0714"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc64" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1835"/><outer-radius val="0.1885"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0165"/><x-max val="0.0025"/><y-min val="-0.0721"/><y-max val="0.0721"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc65" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1854"/><outer-radius val="0.1904"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0166"/><x-max val="0.0025"/><y-min val="-0.0729"/><y-max val="0.0729"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc66" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1873"/><outer-radius val="0.1923"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0168"/><x-max val="0.0025"/><y-min val="-0.0736"/><y-max val="0.0736"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc67" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1892"/><outer-radius val="0.1942"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0169"/><x-max val="0.0025"/><y-min val="-0.0743"/><y-max val="0.0743"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc68" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1911"/><outer-radius val="0.1961"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0171"/><x-max val="0.0025"/><y-min val="-0.0751"/><y-max val="0.0751"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc69" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1931"/><outer-radius val="0.1981"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0172"/><x-max val="0.0025"/><y-min val="-0.0758"/><y-max val="0.0758"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc70" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1950"/><outer-radius val="0.2000"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.0765"/><y-max val="0.0765"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc71" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1969"/><outer-radius val="0.2019"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0175"/><x-max val="0.0025"/><y-min val="-0.0773"/><y-max val="0.0773"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc72" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1988"/><outer-radius val="0.2038"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0176"/><x-max val="0.0025"/><y-min val="-0.0780"/><y-max val="0.0780"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc73" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2007"/><outer-radius val="0.2057"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0178"/><x-max val="0.0025"/><y-min val="-0.0787"/><y-max val="0.0787"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc74" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2026"/><outer-radius val="0.2076"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0179"/><x-max val="0.0025"/><y-min val="-0.0794"/><y-max val="0.0794"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc75" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2045"/><outer-radius val="0.2095"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0181"/><x-max val="0.0025"/><y-min val="-0.0802"/><y-max val="0.0802"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc76" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2064"/><outer-radius val="0.2114"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0182"/><x-max val="0.0025"/><y-min val="-0.0809"/><y-max val="0.0809"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc77" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2083"/><outer-radius val="0.2133"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0184"/><x-max val="0.0025"/><y-min val="-0.0816"/><y-max val="0.0816"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc78" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2102"/><outer-radius val="0.2152"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0185"/><x-max val="0.0025"/><y-min val="-0.0824"/><y-max val="0.0824"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc79" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2121"/><outer-radius val="0.2171"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0186"/><x-max val="0.0025"/><y-min val="-0.0831"/><y-max val="0.0831"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc80" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2140"/><outer-radius val="0.2190"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0188"/><x-max val="0.0025"/><y-min val="-0.0838"/><y-max val="0.0838"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc81" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2159"/><outer-radius val="0.2209"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.0845"/><y-max val="0.0845"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc82" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2178"/><outer-radius val="0.2228"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0191"/><x-max val="0.0025"/><y-min val="-0.0853"/><y-max val="0.0853"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc83" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2197"/><outer-radius val="0.2247"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0192"/><x-max val="0.0025"/><y-min val="-0.0860"/><y-max val="0.0860"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc84" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2216"/><outer-radius val="0.2266"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0194"/><x-max val="0.0025"/><y-min val="-0.0867"/><y-max val="0.0867"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc85" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2235"/><outer-radius val="0.2285"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0195"/><x-max val="0.0025"/><y-min val="-0.0874"/><y-max val="0.0874"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc86" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2254"/><outer-radius val="0.2304"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0197"/><x-max val="0.0025"/><y-min val="-0.0882"/><y-max val="0.0882"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc87" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2273"/><outer-radius val="0.2323"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0198"/><x-max val="0.0025"/><y-min val="-0.0889"/><y-max val="0.0889"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc88" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2292"/><outer-radius val="0.2342"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0199"/><x-max val="0.0025"/><y-min val="-0.0896"/><y-max val="0.0896"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc89" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2310"/><outer-radius val="0.2360"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0201"/><x-max val="0.0025"/><y-min val="-0.0903"/><y-max val="0.0903"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc90" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2329"/><outer-radius val="0.2379"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0202"/><x-max val="0.0025"/><y-min val="-0.0911"/><y-max val="0.0911"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc91" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2348"/><outer-radius val="0.2398"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0204"/><x-max val="0.0025"/><y-min val="-0.0918"/><y-max val="0.0918"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc92" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2367"/><outer-radius val="0.2417"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0205"/><x-max val="0.0025"/><y-min val="-0.0925"/><y-max val="0.0925"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc93" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2386"/><outer-radius val="0.2436"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0207"/><x-max val="0.0025"/><y-min val="-0.0932"/><y-max val="0.0932"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc94" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2405"/><outer-radius val="0.2455"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0208"/><x-max val="0.0025"/><y-min val="-0.0939"/><y-max val="0.0939"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc95" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2424"/><outer-radius val="0.2474"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0209"/><x-max val="0.0025"/><y-min val="-0.0947"/><y-max val="0.0947"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc96" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2442"/><outer-radius val="0.2492"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0211"/><x-max val="0.0025"/><y-min val="-0.0954"/><y-max val="0.0954"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc97" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2461"/><outer-radius val="0.2511"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0212"/><x-max val="0.0025"/><y-min val="-0.0961"/><y-max val="0.0961"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc98" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2480"/><outer-radius val="0.2530"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0214"/><x-max val="0.0025"/><y-min val="-0.0968"/><y-max val="0.0968"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc99" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2499"/><outer-radius val="0.2549"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0215"/><x-max val="0.0025"/><y-min val="-0.0975"/><y-max val="0.0975"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc100" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2517"/><outer-radius val="0.2567"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0217"/><x-max val="0.0025"/><y-min val="-0.0982"/><y-max val="0.0982"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc101" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2536"/><outer-radius val="0.2586"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0218"/><x-max val="0.0025"/><y-min val="-0.0990"/><y-max val="0.0990"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc102" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2555"/><outer-radius val="0.2605"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0219"/><x-max val="0.0025"/><y-min val="-0.0997"/><y-max val="0.0997"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc103" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2574"/><outer-radius val="0.2624"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0221"/><x-max val="0.0025"/><y-min val="-0.1004"/><y-max val="0.1004"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc104" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2592"/><outer-radius val="0.2642"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0222"/><x-max val="0.0025"/><y-min val="-0.1011"/><y-max val="0.1011"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc105" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2611"/><outer-radius val="0.2661"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0224"/><x-max val="0.0025"/><y-min val="-0.1018"/><y-max val="0.1018"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc106" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2630"/><outer-radius val="0.2680"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0225"/><x-max val="0.0025"/><y-min val="-0.1025"/><y-max val="0.1025"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc107" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2648"/><outer-radius val="0.2698"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0227"/><x-max val="0.0025"/><y-min val="-0.1033"/><y-max val="0.1033"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc108" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2667"/><outer-radius val="0.2717"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0228"/><x-max val="0.0025"/><y-min val="-0.1040"/><y-max val="0.1040"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc109" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2686"/><outer-radius val="0.2736"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0229"/><x-max val="0.0025"/><y-min val="-0.1047"/><y-max val="0.1047"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc110" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2704"/><outer-radius val="0.2754"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0231"/><x-max val="0.0025"/><y-min val="-0.1054"/><y-max val="0.1054"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc111" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2723"/><outer-radius val="0.2773"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0232"/><x-max val="0.0025"/><y-min val="-0.1061"/><y-max val="0.1061"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc112" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2741"/><outer-radius val="0.2791"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0234"/><x-max val="0.0025"/><y-min val="-0.1068"/><y-max val="0.1068"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc113" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2760"/><outer-radius val="0.2810"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0235"/><x-max val="0.0025"/><y-min val="-0.1075"/><y-max val="0.1075"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc114" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2779"/><outer-radius val="0.2829"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0237"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc115" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2797"/><outer-radius val="0.2847"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0238"/><x-max val="0.0025"/><y-min val="-0.1090"/><y-max val="0.1090"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc116" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2816"/><outer-radius val="0.2866"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0239"/><x-max val="0.0025"/><y-min val="-0.1097"/><y-max val="0.1097"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc117" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2834"/><outer-radius val="0.2884"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0241"/><x-max val="0.0025"/><y-min val="-0.1104"/><y-max val="0.1104"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc118" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2853"/><outer-radius val="0.2903"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0242"/><x-max val="0.0025"/><y-min val="-0.1111"/><y-max val="0.1111"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc119" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2871"/><outer-radius val="0.2921"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0244"/><x-max val="0.0025"/><y-min val="-0.1118"/><y-max val="0.1118"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc120" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2890"/><outer-radius val="0.2940"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0245"/><x-max val="0.0025"/><y-min val="-0.1125"/><y-max val="0.1125"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc121" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2908"/><outer-radius val="0.2958"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0246"/><x-max val="0.0025"/><y-min val="-0.1132"/><y-max val="0.1132"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc122" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2927"/><outer-radius val="0.2977"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0248"/><x-max val="0.0025"/><y-min val="-0.1139"/><y-max val="0.1139"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc123" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2945"/><outer-radius val="0.2995"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0249"/><x-max val="0.0025"/><y-min val="-0.1146"/><y-max val="0.1146"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc124" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2964"/><outer-radius val="0.3014"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0251"/><x-max val="0.0025"/><y-min val="-0.1153"/><y-max val="0.1153"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc125" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2982"/><outer-radius val="0.3032"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0252"/><x-max val="0.0025"/><y-min val="-0.1160"/><y-max val="0.1160"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc126" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3001"/><outer-radius val="0.3051"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0253"/><x-max val="0.0025"/><y-min val="-0.1167"/><y-max val="0.1167"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 <type name="arc127" is="detector"> 
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3019"/><outer-radius val="0.3069"/><depth val="0.001"/><arc val="45.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0255"/><x-max val="0.0025"/><y-min val="-0.1174"/><y-max val="0.1174"/><z-min val="0.0000"/><z-max val="0.0100"/></bounding-box>
 </type>
 
 

--- a/instrument/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING2.xml
+++ b/instrument/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING2.xml
@@ -263,16 +263,7 @@
     <height val="0.01" />
   </cylinder>  
   
-  <algebra val="outer-cylinder # inner-cylinder" />    
-  
-  <bounding-box>
-    <x-min val="-0.1368" />
-    <x-max val="0.036" />
-    <y-min val="-0.0756" />
-    <y-max val="0.0756" />
-    <z-min val="-0.011" />
-    <z-max val="0.021" />
-  </bounding-box>
+  <algebra val="outer-cylinder # inner-cylinder" />
 </type>
 
 

--- a/instrument/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING5.xml
+++ b/instrument/IDFs_for_UNIT_TESTING/IDF_for_UNIT_TESTING5.xml
@@ -62,15 +62,6 @@
     <location name="B" y="10" rot="90" axis-x="1" axis-y="0" axis-z="0" />
   </component>
   <algebra val="A : B" />
-  
-  <bounding-box>
-    <x-min val="-0.5"/>
-    <x-max val="0.5"/>
-    <y-min val="-5.0"/>
-    <y-max val="10.5"/>
-    <z-min val="-5.0"/>
-    <z-max val="5.0"/>
-  </bounding-box>
 </type>
 
 <type name="nested cuboid" is="detector">
@@ -101,15 +92,6 @@
     <location name="B" y="20" />
   </component>
   <algebra val="A : B" />
-  
-  <bounding-box>
-    <x-min val="0.5"/>
-    <x-max val="1.5"/>
-    <y-min val="-5.0"/>
-    <y-max val="10.5"/>
-    <z-min val="-5.0"/>
-    <z-max val="5.0"/>
-  </bounding-box>
 </type>
 
 <type name="cuboid1" is="detector"> 

--- a/instrument/OSIRIS_Definition.xml
+++ b/instrument/OSIRIS_Definition.xml
@@ -238,583 +238,463 @@
 
 <type name="arc_1" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1535"/><outer-radius val="0.1585"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0141"/><x-max val="0.0025"/><y-min val="-0.0605"/><y-max val="0.0605"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_2" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1588"/><outer-radius val="0.1638"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0145"/><x-max val="0.0025"/><y-min val="-0.0625"/><y-max val="0.0625"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_3" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1640"/><outer-radius val="0.1690"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0149"/><x-max val="0.0025"/><y-min val="-0.0645"/><y-max val="0.0645"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_4" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1693"/><outer-radius val="0.1743"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0153"/><x-max val="0.0025"/><y-min val="-0.0665"/><y-max val="0.0665"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_5" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1745"/><outer-radius val="0.1795"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0157"/><x-max val="0.0025"/><y-min val="-0.0686"/><y-max val="0.0686"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_6" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1798"/><outer-radius val="0.1848"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0161"/><x-max val="0.0025"/><y-min val="-0.0706"/><y-max val="0.0706"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_7" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1850"/><outer-radius val="0.1900"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0165"/><x-max val="0.0025"/><y-min val="-0.0726"/><y-max val="0.0726"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_8" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1902"/><outer-radius val="0.1952"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0169"/><x-max val="0.0025"/><y-min val="-0.0746"/><y-max val="0.0746"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_9" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.1955"/><outer-radius val="0.2005"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0173"/><x-max val="0.0025"/><y-min val="-0.0765"/><y-max val="0.0765"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_10" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2007"/><outer-radius val="0.2057"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0177"/><x-max val="0.0025"/><y-min val="-0.0785"/><y-max val="0.0785"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_11" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2059"/><outer-radius val="0.2109"/><depth val="0.001"/><arc val="43.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0181"/><x-max val="0.0025"/><y-min val="-0.0805"/><y-max val="0.0805"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_12" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2111"/><outer-radius val="0.2161"/><depth val="0.001"/><arc val="42.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0185"/><x-max val="0.0025"/><y-min val="-0.0825"/><y-max val="0.0825"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_13" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2163"/><outer-radius val="0.2213"/><depth val="0.001"/><arc val="41.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0189"/><x-max val="0.0025"/><y-min val="-0.0845"/><y-max val="0.0845"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_14" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2215"/><outer-radius val="0.2265"/><depth val="0.001"/><arc val="40.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0193"/><x-max val="0.0025"/><y-min val="-0.0865"/><y-max val="0.0865"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_15" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2267"/><outer-radius val="0.2317"/><depth val="0.001"/><arc val="39.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0197"/><x-max val="0.0025"/><y-min val="-0.0885"/><y-max val="0.0885"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_16" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2319"/><outer-radius val="0.2369"/><depth val="0.001"/><arc val="38.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0201"/><x-max val="0.0025"/><y-min val="-0.0905"/><y-max val="0.0905"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_17" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2371"/><outer-radius val="0.2421"/><depth val="0.001"/><arc val="38.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0205"/><x-max val="0.0025"/><y-min val="-0.0924"/><y-max val="0.0924"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_18" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2423"/><outer-radius val="0.2473"/><depth val="0.001"/><arc val="37.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0209"/><x-max val="0.0025"/><y-min val="-0.0944"/><y-max val="0.0944"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_19" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2474"/><outer-radius val="0.2524"/><depth val="0.001"/><arc val="36.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0213"/><x-max val="0.0025"/><y-min val="-0.0964"/><y-max val="0.0964"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_20" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2526"/><outer-radius val="0.2576"/><depth val="0.001"/><arc val="35.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0216"/><x-max val="0.0025"/><y-min val="-0.0984"/><y-max val="0.0984"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_22" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2577"/><outer-radius val="0.2627"/><depth val="0.001"/><arc val="35.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0220"/><x-max val="0.0025"/><y-min val="-0.1003"/><y-max val="0.1003"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_24" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2629"/><outer-radius val="0.2679"/><depth val="0.001"/><arc val="34.3"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0224"/><x-max val="0.0025"/><y-min val="-0.1023"/><y-max val="0.1023"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_26" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2680"/><outer-radius val="0.2730"/><depth val="0.001"/><arc val="33.6"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0228"/><x-max val="0.0025"/><y-min val="-0.1043"/><y-max val="0.1043"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_28" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2731"/><outer-radius val="0.2781"/><depth val="0.001"/><arc val="33.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0232"/><x-max val="0.0025"/><y-min val="-0.1062"/><y-max val="0.1062"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_30" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2783"/><outer-radius val="0.2833"/><depth val="0.001"/><arc val="32.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0236"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_32" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2834"/><outer-radius val="0.2884"/><depth val="0.001"/><arc val="31.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0240"/><x-max val="0.0025"/><y-min val="-0.1101"/><y-max val="0.1101"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_34" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2885"/><outer-radius val="0.2935"/><depth val="0.001"/><arc val="31.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0244"/><x-max val="0.0025"/><y-min val="-0.1121"/><y-max val="0.1121"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_36" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2936"/><outer-radius val="0.2986"/><depth val="0.001"/><arc val="30.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0248"/><x-max val="0.0025"/><y-min val="-0.1140"/><y-max val="0.1140"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_38" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2987"/><outer-radius val="0.3037"/><depth val="0.001"/><arc val="30.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0251"/><x-max val="0.0025"/><y-min val="-0.1160"/><y-max val="0.1160"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_40" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3038"/><outer-radius val="0.3088"/><depth val="0.001"/><arc val="29.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0255"/><x-max val="0.0025"/><y-min val="-0.1179"/><y-max val="0.1179"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_42" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3088"/><outer-radius val="0.3138"/><depth val="0.001"/><arc val="29.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0259"/><x-max val="0.0025"/><y-min val="-0.1199"/><y-max val="0.1199"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_44" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3139"/><outer-radius val="0.3189"/><depth val="0.001"/><arc val="28.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0263"/><x-max val="0.0025"/><y-min val="-0.1218"/><y-max val="0.1218"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_46" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3190"/><outer-radius val="0.3240"/><depth val="0.001"/><arc val="28.3"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0267"/><x-max val="0.0025"/><y-min val="-0.1237"/><y-max val="0.1237"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_48" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3240"/><outer-radius val="0.3290"/><depth val="0.001"/><arc val="27.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0271"/><x-max val="0.0025"/><y-min val="-0.1256"/><y-max val="0.1256"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_50" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3290"/><outer-radius val="0.3340"/><depth val="0.001"/><arc val="27.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0274"/><x-max val="0.0025"/><y-min val="-0.1276"/><y-max val="0.1276"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_52" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3341"/><outer-radius val="0.3391"/><depth val="0.001"/><arc val="27.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0278"/><x-max val="0.0025"/><y-min val="-0.1295"/><y-max val="0.1295"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_54" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3391"/><outer-radius val="0.3441"/><depth val="0.001"/><arc val="26.6"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0282"/><x-max val="0.0025"/><y-min val="-0.1314"/><y-max val="0.1314"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_56" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3441"/><outer-radius val="0.3491"/><depth val="0.001"/><arc val="26.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0286"/><x-max val="0.0025"/><y-min val="-0.1333"/><y-max val="0.1333"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_58" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3491"/><outer-radius val="0.3541"/><depth val="0.001"/><arc val="25.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0290"/><x-max val="0.0025"/><y-min val="-0.1352"/><y-max val="0.1352"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_60" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3541"/><outer-radius val="0.3591"/><depth val="0.001"/><arc val="25.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0293"/><x-max val="0.0025"/><y-min val="-0.1371"/><y-max val="0.1371"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_62" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3591"/><outer-radius val="0.3641"/><depth val="0.001"/><arc val="25.1"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0297"/><x-max val="0.0025"/><y-min val="-0.1390"/><y-max val="0.1390"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_64" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3641"/><outer-radius val="0.3691"/><depth val="0.001"/><arc val="24.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0301"/><x-max val="0.0025"/><y-min val="-0.1409"/><y-max val="0.1409"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_66" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3690"/><outer-radius val="0.3740"/><depth val="0.001"/><arc val="24.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0305"/><x-max val="0.0025"/><y-min val="-0.1428"/><y-max val="0.1428"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_68" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3740"/><outer-radius val="0.3790"/><depth val="0.001"/><arc val="24.1"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0308"/><x-max val="0.0025"/><y-min val="-0.1447"/><y-max val="0.1447"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_70" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3789"/><outer-radius val="0.3839"/><depth val="0.001"/><arc val="23.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0312"/><x-max val="0.0025"/><y-min val="-0.1466"/><y-max val="0.1466"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_72" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3838"/><outer-radius val="0.3888"/><depth val="0.001"/><arc val="23.5"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0316"/><x-max val="0.0025"/><y-min val="-0.1485"/><y-max val="0.1485"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_74" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3888"/><outer-radius val="0.3938"/><depth val="0.001"/><arc val="23.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0320"/><x-max val="0.0025"/><y-min val="-0.1504"/><y-max val="0.1504"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_76" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3937"/><outer-radius val="0.3987"/><depth val="0.001"/><arc val="22.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0323"/><x-max val="0.0025"/><y-min val="-0.1522"/><y-max val="0.1522"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_78" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3986"/><outer-radius val="0.4036"/><depth val="0.001"/><arc val="22.6"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0327"/><x-max val="0.0025"/><y-min val="-0.1541"/><y-max val="0.1541"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_80" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4035"/><outer-radius val="0.4085"/><depth val="0.001"/><arc val="22.3"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0331"/><x-max val="0.0025"/><y-min val="-0.1560"/><y-max val="0.1560"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_82" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4083"/><outer-radius val="0.4133"/><depth val="0.001"/><arc val="22.1"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0334"/><x-max val="0.0025"/><y-min val="-0.1578"/><y-max val="0.1578"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_84" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4132"/><outer-radius val="0.4182"/><depth val="0.001"/><arc val="21.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0338"/><x-max val="0.0025"/><y-min val="-0.1597"/><y-max val="0.1597"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_86" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4180"/><outer-radius val="0.4230"/><depth val="0.001"/><arc val="21.6"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0342"/><x-max val="0.0025"/><y-min val="-0.1615"/><y-max val="0.1615"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_88" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4229"/><outer-radius val="0.4279"/><depth val="0.001"/><arc val="21.3"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0345"/><x-max val="0.0025"/><y-min val="-0.1634"/><y-max val="0.1634"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_90" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4277"/><outer-radius val="0.4327"/><depth val="0.001"/><arc val="21.1"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0349"/><x-max val="0.0025"/><y-min val="-0.1652"/><y-max val="0.1652"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_92" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4325"/><outer-radius val="0.4375"/><depth val="0.001"/><arc val="20.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0353"/><x-max val="0.0025"/><y-min val="-0.1671"/><y-max val="0.1671"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_94" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4373"/><outer-radius val="0.4423"/><depth val="0.001"/><arc val="20.6"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0356"/><x-max val="0.0025"/><y-min val="-0.1689"/><y-max val="0.1689"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_96" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4421"/><outer-radius val="0.4471"/><depth val="0.001"/><arc val="20.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0360"/><x-max val="0.0025"/><y-min val="-0.1707"/><y-max val="0.1707"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_98" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4469"/><outer-radius val="0.4519"/><depth val="0.001"/><arc val="20.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0364"/><x-max val="0.0025"/><y-min val="-0.1726"/><y-max val="0.1726"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_100" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4517"/><outer-radius val="0.4567"/><depth val="0.001"/><arc val="19.9"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0367"/><x-max val="0.0025"/><y-min val="-0.1744"/><y-max val="0.1744"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_102" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4564"/><outer-radius val="0.4614"/><depth val="0.001"/><arc val="19.7"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0371"/><x-max val="0.0025"/><y-min val="-0.1762"/><y-max val="0.1762"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_104" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4612"/><outer-radius val="0.4662"/><depth val="0.001"/><arc val="19.5"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0374"/><x-max val="0.0025"/><y-min val="-0.1780"/><y-max val="0.1780"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_106" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4659"/><outer-radius val="0.4709"/><depth val="0.001"/><arc val="19.3"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0378"/><x-max val="0.0025"/><y-min val="-0.1798"/><y-max val="0.1798"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_108" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4706"/><outer-radius val="0.4756"/><depth val="0.001"/><arc val="19.1"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0382"/><x-max val="0.0025"/><y-min val="-0.1816"/><y-max val="0.1816"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_110" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4753"/><outer-radius val="0.4803"/><depth val="0.001"/><arc val="19.0"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0385"/><x-max val="0.0025"/><y-min val="-0.1834"/><y-max val="0.1834"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_112" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4800"/><outer-radius val="0.4850"/><depth val="0.001"/><arc val="18.8"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0389"/><x-max val="0.0025"/><y-min val="-0.1852"/><y-max val="0.1852"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_114" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4847"/><outer-radius val="0.4897"/><depth val="0.001"/><arc val="18.6"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0392"/><x-max val="0.0025"/><y-min val="-0.1870"/><y-max val="0.1870"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_116" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4893"/><outer-radius val="0.4943"/><depth val="0.001"/><arc val="18.4"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0396"/><x-max val="0.0025"/><y-min val="-0.1888"/><y-max val="0.1888"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_118" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4940"/><outer-radius val="0.4990"/><depth val="0.001"/><arc val="18.2"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0399"/><x-max val="0.0025"/><y-min val="-0.1906"/><y-max val="0.1906"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_120" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4986"/><outer-radius val="0.5036"/><depth val="0.001"/><arc val="18.1"/> </slice-of-cylinder-ring> <algebra val="A"/>
-  <bounding-box><x-min val="-0.0403"/><x-max val="0.0025"/><y-min val="-0.1923"/><y-max val="0.1923"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_21" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2577"/><outer-radius val="0.2627"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2577"/><outer-radius val="0.2627"/><depth val="0.001"/><arc val="35.1"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0220"/><x-max val="0.0025"/><y-min val="-0.1003"/><y-max val="0.1003"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_23" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2629"/><outer-radius val="0.2679"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2629"/><outer-radius val="0.2679"/><depth val="0.001"/><arc val="34.4"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0224"/><x-max val="0.0025"/><y-min val="-0.1023"/><y-max val="0.1023"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_25" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2680"/><outer-radius val="0.2730"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2680"/><outer-radius val="0.2730"/><depth val="0.001"/><arc val="33.7"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0228"/><x-max val="0.0025"/><y-min val="-0.1043"/><y-max val="0.1043"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_27" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2731"/><outer-radius val="0.2781"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2731"/><outer-radius val="0.2781"/><depth val="0.001"/><arc val="33.1"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0232"/><x-max val="0.0025"/><y-min val="-0.1062"/><y-max val="0.1062"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_29" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2783"/><outer-radius val="0.2833"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2783"/><outer-radius val="0.2833"/><depth val="0.001"/><arc val="32.5"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0236"/><x-max val="0.0025"/><y-min val="-0.1082"/><y-max val="0.1082"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_31" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2834"/><outer-radius val="0.2884"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2834"/><outer-radius val="0.2884"/><depth val="0.001"/><arc val="31.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0240"/><x-max val="0.0025"/><y-min val="-0.1101"/><y-max val="0.1101"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_33" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2885"/><outer-radius val="0.2935"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2885"/><outer-radius val="0.2935"/><depth val="0.001"/><arc val="31.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0244"/><x-max val="0.0025"/><y-min val="-0.1121"/><y-max val="0.1121"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_35" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2936"/><outer-radius val="0.2986"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2936"/><outer-radius val="0.2986"/><depth val="0.001"/><arc val="30.8"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0248"/><x-max val="0.0025"/><y-min val="-0.1140"/><y-max val="0.1140"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_37" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.2987"/><outer-radius val="0.3037"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.2987"/><outer-radius val="0.3037"/><depth val="0.001"/><arc val="30.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0251"/><x-max val="0.0025"/><y-min val="-0.1160"/><y-max val="0.1160"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_39" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3038"/><outer-radius val="0.3088"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3038"/><outer-radius val="0.3088"/><depth val="0.001"/><arc val="29.8"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0255"/><x-max val="0.0025"/><y-min val="-0.1179"/><y-max val="0.1179"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_41" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3088"/><outer-radius val="0.3138"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3088"/><outer-radius val="0.3138"/><depth val="0.001"/><arc val="29.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0259"/><x-max val="0.0025"/><y-min val="-0.1199"/><y-max val="0.1199"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_43" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3139"/><outer-radius val="0.3189"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3139"/><outer-radius val="0.3189"/><depth val="0.001"/><arc val="28.8"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0263"/><x-max val="0.0025"/><y-min val="-0.1218"/><y-max val="0.1218"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_45" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3190"/><outer-radius val="0.3240"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3190"/><outer-radius val="0.3240"/><depth val="0.001"/><arc val="28.4"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0267"/><x-max val="0.0025"/><y-min val="-0.1237"/><y-max val="0.1237"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_47" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3240"/><outer-radius val="0.3290"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3240"/><outer-radius val="0.3290"/><depth val="0.001"/><arc val="27.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0271"/><x-max val="0.0025"/><y-min val="-0.1256"/><y-max val="0.1256"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_49" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3290"/><outer-radius val="0.3340"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3290"/><outer-radius val="0.3340"/><depth val="0.001"/><arc val="27.5"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0274"/><x-max val="0.0025"/><y-min val="-0.1276"/><y-max val="0.1276"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_51" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3341"/><outer-radius val="0.3391"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3341"/><outer-radius val="0.3391"/><depth val="0.001"/><arc val="27.1"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0278"/><x-max val="0.0025"/><y-min val="-0.1295"/><y-max val="0.1295"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_53" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3391"/><outer-radius val="0.3441"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3391"/><outer-radius val="0.3441"/><depth val="0.001"/><arc val="26.7"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0282"/><x-max val="0.0025"/><y-min val="-0.1314"/><y-max val="0.1314"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_55" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3441"/><outer-radius val="0.3491"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3441"/><outer-radius val="0.3491"/><depth val="0.001"/><arc val="26.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0286"/><x-max val="0.0025"/><y-min val="-0.1333"/><y-max val="0.1333"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_57" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3491"/><outer-radius val="0.3541"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3491"/><outer-radius val="0.3541"/><depth val="0.001"/><arc val="25.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0290"/><x-max val="0.0025"/><y-min val="-0.1352"/><y-max val="0.1352"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_59" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3541"/><outer-radius val="0.3591"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3541"/><outer-radius val="0.3591"/><depth val="0.001"/><arc val="25.5"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0293"/><x-max val="0.0025"/><y-min val="-0.1371"/><y-max val="0.1371"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_61" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3591"/><outer-radius val="0.3641"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3591"/><outer-radius val="0.3641"/><depth val="0.001"/><arc val="25.2"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0297"/><x-max val="0.0025"/><y-min val="-0.1390"/><y-max val="0.1390"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_63" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3641"/><outer-radius val="0.3691"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3641"/><outer-radius val="0.3691"/><depth val="0.001"/><arc val="24.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0301"/><x-max val="0.0025"/><y-min val="-0.1409"/><y-max val="0.1409"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_65" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3690"/><outer-radius val="0.3740"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3690"/><outer-radius val="0.3740"/><depth val="0.001"/><arc val="24.5"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0305"/><x-max val="0.0025"/><y-min val="-0.1428"/><y-max val="0.1428"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_67" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3740"/><outer-radius val="0.3790"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3740"/><outer-radius val="0.3790"/><depth val="0.001"/><arc val="24.2"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0308"/><x-max val="0.0025"/><y-min val="-0.1447"/><y-max val="0.1447"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_69" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3789"/><outer-radius val="0.3839"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3789"/><outer-radius val="0.3839"/><depth val="0.001"/><arc val="23.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0312"/><x-max val="0.0025"/><y-min val="-0.1466"/><y-max val="0.1466"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_71" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3838"/><outer-radius val="0.3888"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3838"/><outer-radius val="0.3888"/><depth val="0.001"/><arc val="23.6"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0316"/><x-max val="0.0025"/><y-min val="-0.1485"/><y-max val="0.1485"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_73" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3888"/><outer-radius val="0.3938"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3888"/><outer-radius val="0.3938"/><depth val="0.001"/><arc val="23.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0320"/><x-max val="0.0025"/><y-min val="-0.1504"/><y-max val="0.1504"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_75" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3937"/><outer-radius val="0.3987"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3937"/><outer-radius val="0.3987"/><depth val="0.001"/><arc val="23.0"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0323"/><x-max val="0.0025"/><y-min val="-0.1522"/><y-max val="0.1522"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_77" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.3986"/><outer-radius val="0.4036"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.3986"/><outer-radius val="0.4036"/><depth val="0.001"/><arc val="22.7"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0327"/><x-max val="0.0025"/><y-min val="-0.1541"/><y-max val="0.1541"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_79" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4035"/><outer-radius val="0.4085"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4035"/><outer-radius val="0.4085"/><depth val="0.001"/><arc val="22.4"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0331"/><x-max val="0.0025"/><y-min val="-0.1560"/><y-max val="0.1560"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_81" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4083"/><outer-radius val="0.4133"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4083"/><outer-radius val="0.4133"/><depth val="0.001"/><arc val="22.2"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0334"/><x-max val="0.0025"/><y-min val="-0.1578"/><y-max val="0.1578"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_83" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4132"/><outer-radius val="0.4182"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4132"/><outer-radius val="0.4182"/><depth val="0.001"/><arc val="21.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0338"/><x-max val="0.0025"/><y-min val="-0.1597"/><y-max val="0.1597"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_85" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4180"/><outer-radius val="0.4230"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4180"/><outer-radius val="0.4230"/><depth val="0.001"/><arc val="21.7"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0342"/><x-max val="0.0025"/><y-min val="-0.1615"/><y-max val="0.1615"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_87" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4229"/><outer-radius val="0.4279"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4229"/><outer-radius val="0.4279"/><depth val="0.001"/><arc val="21.4"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0345"/><x-max val="0.0025"/><y-min val="-0.1634"/><y-max val="0.1634"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_89" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4277"/><outer-radius val="0.4327"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4277"/><outer-radius val="0.4327"/><depth val="0.001"/><arc val="21.2"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0349"/><x-max val="0.0025"/><y-min val="-0.1652"/><y-max val="0.1652"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_91" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4325"/><outer-radius val="0.4375"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4325"/><outer-radius val="0.4375"/><depth val="0.001"/><arc val="20.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0353"/><x-max val="0.0025"/><y-min val="-0.1671"/><y-max val="0.1671"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_93" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4373"/><outer-radius val="0.4423"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4373"/><outer-radius val="0.4423"/><depth val="0.001"/><arc val="20.7"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0356"/><x-max val="0.0025"/><y-min val="-0.1689"/><y-max val="0.1689"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_95" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4421"/><outer-radius val="0.4471"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4421"/><outer-radius val="0.4471"/><depth val="0.001"/><arc val="20.5"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0360"/><x-max val="0.0025"/><y-min val="-0.1707"/><y-max val="0.1707"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_97" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4469"/><outer-radius val="0.4519"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4469"/><outer-radius val="0.4519"/><depth val="0.001"/><arc val="20.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0364"/><x-max val="0.0025"/><y-min val="-0.1726"/><y-max val="0.1726"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_99" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4517"/><outer-radius val="0.4567"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4517"/><outer-radius val="0.4567"/><depth val="0.001"/><arc val="20.0"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0367"/><x-max val="0.0025"/><y-min val="-0.1744"/><y-max val="0.1744"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_101" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4564"/><outer-radius val="0.4614"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4564"/><outer-radius val="0.4614"/><depth val="0.001"/><arc val="19.8"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0371"/><x-max val="0.0025"/><y-min val="-0.1762"/><y-max val="0.1762"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_103" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4612"/><outer-radius val="0.4662"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4612"/><outer-radius val="0.4662"/><depth val="0.001"/><arc val="19.6"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0374"/><x-max val="0.0025"/><y-min val="-0.1780"/><y-max val="0.1780"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_105" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4659"/><outer-radius val="0.4709"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4659"/><outer-radius val="0.4709"/><depth val="0.001"/><arc val="19.4"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0378"/><x-max val="0.0025"/><y-min val="-0.1798"/><y-max val="0.1798"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_107" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4706"/><outer-radius val="0.4756"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4706"/><outer-radius val="0.4756"/><depth val="0.001"/><arc val="19.2"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0382"/><x-max val="0.0025"/><y-min val="-0.1816"/><y-max val="0.1816"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_109" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4753"/><outer-radius val="0.4803"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4753"/><outer-radius val="0.4803"/><depth val="0.001"/><arc val="19.1"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0385"/><x-max val="0.0025"/><y-min val="-0.1834"/><y-max val="0.1834"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_111" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4800"/><outer-radius val="0.4850"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4800"/><outer-radius val="0.4850"/><depth val="0.001"/><arc val="18.9"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0389"/><x-max val="0.0025"/><y-min val="-0.1852"/><y-max val="0.1852"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_113" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4847"/><outer-radius val="0.4897"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4847"/><outer-radius val="0.4897"/><depth val="0.001"/><arc val="18.7"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0392"/><x-max val="0.0025"/><y-min val="-0.1870"/><y-max val="0.1870"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_115" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4893"/><outer-radius val="0.4943"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4893"/><outer-radius val="0.4943"/><depth val="0.001"/><arc val="18.5"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0396"/><x-max val="0.0025"/><y-min val="-0.1888"/><y-max val="0.1888"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_117" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4940"/><outer-radius val="0.4990"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4940"/><outer-radius val="0.4990"/><depth val="0.001"/><arc val="18.3"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0399"/><x-max val="0.0025"/><y-min val="-0.1906"/><y-max val="0.1906"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 <type name="arc_119" is="detector">
   <slice-of-cylinder-ring id="A"> <inner-radius val="0.4986"/><outer-radius val="0.5036"/><depth val="0.001"/><arc val="44.9"/> </slice-of-cylinder-ring>
   <slice-of-cylinder-ring id="B"> <inner-radius val="0.4986"/><outer-radius val="0.5036"/><depth val="0.001"/><arc val="18.2"/> </slice-of-cylinder-ring>
   <algebra val="A # B"/>
-  <bounding-box><x-min val="-0.0403"/><x-max val="0.0025"/><y-min val="-0.1923"/><y-max val="0.1923"/><z-min val="0.0000"/><z-max val="0.0010"/></bounding-box>
 </type>
 
 

--- a/instrument/POLARIS_Definition_115.xml
+++ b/instrument/POLARIS_Definition_115.xml
@@ -344,11 +344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone002" is="detector">
@@ -404,11 +399,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone003" is="detector">
@@ -464,11 +454,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone004" is="detector">
@@ -524,11 +509,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone005" is="detector">
@@ -584,11 +564,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone006" is="detector">
@@ -644,11 +619,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone007" is="detector">
@@ -704,11 +674,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone008" is="detector">
@@ -764,11 +729,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone009" is="detector">
@@ -824,11 +784,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone010" is="detector">
@@ -884,11 +839,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone011" is="detector">
@@ -944,11 +894,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone012" is="detector">
@@ -1004,11 +949,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone013" is="detector">
@@ -1064,11 +1004,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone014" is="detector">
@@ -1124,11 +1059,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone015" is="detector">
@@ -1184,11 +1114,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone016" is="detector">
@@ -1244,11 +1169,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone017" is="detector">
@@ -1304,11 +1224,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone018" is="detector">
@@ -1364,11 +1279,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone019" is="detector">
@@ -1424,11 +1334,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone020" is="detector">
@@ -1484,11 +1389,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone021" is="detector">
@@ -1544,11 +1444,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone022" is="detector">
@@ -1604,11 +1499,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone023" is="detector">
@@ -1664,11 +1554,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone024" is="detector">
@@ -1724,11 +1609,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone025" is="detector">
@@ -1784,11 +1664,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone026" is="detector">
@@ -1844,11 +1719,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone027" is="detector">
@@ -1904,11 +1774,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone028" is="detector">
@@ -1964,11 +1829,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone029" is="detector">
@@ -2024,11 +1884,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone030" is="detector">
@@ -2084,11 +1939,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone031" is="detector">
@@ -2144,11 +1994,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone032" is="detector">
@@ -2204,11 +2049,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone033" is="detector">
@@ -2264,11 +2104,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone034" is="detector">
@@ -2334,11 +2169,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone035" is="detector">
@@ -2404,11 +2234,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone036" is="detector">
@@ -2474,11 +2299,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone037" is="detector">
@@ -2544,11 +2364,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone038" is="detector">
@@ -2614,11 +2429,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone039" is="detector">
@@ -2684,11 +2494,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone040" is="detector">
@@ -2754,11 +2559,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone041" is="detector">
@@ -2824,11 +2624,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone042" is="detector">
@@ -2894,11 +2689,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone043" is="detector">
@@ -2964,11 +2754,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone044" is="detector">
@@ -3034,11 +2819,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone045" is="detector">
@@ -3104,11 +2884,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone046" is="detector">
@@ -3174,11 +2949,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone047" is="detector">
@@ -3244,11 +3014,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone048" is="detector">
@@ -3314,11 +3079,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone049" is="detector">
@@ -3384,11 +3144,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone050" is="detector">
@@ -3454,11 +3209,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone051" is="detector">
@@ -3524,11 +3274,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone052" is="detector">
@@ -3594,11 +3339,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone053" is="detector">
@@ -3664,11 +3404,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone054" is="detector">
@@ -3734,11 +3469,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone055" is="detector">
@@ -3804,11 +3534,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -4098,11 +3823,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone057" is="detector">
@@ -4138,11 +3858,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone058" is="detector">
@@ -4178,11 +3893,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone059" is="detector">
@@ -4218,11 +3928,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone060" is="detector">
@@ -4258,11 +3963,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone061" is="detector">
@@ -4298,11 +3998,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone062" is="detector">
@@ -4338,11 +4033,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone063" is="detector">
@@ -4378,11 +4068,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone064" is="detector">
@@ -4418,11 +4103,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone065" is="detector">
@@ -4458,11 +4138,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone066" is="detector">
@@ -4498,11 +4173,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone067" is="detector">
@@ -4538,11 +4208,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone068" is="detector">
@@ -4578,11 +4243,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone069" is="detector">
@@ -4618,11 +4278,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone070" is="detector">
@@ -4658,11 +4313,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone071" is="detector">
@@ -4698,11 +4348,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone072" is="detector">
@@ -4738,11 +4383,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone073" is="detector">
@@ -4778,11 +4418,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone074" is="detector">
@@ -4818,11 +4453,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone075" is="detector">
@@ -4858,11 +4488,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone076" is="detector">
@@ -4898,11 +4523,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone077" is="detector">
@@ -4938,11 +4558,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone078" is="detector">
@@ -4978,11 +4593,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone079" is="detector">
@@ -5018,11 +4628,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone080" is="detector">
@@ -5058,11 +4663,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone081" is="detector">
@@ -5098,11 +4698,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone082" is="detector">
@@ -5138,11 +4733,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone083" is="detector">
@@ -5178,11 +4768,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone084" is="detector">
@@ -5218,11 +4803,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone085" is="detector">
@@ -5258,11 +4838,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone086" is="detector">
@@ -5298,11 +4873,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone087" is="detector">
@@ -5338,11 +4908,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone088" is="detector">
@@ -5378,11 +4943,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone089" is="detector">
@@ -5418,11 +4978,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone090" is="detector">
@@ -5458,11 +5013,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone091" is="detector">
@@ -5498,11 +5048,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone092" is="detector">
@@ -5538,11 +5083,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone093" is="detector">
@@ -5578,11 +5118,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone094" is="detector">
@@ -5618,11 +5153,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone095" is="detector">
@@ -5658,11 +5188,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone096" is="detector">
@@ -5698,11 +5223,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone097" is="detector">
@@ -5738,11 +5258,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone098" is="detector">
@@ -5778,11 +5293,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone099" is="detector">
@@ -5818,11 +5328,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone100" is="detector">
@@ -5858,11 +5363,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone101" is="detector">
@@ -5898,11 +5398,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone102" is="detector">
@@ -5938,11 +5433,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone103" is="detector">
@@ -5978,11 +5468,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone104" is="detector">
@@ -6018,11 +5503,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone105" is="detector">
@@ -6058,11 +5538,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone106" is="detector">
@@ -6098,11 +5573,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone107" is="detector">
@@ -6138,11 +5608,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone108" is="detector">
@@ -6178,11 +5643,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone109" is="detector">
@@ -6218,11 +5678,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone110" is="detector">
@@ -6258,11 +5713,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone111" is="detector">
@@ -6298,11 +5748,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone112" is="detector">
@@ -6338,11 +5783,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone113" is="detector">
@@ -6378,11 +5818,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone114" is="detector">
@@ -6418,11 +5853,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone115" is="detector">
@@ -6458,11 +5888,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone116" is="detector">
@@ -6498,11 +5923,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone117" is="detector">
@@ -6538,11 +5958,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone118" is="detector">
@@ -6578,11 +5993,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone119" is="detector">
@@ -6618,11 +6028,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone120" is="detector">
@@ -6658,11 +6063,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone121" is="detector">
@@ -6698,11 +6098,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone122" is="detector">
@@ -6738,11 +6133,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone123" is="detector">
@@ -6778,11 +6168,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone124" is="detector">
@@ -6818,11 +6203,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone125" is="detector">
@@ -6858,11 +6238,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone126" is="detector">
@@ -6898,11 +6273,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone127" is="detector">
@@ -6938,11 +6308,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone128" is="detector">
@@ -6978,11 +6343,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone129" is="detector">
@@ -7018,11 +6378,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone130" is="detector">
@@ -7058,11 +6413,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone131" is="detector">
@@ -7098,11 +6448,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone132" is="detector">
@@ -7138,11 +6483,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone133" is="detector">
@@ -7178,11 +6518,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone134" is="detector">
@@ -7218,11 +6553,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone135" is="detector">
@@ -7258,11 +6588,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone136" is="detector">
@@ -7298,11 +6623,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone137" is="detector">
@@ -7338,11 +6658,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone138" is="detector">
@@ -7378,11 +6693,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone139" is="detector">
@@ -7418,11 +6728,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone140" is="detector">
@@ -7458,11 +6763,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone141" is="detector">
@@ -7498,11 +6798,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone142" is="detector">
@@ -7538,11 +6833,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone143" is="detector">
@@ -7578,11 +6868,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -8051,11 +7336,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone145" is="detector">
@@ -8116,11 +7396,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone146" is="detector">
@@ -8181,11 +7456,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone147" is="detector">
@@ -8246,11 +7516,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone148" is="detector">
@@ -8311,11 +7576,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone149" is="detector">
@@ -8376,11 +7636,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone150" is="detector">
@@ -8441,11 +7696,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone151" is="detector">
@@ -8506,11 +7756,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone152" is="detector">
@@ -8571,11 +7816,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone153" is="detector">
@@ -8636,11 +7876,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone154" is="detector">
@@ -8701,11 +7936,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone155" is="detector">
@@ -8756,11 +7986,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone156" is="detector">
@@ -8811,11 +8036,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone157" is="detector">
@@ -8866,11 +8086,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone158" is="detector">
@@ -8921,11 +8136,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone159" is="detector">
@@ -8976,11 +8186,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone160" is="detector">
@@ -9031,11 +8236,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone161" is="detector">
@@ -9086,11 +8286,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone162" is="detector">
@@ -9141,11 +8336,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone163" is="detector">
@@ -9196,11 +8386,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone164" is="detector">
@@ -9251,11 +8436,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone165" is="detector">
@@ -9306,11 +8486,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone166" is="detector">
@@ -9371,11 +8546,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone167" is="detector">
@@ -9436,11 +8606,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone168" is="detector">
@@ -9501,11 +8666,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone169" is="detector">
@@ -9566,11 +8726,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone170" is="detector">
@@ -9631,11 +8786,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone171" is="detector">
@@ -9696,11 +8846,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone172" is="detector">
@@ -9761,11 +8906,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone173" is="detector">
@@ -9826,11 +8966,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone174" is="detector">
@@ -9891,11 +9026,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone175" is="detector">
@@ -9956,11 +9086,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone176" is="detector">
@@ -10021,11 +9146,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone177" is="detector">
@@ -10076,11 +9196,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone178" is="detector">
@@ -10131,11 +9246,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone179" is="detector">
@@ -10186,11 +9296,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone180" is="detector">
@@ -10241,11 +9346,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone181" is="detector">
@@ -10296,11 +9396,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone182" is="detector">
@@ -10351,11 +9446,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone183" is="detector">
@@ -10406,11 +9496,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone184" is="detector">
@@ -10461,11 +9546,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone185" is="detector">
@@ -10516,11 +9596,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone186" is="detector">
@@ -10571,11 +9646,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone187" is="detector">
@@ -10626,11 +9696,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone188" is="detector">
@@ -10686,11 +9751,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone189" is="detector">
@@ -10746,11 +9806,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone190" is="detector">
@@ -10806,11 +9861,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone191" is="detector">
@@ -10866,11 +9916,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone192" is="detector">
@@ -10926,11 +9971,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone193" is="detector">
@@ -10986,11 +10026,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone194" is="detector">
@@ -11046,11 +10081,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone195" is="detector">
@@ -11106,11 +10136,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone196" is="detector">
@@ -11166,11 +10191,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone197" is="detector">
@@ -11226,11 +10246,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone198" is="detector">
@@ -11286,11 +10301,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone199" is="detector">
@@ -11336,11 +10346,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone200" is="detector">
@@ -11386,11 +10391,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone201" is="detector">
@@ -11436,11 +10436,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone202" is="detector">
@@ -11486,11 +10481,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone203" is="detector">
@@ -11536,11 +10526,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone204" is="detector">
@@ -11586,11 +10571,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone205" is="detector">
@@ -11636,11 +10616,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone206" is="detector">
@@ -11686,11 +10661,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone207" is="detector">
@@ -11736,11 +10706,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone208" is="detector">
@@ -11786,11 +10751,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone209" is="detector">
@@ -11836,11 +10796,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone210" is="detector">
@@ -11891,11 +10846,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone211" is="detector">
@@ -11946,11 +10896,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone212" is="detector">
@@ -12001,11 +10946,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone213" is="detector">
@@ -12056,11 +10996,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone214" is="detector">
@@ -12111,11 +11046,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone215" is="detector">
@@ -12166,11 +11096,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone216" is="detector">
@@ -12221,11 +11146,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone217" is="detector">
@@ -12276,11 +11196,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone218" is="detector">
@@ -12331,11 +11246,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone219" is="detector">
@@ -12386,11 +11296,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone220" is="detector">
@@ -12441,11 +11346,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone221" is="detector">
@@ -12496,11 +11396,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone222" is="detector">
@@ -12551,11 +11446,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone223" is="detector">
@@ -12606,11 +11496,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone224" is="detector">
@@ -12661,11 +11546,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone225" is="detector">
@@ -12716,11 +11596,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone226" is="detector">
@@ -12771,11 +11646,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone227" is="detector">
@@ -12826,11 +11696,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone228" is="detector">
@@ -12881,11 +11746,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone229" is="detector">
@@ -12936,11 +11796,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone230" is="detector">
@@ -12991,11 +11846,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone231" is="detector">
@@ -13046,11 +11896,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone232" is="detector">
@@ -13101,11 +11946,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone233" is="detector">
@@ -13156,11 +11996,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone234" is="detector">
@@ -13211,11 +12046,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone235" is="detector">
@@ -13266,11 +12096,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone236" is="detector">
@@ -13321,11 +12146,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone237" is="detector">
@@ -13376,11 +12196,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone238" is="detector">
@@ -13431,11 +12246,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone239" is="detector">
@@ -13486,11 +12296,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone240" is="detector">
@@ -13541,11 +12346,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone241" is="detector">
@@ -13596,11 +12396,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone242" is="detector">
@@ -13651,11 +12446,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -14147,11 +12937,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone244" is="detector">
@@ -14207,11 +12992,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone245" is="detector">
@@ -14267,11 +13047,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone246" is="detector">
@@ -14327,11 +13102,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone247" is="detector">
@@ -14387,11 +13157,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone248" is="detector">
@@ -14447,11 +13212,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone249" is="detector">
@@ -14507,11 +13267,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone250" is="detector">
@@ -14567,11 +13322,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone251" is="detector">
@@ -14627,11 +13377,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone252" is="detector">
@@ -14687,11 +13432,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone253" is="detector">
@@ -14747,11 +13487,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone254" is="detector">
@@ -14807,11 +13542,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone255" is="detector">
@@ -14867,11 +13597,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone256" is="detector">
@@ -14927,11 +13652,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone257" is="detector">
@@ -14987,11 +13707,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone258" is="detector">
@@ -15047,11 +13762,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone259" is="detector">
@@ -15107,11 +13817,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone260" is="detector">
@@ -15167,11 +13872,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone261" is="detector">
@@ -15227,11 +13927,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone262" is="detector">
@@ -15287,11 +13982,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone263" is="detector">
@@ -15347,11 +14037,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone264" is="detector">
@@ -15407,11 +14092,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone265" is="detector">
@@ -15462,11 +14142,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone266" is="detector">
@@ -15517,11 +14192,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone267" is="detector">
@@ -15572,11 +14242,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone268" is="detector">
@@ -15627,11 +14292,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone269" is="detector">
@@ -15682,11 +14342,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone270" is="detector">
@@ -15737,11 +14392,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone271" is="detector">
@@ -15792,11 +14442,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone272" is="detector">
@@ -15847,11 +14492,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone273" is="detector">
@@ -15902,11 +14542,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone274" is="detector">
@@ -15957,11 +14592,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone275" is="detector">
@@ -16012,11 +14642,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone276" is="detector">
@@ -16067,11 +14692,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone277" is="detector">
@@ -16122,11 +14742,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone278" is="detector">
@@ -16177,11 +14792,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone279" is="detector">
@@ -16232,11 +14842,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone280" is="detector">
@@ -16287,11 +14892,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone281" is="detector">
@@ -16342,11 +14942,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone282" is="detector">
@@ -16397,11 +14992,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone283" is="detector">
@@ -16452,11 +15042,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone284" is="detector">
@@ -16507,11 +15092,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone285" is="detector">
@@ -16562,11 +15142,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone286" is="detector">
@@ -16617,11 +15192,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone287" is="detector">
@@ -16662,11 +15232,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone288" is="detector">
@@ -16707,11 +15272,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone289" is="detector">
@@ -16752,11 +15312,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone290" is="detector">
@@ -16797,11 +15352,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone291" is="detector">
@@ -16842,11 +15392,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone292" is="detector">
@@ -16887,11 +15432,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone293" is="detector">
@@ -16932,11 +15472,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone294" is="detector">
@@ -16977,11 +15512,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone295" is="detector">
@@ -17022,11 +15552,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone296" is="detector">
@@ -17067,11 +15592,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone297" is="detector">
@@ -17112,11 +15632,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone298" is="detector">
@@ -17157,11 +15672,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone299" is="detector">
@@ -17202,11 +15712,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone300" is="detector">
@@ -17247,11 +15752,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone301" is="detector">
@@ -17292,11 +15792,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone302" is="detector">
@@ -17337,11 +15832,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone303" is="detector">
@@ -17382,11 +15872,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone304" is="detector">
@@ -17427,11 +15912,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone305" is="detector">
@@ -17472,11 +15952,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone306" is="detector">
@@ -17517,11 +15992,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone307" is="detector">
@@ -17562,11 +16032,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone308" is="detector">
@@ -17607,11 +16072,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone309" is="detector">
@@ -17652,11 +16112,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone310" is="detector">
@@ -17697,11 +16152,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone311" is="detector">
@@ -17742,11 +16192,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone312" is="detector">
@@ -17787,11 +16232,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone313" is="detector">
@@ -17832,11 +16272,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone314" is="detector">
@@ -17877,11 +16312,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone315" is="detector">
@@ -17922,11 +16352,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone316" is="detector">
@@ -17967,11 +16392,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone317" is="detector">
@@ -18012,11 +16432,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone318" is="detector">
@@ -18057,11 +16472,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone319" is="detector">
@@ -18102,11 +16512,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone320" is="detector">
@@ -18142,11 +16547,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone321" is="detector">
@@ -18182,11 +16582,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone322" is="detector">
@@ -18222,11 +16617,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone323" is="detector">
@@ -18262,11 +16652,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone324" is="detector">
@@ -18302,11 +16687,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone325" is="detector">
@@ -18342,11 +16722,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone326" is="detector">
@@ -18382,11 +16757,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone327" is="detector">
@@ -18422,11 +16792,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone328" is="detector">
@@ -18462,11 +16827,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone329" is="detector">
@@ -18502,11 +16862,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone330" is="detector">
@@ -18542,11 +16897,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone331" is="detector">
@@ -18582,11 +16932,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone332" is="detector">
@@ -18622,11 +16967,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone333" is="detector">
@@ -18662,11 +17002,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone334" is="detector">
@@ -18702,11 +17037,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone335" is="detector">
@@ -18742,11 +17072,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone336" is="detector">
@@ -18782,11 +17107,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone337" is="detector">
@@ -18822,11 +17142,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone338" is="detector">
@@ -18862,11 +17177,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone339" is="detector">
@@ -18902,11 +17212,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone340" is="detector">
@@ -18942,11 +17247,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone341" is="detector">
@@ -18982,11 +17282,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone342" is="detector">
@@ -19017,11 +17312,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone343" is="detector">
@@ -19052,11 +17342,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone344" is="detector">
@@ -19087,11 +17372,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone345" is="detector">
@@ -19122,11 +17402,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone346" is="detector">
@@ -19157,11 +17432,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone347" is="detector">
@@ -19192,11 +17462,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone348" is="detector">
@@ -19227,11 +17492,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone349" is="detector">
@@ -19262,11 +17522,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone350" is="detector">
@@ -19297,11 +17552,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone351" is="detector">
@@ -19332,11 +17582,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone352" is="detector">
@@ -19367,11 +17612,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -19932,11 +18172,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone354" is="detector">
@@ -20017,11 +18252,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone355" is="detector">
@@ -20102,11 +18332,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone356" is="detector">
@@ -20187,11 +18412,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone357" is="detector">
@@ -20272,11 +18492,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone358" is="detector">
@@ -20357,11 +18572,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone359" is="detector">
@@ -20442,11 +18652,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone360" is="detector">
@@ -20527,11 +18732,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone361" is="detector">
@@ -20612,11 +18812,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone362" is="detector">
@@ -20697,11 +18892,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone363" is="detector">
@@ -20767,11 +18957,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone364" is="detector">
@@ -20837,11 +19022,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone365" is="detector">
@@ -20907,11 +19087,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone366" is="detector">
@@ -20977,11 +19152,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone367" is="detector">
@@ -21047,11 +19217,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone368" is="detector">
@@ -21117,11 +19282,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone369" is="detector">
@@ -21187,11 +19347,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone370" is="detector">
@@ -21257,11 +19412,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone371" is="detector">
@@ -21327,11 +19477,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone372" is="detector">
@@ -21397,11 +19542,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone373" is="detector">
@@ -21467,11 +19607,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone374" is="detector">
@@ -21537,11 +19672,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone375" is="detector">
@@ -21607,11 +19737,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone376" is="detector">
@@ -21677,11 +19802,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone377" is="detector">
@@ -21747,11 +19867,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone378" is="detector">
@@ -21817,11 +19932,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone379" is="detector">
@@ -21887,11 +19997,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone380" is="detector">
@@ -21957,11 +20062,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone381" is="detector">
@@ -22027,11 +20127,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone382" is="detector">
@@ -22097,11 +20192,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone383" is="detector">
@@ -22157,11 +20247,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone384" is="detector">
@@ -22217,11 +20302,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone385" is="detector">
@@ -22277,11 +20357,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone386" is="detector">
@@ -22337,11 +20412,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone387" is="detector">
@@ -22397,11 +20467,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone388" is="detector">
@@ -22457,11 +20522,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone389" is="detector">
@@ -22517,11 +20577,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone390" is="detector">
@@ -22577,11 +20632,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone391" is="detector">
@@ -22637,11 +20687,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone392" is="detector">
@@ -22697,11 +20742,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <!--  Bank 6 ( 4 modules):  7 groups (10 elements/group)  -->
@@ -22789,11 +20829,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone394" is="detector">
@@ -22879,11 +20914,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone395" is="detector">
@@ -22969,11 +20999,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone396" is="detector">
@@ -23059,11 +21084,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone397" is="detector">
@@ -23149,11 +21169,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone398" is="detector">
@@ -23239,11 +21254,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone399" is="detector">
@@ -23329,11 +21339,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone400" is="detector">
@@ -23419,11 +21424,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone401" is="detector">
@@ -23509,11 +21509,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone402" is="detector">
@@ -23599,11 +21594,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone403" is="detector">
@@ -23679,11 +21669,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone404" is="detector">
@@ -23759,11 +21744,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone405" is="detector">
@@ -23839,11 +21819,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone406" is="detector">
@@ -23919,11 +21894,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone407" is="detector">
@@ -23999,11 +21969,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone408" is="detector">
@@ -24079,11 +22044,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone409" is="detector">
@@ -24159,11 +22119,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone410" is="detector">
@@ -24239,11 +22194,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone411" is="detector">
@@ -24319,11 +22269,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone412" is="detector">
@@ -24399,11 +22344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone413" is="detector">
@@ -24469,11 +22409,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone414" is="detector">
@@ -24539,11 +22474,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone415" is="detector">
@@ -24609,11 +22539,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone416" is="detector">
@@ -24679,11 +22604,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone417" is="detector">
@@ -24749,11 +22669,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone418" is="detector">
@@ -24819,11 +22734,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone419" is="detector">
@@ -24889,11 +22799,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone420" is="detector">
@@ -24959,11 +22864,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone421" is="detector">
@@ -25029,11 +22929,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone422" is="detector">
@@ -25099,11 +22994,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone423" is="detector">
@@ -25159,11 +23049,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone424" is="detector">
@@ -25219,11 +23104,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone425" is="detector">
@@ -25279,11 +23159,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone426" is="detector">
@@ -25339,11 +23214,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone427" is="detector">
@@ -25399,11 +23269,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone428" is="detector">
@@ -25459,11 +23324,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone429" is="detector">
@@ -25519,11 +23379,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone430" is="detector">
@@ -25579,11 +23434,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone431" is="detector">
@@ -25639,11 +23489,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone432" is="detector">
@@ -25699,11 +23544,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone433" is="detector">
@@ -25754,11 +23594,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone434" is="detector">
@@ -25809,11 +23644,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone435" is="detector">
@@ -25864,11 +23694,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone436" is="detector">
@@ -25919,11 +23744,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone437" is="detector">
@@ -25974,11 +23794,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone438" is="detector">
@@ -26029,11 +23844,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone439" is="detector">
@@ -26084,11 +23894,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone440" is="detector">
@@ -26139,11 +23944,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone441" is="detector">
@@ -26194,11 +23994,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone442" is="detector">
@@ -26249,11 +24044,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone443" is="detector">
@@ -26299,11 +24089,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone444" is="detector">
@@ -26349,11 +24134,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone445" is="detector">
@@ -26399,11 +24179,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone446" is="detector">
@@ -26449,11 +24224,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone447" is="detector">
@@ -26499,11 +24269,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone448" is="detector">
@@ -26549,11 +24314,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone449" is="detector">
@@ -26599,11 +24359,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone450" is="detector">
@@ -26649,11 +24404,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone451" is="detector">
@@ -26699,11 +24449,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone452" is="detector">
@@ -26749,11 +24494,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone453" is="detector">
@@ -26789,11 +24529,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone454" is="detector">
@@ -26829,11 +24564,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone455" is="detector">
@@ -26869,11 +24599,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone456" is="detector">
@@ -26909,11 +24634,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone457" is="detector">
@@ -26949,11 +24669,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone458" is="detector">
@@ -26989,11 +24704,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone459" is="detector">
@@ -27029,11 +24739,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone460" is="detector">
@@ -27069,11 +24774,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone461" is="detector">
@@ -27109,11 +24809,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone462" is="detector">
@@ -27149,11 +24844,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 

--- a/instrument/POLARIS_Definition_121.xml
+++ b/instrument/POLARIS_Definition_121.xml
@@ -344,11 +344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone002" is="detector">
@@ -404,11 +399,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone003" is="detector">
@@ -464,11 +454,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone004" is="detector">
@@ -524,11 +509,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone005" is="detector">
@@ -584,11 +564,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone006" is="detector">
@@ -644,11 +619,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone007" is="detector">
@@ -704,11 +674,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone008" is="detector">
@@ -764,11 +729,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone009" is="detector">
@@ -824,11 +784,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone010" is="detector">
@@ -884,11 +839,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone011" is="detector">
@@ -944,11 +894,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone012" is="detector">
@@ -1004,11 +949,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone013" is="detector">
@@ -1064,11 +1004,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone014" is="detector">
@@ -1124,11 +1059,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone015" is="detector">
@@ -1184,11 +1114,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone016" is="detector">
@@ -1244,11 +1169,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone017" is="detector">
@@ -1304,11 +1224,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone018" is="detector">
@@ -1364,11 +1279,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone019" is="detector">
@@ -1424,11 +1334,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone020" is="detector">
@@ -1484,11 +1389,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone021" is="detector">
@@ -1544,11 +1444,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone022" is="detector">
@@ -1604,11 +1499,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone023" is="detector">
@@ -1664,11 +1554,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone024" is="detector">
@@ -1724,11 +1609,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone025" is="detector">
@@ -1784,11 +1664,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone026" is="detector">
@@ -1844,11 +1719,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone027" is="detector">
@@ -1904,11 +1774,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone028" is="detector">
@@ -1964,11 +1829,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone029" is="detector">
@@ -2024,11 +1884,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone030" is="detector">
@@ -2084,11 +1939,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone031" is="detector">
@@ -2144,11 +1994,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone032" is="detector">
@@ -2204,11 +2049,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone033" is="detector">
@@ -2264,11 +2104,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone034" is="detector">
@@ -2334,11 +2169,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone035" is="detector">
@@ -2404,11 +2234,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone036" is="detector">
@@ -2474,11 +2299,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone037" is="detector">
@@ -2544,11 +2364,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone038" is="detector">
@@ -2614,11 +2429,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone039" is="detector">
@@ -2684,11 +2494,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone040" is="detector">
@@ -2754,11 +2559,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone041" is="detector">
@@ -2824,11 +2624,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone042" is="detector">
@@ -2894,11 +2689,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone043" is="detector">
@@ -2964,11 +2754,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone044" is="detector">
@@ -3034,11 +2819,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone045" is="detector">
@@ -3104,11 +2884,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone046" is="detector">
@@ -3174,11 +2949,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone047" is="detector">
@@ -3244,11 +3014,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone048" is="detector">
@@ -3314,11 +3079,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone049" is="detector">
@@ -3384,11 +3144,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone050" is="detector">
@@ -3454,11 +3209,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone051" is="detector">
@@ -3524,11 +3274,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone052" is="detector">
@@ -3594,11 +3339,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone053" is="detector">
@@ -3664,11 +3404,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone054" is="detector">
@@ -3734,11 +3469,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone055" is="detector">
@@ -3804,11 +3534,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -4096,11 +3821,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone057" is="detector">
@@ -4136,11 +3856,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone058" is="detector">
@@ -4176,11 +3891,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone059" is="detector">
@@ -4216,11 +3926,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone060" is="detector">
@@ -4256,11 +3961,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone061" is="detector">
@@ -4296,11 +3996,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone062" is="detector">
@@ -4336,11 +4031,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone063" is="detector">
@@ -4376,11 +4066,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone064" is="detector">
@@ -4416,11 +4101,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone065" is="detector">
@@ -4456,11 +4136,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone066" is="detector">
@@ -4496,11 +4171,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone067" is="detector">
@@ -4536,11 +4206,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone068" is="detector">
@@ -4576,11 +4241,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone069" is="detector">
@@ -4616,11 +4276,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone070" is="detector">
@@ -4656,11 +4311,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone071" is="detector">
@@ -4696,11 +4346,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone072" is="detector">
@@ -4736,11 +4381,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone073" is="detector">
@@ -4776,11 +4416,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone074" is="detector">
@@ -4816,11 +4451,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone075" is="detector">
@@ -4856,11 +4486,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone076" is="detector">
@@ -4896,11 +4521,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone077" is="detector">
@@ -4936,11 +4556,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone078" is="detector">
@@ -4976,11 +4591,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone079" is="detector">
@@ -5016,11 +4626,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone080" is="detector">
@@ -5056,11 +4661,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone081" is="detector">
@@ -5096,11 +4696,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone082" is="detector">
@@ -5136,11 +4731,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone083" is="detector">
@@ -5176,11 +4766,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone084" is="detector">
@@ -5216,11 +4801,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone085" is="detector">
@@ -5256,11 +4836,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone086" is="detector">
@@ -5296,11 +4871,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone087" is="detector">
@@ -5336,11 +4906,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone088" is="detector">
@@ -5376,11 +4941,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone089" is="detector">
@@ -5416,11 +4976,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone090" is="detector">
@@ -5456,11 +5011,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone091" is="detector">
@@ -5496,11 +5046,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone092" is="detector">
@@ -5536,11 +5081,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone093" is="detector">
@@ -5576,11 +5116,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone094" is="detector">
@@ -5616,11 +5151,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone095" is="detector">
@@ -5656,11 +5186,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone096" is="detector">
@@ -5696,11 +5221,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone097" is="detector">
@@ -5736,11 +5256,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone098" is="detector">
@@ -5776,11 +5291,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone099" is="detector">
@@ -5816,11 +5326,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone100" is="detector">
@@ -5856,11 +5361,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone101" is="detector">
@@ -5896,11 +5396,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone102" is="detector">
@@ -5936,11 +5431,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone103" is="detector">
@@ -5976,11 +5466,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone104" is="detector">
@@ -6016,11 +5501,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone105" is="detector">
@@ -6056,11 +5536,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone106" is="detector">
@@ -6096,11 +5571,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone107" is="detector">
@@ -6136,11 +5606,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone108" is="detector">
@@ -6176,11 +5641,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone109" is="detector">
@@ -6216,11 +5676,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone110" is="detector">
@@ -6256,11 +5711,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone111" is="detector">
@@ -6296,11 +5746,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone112" is="detector">
@@ -6336,11 +5781,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone113" is="detector">
@@ -6376,11 +5816,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone114" is="detector">
@@ -6416,11 +5851,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone115" is="detector">
@@ -6456,11 +5886,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone116" is="detector">
@@ -6496,11 +5921,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone117" is="detector">
@@ -6536,11 +5956,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone118" is="detector">
@@ -6576,11 +5991,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone119" is="detector">
@@ -6616,11 +6026,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone120" is="detector">
@@ -6656,11 +6061,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone121" is="detector">
@@ -6696,11 +6096,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone122" is="detector">
@@ -6736,11 +6131,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone123" is="detector">
@@ -6776,11 +6166,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone124" is="detector">
@@ -6816,11 +6201,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone125" is="detector">
@@ -6856,11 +6236,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone126" is="detector">
@@ -6896,11 +6271,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone127" is="detector">
@@ -6936,11 +6306,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone128" is="detector">
@@ -6976,11 +6341,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone129" is="detector">
@@ -7016,11 +6376,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone130" is="detector">
@@ -7056,11 +6411,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone131" is="detector">
@@ -7096,11 +6446,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone132" is="detector">
@@ -7136,11 +6481,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone133" is="detector">
@@ -7176,11 +6516,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone134" is="detector">
@@ -7216,11 +6551,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone135" is="detector">
@@ -7256,11 +6586,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone136" is="detector">
@@ -7296,11 +6621,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone137" is="detector">
@@ -7336,11 +6656,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone138" is="detector">
@@ -7376,11 +6691,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone139" is="detector">
@@ -7416,11 +6726,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone140" is="detector">
@@ -7456,11 +6761,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone141" is="detector">
@@ -7496,11 +6796,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone142" is="detector">
@@ -7536,11 +6831,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone143" is="detector">
@@ -7576,11 +6866,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -8049,11 +7334,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone145" is="detector">
@@ -8114,11 +7394,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone146" is="detector">
@@ -8179,11 +7454,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone147" is="detector">
@@ -8244,11 +7514,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone148" is="detector">
@@ -8309,11 +7574,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone149" is="detector">
@@ -8374,11 +7634,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone150" is="detector">
@@ -8439,11 +7694,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone151" is="detector">
@@ -8504,11 +7754,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone152" is="detector">
@@ -8569,11 +7814,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone153" is="detector">
@@ -8634,11 +7874,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone154" is="detector">
@@ -8699,11 +7934,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone155" is="detector">
@@ -8754,11 +7984,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone156" is="detector">
@@ -8809,11 +8034,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone157" is="detector">
@@ -8864,11 +8084,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone158" is="detector">
@@ -8919,11 +8134,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone159" is="detector">
@@ -8974,11 +8184,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone160" is="detector">
@@ -9029,11 +8234,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone161" is="detector">
@@ -9084,11 +8284,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone162" is="detector">
@@ -9139,11 +8334,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone163" is="detector">
@@ -9194,11 +8384,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone164" is="detector">
@@ -9249,11 +8434,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone165" is="detector">
@@ -9304,11 +8484,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone166" is="detector">
@@ -9369,11 +8544,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone167" is="detector">
@@ -9434,11 +8604,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone168" is="detector">
@@ -9499,11 +8664,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone169" is="detector">
@@ -9564,11 +8724,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone170" is="detector">
@@ -9629,11 +8784,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone171" is="detector">
@@ -9694,11 +8844,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone172" is="detector">
@@ -9759,11 +8904,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone173" is="detector">
@@ -9824,11 +8964,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone174" is="detector">
@@ -9889,11 +9024,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone175" is="detector">
@@ -9954,11 +9084,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone176" is="detector">
@@ -10019,11 +9144,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone177" is="detector">
@@ -10074,11 +9194,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone178" is="detector">
@@ -10129,11 +9244,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone179" is="detector">
@@ -10184,11 +9294,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone180" is="detector">
@@ -10239,11 +9344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone181" is="detector">
@@ -10294,11 +9394,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone182" is="detector">
@@ -10349,11 +9444,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone183" is="detector">
@@ -10404,11 +9494,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone184" is="detector">
@@ -10459,11 +9544,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone185" is="detector">
@@ -10514,11 +9594,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone186" is="detector">
@@ -10569,11 +9644,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone187" is="detector">
@@ -10624,11 +9694,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone188" is="detector">
@@ -10684,11 +9749,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone189" is="detector">
@@ -10744,11 +9804,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone190" is="detector">
@@ -10804,11 +9859,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone191" is="detector">
@@ -10864,11 +9914,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone192" is="detector">
@@ -10924,11 +9969,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone193" is="detector">
@@ -10984,11 +10024,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone194" is="detector">
@@ -11044,11 +10079,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone195" is="detector">
@@ -11104,11 +10134,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone196" is="detector">
@@ -11164,11 +10189,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone197" is="detector">
@@ -11224,11 +10244,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone198" is="detector">
@@ -11284,11 +10299,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone199" is="detector">
@@ -11334,11 +10344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone200" is="detector">
@@ -11384,11 +10389,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone201" is="detector">
@@ -11434,11 +10434,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone202" is="detector">
@@ -11484,11 +10479,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone203" is="detector">
@@ -11534,11 +10524,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone204" is="detector">
@@ -11584,11 +10569,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone205" is="detector">
@@ -11634,11 +10614,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone206" is="detector">
@@ -11684,11 +10659,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone207" is="detector">
@@ -11734,11 +10704,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone208" is="detector">
@@ -11784,11 +10749,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone209" is="detector">
@@ -11834,11 +10794,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone210" is="detector">
@@ -11889,11 +10844,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone211" is="detector">
@@ -11944,11 +10894,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone212" is="detector">
@@ -11999,11 +10944,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone213" is="detector">
@@ -12054,11 +10994,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone214" is="detector">
@@ -12109,11 +11044,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone215" is="detector">
@@ -12164,11 +11094,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone216" is="detector">
@@ -12219,11 +11144,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone217" is="detector">
@@ -12274,11 +11194,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone218" is="detector">
@@ -12329,11 +11244,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone219" is="detector">
@@ -12384,11 +11294,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone220" is="detector">
@@ -12439,11 +11344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone221" is="detector">
@@ -12494,11 +11394,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone222" is="detector">
@@ -12549,11 +11444,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone223" is="detector">
@@ -12604,11 +11494,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone224" is="detector">
@@ -12659,11 +11544,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone225" is="detector">
@@ -12714,11 +11594,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone226" is="detector">
@@ -12769,11 +11644,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone227" is="detector">
@@ -12824,11 +11694,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone228" is="detector">
@@ -12879,11 +11744,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone229" is="detector">
@@ -12934,11 +11794,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone230" is="detector">
@@ -12989,11 +11844,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone231" is="detector">
@@ -13044,11 +11894,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone232" is="detector">
@@ -13099,11 +11944,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone233" is="detector">
@@ -13154,11 +11994,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone234" is="detector">
@@ -13209,11 +12044,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone235" is="detector">
@@ -13264,11 +12094,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone236" is="detector">
@@ -13319,11 +12144,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone237" is="detector">
@@ -13374,11 +12194,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone238" is="detector">
@@ -13429,11 +12244,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone239" is="detector">
@@ -13484,11 +12294,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone240" is="detector">
@@ -13539,11 +12344,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone241" is="detector">
@@ -13594,11 +12394,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone242" is="detector">
@@ -13649,11 +12444,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -14145,11 +12935,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone244" is="detector">
@@ -14205,11 +12990,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone245" is="detector">
@@ -14265,11 +13045,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone246" is="detector">
@@ -14325,11 +13100,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone247" is="detector">
@@ -14385,11 +13155,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone248" is="detector">
@@ -14445,11 +13210,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone249" is="detector">
@@ -14505,11 +13265,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone250" is="detector">
@@ -14565,11 +13320,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone251" is="detector">
@@ -14625,11 +13375,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone252" is="detector">
@@ -14685,11 +13430,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone253" is="detector">
@@ -14745,11 +13485,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone254" is="detector">
@@ -14805,11 +13540,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone255" is="detector">
@@ -14865,11 +13595,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone256" is="detector">
@@ -14925,11 +13650,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone257" is="detector">
@@ -14985,11 +13705,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone258" is="detector">
@@ -15045,11 +13760,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone259" is="detector">
@@ -15105,11 +13815,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone260" is="detector">
@@ -15165,11 +13870,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone261" is="detector">
@@ -15225,11 +13925,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone262" is="detector">
@@ -15285,11 +13980,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone263" is="detector">
@@ -15345,11 +14035,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone264" is="detector">
@@ -15405,11 +14090,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone265" is="detector">
@@ -15460,11 +14140,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone266" is="detector">
@@ -15515,11 +14190,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone267" is="detector">
@@ -15570,11 +14240,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone268" is="detector">
@@ -15625,11 +14290,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone269" is="detector">
@@ -15680,11 +14340,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone270" is="detector">
@@ -15735,11 +14390,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone271" is="detector">
@@ -15790,11 +14440,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone272" is="detector">
@@ -15845,11 +14490,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone273" is="detector">
@@ -15900,11 +14540,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone274" is="detector">
@@ -15955,11 +14590,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone275" is="detector">
@@ -16010,11 +14640,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone276" is="detector">
@@ -16065,11 +14690,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone277" is="detector">
@@ -16120,11 +14740,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone278" is="detector">
@@ -16175,11 +14790,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone279" is="detector">
@@ -16230,11 +14840,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone280" is="detector">
@@ -16285,11 +14890,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone281" is="detector">
@@ -16340,11 +14940,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone282" is="detector">
@@ -16395,11 +14990,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone283" is="detector">
@@ -16450,11 +15040,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone284" is="detector">
@@ -16505,11 +15090,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone285" is="detector">
@@ -16560,11 +15140,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone286" is="detector">
@@ -16615,11 +15190,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone287" is="detector">
@@ -16660,11 +15230,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone288" is="detector">
@@ -16705,11 +15270,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone289" is="detector">
@@ -16750,11 +15310,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone290" is="detector">
@@ -16795,11 +15350,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone291" is="detector">
@@ -16840,11 +15390,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone292" is="detector">
@@ -16885,11 +15430,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone293" is="detector">
@@ -16930,11 +15470,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone294" is="detector">
@@ -16975,11 +15510,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone295" is="detector">
@@ -17020,11 +15550,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone296" is="detector">
@@ -17065,11 +15590,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone297" is="detector">
@@ -17110,11 +15630,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone298" is="detector">
@@ -17155,11 +15670,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone299" is="detector">
@@ -17200,11 +15710,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone300" is="detector">
@@ -17245,11 +15750,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone301" is="detector">
@@ -17290,11 +15790,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone302" is="detector">
@@ -17335,11 +15830,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone303" is="detector">
@@ -17380,11 +15870,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone304" is="detector">
@@ -17425,11 +15910,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone305" is="detector">
@@ -17470,11 +15950,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone306" is="detector">
@@ -17515,11 +15990,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone307" is="detector">
@@ -17560,11 +16030,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone308" is="detector">
@@ -17605,11 +16070,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone309" is="detector">
@@ -17650,11 +16110,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone310" is="detector">
@@ -17695,11 +16150,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone311" is="detector">
@@ -17740,11 +16190,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone312" is="detector">
@@ -17785,11 +16230,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone313" is="detector">
@@ -17830,11 +16270,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone314" is="detector">
@@ -17875,11 +16310,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone315" is="detector">
@@ -17920,11 +16350,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone316" is="detector">
@@ -17965,11 +16390,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone317" is="detector">
@@ -18010,11 +16430,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone318" is="detector">
@@ -18055,11 +16470,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone319" is="detector">
@@ -18100,11 +16510,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone320" is="detector">
@@ -18140,11 +16545,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone321" is="detector">
@@ -18180,11 +16580,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone322" is="detector">
@@ -18220,11 +16615,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone323" is="detector">
@@ -18260,11 +16650,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone324" is="detector">
@@ -18300,11 +16685,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone325" is="detector">
@@ -18340,11 +16720,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone326" is="detector">
@@ -18380,11 +16755,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone327" is="detector">
@@ -18420,11 +16790,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone328" is="detector">
@@ -18460,11 +16825,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone329" is="detector">
@@ -18500,11 +16860,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone330" is="detector">
@@ -18540,11 +16895,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone331" is="detector">
@@ -18580,11 +16930,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone332" is="detector">
@@ -18620,11 +16965,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone333" is="detector">
@@ -18660,11 +17000,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone334" is="detector">
@@ -18700,11 +17035,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone335" is="detector">
@@ -18740,11 +17070,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone336" is="detector">
@@ -18780,11 +17105,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone337" is="detector">
@@ -18820,11 +17140,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone338" is="detector">
@@ -18860,11 +17175,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone339" is="detector">
@@ -18900,11 +17210,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone340" is="detector">
@@ -18940,11 +17245,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone341" is="detector">
@@ -18980,11 +17280,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone342" is="detector">
@@ -19015,11 +17310,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone343" is="detector">
@@ -19050,11 +17340,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone344" is="detector">
@@ -19085,11 +17370,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone345" is="detector">
@@ -19120,11 +17400,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone346" is="detector">
@@ -19155,11 +17430,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone347" is="detector">
@@ -19190,11 +17460,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone348" is="detector">
@@ -19225,11 +17490,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone349" is="detector">
@@ -19260,11 +17520,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone350" is="detector">
@@ -19295,11 +17550,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone351" is="detector">
@@ -19330,11 +17580,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone352" is="detector">
@@ -19365,11 +17610,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 
@@ -19930,11 +18170,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone354" is="detector">
@@ -20015,11 +18250,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone355" is="detector">
@@ -20100,11 +18330,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone356" is="detector">
@@ -20185,11 +18410,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone357" is="detector">
@@ -20270,11 +18490,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone358" is="detector">
@@ -20355,11 +18570,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone359" is="detector">
@@ -20440,11 +18650,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone360" is="detector">
@@ -20525,11 +18730,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone361" is="detector">
@@ -20610,11 +18810,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone362" is="detector">
@@ -20695,11 +18890,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone363" is="detector">
@@ -20765,11 +18955,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone364" is="detector">
@@ -20835,11 +19020,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone365" is="detector">
@@ -20905,11 +19085,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone366" is="detector">
@@ -20975,11 +19150,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone367" is="detector">
@@ -21045,11 +19215,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone368" is="detector">
@@ -21115,11 +19280,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone369" is="detector">
@@ -21185,11 +19345,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone370" is="detector">
@@ -21255,11 +19410,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone371" is="detector">
@@ -21325,11 +19475,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone372" is="detector">
@@ -21395,11 +19540,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone373" is="detector">
@@ -21465,11 +19605,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone374" is="detector">
@@ -21535,11 +19670,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone375" is="detector">
@@ -21605,11 +19735,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone376" is="detector">
@@ -21675,11 +19800,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone377" is="detector">
@@ -21745,11 +19865,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone378" is="detector">
@@ -21815,11 +19930,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone379" is="detector">
@@ -21885,11 +19995,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone380" is="detector">
@@ -21955,11 +20060,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone381" is="detector">
@@ -22025,11 +20125,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone382" is="detector">
@@ -22095,11 +20190,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone383" is="detector">
@@ -22155,11 +20245,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone384" is="detector">
@@ -22215,11 +20300,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone385" is="detector">
@@ -22275,11 +20355,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone386" is="detector">
@@ -22335,11 +20410,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone387" is="detector">
@@ -22395,11 +20465,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone388" is="detector">
@@ -22455,11 +20520,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone389" is="detector">
@@ -22515,11 +20575,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone390" is="detector">
@@ -22575,11 +20630,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone391" is="detector">
@@ -22635,11 +20685,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone392" is="detector">
@@ -22695,11 +20740,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <!--  Bank 6 ( 4 modules):  7 groups (10 elements/group)  -->
@@ -22787,11 +20827,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone394" is="detector">
@@ -22877,11 +20912,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone395" is="detector">
@@ -22967,11 +20997,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone396" is="detector">
@@ -23057,11 +21082,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone397" is="detector">
@@ -23147,11 +21167,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone398" is="detector">
@@ -23237,11 +21252,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone399" is="detector">
@@ -23327,11 +21337,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone400" is="detector">
@@ -23417,11 +21422,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone401" is="detector">
@@ -23507,11 +21507,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone402" is="detector">
@@ -23597,11 +21592,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14 : s15 : s16" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone403" is="detector">
@@ -23677,11 +21667,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone404" is="detector">
@@ -23757,11 +21742,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone405" is="detector">
@@ -23837,11 +21817,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone406" is="detector">
@@ -23917,11 +21892,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone407" is="detector">
@@ -23997,11 +21967,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone408" is="detector">
@@ -24077,11 +22042,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone409" is="detector">
@@ -24157,11 +22117,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone410" is="detector">
@@ -24237,11 +22192,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone411" is="detector">
@@ -24317,11 +22267,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone412" is="detector">
@@ -24397,11 +22342,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12 : s13 : s14" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone413" is="detector">
@@ -24467,11 +22407,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone414" is="detector">
@@ -24537,11 +22472,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone415" is="detector">
@@ -24607,11 +22537,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone416" is="detector">
@@ -24677,11 +22602,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone417" is="detector">
@@ -24747,11 +22667,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone418" is="detector">
@@ -24817,11 +22732,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone419" is="detector">
@@ -24887,11 +22797,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone420" is="detector">
@@ -24957,11 +22862,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone421" is="detector">
@@ -25027,11 +22927,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone422" is="detector">
@@ -25097,11 +22992,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10 : s11 : s12" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone423" is="detector">
@@ -25157,11 +23047,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone424" is="detector">
@@ -25217,11 +23102,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone425" is="detector">
@@ -25277,11 +23157,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone426" is="detector">
@@ -25337,11 +23212,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone427" is="detector">
@@ -25397,11 +23267,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone428" is="detector">
@@ -25457,11 +23322,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone429" is="detector">
@@ -25517,11 +23377,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone430" is="detector">
@@ -25577,11 +23432,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone431" is="detector">
@@ -25637,11 +23487,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone432" is="detector">
@@ -25697,11 +23542,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09 : s10" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone433" is="detector">
@@ -25752,11 +23592,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone434" is="detector">
@@ -25807,11 +23642,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone435" is="detector">
@@ -25862,11 +23692,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone436" is="detector">
@@ -25917,11 +23742,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone437" is="detector">
@@ -25972,11 +23792,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone438" is="detector">
@@ -26027,11 +23842,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone439" is="detector">
@@ -26082,11 +23892,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone440" is="detector">
@@ -26137,11 +23942,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone441" is="detector">
@@ -26192,11 +23992,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone442" is="detector">
@@ -26247,11 +24042,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08 : s09" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone443" is="detector">
@@ -26297,11 +24087,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone444" is="detector">
@@ -26347,11 +24132,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone445" is="detector">
@@ -26397,11 +24177,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone446" is="detector">
@@ -26447,11 +24222,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone447" is="detector">
@@ -26497,11 +24267,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone448" is="detector">
@@ -26547,11 +24312,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone449" is="detector">
@@ -26597,11 +24357,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone450" is="detector">
@@ -26647,11 +24402,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone451" is="detector">
@@ -26697,11 +24447,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone452" is="detector">
@@ -26747,11 +24492,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06 : s07 : s08" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone453" is="detector">
@@ -26787,11 +24527,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone454" is="detector">
@@ -26827,11 +24562,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone455" is="detector">
@@ -26867,11 +24597,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone456" is="detector">
@@ -26907,11 +24632,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone457" is="detector">
@@ -26947,11 +24667,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone458" is="detector">
@@ -26987,11 +24702,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone459" is="detector">
@@ -27027,11 +24737,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone460" is="detector">
@@ -27067,11 +24772,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone461" is="detector">
@@ -27107,11 +24807,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
   <type name="cone462" is="detector">
@@ -27147,11 +24842,6 @@
       </location>
     </component>
     <algebra val="s01 : s02 : s03 : s04 : s05 : s06" />
-    <bounding-box>
-      <x-min val="-1.15" /> <x-max val="0.05" />
-      <y-min val="-1.15" /> <y-max val="1.15" />
-      <z-min val="-0.005" /> <z-max val="0.005" />
-    </bounding-box>
   </type>
 
 


### PR DESCRIPTION
Fixes #14555. 

Release notes not yet updated.

All explicit bounding box definitions have been removed from Instrument Definition Files since they are no longer needed.

Following instruments have been modified:

```
CORELLI_Definition.xml
GEM_Definition.xml
HIFI_Definition.xml
HRPD_Definition.xml
OSIRIS_Definition.xml
POLARIS_Definition_115.xml
POLARIS_Definition_121.xml
```

As well as the following IDFs for Unit Testing:

```
HRPD_for_UNIT_TESTING.xml
HRPD_for_UNIT_TESTING2.xml
IDF_for_UNIT_TESTING2.xml
IDF_for_UNIT_TESTING5.xml
```

Most have not been affected in any functional way by the removal of the manual bounding box definitions.

POLARIS now shows up zoomed in a bit more by default (the instrument shows up flush with the viewport rather than zoomed out a bit) because the previously defined bounding boxes were larger than the instrument geometry itself.  Now that they are calculated automatically, the bounding boxes fit the geometry as closely as possible. The unwrapped (cylindrical and spherical) render modes seem to have improved as a result.

Similarly, some of the unit test IDFs have tiny deviations (not enough to affect the unit tests that use them).
### Testing

Load the affected instruments using `LoadEmptyInstrument` algorithm, or by loading a workspace that uses them, and ensure they render well when displayed using "Show Instrument" and still work the same way as before.
