### PR TITLE
Corrected Syntax Error in StaticKuboToyabeTimesStretchExp documentations

### DIFF
--- a/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
+++ b/docs/source/fitfunctions/StaticKuboToyabeTimesStretchExp.rst
@@ -13,7 +13,7 @@ Fitting function for use by Muon scientists defined by:
 
 .. math::
 
-   \mbox{A}\times ( \exp(-{Delta}^2 \times {x}^2 / 2 ) \times ( 1 - ( {Delta}^2 \times {x}^2 ) ) \times  \frac 2 3 + \frac 1 3 ) \times \{exp(-{{Lambda} \times {x}}^{Beta})}
+   \mbox{A}\times ( \exp(-{Delta}^2 \times {x}^2 / 2 ) \times ( 1 - ( {Delta}^2 \times {x}^2 ) ) \times  \frac 2 3 + \frac 1 3 ) \times \exp({-{Lambda} \times {x}}^{Beta})
 
 .. attributes::
 


### PR DESCRIPTION
Fixes #14662 
## Changes

The syntax error has been identified and corrected.
