### PR TITLE
Create a surface plot from a WorkspaceGroup

### DIFF
--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -241,6 +241,9 @@ void MantidDockWidget::createWorkspaceMenuActions()
 
   m_clearUB = new QAction(tr("Clear UB Matrix"), this);
   connect(m_clearUB, SIGNAL(activated()), this, SLOT(clearUB()));
+
+  m_plotSurface = new QAction(tr("Plot Surface from Group"), this);
+  connect(m_plotSurface, SIGNAL(triggered()), this, SLOT(plotSurface()));
 }
 
 /**
@@ -638,6 +641,8 @@ void MantidDockWidget::addWorkspaceGroupMenuItems(QMenu *menu) const
   menu->addAction(m_plotSpecErr);
   menu->addAction(m_colorFill);
   m_colorFill->setEnabled(true);
+  menu->addAction(m_plotSurface);
+  m_plotSurface->setEnabled(true);
   menu->addSeparator();
   menu->addAction(m_saveNexus);
 }
@@ -1498,6 +1503,17 @@ void MantidDockWidget::clearUB()
 void MantidDockWidget::dropEvent(QDropEvent *de)
 {
   m_tree->dropEvent(de);
+}
+
+/**
+ * Create a 3D surface plot from the selected workspace group
+ */
+void MantidDockWidget::plotSurface() {
+  // find the workspace group clicked on
+  // create empty table workspace
+  // populate table ws as in python example
+  // MantidUI::importTableWorkspace to Table*
+  // plotXYZ, or Graph3D from a Table...
 }
 
 //------------ MantidTreeWidget -----------------------//

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -88,6 +88,7 @@ private slots:
   void recordWorkspaceRename(QString,QString);
   void clearUB();
   void filterWorkspaceTree(const QString &text);
+  void plotSurface();
 
 private:
   void addSaveMenuOption(QString algorithmString, QString menuEntryName = "");
@@ -132,17 +133,14 @@ private:
 
   //Context-menu actions
   QAction *m_showData, *m_showInst, *m_plotSpec, *m_plotSpecErr,
-  *m_showDetectors, *m_showBoxData, *m_showVatesGui,
-  *m_showSpectrumViewer,
-  *m_showSliceViewer,
-  *m_colorFill, *m_showLogs, *m_showSampleMaterial,  *m_showHist, *m_showMDPlot, *m_showListData,
-  *m_saveNexus, *m_rename, *m_delete,
-  *m_program, * m_ascendingSortAction,
-  *m_descendingSortAction, *m_byNameChoice, *m_byLastModifiedChoice, *m_showTransposed,
-  *m_convertToMatrixWorkspace,
-  *m_convertMDHistoToMatrixWorkspace,
-  *m_clearUB;
-  
+      *m_showDetectors, *m_showBoxData, *m_showVatesGui, *m_showSpectrumViewer,
+      *m_showSliceViewer, *m_colorFill, *m_showLogs, *m_showSampleMaterial,
+      *m_showHist, *m_showMDPlot, *m_showListData, *m_saveNexus, *m_rename,
+      *m_delete, *m_program, *m_ascendingSortAction, *m_descendingSortAction,
+      *m_byNameChoice, *m_byLastModifiedChoice, *m_showTransposed,
+      *m_convertToMatrixWorkspace, *m_convertMDHistoToMatrixWorkspace,
+      *m_clearUB, *m_plotSurface;
+
   ApplicationWindow *m_appParent;
 
   QAtomicInt m_updateCount;


### PR DESCRIPTION
Resolves #14461 

Adds a right-click option to create a surface plot from a group workspace.
- [x] Updated [release notes](http://www.mantidproject.org/ReleaseNotes_3_6_UI_Changes#Plotting_improvements)

**To test:**
- Run the following to create a workspace group:

``` python
def create_sample_group(n_items):
    to_group = list()
    for i in range(n_items):
        name = 'ws' + str(i)
        to_group.append(name)
        CreateWorkspace(DataX=range(200, 210, 1), DataY=[i+1]*10, NSpec=1, OutputWorkspace=name)
    group = GroupWorkspaces(InputWorkspaces=','.join(to_group))
    return group

create_sample_group(n_items=10)
```
- Right-click on the WorkspaceGroup `group` and verify there is an option "Plot Surface from Group"
- Select this option and verify that a plot is produced, and that the plot looks sensible.
- The plot should look like the one produced from the example code in the [issue](https://github.com/mantidproject/mantid/issues/14461).
