### PR TITLE
Python interface without ADS issues

### DIFF
--- a/Framework/PythonInterface/mantid/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/CMakeLists.txt
@@ -41,10 +41,11 @@ add_dependencies ( PythonKernelModule PythonModule ) # Ensure the module files a
 add_subdirectory ( geometry )
 add_subdirectory ( api )
 add_subdirectory ( dataobjects )
+add_subdirectory ( experimental )
 
 # Create an overall target
 add_custom_target ( PythonInterface DEPENDS PythonKernelModule PythonGeometryModule 
-                    PythonAPIModule PythonDataObjectsModule )
+  PythonAPIModule PythonDataObjectsModule PythonExperimentalModule )
 set_property ( TARGET PythonInterface PROPERTY FOLDER "MantidFramework/Python" )
 
 ###########################################################################

--- a/Framework/PythonInterface/mantid/experimental/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/experimental/CMakeLists.txt
@@ -1,0 +1,67 @@
+set ( MODULE_TEMPLATE src/experimental.cpp.in )
+
+set ( EXPORT_FILES
+  src/Exports/PythonSmartPointerHelpers.cpp
+  )
+
+set ( MODULE_DEFINITION ${CMAKE_CURRENT_BINARY_DIR}/experimental.cpp )
+create_module ( ${MODULE_TEMPLATE} ${MODULE_DEFINITION} ${EXPORT_FILES} )
+
+set ( SRC_FILES )
+
+set ( INC_FILES )
+
+set ( PY_FILES
+  __init__.py
+  _aliases.py
+  pythonapi.py
+  )
+
+#############################################################################################
+# Add rule to copy over the pure Python files for the module
+#############################################################################################
+set ( OUTPUT_DIR ${PYTHON_PKG_ROOT}/experimental )
+
+if(CMAKE_GENERATOR STREQUAL Xcode)
+  # Set the output directory for the libraries.
+  set ( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PYTHON_PKG_ROOT}/experimental )
+endif()
+
+copy_files_to_dir ( "${PY_FILES}" ${CMAKE_CURRENT_SOURCE_DIR} ${OUTPUT_DIR}
+                     PYTHON_INSTALL_FILES )
+
+#############################################################################################
+# Create the target for this directory
+#############################################################################################
+
+add_library ( PythonExperimentalModule ${MODULE_DEFINITION} ${EXPORT_FILES} ${SRC_FILES}
+              ${INC_FILES} ${PYTHON_INSTALL_FILES} )
+set_python_properties( PythonExperimentalModule _experimental )
+set_target_output_directory ( PythonExperimentalModule ${OUTPUT_DIR} .pyd )
+
+# Add the required dependencies
+target_link_libraries ( PythonExperimentalModule LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
+            PythonAPIModule
+            PythonGeometryModule
+            PythonKernelModule
+            PythonDataObjectsModule
+            API
+            DataObjects
+            Kernel
+            Geometry
+            ${PYTHON_LIBRARIES}
+            ${POCO_LIBRARIES}
+            ${Boost_LIBRARIES} )
+
+
+if (OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties( PythonExperimentalModule PROPERTIES
+                         INSTALL_RPATH "@loader_path/../../../MacOS;@loader_path/../kernel/;@loader_path/../geometry/;@loader_path/../api/")
+endif ()
+###########################################################################
+# Installation settings
+###########################################################################
+install ( TARGETS PythonExperimentalModule ${SYSTEM_PACKAGE_TARGET} DESTINATION ${BIN_DIR}/mantid/experimental )
+
+# Pure Python files
+install ( FILES ${PY_FILES} DESTINATION ${BIN_DIR}/mantid/experimental )

--- a/Framework/PythonInterface/mantid/experimental/__init__.py
+++ b/Framework/PythonInterface/mantid/experimental/__init__.py
@@ -1,0 +1,18 @@
+"""
+mantid.experimental
+===================
+
+Defines Python objects that wrap the C++ Experimental namespace.
+
+"""
+from __future__ import absolute_import
+
+###############################################################################
+# Load the C++ library
+###############################################################################
+from ._experimental import *
+
+###############################################################################
+# Make aliases accessible in this namespace
+###############################################################################
+from ._aliases import *

--- a/Framework/PythonInterface/mantid/experimental/_aliases.py
+++ b/Framework/PythonInterface/mantid/experimental/_aliases.py
@@ -1,0 +1,1 @@
+from _experimental import (convert_weak_ptr_to_shared_ptr, swap_shared_ptrs)

--- a/Framework/PythonInterface/mantid/experimental/pythonapi.py
+++ b/Framework/PythonInterface/mantid/experimental/pythonapi.py
@@ -1,15 +1,18 @@
 import mantid
 
 
+def _get_temporary_workspace_name(workspace):
+    return 'algorithm-internal-temporary_{0}'.format(id(workspace))
+
 def _pythonapi_create_algorithm_function_post_process_lhs_info(lhs):
-    modified_names = [ 'algorithm-internal-temporary_{}'.format(id(i)) for i in lhs[1] ]
+    modified_names = [ _get_temporary_workspace_name(i) for i in lhs[1] ]
     return (lhs[0], modified_names)
 
 def _pythonapi_create_algorithm_function_get_initial_workspaces(args, kwargs):
     initial_workspaces = {}
     for i in list(args) + kwargs.values():
         if isinstance(i, _api.Workspace):
-            name = 'algorithm-internal-temporary_{}'.format(id(i))
+            name = _get_temporary_workspace_name(i)
             initial_workspaces[name] = i
             _api.AnalysisDataService[name] = i
     return initial_workspaces

--- a/Framework/PythonInterface/mantid/experimental/pythonapi.py
+++ b/Framework/PythonInterface/mantid/experimental/pythonapi.py
@@ -1,0 +1,39 @@
+import mantid
+
+
+def _pythonapi_create_algorithm_function_post_process_lhs_info(lhs):
+    modified_names = [ 'algorithm-internal-temporary_{}'.format(id(i)) for i in lhs[1] ]
+    return (lhs[0], modified_names)
+
+def _pythonapi_create_algorithm_function_get_initial_workspaces(args, kwargs):
+    initial_workspaces = {}
+    for i in list(args) + kwargs.values():
+        if isinstance(i, _api.Workspace):
+            name = 'algorithm-internal-temporary_{}'.format(id(i))
+            initial_workspaces[name] = i
+            _api.AnalysisDataService[name] = i
+    return initial_workspaces
+
+def _pythonapi_gather_returns_internal_get_workspace_from_ADS(value_str, output_workspaces):
+    ws = mantid.experimental.convert_weak_ptr_to_shared_ptr(_api.AnalysisDataService[value_str])
+    if value_str in output_workspaces:
+        mantid.experimental.swap_shared_ptrs(output_workspaces[value_str], ws)
+        retval = output_workspaces[value_str]
+    else:
+        retval = ws
+    del _api.AnalysisDataService[value_str]
+    return retval
+
+def _pythonapi_gather_returns_cleanup_workspaces(workspaces):
+    # Remove remaining temporary workspaces. Note that some may already have been deleted by _gather_returns, but ADS does not mind double deletes.
+    for i in workspaces.keys():
+        del _api.AnalysisDataService[i]
+
+
+mantid.simpleapi._create_algorithm_function_post_process_lhs_info = _pythonapi_create_algorithm_function_post_process_lhs_info
+mantid.simpleapi._create_algorithm_function_get_initial_workspaces = _pythonapi_create_algorithm_function_get_initial_workspaces
+mantid.simpleapi._gather_returns_internal_get_workspace_from_ADS = _pythonapi_gather_returns_internal_get_workspace_from_ADS
+mantid.simpleapi._gather_returns_cleanup_workspaces = _pythonapi_gather_returns_cleanup_workspaces
+
+
+globals().update(vars(mantid.simpleapi))

--- a/Framework/PythonInterface/mantid/experimental/src/Exports/PythonSmartPointerHelpers.cpp
+++ b/Framework/PythonInterface/mantid/experimental/src/Exports/PythonSmartPointerHelpers.cpp
@@ -1,0 +1,26 @@
+#include "MantidAPI/Workspace.h"
+
+#include <boost/python/def.hpp>
+#include <boost/weak_ptr.hpp>
+
+namespace {
+using namespace Mantid::API;
+boost::shared_ptr<Workspace>
+convertWeakToShared(const boost::weak_ptr<Workspace> &weak) {
+  return boost::shared_ptr<Workspace>(weak);
+}
+
+void swap(boost::shared_ptr<Workspace> &a, boost::shared_ptr<Workspace> &b) {
+  a.swap(b);
+}
+}
+
+void export_PythonSmartPointerHelpers() {
+  using namespace Mantid::API;
+  using namespace boost::python;
+
+  using boost::python::def;
+
+  def("convert_weak_ptr_to_shared_ptr", &::convertWeakToShared);
+  def("swap_shared_ptrs", &::swap);
+}

--- a/Framework/PythonInterface/mantid/experimental/src/experimental.cpp.in
+++ b/Framework/PythonInterface/mantid/experimental/src/experimental.cpp.in
@@ -1,0 +1,26 @@
+/*****************************************************************************************/
+/********** PLEASE NOTE! THIS FILE WAS AUTO-GENERATED FROM CMAKE.  ***********************/
+/********** Source = experimental.cpp.in *************************************************/
+/*****************************************************************************************/
+#include <boost/python/def.hpp>
+#include <boost/python/module.hpp>
+#include <boost/python/docstring_options.hpp>
+
+// See http://docs.scipy.org/doc/numpy/reference/c-api.array.html#PY_ARRAY_UNIQUE_SYMBOL
+#define PY_ARRAY_UNIQUE_SYMBOL EXPERIMENTAL_ARRAY_API
+#include <numpy/arrayobject.h>
+#include <boost/python/numeric.hpp>
+
+// Forward declare
+@EXPORT_DECLARE@
+
+BOOST_PYTHON_MODULE(_experimental)
+{
+  // Doc string options - User defined, python arguments, C++ call signatures
+  boost::python::docstring_options docstrings(true, true, false);
+  // Import numpy
+  _import_array();
+  boost::python::numeric::array::set_module_and_type("numpy", "ndarray");
+
+@EXPORT_FUNCTIONS@
+}

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -699,7 +699,7 @@ def _merge_keywords_with_lhs(keywords, lhs_args):
     final_keywords.update(keywords)
     return final_keywords
 
-def _gather_returns(func_name, lhs, algm_obj, ignore_regex=[]):
+def _gather_returns(func_name, lhs, algm_obj, ignore_regex=[], output_workspaces={}):
     """Gather the return values and ensure they are in the
        correct order as defined by the output properties and
        return them as a tuple. If their is a single return
@@ -736,7 +736,7 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=[]):
         if _is_workspace_property(prop):
             value_str = prop.valueAsStr
             try:
-                retvals.append(_api.AnalysisDataService[value_str])
+                retvals.append(_gather_returns_internal_get_workspace_from_ADS(value_str, output_workspaces))
             except KeyError:
                 if not prop.isOptional():
                     raise RuntimeError("Internal error. Output workspace property '%s' on algorithm '%s' has not been stored correctly."
@@ -748,6 +748,7 @@ def _gather_returns(func_name, lhs, algm_obj, ignore_regex=[]):
                 raise RuntimeError('Internal error. Unknown property type encountered. "%s" on algorithm "%s" is not understood by '
                        'Python. Please contact development team' % (name, algm_obj.name()))
 
+    _gather_returns_cleanup_workspaces(output_workspaces)
 
     nvals = len(retvals)
     nlhs = lhs[0]
@@ -813,6 +814,18 @@ def set_properties(alg_object, *args, **kwargs):
         else:
             alg_object.setProperty(key, value)
 
+def _create_algorithm_function_post_process_lhs_info(lhs):
+    return lhs
+
+def _create_algorithm_function_get_initial_workspaces(args, kwargs):
+    return {}
+
+def _gather_returns_internal_get_workspace_from_ADS(value_str, output_workspaces):
+    # output_workspaces is irrelevant for the default implementation.
+    return _api.AnalysisDataService[value_str]
+
+def _gather_returns_cleanup_workspaces(workspaces):
+    pass
 
 def _create_algorithm_function(name, version, algm_object):
     """
@@ -855,7 +868,10 @@ def _create_algorithm_function(name, version, algm_object):
         except KeyError:
             frame = None
 
+        output_workspaces = _create_algorithm_function_get_initial_workspaces(args, kwargs)
+
         lhs = _kernel.funcinspect.lhs_info(frame=frame)
+        lhs = _create_algorithm_function_post_process_lhs_info(lhs)
         lhs_args = _get_args_from_lhs(lhs, algm)
         final_keywords = _merge_keywords_with_lhs(kwargs, lhs_args)
         set_properties(algm, *args, **final_keywords)
@@ -868,7 +884,8 @@ def _create_algorithm_function(name, version, algm_object):
             else:
                 raise
 
-        return _gather_returns(name, lhs, algm)
+        return _gather_returns(name, lhs, algm, output_workspaces=output_workspaces)
+
     #enddef
     # Insert definition in to global dict
     algm_wrapper = _customise_func(algorithm_wrapper, name,

--- a/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory( kernel )
 add_subdirectory( geometry )
 add_subdirectory( api )
 add_subdirectory( dataobjects )
+add_subdirectory( experimental )
 
 set ( TEST_PY_FILES
   ImportModuleTest.py

--- a/Framework/PythonInterface/test/python/mantid/experimental/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/experimental/CMakeLists.txt
@@ -1,0 +1,12 @@
+##
+## mantid.experimental tests
+##
+set ( TEST_PY_FILES
+  pythonapiTest.py
+  simpleapiTest.py
+)
+
+check_tests_valid ( ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES} )
+
+# Prefix for test=PythonInterfaceExperimental
+pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR} PythonInterfaceExperimental ${TEST_PY_FILES} )

