### PR TITLE
Enable autoscaling in ALC (and other) data plots

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCDataLoadingView.cpp
@@ -179,6 +179,7 @@ ALCDataLoadingView::~ALCDataLoadingView() {
     m_dataErrorCurve =
         new MantidQt::MantidWidgets::ErrorCurve(m_dataCurve, errors);
     m_dataErrorCurve->attach(m_ui.dataPlot);
+    m_dataErrorCurve->setItemAttribute(QwtPlotItem::AutoScale, true);
 
     m_ui.dataPlot->replot();
   }

--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ErrorCurve.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/ErrorCurve.h
@@ -24,6 +24,7 @@ public:
   void draw(QPainter *painter, 
         const QwtScaleMap &xMap, const QwtScaleMap &yMap,
         const QRect &canvasRect) const;
+  QRectF boundingRect() const override;
 private:
 
   std::vector<double> m_x; ///< The x coordinates

--- a/MantidQt/MantidWidgets/src/ErrorCurve.cpp
+++ b/MantidQt/MantidWidgets/src/ErrorCurve.cpp
@@ -97,7 +97,8 @@ QRectF ErrorCurve::boundingRect() const {
   if (!m_e.empty()) {
     int n = dataSize();
     const double width = m_x[n - 1] - m_x[0];
-    double max = DBL_MIN, min = DBL_MAX;
+    double max = std::numeric_limits<double>::min();
+    double min = std::numeric_limits<double>::max();
     for (int i = 0; i < n; i++) {
       const double upper = m_y[i] + m_e[i];
       const double lower = m_y[i] - m_e[i];

--- a/MantidQt/MantidWidgets/src/ErrorCurve.cpp
+++ b/MantidQt/MantidWidgets/src/ErrorCurve.cpp
@@ -55,7 +55,7 @@ void ErrorCurve::draw(QPainter *painter,
   if (m_e.empty()) return;
   painter->save();
   painter->setPen(m_pen);
-  int n = static_cast<int>(m_x.size());
+  int n = dataSize();
   const int dx = 4;
 
   for (int i = 0; i < n; ++i)
@@ -84,6 +84,38 @@ void ErrorCurve::draw(QPainter *painter,
 int ErrorCurve::dataSize() const
 {
   return static_cast<int>(m_x.size());
+}
+
+/**
+ * Bounding rectangle of all points and error bars, used for autoscaling.
+ * For an empty series the rectangle is invalid, meaning autoscaler ignores it.
+ * @returns Bounding rectangle
+ */
+QRectF ErrorCurve::boundingRect() const {
+  // Default returns an invalid rect, like base class
+  QRectF rect = QRectF(1, 1, -2, -2);
+  if (!m_e.empty()) {
+    int n = dataSize();
+    const double width = m_x[n - 1] - m_x[0];
+    double max = DBL_MIN, min = DBL_MAX;
+    for (int i = 0; i < n; i++) {
+      const double upper = m_y[i] + m_e[i];
+      const double lower = m_y[i] - m_e[i];
+      if (upper > max) {
+        max = upper;
+      }
+      if (lower < min) {
+        min = lower;
+      }
+    }
+    const double height = max - min;
+    // On a graph, y increases from bottom to top.
+    // Coordinate system expects y to increase from top to bottom.
+    // That's why we set rect's "top left" to the bottom left
+    // (can't set a negative height or it won't autoscale).
+    rect.setRect(m_x[0], min, width, height);
+  }
+  return rect;
 }
 
 } // MantidWidgets


### PR DESCRIPTION
Resolves #14048 

Set autoscale to on in ALC, so that error bars are displayed correctly. 

For Qwt's autoscaler to work correctly with the ErrorCurve Mantid widget, the function boundingRect() has to be overridden to provide the bounding rectangle of all points and error bars. The default from the base class is to return an invalid rectangle, so no autoscaling.

ErrorCurve is also used in other places in Mantid, for example multi dataset fitting. 
- [x] Updated [release notes](http://www.mantidproject.org/Release_Notes_3_6_MuonAnalysis#Muon_ALC)

**To test:**
- Open Interfaces->Muon->ALC and load some data sets (for example HIFI00051636 - HIFI00051640 from the issue). Click Load and verify that the plot is scaled correctly. Compare to installed version of Mantid.
- It would be good to check that the change has not broken other areas where the ErrorCurve is used, e.g. test multi dataset fitting to make sure the graphs there look ok too.
