### PR TITLE
Add ability to copy property values in Algorithm History

### DIFF
--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.cpp
@@ -435,37 +435,66 @@ void AlgorithmHistoryWindow::doRoll( int index )
 // AlgHistoryProperties Definitions
 //--------------------------------------------------------------------------------------------------
 
-AlgHistoryProperties::AlgHistoryProperties(QWidget*w,const std::vector<PropertyHistory_sptr>& propHist):
-  m_Histprop(propHist)
-{
+AlgHistoryProperties::AlgHistoryProperties(
+    QWidget *w, const std::vector<PropertyHistory_sptr> &propHist)
+    : m_Histprop(propHist) {
   QStringList hList;
-  hList<<"Name"<<"Value"<<"Default?:"<<"Direction"<<"";
-  m_histpropTree = new  QTreeWidget(w);
-  if(m_histpropTree)
-  {
-    m_histpropTree->setColumnCount(5);
-    m_histpropTree->setSelectionMode(QAbstractItemView::NoSelection);
-    m_histpropTree->setHeaderLabels(hList);
-    m_histpropTree->setGeometry (213,5,350,200);
-  }
+  hList << "Name"
+        << "Value"
+        << "Default?:"
+        << "Direction"
+        << "";
+
+  m_histpropTree = new QTreeWidget(w);
+  m_histpropTree->setColumnCount(5);
+  m_histpropTree->setSelectionMode(QAbstractItemView::NoSelection);
+  m_histpropTree->setHeaderLabels(hList);
+  m_histpropTree->setGeometry(213, 5, 350, 200);
+
+  m_contextMenu = new QMenu(w);
+
+  m_copyAction = new QAction("Copy to Clipboard", m_contextMenu);
+  connect(m_copyAction, SIGNAL(triggered()), this,
+          SLOT(copySelectedItemText()));
+  m_contextMenu->addAction(m_copyAction);
+
+  m_histpropTree->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(m_histpropTree, SIGNAL(customContextMenuRequested(const QPoint &)),
+          this, SLOT(popupMenu(const QPoint &)));
 }
-void AlgHistoryProperties::clearData()
-{
-  if(m_histpropTree)
-  {   m_histpropTree->clear();
-    int ntopcount=m_histpropTree->topLevelItemCount() ;
-    while(ntopcount--)
-    {m_histpropTree->topLevelItem(ntopcount);
+
+void AlgHistoryProperties::clearData() {
+  if (m_histpropTree) {
+    m_histpropTree->clear();
+    int ntopcount = m_histpropTree->topLevelItemCount();
+    while (ntopcount--) {
+      m_histpropTree->topLevelItem(ntopcount);
     }
   }
 }
-void AlgHistoryProperties::setAlgProperties( const std::vector<PropertyHistory_sptr>& histProp)
-{
-  m_Histprop.assign(histProp.begin(),histProp.end());
+
+void AlgHistoryProperties::setAlgProperties(
+    const std::vector<PropertyHistory_sptr> &histProp) {
+  m_Histprop.assign(histProp.begin(), histProp.end());
 }
-const PropertyHistories& AlgHistoryProperties:: getAlgProperties()
-{
+
+const PropertyHistories &AlgHistoryProperties::getAlgProperties() {
   return m_Histprop;
+}
+
+void AlgHistoryProperties::popupMenu(const QPoint &pos) {
+  QTreeWidgetItem *treeItem = m_histpropTree->itemAt(pos);
+  if (!treeItem)
+    return;
+
+  m_selectedItemText = treeItem->text(m_histpropTree->currentColumn());
+  m_contextMenu->popup(QCursor::pos());
+}
+
+void AlgHistoryProperties::copySelectedItemText() {
+  QClipboard *clipboard = QApplication::clipboard();
+  if (clipboard)
+    clipboard->setText(m_selectedItemText);
 }
 
 /**

--- a/MantidPlot/src/Mantid/AlgorithmHistoryWindow.h
+++ b/MantidPlot/src/Mantid/AlgorithmHistoryWindow.h
@@ -171,21 +171,34 @@ private:
 };
 
 
-class AlgHistoryProperties: public QObject
-{
+class AlgHistoryProperties : public QObject {
   Q_OBJECT
-  public:
-  AlgHistoryProperties(QWidget*w,const std::vector<Mantid::Kernel::PropertyHistory_sptr>& propHist);
+
+public:
+  AlgHistoryProperties(
+      QWidget *w,
+      const std::vector<Mantid::Kernel::PropertyHistory_sptr> &propHist);
+
   void displayAlgHistoryProperties();
   void clearData();
-  void setAlgProperties( const std::vector<Mantid::Kernel::PropertyHistory_sptr>& histProp);
-  const Mantid::Kernel::PropertyHistories& getAlgProperties();
+
+  void setAlgProperties(
+      const std::vector<Mantid::Kernel::PropertyHistory_sptr> &histProp);
+  const Mantid::Kernel::PropertyHistories &getAlgProperties();
+
+public slots:
+  void popupMenu(const QPoint &pos);
+  void copySelectedItemText();
+
 public:
   QTreeWidget *m_histpropTree;
+
 private:
+  QAction *m_copyAction;
+  QMenu *m_contextMenu;
+  QString m_selectedItemText;
+
   std::vector<Mantid::Kernel::PropertyHistory_sptr> m_Histprop;
 };
-#endif
 
-
-
+#endif // ALGORITHMHISTORYWINDOW_H


### PR DESCRIPTION
Fixes #13422.

It is sometimes useful to copy the values from the properties list in the Algorithm History window.

It was already possible to do this by clicking the item and using the Ctrl-C shortcut. However, this is very unintuitive since that widget is set up so that clicked items are not highlighted. 

I've added a right-click context menu that copies the item under the cursor to the clipboard.
### Testing

Load a workspace, right-click it in the dock and select "Show History".

Right-clicking any item in the property list should bring up a context menu with a "Copy to Clipboard" option. Ensure it works as expected.