--- a/Framework/PythonInterface/test/python/mantid/experimental/pythonapiTest.py
+++ b/Framework/PythonInterface/test/python/mantid/experimental/pythonapiTest.py
@@ -1,0 +1,91 @@
+import unittest
+import mantid.experimental.pythonapi as mantid
+
+
+class TestPythonAPI(unittest.TestCase):
+
+    def test_inplace(self):
+        ws = mantid.CreateSampleWorkspace()
+        # Verify that CreateSampleWorkspace is still producing an input workspace
+        # with same values as used when computing 2.94020841 below.
+        self.assertAlmostEqual(ws.dataX(0)[0], 0.0)
+        old_id = id(ws)
+
+        mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws, Target='Energy')
+
+        # ConvertUnits is in-place, so ws is still the same
+        self.assertEqual(id(ws), old_id)
+        # And has new units
+        self.assertAlmostEqual(ws.dataX(0)[0], 2.94020841e+00)
+
+    def test_output_as_argument(self):
+        ws_in = mantid.CreateSampleWorkspace()
+        ws = mantid.CreateSampleWorkspace()
+        self.assertNotAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+
+        mantid.Rebin(InputWorkspace=ws_in, OutputWorkspace=ws, Params=2)
+
+        self.assertAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        self.assertEqual(len(mantid.AnalysisDataService), 0)
+
+    def test_output_as_lhs(self):
+        ws_in = mantid.CreateSampleWorkspace()
+        ws = mantid.CreateSampleWorkspace()
+        self.assertNotAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+
+        ws = mantid.Rebin(InputWorkspace=ws_in, Params=2)
+
+        self.assertAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        self.assertEqual(len(mantid.AnalysisDataService), 0)
+
+    def test_output_as_lhs_and_argument(self):
+        ws_in = mantid.CreateSampleWorkspace()
+        ws = mantid.CreateSampleWorkspace()
+        self.assertNotAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+
+        # Probably this should not be used, but Mantid supports it.
+        ws2 = mantid.Rebin(InputWorkspace=ws_in, OutputWorkspace=ws, Params=2)
+
+        self.assertAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        self.assertAlmostEqual(ws2.dataX(0)[1]-ws2.dataX(0)[0], 2.0)
+        self.assertEqual(len(mantid.AnalysisDataService), 0)
+
+    def test_in_equal_out(self):
+        ws = mantid.CreateSampleWorkspace()
+        self.assertNotAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+
+        mantid.Rebin(InputWorkspace=ws, OutputWorkspace=ws, Params=2)
+
+        self.assertAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        self.assertEqual(len(mantid.AnalysisDataService), 0)
+
+    def test_scope(self):
+        def scope():
+            # Creating workspace with same variable name
+            ws = mantid.CreateSampleWorkspace()
+            # Make sure it has not the same bin size
+            self.assertNotAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        ws_in = mantid.CreateSampleWorkspace()
+        ws = mantid.Rebin(InputWorkspace=ws_in, Params=2)
+        self.assertAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        scope()
+        # After calling the function, the original ws still exists and has
+        # its original bin size, as it should.
+        self.assertAlmostEqual(ws.dataX(0)[1]-ws.dataX(0)[0], 2.0)
+        self.assertEqual(len(mantid.AnalysisDataService), 0)
+
+    def test_python_container(self):
+        workspaces = []
+        for i in range(2):
+            ws = mantid.CreateSampleWorkspace()
+            ws = mantid.Rebin(InputWorkspace=ws, Params=1.0+i)
+            workspaces.append(ws)
+
+        for i in range(2):
+            # All workspaces still valid and in the state they were created in
+            self.assertAlmostEqual(workspaces[i].dataX(0)[1]-workspaces[i].dataX(0)[0], 1.0+i)
+        self.assertEqual(len(mantid.AnalysisDataService), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/experimental/simpleapiTest.py
+++ b/Framework/PythonInterface/test/python/mantid/experimental/simpleapiTest.py
@@ -1,0 +1,55 @@
+import unittest
+import mantid.simpleapi as simpleapi
+
+
+class TestSimpleAPI(unittest.TestCase):
+
+    def tearDown(self):
+        simpleapi.AnalysisDataService.clear()
+
+    def test_inplace(self):
+        ws = simpleapi.CreateSampleWorkspace()
+        # Verify that CreateSampleWorkspace is still producing an input workspace
+        # with same values as used when computing 2.94020841 below.
+        self.assertAlmostEqual(ws.dataX(0)[0], 0.0)
+        old_id = id(ws)
+        simpleapi.ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws, Target='Energy')
+        # ConvertUnits is in-place, so ws is still the same
+        self.assertEqual(id(ws), old_id)
+        # And has new units
+        self.assertAlmostEqual(ws.dataX(0)[0], 2.94020841e+00)
+
+    def test_output_silent_replace(self):
+        ws_in = simpleapi.CreateSampleWorkspace()
+        ws = simpleapi.CreateSampleWorkspace()
+        name = str(ws.name())
+        simpleapi.Rebin(InputWorkspace=ws_in, OutputWorkspace=ws, Params=2)
+        # Rebin makes a copy of ws_in and gives it the same name as ws. When
+        # that output is put in the ADS 'addOrReplace' is called, i.e., the
+        # original workspace it kicked out of the ADS. Since in simpleapi a
+        # Python workspace variable is a weak_ptr it es deleted.
+        # Note also that simpleapi does not update the raw pointer inside ws,
+        # i.e., ws does not point to the newly created output workspace either.
+        self.assertTrue(name in simpleapi.AnalysisDataService)
+        self.assertRaises(RuntimeError, ws.name)
+
+    def test_scope_violation(self):
+        def scope_violator():
+            # This implicitly write to a global variable (in the ADS) with name "ws".
+            ws = simpleapi.CreateSampleWorkspace()
+        ws = simpleapi.CreateSampleWorkspace()
+        scope_violator()
+        # ws still refers to the old object
+        self.assertRaises(RuntimeError, ws.name)
+
+    def test_python_container(self):
+        workspaces = []
+        for i in range(2):
+            ws = simpleapi.CreateSampleWorkspace()
+            workspaces.append(ws)
+        # Cannot use Mantid workspaces in Python container, risk of deletion.
+        self.assertRaises(RuntimeError, workspaces[0].name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#14685

This pull request is meant as a discussion platform for an alternative Python interface. For now it is probably quite incomplete, and this is just to get an idea what people think about this solution.

Basically this provides `mantid.experimental.pythonapi`. It should provide access to algorithms just like `simpleapi` does, but any workspace variable should behave like expected in Python. See the unit test for some examples.

I would be glad about input, e.g., about what cases I have not covered (I know about some special cases in `simpleapi.py` that I did not check yet, and there also might be issues with group workspaces), and about better ways to implement this (For example, I am unhappy about the `globals().update(vars(mantid.simpleapi))` call in `pythonapi.py`).
