### PR TITLE
Make plots created by "Plot MD" handle masked data correctly

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -101,7 +101,7 @@ public:
   getSignalAtCoord(const coord_t *coords,
                    const Mantid::API::MDNormalization &normalization) const = 0;
 
-  /// Returns the (normalized) signal at a given coordinates or NaN if the value
+  /// Returns the (normalized) signal at a given coordinates or 0 if the value
   // is masked, used for plotting
   virtual signal_t getSignalWithMaskAtCoord(
       const coord_t *coords,

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -159,6 +159,9 @@ protected:
 
   virtual const std::string toString() const;
 
+  // Value to be used for masked data in plots of MDWorkspaces
+  static const signal_t m_maskValue;
+
 private:
   virtual IMDWorkspace *doClone() const = 0;
 };

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -21,6 +21,9 @@ IMDWorkspace::IMDWorkspace(const IMDWorkspace &other)
 /// Destructor
 IMDWorkspace::~IMDWorkspace() {}
 
+// Value to be used for masked data in plots of MDWorkspaces
+const signal_t IMDWorkspace::m_maskValue = 0.0;
+
 /** Creates a single iterator and returns it.
  *
  * This calls createIterators(), a pure virtual method on IMDWorkspace which

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -77,7 +77,7 @@ public:
                    const Mantid::API::MDNormalization &normalization) const;
 
   /// Returns the (normalized) signal at a given coordinates
-  // or NaN if masked
+  // or 0 if masked
   virtual signal_t getSignalWithMaskAtCoord(
       const coord_t *coords,
       const Mantid::API::MDNormalization &normalization) const;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -764,22 +764,28 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
       box = this->data->getBoxAtCoord(coord.getBareArray());
 
       if (box != NULL) {
-        // What is our normalization factor?
-        signal_t normalizer = 1.0;
-        switch (normalize) {
-        case NoNormalization:
-          break;
-        case VolumeNormalization:
-          normalizer = box->getInverseVolume();
-          break;
-        case NumEventsNormalization:
-          normalizer = 1.0 / double(box->getNPoints());
-          break;
+        if (box->getIsMasked()) {
+          y.push_back(0.0);
+          e.push_back(0.0);
         }
+        else {
+          // What is our normalization factor?
+          signal_t normalizer = 1.0;
+          switch (normalize) {
+            case NoNormalization:
+              break;
+            case VolumeNormalization:
+              normalizer = box->getInverseVolume();
+              break;
+            case NumEventsNormalization:
+              normalizer = 1.0 / double(box->getNPoints());
+              break;
+          }
 
-        // And add the normalized signal/error to the list
-        y.push_back(box->getSignal() * normalizer);
-        e.push_back(box->getError() * normalizer);
+          // And add the normalized signal/error to the list
+          y.push_back(box->getSignal() * normalizer);
+          e.push_back(box->getError() * normalizer);
+        }
       } else {
         y.push_back(std::numeric_limits<double>::quiet_NaN());
         e.push_back(std::numeric_limits<double>::quiet_NaN());

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -326,7 +326,7 @@ TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(
   // Check if masked
   const API::IMDNode *box = data->getBoxAtCoord(coords);
   if (box->getIsMasked()) {
-    return 0.0;
+    return m_maskValue;
   }
   return getNormalizedSignal(box, normalization);
 }
@@ -765,8 +765,8 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
 
       if (box != NULL) {
         if (box->getIsMasked()) {
-          y.push_back(0.0);
-          e.push_back(0.0);
+          y.push_back(m_maskValue);
+          e.push_back(m_maskValue);
         } else {
           // What is our normalization factor?
           signal_t normalizer = 1.0;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -759,17 +759,8 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
     // const MDBoxBase<MDE,nd> * box = NULL;
     const IMDNode *box = NULL;
 
-    // Do an initial bounds check
-    bool outOfBounds = false;
-    for (size_t d = 0; d < nd; d++) {
-      if (data->getExtents(d).outside(coord[d])) {
-        outOfBounds = true;
-        break;
-      }
-    }
-
     // TODO: make the logic/reuse in the following nicer.
-    if (!outOfBounds) {
+    if (isInBounds(coord.getBareArray())) {
       box = this->data->getBoxAtCoord(coord.getBareArray());
 
       if (box != NULL) {

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -767,19 +767,18 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
         if (box->getIsMasked()) {
           y.push_back(0.0);
           e.push_back(0.0);
-        }
-        else {
+        } else {
           // What is our normalization factor?
           signal_t normalizer = 1.0;
           switch (normalize) {
-            case NoNormalization:
-              break;
-            case VolumeNormalization:
-              normalizer = box->getInverseVolume();
-              break;
-            case NumEventsNormalization:
-              normalizer = 1.0 / double(box->getNPoints());
-              break;
+          case NoNormalization:
+            break;
+          case VolumeNormalization:
+            normalizer = box->getInverseVolume();
+            break;
+          case NumEventsNormalization:
+            normalizer = 1.0 / double(box->getNPoints());
+            break;
           }
 
           // And add the normalized signal/error to the list

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -469,7 +469,6 @@ protected:
 
   /// Linear array of masks for each bin
   bool *m_masks;
-
 };
 
 /// A shared pointer to a MDHistoWorkspace

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -452,6 +452,15 @@ private:
   /// Display normalization to use
   Mantid::API::MDNormalization m_displayNormalization;
 
+  // Get ordered list of boundaries in position-along-the-line coordinates
+  std::set<coord_t> getBinBoundariesOnLine(const Kernel::VMD &start,
+                                           const Kernel::VMD &end, size_t nd,
+                                           const Kernel::VMD &dir,
+                                           coord_t length) const;
+
+  signal_t getNormalizationFactor(const API::MDNormalization &normalize,
+                                  size_t linearIndex) const;
+
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
   MDHistoWorkspace(const MDHistoWorkspace &other);
@@ -460,6 +469,7 @@ protected:
 
   /// Linear array of masks for each bin
   bool *m_masks;
+
 };
 
 /// A shared pointer to a MDHistoWorkspace

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -610,6 +610,14 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
   }   // if there is at least one point
 }
 
+//----------------------------------------------------------------------------------------------
+/** Find the normalization factor
+ *
+ * @param normalize :: how to normalize the signal
+ * @param linearIndex :: the position in the workspace of the signal value to be
+ *normalized
+ * @returns :: the normalization factor
+ */
 signal_t
 MDHistoWorkspace::getNormalizationFactor(const MDNormalization &normalize,
                                          size_t linearIndex) const {

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -389,7 +389,7 @@ signal_t MDHistoWorkspace::getSignalWithMaskAtCoord(
     const Mantid::API::MDNormalization &normalization) const {
   size_t linearIndex = this->getLinearIndexAtCoord(coords);
   if (this->getIsMaskedAt(linearIndex)) {
-    return 0.0;
+    return m_maskValue;
   }
   return getSignalAtCoord(coords, normalization);
 }
@@ -586,8 +586,8 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
 
         // Is the signal here masked?
         if (this->getIsMaskedAt(linearIndex)) {
-          y.push_back(0.0);
-          e.push_back(0.0);
+          y.push_back(m_maskValue);
+          e.push_back(m_maskValue);
         } else {
           signal_t normalizer = getNormalizationFactor(normalize, linearIndex);
           // And add the normalized signal/error to the list too

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -626,19 +626,18 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
         if (this->getIsMaskedAt(linearIndex)) {
           y.push_back(0.0);
           e.push_back(0.0);
-        }
-        else {
+        } else {
           // What is our normalization factor?
           signal_t normalizer = 1.0;
           switch (normalize) {
-            case NoNormalization:
-              break;
-            case VolumeNormalization:
-              normalizer = m_inverseVolume;
-              break;
-            case NumEventsNormalization:
-              normalizer = 1.0 / m_numEvents[linearIndex];
-              break;
+          case NoNormalization:
+            break;
+          case VolumeNormalization:
+            normalizer = m_inverseVolume;
+            break;
+          case NumEventsNormalization:
+            normalizer = 1.0 / m_numEvents[linearIndex];
+            break;
           }
           // And add the normalized signal/error to the list too
           auto signal = this->getSignalAt(linearIndex) * normalizer;

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -568,6 +568,29 @@ public:
     }
   }
 
+  void test_getLinePlotWithMaskedData() {
+    MDEventWorkspace3Lean::sptr ew =
+      MDEventsTestHelper::makeMDEW<3>(4, 0.0, 7.0, 3);
+
+    // Mask some of the workspace
+    std::vector<coord_t> min{0, 0, 0};
+    std::vector<coord_t> max{0.5, 0.5, 0.5};
+
+    // Create an function to mask some of the workspace.
+    MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
+    ew->setMDMasking(function);
+    ew->refreshCache();
+
+    Mantid::Kernel::VMD start(0, 0, 0);
+    Mantid::Kernel::VMD end(2, 0, 0);
+    std::vector<coord_t> x;
+    std::vector<signal_t> y, e;
+    ew->getLinePlot(start, end, NoNormalization, x, y, e);
+    TS_ASSERT_EQUALS(y.size(), 200);
+    TS_ASSERT_EQUALS(y[60], 0.0); // Masked data is zero
+    TS_ASSERT_EQUALS(y[180], 3.0); // Unmasked data
+  }
+
   void test_that_sets_default_normalization_flags_to_volume_normalization() {
     // Arrange + Act
     MDEventWorkspace3Lean::sptr ew =

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -570,7 +570,7 @@ public:
 
   void test_getLinePlotWithMaskedData() {
     MDEventWorkspace3Lean::sptr ew =
-      MDEventsTestHelper::makeMDEW<3>(4, 0.0, 7.0, 3);
+        MDEventsTestHelper::makeMDEW<3>(4, 0.0, 7.0, 3);
 
     // Mask some of the workspace
     std::vector<coord_t> min{0, 0, 0};
@@ -587,7 +587,7 @@ public:
     std::vector<signal_t> y, e;
     ew->getLinePlot(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(y.size(), 200);
-    TS_ASSERT_EQUALS(y[60], 0.0); // Masked data is zero
+    TS_ASSERT_EQUALS(y[60], 0.0);  // Masked data is zero
     TS_ASSERT_EQUALS(y[180], 3.0); // Unmasked data
   }
 

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -572,6 +572,35 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive */
+  void test_getLinePlot_horizontal_withMask() {
+    MDHistoWorkspace_sptr ws =
+      MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
+    for (size_t i = 0; i < 100; i++)
+      ws->setSignalAt(i, double(i));
+
+    std::vector<coord_t> min{0, 0};
+    std::vector<coord_t> max{5, 5};
+
+    // Mask part of the workspace
+    MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
+    ws->setMDMasking(function);
+
+    VMD start(0.5, 0.5);
+    VMD end(9.5, 0.5);
+    std::vector<coord_t> x;
+    std::vector<signal_t> y;
+    std::vector<signal_t> e;
+    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+
+    TS_ASSERT_EQUALS(y.size(), 10);
+    // Masked value should be zero
+    TS_ASSERT_DELTA(y[2], 0.0, 1e-5);
+    // Unmasked value
+    TS_ASSERT_DELTA(y[9], 9.0, 1e-5);
+  }
+
+  //---------------------------------------------------------------------------------------------------
+  /** Line along X, going positive */
   void test_getLinePlot_3D() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3, 10);

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -574,7 +574,7 @@ public:
   /** Line along X, going positive */
   void test_getLinePlot_horizontal_withMask() {
     MDHistoWorkspace_sptr ws =
-      MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
+        MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
       ws->setSignalAt(i, double(i));
 


### PR DESCRIPTION
Closes #14631

Masked data should have a signal and error of 0 in the plot. This is consistent with 1D plots of masked MatrixWorkspaces.

**To Test:**

The following python can be used to create a masked and an unmasked MDHistoWorkspace for comparison with each other.  Right-click on each workspace in the dock and select "Plot MD" to plot (defaults in the dialog are fine). In the masked workspace, signal values and errors for -1<h<1 should be zero.

``` python

ws_mdhw = CreateMDWorkspace(Dimensions='1', Extents='-2,2', Names='h',
                       Units='rlu', SplitInto='4')
FakeMDEventData(ws_mdhw, UniformParams='1000', RandomizeSignal='1')
ws_mdhw = BinMD(ws_mdhw,AlignedDim0='h,-2,2,64')
ws_masked_mdhw = CloneMDWorkspace(ws_mdhw)
MaskMD(Workspace=ws_masked_mdhw,Dimensions="h",Extents="-1,1")

```
