### PR TITLE
Indirect Data Analysis Convfit error with Single Fit 

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -27,7 +27,8 @@ private slots:
   void newDataLoaded(const QString wsName);
   void updatePlot();
   void plotGuess();
-  void singleFit();
+  void singleFitExtension();
+  void singleFit(const bool &error);
   void specMinChanged(int value);
   void specMaxChanged(int value);
   void minChanged(double);

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -64,7 +64,7 @@ private:
   void updatePlotOptions();
   QString convertFuncToShort(const QString &);
   QString convertBackToShort(const std::string &original);
-  void extendResolutionWorkspace();
+  void extendResolutionWorkspace(const bool &run);
   Ui::ConvFit m_uiForm;
   QtStringPropertyManager *m_stringManager;
   QtTreePropertyBrowser *m_cfTree;

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -223,7 +223,7 @@ void ConvFit::run() {
     g_log.error("No workspace loaded");
     return;
   }
-  extendResolutionWorkspace();
+  extendResolutionWorkspace(true);
 }
 
 /**
@@ -233,8 +233,10 @@ void ConvFit::run() {
 * Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as
 * they need
 * to have the WorkspaceIndex attribute set.
+* @param run :: if the call is from running the algorithm or single fit (true =
+* algorithm)
 */
-void ConvFit::extendResolutionWorkspace() {
+void ConvFit::extendResolutionWorkspace(const bool &run) {
   if (m_cfInputWS && m_uiForm.dsResInput->isValid()) {
     const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
     API::BatchAlgorithmRunner::AlgorithmRuntimeProps appendProps;
@@ -255,8 +257,10 @@ void ConvFit::extendResolutionWorkspace() {
         m_batchAlgoRunner->addAlgorithm(appendAlg, appendProps);
       }
     }
-    connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-            SLOT(extensionComplete(bool)));
+    if (run) {
+      connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+              SLOT(extensionComplete(bool)));
+    }
     m_batchAlgoRunner->executeBatchAsync();
   }
 }
@@ -1147,7 +1151,7 @@ void ConvFit::singleFit() {
   if (fitType == "") {
     g_log.error("No fit type defined.");
   }
-
+  extendResolutionWorkspace(false);
   m_singleFitOutputName =
       runPythonCode(
           QString(


### PR DESCRIPTION
Fixes #14722

Running a single fit in ConvFit should no longer produce an error.

**Files available from `\\olympic\Babylon5\Public\ElliotOram\DataAnalysis\ConvFit\IRIS`**
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Sample = `irs26176_graphite002_red.nxs`
- Resolution = `irs26173_graphite002_res.nxs`
- Click `Fit Single Spectrum` 
- Ensure the Fit runs without error and the plot is updated correctly
- Change the Plot Spectrum number (default = 0)
- Click `Fit Single Spectrum` again
- Ensure the fit runs successfully
