### PR TITLE
Indirect Data Reduction Remove AutoRun in interfaces

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ISISDiagnostics.h
@@ -72,7 +72,6 @@ private slots:
   void rangeSelectorDropped(double, double);
   void doublePropertyChanged(QtProperty *, double);
   void setDefaultInstDetails();
-  void updatePreviewPlot();
   void sliceAlgDone(bool error);
   void
   pbRunEditing(); //< Called when a user starts to type / edit the runs to load.

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.h
@@ -12,7 +12,7 @@ namespace MantidQt
 {
 namespace CustomInterfaces
 {
-  /** IndirectMoments : TODO: DESCRIPTION
+  /** IndirectMoments : Calculates the S(Q,w) Moments of the provided data with the user specified range and scale factor
 
 
     @author Samuel Jackson
@@ -56,9 +56,7 @@ namespace CustomInterfaces
     /// Slot for when the range selector changes
     void rangeChanged(double min, double max);
     /// Slot to update the guides when the range properties change
-    void updateProperties(QtProperty* prop, double val);
-    /// Triggers an update of the preview plot
-    void updatePreviewPlot(QString workspaceName = "");
+	void updateProperties(QtProperty* prop, double val);
     /// Called when the algorithm completes to update preview plot
     void momentsAlgComplete(bool error);
 

--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -120,9 +120,6 @@ namespace CustomInterfaces
     setPlotPropertyRange(xRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
 
     connect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(updateProperties(QtProperty*, double)));
-
-    // Update the results preview plot
-    updatePreviewPlot();
   }
 
   /**
@@ -171,42 +168,6 @@ namespace CustomInterfaces
         m_uiForm.ppRawPlot->getRangeSelector("XRange")->setMaximum(val);
       }
     }
-
-    updatePreviewPlot();
-  }
-
-  /**
-   * Runs the moments algorithm with preview properties.
-   */
-  void IndirectMoments::updatePreviewPlot(QString workspaceName)
-  {
-    if(workspaceName.isEmpty())
-      workspaceName = m_uiForm.dsInput->getCurrentDataName();
-
-    QString outputName = workspaceName.left(workspaceName.length() - 4);
-    double scale = m_uiForm.spScale->value();
-    double eMin = m_dblManager->value(m_properties["EMin"]);
-    double eMax = m_dblManager->value(m_properties["EMax"]);
-
-    std::string outputWorkspaceName = outputName.toStdString() + "_Moments";
-
-    IAlgorithm_sptr momentsAlg = AlgorithmManager::Instance().create("SofQWMoments");
-    momentsAlg->initialize();
-    momentsAlg->setProperty("Sample", workspaceName.toStdString());
-    momentsAlg->setProperty("EnergyMin", eMin);
-    momentsAlg->setProperty("EnergyMax", eMax);
-    momentsAlg->setProperty("Plot", false);
-    momentsAlg->setProperty("Save", false);
-    momentsAlg->setProperty("OutputWorkspace", outputWorkspaceName);
-
-    if(m_uiForm.ckScale->isChecked())
-      momentsAlg->setProperty("Scale", scale);
-
-    // Make sure there are no other algorithms in the queue.
-    // It seems to be possible to have the selctionChangedLazy signal fire multiple times
-    // if the renage selector is moved in a certain way.
-    if(m_batchAlgoRunner->queueLength() == 0)
-      runAlgorithm(momentsAlg);
   }
 
   /**


### PR DESCRIPTION
Fixes #14688

The ISISDiagnostics and Moments interfaces should no longer auto run the main algorithms when data is changed including file changes and property changes.
# To Test
- Change default instrument to `IRIS` at `ISIS` View> Preferences > Mantid > Facility/Default Instrument (This should not have to be done after 14607)
- Ensure `Search Data Archive` is checked in the `Manager User Directory` window
# ISIS Diagnostics
- Open ISIS Diagnostics (Interfaces > Indirect > Data Reduction > ISIS Diagnostics)
- Input Files = 26176
- Ensure that this only calls the `Load` algorithm
  - This can be confirmed by checking in the Results Log
- Change any/all of the values in the property tree
  - Ensure that this does not call any algorithms (excluding `Load` when changing `Preview Spectrum`)
- Finally click `Run`
  - Ensure that `iris26176_graphite002_slice` is now in the ADS and the preview plot is now displayed at the bottom of the tab.
# Moments
- Open Moments (same interface as before - final tab)
- Input File = `deltaE_010_sqw.nxs` available from `\\olympic\babylon5\Public\ElliotOram\DataReduction\Moments`
- Ensure that this only calls the Load algorithm and adds a curve to the mini plot in the interface
- Change the values for `EMin` and `EMax` 
  - Ensure this does not run any algorithms
- Click `Run`
  - Ensure that this updates the preview plot at the bottom of the interface
  - Ensure that the WorkspaceGroup `deltaE_010_Moments` is now in the ADS
