### PR TITLE
Fill in argument list in mantid.dataobjects python bindings

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -202,7 +202,8 @@ void export_IMDHistoWorkspace() {
            "Sets the signal from a numpy array. The sizes must match the "
            "current workspace sizes. A ValueError is thrown if not")
 
-      .def("setErrorSquaredArray", &setErrorSquaredArray, arg("self"),
+      .def("setErrorSquaredArray", &setErrorSquaredArray,
+           (arg("self"), arg("errorSquared")),
            "Sets the square of the errors from a numpy array. The sizes must "
            "match the current workspace sizes. A ValueError is thrown if not")
 


### PR DESCRIPTION
**To test:** Run the python script (via `mantidpython`):

``` python
import mantid.dataobjects as module
import inspect
import re

counter=0
classes=inspect.getmembers(module,inspect.isclass)
for c in classes:
    member_class_object=getattr(module,c[0])
    functions=inspect.getmembers(member_class_object,inspect.ismethod)
    for f in functions:
        function_object=getattr(member_class_object,f[0])
        function_doc=function_object.__doc__
        if function_doc!=None and re.search('arg[0-9]',function_doc):
            print "\n*****\n",c[0], f[0], function_doc
            counter+=1

print "Found "+str(counter)+" functions with undocumented arguments"
```

This does not need to be in the release notes.

Fixes #13693.
