### PR TITLE
Fixing compiler warning in gcc>4.4

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -27,7 +27,7 @@
 #if __GNUC__ > 4 ||                                                            \
     (__GNUC__ == 4 &&                                                          \
      (__GNUC_MINOR__ > 4 || (__GNUC_MINOR__ == 4 && __GNUC_PATCHLEVEL__ > 0)))
-GCC_DIAG_OFF(strict - aliasing)
+GCC_DIAG_OFF(strict-aliasing)
 #endif
 
 using namespace Mantid;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -27,7 +27,9 @@
 #if __GNUC__ > 4 ||                                                            \
     (__GNUC__ == 4 &&                                                          \
      (__GNUC_MINOR__ > 4 || (__GNUC_MINOR__ == 4 && __GNUC_PATCHLEVEL__ > 0)))
+// clang-format off
 GCC_DIAG_OFF(strict-aliasing)
+// clang-format on
 #endif
 
 using namespace Mantid;


### PR DESCRIPTION
**To test:** If it builds, then it is tested.

This does not need to be in the release notes.
