### PR TITLE
New RotateSource algorithm

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -58,7 +58,7 @@ set ( SRC_FILES
 	src/LoadLLB.cpp
 	src/LoadLog.cpp
 	src/LoadLogsForSNSPulsedMagnet.cpp
-        src/LoadMLZ.cpp
+	src/LoadMLZ.cpp
 	src/LoadMappingTable.cpp
 	src/LoadMask.cpp
 	src/LoadMcStas.cpp
@@ -112,6 +112,7 @@ set ( SRC_FILES
 	src/RemoveLogs.cpp
 	src/RenameLog.cpp
 	src/RotateInstrumentComponent.cpp
+	src/RotateSource.cpp
 	src/SNSDataArchive.cpp
 	src/SaveANSTOAscii.cpp
 	src/SaveAscii.cpp
@@ -217,7 +218,7 @@ set ( INC_FILES
 	inc/MantidDataHandling/LoadLLB.h
 	inc/MantidDataHandling/LoadLog.h
 	inc/MantidDataHandling/LoadLogsForSNSPulsedMagnet.h
-        inc/MantidDataHandling/LoadMLZ.h
+	inc/MantidDataHandling/LoadMLZ.h
 	inc/MantidDataHandling/LoadMappingTable.h
 	inc/MantidDataHandling/LoadMask.h
 	inc/MantidDataHandling/LoadMcStas.h
@@ -266,6 +267,7 @@ set ( INC_FILES
 	inc/MantidDataHandling/RemoveLogs.h
 	inc/MantidDataHandling/RenameLog.h
 	inc/MantidDataHandling/RotateInstrumentComponent.h
+	inc/MantidDataHandling/RotateSource.h
 	inc/MantidDataHandling/SNSDataArchive.h
 	inc/MantidDataHandling/SaveANSTOAscii.h
 	inc/MantidDataHandling/SaveAscii.h
@@ -369,7 +371,7 @@ set ( TEST_FILES
 	LoadIsawDetCalTest.h
 	LoadLLBTest.h
 	LoadLogTest.h
-        LoadMLZTest.h
+	LoadMLZTest.h
 	LoadMappingTableTest.h
 	LoadMaskTest.h
 	LoadMcStasNexusTest.h
@@ -417,6 +419,7 @@ set ( TEST_FILES
 	RemoveLogsTest.h
 	RenameLogTest.h
 	RotateInstrumentComponentTest.h
+	RotateSourceTest.h
 	SNSDataArchiveTest.h
 	SaveANSTOAsciiTest.h
 	SaveAscii2Test.h

--- a/Framework/DataHandling/inc/MantidDataHandling/RotateSource.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/RotateSource.h
@@ -6,7 +6,7 @@
 namespace Mantid {
 namespace DataHandling {
 
-/** RotateSource : TODO: DESCRIPTION
+/** RotateSource : Moves the source by a given angle
 
   Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source
@@ -29,10 +29,10 @@ namespace DataHandling {
   File change history is stored at: <https://github.com/mantidproject/mantid>
   Code Documentation is available at: <http://doxygen.mantidproject.org>
 */
-class MANTID_DATAHANDLING_DLL RotateSource : public API::Algorithm {
+class DLLExport RotateSource : public API::Algorithm {
 public:
-	RotateSource() {};
-	virtual ~RotateSource() {};
+  RotateSource(){};
+  virtual ~RotateSource(){};
 
   virtual const std::string name() const { return "RotateSource"; };
   virtual int version() const { return 1; };
@@ -40,7 +40,7 @@ public:
     return "DataHandling\\Instrument";
   };
   virtual const std::string summary() const {
-    return "Rotates the source around the specified axis by a given angle";
+    return "Rotates the source by a given angle";
   };
 
 private:

--- a/Framework/DataHandling/inc/MantidDataHandling/RotateSource.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/RotateSource.h
@@ -1,0 +1,54 @@
+#ifndef MANTID_DATAHANDLING_ROTATESOURCE_H_
+#define MANTID_DATAHANDLING_ROTATESOURCE_H_
+
+#include "MantidDataHandling/DllConfig.h"
+#include "MantidAPI/Algorithm.h"
+namespace Mantid {
+namespace DataHandling {
+
+/** RotateSource : TODO: DESCRIPTION
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class MANTID_DATAHANDLING_DLL RotateSource : public API::Algorithm {
+public:
+	RotateSource() {};
+	virtual ~RotateSource() {};
+
+  virtual const std::string name() const { return "RotateSource"; };
+  virtual int version() const { return 1; };
+  virtual const std::string category() const {
+    return "DataHandling\\Instrument";
+  };
+  virtual const std::string summary() const {
+    return "Rotates the source around the specified axis by a given angle";
+  };
+
+private:
+  void init();
+  void exec();
+};
+
+} // namespace DataHandling
+} // namespace Mantid
+
+#endif /* MANTID_DATAHANDLING_ROTATESOURCE_H_ */

--- a/Framework/DataHandling/inc/MantidDataHandling/RotateSource.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/RotateSource.h
@@ -6,7 +6,10 @@
 namespace Mantid {
 namespace DataHandling {
 
-/** RotateSource : Moves the source by a given angle
+/** RotateSource : Moves the source by a given angle taking into account the
+  handedness. The centre of rotation is the sample's position and the rotation
+  axis (X, Y, Z) is calculated from the instrument geometry as the axis
+  perpendicular to the plane defined by the beam and "up" vectors.
 
   Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
   National Laboratory & European Spallation Source

--- a/Framework/DataHandling/src/RotateSource.cpp
+++ b/Framework/DataHandling/src/RotateSource.cpp
@@ -1,0 +1,38 @@
+#include "MantidDataHandling/RotateSource.h"
+
+namespace Mantid {
+namespace DataHandling {
+
+using Mantid::Kernel::Direction;
+using Mantid::API::WorkspaceProperty;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(RotateSource)
+
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void RotateSource::init() {
+	// When used as a Child Algorithm the workspace name is not used - hence the
+	// "Anonymous" to satisfy the validator
+	declareProperty(new WorkspaceProperty<Workspace>("Workspace", "Anonymous",
+		Direction::InOut),
+		"The name of the workspace for which the new instrument "
+		"configuration will have an effect. Any other workspaces "
+		"stored in the analysis data service will be unaffected.");
+	declareProperty("X", 0.0, "The x-part of the rotation axis.");
+	declareProperty("Y", 0.0, "The y-part of the rotation axis.");
+	declareProperty("Z", 0.0, "The z-part of the rotation axis.");
+	declareProperty("Angle", 0.0, "The angle of rotation in degrees.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void RotateSource::exec() {
+  // TODO Auto-generated execute stub
+}
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/src/RotateSource.cpp
+++ b/Framework/DataHandling/src/RotateSource.cpp
@@ -1,37 +1,128 @@
 #include "MantidDataHandling/RotateSource.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidKernel/Quat.h"
+#include "MantidKernel/V3D.h"
 
 namespace Mantid {
 namespace DataHandling {
 
 using Mantid::Kernel::Direction;
+using Mantid::Kernel::Quat;
+using Mantid::Kernel::V3D;
 using Mantid::API::WorkspaceProperty;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(RotateSource)
 
+using namespace Geometry;
+using namespace API;
 
 //----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
  */
 void RotateSource::init() {
-	// When used as a Child Algorithm the workspace name is not used - hence the
-	// "Anonymous" to satisfy the validator
-	declareProperty(new WorkspaceProperty<Workspace>("Workspace", "Anonymous",
-		Direction::InOut),
-		"The name of the workspace for which the new instrument "
-		"configuration will have an effect. Any other workspaces "
-		"stored in the analysis data service will be unaffected.");
-	declareProperty("X", 0.0, "The x-part of the rotation axis.");
-	declareProperty("Y", 0.0, "The y-part of the rotation axis.");
-	declareProperty("Z", 0.0, "The z-part of the rotation axis.");
-	declareProperty("Angle", 0.0, "The angle of rotation in degrees.");
+
+  // When used as a Child Algorithm the workspace name is not used - hence the
+  // "Anonymous" to satisfy the validator
+  declareProperty(new WorkspaceProperty<Workspace>("Workspace", "Anonymous",
+                                                   Direction::InOut),
+                  "The name of the workspace for which the new instrument "
+                  "configuration will have an effect. Any other workspaces "
+                  "stored in the analysis data service will be unaffected.");
+  declareProperty("Angle", 0.0, "The angle of rotation in degrees.");
 }
 
 //----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
  */
 void RotateSource::exec() {
-  // TODO Auto-generated execute stub
+
+  // Get the input workspace
+  Workspace_sptr ws = getProperty("Workspace");
+
+  MatrixWorkspace_sptr inputW =
+      boost::dynamic_pointer_cast<MatrixWorkspace>(ws);
+  DataObjects::PeaksWorkspace_sptr inputP =
+      boost::dynamic_pointer_cast<DataObjects::PeaksWorkspace>(ws);
+
+  // Get some stuff from the input workspace
+  Instrument_const_sptr inst;
+  if (inputW) {
+    inst = inputW->getInstrument();
+    if (!inst)
+      throw std::runtime_error("Could not get a valid instrument from the "
+                               "MatrixWorkspace provided as input");
+  } else if (inputP) {
+    inst = inputP->getInstrument();
+    if (!inst)
+      throw std::runtime_error("Could not get a valid instrument from the "
+                               "PeaksWorkspace provided as input");
+  } else {
+    throw std::runtime_error("Input workspaces does not seem to be valid (must "
+                             "be either MatrixWorkspace or PeaksWorkspace)");
+  }
+
+  const double angle = getProperty("Angle");
+
+  if (angle != 0.) {
+
+    // Need the reference frame to decide around which axis to rotate
+    auto refFrame = inst->getReferenceFrame();
+
+    if (!refFrame) {
+      throw std::runtime_error("Could not get a valid reference frame");
+    }
+
+    auto pointingAlong = refFrame->pointingHorizontal();
+
+		// (x, y, z) -> the rotation axis
+    double x = 0.;
+    double y = 0.;
+    double z = 0.;
+
+    if (pointingAlong == X) {
+      x = 1.;
+    } else if (pointingAlong == Y) {
+      y = 1.;
+    } else if (pointingAlong == Z) {
+      z = 1.;
+    } else {
+      throw std::runtime_error("Could not get a valid rotation axis");
+    }
+
+    // Get the source's position
+    auto source = inst->getSource();
+		if (!source) {
+			throw std::runtime_error("Could not get the source's position");
+		}
+		// Get the sample's position
+    auto sample = inst->getSample();
+		if (!sample) {
+			throw std::runtime_error("Could not get the sample's position");
+		}
+    // The vector we want to rotate
+    auto sourcePos = source->getPos() - sample->getPos();
+
+    // The new position
+    Quat quat(angle, V3D(x, y, z));
+    quat.rotate(sourcePos);
+
+    // The source's name
+    std::string sourceName = source->getName();
+
+    // Move the source to the new location
+    auto move = this->createChildAlgorithm("MoveInstrumentComponent");
+    move->initialize();
+    move->setProperty("Workspace", ws);
+    move->setProperty("ComponentName", sourceName);
+    move->setProperty("X", sourcePos.X());
+    move->setProperty("Y", sourcePos.Y());
+    move->setProperty("Z", sourcePos.Z());
+    move->setProperty("RelativePosition", false);
+    move->execute();
+  }
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/RotateSource.cpp
+++ b/Framework/DataHandling/src/RotateSource.cpp
@@ -77,7 +77,7 @@ void RotateSource::exec() {
 
     auto pointingAlong = refFrame->pointingHorizontal();
 
-		// (x, y, z) -> the rotation axis
+    // (x, y, z) -> the rotation axis
     double x = 0.;
     double y = 0.;
     double z = 0.;
@@ -94,20 +94,22 @@ void RotateSource::exec() {
 
     // Get the source's position
     auto source = inst->getSource();
-		if (!source) {
-			throw std::runtime_error("Could not get the source's position");
-		}
-		// Get the sample's position
+    if (!source) {
+      throw std::runtime_error("Could not get the source's position");
+    }
+    // Get the sample's position
     auto sample = inst->getSample();
-		if (!sample) {
-			throw std::runtime_error("Could not get the sample's position");
-		}
+    if (!sample) {
+      throw std::runtime_error("Could not get the sample's position");
+    }
+    auto samplePos = sample->getPos();
     // The vector we want to rotate
-    auto sourcePos = source->getPos() - sample->getPos();
+    auto sourcePos = source->getPos() - samplePos;
 
     // The new position
     Quat quat(angle, V3D(x, y, z));
     quat.rotate(sourcePos);
+    sourcePos += samplePos;
 
     // The source's name
     std::string sourceName = source->getName();

--- a/Framework/DataHandling/src/RotateSource.cpp
+++ b/Framework/DataHandling/src/RotateSource.cpp
@@ -64,7 +64,7 @@ void RotateSource::exec() {
                              "be either MatrixWorkspace or PeaksWorkspace)");
   }
 
-  const double angle = getProperty("Angle");
+  double angle = getProperty("Angle");
 
   if (angle != 0.) {
 
@@ -90,6 +90,12 @@ void RotateSource::exec() {
       z = 1.;
     } else {
       throw std::runtime_error("Could not get a valid rotation axis");
+    }
+
+    // The handedness
+    auto handedness = refFrame->getHandedness();
+    if (handedness == Left) {
+      angle *= -1.;
     }
 
     // Get the source's position

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -64,7 +64,7 @@ public:
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
     TS_ASSERT_DELTA(newPos.X(), 0.0, 1E-5);
-    TS_ASSERT_DELTA(newPos.Y(), -1.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Y(), 1.0, 1E-5);
     TS_ASSERT_DELTA(newPos.Z(), 0.0, 1E-5);
   }
 
@@ -103,7 +103,7 @@ public:
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
     TS_ASSERT_DELTA(newPos.X(), 0.0, 1E-5);
-    TS_ASSERT_DELTA(newPos.Y(), 1.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Y(), -1.0, 1E-5);
     TS_ASSERT_DELTA(newPos.Z(), 0.0, 1E-5);
   }
 
@@ -112,7 +112,7 @@ public:
     // The instrument
     Instrument_sptr instr = boost::make_shared<Instrument>();
     instr->setReferenceFrame(
-        boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
+        boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Right, "")));
 
     // The source
     ObjComponent *source = new ObjComponent("source");
@@ -151,7 +151,7 @@ public:
     // The instrument
     Instrument_sptr instr = boost::make_shared<Instrument>();
     instr->setReferenceFrame(
-        boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
+        boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Right, "")));
 
     // The source
     ObjComponent *source = new ObjComponent("source");

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -1,0 +1,57 @@
+#ifndef MANTID_DATAHANDLING_ROTATESOURCETEST_H_
+#define MANTID_DATAHANDLING_ROTATESOURCETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidDataHandling/RotateSource.h"
+
+using Mantid::DataHandling::RotateSource;
+
+class RotateSourceTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static RotateSourceTest *createSuite() { return new RotateSourceTest(); }
+  static void destroySuite( RotateSourceTest *suite ) { delete suite; }
+
+
+  void test_Init()
+  {
+    RotateSource alg;
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+  }
+
+  void test_exec()
+  {
+    // Create test input if necessary
+    MatrixWorkspace_sptr inputWS = //-- Fill in appropriate code. Consider using TestHelpers/WorkspaceCreationHelpers.h --
+
+    RotateSource alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING( alg.initialize() )
+    TS_ASSERT( alg.isInitialized() )
+    TS_ASSERT_THROWS_NOTHING( alg.setProperty("InputWorkspace", inputWS) );
+    TS_ASSERT_THROWS_NOTHING( alg.setPropertyValue("OutputWorkspace", "_unused_for_child") );
+    TS_ASSERT_THROWS_NOTHING( alg.execute(); );
+    TS_ASSERT( alg.isExecuted() );
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+  
+  void test_Something()
+  {
+    TS_FAIL( "You forgot to write a test!");
+  }
+
+
+};
+
+
+#endif /* MANTID_DATAHANDLING_ROTATESOURCETEST_H_ */

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -63,9 +63,9 @@ public:
 
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
-    TS_ASSERT_DELTA(newPos.X(), 0);
-    TS_ASSERT_DELTA(newPos.Y(), -1);
-    TS_ASSERT_DELTA(newPos.Z(), 0);
+    TS_ASSERT_DELTA(newPos.X(), 0.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Y(), -1.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Z(), 0.0, 1E-5);
   }
 
   void testRotateCounterClockwise() {

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -63,9 +63,9 @@ public:
 
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
-    TS_ASSERT_EQUALS(newPos.X(), 0);
-    TS_ASSERT_EQUALS(newPos.Y(), -1);
-    TS_ASSERT_EQUALS(newPos.Z(), 0);
+    TS_ASSERT_DELTA(newPos.X(), 0);
+    TS_ASSERT_DELTA(newPos.Y(), -1);
+    TS_ASSERT_DELTA(newPos.Z(), 0);
   }
 
   void testRotateCounterClockwise() {
@@ -102,9 +102,9 @@ public:
 
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
-    TS_ASSERT_EQUALS(newPos.X(), 0);
-    TS_ASSERT_EQUALS(newPos.Y(), 1);
-    TS_ASSERT_EQUALS(newPos.Z(), 0);
+    TS_ASSERT_DELTA(newPos.X(), 0.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Y(), 1.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Z(), 0.0, 1E-5);
   }
 
   void testRotateClockwiseSampleAt001() {
@@ -141,9 +141,9 @@ public:
 
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
-    TS_ASSERT_EQUALS(newPos.X(), 0);
-    TS_ASSERT_EQUALS(newPos.Y(), -1);
-    TS_ASSERT_EQUALS(newPos.Z(), 1);
+    TS_ASSERT_DELTA(newPos.X(), 0.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Y(), -1.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Z(), 1.0, 1E-5);
   }
 
   void testRotateClockwiseSampleAt111() {
@@ -180,9 +180,9 @@ public:
 
     auto newPos = ws->getInstrument()->getSource()->getPos();
 
-    TS_ASSERT_EQUALS(newPos.X(), 1);
-    TS_ASSERT_EQUALS(newPos.Y(), 0);
-    TS_ASSERT_EQUALS(newPos.Z(), 1);
+    TS_ASSERT_DELTA(newPos.X(), 1.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Y(), 0.0, 1E-5);
+    TS_ASSERT_DELTA(newPos.Z(), 1.0, 1E-5);
   }
 };
 

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -107,6 +107,83 @@ public:
     TS_ASSERT_EQUALS(newPos.Z(), 0);
   }
 
+	void testRotateClockwiseSampleAt001() {
+
+		// The instrument
+		Instrument_sptr instr = boost::make_shared<Instrument>();
+		instr->setReferenceFrame(
+			boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
+
+		// The source
+		ObjComponent *source = new ObjComponent("source");
+		source->setPos(V3D(0, 0, 2));
+		instr->add(source);
+		instr->markAsSource(source);
+
+		// The sample
+		ObjComponent *sample = new ObjComponent("sample");
+		sample->setPos(V3D(0, 0, 1));
+		instr->add(sample);
+		instr->markAsSamplePos(sample);
+
+		// The workspace
+		auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 1);
+		ws->setInstrument(instr);
+		// The angle
+		double theta = 90.;
+
+		IAlgorithm_sptr alg = AlgorithmManager::Instance().create("RotateSource");
+		alg->setChild(true);
+		alg->setProperty("Workspace", ws);
+		alg->setProperty("Angle", theta);
+
+		TS_ASSERT_THROWS_NOTHING(alg->execute());
+
+		auto newPos = ws->getInstrument()->getSource()->getPos();
+
+		TS_ASSERT_EQUALS(newPos.X(), 0);
+		TS_ASSERT_EQUALS(newPos.Y(), -1);
+		TS_ASSERT_EQUALS(newPos.Z(), 1);
+	}
+
+	void testRotateClockwiseSampleAt111() {
+
+		// The instrument
+		Instrument_sptr instr = boost::make_shared<Instrument>();
+		instr->setReferenceFrame(
+			boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
+
+		// The source
+		ObjComponent *source = new ObjComponent("source");
+		source->setPos(V3D(1, 1, 2));
+		instr->add(source);
+		instr->markAsSource(source);
+
+		// The sample
+		ObjComponent *sample = new ObjComponent("sample");
+		sample->setPos(V3D(1, 1, 1));
+		instr->add(sample);
+		instr->markAsSamplePos(sample);
+
+		// The workspace
+		auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 1);
+		ws->setInstrument(instr);
+		// The angle
+		double theta = 90.;
+
+		IAlgorithm_sptr alg = AlgorithmManager::Instance().create("RotateSource");
+		alg->setChild(true);
+		alg->setProperty("Workspace", ws);
+		alg->setProperty("Angle", theta);
+
+		TS_ASSERT_THROWS_NOTHING(alg->execute());
+
+		auto newPos = ws->getInstrument()->getSource()->getPos();
+
+		TS_ASSERT_EQUALS(newPos.X(), 1);
+		TS_ASSERT_EQUALS(newPos.Y(), 0);
+		TS_ASSERT_EQUALS(newPos.Z(), 1);
+	}
 };
 
 #endif /* MANTID_DATAHANDLING_ROTATESOURCETEST_H_ */

--- a/Framework/DataHandling/test/RotateSourceTest.h
+++ b/Framework/DataHandling/test/RotateSourceTest.h
@@ -107,83 +107,83 @@ public:
     TS_ASSERT_EQUALS(newPos.Z(), 0);
   }
 
-	void testRotateClockwiseSampleAt001() {
+  void testRotateClockwiseSampleAt001() {
 
-		// The instrument
-		Instrument_sptr instr = boost::make_shared<Instrument>();
-		instr->setReferenceFrame(
-			boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
+    // The instrument
+    Instrument_sptr instr = boost::make_shared<Instrument>();
+    instr->setReferenceFrame(
+        boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
 
-		// The source
-		ObjComponent *source = new ObjComponent("source");
-		source->setPos(V3D(0, 0, 2));
-		instr->add(source);
-		instr->markAsSource(source);
+    // The source
+    ObjComponent *source = new ObjComponent("source");
+    source->setPos(V3D(0, 0, 2));
+    instr->add(source);
+    instr->markAsSource(source);
 
-		// The sample
-		ObjComponent *sample = new ObjComponent("sample");
-		sample->setPos(V3D(0, 0, 1));
-		instr->add(sample);
-		instr->markAsSamplePos(sample);
+    // The sample
+    ObjComponent *sample = new ObjComponent("sample");
+    sample->setPos(V3D(0, 0, 1));
+    instr->add(sample);
+    instr->markAsSamplePos(sample);
 
-		// The workspace
-		auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 1);
-		ws->setInstrument(instr);
-		// The angle
-		double theta = 90.;
+    // The workspace
+    auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 1);
+    ws->setInstrument(instr);
+    // The angle
+    double theta = 90.;
 
-		IAlgorithm_sptr alg = AlgorithmManager::Instance().create("RotateSource");
-		alg->setChild(true);
-		alg->setProperty("Workspace", ws);
-		alg->setProperty("Angle", theta);
+    IAlgorithm_sptr alg = AlgorithmManager::Instance().create("RotateSource");
+    alg->setChild(true);
+    alg->setProperty("Workspace", ws);
+    alg->setProperty("Angle", theta);
 
-		TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
 
-		auto newPos = ws->getInstrument()->getSource()->getPos();
+    auto newPos = ws->getInstrument()->getSource()->getPos();
 
-		TS_ASSERT_EQUALS(newPos.X(), 0);
-		TS_ASSERT_EQUALS(newPos.Y(), -1);
-		TS_ASSERT_EQUALS(newPos.Z(), 1);
-	}
+    TS_ASSERT_EQUALS(newPos.X(), 0);
+    TS_ASSERT_EQUALS(newPos.Y(), -1);
+    TS_ASSERT_EQUALS(newPos.Z(), 1);
+  }
 
-	void testRotateClockwiseSampleAt111() {
+  void testRotateClockwiseSampleAt111() {
 
-		// The instrument
-		Instrument_sptr instr = boost::make_shared<Instrument>();
-		instr->setReferenceFrame(
-			boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
+    // The instrument
+    Instrument_sptr instr = boost::make_shared<Instrument>();
+    instr->setReferenceFrame(
+        boost::shared_ptr<ReferenceFrame>(new ReferenceFrame(Y, Z, Left, "")));
 
-		// The source
-		ObjComponent *source = new ObjComponent("source");
-		source->setPos(V3D(1, 1, 2));
-		instr->add(source);
-		instr->markAsSource(source);
+    // The source
+    ObjComponent *source = new ObjComponent("source");
+    source->setPos(V3D(1, 1, 2));
+    instr->add(source);
+    instr->markAsSource(source);
 
-		// The sample
-		ObjComponent *sample = new ObjComponent("sample");
-		sample->setPos(V3D(1, 1, 1));
-		instr->add(sample);
-		instr->markAsSamplePos(sample);
+    // The sample
+    ObjComponent *sample = new ObjComponent("sample");
+    sample->setPos(V3D(1, 1, 1));
+    instr->add(sample);
+    instr->markAsSamplePos(sample);
 
-		// The workspace
-		auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 1);
-		ws->setInstrument(instr);
-		// The angle
-		double theta = 90.;
+    // The workspace
+    auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 1);
+    ws->setInstrument(instr);
+    // The angle
+    double theta = 90.;
 
-		IAlgorithm_sptr alg = AlgorithmManager::Instance().create("RotateSource");
-		alg->setChild(true);
-		alg->setProperty("Workspace", ws);
-		alg->setProperty("Angle", theta);
+    IAlgorithm_sptr alg = AlgorithmManager::Instance().create("RotateSource");
+    alg->setChild(true);
+    alg->setProperty("Workspace", ws);
+    alg->setProperty("Angle", theta);
 
-		TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
 
-		auto newPos = ws->getInstrument()->getSource()->getPos();
+    auto newPos = ws->getInstrument()->getSource()->getPos();
 
-		TS_ASSERT_EQUALS(newPos.X(), 1);
-		TS_ASSERT_EQUALS(newPos.Y(), 0);
-		TS_ASSERT_EQUALS(newPos.Z(), 1);
-	}
+    TS_ASSERT_EQUALS(newPos.X(), 1);
+    TS_ASSERT_EQUALS(newPos.Y(), 0);
+    TS_ASSERT_EQUALS(newPos.Z(), 1);
+  }
 };
 
 #endif /* MANTID_DATAHANDLING_ROTATESOURCETEST_H_ */

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -31,7 +31,7 @@ Usage
    print "Original position of the source: [%.1f, %.1f, %.1f]" % (sourcePos.X(), sourcePos.Y(), sourcePos.Z())
 
    # Move (rotate) the source around X axis
-   RotateSource(ws, 90)
+   RotateSource(ws, -90)
 
    # New positions
    samplePos = ws.getInstrument().getSample().getPos()

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -25,24 +25,28 @@ Usage
    ws = CreateSampleWorkspace()
 
    # Original positions
-   print "Original position of the sample", ws.getInstrument().getSample().getPos()
-   print "Original position of the source", ws.getInstrument().getSource().getPos()
+   samplePos = ws.getInstrument().getSample().getPos()
+   sourcePos = ws.getInstrument().getSource().getPos()
+   print "Original position of the sample: [%.1f, %.1f, %.1f]" % (samplePos.X(), samplePos.Y(), samplePos.Z())
+   print "Original position of the source: [%.1f, %.1f, %.1f]" % (sourcePos.X(), sourcePos.Y(), sourcePos.Z())
 
    # Move (rotate) the source around X axis
    RotateSource(ws, 90)
 
    # New positions
-   print "New position of the sample", ws.getInstrument().getSample().getPos()
-   print "New position of the source", ws.getInstrument().getSource().getPos()
+   samplePos = ws.getInstrument().getSample().getPos()
+   sourcePos = ws.getInstrument().getSource().getPos()
+   print "New position of the sample: [%.1f, %.1f, %.1f]" % (samplePos.X(), samplePos.Y(), samplePos.Z())
+   print "New position of the source: [%.1f, %.1f, %.1f]" % (sourcePos.X(), sourcePos.Y(), sourcePos.Z())
 
 Output:
 
 .. testoutput:: RotateSourceExample
 
-   Original position of the sample [0,0,0]
-   Original position of the source [0,0,-10]
-   New position of the sample [0,0,0]
-   New position of the source [0,10,0]
+   Original position of the sample: [0.0, 0.0, 0.0]
+   Original position of the source: [0.0, 0.0, -10.0]
+   New position of the sample: [0.0, 0.0, 0.0]
+   New position of the source: [0.0, 10.0, 0.0]
 
 .. categories::
 

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - RotateSource**
+
+.. testcode:: RotateSourceExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = RotateSource()
+
+   # Print the result
+   print "The output workspace has %i spectra" % wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: RotateSourceExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -10,35 +10,39 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+This algorithm corrects the source's position by rotating it around an axis centered at the sample.
+The rotation axis is perpendicular to the plane determined by the beam direction and the *up* direction.
 
 
 Usage
 -----
-..  Try not to use files in your examples,
-    but if you cannot avoid it then the (small) files must be added to
-    autotestdata\UsageData and the following tag unindented
-    .. include:: ../usagedata-note.txt
 
 **Example - RotateSource**
 
 .. testcode:: RotateSourceExample
 
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
+   # Create a workspace with a simple instrument
    ws = CreateSampleWorkspace()
 
-   wsOut = RotateSource()
+   # Original positions
+   print "Original position of the sample", ws.getInstrument().getSample().getPos()
+   print "Original position of the source", ws.getInstrument().getSource().getPos()
 
-   # Print the result
-   print "The output workspace has %i spectra" % wsOut.getNumberHistograms()
+   # Move (rotate) the source around X axis
+   RotateSource(ws, 90)
+
+   # New positions
+   print "New position of the sample", ws.getInstrument().getSample().getPos()
+   print "New position of the source", ws.getInstrument().getSource().getPos()
 
 Output:
 
 .. testoutput:: RotateSourceExample
 
-  The output workspace has ?? spectra
+   Original position of the sample [0,0,0]
+   Original position of the source [0,0,-10]
+   New position of the sample [0,0,0]
+   New position of the source [0,10,0]
 
 .. categories::
 

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -46,7 +46,7 @@ Output:
    Original position of the sample: [0.0, 0.0, 0.0]
    Original position of the source: [0.0, 0.0, -10.0]
    New position of the sample: [0.0, 0.0, 0.0]
-   New position of the source: [0.0, 10.0, 0.0]
+   New position of the source: [0.0, 10.0, -0.0]
 
 .. categories::
 

--- a/docs/source/algorithms/RotateSource-v1.rst
+++ b/docs/source/algorithms/RotateSource-v1.rst
@@ -12,6 +12,8 @@ Description
 
 This algorithm corrects the source's position by rotating it around an axis centered at the sample.
 The rotation axis is perpendicular to the plane determined by the beam direction and the *up* direction.
+The handedness of the coordinate system is considered to determine whether a positive/negative angle
+corresponds to a clockwise or counterclockwise rotation.
 
 
 Usage


### PR DESCRIPTION
Fixes #14684 

We need this algorithm to fix issue #14575. The new algorithm basically moves the source to the correct position given the incident theta, that is, it performs a rotation around an axis centered at the sample's position, this axis is perpendicular to the plane described by the beam and `up` vectors, both read from the instrument reference frame.

To test: I am not sure if this is the most general approach, I am assuming for instance that we always want to rotate the source around the sample, and that the rotation axis is perpendicular to the beam and the `up` vectors. Code review should be enough. Alternatively, if this algorithm is used in `ReflectometryReductionOne` before `ConvertUnits`, the correct `IvsQ` should be produced.

Release notes: not sure if we need to mention this in the release notes?
