### PR TITLE
Stop masked data in MDWorkspaces being displayed in slice viewer

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -101,6 +101,12 @@ public:
   getSignalAtCoord(const coord_t *coords,
                    const Mantid::API::MDNormalization &normalization) const = 0;
 
+  /// Returns the (normalized) signal at a given coordinates or NaN if the value
+  // is masked, used for plotting
+  virtual signal_t
+    getSignalWithMaskAtCoord(const coord_t *coords,
+                     const Mantid::API::MDNormalization &normalization) const = 0;
+
   /// Method to generate a line plot through a MD-workspace
   virtual void getLinePlot(const Mantid::Kernel::VMD &start,
                            const Mantid::Kernel::VMD &end,

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -103,9 +103,9 @@ public:
 
   /// Returns the (normalized) signal at a given coordinates or NaN if the value
   // is masked, used for plotting
-  virtual signal_t
-    getSignalWithMaskAtCoord(const coord_t *coords,
-                     const Mantid::API::MDNormalization &normalization) const = 0;
+  virtual signal_t getSignalWithMaskAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const = 0;
 
   /// Method to generate a line plot through a MD-workspace
   virtual void getLinePlot(const Mantid::Kernel::VMD &start,
@@ -120,6 +120,11 @@ public:
   signal_t getSignalAtVMD(const Mantid::Kernel::VMD &coords,
                           const Mantid::API::MDNormalization &normalization =
                               Mantid::API::VolumeNormalization) const;
+
+  signal_t
+  getSignalWithMaskAtVMD(const Mantid::Kernel::VMD &coords,
+                         const Mantid::API::MDNormalization &normalization =
+                             Mantid::API::VolumeNormalization) const;
 
   /// Setter for the masking region.
   virtual void

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -418,6 +418,10 @@ public:
   virtual signal_t
   getSignalAtCoord(const coord_t *coords,
                    const Mantid::API::MDNormalization &normalization) const;
+  /// Get the signal at a coordinate in the workspace
+  virtual signal_t
+    getSignalWithMaskAtCoord(const coord_t *coords,
+                             const Mantid::API::MDNormalization &normalization) const;
   /// Create iterators. Partitions the iterators according to the number of
   /// cores.
   virtual std::vector<IMDIterator *>

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -419,9 +419,9 @@ public:
   getSignalAtCoord(const coord_t *coords,
                    const Mantid::API::MDNormalization &normalization) const;
   /// Get the signal at a coordinate in the workspace
-  virtual signal_t
-    getSignalWithMaskAtCoord(const coord_t *coords,
-                             const Mantid::API::MDNormalization &normalization) const;
+  virtual signal_t getSignalWithMaskAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const;
   /// Create iterators. Partitions the iterators according to the number of
   /// cores.
   virtual std::vector<IMDIterator *>

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -53,6 +53,20 @@ signal_t IMDWorkspace::getSignalAtVMD(
   return this->getSignalAtCoord(coords.getBareArray(), normalization);
 }
 
+//-------------------------------------------------------------------------------------------
+/** Returns the signal (normalized by volume) at a given coordinates
+ * or 0 if masked
+ *
+ * @param coords :: coordinate as a VMD vector
+ * @param normalization :: how to normalize the signal returned
+ * @return normalized signal
+ */
+signal_t IMDWorkspace::getSignalWithMaskAtVMD(
+    const Mantid::Kernel::VMD &coords,
+    const Mantid::API::MDNormalization &normalization) const {
+  return this->getSignalWithMaskAtCoord(coords.getBareArray(), normalization);
+}
+
 //-----------------------------------------------------------------------------------------------
 
 /**

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1609,9 +1609,9 @@ signal_t MatrixWorkspace::getSignalAtCoord(
 * @param normalization :: how to normalize the signal
 * @return normalized signal.
 */
-signal_t
-MatrixWorkspace::getSignalWithMaskAtCoord(const coord_t *coords,
-                           const Mantid::API::MDNormalization &normalization) const {
+signal_t MatrixWorkspace::getSignalWithMaskAtCoord(
+    const coord_t *coords,
+    const Mantid::API::MDNormalization &normalization) const {
   return getSignalAtCoord(coords, normalization);
 }
 

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1601,6 +1601,20 @@ signal_t MatrixWorkspace::getSignalAtCoord(
     return std::numeric_limits<double>::quiet_NaN();
 }
 
+//------------------------------------------------------------------------------------
+/** Returns the (normalized) signal at a given coordinates
+ * Implementation differs from getSignalAtCoord for MD workspaces
+*
+* @param coords :: bare array, size 2, of coordinates. X, Y
+* @param normalization :: how to normalize the signal
+* @return normalized signal.
+*/
+signal_t
+MatrixWorkspace::getSignalWithMaskAtCoord(const coord_t *coords,
+                           const Mantid::API::MDNormalization &normalization) const {
+  return getSignalAtCoord(coords, normalization);
+}
+
 //--------------------------------------------------------------------------------------------
 /** Save the spectra detector map to an open NeXus file.
 * @param file :: open NeXus file

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -84,6 +84,8 @@ public:
 
   bool isInBounds(const coord_t *coords) const;
 
+  signal_t getNormalizedSignal(const API::IMDNode *box, const Mantid::API::MDNormalization &normalization) const;
+
   virtual void getLinePlot(const Mantid::Kernel::VMD &start,
                            const Mantid::Kernel::VMD &end,
                            API::MDNormalization normalize,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -78,13 +78,15 @@ public:
 
   /// Returns the (normalized) signal at a given coordinates
   // or NaN if masked
-  virtual signal_t
-    getSignalWithMaskAtCoord(const coord_t *coords,
-                     const Mantid::API::MDNormalization &normalization) const;
+  virtual signal_t getSignalWithMaskAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const;
 
   bool isInBounds(const coord_t *coords) const;
 
-  signal_t getNormalizedSignal(const API::IMDNode *box, const Mantid::API::MDNormalization &normalization) const;
+  signal_t
+  getNormalizedSignal(const API::IMDNode *box,
+                      const Mantid::API::MDNormalization &normalization) const;
 
   virtual void getLinePlot(const Mantid::Kernel::VMD &start,
                            const Mantid::Kernel::VMD &end,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -76,6 +76,14 @@ public:
   getSignalAtCoord(const coord_t *coords,
                    const Mantid::API::MDNormalization &normalization) const;
 
+  /// Returns the (normalized) signal at a given coordinates
+  // or NaN if masked
+  virtual signal_t
+    getSignalWithMaskAtCoord(const coord_t *coords,
+                     const Mantid::API::MDNormalization &normalization) const;
+
+  bool isInBounds(const coord_t *coords) const;
+
   virtual void getLinePlot(const Mantid::Kernel::VMD &start,
                            const Mantid::Kernel::VMD &end,
                            API::MDNormalization normalize,

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -24,11 +24,10 @@
 #include "MantidKernel/Exception.h"
 
 // Test for gcc 4.4
-#if __GNUC__ > 4 || \
-    (__GNUC__ == 4 && (__GNUC_MINOR__ > 4 || \
-		       (__GNUC_MINOR__ == 4 && \
-			__GNUC_PATCHLEVEL__ > 0)))
-GCC_DIAG_OFF(strict-aliasing)
+#if __GNUC__ > 4 ||                                                            \
+    (__GNUC__ == 4 &&                                                          \
+     (__GNUC_MINOR__ > 4 || (__GNUC_MINOR__ == 4 && __GNUC_PATCHLEVEL__ > 0)))
+GCC_DIAG_OFF(strict - aliasing)
 #endif
 
 using namespace Mantid;
@@ -281,17 +280,18 @@ TMDE(signal_t MDEventWorkspace)::getSignalAtCoord(
   return getNormalizedSignal(box, normalization);
 }
 
-TMDE(signal_t MDEventWorkspace)::getNormalizedSignal(const API::IMDNode *box,
-                                                     const Mantid::API::MDNormalization &normalization) const {
+TMDE(signal_t MDEventWorkspace)::getNormalizedSignal(
+    const API::IMDNode *box,
+    const Mantid::API::MDNormalization &normalization) const {
   if (box) {
     // What is our normalization factor?
     switch (normalization) {
-      case NoNormalization:
-        return box->getSignal();
-      case VolumeNormalization:
-        return box->getSignal() * box->getInverseVolume();
-      case NumEventsNormalization:
-        return box->getSignal() / double(box->getNPoints());
+    case NoNormalization:
+      return box->getSignal();
+    case VolumeNormalization:
+      return box->getSignal() * box->getInverseVolume();
+    case NumEventsNormalization:
+      return box->getSignal() / double(box->getNPoints());
     }
     // Should not reach here
     return box->getSignal();
@@ -317,8 +317,9 @@ TMDE(bool MDEventWorkspace)::isInBounds(const coord_t *coords) const {
  * @return the (normalized) signal at a given coordinates.
  *         NaN if outside the range of this workspace
  */
-TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(const coord_t *coords,
-                                           const Mantid::API::MDNormalization &normalization) const {
+TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(
+    const coord_t *coords,
+    const Mantid::API::MDNormalization &normalization) const {
   if (!isInBounds(coords)) {
     return std::numeric_limits<signal_t>::quiet_NaN();
   }
@@ -858,13 +859,13 @@ TMDE(void MDEventWorkspace)::setCoordinateSystem(
   m_coordSystem = coordSystem;
 }
 
-
 /**
   Set the display normalization for any subsequently generated histoworkspaces.
-  @param preferredNormalization : Display normalization preference to pass on to generated histo workspaces.
+  @param preferredNormalization : Display normalization preference to pass on to
+  generated histo workspaces.
 */
 TMDE(void MDEventWorkspace)::setDisplayNormalizationHisto(
-     const Mantid::API::MDNormalization preferredNormalizationHisto) {
+    const Mantid::API::MDNormalization preferredNormalizationHisto) {
   m_displayNormalizationHisto = preferredNormalizationHisto;
 }
 
@@ -875,25 +876,21 @@ TMDE(MDNormalization MDEventWorkspace)::displayNormalizationHisto() const {
   return m_displayNormalizationHisto;
 }
 
-
 /**
   Set the display normalization
   @param preferredNormalization : Display normalization preference.
 */
 TMDE(void MDEventWorkspace)::setDisplayNormalization(
-     const Mantid::API::MDNormalization preferredNormalization) {
+    const Mantid::API::MDNormalization preferredNormalization) {
   m_displayNormalization = preferredNormalization;
 }
-
 
 /**
 Return the preferred normalization to use for visualization.
 */
 TMDE(MDNormalization MDEventWorkspace)::displayNormalization() const {
-  return m_displayNormalization ;
+  return m_displayNormalization;
 }
-
-
 
 } // namespace DataObjects
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -310,7 +310,7 @@ TMDE(bool MDEventWorkspace)::isInBounds(const coord_t *coords) const {
 
 //----------------------------------------------------------------------------------------------
 /** Get the signal at a particular coordinate in the workspace
- * or return NaN if masked
+ * or return 0 if masked
  *
  * @param coords :: numDimensions-sized array of the coordinates to look at
  * @param normalization : Normalisation to use.
@@ -325,7 +325,7 @@ TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(const coord_t *coords,
   // Check if masked
   const API::IMDNode *box = data->getBoxAtCoord(coords);
   if (box->getIsMasked()) {
-    return std::numeric_limits<signal_t>::quiet_NaN();
+    return 0.0;
   }
   return getNormalizedSignal(box, normalization);
 }

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -278,15 +278,20 @@ TMDE(signal_t MDEventWorkspace)::getSignalAtCoord(
   }
   // If you got here, then the point is in the workspace.
   const API::IMDNode *box = data->getBoxAtCoord(coords);
+  return getNormalizedSignal(box, normalization);
+}
+
+TMDE(signal_t MDEventWorkspace)::getNormalizedSignal(const API::IMDNode *box,
+                                                     const Mantid::API::MDNormalization &normalization) const {
   if (box) {
     // What is our normalization factor?
     switch (normalization) {
-    case NoNormalization:
-      return box->getSignal();
-    case VolumeNormalization:
-      return box->getSignal() * box->getInverseVolume();
-    case NumEventsNormalization:
-      return box->getSignal() / double(box->getNPoints());
+      case NoNormalization:
+        return box->getSignal();
+      case VolumeNormalization:
+        return box->getSignal() * box->getInverseVolume();
+      case NumEventsNormalization:
+        return box->getSignal() / double(box->getNPoints());
     }
     // Should not reach here
     return box->getSignal();
@@ -322,7 +327,7 @@ TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(const coord_t *coords,
   if (box->getIsMasked()) {
     return std::numeric_limits<signal_t>::quiet_NaN();
   }
-  return getSignalAtCoord(coords, normalization);
+  return getNormalizedSignal(box, normalization);
 }
 
 //-----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -175,6 +175,12 @@ public:
   getSignalAtCoord(const coord_t *coords,
                    const Mantid::API::MDNormalization &normalization) const;
 
+  /// Returns the (normalized) signal at a given coordinates
+  // or NaN if masked
+  virtual signal_t
+    getSignalWithMaskAtCoord(const coord_t *coords,
+                             const Mantid::API::MDNormalization &normalization) const;
+
   /// Sets the signal at the specified index.
   void setSignalAt(size_t index, signal_t value) { m_signals[index] = value; }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -177,9 +177,9 @@ public:
 
   /// Returns the (normalized) signal at a given coordinates
   // or 0 if masked
-  virtual signal_t
-    getSignalWithMaskAtCoord(const coord_t *coords,
-                             const Mantid::API::MDNormalization &normalization) const;
+  virtual signal_t getSignalWithMaskAtCoord(
+      const coord_t *coords,
+      const Mantid::API::MDNormalization &normalization) const;
 
   /// Sets the signal at the specified index.
   void setSignalAt(size_t index, signal_t value) { m_signals[index] = value; }

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -176,7 +176,7 @@ public:
                    const Mantid::API::MDNormalization &normalization) const;
 
   /// Returns the (normalized) signal at a given coordinates
-  // or NaN if masked
+  // or 0 if masked
   virtual signal_t
     getSignalWithMaskAtCoord(const coord_t *coords,
                              const Mantid::API::MDNormalization &normalization) const;

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -386,7 +386,7 @@ signal_t MDHistoWorkspace::getSignalAtCoord(
 
 //----------------------------------------------------------------------------------------------
 /** Get the signal at a particular coordinate in the workspace
- * or return NaN if masked
+ * or return 0 if masked
  *
  * @param coords :: numDimensions-sized array of the coordinates to look at
  * @param normalization : Normalisation to use.
@@ -398,7 +398,7 @@ MDHistoWorkspace::getSignalWithMaskAtCoord(const coord_t *coords,
                            const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
   if (this->getIsMaskedAt(linearIndex)) {
-    return std::numeric_limits<signal_t>::quiet_NaN();
+    return 0.0;
   }
   return getSignalAtCoord(coords, normalization);
 }

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -368,9 +368,6 @@ signal_t MDHistoWorkspace::getSignalAtCoord(
     const coord_t *coords,
     const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
-  if (this->getIsMaskedAt(linearIndex)) {
-    return std::numeric_limits<signal_t>::quiet_NaN();
-  }
   if (linearIndex < m_length) {
     // What is our normalization factor?
     switch (normalization) {
@@ -385,6 +382,25 @@ signal_t MDHistoWorkspace::getSignalAtCoord(
     return m_signals[linearIndex];
   } else
     return std::numeric_limits<signal_t>::quiet_NaN();
+}
+
+//----------------------------------------------------------------------------------------------
+/** Get the signal at a particular coordinate in the workspace
+ * or return NaN if masked
+ *
+ * @param coords :: numDimensions-sized array of the coordinates to look at
+ * @param normalization : Normalisation to use.
+ * @return the (normalized) signal at a given coordinates.
+ *         NaN if outside the range of this workspace
+ */
+signal_t
+MDHistoWorkspace::getSignalWithMaskAtCoord(const coord_t *coords,
+                           const Mantid::API::MDNormalization &normalization) const {
+  size_t linearIndex = this->getLinearIndexAtCoord(coords);
+  if (this->getIsMaskedAt(linearIndex)) {
+    return std::numeric_limits<signal_t>::quiet_NaN();
+  }
+  return getSignalAtCoord(coords, normalization);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -393,9 +393,9 @@ signal_t MDHistoWorkspace::getSignalAtCoord(
  * @return the (normalized) signal at a given coordinates.
  *         NaN if outside the range of this workspace
  */
-signal_t
-MDHistoWorkspace::getSignalWithMaskAtCoord(const coord_t *coords,
-                           const Mantid::API::MDNormalization &normalization) const {
+signal_t MDHistoWorkspace::getSignalWithMaskAtCoord(
+    const coord_t *coords,
+    const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
   if (this->getIsMaskedAt(linearIndex)) {
     return 0.0;

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -368,6 +368,9 @@ signal_t MDHistoWorkspace::getSignalAtCoord(
     const coord_t *coords,
     const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
+  if (this->getIsMaskedAt(linearIndex)) {
+    return std::numeric_limits<signal_t>::quiet_NaN();
+  }
   if (linearIndex < m_length) {
     // What is our normalization factor?
     switch (normalization) {

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -299,7 +299,7 @@ public:
   void test_getSignalWithMaskAtCoord() {
     MDEventWorkspace3Lean::sptr ew =
       MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
-    coord_t coords1[3] = {1.5, 1.5, 1.5};
+    coord_t coords1[3] = {0.5, 0.5, 0.5};
     coord_t coords2[3] = {2.5, 2.5, 2.5};
     coord_t coords3[3] = {-0.1f, 2, 2};
     coord_t coords4[3] = {2, 2, 4.1f};
@@ -314,17 +314,14 @@ public:
     min.push_back(0);
     max.push_back(2);
     max.push_back(2);
-    max.push_back(0.99f);
+    max.push_back(2);
 
-    // Create an function that encompases 1/4 of the total bins.
+    // Create an function that encompasses 1/4 of the total bins.
     MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
 
     ew->setMDMasking(function);
 
     ew->refreshCache();
-    TSM_ASSERT_DELTA(
-      "A regular box with a single event",
-      ew->getSignalWithMaskAtCoord(coords1, Mantid::API::NoNormalization), 1.0, 1e-5);
     TSM_ASSERT("Masked returns NAN",
                boost::math::isnan(ew->getSignalWithMaskAtCoord(
                  coords1, Mantid::API::NoNormalization)));

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -298,7 +298,7 @@ public:
   /** Get the signal at a given coord or 0 if masked */
   void test_getSignalWithMaskAtCoord() {
     MDEventWorkspace3Lean::sptr ew =
-      MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
+        MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
     coord_t coords1[3] = {0.5, 0.5, 0.5};
     coord_t coords2[3] = {2.5, 2.5, 2.5};
     ew->addEvent(MDLeanEvent<3>(2.0, 2.0, coords2));
@@ -319,11 +319,12 @@ public:
     ew->refreshCache();
 
     TSM_ASSERT_DELTA(
-      "Value ignoring mask is 1.0",
-      ew->getSignalAtCoord(coords1, Mantid::API::NoNormalization), 1.0, 1e-5);
+        "Value ignoring mask is 1.0",
+        ew->getSignalAtCoord(coords1, Mantid::API::NoNormalization), 1.0, 1e-5);
     TSM_ASSERT_DELTA(
-      "Masked returns 0",
-      ew->getSignalWithMaskAtCoord(coords1, Mantid::API::NoNormalization), 0.0, 1e-5);
+        "Masked returns 0",
+        ew->getSignalWithMaskAtCoord(coords1, Mantid::API::NoNormalization),
+        0.0, 1e-5);
   }
 
   //-------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -295,45 +295,35 @@ public:
   }
 
   //-------------------------------------------------------------------------------------
-  /** Get the signal at a given coord or NaN if masked */
+  /** Get the signal at a given coord or 0 if masked */
   void test_getSignalWithMaskAtCoord() {
     MDEventWorkspace3Lean::sptr ew =
       MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
     coord_t coords1[3] = {0.5, 0.5, 0.5};
     coord_t coords2[3] = {2.5, 2.5, 2.5};
-    coord_t coords3[3] = {-0.1f, 2, 2};
-    coord_t coords4[3] = {2, 2, 4.1f};
     ew->addEvent(MDLeanEvent<3>(2.0, 2.0, coords2));
 
     std::vector<coord_t> min;
     std::vector<coord_t> max;
 
-    // Make the box that covers a quarter the bins in the workspace.
     min.push_back(0);
     min.push_back(0);
     min.push_back(0);
-    max.push_back(2);
-    max.push_back(2);
-    max.push_back(2);
+    max.push_back(1.5);
+    max.push_back(1.5);
+    max.push_back(1.5);
 
-    // Create an function that encompasses 1/4 of the total bins.
+    // Create an function to mask some of the workspace.
     MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
-
     ew->setMDMasking(function);
-
     ew->refreshCache();
-    TSM_ASSERT("Masked returns NAN",
-               boost::math::isnan(ew->getSignalWithMaskAtCoord(
-                 coords1, Mantid::API::NoNormalization)));
+
     TSM_ASSERT_DELTA(
-      "The box with 2 events",
-      ew->getSignalAtCoord(coords2, Mantid::API::NoNormalization), 3.0, 1e-5);
-    TSM_ASSERT("Out of bounds returns NAN",
-               boost::math::isnan(ew->getSignalWithMaskAtCoord(
-                 coords3, Mantid::API::NoNormalization)));
-    TSM_ASSERT("Out of bounds returns NAN",
-               boost::math::isnan(ew->getSignalWithMaskAtCoord(
-                 coords4, Mantid::API::NoNormalization)));
+      "Value ignoring mask is 1.0",
+      ew->getSignalAtCoord(coords1, Mantid::API::NoNormalization), 1.0, 1e-5);
+    TSM_ASSERT_DELTA(
+      "Masked returns 0",
+      ew->getSignalWithMaskAtCoord(coords1, Mantid::API::NoNormalization), 0.0, 1e-5);
   }
 
   //-------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -514,6 +514,38 @@ public:
   }
 
   //---------------------------------------------------------------------------------------------------
+  void test_getSignalWithMaskAtVMD() {
+    // 2D workspace with signal[i] = i (linear index)
+    MDHistoWorkspace_sptr ws =
+        MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10, 20);
+    for (size_t i = 0; i < 100; i++) {
+      ws->setSignalAt(i, double(i));
+      ws->setNumEventsAt(i, 10.0);
+    }
+
+    std::vector<coord_t> min;
+    std::vector<coord_t> max;
+    min.push_back(0);
+    min.push_back(0);
+    max.push_back(5);
+    max.push_back(5);
+
+    // Mask part of the workspace
+    MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
+    ws->setMDMasking(function);
+
+    IMDWorkspace_sptr iws(ws);
+    TS_ASSERT_DELTA(iws->getSignalAtVMD(VMD(0.5, 0.5)), 0.0, 1e-6);
+    TS_ASSERT_DELTA(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5)), 0.0, 1e-6);
+
+    TS_ASSERT_DELTA(iws->getSignalAtVMD(VMD(3.5, 0.5), VolumeNormalization),
+                    0.25, 1e-6);
+    TS_ASSERT_DELTA(
+        iws->getSignalWithMaskAtVMD(VMD(3.5, 0.5), VolumeNormalization), 0.0,
+        1e-6);
+  }
+
+  //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive */
   void test_getLinePlot_horizontal() {
     MDHistoWorkspace_sptr ws =

--- a/MantidQt/API/inc/MantidQtAPI/QwtRasterDataMD.h
+++ b/MantidQt/API/inc/MantidQtAPI/QwtRasterDataMD.h
@@ -14,10 +14,8 @@
 
 #include <vector>
 
-namespace MantidQt
-{
-namespace API
-{
+namespace MantidQt {
+namespace API {
 
 /** Implemenation of QwtRasterData that can display the data
  * from a slice of an IMDWorkspace.
@@ -29,12 +27,11 @@ namespace API
  * @date Sep 29, 2011
  */
 
-class EXPORT_OPT_MANTIDQT_API QwtRasterDataMD : public QwtRasterData
-{
+class EXPORT_OPT_MANTIDQT_API QwtRasterDataMD : public QwtRasterData {
 public:
   QwtRasterDataMD();
   virtual ~QwtRasterDataMD();
-  QwtRasterDataMD* copy() const;
+  QwtRasterDataMD *copy() const;
 
   virtual void setWorkspace(Mantid::API::IMDWorkspace_const_sptr ws);
   Mantid::API::IMDWorkspace_const_sptr getWorkspace() const;
@@ -42,9 +39,12 @@ public:
   void setOverlayWorkspace(Mantid::API::IMDWorkspace_const_sptr ws);
 
   QwtDoubleInterval range() const;
-  void setRange(const QwtDoubleInterval & range);
+  void setRange(const QwtDoubleInterval &range);
 
-  void setSliceParams(size_t dimX, size_t dimY, Mantid::Geometry::IMDDimension_const_sptr X, Mantid::Geometry::IMDDimension_const_sptr Y, std::vector<Mantid::coord_t> & slicePoint);
+  void setSliceParams(size_t dimX, size_t dimY,
+                      Mantid::Geometry::IMDDimension_const_sptr X,
+                      Mantid::Geometry::IMDDimension_const_sptr Y,
+                      std::vector<Mantid::coord_t> &slicePoint);
 
   double value(double x, double y) const;
 
@@ -58,8 +58,7 @@ public:
   Mantid::API::MDNormalization getNormalization() const;
 
 protected:
-
-  void copyFrom(const QwtRasterDataMD & source, QwtRasterDataMD& dest) const;
+  void copyFrom(const QwtRasterDataMD &source, QwtRasterDataMD &dest) const;
 
   /// Workspace being shown
   Mantid::API::IMDWorkspace_const_sptr m_ws;
@@ -82,8 +81,9 @@ protected:
   /// The Y dimensions of the workspace (with the estimated bin resolution)
   Mantid::Geometry::IMDDimension_const_sptr m_Y;
 
-  /// nd-sized array indicating where the slice is being done in the OTHER dimensions
-  Mantid::coord_t * m_slicePoint;
+  /// nd-sized array indicating where the slice is being done in the OTHER
+  /// dimensions
+  Mantid::coord_t *m_slicePoint;
 
   /// Range of colors to plot
   QwtDoubleInterval m_range;

--- a/MantidQt/API/src/QwtRasterDataMD.cpp
+++ b/MantidQt/API/src/QwtRasterDataMD.cpp
@@ -5,10 +5,8 @@
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-namespace MantidQt
-{
-namespace API
-{
+namespace MantidQt {
+namespace API {
 
 using namespace Mantid;
 using namespace Mantid::API;
@@ -17,14 +15,10 @@ using Mantid::Geometry::IMDDimension_const_sptr;
 //-------------------------------------------------------------------------
 /// Constructor
 QwtRasterDataMD::QwtRasterDataMD()
-: m_ws(), m_overlayWS(),
-  m_slicePoint(NULL),
-  m_overlayXMin(0.0), m_overlayXMax(0.0),
-  m_overlayYMin(0.0), m_overlayYMax(0.0),
-  m_overlayInSlice(false),
-  m_fast(true), m_zerosAsNan(true),
-  m_normalization(Mantid::API::VolumeNormalization)
-{
+    : m_ws(), m_overlayWS(), m_slicePoint(NULL), m_overlayXMin(0.0),
+      m_overlayXMax(0.0), m_overlayYMin(0.0), m_overlayYMax(0.0),
+      m_overlayInSlice(false), m_fast(true), m_zerosAsNan(true),
+      m_normalization(Mantid::API::VolumeNormalization) {
   m_range = QwtDoubleInterval(0.0, 1.0);
   m_nd = 0;
   m_dimX = 0;
@@ -34,27 +28,21 @@ QwtRasterDataMD::QwtRasterDataMD()
 
 //-------------------------------------------------------------------------
 /// Destructor
-QwtRasterDataMD::~QwtRasterDataMD()
-{
-  delete [] m_slicePoint;
-}
-
+QwtRasterDataMD::~QwtRasterDataMD() { delete[] m_slicePoint; }
 
 //-------------------------------------------------------------------------
 /** Perform a copy of this data object */
-QwtRasterDataMD *QwtRasterDataMD::copy() const
-{
-  QwtRasterDataMD* out = new QwtRasterDataMD();
+QwtRasterDataMD *QwtRasterDataMD::copy() const {
+  QwtRasterDataMD *out = new QwtRasterDataMD();
   this->copyFrom(*this, *out);
   return out;
 }
 
 //-------------------------------------------------------------------------
 /** Set the data range (min/max) to display */
-void QwtRasterDataMD::setRange(const QwtDoubleInterval & range)
-{ m_range = range; }
-
-
+void QwtRasterDataMD::setRange(const QwtDoubleInterval &range) {
+  m_range = range;
+}
 
 //-------------------------------------------------------------------------
 /** Return the data value to plot at the given position
@@ -63,17 +51,16 @@ void QwtRasterDataMD::setRange(const QwtDoubleInterval & range)
  * @param y :: position in coordinates of the MDWorkspace
  * @return signal to plot
  */
-double QwtRasterDataMD::value(double x, double y) const
-{
-  if (!m_ws) return 0;
+double QwtRasterDataMD::value(double x, double y) const {
+  if (!m_ws)
+    return 0;
 
   // Generate the vector of coordinates, filling in X and Y
-  coord_t * lookPoint = new coord_t[m_nd];
-  for (size_t d=0; d<m_nd; d++)
-  {
-    if (d==m_dimX)
+  coord_t *lookPoint = new coord_t[m_nd];
+  for (size_t d = 0; d < m_nd; d++) {
+    if (d == m_dimX)
       lookPoint[d] = static_cast<coord_t>(x);
-    else if (d==m_dimY)
+    else if (d == m_dimY)
       lookPoint[d] = static_cast<coord_t>(y);
     else
       lookPoint[d] = m_slicePoint[d];
@@ -83,19 +70,15 @@ double QwtRasterDataMD::value(double x, double y) const
   signal_t value = 0;
 
   // Check if the overlay WS is within range of being viewed
-  if (m_overlayWS && m_overlayInSlice
-      && (x >= m_overlayXMin) && (x < m_overlayXMax)
-      && (y >= m_overlayYMin) && (y < m_overlayYMax))
-  {
+  if (m_overlayWS && m_overlayInSlice && (x >= m_overlayXMin) &&
+      (x < m_overlayXMax) && (y >= m_overlayYMin) && (y < m_overlayYMax)) {
     // Point is in the overlaid workspace
     value = m_overlayWS->getSignalWithMaskAtCoord(lookPoint, m_normalization);
-  }
-  else
-  {
+  } else {
     // No overlay, or not within range of that workspace
     value = m_ws->getSignalWithMaskAtCoord(lookPoint, m_normalization);
   }
-  delete [] lookPoint;
+  delete[] lookPoint;
 
   // Special case for 0 = show as NAN
   if (m_zerosAsNan && value == 0.)
@@ -104,11 +87,9 @@ double QwtRasterDataMD::value(double x, double y) const
   return value;
 }
 
-
 //------------------------------------------------------------------------------------------------------
 /** Return the data range to show */
-QwtDoubleInterval QwtRasterDataMD::range() const
-{
+QwtDoubleInterval QwtRasterDataMD::range() const {
   // Linear color plot
   return m_range;
 }
@@ -118,34 +99,27 @@ QwtDoubleInterval QwtRasterDataMD::range() const
  * @param fast :: if true, will guess at the number of pixels to render based
  * on workspace resolution
  */
-void QwtRasterDataMD::setFastMode(bool fast)
-{
-  this->m_fast = fast;
-}
+void QwtRasterDataMD::setFastMode(bool fast) { this->m_fast = fast; }
 
 //------------------------------------------------------------------------------------------------------
 /** Set to convert Zeros to NAN to make them transparent when displaying
  *
  * @param val :: true to make 0 = nan
  */
-void QwtRasterDataMD::setZerosAsNan(bool val)
-{
-  this->m_zerosAsNan = val;
-}
+void QwtRasterDataMD::setZerosAsNan(bool val) { this->m_zerosAsNan = val; }
 
 //------------------------------------------------------------------------------------------------------
 /** Set how the signal is normalized
  *
  * @param normalization :: option from MDNormalization enum.
  */
-void QwtRasterDataMD::setNormalization(Mantid::API::MDNormalization normalization)
-{
+void QwtRasterDataMD::setNormalization(
+    Mantid::API::MDNormalization normalization) {
   m_normalization = normalization;
 }
 
 /** @return how the signal is normalized */
-Mantid::API::MDNormalization QwtRasterDataMD::getNormalization() const
-{
+Mantid::API::MDNormalization QwtRasterDataMD::getNormalization() const {
   return m_normalization;
 }
 
@@ -155,31 +129,35 @@ Mantid::API::MDNormalization QwtRasterDataMD::getNormalization() const
  * @param area :: area under view
  * @return # of pixels in each direction
  */
-QSize QwtRasterDataMD::rasterHint(const QwtDoubleRect &area) const
-{
-  if (!m_ws || !m_X || !m_Y) return QSize();
+QSize QwtRasterDataMD::rasterHint(const QwtDoubleRect &area) const {
+  if (!m_ws || !m_X || !m_Y)
+    return QSize();
   // Slow mode? Don't give a raster hint. This will be 1 pixel per point
-  if (!m_fast) return QSize();
+  if (!m_fast)
+    return QSize();
 
   // Fast mode: use the bin size to guess at the pixel density
   coord_t binX = m_X->getBinWidth();
   coord_t binY = m_Y->getBinWidth();
 
   // Use the overlay workspace, if any, and if its bins are smaller
-  if (m_overlayWS && m_overlayInSlice)
-  {
+  if (m_overlayWS && m_overlayInSlice) {
     coord_t temp;
     temp = m_overlayWS->getDimension(m_dimX)->getBinWidth();
-    if (temp < binX) binX = temp;
+    if (temp < binX)
+      binX = temp;
     temp = m_overlayWS->getDimension(m_dimY)->getBinWidth();
-    if (temp < binY) binY = temp;
+    if (temp < binY)
+      binY = temp;
   }
 
   int w = 3 * int(area.width() / binX);
   int h = 3 * int(area.height() / binY);
-  if (w<10) w = 10;
-  if (h<10) h = 10;
-  return QSize(w,h);
+  if (w < 10)
+    w = 10;
+  if (h < 10)
+    h = 10;
+  return QSize(w, h);
 }
 
 //------------------------------------------------------------------------------------------------------
@@ -187,23 +165,22 @@ QSize QwtRasterDataMD::rasterHint(const QwtDoubleRect &area) const
  *
  * @param ws :: IMDWorkspace to show
  */
-void QwtRasterDataMD::setWorkspace(IMDWorkspace_const_sptr ws)
-{
+void QwtRasterDataMD::setWorkspace(IMDWorkspace_const_sptr ws) {
   if (!ws)
-    throw std::runtime_error("QwtRasterDataMD::setWorkspace(): NULL workspace passed.");
+    throw std::runtime_error(
+        "QwtRasterDataMD::setWorkspace(): NULL workspace passed.");
   m_ws = ws;
   m_nd = m_ws->getNumDims();
   m_dimX = 0;
   m_dimY = 1;
-  delete [] m_slicePoint;
+  delete[] m_slicePoint;
   m_slicePoint = new coord_t[m_nd];
 }
 
 //------------------------------------------------------------------------------------------------------
 /** Gets the workspace being displayed
  */
-Mantid::API::IMDWorkspace_const_sptr QwtRasterDataMD::getWorkspace() const
-{
+Mantid::API::IMDWorkspace_const_sptr QwtRasterDataMD::getWorkspace() const {
   return m_ws;
 }
 
@@ -213,15 +190,16 @@ Mantid::API::IMDWorkspace_const_sptr QwtRasterDataMD::getWorkspace() const
  *
  * @param ws :: IMDWorkspace to show
  */
-void QwtRasterDataMD::setOverlayWorkspace(Mantid::API::IMDWorkspace_const_sptr ws)
-{
-  if (!ws)
-  {
+void QwtRasterDataMD::setOverlayWorkspace(
+    Mantid::API::IMDWorkspace_const_sptr ws) {
+  if (!ws) {
     m_overlayWS.reset();
     return;
   }
   if (ws->getNumDims() != m_nd)
-    throw std::runtime_error("QwtRasterDataMD::setOverlayWorkspace(): workspace does not have the same number of dimensions!");
+    throw std::runtime_error("QwtRasterDataMD::setOverlayWorkspace(): "
+                             "workspace does not have the same number of "
+                             "dimensions!");
   m_overlayWS = ws;
 }
 
@@ -234,35 +212,34 @@ void QwtRasterDataMD::setOverlayWorkspace(Mantid::API::IMDWorkspace_const_sptr w
  * @param Y : Y Dimension
  * @param slicePoint :: vector of slice points
  */
-void QwtRasterDataMD::setSliceParams(size_t dimX, size_t dimY,
-    Mantid::Geometry::IMDDimension_const_sptr X, Mantid::Geometry::IMDDimension_const_sptr Y,
-    std::vector<Mantid::coord_t> & slicePoint)
-{
+void QwtRasterDataMD::setSliceParams(
+    size_t dimX, size_t dimY, Mantid::Geometry::IMDDimension_const_sptr X,
+    Mantid::Geometry::IMDDimension_const_sptr Y,
+    std::vector<Mantid::coord_t> &slicePoint) {
   if (slicePoint.size() != m_nd)
-    throw std::runtime_error("QwtRasterDataMD::setSliceParams(): inconsistent vector/number of dimensions size.");
+    throw std::runtime_error("QwtRasterDataMD::setSliceParams(): inconsistent "
+                             "vector/number of dimensions size.");
   m_dimX = dimX;
   m_dimY = dimY;
   m_X = X;
   m_Y = Y;
   if (!m_X || !m_Y)
-    throw std::runtime_error("QwtRasterDataMD::setSliceParams(): one of the input dimensions is NULL");
-  delete [] m_slicePoint;
+    throw std::runtime_error("QwtRasterDataMD::setSliceParams(): one of the "
+                             "input dimensions is NULL");
+  delete[] m_slicePoint;
   m_slicePoint = new coord_t[slicePoint.size()];
   m_overlayInSlice = true;
-  for (size_t d=0; d<m_nd; d++)
-  {
+  for (size_t d = 0; d < m_nd; d++) {
     m_slicePoint[d] = slicePoint[d];
     // Don't show the overlay WS if it is outside of range in the slice points
-    if (m_overlayWS && d != m_dimX && d != m_dimY)
-    {
-      if (slicePoint[d] < m_overlayWS->getDimension(d)->getMinimum()
-          || slicePoint[d] >= m_overlayWS->getDimension(d)->getMaximum())
+    if (m_overlayWS && d != m_dimX && d != m_dimY) {
+      if (slicePoint[d] < m_overlayWS->getDimension(d)->getMinimum() ||
+          slicePoint[d] >= m_overlayWS->getDimension(d)->getMaximum())
         m_overlayInSlice = false;
     }
   }
   // Cache the edges of the overlaid workspace
-  if (m_overlayWS)
-  {
+  if (m_overlayWS) {
     m_overlayXMin = m_overlayWS->getDimension(m_dimX)->getMinimum();
     m_overlayXMax = m_overlayWS->getDimension(m_dimX)->getMaximum();
     m_overlayYMin = m_overlayWS->getDimension(m_dimY)->getMinimum();
@@ -279,9 +256,9 @@ void QwtRasterDataMD::setSliceParams(size_t dimX, size_t dimY,
  * @param source A source object to copy from
  * @param dest The destination object that receives the contents
  */
-void QwtRasterDataMD::copyFrom(const QwtRasterDataMD &source, QwtRasterDataMD &dest) const
-{
-  //base bounding box
+void QwtRasterDataMD::copyFrom(const QwtRasterDataMD &source,
+                               QwtRasterDataMD &dest) const {
+  // base bounding box
   dest.setBoundingRect(source.boundingRect());
 
   dest.m_ws = source.m_ws;
@@ -290,7 +267,7 @@ void QwtRasterDataMD::copyFrom(const QwtRasterDataMD &source, QwtRasterDataMD &d
   dest.m_nd = source.m_nd;
   dest.m_range = source.m_range;
   dest.m_slicePoint = new coord_t[m_nd];
-  for (size_t d=0; d<m_nd; d++)
+  for (size_t d = 0; d < m_nd; d++)
     dest.m_slicePoint[d] = source.m_slicePoint[d];
   dest.m_ws = source.m_ws;
   dest.m_fast = source.m_fast;
@@ -305,5 +282,5 @@ void QwtRasterDataMD::copyFrom(const QwtRasterDataMD &source, QwtRasterDataMD &d
   dest.m_overlayInSlice = source.m_overlayInSlice;
 }
 
-} //namespace
-} //namespace
+} // namespace
+} // namespace

--- a/MantidQt/API/src/QwtRasterDataMD.cpp
+++ b/MantidQt/API/src/QwtRasterDataMD.cpp
@@ -88,12 +88,12 @@ double QwtRasterDataMD::value(double x, double y) const
       && (y >= m_overlayYMin) && (y < m_overlayYMax))
   {
     // Point is in the overlaid workspace
-    value = m_overlayWS->getSignalAtCoord(lookPoint, m_normalization);
+    value = m_overlayWS->getSignalWithMaskAtCoord(lookPoint, m_normalization);
   }
   else
   {
     // No overlay, or not within range of that workspace
-    value = m_ws->getSignalAtCoord(lookPoint, m_normalization);
+    value = m_ws->getSignalWithMaskAtCoord(lookPoint, m_normalization);
   }
   delete [] lookPoint;
 

--- a/MantidQt/API/test/SignalRangeTest.h
+++ b/MantidQt/API/test/SignalRangeTest.h
@@ -24,6 +24,8 @@ private:
                        std::vector<Mantid::API::IMDIterator*>(size_t,Mantid::Geometry::MDImplicitFunction *));
     MOCK_CONST_METHOD2(getSignalAtCoord,
                        Mantid::signal_t(const Mantid::coord_t *, const Mantid::API::MDNormalization &));
+    MOCK_CONST_METHOD2(getSignalWithMaskAtCoord,
+      Mantid::signal_t(const Mantid::coord_t *, const Mantid::API::MDNormalization &));
     MOCK_CONST_METHOD6(getLinePlot,
                       void(const Mantid::Kernel::VMD &, const Mantid::Kernel::VMD &,
                            Mantid::API::MDNormalization, std::vector<Mantid::coord_t> &,

--- a/MantidQt/API/test/SignalRangeTest.h
+++ b/MantidQt/API/test/SignalRangeTest.h
@@ -10,33 +10,40 @@
 
 #include "MantidAPI/IMDIterator.h"
 
-class SignalRangeTest : public CxxTest::TestSuite
-{
+class SignalRangeTest : public CxxTest::TestSuite {
 private:
-  class MockMDWorkspace : public Mantid::API::IMDWorkspace
-  {
+  class MockMDWorkspace : public Mantid::API::IMDWorkspace {
   public:
     const std::string id() const { return "MockMDWorkspace"; }
     size_t getMemorySize() const { return 0; }
     MOCK_CONST_METHOD0(getNPoints, uint64_t());
     MOCK_CONST_METHOD0(getNEvents, uint64_t());
     MOCK_CONST_METHOD2(createIterators,
-                       std::vector<Mantid::API::IMDIterator*>(size_t,Mantid::Geometry::MDImplicitFunction *));
+                       std::vector<Mantid::API::IMDIterator *>(
+                           size_t, Mantid::Geometry::MDImplicitFunction *));
     MOCK_CONST_METHOD2(getSignalAtCoord,
-                       Mantid::signal_t(const Mantid::coord_t *, const Mantid::API::MDNormalization &));
+                       Mantid::signal_t(const Mantid::coord_t *,
+                                        const Mantid::API::MDNormalization &));
     MOCK_CONST_METHOD2(getSignalWithMaskAtCoord,
-      Mantid::signal_t(const Mantid::coord_t *, const Mantid::API::MDNormalization &));
-    MOCK_CONST_METHOD6(getLinePlot,
-                      void(const Mantid::Kernel::VMD &, const Mantid::Kernel::VMD &,
-                           Mantid::API::MDNormalization, std::vector<Mantid::coord_t> &,
-                           std::vector<Mantid::signal_t> &, std::vector<Mantid::signal_t> &));
-    MOCK_CONST_METHOD1(createIterator, Mantid::API::IMDIterator*(Mantid::Geometry::MDImplicitFunction *));
+                       Mantid::signal_t(const Mantid::coord_t *,
+                                        const Mantid::API::MDNormalization &));
+    MOCK_CONST_METHOD6(getLinePlot, void(const Mantid::Kernel::VMD &,
+                                         const Mantid::Kernel::VMD &,
+                                         Mantid::API::MDNormalization,
+                                         std::vector<Mantid::coord_t> &,
+                                         std::vector<Mantid::signal_t> &,
+                                         std::vector<Mantid::signal_t> &));
+    MOCK_CONST_METHOD1(
+        createIterator,
+        Mantid::API::IMDIterator *(Mantid::Geometry::MDImplicitFunction *));
     MOCK_CONST_METHOD2(getSignalAtVMD,
                        Mantid::signal_t(const Mantid::Kernel::VMD &,
                                         const Mantid::API::MDNormalization &));
-    MOCK_METHOD1(setMDMasking, void(Mantid::Geometry::MDImplicitFunction*));
+    MOCK_METHOD1(setMDMasking, void(Mantid::Geometry::MDImplicitFunction *));
     MOCK_METHOD0(clearMDMasking, void());
-    MOCK_CONST_METHOD0(getSpecialCoordinateSystem, Mantid::Kernel::SpecialCoordinateSystem());
+    MOCK_CONST_METHOD0(getSpecialCoordinateSystem,
+                       Mantid::Kernel::SpecialCoordinateSystem());
+
   private:
     virtual MockMDWorkspace *doClone() const {
       throw std::runtime_error(
@@ -44,8 +51,7 @@ private:
     }
   };
 
-  class MockMDIterator : public Mantid::API::IMDIterator
-  {
+  class MockMDIterator : public Mantid::API::IMDIterator {
   public:
     MOCK_CONST_METHOD0(getDataSize, size_t());
     MOCK_METHOD0(next, bool());
@@ -56,13 +62,14 @@ private:
     MOCK_CONST_METHOD0(getNormalizedError, Mantid::signal_t());
     MOCK_CONST_METHOD0(getSignal, Mantid::signal_t());
     MOCK_CONST_METHOD0(getError, Mantid::signal_t());
-    MOCK_CONST_METHOD1(getVertexesArray, Mantid::coord_t *(size_t&));
-    MOCK_CONST_METHOD3(getVertexesArray, Mantid::coord_t *(size_t&,const size_t,const bool *));
+    MOCK_CONST_METHOD1(getVertexesArray, Mantid::coord_t *(size_t &));
+    MOCK_CONST_METHOD3(getVertexesArray,
+                       Mantid::coord_t *(size_t &, const size_t, const bool *));
     MOCK_CONST_METHOD0(getCenter, Mantid::Kernel::VMD());
     MOCK_CONST_METHOD0(getNumEvents, size_t());
     MOCK_CONST_METHOD1(getInnerRunIndex, uint16_t(size_t));
     MOCK_CONST_METHOD1(getInnerDetectorID, int32_t(size_t));
-    MOCK_CONST_METHOD2(getInnerPosition, Mantid::coord_t(size_t,size_t));
+    MOCK_CONST_METHOD2(getInnerPosition, Mantid::coord_t(size_t, size_t));
     MOCK_CONST_METHOD1(getInnerSignal, Mantid::signal_t(size_t));
     MOCK_CONST_METHOD1(getInnerError, Mantid::signal_t(size_t));
     MOCK_CONST_METHOD0(getIsMasked, bool());
@@ -72,34 +79,35 @@ private:
     MOCK_CONST_METHOD1(isWithinBounds, bool(size_t));
   };
 
-  class NormalizableMockIterator : public MockMDIterator
-  {
+  class NormalizableMockIterator : public MockMDIterator {
   public:
-    Mantid::signal_t getNormalizedSignal() const
-    {
+    Mantid::signal_t getNormalizedSignal() const {
       return this->getSignal() / static_cast<double>(this->getNumEvents());
     }
   };
-
 
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
   static SignalRangeTest *createSuite() { return new SignalRangeTest(); }
-  static void destroySuite( SignalRangeTest *suite ) { delete suite; }
+  static void destroySuite(SignalRangeTest *suite) { delete suite; }
 
-  void test_IMDWorkspace_Without_Function_Or_Normalization_Gives_Expected_Full_Range()
-  {
+  void
+  test_IMDWorkspace_Without_Function_Or_Normalization_Gives_Expected_Full_Range() {
     using namespace ::testing;
 
     int nthreads = PARALLEL_GET_MAX_THREADS;
-    std::vector<Mantid::API::IMDIterator*> iterators(nthreads);
-    for(int i = 0;i < nthreads; ++i)
-    {
-      auto * iterator = new MockMDIterator; // deleted by call to SignalRange below
+    std::vector<Mantid::API::IMDIterator *> iterators(nthreads);
+    for (int i = 0; i < nthreads; ++i) {
+      auto *iterator =
+          new MockMDIterator; // deleted by call to SignalRange below
       EXPECT_CALL(*iterator, valid()).WillRepeatedly(Return(true));
-      EXPECT_CALL(*iterator, next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
-      EXPECT_CALL(*iterator, getNormalizedSignal()).WillOnce(Return(-1.5)).WillRepeatedly(Return(10.0));
+      EXPECT_CALL(*iterator, next())
+          .WillOnce(Return(true))
+          .WillRepeatedly(Return(false));
+      EXPECT_CALL(*iterator, getNormalizedSignal())
+          .WillOnce(Return(-1.5))
+          .WillRepeatedly(Return(10.0));
       iterators[i] = iterator;
     }
 
@@ -117,19 +125,24 @@ public:
     TS_ASSERT_DELTA(10.0, range.maxValue(), 1e-10);
   }
 
-  void test_IMDWorkspace_Uses_Specified_Normalization()
-  {
+  void test_IMDWorkspace_Uses_Specified_Normalization() {
     using namespace ::testing;
 
     int nthreads = PARALLEL_GET_MAX_THREADS;
-    std::vector<Mantid::API::IMDIterator*> iterators(nthreads);
-    for(int i = 0;i < nthreads; ++i)
-    {
-      auto * iterator = new NormalizableMockIterator;  // deleted by call to SignalRange below
-      EXPECT_CALL(*iterator, getNumEvents()).Times(Exactly(2)).WillRepeatedly(Return(2));
+    std::vector<Mantid::API::IMDIterator *> iterators(nthreads);
+    for (int i = 0; i < nthreads; ++i) {
+      auto *iterator =
+          new NormalizableMockIterator; // deleted by call to SignalRange below
+      EXPECT_CALL(*iterator, getNumEvents())
+          .Times(Exactly(2))
+          .WillRepeatedly(Return(2));
       EXPECT_CALL(*iterator, valid()).WillRepeatedly(Return(true));
-      EXPECT_CALL(*iterator, next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
-      EXPECT_CALL(*iterator, getSignal()).WillOnce(Return(1.5)).WillRepeatedly(Return(10.0));
+      EXPECT_CALL(*iterator, next())
+          .WillOnce(Return(true))
+          .WillRepeatedly(Return(false));
+      EXPECT_CALL(*iterator, getSignal())
+          .WillOnce(Return(1.5))
+          .WillRepeatedly(Return(10.0));
       iterators[i] = iterator;
     }
 
@@ -147,32 +160,36 @@ public:
     TS_ASSERT_DELTA(5.0, range.maxValue(), 1e-10);
   }
 
-  void test_IMDWorkspace_With_Function_()
-  {
+  void test_IMDWorkspace_With_Function_() {
     using namespace ::testing;
 
     int nthreads = PARALLEL_GET_MAX_THREADS;
-    std::vector<Mantid::API::IMDIterator*> iterators(nthreads);
-    for(int i = 0;i < nthreads; ++i)
-    {
-      auto * iterator = new NormalizableMockIterator;  // deleted by call to SignalRange below
-      EXPECT_CALL(*iterator, getNumEvents()).Times(Exactly(2)).WillRepeatedly(Return(2));
+    std::vector<Mantid::API::IMDIterator *> iterators(nthreads);
+    for (int i = 0; i < nthreads; ++i) {
+      auto *iterator =
+          new NormalizableMockIterator; // deleted by call to SignalRange below
+      EXPECT_CALL(*iterator, getNumEvents())
+          .Times(Exactly(2))
+          .WillRepeatedly(Return(2));
       EXPECT_CALL(*iterator, valid()).WillRepeatedly(Return(true));
-      EXPECT_CALL(*iterator, next()).WillOnce(Return(true)).WillRepeatedly(Return(false));
-      EXPECT_CALL(*iterator, getSignal()).WillOnce(Return(1.5)).WillRepeatedly(Return(10.0));
+      EXPECT_CALL(*iterator, next())
+          .WillOnce(Return(true))
+          .WillRepeatedly(Return(false));
+      EXPECT_CALL(*iterator, getSignal())
+          .WillOnce(Return(1.5))
+          .WillRepeatedly(Return(10.0));
       iterators[i] = iterator;
     }
 
     MockMDWorkspace data;
     Mantid::Geometry::MDImplicitFunction function;
     Mantid::coord_t normal[3] = {1234, 456, 678};
-    Mantid::coord_t point[3] = {1,2,3};
+    Mantid::coord_t point[3] = {1, 2, 3};
     function.addPlane(Mantid::Geometry::MDPlane(3, normal, point));
 
     EXPECT_CALL(data, createIterators(nthreads, &function))
         .Times(Exactly(1))
         .WillOnce(Return(iterators));
-
 
     MantidQt::API::SignalRange sr(data, function, Mantid::API::NoNormalization);
     QwtDoubleInterval range = sr.interval();
@@ -182,8 +199,6 @@ public:
     TS_ASSERT_DELTA(0.75, range.minValue(), 1e-10);
     TS_ASSERT_DELTA(5.0, range.maxValue(), 1e-10);
   }
-
 };
-
 
 #endif /* MANTIDQT_API_SIGNALRANGETEST */

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/LineViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/LineViewer.h
@@ -14,164 +14,160 @@
 #include "MantidQtSliceViewer/LinePlotOptions.h"
 #include "MantidQtAPI/AlgorithmRunner.h"
 
-namespace MantidQt
-{
-namespace SliceViewer
-{
-class EXPORT_OPT_MANTIDQT_SLICEVIEWER LineViewer : public QWidget
-{
-    Q_OBJECT
+namespace MantidQt {
+namespace SliceViewer {
+class EXPORT_OPT_MANTIDQT_SLICEVIEWER LineViewer : public QWidget {
+  Q_OBJECT
 
 public:
+  LineViewer(QWidget *parent = 0);
+  ~LineViewer();
 
-    LineViewer(QWidget *parent = 0);
-    ~LineViewer();
+  void setWorkspace(Mantid::API::IMDWorkspace_sptr ws);
+  void setFreeDimensions(bool all, int dimX, int dimY);
+  void setStart(Mantid::Kernel::VMD start);
+  void setEnd(Mantid::Kernel::VMD end);
+  void setThickness(Mantid::Kernel::VMD width);
+  void setPlanarWidth(double width);
+  void setNumBins(int numBins);
+  void setFixedBinWidthMode(bool fixedWidth, double binWidth);
+  void setPlotAxis(int choice);
 
-    void setWorkspace(Mantid::API::IMDWorkspace_sptr ws);
-    void setFreeDimensions(bool all, int dimX, int dimY);
-    void setStart(Mantid::Kernel::VMD start);
-    void setEnd(Mantid::Kernel::VMD end);
-    void setThickness(Mantid::Kernel::VMD width);
-    void setPlanarWidth(double width);
-    void setNumBins(int numBins);
-    void setFixedBinWidthMode(bool fixedWidth, double binWidth);
-    void setPlotAxis(int choice);
+  void showPreview();
+  void showFull();
 
-    void showPreview();
-    void showFull();
+  double getPlanarWidth() const;
+  Mantid::Kernel::VMD getWidth() const;
+  double getFixedBinWidth() const;
+  bool getFixedBinWidthMode() const;
+  int getNumBins() const;
+  double getBinWidth() const;
+  int getPlotAxis() const;
 
-    double getPlanarWidth() const;
-    Mantid::Kernel::VMD getWidth() const;
-    double getFixedBinWidth() const;
-    bool getFixedBinWidthMode() const;
-    int getNumBins() const;
-    double getBinWidth() const;
-    int getPlotAxis() const;
-
-    // For python
-    void setStartXY(double x, double y);
-    void setEndXY(double x, double y);
-    void setThickness(double width);
-    void setThickness(int dim, double width);
-    void setThickness(const QString & dim, double width);
-    QPointF getStartXY() const;
-    QPointF getEndXY() const;
-    int getXAxisDimensionIndex() const;
+  // For python
+  void setStartXY(double x, double y);
+  void setEndXY(double x, double y);
+  void setThickness(double width);
+  void setThickness(int dim, double width);
+  void setThickness(const QString &dim, double width);
+  QPointF getStartXY() const;
+  QPointF getEndXY() const;
+  int getXAxisDimensionIndex() const;
 
 private:
-    void createDimensionWidgets();
-    void updateFreeDimensions();
-    void updateStartEnd();
-    void updateBinWidth();
-    void readTextboxes();
-    bool isLogScaledY() const;
+  void createDimensionWidgets();
+  void updateFreeDimensions();
+  void updateStartEnd();
+  void updateBinWidth();
+  void readTextboxes();
+  bool isLogScaledY() const;
 
 public slots:
-    void startEndTextEdited();
-    void thicknessTextEdited();
-    void startLinkedToEndText();
-    void apply();
-    void numBinsChanged();
-    void adaptiveBinsChanged();
-    void setFreeDimensions(size_t dimX, size_t dimY);
-    void on_radNumBins_toggled();
-    void textBinWidth_changed();
-    void refreshPlot();
-    void lineIntegrationComplete(bool error);
-    void onToggleLogYAxis();
+  void startEndTextEdited();
+  void thicknessTextEdited();
+  void startLinkedToEndText();
+  void apply();
+  void numBinsChanged();
+  void adaptiveBinsChanged();
+  void setFreeDimensions(size_t dimX, size_t dimY);
+  void on_radNumBins_toggled();
+  void textBinWidth_changed();
+  void refreshPlot();
+  void lineIntegrationComplete(bool error);
+  void onToggleLogYAxis();
 
 signals:
-    /// Signal emitted when the planar width changes
-    void changedPlanarWidth(double);
-    /// Signal emitted when the start or end position has changed
-    void changedStartOrEnd(Mantid::Kernel::VMD, Mantid::Kernel::VMD);
-    /// Signal emitted when changing fixed bin width mode
-    void changedFixedBinWidth(bool, double);
+  /// Signal emitted when the planar width changes
+  void changedPlanarWidth(double);
+  /// Signal emitted when the start or end position has changed
+  void changedStartOrEnd(Mantid::Kernel::VMD, Mantid::Kernel::VMD);
+  /// Signal emitted when changing fixed bin width mode
+  void changedFixedBinWidth(bool, double);
 
 private:
-    Mantid::API::IAlgorithm_sptr applyMDWorkspace(Mantid::API::IMDWorkspace_sptr ws);
-    Mantid::API::IAlgorithm_sptr applyMatrixWorkspace(Mantid::API::MatrixWorkspace_sptr ws);
-    void setupScaleEngine(MantidQwtWorkspaceData& curveData);
+  Mantid::API::IAlgorithm_sptr
+  applyMDWorkspace(Mantid::API::IMDWorkspace_sptr ws);
+  Mantid::API::IAlgorithm_sptr
+  applyMatrixWorkspace(Mantid::API::MatrixWorkspace_sptr ws);
+  void setupScaleEngine(MantidQwtWorkspaceData &curveData);
 
-    // -------------------------- Widgets ----------------------------
+  // -------------------------- Widgets ----------------------------
 
-    /// Auto-generated UI controls.
-    Ui::LineViewerClass ui;
+  /// Auto-generated UI controls.
+  Ui::LineViewerClass ui;
 
-    /// Layout containing the plot
-    QVBoxLayout * m_plotLayout;
+  /// Layout containing the plot
+  QVBoxLayout *m_plotLayout;
 
-    /// Main plot object
-    QwtPlot * m_plot;
+  /// Main plot object
+  QwtPlot *m_plot;
 
-    /// Curve of the preview
-    QwtPlotCurve * m_previewCurve;
+  /// Curve of the preview
+  QwtPlotCurve *m_previewCurve;
 
-    /// Curve of the full integrated
-    QwtPlotCurve * m_fullCurve;
+  /// Curve of the full integrated
+  QwtPlotCurve *m_fullCurve;
 
-    /// Vector of labels with the dimension names
-    QVector<QLabel *> m_dimensionLabel;
-    /// Vector of text boxes with the start point
-    QVector<QLineEdit *> m_startText;
-    /// Vector of text boxes with the end point
-    QVector<QLineEdit *> m_endText;
-    /// Vector of text boxes with the thicknesses
-    QVector<QLineEdit *> m_thicknessText;
+  /// Vector of labels with the dimension names
+  QVector<QLabel *> m_dimensionLabel;
+  /// Vector of text boxes with the start point
+  QVector<QLineEdit *> m_startText;
+  /// Vector of text boxes with the end point
+  QVector<QLineEdit *> m_endText;
+  /// Vector of text boxes with the thicknesses
+  QVector<QLineEdit *> m_thicknessText;
 
-    /// Widget to choose X plot axis and normalization
-    LinePlotOptions * m_lineOptions;
+  /// Widget to choose X plot axis and normalization
+  LinePlotOptions *m_lineOptions;
 
-    /// Object for running algorithms in the background
-    MantidQt::API::AlgorithmRunner * m_algoRunner;
+  /// Object for running algorithms in the background
+  MantidQt::API::AlgorithmRunner *m_algoRunner;
 
-    // -------------------------- Data Members ----------------------------
+  // -------------------------- Data Members ----------------------------
 
-    /// Workspace being sliced
-    Mantid::API::IMDWorkspace_sptr m_ws;
+  /// Workspace being sliced
+  Mantid::API::IMDWorkspace_sptr m_ws;
 
-    /// Workspace of the slice
-    Mantid::API::IMDWorkspace_sptr m_sliceWS;
+  /// Workspace of the slice
+  Mantid::API::IMDWorkspace_sptr m_sliceWS;
 
-    /// Name of the workspace that was integrated (asynchronously).
-    std::string m_integratedWSName;
+  /// Name of the workspace that was integrated (asynchronously).
+  std::string m_integratedWSName;
 
-    /// Start point of the line
-    Mantid::Kernel::VMD m_start;
-    /// End point of the line
-    Mantid::Kernel::VMD m_end;
-    /// Width in each dimension (some will be ignored)
-    Mantid::Kernel::VMD m_thickness;
-    /// Width in the in-plane, perpendicular-to-line direction
-    double m_planeWidth;
+  /// Start point of the line
+  Mantid::Kernel::VMD m_start;
+  /// End point of the line
+  Mantid::Kernel::VMD m_end;
+  /// Width in each dimension (some will be ignored)
+  Mantid::Kernel::VMD m_thickness;
+  /// Width in the in-plane, perpendicular-to-line direction
+  double m_planeWidth;
 
+  /// Number of bins (for regular spacing)
+  size_t m_numBins;
 
-    /// Number of bins (for regular spacing)
-    size_t m_numBins;
+  /// Flag that is true when all dimensions are allowed to change
+  bool m_allDimsFree;
+  /// Index of the X dimension in the 2D slice
+  int m_freeDimX;
+  /// Index of the Y dimension in the 2D slice
+  int m_freeDimY;
 
-    /// Flag that is true when all dimensions are allowed to change
-    bool m_allDimsFree;
-    /// Index of the X dimension in the 2D slice
-    int m_freeDimX;
-    /// Index of the Y dimension in the 2D slice
-    int m_freeDimY;
+  /// Index of the first selected X dimension in the 2D slice
+  int m_initFreeDimX;
+  /// Index of the first selected Y dimension in the 2D slice
+  int m_initFreeDimY;
 
-    /// Index of the first selected X dimension in the 2D slice
-    int m_initFreeDimX;
-    /// Index of the first selected Y dimension in the 2D slice
-    int m_initFreeDimY;
+  /// When True, then the bin width is fixed and the number of bins changes
+  bool m_fixedBinWidthMode;
 
-    /// When True, then the bin width is fixed and the number of bins changes
-    bool m_fixedBinWidthMode;
+  /// Desired bin width in fixedBinWidthMode
+  double m_fixedBinWidth;
 
-    /// Desired bin width in fixedBinWidthMode
-    double m_fixedBinWidth;
-
-    /// ACTUAL bin width, whether in fixed or not-fixed bin width mode
-    double m_binWidth;
-
+  /// ACTUAL bin width, whether in fixed or not-fixed bin width mode
+  double m_binWidth;
 };
 
-} //namespace
+} // namespace
 }
 #endif // LINEVIEWER_H

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -121,7 +121,7 @@ SliceViewer::SliceViewer(QWidget *parent)
   initZoomer();
 
   // hide unused buttons
-  ui.btnZoom->hide();      // hidden for a long time
+  ui.btnZoom->hide(); // hidden for a long time
 
   // ----------- Toolbar button signals ----------------
   QObject::connect(ui.btnResetZoom, SIGNAL(clicked()), this, SLOT(resetZoom()));
@@ -717,7 +717,8 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   if (!mess.str().empty()) {
     mess << "Bad ranges could cause memory allocation errors. Please fix the "
             "workspace.";
-    mess << std::endl << "You can continue using Mantid.";
+    mess << std::endl
+         << "You can continue using Mantid.";
     throw std::out_of_range(mess.str());
   }
 
@@ -1102,7 +1103,6 @@ void SliceViewer::RebinMode_toggled(bool checked) {
   this->updateDisplay();
 }
 
-
 //------------------------------------------------------------------------------
 /// Slot for zooming into
 void SliceViewer::zoomInSlot() { this->zoomBy(1.1); }
@@ -1357,7 +1357,7 @@ void SliceViewer::findRangeFull() {
   double minR = m_colorRangeFull.minValue();
   if (minR <= 0 && this->getColorScaleType() == 1) {
     double maxR = m_colorRangeFull.maxValue();
-    minR = pow(10., log10(maxR)-10.);
+    minR = pow(10., log10(maxR) - 10.);
     m_colorRangeFull = QwtDoubleInterval(minR, maxR);
   }
 }
@@ -1430,7 +1430,7 @@ void SliceViewer::showInfoAt(double x, double y) {
   coords[m_dimX] = VMD_t(x);
   coords[m_dimY] = VMD_t(y);
   signal_t signal =
-      m_ws->getSignalAtVMD(coords, this->m_data->getNormalization());
+      m_ws->getSignalWithMaskAtVMD(coords, this->m_data->getNormalization());
   ui.lblInfoX->setText(QString::number(x, 'g', 4));
   ui.lblInfoY->setText(QString::number(y, 'g', 4));
   ui.lblInfoSignal->setText(QString::number(signal, 'g', 4));

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -39,147 +39,136 @@ using Mantid::coord_t;
 //=====================================================================================
 // Test Helper Types. These are shared by several tests in VatesAPI
 //=====================================================================================
-namespace
-{
-
+namespace {
 
 const int dimension_size = 9;
 
-
-
 //=================================================================================================
-///Helper class. Concrete instance of IMDDimension.
-class FakeIMDDimension: public Mantid::Geometry::IMDDimension
-{
+/// Helper class. Concrete instance of IMDDimension.
+class FakeIMDDimension : public Mantid::Geometry::IMDDimension {
 private:
   std::string m_id;
   const unsigned int m_nbins;
+
 public:
-  FakeIMDDimension(std::string id, unsigned int nbins=10) : m_id(id), m_nbins(nbins) {}
-  std::string getName() const {throw std::runtime_error("Not implemented");}
-  const Mantid::Kernel::UnitLabel getUnits() const {throw std::runtime_error("Not implemented");}
-  std::string getDimensionId() const {return m_id;}
-  coord_t getMaximum() const {return 10;}
-  coord_t getMinimum() const {return 0;};
-  size_t getNBins() const {return m_nbins;};
-  std::string toXMLString() const {throw std::runtime_error("Not implemented");};
-  coord_t getX(size_t) const {throw std::runtime_error("Not implemented");};
-  virtual void setRange(size_t /*nBins*/, coord_t /*min*/, coord_t /*max*/){ };
-  virtual ~FakeIMDDimension()
-  {
+  FakeIMDDimension(std::string id, unsigned int nbins = 10)
+      : m_id(id), m_nbins(nbins) {}
+  std::string getName() const { throw std::runtime_error("Not implemented"); }
+  const Mantid::Kernel::UnitLabel getUnits() const {
+    throw std::runtime_error("Not implemented");
   }
+  std::string getDimensionId() const { return m_id; }
+  coord_t getMaximum() const { return 10; }
+  coord_t getMinimum() const { return 0; };
+  size_t getNBins() const { return m_nbins; };
+  std::string toXMLString() const {
+    throw std::runtime_error("Not implemented");
+  };
+  coord_t getX(size_t) const { throw std::runtime_error("Not implemented"); };
+  virtual void setRange(size_t /*nBins*/, coord_t /*min*/, coord_t /*max*/){};
+  virtual ~FakeIMDDimension() {}
 };
 
 //=================================================================================================
 /// Concrete mocked implementation of IMDWorkspace for testing.
-class MockIMDWorkspace: public Mantid::API::IMDWorkspace
-{
+class MockIMDWorkspace : public Mantid::API::IMDWorkspace {
 public:
-
   MOCK_CONST_METHOD0(id, const std::string());
   MOCK_CONST_METHOD0(getMemorySize, size_t());
-  MOCK_CONST_METHOD0(getGeometryXML,std::string());
+  MOCK_CONST_METHOD0(getGeometryXML, std::string());
   MOCK_CONST_METHOD0(getNPoints, uint64_t());
-  MOCK_CONST_METHOD0(getNEvents, uint64_t());  
+  MOCK_CONST_METHOD0(getNEvents, uint64_t());
   MOCK_CONST_METHOD1(getSignalNormalizedAt, Mantid::signal_t(size_t index1));
-  MOCK_CONST_METHOD2(getSignalNormalizedAt, double(size_t index1, size_t index2));
-  MOCK_CONST_METHOD3(getSignalNormalizedAt, double(size_t index1, size_t index2, size_t index3));
-  MOCK_CONST_METHOD4(getSignalNormalizedAt, double(size_t index1, size_t index2, size_t index3, size_t index4));
-  MOCK_CONST_METHOD0(getNonIntegratedDimensions, Mantid::Geometry::VecIMDDimension_const_sptr());
-  MOCK_METHOD1(setMDMasking, void(Mantid::Geometry::MDImplicitFunction*));
-  MOCK_METHOD0(clearMDMasking,void());
-  MOCK_CONST_METHOD0(getSpecialCoordinateSystem, Mantid::Kernel::SpecialCoordinateSystem()); 
+  MOCK_CONST_METHOD2(getSignalNormalizedAt,
+                     double(size_t index1, size_t index2));
+  MOCK_CONST_METHOD3(getSignalNormalizedAt,
+                     double(size_t index1, size_t index2, size_t index3));
+  MOCK_CONST_METHOD4(getSignalNormalizedAt,
+                     double(size_t index1, size_t index2, size_t index3,
+                            size_t index4));
+  MOCK_CONST_METHOD0(getNonIntegratedDimensions,
+                     Mantid::Geometry::VecIMDDimension_const_sptr());
+  MOCK_METHOD1(setMDMasking, void(Mantid::Geometry::MDImplicitFunction *));
+  MOCK_METHOD0(clearMDMasking, void());
+  MOCK_CONST_METHOD0(getSpecialCoordinateSystem,
+                     Mantid::Kernel::SpecialCoordinateSystem());
 
-  virtual void getLinePlot(const Mantid::Kernel::VMD & , const Mantid::Kernel::VMD & ,
-    Mantid::API::MDNormalization , std::vector<Mantid::coord_t> & , std::vector<Mantid::signal_t> & , std::vector<Mantid::signal_t> & ) const
-  {}
+  virtual void getLinePlot(const Mantid::Kernel::VMD &,
+                           const Mantid::Kernel::VMD &,
+                           Mantid::API::MDNormalization,
+                           std::vector<Mantid::coord_t> &,
+                           std::vector<Mantid::signal_t> &,
+                           std::vector<Mantid::signal_t> &) const {}
 
-  virtual std::vector<Mantid::API::IMDIterator*> createIterators(size_t  = 1,
-      Mantid::Geometry::MDImplicitFunction *  = NULL) const
-  {
+  virtual std::vector<Mantid::API::IMDIterator *>
+      createIterators(size_t = 1,
+                      Mantid::Geometry::MDImplicitFunction * = NULL) const {
     throw std::runtime_error("Not Implemented");
   }
 
-  virtual Mantid::signal_t getSignalAtCoord(const Mantid::coord_t * , const Mantid::API::MDNormalization & ) const
-  {
+  virtual Mantid::signal_t
+  getSignalAtCoord(const Mantid::coord_t *,
+                   const Mantid::API::MDNormalization &) const {
     return 0;
   }
 
-  virtual Mantid::signal_t getSignalWithMaskAtCoord(const Mantid::coord_t * , const Mantid::API::MDNormalization & ) const
-  {
+  virtual Mantid::signal_t
+  getSignalWithMaskAtCoord(const Mantid::coord_t *,
+                           const Mantid::API::MDNormalization &) const {
     return 0;
   }
 
-  MockIMDWorkspace()
-  : IMDWorkspace()
-  {
-  }
+  MockIMDWorkspace() : IMDWorkspace() {}
 
   virtual ~MockIMDWorkspace() {}
 
 private:
   virtual MockIMDWorkspace *doClone() const {
-    throw std::runtime_error(
-        "Cloning of MockIMDWorkspace is not implemented.");
+    throw std::runtime_error("Cloning of MockIMDWorkspace is not implemented.");
   }
 };
 
-
 //=================================================================================================
 /// Mock to allow the behaviour of the chain of responsibility to be tested.
-class MockvtkDataSetFactory : public Mantid::VATES::vtkDataSetFactory
-{
+class MockvtkDataSetFactory : public Mantid::VATES::vtkDataSetFactory {
 public:
-  MOCK_CONST_METHOD1(create,
-    vtkDataSet*(Mantid::VATES::ProgressAction&));
-  MOCK_CONST_METHOD0(createMeshOnly,
-    vtkDataSet*());
-  MOCK_CONST_METHOD0(createScalarArray,
-    vtkFloatArray*());
-  MOCK_METHOD1(initialize,
-    void(Mantid::API::Workspace_sptr));
-  MOCK_METHOD1(SetSuccessor,
-    void(vtkDataSetFactory* pSuccessor));
-  MOCK_CONST_METHOD0(hasSuccessor,
-    bool());
-  MOCK_CONST_METHOD0(validate,
-    void());
+  MOCK_CONST_METHOD1(create, vtkDataSet *(Mantid::VATES::ProgressAction &));
+  MOCK_CONST_METHOD0(createMeshOnly, vtkDataSet *());
+  MOCK_CONST_METHOD0(createScalarArray, vtkFloatArray *());
+  MOCK_METHOD1(initialize, void(Mantid::API::Workspace_sptr));
+  MOCK_METHOD1(SetSuccessor, void(vtkDataSetFactory *pSuccessor));
+  MOCK_CONST_METHOD0(hasSuccessor, bool());
+  MOCK_CONST_METHOD0(validate, void());
   MOCK_CONST_METHOD0(getFactoryTypeName, std::string());
   MOCK_METHOD1(setRecursionDepth, void(size_t));
 };
 
 //=================================================================================================
 /// Mock to allow the behaviour of MDLoadingPresenters to be tested.
-class MockMDLoadingView : public Mantid::VATES::MDLoadingView
-{
+class MockMDLoadingView : public Mantid::VATES::MDLoadingView {
 public:
   MOCK_CONST_METHOD0(getTime, double());
   MOCK_CONST_METHOD0(getRecursionDepth, size_t());
   MOCK_CONST_METHOD0(getLoadInMemory, bool());
-  MOCK_METHOD2(updateAlgorithmProgress, void(double, const std::string&));
-  ~MockMDLoadingView(){}
+  MOCK_METHOD2(updateAlgorithmProgress, void(double, const std::string &));
+  ~MockMDLoadingView() {}
 };
 
-class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider
-{
+class MockWorkspaceProvider : public Mantid::VATES::WorkspaceProvider {
 public:
   MOCK_CONST_METHOD1(canProvideWorkspace, bool(std::string));
   MOCK_CONST_METHOD1(fetchWorkspace, Mantid::API::Workspace_sptr(std::string));
   MOCK_CONST_METHOD1(disposeWorkspace, void(std::string));
-  ~MockWorkspaceProvider(){}
+  ~MockWorkspaceProvider() {}
 };
 
-class MockProgressAction : public Mantid::VATES::ProgressAction
-{
+class MockProgressAction : public Mantid::VATES::ProgressAction {
 public:
   MOCK_METHOD1(eventRaised, void(double));
 };
 
-class FakeProgressAction : public Mantid::VATES::ProgressAction
-{
-  virtual void eventRaised(double)
-  {
-  }
+class FakeProgressAction : public Mantid::VATES::ProgressAction {
+  virtual void eventRaised(double) {}
 };
 
 /**
@@ -187,313 +176,263 @@ Create a field data entry containing (as contents) the argument text.
 @param testData : Text to enter
 @return new vtkFieldData object containing text.
 */
-  vtkFieldData* createFieldDataWithCharArray(std::string testData)
-  {
-    vtkFieldData* fieldData = vtkFieldData::New();
-    vtkCharArray* charArray = vtkCharArray::New();
-    charArray->SetName(Mantid::VATES::XMLDefinitions::metaDataId().c_str());
-    charArray->Allocate(100);
-    for(unsigned int i = 0; i < testData.size(); i++)
-    {
-      char cNextVal = testData.at(i);
-      if(int(cNextVal) > 1)
-      {
-        charArray->InsertNextValue(cNextVal);
-
-      }
+vtkFieldData *createFieldDataWithCharArray(std::string testData) {
+  vtkFieldData *fieldData = vtkFieldData::New();
+  vtkCharArray *charArray = vtkCharArray::New();
+  charArray->SetName(Mantid::VATES::XMLDefinitions::metaDataId().c_str());
+  charArray->Allocate(100);
+  for (unsigned int i = 0; i < testData.size(); i++) {
+    char cNextVal = testData.at(i);
+    if (int(cNextVal) > 1) {
+      charArray->InsertNextValue(cNextVal);
     }
-    fieldData->AddArray(charArray);
-    charArray->Delete();
-    return fieldData;
   }
+  fieldData->AddArray(charArray);
+  charArray->Delete();
+  return fieldData;
+}
 
-  /**
-  Construct an example Geometry section of the XML passed via field-data.
+/**
+Construct an example Geometry section of the XML passed via field-data.
 
-  Note that this function doesn't give complete control over the geometry. For example, the Upper and Lower bounds are hard-coded.
+Note that this function doesn't give complete control over the geometry. For
+example, the Upper and Lower bounds are hard-coded.
 
-  @param xDimensionIdMapping : Dimension name for dimension to be used as the x-dimension in the view.
-  @param yDimensionIdMapping : Dimension name for dimension y-dimension in the view.
-  @param zDimensionIdMapping : Dimension name for dimension z-dimension in the view.
-  @param tDimensionIdMapping : Dimension name for dimension t-dimension in the view.
-  @param xBins : number of bins in the x dimension
-  @param yBins : number of bins in the x dimension
-  @param zBins : number of bins in the x dimension
-  @param tBins : number of bins in the x dimension
-  @return xml snippet as string.
-  */
-  std::string constrctGeometryOnlyXML(const std::string& xDimensionIdMapping, const std::string& yDimensionIdMapping, const std::string& zDimensionIdMapping, const std::string& tDimensionIdMapping
-    ,std::string xBins = "10",
-    std::string yBins = "10",
-    std::string zBins = "10",
-    std::string tBins = "10"
-    )
-  {
-    std::string body = std::string("<DimensionSet>") +
-      "<Dimension ID=\"en\">" +
-      "<Name>Energy</Name>" +
-      "<Units>None</Units>" +
+@param xDimensionIdMapping : Dimension name for dimension to be used as the
+x-dimension in the view.
+@param yDimensionIdMapping : Dimension name for dimension y-dimension in the
+view.
+@param zDimensionIdMapping : Dimension name for dimension z-dimension in the
+view.
+@param tDimensionIdMapping : Dimension name for dimension t-dimension in the
+view.
+@param xBins : number of bins in the x dimension
+@param yBins : number of bins in the x dimension
+@param zBins : number of bins in the x dimension
+@param tBins : number of bins in the x dimension
+@return xml snippet as string.
+*/
+std::string constrctGeometryOnlyXML(const std::string &xDimensionIdMapping,
+                                    const std::string &yDimensionIdMapping,
+                                    const std::string &zDimensionIdMapping,
+                                    const std::string &tDimensionIdMapping,
+                                    std::string xBins = "10",
+                                    std::string yBins = "10",
+                                    std::string zBins = "10",
+                                    std::string tBins = "10") {
+  std::string body =
+      std::string("<DimensionSet>") + "<Dimension ID=\"en\">" +
+      "<Name>Energy</Name>" + "<Units>None</Units>" +
       "<UpperBounds>150.0000</UpperBounds>" +
-      "<LowerBounds>0.0000</LowerBounds>" +
-      "<NumberOfBins>" + xBins + "</NumberOfBins>" +
-      "</Dimension>" +
-      "<Dimension ID=\"qx\">" +
-      "<Name>Qx</Name>" +
-      "<Units>None</Units>" +
+      "<LowerBounds>0.0000</LowerBounds>" + "<NumberOfBins>" + xBins +
+      "</NumberOfBins>" + "</Dimension>" + "<Dimension ID=\"qx\">" +
+      "<Name>Qx</Name>" + "<Units>None</Units>" +
       "<UpperBounds>5.0000</UpperBounds>" +
-      "<LowerBounds>-1.5000</LowerBounds>" +
-      "<NumberOfBins>" + yBins + "</NumberOfBins>" +
-      "</Dimension>" +
-      "<Dimension ID=\"qy\">" +
-      "<Name>Qy</Name>" +
-      "<Units>None</Units>" +
+      "<LowerBounds>-1.5000</LowerBounds>" + "<NumberOfBins>" + yBins +
+      "</NumberOfBins>" + "</Dimension>" + "<Dimension ID=\"qy\">" +
+      "<Name>Qy</Name>" + "<Units>None</Units>" +
       "<UpperBounds>6.6000</UpperBounds>" +
-      "<LowerBounds>-6.6000</LowerBounds>" +
-      "<NumberOfBins>" + zBins  + "</NumberOfBins>" +
-      "</Dimension>" +
-      "<Dimension ID=\"qz\">" +
-      "<Name>Qz</Name>" +
-      "<Units>None</Units>" +
+      "<LowerBounds>-6.6000</LowerBounds>" + "<NumberOfBins>" + zBins +
+      "</NumberOfBins>" + "</Dimension>" + "<Dimension ID=\"qz\">" +
+      "<Name>Qz</Name>" + "<Units>None</Units>" +
       "<UpperBounds>6.6000</UpperBounds>" +
-      "<LowerBounds>-6.6000</LowerBounds>" +
-      "<NumberOfBins>" + tBins + "</NumberOfBins>" +
-      "</Dimension>" +
-      "<XDimension>" +
-      "<RefDimensionId>" +
-      xDimensionIdMapping +
-      "</RefDimensionId>" +
-      "</XDimension>" +
-      "<YDimension>" +
-      "<RefDimensionId>" +
-      yDimensionIdMapping +
-      "</RefDimensionId>" +
-      "</YDimension>" +
-      "<ZDimension>" +
-      "<RefDimensionId>" + 
-      zDimensionIdMapping +
-      "</RefDimensionId>" +
-      "</ZDimension>" +
-      "<TDimension>" +
-      "<RefDimensionId>" +
-      tDimensionIdMapping +
-      "</RefDimensionId>" +
-      "</TDimension>" +
+      "<LowerBounds>-6.6000</LowerBounds>" + "<NumberOfBins>" + tBins +
+      "</NumberOfBins>" + "</Dimension>" + "<XDimension>" + "<RefDimensionId>" +
+      xDimensionIdMapping + "</RefDimensionId>" + "</XDimension>" +
+      "<YDimension>" + "<RefDimensionId>" + yDimensionIdMapping +
+      "</RefDimensionId>" + "</YDimension>" + "<ZDimension>" +
+      "<RefDimensionId>" + zDimensionIdMapping + "</RefDimensionId>" +
+      "</ZDimension>" + "<TDimension>" + "<RefDimensionId>" +
+      tDimensionIdMapping + "</RefDimensionId>" + "</TDimension>" +
       "</DimensionSet>";
-    return body;
+  return body;
+}
+
+/**
+Construct test xml describing the transformations and the inputs.
+@param xDimensionIdMapping : Dimension name for dimension to be used as the
+x-dimension in the view.
+@param yDimensionIdMapping : Dimension name for dimension y-dimension in the
+view.
+@param zDimensionIdMapping : Dimension name for dimension z-dimension in the
+view.
+@param tDimensionIdMapping : Dimension name for dimension t-dimension in the
+view.
+@return full xml as string.
+*/
+std::string constructXML(const std::string &xDimensionIdMapping,
+                         const std::string &yDimensionIdMapping,
+                         const std::string &zDimensionIdMapping,
+                         const std::string &tDimensionIdMapping) {
+  return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
+         "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
+         "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
+         constrctGeometryOnlyXML(xDimensionIdMapping, yDimensionIdMapping,
+                                 zDimensionIdMapping, tDimensionIdMapping) +
+         "</MDInstruction>";
+}
+
+/**
+Construct an example Geometry section of the XML passed via field-data.
+
+Note that this function doesn't give complete control over the geometry. For
+example, the Upper and Lower bounds are hard-coded.
+
+@param xDimensionIdMapping : Dimension name for dimension to be used as the
+x-dimension in the view.
+@param yDimensionIdMapping : Dimension name for dimension y-dimension in the
+view.
+@param zDimensionIdMapping : Dimension name for dimension z-dimension in the
+view.
+@param tDimensionIdMapping : Dimension name for dimension t-dimension in the
+view.
+@param xBins : number of bins in the x dimension
+@param yBins : number of bins in the x dimension
+@param zBins : number of bins in the x dimension
+@param tBins : number of bins in the x dimension
+@return xml snippet as string.
+*/
+std::string constructGeometryOnlyXMLForMDEvHelperData(
+    const std::string &xDimensionIdMapping,
+    const std::string &yDimensionIdMapping,
+    const std::string &zDimensionIdMapping,
+    const std::string &tDimensionIdMapping, std::string xBins = "10",
+    std::string yBins = "10", std::string zBins = "10",
+    std::string tBins = "10") {
+  std::string cardDirSpec =
+      std::string("<DimensionSet>") + "<Dimension ID=\"Axis0\">" +
+      "<Name>Axis0</Name>" + "<Units>m</Units>" +
+      "<UpperBounds>10.0000</UpperBounds>" +
+      "<LowerBounds>0.0000</LowerBounds>" + "<NumberOfBins>" + xBins +
+      "</NumberOfBins>" + "</Dimension>" + "<Dimension ID=\"Axis1\">" +
+      "<Name>Axis1</Name>" + "<Units>m</Units>" +
+      "<UpperBounds>10.0000</UpperBounds>" +
+      "<LowerBounds>0.0000</LowerBounds>" + "<NumberOfBins>" + yBins +
+      "</NumberOfBins>" + "</Dimension>" + "<Dimension ID=\"Axis2\">" +
+      "<Name>Axis2</Name>" + "<Units>m</Units>" +
+      "<UpperBounds>10.0000</UpperBounds>" +
+      "<LowerBounds>0.0000</LowerBounds>" + "<NumberOfBins>" + zBins +
+      "</NumberOfBins>" + "</Dimension>";
+  std::string timeSpec;
+  if (!tDimensionIdMapping.empty()) {
+    timeSpec = std::string("<Dimension ID=\"Axis3\">") + "<Name>Axis3</Name>" +
+               "<Units>s</Units>" + "<UpperBounds>10.0000</UpperBounds>" +
+               "<LowerBounds>0.0000</LowerBounds>" + "<NumberOfBins>" + tBins +
+               "</NumberOfBins>" + "</Dimension>";
   }
-
-
-  /**
-  Construct test xml describing the transformations and the inputs.
-  @param xDimensionIdMapping : Dimension name for dimension to be used as the x-dimension in the view.
-  @param yDimensionIdMapping : Dimension name for dimension y-dimension in the view.
-  @param zDimensionIdMapping : Dimension name for dimension z-dimension in the view.
-  @param tDimensionIdMapping : Dimension name for dimension t-dimension in the view.
-  @return full xml as string.
-  */
-  std::string constructXML(const std::string& xDimensionIdMapping, const std::string& yDimensionIdMapping, const std::string& zDimensionIdMapping, const std::string& tDimensionIdMapping)
-  {
-    return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
-      "<MDInstruction>" +
-      "<MDWorkspaceName>Input</MDWorkspaceName>" +
-      "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
-      constrctGeometryOnlyXML(xDimensionIdMapping, yDimensionIdMapping, zDimensionIdMapping, tDimensionIdMapping) +
-      "</MDInstruction>";
+  std::string cardDirRef =
+      std::string("<XDimension>") + "<RefDimensionId>" + xDimensionIdMapping +
+      "</RefDimensionId>" + "</XDimension>" + "<YDimension>" +
+      "<RefDimensionId>" + yDimensionIdMapping + "</RefDimensionId>" +
+      "</YDimension>" + "<ZDimension>" + "<RefDimensionId>" +
+      zDimensionIdMapping + "</RefDimensionId>" + "</ZDimension>";
+  std::string timeRef;
+  if (!tDimensionIdMapping.empty()) {
+    timeRef = std::string("<TDimension>") + "<RefDimensionId>" +
+              tDimensionIdMapping + "</RefDimensionId>" + "</TDimension>";
+  } else {
+    timeRef = std::string("<TDimension>") + "<RefDimensionId>" +
+              "</RefDimensionId>" + "</TDimension>";
   }
-
-  /**
-  Construct an example Geometry section of the XML passed via field-data.
-
-  Note that this function doesn't give complete control over the geometry. For example, the Upper and Lower bounds are hard-coded.
-
-  @param xDimensionIdMapping : Dimension name for dimension to be used as the x-dimension in the view.
-  @param yDimensionIdMapping : Dimension name for dimension y-dimension in the view.
-  @param zDimensionIdMapping : Dimension name for dimension z-dimension in the view.
-  @param tDimensionIdMapping : Dimension name for dimension t-dimension in the view.
-  @param xBins : number of bins in the x dimension
-  @param yBins : number of bins in the x dimension
-  @param zBins : number of bins in the x dimension
-  @param tBins : number of bins in the x dimension
-  @return xml snippet as string.
-  */
-  std::string constructGeometryOnlyXMLForMDEvHelperData(\
-      const std::string& xDimensionIdMapping,
-      const std::string& yDimensionIdMapping,
-      const std::string& zDimensionIdMapping,
-      const std::string& tDimensionIdMapping,
-      std::string xBins = "10",
-      std::string yBins = "10",
-      std::string zBins = "10",
-      std::string tBins = "10"
-      )
-  {
-    std::string cardDirSpec = std::string("<DimensionSet>") +
-        "<Dimension ID=\"Axis0\">" +
-        "<Name>Axis0</Name>" +
-        "<Units>m</Units>" +
-        "<UpperBounds>10.0000</UpperBounds>" +
-        "<LowerBounds>0.0000</LowerBounds>" +
-        "<NumberOfBins>" + xBins + "</NumberOfBins>" +
-        "</Dimension>" +
-        "<Dimension ID=\"Axis1\">" +
-        "<Name>Axis1</Name>" +
-        "<Units>m</Units>" +
-        "<UpperBounds>10.0000</UpperBounds>" +
-        "<LowerBounds>0.0000</LowerBounds>" +
-        "<NumberOfBins>" + yBins + "</NumberOfBins>" +
-        "</Dimension>" +
-        "<Dimension ID=\"Axis2\">" +
-        "<Name>Axis2</Name>" +
-        "<Units>m</Units>" +
-        "<UpperBounds>10.0000</UpperBounds>" +
-        "<LowerBounds>0.0000</LowerBounds>" +
-        "<NumberOfBins>" + zBins  + "</NumberOfBins>" +
-        "</Dimension>";
-    std::string timeSpec;
-    if (!tDimensionIdMapping.empty())
-    {
-      timeSpec = std::string("<Dimension ID=\"Axis3\">") +
-          "<Name>Axis3</Name>" +
-          "<Units>s</Units>" +
-          "<UpperBounds>10.0000</UpperBounds>" +
-          "<LowerBounds>0.0000</LowerBounds>" +
-          "<NumberOfBins>" + tBins + "</NumberOfBins>" +
-          "</Dimension>";
-    }
-    std::string cardDirRef = std::string("<XDimension>") +
-        "<RefDimensionId>" +
-        xDimensionIdMapping +
-        "</RefDimensionId>" +
-        "</XDimension>" +
-        "<YDimension>" +
-        "<RefDimensionId>" +
-        yDimensionIdMapping +
-        "</RefDimensionId>" +
-        "</YDimension>" +
-        "<ZDimension>" +
-        "<RefDimensionId>" +
-        zDimensionIdMapping +
-        "</RefDimensionId>" +
-        "</ZDimension>";
-    std::string timeRef;
-    if (!tDimensionIdMapping.empty())
-    {
-      timeRef = std::string("<TDimension>") +
-          "<RefDimensionId>" +
-          tDimensionIdMapping +
-          "</RefDimensionId>" +
-          "</TDimension>";
-    }
-    else
-    {
-      timeRef = std::string("<TDimension>") +
-          "<RefDimensionId>" +
-          "</RefDimensionId>" +
-          "</TDimension>";
-    }
-    std::string endTag = "</DimensionSet>";
-    std::string body = cardDirSpec;
-    if (!timeSpec.empty())
-    {
-      body += timeSpec;
-    }
-    body += cardDirRef;
-    body += timeRef;
-    body += endTag;
-    return body;
+  std::string endTag = "</DimensionSet>";
+  std::string body = cardDirSpec;
+  if (!timeSpec.empty()) {
+    body += timeSpec;
   }
+  body += cardDirRef;
+  body += timeRef;
+  body += endTag;
+  return body;
+}
 
-  /**
-  Construct test xml describing the transformations and the inputs.
-  @param xDimensionIdMapping : Dimension name for dimension to be used as the x-dimension in the view.
-  @param yDimensionIdMapping : Dimension name for dimension y-dimension in the view.
-  @param zDimensionIdMapping : Dimension name for dimension z-dimension in the view.
-  @param tDimensionIdMapping : Dimension name for dimension t-dimension in the view.
-  @return full xml as string.
-  */
-  std::string constructXMLForMDEvHelperData(const std::string& xDimensionIdMapping,
-                                            const std::string& yDimensionIdMapping,
-                                            const std::string& zDimensionIdMapping,
-                                            const std::string& tDimensionIdMapping)
-  {
-    return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
-      "<MDInstruction>" +
-      "<MDWorkspaceName>Input</MDWorkspaceName>" +
-      "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
-      constructGeometryOnlyXMLForMDEvHelperData(xDimensionIdMapping,
-                                                yDimensionIdMapping,
-                                                zDimensionIdMapping,
-                                                tDimensionIdMapping) +
-      "</MDInstruction>";
+/**
+Construct test xml describing the transformations and the inputs.
+@param xDimensionIdMapping : Dimension name for dimension to be used as the
+x-dimension in the view.
+@param yDimensionIdMapping : Dimension name for dimension y-dimension in the
+view.
+@param zDimensionIdMapping : Dimension name for dimension z-dimension in the
+view.
+@param tDimensionIdMapping : Dimension name for dimension t-dimension in the
+view.
+@return full xml as string.
+*/
+std::string
+constructXMLForMDEvHelperData(const std::string &xDimensionIdMapping,
+                              const std::string &yDimensionIdMapping,
+                              const std::string &zDimensionIdMapping,
+                              const std::string &tDimensionIdMapping) {
+  return std::string("<?xml version=\"1.0\" encoding=\"utf-8\"?>") +
+         "<MDInstruction>" + "<MDWorkspaceName>Input</MDWorkspaceName>" +
+         "<MDWorkspaceLocation>test_horace_reader.sqw</MDWorkspaceLocation>" +
+         constructGeometryOnlyXMLForMDEvHelperData(
+             xDimensionIdMapping, yDimensionIdMapping, zDimensionIdMapping,
+             tDimensionIdMapping) +
+         "</MDInstruction>";
+}
+
+Mantid::API::Workspace_sptr createSimple3DWorkspace() {
+  using namespace Mantid::API;
+
+  IAlgorithm *create =
+      FrameworkManager::Instance().createAlgorithm("CreateMDWorkspace");
+  create->setChild(true);
+  create->initialize();
+  create->setProperty("Dimensions", 4);
+  create->setPropertyValue("Extents", "0,5,0,5,0,5,0,5");
+  create->setPropertyValue("Names", "A,B,C,D");
+  create->setPropertyValue("Units", "A,A,A,A");
+  create->setPropertyValue("OutputWorkspace", "dummy");
+  create->execute();
+  Workspace_sptr outWs = create->getProperty("OutputWorkspace");
+  return outWs;
+}
+
+Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension,
+                                           bool sliceMD) {
+  using namespace Mantid::API;
+  using namespace Mantid::DataObjects;
+
+  Mantid::API::Workspace_sptr inputWs = createSimple3DWorkspace();
+
+  std::string binningAlgName;
+  if (sliceMD) {
+    binningAlgName = "SliceMD";
+  } else {
+    binningAlgName = "BinMD";
   }
+  IAlgorithm_sptr binningAlg =
+      AlgorithmManager::Instance().createUnmanaged(binningAlgName);
+  binningAlg->setChild(true);
+  binningAlg->initialize();
+  binningAlg->setProperty("InputWorkspace", inputWs);
+  binningAlg->setPropertyValue("AlignedDim0", "A,0,5,2");
+  binningAlg->setPropertyValue("AlignedDim1", "B,0,5,2");
+  binningAlg->setPropertyValue("AlignedDim2", "C,0,5,2");
 
-  Mantid::API::Workspace_sptr createSimple3DWorkspace()
-  {
-    using namespace Mantid::API;
-
-    IAlgorithm* create = FrameworkManager::Instance().createAlgorithm("CreateMDWorkspace");
-    create->setChild(true);
-    create->initialize();
-    create->setProperty("Dimensions", 4);
-    create->setPropertyValue("Extents","0,5,0,5,0,5,0,5");
-    create->setPropertyValue("Names","A,B,C,D");
-    create->setPropertyValue("Units","A,A,A,A");
-    create->setPropertyValue("OutputWorkspace", "dummy");
-    create->execute();
-    Workspace_sptr outWs = create->getProperty("OutputWorkspace");
-    return outWs;
+  if (integratedTDimension) {
+    binningAlg->setPropertyValue("AlignedDim3", "D,0,5,1");
+  } else {
+    binningAlg->setPropertyValue("AlignedDim3", "D,0,5,2");
   }
+  binningAlg->setPropertyValue("OutputWorkspace", "dummy");
+  binningAlg->execute();
+  Workspace_sptr outWs = binningAlg->getProperty("OutputWorkspace");
+  return outWs;
+}
 
-  Mantid::API::Workspace_sptr get3DWorkspace(bool integratedTDimension, bool sliceMD)
-  {
-    using namespace Mantid::API;
-    using namespace Mantid::DataObjects;
-
-    Mantid::API::Workspace_sptr inputWs = createSimple3DWorkspace();
-
-    std::string binningAlgName;
-    if(sliceMD)
-    {
-      binningAlgName = "SliceMD";
-    }
-    else
-    {
-      binningAlgName = "BinMD";
-    }
-    IAlgorithm_sptr binningAlg = AlgorithmManager::Instance().createUnmanaged(binningAlgName);
-    binningAlg->setChild(true);
-    binningAlg->initialize();
-    binningAlg->setProperty("InputWorkspace", inputWs);
-    binningAlg->setPropertyValue("AlignedDim0","A,0,5,2");
-    binningAlg->setPropertyValue("AlignedDim1","B,0,5,2");
-    binningAlg->setPropertyValue("AlignedDim2","C,0,5,2");
-
-    if(integratedTDimension)
-    {
-      binningAlg->setPropertyValue("AlignedDim3","D,0,5,1");
-    }
-    else
-    {
-      binningAlg->setPropertyValue("AlignedDim3","D,0,5,2");
-    }
-    binningAlg->setPropertyValue("OutputWorkspace", "dummy");
-    binningAlg->execute();
-    Workspace_sptr outWs = binningAlg->getProperty("OutputWorkspace");
-    return outWs;
-  }
-
-  /**
-   * Get a string array from a particular field data entry in a vtkDataSet.
-   * @param ds : The dataset to retrieve the field data from
-   * @param fieldName : The requested field data entry
-   * @return The value of the requested field data entry
-   */
-  std::string getStringFieldDataValue(vtkDataSet *ds, std::string fieldName)
-  {
-    vtkAbstractArray *value = ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
-    vtkStringArray *array = vtkStringArray::SafeDownCast(value);
-    return static_cast<std::string>(array->GetValue(0));
-  }
+/**
+ * Get a string array from a particular field data entry in a vtkDataSet.
+ * @param ds : The dataset to retrieve the field data from
+ * @param fieldName : The requested field data entry
+ * @return The value of the requested field data entry
+ */
+std::string getStringFieldDataValue(vtkDataSet *ds, std::string fieldName) {
+  vtkAbstractArray *value =
+      ds->GetFieldData()->GetAbstractArray(fieldName.c_str());
+  vtkStringArray *array = vtkStringArray::SafeDownCast(value);
+  return static_cast<std::string>(array->GetValue(0));
+}
 
 } // namespace
 

--- a/Vates/VatesAPI/test/MockObjects.h
+++ b/Vates/VatesAPI/test/MockObjects.h
@@ -105,6 +105,11 @@ public:
     return 0;
   }
 
+  virtual Mantid::signal_t getSignalWithMaskAtCoord(const Mantid::coord_t * , const Mantid::API::MDNormalization & ) const
+  {
+    return 0;
+  }
+
   MockIMDWorkspace()
   : IMDWorkspace()
   {


### PR DESCRIPTION
Closes #14523 

Masked data in MDWorkspaces now is now displayed with a value of 0 in the Slice Viewer. This is consistent with MatrixWorkspaces.

**To Test:**
Use the following script to make a masked and unmasked workspace of each MDWorkspace type (MDHistoWorkspace and MDEventWorkspace).
Compare the appearance of masked and unmasked of each type in the Slice Viewer. The central unit cube of the masked workspaces should be masked and data cursor should show a value of 0 ("Intensity=" in the top right of the viewer window).

``` python

ws_mdhw = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='12')
FakeMDEventData(ws_mdhw, UniformParams='1000', RandomizeSignal='1')
ws_mdhw = BinMD(ws_mdhw,AlignedDim0='h,-2,2,12',AlignedDim1='k,-2,2,12',AlignedDim2='l,-2,2,12')
ws_masked_mdhw = CloneMDWorkspace(ws_mdhw)
MaskMD(Workspace=ws_masked_mdhw,Dimensions="h,k,l",Extents="-1,1,-1,1,-1,1")

ws_mdew = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='12')
FakeMDEventData(ws_mdew, UniformParams='1000', RandomizeSignal='1')
ws_masked_mdew = CloneMDWorkspace(ws_mdew)
MaskMD(Workspace=ws_masked_mdew,Dimensions="h,k,l",Extents="-1,1,-1,1,-1,1")

```
