### PR TITLE
MaskAngle now accepts group workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init,invalid-name
+﻿#pylint: disable=no-init,invalid-name
 import mantid.simpleapi
 import mantid.kernel
 import mantid.api
@@ -24,8 +24,9 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         return "Algorithm to mask detectors with scattering angles in a given interval (in degrees)."
 
     def PyInit(self):
-        self.declareProperty(mantid.api.WorkspaceProperty("Workspace", "",direction=mantid.kernel.Direction.Input,
-                                                          validator=mantid.api.InstrumentValidator()), "Input workspace")
+        self.declareProperty(mantid.api.WorkspaceProperty("Workspace", "",direction=mantid.kernel.Direction.Input),
+                             "Input workspace")
+
         angleValidator=mantid.kernel.FloatBoundedValidator()
         angleValidator.setBounds(0.,180.)
         self.declareProperty(name="MinAngle", defaultValue=0.0, validator=angleValidator,

--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -36,6 +36,22 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         self.declareProperty(mantid.kernel.IntArrayProperty(name="MaskedDetectors", direction=mantid.kernel.Direction.Output),
                              doc="List of detector masked, with scatterin angles between MinAngle and MaxAngle")
 
+    def validateInputs(self):
+        issues = dict()
+
+        ws = self.getProperty("Workspace").value
+
+        try:
+            if type(ws).__name__ == "WorkspaceGroup":
+                for w in ws:
+                    src = w.getInstrument().getSource().getPos()
+            else: 
+                source = ws.getInstrument().getSource().getPos()
+        except (RuntimeError, ValueError, AttributeError, TypeError):
+            issues["Workspace"] = "Workspace must have an associated instrument."
+   
+        return issues
+
     def PyExec(self):
         ws = self.getProperty("Workspace").value
         ttmin = self.getProperty("MinAngle").value

--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -44,12 +44,12 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         try:
             if type(ws).__name__ == "WorkspaceGroup":
                 for w in ws:
-                    src = w.getInstrument().getSource().getPos()
-            else: 
-                source = ws.getInstrument().getSource().getPos()
+                    w.getInstrument().getSource().getPos()
+            else:
+                ws.getInstrument().getSource().getPos()
         except (RuntimeError, ValueError, AttributeError, TypeError):
             issues["Workspace"] = "Workspace must have an associated instrument."
-   
+
         return issues
 
     def PyExec(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
@@ -1,4 +1,4 @@
-import unittest
+﻿import unittest
 from mantid.simpleapi import *
 from mantid.api import *
 from testhelpers import *
@@ -23,7 +23,7 @@ class MaskAngleTest(unittest.TestCase):
         try:
             MaskAngle(w1,10,20)
             self.fail("Should not have got here. Should throw because no instrument.")
-        except ValueError:
+        except (RuntimeError, ValueError):
             pass
         finally:
             DeleteWorkspace(w1)


### PR DESCRIPTION
Fixes #13979 

Release notes not updated
## Changes

A small change was made to the MaskAngle algorithm which allows it to accept group workspaces. This involved removing an unused input validator which creating the workspace property.
## Testing

Run the following script which should now go completion:

``` python
ws1 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=1, BankPixelWidth=1, BinWidth=10, Xmax=50)
ws2 = CreateSampleWorkspace(WorkspaceType="Histogram", NumBanks=1, BankPixelWidth=1, BinWidth=10, Xmax=50)
group = GroupWorkspaces([ws1, ws2])
MaskAngle(group, MinAngle=0, MaxAngle=1)
```
