### PR TITLE
Fix color scale issue

### DIFF
--- a/Vates/VatesAPI/CMakeLists.txt
+++ b/Vates/VatesAPI/CMakeLists.txt
@@ -265,6 +265,7 @@ if( CXXTEST_FOUND AND GMOCK_FOUND AND GTEST_FOUND )
   ${Boost_LIBRARIES}
   ${JSONCPP_LIBRARIES}
   ${GMOCK_LIBRARIES} 
+  ${QWT_LIBRARIES}
   ${GTEST_LIBRARIES} )
   add_dependencies( AllTests VatesAPITest )
   # Add to the 'UnitTests' group in VS

--- a/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/StandardView.cpp
@@ -228,28 +228,37 @@ void StandardView::render()
   emit this->triggerAccept();
 }
 
-void StandardView::onCutButtonClicked()
-{
+void StandardView::onCutButtonClicked() {
   // Apply cut to currently viewed data
-  pqObjectBuilder* builder = pqApplicationCore::instance()->getObjectBuilder();
+  pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
   builder->createFilter("filters", "Cut", this->getPvActiveSrc());
+
+  // We need to attach the visibility listener to the newly
+  // created filter, this is required for automatic updating the color scale
+  setVisibilityListener();
 }
 
-void StandardView::onScaleButtonClicked()
-{
+void StandardView::onScaleButtonClicked() {
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
-  this->m_scaler = builder->createFilter("filters",
-                                       "MantidParaViewScaleWorkspace",
-                                       this->getPvActiveSrc());
+  this->m_scaler = builder->createFilter(
+      "filters", "MantidParaViewScaleWorkspace", this->getPvActiveSrc());
 
   /*
-   Paraview will try to set the respresentation to Outline. This is not good. Instead we listen for the
-   represnetation added as a result of the filter completion, and change the representation to be
+   Paraview will try to set the respresentation to Outline. This is not good.
+   Instead we listen for the
+   represnetation added as a result of the filter completion, and change the
+   representation to be
    Surface instead.
    */
-  QObject::connect(this->m_scaler, SIGNAL(representationAdded (pqPipelineSource *, pqDataRepresentation* , int)), this,
-                                          SLOT(onScaleRepresentationAdded(pqPipelineSource *, pqDataRepresentation* , int)));
+  QObject::connect(this->m_scaler,
+                   SIGNAL(representationAdded(pqPipelineSource *,
+                                              pqDataRepresentation *, int)),
+                   this, SLOT(onScaleRepresentationAdded(
+                             pqPipelineSource *, pqDataRepresentation *, int)));
 
+  // We need to attach the visibility listener to the newly
+  // created filter, this is required for automatic updating the color scale
+  setVisibilityListener();
 }
 
 /**


### PR DESCRIPTION
Fixes  #14692 
# For Testing

The sample data set can be found here: \olympic\Babylon5\Scratch\Anton\VSI\SAMPLE_WORKSPACES
The sample data set is  MDEvent_Osiris.nxs
1. Load the sample data set into the VSI. Make sure you are in the Standard View.
2. Apply a Scale filter, e.g. 2x in the x direction
3. Apply a cut filter.
4. Remove the cut filter
   - Confirm that the color scale for the data set looks the same as in 2). Note that the color scale was corrupted at this point previously.
