### PR TITLE
Resolve confidence tie between ISISNexus and TOFRaw in favour of ISISNexus

### DIFF
--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -65,8 +65,6 @@ int LoadTOFRawNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
   int confidence(0);
   if (descriptor.pathOfTypeExists("/entry", "NXentry") ||
       descriptor.pathOfTypeExists("/entry-state0", "NXentry")) {
-    // descriptor.pathOfTypeExists("/raw_data_1", "NXentry")) is also valid,
-    // but is currently taken to be ISIS Nexus, till issue #14614 is fixed.
     const bool hasEventData = descriptor.classTypeExists("NXevent_data");
     const bool hasData = descriptor.classTypeExists("NXdata");
     if (hasData && hasEventData)


### PR DESCRIPTION
Fixes #14614 

To Test: A code review should be sufficient. 

Load no longer attempts to support LoadTOFRawNexus when the main folder is `raw_data_1`, because this is an 'old' SNS format.
