### PR TITLE
Duplicated windows now copy data

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -8716,6 +8716,21 @@ MdiSubWindow *ApplicationWindow::clone(MdiSubWindow *w) {
       return NULL;
     QString caption = generateUniqueName(tr("Table"));
     nw = newTable(caption, t->numRows(), t->numCols());
+
+    Table *nt = dynamic_cast<Table *>(nw);
+
+    nt->setHeader(t->colNames());
+
+    Q3TableItem *io;
+
+    for (auto i = 0; i < nt->numCols(); i++) {
+      for (auto j = 0; j < nt->numRows(); j++) {
+        io = t->table()->item(j, i);
+        nt->table()->setItem(j, i, io);
+        // nt->table()->item(j, i)->setText(t->table()->item(j, i)->text());
+      }
+    }
+
   } else if (w->isA("Graph3D")) {
     Graph3D *g = dynamic_cast<Graph3D *>(w);
     if (!g)
@@ -10233,7 +10248,8 @@ void ApplicationWindow::showGraphContextMenu() {
 
     QAction *eventsNormMD = new QAction(tr("&Events"), &normMD);
     eventsNormMD->setCheckable(true);
-    connect(eventsNormMD, SIGNAL(activated()), ag, SLOT(numEventsNormalizationMD()));
+    connect(eventsNormMD, SIGNAL(activated()), ag,
+            SLOT(numEventsNormalizationMD()));
     normMD.addAction(eventsNormMD);
 
     int normalization = ag->normalizationMD();

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -4035,8 +4035,15 @@ void Graph::copy(Graph *g) {
   for (int i = 0; i < g->curves(); i++) {
     QwtPlotItem *it = dynamic_cast<QwtPlotItem *>(g->curve(i));
 
-    if (it == nullptr)
-      continue;
+	if (it == nullptr)
+	{
+		Spectrogram *s = g->spectrogram();
+		Spectrogram *s_cpy = s->copy();
+		s_cpy->setData(s->data());
+		s_cpy->setColorMapPen();
+		plotSpectrogram(s_cpy, (CurveType)g->curveType(i));
+		continue;
+	}
 
     if (it->rtti() == QwtPlotItem::Rtti_PlotUserItem) {
       MantidMatrixCurve *mmc = dynamic_cast<MantidMatrixCurve *>(it);

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -2,7 +2,8 @@
     File                 : Graph.cpp
     Project              : QtiPlot
     --------------------------------------------------------------------
-    Copyright            : (C) 2006 by Ion Vasilief, Tilman Hoener zu Siederdissen
+    Copyright            : (C) 2006 by Ion Vasilief, Tilman Hoener zu
+ Siederdissen
     Email (use @ for *)  : ion_vasilief*yahoo.fr, thzs*gmx.net
     Description          : Graph widget
 
@@ -109,23 +110,22 @@
 #include <stdio.h>
 #include <stddef.h>
 
-// We can safely ignore warnings about assuming signed overflow does not occur from qvector.h
+// We can safely ignore warnings about assuming signed overflow does not occur
+// from qvector.h
 // (They really should have implemented it with unsigned types!
 #if defined(__GNUC__) && !(defined(__INTEL_COMPILER))
- #pragma GCC diagnostic ignored "-Wstrict-overflow"
+#pragma GCC diagnostic ignored "-Wstrict-overflow"
 #endif
 
-namespace
-{
-  /// static logger
-  Mantid::Kernel::Logger g_log("Graph");
+namespace {
+/// static logger
+Mantid::Kernel::Logger g_log("Graph");
 }
 
-Graph::Graph(int x, int y, int width, int height, QWidget* parent, Qt::WFlags f)
-: QWidget(parent, f)
-{	
+Graph::Graph(int x, int y, int width, int height, QWidget *parent, Qt::WFlags f)
+    : QWidget(parent, f) {
   setWindowFlags(f);
-  n_curves=0;
+  n_curves = 0;
 
   d_waterfall_offset_x = 0;
   d_waterfall_offset_y = 0;
@@ -135,16 +135,16 @@ Graph::Graph(int x, int y, int width, int height, QWidget* parent, Qt::WFlags f)
   d_legend = NULL; // no legend for an empty graph
   d_peak_fit_tool = NULL;
   d_magnifier = NULL;
-  d_panner=NULL;
+  d_panner = NULL;
 #if QWT_VERSION >= 0x050200
   d_rescaler = NULL;
 #endif
 
-  widthLine=1;
-  selectedMarker=-1;
-  drawTextOn=false;
-  drawLineOn=false;
-  drawArrowOn=false;
+  widthLine = 1;
+  selectedMarker = -1;
+  drawTextOn = false;
+  drawLineOn = false;
+  drawArrowOn = false;
   ignoreResize = false;
   drawAxesBackbone = true;
   autoScaleFonts = false;
@@ -154,7 +154,7 @@ Graph::Graph(int x, int y, int width, int height, QWidget* parent, Qt::WFlags f)
   d_synchronize_scales = false;
 
   d_user_step = QVector<double>(QwtPlot::axisCnt);
-  for (int i=0; i<QwtPlot::axisCnt; i++)
+  for (int i = 0; i < QwtPlot::axisCnt; i++)
     d_user_step[i] = 0.0;
 
   setGeometry(x, y, width, height);
@@ -162,51 +162,63 @@ Graph::Graph(int x, int y, int width, int height, QWidget* parent, Qt::WFlags f)
   setAttribute(Qt::WA_DeleteOnClose, false);
 
   d_plot = new Plot(width, height, this);
-  connect (d_plot,SIGNAL(dragMousePress(QPoint)), this, SLOT(slotDragMousePress(QPoint)));
-  connect (d_plot,SIGNAL(dragMouseRelease(QPoint)), this, SLOT(slotDragMouseRelease(QPoint)));
-  connect (d_plot,SIGNAL(dragMouseMove(QPoint)), this, SLOT(slotDragMouseMove(QPoint)));
+  connect(d_plot, SIGNAL(dragMousePress(QPoint)), this,
+          SLOT(slotDragMousePress(QPoint)));
+  connect(d_plot, SIGNAL(dragMouseRelease(QPoint)), this,
+          SLOT(slotDragMouseRelease(QPoint)));
+  connect(d_plot, SIGNAL(dragMouseMove(QPoint)), this,
+          SLOT(slotDragMouseMove(QPoint)));
 
   cp = new CanvasPicker(this);
 
   titlePicker = new TitlePicker(d_plot);
   scalePicker = new ScalePicker(d_plot);
 
-  d_zoomer[0]= new QwtPlotZoomer(QwtPlot::xBottom, QwtPlot::yLeft,
-      QwtPicker::DragSelection | QwtPicker::CornerToCorner, QwtPicker::AlwaysOff, d_plot->canvas());
+  d_zoomer[0] =
+      new QwtPlotZoomer(QwtPlot::xBottom, QwtPlot::yLeft,
+                        QwtPicker::DragSelection | QwtPicker::CornerToCorner,
+                        QwtPicker::AlwaysOff, d_plot->canvas());
   d_zoomer[0]->setRubberBandPen(QPen(Qt::black));
-  d_zoomer[1] = new QwtPlotZoomer(QwtPlot::xTop, QwtPlot::yRight,
-      QwtPicker::DragSelection | QwtPicker::CornerToCorner,
-      QwtPicker::AlwaysOff, d_plot->canvas());
+  d_zoomer[1] =
+      new QwtPlotZoomer(QwtPlot::xTop, QwtPlot::yRight,
+                        QwtPicker::DragSelection | QwtPicker::CornerToCorner,
+                        QwtPicker::AlwaysOff, d_plot->canvas());
   zoom(false);
 
   c_type = QVector<int>();
   c_keys = QVector<int>();
 
   setFocusPolicy(Qt::StrongFocus);
-  //setFocusProxy(d_plot);
-  setMouseTracking(true );
+  // setFocusProxy(d_plot);
+  setMouseTracking(true);
 
+  connect(cp, SIGNAL(selectPlot()), this, SLOT(activateGraph()));
+  connect(cp, SIGNAL(viewImageDialog()), this, SIGNAL(viewImageDialog()));
+  connect(cp, SIGNAL(viewLineDialog()), this, SIGNAL(viewLineDialog()));
+  connect(cp, SIGNAL(showPlotDialog(int)), this, SIGNAL(showPlotDialog(int)));
+  connect(cp, SIGNAL(showMarkerPopupMenu()), this,
+          SIGNAL(showMarkerPopupMenu()));
+  connect(cp, SIGNAL(modified()), this, SIGNAL(modifiedGraph()));
 
-  connect (cp,SIGNAL(selectPlot()),this,SLOT(activateGraph()));
-  connect (cp,SIGNAL(viewImageDialog()),this,SIGNAL(viewImageDialog()));
-  connect (cp,SIGNAL(viewLineDialog()),this,SIGNAL(viewLineDialog()));
-  connect (cp,SIGNAL(showPlotDialog(int)),this,SIGNAL(showPlotDialog(int)));
-  connect (cp,SIGNAL(showMarkerPopupMenu()),this,SIGNAL(showMarkerPopupMenu()));
-  connect (cp,SIGNAL(modified()), this, SIGNAL(modifiedGraph()));
+  connect(titlePicker, SIGNAL(showTitleMenu()), this,
+          SLOT(showTitleContextMenu()));
+  connect(titlePicker, SIGNAL(doubleClicked()), this, SLOT(enableTextEditor()));
+  connect(titlePicker, SIGNAL(removeTitle()), this, SLOT(removeTitle()));
+  connect(titlePicker, SIGNAL(clicked()), this, SLOT(selectTitle()));
 
-  connect (titlePicker,SIGNAL(showTitleMenu()),this,SLOT(showTitleContextMenu()));
-  connect (titlePicker,SIGNAL(doubleClicked()),this, SLOT(enableTextEditor()));
-  connect (titlePicker,SIGNAL(removeTitle()),this,SLOT(removeTitle()));
-  connect (titlePicker,SIGNAL(clicked()), this,SLOT(selectTitle()));
+  connect(scalePicker, SIGNAL(clicked()), this, SLOT(activateGraph()));
+  connect(scalePicker, SIGNAL(clicked()), this, SLOT(deselectMarker()));
+  connect(scalePicker, SIGNAL(axisDblClicked(int)), this,
+          SIGNAL(axisDblClicked(int)));
+  connect(scalePicker, SIGNAL(axisTitleDblClicked()), this,
+          SLOT(enableTextEditor()));
+  connect(scalePicker, SIGNAL(axisTitleRightClicked()), this,
+          SLOT(showAxisTitleMenu()));
+  connect(scalePicker, SIGNAL(axisRightClicked(int)), this,
+          SLOT(showAxisContextMenu(int)));
 
-  connect (scalePicker,SIGNAL(clicked()),this,SLOT(activateGraph()));
-  connect (scalePicker,SIGNAL(clicked()),this,SLOT(deselectMarker()));
-  connect (scalePicker,SIGNAL(axisDblClicked(int)),this,SIGNAL(axisDblClicked(int)));
-  connect (scalePicker,SIGNAL(axisTitleDblClicked()), this, SLOT(enableTextEditor()));
-  connect (scalePicker,SIGNAL(axisTitleRightClicked()),this,SLOT(showAxisTitleMenu()));
-  connect (scalePicker,SIGNAL(axisRightClicked(int)),this,SLOT(showAxisContextMenu(int)));
-
-  connect (d_zoomer[0],SIGNAL(zoomed (const QwtDoubleRect &)),this,SLOT(zoomed (const QwtDoubleRect &)));
+  connect(d_zoomer[0], SIGNAL(zoomed(const QwtDoubleRect &)), this,
+          SLOT(zoomed(const QwtDoubleRect &)));
 
   m_isDistribution = false;
   m_normalizable = false;
@@ -215,24 +227,18 @@ Graph::Graph(int x, int y, int width, int height, QWidget* parent, Qt::WFlags f)
   m_normalizationMD = 0;
 }
 
-void Graph::notifyChanges()
-{
-  emit modifiedGraph();
-}
+void Graph::notifyChanges() { emit modifiedGraph(); }
 
-void Graph::activateGraph()
-{
+void Graph::activateGraph() {
   emit selectedGraph(this);
   setFocus();
 }
 
-MultiLayer * Graph::multiLayer()
-{
+MultiLayer *Graph::multiLayer() {
   return dynamic_cast<MultiLayer *>(this->parent()->parent()->parent());
 }
 
-void Graph::deselectMarker()
-{
+void Graph::deselectMarker() {
   selectedMarker = -1;
   if (d_markers_selector)
     delete d_markers_selector;
@@ -242,7 +248,7 @@ void Graph::deselectMarker()
   cp->disableEditing();
 
   QObjectList lst = d_plot->children();
-  foreach(QObject *o, lst) {
+  foreach (QObject *o, lst) {
     if (o->inherits("LegendWidget")) {
       LegendWidget *lw = dynamic_cast<LegendWidget *>(o);
       if (lw)
@@ -251,8 +257,7 @@ void Graph::deselectMarker()
   }
 }
 
-void Graph::enableTextEditor()
-{
+void Graph::enableTextEditor() {
   ApplicationWindow *app = multiLayer()->applicationWindow();
   if (!app)
     return;
@@ -265,30 +270,24 @@ void Graph::enableTextEditor()
     showAxisTitleDialog();
 }
 
-QList <LegendWidget *> Graph::textsList()
-{
-  QList <LegendWidget *> texts;
+QList<LegendWidget *> Graph::textsList() {
+  QList<LegendWidget *> texts;
   QObjectList lst = d_plot->children();
-  foreach(QObject *o, lst){
+  foreach (QObject *o, lst) {
     if (o->inherits("LegendWidget"))
       texts << dynamic_cast<LegendWidget *>(o);
   }
   return texts;
 }
 
-int Graph::selectedMarkerKey()
-{
-  return selectedMarker;
-}
+int Graph::selectedMarkerKey() { return selectedMarker; }
 
-QwtPlotMarker* Graph::selectedMarkerPtr()
-{
+QwtPlotMarker *Graph::selectedMarkerPtr() {
   return d_plot->marker(int(selectedMarker));
 }
 
-void Graph::setSelectedText(LegendWidget *l)
-{
-  if (l){
+void Graph::setSelectedText(LegendWidget *l) {
+  if (l) {
     selectTitle(false);
     scalePicker->deselect();
     deselectCurves();
@@ -298,10 +297,9 @@ void Graph::setSelectedText(LegendWidget *l)
   d_selected_text = l;
 }
 
-void Graph::setSelectedMarker(int _mrk, bool add)
-{
+void Graph::setSelectedMarker(int _mrk, bool add) {
   int mrk = int(_mrk);
-  if (mrk >= 0){
+  if (mrk >= 0) {
     selectTitle(false);
     scalePicker->deselect();
   }
@@ -337,12 +335,14 @@ void Graph::setSelectedMarker(int _mrk, bool add)
         return;
       }
 
-      connect(d_markers_selector, SIGNAL(targetsChanged()), this, SIGNAL(modifiedGraph()));
+      connect(d_markers_selector, SIGNAL(targetsChanged()), this,
+              SIGNAL(modifiedGraph()));
     }
   } else {
     if (d_lines.contains(mrk)) {
       if (d_markers_selector) {
-        if (d_markers_selector->contains(dynamic_cast<ArrowMarker *>(d_plot->marker(mrk))))
+        if (d_markers_selector->contains(
+                dynamic_cast<ArrowMarker *>(d_plot->marker(mrk))))
           return;
         delete d_markers_selector;
       }
@@ -352,7 +352,8 @@ void Graph::setSelectedMarker(int _mrk, bool add)
       d_markers_selector = new SelectionMoveResizer(am);
     } else if (d_images.contains(mrk)) {
       if (d_markers_selector) {
-        if (d_markers_selector->contains(dynamic_cast<ImageMarker *>(d_plot->marker(mrk))))
+        if (d_markers_selector->contains(
+                dynamic_cast<ImageMarker *>(d_plot->marker(mrk))))
           return;
         delete d_markers_selector;
       }
@@ -363,55 +364,49 @@ void Graph::setSelectedMarker(int _mrk, bool add)
     } else
       return;
 
-    connect(d_markers_selector, SIGNAL(targetsChanged()), this, SIGNAL(modifiedGraph()));
+    connect(d_markers_selector, SIGNAL(targetsChanged()), this,
+            SIGNAL(modifiedGraph()));
   }
 }
 
-void Graph::initFonts(const QFont &scaleTitleFnt, const QFont &numbersFnt)
-{
-  for (int i = 0;i<QwtPlot::axisCnt;i++)
-  {
-    d_plot->setAxisFont (i,numbersFnt);
-    QwtText t = d_plot->axisTitle (i);
-    t.setFont (scaleTitleFnt);
+void Graph::initFonts(const QFont &scaleTitleFnt, const QFont &numbersFnt) {
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    d_plot->setAxisFont(i, numbersFnt);
+    QwtText t = d_plot->axisTitle(i);
+    t.setFont(scaleTitleFnt);
     d_plot->setAxisTitle(i, t);
   }
 }
 
-void Graph::setAxisFont(int axis,const QFont &fnt)
-{
-  d_plot->setAxisFont (axis, fnt);
+void Graph::setAxisFont(int axis, const QFont &fnt) {
+  d_plot->setAxisFont(axis, fnt);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-QFont Graph::axisFont(int axis)
-{
-  return d_plot->axisFont (axis);
-}
+QFont Graph::axisFont(int axis) { return d_plot->axisFont(axis); }
 
-void Graph::enableAxis(int axis, bool on)
-{
+void Graph::enableAxis(int axis, bool on) {
   d_plot->enableAxis(axis, on);
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (scale)
     scale->setMargin(0);
 
   scalePicker->refresh();
 }
 
-void Graph::setAxisMargin(int axis, int margin)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+void Graph::setAxisMargin(int axis, int margin) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (scale)
     scale->setMargin(margin);
 }
 
-bool Graph::isColorBarEnabled(int axis) const
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
-  if (scale)
-  {
+bool Graph::isColorBarEnabled(int axis) const {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  if (scale) {
     return scale->isColorBarEnabled();
   }
   return false;
@@ -420,14 +415,13 @@ bool Graph::isColorBarEnabled(int axis) const
 *  @param axis the aixs to check e.g. yright ...
 *  @return true if there is a log scale on that axis
 */
-bool Graph::isLog(const QwtPlot::Axis& axis) const
-{
-  ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
-  return ( sc_engine && sc_engine->type() == ScaleTransformation::Log10 );
+bool Graph::isLog(const QwtPlot::Axis &axis) const {
+  ScaleEngine *sc_engine =
+      dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
+  return (sc_engine && sc_engine->type() == ScaleTransformation::Log10);
 }
 
-ScaleDraw::ScaleType Graph::axisType(int axis)
-{
+ScaleDraw::ScaleType Graph::axisType(int axis) {
   if (!d_plot->axisEnabled(axis))
     return ScaleDraw::Numeric;
 
@@ -438,51 +432,47 @@ ScaleDraw::ScaleType Graph::axisType(int axis)
     return ScaleDraw::Numeric;
 }
 
-void Graph::setLabelsNumericFormat(int axis, int format, int prec, const QString& formula)
-{
+void Graph::setLabelsNumericFormat(int axis, int format, int prec,
+                                   const QString &formula) {
   ScaleDraw *sd = new ScaleDraw(d_plot, formula.ascii());
   sd->setNumericFormat((ScaleDraw::NumericFormat)format);
   sd->setNumericPrecision(prec);
   sd->setScaleDiv(d_plot->axisScaleDraw(axis)->scaleDiv());
-  d_plot->setAxisScaleDraw (axis, sd);
+  d_plot->setAxisScaleDraw(axis, sd);
 }
 
-void Graph::setLabelsNumericFormat(const QStringList& l)
-{
-  for (int axis = 0; axis<4; axis++){
+void Graph::setLabelsNumericFormat(const QStringList &l) {
+  for (int axis = 0; axis < 4; axis++) {
     ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(axis));
     if (!sd || !sd->hasComponent(QwtAbstractScaleDraw::Labels))
       continue;
 
-    int aux = 2*axis;
-    setLabelsNumericFormat(axis, l[aux].toInt(), l[aux + 1].toInt(), sd->formula());
+    int aux = 2 * axis;
+    setLabelsNumericFormat(axis, l[aux].toInt(), l[aux + 1].toInt(),
+                           sd->formula());
   }
 }
 
-void Graph::enableAxisLabels(int axis, bool on)
-{
+void Graph::enableAxisLabels(int axis, bool on) {
   QwtScaleWidget *sc = d_plot->axisWidget(axis);
-  if (sc){
-    QwtScaleDraw *sd = d_plot->axisScaleDraw (axis);
-    sd->enableComponent (QwtAbstractScaleDraw::Labels, on);
+  if (sc) {
+    QwtScaleDraw *sd = d_plot->axisScaleDraw(axis);
+    sd->enableComponent(QwtAbstractScaleDraw::Labels, on);
   }
 }
 
-void Graph::setMajorTicksType(const QList<int>& lst)
-{
+void Graph::setMajorTicksType(const QList<int> &lst) {
   if (d_plot->getMajorTicksType() == lst)
     return;
 
-  for (int i=0;i<(int)lst.count();i++)
-  {
-    ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw (i));
+  for (int i = 0; i < (int)lst.count(); i++) {
+    ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(i));
     if (!sd)
       continue;
 
-    if (lst[i]==ScaleDraw::None || lst[i]==ScaleDraw::In)
-      sd->enableComponent (QwtAbstractScaleDraw::Ticks, false);
-    else
-    {
+    if (lst[i] == ScaleDraw::None || lst[i] == ScaleDraw::In)
+      sd->enableComponent(QwtAbstractScaleDraw::Ticks, false);
+    else {
       sd->enableComponent(QwtAbstractScaleDraw::Ticks);
       sd->setTickLength(QwtScaleDiv::MinorTick, d_plot->minorTickLength());
       sd->setTickLength(QwtScaleDiv::MediumTick, d_plot->minorTickLength());
@@ -492,41 +482,32 @@ void Graph::setMajorTicksType(const QList<int>& lst)
   }
 }
 
-void Graph::setMajorTicksType(const QStringList& lst)
-{
-  for (int i=0; i<(int)lst.count(); i++)
+void Graph::setMajorTicksType(const QStringList &lst) {
+  for (int i = 0; i < (int)lst.count(); i++)
     d_plot->setMajorTicksType(i, lst[i].toInt());
 }
 
-void Graph::setMinorTicksType(const QList<int>& lst)
-{
+void Graph::setMinorTicksType(const QList<int> &lst) {
   if (d_plot->getMinorTicksType() == lst)
     return;
 
-  for (int i=0;i<(int)lst.count();i++)
+  for (int i = 0; i < (int)lst.count(); i++)
     d_plot->setMinorTicksType(i, lst[i]);
 }
 
-void Graph::setMinorTicksType(const QStringList& lst)
-{
-  for (int i=0;i<(int)lst.count();i++)
-    d_plot->setMinorTicksType(i,lst[i].toInt());
+void Graph::setMinorTicksType(const QStringList &lst) {
+  for (int i = 0; i < (int)lst.count(); i++)
+    d_plot->setMinorTicksType(i, lst[i].toInt());
 }
 
-int Graph::minorTickLength()
-{
-  return d_plot->minorTickLength();
-}
+int Graph::minorTickLength() { return d_plot->minorTickLength(); }
 
-int Graph::majorTickLength()
-{
-  return d_plot->majorTickLength();
-}
+int Graph::majorTickLength() { return d_plot->majorTickLength(); }
 
 void Graph::setAxisTicksLength(int axis, int majTicksType, int minTicksType,
-    int minLength, int majLength)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+                               int minLength, int majLength) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (!scale)
     return;
 
@@ -540,31 +521,30 @@ void Graph::setAxisTicksLength(int axis, int majTicksType, int minTicksType,
   sd->setMinorTicksStyle((ScaleDraw::TicksStyle)minTicksType);
 
   if (majTicksType == ScaleDraw::None && minTicksType == ScaleDraw::None)
-    sd->enableComponent (QwtAbstractScaleDraw::Ticks, false);
+    sd->enableComponent(QwtAbstractScaleDraw::Ticks, false);
   else
-    sd->enableComponent (QwtAbstractScaleDraw::Ticks);
+    sd->enableComponent(QwtAbstractScaleDraw::Ticks);
 
   if (majTicksType == ScaleDraw::None || majTicksType == ScaleDraw::In)
     majLength = minLength;
   if (minTicksType == ScaleDraw::None || minTicksType == ScaleDraw::In)
     minLength = 0;
 
-  sd->setTickLength (QwtScaleDiv::MinorTick, minLength);
-  sd->setTickLength (QwtScaleDiv::MediumTick, minLength);
-  sd->setTickLength (QwtScaleDiv::MajorTick, majLength);
+  sd->setTickLength(QwtScaleDiv::MinorTick, minLength);
+  sd->setTickLength(QwtScaleDiv::MediumTick, minLength);
+  sd->setTickLength(QwtScaleDiv::MajorTick, majLength);
 }
 
-void Graph::setTicksLength(int minLength, int majLength)
-{
+void Graph::setTicksLength(int minLength, int majLength) {
   QList<int> majTicksType = d_plot->getMajorTicksType();
   QList<int> minTicksType = d_plot->getMinorTicksType();
 
-  for (int i=0; i<4; i++)
-    setAxisTicksLength (i, majTicksType[i], minTicksType[i], minLength, majLength);
+  for (int i = 0; i < 4; i++)
+    setAxisTicksLength(i, majTicksType[i], minTicksType[i], minLength,
+                       majLength);
 }
 
-void Graph::changeTicksLength(int minLength, int majLength)
-{
+void Graph::changeTicksLength(int minLength, int majLength) {
   if (d_plot->minorTickLength() == minLength &&
       d_plot->majorTickLength() == majLength)
     return;
@@ -572,12 +552,10 @@ void Graph::changeTicksLength(int minLength, int majLength)
   setTicksLength(minLength, majLength);
 
   d_plot->hide();
-  for (int i=0; i<4; i++)
-  {
-    if (d_plot->axisEnabled(i))
-    {
-      d_plot->enableAxis (i,false);
-      d_plot->enableAxis (i,true);
+  for (int i = 0; i < 4; i++) {
+    if (d_plot->axisEnabled(i)) {
+      d_plot->enableAxis(i, false);
+      d_plot->enableAxis(i, true);
     }
   }
   d_plot->replot();
@@ -586,16 +564,17 @@ void Graph::changeTicksLength(int minLength, int majLength)
   emit modifiedGraph();
 }
 
-void Graph::showAxis(int axis, int type, const QString& formatInfo, Table *table,
-    bool axisOn, int majTicksType, int minTicksType, bool labelsOn,
-    const QColor& c,  int format, int prec, int rotation, int baselineDist,
-    const QString& formula, const QColor& labelsColor)
-{
+void Graph::showAxis(int axis, int type, const QString &formatInfo,
+                     Table *table, bool axisOn, int majTicksType,
+                     int minTicksType, bool labelsOn, const QColor &c,
+                     int format, int prec, int rotation, int baselineDist,
+                     const QString &formula, const QColor &labelsColor) {
   d_plot->enableAxis(axis, axisOn);
   if (!axisOn)
     return;
 
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (!scale)
     return;
 
@@ -606,19 +585,16 @@ void Graph::showAxis(int axis, int type, const QString& formatInfo, Table *table
   QList<int> majTicksTypeList = d_plot->getMajorTicksType();
   QList<int> minTicksTypeList = d_plot->getMinorTicksType();
 
-  if (d_plot->axisEnabled (axis) == axisOn &&
+  if (d_plot->axisEnabled(axis) == axisOn &&
       majTicksTypeList[axis] == majTicksType &&
-      minTicksTypeList[axis] == minTicksType &&
-      axisColor(axis) == c &&
+      minTicksTypeList[axis] == minTicksType && axisColor(axis) == c &&
       axisLabelsColor(axis) == labelsColor &&
-      prec == d_plot->axisLabelPrecision (axis) &&
-      format == d_plot->axisLabelFormat (axis) &&
-      labelsRotation(axis) == rotation &&
-      (int)sd->scaleType() == type &&
-      sd->formatString() == formatInfo &&
-      sd->formula() == formula &&
+      prec == d_plot->axisLabelPrecision(axis) &&
+      format == d_plot->axisLabelFormat(axis) &&
+      labelsRotation(axis) == rotation && (int)sd->scaleType() == type &&
+      sd->formatString() == formatInfo && sd->formula() == formula &&
       scale->margin() == baselineDist &&
-      sd->hasComponent (QwtAbstractScaleDraw::Labels) == labelsOn)
+      sd->hasComponent(QwtAbstractScaleDraw::Labels) == labelsOn)
     return;
 
   scale->setMargin(baselineDist);
@@ -630,16 +606,16 @@ void Graph::showAxis(int axis, int type, const QString& formatInfo, Table *table
   scale->setPalette(pal);
 
   if (!labelsOn)
-    sd->enableComponent (QwtAbstractScaleDraw::Labels, false);
+    sd->enableComponent(QwtAbstractScaleDraw::Labels, false);
   else {
     if (type == ScaleDraw::Numeric)
       setLabelsNumericFormat(axis, format, prec, formula);
     else if (type == ScaleDraw::Day)
-      setLabelsDayFormat (axis, format);
+      setLabelsDayFormat(axis, format);
     else if (type == ScaleDraw::Month)
-      setLabelsMonthFormat (axis, format);
+      setLabelsMonthFormat(axis, format);
     else if (type == ScaleDraw::Time || type == ScaleDraw::Date)
-      setLabelsDateTimeFormat (axis, type, formatInfo);
+      setLabelsDateTimeFormat(axis, type, formatInfo);
     else
       setLabelsTextFormat(axis, type, formatInfo, table);
 
@@ -650,276 +626,256 @@ void Graph::showAxis(int axis, int type, const QString& formatInfo, Table *table
   sd->enableComponent(QwtAbstractScaleDraw::Backbone, drawAxesBackbone);
 
   setAxisTicksLength(axis, majTicksType, minTicksType,
-      d_plot->minorTickLength(), d_plot->majorTickLength());
+                     d_plot->minorTickLength(), d_plot->majorTickLength());
 
-  if (d_synchronize_scales && axisOn && (axis == QwtPlot::xTop || axis == QwtPlot::yRight))
-  {
-    updateSecondaryAxis(axis);//synchronize scale divisions
+  if (d_synchronize_scales && axisOn &&
+      (axis == QwtPlot::xTop || axis == QwtPlot::yRight)) {
+    updateSecondaryAxis(axis); // synchronize scale divisions
   }
 
   scalePicker->refresh();
-  d_plot->updateLayout();	//This is necessary in order to enable/disable tick labels
+  d_plot->updateLayout(); // This is necessary in order to enable/disable tick
+                          // labels
   scale->repaint();
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setLabelsDayFormat(int axis, int format)
-{
+void Graph::setLabelsDayFormat(int axis, int format) {
   ScaleDraw *sd = new ScaleDraw(d_plot);
   sd->setDayFormat((ScaleDraw::NameFormat)format);
   sd->setScaleDiv(d_plot->axisScaleDraw(axis)->scaleDiv());
-  d_plot->setAxisScaleDraw (axis, sd);
+  d_plot->setAxisScaleDraw(axis, sd);
 }
 
-void Graph::setLabelsMonthFormat(int axis, int format)
-{
+void Graph::setLabelsMonthFormat(int axis, int format) {
   ScaleDraw *sd = new ScaleDraw(d_plot);
   sd->setMonthFormat((ScaleDraw::NameFormat)format);
   sd->setScaleDiv(d_plot->axisScaleDraw(axis)->scaleDiv());
-  d_plot->setAxisScaleDraw (axis, sd);
+  d_plot->setAxisScaleDraw(axis, sd);
 }
 
-void Graph::setLabelsTextFormat(int axis, int type, const QString& name, const QStringList& lst)
-{
+void Graph::setLabelsTextFormat(int axis, int type, const QString &name,
+                                const QStringList &lst) {
   if (type != ScaleDraw::Text && type != ScaleDraw::ColHeader)
     return;
 
-  d_plot->setAxisScaleDraw(axis, new ScaleDraw(d_plot, lst, name, (ScaleDraw::ScaleType)type));
+  d_plot->setAxisScaleDraw(
+      axis, new ScaleDraw(d_plot, lst, name, (ScaleDraw::ScaleType)type));
 }
 
-void Graph::setLabelsTextFormat(int axis, int type, const QString& labelsColName, Table *table)
-{
+void Graph::setLabelsTextFormat(int axis, int type,
+                                const QString &labelsColName, Table *table) {
   if (type != ScaleDraw::Text && type != ScaleDraw::ColHeader)
     return;
 
   QStringList list = QStringList();
-  if (type == ScaleDraw::Text){
+  if (type == ScaleDraw::Text) {
     if (!table)
       return;
 
     int r = table->numRows();
     int col = table->colIndex(labelsColName);
-    for (int i=0; i < r; i++){
+    for (int i = 0; i < r; i++) {
       QString s = table->text(i, col);
       if (!s.isEmpty())
         list << s;
     }
-    d_plot->setAxisScaleDraw(axis, new ScaleDraw(d_plot, list, labelsColName, ScaleDraw::Text));
+    d_plot->setAxisScaleDraw(
+        axis, new ScaleDraw(d_plot, list, labelsColName, ScaleDraw::Text));
   } else if (type == ScaleDraw::ColHeader) {
     if (!table)
       return;
 
-    for (int i=0; i<table->numCols(); i++){
+    for (int i = 0; i < table->numCols(); i++) {
       if (table->colPlotDesignation(i) == Table::Y)
         list << table->colLabel(i);
     }
-    d_plot->setAxisScaleDraw(axis, new ScaleDraw(d_plot, list, table->objectName(), ScaleDraw::ColHeader));
+    d_plot->setAxisScaleDraw(
+        axis,
+        new ScaleDraw(d_plot, list, table->objectName(), ScaleDraw::ColHeader));
   }
 }
 
-void Graph::setLabelsDateTimeFormat(int axis, int type, const QString& formatInfo)
-{
+void Graph::setLabelsDateTimeFormat(int axis, int type,
+                                    const QString &formatInfo) {
   if (type < ScaleDraw::Time)
     return;
 
   QStringList list = formatInfo.split(";", QString::KeepEmptyParts);
-  if ((int)list.count() < 2)
-  {
-    QMessageBox::critical(this, tr("MantidPlot - Error"),
+  if ((int)list.count() < 2) {
+    QMessageBox::critical(
+        this, tr("MantidPlot - Error"),
         tr("Couldn't change the axis type to the requested format!"));
     return;
   }
-  if (list[0].isEmpty() || list[1].isEmpty())
-  {
-    QMessageBox::critical(this, tr("MantidPlot - Error"),
+  if (list[0].isEmpty() || list[1].isEmpty()) {
+    QMessageBox::critical(
+        this, tr("MantidPlot - Error"),
         tr("Couldn't change the axis type to the requested format!"));
     return;
   }
 
-  if (type == ScaleDraw::Time)
-  {
+  if (type == ScaleDraw::Time) {
     ScaleDraw *sd = new ScaleDraw(d_plot);
-    sd->setTimeFormat(QTime::fromString (list[0]), list[1]);
-    sd->enableComponent (QwtAbstractScaleDraw::Backbone, drawAxesBackbone);
-    d_plot->setAxisScaleDraw (axis, sd);
-  }
-  else if (type == ScaleDraw::Date)
-  {
+    sd->setTimeFormat(QTime::fromString(list[0]), list[1]);
+    sd->enableComponent(QwtAbstractScaleDraw::Backbone, drawAxesBackbone);
+    d_plot->setAxisScaleDraw(axis, sd);
+  } else if (type == ScaleDraw::Date) {
     ScaleDraw *sd = new ScaleDraw(d_plot);
-    sd->setDateFormat(QDateTime::fromString (list[0], Qt::ISODate), list[1]);
-    sd->enableComponent (QwtAbstractScaleDraw::Backbone, drawAxesBackbone);
-    d_plot->setAxisScaleDraw (axis, sd);
+    sd->setDateFormat(QDateTime::fromString(list[0], Qt::ISODate), list[1]);
+    sd->enableComponent(QwtAbstractScaleDraw::Backbone, drawAxesBackbone);
+    d_plot->setAxisScaleDraw(axis, sd);
   }
 }
 
-void Graph::setAxisLabelRotation(int axis, int rotation)
-{
-  if (axis==QwtPlot::xBottom)
-  {
+void Graph::setAxisLabelRotation(int axis, int rotation) {
+  if (axis == QwtPlot::xBottom) {
     if (rotation > 0)
-      d_plot->setAxisLabelAlignment(axis, Qt::AlignRight|Qt::AlignVCenter);
+      d_plot->setAxisLabelAlignment(axis, Qt::AlignRight | Qt::AlignVCenter);
     else if (rotation < 0)
-      d_plot->setAxisLabelAlignment(axis, Qt::AlignLeft|Qt::AlignVCenter);
+      d_plot->setAxisLabelAlignment(axis, Qt::AlignLeft | Qt::AlignVCenter);
     else if (rotation == 0)
-      d_plot->setAxisLabelAlignment(axis, Qt::AlignHCenter|Qt::AlignBottom);
-  }
-  else if (axis==QwtPlot::xTop)
-  {
+      d_plot->setAxisLabelAlignment(axis, Qt::AlignHCenter | Qt::AlignBottom);
+  } else if (axis == QwtPlot::xTop) {
     if (rotation > 0)
-      d_plot->setAxisLabelAlignment(axis, Qt::AlignLeft|Qt::AlignVCenter);
+      d_plot->setAxisLabelAlignment(axis, Qt::AlignLeft | Qt::AlignVCenter);
     else if (rotation < 0)
-      d_plot->setAxisLabelAlignment(axis, Qt::AlignRight|Qt::AlignVCenter);
+      d_plot->setAxisLabelAlignment(axis, Qt::AlignRight | Qt::AlignVCenter);
     else if (rotation == 0)
-      d_plot->setAxisLabelAlignment(axis, Qt::AlignHCenter|Qt::AlignTop);
+      d_plot->setAxisLabelAlignment(axis, Qt::AlignHCenter | Qt::AlignTop);
   }
-  d_plot->setAxisLabelRotation (axis, (double)rotation);
+  d_plot->setAxisLabelRotation(axis, (double)rotation);
 }
 
-int Graph::labelsRotation(int axis)
-{
+int Graph::labelsRotation(int axis) {
   ScaleDraw *sclDraw = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(axis));
   return (int)sclDraw->labelRotation();
 }
 
-void Graph::setAxisTitleFont(int axis,const QFont &fnt)
-{
-  QwtText t = d_plot->axisTitle (axis);
-  t.setFont (fnt);
+void Graph::setAxisTitleFont(int axis, const QFont &fnt) {
+  QwtText t = d_plot->axisTitle(axis);
+  t.setFont(fnt);
   d_plot->setAxisTitle(axis, t);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-QFont Graph::axisTitleFont(int axis)
-{
-  return d_plot->axisTitle(axis).font();
-}
+QFont Graph::axisTitleFont(int axis) { return d_plot->axisTitle(axis).font(); }
 
-QColor Graph::axisTitleColor(int axis)
-{
+QColor Graph::axisTitleColor(int axis) {
   QColor c;
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (scale)
     c = scale->title().color();
   return c;
 }
 
-void Graph::setAxisLabelsColor(int axis, const QColor& color)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
-  if (scale){
+void Graph::setAxisLabelsColor(int axis, const QColor &color) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  if (scale) {
     QPalette pal = scale->palette();
     pal.setColor(QColorGroup::Text, color);
     scale->setPalette(pal);
   }
 }
 
-void Graph::setAxisColor(int axis, const QColor& color)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
-  if (scale){
+void Graph::setAxisColor(int axis, const QColor &color) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  if (scale) {
     QPalette pal = scale->palette();
     pal.setColor(QColorGroup::Foreground, color);
     scale->setPalette(pal);
   }
 }
 
-QColor Graph::axisColor(int axis)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+QColor Graph::axisColor(int axis) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (scale)
     return scale->palette().color(QPalette::Active, QColorGroup::Foreground);
   else
     return QColor(Qt::black);
 }
 
-QColor Graph::axisLabelsColor(int axis)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+QColor Graph::axisLabelsColor(int axis) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
   if (scale)
     return scale->palette().color(QPalette::Active, QColorGroup::Text);
   else
     return QColor(Qt::black);
 }
 
-void Graph::setTitleColor(const QColor & c)
-{
+void Graph::setTitleColor(const QColor &c) {
   QwtText t = d_plot->title();
   t.setColor(c);
-  d_plot->setTitle (t);
+  d_plot->setTitle(t);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setTitleAlignment(int align)
-{
+void Graph::setTitleAlignment(int align) {
   QwtText t = d_plot->title();
   t.setRenderFlags(static_cast<int>(align));
-  d_plot->setTitle (t);
+  d_plot->setTitle(t);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setTitleFont(const QFont &fnt)
-{
+void Graph::setTitleFont(const QFont &fnt) {
   QwtText t = d_plot->title();
   t.setFont(fnt);
-  d_plot->setTitle (t);
+  d_plot->setTitle(t);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setYAxisTitle(const QString& text)
-{
+void Graph::setYAxisTitle(const QString &text) {
   d_plot->setAxisTitle(QwtPlot::yLeft, text);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setXAxisTitle(const QString& text)
-{
+void Graph::setXAxisTitle(const QString &text) {
   d_plot->setAxisTitle(QwtPlot::xBottom, text);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setRightAxisTitle(const QString& text)
-{
+void Graph::setRightAxisTitle(const QString &text) {
   d_plot->setAxisTitle(QwtPlot::yRight, text);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::setTopAxisTitle(const QString& text)
-{
+void Graph::setTopAxisTitle(const QString &text) {
   d_plot->setAxisTitle(QwtPlot::xTop, text);
   d_plot->replot();
   emit modifiedGraph();
 }
 
-int Graph::axisTitleAlignment (int axis)
-{
+int Graph::axisTitleAlignment(int axis) {
   return d_plot->axisTitle(axis).renderFlags();
 }
 
-void Graph::setAxisTitleAlignment(int axis, int align)
-{
+void Graph::setAxisTitleAlignment(int axis, int align) {
   QwtText t = d_plot->axisTitle(axis);
   t.setRenderFlags(align);
-  d_plot->setAxisTitle (axis, t);
+  d_plot->setAxisTitle(axis, t);
 }
 
-int Graph::axisTitleDistance(int axis)
-{
+int Graph::axisTitleDistance(int axis) {
   if (!d_plot->axisEnabled(axis))
     return 0;
 
   return d_plot->axisWidget(axis)->spacing();
 }
 
-void Graph::setAxisTitleDistance(int axis, int dist)
-{
+void Graph::setAxisTitleDistance(int axis, int dist) {
   if (!d_plot->axisEnabled(axis))
     return;
 
@@ -928,31 +884,27 @@ void Graph::setAxisTitleDistance(int axis, int dist)
     scale->setSpacing(dist);
 }
 
-
-void Graph::setScaleTitle(int axis, const QString& text)
-{
+void Graph::setScaleTitle(int axis, const QString &text) {
   int a = 0;
-  switch (axis)
-  {
+  switch (axis) {
   case 0:
-    a=2;
+    a = 2;
     break;
   case 1:
-    a=0;
+    a = 0;
     break;
   case 2:
-    a=3;
+    a = 3;
     break;
   case 3:
-    a=1;
+    a = 1;
     break;
   }
   d_plot->setAxisTitle(a, text);
 }
 
-void Graph::setAxisTitle(int axis, const QString& text)
-{
-  if (text.isEmpty())//avoid empty titles due to plot layout behavior
+void Graph::setAxisTitle(int axis, const QString &text) {
+  if (text.isEmpty()) // avoid empty titles due to plot layout behavior
     d_plot->setAxisTitle(axis, " ");
   else
     d_plot->setAxisTitle(axis, text);
@@ -961,21 +913,20 @@ void Graph::setAxisTitle(int axis, const QString& text)
   emit modifiedGraph();
 }
 
-void Graph::updateSecondaryAxis(int axis)
-{
-  for (int i=0; i<n_curves; i++){
+void Graph::updateSecondaryAxis(int axis) {
+  for (int i = 0; i < n_curves; i++) {
     QwtPlotItem *it = plotItem(i);
     if (!it)
       continue;
 
-    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram){
+    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
       Spectrogram *sp = dynamic_cast<Spectrogram *>(it);
       if (!sp || sp->colorScaleAxis() == axis)
         return;
     }
 
     if ((axis == QwtPlot::yRight && it->yAxis() == QwtPlot::yRight) ||
-        (axis == QwtPlot::xTop && it->xAxis () == QwtPlot::xTop))
+        (axis == QwtPlot::xTop && it->xAxis() == QwtPlot::xTop))
       return;
   }
 
@@ -986,66 +937,62 @@ void Graph::updateSecondaryAxis(int axis)
   if (!d_plot->axisEnabled(a))
     return;
 
-  ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
+  ScaleEngine *sc_engine =
+      dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
   if (sc_engine) {
-    if (ScaleEngine *a_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(a))) {
+    if (ScaleEngine *a_engine =
+            dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(a))) {
       sc_engine->clone(a_engine);
     }
   }
 
   /*QwtScaleEngine *qwtsc_engine = d_plot->axisScaleEngine(axis);
-	ScaleEngine *sc_engine=dynamic_cast<ScaleEngine*>(qwtsc_engine);
-	if(sc_engine!=NULL)
-	{
-		sc_engine->clone(sc_engine);
-	}*/
+        ScaleEngine *sc_engine=dynamic_cast<ScaleEngine*>(qwtsc_engine);
+        if(sc_engine!=NULL)
+        {
+                sc_engine->clone(sc_engine);
+        }*/
 
-  d_plot->setAxisScaleDiv (axis, *d_plot->axisScaleDiv(a));
+  d_plot->setAxisScaleDiv(axis, *d_plot->axisScaleDiv(a));
   d_user_step[axis] = d_user_step[a];
 }
 
-void Graph::enableAutoscaling(bool yes)
-{
-  for (int i = 0; i < QwtPlot::axisCnt; i++)
-  {
-    if (yes)
-    {
+void Graph::enableAutoscaling(bool yes) {
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    if (yes) {
       d_plot->setAxisAutoScale(i);
-    }
-    else
-    {
+    } else {
       // We need this hack due to the fact that in Qwt 5.0 we can't
-      // disable autoscaling in an easier way, like for example: setAxisAutoScale(axisId, false)
+      // disable autoscaling in an easier way, like for example:
+      // setAxisAutoScale(axisId, false)
       d_plot->setAxisScaleDiv(i, *d_plot->axisScaleDiv(i));
     }
   }
 }
 
-void Graph::setAutoScale()
-{
+void Graph::setAutoScale() {
   enableAutoscaling(true);
-  
+
   updateScale();
-  
-  for (int i = 0; i < QwtPlot::axisCnt; i++)
-  {
-    if ( isLog(QwtPlot::Axis(i)) )
-    {
+
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    if (isLog(QwtPlot::Axis(i))) {
       niceLogScales(QwtPlot::Axis(i));
     }
   }
   emit modifiedGraph();
 }
 
-void Graph::initScaleLimits()
-{//We call this function the first time we add curves to a plot in order to avoid curves with cut symbols.
+void Graph::initScaleLimits() { // We call this function the first time we add
+                                // curves to a plot in order to avoid curves
+                                // with cut symbols.
   d_plot->replot();
 
   QwtDoubleInterval intv[QwtPlot::axisCnt];
-  const QwtPlotItemList& itmList = d_plot->itemList();
+  const QwtPlotItemList &itmList = d_plot->itemList();
   QwtPlotItemIterator it;
   double maxSymbolSize = 0;
-  for ( it = itmList.begin(); it != itmList.end(); ++it ){
+  for (it = itmList.begin(); it != itmList.end(); ++it) {
     const QwtPlotItem *item = *it;
     if (item->rtti() != QwtPlotItem::Rtti_PlotCurve)
       continue;
@@ -1070,7 +1017,7 @@ void Graph::initScaleLimits()
   double end = div->hBound();
   QwtValueList majTicksLst = div->ticks(QwtScaleDiv::MajorTick);
   int ticks = majTicksLst.size();
-  double step = fabs(end - start)/(double)(ticks - 1.0);
+  double step = fabs(end - start) / (double)(ticks - 1.0);
   d_user_step[QwtPlot::xBottom] = step;
   d_user_step[QwtPlot::xTop] = step;
 
@@ -1092,7 +1039,7 @@ void Graph::initScaleLimits()
   end = div->hBound();
   majTicksLst = div->ticks(QwtScaleDiv::MajorTick);
   ticks = majTicksLst.size();
-  step = fabs(end - start)/(double)(ticks - 1.0);
+  step = fabs(end - start) / (double)(ticks - 1.0);
   d_user_step[QwtPlot::yLeft] = step;
   d_user_step[QwtPlot::yRight] = step;
 
@@ -1114,8 +1061,7 @@ void Graph::initScaleLimits()
  *  by setting the extreme ends of the scale to major tick
  *  numbers e.g. 1, 10, 100 etc.
  */
-void Graph::niceLogScales(QwtPlot::Axis axis)
-{
+void Graph::niceLogScales(QwtPlot::Axis axis) {
   const QwtScaleDiv *scDiv = d_plot->axisScaleDiv(axis);
   double start = QMIN(scDiv->lBound(), scDiv->hBound());
   double end = QMAX(scDiv->lBound(), scDiv->hBound());
@@ -1131,34 +1077,32 @@ void Graph::niceLogScales(QwtPlot::Axis axis)
   end = ceil(log10(end));
   end = pow(10.0, end);
 
-  ScaleEngine *scaleEng = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
+  ScaleEngine *scaleEng =
+      dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
   if (!scaleEng)
     return;
 
   // call the QTiPlot function set scale which takes many arguments,
   // fill the arguments with the same settings the plot already has
   setScale(axis, start, end, axisStep(axis),
-      scDiv->ticks(QwtScaleDiv::MajorTick).count(),
-      d_plot->axisMaxMinor(axis),
-      ScaleTransformation::Log10,
-      scaleEng->testAttribute(QwtScaleEngine::Inverted),
-      scaleEng->axisBreakLeft(),
-      scaleEng->axisBreakRight(),
-      scaleEng->minTicksBeforeBreak(),
-      scaleEng->minTicksAfterBreak(),
-      scaleEng->log10ScaleAfterBreak(),
-      scaleEng->breakWidth(),
-      scaleEng->hasBreakDecoration());
+           scDiv->ticks(QwtScaleDiv::MajorTick).count(),
+           d_plot->axisMaxMinor(axis), ScaleTransformation::Log10,
+           scaleEng->testAttribute(QwtScaleEngine::Inverted),
+           scaleEng->axisBreakLeft(), scaleEng->axisBreakRight(),
+           scaleEng->minTicksBeforeBreak(), scaleEng->minTicksAfterBreak(),
+           scaleEng->log10ScaleAfterBreak(), scaleEng->breakWidth(),
+           scaleEng->hasBreakDecoration());
 }
 
 void Graph::setScale(int axis, double start, double end, double step,
-    int majorTicks, int minorTicks, int type, bool inverted,
-    double left_break, double right_break, int breakPos,
-    double stepBeforeBreak, double stepAfterBreak, int minTicksBeforeBreak,
-    int minTicksAfterBreak, bool log10AfterBreak, int breakWidth,
-    bool breakDecoration, double nth_power)
-{
-  if (ScaleEngine* se = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis))){
+                     int majorTicks, int minorTicks, int type, bool inverted,
+                     double left_break, double right_break, int breakPos,
+                     double stepBeforeBreak, double stepAfterBreak,
+                     int minTicksBeforeBreak, int minTicksAfterBreak,
+                     bool log10AfterBreak, int breakWidth, bool breakDecoration,
+                     double nth_power) {
+  if (ScaleEngine *se =
+          dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis))) {
     se->setBreakRegion(left_break, right_break);
     se->setBreakPosition(breakPos);
     se->setBreakWidth(breakWidth);
@@ -1174,14 +1118,14 @@ void Graph::setScale(int axis, double start, double end, double step,
 
   setAxisScale(axis, start, end, type, step, majorTicks, minorTicks);
 
-  for (int i=0; i<n_curves; i++){
+  for (int i = 0; i < n_curves; i++) {
     QwtPlotItem *it = plotItem(i);
     if (!it)
       continue;
-    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram){
+    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
       Spectrogram *sp = dynamic_cast<Spectrogram *>(it);
-      if(sp)
-      {	updatedaxis[axis]=1;
+      if (sp) {
+        updatedaxis[axis] = 1;
       }
     }
   }
@@ -1191,23 +1135,19 @@ void Graph::setScale(int axis, double start, double end, double step,
  *  @param axis :: the scale to change either QwtPlot::xBottom or QwtPlot::yLeft
  *  @param scaleType :: either ScaleTransformation::Log10 or ::Linear
  */
-void Graph::setScale(QwtPlot::Axis axis, ScaleTransformation::Type scaleType)
-{
-  //check if the scale is already of the desired type, 
-  ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
+void Graph::setScale(QwtPlot::Axis axis, ScaleTransformation::Type scaleType) {
+  // check if the scale is already of the desired type,
+  ScaleEngine *sc_engine =
+      dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
   if (!sc_engine)
     return;
 
   ScaleTransformation::Type type = sc_engine->type();
-  if ( scaleType == ScaleTransformation::Log10 )
-  {
-    if ( type ==  ScaleTransformation::Log10 )
-    {
+  if (scaleType == ScaleTransformation::Log10) {
+    if (type == ScaleTransformation::Log10) {
       return;
     }
-  }
-  else if ( type == ScaleTransformation::Linear )
-  {
+  } else if (type == ScaleTransformation::Linear) {
     return;
   }
 
@@ -1215,95 +1155,85 @@ void Graph::setScale(QwtPlot::Axis axis, ScaleTransformation::Type scaleType)
   double start = QMIN(scDiv->lBound(), scDiv->hBound());
   double end = QMAX(scDiv->lBound(), scDiv->hBound());
 
-  ScaleEngine *scaleEng = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
+  ScaleEngine *scaleEng =
+      dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
   if (!scaleEng)
     return;
 
   // call the QTiPlot function set scale which takes many arguments,
   // fill the arguments with the same settings the plot already has
   setScale(axis, start, end, axisStep(axis),
-      scDiv->ticks(QwtScaleDiv::MajorTick).count(),
-      d_plot->axisMaxMinor(axis), scaleType,
-      scaleEng->testAttribute(QwtScaleEngine::Inverted),
-      scaleEng->axisBreakLeft(),
-      scaleEng->axisBreakRight(),
-      scaleEng->minTicksBeforeBreak(),
-      scaleEng->minTicksAfterBreak(),
-      scaleEng->log10ScaleAfterBreak(),
-      scaleEng->breakWidth(),
-      scaleEng->hasBreakDecoration());
+           scDiv->ticks(QwtScaleDiv::MajorTick).count(),
+           d_plot->axisMaxMinor(axis), scaleType,
+           scaleEng->testAttribute(QwtScaleEngine::Inverted),
+           scaleEng->axisBreakLeft(), scaleEng->axisBreakRight(),
+           scaleEng->minTicksBeforeBreak(), scaleEng->minTicksAfterBreak(),
+           scaleEng->log10ScaleAfterBreak(), scaleEng->breakWidth(),
+           scaleEng->hasBreakDecoration());
 }
 /** This setScale overload allows setting the scale type by passing "linear"
  *  or "log" as a string
  *  @param axis :: the scale to change either QwtPlot::xBottom or QwtPlot::yLeft
  *  @param logOrLin :: either "log" or "linear"
  */
-void Graph::setScale(QwtPlot::Axis axis, QString logOrLin)
-{
-  if ( logOrLin == "log" )
-  {
+void Graph::setScale(QwtPlot::Axis axis, QString logOrLin) {
+  if (logOrLin == "log") {
     setScale(axis, ScaleTransformation::Log10);
-  }
-  else if ( logOrLin == "linear" )
-  {
+  } else if (logOrLin == "linear") {
     setScale(axis, ScaleTransformation::Linear);
   }
 }
 
-void Graph::logLogAxes()
-{
+void Graph::logLogAxes() {
   setScale(QwtPlot::xBottom, ScaleTransformation::Log10);
   setScale(QwtPlot::yLeft, ScaleTransformation::Log10);
   notifyChanges();
 }
 
-void Graph::logXLinY()
-{
+void Graph::logXLinY() {
   setScale(QwtPlot::xBottom, ScaleTransformation::Log10);
   setScale(QwtPlot::yLeft, ScaleTransformation::Linear);
   notifyChanges();
 }
 
-void Graph::logYlinX()
-{
+void Graph::logYlinX() {
   setScale(QwtPlot::xBottom, ScaleTransformation::Linear);
   setScale(QwtPlot::yLeft, ScaleTransformation::Log10);
   notifyChanges();
 }
 
-void Graph::linearAxes()
-{
+void Graph::linearAxes() {
   setScale(QwtPlot::xBottom, ScaleTransformation::Linear);
   setScale(QwtPlot::yLeft, ScaleTransformation::Linear);
   notifyChanges();
 }
 
-void Graph::logColor()
-{
+void Graph::logColor() {
   setScale(QwtPlot::yRight, ScaleTransformation::Log10);
   notifyChanges();
 }
 
-void Graph::linColor()
-{
+void Graph::linColor() {
   setScale(QwtPlot::yRight, ScaleTransformation::Linear);
   notifyChanges();
 }
 
-void Graph::setAxisScale(int axis, double start, double end, int scaleType, double step,
-    int majorTicks, int minorTicks)
-{
-  ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
-  if(!sc_engine)
+void Graph::setAxisScale(int axis, double start, double end, int scaleType,
+                         double step, int majorTicks, int minorTicks) {
+  ScaleEngine *sc_engine =
+      dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(axis));
+  if (!sc_engine)
     return;
 
   ScaleTransformation::Type old_type = sc_engine->type();
 
   // If not specified, keep the same as now
-  if( scaleType < 0 ) scaleType = axisType(axis);
+  if (scaleType < 0)
+    scaleType = axisType(axis);
 
   int type = ScaleTransformation::Linear;
-  // just to have the one-by-one ScaleType => GraphOptions; higher values of ScaleType
+  // just to have the one-by-one ScaleType => GraphOptions; higher values of
+  // ScaleType
   // will be GraphOptions::Linear
   if (ScaleDraw::ScaleType::Numeric == scaleType) {
     type = ScaleTransformation::Linear;
@@ -1313,154 +1243,119 @@ void Graph::setAxisScale(int axis, double start, double end, int scaleType, doub
     type = ScaleTransformation::Power;
   }
 
-  if (static_cast<int>(type) != static_cast<int>(old_type))
-  {
+  if (static_cast<int>(type) != static_cast<int>(old_type)) {
     // recalculate boundingRect of MantidCurves
     emit axisScaleChanged(axis, type == ScaleTransformation::Log10);
   }
 
-  if (type == ScaleTransformation::Log10)
-  {
+  if (type == ScaleTransformation::Log10) {
     sc_engine->setType(ScaleTransformation::Log10);
-  }
-  else if (type == ScaleTransformation::Power)
-  {
+  } else if (type == ScaleTransformation::Power) {
     sc_engine->setType(ScaleTransformation::Power);
-  }
-  else
-  {
+  } else {
     sc_engine->setType(ScaleTransformation::Linear);
   }
 
-  if (type == ScaleTransformation::Log10)
-  {
-    if (start <= 0)
-    {
+  if (type == ScaleTransformation::Log10) {
+    if (start <= 0) {
       double s_min = DBL_MAX;
       // for the y axis rely on the bounding rects
-      for(int i=0;i<curves();++i)
-      {
-        QwtPlotCurve* c = curve(i);
-        if (c)
-        {
+      for (int i = 0; i < curves(); ++i) {
+        QwtPlotCurve *c = curve(i);
+        if (c) {
           double s;
-          if (axis == QwtPlot::yRight || axis == QwtPlot::yLeft)
-          {
+          if (axis == QwtPlot::yRight || axis == QwtPlot::yLeft) {
             s = c->boundingRect().y();
-          }
-          else
-          {
+          } else {
             s = c->boundingRect().x();
           }
-          if (s > 0 && s < s_min)
-          {
+          if (s > 0 && s < s_min) {
             s_min = s;
           }
         }
       }
 
-      if (s_min != DBL_MAX && s_min > 0)
-      {
+      if (s_min != DBL_MAX && s_min > 0) {
         start = s_min;
-      }
-      else
-      {
-        if (end <= 0)
-        {
+      } else {
+        if (end <= 0) {
           start = 1;
           end = 1000;
-        }
-        else
-        {
+        } else {
           start = 0.01 * end;
         }
       }
     }
-    // log scales can't represent zero or negative values, 1e-10 is a low number that I hope will be lower than most of the data but is still sensible for many color plots
-    //start = start < 1e-90 ? 1e-10 : start;
-  }
-  else if (type == ScaleTransformation::Power)
-  {
+    // log scales can't represent zero or negative values, 1e-10 is a low number
+    // that I hope will be lower than most of the data but is still sensible for
+    // many color plots
+    // start = start < 1e-90 ? 1e-10 : start;
+  } else if (type == ScaleTransformation::Power) {
     double const nth_power = sc_engine->nthPower();
-    if (start <= 0 && nth_power < 0)
-    {
+    if (start <= 0 && nth_power < 0) {
       double s_min = DBL_MAX;
       // for the y axis rely on the bounding rects
-      for(int i=0;i<curves();++i)
-      {
-        QwtPlotCurve* c = curve(i);
-        if (c)
-        {
+      for (int i = 0; i < curves(); ++i) {
+        QwtPlotCurve *c = curve(i);
+        if (c) {
           double s;
-          if (axis == QwtPlot::yRight || axis == QwtPlot::yLeft)
-          {
+          if (axis == QwtPlot::yRight || axis == QwtPlot::yLeft) {
             s = c->boundingRect().y();
-          }
-          else
-          {
+          } else {
             s = c->boundingRect().x();
           }
-          if (s < s_min)
-          {
+          if (s < s_min) {
             s_min = s;
           }
         }
       }
 
-      if (s_min != DBL_MAX)
-      {
+      if (s_min != DBL_MAX) {
         start = s_min;
-      }
-      else
-      {
+      } else {
         start = 0.01 * end;
       }
-      if (start == 0)
-      {
+      if (start == 0) {
         start = 0.01 * end;
-      }
-      else if (end == 0)
-      {
+      } else if (end == 0) {
         end = 0.01 * start;
       }
     }
     // If n is +ve even integer then negative scale values are not valid
     // so set start of axis to 0
-    if (start < 0 &&
-      std::floor(nth_power) == nth_power &&
-      (long)nth_power % 2 == 0)
-    {
+    if (start < 0 && std::floor(nth_power) == nth_power &&
+        (long)nth_power % 2 == 0) {
       start = 0;
-      if (end < 0)
-      {
+      if (end < 0) {
         end = 1;
       }
     }
   }
 
-  if (axis == QwtPlot::yRight)
-  {
-    for (int i=0; i<n_curves; i++){
+  if (axis == QwtPlot::yRight) {
+    for (int i = 0; i < n_curves; i++) {
       QwtPlotItem *it = plotItem(i);
       if (!it)
         continue;
-      if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram){
+      if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
         Spectrogram *sp = dynamic_cast<Spectrogram *>(it);
-        if(sp)
-        {
+        if (sp) {
           QwtScaleWidget *rightAxis = d_plot->axisWidget(QwtPlot::yRight);
-          if(rightAxis)
-          {
-            if (type == ScaleTransformation::Log10 && (start <= 0 || start == DBL_MAX))
-            {
+          if (rightAxis) {
+            if (type == ScaleTransformation::Log10 &&
+                (start <= 0 || start == DBL_MAX)) {
               start = sp->getMinPositiveValue();
             }
-            sp->mutableColorMap().changeScaleType((GraphOptions::ScaleType)type);
+            sp->mutableColorMap().changeScaleType(
+                (GraphOptions::ScaleType)type);
             sp->mutableColorMap().setNthPower(sc_engine->nthPower());
-            rightAxis->setColorMap(QwtDoubleInterval(start, end), sp->getColorMap());
+            rightAxis->setColorMap(QwtDoubleInterval(start, end),
+                                   sp->getColorMap());
             sp->setColorMap(sp->getColorMap());
-            // we could check if(sp->isIntensityChanged()) but this doesn't work when one value is changing from zero to say 10^-10, which is a big problem for log plots
-            sp->changeIntensity( start,end);
+            // we could check if(sp->isIntensityChanged()) but this doesn't work
+            // when one value is changing from zero to say 10^-10, which is a
+            // big problem for log plots
+            sp->changeIntensity(start, end);
           }
         }
       }
@@ -1468,22 +1363,24 @@ void Graph::setAxisScale(int axis, double start, double end, int scaleType, doub
   }
 
   int max_min_intervals = minorTicks;
-  if (minorTicks == 1) max_min_intervals = 3;
-  if (minorTicks > 1) max_min_intervals = minorTicks + 1;
-  QwtScaleDiv div = sc_engine->divideScale (QMIN(start, end), QMAX(start, end), majorTicks, max_min_intervals, step);
-  d_plot->setAxisMaxMajor (axis, majorTicks);
-  d_plot->setAxisMaxMinor (axis, minorTicks);
+  if (minorTicks == 1)
+    max_min_intervals = 3;
+  if (minorTicks > 1)
+    max_min_intervals = minorTicks + 1;
+  QwtScaleDiv div = sc_engine->divideScale(QMIN(start, end), QMAX(start, end),
+                                           majorTicks, max_min_intervals, step);
+  d_plot->setAxisMaxMajor(axis, majorTicks);
+  d_plot->setAxisMaxMinor(axis, minorTicks);
 
-  d_plot->setAxisScaleDiv (axis, div);
+  d_plot->setAxisScaleDiv(axis, div);
 
   d_zoomer[0]->setZoomBase();
-  //below code is commented as it was zooming the right color  axis on scaling
+  // below code is commented as it was zooming the right color  axis on scaling
   d_zoomer[1]->setZoomBase();
 
   d_user_step[axis] = step;
 
-  if (axis == QwtPlot::xBottom || axis == QwtPlot::yLeft)
-  {
+  if (axis == QwtPlot::xBottom || axis == QwtPlot::yLeft) {
     updateSecondaryAxis(QwtPlot::xTop);
     updateSecondaryAxis(QwtPlot::yRight);
   }
@@ -1492,16 +1389,12 @@ void Graph::setAxisScale(int axis, double start, double end, int scaleType, doub
   updateMarkersBoundingRect();
   d_plot->replot();
   d_plot->axisWidget(axis)->repaint();
-
 }
 
-
-QStringList Graph::analysableCurvesList()
-{
+QStringList Graph::analysableCurvesList() {
   QStringList cList;
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotCurve *c = d_plot->curve(keys[i]);
     if (c && c_type[i] != ErrorBars)
       cList << c->title().text();
@@ -1509,12 +1402,10 @@ QStringList Graph::analysableCurvesList()
   return cList;
 }
 
-QStringList Graph::curvesList()
-{
+QStringList Graph::curvesList() {
   QStringList cList;
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotCurve *c = d_plot->curve(keys[i]);
     if (c)
       cList << c->title().text();
@@ -1522,12 +1413,10 @@ QStringList Graph::curvesList()
   return cList;
 }
 
-QStringList Graph::plotItemsList()
-{
+QStringList Graph::plotItemsList() {
   QStringList cList;
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
     if (it)
       cList << it->title().text();
@@ -1535,59 +1424,57 @@ QStringList Graph::plotItemsList()
   return cList;
 }
 
-void Graph::copyImage()
-{
+void Graph::copyImage() {
   QApplication::clipboard()->setPixmap(graphPixmap(), QClipboard::Clipboard);
 }
 
-QPixmap Graph::graphPixmap()
-{
-  return QPixmap::grabWidget(this);
-}
+QPixmap Graph::graphPixmap() { return QPixmap::grabWidget(this); }
 
-void Graph::exportToFile(const QString& fileName)
-{
-  if ( fileName.isEmpty() ){
-    QMessageBox::critical(this, tr("MantidPlot - Error"), tr("Please provide a valid file name!"));
+void Graph::exportToFile(const QString &fileName) {
+  if (fileName.isEmpty()) {
+    QMessageBox::critical(this, tr("MantidPlot - Error"),
+                          tr("Please provide a valid file name!"));
     return;
   }
 
-  if (fileName.contains(".eps") || fileName.contains(".pdf") || fileName.contains(".ps")){
+  if (fileName.contains(".eps") || fileName.contains(".pdf") ||
+      fileName.contains(".ps")) {
     exportVector(fileName);
     return;
-  } else if(fileName.contains(".svg")){
+  } else if (fileName.contains(".svg")) {
     exportSVG(fileName);
     return;
   } else {
     QList<QByteArray> list = QImageWriter::supportedImageFormats();
-    for(int i=0 ; i<list.count() ; i++){
-      if (fileName.contains( "." + list[i].toLower())){
+    for (int i = 0; i < list.count(); i++) {
+      if (fileName.contains("." + list[i].toLower())) {
         exportImage(fileName);
         return;
       }
     }
-    QMessageBox::critical(this, tr("MantidPlot - Error"), tr("File format not handled, operation aborted!"));
+    QMessageBox::critical(this, tr("MantidPlot - Error"),
+                          tr("File format not handled, operation aborted!"));
   }
 }
 
-void Graph::exportImage(const QString& fileName, int quality, bool transparent)
-{
+void Graph::exportImage(const QString &fileName, int quality,
+                        bool transparent) {
   QPixmap pic(d_plot->size());
   QPainter p(&pic);
   d_plot->print(&p, d_plot->rect());
   p.end();
 
-  if (transparent){
+  if (transparent) {
     QBitmap mask(pic.size());
     mask.fill(Qt::color1);
     QPainter p(&mask);
     p.setPen(Qt::color0);
 
-    QColor background = QColor (Qt::white);
-    QRgb backgroundPixel = background.rgb ();
+    QColor background = QColor(Qt::white);
+    QRgb backgroundPixel = background.rgb();
     QImage image = pic.convertToImage();
-    for (int y=0; y<image.height(); y++){
-      for ( int x=0; x<image.width(); x++ ){
+    for (int y = 0; y < image.height(); y++) {
+      for (int x = 0; x < image.width(); x++) {
         QRgb rgb = image.pixel(x, y);
         if (rgb == backgroundPixel) // we want the frame transparent
           p.drawPoint(x, y);
@@ -1599,18 +1486,20 @@ void Graph::exportImage(const QString& fileName, int quality, bool transparent)
   pic.save(fileName, 0, quality);
 }
 
-void Graph::exportVector(const QString& fileName, int, bool color, bool keepAspect, QPrinter::PageSize pageSize)
-{
-  if ( fileName.isEmpty() ){
-    QMessageBox::critical(this, tr("MantidPlot - Error"), tr("Please provide a valid file name!"));
+void Graph::exportVector(const QString &fileName, int, bool color,
+                         bool keepAspect, QPrinter::PageSize pageSize) {
+  if (fileName.isEmpty()) {
+    QMessageBox::critical(this, tr("MantidPlot - Error"),
+                          tr("Please provide a valid file name!"));
     return;
   }
 
   QPrinter printer;
   printer.setCreator("MantidPlot");
   printer.setFullPage(true);
-  //if (res) //only printing with screen resolution works correctly for the moment
-  //printer.setResolution(res);
+  // if (res) //only printing with screen resolution works correctly for the
+  // moment
+  // printer.setResolution(res);
 
   printer.setOutputFileName(fileName);
   if (fileName.contains(".eps"))
@@ -1627,32 +1516,33 @@ void Graph::exportVector(const QString& fileName, int, bool color, bool keepAspe
   else
     printer.setPageSize(pageSize);
 
-  double plot_aspect = double(d_plot->frameGeometry().width())/double(d_plot->frameGeometry().height());
+  double plot_aspect = double(d_plot->frameGeometry().width()) /
+                       double(d_plot->frameGeometry().height());
   if (plot_aspect < 1)
     printer.setOrientation(QPrinter::Portrait);
   else
     printer.setOrientation(QPrinter::Landscape);
 
-  if (keepAspect){// export should preserve plot aspect ratio
-    double page_aspect = double(printer.width())/double(printer.height());
-    if (page_aspect > plot_aspect){
-      int margin = (int) ((0.1/2.54)*printer.logicalDpiY()); // 1 mm margins
-      int height = printer.height() - 2*margin;
-      int width = static_cast<int>(height*plot_aspect);
-      int x = (printer.width()- width)/2;
+  if (keepAspect) { // export should preserve plot aspect ratio
+    double page_aspect = double(printer.width()) / double(printer.height());
+    if (page_aspect > plot_aspect) {
+      int margin = (int)((0.1 / 2.54) * printer.logicalDpiY()); // 1 mm margins
+      int height = printer.height() - 2 * margin;
+      int width = static_cast<int>(height * plot_aspect);
+      int x = (printer.width() - width) / 2;
       plotRect = QRect(x, margin, width, height);
-    } else if (plot_aspect >= page_aspect){
-      int margin = (int) ((0.1/2.54)*printer.logicalDpiX()); // 1 mm margins
-      int width = printer.width() - 2*margin;
-      int height = static_cast<int>(width/plot_aspect);
-      int y = (printer.height()- height)/2;
+    } else if (plot_aspect >= page_aspect) {
+      int margin = (int)((0.1 / 2.54) * printer.logicalDpiX()); // 1 mm margins
+      int width = printer.width() - 2 * margin;
+      int height = static_cast<int>(width / plot_aspect);
+      int y = (printer.height() - height) / 2;
       plotRect = QRect(margin, y, width, height);
     }
   } else {
-    int x_margin = (int) ((0.1/2.54)*printer.logicalDpiX()); // 1 mm margins
-    int y_margin = (int) ((0.1/2.54)*printer.logicalDpiY()); // 1 mm margins
-    int width = printer.width() - 2*x_margin;
-    int height = printer.height() - 2*y_margin;
+    int x_margin = (int)((0.1 / 2.54) * printer.logicalDpiX()); // 1 mm margins
+    int y_margin = (int)((0.1 / 2.54) * printer.logicalDpiY()); // 1 mm margins
+    int width = printer.width() - 2 * x_margin;
+    int height = printer.height() - 2 * y_margin;
     plotRect = QRect(x_margin, y_margin, width, height);
   }
 
@@ -1660,51 +1550,52 @@ void Graph::exportVector(const QString& fileName, int, bool color, bool keepAspe
   d_plot->print(&paint, plotRect);
 }
 
-void Graph::print()
-{
+void Graph::print() {
   QPrinter printer;
-  printer.setColorMode (QPrinter::Color);
+  printer.setColorMode(QPrinter::Color);
   printer.setFullPage(true);
 
-  //printing should preserve plot aspect ratio, if possible
-  double aspect = double(d_plot->width())/double(d_plot->height());
+  // printing should preserve plot aspect ratio, if possible
+  double aspect = double(d_plot->width()) / double(d_plot->height());
   if (aspect < 1)
     printer.setOrientation(QPrinter::Portrait);
   else
     printer.setOrientation(QPrinter::Landscape);
 
   QPrintDialog printDialog(&printer);
-  if (printDialog.exec() == QDialog::Accepted){
+  if (printDialog.exec() == QDialog::Accepted) {
     QRect plotRect = d_plot->rect();
     QRect paperRect = printer.paperRect();
-    if (d_scale_on_print){
+    if (d_scale_on_print) {
       int dpiy = printer.logicalDpiY();
-      int margin = (int) ((2/2.54)*dpiy ); // 2 cm margins
+      int margin = (int)((2 / 2.54) * dpiy); // 2 cm margins
 
-      int width = qRound(aspect*printer.height()) - 2*margin;
-      int x=qRound(abs(printer.width()- width)*0.5);
+      int width = qRound(aspect * printer.height()) - 2 * margin;
+      int x = qRound(abs(printer.width() - width) * 0.5);
 
-      plotRect = QRect(x, margin, width, printer.height() - 2*margin);
-      if (x < margin){
+      plotRect = QRect(x, margin, width, printer.height() - 2 * margin);
+      if (x < margin) {
         plotRect.setLeft(margin);
-        plotRect.setWidth(printer.width() - 2*margin);
+        plotRect.setWidth(printer.width() - 2 * margin);
       }
     } else {
-      int x_margin = (paperRect.width() - plotRect.width())/2;
-      int y_margin = (paperRect.height() - plotRect.height())/2;
+      int x_margin = (paperRect.width() - plotRect.width()) / 2;
+      int y_margin = (paperRect.height() - plotRect.height()) / 2;
       plotRect.moveTo(x_margin, y_margin);
     }
 
     QPainter paint(&printer);
-    if (d_print_cropmarks){
+    if (d_print_cropmarks) {
       QRect cr = plotRect; // cropmarks rectangle
       cr.addCoords(-1, -1, 2, 2);
       paint.save();
       paint.setPen(QPen(QColor(Qt::black), 0.5, Qt::DashLine));
       paint.drawLine(paperRect.left(), cr.top(), paperRect.right(), cr.top());
-      paint.drawLine(paperRect.left(), cr.bottom(), paperRect.right(), cr.bottom());
+      paint.drawLine(paperRect.left(), cr.bottom(), paperRect.right(),
+                     cr.bottom());
       paint.drawLine(cr.left(), paperRect.top(), cr.left(), paperRect.bottom());
-      paint.drawLine(cr.right(), paperRect.top(), cr.right(), paperRect.bottom());
+      paint.drawLine(cr.right(), paperRect.top(), cr.right(),
+                     paperRect.bottom());
       paint.restore();
     }
 
@@ -1712,8 +1603,7 @@ void Graph::print()
   }
 }
 
-void Graph::exportSVG(const QString& fname)
-{
+void Graph::exportSVG(const QString &fname) {
   QSvgGenerator svg;
   svg.setFileName(fname);
   svg.setSize(d_plot->size());
@@ -1723,56 +1613,53 @@ void Graph::exportSVG(const QString& fname)
   p.end();
 }
 
-int Graph::selectedCurveID()
-{
+int Graph::selectedCurveID() {
   if (d_range_selector)
     return curveKey(curveIndex(d_range_selector->selectedCurve()));
   else
     return -1;
 }
 
-QString Graph::selectedCurveTitle()
-{
+QString Graph::selectedCurveTitle() {
   if (d_range_selector)
     return d_range_selector->selectedCurve()->title().text();
   else
     return QString::null;
 }
 
-bool Graph::markerSelected()
-{
+bool Graph::markerSelected() {
   return (selectedMarker >= 0 || d_selected_text);
 }
 
-void Graph::removeMarker()
-{
-  if (selectedMarker>=0){
+void Graph::removeMarker() {
+  if (selectedMarker >= 0) {
     if (d_markers_selector) {
       if (d_lines.contains(selectedMarker))
-        d_markers_selector->removeAll(dynamic_cast<ArrowMarker *>(d_plot->marker(selectedMarker)));
+        d_markers_selector->removeAll(
+            dynamic_cast<ArrowMarker *>(d_plot->marker(selectedMarker)));
       else if (d_images.contains(selectedMarker))
-        d_markers_selector->removeAll(dynamic_cast<ImageMarker *>(d_plot->marker(selectedMarker)));
+        d_markers_selector->removeAll(
+            dynamic_cast<ImageMarker *>(d_plot->marker(selectedMarker)));
     }
     d_plot->removeMarker(selectedMarker);
     d_plot->replot();
     emit modifiedGraph();
 
-    if (d_lines.contains(selectedMarker))
-    {
+    if (d_lines.contains(selectedMarker)) {
       int index = d_lines.indexOf(selectedMarker);
       int last_line_marker = (int)d_lines.size() - 1;
-      for (int i=index; i < last_line_marker; i++)
-        d_lines[i]=d_lines[i+1];
+      for (int i = index; i < last_line_marker; i++)
+        d_lines[i] = d_lines[i + 1];
       d_lines.resize(last_line_marker);
-    } else if(d_images.contains(selectedMarker)){
-      int index=d_images.indexOf(selectedMarker);
+    } else if (d_images.contains(selectedMarker)) {
+      int index = d_images.indexOf(selectedMarker);
       int last_image_marker = d_images.size() - 1;
-      for (int i=index; i < last_image_marker; i++)
-        d_images[i]=d_images[i+1];
+      for (int i = index; i < last_image_marker; i++)
+        d_images[i] = d_images[i + 1];
       d_images.resize(last_image_marker);
     }
-    selectedMarker=-1;
-  } else if (d_selected_text){
+    selectedMarker = -1;
+  } else if (d_selected_text) {
     if (d_selected_text == d_legend)
       d_legend = NULL;
     d_selected_text->close();
@@ -1780,120 +1667,100 @@ void Graph::removeMarker()
   }
 }
 
-bool Graph::arrowMarkerSelected()
-{
-  return (d_lines.contains(selectedMarker));
-}
+bool Graph::arrowMarkerSelected() { return (d_lines.contains(selectedMarker)); }
 
-bool Graph::imageMarkerSelected()
-{
+bool Graph::imageMarkerSelected() {
   return (d_images.contains(selectedMarker));
 }
 
-void Graph::deselect()
-{
+void Graph::deselect() {
   deselectMarker();
-  scalePicker->deselect();  
-  if(d_legend != NULL)
-  {
+  scalePicker->deselect();
+  if (d_legend != NULL) {
     d_legend->setSelected(false);
   }
   titlePicker->setSelected(false);
   deselectCurves();
 }
 
-void Graph::deselectCurves()
-{
+void Graph::deselectCurves() {
   QList<QwtPlotItem *> curves = d_plot->curvesList();
-  foreach(QwtPlotItem *i, curves){
+  foreach (QwtPlotItem *i, curves) {
     PlotCurve *c = dynamic_cast<PlotCurve *>(i);
     DataCurve *dc = dynamic_cast<DataCurve *>(i);
-    if(c && dc &&
-       i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
-       c->type() != Graph::Function &&  dc->hasSelectedLabels()  )
-      {
-        dc->setLabelsSelected(false);
-        return;
-      }
+    if (c && dc && i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
+        c->type() != Graph::Function && dc->hasSelectedLabels()) {
+      dc->setLabelsSelected(false);
+      return;
+    }
   }
 }
 
-DataCurve* Graph::selectedCurveLabels()
-{
+DataCurve *Graph::selectedCurveLabels() {
   QList<QwtPlotItem *> curves = d_plot->curvesList();
-  foreach(QwtPlotItem *i, curves){
+  foreach (QwtPlotItem *i, curves) {
     PlotCurve *c = dynamic_cast<PlotCurve *>(i);
     DataCurve *dc = dynamic_cast<DataCurve *>(i);
-    if(dc && c &&
-       i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
-       c->type() != Graph::Function && dc->hasSelectedLabels())
+    if (dc && c && i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
+        c->type() != Graph::Function && dc->hasSelectedLabels())
       return dc;
   }
   return NULL;
 }
 
-bool Graph::titleSelected()
-{
-  return titlePicker->selected();
-}
+bool Graph::titleSelected() { return titlePicker->selected(); }
 
-void Graph::selectTitle(bool select)
-{
-  if(d_legend != NULL)
-  {
+void Graph::selectTitle(bool select) {
+  if (d_legend != NULL) {
     d_legend->setSelected(!select);
   }
   titlePicker->setSelected(select);
-  
-  if (select){
+
+  if (select) {
     deselect();
     emit selectedGraph(this);
     emit currentFontChanged(d_plot->title().font());
   }
 }
 
-void Graph::setTitle(const QString& t)
-{
-  d_plot->setTitle (t);
+void Graph::setTitle(const QString &t) {
+  d_plot->setTitle(t);
   emit modifiedGraph();
 }
 
-void Graph::removeTitle()
-{
+void Graph::removeTitle() {
   d_plot->setTitle("");
   emit modifiedGraph();
 }
 
-void Graph::initTitle(bool on, const QFont& fnt)
-{
-  if (on){
+void Graph::initTitle(bool on, const QFont &fnt) {
+  if (on) {
     QwtText t = d_plot->title();
     t.setFont(fnt);
     t.setText(tr("Title"));
-    d_plot->setTitle (t);
+    d_plot->setTitle(t);
   }
 }
 
-void Graph::setCurveTitle(int index, const QString & title)
-{
+void Graph::setCurveTitle(int index, const QString &title) {
   QwtPlotItem *curve = plotItem(index);
-  if( !curve ) return;
+  if (!curve)
+    return;
   curve->setTitle(title);
   legend()->setText(legendText());
   legend()->repaint();
 }
 
-void Graph::removeLegend()
-{
-  if (d_legend){
+void Graph::removeLegend() {
+  if (d_legend) {
     d_legend->deleteLater();
     d_legend = NULL;
   }
 }
 
-void Graph::updateImageMarker(int x, int y, int w, int h)
-{
-  ImageMarker* mrk = dynamic_cast<ImageMarker *>(d_plot->marker(selectedMarker));
+void Graph::updateImageMarker(int x, int y, int w, int h) {
+  ImageMarker *mrk =
+      dynamic_cast<ImageMarker *>(d_plot->marker(selectedMarker));
   if (!mrk)
     return;
 
@@ -1902,86 +1769,87 @@ void Graph::updateImageMarker(int x, int y, int w, int h)
   emit modifiedGraph();
 }
 
-QString Graph::legendText()
-{
-  QString text="";
-  for (int i=0; i<n_curves; i++){
+QString Graph::legendText() {
+  QString text = "";
+  for (int i = 0; i < n_curves; i++) {
     const QwtPlotCurve *c = curve(i);
-    if (c && c->rtti() != QwtPlotItem::Rtti_PlotSpectrogram && c_type[i] != ErrorBars ){
-      text+="\\l(";
-      text+=QString::number(i+1);
-      text+=")%(";
-      text+=QString::number(i+1);
-      text+=")\n";
+    if (c && c->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
+        c_type[i] != ErrorBars) {
+      text += "\\l(";
+      text += QString::number(i + 1);
+      text += ")%(";
+      text += QString::number(i + 1);
+      text += ")\n";
     }
   }
   return text.trimmed();
 }
 
-QString Graph::pieLegendText()
-{
-  QString text="";
-  QList<int> keys= d_plot->curveKeys();
-  const QwtPlotCurve *curve = dynamic_cast<QwtPlotCurve *>(d_plot->curve(keys[0]));
-  if (curve){
-    for (int i=0;i<static_cast<int>(curve->dataSize());i++){
-      text+="\\p{";
-      text+=QString::number(i+1);
-      text+="} ";
-      text+=QString::number(i+1);
-      text+="\n";
+QString Graph::pieLegendText() {
+  QString text = "";
+  QList<int> keys = d_plot->curveKeys();
+  const QwtPlotCurve *curve =
+      dynamic_cast<QwtPlotCurve *>(d_plot->curve(keys[0]));
+  if (curve) {
+    for (int i = 0; i < static_cast<int>(curve->dataSize()); i++) {
+      text += "\\p{";
+      text += QString::number(i + 1);
+      text += "} ";
+      text += QString::number(i + 1);
+      text += "\n";
     }
   }
   return text.trimmed();
 }
 
-void Graph::updateCurvesData(Table* w, const QString& yColName)
-{
+void Graph::updateCurvesData(Table *w, const QString &yColName) {
   QList<int> keys = d_plot->curveKeys();
   int updated_curves = 0;
-  for (int i=0; i<(int)keys.count(); i++){
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
-    if (!it) continue;
+    if (!it)
+      continue;
 
     if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
       continue;
     PlotCurve *c = dynamic_cast<PlotCurve *>(it);
-    if (!c) continue;
+    if (!c)
+      continue;
 
-    if (c->type() == Function) continue;
+    if (c->type() == Function)
+      continue;
 
     DataCurve *dc = dynamic_cast<DataCurve *>(it);
-    if (!dc) continue;
+    if (!dc)
+      continue;
 
-    if(dc->updateData(w, yColName))
+    if (dc->updateData(w, yColName))
       updated_curves++;
   }
-  if (updated_curves){
-    for (int i = 0; i < QwtPlot::axisCnt; i++){
+  if (updated_curves) {
+    for (int i = 0; i < QwtPlot::axisCnt; i++) {
       QwtScaleWidget *scale = d_plot->axisWidget(i);
       if (scale)
-        connect(scale, SIGNAL(scaleDivChanged()), this, SLOT(updateMarkersBoundingRect()));
+        connect(scale, SIGNAL(scaleDivChanged()), this,
+                SLOT(updateMarkersBoundingRect()));
     }
     updatePlot();
   }
 }
 
-QColor Graph::canvasFrameColor()
-{
-  QwtPlotCanvas* canvas=(QwtPlotCanvas*) d_plot->canvas();
-  QPalette pal =canvas->palette();
+QColor Graph::canvasFrameColor() {
+  QwtPlotCanvas *canvas = (QwtPlotCanvas *)d_plot->canvas();
+  QPalette pal = canvas->palette();
   return pal.color(QPalette::Active, QColorGroup::Foreground);
 }
 
-int Graph::canvasFrameWidth()
-{
-  QwtPlotCanvas* canvas=(QwtPlotCanvas*) d_plot->canvas();
+int Graph::canvasFrameWidth() {
+  QwtPlotCanvas *canvas = (QwtPlotCanvas *)d_plot->canvas();
   return canvas->lineWidth();
 }
 
-void Graph::setCanvasFrame(int width, const QColor& color)
-{
-  QwtPlotCanvas* canvas=(QwtPlotCanvas*) d_plot->canvas();
+void Graph::setCanvasFrame(int width, const QColor &color) {
+  QwtPlotCanvas *canvas = (QwtPlotCanvas *)d_plot->canvas();
   QPalette pal = canvas->palette();
 
   if (canvas->lineWidth() == width &&
@@ -1989,29 +1857,26 @@ void Graph::setCanvasFrame(int width, const QColor& color)
     return;
 
   canvas->setLineWidth(width);
-  pal.setColor(QColorGroup::Foreground,color);
+  pal.setColor(QColorGroup::Foreground, color);
   canvas->setPalette(pal);
   emit modifiedGraph();
 }
 
-void Graph::drawAxesBackbones(bool yes)
-{
+void Graph::drawAxesBackbones(bool yes) {
 
   drawAxesBackbone = yes;
 
-  for (int i=0; i<QwtPlot::axisCnt; i++)
-  {
-    QwtScaleWidget *scale= dynamic_cast<QwtScaleWidget*>(d_plot->axisWidget(i));
-    if (scale)
-    {
-      ScaleDraw *sclDraw = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw (i));
-      if (isColorBarEnabled(i)) //always draw the backbone for a colour bar axis
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+    if (scale) {
+      ScaleDraw *sclDraw = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(i));
+      if (isColorBarEnabled(
+              i)) // always draw the backbone for a colour bar axis
       {
-        sclDraw->enableComponent (QwtAbstractScaleDraw::Backbone, true);
-      }
-      else
-      {
-        sclDraw->enableComponent (QwtAbstractScaleDraw::Backbone, yes);
+        sclDraw->enableComponent(QwtAbstractScaleDraw::Backbone, true);
+      } else {
+        sclDraw->enableComponent(QwtAbstractScaleDraw::Backbone, yes);
       }
       scale->repaint();
     }
@@ -2020,35 +1885,33 @@ void Graph::drawAxesBackbones(bool yes)
   emit modifiedGraph();
 }
 
-void Graph::loadAxesOptions(const QString& s)
-{
+void Graph::loadAxesOptions(const QString &s) {
   if (s == "1")
     return;
 
   drawAxesBackbone = false;
 
-  for (int i=0; i<QwtPlot::axisCnt; i++)
-  {
-    QwtScaleWidget *scale=dynamic_cast<QwtScaleWidget*>(d_plot->axisWidget(i));
-    if (scale)
-    {
-      ScaleDraw *sclDraw = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw (i));
-      sclDraw->enableComponent (QwtAbstractScaleDraw::Backbone, false);
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+    if (scale) {
+      ScaleDraw *sclDraw = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(i));
+      sclDraw->enableComponent(QwtAbstractScaleDraw::Backbone, false);
       scale->repaint();
     }
   }
 }
 
-void Graph::setAxesLinewidth(int width)
-{
+void Graph::setAxesLinewidth(int width) {
   if (d_plot->axesLinewidth() == width)
     return;
 
   d_plot->setAxesLinewidth(width);
 
-  for (int i=0; i<QwtPlot::axisCnt; i++){
-    QwtScaleWidget *scale=dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
-    if (scale){
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+    if (scale) {
       scale->setPenWidth(width);
       scale->repaint();
     }
@@ -2057,147 +1920,143 @@ void Graph::setAxesLinewidth(int width)
   emit modifiedGraph();
 }
 
-void Graph::loadAxesLinewidth(int width)
-{
-  d_plot->setAxesLinewidth(width);
-}
+void Graph::loadAxesLinewidth(int width) { d_plot->setAxesLinewidth(width); }
 
-void Graph::setAxisTitleColor(int axis, const QColor& c)
-{
-  QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
-  if (scale){
+void Graph::setAxisTitleColor(int axis, const QColor &c) {
+  QwtScaleWidget *scale =
+      dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(axis));
+  if (scale) {
     QwtText title = scale->title();
     title.setColor(c);
     scale->setTitle(title);
   }
 }
 
-QString Graph::savePieCurveLayout()
-{
-  QString s="PieCurve\t";
+QString Graph::savePieCurveLayout() {
+  QString s = "PieCurve\t";
 
-  QwtPieCurve *pie = dynamic_cast<QwtPieCurve*>(curve(0));
+  QwtPieCurve *pie = dynamic_cast<QwtPieCurve *>(curve(0));
   if (!pie)
     return s;
 
-  s+= pie->title().text()+"\t";
+  s += pie->title().text() + "\t";
   QPen pen = pie->pen();
-  s+=QString::number(pen.widthF())+"\t";
-  s+=pen.color().name()+"\t";
-  s+=penStyleName(pen.style()) + "\t";
-  s+=QString::number(PatternBox::patternIndex(pie->pattern()))+"\t";
-  s+=QString::number(pie->radius())+"\t";
-  s+=QString::number(pie->firstColor())+"\t";
-  s+=QString::number(pie->startRow())+"\t"+QString::number(pie->endRow())+"\t";
-  s+=QString::number(pie->isVisible())+"\t";
+  s += QString::number(pen.widthF()) + "\t";
+  s += pen.color().name() + "\t";
+  s += penStyleName(pen.style()) + "\t";
+  s += QString::number(PatternBox::patternIndex(pie->pattern())) + "\t";
+  s += QString::number(pie->radius()) + "\t";
+  s += QString::number(pie->firstColor()) + "\t";
+  s += QString::number(pie->startRow()) + "\t" +
+       QString::number(pie->endRow()) + "\t";
+  s += QString::number(pie->isVisible()) + "\t";
 
-  //Starting with version 0.9.3-rc3
-  s+=QString::number(pie->startAzimuth())+"\t";
-  s+=QString::number(pie->viewAngle())+"\t";
-  s+=QString::number(pie->thickness())+"\t";
-  s+=QString::number(pie->horizontalOffset())+"\t";
-  s+=QString::number(pie->labelsEdgeDistance())+"\t";
-  s+=QString::number(pie->counterClockwise())+"\t";
-  s+=QString::number(pie->labelsAutoFormat())+"\t";
-  s+=QString::number(pie->labelsValuesFormat())+"\t";
-  s+=QString::number(pie->labelsPercentagesFormat())+"\t";
-  s+=QString::number(pie->labelCategories())+"\t";
-  s+=QString::number(pie->fixedLabelsPosition())+"\n";
+  // Starting with version 0.9.3-rc3
+  s += QString::number(pie->startAzimuth()) + "\t";
+  s += QString::number(pie->viewAngle()) + "\t";
+  s += QString::number(pie->thickness()) + "\t";
+  s += QString::number(pie->horizontalOffset()) + "\t";
+  s += QString::number(pie->labelsEdgeDistance()) + "\t";
+  s += QString::number(pie->counterClockwise()) + "\t";
+  s += QString::number(pie->labelsAutoFormat()) + "\t";
+  s += QString::number(pie->labelsValuesFormat()) + "\t";
+  s += QString::number(pie->labelsPercentagesFormat()) + "\t";
+  s += QString::number(pie->labelCategories()) + "\t";
+  s += QString::number(pie->fixedLabelsPosition()) + "\n";
   return s;
 }
 
-QString Graph::saveCurveLayout(int index)
-{
+QString Graph::saveCurveLayout(int index) {
   QString s = QString::null;
   int style = c_type[index];
-  QwtPlotCurve *c = dynamic_cast<QwtPlotCurve*>(curve(index));
-  if (c){
-    s += QString::number(style)+"\t";
+  QwtPlotCurve *c = dynamic_cast<QwtPlotCurve *>(curve(index));
+  if (c) {
+    s += QString::number(style) + "\t";
     if (style == Spline)
-      s+="5\t";
+      s += "5\t";
     else if (style == VerticalSteps)
-      s+="6\t";
+      s += "6\t";
     else
-      s+=QString::number(c->style())+"\t";
-    s+=QString::number(ColorBox::colorIndex(c->pen().color()))+"\t";
-    s+=QString::number(c->pen().style()-1)+"\t";
-    s+=QString::number(c->pen().widthF())+"\t";
+      s += QString::number(c->style()) + "\t";
+    s += QString::number(ColorBox::colorIndex(c->pen().color())) + "\t";
+    s += QString::number(c->pen().style() - 1) + "\t";
+    s += QString::number(c->pen().widthF()) + "\t";
 
     const QwtSymbol symbol = c->symbol();
-    s+=QString::number(symbol.size().width())+"\t";
-    s+=QString::number(SymbolBox::symbolIndex(symbol.style()))+"\t";
-    s+=QString::number(ColorBox::colorIndex(symbol.pen().color()))+"\t";
+    s += QString::number(symbol.size().width()) + "\t";
+    s += QString::number(SymbolBox::symbolIndex(symbol.style())) + "\t";
+    s += QString::number(ColorBox::colorIndex(symbol.pen().color())) + "\t";
     if (symbol.brush().style() != Qt::NoBrush)
-      s+=QString::number(ColorBox::colorIndex(symbol.brush().color()))+"\t";
+      s += QString::number(ColorBox::colorIndex(symbol.brush().color())) + "\t";
     else
-      s+=QString::number(-1)+"\t";
+      s += QString::number(-1) + "\t";
 
     bool filled = c->brush().style() == Qt::NoBrush ? false : true;
-    s+=QString::number(filled)+"\t";
+    s += QString::number(filled) + "\t";
 
-    s+=QString::number(ColorBox::colorIndex(c->brush().color()))+"\t";
-    s+=QString::number(PatternBox::patternIndex(c->brush().style()))+"\t";
+    s += QString::number(ColorBox::colorIndex(c->brush().color())) + "\t";
+    s += QString::number(PatternBox::patternIndex(c->brush().style())) + "\t";
     if (style <= LineSymbols || style == Box)
-      s+=QString::number(symbol.pen().widthF())+"\t";
+      s += QString::number(symbol.pen().widthF()) + "\t";
   }
 
-  if(style == VerticalBars || style == HorizontalBars || style == Histogram){
+  if (style == VerticalBars || style == HorizontalBars || style == Histogram) {
     QwtBarCurve *b = dynamic_cast<QwtBarCurve *>(c);
     if (b) {
-      s+=QString::number(b->gap())+"\t";
-      s+=QString::number(b->offset())+"\t";
+      s += QString::number(b->gap()) + "\t";
+      s += QString::number(b->offset()) + "\t";
     }
   }
 
-  if (style == Histogram){
+  if (style == Histogram) {
     QwtHistogram *h = dynamic_cast<QwtHistogram *>(c);
     if (h) {
-      s+=QString::number(h->autoBinning())+"\t";
-      s+=QString::number(h->binSize())+"\t";
-      s+=QString::number(h->begin())+"\t";
-      s+=QString::number(h->end())+"\t";
+      s += QString::number(h->autoBinning()) + "\t";
+      s += QString::number(h->binSize()) + "\t";
+      s += QString::number(h->begin()) + "\t";
+      s += QString::number(h->end()) + "\t";
     }
-  } else if(style == VectXYXY || style == VectXYAM){
+  } else if (style == VectXYXY || style == VectXYAM) {
     VectorCurve *v = dynamic_cast<VectorCurve *>(c);
     if (v) {
-      s+=v->color().name()+"\t";
-      s+=QString::number(v->width())+"\t";
-      s+=QString::number(v->headLength())+"\t";
-      s+=QString::number(v->headAngle())+"\t";
-      s+=QString::number(v->filledArrowHead())+"\t";
+      s += v->color().name() + "\t";
+      s += QString::number(v->width()) + "\t";
+      s += QString::number(v->headLength()) + "\t";
+      s += QString::number(v->headAngle()) + "\t";
+      s += QString::number(v->filledArrowHead()) + "\t";
 
-      QStringList colsList = v->plotAssociation().split(",", QString::SkipEmptyParts);
-      s+=colsList[2].remove("(X)").remove("(A)")+"\t";
-      s+=colsList[3].remove("(Y)").remove("(M)");
+      QStringList colsList =
+          v->plotAssociation().split(",", QString::SkipEmptyParts);
+      s += colsList[2].remove("(X)").remove("(A)") + "\t";
+      s += colsList[3].remove("(Y)").remove("(M)");
       if (style == VectXYAM)
-        s+="\t"+QString::number(v->position());
-      s+="\t";
+        s += "\t" + QString::number(v->position());
+      s += "\t";
     }
-  } else if(style == Box){
-    BoxCurve *b = static_cast<BoxCurve*>(c);
+  } else if (style == Box) {
+    BoxCurve *b = static_cast<BoxCurve *>(c);
     if (b) {
-      s+=QString::number(SymbolBox::symbolIndex(b->maxStyle()))+"\t";
-      s+=QString::number(SymbolBox::symbolIndex(b->p99Style()))+"\t";
-      s+=QString::number(SymbolBox::symbolIndex(b->meanStyle()))+"\t";
-      s+=QString::number(SymbolBox::symbolIndex(b->p1Style()))+"\t";
-      s+=QString::number(SymbolBox::symbolIndex(b->minStyle()))+"\t";
-      s+=QString::number(b->boxStyle())+"\t";
-      s+=QString::number(b->boxWidth())+"\t";
-      s+=QString::number(b->boxRangeType())+"\t";
-      s+=QString::number(b->boxRange())+"\t";
-      s+=QString::number(b->whiskersRangeType())+"\t";
-      s+=QString::number(b->whiskersRange())+"\t";
+      s += QString::number(SymbolBox::symbolIndex(b->maxStyle())) + "\t";
+      s += QString::number(SymbolBox::symbolIndex(b->p99Style())) + "\t";
+      s += QString::number(SymbolBox::symbolIndex(b->meanStyle())) + "\t";
+      s += QString::number(SymbolBox::symbolIndex(b->p1Style())) + "\t";
+      s += QString::number(SymbolBox::symbolIndex(b->minStyle())) + "\t";
+      s += QString::number(b->boxStyle()) + "\t";
+      s += QString::number(b->boxWidth()) + "\t";
+      s += QString::number(b->boxRangeType()) + "\t";
+      s += QString::number(b->boxRange()) + "\t";
+      s += QString::number(b->whiskersRangeType()) + "\t";
+      s += QString::number(b->whiskersRange()) + "\t";
     }
   }
   return s;
 }
 
-LegendWidget* Graph::newLegend(const QString& text)
-{
-  LegendWidget* l = new LegendWidget(d_plot);
+LegendWidget *Graph::newLegend(const QString &text) {
+  LegendWidget *l = new LegendWidget(d_plot);
 
   QString s = text;
-  if (s.isEmpty()){
+  if (s.isEmpty()) {
     if (isPiePlot())
       s = pieLegendText();
     else
@@ -2205,7 +2064,7 @@ LegendWidget* Graph::newLegend(const QString& text)
   }
   l->setText(s);
   ApplicationWindow *app = multiLayer()->applicationWindow();
-  if (app){
+  if (app) {
     l->setFrameStyle(app->legendFrameStyle);
     l->setFont(app->plotLegendFont);
     l->setTextColor(app->legendTextColor);
@@ -2217,29 +2076,30 @@ LegendWidget* Graph::newLegend(const QString& text)
   return l;
 }
 
-void Graph::addTimeStamp()
-{
-  LegendWidget* l = newLegend(QDateTime::currentDateTime().toString(Qt::LocalDate));
+void Graph::addTimeStamp() {
+  LegendWidget *l =
+      newLegend(QDateTime::currentDateTime().toString(Qt::LocalDate));
 
   QPoint p = d_plot->canvas()->pos();
-  l->move(QPoint(p.x() + d_plot->canvas()->width()/2, p.y() + 10));
+  l->move(QPoint(p.x() + d_plot->canvas()->width() / 2, p.y() + 10));
   emit modifiedGraph();
 }
 
-LegendWidget* Graph::insertText(const std::string& type, const std::string& line)
-{
+LegendWidget *Graph::insertText(const std::string &type,
+                                const std::string &line) {
   const QStringList list = QString::fromUtf8(line.c_str()).split("\t");
   QStringList fList = list;
   bool pieLabel = (type == "PieLabel") ? true : false;
-  LegendWidget* l = NULL;
+  LegendWidget *l = NULL;
   if (pieLabel)
     l = new PieLabel(d_plot);
   else
     l = new LegendWidget(d_plot);
 
-  l->move(QPoint(fList[1].toInt(),fList[2].toInt()));
+  l->move(QPoint(fList[1].toInt(), fList[2].toInt()));
 
-  QFont fnt=QFont (fList[3],fList[4].toInt(),fList[5].toInt(),fList[6].toInt());
+  QFont fnt =
+      QFont(fList[3], fList[4].toInt(), fList[5].toInt(), fList[6].toInt());
   fnt.setUnderline(fList[7].toInt());
   fnt.setStrikeOut(fList[8].toInt());
   l->setFont(fnt);
@@ -2257,57 +2117,55 @@ LegendWidget* Graph::insertText(const std::string& type, const std::string& line
   if (n > 14)
     text += fList[14];
 
-  for (int i=1; i<n-14; i++){
-    int j = 14+i;
+  for (int i = 1; i < n - 14; i++) {
+    int j = 14 + i;
     if (n > j)
       text += "\n" + fList[j];
   }
 
   l->setText(text);
-  if (pieLabel){
+  if (pieLabel) {
     QwtPieCurve *pie = dynamic_cast<QwtPieCurve *>(curve(0));
-    if(pie)
+    if (pie)
       pie->addLabel(dynamic_cast<PieLabel *>(l));
   }
   return l;
 }
 
-void Graph::addArrow(QStringList list, int fileVersion)
-{
-  ArrowMarker* mrk = new ArrowMarker();
-  int mrkID=d_plot->insertMarker(mrk);
+void Graph::addArrow(QStringList list, int fileVersion) {
+  ArrowMarker *mrk = new ArrowMarker();
+  int mrkID = d_plot->insertMarker(mrk);
   int linesOnPlot = d_lines.size();
   d_lines.resize(++linesOnPlot);
-  d_lines[linesOnPlot-1]=mrkID;
+  d_lines[linesOnPlot - 1] = mrkID;
 
-  if (fileVersion < 86){
+  if (fileVersion < 86) {
     mrk->setStartPoint(QPoint(list[1].toInt(), list[2].toInt()));
     mrk->setEndPoint(QPoint(list[3].toInt(), list[4].toInt()));
   } else
     mrk->setBoundingRect(list[1].toDouble(), list[2].toDouble(),
-        list[3].toDouble(), list[4].toDouble());
+                         list[3].toDouble(), list[4].toDouble());
 
   mrk->setWidth(list[5].toDouble());
   mrk->setColor(QColor(list[6]));
   mrk->setStyle(getPenStyle(list[7]));
-  mrk->drawEndArrow(list[8]=="1");
-  mrk->drawStartArrow(list[9]=="1");
-  if (list.count()>10){
+  mrk->drawEndArrow(list[8] == "1");
+  mrk->drawStartArrow(list[9] == "1");
+  if (list.count() > 10) {
     mrk->setHeadLength(list[10].toInt());
     mrk->setHeadAngle(list[11].toInt());
-    mrk->fillArrowHead(list[12]=="1");
+    mrk->fillArrowHead(list[12] == "1");
   }
 }
 
-ArrowMarker* Graph::addArrow(ArrowMarker* mrk)
-{
-  ArrowMarker* aux = new ArrowMarker();
+ArrowMarker *Graph::addArrow(ArrowMarker *mrk) {
+  ArrowMarker *aux = new ArrowMarker();
   int linesOnPlot = d_lines.size();
   d_lines.resize(++linesOnPlot);
-  d_lines[linesOnPlot-1] = d_plot->insertMarker(aux);
+  d_lines[linesOnPlot - 1] = d_plot->insertMarker(aux);
 
   aux->setBoundingRect(mrk->startPointCoord().x(), mrk->startPointCoord().y(),
-      mrk->endPointCoord().x(), mrk->endPointCoord().y());
+                       mrk->endPointCoord().x(), mrk->endPointCoord().y());
   aux->setWidth(mrk->width());
   aux->setColor(mrk->color());
   aux->setStyle(mrk->style());
@@ -2319,84 +2177,71 @@ ArrowMarker* Graph::addArrow(ArrowMarker* mrk)
   return aux;
 }
 
-ArrowMarker* Graph::arrow(int id)
-{
-  return dynamic_cast<ArrowMarker*>(d_plot->marker(id));
+ArrowMarker *Graph::arrow(int id) {
+  return dynamic_cast<ArrowMarker *>(d_plot->marker(id));
 }
 
-ImageMarker* Graph::imageMarker(int id)
-{
-  return dynamic_cast<ImageMarker*>(d_plot->marker(id));
+ImageMarker *Graph::imageMarker(int id) {
+  return dynamic_cast<ImageMarker *>(d_plot->marker(id));
 }
 
-LegendWidget* Graph::insertText(LegendWidget* t)
-{
-  LegendWidget* aux = new LegendWidget(d_plot);
+LegendWidget *Graph::insertText(LegendWidget *t) {
+  LegendWidget *aux = new LegendWidget(d_plot);
   aux->clone(t);
   return aux;
 }
 
-double Graph::selectedXStartValue()
-{
+double Graph::selectedXStartValue() {
   if (d_range_selector)
     return d_range_selector->minXValue();
   else
     return 0;
 }
 
-double Graph::selectedXEndValue()
-{
+double Graph::selectedXEndValue() {
   if (d_range_selector)
     return d_range_selector->maxXValue();
   else
     return 0;
 }
 
-QwtPlotItem* Graph::plotItem(int index)
-{
+QwtPlotItem *Graph::plotItem(int index) {
   if (!n_curves || index >= n_curves || index < 0)
     return 0;
 
   return d_plot->plotItem(c_keys[index]);
 }
 
-int Graph::plotItemIndex(QwtPlotItem *it) const
-{
+int Graph::plotItemIndex(QwtPlotItem *it) const {
   if (!it)
     return -1;
 
-  for (int i = 0; i < n_curves; i++){
+  for (int i = 0; i < n_curves; i++) {
     if (d_plot->plotItem(c_keys[i]) == it)
       return i;
   }
   return -1;
 }
 
-QwtPlotCurve *Graph::curve(int index)
-{
+QwtPlotCurve *Graph::curve(int index) {
   if (!n_curves || index >= n_curves || index < 0)
     return 0;
 
   return d_plot->curve(c_keys[index]);
 }
 
-int Graph::curveIndex(QwtPlotCurve *c) const
-{
-  return plotItemIndex(c);
-}
+int Graph::curveIndex(QwtPlotCurve *c) const { return plotItemIndex(c); }
 
 //! get curve title string by index (convenience function for scripts)
-QString Graph::curveTitle(int index)
-{
-        QwtPlotItem *item = plotItem(index);
-        if (item)
-                return item->title().text();
+QString Graph::curveTitle(int index) {
+  QwtPlotItem *item = plotItem(index);
+  if (item)
+    return item->title().text();
 
-        return QString::null;
+  return QString::null;
 }
 
-int Graph::range(int index, double *start, double *end)
-{
+int Graph::range(int index, double *start, double *end) {
   if (d_range_selector && d_range_selector->selectedCurve() == curve(index)) {
     *start = d_range_selector->minXValue();
     *end = d_range_selector->maxXValue();
@@ -2412,8 +2257,7 @@ int Graph::range(int index, double *start, double *end)
   }
 }
 
-CurveLayout Graph::initCurveLayout()
-{
+CurveLayout Graph::initCurveLayout() {
   CurveLayout cl;
   cl.connectType = 1;
   cl.lStyle = 0;
@@ -2430,8 +2274,7 @@ CurveLayout Graph::initCurveLayout()
   return cl;
 }
 
-CurveLayout Graph::initCurveLayout(int style, int curves)
-{
+CurveLayout Graph::initCurveLayout(int style, int curves) {
   int i = n_curves - 1;
 
   CurveLayout cl = initCurveLayout();
@@ -2448,30 +2291,31 @@ CurveLayout Graph::initCurveLayout(int style, int curves)
     cl.connectType = 0;
   else if (style == Graph::VerticalDropLines)
     cl.connectType = 2;
-  else if (style == Graph::HorizontalSteps || style == Graph::VerticalSteps){
+  else if (style == Graph::HorizontalSteps || style == Graph::VerticalSteps) {
     cl.connectType = 3;
     cl.sType = 0;
   } else if (style == Graph::Spline)
     cl.connectType = 5;
-  else if (curves && (style == Graph::VerticalBars || style == Graph::HorizontalBars)){
+  else if (curves &&
+           (style == Graph::VerticalBars || style == Graph::HorizontalBars)) {
     cl.filledArea = 1;
-    cl.lCol = 0;//black color pen
+    cl.lCol = 0; // black color pen
     cl.aCol = i + 1;
     cl.sType = 0;
-    if (c_type[i] == Graph::VerticalBars || style == Graph::HorizontalBars){
+    if (c_type[i] == Graph::VerticalBars || style == Graph::HorizontalBars) {
       QwtBarCurve *b = dynamic_cast<QwtBarCurve *>(curve(i));
-      if (b){
-        b->setGap(qRound(100*(1-1.0/(double)curves)));
-        b->setOffset(-50*(curves-1) + i*100);
+      if (b) {
+        b->setGap(qRound(100 * (1 - 1.0 / (double)curves)));
+        b->setOffset(-50 * (curves - 1) + i * 100);
       }
     }
-  } else if (style == Graph::Histogram){
+  } else if (style == Graph::Histogram) {
     cl.filledArea = 1;
-    cl.lCol = i + 1;//start with red color pen
-    cl.aCol = i + 1; //start with red fill color
+    cl.lCol = i + 1; // start with red color pen
+    cl.aCol = i + 1; // start with red fill color
     cl.aStyle = 4;
     cl.sType = 0;
-  } else if (style == Graph::Area){
+  } else if (style == Graph::Area) {
     cl.filledArea = 1;
     cl.aCol = color;
     cl.sType = 0;
@@ -2480,13 +2324,9 @@ CurveLayout Graph::initCurveLayout(int style, int curves)
   return cl;
 }
 
-void Graph::setCurveType(int curve, int style)
-{
-  c_type[curve] = style;
-}
+void Graph::setCurveType(int curve, int style) { c_type[curve] = style; }
 
-void Graph::updateCurveLayout(PlotCurve* c, const CurveLayout *cL)
-{	
+void Graph::updateCurveLayout(PlotCurve *c, const CurveLayout *cL) {
   if (!c || c_type.isEmpty())
     return;
 
@@ -2496,13 +2336,17 @@ void Graph::updateCurveLayout(PlotCurve* c, const CurveLayout *cL)
 
   QPen pen = QPen(ColorBox::color(cL->symCol), cL->penWidth, Qt::SolidLine);
   if (cL->fillCol != -1)
-    c->setSymbol(QwtSymbol(SymbolBox::style(cL->sType), QBrush(ColorBox::color(cL->fillCol)), pen, QSize(cL->sSize, cL->sSize)));
+    c->setSymbol(QwtSymbol(SymbolBox::style(cL->sType),
+                           QBrush(ColorBox::color(cL->fillCol)), pen,
+                           QSize(cL->sSize, cL->sSize)));
   else
-    c->setSymbol(QwtSymbol(SymbolBox::style(cL->sType), QBrush(), pen, QSize(cL->sSize, cL->sSize)));
+    c->setSymbol(QwtSymbol(SymbolBox::style(cL->sType), QBrush(), pen,
+                           QSize(cL->sSize, cL->sSize)));
 
-  c->setPen(QPen(ColorBox::color(cL->lCol), cL->lWidth, getPenStyle(cL->lStyle)));
+  c->setPen(
+      QPen(ColorBox::color(cL->lCol), cL->lWidth, getPenStyle(cL->lStyle)));
 
-  switch (c_type[index]){
+  switch (c_type[index]) {
   case Scatter:
     c->setStyle(QwtPlotCurve::NoCurve);
     break;
@@ -2527,15 +2371,15 @@ void Graph::updateCurveLayout(PlotCurve* c, const CurveLayout *cL)
   c->setBrush(brush);
 }
 
-void Graph::updateErrorBars(QwtErrorPlotCurve *er, bool xErr, double width, int cap, const QColor& c,
-    bool plus, bool minus, bool through)
-{
+void Graph::updateErrorBars(QwtErrorPlotCurve *er, bool xErr, double width,
+                            int cap, const QColor &c, bool plus, bool minus,
+                            bool through) {
   if (!er)
     return;
 
-  if (er->width() == width && er->capLength() == cap &&
-      er->color() == c && er->plusSide() == plus &&
-      er->minusSide() == minus && er->throughSymbol() == through && er->xErrors() == xErr)
+  if (er->width() == width && er->capLength() == cap && er->color() == c &&
+      er->plusSide() == plus && er->minusSide() == minus &&
+      er->throughSymbol() == through && er->xErrors() == xErr)
     return;
 
   er->setWidth(width);
@@ -2549,24 +2393,28 @@ void Graph::updateErrorBars(QwtErrorPlotCurve *er, bool xErr, double width, int 
   emit modifiedGraph();
 }
 
-QwtErrorPlotCurve* Graph::addErrorBars(const QString& yColName, Table *errTable, const QString& errColName,
-    int type, double width, int cap, const QColor& color, bool through, bool minus, bool plus)
-{
+QwtErrorPlotCurve *Graph::addErrorBars(const QString &yColName, Table *errTable,
+                                       const QString &errColName, int type,
+                                       double width, int cap,
+                                       const QColor &color, bool through,
+                                       bool minus, bool plus) {
   QList<int> keys = d_plot->curveKeys();
-  for (int i = 0; i<n_curves; i++ ){
+  for (int i = 0; i < n_curves; i++) {
     DataCurve *c = dynamic_cast<DataCurve *>(d_plot->curve(keys[i]));
-    if (c && c->title().text() == yColName && c_type[i] != ErrorBars){
+    if (c && c->title().text() == yColName && c_type[i] != ErrorBars) {
       return addErrorBars(c->xColumnName(), yColName, errTable, errColName,
-          type, width, cap, color, through, minus, plus);
+                          type, width, cap, color, through, minus, plus);
     }
   }
   return NULL;
 }
 
-QwtErrorPlotCurve* Graph::addErrorBars(const QString& xColName, const QString& yColName,
-    Table *errTable, const QString& errColName, int type, double width, int cap,
-    const QColor& color, bool through, bool minus, bool plus)
-{
+QwtErrorPlotCurve *Graph::addErrorBars(const QString &xColName,
+                                       const QString &yColName, Table *errTable,
+                                       const QString &errColName, int type,
+                                       double width, int cap,
+                                       const QColor &color, bool through,
+                                       bool minus, bool plus) {
   DataCurve *master_curve = masterCurve(xColName, yColName);
   if (!master_curve)
     return NULL;
@@ -2574,10 +2422,10 @@ QwtErrorPlotCurve* Graph::addErrorBars(const QString& xColName, const QString& y
   QwtErrorPlotCurve *er = new QwtErrorPlotCurve(type, errTable, errColName);
 
   c_type.resize(++n_curves);
-  c_type[n_curves-1] = ErrorBars;
+  c_type[n_curves - 1] = ErrorBars;
 
   c_keys.resize(n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(er);
+  c_keys[n_curves - 1] = d_plot->insertCurve(er);
 
   er->setMasterCurve(master_curve);
   er->setCapLength(cap);
@@ -2594,17 +2442,16 @@ QwtErrorPlotCurve* Graph::addErrorBars(const QString& xColName, const QString& y
 /** Adds the display of error to an existing MantidCurve
  *  @param curveName :: The name of the curve
  */
-void Graph::addMantidErrorBars(const QString& curveName,bool drawAll)
-{
-  MantidMatrixCurve * c = dynamic_cast<MantidMatrixCurve*>(curve(curveName));
+void Graph::addMantidErrorBars(const QString &curveName, bool drawAll) {
+  MantidMatrixCurve *c = dynamic_cast<MantidMatrixCurve *>(curve(curveName));
   // Give a message if this isn't a MantidCurve
-  if (!c)
-  {
-    QMessageBox::critical(0,"MantidPlot","The selected curve is not Mantid workspace data");
+  if (!c) {
+    QMessageBox::critical(0, "MantidPlot",
+                          "The selected curve is not Mantid workspace data");
     return;
   }
 
-  c->setErrorBars(true,drawAll);
+  c->setErrorBars(true, drawAll);
   updatePlot();
   return;
 }
@@ -2612,13 +2459,12 @@ void Graph::addMantidErrorBars(const QString& curveName,bool drawAll)
 /** Removes the error bars form a MantidCurve
  *  @param curveName :: The name of the curve
  */
-void Graph::removeMantidErrorBars(const QString& curveName)
-{
-  MantidMatrixCurve * c = dynamic_cast<MantidMatrixCurve*>(curve(curveName));
+void Graph::removeMantidErrorBars(const QString &curveName) {
+  MantidMatrixCurve *c = dynamic_cast<MantidMatrixCurve *>(curve(curveName));
   // Give a message if this isn't a MantidCurve
-  if (!c)
-  {
-    QMessageBox::critical(0,"MantidPlot","The selected curve is not Mantid workspace data");
+  if (!c) {
+    QMessageBox::critical(0, "MantidPlot",
+                          "The selected curve is not Mantid workspace data");
     return;
   }
 
@@ -2627,37 +2473,35 @@ void Graph::removeMantidErrorBars(const QString& curveName)
   return;
 }
 
-ErrorBarSettings* Graph::errorBarSettings(int curveIndex, int errorBarIndex)
-{
-  PlotCurve* c = dynamic_cast<PlotCurve*>(curve(curveIndex));
-  if ( c && errorBarIndex >= 0 )
-  {
-    QList<ErrorBarSettings*> settings = c->errorBarSettingsList();
-    if ( errorBarIndex < settings.size() )
-    {
+ErrorBarSettings *Graph::errorBarSettings(int curveIndex, int errorBarIndex) {
+  PlotCurve *c = dynamic_cast<PlotCurve *>(curve(curveIndex));
+  if (c && errorBarIndex >= 0) {
+    QList<ErrorBarSettings *> settings = c->errorBarSettingsList();
+    if (errorBarIndex < settings.size()) {
       return settings[errorBarIndex];
     }
   }
   return NULL;
 }
 
-QwtPieCurve* Graph::plotPie(Table* w, const QString& name, const QPen& pen, int brush,
-    int size, int firstColor, int startRow, int endRow, bool visible,
-    double d_start_azimuth, double d_view_angle, double d_thickness,
-    double d_horizontal_offset, double d_edge_dist, bool d_counter_clockwise,
-    bool d_auto_labeling, bool d_values, bool d_percentages,
-    bool d_categories, bool d_fixed_labels_pos)
-{
+QwtPieCurve *Graph::plotPie(Table *w, const QString &name, const QPen &pen,
+                            int brush, int size, int firstColor, int startRow,
+                            int endRow, bool visible, double d_start_azimuth,
+                            double d_view_angle, double d_thickness,
+                            double d_horizontal_offset, double d_edge_dist,
+                            bool d_counter_clockwise, bool d_auto_labeling,
+                            bool d_values, bool d_percentages,
+                            bool d_categories, bool d_fixed_labels_pos) {
   if (endRow < 0)
     endRow = w->numRows() - 1;
 
   QwtPieCurve *pie = new QwtPieCurve(w, name, startRow, endRow);
 
   c_keys.resize(++n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(pie);
+  c_keys[n_curves - 1] = d_plot->insertCurve(pie);
 
   c_type.resize(n_curves);
-  c_type[n_curves-1] = Pie;
+  c_type[n_curves - 1] = Pie;
 
   pie->loadData();
   pie->setPen(pen);
@@ -2680,24 +2524,24 @@ QwtPieCurve* Graph::plotPie(Table* w, const QString& name, const QPen& pen, int 
   return pie;
 }
 
-QwtPieCurve* Graph::plotPie(Table* w, const QString& name, int startRow, int endRow)
-{
-  for (int i=0; i<QwtPlot::axisCnt; i++)
+QwtPieCurve *Graph::plotPie(Table *w, const QString &name, int startRow,
+                            int endRow) {
+  for (int i = 0; i < QwtPlot::axisCnt; i++)
     d_plot->enableAxis(i, false);
   scalePicker->refresh();
 
   d_plot->setTitle(QString::null);
 
-  QwtPlotCanvas* canvas=(QwtPlotCanvas*) d_plot->canvas();
+  QwtPlotCanvas *canvas = (QwtPlotCanvas *)d_plot->canvas();
   canvas->setLineWidth(1);
 
   QwtPieCurve *pie = new QwtPieCurve(w, name, startRow, endRow);
 
   c_keys.resize(++n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(pie);
+  c_keys[n_curves - 1] = d_plot->insertCurve(pie);
 
   c_type.resize(n_curves);
-  c_type[n_curves-1] = Pie;
+  c_type[n_curves - 1] = Pie;
 
   pie->loadData();
   pie->initLabels();
@@ -2705,21 +2549,19 @@ QwtPieCurve* Graph::plotPie(Table* w, const QString& name, int startRow, int end
   return pie;
 }
 
-void Graph::insertPlotItem(QwtPlotItem *i, int type)
-{
+void Graph::insertPlotItem(QwtPlotItem *i, int type) {
   c_type.resize(++n_curves);
-  c_type[n_curves-1] = type;
+  c_type[n_curves - 1] = type;
 
   c_keys.resize(n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(i);
+  c_keys[n_curves - 1] = d_plot->insertCurve(i);
 
   if (i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram)
     addLegendItem();
 }
 
-bool Graph::addCurves(Table* w, const QStringList& names, int style, double lWidth,
-    int sSize, int startRow, int endRow)
-{
+bool Graph::addCurves(Table *w, const QStringList &names, int style,
+                      double lWidth, int sSize, int startRow, int endRow) {
   if (style == Pie)
     plotPie(w, names[0], startRow, endRow);
   else if (style == Box)
@@ -2731,60 +2573,62 @@ bool Graph::addCurves(Table* w, const QStringList& names, int style, double lWid
     int noOfErrorCols = 0;
     QString xColNameGiven;
 
-    // Select only those column names which we can draw and search for any X columns specified
-    for (int i = 0; i < names.count(); i++)
-    {
+    // Select only those column names which we can draw and search for any X
+    // columns specified
+    for (int i = 0; i < names.count(); i++) {
       int c = w->colIndex(names[i]);
-      if (c < 0)
-      {
+      if (c < 0) {
         continue;
       }
       int d = w->colPlotDesignation(c);
 
-      switch(d)
-      {
-        case Table::Y:
-          // Y columns should be drawn first, so we are keeping them at the beginning of the list
-          drawableNames.prepend(names[i]);
-          break;
+      switch (d) {
+      case Table::Y:
+        // Y columns should be drawn first, so we are keeping them at the
+        // beginning of the list
+        drawableNames.prepend(names[i]);
+        break;
 
-        case Table::xErr: case Table::yErr:
-          noOfErrorCols++;
-          // Fall through, as we want errors to be at the end of the list in the same way as labels
-          // are. So _no break_ here on purpose.
+      case Table::xErr:
+      case Table::yErr:
+        noOfErrorCols++;
+      // Fall through, as we want errors to be at the end of the list in the
+      // same way as labels
+      // are. So _no break_ here on purpose.
 
-        case Table::Label:
-          // Keep error/label columns at the end of the list
-          drawableNames.append(names[i]);
-          break;
+      case Table::Label:
+        // Keep error/label columns at the end of the list
+        drawableNames.append(names[i]);
+        break;
 
-        case Table::X:
-          if(!xColNameGiven.isEmpty())
-            // If multiple X columns are specified, it's an error, as we don't know which one to use
-            return false;
-          xColNameGiven = names[i];
-          break;
+      case Table::X:
+        if (!xColNameGiven.isEmpty())
+          // If multiple X columns are specified, it's an error, as we don't
+          // know which one to use
+          return false;
+        xColNameGiven = names[i];
+        break;
 
-        default:
-          break;
+      default:
+        break;
       }
     }
 
-    for (int i = 0; i < drawableNames.count(); i++){
+    for (int i = 0; i < drawableNames.count(); i++) {
       QString colName = drawableNames[i];
       int colIndex = w->colIndex(colName);
       int colType = w->colPlotDesignation(colIndex);
 
       QString yColName;
-      if(colType == Table::Y)
+      if (colType == Table::Y)
         // For Y columns we use the column itself as Y
         yColName = colName;
-      else 
+      else
         // For other column types, we find associated Y column
         yColName = w->colName(w->colY(colIndex));
 
       QString xColName;
-      if(!xColNameGiven.isEmpty())
+      if (!xColNameGiven.isEmpty())
         // If X column is given - use it
         xColName = xColNameGiven;
       else
@@ -2794,35 +2638,34 @@ bool Graph::addCurves(Table* w, const QStringList& names, int style, double lWid
       if (xColName.isEmpty() || yColName.isEmpty())
         return false;
 
-      PlotCurve* newCurve(NULL);
+      PlotCurve *newCurve(NULL);
 
       // --- Drawing error columns -----------------------------
-      if (colType == Table::xErr || colType == Table::yErr){
+      if (colType == Table::xErr || colType == Table::yErr) {
         int dir;
-        if(colType == Table::xErr)
+        if (colType == Table::xErr)
           dir = QwtErrorPlotCurve::Horizontal;
         else
           dir = QwtErrorPlotCurve::Vertical;
 
         newCurve = addErrorBars(xColName, yColName, w, colName, dir);
-      // --- Drawing label columns -----------------------------
-      } else if (colType == Table::Label){
-        DataCurve* mc = masterCurve(xColName, yColName);
+        // --- Drawing label columns -----------------------------
+      } else if (colType == Table::Label) {
+        DataCurve *mc = masterCurve(xColName, yColName);
         if (!mc)
           return false;
 
         d_plot->replot();
         mc->setLabelsColumnName(colName);
-      // --- Drawing Y columns -----------------------------
-      } else if (colType == Table::Y)
-      {
+        // --- Drawing Y columns -----------------------------
+      } else if (colType == Table::Y) {
         newCurve = insertCurve(w, xColName, yColName, style, startRow, endRow);
       }
 
       // Set a layout for the new curve, if we've added one
-      if (newCurve)
-      {
-        CurveLayout cl = initCurveLayout(style, drawableNames.count() - noOfErrorCols);
+      if (newCurve) {
+        CurveLayout cl =
+            initCurveLayout(style, drawableNames.count() - noOfErrorCols);
         cl.sSize = sSize;
         cl.lWidth = static_cast<float>(lWidth);
 
@@ -2834,34 +2677,37 @@ bool Graph::addCurves(Table* w, const QStringList& names, int style, double lWid
   return true;
 }
 
-PlotCurve* Graph::insertCurve(Table* w, const QString& name, int style, int startRow, int endRow)
-{//provided for convenience
+PlotCurve *Graph::insertCurve(Table *w, const QString &name, int style,
+                              int startRow,
+                              int endRow) { // provided for convenience
   int ycol = w->colIndex(name);
   int xcol = w->colX(ycol);
 
-  PlotCurve* c = insertCurve(w, w->colName(xcol), w->colName(ycol), style, startRow, endRow);
+  PlotCurve *c = insertCurve(w, w->colName(xcol), w->colName(ycol), style,
+                             startRow, endRow);
   if (c)
     emit modifiedGraph();
   return c;
 }
 
-PlotCurve* Graph::insertCurve(Table* w, int xcol, const QString& name, int style)
-{
+PlotCurve *Graph::insertCurve(Table *w, int xcol, const QString &name,
+                              int style) {
   return insertCurve(w, w->colName(xcol), w->colName(w->colIndex(name)), style);
 }
 
-PlotCurve* Graph::insertCurve(Table* w, const QString& xColName, const QString& yColName, int style, int startRow, int endRow)
-{
-  int xcol=w->colIndex(xColName);
-  int ycol=w->colIndex(yColName);
+PlotCurve *Graph::insertCurve(Table *w, const QString &xColName,
+                              const QString &yColName, int style, int startRow,
+                              int endRow) {
+  int xcol = w->colIndex(xColName);
+  int ycol = w->colIndex(yColName);
   if (xcol < 0 || ycol < 0)
     return NULL;
 
   int xColType = w->columnType(xcol);
   int yColType = w->columnType(ycol);
-  int size=0;
+  int size = 0;
   QString date_time_fmt = w->columnFormat(xcol);
-  QStringList xLabels, yLabels;// store text labels
+  QStringList xLabels, yLabels; // store text labels
   QTime time0;
   QDateTime date0;
 
@@ -2870,19 +2716,19 @@ PlotCurve* Graph::insertCurve(Table* w, const QString& xColName, const QString& 
 
   int r = abs(endRow - startRow) + 1;
   QVector<double> X(r), Y(r);
-  if (xColType == Table::Time){
-    for (int i = startRow; i<=endRow; i++ ){
-      QString xval=w->text(i,xcol);
-      if (!xval.isEmpty()){
-        time0 = QTime::fromString (xval, date_time_fmt);
+  if (xColType == Table::Time) {
+    for (int i = startRow; i <= endRow; i++) {
+      QString xval = w->text(i, xcol);
+      if (!xval.isEmpty()) {
+        time0 = QTime::fromString(xval, date_time_fmt);
         if (time0.isValid())
           break;
       }
     }
-  } else if (xColType == Table::Date){
-    for (int i = startRow; i<=endRow; i++ ){
-      QString xval=w->text(i,xcol);
-      if (!xval.isEmpty()){
+  } else if (xColType == Table::Date) {
+    for (int i = startRow; i <= endRow; i++) {
+      QString xval = w->text(i, xcol);
+      if (!xval.isEmpty()) {
         date0 = QDateTime::fromString(xval, date_time_fmt);
         if (date0.isValid())
           break;
@@ -2890,31 +2736,31 @@ PlotCurve* Graph::insertCurve(Table* w, const QString& xColName, const QString& 
     }
   }
 
-  for (int i = startRow; i<=endRow; i++ ){
-    QString xval=w->text(i,xcol);
-    QString yval=w->text(i,ycol);
-    if (!xval.isEmpty() && !yval.isEmpty()){
+  for (int i = startRow; i <= endRow; i++) {
+    QString xval = w->text(i, xcol);
+    QString yval = w->text(i, ycol);
+    if (!xval.isEmpty() && !yval.isEmpty()) {
       bool valid_data = true;
-      if (xColType == Table::Text){
+      if (xColType == Table::Text) {
         if (xLabels.contains(xval) == 0)
           xLabels << xval;
-        X[size] = (double)(xLabels.findIndex(xval)+1);
-      } else if (xColType == Table::Time){
-        QTime time = QTime::fromString (xval, date_time_fmt);
+        X[size] = (double)(xLabels.findIndex(xval) + 1);
+      } else if (xColType == Table::Time) {
+        QTime time = QTime::fromString(xval, date_time_fmt);
         if (time.isValid())
-          X[size] = time0.msecsTo (time);
+          X[size] = time0.msecsTo(time);
         else
           X[size] = 0;
-      } else if (xColType == Table::Date){
-        QDateTime d = QDateTime::fromString (xval, date_time_fmt);
+      } else if (xColType == Table::Date) {
+        QDateTime d = QDateTime::fromString(xval, date_time_fmt);
         if (d.isValid())
-          X[size] = (double) date0.secsTo(d);
+          X[size] = (double)date0.secsTo(d);
       } else
         X[size] = d_plot->locale().toDouble(xval, &valid_data);
 
-      if (yColType == Table::Text){
+      if (yColType == Table::Text) {
         yLabels << yval;
-        Y[size] = (double) (size + 1);
+        Y[size] = (double)(size + 1);
       } else
         Y[size] = d_plot->locale().toDouble(yval, &valid_data);
 
@@ -2930,11 +2776,13 @@ PlotCurve* Graph::insertCurve(Table* w, const QString& xColName, const QString& 
   Y.resize(size);
 
   DataCurve *c = 0;
-  if (style == VerticalBars){
-    c = new QwtBarCurve(QwtBarCurve::Vertical, w, xColName, yColName, startRow, endRow);
-  } else if (style == HorizontalBars){
-    c = new QwtBarCurve(QwtBarCurve::Horizontal, w, xColName, yColName, startRow, endRow);
-  } else if (style == Histogram){
+  if (style == VerticalBars) {
+    c = new QwtBarCurve(QwtBarCurve::Vertical, w, xColName, yColName, startRow,
+                        endRow);
+  } else if (style == HorizontalBars) {
+    c = new QwtBarCurve(QwtBarCurve::Horizontal, w, xColName, yColName,
+                        startRow, endRow);
+  } else if (style == Histogram) {
     c = new QwtHistogram(w, xColName, yColName, startRow, endRow);
     QwtHistogram *histo = dynamic_cast<QwtHistogram *>(c);
     if (histo)
@@ -2954,18 +2802,20 @@ PlotCurve* Graph::insertCurve(Table* w, const QString& xColName, const QString& 
   else if (style != Histogram)
     c->setData(X.data(), Y.data(), size);
 
-  if (xColType == Table::Text ){
+  if (xColType == Table::Text) {
     if (style == HorizontalBars)
-      d_plot->setAxisScaleDraw(QwtPlot::yLeft, new ScaleDraw(d_plot, xLabels, xColName));
+      d_plot->setAxisScaleDraw(QwtPlot::yLeft,
+                               new ScaleDraw(d_plot, xLabels, xColName));
     else
-      d_plot->setAxisScaleDraw (QwtPlot::xBottom, new ScaleDraw(d_plot, xLabels, xColName));
-  } else if (xColType == Table::Time){
+      d_plot->setAxisScaleDraw(QwtPlot::xBottom,
+                               new ScaleDraw(d_plot, xLabels, xColName));
+  } else if (xColType == Table::Time) {
     QString fmtInfo = time0.toString() + ";" + date_time_fmt;
     if (style == HorizontalBars)
       setLabelsDateTimeFormat(QwtPlot::yLeft, ScaleDraw::Time, fmtInfo);
     else
       setLabelsDateTimeFormat(QwtPlot::xBottom, ScaleDraw::Time, fmtInfo);
-  } else if (xColType == Table::Date ){
+  } else if (xColType == Table::Date) {
     QString fmtInfo = date0.toString(Qt::ISODate) + ";" + date_time_fmt;
     if (style == HorizontalBars)
       setLabelsDateTimeFormat(QwtPlot::yLeft, ScaleDraw::Date, fmtInfo);
@@ -2974,48 +2824,51 @@ PlotCurve* Graph::insertCurve(Table* w, const QString& xColName, const QString& 
   }
 
   if (yColType == Table::Text)
-    d_plot->setAxisScaleDraw (QwtPlot::yLeft, new ScaleDraw(d_plot, yLabels, yColName));
+    d_plot->setAxisScaleDraw(QwtPlot::yLeft,
+                             new ScaleDraw(d_plot, yLabels, yColName));
 
   addLegendItem();
   return c;
 }
 
-PlotCurve* Graph::insertCurve(QString workspaceName, int index, bool err, Graph::CurveType style)
-{
-  return (new MantidMatrixCurve(workspaceName,this,index, MantidMatrixCurve::Spectrum, err,false,style));
+PlotCurve *Graph::insertCurve(QString workspaceName, int index, bool err,
+                              Graph::CurveType style) {
+  return (new MantidMatrixCurve(workspaceName, this, index,
+                                MantidMatrixCurve::Spectrum, err, false,
+                                style));
 }
 
 /**  Insert a curve with its own data source. It does not have to be
  *   a Table or a Function. The Graph takes ownership of the curve.
  */
-PlotCurve* Graph::insertCurve(PlotCurve* c, int lineWidth, int curveType)
-{
-  MantidMatrixCurve* mc = dynamic_cast<MantidMatrixCurve*>(c);
-  if (mc)
-  {
-    if (curves() == 0)
-    {
+PlotCurve *Graph::insertCurve(PlotCurve *c, int lineWidth, int curveType) {
+  MantidMatrixCurve *mc = dynamic_cast<MantidMatrixCurve *>(c);
+  if (mc) {
+    if (curves() == 0) {
       m_xUnits = mc->xUnits();
       m_yUnits = mc->yUnits();
       m_isDistribution = mc->isDistribution();
     }
 
-    //If we don't have any units, let's use the new curve's units.
-    if(!m_xUnits)
+    // If we don't have any units, let's use the new curve's units.
+    if (!m_xUnits)
       m_xUnits = mc->xUnits();
-    if(!m_yUnits)
+    if (!m_yUnits)
       m_yUnits = mc->yUnits();
 
-    // Compare units. X units are compared by ID, Y units - by caption. That's because Y units will
-    // always be of type Label, hence will always have ID "Label", and the caption is what we are
+    // Compare units. X units are compared by ID, Y units - by caption. That's
+    // because Y units will
+    // always be of type Label, hence will always have ID "Label", and the
+    // caption is what we are
     // interested in.
-    if((m_xUnits && m_xUnits->unitID() != mc->xUnits()->unitID()) || (m_yUnits && m_yUnits->caption() != mc->yUnits()->caption()))
-    {
-      g_log.warning("You are overlaying plots from data having differing units!");
+    if ((m_xUnits && m_xUnits->unitID() != mc->xUnits()->unitID()) ||
+        (m_yUnits && m_yUnits->caption() != mc->yUnits()->caption())) {
+      g_log.warning(
+          "You are overlaying plots from data having differing units!");
     }
-    if ( m_isDistribution != mc->isDistribution() )
-    {
-      g_log.warning("You are overlaying distribution and non-distribution data!");
+    if (m_isDistribution != mc->isDistribution()) {
+      g_log.warning(
+          "You are overlaying distribution and non-distribution data!");
     }
   }
 
@@ -3024,9 +2877,10 @@ PlotCurve* Graph::insertCurve(PlotCurve* c, int lineWidth, int curveType)
   c_keys.resize(n_curves);
   c_keys[n_curves - 1] = d_plot->insertCurve(c);
 
-  int colorIndex , symbolIndex;
+  int colorIndex, symbolIndex;
   guessUniqueCurveLayout(colorIndex, symbolIndex);
-  if (lineWidth < 0) lineWidth = widthLine;
+  if (lineWidth < 0)
+    lineWidth = widthLine;
   c->setPen(QPen(ColorBox::color(colorIndex), lineWidth));
   QwtSymbol symbol = c->symbol();
   symbol.setPen(c->pen());
@@ -3034,23 +2888,24 @@ PlotCurve* Graph::insertCurve(PlotCurve* c, int lineWidth, int curveType)
   c->setSymbol(symbol);
 
   addLegendItem();
-  connect(c,SIGNAL(removeMe(PlotCurve*)),this,SLOT(removeCurve(PlotCurve*)));
-  connect(c,SIGNAL(dataUpdated()), this, SLOT(updatePlot()), Qt::QueuedConnection);
+  connect(c, SIGNAL(removeMe(PlotCurve *)), this,
+          SLOT(removeCurve(PlotCurve *)));
+  connect(c, SIGNAL(dataUpdated()), this, SLOT(updatePlot()),
+          Qt::QueuedConnection);
   return c;
 }
 
-void Graph::insertCurve(Graph* g, int i)
-{
-  if( g == this || !g ) return;
-  PlotCurve *plotCurve = dynamic_cast<PlotCurve*>(g->curve(i));
-  if( !plotCurve ) return;
+void Graph::insertCurve(Graph *g, int i) {
+  if (g == this || !g)
+    return;
+  PlotCurve *plotCurve = dynamic_cast<PlotCurve *>(g->curve(i));
+  if (!plotCurve)
+    return;
   int curveType = g->curveType(i);
   this->insertCurve(plotCurve, -1, curveType);
 }
 
-
-QwtHistogram* Graph::addHistogram(Matrix *m)
-{
+QwtHistogram *Graph::addHistogram(Matrix *m) {
   if (!m)
     return NULL;
 
@@ -3070,17 +2925,17 @@ QwtHistogram* Graph::addHistogram(Matrix *m)
   return c;
 }
 
-QwtHistogram* Graph::restoreHistogram(Matrix *m, const QStringList& l)
-{
+QwtHistogram *Graph::restoreHistogram(Matrix *m, const QStringList &l) {
   if (!m)
     return NULL;
 
   QwtHistogram *h = new QwtHistogram(m);
-  h->setBinning(l[17].toInt(), l[18].toDouble(), l[19].toDouble(), l[20].toDouble());
+  h->setBinning(l[17].toInt(), l[18].toDouble(), l[19].toDouble(),
+                l[20].toDouble());
   h->setGap(l[15].toInt());
   h->setOffset(l[16].toInt());
   h->loadData();
-  h->setAxis(l[l.count()-5].toInt(), l[l.count()-4].toInt());
+  h->setAxis(l[l.count() - 5].toInt(), l[l.count() - 4].toInt());
   h->setVisible(l.last().toInt());
 
   c_type.resize(++n_curves);
@@ -3090,8 +2945,8 @@ QwtHistogram* Graph::restoreHistogram(Matrix *m, const QStringList& l)
   return h;
 }
 
-VectorCurve* Graph::plotVectorCurve(Table* w, const QStringList& colList, int style, int startRow, int endRow)
-{
+VectorCurve *Graph::plotVectorCurve(Table *w, const QStringList &colList,
+                                    int style, int startRow, int endRow) {
   if (colList.count() != 4)
     return NULL;
 
@@ -3100,18 +2955,20 @@ VectorCurve* Graph::plotVectorCurve(Table* w, const QStringList& colList, int st
 
   VectorCurve *v = 0;
   if (style == VectXYAM)
-    v = new VectorCurve(VectorCurve::XYAM, w, colList[0], colList[1], colList[2], colList[3], startRow, endRow);
+    v = new VectorCurve(VectorCurve::XYAM, w, colList[0], colList[1],
+                        colList[2], colList[3], startRow, endRow);
   else
-    v = new VectorCurve(VectorCurve::XYXY, w, colList[0], colList[1], colList[2], colList[3], startRow, endRow);
+    v = new VectorCurve(VectorCurve::XYXY, w, colList[0], colList[1],
+                        colList[2], colList[3], startRow, endRow);
 
   if (!v)
     return NULL;
 
   c_type.resize(++n_curves);
-  c_type[n_curves-1] = style;
+  c_type[n_curves - 1] = style;
 
   c_keys.resize(n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(v);
+  c_keys[n_curves - 1] = d_plot->insertCurve(v);
 
   v->loadData();
   v->setStyle(QwtPlotCurve::NoCurve);
@@ -3121,10 +2978,10 @@ VectorCurve* Graph::plotVectorCurve(Table* w, const QStringList& colList, int st
   return v;
 }
 
-void Graph::updateVectorsLayout(int curve, const QColor& color, double width,
-    int arrowLength, int arrowAngle, bool filled, int position,
-    const QString& xEndColName, const QString& yEndColName)
-{
+void Graph::updateVectorsLayout(int curve, const QColor &color, double width,
+                                int arrowLength, int arrowAngle, bool filled,
+                                int position, const QString &xEndColName,
+                                const QString &yEndColName) {
   VectorCurve *vect = dynamic_cast<VectorCurve *>(this->curve(curve));
   if (!vect)
     return;
@@ -3142,59 +2999,51 @@ void Graph::updateVectorsLayout(int curve, const QColor& color, double width,
   emit modifiedGraph();
 }
 
-void Graph::updatePlot()
-{
-  if ( isWaterfallPlot() ) updateDataCurves();
+void Graph::updatePlot() {
+  if (isWaterfallPlot())
+    updateDataCurves();
 
   updateScale();
 }
 
-void Graph::updateScale()
-{
+void Graph::updateScale() {
   d_plot->replot();
   updateMarkersBoundingRect();
 
-  if (d_synchronize_scales)
-  {
+  if (d_synchronize_scales) {
     updateSecondaryAxis(QwtPlot::xTop);
     updateSecondaryAxis(QwtPlot::yRight);
   }
 
-  auto mantidCurve = dynamic_cast<MantidCurve*>(curve(0));
-  auto dataCurve = dynamic_cast<DataCurve*>(curve(0));
+  auto mantidCurve = dynamic_cast<MantidCurve *>(curve(0));
+  auto dataCurve = dynamic_cast<DataCurve *>(curve(0));
 
-  if (mantidCurve)
-  {
+  if (mantidCurve) {
     setXAxisTitle(mantidCurve->mantidData()->getXAxisLabel());
     setYAxisTitle(mantidCurve->mantidData()->getYAxisLabel());
-  }
-  else if (dataCurve && dataCurve->table())
-  {
+  } else if (dataCurve && dataCurve->table()) {
     setXAxisTitle(dataCurve->table()->colLabel(0));
-    setYAxisTitle(dataCurve->table()->colLabel(1).section(".",0,0));
+    setYAxisTitle(dataCurve->table()->colLabel(1).section(".", 0, 0));
   }
 
-  Spectrogram* spec = spectrogram();
-  if (spec)
-  {
-    auto specData = dynamic_cast<const MantidQt::API::QwtRasterDataMD*>(&spec->data());
-    if (specData)
-    {
+  Spectrogram *spec = spectrogram();
+  if (spec) {
+    auto specData =
+        dynamic_cast<const MantidQt::API::QwtRasterDataMD *>(&spec->data());
+    if (specData) {
       Mantid::API::IMDWorkspace_const_sptr ws = specData->getWorkspace();
-      if(ws)
-      {
+      if (ws) {
         setXAxisTitle(MantidQt::API::PlotAxis(*ws, 0).title());
         setYAxisTitle(MantidQt::API::PlotAxis(*ws, 1).title());
       }
     }
   }
 
-  d_plot->replot();//TODO: avoid 2nd replot!
+  d_plot->replot(); // TODO: avoid 2nd replot!
   d_zoomer[0]->setZoomBase(false);
 }
 
-void Graph::setBarsGap(int curve, int gapPercent, int offset)
-{
+void Graph::setBarsGap(int curve, int gapPercent, int offset) {
   QwtBarCurve *bars = dynamic_cast<QwtBarCurve *>(this->curve(curve));
   if (!bars)
     return;
@@ -3206,8 +3055,7 @@ void Graph::setBarsGap(int curve, int gapPercent, int offset)
   bars->setOffset(offset);
 }
 
-void Graph::removePie()
-{
+void Graph::removePie() {
   if (d_legend)
     d_legend->setText(QString::null);
 
@@ -3215,8 +3063,8 @@ void Graph::removePie()
   if (!pieCurve)
     return;
 
-  QList <PieLabel *> labels = pieCurve->labelsList();
-  foreach(PieLabel *l, labels)
+  QList<PieLabel *> labels = pieCurve->labelsList();
+  foreach (PieLabel *l, labels)
     l->setPieCurve(0);
 
   d_plot->removeCurve(c_keys[0]);
@@ -3224,21 +3072,18 @@ void Graph::removePie()
 
   c_keys.resize(0);
   c_type.resize(0);
-  n_curves=0;
+  n_curves = 0;
   emit modifiedGraph();
 }
 
-void Graph::removeCurves(const QString& s)
-{
+void Graph::removeCurves(const QString &s) {
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
     if (!it)
       continue;
 
-    if (it->title().text() == s)
-    {
+    if (it->title().text() == s) {
       removeCurve(i);
       continue;
     }
@@ -3250,21 +3095,20 @@ void Graph::removeCurves(const QString& s)
     if (!pc || pc->type() == Function)
       continue;
 
-    DataCurve * dc = dynamic_cast<DataCurve *>(it);
-    if (!dc) continue;
-    if(dc->plotAssociation().contains(s))
+    DataCurve *dc = dynamic_cast<DataCurve *>(it);
+    if (!dc)
+      continue;
+    if (dc->plotAssociation().contains(s))
       removeCurve(i);
   }
   d_plot->replot();
 }
 
-void Graph::removeCurve(const QString& s)
-{
+void Graph::removeCurve(const QString &s) {
   removeCurve(plotItemsList().findIndex(s));
 }
 
-void Graph::removeCurve(int index)
-{
+void Graph::removeCurve(int index) {
   if (index < 0 || index >= n_curves)
     return;
 
@@ -3272,18 +3116,18 @@ void Graph::removeCurve(int index)
   if (!it)
     return;
 
-  PlotCurve * c = dynamic_cast<PlotCurve *>(it);
-  if(c) // Only 1D curves need to be considered here
+  PlotCurve *c = dynamic_cast<PlotCurve *>(it);
+  if (c) // Only 1D curves need to be considered here
   {
-    disconnect(c,SIGNAL(removeMe(PlotCurve*)),this,SLOT(removeCurve(PlotCurve*)));
-    disconnect(c,SIGNAL(dataUpdated()), this, SLOT(updatePlot()));
+    disconnect(c, SIGNAL(removeMe(PlotCurve *)), this,
+               SLOT(removeCurve(PlotCurve *)));
+    disconnect(c, SIGNAL(dataUpdated()), this, SLOT(updatePlot()));
 
-    DataCurve * dc = dynamic_cast<DataCurve *>(it);
+    DataCurve *dc = dynamic_cast<DataCurve *>(it);
 
     removeLegendItem(index);
 
-    if (it->rtti() != QwtPlotItem::Rtti_PlotSpectrogram)
-    {
+    if (it->rtti() != QwtPlotItem::Rtti_PlotSpectrogram) {
       if (c->type() == ErrorBars) {
         QwtErrorPlotCurve *epc = dynamic_cast<QwtErrorPlotCurve *>(it);
         epc->detachFromMasterCurve();
@@ -3292,16 +3136,14 @@ void Graph::removeCurve(int index)
         dc->clearLabels();
       }
 
-      if (d_fit_curves.contains(dynamic_cast<QwtPlotCurve *>(it)))
-      {
+      if (d_fit_curves.contains(dynamic_cast<QwtPlotCurve *>(it))) {
         int i = d_fit_curves.indexOf(dynamic_cast<QwtPlotCurve *>(it));
         if (i >= 0 && i < d_fit_curves.size())
           d_fit_curves.removeAt(i);
       }
     }
 
-    if (d_range_selector && curve(index) == d_range_selector->selectedCurve())
-    {
+    if (d_range_selector && curve(index) == d_range_selector->selectedCurve()) {
       if (n_curves > 1 && (index - 1) >= 0)
         d_range_selector->setSelectedCurve(curve(index - 1));
       else if (n_curves > 1 && index + 1 < n_curves)
@@ -3316,10 +3158,9 @@ void Graph::removeCurve(int index)
   d_plot->replot();
   n_curves--;
 
-  for (int i=index; i<n_curves; i++)
-  {
-    c_type[i] = c_type[i+1];
-    c_keys[i] = c_keys[i+1];
+  for (int i = index; i < n_curves; i++) {
+    c_type[i] = c_type[i + 1];
+    c_keys[i] = c_keys[i + 1];
   }
   c_type.resize(n_curves);
   c_keys.resize(n_curves);
@@ -3327,53 +3168,49 @@ void Graph::removeCurve(int index)
   emit curveRemoved();
 }
 
-/** Intended to be called in response of PlotCurve::removeMe signal; 
+/** Intended to be called in response of PlotCurve::removeMe signal;
  *  the Graph is replotted.
  */
-void Graph::removeCurve(PlotCurve* c)
-{
-  removeCurve(curveIndex(c));
-}
+void Graph::removeCurve(PlotCurve *c) { removeCurve(curveIndex(c)); }
 
 /**
  * Removes the spectrogram from being managed by this Graph
  * @param sp A pointer to the Spectrogram to delete
  */
-void Graph::removeSpectrogram(Spectrogram *sp)
-{
+void Graph::removeSpectrogram(Spectrogram *sp) {
   removeCurve(plotItemIndex(sp));
 }
 
-void Graph::removeLegendItem(int index)
-{
+void Graph::removeLegendItem(int index) {
   if (!d_legend || c_type[index] == ErrorBars)
     return;
 
-  if (isPiePlot()){
+  if (isPiePlot()) {
     d_legend->setText(QString::null);
     return;
   }
 
   QString text = d_legend->text();
-  QStringList items = text.split( "\n", QString::SkipEmptyParts);
+  QStringList items = text.split("\n", QString::SkipEmptyParts);
 
-  if (index >= (int) items.count())
+  if (index >= (int)items.count())
     return;
 
-  QStringList l = items.grep( "\\l(" + QString::number(index+1) + ")" );
+  QStringList l = items.grep("\\l(" + QString::number(index + 1) + ")");
   if (l.isEmpty())
     return;
 
-  items.remove(l[0]);//remove the corresponding legend string
+  items.remove(l[0]); // remove the corresponding legend string
 
-  for (int i=0; i<items.count(); i++){//set new curves indexes in legend text
+  for (int i = 0; i < items.count();
+       i++) { // set new curves indexes in legend text
     QString item = items[i];
     int pos1 = item.indexOf("\\l(");
     int pos2 = item.indexOf(")", pos1);
     int pos = pos1 + 3;
     int n = pos2 - pos;
     int cv = item.mid(pos, n).toInt();
-    if (cv > index){
+    if (cv > index) {
       int id = cv - 1;
       if (!id)
         id = 1;
@@ -3384,7 +3221,7 @@ void Graph::removeLegendItem(int index)
     pos = pos1 + 2;
     n = pos2 - pos;
     cv = item.mid(pos, n).toInt();
-    if (cv > index){
+    if (cv > index) {
       int id = cv - 1;
       if (!id)
         id = 1;
@@ -3392,44 +3229,45 @@ void Graph::removeLegendItem(int index)
     }
     items[i] = item;
   }
-  text = items.join ( "\n" );
+  text = items.join("\n");
   d_legend->setText(text);
 }
 
-void Graph::addLegendItem()
-{
+void Graph::addLegendItem() {
   const int curveIndex = n_curves - 1;
-  if( c_type[curveIndex] == ErrorBars ) return;
-  if (d_legend){
+  if (c_type[curveIndex] == ErrorBars)
+    return;
+  if (d_legend) {
     QString text = d_legend->text();
-    if ( !text.endsWith ("\n") && !text.isEmpty() )
+    if (!text.endsWith("\n") && !text.isEmpty())
       text.append("\n");
-    text.append("\\l("+QString::number(n_curves)+")");//+"%("+QString::number(n_curves)+")");
+    text.append("\\l(" + QString::number(n_curves) +
+                ")"); //+"%("+QString::number(n_curves)+")");
 
-    // RJT (23/09/09): Insert actual text directly into legend rather than a 'code' for later parsing
+    // RJT (23/09/09): Insert actual text directly into legend rather than a
+    // 'code' for later parsing
     PlotCurve *c = dynamic_cast<PlotCurve *>(d_plot->curve(c_keys[curveIndex]));
-    if (c )
+    if (c)
       text.append(c->title().text());
     else
-      text.append("%("+QString::number(c_keys[curveIndex])+")");
+      text.append("%(" + QString::number(c_keys[curveIndex]) + ")");
 
     d_legend->setText(text);
     d_legend->repaint();
   }
 }
 
-QString Graph::yAxisTitleFromFirstCurve()
-{
+QString Graph::yAxisTitleFromFirstCurve() {
   // I really don't like this...
-  if(auto *firstCurve = dynamic_cast<MantidMatrixCurve*>(curve(0)))
-  {
+  if (auto *firstCurve = dynamic_cast<MantidMatrixCurve *>(curve(0))) {
     using namespace Mantid::API;
     QString wsName = firstCurve->workspaceName();
-    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName.toStdString());
+    auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        wsName.toStdString());
     if (ws)
       return MantidQt::API::PlotAxis(m_isDistribution, *ws).title();
-  } else if (auto *firstCurve = dynamic_cast<MantidMDCurve*>(curve(0))) {
-    MantidQwtIMDWorkspaceData* data = firstCurve->mantidData();
+  } else if (auto *firstCurve = dynamic_cast<MantidMDCurve *>(curve(0))) {
+    MantidQwtIMDWorkspaceData *data = firstCurve->mantidData();
     if (data)
       return data->getYAxisLabel();
   }
@@ -3437,9 +3275,8 @@ QString Graph::yAxisTitleFromFirstCurve()
   return axisTitle(0);
 }
 
-void Graph::contextMenuEvent(QContextMenuEvent *e)
-{
-  if (selectedMarker>=0) {
+void Graph::contextMenuEvent(QContextMenuEvent *e) {
+  if (selectedMarker >= 0) {
     emit showMarkerPopupMenu();
     return;
   }
@@ -3449,7 +3286,7 @@ void Graph::contextMenuEvent(QContextMenuEvent *e)
   const int curve = d_plot->closestCurve(pos.x(), pos.y(), dist, point);
   const DataCurve *c = dynamic_cast<DataCurve *>(d_plot->curve(curve));
 
-  if (c && dist < 10)//10 pixels tolerance
+  if (c && dist < 10) // 10 pixels tolerance
     emit showCurveContextMenu(curve);
   else
     emit showContextMenu();
@@ -3457,36 +3294,27 @@ void Graph::contextMenuEvent(QContextMenuEvent *e)
   e->accept();
 }
 
-void Graph::closeEvent(QCloseEvent *e)
-{
+void Graph::closeEvent(QCloseEvent *e) {
   emit closedGraph();
   e->accept();
 }
 
-void Graph::hideEvent(QHideEvent* e)
-{
-  (void) e;
-  for(int i=0;i<curves();++i)
-  {
-    PlotCurve* c = dynamic_cast<PlotCurve*>(curve(i));
-    if (c)
-    {
+void Graph::hideEvent(QHideEvent *e) {
+  (void)e;
+  for (int i = 0; i < curves(); ++i) {
+    PlotCurve *c = dynamic_cast<PlotCurve *>(curve(i));
+    if (c) {
       c->aboutToBeDeleted();
     }
   }
 }
 
-bool Graph::zoomOn()
-{
+bool Graph::zoomOn() {
   return (d_zoomer[0]->isEnabled() || d_zoomer[1]->isEnabled());
 }
 
-void Graph::zoomed (const QwtDoubleRect &)
-{
-  emit modifiedGraph();
-}
-bool Graph::hasActiveTool()
-{
+void Graph::zoomed(const QwtDoubleRect &) { emit modifiedGraph(); }
+bool Graph::hasActiveTool() {
   if (zoomOn() || drawLineActive() || d_active_tool || d_peak_fit_tool ||
       d_magnifier || d_panner ||
       (d_range_selector && d_range_selector->isVisible()))
@@ -3495,97 +3323,87 @@ bool Graph::hasActiveTool()
   return false;
 }
 
-
-void Graph::zoom(bool on)
-{
+void Graph::zoom(bool on) {
   d_zoomer[0]->setEnabled(on);
   d_zoomer[1]->setEnabled(false);
-  for (int i=0; i<n_curves; i++)
-  {
+  for (int i = 0; i < n_curves; i++) {
     Spectrogram *sp = dynamic_cast<Spectrogram *>(this->curve(i));
-    if (sp && sp->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
-    {
-      if (sp->colorScaleAxis() == QwtPlot::xBottom || sp->colorScaleAxis() == QwtPlot::yLeft)
+    if (sp && sp->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
+      if (sp->colorScaleAxis() == QwtPlot::xBottom ||
+          sp->colorScaleAxis() == QwtPlot::yLeft)
         d_zoomer[0]->setEnabled(false);
       else
         d_zoomer[1]->setEnabled(false);
-
-
     }
   }
 
-  QCursor cursor=QCursor (getQPixmap("lens_xpm"),-1,-1);
+  QCursor cursor = QCursor(getQPixmap("lens_xpm"), -1, -1);
   if (on)
     d_plot->canvas()->setCursor(cursor);
   else
     d_plot->canvas()->setCursor(Qt::arrowCursor);
-
 }
 
-void Graph::zoomOut()
-{
+void Graph::zoomOut() {
   d_zoomer[0]->zoom(-1);
-  //d_zoomer[1]->zoom(-1);
+  // d_zoomer[1]->zoom(-1);
 
-  if (d_synchronize_scales)
-  {
+  if (d_synchronize_scales) {
     updateSecondaryAxis(QwtPlot::xTop);
     updateSecondaryAxis(QwtPlot::yRight);
   }
 }
 
-
-void Graph::drawText(bool on)
-{
+void Graph::drawText(bool on) {
   deselectMarker();
 
   QCursor c = QCursor(Qt::IBeamCursor);
-  if (on){
+  if (on) {
     d_plot->canvas()->setCursor(c);
-    //d_plot->setCursor(c);
+    // d_plot->setCursor(c);
   } else {
     d_plot->canvas()->setCursor(Qt::arrowCursor);
-    //d_plot->setCursor(Qt::arrowCursor);
+    // d_plot->setCursor(Qt::arrowCursor);
   }
   drawTextOn = on;
 }
 
-
-ImageMarker* Graph::addImage(ImageMarker* mrk)
-{
+ImageMarker *Graph::addImage(ImageMarker *mrk) {
   if (!mrk)
     return 0;
 
-  ImageMarker* mrk2 = new ImageMarker(mrk->fileName());
+  ImageMarker *mrk2 = new ImageMarker(mrk->fileName());
 
   int imagesOnPlot = d_images.size();
   d_images.resize(++imagesOnPlot);
-  d_images[imagesOnPlot-1]=d_plot->insertMarker(mrk2);
+  d_images[imagesOnPlot - 1] = d_plot->insertMarker(mrk2);
 
-  mrk2->setBoundingRect(mrk->xValue(), mrk->yValue(), mrk->right(), mrk->bottom());
+  mrk2->setBoundingRect(mrk->xValue(), mrk->yValue(), mrk->right(),
+                        mrk->bottom());
   return mrk2;
 }
 
-ImageMarker* Graph::addImage(const QString& fileName)
-{
-  if (fileName.isEmpty() || !QFile::exists(fileName)){
-    QMessageBox::warning(0, tr("MantidPlot - File open error"),
-        tr("Image file: <p><b> %1 </b><p>does not exist anymore!").arg(fileName));
+ImageMarker *Graph::addImage(const QString &fileName) {
+  if (fileName.isEmpty() || !QFile::exists(fileName)) {
+    QMessageBox::warning(
+        0, tr("MantidPlot - File open error"),
+        tr("Image file: <p><b> %1 </b><p>does not exist anymore!")
+            .arg(fileName));
     return 0;
   }
 
-  ImageMarker* mrk = new ImageMarker(fileName);
+  ImageMarker *mrk = new ImageMarker(fileName);
   int imagesOnPlot = d_images.size();
   d_images.resize(++imagesOnPlot);
-  d_images[imagesOnPlot-1] = d_plot->insertMarker(mrk);
+  d_images[imagesOnPlot - 1] = d_plot->insertMarker(mrk);
 
   QSize picSize = mrk->pixmap().size();
   int w = d_plot->canvas()->width();
-  if (picSize.width()>w)
+  if (picSize.width() > w)
     picSize.setWidth(w);
 
-  int h=d_plot->canvas()->height();
-  if (picSize.height()>h)
+  int h = d_plot->canvas()->height();
+  if (picSize.height() > h)
     picSize.setHeight(h);
 
   mrk->setSize(picSize);
@@ -3595,22 +3413,22 @@ ImageMarker* Graph::addImage(const QString& fileName)
   return mrk;
 }
 
-void Graph::insertImageMarker(const QStringList& lst, int fileVersion)
-{
+void Graph::insertImageMarker(const QStringList &lst, int fileVersion) {
   QString fn = lst[1];
-  if (!QFile::exists(fn)){
-    QMessageBox::warning(0, tr("MantidPlot - File open error"),
+  if (!QFile::exists(fn)) {
+    QMessageBox::warning(
+        0, tr("MantidPlot - File open error"),
         tr("Image file: <p><b> %1 </b><p>does not exist anymore!").arg(fn));
   } else {
-    ImageMarker* mrk = new ImageMarker(fn);
+    ImageMarker *mrk = new ImageMarker(fn);
     if (!mrk)
       return;
 
     int imagesOnPlot = d_images.size();
     d_images.resize(++imagesOnPlot);
-    d_images[imagesOnPlot-1] = d_plot->insertMarker(mrk);
+    d_images[imagesOnPlot - 1] = d_plot->insertMarker(mrk);
 
-    if (fileVersion < 86){
+    if (fileVersion < 86) {
       mrk->setOrigin(QPoint(lst[2].toInt(), lst[3].toInt()));
       mrk->setSize(QSize(lst[4].toInt(), lst[5].toInt()));
     } else if (fileVersion < 90) {
@@ -3620,31 +3438,28 @@ void Graph::insertImageMarker(const QStringList& lst, int fileVersion)
       double bottom = top - lst[5].toDouble();
       mrk->setBoundingRect(left, top, right, bottom);
     } else
-      mrk->setBoundingRect(lst[2].toDouble(), lst[3].toDouble(), lst[4].toDouble(), lst[5].toDouble());
+      mrk->setBoundingRect(lst[2].toDouble(), lst[3].toDouble(),
+                           lst[4].toDouble(), lst[5].toDouble());
   }
 }
 
-void Graph::drawLine(bool on, bool arrow)
-{
-  drawLineOn=on;
-  drawArrowOn=arrow;
+void Graph::drawLine(bool on, bool arrow) {
+  drawLineOn = on;
+  drawArrowOn = arrow;
   if (!on)
     emit drawLineEnded(true);
 }
 
-void Graph::modifyFunctionCurve(int curve, int type, const QStringList &formulas,
-    const QString& var, double start, double end, int points)
-{
+void Graph::modifyFunctionCurve(int curve, int type,
+                                const QStringList &formulas, const QString &var,
+                                double start, double end, int points) {
   FunctionCurve *c = dynamic_cast<FunctionCurve *>(this->curve(curve));
   if (!c)
     return;
 
-  if (c->functionType() == type &&
-      c->variable() == var &&
-      c->formulas() == formulas &&
-      c->startRange() == start &&
-      c->endRange() == end &&
-      c->dataSize() == points)
+  if (c->functionType() == type && c->variable() == var &&
+      c->formulas() == formulas && c->startRange() == start &&
+      c->endRange() == end && c->dataSize() == points)
     return;
 
   QString oldLegend = c->legend();
@@ -3655,7 +3470,7 @@ void Graph::modifyFunctionCurve(int curve, int type, const QStringList &formulas
   c->setVariable(var);
   c->loadData(points);
 
-  if (d_legend){//update the legend marker
+  if (d_legend) { // update the legend marker
     QString text = (d_legend->text()).replace(oldLegend, c->legend());
     d_legend->setText(text);
   }
@@ -3663,14 +3478,13 @@ void Graph::modifyFunctionCurve(int curve, int type, const QStringList &formulas
   emit modifiedGraph();
 }
 
-QString Graph::generateFunctionName(const QString& name)
-{
+QString Graph::generateFunctionName(const QString &name) {
   int index = 1;
   QString newName = name + QString::number(index);
 
   QStringList lst;
-  for (int i=0; i<n_curves; i++){
-    PlotCurve *c = dynamic_cast<PlotCurve*>(this->curve(i));
+  for (int i = 0; i < n_curves; i++) {
+    PlotCurve *c = dynamic_cast<PlotCurve *>(this->curve(i));
     if (!c)
       continue;
 
@@ -3678,13 +3492,14 @@ QString Graph::generateFunctionName(const QString& name)
       lst << c->title().text();
   }
 
-  while(lst.contains(newName))
+  while (lst.contains(newName))
     newName = name + QString::number(++index);
   return newName;
 }
 
-FunctionCurve* Graph::addFunction(const QStringList &formulas, double start, double end, int points, const QString &var, int type, const QString& title)
-{
+FunctionCurve *Graph::addFunction(const QStringList &formulas, double start,
+                                  double end, int points, const QString &var,
+                                  int type, const QString &title) {
   QString name;
   if (!title.isEmpty())
     name = title;
@@ -3698,10 +3513,10 @@ FunctionCurve* Graph::addFunction(const QStringList &formulas, double start, dou
   c->loadData(points);
 
   c_type.resize(++n_curves);
-  c_type[n_curves-1] = Line;
+  c_type[n_curves - 1] = Line;
 
   c_keys.resize(n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(c);
+  c_keys[n_curves - 1] = d_plot->insertCurve(c);
 
   int colorIndex = 0, symbolIndex;
   guessUniqueCurveLayout(colorIndex, symbolIndex);
@@ -3714,8 +3529,8 @@ FunctionCurve* Graph::addFunction(const QStringList &formulas, double start, dou
   return c;
 }
 
-FunctionCurve* Graph::insertFunctionCurve(const QString& formula, int points, int fileVersion)
-{
+FunctionCurve *Graph::insertFunctionCurve(const QString &formula, int points,
+                                          int fileVersion) {
   int type = 0;
   QStringList formulas;
   QString var, name = QString::null;
@@ -3723,23 +3538,23 @@ FunctionCurve* Graph::insertFunctionCurve(const QString& formula, int points, in
 
   QStringList curve = formula.split(",");
   if (fileVersion < 87) {
-    if (curve[0][0]=='f') {
+    if (curve[0][0] == 'f') {
       type = FunctionCurve::Normal;
-      formulas += curve[0].section('=',1,1);
+      formulas += curve[0].section('=', 1, 1);
       var = curve[1];
       start = curve[2].toDouble();
       end = curve[3].toDouble();
-    } else if (curve[0][0]=='X') {
+    } else if (curve[0][0] == 'X') {
       type = FunctionCurve::Parametric;
-      formulas += curve[0].section('=',1,1);
-      formulas += curve[1].section('=',1,1);
+      formulas += curve[0].section('=', 1, 1);
+      formulas += curve[1].section('=', 1, 1);
       var = curve[2];
       start = curve[3].toDouble();
       end = curve[4].toDouble();
-    } else if (curve[0][0]=='R') {
+    } else if (curve[0][0] == 'R') {
       type = FunctionCurve::Polar;
-      formulas += curve[0].section('=',1,1);
-      formulas += curve[1].section('=',1,1);
+      formulas += curve[0].section('=', 1, 1);
+      formulas += curve[1].section('=', 1, 1);
       var = curve[2];
       start = curve[3].toDouble();
       end = curve[4].toDouble();
@@ -3753,7 +3568,8 @@ FunctionCurve* Graph::insertFunctionCurve(const QString& formula, int points, in
       var = curve[3];
       start = curve[4].toDouble();
       end = curve[5].toDouble();
-    } else if (type == FunctionCurve::Polar || type == FunctionCurve::Parametric) {
+    } else if (type == FunctionCurve::Polar ||
+               type == FunctionCurve::Parametric) {
       formulas << curve[2];
       formulas << curve[3];
       var = curve[4];
@@ -3761,11 +3577,10 @@ FunctionCurve* Graph::insertFunctionCurve(const QString& formula, int points, in
       end = curve[6].toDouble();
     }
   }
-  return addFunction(formulas, start, end, points,  var, type, name);
+  return addFunction(formulas, start, end, points, var, type, name);
 }
 
-void Graph::restoreFunction(const QStringList& lst)
-{	
+void Graph::restoreFunction(const QStringList &lst) {
   FunctionCurve::FunctionType type = FunctionCurve::Normal;
   int points = 0, style = 0;
   QStringList formulas;
@@ -3773,25 +3588,29 @@ void Graph::restoreFunction(const QStringList& lst)
   double start = 0.0, end = 0.0;
 
   QStringList::const_iterator line = lst.begin();
-  for (++line; line != lst.end(); ++line){
+  for (++line; line != lst.end(); ++line) {
     QString s = *line;
     if (s.contains("<Type>"))
-      type = (FunctionCurve::FunctionType)s.remove("<Type>").remove("</Type>").stripWhiteSpace().toInt();
+      type = (FunctionCurve::FunctionType)s.remove("<Type>")
+                 .remove("</Type>")
+                 .stripWhiteSpace()
+                 .toInt();
     else if (s.contains("<Title>"))
       title = s.remove("<Title>").remove("</Title>").stripWhiteSpace();
     else if (s.contains("<Expression>"))
       formulas = s.remove("<Expression>").remove("</Expression>").split("\t");
     else if (s.contains("<Variable>"))
       var = s.remove("<Variable>").remove("</Variable>").stripWhiteSpace();
-    else if (s.contains("<Range>")){
+    else if (s.contains("<Range>")) {
       QStringList l = s.remove("<Range>").remove("</Range>").split("\t");
-      if (l.size() == 2){
+      if (l.size() == 2) {
         start = l[0].toDouble();
         end = l[1].toDouble();
       }
     } else if (s.contains("<Points>"))
-      points = s.remove("<Points>").remove("</Points>").stripWhiteSpace().toInt();
-    else if (s.contains("<Style>")){
+      points =
+          s.remove("<Points>").remove("</Points>").stripWhiteSpace().toInt();
+    else if (s.contains("<Style>")) {
       style = s.remove("<Style>").remove("</Style>").stripWhiteSpace().toInt();
       break;
     }
@@ -3804,9 +3623,9 @@ void Graph::restoreFunction(const QStringList& lst)
   c->loadData(points);
 
   c_type.resize(++n_curves);
-  c_type[n_curves-1] = style;
+  c_type[n_curves - 1] = style;
   c_keys.resize(n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(c);
+  c_keys[n_curves - 1] = d_plot->insertCurve(c);
 
   QStringList l;
   for (++line; line != lst.end(); ++line)
@@ -3817,107 +3636,101 @@ void Graph::restoreFunction(const QStringList& lst)
   updatePlot();
 }
 
-void Graph::createTable(const QString& curveName)
-{
+void Graph::createTable(const QString &curveName) {
   if (curveName.isEmpty())
     return;
 
-  const QwtPlotCurve* cv = curve(curveName);
+  const QwtPlotCurve *cv = curve(curveName);
   if (!cv)
     return;
 
   createTable(cv);
 }
 
-void Graph::createTable(const QwtPlotCurve* curve)
-{
+void Graph::createTable(const QwtPlotCurve *curve) {
   if (!curve)
     return;
 
   int size = curve->dataSize();
   QString text = "1\t2\n";
-  for (int i=0; i<size; i++)
-  {
-    text += QString::number(curve->x(i))+"\t";
-    text += QString::number(curve->y(i))+"\n";
+  for (int i = 0; i < size; i++) {
+    text += QString::number(curve->x(i)) + "\t";
+    text += QString::number(curve->y(i)) + "\n";
   }
-  QString legend = tr("Data set generated from curve") + ": " + curve->title().text();
+  QString legend =
+      tr("Data set generated from curve") + ": " + curve->title().text();
   emit createTable(tr("Table") + "1" + "\t" + legend, size, 2, text);
 }
 
-void Graph::updateMarkersBoundingRect()
-{
+void Graph::updateMarkersBoundingRect() {
   int lines = d_lines.size();
   int images = d_images.size();
   if (!lines && !images)
     return;
 
-  for (int i=0; i<lines; i++){
-    ArrowMarker* a = dynamic_cast<ArrowMarker*>(d_plot->marker(d_lines[i]));
+  for (int i = 0; i < lines; i++) {
+    ArrowMarker *a = dynamic_cast<ArrowMarker *>(d_plot->marker(d_lines[i]));
     if (a)
       a->updateBoundingRect();
   }
 
-  for (int i=0; i<images; i++){
-    ImageMarker* im = dynamic_cast<ImageMarker*>(d_plot->marker(d_images[i]));
+  for (int i = 0; i < images; i++) {
+    ImageMarker *im = dynamic_cast<ImageMarker *>(d_plot->marker(d_images[i]));
     if (im)
       im->updateBoundingRect();
   }
   d_plot->replot();
 }
 
-void Graph::resizeEvent ( QResizeEvent *e )
-{
+void Graph::resizeEvent(QResizeEvent *e) {
   if (ignoreResize || !this->isVisible())
     return;
 
-  if (!autoScaleFonts){
+  if (!autoScaleFonts) {
     d_plot->resize(e->size());
     d_plot->updateCurveLabels();
   }
 }
 
-void Graph::scaleFonts(double factor)
-{
+void Graph::scaleFonts(double factor) {
   QObjectList lst = d_plot->children();
-  foreach(QObject *o, lst){
-    if (o->inherits("LegendWidget")){
+  foreach (QObject *o, lst) {
+    if (o->inherits("LegendWidget")) {
       LegendWidget *lw = dynamic_cast<LegendWidget *>(o);
       if (!lw)
         continue;
 
       QFont font = lw->font();
-      font.setPointSizeFloat(factor*font.pointSizeFloat());
+      font.setPointSizeFloat(factor * font.pointSizeFloat());
       lw->setFont(font);
     }
   }
 
-  for (int i = 0; i<QwtPlot::axisCnt; i++){
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
     QFont font = axisFont(i);
-    font.setPointSizeFloat(factor*font.pointSizeFloat());
+    font.setPointSizeFloat(factor * font.pointSizeFloat());
     d_plot->setAxisFont(i, font);
 
     QwtText title = d_plot->axisTitle(i);
     font = title.font();
-    font.setPointSizeFloat(factor*font.pointSizeFloat());
+    font.setPointSizeFloat(factor * font.pointSizeFloat());
     title.setFont(font);
     d_plot->setAxisTitle(i, title);
   }
 
   QwtText title = d_plot->title();
   QFont font = title.font();
-  font.setPointSizeFloat(factor*font.pointSizeFloat());
+  font.setPointSizeFloat(factor * font.pointSizeFloat());
   title.setFont(font);
   d_plot->setTitle(title);
 
   QList<QwtPlotItem *> curves = d_plot->curvesList();
-  foreach(QwtPlotItem *i, curves){
+  foreach (QwtPlotItem *i, curves) {
     DataCurve *dc = dynamic_cast<DataCurve *>(i);
     if (dc && dc->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
-        dc->type() != Graph::Function &&
-        dc->hasLabels()){
+        dc->type() != Graph::Function && dc->hasLabels()) {
       QFont font = dc->labelsFont();
-      font.setPointSizeFloat(factor*font.pointSizeFloat());
+      font.setPointSizeFloat(factor * font.pointSizeFloat());
       dc->setLabelsFont(font);
       if (dc->hasSelectedLabels())
         notifyFontChange(font);
@@ -3926,8 +3739,7 @@ void Graph::scaleFonts(double factor)
   d_plot->replot();
 }
 
-void Graph::setMargin (int d)
-{
+void Graph::setMargin(int d) {
   if (d_plot->margin() == d)
     return;
 
@@ -3935,8 +3747,7 @@ void Graph::setMargin (int d)
   emit modifiedGraph();
 }
 
-void Graph::setFrame (int width, const QColor& color)
-{
+void Graph::setFrame(int width, const QColor &color) {
   if (d_plot->frameColor() == color && width == d_plot->lineWidth())
     return;
 
@@ -3947,8 +3758,7 @@ void Graph::setFrame (int width, const QColor& color)
   d_plot->setLineWidth(width);
 }
 
-void Graph::setBackgroundColor(const QColor& color)
-{
+void Graph::setBackgroundColor(const QColor &color) {
   QColorGroup cg;
   QPalette p = d_plot->palette();
   p.setColor(QColorGroup::Window, color);
@@ -3958,168 +3768,166 @@ void Graph::setBackgroundColor(const QColor& color)
   emit modifiedGraph();
 }
 
-void Graph::setCanvasBackground(const QColor& color)
-{
+void Graph::setCanvasBackground(const QColor &color) {
   d_plot->setCanvasBackground(color);
   emit modifiedGraph();
 }
 
-QString Graph::penStyleName(Qt::PenStyle style)
-{
-  if (style==Qt::SolidLine)
+QString Graph::penStyleName(Qt::PenStyle style) {
+  if (style == Qt::SolidLine)
     return "SolidLine";
-  else if (style==Qt::DashLine)
+  else if (style == Qt::DashLine)
     return "DashLine";
-  else if (style==Qt::DotLine)
+  else if (style == Qt::DotLine)
     return "DotLine";
-  else if (style==Qt::DashDotLine)
+  else if (style == Qt::DashDotLine)
     return "DashDotLine";
-  else if (style==Qt::DashDotDotLine)
+  else if (style == Qt::DashDotDotLine)
     return "DashDotDotLine";
   else
     return "SolidLine";
 }
 
-Qt::PenStyle Graph::getPenStyle(int style)
-{
+Qt::PenStyle Graph::getPenStyle(int style) {
   Qt::PenStyle linePen = Qt::SolidLine;
-  switch (style)
-  {
+  switch (style) {
   case 0:
     break;
   case 1:
-    linePen=Qt::DashLine;
+    linePen = Qt::DashLine;
     break;
   case 2:
-    linePen=Qt::DotLine;
+    linePen = Qt::DotLine;
     break;
   case 3:
-    linePen=Qt::DashDotLine;
+    linePen = Qt::DashDotLine;
     break;
   case 4:
-    linePen=Qt::DashDotDotLine;
+    linePen = Qt::DashDotDotLine;
     break;
   }
   return linePen;
 }
 
-Qt::PenStyle Graph::getPenStyle(const QString& s)
-{
+Qt::PenStyle Graph::getPenStyle(const QString &s) {
   Qt::PenStyle style = Qt::SolidLine;
   if (s == "DashLine")
-    style=Qt::DashLine;
+    style = Qt::DashLine;
   else if (s == "DotLine")
-    style=Qt::DotLine;
+    style = Qt::DotLine;
   else if (s == "DashDotLine")
-    style=Qt::DashDotLine;
+    style = Qt::DashDotLine;
   else if (s == "DashDotDotLine")
-    style=Qt::DashDotDotLine;
+    style = Qt::DashDotDotLine;
   return style;
 }
 
-int Graph::obsoleteSymbolStyle(int type)
-{
+int Graph::obsoleteSymbolStyle(int type) {
   if (type <= 4)
-    return type+1;
+    return type + 1;
   else
-    return type+2;
+    return type + 2;
 }
 
-int Graph::curveType(int curveIndex)
-{
+int Graph::curveType(int curveIndex) {
   if (curveIndex < (int)c_type.size() && curveIndex >= 0)
     return c_type[curveIndex];
   else
     return -1;
 }
 
-void Graph::showPlotErrorMessage(QWidget *parent, const QStringList& emptyColumns)
-{
+void Graph::showPlotErrorMessage(QWidget *parent,
+                                 const QStringList &emptyColumns) {
   QApplication::restoreOverrideCursor();
 
   int n = (int)emptyColumns.count();
-  if (n > 1)
-  {
+  if (n > 1) {
     QString columns;
     for (int i = 0; i < n; i++)
       columns += "<p><b>" + emptyColumns[i] + "</b></p>";
 
+    QMessageBox::warning(
+        parent, tr("MantidPlot - Warning"),
+        tr("The columns") + ": " + columns +
+            tr("are empty and will not be added to the plot!"));
+  } else if (n == 1)
     QMessageBox::warning(parent, tr("MantidPlot - Warning"),
-        tr("The columns") + ": " + columns + tr("are empty and will not be added to the plot!"));
-  }
-  else if (n == 1)
-    QMessageBox::warning(parent, tr("MantidPlot - Warning"),
-        tr("The column") + " <b>" + emptyColumns[0] + "</b> " + tr("is empty and will not be added to the plot!"));
+                         tr("The column") + " <b>" + emptyColumns[0] + "</b> " +
+                             tr("is empty and will not be added to the plot!"));
 }
 
-void Graph::showTitleContextMenu()
-{
+void Graph::showTitleContextMenu() {
   QMenu titleMenu(this);
-  titleMenu.insertItem(getQPixmap("cut_xpm"), tr("&Cut"),this, SLOT(cutTitle()));
-  titleMenu.insertItem(getQPixmap("copy_xpm"), tr("&Copy"),this, SLOT(copyTitle()));
-  titleMenu.insertItem(tr("&Delete"),this, SLOT(removeTitle()));
+  titleMenu.insertItem(getQPixmap("cut_xpm"), tr("&Cut"), this,
+                       SLOT(cutTitle()));
+  titleMenu.insertItem(getQPixmap("copy_xpm"), tr("&Copy"), this,
+                       SLOT(copyTitle()));
+  titleMenu.insertItem(tr("&Delete"), this, SLOT(removeTitle()));
   titleMenu.insertSeparator();
   titleMenu.insertItem(tr("&Properties..."), this, SIGNAL(viewTitleDialog()));
   titleMenu.exec(QCursor::pos());
 }
 
-void Graph::cutTitle()
-{
-  QApplication::clipboard()->setText(d_plot->title().text(), QClipboard::Clipboard);
+void Graph::cutTitle() {
+  QApplication::clipboard()->setText(d_plot->title().text(),
+                                     QClipboard::Clipboard);
   removeTitle();
 }
 
-void Graph::copyTitle()
-{
-  QApplication::clipboard()->setText(d_plot->title().text(), QClipboard::Clipboard);
+void Graph::copyTitle() {
+  QApplication::clipboard()->setText(d_plot->title().text(),
+                                     QClipboard::Clipboard);
 }
 
-void Graph::removeAxisTitle()
-{
+void Graph::removeAxisTitle() {
   int selectedAxis = scalePicker->currentAxis()->alignment();
-  int axis = (selectedAxis + 2)%4;//unconsistent notation in Qwt enumerations between
-  //QwtScaleDraw::alignment and QwtPlot::Axis
-  d_plot->setAxisTitle(axis, " ");//due to the plot layout updates, we must always have a non empty title
+  int axis = (selectedAxis + 2) %
+             4; // unconsistent notation in Qwt enumerations between
+  // QwtScaleDraw::alignment and QwtPlot::Axis
+  d_plot->setAxisTitle(axis, " "); // due to the plot layout updates, we must
+                                   // always have a non empty title
   d_plot->replot();
   emit modifiedGraph();
 }
 
-void Graph::cutAxisTitle()
-{
+void Graph::cutAxisTitle() {
   copyAxisTitle();
   removeAxisTitle();
 }
 
-void Graph::copyAxisTitle()
-{
+void Graph::copyAxisTitle() {
   int selectedAxis = scalePicker->currentAxis()->alignment();
-  int axis = (selectedAxis + 2)%4;//unconsistent notation in Qwt enumerations between
-  //QwtScaleDraw::alignment and QwtPlot::Axis
-  QApplication::clipboard()->setText(d_plot->axisTitle(axis).text(), QClipboard::Clipboard);
+  int axis = (selectedAxis + 2) %
+             4; // unconsistent notation in Qwt enumerations between
+  // QwtScaleDraw::alignment and QwtPlot::Axis
+  QApplication::clipboard()->setText(d_plot->axisTitle(axis).text(),
+                                     QClipboard::Clipboard);
 }
 
-void Graph::showAxisTitleMenu()
-{
+void Graph::showAxisTitleMenu() {
   QMenu titleMenu(this);
-  titleMenu.insertItem(getQPixmap("cut_xpm"), tr("&Cut"), this, SLOT(cutAxisTitle()));
-  titleMenu.insertItem(getQPixmap("copy_xpm"), tr("&Copy"), this, SLOT(copyAxisTitle()));
-  titleMenu.insertItem(tr("&Delete"),this, SLOT(removeAxisTitle()));
+  titleMenu.insertItem(getQPixmap("cut_xpm"), tr("&Cut"), this,
+                       SLOT(cutAxisTitle()));
+  titleMenu.insertItem(getQPixmap("copy_xpm"), tr("&Copy"), this,
+                       SLOT(copyAxisTitle()));
+  titleMenu.insertItem(tr("&Delete"), this, SLOT(removeAxisTitle()));
   titleMenu.insertSeparator();
-  titleMenu.insertItem(tr("&Properties..."), this, SIGNAL(showAxisTitleDialog()));
+  titleMenu.insertItem(tr("&Properties..."), this,
+                       SIGNAL(showAxisTitleDialog()));
   titleMenu.exec(QCursor::pos());
 }
 
-void Graph::showAxisContextMenu(int axis)
-{
+void Graph::showAxisContextMenu(int axis) {
   QMenu menu(this);
   menu.setCheckable(true);
 
-  menu.insertItem(getQPixmap("unzoom_xpm"), tr("&Rescale to show all"), this, SLOT(setAutoScale()), tr("Ctrl+Shift+R"));
+  menu.insertItem(getQPixmap("unzoom_xpm"), tr("&Rescale to show all"), this,
+                  SLOT(setAutoScale()), tr("Ctrl+Shift+R"));
   menu.insertSeparator();
   menu.insertItem(tr("&Hide axis"), this, SLOT(hideSelectedAxis()));
 
   int gridsID = menu.insertItem(tr("&Show grids"), this, SLOT(showGrids()));
-  if (axis == QwtScaleDraw::LeftScale || axis == QwtScaleDraw::RightScale){
+  if (axis == QwtScaleDraw::LeftScale || axis == QwtScaleDraw::RightScale) {
     if (d_plot->grid()->yEnabled())
       menu.setItemChecked(gridsID, true);
   } else {
@@ -4134,23 +3942,21 @@ void Graph::showAxisContextMenu(int axis)
   menu.exec(QCursor::pos());
 }
 
-void Graph::showAxisDialog()
-{
+void Graph::showAxisDialog() {
   QwtScaleWidget *scale = scalePicker->currentAxis();
   if (scale)
     emit showAxisDialog(scale->alignment());
 }
 
-void Graph::showScaleDialog()
-{
+void Graph::showScaleDialog() {
   emit axisDblClicked(scalePicker->currentAxis()->alignment());
 }
 
-void Graph::hideSelectedAxis()
-{
+void Graph::hideSelectedAxis() {
   int axis = -1;
   int selectedAxis = scalePicker->currentAxis()->alignment();
-  if (selectedAxis == QwtScaleDraw::LeftScale || selectedAxis == QwtScaleDraw::RightScale)
+  if (selectedAxis == QwtScaleDraw::LeftScale ||
+      selectedAxis == QwtScaleDraw::RightScale)
     axis = selectedAxis - 2;
   else
     axis = selectedAxis + 2;
@@ -4160,27 +3966,23 @@ void Graph::hideSelectedAxis()
   emit modifiedGraph();
 }
 
-void Graph::showGrids()
-{
-  showGrid (scalePicker->currentAxis()->alignment());
-}
+void Graph::showGrids() { showGrid(scalePicker->currentAxis()->alignment()); }
 
-void Graph::showGrid()
-{
+void Graph::showGrid() {
   showGrid(QwtScaleDraw::LeftScale);
   showGrid(QwtScaleDraw::BottomScale);
 }
 
-void Graph::showGrid(int axis)
-{
+void Graph::showGrid(int axis) {
   Grid *grid = d_plot->grid();
   if (!grid)
     return;
 
-  if (axis == QwtScaleDraw::LeftScale || axis == QwtScaleDraw::RightScale){
+  if (axis == QwtScaleDraw::LeftScale || axis == QwtScaleDraw::RightScale) {
     grid->enableY(!grid->yEnabled());
     grid->enableYMin(!grid->yMinEnabled());
-  } else if (axis == QwtScaleDraw::BottomScale || axis == QwtScaleDraw::TopScale){
+  } else if (axis == QwtScaleDraw::BottomScale ||
+             axis == QwtScaleDraw::TopScale) {
     grid->enableX(!grid->xEnabled());
     grid->enableXMin(!grid->xMinEnabled());
   } else
@@ -4189,8 +3991,7 @@ void Graph::showGrid(int axis)
   emit modifiedGraph();
 }
 
-void Graph::copy(Graph* g)
-{
+void Graph::copy(Graph *g) {
   d_waterfall_offset_x = g->waterfallXOffset();
   d_waterfall_offset_y = g->waterfallYOffset();
 
@@ -4200,23 +4001,24 @@ void Graph::copy(Graph* g)
   setFrame(plot->lineWidth(), plot->frameColor());
   setCanvasBackground(plot->canvasBackground());
 
-  for (int i = 0; i<QwtPlot::axisCnt; i++){
-    if (plot->axisEnabled (i)){
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    if (plot->axisEnabled(i)) {
       d_plot->enableAxis(i);
-      QwtScaleWidget *scale = dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
-      if (scale){
+      QwtScaleWidget *scale =
+          dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+      if (scale) {
         scale->setMargin(plot->axisWidget(i)->margin());
         QPalette pal = scale->palette();
         pal.setColor(QColorGroup::Foreground, g->axisColor(i));
         pal.setColor(QColorGroup::Text, g->axisLabelsColor(i));
         scale->setPalette(pal);
-        d_plot->setAxisFont (i, plot->axisFont(i));
+        d_plot->setAxisFont(i, plot->axisFont(i));
 
         QwtText src_axis_title = plot->axisTitle(i);
         QwtText title = scale->title();
         title.setText(src_axis_title.text());
         title.setColor(src_axis_title.color());
-        title.setFont (src_axis_title.font());
+        title.setFont(src_axis_title.font());
         title.setRenderFlags(src_axis_title.renderFlags());
         scale->setTitle(title);
       }
@@ -4225,14 +4027,49 @@ void Graph::copy(Graph* g)
   }
 
   grid()->copy(g->grid());
-  d_plot->setTitle (g->plotWidget()->title());
+  d_plot->setTitle(g->plotWidget()->title());
   setCanvasFrame(g->canvasFrameWidth(), g->canvasFrameColor());
   setAxesLinewidth(plot->axesLinewidth());
   removeLegend();
 
-  for (int i=0; i<g->curves(); i++){
-    QwtPlotItem *it = (QwtPlotItem *)g->plotItem(i);
-    if (it->rtti() == QwtPlotItem::Rtti_PlotCurve){
+  for (int i = 0; i < g->curves(); i++) {
+    QwtPlotItem *it = dynamic_cast<QwtPlotItem *>(g->curve(i));
+
+    if (it == nullptr)
+      continue;
+
+    if (it->rtti() == QwtPlotItem::Rtti_PlotUserItem) {
+      MantidMatrixCurve *mmc = dynamic_cast<MantidMatrixCurve *>(it);
+      MantidMDCurve *mdc = dynamic_cast<MantidMDCurve *>(it);
+      PlotCurve *pc = dynamic_cast<PlotCurve *>(it);
+      PlotCurve *pc_cpy;
+
+      if (mmc != nullptr) {
+        pc_cpy = dynamic_cast<PlotCurve *>(mmc->clone(g));
+        d_plot->insertCurve(pc_cpy);
+      } else if (mdc != nullptr) {
+        pc_cpy = dynamic_cast<PlotCurve *>(mdc->clone(g));
+        d_plot->insertCurve(pc_cpy);
+      } else
+        continue;
+
+      pc_cpy->setPen(pc->pen());
+      pc_cpy->setBrush(pc->brush());
+      pc_cpy->setStyle(pc->style());
+      pc_cpy->setSymbol(pc->symbol());
+
+      if (pc->testCurveAttribute(QwtPlotCurve::Fitted))
+        pc_cpy->setCurveAttribute(QwtPlotCurve::Fitted, true);
+      else if (pc->testCurveAttribute(QwtPlotCurve::Inverted))
+        pc_cpy->setCurveAttribute(QwtPlotCurve::Inverted, true);
+
+      pc_cpy->setAxis(pc->xAxis(), pc->yAxis());
+      pc_cpy->setVisible(pc->isVisible());
+
+      QList<QwtPlotCurve *> lst = g->fitCurvesList();
+      if (lst.contains(dynamic_cast<QwtPlotCurve *>(it)))
+        d_fit_curves << pc_cpy;
+    } else if (it->rtti() == QwtPlotItem::Rtti_PlotCurve) {
       DataCurve *cv = dynamic_cast<DataCurve *>(it);
       if (!cv)
         continue;
@@ -4244,9 +4081,9 @@ void Graph::copy(Graph* g)
       int n = cv->dataSize();
       QVector<double> x(n);
       QVector<double> y(n);
-      for (int j=0; j<n; j++){
-        x[j]=cv->x(j);
-        y[j]=cv->y(j);
+      for (int j = 0; j < n; j++) {
+        x[j] = cv->x(j);
+        y[j] = cv->y(j);
       }
 
       int style = pc->type();
@@ -4256,15 +4093,16 @@ void Graph::copy(Graph* g)
       c_type.resize(n_curves);
       c_type[i] = g->curveType(i);
 
-      if (style == Pie){
-        c = new QwtPieCurve(cv->table(), cv->title().text(), cv->startRow(), cv->endRow());
+      if (style == Pie) {
+        c = new QwtPieCurve(cv->table(), cv->title().text(), cv->startRow(),
+                            cv->endRow());
         c_keys[i] = d_plot->insertCurve(c);
       } else if (style == Function) {
         c = new FunctionCurve(cv->title().text());
         c_keys[i] = d_plot->insertCurve(c);
-        FunctionCurve *fc = dynamic_cast<FunctionCurve*>(c);
+        FunctionCurve *fc = dynamic_cast<FunctionCurve *>(c);
         if (fc) {
-          FunctionCurve *fcCV = dynamic_cast<FunctionCurve*>(cv);
+          FunctionCurve *fcCV = dynamic_cast<FunctionCurve *>(cv);
           if (fcCV)
             fc->copy(fcCV);
         }
@@ -4280,13 +4118,13 @@ void Graph::copy(Graph* g)
             bc->copy(cvBC);
         }
       } else if (style == ErrorBars) {
-        QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve*>(cv);
+        QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve *>(cv);
         if (er) {
           DataCurve *master_curve = masterCurve(er);
           if (master_curve) {
             c = new QwtErrorPlotCurve(cv->table(), cv->title().text());
             c_keys[i] = d_plot->insertCurve(c);
-            QwtErrorPlotCurve *epc = dynamic_cast<QwtErrorPlotCurve*>(c);
+            QwtErrorPlotCurve *epc = dynamic_cast<QwtErrorPlotCurve *>(c);
             if (epc) {
               epc->copy(er);
               epc->setMasterCurve(master_curve);
@@ -4298,10 +4136,12 @@ void Graph::copy(Graph* g)
         if (h && h->matrix())
           c = new QwtHistogram(h->matrix());
         else
-          c = new QwtHistogram(cv->table(), cv->xColumnName(), cv->title().text(), cv->startRow(), cv->endRow());
+          c = new QwtHistogram(cv->table(), cv->xColumnName(),
+                               cv->title().text(), cv->startRow(),
+                               cv->endRow());
         c_keys[i] = d_plot->insertCurve(c);
 
-        QwtHistogram *cQH = dynamic_cast<QwtHistogram*>(c);
+        QwtHistogram *cQH = dynamic_cast<QwtHistogram *>(c);
         if (cQH && h)
           cQH->copy(h);
       } else if (style == VectXYXY || style == VectXYAM) {
@@ -4310,10 +4150,10 @@ void Graph::copy(Graph* g)
           vs = VectorCurve::XYAM;
         VectorCurve *cvVC = dynamic_cast<VectorCurve *>(cv);
         if (cvVC) {
-          c = new VectorCurve(vs, cv->table(), cv->xColumnName(), cv->title().text(),
-                              cvVC->vectorEndXAColName(),
-                              cvVC->vectorEndYMColName(),
-                              cv->startRow(), cv->endRow());
+          c = new VectorCurve(vs, cv->table(), cv->xColumnName(),
+                              cv->title().text(), cvVC->vectorEndXAColName(),
+                              cvVC->vectorEndYMColName(), cv->startRow(),
+                              cv->endRow());
           c_keys[i] = d_plot->insertCurve(c);
 
           VectorCurve *cVC = dynamic_cast<VectorCurve *>(c);
@@ -4321,9 +4161,10 @@ void Graph::copy(Graph* g)
             cVC->copy(cvVC);
         }
       } else if (style == Box) {
-        c = new BoxCurve(cv->table(), cv->title().text(), cv->startRow(), cv->endRow());
+        c = new BoxCurve(cv->table(), cv->title().text(), cv->startRow(),
+                         cv->endRow());
         c_keys[i] = d_plot->insertCurve(c);
-        BoxCurve *bc = dynamic_cast<BoxCurve*>(c);
+        BoxCurve *bc = dynamic_cast<BoxCurve *>(c);
         if (bc) {
           const BoxCurve *cvBC = dynamic_cast<const BoxCurve *>(cv);
           if (cvBC)
@@ -4332,21 +4173,22 @@ void Graph::copy(Graph* g)
         QwtSingleArrayData dat(x[0], y, n);
         c->setData(dat);
       } else {
-        c = new DataCurve(cv->table(), cv->xColumnName(), cv->title().text(), cv->startRow(), cv->endRow());
+        c = new DataCurve(cv->table(), cv->xColumnName(), cv->title().text(),
+                          cv->startRow(), cv->endRow());
         c_keys[i] = d_plot->insertCurve(c);
       }
 
-      if (c_type[i] != Box && c_type[i] != ErrorBars){
+      if (c_type[i] != Box && c_type[i] != ErrorBars) {
         if (c) {
           c->setData(x.data(), y.data(), n);
           if (c->type() != Function && c->type() != Pie) {
-            DataCurve *dc = dynamic_cast<DataCurve*>(c);
+            DataCurve *dc = dynamic_cast<DataCurve *>(c);
             if (dc)
               dc->clone(cv);
           } else if (c->type() == Pie) {
-            QwtPieCurve *cPie = dynamic_cast<QwtPieCurve*>(c);
+            QwtPieCurve *cPie = dynamic_cast<QwtPieCurve *>(c);
             if (cPie) {
-              QwtPieCurve *cvPie = dynamic_cast<QwtPieCurve*>(cv);
+              QwtPieCurve *cvPie = dynamic_cast<QwtPieCurve *>(cv);
               if (cvPie)
                 cPie->clone(cvPie);
             }
@@ -4362,25 +4204,24 @@ void Graph::copy(Graph* g)
       c->setStyle(cv->style());
       c->setSymbol(cv->symbol());
 
-      if (cv->testCurveAttribute (QwtPlotCurve::Fitted))
+      if (cv->testCurveAttribute(QwtPlotCurve::Fitted))
         c->setCurveAttribute(QwtPlotCurve::Fitted, true);
-      else if (cv->testCurveAttribute (QwtPlotCurve::Inverted))
+      else if (cv->testCurveAttribute(QwtPlotCurve::Inverted))
         c->setCurveAttribute(QwtPlotCurve::Inverted, true);
 
       c->setAxis(cv->xAxis(), cv->yAxis());
       c->setVisible(cv->isVisible());
 
-      QList<QwtPlotCurve *>lst = g->fitCurvesList();
+      QList<QwtPlotCurve *> lst = g->fitCurvesList();
       if (lst.contains(dynamic_cast<QwtPlotCurve *>(it)))
         d_fit_curves << c;
-    } else if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram){
+    } else if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
       Spectrogram *spc = (dynamic_cast<Spectrogram *>(it));
       if (!spc)
         continue;
       Spectrogram *sp = spc->copy();
       c_keys.resize(++n_curves);
       c_keys[i] = d_plot->insertCurve(sp);
-
 
       QwtScaleWidget *rightAxis = sp->plot()->axisWidget(QwtPlot::yRight);
       if (g->curveType(i) == ColorMap)
@@ -4391,32 +4232,29 @@ void Graph::copy(Graph* g)
       sp->mutableColorMap().changeScaleType(sp->getColorMap().getScaleType());
       sp->mutableColorMap().setNthPower(sp->getColorMap().getNthPower());
 
-      rightAxis->setColorMap(sp->data().range(),sp->mutableColorMap());
-      sp->plot()->setAxisScale(QwtPlot::yRight,
-          sp->data().range().minValue(),
-          sp->data().range().maxValue());
-      sp->plot()->setAxisScaleDiv(QwtPlot::yRight, *sp->plot()->axisScaleDiv(QwtPlot::yRight));
-
-      //sp->showColorScale((dynamic_cast<Spectrogram *>(it))->colorScaleAxis(), (dynamic_cast<Spectrogram *>(it))->hasColorScale());
-      /* sp->setColorBarWidth((dynamic_cast<Spectrogram *>(it))->colorBarWidth());
-      sp->setVisible(it->isVisible());*/
+      rightAxis->setColorMap(sp->data().range(), sp->mutableColorMap());
+      sp->plot()->setAxisScale(QwtPlot::yRight, sp->data().range().minValue(),
+                               sp->data().range().maxValue());
+      sp->plot()->setAxisScaleDiv(QwtPlot::yRight,
+                                  *sp->plot()->axisScaleDiv(QwtPlot::yRight));
 
       c_type.resize(n_curves);
       c_type[i] = g->curveType(i);
     }
   }
 
-  for (int i=0; i<QwtPlot::axisCnt; i++){
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
     QwtScaleWidget *sc = g->plotWidget()->axisWidget(i);
     if (!sc)
       continue;
 
-    ScaleDraw *sdg = dynamic_cast<ScaleDraw *>(g->plotWidget()->axisScaleDraw (i));
-    if (sdg && sdg->hasComponent(QwtAbstractScaleDraw::Labels))
-    {
+    ScaleDraw *sdg =
+        dynamic_cast<ScaleDraw *>(g->plotWidget()->axisScaleDraw(i));
+    if (sdg && sdg->hasComponent(QwtAbstractScaleDraw::Labels)) {
       ScaleDraw::ScaleType type = sdg->scaleType();
       if (type == ScaleDraw::Numeric)
-        setLabelsNumericFormat(i, plot->axisLabelFormat(i), plot->axisLabelPrecision(i), sdg->formula());
+        setLabelsNumericFormat(i, plot->axisLabelFormat(i),
+                               plot->axisLabelPrecision(i), sdg->formula());
       else if (type == ScaleDraw::Day)
         setLabelsDayFormat(i, sdg->nameFormat());
       else if (type == ScaleDraw::Month)
@@ -4426,38 +4264,43 @@ void Graph::copy(Graph* g)
       else {
         ScaleDraw *sd = dynamic_cast<ScaleDraw *>(plot->axisScaleDraw(i));
         if (sd)
-          d_plot->setAxisScaleDraw(i, new ScaleDraw(d_plot, sd->labelsList(), sd->formatString(), sd->scaleType()));
+          d_plot->setAxisScaleDraw(i, new ScaleDraw(d_plot, sd->labelsList(),
+                                                    sd->formatString(),
+                                                    sd->scaleType()));
       }
     } else {
-      ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw (i));
-      sd->enableComponent (QwtAbstractScaleDraw::Labels, false);
+      ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(i));
+      sd->enableComponent(QwtAbstractScaleDraw::Labels, false);
     }
   }
-  for (int i=0; i<QwtPlot::axisCnt; i++){//set same scales
-    const ScaleEngine *se = dynamic_cast<ScaleEngine *>(plot->axisScaleEngine(i));
+  for (int i = 0; i < QwtPlot::axisCnt; i++) { // set same scales
+    const ScaleEngine *se =
+        dynamic_cast<ScaleEngine *>(plot->axisScaleEngine(i));
     if (!se)
       continue;
 
     int majorTicks = plot->axisMaxMajor(i);
     int minorTicks = plot->axisMaxMinor(i);
-    d_plot->setAxisMaxMajor (i, majorTicks);
-    d_plot->setAxisMaxMinor (i, minorTicks);
+    d_plot->setAxisMaxMajor(i, majorTicks);
+    d_plot->setAxisMaxMinor(i, minorTicks);
 
     double step = g->axisStep(i);
     d_user_step[i] = step;
 
-    ScaleEngine *sc_engine = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(i));
+    ScaleEngine *sc_engine =
+        dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(i));
     if (!sc_engine)
       continue;
 
     sc_engine->clone(se);
     const QwtScaleDiv *sd = plot->axisScaleDiv(i);
-    QwtScaleDiv div = sc_engine->divideScale (QMIN(sd->lBound(), sd->hBound()),
-        QMAX(sd->lBound(), sd->hBound()), majorTicks, minorTicks, step);
+    QwtScaleDiv div = sc_engine->divideScale(QMIN(sd->lBound(), sd->hBound()),
+                                             QMAX(sd->lBound(), sd->hBound()),
+                                             majorTicks, minorTicks, step);
 
     if (se->testAttribute(QwtScaleEngine::Inverted))
       div.invert();
-    d_plot->setAxisScaleDiv (i, div);
+    d_plot->setAxisScaleDiv(i, div);
   }
 
   drawAxesBackbones(g->drawAxesBackbone);
@@ -4469,15 +4312,15 @@ void Graph::copy(Graph* g)
   setAxisLabelRotation(QwtPlot::xTop, g->labelsRotation(QwtPlot::xTop));
 
   QVector<int> imag = g->imageMarkerKeys();
-  for (int i=0; i<(int)imag.size(); i++)
-    addImage(dynamic_cast<ImageMarker*>(g->imageMarker(imag[i])));
+  for (int i = 0; i < (int)imag.size(); i++)
+    addImage(dynamic_cast<ImageMarker *>(g->imageMarker(imag[i])));
 
   QList<LegendWidget *> texts = g->textsList();
-  foreach (LegendWidget *t, texts){
+  foreach (LegendWidget *t, texts) {
     if (t == g->legend())
       d_legend = insertText(t);
-    else if (t->isA("PieLabel")){
-      QwtPieCurve *pie = dynamic_cast<QwtPieCurve*>(curve(0));
+    else if (t->isA("PieLabel")) {
+      QwtPieCurve *pie = dynamic_cast<QwtPieCurve *>(curve(0));
       if (pie)
         pie->addLabel(dynamic_cast<PieLabel *>(t), true);
       else
@@ -4487,8 +4330,8 @@ void Graph::copy(Graph* g)
   }
 
   QVector<int> l = g->lineMarkerKeys();
-  for (int i=0; i<(int)l.size(); i++){
-    ArrowMarker* lmrk=dynamic_cast<ArrowMarker*>(g->arrow(l[i]));
+  for (int i = 0; i < (int)l.size(); i++) {
+    ArrowMarker *lmrk = dynamic_cast<ArrowMarker *>(g->arrow(l[i]));
     if (lmrk)
       addArrow(lmrk);
   }
@@ -4497,70 +4340,77 @@ void Graph::copy(Graph* g)
   d_plot->replot();
 }
 
-void Graph::plotBoxDiagram(Table *w, const QStringList& names, int startRow, int endRow)
-{
+void Graph::plotBoxDiagram(Table *w, const QStringList &names, int startRow,
+                           int endRow) {
   if (endRow < 0)
     endRow = w->numRows() - 1;
 
-  for (int j = 0; j <(int)names.count(); j++){
+  for (int j = 0; j < (int)names.count(); j++) {
     BoxCurve *c = new BoxCurve(w, names[j], startRow, endRow);
 
     c_keys.resize(++n_curves);
-    c_keys[n_curves-1] = d_plot->insertCurve(c);
+    c_keys[n_curves - 1] = d_plot->insertCurve(c);
     c_type.resize(n_curves);
-    c_type[n_curves-1] = Box;
+    c_type[n_curves - 1] = Box;
 
-    c->setData(QwtSingleArrayData(double(j+1), QwtArray<double>(), 0));
+    c->setData(QwtSingleArrayData(double(j + 1), QwtArray<double>(), 0));
     c->loadData();
 
     c->setPen(QPen(ColorBox::color(j), 1));
-    c->setSymbol(QwtSymbol(QwtSymbol::NoSymbol, QBrush(), QPen(ColorBox::color(j), 1), QSize(7,7)));
+    c->setSymbol(QwtSymbol(QwtSymbol::NoSymbol, QBrush(),
+                           QPen(ColorBox::color(j), 1), QSize(7, 7)));
   }
 
   if (d_legend)
     d_legend->setText(legendText());
 
-  d_plot->setAxisScaleDraw (QwtPlot::xBottom, new ScaleDraw(d_plot, w->selectedYLabels(), w->objectName(), ScaleDraw::ColHeader));
-  d_plot->setAxisMaxMajor(QwtPlot::xBottom, names.count()+1);
+  d_plot->setAxisScaleDraw(
+      QwtPlot::xBottom, new ScaleDraw(d_plot, w->selectedYLabels(),
+                                      w->objectName(), ScaleDraw::ColHeader));
+  d_plot->setAxisMaxMajor(QwtPlot::xBottom, names.count() + 1);
   d_plot->setAxisMaxMinor(QwtPlot::xBottom, 0);
 
-  d_plot->setAxisScaleDraw (QwtPlot::xTop, new ScaleDraw(d_plot, w->selectedYLabels(), w->objectName(), ScaleDraw::ColHeader));
-  d_plot->setAxisMaxMajor(QwtPlot::xTop, names.count()+1);
+  d_plot->setAxisScaleDraw(
+      QwtPlot::xTop, new ScaleDraw(d_plot, w->selectedYLabels(),
+                                   w->objectName(), ScaleDraw::ColHeader));
+  d_plot->setAxisMaxMajor(QwtPlot::xTop, names.count() + 1);
   d_plot->setAxisMaxMinor(QwtPlot::xTop, 0);
 }
 
-void Graph::setCurveStyle(int index, int s)
-{
+void Graph::setCurveStyle(int index, int s) {
   QwtPlotCurve *c = curve(index);
   if (!c)
     return;
 
   int curve_type = c_type[index];
-  if (curve_type == VerticalBars || curve_type == HorizontalBars || curve_type == Histogram ||
-      curve_type == Pie || curve_type == Box || curve_type == ErrorBars ||
-      curve_type == VectXYXY || curve_type == VectXYAM)
-    return;//these are not line styles, but distinct curve types and this function must not change the curve type
+  if (curve_type == VerticalBars || curve_type == HorizontalBars ||
+      curve_type == Histogram || curve_type == Pie || curve_type == Box ||
+      curve_type == ErrorBars || curve_type == VectXYXY ||
+      curve_type == VectXYAM)
+    return; // these are not line styles, but distinct curve types and this
+            // function must not change the curve type
 
   c->setCurveAttribute(QwtPlotCurve::Fitted, false);
   c->setCurveAttribute(QwtPlotCurve::Inverted, false);
 
-  if (s == 5){//ancient spline style in Qwt 4.2.0
+  if (s == 5) { // ancient spline style in Qwt 4.2.0
     s = QwtPlotCurve::Lines;
     c->setCurveAttribute(QwtPlotCurve::Fitted, true);
     c_type[index] = Spline;
-  } else if (s == 6){// Vertical Steps
+  } else if (s == 6) { // Vertical Steps
     s = QwtPlotCurve::Steps;
     c->setCurveAttribute(QwtPlotCurve::Inverted, false);
     c_type[index] = VerticalSteps;
-  } else if (s == QwtPlotCurve::Steps){// Horizontal Steps
+  } else if (s == QwtPlotCurve::Steps) { // Horizontal Steps
     c_type[index] = HorizontalSteps;
     c->setCurveAttribute(QwtPlotCurve::Inverted, true);
   } else if (s == QwtPlotCurve::Sticks)
     c_type[index] = VerticalDropLines;
-  else {//QwtPlotCurve::Lines || QwtPlotCurve::Dots
+  else { // QwtPlotCurve::Lines || QwtPlotCurve::Dots
     if (c->symbol().style() == QwtSymbol::NoSymbol)
       c_type[index] = Line;
-    else if (c->symbol().style() != QwtSymbol::NoSymbol && (QwtPlotCurve::CurveStyle)s == QwtPlotCurve::NoCurve)
+    else if (c->symbol().style() != QwtSymbol::NoSymbol &&
+             (QwtPlotCurve::CurveStyle)s == QwtPlotCurve::NoCurve)
       c_type[index] = Scatter;
     else
       c_type[index] = LineSymbols;
@@ -4569,8 +4419,7 @@ void Graph::setCurveStyle(int index, int s)
   c->setStyle((QwtPlotCurve::CurveStyle)s);
 }
 
-void Graph::setCurveSymbol(int index, const QwtSymbol& s)
-{
+void Graph::setCurveSymbol(int index, const QwtSymbol &s) {
   QwtPlotCurve *c = curve(index);
   if (!c)
     return;
@@ -4578,8 +4427,7 @@ void Graph::setCurveSymbol(int index, const QwtSymbol& s)
   c->setSymbol(s);
 }
 
-void Graph::setCurvePen(int index, const QPen& p)
-{
+void Graph::setCurvePen(int index, const QPen &p) {
   QwtPlotCurve *c = curve(index);
   if (!c)
     return;
@@ -4587,8 +4435,7 @@ void Graph::setCurvePen(int index, const QPen& p)
   c->setPen(p);
 }
 
-void Graph::setCurveBrush(int index, const QBrush& b)
-{
+void Graph::setCurveBrush(int index, const QBrush &b) {
   QwtPlotCurve *c = curve(index);
   if (!c)
     return;
@@ -4596,33 +4443,32 @@ void Graph::setCurveBrush(int index, const QBrush& b)
   c->setBrush(b);
 }
 
-void Graph::setCurveSkipSymbolsCount(int index, int count)
-{
-  PlotCurve *c = dynamic_cast<PlotCurve*>(curve(index));
+void Graph::setCurveSkipSymbolsCount(int index, int count) {
+  PlotCurve *c = dynamic_cast<PlotCurve *>(curve(index));
   if (!c)
     return;
 
   c->setSkipSymbolsCount(count);
 }
 
-BoxCurve* Graph::openBoxDiagram(Table *w, const QStringList& l, int fileVersion)
-{
+BoxCurve *Graph::openBoxDiagram(Table *w, const QStringList &l,
+                                int fileVersion) {
   if (!w)
     return NULL;
 
   int startRow = 0;
-  int endRow = w->numRows()-1;
+  int endRow = w->numRows() - 1;
   if (fileVersion >= 90) {
-    startRow = l[l.count()-3].toInt();
-    endRow = l[l.count()-2].toInt();
+    startRow = l[l.count() - 3].toInt();
+    endRow = l[l.count() - 2].toInt();
   }
 
   BoxCurve *c = new BoxCurve(w, l[2], startRow, endRow);
 
   c_keys.resize(++n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(c);
+  c_keys[n_curves - 1] = d_plot->insertCurve(c);
   c_type.resize(n_curves);
-  c_type[n_curves-1] = Box;
+  c_type[n_curves - 1] = Box;
 
   c->setData(QwtSingleArrayData(l[1].toDouble(), QwtArray<double>(), 0));
   c->setData(QwtSingleArrayData(l[1].toDouble(), QwtArray<double>(), 0));
@@ -4641,29 +4487,27 @@ BoxCurve* Graph::openBoxDiagram(Table *w, const QStringList& l, int fileVersion)
   return c;
 }
 
-void Graph::setActiveTool(PlotToolInterface *tool)
-{
-  if (tool && tool->rtti() == PlotToolInterface::Rtti_MultiPeakFitTool){
+void Graph::setActiveTool(PlotToolInterface *tool) {
+  if (tool && tool->rtti() == PlotToolInterface::Rtti_MultiPeakFitTool) {
     if (d_range_selector)
       d_range_selector->setEnabled(false);
     return;
   }
 
-  if(d_active_tool)
+  if (d_active_tool)
     delete d_active_tool;
 
-  d_active_tool=tool;
+  d_active_tool = tool;
 }
 
-void Graph::disableTools()
-{
+void Graph::disableTools() {
   if (zoomOn())
     zoom(false);
   enablePanningMagnifier(false);
   if (drawLineActive())
     drawLine(false);
 
-  if(d_active_tool)
+  if (d_active_tool)
     delete d_active_tool;
   d_active_tool = NULL;
 
@@ -4672,42 +4516,42 @@ void Graph::disableTools()
   d_range_selector = NULL;
 }
 
-bool Graph::enableRangeSelectors(const QObject *status_target, const char *status_slot)
-{
-  if (d_range_selector){
+bool Graph::enableRangeSelectors(const QObject *status_target,
+                                 const char *status_slot) {
+  if (d_range_selector) {
     delete d_range_selector;
     d_range_selector = NULL;
   }
   d_range_selector = new RangeSelectorTool(this, status_target, status_slot);
   setActiveTool(d_range_selector);
-  connect(d_range_selector, SIGNAL(changed()), this, SIGNAL(dataRangeChanged()));
+  connect(d_range_selector, SIGNAL(changed()), this,
+          SIGNAL(dataRangeChanged()));
   return true;
 }
 
-void Graph::guessUniqueCurveLayout(int& colorIndex, int& symbolIndex)
-{
+void Graph::guessUniqueCurveLayout(int &colorIndex, int &symbolIndex) {
   colorIndex = 0;
   symbolIndex = 0;
 
   int curve_index = n_curves - 1;
-  if (curve_index >= 0 && c_type[curve_index] == ErrorBars)
-  {// find out the pen color of the master curve
-    QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve *>(d_plot->curve(c_keys[curve_index]));
+  if (curve_index >= 0 &&
+      c_type[curve_index] ==
+          ErrorBars) { // find out the pen color of the master curve
+    QwtErrorPlotCurve *er =
+        dynamic_cast<QwtErrorPlotCurve *>(d_plot->curve(c_keys[curve_index]));
     if (!er)
       return;
 
     DataCurve *master_curve = er->masterCurve();
-    if (master_curve){
+    if (master_curve) {
       colorIndex = ColorBox::colorIndex(master_curve->pen().color());
       return;
     }
   }
 
-  for (int i=0; i<n_curves; ++i)
-  {
+  for (int i = 0; i < n_curves; ++i) {
     const PlotCurve *c = dynamic_cast<PlotCurve *>(curve(i));
-    if (c)
-    {
+    if (c) {
       colorIndex = std::max(ColorBox::colorIndex(c->pen().color()), colorIndex);
 
       QwtSymbol symb = c->symbol();
@@ -4715,46 +4559,46 @@ void Graph::guessUniqueCurveLayout(int& colorIndex, int& symbolIndex)
     }
   }
   if (n_curves > 1)
-    colorIndex = (colorIndex+1)%ColorBox::numPredefinedColors();
-  if (ColorBox::color(colorIndex) == Qt::white) //avoid white invisible curves
+    colorIndex = (colorIndex + 1) % ColorBox::numPredefinedColors();
+  if (ColorBox::color(colorIndex) == Qt::white) // avoid white invisible curves
     ++colorIndex;
 
-  symbolIndex = (symbolIndex+1)%15;
+  symbolIndex = (symbolIndex + 1) % 15;
   if (symbolIndex == 0)
     ++symbolIndex;
 }
 
-void Graph::addFitCurve(QwtPlotCurve *c)
-{
+void Graph::addFitCurve(QwtPlotCurve *c) {
   if (c)
     d_fit_curves << c;
 }
 
-void Graph::deleteFitCurves()
-{
+void Graph::deleteFitCurves() {
   QList<int> keys = d_plot->curveKeys();
-  foreach(QwtPlotCurve *c, d_fit_curves)
-  removeCurve(curveIndex(c));
+  foreach (QwtPlotCurve *c, d_fit_curves)
+    removeCurve(curveIndex(c));
 
   d_plot->replot();
 }
 
-Spectrogram* Graph::plotSpectrogram(Matrix *m, CurveType type)
-{
+Spectrogram *Graph::plotSpectrogram(Matrix *m, CurveType type) {
   if (type != GrayScale && type != ColorMap && type != Contour)
     return 0;
 
   Spectrogram *d_spectrogram = new Spectrogram(m);
-  return plotSpectrogram(d_spectrogram,type);
+  return plotSpectrogram(d_spectrogram, type);
 }
-Spectrogram* Graph::plotSpectrogram(Function2D *f,int nrows, int ncols,double left, double top, double width, double height,double minz,double maxz, CurveType type)
-{
+Spectrogram *Graph::plotSpectrogram(Function2D *f, int nrows, int ncols,
+                                    double left, double top, double width,
+                                    double height, double minz, double maxz,
+                                    CurveType type) {
   if (type != GrayScale && type != ColorMap && type != Contour)
     return 0;
 
-  Spectrogram *d_spectrogram = new Spectrogram(f,nrows,ncols,left,top,width,height,minz,maxz);
+  Spectrogram *d_spectrogram =
+      new Spectrogram(f, nrows, ncols, left, top, width, height, minz, maxz);
 
-  return plotSpectrogram(d_spectrogram,type);
+  return plotSpectrogram(d_spectrogram, type);
 }
 
 /*
@@ -4763,104 +4607,104 @@ Spectrogram* Graph::plotSpectrogram(Function2D *f,int nrows, int ncols,double le
  * NOTE: returns false if we are running an old version of QWT (pre-5.2.0)
  *
  */
-bool Graph::isSpectrogram()
-{
+bool Graph::isSpectrogram() {
 #if QWT_VERSION >= 0x050200
-  for (int i=0; i<c_type.count(); i++)
-  {
-    if (!(c_type[i] == GrayScale || c_type[i] == ColorMap || c_type[i] == Contour || c_type[i] == ColorMapContour))
+  for (int i = 0; i < c_type.count(); i++) {
+    if (!(c_type[i] == GrayScale || c_type[i] == ColorMap ||
+          c_type[i] == Contour || c_type[i] == ColorMapContour))
       return false;
   }
   return true;
 #else
   return false;
 #endif
-
 }
 
-/** Returns a pointer to a 2D plot, if the Graph has one (if more than one, will return the first).
+/** Returns a pointer to a 2D plot, if the Graph has one (if more than one, will
+ * return the first).
  *  Otherwise, returns a null pointer.
  */
-Spectrogram* Graph::spectrogram()
-{
-  foreach (QwtPlotItem *item, d_plot->curves())
-  {
-    if(item && item->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
-    {
+Spectrogram *Graph::spectrogram() {
+  foreach (QwtPlotItem *item, d_plot->curves()) {
+    if (item && item->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
       Spectrogram *s = dynamic_cast<Spectrogram *>(item);
-      if (s) return s;
+      if (s)
+        return s;
     }
   }
   return NULL;
-
 }
 
-Spectrogram* Graph::plotSpectrogram(Function2D *f,int nrows, int ncols,QwtDoubleRect bRect,double minz,double maxz,CurveType type)
-{
-  if (type != GrayScale && type != ColorMap && type != Contour && type != ColorMapContour)
+Spectrogram *Graph::plotSpectrogram(Function2D *f, int nrows, int ncols,
+                                    QwtDoubleRect bRect, double minz,
+                                    double maxz, CurveType type) {
+  if (type != GrayScale && type != ColorMap && type != Contour &&
+      type != ColorMapContour)
     return 0;
 
-  Spectrogram *d_spectrogram = new Spectrogram(f,nrows,ncols,bRect,minz,maxz);
+  Spectrogram *d_spectrogram =
+      new Spectrogram(f, nrows, ncols, bRect, minz, maxz);
 
-  return plotSpectrogram(d_spectrogram,type);
+  return plotSpectrogram(d_spectrogram, type);
 }
 
-Spectrogram* Graph::plotSpectrogram(Spectrogram *d_spectrogram, CurveType type)
-{
+Spectrogram *Graph::plotSpectrogram(Spectrogram *d_spectrogram,
+                                    CurveType type) {
   if (type == GrayScale)
     d_spectrogram->setGrayScale();
 
-  else if (type == Contour)
-  {
+  else if (type == Contour) {
     d_spectrogram->setDisplayMode(QwtPlotSpectrogram::ImageMode, false);
     d_spectrogram->setDisplayMode(QwtPlotSpectrogram::ContourMode, true);
-  }
-  else if (type == ColorMap)
-  {
+  } else if (type == ColorMap) {
     d_spectrogram->mutableColorMap().changeScaleType(GraphOptions::Linear);
     d_spectrogram->setDefaultColorMap();
     d_spectrogram->setDisplayMode(QwtPlotSpectrogram::ImageMode, true);
     d_spectrogram->setDisplayMode(QwtPlotSpectrogram::ContourMode, false);
-  }
-  else if (type == ColorMapContour)
-  {
+  } else if (type == ColorMapContour) {
     d_spectrogram->mutableColorMap().changeScaleType(GraphOptions::Linear);
     d_spectrogram->setDefaultColorMap();
     d_spectrogram->setDisplayMode(QwtPlotSpectrogram::ImageMode, true);
     d_spectrogram->setDisplayMode(QwtPlotSpectrogram::ContourMode, true);
   }
   c_keys.resize(++n_curves);
-  c_keys[n_curves-1] = d_plot->insertCurve(d_spectrogram);
+  c_keys[n_curves - 1] = d_plot->insertCurve(d_spectrogram);
 
   c_type.resize(n_curves);
-  c_type[n_curves-1] = type;
+  c_type[n_curves - 1] = type;
 
   QwtScaleWidget *rightAxis = d_plot->axisWidget(QwtPlot::yRight);
-  if(!rightAxis) return 0;
+  if (!rightAxis)
+    return 0;
   rightAxis->setColorBarEnabled(type != Contour);
   d_plot->enableAxis(QwtPlot::yRight, type != Contour);
   // Ensure that labels are shown on color scale axis
   enableAxisLabels(QwtPlot::yRight);
 
-  //d_spectrogram->setDefaultColorMap();
-  if(type == GrayScale) rightAxis->setColorBarEnabled(false); //rightAxis->setColorMap(d_spectrogram->data().range(),d_spectrogram->colorMap());
-  else rightAxis->setColorMap(d_spectrogram->data().range(),d_spectrogram->mutableColorMap());
+  // d_spectrogram->setDefaultColorMap();
+  if (type == GrayScale)
+    rightAxis->setColorBarEnabled(
+        false); // rightAxis->setColorMap(d_spectrogram->data().range(),d_spectrogram->colorMap());
+  else
+    rightAxis->setColorMap(d_spectrogram->data().range(),
+                           d_spectrogram->mutableColorMap());
   d_plot->setAxisScale(QwtPlot::yRight,
-      d_spectrogram->data().range().minValue(),
-      d_spectrogram->data().range().maxValue());
+                       d_spectrogram->data().range().minValue(),
+                       d_spectrogram->data().range().maxValue());
 
+  d_plot->setAxisScaleDiv(QwtPlot::yRight,
+                          *d_plot->axisScaleDiv(QwtPlot::yRight));
 
-  d_plot->setAxisScaleDiv(QwtPlot::yRight, *d_plot->axisScaleDiv(QwtPlot::yRight));
+  for (int i = 0; i < QwtPlot::axisCnt; i++) {
+    updatedaxis.push_back(0);
+  }
 
-  for (int i=0; i < QwtPlot::axisCnt; i++)
-  {updatedaxis.push_back(0);  }
-
-  enableFixedAspectRatio(multiLayer()->applicationWindow()->fixedAspectRatio2DPlots);
+  enableFixedAspectRatio(
+      multiLayer()->applicationWindow()->fixedAspectRatio2DPlots);
   return d_spectrogram;
 }
 
-void Graph::restoreCurveLabels(int curveID, const QStringList& lst)
-{
+void Graph::restoreCurveLabels(int curveID, const QStringList &lst) {
   DataCurve *c = dynamic_cast<DataCurve *>(curve(curveID));
   if (!c)
     return;
@@ -4872,14 +4716,17 @@ void Graph::restoreCurveLabels(int curveID, const QStringList& lst)
   if (s.contains("<column>"))
     labelsColumn = s.remove("<column>").remove("</column>").trimmed();
 
-  for (++line; line != lst.end(); ++line){
+  for (++line; line != lst.end(); ++line) {
     s = *line;
     if (s.contains("<color>"))
-      c->setLabelsColor(QColor(s.remove("<color>").remove("</color>").trimmed()));
+      c->setLabelsColor(
+          QColor(s.remove("<color>").remove("</color>").trimmed()));
     else if (s.contains("<whiteOut>"))
-      c->setLabelsWhiteOut(s.remove("<whiteOut>").remove("</whiteOut>").toInt());
-    else if (s.contains("<font>")){
-      QStringList fontList = s.remove("<font>").remove("</font>").trimmed().split("\t");
+      c->setLabelsWhiteOut(
+          s.remove("<whiteOut>").remove("</whiteOut>").toInt());
+    else if (s.contains("<font>")) {
+      QStringList fontList =
+          s.remove("<font>").remove("</font>").trimmed().split("\t");
       QFont font = QFont(fontList[0], fontList[1].toInt());
       if (fontList.count() >= 3)
         font.setBold(fontList[2].toInt());
@@ -4901,32 +4748,32 @@ void Graph::restoreCurveLabels(int curveID, const QStringList& lst)
   c->setLabelsColumnName(labelsColumn);
 }
 
-bool Graph::validCurvesDataSize()
-{
-  if (!n_curves){
-    QMessageBox::warning(this, tr("MantidPlot - Warning"), tr("There are no curves available on this plot!"));
+bool Graph::validCurvesDataSize() {
+  if (!n_curves) {
+    QMessageBox::warning(this, tr("MantidPlot - Warning"),
+                         tr("There are no curves available on this plot!"));
     return false;
   } else {
-    for (int i=0; i < n_curves; i++){
+    for (int i = 0; i < n_curves; i++) {
       QwtPlotItem *item = curve(i);
-      if(item && item->rtti() != QwtPlotItem::Rtti_PlotSpectrogram){
-        QwtPlotCurve *c = dynamic_cast<QwtPlotCurve*>(item);
+      if (item && item->rtti() != QwtPlotItem::Rtti_PlotSpectrogram) {
+        QwtPlotCurve *c = dynamic_cast<QwtPlotCurve *>(item);
         if (c->dataSize() >= 2)
           return true;
       }
     }
     QMessageBox::warning(this, tr("MantidPlot - Error"),
-        tr("There are no curves with more than two points on this plot. Operation aborted!"));
+                         tr("There are no curves with more than two points on "
+                            "this plot. Operation aborted!"));
     return false;
   }
 }
 
-Graph::~Graph()
-{
+Graph::~Graph() {
   setActiveTool(NULL);
   if (d_range_selector)
     delete d_range_selector;
-  if(d_peak_fit_tool)
+  if (d_peak_fit_tool)
     delete d_peak_fit_tool;
   if (d_magnifier)
     delete d_magnifier;
@@ -4938,24 +4785,21 @@ Graph::~Graph()
   delete d_plot;
 }
 
-void Graph::setAntialiasing(bool on, bool update)
-{
+void Graph::setAntialiasing(bool on, bool update) {
   if (d_antialiasing == on)
     return;
 
   d_antialiasing = on;
 
-  if (update){
+  if (update) {
     QList<int> curve_keys = d_plot->curveKeys();
-    for (int i=0; i<(int)curve_keys.count(); i++)
-    {
+    for (int i = 0; i < (int)curve_keys.count(); i++) {
       QwtPlotItem *c = d_plot->curve(curve_keys[i]);
       if (c)
         c->setRenderHint(QwtPlotItem::RenderAntialiased, d_antialiasing);
     }
     QList<int> marker_keys = d_plot->markerKeys();
-    for (int i=0; i<(int)marker_keys.count(); i++)
-    {
+    for (int i = 0; i < (int)marker_keys.count(); i++) {
       QwtPlotMarker *m = d_plot->marker(marker_keys[i]);
       if (m)
         m->setRenderHint(QwtPlotItem::RenderAntialiased, d_antialiasing);
@@ -4965,16 +4809,14 @@ void Graph::setAntialiasing(bool on, bool update)
   }
 }
 
-bool Graph::focusNextPrevChild ( bool )
-{
+bool Graph::focusNextPrevChild(bool) {
   QList<int> mrkKeys = d_plot->markerKeys();
   int n = mrkKeys.size();
   if (n < 2)
     return false;
 
   int min_key = mrkKeys[0], max_key = mrkKeys[0];
-  for (int i = 0; i<n; i++ )
-  {
+  for (int i = 0; i < n; i++) {
     if (mrkKeys[i] >= max_key)
       max_key = mrkKeys[i];
     if (mrkKeys[i] <= min_key)
@@ -4982,10 +4824,9 @@ bool Graph::focusNextPrevChild ( bool )
   }
 
   int key = selectedMarker;
-  if (key >= 0)
-  {
+  if (key >= 0) {
     key++;
-    if ( key > max_key )
+    if (key > max_key)
       key = min_key;
   } else
     key = min_key;
@@ -4996,8 +4837,7 @@ bool Graph::focusNextPrevChild ( bool )
   return true;
 }
 
-QString Graph::axisFormatInfo(int axis)
-{
+QString Graph::axisFormatInfo(int axis) {
   if (axis < 0 || axis > QwtPlot::axisCnt)
     return QString();
 
@@ -5008,11 +4848,11 @@ QString Graph::axisFormatInfo(int axis)
     return "Not available!";
 }
 
-void Graph::updateCurveNames(const QString& oldName, const QString& newName, bool updateTableName)
-{
-  //update plotted curves list
+void Graph::updateCurveNames(const QString &oldName, const QString &newName,
+                             bool updateTableName) {
+  // update plotted curves list
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++){
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
     if (!it)
       continue;
@@ -5026,21 +4866,18 @@ void Graph::updateCurveNames(const QString& oldName, const QString& newName, boo
   d_plot->replot();
 }
 
-void Graph::setCurveFullRange(int curveIndex)
-{
+void Graph::setCurveFullRange(int curveIndex) {
   DataCurve *c = dynamic_cast<DataCurve *>(curve(curveIndex));
-  if (c)
-  {
+  if (c) {
     c->setFullRange();
     updatePlot();
     emit modifiedGraph();
   }
 }
 
-void Graph::setCurveLineColor(int curveIndex, int colorIndex)
-{
+void Graph::setCurveLineColor(int curveIndex, int colorIndex) {
   QwtPlotCurve *c = curve(curveIndex);
-  if (c){
+  if (c) {
     QPen pen = c->pen();
     pen.setColor(ColorBox::defaultColor(colorIndex));
     c->setPen(pen);
@@ -5049,10 +4886,9 @@ void Graph::setCurveLineColor(int curveIndex, int colorIndex)
   }
 }
 
-void Graph::setCurveLineColor(int curveIndex, QColor qColor)
-{
+void Graph::setCurveLineColor(int curveIndex, QColor qColor) {
   QwtPlotCurve *c = curve(curveIndex);
-  if (c){
+  if (c) {
     QPen pen = c->pen();
     pen.setColor(qColor);
     c->setPen(pen);
@@ -5061,10 +4897,9 @@ void Graph::setCurveLineColor(int curveIndex, QColor qColor)
   }
 }
 
-void Graph::setCurveLineStyle(int curveIndex, Qt::PenStyle style)
-{
+void Graph::setCurveLineStyle(int curveIndex, Qt::PenStyle style) {
   QwtPlotCurve *c = curve(curveIndex);
-  if (c){
+  if (c) {
     QPen pen = c->pen();
     pen.setStyle(style);
     c->setPen(pen);
@@ -5073,10 +4908,9 @@ void Graph::setCurveLineStyle(int curveIndex, Qt::PenStyle style)
   }
 }
 
-void Graph::setCurveLineWidth(int curveIndex, double width)
-{
+void Graph::setCurveLineWidth(int curveIndex, double width) {
   QwtPlotCurve *c = curve(curveIndex);
-  if (c){
+  if (c) {
     QPen pen = c->pen();
     pen.setWidthF(width);
     c->setPen(pen);
@@ -5085,34 +4919,32 @@ void Graph::setCurveLineWidth(int curveIndex, double width)
   }
 }
 
-void Graph::setGrayScale()
-{
+void Graph::setGrayScale() {
   if (isPiePlot())
     return;
 
-  int curves = d_plot->curvesList().size(); //QtiPlot: d_curves.size();
+  int curves = d_plot->curvesList().size(); // QtiPlot: d_curves.size();
   int dv = int(255 / double(curves));
   // QtiPlot: int i = 0;
   QColor color = Qt::black;
   int hue = color.hue();
-  for (int i = 0; i < curves; i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
+  for (int i = 0; i < curves;
+       i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
   {
-    QwtPlotItem * it = plotItem(i);
-    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
-    {
-      Spectrogram *spec = dynamic_cast<Spectrogram*>(it);
+    QwtPlotItem *it = plotItem(i);
+    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
+      Spectrogram *spec = dynamic_cast<Spectrogram *>(it);
       if (spec)
         spec->setGrayScale();
       continue;
     }
 
-    PlotCurve *c = dynamic_cast<PlotCurve*>(it);
+    PlotCurve *c = dynamic_cast<PlotCurve *>(it);
     if (!c || c->type() == ErrorBars)
       continue;
 
     QPen pen = c->pen();
-    if (i)
-    {
+    if (i) {
       int v = i * dv;
       if (v > 255)
         v = 0;
@@ -5122,8 +4954,7 @@ void Graph::setGrayScale()
     c->setPen(pen);
 
     QBrush brush = c->brush();
-    if (brush.style() != Qt::NoBrush)
-    {
+    if (brush.style() != Qt::NoBrush) {
       brush.setColor(color);
       c->setBrush(brush);
     }
@@ -5138,20 +4969,20 @@ void Graph::setGrayScale()
     // QtiPlot: i++;
   }
 
-  for (int i = 0; i < curves; i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
+  for (int i = 0; i < curves;
+       i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
   {
-    QwtPlotItem * it = plotItem(i);
+    QwtPlotItem *it = plotItem(i);
     if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
       continue;
 
-    PlotCurve *c = dynamic_cast<PlotCurve*>(it);
-    if (c && c->type() == ErrorBars)
-    {
+    PlotCurve *c = dynamic_cast<PlotCurve *>(it);
+    if (c && c->type() == ErrorBars) {
       // QtiPlot: ErrorBarsCurve *er = (ErrorBarsCurve *) it;
-      QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve*>(it);
+      QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve *>(it);
       if (!er)
         continue;
-      DataCurve* mc = er->masterCurve();
+      DataCurve *mc = er->masterCurve();
       if (mc)
         er->setColor(mc->pen().color());
     }
@@ -5161,25 +4992,25 @@ void Graph::setGrayScale()
   emit modifiedGraph();
 }
 
-void Graph::setIndexedColors()
-{
+void Graph::setIndexedColors() {
   QList<QColor> colors(ColorBox::defaultColors());
-// QtiPlot:
-//  MultiLayer *ml = multiLayer();
-//  if (ml && ml->applicationWindow())
-//    colors = ml->applicationWindow()->indexedColors();
-//  else
-//    colors = ColorBox::defaultColors();
+  // QtiPlot:
+  //  MultiLayer *ml = multiLayer();
+  //  if (ml && ml->applicationWindow())
+  //    colors = ml->applicationWindow()->indexedColors();
+  //  else
+  //    colors = ColorBox::defaultColors();
 
   // QtiPlot: int i = 0;
   int curves = d_plot->curvesList().size();
-  for (int i = 0; i < curves; i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
+  for (int i = 0; i < curves;
+       i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
   {
-    QwtPlotItem * it = plotItem(i);
+    QwtPlotItem *it = plotItem(i);
     if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
       continue;
 
-    PlotCurve *c = dynamic_cast<PlotCurve*>(it);
+    PlotCurve *c = dynamic_cast<PlotCurve *>(it);
     if (!c || c->type() == ErrorBars)
       continue;
 
@@ -5189,8 +5020,7 @@ void Graph::setIndexedColors()
     c->setPen(pen);
 
     QBrush brush = c->brush();
-    if (brush.style() != Qt::NoBrush)
-    {
+    if (brush.style() != Qt::NoBrush) {
       brush.setColor(color);
       c->setBrush(brush);
     }
@@ -5205,21 +5035,21 @@ void Graph::setIndexedColors()
     // QtiPlot: i++;
   }
 
-  for (int i = 0; i < curves; i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
+  for (int i = 0; i < curves;
+       i++) // QtiPlot: foreach (QwtPlotItem *it, d_curves)
   {
-    QwtPlotItem * it = plotItem(i);
+    QwtPlotItem *it = plotItem(i);
     if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
       continue;
 
-    PlotCurve *c = dynamic_cast<PlotCurve*>(it);
-    if (c && c->type() == ErrorBars)
-    {
+    PlotCurve *c = dynamic_cast<PlotCurve *>(it);
+    if (c && c->type() == ErrorBars) {
       // QtiPlot: ErrorBarsCurve *er = (ErrorBarsCurve *) it;
-      QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve*>(it);
+      QwtErrorPlotCurve *er = dynamic_cast<QwtErrorPlotCurve *>(it);
       if (!er)
         continue;
 
-      DataCurve* mc = er->masterCurve();
+      DataCurve *mc = er->masterCurve();
       if (mc)
         er->setColor(mc->pen().color());
     }
@@ -5229,11 +5059,9 @@ void Graph::setIndexedColors()
   emit modifiedGraph();
 }
 
-DataCurve* Graph::masterCurve(QwtErrorPlotCurve *er)
-{
+DataCurve *Graph::masterCurve(QwtErrorPlotCurve *er) {
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
     if (!it)
       continue;
@@ -5243,20 +5071,20 @@ DataCurve* Graph::masterCurve(QwtErrorPlotCurve *er)
     if (!pc || pc->type() == Function)
       continue;
 
-    DataCurve* dc = dynamic_cast<DataCurve *>(it);
-    if (!dc) return 0;
+    DataCurve *dc = dynamic_cast<DataCurve *>(it);
+    if (!dc)
+      return 0;
     if (dc->plotAssociation() == er->masterCurve()->plotAssociation())
       return dc;
   }
   return 0;
 }
 
-DataCurve* Graph::masterCurve(const QString& xColName, const QString& yColName)
-{
+DataCurve *Graph::masterCurve(const QString &xColName,
+                              const QString &yColName) {
   QString master_curve = xColName + "(X)," + yColName + "(Y)";
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
     if (!it)
       continue;
@@ -5266,16 +5094,16 @@ DataCurve* Graph::masterCurve(const QString& xColName, const QString& yColName)
     if (!pc || pc->type() == Function)
       continue;
 
-    DataCurve* dc = dynamic_cast<DataCurve *>(it);
-    if (!dc) return 0;
+    DataCurve *dc = dynamic_cast<DataCurve *>(it);
+    if (!dc)
+      return 0;
     if (dc->plotAssociation() == master_curve)
       return dc;
   }
   return 0;
 }
 
-void Graph::showCurve(int index, bool visible)
-{
+void Graph::showCurve(int index, bool visible) {
   QwtPlotItem *it = plotItem(index);
   if (it)
     it->setVisible(visible);
@@ -5283,12 +5111,10 @@ void Graph::showCurve(int index, bool visible)
   emit modifiedGraph();
 }
 
-int Graph::visibleCurves()
-{
+int Graph::visibleCurves() {
   int c = 0;
   QList<int> keys = d_plot->curveKeys();
-  for (int i=0; i<(int)keys.count(); i++)
-  {
+  for (int i = 0; i < (int)keys.count(); i++) {
     QwtPlotItem *it = d_plot->plotItem(keys[i]);
     if (it && it->isVisible())
       c++;
@@ -5296,131 +5122,120 @@ int Graph::visibleCurves()
   return c;
 }
 
-QPrinter::PageSize Graph::minPageSize(const QPrinter& printer, const QRect& r)
-{
-  double x_margin = 0.2/2.54*printer.logicalDpiX(); // 2 mm margins
-  double y_margin = 0.2/2.54*printer.logicalDpiY();
-  double w_mm = 2*x_margin + (double)(r.width())/(double)printer.logicalDpiX() * 25.4;
-  double h_mm = 2*y_margin + (double)(r.height())/(double)printer.logicalDpiY() * 25.4;
+QPrinter::PageSize Graph::minPageSize(const QPrinter &printer, const QRect &r) {
+  double x_margin = 0.2 / 2.54 * printer.logicalDpiX(); // 2 mm margins
+  double y_margin = 0.2 / 2.54 * printer.logicalDpiY();
+  double w_mm =
+      2 * x_margin + (double)(r.width()) / (double)printer.logicalDpiX() * 25.4;
+  double h_mm = 2 * y_margin +
+                (double)(r.height()) / (double)printer.logicalDpiY() * 25.4;
 
   int w, h;
-  if (w_mm/h_mm > 1)
-  {
+  if (w_mm / h_mm > 1) {
     w = (int)ceil(w_mm);
     h = (int)ceil(h_mm);
-  }
-  else
-  {
+  } else {
     h = (int)ceil(w_mm);
     w = (int)ceil(h_mm);
   }
 
   QPrinter::PageSize size = QPrinter::A5;
   if (w < 45 && h < 32)
-    size =  QPrinter::B10;
+    size = QPrinter::B10;
   else if (w < 52 && h < 37)
-    size =  QPrinter::A9;
+    size = QPrinter::A9;
   else if (w < 64 && h < 45)
-    size =  QPrinter::B9;
+    size = QPrinter::B9;
   else if (w < 74 && h < 52)
-    size =  QPrinter::A8;
+    size = QPrinter::A8;
   else if (w < 91 && h < 64)
-    size =  QPrinter::B8;
+    size = QPrinter::B8;
   else if (w < 105 && h < 74)
-    size =  QPrinter::A7;
+    size = QPrinter::A7;
   else if (w < 128 && h < 91)
-    size =  QPrinter::B7;
+    size = QPrinter::B7;
   else if (w < 148 && h < 105)
-    size =  QPrinter::A6;
+    size = QPrinter::A6;
   else if (w < 182 && h < 128)
-    size =  QPrinter::B6;
+    size = QPrinter::B6;
   else if (w < 210 && h < 148)
-    size =  QPrinter::A5;
+    size = QPrinter::A5;
   else if (w < 220 && h < 110)
-    size =  QPrinter::DLE;
+    size = QPrinter::DLE;
   else if (w < 229 && h < 163)
-    size =  QPrinter::C5E;
+    size = QPrinter::C5E;
   else if (w < 241 && h < 105)
-    size =  QPrinter::Comm10E;
+    size = QPrinter::Comm10E;
   else if (w < 257 && h < 182)
-    size =  QPrinter::B5;
+    size = QPrinter::B5;
   else if (w < 279 && h < 216)
-    size =  QPrinter::Letter;
+    size = QPrinter::Letter;
   else if (w < 297 && h < 210)
-    size =  QPrinter::A4;
+    size = QPrinter::A4;
   else if (w < 330 && h < 210)
-    size =  QPrinter::Folio;
+    size = QPrinter::Folio;
   else if (w < 356 && h < 216)
-    size =  QPrinter::Legal;
+    size = QPrinter::Legal;
   else if (w < 364 && h < 257)
-    size =  QPrinter::B4;
+    size = QPrinter::B4;
   else if (w < 420 && h < 297)
-    size =  QPrinter::A3;
+    size = QPrinter::A3;
   else if (w < 515 && h < 364)
-    size =  QPrinter::B3;
+    size = QPrinter::B3;
   else if (w < 594 && h < 420)
-    size =  QPrinter::A2;
+    size = QPrinter::A2;
   else if (w < 728 && h < 515)
-    size =  QPrinter::B2;
+    size = QPrinter::B2;
   else if (w < 841 && h < 594)
-    size =  QPrinter::A1;
+    size = QPrinter::A1;
   else if (w < 1030 && h < 728)
-    size =  QPrinter::B1;
+    size = QPrinter::B1;
   else if (w < 1189 && h < 841)
-    size =  QPrinter::A0;
+    size = QPrinter::A0;
   else if (w < 1456 && h < 1030)
-    size =  QPrinter::B0;
+    size = QPrinter::B0;
 
   return size;
 }
 
-QwtScaleWidget* Graph::selectedScale()
-{
-  return scalePicker->selectedAxis();
-}
+QwtScaleWidget *Graph::selectedScale() { return scalePicker->selectedAxis(); }
 
-QwtScaleWidget* Graph::currentScale()
-{
-  return scalePicker->currentAxis();
-}
+QwtScaleWidget *Graph::currentScale() { return scalePicker->currentAxis(); }
 
-QRect Graph::axisTitleRect(const QwtScaleWidget *scale)
-{
+QRect Graph::axisTitleRect(const QwtScaleWidget *scale) {
   if (!scale)
     return QRect();
 
   return scalePicker->titleRect(scale);
 }
 
-void Graph::setCurrentFont(const QFont& f)
-{
+void Graph::setCurrentFont(const QFont &f) {
   QwtScaleWidget *axis = scalePicker->selectedAxis();
-  if (axis){
-    if (scalePicker->titleSelected()){
+  if (axis) {
+    if (scalePicker->titleSelected()) {
       QwtText title = axis->title();
       title.setFont(f);
       axis->setTitle(title);
     } else if (scalePicker->labelsSelected())
       axis->setFont(f);
     emit modifiedGraph();
-  } else if (d_selected_text){
+  } else if (d_selected_text) {
     d_selected_text->setFont(f);
     d_selected_text->repaint();
     emit modifiedGraph();
-  } else if (titlePicker->selected()){
+  } else if (titlePicker->selected()) {
     QwtText title = d_plot->title();
     title.setFont(f);
     d_plot->setTitle(title);
     emit modifiedGraph();
   } else {
     QList<QwtPlotItem *> curves = d_plot->curvesList();
-    foreach(QwtPlotItem *i, curves){
-      DataCurve* dc = dynamic_cast<DataCurve *>(i);
-      PlotCurve* pc = dynamic_cast<PlotCurve*>(i);
-      if(pc && dc
-         && i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
-         pc->type() != Graph::Function){
-        if(dc->hasSelectedLabels()){
+    foreach (QwtPlotItem *i, curves) {
+      DataCurve *dc = dynamic_cast<DataCurve *>(i);
+      PlotCurve *pc = dynamic_cast<PlotCurve *>(i);
+      if (pc && dc && i->rtti() != QwtPlotItem::Rtti_PlotSpectrogram &&
+          pc->type() != Graph::Function) {
+        if (dc->hasSelectedLabels()) {
           dc->setLabelsFont(f);
           d_plot->replot();
           emit modifiedGraph();
@@ -5431,8 +5246,7 @@ void Graph::setCurrentFont(const QFont& f)
   }
 }
 
-QString Graph::axisFormula(int axis)
-{
+QString Graph::axisFormula(int axis) {
   ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(axis));
   if (sd)
     return sd->formula();
@@ -5440,8 +5254,7 @@ QString Graph::axisFormula(int axis)
   return QString();
 }
 
-void Graph::setAxisFormula(int axis, const QString &formula)
-{
+void Graph::setAxisFormula(int axis, const QString &formula) {
   ScaleDraw *sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(axis));
   if (sd)
     sd->setFormula(formula);
@@ -5449,47 +5262,45 @@ void Graph::setAxisFormula(int axis, const QString &formula)
 /*
      Sets the spectrogram intensity changed boolean flag
  */
-void Graph::changeIntensity(bool bIntensityChanged)
-{
+void Graph::changeIntensity(bool bIntensityChanged) {
   /*if(m_spectrogram)
-	{
-		m_bIntensityChanged=bIntensityChanged;
-	}*/
-  for (int i=0; i<n_curves; i++){
+        {
+                m_bIntensityChanged=bIntensityChanged;
+        }*/
+  for (int i = 0; i < n_curves; i++) {
     QwtPlotItem *it = plotItem(i);
     if (!it)
       continue;
-    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram){
+    if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
       Spectrogram *sp = dynamic_cast<Spectrogram *>(it);
-      if(sp)
-      {	sp->setIntensityChange(bIntensityChanged);
+      if (sp) {
+        sp->setIntensityChange(bIntensityChanged);
       }
-
     }
   }
 }
 /* This method zooms the selected graph using using zoom tool and mouse drag
  * @param on :: boolean parameter to switch on zooming
  */
-void Graph::enablePanningMagnifier(bool on)
-{
+void Graph::enablePanningMagnifier(bool on) {
   if (d_magnifier)
     delete d_magnifier;
   if (d_panner)
     delete d_panner;
 
-  QwtPlotCanvas *cnvs =d_plot->canvas(); //canvas();
+  QwtPlotCanvas *cnvs = d_plot->canvas(); // canvas();
   if (on) {
     cnvs->setCursor(Qt::pointingHandCursor);
     d_magnifier = new QwtPlotMagnifier(cnvs);
     // Disable the mouse button as it causes issues with the context menu
     d_magnifier->setMouseButton(Qt::NoButton);
-    d_magnifier->setAxisEnabled(QwtPlot::yRight,false);
+    d_magnifier->setAxisEnabled(QwtPlot::yRight, false);
     d_magnifier->setZoomInKey(Qt::Key_Plus, Qt::ShiftModifier);
 
     d_panner = new QwtPlotPanner(cnvs);
-    d_panner->setAxisEnabled(QwtPlot::yRight,false);
-    connect(d_panner, SIGNAL(panned(int, int)), multiLayer(), SLOT(notifyChanges()));
+    d_panner->setAxisEnabled(QwtPlot::yRight, false);
+    connect(d_panner, SIGNAL(panned(int, int)), multiLayer(),
+            SLOT(notifyChanges()));
   } else {
     cnvs->setCursor(Qt::arrowCursor);
     d_magnifier = NULL;
@@ -5499,42 +5310,42 @@ void Graph::enablePanningMagnifier(bool on)
 
 /* Get the fixed aspect ratio option
  */
-bool Graph::isFixedAspectRatioEnabled()
-{
+bool Graph::isFixedAspectRatioEnabled() {
 #if QWT_VERSION >= 0x050200
-  if (d_rescaler) return true;
+  if (d_rescaler)
+    return true;
 #endif
   return false;
 }
 /* Enable or disable fixing the aspect ratio of plots
  * @param on :: If true, aspect ratio will be fixed
  */
-void Graph::enableFixedAspectRatio(bool on)
-{
+void Graph::enableFixedAspectRatio(bool on) {
 #if QWT_VERSION >= 0x050200
   if (d_rescaler)
     delete d_rescaler;
 
-  QwtPlotCanvas *cnvs =d_plot->canvas();
-  if (on){
-    d_rescaler = new QwtPlotRescaler(cnvs, QwtPlot::xBottom, QwtPlotRescaler::Fixed);
+  QwtPlotCanvas *cnvs = d_plot->canvas();
+  if (on) {
+    d_rescaler =
+        new QwtPlotRescaler(cnvs, QwtPlot::xBottom, QwtPlotRescaler::Fixed);
     d_rescaler->setExpandingDirection(QwtPlotRescaler::ExpandBoth);
     // prevent the colormap axis from rescaling
-    d_rescaler->setAspectRatio(QwtPlot::yRight,0);
+    d_rescaler->setAspectRatio(QwtPlot::yRight, 0);
   } else {
     d_rescaler = NULL;
   }
 #else
   UNUSED_ARG(on)
-    #endif
+#endif
 }
 
 /**
  * Turn off any normalization
  */
-void Graph::noNormalization()
-{
-  if(!m_isDistribution) return; // Nothing to do
+void Graph::noNormalization() {
+  if (!m_isDistribution)
+    return; // Nothing to do
 
   m_isDistribution = false;
 
@@ -5546,9 +5357,9 @@ void Graph::noNormalization()
 /**
  * Turn on normalization by bin width if it is appropriate
  */
-void Graph::binWidthNormalization()
-{
-  if(m_isDistribution) return; // Nothing to do
+void Graph::binWidthNormalization() {
+  if (m_isDistribution)
+    return; // Nothing to do
 
   m_isDistribution = true;
 
@@ -5560,8 +5371,7 @@ void Graph::binWidthNormalization()
 /**
  * Set 'None' normalization for MD plots
  */
-void Graph::noNormalizationMD()
-{
+void Graph::noNormalizationMD() {
   if (!normalizableMD())
     return;
 
@@ -5575,8 +5385,7 @@ void Graph::noNormalizationMD()
 /**
  * Set volume normalization for MD plots
  */
-void Graph::volumeNormalizationMD()
-{
+void Graph::volumeNormalizationMD() {
   if (!normalizableMD())
     return;
 
@@ -5590,8 +5399,7 @@ void Graph::volumeNormalizationMD()
 /**
  * Set number of events normalization for MD plots
  */
-void Graph::numEventsNormalizationMD()
-{
+void Graph::numEventsNormalizationMD() {
   if (!normalizableMD())
     return;
 
@@ -5612,53 +5420,55 @@ void Graph::updateCurvesAndAxes() {
   setYAxisTitle(yAxisTitleFromFirstCurve());
 }
 
-void Graph::setWaterfallXOffset(int offset)
-{
+void Graph::setWaterfallXOffset(int offset) {
   if (offset == d_waterfall_offset_x)
     return;
 
-  if ( offset >= 0 ) d_waterfall_offset_x = offset;
+  if (offset >= 0)
+    d_waterfall_offset_x = offset;
   updateDataCurves();
   replot();
   emit modifiedGraph();
 }
 
-void Graph::setWaterfallYOffset(int offset)
-{
+void Graph::setWaterfallYOffset(int offset) {
   if (offset == d_waterfall_offset_y)
     return;
 
-  if ( offset >= 0 ) d_waterfall_offset_y = offset;
+  if (offset >= 0)
+    d_waterfall_offset_y = offset;
   updateDataCurves();
   replot();
   emit modifiedGraph();
 }
 
-void Graph::setWaterfallOffset(int x, int y, bool update)
-{
-  if ( x >= 0 ) d_waterfall_offset_x = x;
-  if ( y >= 0 ) d_waterfall_offset_y = y;
+void Graph::setWaterfallOffset(int x, int y, bool update) {
+  if (x >= 0)
+    d_waterfall_offset_x = x;
+  if (y >= 0)
+    d_waterfall_offset_y = y;
 
-  if (update){
+  if (update) {
     updateDataCurves();
     replot();
     emit modifiedGraph();
   }
 }
 
-void Graph::updateWaterfallFill(bool on)
-{
-  int n = d_plot->curvesList().size(); //d_curves.size();
+void Graph::updateWaterfallFill(bool on) {
+  int n = d_plot->curvesList().size(); // d_curves.size();
   if (!n)
     return;
 
-  for (int i = 0; i < n; i++){
+  for (int i = 0; i < n; i++) {
     PlotCurve *cv = dynamic_cast<PlotCurve *>(curve(i));
     if (!cv)
       continue;
 
     if (on && multiLayer())
-      cv->setBrush(QBrush(cv->pen().color())); // Default is that each fill color matches line color
+      cv->setBrush(QBrush(
+          cv->pen()
+              .color())); // Default is that each fill color matches line color
     else
       cv->setBrush(QBrush());
   }
@@ -5666,18 +5476,17 @@ void Graph::updateWaterfallFill(bool on)
   emit modifiedGraph();
 }
 
-void Graph::setWaterfallSideLines(bool on)
-{
-  int n = d_plot->curvesList().size(); //d_curves.size();
+void Graph::setWaterfallSideLines(bool on) {
+  int n = d_plot->curvesList().size(); // d_curves.size();
   if (!n)
     return;
 
-  PlotCurve *cv = dynamic_cast<PlotCurve*>(curve(0));
-  if ( cv && cv->sideLinesEnabled() == on)
+  PlotCurve *cv = dynamic_cast<PlotCurve *>(curve(0));
+  if (cv && cv->sideLinesEnabled() == on)
     return;
 
-  for (int i = 0; i < n; i++){
-    cv = dynamic_cast<PlotCurve*>(curve(i));
+  for (int i = 0; i < n; i++) {
+    cv = dynamic_cast<PlotCurve *>(curve(i));
     if (cv)
       cv->enableSideLines(on);
   }
@@ -5685,14 +5494,13 @@ void Graph::setWaterfallSideLines(bool on)
   emit modifiedGraph();
 }
 
-void Graph::setWaterfallFillColor(const QColor& c)
-{
-  int n = d_plot->curvesList().size(); //d_curves.size();
+void Graph::setWaterfallFillColor(const QColor &c) {
+  int n = d_plot->curvesList().size(); // d_curves.size();
   if (!n)
     return;
 
-  for (int i = 0; i < n; i++){
-    PlotCurve *cv = dynamic_cast<PlotCurve*>(curve(i));
+  for (int i = 0; i < n; i++) {
+    PlotCurve *cv = dynamic_cast<PlotCurve *>(curve(i));
     if (cv)
       cv->setBrush(QBrush(c));
   }
@@ -5700,72 +5508,64 @@ void Graph::setWaterfallFillColor(const QColor& c)
   emit modifiedGraph();
 }
 
-void Graph::reverseCurveOrder()
-{
+void Graph::reverseCurveOrder() {
   // RJT: Just call through to Plot - functionality placed there
   d_plot->reverseCurveOrder();
 
   emit modifiedGraph();
 }
 
-void Graph::updateDataCurves()
-{
-  int n = d_plot->curvesList().size(); //d_curves.size();
+void Graph::updateDataCurves() {
+  int n = d_plot->curvesList().size(); // d_curves.size();
   if (!n)
     return;
 
   QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
-  for (int i = 0; i < n; i++){
-    PlotCurve *pc = dynamic_cast<PlotCurve*>(curve(i));
-    if (DataCurve *c = dynamic_cast<DataCurve*>(pc))
+  for (int i = 0; i < n; i++) {
+    PlotCurve *pc = dynamic_cast<PlotCurve *>(curve(i));
+    if (DataCurve *c = dynamic_cast<DataCurve *>(pc))
       c->loadData();
-    else if (MantidMatrixCurve *mc = dynamic_cast<MantidMatrixCurve*>(pc))
-    {
+    else if (MantidMatrixCurve *mc = dynamic_cast<MantidMatrixCurve *>(pc)) {
       mc->setDrawAsDistribution(m_isDistribution);
       mc->invalidateBoundingRect();
       mc->loadData();
-    }
-    else if (MantidMDCurve *mdc = dynamic_cast<MantidMDCurve*>(pc))
-    {
-      //mdc->setDrawAsDistribution(m_isDistribution);
-      // yes, using int in Graph and ApplicationWindow instead of the proper enum, just so that
-      // IMDWorkspace.h does not need to be included in more places in MantidPlot
-      mdc->mantidData()->setNormalization(static_cast<Mantid::API::MDNormalization>(m_normalizationMD));
+    } else if (MantidMDCurve *mdc = dynamic_cast<MantidMDCurve *>(pc)) {
+      // mdc->setDrawAsDistribution(m_isDistribution);
+      // yes, using int in Graph and ApplicationWindow instead of the proper
+      // enum, just so that
+      // IMDWorkspace.h does not need to be included in more places in
+      // MantidPlot
+      mdc->mantidData()->setNormalization(
+          static_cast<Mantid::API::MDNormalization>(m_normalizationMD));
       mdc->invalidateBoundingRect();
     }
-
   }
   QApplication::restoreOverrideCursor();
 }
 
-void Graph::checkValuesInAxisRange(MantidMatrixCurve* mc)
-{
-  auto* data = mc->mantidData();
+void Graph::checkValuesInAxisRange(MantidMatrixCurve *mc) {
+  auto *data = mc->mantidData();
   double xMin(data->x(0)); // Needs to be min of current graph (x-axis)
-  double xMax(data->x(data->size()-1)); // Needs to be max of current graph (x-axis)
-  if (xMin > xMax)
-  {
+  double xMax(
+      data->x(data->size() - 1)); // Needs to be max of current graph (x-axis)
+  if (xMin > xMax) {
     std::swap(xMin, xMax);
   }
   bool changed(false);
-  for (size_t i = 1; i<data->size(); ++i)
-  {
+  for (size_t i = 1; i < data->size(); ++i) {
     // Sort X
-    if(data->x(i) < xMin)
-    {
+    if (data->x(i) < xMin) {
       xMin = data->x(i);
       changed = true;
-    }
-    else if (data->x(i) > xMax)
-    {
+    } else if (data->x(i) > xMax) {
       xMax = data->x(i);
       changed = true;
     }
   }
 
-  // If there were values outside the range of the axis then update the axis with the new positions.
-  if(changed)
-  {
+  // If there were values outside the range of the axis then update the axis
+  // with the new positions.
+  if (changed) {
     d_plot->setAxisScale(QwtPlot::Axis(QwtPlot::xTop), xMin, xMax);
     d_plot->setAxisScale(QwtPlot::Axis(QwtPlot::xBottom), xMin, xMax);
   }
@@ -5775,9 +5575,9 @@ void Graph::checkValuesInAxisRange(MantidMatrixCurve* mc)
   * Process dragMousePress signal from d_plot.
   * @param pos :: Mouse position.
   */
-void Graph::slotDragMousePress(QPoint pos)
-{
-  if ( hasActiveTool() ) return;
+void Graph::slotDragMousePress(QPoint pos) {
+  if (hasActiveTool())
+    return;
   emit dragMousePress(pos);
 }
 
@@ -5785,9 +5585,9 @@ void Graph::slotDragMousePress(QPoint pos)
   * Process dragMouseRelease signal from d_plot.
   * @param pos :: Mouse position.
   */
-void Graph::slotDragMouseRelease(QPoint pos)
-{
-  if ( hasActiveTool() ) return;
+void Graph::slotDragMouseRelease(QPoint pos) {
+  if (hasActiveTool())
+    return;
   emit dragMouseRelease(pos);
 }
 
@@ -5795,112 +5595,105 @@ void Graph::slotDragMouseRelease(QPoint pos)
   * Process dragMouseMove signal from d_plot.
   * @param pos :: Mouse position.
   */
-void Graph::slotDragMouseMove(QPoint pos)
-{
-  if ( hasActiveTool() ) return;
+void Graph::slotDragMouseMove(QPoint pos) {
+  if (hasActiveTool())
+    return;
   emit dragMouseMove(pos);
 }
 
-void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, const int fileVersion)
-{
+void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
+                            const int fileVersion) {
   blockSignals(true);
 
   enableAutoscaling(app->autoscale2DPlots);
 
   TSVSerialiser tsv(lines);
 
-  if(tsv.selectSection("Antialiasing"))
-  {
+  if (tsv.selectSection("Antialiasing")) {
     int aa;
     tsv >> aa;
     setAntialiasing(aa);
   }
 
-  if(tsv.selectSection("Autoscaling"))
-  {
+  if (tsv.selectSection("Autoscaling")) {
     int as;
     tsv >> as;
     enableAutoscaling(as);
   }
 
-  if(tsv.selectLine("AxesColors"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("AxesColors").c_str()).split("\t");
+  if (tsv.selectLine("AxesColors")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("AxesColors").c_str()).split("\t");
     sl.pop_front();
-    for(int i = 0; i < sl.count(); ++i)
+    for (int i = 0; i < sl.count(); ++i)
       setAxisColor(i, QColor(sl[i]));
   }
 
-  if(tsv.selectLine("AxesNumberColors"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("AxesNumberColors").c_str()).split("\t");
+  if (tsv.selectLine("AxesNumberColors")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("AxesNumberColors").c_str())
+            .split("\t");
     sl.pop_front();
-    for(int i = 0; i < sl.count(); ++i)
+    for (int i = 0; i < sl.count(); ++i)
       setAxisLabelsColor(i, QColor(sl[i]));
   }
 
-  if(tsv.selectLine("AxesTitleColors"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("AxesTitleColors").c_str()).split("\t");
+  if (tsv.selectLine("AxesTitleColors")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("AxesTitleColors").c_str())
+            .split("\t");
     sl.pop_front();
-    for(int i = 0; i < sl.count(); ++i)
+    for (int i = 0; i < sl.count(); ++i)
       setAxisTitleColor(i, QColor(sl[i]));
   }
 
-  if(tsv.selectLine("AxesTitleAlignment"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("AxesTitleAlignment").c_str()).split("\t");
+  if (tsv.selectLine("AxesTitleAlignment")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("AxesTitleAlignment").c_str())
+            .split("\t");
     sl.pop_front();
-    for(int i = 0; i < sl.count(); ++i)
+    for (int i = 0; i < sl.count(); ++i)
       setAxisTitleAlignment(i, sl[i].toInt());
   }
 
-  if(tsv.selectLine("AxesBaseline"))
-  {
+  if (tsv.selectLine("AxesBaseline")) {
     size_t n = tsv.values("AxesBaseline").size();
-    for(size_t i = 0; i < n - 1; ++i)
-    {
-      setAxisMargin((int)i, tsv.asInt(i+1));
+    for (size_t i = 0; i < n - 1; ++i) {
+      setAxisMargin((int)i, tsv.asInt(i + 1));
     }
   }
 
-  if(tsv.selectLine("AxesTitles"))
-  {
+  if (tsv.selectLine("AxesTitles")) {
     std::vector<std::string> values = tsv.values("AxesTitles");
-    for(size_t i = 1; i < values.size(); ++i)
+    for (size_t i = 1; i < values.size(); ++i)
       setScaleTitle((int)(i - 1), QString::fromUtf8(values[i].c_str()));
   }
 
-  if(tsv.selectLine("AxisType"))
-  {
+  if (tsv.selectLine("AxisType")) {
     std::vector<std::string> values = tsv.values("AxisType");
 
-    if(values.size() >= 4)
-    {
-      for(int i = 0; i < 4; ++i)
-      {
+    if (values.size() >= 4) {
+      for (int i = 0; i < 4; ++i) {
         QStringList sl = QString::fromUtf8(values[i].c_str()).split(";");
         int format = sl[0].toInt();
-        if(format == ScaleDraw::Numeric)
+        if (format == ScaleDraw::Numeric)
           continue;
-        if(format == ScaleDraw::Day)
+        if (format == ScaleDraw::Day)
           setLabelsDayFormat(i, sl[1].toInt());
-        else if(format == ScaleDraw::Month)
+        else if (format == ScaleDraw::Month)
           setLabelsMonthFormat(i, sl[1].toInt());
-        else if(format == ScaleDraw::Time || format == ScaleDraw::Date)
-          setLabelsDateTimeFormat(i, format, sl[1]+";"+sl[2]);
-        else if(sl.size() > 1)
+        else if (format == ScaleDraw::Time || format == ScaleDraw::Date)
+          setLabelsDateTimeFormat(i, format, sl[1] + ";" + sl[2]);
+        else if (sl.size() > 1)
           setLabelsTextFormat(i, format, sl[1], app->table(sl[1]));
       }
     }
   }
 
-  for(int i = 0; i < 4; ++i)
-  {
+  for (int i = 0; i < 4; ++i) {
     std::stringstream ss;
     ss << "AxisFont" << i;
-    if(tsv.selectLine(ss.str()))
-    {
+    if (tsv.selectLine(ss.str())) {
       QString font;
       int pointSize, weight, italic, underline, strikeout;
       tsv >> font >> pointSize >> weight >> italic >> underline >> strikeout;
@@ -5912,170 +5705,159 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     }
   }
 
-  for(int i = 0; i < 4; ++i)
-  {
+  for (int i = 0; i < 4; ++i) {
     std::stringstream ss;
     ss << "AxisFormula " << i;
     auto afSections = tsv.sections(ss.str());
-    if(afSections.size() > 0)
+    if (afSections.size() > 0)
       setAxisFormula(i, QString::fromUtf8(afSections.front().c_str()));
   }
 
-  if(tsv.selectLine("AxesLineWidth"))
-  {
+  if (tsv.selectLine("AxesLineWidth")) {
     int lineWidth;
     tsv >> lineWidth;
     loadAxesLinewidth(lineWidth);
   }
 
-  if(tsv.selectLine("Background"))
-  {
+  if (tsv.selectLine("Background")) {
     QString color;
     int alpha;
     tsv >> color >> alpha;
 
     QColor c(color);
-    if(alpha > 0)
+    if (alpha > 0)
       c.setAlpha(alpha);
 
     setBackgroundColor(c);
   }
 
-  if(tsv.selectLine("Border"))
-  {
+  if (tsv.selectLine("Border")) {
     int border;
     QString color;
     tsv >> border >> color;
     setFrame(border, QColor(color));
   }
 
-  if(tsv.selectLine("CanvasFrame"))
-  {
+  if (tsv.selectLine("CanvasFrame")) {
     int lineWidth;
     QString color;
     tsv >> lineWidth >> color;
     setCanvasFrame(lineWidth, QColor(color));
   }
 
-  if(tsv.selectLine("CanvasBackground"))
-  {
+  if (tsv.selectLine("CanvasBackground")) {
     QString color;
     int alpha;
     tsv >> color >> alpha;
     QColor c = QColor(color);
-    if(alpha > 0)
+    if (alpha > 0)
       c.setAlpha(alpha);
     setCanvasBackground(c);
   }
 
-  if(tsv.selectLine("DrawAxesBackbone"))
-  {
+  if (tsv.selectLine("DrawAxesBackbone")) {
     QString axesOptions;
     tsv >> axesOptions;
     loadAxesOptions(axesOptions);
   }
 
-  if(tsv.selectLine("EnabledAxes"))
-  {
+  if (tsv.selectLine("EnabledAxes")) {
     size_t n = tsv.values("EnabledAxes").size();
-    for(size_t i = 0; i < n - 1; ++i)
-      enableAxis((int)i, tsv.asInt(i+1));
+    for (size_t i = 0; i < n - 1; ++i)
+      enableAxis((int)i, tsv.asInt(i + 1));
   }
 
-  if(tsv.selectLine("EnabledTicks"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("EnabledTicks").c_str()).split("\t");
+  if (tsv.selectLine("EnabledTicks")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("EnabledTicks").c_str()).split("\t");
     sl.pop_front();
     sl.replaceInStrings("-1", "3");
     setMajorTicksType(sl);
     setMinorTicksType(sl);
   }
 
-  if(tsv.selectLine("EnabledTickLabels"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("EnabledTickLabels").c_str()).split("\t");
+  if (tsv.selectLine("EnabledTickLabels")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("EnabledTickLabels").c_str())
+            .split("\t");
     sl.pop_front();
-    for(int i = 0; i < sl.count(); ++i)
+    for (int i = 0; i < sl.count(); ++i)
       enableAxisLabels(i, sl[i].toInt());
   }
 
-  if(tsv.selectLine("grid"))
-  {
-    plotWidget()->grid()->load(QString::fromUtf8(tsv.lineAsString("grid").c_str()).split("\t"));
+  if (tsv.selectLine("grid")) {
+    plotWidget()->grid()->load(
+        QString::fromUtf8(tsv.lineAsString("grid").c_str()).split("\t"));
   }
 
-  for(int i = 0; tsv.selectLine("ImageMarker", i); ++i)
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("ImageMarker", i).c_str()).split("\t");
+  for (int i = 0; tsv.selectLine("ImageMarker", i); ++i) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("ImageMarker", i).c_str())
+            .split("\t");
     insertImageMarker(sl, fileVersion);
   }
 
   std::vector<std::string> imageSections = tsv.sections("image");
-  for(auto it = imageSections.begin(); it != imageSections.end(); ++it)
-  {
+  for (auto it = imageSections.begin(); it != imageSections.end(); ++it) {
     QStringList sl = QString::fromUtf8((*it).c_str()).split("\t");
     insertImageMarker(sl, fileVersion);
   }
 
-  if(tsv.selectLine("LabelsFormat"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("LabelsFormat").c_str()).split("\t");
+  if (tsv.selectLine("LabelsFormat")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("LabelsFormat").c_str()).split("\t");
     sl.pop_front();
     setLabelsNumericFormat(sl);
   }
 
-  if(tsv.selectLine("LabelsRotation"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("LabelsRotation").c_str()).split("\t");
+  if (tsv.selectLine("LabelsRotation")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("LabelsRotation").c_str())
+            .split("\t");
     setAxisLabelRotation(QwtPlot::xBottom, sl[1].toInt());
     setAxisLabelRotation(QwtPlot::xTop, sl[2].toInt());
   }
 
   std::vector<std::string> legendSections = tsv.sections("legend");
-  for(auto it = legendSections.begin(); it != legendSections.end(); ++it)
+  for (auto it = legendSections.begin(); it != legendSections.end(); ++it)
     insertText("legend", *it);
 
   std::vector<std::string> lineSections = tsv.sections("line");
-  for(auto it = lineSections.begin(); it != lineSections.end(); ++it)
-  {
+  for (auto it = lineSections.begin(); it != lineSections.end(); ++it) {
     QStringList sl = QString::fromUtf8((*it).c_str()).split("\t");
     addArrow(sl, fileVersion);
   }
 
-  if(tsv.selectLine("Margin"))
-  {
+  if (tsv.selectLine("Margin")) {
     int margin;
     tsv >> margin;
     plotWidget()->setMargin(margin);
   }
 
-  if(tsv.selectLine("MajorTicks"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("MajorTicks").c_str()).split("\t");
+  if (tsv.selectLine("MajorTicks")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("MajorTicks").c_str()).split("\t");
     sl.pop_front();
     setMajorTicksType(sl);
   }
 
-  if(tsv.selectLine("MinorTicks"))
-  {
-    QStringList sl = QString::fromUtf8(tsv.lineAsString("MinorTicks").c_str()).split("\t");
+  if (tsv.selectLine("MinorTicks")) {
+    QStringList sl =
+        QString::fromUtf8(tsv.lineAsString("MinorTicks").c_str()).split("\t");
     sl.pop_front();
     setMinorTicksType(sl);
   }
 
-  for(int i = 0; tsv.selectLine("PieCurve", i); ++i)
-  {
+  for (int i = 0; tsv.selectLine("PieCurve", i); ++i) {
     QString pieName;
     tsv >> pieName;
 
-    if(!app->renamedTables.isEmpty())
-    {
+    if (!app->renamedTables.isEmpty()) {
       QString caption = pieName.left(pieName.find("_", 0));
-      if(app->renamedTables.contains(caption))
-      {
+      if (app->renamedTables.contains(caption)) {
         int index = app->renamedTables.findIndex(caption);
         QString newCaption = app->renamedTables[++index];
-        pieName.replace(caption+"_", newCaption+"_");
+        pieName.replace(caption + "_", newCaption + "_");
       }
     }
 
@@ -6084,8 +5866,8 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     tsv >> penThickness >> penColor >> penStyle;
     QPen pen(QColor(penColor), penThickness, Graph::getPenStyle(penStyle));
 
-    Table* table = app->table(pieName);
-    if(!table)
+    Table *table = app->table(pieName);
+    if (!table)
       continue;
 
     int startRow = 0;
@@ -6102,19 +5884,17 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     tsv >> edgeDist >> antiClockwise >> autoLabelling >> values;
     tsv >> percentages >> categories >> fixedLabels;
 
-    plotPie(table, pieName, pen, brush,
-        brushSize, firstColor, startRow, endRow, visible,
-        startAzi, viewAngle, thickness, horOffset, edgeDist,
-        antiClockwise, autoLabelling, values, percentages,
-        categories, fixedLabels);
+    plotPie(table, pieName, pen, brush, brushSize, firstColor, startRow, endRow,
+            visible, startAzi, viewAngle, thickness, horOffset, edgeDist,
+            antiClockwise, autoLabelling, values, percentages, categories,
+            fixedLabels);
   }
 
   std::vector<std::string> pieLabelSections = tsv.sections("PieLabel");
-  for(auto it = pieLabelSections.begin(); it != pieLabelSections.end(); ++it)
+  for (auto it = pieLabelSections.begin(); it != pieLabelSections.end(); ++it)
     insertText("PieLabel", *it);
 
-  if(tsv.selectLine("PlotTitle"))
-  {
+  if (tsv.selectLine("PlotTitle")) {
     QString title, color;
     int alignment;
     tsv >> title >> color >> alignment;
@@ -6123,23 +5903,21 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     setTitleAlignment((Qt::AlignmentFlag)alignment);
   }
 
-  for(int i = 0; tsv.selectLine("scale", i); ++i)
-  {
-    QStringList scl = QString::fromUtf8(tsv.lineAsString("scale", i).c_str()).split("\t");
+  for (int i = 0; tsv.selectLine("scale", i); ++i) {
+    QStringList scl =
+        QString::fromUtf8(tsv.lineAsString("scale", i).c_str()).split("\t");
     scl.pop_front();
-    if(scl.count() >= 8)
-    {
-      setScale(scl[0].toInt(), scl[1].toDouble(), scl[2].toDouble(), scl[3].toDouble(),
-        scl[4].toInt(), scl[5].toInt(),  scl[6].toInt(), bool(scl[7].toInt()));
+    if (scl.count() >= 8) {
+      setScale(scl[0].toInt(), scl[1].toDouble(), scl[2].toDouble(),
+               scl[3].toDouble(), scl[4].toInt(), scl[5].toInt(),
+               scl[6].toInt(), bool(scl[7].toInt()));
     }
   }
 
-  for(int i = 0; i < 4; ++i)
-  {
+  for (int i = 0; i < 4; ++i) {
     std::stringstream ss;
     ss << "ScaleFont" << i;
-    if(tsv.selectLine(ss.str()))
-    {
+    if (tsv.selectLine(ss.str())) {
       QString font;
       int pointSize, weight, italic, underline, strikeout;
       tsv >> font >> pointSize >> weight >> italic >> underline >> strikeout;
@@ -6151,19 +5929,17 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     }
   }
 
-  if(tsv.selectSection("SyncScales"))
-  {
+  if (tsv.selectSection("SyncScales")) {
     int ss;
     tsv >> ss;
     setSynchronizedScaleDivisions(ss);
   }
 
   std::vector<std::string> textSections = tsv.sections("text");
-  for(auto it = textSections.begin(); it != textSections.end(); ++it)
+  for (auto it = textSections.begin(); it != textSections.end(); ++it)
     insertText("text", *it);
 
-  if(tsv.selectLine("TitleFont"))
-  {
+  if (tsv.selectLine("TitleFont")) {
     QString font;
     int pointSize, weight, italic, underline, strikeout;
     tsv >> font >> pointSize >> weight >> italic >> underline >> strikeout;
@@ -6173,51 +5949,52 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     setTitleFont(fnt);
   }
 
-  if(tsv.selectLine("TicksLength"))
-  {
+  if (tsv.selectLine("TicksLength")) {
     setTicksLength(tsv.asInt(1), tsv.asInt(2));
   }
 
-  //curveID section
+  // curveID section
   {
-    //All of the lines and sections are assigned curveIDs based on the order in which they are loaded.
+    // All of the lines and sections are assigned curveIDs based on the order in
+    // which they are loaded.
     int curveID = 0;
 
-    for(int i = 0; tsv.selectLine("MantidMatrixCurve", i); ++i)
-    {
+    for (int i = 0; tsv.selectLine("MantidMatrixCurve", i); ++i) {
       std::vector<std::string> values = tsv.values("MantidMatrixCurve", i);
 
-      if(values.size() < 5)
+      if (values.size() < 5)
         continue;
 
       QString wsName = tsv.asString(1).c_str();
       int index = tsv.asInt(3);
       int skipSymbolsCount = tsv.asInt(5);
 
-      if(values.size() < 7) //Pre 29 Feb 2012
+      if (values.size() < 7) // Pre 29 Feb 2012
       {
-        PlotCurve* c = new MantidMatrixCurve(wsName, this, index,
-            MantidMatrixCurve::Spectrum, tsv.asInt(4));
+        PlotCurve *c = new MantidMatrixCurve(
+            wsName, this, index, MantidMatrixCurve::Spectrum, tsv.asInt(4));
 
-        if(values.size() == 6 && values[5].length() > 0)
+        if (values.size() == 6 && values[5].length() > 0)
           c->setSkipSymbolsCount(skipSymbolsCount);
-      }
-      else //Post 29 Feb 2012
+      } else // Post 29 Feb 2012
       {
-        PlotCurve* c = new MantidMatrixCurve(wsName, this, index,
-            MantidMatrixCurve::Spectrum, tsv.asInt(4), tsv.asInt(5));
+        PlotCurve *c = new MantidMatrixCurve(wsName, this, index,
+                                             MantidMatrixCurve::Spectrum,
+                                             tsv.asInt(4), tsv.asInt(5));
         setCurveType(curveID, tsv.asInt(6));
 
-        QStringList sl = QString::fromUtf8(tsv.lineAsString("MantidMatrixCurve", i).c_str()).split("\t");
+        QStringList sl =
+            QString::fromUtf8(tsv.lineAsString("MantidMatrixCurve", i).c_str())
+                .split("\t");
         CurveLayout cl = fillCurveSettings(sl, fileVersion, 3);
-        updateCurveLayout(c,&cl);
+        updateCurveLayout(c, &cl);
       }
       curveID++;
     }
 
-    for(int i = 0; tsv.selectLine("curve", i); ++i)
-    {
-      QStringList curveValues = QString::fromUtf8(tsv.lineAsString("curve",i).c_str()).split("\t");
+    for (int i = 0; tsv.selectLine("curve", i); ++i) {
+      QStringList curveValues =
+          QString::fromUtf8(tsv.lineAsString("curve", i).c_str()).split("\t");
       CurveLayout cl = fillCurveSettings(curveValues, fileVersion, 0);
 
       QString tableName;
@@ -6225,99 +6002,88 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
 
       tsv >> tableName >> plotType;
 
-      Table* table = app->table(tableName);
-      if(table)
-      {
-        PlotCurve* c = NULL;
-        if(plotType == Graph::VectXYXY || plotType == Graph::VectXYAM)
-        {
+      Table *table = app->table(tableName);
+      if (table) {
+        PlotCurve *c = NULL;
+        if (plotType == Graph::VectXYXY || plotType == Graph::VectXYAM) {
           QStringList colsList;
           colsList << curveValues[1] << curveValues[2];
           colsList << curveValues[20] << curveValues[21];
 
-          int startRow = curveValues[curveValues.count()-3].toInt();
-          int endRow = curveValues[curveValues.count()-2].toInt();
+          int startRow = curveValues[curveValues.count() - 3].toInt();
+          int endRow = curveValues[curveValues.count() - 2].toInt();
 
-          c = reinterpret_cast<PlotCurve*>(plotVectorCurve(
-              table, colsList, plotType, startRow, endRow));
+          c = reinterpret_cast<PlotCurve *>(
+              plotVectorCurve(table, colsList, plotType, startRow, endRow));
 
-          if(plotType == Graph::VectXYXY)
-          {
-            updateVectorsLayout(curveID, curveValues[15],
-                curveValues[16].toDouble(), curveValues[17].toInt(),
-                curveValues[18].toInt(), curveValues[19].toInt(), 0);
+          if (plotType == Graph::VectXYXY) {
+            updateVectorsLayout(
+                curveID, curveValues[15], curveValues[16].toDouble(),
+                curveValues[17].toInt(), curveValues[18].toInt(),
+                curveValues[19].toInt(), 0);
+          } else {
+            updateVectorsLayout(
+                curveID, curveValues[15], curveValues[16].toDouble(),
+                curveValues[17].toInt(), curveValues[18].toInt(),
+                curveValues[19].toInt(), curveValues[22].toInt());
           }
-          else
-          {
-            updateVectorsLayout(curveID, curveValues[15],
-                curveValues[16].toDouble(), curveValues[17].toInt(),
-                curveValues[18].toInt(), curveValues[19].toInt(),
-                curveValues[22].toInt());
-          }
-        }
-        else if(plotType == Graph::Box)
-        {
-          c = reinterpret_cast<PlotCurve*>(openBoxDiagram(table, curveValues, fileVersion));
-        }
-        else
-        {
-          int startRow = curveValues[curveValues.count()-3].toInt();
-          int endRow = curveValues[curveValues.count()-2].toInt();
-          c = dynamic_cast<PlotCurve*>(insertCurve(table, curveValues[1], curveValues[2], plotType, startRow, endRow));
+        } else if (plotType == Graph::Box) {
+          c = reinterpret_cast<PlotCurve *>(
+              openBoxDiagram(table, curveValues, fileVersion));
+        } else {
+          int startRow = curveValues[curveValues.count() - 3].toInt();
+          int endRow = curveValues[curveValues.count() - 2].toInt();
+          c = dynamic_cast<PlotCurve *>(insertCurve(table, curveValues[1],
+                                                    curveValues[2], plotType,
+                                                    startRow, endRow));
         }
 
-        if(plotType == Graph::Histogram)
-        {
-          QwtHistogram* h = dynamic_cast<QwtHistogram*>(curve(curveID));
+        if (plotType == Graph::Histogram) {
+          QwtHistogram *h = dynamic_cast<QwtHistogram *>(curve(curveID));
           if (h) {
-            h->setBinning(curveValues[17].toInt(),
-                          curveValues[18].toDouble(),
+            h->setBinning(curveValues[17].toInt(), curveValues[18].toDouble(),
                           curveValues[19].toDouble(),
                           curveValues[20].toDouble());
             h->loadData();
           }
         }
 
-        if(plotType == Graph::VerticalBars
-            || plotType == Graph::HorizontalBars
-            || plotType == Graph::Histogram)
-        {
+        if (plotType == Graph::VerticalBars ||
+            plotType == Graph::HorizontalBars || plotType == Graph::Histogram) {
           setBarsGap(curveID, curveValues[15].toInt(), curveValues[16].toInt());
         }
 
         updateCurveLayout(c, &cl);
 
-        if(c && c->rtti() == QwtPlotItem::Rtti_PlotCurve)
-        {
-          c->setAxis(curveValues[curveValues.count()-5].toInt(), curveValues[curveValues.count()-4].toInt());
+        if (c && c->rtti() == QwtPlotItem::Rtti_PlotCurve) {
+          c->setAxis(curveValues[curveValues.count() - 5].toInt(),
+                     curveValues[curveValues.count() - 4].toInt());
           c->setVisible(curveValues.last().toInt());
         }
-      }
-      else if(plotType == Graph::Histogram)
-      {
-        Matrix* m = app->matrix(tableName);
-        QwtHistogram* h = restoreHistogram(m, curveValues);
+      } else if (plotType == Graph::Histogram) {
+        Matrix *m = app->matrix(tableName);
+        QwtHistogram *h = restoreHistogram(m, curveValues);
         updateCurveLayout(h, &cl);
       }
       curveID++;
     }
 
     std::vector<std::string> functionSections = tsv.sections("Function");
-    for(auto it = functionSections.begin(); it != functionSections.end(); ++it)
-    {
+    for (auto it = functionSections.begin(); it != functionSections.end();
+         ++it) {
       curveID++;
       QStringList sl = QString::fromUtf8((*it).c_str()).split("\n");
       restoreFunction(sl);
     }
 
-    for(int i = 0; tsv.selectLine("FunctionCurve", i); ++i)
-    {
+    for (int i = 0; tsv.selectLine("FunctionCurve", i); ++i) {
       CurveLayout cl;
       QString formula, discarded;
       int points, curveStyle, axis1, axis2, visible;
 
-      //CurveLayout members
-      int connectType, lCol, lStyle, sSize, sType, symCol, fillCol, filledArea, aCol, aStyle;
+      // CurveLayout members
+      int connectType, lCol, lStyle, sSize, sType, symCol, fillCol, filledArea,
+          aCol, aStyle;
       float lWidth;
 
       tsv >> formula >> points >> discarded >> discarded;
@@ -6338,30 +6104,25 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
       cl.aCol = aCol;
       cl.aStyle = aStyle;
 
-      if(curveStyle == Graph::Box)
-      {
+      if (curveStyle == Graph::Box) {
         float penWidth;
         tsv >> penWidth;
         cl.penWidth = penWidth;
-      }
-      else if(curveStyle <= Graph::LineSymbols)
-      {
+      } else if (curveStyle <= Graph::LineSymbols) {
         float penWidth;
         tsv >> penWidth;
         cl.penWidth = penWidth;
-      }
-      else
-      {
+      } else {
         cl.penWidth = cl.lWidth;
       }
 
-      PlotCurve* c = dynamic_cast<PlotCurve*>(insertFunctionCurve(formula, points, fileVersion));
+      PlotCurve *c = dynamic_cast<PlotCurve *>(
+          insertFunctionCurve(formula, points, fileVersion));
 
       setCurveType(curveID, curveStyle);
       updateCurveLayout(c, &cl);
-      QwtPlotCurve* qc = curve(curveID);
-      if(qc)
-      {
+      QwtPlotCurve *qc = curve(curveID);
+      if (qc) {
         qc->setAxis(axis1, axis2);
         qc->setVisible(visible);
       }
@@ -6369,69 +6130,66 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
       curveID++;
     }
 
-    if(tsv.selectLine("ErrorBars"))
-    {
-      QStringList sl = QString::fromUtf8(tsv.lineAsString("ErrorBars").c_str()).split("\t");
-      if(!app->renamedTables.isEmpty())
-      {
-        QString caption = sl[4].left(sl[4].find("_",0));
-        if(app->renamedTables.contains(caption))
-        {
-          //modify the name of the curve according to the new table name
+    if (tsv.selectLine("ErrorBars")) {
+      QStringList sl =
+          QString::fromUtf8(tsv.lineAsString("ErrorBars").c_str()).split("\t");
+      if (!app->renamedTables.isEmpty()) {
+        QString caption = sl[4].left(sl[4].find("_", 0));
+        if (app->renamedTables.contains(caption)) {
+          // modify the name of the curve according to the new table name
           int index = app->renamedTables.findIndex(caption);
           QString newCaption = app->renamedTables[++index];
-          sl.replaceInStrings(caption+"_", newCaption+"_");
+          sl.replaceInStrings(caption + "_", newCaption + "_");
         }
       }
-      Table* w = app->table(sl[3]);
-      Table* errTable = app->table(sl[4]);
-      if(w && errTable)
-      {
+      Table *w = app->table(sl[3]);
+      Table *errTable = app->table(sl[4]);
+      if (w && errTable) {
         addErrorBars(sl[2], sl[3], errTable, sl[4], sl[1].toInt(),
-            sl[5].toDouble(), sl[6].toInt(), QColor(sl[7]),
-            sl[8].toInt(), sl[10].toInt(), sl[9].toInt());
+                     sl[5].toDouble(), sl[6].toInt(), QColor(sl[7]),
+                     sl[8].toInt(), sl[10].toInt(), sl[9].toInt());
       }
       curveID++;
     }
 
     std::vector<std::string> specSections = tsv.sections("spectrogram");
-    for(auto it = specSections.begin(); it != specSections.end(); ++it)
-    {
+    for (auto it = specSections.begin(); it != specSections.end(); ++it) {
       TSVSerialiser specTSV(*it);
 
-      if(specTSV.selectLine("workspace"))
-      {
+      if (specTSV.selectLine("workspace")) {
         std::string wsName;
         specTSV >> wsName;
 
-        Mantid::API::IMDWorkspace_const_sptr wsPtr = Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::API::IMDWorkspace>(wsName);
+        Mantid::API::IMDWorkspace_const_sptr wsPtr =
+            Mantid::API::AnalysisDataService::Instance()
+                .retrieveWS<Mantid::API::IMDWorkspace>(wsName);
 
-        //Check the pointer
-        if(!wsPtr.get())
+        // Check the pointer
+        if (!wsPtr.get())
           continue;
 
         /* You may notice we plot the spectrogram before loading it.
         * Why? Because plotSpectrogram overrides the spectrograms' settings
         * based off the second parameter (which has been chosen arbitrarily
         * in this case). We're just use plotSpectrogram to add the spectrogram
-        * to the graph for us, and then loading the settings into the spectrogram.
+        * to the graph for us, and then loading the settings into the
+        * spectrogram.
         */
-        Spectrogram* s = new Spectrogram(QString::fromUtf8(wsName.c_str()), wsPtr);
+        Spectrogram *s =
+            new Spectrogram(QString::fromUtf8(wsName.c_str()), wsPtr);
         plotSpectrogram(s, Graph::ColorMap);
         s->loadFromProject(*it);
         curveID++;
-      }
-      else if(specTSV.selectLine("matrix"))
-      {
+      } else if (specTSV.selectLine("matrix")) {
         std::string matrixName;
         specTSV >> matrixName;
 
-        Matrix* m = app->matrix(QString::fromStdString(matrixName));
+        Matrix *m = app->matrix(QString::fromStdString(matrixName));
 
-        if(!m)
+        if (!m)
           continue;
 
-        Spectrogram* s = new Spectrogram(m);
+        Spectrogram *s = new Spectrogram(m);
         plotSpectrogram(s, Graph::ColorMap);
         s->loadFromProject(*it);
         curveID++;
@@ -6439,76 +6197,76 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
     }
 
     //<SkipPoints>, <CurveLabels>, and <MantidYErrors> all apply to the
-    //MantidMatrixCurve that was before it in the file. This is an annoying
-    //edge case, but not too difficult to solve.
+    // MantidMatrixCurve that was before it in the file. This is an annoying
+    // edge case, but not too difficult to solve.
 
-    //Because we load all the MantidMatrixCurves from the file first (and in order),
-    //we can simply iterate through the file, counting them and using the count as
-    //the curveID for the section we're loading.
+    // Because we load all the MantidMatrixCurves from the file first (and in
+    // order),
+    // we can simply iterate through the file, counting them and using the count
+    // as
+    // the curveID for the section we're loading.
 
     std::vector<std::string> lineVec;
     boost::split(lineVec, lines, boost::is_any_of("\n"));
 
     int lastCurveID = -1;
-    for(auto lineIt = lineVec.begin(); lineIt != lineVec.end(); ++lineIt)
-    {
+    for (auto lineIt = lineVec.begin(); lineIt != lineVec.end(); ++lineIt) {
       const std::string &line = *lineIt;
 
       if (line.compare("MantidMatrixCurve") == 0) {
-        //Moving onto the next MantidMatrixCurve.
+        // Moving onto the next MantidMatrixCurve.
         lastCurveID++;
         continue;
       }
 
-      //Handle sections as appropriate.
+      // Handle sections as appropriate.
       if (line.compare("<SkipPoints>") == 0) {
-        PlotCurve* c = dynamic_cast<PlotCurve*>(curve(lastCurveID));
-        if(!c)
+        PlotCurve *c = dynamic_cast<PlotCurve *>(curve(lastCurveID));
+        if (!c)
           continue;
 
-        //Remove surrounding tags.
+        // Remove surrounding tags.
         const std::string contents = line.substr(12, line.length() - 25);
 
         int value = 0;
         Mantid::Kernel::Strings::convert<int>(contents, value);
         c->setSkipSymbolsCount(value);
       } else if (line.compare("<CurveLabels>") == 0) {
-        //Start reading from next line
+        // Start reading from next line
         lineIt++;
-        if(lineIt == lineVec.end())
+        if (lineIt == lineVec.end())
           break;
 
         QStringList lst;
-        while(*lineIt != "</CurveLabels")
-        {
+        while (*lineIt != "</CurveLabels") {
           lst << QString::fromUtf8((*(lineIt++)).c_str());
 
-          if(lineIt == lineVec.end())
+          if (lineIt == lineVec.end())
             break;
         }
 
-        //We now have StringList of the lines we want.
+        // We now have StringList of the lines we want.
         restoreCurveLabels(lastCurveID, lst);
       } else if (line.compare("<MantidYErrors>") == 0) {
-        MantidCurve *c = dynamic_cast<MantidCurve*>(curve(lastCurveID));
-        if(!c)
+        MantidCurve *c = dynamic_cast<MantidCurve *>(curve(lastCurveID));
+        if (!c)
           continue;
 
-        //Remove surrounding tags.
+        // Remove surrounding tags.
         const std::string contents = line.substr(15, line.length() - 31);
 
-        c->errorBarSettingsList().front()->fromString(QString::fromUtf8(contents.c_str()));
+        c->errorBarSettingsList().front()->fromString(
+            QString::fromUtf8(contents.c_str()));
       }
     }
-  }//end of curveID section
+  } // end of curveID section
 
-  if(tsv.hasSection("waterfall"))
-  {
+  if (tsv.hasSection("waterfall")) {
     std::string contents = tsv.sections("waterfall").front();
     QStringList sl = QString::fromUtf8(contents.c_str()).split(",");
-    if(sl.size() >= 2)
+    if (sl.size() >= 2)
       setWaterfallOffset(sl[0].toInt(), sl[1].toInt());
-    if(sl.size() >= 3)
+    if (sl.size() >= 3)
       setWaterfallSideLines(sl[2].toInt());
     updateDataCurves();
   }
@@ -6520,19 +6278,20 @@ void Graph::loadFromProject(const std::string& lines, ApplicationWindow* app, co
   setAutoscaleFonts(app->autoScaleFonts);
 }
 
-std::string Graph::saveToProject()
-{
+std::string Graph::saveToProject() {
   TSVSerialiser tsv;
 
-  tsv.writeLine("ggeometry") << pos().x() << pos().y() << frameGeometry().width() << frameGeometry().height();
+  tsv.writeLine("ggeometry") << pos().x() << pos().y()
+                             << frameGeometry().width()
+                             << frameGeometry().height();
 
   tsv.writeLine("PlotTitle");
   tsv << d_plot->title().text().replace("\n", "<br>");
   tsv << d_plot->title().color().name();
   tsv << d_plot->title().renderFlags();
 
-  tsv.writeInlineSection("Antialiasing", d_antialiasing       ? "1" : "0");
-  tsv.writeInlineSection("SyncScales",   d_synchronize_scales ? "1" : "0");
+  tsv.writeInlineSection("Antialiasing", d_antialiasing ? "1" : "0");
+  tsv.writeInlineSection("SyncScales", d_synchronize_scales ? "1" : "0");
 
   tsv.writeLine("Background");
   tsv << d_plot->paletteBackgroundColor().name();
@@ -6544,7 +6303,7 @@ std::string Graph::saveToProject()
   tsv.writeRaw(grid()->saveToString());
 
   tsv.writeLine("EnabledAxes");
-  for(int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i)
     tsv << d_plot->axisEnabled(i);
 
   tsv.writeLine("AxesTitles");
@@ -6554,16 +6313,16 @@ std::string Graph::saveToProject()
   tsv << d_plot->axisTitle(1).text().replace("\n", "<br>");
 
   tsv.writeLine("AxesTitleColors");
-  for(int i = 0; i < 4; ++i)
-  {
-    QwtScaleWidget* scale = dynamic_cast<QwtScaleWidget*>(d_plot->axisWidget(i));
+  for (int i = 0; i < 4; ++i) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
     QColor color = scale ? scale->title().color() : QColor(Qt::black);
     tsv << color.name();
   }
 
   tsv.writeLine("AxesTitleAlignment");
-  for(int i = 0; i < 4; ++i)
-    if(d_plot->axisEnabled(i))
+  for (int i = 0; i < 4; ++i)
+    if (d_plot->axisEnabled(i))
       tsv << d_plot->axisTitle(i).renderFlags();
     else
       tsv << Qt::AlignHCenter;
@@ -6571,108 +6330,111 @@ std::string Graph::saveToProject()
   tsv.writeLine("TitleFont");
   {
     QFont f = d_plot->title().font();
-    tsv << f.family().toStdString() << f.pointSize() << f.weight() << f.italic() << f.underline() << f.strikeOut();
+    tsv << f.family().toStdString() << f.pointSize() << f.weight() << f.italic()
+        << f.underline() << f.strikeOut();
   }
 
-  for(int i = 0; i < 4; ++i)
-  {
+  for (int i = 0; i < 4; ++i) {
     std::stringstream ss;
     ss << "ScaleFont" << i;
     tsv.writeLine(ss.str());
     QFont f = d_plot->axisTitle(i).font();
-    tsv << f.family().toStdString() << f.pointSize() << f.weight() << f.italic() << f.underline() << f.strikeOut();
+    tsv << f.family().toStdString() << f.pointSize() << f.weight() << f.italic()
+        << f.underline() << f.strikeOut();
   }
 
-  for(int i = 0; i < 4; ++i)
-  {
+  for (int i = 0; i < 4; ++i) {
     std::stringstream ss;
     ss << "AxisFont" << i;
     tsv.writeLine(ss.str());
     QFont f = d_plot->axisFont(i);
-    tsv << f.family().toStdString() << f.pointSize() << f.weight() << f.italic() << f.underline() << f.strikeOut();
+    tsv << f.family().toStdString() << f.pointSize() << f.weight() << f.italic()
+        << f.underline() << f.strikeOut();
   }
 
   tsv.writeLine("EnabledTickLabels");
-  for(int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i)
     tsv << d_plot->axisScaleDraw(i)->hasComponent(QwtAbstractScaleDraw::Labels);
 
   tsv.writeLine("AxesColors");
-  for(int i = 0; i < 4; ++i)
-  {
-    QwtScaleWidget* scale = dynamic_cast<QwtScaleWidget*>(d_plot->axisWidget(i));
-    QColor col = scale ? scale->palette().color(QPalette::Active, QColorGroup::Foreground) : QColor(Qt::black);
+  for (int i = 0; i < 4; ++i) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+    QColor col =
+        scale
+            ? scale->palette().color(QPalette::Active, QColorGroup::Foreground)
+            : QColor(Qt::black);
     tsv << col.name();
   }
 
   tsv.writeLine("AxesNumberColors");
-  for(int i = 0; i < 4; ++i)
-  {
-    QwtScaleWidget* scale = dynamic_cast<QwtScaleWidget*>(d_plot->axisWidget(i));
-    QColor col = scale ? scale->palette().color(QPalette::Active, QColorGroup::Text) : QColor(Qt::black);
+  for (int i = 0; i < 4; ++i) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+    QColor col =
+        scale ? scale->palette().color(QPalette::Active, QColorGroup::Text)
+              : QColor(Qt::black);
     tsv << col.name();
   }
 
   tsv.writeLine("AxesBaseline");
-  for(int i = 0; i < 4; ++i)
-  {
-    QwtScaleWidget* scale = dynamic_cast<QwtScaleWidget*>(d_plot->axisWidget(i));
-    if(scale)
+  for (int i = 0; i < 4; ++i) {
+    QwtScaleWidget *scale =
+        dynamic_cast<QwtScaleWidget *>(d_plot->axisWidget(i));
+    if (scale)
       tsv << scale->margin();
     else
       tsv << 0;
   }
 
-  if(d_plot->canvas()->lineWidth() > 0)
-    tsv.writeLine("CanvasFrame") << d_plot->canvas()->lineWidth() << canvasFrameColor().name();
+  if (d_plot->canvas()->lineWidth() > 0)
+    tsv.writeLine("CanvasFrame") << d_plot->canvas()->lineWidth()
+                                 << canvasFrameColor().name();
 
   tsv.writeLine("CanvasBackground");
   tsv << d_plot->canvasBackground().name();
   tsv << d_plot->canvasBackground().alpha();
 
-  if(isPiePlot())
-  {
+  if (isPiePlot()) {
     tsv.writeRaw(savePieCurveLayout().toStdString());
-  }
-  else
-  {
-    for(int i = 0; i < n_curves; ++i)
+  } else {
+    for (int i = 0; i < n_curves; ++i)
       tsv.writeRaw(saveCurve(i));
   }
 
   tsv.writeRaw(saveScale());
 
-  //Axis formulae
-  for(int i = 0; i < 4; ++i)
-  {
-    auto sd = dynamic_cast<ScaleDraw*>(d_plot->axisScaleDraw(i));
-    if(!sd)
+  // Axis formulae
+  for (int i = 0; i < 4; ++i) {
+    auto sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(i));
+    if (!sd)
       continue;
 
-    if(sd->formula().isEmpty())
+    if (sd->formula().isEmpty())
       continue;
 
     std::stringstream ss;
-    ss << "<AxisFormula pos=\"" << i << "\">" << "\n";
-    ss << sd->formula().toStdString()         << "\n";
-    ss << "</AxisFormula>"                    << "\n";
+    ss << "<AxisFormula pos=\"" << i << "\">"
+       << "\n";
+    ss << sd->formula().toStdString() << "\n";
+    ss << "</AxisFormula>"
+       << "\n";
     tsv.writeRaw(ss.str());
   }
 
   tsv.writeLine("LabelsFormat");
-  for(int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i)
     tsv << d_plot->axisLabelFormat(i) << d_plot->axisLabelPrecision(i);
 
   tsv.writeLine("AxisType");
-  for(int i = 0; i < 4; ++i)
-  {
-    if(!d_plot->axisEnabled(i))
-    {
+  for (int i = 0; i < 4; ++i) {
+    if (!d_plot->axisEnabled(i)) {
       tsv << ScaleDraw::Numeric;
       continue;
     }
 
-    auto sd = dynamic_cast<ScaleDraw*>(d_plot->axisScaleDraw(i));
-    if(!sd)
+    auto sd = dynamic_cast<ScaleDraw *>(d_plot->axisScaleDraw(i));
+    if (!sd)
       continue;
 
     const int type = sd->scaleType();
@@ -6680,9 +6442,9 @@ std::string Graph::saveToProject()
     std::stringstream ss;
     ss << type;
 
-    if(type == ScaleDraw::Time  || type == ScaleDraw::Date ||
-       type == ScaleDraw::Text  || type == ScaleDraw::Day  ||
-       type == ScaleDraw::Month || type == ScaleDraw::ColHeader)
+    if (type == ScaleDraw::Time || type == ScaleDraw::Date ||
+        type == ScaleDraw::Text || type == ScaleDraw::Day ||
+        type == ScaleDraw::Month || type == ScaleDraw::ColHeader)
       ss << ";" << sd->formatString().toUtf8().constData();
 
     tsv << ss.str();
@@ -6690,12 +6452,12 @@ std::string Graph::saveToProject()
 
   tsv.writeLine("MajorTicks");
   QList<int> majorTicksTypeList = d_plot->getMajorTicksType();
-  for(int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i)
     tsv << majorTicksTypeList[i];
 
   tsv.writeLine("MinorTicks");
   QList<int> minorTicksTypeList = d_plot->getMinorTicksType();
-  for(int i = 0; i < 4; ++i)
+  for (int i = 0; i < 4; ++i)
     tsv << minorTicksTypeList[i];
 
   tsv.writeLine("TicksLength") << minorTickLength() << majorTickLength();
@@ -6707,15 +6469,13 @@ std::string Graph::saveToProject()
 
   tsv.writeRaw(saveMarkers());
 
-  if(isWaterfallPlot())
-  {
+  if (isWaterfallPlot()) {
     QString s = "<waterfall>" + QString::number(d_waterfall_offset_x) + ",";
     s += QString::number(d_waterfall_offset_y) + ",";
     bool sideLines = false;
-    if(d_plot->curvesList().size() > 0)
-    {
-      auto cv = dynamic_cast<PlotCurve*>(curve(0));
-      if(cv && cv->sideLinesEnabled())
+    if (d_plot->curvesList().size() > 0) {
+      auto cv = dynamic_cast<PlotCurve *>(curve(0));
+      if (cv && cv->sideLinesEnabled())
         sideLines = true;
     }
     s += QString::number(sideLines) + "</waterfall>\n";
@@ -6727,79 +6487,80 @@ std::string Graph::saveToProject()
 }
 
 /** A method to populate the CurveLayout struct on loading a project
- *  @param curve  The list of numbers corresponding to settings loaded from the project file
+ *  @param curve  The list of numbers corresponding to settings loaded from the
+ * project file
  *  @param fileVersion  The version number of the project file being loaded
- *  @param offset An offset to add to each index. Used when loading a MantidMatrixCurve
+ *  @param offset An offset to add to each index. Used when loading a
+ * MantidMatrixCurve
  *  @return The filled in CurveLayout struct
  */
-CurveLayout Graph::fillCurveSettings(const QStringList & curve, int fileVersion, unsigned int offset)
-{
+CurveLayout Graph::fillCurveSettings(const QStringList &curve, int fileVersion,
+                                     unsigned int offset) {
   CurveLayout cl;
-  cl.connectType=curve[4+offset].toInt();
-  cl.lCol=curve[5+offset].toInt();
-  cl.lStyle=curve[6+offset].toInt();
-  cl.lWidth=curve[7+offset].toFloat();
-  cl.sSize=curve[8+offset].toInt();
-  cl.sType=curve[9+offset].toInt();
-  cl.symCol=curve[10+offset].toInt();
-  cl.fillCol=curve[11+offset].toInt();
-  cl.filledArea=curve[12+offset].toInt();
-  cl.aCol=curve[13+offset].toInt();
-  cl.aStyle=curve[14+offset].toInt();
-  if(curve.count() < 16)
+  cl.connectType = curve[4 + offset].toInt();
+  cl.lCol = curve[5 + offset].toInt();
+  cl.lStyle = curve[6 + offset].toInt();
+  cl.lWidth = curve[7 + offset].toFloat();
+  cl.sSize = curve[8 + offset].toInt();
+  cl.sType = curve[9 + offset].toInt();
+  cl.symCol = curve[10 + offset].toInt();
+  cl.fillCol = curve[11 + offset].toInt();
+  cl.filledArea = curve[12 + offset].toInt();
+  cl.aCol = curve[13 + offset].toInt();
+  cl.aStyle = curve[14 + offset].toInt();
+  if (curve.count() < 16)
     cl.penWidth = cl.lWidth;
-  else if ((fileVersion >= 79) && (curve[3+offset].toInt() == Graph::Box))
-    cl.penWidth = curve[15+offset].toFloat();
-  else if ((fileVersion >= 78) && (curve[3+offset].toInt() <= Graph::LineSymbols))
-    cl.penWidth = curve[15+offset].toFloat();
+  else if ((fileVersion >= 79) && (curve[3 + offset].toInt() == Graph::Box))
+    cl.penWidth = curve[15 + offset].toFloat();
+  else if ((fileVersion >= 78) &&
+           (curve[3 + offset].toInt() <= Graph::LineSymbols))
+    cl.penWidth = curve[15 + offset].toFloat();
   else
     cl.penWidth = cl.lWidth;
 
   return cl;
 }
 
-std::string Graph::saveCurve(int i)
-{
-  QwtPlotItem* it = plotItem(i);
-  if(!it)
+std::string Graph::saveCurve(int i) {
+  QwtPlotItem *it = plotItem(i);
+  if (!it)
     return "";
 
-  if(it->rtti() == QwtPlotItem::Rtti_PlotUserItem)
-  {
-    auto mmc = dynamic_cast<MantidMatrixCurve*>(it);
-    if(!mmc)
+  if (it->rtti() == QwtPlotItem::Rtti_PlotUserItem) {
+    auto mmc = dynamic_cast<MantidMatrixCurve *>(it);
+    if (!mmc)
       return "";
 
     QString s = mmc->saveToString();
     s += saveCurveLayout(i);
     s += "\n";
 
-    if(mmc->hasErrorBars())
-      s += "<MantidYErrors>" + mmc->errorBarSettingsList().front()->toString() + "</MantidYErrors>\n";
+    if (mmc->hasErrorBars())
+      s += "<MantidYErrors>" + mmc->errorBarSettingsList().front()->toString() +
+           "</MantidYErrors>\n";
 
-    if(mmc->skipSymbolsCount() > 1)
-      s += "<SkipPoints>" + QString::number(mmc->skipSymbolsCount()) + "</SkipPoints>\n";
+    if (mmc->skipSymbolsCount() > 1)
+      s += "<SkipPoints>" + QString::number(mmc->skipSymbolsCount()) +
+           "</SkipPoints>\n";
 
     return s.toUtf8().constData();
   }
 
-  if(it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
-  {
-    auto spec = dynamic_cast<Spectrogram*>(it);
-    if(spec)
+  if (it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram) {
+    auto spec = dynamic_cast<Spectrogram *>(it);
+    if (spec)
       return spec->saveToProject();
     return "";
   }
 
-  auto funcCurve = dynamic_cast<FunctionCurve*>(it);
-  if(funcCurve)
+  auto funcCurve = dynamic_cast<FunctionCurve *>(it);
+  if (funcCurve)
     return funcCurve->saveToString().toUtf8().constData();
 
   auto er = dynamic_cast<QwtErrorPlotCurve *>(it);
-  if(er)
-  {
+  if (er) {
     QString s = "ErrorBars\t";
-    s += QString::number(er->direction())+"\t";
+    s += QString::number(er->direction()) + "\t";
     s += er->masterCurve()->xColumnName() + "\t";
     s += er->masterCurve()->title().text() + "\t";
     s += er->title().text() + "\t";
@@ -6807,20 +6568,22 @@ std::string Graph::saveCurve(int i)
     return s.toUtf8().constData();
   }
 
-  //If we're none of the above...
-  auto c = dynamic_cast<DataCurve*>(it);
-  if(c)
-  {
+  // If we're none of the above...
+  auto c = dynamic_cast<DataCurve *>(it);
+  if (c) {
     QString s;
-    if(c->type() == Box)
-      s += "curve\t" + QString::number(c->x(0)) + "\t" + c->title().text() + "\t";
+    if (c->type() == Box)
+      s += "curve\t" + QString::number(c->x(0)) + "\t" + c->title().text() +
+           "\t";
     else
       s += "curve\t" + c->xColumnName() + "\t" + c->title().text() + "\t";
 
     s += saveCurveLayout(i);
-    s += QString::number(c->xAxis())+"\t"+QString::number(c->yAxis())+"\t";
-    s += QString::number(c->startRow())+"\t"+QString::number(c->endRow())+"\t";
-    s += QString::number(c->isVisible())+"\n";
+    s +=
+        QString::number(c->xAxis()) + "\t" + QString::number(c->yAxis()) + "\t";
+    s += QString::number(c->startRow()) + "\t" + QString::number(c->endRow()) +
+         "\t";
+    s += QString::number(c->isVisible()) + "\n";
     s += c->saveToString();
     return s.toUtf8().constData();
   }
@@ -6828,15 +6591,13 @@ std::string Graph::saveCurve(int i)
   return "";
 }
 
-std::string Graph::saveScale()
-{
+std::string Graph::saveScale() {
   TSVSerialiser tsv;
-  for(int i = 0; i < 4; i++)
-  {
+  for (int i = 0; i < 4; i++) {
     tsv.writeLine("scale") << i;
 
-    const QwtScaleDiv* scDiv = d_plot->axisScaleDiv(i);
-    if(!scDiv)
+    const QwtScaleDiv *scDiv = d_plot->axisScaleDiv(i);
+    if (!scDiv)
       return "";
 
     tsv << QString::number(QMIN(scDiv->lBound(), scDiv->hBound()), 'g', 15);
@@ -6846,14 +6607,13 @@ std::string Graph::saveScale()
     tsv << d_plot->axisMaxMajor(i);
     tsv << d_plot->axisMaxMinor(i);
 
-    auto se = dynamic_cast<ScaleEngine*>(d_plot->axisScaleEngine(i));
-    if(!se)
+    auto se = dynamic_cast<ScaleEngine *>(d_plot->axisScaleEngine(i));
+    if (!se)
       return "";
 
     tsv << (int)se->type();
     tsv << se->testAttribute(QwtScaleEngine::Inverted);
-    if (se->hasBreak())
-    {
+    if (se->hasBreak()) {
       tsv << QString::number(se->axisBreakLeft(), 'g', 15);
       tsv << QString::number(se->axisBreakRight(), 'g', 15);
       tsv << se->breakPosition();
@@ -6866,45 +6626,41 @@ std::string Graph::saveScale()
       tsv << se->hasBreakDecoration();
     }
 
-    for(int j = 0; j < n_curves; j++)
-    {
-      QwtPlotItem* it = plotItem(j);
-      if(it && it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
+    for (int j = 0; j < n_curves; j++) {
+      QwtPlotItem *it = plotItem(j);
+      if (it && it->rtti() == QwtPlotItem::Rtti_PlotSpectrogram)
         tsv << updatedaxis[i];
     }
   }
   return tsv.outputLines();
 }
 
-std::string Graph::saveMarkers()
-{
+std::string Graph::saveMarkers() {
   TSVSerialiser tsv;
-  for(int i = 0; i < d_images.size(); ++i)
-  {
-    auto mrkI = dynamic_cast<ImageMarker*>(d_plot->marker(d_images[i]));
-    if(!mrkI)
+  for (int i = 0; i < d_images.size(); ++i) {
+    auto mrkI = dynamic_cast<ImageMarker *>(d_plot->marker(d_images[i]));
+    if (!mrkI)
       continue;
 
     QString s = "<image>";
     s += "\t" + mrkI->fileName();
     s += "\t" + QString::number(mrkI->xValue(), 'g', 15);
     s += "\t" + QString::number(mrkI->yValue(), 'g', 15);
-    s += "\t" + QString::number(mrkI->right(),  'g', 15);
+    s += "\t" + QString::number(mrkI->right(), 'g', 15);
     s += "\t" + QString::number(mrkI->bottom(), 'g', 15);
     s += "</image>\n";
     tsv.writeRaw(s.toStdString());
   }
 
-  for(int i = 0; i < d_lines.size(); ++i)
-  {
-    auto mrkL = dynamic_cast<ArrowMarker*>(d_plot->marker(d_lines[i]));
-    if(!mrkL)
+  for (int i = 0; i < d_lines.size(); ++i) {
+    auto mrkL = dynamic_cast<ArrowMarker *>(d_plot->marker(d_lines[i]));
+    if (!mrkL)
       continue;
 
     QwtDoublePoint sp = mrkL->startPointCoord();
     QwtDoublePoint ep = mrkL->endPointCoord();
 
-    QString s ="<line>";
+    QString s = "<line>";
     s += "\t" + (QString::number(sp.x(), 'g', 15));
     s += "\t" + (QString::number(sp.y(), 'g', 15));
     s += "\t" + (QString::number(ep.x(), 'g', 15));
@@ -6922,24 +6678,21 @@ std::string Graph::saveMarkers()
   }
 
   QObjectList lst = d_plot->children();
-  foreach(QObject* o, lst)
-  {
-    auto l = dynamic_cast<LegendWidget*>(o);
-    if(!l)
+  foreach (QObject *o, lst) {
+    auto l = dynamic_cast<LegendWidget *>(o);
+    if (!l)
       continue;
 
     QString s;
 
-    if(l == d_legend)
+    if (l == d_legend)
       s += "<legend>";
-    else if(l->isA("PieLabel"))
-    {
+    else if (l->isA("PieLabel")) {
       if (l->text().isEmpty())
         continue;
 
       s += "<PieLabel>";
-    }
-    else
+    } else
       s += "<text>";
 
     s += "\t" + QString::number(l->x());
@@ -6960,7 +6713,7 @@ std::string Graph::saveMarkers()
 
     QStringList textList = l->text().split("\n", QString::KeepEmptyParts);
     s += "\t" + textList.join("\t");
-    if(l == d_legend)
+    if (l == d_legend)
       s += "</legend>\n";
     else if (l->isA("PieLabel"))
       s += "</PieLabel>\n";

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -4035,15 +4035,14 @@ void Graph::copy(Graph *g) {
   for (int i = 0; i < g->curves(); i++) {
     QwtPlotItem *it = dynamic_cast<QwtPlotItem *>(g->curve(i));
 
-	if (it == nullptr)
-	{
-		Spectrogram *s = g->spectrogram();
-		Spectrogram *s_cpy = s->copy();
-		s_cpy->setData(s->data());
-		s_cpy->setColorMapPen();
-		plotSpectrogram(s_cpy, (CurveType)g->curveType(i));
-		continue;
-	}
+    if (it == nullptr) {
+      Spectrogram *s = g->spectrogram();
+      Spectrogram *s_cpy = s->copy();
+      s_cpy->setData(s->data());
+      s_cpy->setColorMapPen();
+      plotSpectrogram(s_cpy, (CurveType)g->curveType(i));
+      continue;
+    }
 
     if (it->rtti() == QwtPlotItem::Rtti_PlotUserItem) {
       MantidMatrixCurve *mmc = dynamic_cast<MantidMatrixCurve *>(it);

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -4041,6 +4041,11 @@ void Graph::copy(Graph *g) {
       s_cpy->setData(s->data());
       s_cpy->setColorMapPen();
       plotSpectrogram(s_cpy, (CurveType)g->curveType(i));
+
+      c_keys.resize(++n_curves);
+      c_type.resize(n_curves);
+      c_type[i] = g->curveType(i);
+
       continue;
     }
 
@@ -4050,12 +4055,16 @@ void Graph::copy(Graph *g) {
       PlotCurve *pc = dynamic_cast<PlotCurve *>(it);
       PlotCurve *pc_cpy;
 
+      c_keys.resize(++n_curves);
+      c_type.resize(n_curves);
+      c_type[i] = g->curveType(i);
+
       if (mmc != nullptr) {
         pc_cpy = dynamic_cast<PlotCurve *>(mmc->clone(g));
-        d_plot->insertCurve(pc_cpy);
+        c_keys[i] = d_plot->insertCurve(pc_cpy);
       } else if (mdc != nullptr) {
         pc_cpy = dynamic_cast<PlotCurve *>(mdc->clone(g));
-        d_plot->insertCurve(pc_cpy);
+        c_keys[i] = d_plot->insertCurve(pc_cpy);
       } else
         continue;
 
@@ -4075,6 +4084,8 @@ void Graph::copy(Graph *g) {
       QList<QwtPlotCurve *> lst = g->fitCurvesList();
       if (lst.contains(dynamic_cast<QwtPlotCurve *>(it)))
         d_fit_curves << pc_cpy;
+
+      addLegendItem();
     } else if (it->rtti() == QwtPlotItem::Rtti_PlotCurve) {
       DataCurve *cv = dynamic_cast<DataCurve *>(it);
       if (!cv)


### PR DESCRIPTION
Fixes #14690 

Release notes must be updated
## Changes

Duplicated Graphs, Color Fill plots and tables did not copy data across, rather duplicated windows contained correct header and axis labels but were completely blank otherwise. This fix adds the extra step of copying the data to the newly duplicated windows.
## Testing
### Graphs
- Load GEM38370_Focussed.nxs 
- Right-click on the workspace and select _Plot Spectrum_ (choose any spectrum/spectra)
- When the graph appears, go to _Windows->Duplicate_. 

You should now see a copy of the graph which also contains curves.
### Color Fill Plot
- Load GEM38370_Focussed.nxs 
- Right-click on the workspace and select  _Color Fill Plot_.
- When the graph appears go to _Windows->Duplicate_.

You should now see a copy of this plot with data.
### Table
- Load GEM38370_Focussed.nxs 
- Right-click on workspace and select _Show Detectors_
- When the table appears, go to _Windows->Duplicate_.

You should now see a copy of the table with data.
