### PR TITLE
Indirect Absorption Corrections Add default value to scale and shift

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/AbsorptionCorrections.ui
@@ -570,6 +570,9 @@
         <property name="singleStep">
          <double>0.100000000000000</double>
         </property>
+        <property name="value">
+          <double>1.000000000000000</double>
+        </property>
        </widget>
       </item>
       <item row="2" column="2">
@@ -595,6 +598,9 @@
           </property>
           <property name="maximum">
             <double>999.99999</double>
+          </property>
+          <property name="value">
+            <double>0.000000000000000</double>
           </property>
         </widget>
       </item>


### PR DESCRIPTION
Fixes #14553

Changed default values for container shift and scale in Absorption corrections.
# To Test
- Open Absorption Corrections (Interfaces > Indirect > Corrections > Absorption corrections) 
- Ensure that in Container details the default value for:
  - `Scale` = 1.00000
  - `Shift x-values of container by adding` = 0.00000
