### PR TITLE
Ensure __TMP workspace is not created in ProcessIndirectFitParameters

### DIFF
--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -87,7 +87,8 @@ void ProcessIndirectFitParameters::exec() {
   std::string parameterNamesProp = getProperty("ParameterNames");
   auto parameterNames = listToVector(parameterNamesProp);
   std::string xUnit = getProperty("XAxisUnit");
-  MatrixWorkspace_sptr outputWsName = getProperty("OutputWorkspace");
+  MatrixWorkspace_sptr outputWs = getProperty("OutputWorkspace");
+  const std::string outputWsName = getPropertyValue("OutputWorkspace");
 
   // Search for any parameters in the table with the given parameter names,
   // ignoring their function index and output them to a workspace
@@ -166,7 +167,7 @@ void ProcessIndirectFitParameters::exec() {
   renamer->setProperty("OutputWorkspace", outputWsName);
   renamer->executeAsChildAlg();
   Workspace_sptr renameWs = renamer->getProperty("OutputWorkspace");
-  auto outputWs = boost::dynamic_pointer_cast<MatrixWorkspace>(renameWs);
+  outputWs = boost::dynamic_pointer_cast<MatrixWorkspace>(renameWs);
 
   // Replace axis on workspaces with text axis
   workflowProg.report("Converting text axis");


### PR DESCRIPTION
Fixes #14625

The `__TMP` file should no longer be creaeted by the `ProcessIndirectFitParameters` algorithm
# To Test
- Turn on the option in Mantid to show hidden workspaces (View > Preferences... > Mantid > Options > Check `Show Invisible Workspaces` option)
- Run the following script in the scripting window:

```
tws = WorkspaceFactory.createTable()
tws.addColumn("double", "A")
tws.addColumn("double", "B")
tws.addColumn("double", "B_Err")
tws.addColumn("double", "D")
tws.addRow([1,2,3,4])
tws.addRow([5,6,7,8])
tws.addRow([9,0,1,2])
tws.addRow([0,0,0,1])


mtd.addOrReplace("TableWs",tws)
wsName = "outputWorkspace"


ProcessIndirectFitParameters(tws, 'A', "B", OutputWorkspace=wsName)
```

_The above is taken from the usage example_
- Ensure that the script run without error **AND** only the `outputWorkspace` and `TableWs` workspaces appear in the ADS
