### PR TITLE
Importing ReflTBL will now load it into processing table in one go

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/QtReflMainView.h
@@ -66,6 +66,7 @@ public:
   virtual void giveUserWarning(std::string prompt, std::string title);
   virtual void giveUserCritical(std::string prompt, std::string title);
   virtual void showAlgorithmDialog(const std::string &algorithm);
+  virtual void showImportDialog();
   virtual std::string requestNotebookPath();
 
   // Settings

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflMainView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Reflectometry/ReflMainView.h
@@ -11,84 +11,89 @@
 #include <set>
 #include <string>
 
-namespace MantidQt
-{
-  namespace CustomInterfaces
-  {
-    /** @class ReflMainView
+namespace MantidQt {
+namespace CustomInterfaces {
+/** @class ReflMainView
 
-    ReflMainView is the base view class for the Reflectometry Interface. It contains no QT specific functionality as that should be handled by a subclass.
+ReflMainView is the base view class for the Reflectometry Interface. It contains
+no QT specific functionality as that should be handled by a subclass.
 
-    Copyright &copy; 2011-14 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge National Laboratory & European Spallation Source
+Copyright &copy; 2011-14 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+National Laboratory & European Spallation Source
 
-    This file is part of Mantid.
+This file is part of Mantid.
 
-    Mantid is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 3 of the License, or
-    (at your option) any later version.
+Mantid is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
 
-    Mantid is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+Mantid is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-    File change history is stored at: <https://github.com/mantidproject/mantid>.
-    Code Documentation is available at: <http://doxygen.mantidproject.org>
-    */
+File change history is stored at: <https://github.com/mantidproject/mantid>.
+Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
 
-    class DLLExport ReflMainView
-    {
-    public:
-      ReflMainView() {};
-      virtual ~ReflMainView() {};
+class DLLExport ReflMainView {
+public:
+  ReflMainView(){};
+  virtual ~ReflMainView(){};
 
-      //Connect the model
-      virtual void showTable(QReflTableModel_sptr model) = 0;
-      virtual void showSearch(ReflSearchModel_sptr model) = 0;
+  // Connect the model
+  virtual void showTable(QReflTableModel_sptr model) = 0;
+  virtual void showSearch(ReflSearchModel_sptr model) = 0;
 
-      //Dialog/Prompt methods
-      virtual std::string askUserString(const std::string& prompt, const std::string& title, const std::string& defaultValue) = 0;
-      virtual bool askUserYesNo(std::string prompt, std::string title) = 0;
-      virtual void giveUserInfo(std::string prompt, std::string title) = 0;
-      virtual void giveUserWarning(std::string prompt, std::string title) = 0;
-      virtual void giveUserCritical(std::string prompt, std::string title) = 0;
-      virtual void showAlgorithmDialog(const std::string& algorithm) = 0;
-      virtual std::string requestNotebookPath() = 0;
+  // Dialog/Prompt methods
+  virtual std::string askUserString(const std::string &prompt,
+                                    const std::string &title,
+                                    const std::string &defaultValue) = 0;
+  virtual bool askUserYesNo(std::string prompt, std::string title) = 0;
+  virtual void giveUserInfo(std::string prompt, std::string title) = 0;
+  virtual void giveUserWarning(std::string prompt, std::string title) = 0;
+  virtual void giveUserCritical(std::string prompt, std::string title) = 0;
+  virtual void showAlgorithmDialog(const std::string &algorithm) = 0;
+  virtual void showImportDialog() = 0;
+  virtual std::string requestNotebookPath() = 0;
 
-      //Settings
-      virtual void saveSettings(const std::map<std::string,QVariant>& options) = 0;
-      virtual void loadSettings(std::map<std::string,QVariant>& options) = 0;
+  // Settings
+  virtual void saveSettings(const std::map<std::string, QVariant> &options) = 0;
+  virtual void loadSettings(std::map<std::string, QVariant> &options) = 0;
 
-      //Plotting
-      virtual void plotWorkspaces(const std::set<std::string>& workspaces) = 0;
+  // Plotting
+  virtual void plotWorkspaces(const std::set<std::string> &workspaces) = 0;
 
-      //Get status of the checkbox which dictates whether an ipython notebook is produced
-      virtual bool getEnableNotebook() = 0;
+  // Get status of the checkbox which dictates whether an ipython notebook is
+  // produced
+  virtual bool getEnableNotebook() = 0;
 
-      //Setter methods
-      virtual void setSelection(const std::set<int>& rows) = 0;
-      virtual void setTableList(const std::set<std::string>& tables) = 0;
-      virtual void setInstrumentList(const std::vector<std::string>& instruments, const std::string& defaultInstrument) = 0;
-      virtual void setOptionsHintStrategy(MantidQt::MantidWidgets::HintStrategy* hintStrategy) = 0;
-      virtual void setClipboard(const std::string& text) = 0;
-      virtual void setTransferMethods(const std::set<std::string>& methods) = 0;
+  // Setter methods
+  virtual void setSelection(const std::set<int> &rows) = 0;
+  virtual void setTableList(const std::set<std::string> &tables) = 0;
+  virtual void setInstrumentList(const std::vector<std::string> &instruments,
+                                 const std::string &defaultInstrument) = 0;
+  virtual void setOptionsHintStrategy(
+      MantidQt::MantidWidgets::HintStrategy *hintStrategy) = 0;
+  virtual void setClipboard(const std::string &text) = 0;
+  virtual void setTransferMethods(const std::set<std::string> &methods) = 0;
 
-      //Accessor methods
-      virtual std::set<int> getSelectedRows() const = 0;
-      virtual std::set<int> getSelectedSearchRows() const = 0;
-      virtual std::string getSearchInstrument() const = 0;
-      virtual std::string getProcessInstrument() const = 0;
-      virtual std::string getWorkspaceToOpen() const = 0;
-      virtual std::string getClipboard() const = 0;
-      virtual std::string getSearchString() const = 0;
-      virtual std::string getTransferMethod() const = 0;
+  // Accessor methods
+  virtual std::set<int> getSelectedRows() const = 0;
+  virtual std::set<int> getSelectedSearchRows() const = 0;
+  virtual std::string getSearchInstrument() const = 0;
+  virtual std::string getProcessInstrument() const = 0;
+  virtual std::string getWorkspaceToOpen() const = 0;
+  virtual std::string getClipboard() const = 0;
+  virtual std::string getSearchString() const = 0;
+  virtual std::string getTransferMethod() const = 0;
 
-      virtual boost::shared_ptr<IReflPresenter> getPresenter() const = 0;
-    };
-  }
+  virtual boost::shared_ptr<IReflPresenter> getPresenter() const = 0;
+};
+}
 }
 #endif

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -438,10 +438,19 @@ Show the user the dialog for an algorithm
 void QtReflMainView::showAlgorithmDialog(const std::string &algorithm) {
   std::stringstream pythonSrc;
   pythonSrc << "try:\n";
-  pythonSrc << "  " << algorithm << "Dialog()\n";
+  pythonSrc << "  algm = " << algorithm << "Dialog()\n";
+  if (algorithm == "LoadReflTBL") {
+    pythonSrc << "  print algm.getPropertyValue(\"OutputWorkspace\")\n";
+  }
   pythonSrc << "except:\n";
   pythonSrc << "  pass\n";
-  runPythonCode(QString::fromStdString(pythonSrc.str()));
+  //if we have LoadReflTBL then outputWorkspaceName will hold the name of the workspace
+  //otherwise this should be an empty string.
+  QString outputWorkspaceName = runPythonCode(QString::fromStdString(pythonSrc.str()), false);
+
+  if (algorithm == "LoadReflTBL") {
+    this->setModel(outputWorkspaceName.trimmed());
+  }
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -439,18 +439,25 @@ void QtReflMainView::showAlgorithmDialog(const std::string &algorithm) {
   std::stringstream pythonSrc;
   pythonSrc << "try:\n";
   pythonSrc << "  algm = " << algorithm << "Dialog()\n";
-  if (algorithm == "LoadReflTBL") {
-    pythonSrc << "  print algm.getPropertyValue(\"OutputWorkspace\")\n";
-  }
   pythonSrc << "except:\n";
   pythonSrc << "  pass\n";
-  //if we have LoadReflTBL then outputWorkspaceName will hold the name of the workspace
-  //otherwise this should be an empty string.
-  QString outputWorkspaceName = runPythonCode(QString::fromStdString(pythonSrc.str()), false);
+  runPythonCode(QString::fromStdString(pythonSrc.str()), false);
+}
 
-  if (algorithm == "LoadReflTBL") {
-    this->setModel(outputWorkspaceName.trimmed());
-  }
+void QtReflMainView::showImportDialog() {
+  std::stringstream pythonSrc;
+  pythonSrc << "try:\n";
+  pythonSrc << "  algm = "
+            << "LoadReflTBL"
+            << "Dialog()\n";
+  pythonSrc << "  print algm.getPropertyValue(\"OutputWorkspace\")\n";
+  pythonSrc << "except:\n";
+  pythonSrc << "  pass\n";
+  // outputWorkspaceName will hold the name of the workspace
+  // otherwise this should be an empty string.
+  QString outputWorkspaceName =
+      runPythonCode(QString::fromStdString(pythonSrc.str()), false);
+  this->setModel(outputWorkspaceName.trimmed());
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflMainViewPresenter.cpp
@@ -1250,9 +1250,7 @@ void ReflMainViewPresenter::openTable() {
 /**
 Import a table from TBL file
 */
-void ReflMainViewPresenter::importTable() {
-  m_view->showAlgorithmDialog("LoadReflTBL");
-}
+void ReflMainViewPresenter::importTable() { m_view->showImportDialog(); }
 
 /**
 Export a table to TBL file
@@ -1693,8 +1691,8 @@ ReflMainViewPresenter::getTransferStrategy() {
 
     // We are going to load from disk to pick up the meta data, so provide the
     // right repository to do this.
-    auto source =
-        std::unique_ptr<ReflMeasurementItemSource>(new ReflNexusMeasurementItemSource);
+    auto source = std::unique_ptr<ReflMeasurementItemSource>(
+        new ReflNexusMeasurementItemSource);
 
     // Finally make and return the Measure based transfer strategy.
     return std::unique_ptr<ReflTransferStrategy>(

--- a/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -40,6 +40,7 @@ public:
   MOCK_METHOD0(requestNotebookPath, std::string());
 
   MOCK_METHOD1(showAlgorithmDialog, void(const std::string&));
+  MOCK_METHOD1(showImportDialog, void());
   MOCK_METHOD1(plotWorkspaces, void(const std::set<std::string>&));
 
   //IO

--- a/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewMockObjects.h
@@ -40,7 +40,7 @@ public:
   MOCK_METHOD0(requestNotebookPath, std::string());
 
   MOCK_METHOD1(showAlgorithmDialog, void(const std::string&));
-  MOCK_METHOD1(showImportDialog, void());
+  MOCK_METHOD0(showImportDialog, void());
   MOCK_METHOD1(plotWorkspaces, void(const std::set<std::string>&));
 
   //IO

--- a/MantidQt/CustomInterfaces/test/ReflMainViewPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ReflMainViewPresenterTest.h
@@ -1531,7 +1531,7 @@ public:
     NiceMock<MockView> mockView;
     NiceMock<MockProgressableView> mockProgress;
     ReflMainViewPresenter presenter(&mockView, &mockProgress);
-    EXPECT_CALL(mockView, showAlgorithmDialog("LoadReflTBL"));
+    EXPECT_CALL(mockView, showImportDialog());
     presenter.notify(IReflPresenter::ImportTableFlag);
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(&mockView));


### PR DESCRIPTION
Previously users had to import the TBL file, which loaded it into the ADS, and then open the table so that it was present in the processing table. Now importing a TBL file will load the table into the ADS and the processing table in one go.

**Code Review**:
- This is currently done based on the string containing the algorithm name in `showAlgorithmDialog`
- if the the algorithm is `LoadReflTBL` then we bring in the loading functionality
- this `showAlgorithmDialog` function is used elsewhere with different algorithms in the MainView
- Could we possible introduce a second parameter to the method called `AdditionalCode` which will contain a string of code specific to running the `LoadReflTBL` algorithm?

**To Test**:
- Data can be found in `SampleData-ISIS`: the TBL file is `INTER_NR_test2.tbl`
- Go to Interfaces > Reflectometry > ISIS Reflectometry (Polref)
- Once the interface has loaded, go to `Reflectometry` on the menu bar
- Click `Import .TBL`
- Navigate to the `INTER_NR_test2.tbl` and give it an OutputWorkspace name
- Click `Load`
- Ensure the table is loaded straight into the Processing table (table on the right of the interface)

**Release Notes**:
http://www.mantidproject.org/Release_Notes_3_6_Reflectometry#Reflectometry_Reduction_Interface

Fixes #14557
