### PR TITLE
Indirect Data Analysis Remove autorun feature from JumpFit interface 

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/JumpFit.h
@@ -36,14 +36,16 @@ private slots:
   void fitAlgDone(bool error);
   /// Handles plotting fit result in MantidPlot
   void plotFitResult(bool error);
-  /// Handles running preview algorithm
-  void runPreviewAlgorithm();
   /// Handles a fit algorithm being selected
   void fitFunctionSelected(const QString &functionName);
+
 
 private:
   /// Gets a list of parameter names for a given fit function
   QStringList getFunctionParameters(const QString &functionName);
+
+  /// Clears the mini plot of data excluding sample
+  void clearPlot();
 
   // The UI form
   Ui::JumpFit m_uiForm;

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -104,12 +104,6 @@ void JumpFit::run() {
 }
 
 /**
- * Runs the JumpFit algorithm with preview parameters to update the preview
- * plot.
- */
-void JumpFit::runPreviewAlgorithm() { runImpl(); }
-
-/**
  * Runs algorithm.
  *
  * @param plot Enable/disable plotting
@@ -309,10 +303,6 @@ void JumpFit::handleSampleInputReady(const QString &filename) {
     m_uiForm.cbWidth->setEnabled(false);
     emit showMessageBox("Workspace doesn't appear to contain any width data");
   }
-
-  // Update preview plot
-  runPreviewAlgorithm();
-
 }
 
 /**
@@ -445,9 +435,6 @@ void JumpFit::fitFunctionSelected(const QString &functionName) {
     }
   }
 
-  // Don't run the algorithm when updating parameter values
-
-
   // Add new parameter elements
   QStringList parameters = getFunctionParameters(functionName);
   for (auto it = parameters.begin(); it != parameters.end(); ++it) {
@@ -457,7 +444,29 @@ void JumpFit::fitFunctionSelected(const QString &functionName) {
     m_properties["FitFunction"]->addSubProperty(m_properties[name]);
   }
 
-  runPreviewAlgorithm();
+  clearPlot();
+}
+
+/**
+ * clears the previous plot curves and readds sample
+ */
+void JumpFit::clearPlot() {
+  m_uiForm.ppPlot->clear();
+  const std::string sampleName =
+      m_uiForm.dsSample->getCurrentDataName().toStdString();
+  if (sampleName.compare("") != 0) {
+    MatrixWorkspace_sptr sample =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(sampleName);
+    if (sample && m_spectraList.size() > 0) {
+      m_uiForm.cbWidth->setEnabled(true);
+
+      std::string currentWidth = m_uiForm.cbWidth->currentText().toStdString();
+
+      m_uiForm.ppPlot->clear();
+      m_uiForm.ppPlot->addSpectrum("Sample", sample,
+                                   m_spectraList[currentWidth]);
+    }
+  }
 }
 
 } // namespace IDA

--- a/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/JumpFit.cpp
@@ -217,10 +217,6 @@ void JumpFit::fitAlgDone(bool error) {
       AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(
           paramTableName);
 
-  // Don't run the algorithm when updating parameter values
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(runPreviewAlgorithm()));
-
   for (auto it = m_properties.begin(); it != m_properties.end(); ++it) {
     QString propName(it.key());
     if (propName.startsWith("parameter_")) {
@@ -232,8 +228,6 @@ void JumpFit::fitAlgDone(bool error) {
     }
   }
 
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(runPreviewAlgorithm()));
 }
 
 /**
@@ -273,12 +267,6 @@ void JumpFit::loadSettings(const QSettings &settings) {
  * @param filename :: The name of the workspace to plot
  */
 void JumpFit::handleSampleInputReady(const QString &filename) {
-  // Disable things that run the preview algorithm
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(runPreviewAlgorithm()));
-  disconnect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString &)),
-             this, SLOT(runPreviewAlgorithm()));
-
   // Scale to convert to HWHM
   IAlgorithm_sptr scaleAlg = AlgorithmManager::Instance().create("Scale");
   scaleAlg->initialize();
@@ -325,11 +313,6 @@ void JumpFit::handleSampleInputReady(const QString &filename) {
   // Update preview plot
   runPreviewAlgorithm();
 
-  // Re-enable things that run the preview algorithm
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(runPreviewAlgorithm()));
-  connect(m_uiForm.cbWidth, SIGNAL(currentIndexChanged(const QString &)), this,
-          SLOT(runPreviewAlgorithm()));
 }
 
 /**
@@ -463,8 +446,7 @@ void JumpFit::fitFunctionSelected(const QString &functionName) {
   }
 
   // Don't run the algorithm when updating parameter values
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(runPreviewAlgorithm()));
+
 
   // Add new parameter elements
   QStringList parameters = getFunctionParameters(functionName);
@@ -474,9 +456,6 @@ void JumpFit::fitFunctionSelected(const QString &functionName) {
     m_dblManager->setValue(m_properties[name], 1.0);
     m_properties["FitFunction"]->addSubProperty(m_properties[name]);
   }
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(runPreviewAlgorithm()));
 
   runPreviewAlgorithm();
 }


### PR DESCRIPTION
Fixes #14671

The JumpFit interface should no longer automatically run when parameters are changed and when data is added.
# To Test
- Open JumpFit (Interfaces > Indirect >  Data Analysis > JumpFit)
- Load in the sample `irs26176_graphite002_result.nxs` available from `//olympic/Babylon5/Public/ElliotOram/DataAnalysis/JumpFit/IRIS/`
- Ensure that the curve for the sample is shown in the mini plot but not any other curves 
  - Ensure in the Result log that only `Load` and `Scale` are run.
- Click `Run` with the default settings.
  - Ensure that the algorithm runs without error
  - Ensure that a `Fit` and `Diff` curve are plotted in the mini plot
- Change the values for `Tau` and `L` in the parameter table
  - Ensure that when the values are changed the algorithm is not run automatically
- Click `Run` again (with the new Fitting Parameters)
  - Ensure that the plot is updated correctly
