### PR TITLE
Add error bars to "corrected data" plot in ALC baseline fitting step

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingView.cpp
@@ -67,6 +67,7 @@ namespace CustomInterfaces
     m_fitCurve->attach(m_ui.dataPlot);
 
     m_correctedCurve->setStyle(QwtPlotCurve::NoCurve);
+    m_correctedCurve->setPen(QPen(Qt::green));
     m_correctedCurve->setSymbol(QwtSymbol(QwtSymbol::Ellipse, QBrush(), QPen(Qt::green), QSize(7,7)));
     m_correctedCurve->setRenderHint(QwtPlotItem::RenderAntialiased, true);
     m_correctedCurve->attach(m_ui.correctedPlot);
@@ -142,7 +143,7 @@ namespace CustomInterfaces
     }
     m_correctedErrorCurve =
         new MantidQt::MantidWidgets::ErrorCurve(m_correctedCurve, errors);
-    m_correctedErrorCurve->attach(m_ui.dataPlot);
+    m_correctedErrorCurve->attach(m_ui.correctedPlot);
 
     // Replot
     m_ui.correctedPlot->replot();


### PR DESCRIPTION
Resolves #14634 

Set error bars to be plotted on "corrected data" plot, and set pen colour for the curve so that they will be drawn in the same colour as the symbols (green).

To test:
- Open Interfaces -> Muon -> ALC
- Load "First" and "Last" data files (for example, MUSR 15189-15193 which can be found in the DocTest external files, or any other set of muon data files)
- Click "Load" button and then "Baseline modelling" to go to step 2
- Right-click on Sections and add a section. Right-click on Function and add a background function (e.g. flat background). Run the fit.
- Select the "Corrected data" tab on the tabbed plot on the right. Verify that the data points shown have error bars. Verify that the errors shown are the same ones as those shown on the next page (Peak fitting).

Release notes not updated as change is too minor.
