### PR TITLE
Fix warnings: clang-analyzer-security.FloatLoopCounter

### DIFF
--- a/Framework/Algorithms/src/ConvertEmptyToTof.cpp
+++ b/Framework/Algorithms/src/ConvertEmptyToTof.cpp
@@ -15,7 +15,6 @@
 #include <map>
 #include <numeric> // std::accumulate
 #include <utility> // std::pair
-#include <iterator>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/ConvertEmptyToTof.cpp
+++ b/Framework/Algorithms/src/ConvertEmptyToTof.cpp
@@ -15,6 +15,7 @@
 #include <map>
 #include <numeric> // std::accumulate
 #include <utility> // std::pair
+#include <iterator>
 
 namespace Mantid {
 namespace Algorithms {
@@ -269,20 +270,17 @@ void ConvertEmptyToTof::estimateFWHM(const Mantid::MantidVec &spec,
   size_t maxIndex =
       std::distance(spec.begin(), maxValueIt); // index of max value
 
-  // indices and values for the fwhm detection
-  size_t minFwhmIndex = maxIndex;
-  size_t maxFwhmIndex = maxIndex;
-  double minFwhmValue = maxValue;
-  double maxFwhmValue = maxValue;
-  // fwhm detection
-  for (; minFwhmValue > 0.5 * maxValue;
-       minFwhmIndex--, minFwhmValue = spec[minFwhmIndex]) {
-  }
-  for (; maxFwhmValue > 0.5 * maxValue;
-       maxFwhmIndex++, maxFwhmValue = spec[maxFwhmIndex]) {
-  }
+  auto minFwhmIt =
+      std::find_if(MantidVec::const_reverse_iterator(maxValueIt),
+                   MantidVec::const_reverse_iterator(spec.cbegin()),
+                   [maxValue](double value) { return value < 0.5 * maxValue; });
+  auto maxFwhmIt =
+      std::find_if(maxValueIt, spec.end(),
+                   [maxValue](double value) { return value < 0.5 * maxValue; });
+
   // double fwhm = thisSpecX[maxFwhmIndex] - thisSpecX[minFwhmIndex + 1];
-  double fwhm = static_cast<double>(maxFwhmIndex - minFwhmIndex + 1);
+  double fwhm =
+      static_cast<double>(std::distance(minFwhmIt.base(), maxFwhmIt) + 1);
 
   // parameters for the gaussian peak fit
   center = static_cast<double>(maxIndex);
@@ -294,13 +292,13 @@ void ConvertEmptyToTof::estimateFWHM(const Mantid::MantidVec &spec,
 
   // determination of the range used for the peak definition
   size_t ipeak_min = std::max(
-      static_cast<size_t>(0),
-      maxIndex - static_cast<size_t>(
-                     2.5 * static_cast<double>(maxIndex - maxFwhmIndex)));
+      std::size_t{0},
+      maxIndex - static_cast<size_t>(2.5 * static_cast<double>(std::distance(
+                                               maxValueIt, maxFwhmIt))));
   size_t ipeak_max = std::min(
       spec.size(),
-      maxIndex + static_cast<size_t>(
-                     2.5 * static_cast<double>(maxFwhmIndex - maxIndex)));
+      maxIndex + static_cast<size_t>(2.5 * static_cast<double>(std::distance(
+                                               maxFwhmIt, maxValueIt))));
   size_t i_delta_peak = ipeak_max - ipeak_min;
 
   g_log.debug() << "Peak estimate xmin/max: " << ipeak_min - 1 << "\t"

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -5,7 +5,6 @@
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include <stdexcept>
 #include <algorithm>
-#include <iostream>
 
 extern "C" {
 #include <gsl/gsl_errno.h>

--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -5,6 +5,7 @@
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include <stdexcept>
 #include <algorithm>
+#include <iostream>
 
 extern "C" {
 #include <gsl/gsl_errno.h>
@@ -2402,32 +2403,31 @@ std::vector<V3D> IndexingUtils::MakeHemisphereDirections(int n_steps) {
 
   double angle_step = M_PI / (2 * n_steps);
 
-  for (double phi = 0; phi <= (1.0001) * M_PI / 2.; phi += angle_step) {
+  for (int iPhi = 0; iPhi < n_steps + 1; ++iPhi) {
+    double phi = static_cast<double>(iPhi) * angle_step;
     double r = sin(phi);
 
     int n_theta = (int)(2. * M_PI * r / angle_step + 0.5);
 
     double theta_step;
-
-    if (n_theta == 0)              // n = ( 0, 1, 0 ).  Just
+    if (n_theta == 0) {            // n = ( 0, 1, 0 ).  Just
       theta_step = 2. * M_PI + 1.; // use one vector at the pole
-
-    else
+      n_theta = 1;
+    } else {
       theta_step = 2. * M_PI / n_theta;
+    }
 
-    double last_theta = 2. * M_PI - theta_step / 2.;
+    // use half the equator to avoid vectors that are the negatives of other
+    // vectors in the list.
+    if (fabs(phi - M_PI / 2.) < angle_step / 2.) {
+      n_theta /= 2;
+    }
 
-    if (fabs(phi - M_PI / 2.) <
-        angle_step / 2.)                   // use half the equator to avoid
-      last_theta = M_PI - theta_step / 2.; // vectors that are the negatives
-                                           // of other vectors in the list.
-
-    for (double theta = 0.; theta < last_theta; theta += theta_step) {
-      V3D direction(r * cos(theta), cos(phi), r * sin(theta));
-      direction_list.push_back(direction);
+    for (int jTheta = 0; jTheta < n_theta; ++jTheta) {
+      double theta = static_cast<double>(jTheta) * theta_step;
+      direction_list.emplace_back(r * cos(theta), cos(phi), r * sin(theta));
     }
   }
-
   return direction_list;
 }
 

--- a/Framework/TestHelpers/src/MDEventsTestHelper.cpp
+++ b/Framework/TestHelpers/src/MDEventsTestHelper.cpp
@@ -194,8 +194,8 @@ MDBox<MDLeanEvent<3>, 3> *makeMDBox3() {
  */
 std::vector<MDLeanEvent<1>> makeMDEvents1(size_t num) {
   std::vector<MDLeanEvent<1>> out;
-  for (double i = 0; i < num; i++) {
-    double coords[1] = {i * 1.0 + 0.5};
+  for (std::size_t i = 0; i < num; i++) {
+    double coords[1] = {static_cast<double>(i) * 1.0 + 0.5};
     out.push_back(MDLeanEvent<1>(1.0, 1.0, coords));
   }
   return out;

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -765,7 +765,7 @@ EventWorkspace_sptr CreateRandomEventWorkspace(size_t numbins, size_t numpixels,
   for (size_t i = 0; i < numpixels; i++) {
     // Create one event for each bin
     EventList &events = retVal->getEventList(static_cast<detid_t>(i));
-    for (double ie = 0; ie < numbins; ie++) {
+    for (std::size_t ie = 0; ie < numbins; ie++) {
       // Create a list of events, randomize
       events += TofEvent(std::rand(), std::rand());
     }

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -36,6 +36,11 @@ message (STATUS "Operating System: Mac OS X ${OSX_VERSION} (${OSX_CODENAME})")
 # Enable the use of the -isystem flag to mark headers in Third_Party as system headers
 set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
 
+execute_process(COMMAND python-config --prefix OUTPUT_VARIABLE PYTHON_PREFIX)
+string(STRIP ${PYTHON_PREFIX} PYTHON_PREFIX)
+set( PYTHON_LIBRARY "${PYTHON_PREFIX}/lib/libpython2.7.dylib" CACHE FILEPATH "PYTHON_LIBRARY")
+set( PYTHON_INCLUDE_DIR "${PYTHON_PREFIX}/include/python2.7" CACHE PATH "PYTHON_INCLUDE_DIR")
+
 ###########################################################################
 # Use the system-installed version of Python.
 ###########################################################################

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -36,11 +36,6 @@ message (STATUS "Operating System: Mac OS X ${OSX_VERSION} (${OSX_CODENAME})")
 # Enable the use of the -isystem flag to mark headers in Third_Party as system headers
 set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")
 
-execute_process(COMMAND python-config --prefix OUTPUT_VARIABLE PYTHON_PREFIX)
-string(STRIP ${PYTHON_PREFIX} PYTHON_PREFIX)
-set( PYTHON_LIBRARY "${PYTHON_PREFIX}/lib/libpython2.7.dylib" CACHE FILEPATH "PYTHON_LIBRARY")
-set( PYTHON_INCLUDE_DIR "${PYTHON_PREFIX}/include/python2.7" CACHE PATH "PYTHON_INCLUDE_DIR")
-
 ###########################################################################
 # Use the system-installed version of Python.
 ###########################################################################


### PR DESCRIPTION
This fixes clang-tidy warnings in the category [clang-analyzer-security.FloatLoopCounter](http://builds.mantidproject.org/view/Static%20Analysis/job/clang_tidy/31/warnings10Result/category.962972639/).

more information on [CERT: FLP30-C](https://www.securecoding.cert.org/confluence/display/c/FLP30-C.+Do+not+use+floating-point+variables+as+loop+counters)

No release notes.

testing: code review.
