### PR TITLE
Refs #14694 Fix 2D merge issue

### DIFF
--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-lines
+﻿#pylint: disable=too-many-lines
 #pylint: disable=invalid-name
 """
     This file defines what happens in each step in the data reduction, it's
@@ -2009,6 +2009,17 @@ class ConvertToQISIS(ReductionStep):
                 ReplaceSpecialValues(InputWorkspace=workspace,
                                      OutputWorkspace= workspace,
                                      NaNValue="0", InfinityValue="0")
+                # We need to correct for special values in the partial outputs. The
+                # counts seem to have NANS.
+                if self.outputParts:
+                    sum_of_counts = workspace + "_sumOfCounts"
+                    sum_of_norm = workspace + "_sumOfNormFactors"
+                    ReplaceSpecialValues(InputWorkspace = sum_of_counts,
+                                         OutputWorkspace = sum_of_counts,
+                                         NaNValue = "0", InfinityValue = "0")
+                    ReplaceSpecialValues(InputWorkspace = sum_of_norm,
+                                         OutputWorkspace = sum_of_norm,
+                                         NaNValue="0", InfinityValue="0")
             else:
                 raise NotImplementedError('The type of Q reduction has not been set, e.g. 1D or 2D')
         except:


### PR DESCRIPTION
 Fixes #14694
# For testing

Find the required files here: \olympic\Babylon5\Scratch\Anton\Investigation\RichardMerge
Make sure that the files are in the Mantid search path

Instrument: SANS2D
User file: USER_SANS2D_153O_2p4_4m_M3_Cosgrove_8mm_SampleCharger

Workspaces: 
             SANS   TRANS   Direct
Sample 33827  33838   33742
Can       33757  33763   33742
1. Open the ISIS SANS GUI and set the isntrument
2. Load the user file
3. Load the files (as above)
4. Go to the ReductionSettings tab and set DetectorBank to merged
5. On the Run Numbers tab press 2D reduce
6. When the reduction has completed open the merged output worksapce (contains the word `merged`)
   - Confirm that there are no NANs inside (especially on the left side of the table)
7. Right-click on the workspace and select `ColorFillPlot`
   - Confirm that you can see something for positions less than 0 in Axis1 direction(x direction on the graph)
