### PR TITLE
Fixed SimpleAPI tuple return issue

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/funcreturns.py
+++ b/Framework/PythonInterface/mantid/kernel/funcreturns.py
@@ -148,7 +148,6 @@ def process_frame(frame):
     # have the incorrect index at last_i due to the call being passed through
     # an intermediate reference. Currently this method does not provide the
     # correct answer and throws a KeyError. Ticket #4186
-    isContainer = False
     output_var_names = []
     max_returns = []
     last_func_offset = call_function_locs[last_i][0]
@@ -158,7 +157,6 @@ def process_frame(frame):
     if name == 'STORE_FAST' or name == 'STORE_NAME': # one return value
         output_var_names.append(argvalue)
     if name == 'UNPACK_SEQUENCE': # Many Return Values, One equal sign
-        isContainer = True
         for index in range(argvalue):
             (offset_, op_, name_, argument_, argtype_, argvalue_) = ins_stack[last_func_offset + 2 +index]
             output_var_names.append(argvalue_)
@@ -189,7 +187,7 @@ def process_frame(frame):
                 output_var_names.append(argvalue_)
             count = count + 1
 
-    return (max_returns, tuple(output_var_names)), isContainer
+    return (max_returns, tuple(output_var_names))
 
 #-------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/mantid/kernel/funcreturns.py
+++ b/Framework/PythonInterface/mantid/kernel/funcreturns.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
     Defines functions that can be used to inspect the properties of a
     function call. For example
 
@@ -148,7 +148,7 @@ def process_frame(frame):
     # have the incorrect index at last_i due to the call being passed through
     # an intermediate reference. Currently this method does not provide the
     # correct answer and throws a KeyError. Ticket #4186
-
+    isContainer = False
     output_var_names = []
     max_returns = []
     last_func_offset = call_function_locs[last_i][0]
@@ -158,6 +158,7 @@ def process_frame(frame):
     if name == 'STORE_FAST' or name == 'STORE_NAME': # one return value
         output_var_names.append(argvalue)
     if name == 'UNPACK_SEQUENCE': # Many Return Values, One equal sign
+        isContainer = True
         for index in range(argvalue):
             (offset_, op_, name_, argument_, argtype_, argvalue_) = ins_stack[last_func_offset + 2 +index]
             output_var_names.append(argvalue_)
@@ -188,7 +189,7 @@ def process_frame(frame):
                 output_var_names.append(argvalue_)
             count = count + 1
 
-    return (max_returns, tuple(output_var_names))
+    return (max_returns, tuple(output_var_names)), isContainer
 
 #-------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -626,7 +626,7 @@ def _is_workspace_property(prop):
         # Doesn't look like a workspace property
         return False
 
-def _get_args_from_lhs(lhs, algm_obj, isContainer):
+def _get_args_from_lhs(lhs, algm_obj):
     """
         Return the extra arguments that are to be passed to the algorithm
         from the information in the lhs tuple. These are basically the names
@@ -646,20 +646,18 @@ def _get_args_from_lhs(lhs, algm_obj, isContainer):
 
     output_props = [ algm_obj.getProperty(p) for p in algm_obj.outputProperties() ]
 
-    if len(output_props) > 0:
-        if len(ret_names) > len(output_props) :
-            raise ValueError("need more than 2 values to unpack")
-
     nprops = len(output_props)
-    
+    nnames = len(ret_names)
+
     name = 0
 
     for p in output_props:
         if _is_workspace_property(p):
-            if len(ret_names) > 0 and nprops > len(ret_names):
+            if nnames > 0 and nprops > nnames:
                 extra_args[p.name] = ret_names[0] # match argument to property name
                 ret_names = ret_names[1:]
-            elif len(ret_names) > 0:
+                nnames -= 1
+            elif nnames > 0:
                 extra_args[p.name] = ret_names[name]
 
         name += 1
@@ -825,8 +823,8 @@ def _create_algorithm_function(algorithm, version, _algm_object):
         except KeyError:
             frame = None
 
-        lhs, isContainer = _kernel.funcreturns.lhs_info(frame=frame)
-        lhs_args = _get_args_from_lhs(lhs, algm, isContainer)
+        lhs = _kernel.funcreturns.lhs_info(frame=frame)
+        lhs_args = _get_args_from_lhs(lhs, algm)
         final_keywords = _merge_keywords_with_lhs(kwargs, lhs_args)
 
         set_properties(algm, *args, **final_keywords)

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -640,24 +640,26 @@ def _get_args_from_lhs(lhs, algm_obj):
         :param algm_obj: An initialised algorithm object
         :returns: A dictionary mapping property names to the values extracted from the lhs variables
     """
