### PR TITLE
Fixing launch scripts

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidplot.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.sh.in
@@ -27,7 +27,7 @@ if [ -z "${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}" ]; then
     # half of available memory
     TCM_REPORT=$(echo "1024*${TCM_REPORT}/2" | bc)
     # minimum is 1GB
-    if [[ ${TCM_REPORT} < 1073741824 ]]; then
+    if [ ${TCM_REPORT} -le 1073741824 ]; then
         TCM_REPORT=1073741824
     fi
 else

--- a/buildconfig/CMake/Packaging/mantidpython.in
+++ b/buildconfig/CMake/Packaging/mantidpython.in
@@ -28,7 +28,7 @@ if [ -z "${TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD}" ]; then
     # half of available memory
     TCM_REPORT=$(echo "1024*${TCM_REPORT}/2" | bc)
     # minimum is 1GB
-    if [[ ${TCM_REPORT} < 1073741824 ]]; then
+    if [ ${TCM_REPORT} -le 1073741824 ]; then
         TCM_REPORT=1073741824
     fi
 else


### PR DESCRIPTION
**To test:** Since this is a bug (only) on ubuntu, it needs to be tested there. Try both `launch_mantidplot.sh` and `mantidpython`

This does not need to be in the release notes.

Fixes #14660.
