### PR TITLE
Fix latex rendering of equations on OS X.

### DIFF
--- a/buildconfig/Jenkins/jenkins-slave.sh
+++ b/buildconfig/Jenkins/jenkins-slave.sh
@@ -36,6 +36,8 @@ JAR_FILE=slave.jar
 [ -z "$USER" ] && export USER=$(whoami)
 # Put /usr/local/bin on the PATH if brew is installed
 [ -f /usr/local/bin/brew ] && export PATH=${PATH}:/usr/local/bin
+# Put /usr/texbin on the PATH if latex is installed
+[ -f /usr/texbin/latex ] && export PATH=${PATH}:/usr/texbin
 
 #####################################################################
 # Script


### PR DESCRIPTION
This fixes #14659. 

cron clears the `PATH` environment variable, preventing sphinx from finding the latex executable. This PR adds /usr/texbin to the `PATH` so that latex is picked up.

This fix needs to be applied to all OS X build servers.

[Release notes](http://www.mantidproject.org/index.php?title=ReleaseNotes_3_6_UI_Changes&diff=25707&oldid=25678)

testing: Code review. 