+
     ret_names = lhs[1]
     extra_args = {}
 
     output_props = [ algm_obj.getProperty(p) for p in algm_obj.outputProperties() ]
 
     nprops = len(output_props)
-
-    i = 0 # properties counter
-    id = 0 # unnamed workspace identifier
     
+    name = 0
+
     for p in output_props:
         if _is_workspace_property(p):
-            if i<len(ret_names):
-                extra_args[p.name] = ret_names[i] # match argument to property name
+            if len(ret_names) > 0 and nprops > len(ret_names):
+                extra_args[p.name] = ret_names[0] # match argument to property name
+                ret_names = ret_names[1:]
             elif len(ret_names) > 0:
-                extra_args[p.name] = ret_names[0]+"_Workspace_"+str(id) # default workspace name if none provided
-            id += 1
-        i += 1
+                extra_args[p.name] = ret_names[name]
+                ret_names = ret_names[name:]
+
+        name += 1
 
     return extra_args
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -655,7 +655,7 @@ def _get_args_from_lhs(lhs, algm_obj):
             if i<len(ret_names):
                 extra_args[p.name] = ret_names[i] # match argument to property name
             else:
-                extra_args[p.name] = "outputWorkspace_"+str(id) # default workspace name if none provided
+                extra_args[p.name] = ret_names[0]+"_Workspace_"+str(id) # default workspace name if none provided
             id += 1
         i += 1
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -654,7 +654,7 @@ def _get_args_from_lhs(lhs, algm_obj):
         if _is_workspace_property(p):
             if i<len(ret_names):
                 extra_args[p.name] = ret_names[i] # match argument to property name
-            else:
+            elif len(ret_names) > 0:
                 extra_args[p.name] = ret_names[0]+"_Workspace_"+str(id) # default workspace name if none provided
             id += 1
         i += 1

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -644,14 +644,21 @@ def _get_args_from_lhs(lhs, algm_obj):
     extra_args = {}
 
     output_props = [ algm_obj.getProperty(p) for p in algm_obj.outputProperties() ]
+
     nprops = len(output_props)
-    i = 0
-    while len(ret_names) > 0 and i < nprops:
-        p = output_props[i]
+
+    i = 0 # properties counter
+    id = 0 # unnamed workspace identifier
+    
+    for p in output_props:
         if _is_workspace_property(p):
-            extra_args[p.name] = ret_names[0]
-            ret_names = ret_names[1:]
+            if i<len(ret_names):
+                extra_args[p.name] = ret_names[i] # match argument to property name
+            else:
+                extra_args[p.name] = "outputWorkspace_"+str(id) # default workspace name if none provided
+            id += 1
         i += 1
+
     return extra_args
 
 def _merge_keywords_with_lhs(keywords, lhs_args):

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -657,7 +657,6 @@ def _get_args_from_lhs(lhs, algm_obj):
                 ret_names = ret_names[1:]
             elif len(ret_names) > 0:
                 extra_args[p.name] = ret_names[name]
-                ret_names = ret_names[name:]
 
         name += 1
 

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -626,7 +626,7 @@ def _is_workspace_property(prop):
         # Doesn't look like a workspace property
         return False
 
-def _get_args_from_lhs(lhs, algm_obj):
+def _get_args_from_lhs(lhs, algm_obj, isContainer):
     """
         Return the extra arguments that are to be passed to the algorithm
         from the information in the lhs tuple. These are basically the names
@@ -645,6 +645,10 @@ def _get_args_from_lhs(lhs, algm_obj):
     extra_args = {}
 
     output_props = [ algm_obj.getProperty(p) for p in algm_obj.outputProperties() ]
+
+    if len(output_props) > 0:
+        if len(ret_names) > len(output_props) :
+            raise ValueError("need more than 2 values to unpack")
 
     nprops = len(output_props)
     
@@ -821,11 +825,12 @@ def _create_algorithm_function(algorithm, version, _algm_object):
         except KeyError:
             frame = None
 
-        lhs = _kernel.funcreturns.lhs_info(frame=frame)
-        lhs_args = _get_args_from_lhs(lhs, algm)
+        lhs, isContainer = _kernel.funcreturns.lhs_info(frame=frame)
+        lhs_args = _get_args_from_lhs(lhs, algm, isContainer)
         final_keywords = _merge_keywords_with_lhs(kwargs, lhs_args)
 
         set_properties(algm, *args, **final_keywords)
+
         try:
             algm.execute()
         except RuntimeError, e:
@@ -834,6 +839,7 @@ def _create_algorithm_function(algorithm, version, _algm_object):
                 _check_mandatory_args(algorithm, _algm_object, e, *args, **kwargs)
             else:
                 raise
+
         return _gather_returns(algorithm, lhs, algm)
 
 

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -1,4 +1,4 @@
-import unittest
+﻿import unittest
 from mantid.api import (AlgorithmFactory, AlgorithmProxy, IAlgorithm, IEventWorkspace, ITableWorkspace,
                         PythonAlgorithm, MatrixWorkspace, mtd, WorkspaceGroup)
 import mantid.simpleapi as simpleapi
@@ -186,6 +186,32 @@ FullBinsOnly(Input) *boolean*       Omit the final bin if it's width is smaller 
         # over the actual object name
         self.assertTrue('workspace' in mtd)
         self.assertTrue('raw' in mtd)
+
+    def test_alg_produces_correct_workspace_in_APS_from_python(self):
+
+        dataX=numpy.linspace(start=1,stop=3,num=11)
+        dataY=numpy.linspace(start=1,stop=3,num=10)
+        workspace1_test = simpleapi.CreateWorkspace(DataX=dataX, dataY=dataY, NSpec=1)
+        workspace2_test = simpleapi.CloneWorkspace(workspace1_test)
+
+        ws1_name = "workspace1_test"
+        ws2_name = "workspace2_test"
+
+        self.assertTrue(ws1_name in mtd)
+        self.assertTrue(ws2_name in mtd)
+
+        outputWs_name = "message"
+
+        if outputWs_name in mtd:
+            simpleapi.DeleteWorkspace(outputWs_name)
+
+        result, message = simpleapi.CompareWorkspaces(workspace1_test, workspace2_test)
+
+        self.assertTrue(outputWs_name in mtd)
+
+        simpleapi.DeleteWorkspace(message)
+        simpleapi.DeleteWorkspace(ws1_name)
+        simpleapi.DeleteWorkspace(ws2_name)
 
     def test_python_alg_can_use_other_python_alg_through_simple_api(self):
         class SimpleAPIPythonAlgorithm1(PythonAlgorithm):

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -130,7 +130,7 @@ FullBinsOnly(Input) *boolean*       Omit the final bin if it's width is smaller 
         try:
             ws, ws2 = simpleapi.CreateWorkspace([1.5],[1.5],NSpec=1,UnitX='Wavelength')
             self.fail("Should not have made it to this point.")
-        except ValueError:
+        except RuntimeError:
             pass
         
     def test_function_returns_correct_args_when_extra_output_props_are_added_at_execute_time(self):

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -81,15 +81,57 @@ FullBinsOnly(Input) *boolean*       Omit the final bin if it's width is smaller 
         except RuntimeError:
             pass
 
-    def test_function_call_raises_RuntimeError_if_num_of_ret_vals_doesnt_match_num_assigned_vars(self):
+    def test_function_call_returns_tuple_when_a_single_argument_is_provided(self):
+        dataX=numpy.linspace(start=1,stop=3,num=11)
+        dataY=numpy.linspace(start=1,stop=3,num=10)
+        workspace1_test = simpleapi.CreateWorkspace(DataX=dataX, dataY=dataY, NSpec=1)
+        workspace2_test = simpleapi.CloneWorkspace(workspace1_test)
+
+        ws1_name = "workspace1_test"
+        ws2_name = "workspace2_test"
+
+        self.assertTrue(ws1_name in mtd)
+        self.assertTrue(ws2_name in mtd)
+
+        outputWs_name = "message"
+
+        if outputWs_name in mtd:
+            simpleapi.DeleteWorkspace(outputWs_name)
+
+        result = simpleapi.CompareWorkspaces(workspace1_test, workspace2_test)
+     
+        self.assertIsInstance(result, tuple)
+
+        simpleapi.DeleteWorkspace(ws1_name)
+        simpleapi.DeleteWorkspace(ws2_name)
+
+    def test_function_call_raises_ValueError_when_not_enough_arguments_in_return_tuple(self):
+        dataX=numpy.linspace(start=1,stop=3,num=11)
+        dataY=numpy.linspace(start=1,stop=3,num=10)
+        workspace1_test = simpleapi.CreateWorkspace(DataX=dataX, dataY=dataY, NSpec=1)
+        workspace2_test = simpleapi.CloneWorkspace(workspace1_test)
+
+        ws1_name = "workspace1_test"
+        ws2_name = "workspace2_test"
+
+        self.assertTrue(ws1_name in mtd)
+        self.assertTrue(ws2_name in mtd)
+
+        try:
+            (result, ) = simpleapi.CompareWorkspaces(workspace1_test, workspace2_test)
+            self.fail("Should not have made it to this point.")
+        except(ValueError):
+            pass
+
+        simpleapi.DeleteWorkspace(ws1_name)
+        simpleapi.DeleteWorkspace(ws2_name)
+
+    def test_function_call_raises_ValueError_if_num_of_ret_vals_doesnt_match_num_assigned_vars(self):
         try:
             ws, ws2 = simpleapi.CreateWorkspace([1.5],[1.5],NSpec=1,UnitX='Wavelength')
-        except RuntimeError, exc:
-            # Check the error is correct and it's not some random runtime error
-            if 'CreateWorkspace is trying to return 1 output(s) but you have provided 2 variable(s). These numbers must match.' == str(exc):
-                pass
-            else:
-                self.fail("Exception was raised but it did not have the correct message: '%s'" % str(exc))
+            self.fail("Should not have made it to this point.")
+        except ValueError:
+            pass
         
     def test_function_returns_correct_args_when_extra_output_props_are_added_at_execute_time(self):
         ws1 = simpleapi.CreateWorkspace([1.5],[1.5],NSpec=1,UnitX='Wavelength')
@@ -188,7 +230,6 @@ FullBinsOnly(Input) *boolean*       Omit the final bin if it's width is smaller 
         self.assertTrue('raw' in mtd)
 
     def test_alg_produces_correct_workspace_in_APS_from_python(self):
-
         dataX=numpy.linspace(start=1,stop=3,num=11)
         dataY=numpy.linspace(start=1,stop=3,num=10)
         workspace1_test = simpleapi.CreateWorkspace(DataX=dataX, dataY=dataY, NSpec=1)

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -100,7 +100,7 @@ FullBinsOnly(Input) *boolean*       Omit the final bin if it's width is smaller 
 
         result = simpleapi.CompareWorkspaces(workspace1_test, workspace2_test)
      
-        self.assertIsInstance(result, tuple)
+        self.assertTrue(isinstance(result, tuple))
 
         simpleapi.DeleteWorkspace(ws1_name)
         simpleapi.DeleteWorkspace(ws2_name)


### PR DESCRIPTION
Fixes #14521 

Release notes need to be updated
## Changes

This fixes the issue where the wrong workspace name was returned from a python call to CompareWorkspaces. The tuple result was supposed to be in the form of (boolean, workspace). However in an example call:

``` python
(result, messages) = CompareWorkspaces(w1, w2)
```

result was set  as the workspace name in the ADS instead of messages. This was due to incorrect argument extraction of the SimpleAPI python layer in the mantid framework. The workspace name selection has been rectified and a unit test to check the output workspace name has been created.
## Testing

Code review and run the following script to see correct workspace name selected: 

``` python
dataX = [0,1,2,3,4,5,6,7,8,9]
dataY = [1,1,1,1,1,1,1,1,1]
ws1 = CreateWorkspace(dataX, dataY)

#create a copy of the workspace
ws2 = CloneWorkspace(ws1)

(result, messages) = CompareWorkspaces(ws1, ws2)

print "Result:", result
print messages.rowCount()
```
