### PR TITLE
Handle cummulative sample logs for SANS

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -192,7 +192,7 @@ public:
                  const std::vector<TYPE> &values);
   /// Replaces the time series with new values time series values
   void replaceValues(const std::vector<Kernel::DateAndTime> &times,
-    const std::vector<TYPE> &values);
+                     const std::vector<TYPE> &values);
 
   /// Returns the last time
   DateAndTime lastTime() const;

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -190,6 +190,9 @@ public:
   /// calls to addValue.
   void addValues(const std::vector<Kernel::DateAndTime> &times,
                  const std::vector<TYPE> &values);
+  /// Replaces the time series with new values time series values
+  void replaceValues(const std::vector<Kernel::DateAndTime> &times,
+    const std::vector<TYPE> &values);
 
   /// Returns the last time
   DateAndTime lastTime() const;

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1005,8 +1005,9 @@ void TimeSeriesProperty<TYPE>::addValues(
 *  @param values :: The associated value
 */
 template <typename TYPE>
-void TimeSeriesProperty<TYPE>::replaceValues(const std::vector<Kernel::DateAndTime> &times,
-  const std::vector<TYPE> &values) {
+void TimeSeriesProperty<TYPE>::replaceValues(
+    const std::vector<Kernel::DateAndTime> &times,
+    const std::vector<TYPE> &values) {
   clear();
   addValues(times, values);
 }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -999,6 +999,18 @@ void TimeSeriesProperty<TYPE>::addValues(
   return;
 }
 
+/** replace vectors of values to the map. First we clear the vectors
+ * and then we run addValues
+*  @param times :: The time as a boost::posix_time::ptime value
+*  @param values :: The associated value
+*/
+template <typename TYPE>
+void TimeSeriesProperty<TYPE>::replaceValues(const std::vector<Kernel::DateAndTime> &times,
+  const std::vector<TYPE> &values) {
+  clear();
+  addValues(times, values);
+}
+
 /**
  * Returns the last time
  * @return Value

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -175,6 +175,33 @@ public:
     delete p;
   }
 
+  void test_replaceValues() {
+    // Arrange 
+    size_t num = 1000;
+    DateAndTime first("2007-11-30T16:17:10");
+    std::vector<DateAndTime> times;
+
+    std::vector<double> values;
+    std::vector<double> replacementValues;
+    double offset = 100.0;
+    for (size_t i = 0; i < num; i++) {
+      times.push_back(first + double(i));
+      values.push_back(double(i));
+      replacementValues.push_back(double(i) + offset);
+    }
+    TimeSeriesProperty<double> tsp("test");
+    tsp.addValues(times, values);
+    TS_ASSERT_EQUALS(tsp.size(), 1000);
+    TS_ASSERT_EQUALS(tsp.nthValue(3), 3.0);
+
+    // Act
+    tsp.replaceValues(times, replacementValues);
+
+    // Assert
+    TSM_ASSERT_EQUALS("Should have 1000 entries", tsp.size(), 1000);
+    TSM_ASSERT_EQUALS("Should be 3 plus the offset of 100", tsp.nthValue(3), 103.0);
+  }
+
   void test_addValues() {
     size_t num = 1000;
     DateAndTime first("2007-11-30T16:17:10");

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -176,7 +176,7 @@ public:
   }
 
   void test_replaceValues() {
-    // Arrange 
+    // Arrange
     size_t num = 1000;
     DateAndTime first("2007-11-30T16:17:10");
     std::vector<DateAndTime> times;
@@ -199,7 +199,8 @@ public:
 
     // Assert
     TSM_ASSERT_EQUALS("Should have 1000 entries", tsp.size(), 1000);
-    TSM_ASSERT_EQUALS("Should be 3 plus the offset of 100", tsp.nthValue(3), 103.0);
+    TSM_ASSERT_EQUALS("Should be 3 plus the offset of 100", tsp.nthValue(3),
+                      103.0);
   }
 
   void test_addValues() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -40,6 +40,7 @@ using Mantid::PythonInterface::Policies::VectorToNumpy;
                            const std::string &, const TYPE)) &                 \
                            TimeSeriesProperty<TYPE>::addValue,                 \
            (arg("self"), arg("time"), arg("value")))                           \
+      .def("clear", &TimeSeriesProperty<TYPE>::clear, arg("self"))              \
       .def("valueAsString", &TimeSeriesProperty<TYPE>::value, arg("self"))     \
       .def("size", &TimeSeriesProperty<TYPE>::size, arg("self"))               \
       .def("firstTime", &TimeSeriesProperty<TYPE>::firstTime, arg("self"))     \

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -40,7 +40,7 @@ using Mantid::PythonInterface::Policies::VectorToNumpy;
                            const std::string &, const TYPE)) &                 \
                            TimeSeriesProperty<TYPE>::addValue,                 \
            (arg("self"), arg("time"), arg("value")))                           \
-      .def("clear", &TimeSeriesProperty<TYPE>::clear, arg("self"))              \
+      .def("clear", &TimeSeriesProperty<TYPE>::clear, arg("self"))             \
       .def("valueAsString", &TimeSeriesProperty<TYPE>::value, arg("self"))     \
       .def("size", &TimeSeriesProperty<TYPE>::size, arg("self"))               \
       .def("firstTime", &TimeSeriesProperty<TYPE>::firstTime, arg("self"))     \

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -961,6 +961,8 @@ def transfer_special_sample_logs(from_ws, to_ws):
     '''
     single_valued_names = [ "gd_prtn_chrg"]
     time_series_names = ['good_uah_log', 'good_frames']
+    type_map = {'good_uah_log': float , 'good_frames' : int, "gd_prtn_chrg" : float}
+
     run_from = from_ws.getRun()
     run_to = to_ws.getRun()
 
@@ -976,7 +978,7 @@ def transfer_special_sample_logs(from_ws, to_ws):
             prop.clear()
             for index in range(0, len(times)):
                 prop.addValue(times[index],
-                              values[index])
+                              type_map[time_series_name](values[index]))
 
     alg_log = AlgorithmManager.createUnmanaged("AddSampleLog")
     alg_log.initialize()
@@ -987,7 +989,7 @@ def transfer_special_sample_logs(from_ws, to_ws):
             value = run_from.getProperty(single_valued_name).value
             alg_log.setProperty("Workspace", to_ws)
             alg_log.setProperty("LogName", single_valued_name)
-            alg_log.setProperty("LogText", str(value))
+            alg_log.setProperty("LogText", str(type_map[single_valued_name](value)))
             alg_log.setProperty("LogType", "Number")
             alg_log.execute()
 
@@ -1035,9 +1037,10 @@ class CummulativeTimeSeriesPropertyAdder(object):
                 self._original_values_rhs[element] = property_rhs.value
 
         log_name_start_time = "start_time"
-        convert_to_date = lambda val: DateAndTime(val) if isinstance(val, str) else val
-        self._start_time_lhs = convert_to_date(run_lhs.getProperty(log_name_start_time).value)
-        self._start_time_rhs = convert_to_date(run_rhs.getProperty(log_name_start_time).value)
+        if (run_lhs.hasProperty(log_name_start_time) and run_rhs.hasProperty(log_name_start_time)):
+            convert_to_date = lambda val: DateAndTime(val) if isinstance(val, str) else val
+            self._start_time_lhs = convert_to_date(run_lhs.getProperty(log_name_start_time).value)
+            self._start_time_rhs = convert_to_date(run_rhs.getProperty(log_name_start_time).value)
 
     def apply_cummulative_logs_to_workspace(self, workspace):
         '''

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -904,7 +904,8 @@ class OverlayWorkspaces(object):
         Plus(LHSWorkspace=LHS_workspace,RHSWorkspace= temp ,OutputWorkspace= output_workspace)
 
         #Apply sample log correciton
-        cummulative_correction.apply_cummulative_logs_to_workspace(output_workspace)
+        out_ws = self._get_workspace(output_workspace)
+        cummulative_correction.apply_cummulative_logs_to_workspace(out_ws)
 
         # Remove the shifted workspace
         if mtd.doesExist(temp_ws_name):
@@ -1067,14 +1068,15 @@ class CummulativeTimeSeriesPropertyAdder(object):
         alg_log.initialize()
         alg_log.setChild(True)
         for key in self._single_values_to_update.keys():
-            # The single-valued entry should be the last entry of the
-            # cummulative time series
-            new_value = run.getProperty(key).value[-1]
-            alg_log.setProperty("Workspace", workspace)
-            alg_log.setProperty("LogName", self._single_values_to_update[key])
-            alg_log.setProperty("LogText", str(new_value))
-            alg_log.setProperty("LogType", "Number")
-            alg_log.execute()
+            if run.hasProperty(key) and run.hasProperty(self._single_values_to_update[key]):
+                # The single-valued entry should be the last entry of the
+                # cummulative time series
+                new_value = run.getProperty(key).value[-1]
+                alg_log.setProperty("Workspace", workspace)
+                alg_log.setProperty("LogName", self._single_values_to_update[key])
+                alg_log.setProperty("LogText", str(new_value))
+                alg_log.setProperty("LogType", "Number")
+                alg_log.execute()
 
     def _get_cummulative_sample_logs(self, log_name):
         '''

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -991,7 +991,7 @@ class CummulativeTimeSeriesPropertyAdder(object):
                 self._populate_property(property_rhs, times, shifted_values)
 
                 self._original_times_rhs[element] = times
-                self._original_values_rhs[element] = values 
+                self._original_values_rhs[element] = values
 
     def restore_original_workspace(self, rhs):
         '''
@@ -1008,7 +1008,7 @@ class CummulativeTimeSeriesPropertyAdder(object):
                 values = self._original_values_rhs[element]
                 self._populate_property(property_rhs, times, values)
 
-    def _populate_property(self, property, times, values):
+    def _populate_property(self, prop, times, values):
         '''
         Populates a time series property
         @param property: the time series property
@@ -1016,8 +1016,8 @@ class CummulativeTimeSeriesPropertyAdder(object):
         @param values: the values array
         '''
         for index in range(0, len(times)):
-            property.addValue(times[index],
-                                values[index])
+            prop.addValue(times[index],
+                          values[index])
 
 def load_monitors_for_multiperiod_event_data(workspace, data_file, monitor_appendix):
     '''

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -929,6 +929,7 @@ class OverlayWorkspaces(object):
         elif isinstance(workspace, basestring) and mtd.doesExist(workspace):
             return mtd[workspace]
 
+#pylint: disable=too-few-public-methods 
 class TimeShifter(object):
     """
     The time shifter stores all time shifts for all runs which are to be added. If there is
@@ -990,6 +991,7 @@ def transfer_special_sample_logs(from_ws, to_ws):
             alg_log.setProperty("LogType", "Number")
             alg_log.execute()
 
+#pylint: disable=too-many-instance-attributes
 class CummulativeTimeSeriesPropertyAdder(object):
     '''
     Apply shift to RHS sample logs where necessary. This is a hack because Plus cannot handle
@@ -1044,11 +1046,11 @@ class CummulativeTimeSeriesPropertyAdder(object):
             if (element in self._original_times_rhs and
                 element in self._original_values_rhs):
                 run = workspace.getRun()
-                property = run.getProperty(element)
-                property.clear()
+                prop = run.getProperty(element)
+                prop.clear()
                 # Get the cummulated values and times
                 times, values = self._get_cummulative_sample_logs(element)
-                self._populate_property(property, times, values)
+                self._populate_property(prop, times, values)
 
         self._update_single_valued_entries(workspace)
 
@@ -1087,7 +1089,7 @@ class CummulativeTimeSeriesPropertyAdder(object):
         values_raw_lhs = self._get_raw_values(values_lhs)
         values_raw_rhs = self._get_raw_values(values_rhs)
 
-        # Shift the times of the rhs workspace if required 
+        # Shift the times of the rhs workspace if required
         times_rhs = self._shift_time_series(times_rhs)
 
         # Now merge and sort the two entries

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -1002,7 +1002,7 @@ class CummulativeTimeSeriesPropertyAdder(object):
     def __init__(self, total_time_shift_seconds = 0):
         super(CummulativeTimeSeriesPropertyAdder, self).__init__()
         self._time_series = ['good_uah_log', 'good_frames']
-        self._single_valued= {"gd_prtn_chrg"}
+        self._single_valued= ["gd_prtn_chrg"]
 
         self._original_times_lhs = dict()
         self._original_values_lhs = dict()

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -14,7 +14,6 @@ import os
 import re
 import types
 import numpy as np
-import copy
 
 sanslog = Logger("SANS")
 ADDED_EVENT_DATA_TAG = '_added_event_data'
@@ -930,7 +929,7 @@ class OverlayWorkspaces(object):
         elif isinstance(workspace, basestring) and mtd.doesExist(workspace):
             return mtd[workspace]
 
-#pylint: disable=too-few-public-methods 
+#pylint: disable=too-few-public-methods
 class TimeShifter(object):
     """
     The time shifter stores all time shifts for all runs which are to be added. If there is
@@ -1055,15 +1054,14 @@ class CummulativeTimeSeriesPropertyAdder(object):
                 times, values = self._get_cummulative_sample_logs(element)
                 self._populate_property(prop, times, values, self._type_map[element])
 
-        self._update_single_valued_entries(workspace, self._type_map[element])
+        self._update_single_valued_entries(workspace)
 
 
-    def _update_single_valued_entries(self, workspace, type_converter):
+    def _update_single_valued_entries(self, workspace):
         '''
         We need to update single-valued entries which are based on the
         cummulative time series
         @param workspace: the workspace which requires the changes
-        @param type_converter: a type converter
         '''
         run = workspace.getRun()
 
@@ -1074,6 +1072,7 @@ class CummulativeTimeSeriesPropertyAdder(object):
             if run.hasProperty(key) and run.hasProperty(self._single_values_to_update[key]):
                 # The single-valued entry should be the last entry of the
                 # cummulative time series
+                type_converter = self._type_map[self._single_values_to_update[key]]
                 new_value = run.getProperty(key).value[-1]
                 alg_log.setProperty("Workspace", workspace)
                 alg_log.setProperty("LogName", self._single_values_to_update[key])

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -1,8 +1,8 @@
-#pylint: disable=invalid-name
+﻿#pylint: disable=invalid-name
 import os
 from mantid.simpleapi import *
 from mantid.kernel import Logger
-from SANSUtility import (bundle_added_event_data_as_group, AddOperation)
+from SANSUtility import (bundle_added_event_data_as_group, AddOperation, transfer_special_sample_logs)
 sanslog = Logger("SANS")
 from shutil import copyfile
 
@@ -126,6 +126,11 @@ def add_runs(runs, inst='sans2d', defType='.nxs', rawTypes=('.raw', '.s*', 'add'
             wsInMonitor = mtd['AddFilesSumTempory_monitors']
             wsOut = mtd['AddFilesSumTempory']
             wsInDetector = mtd['AddFilesSumTempory_Rebin']
+
+            # We loose added sample log information since we reload a single run workspace
+            # and conjoin with the added workspace. In order to preserve some added sample
+            # logs we need to transfer them at this point
+            transfer_special_sample_logs(from_ws = wsInDetector, to_ws = wsOut)
 
             mon_n = wsInMonitor.getNumberHistograms()
             for i in range(mon_n):

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1225,8 +1225,6 @@ class TestCorrectingCummulativeSampleLogs(unittest.TestCase):
         names =['ws1', 'ws2']
         out_ws_name = 'out_ws'
         time_shift = 0
-        import time
-        time.sleep(10)
         log_names = ['good_uah_log', 'good_frames', 'new_series']
 
         start_time_1 = "2010-01-01T00:00:00"

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -1270,19 +1270,22 @@ class TestCorrectingCummulativeSampleLogs(unittest.TestCase):
 
         log_names = ['good_uah_log', 'good_frames', 'new_series']
         start_time_1 = "2010-01-01T00:00:00"
+        proton_charge_1 = 10.2
         lhs = provide_event_ws_with_entries(names[0], start_time_1, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(lhs, "gd_prtn_chrg", lhs.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(lhs, "gd_prtn_chrg", proton_charge_1)
 
         start_time_2 = "2010-01-01T00:00:12"
+        proton_charge_2 = 30.2
         rhs = provide_event_ws_with_entries(names[1],start_time_2, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(rhs, "gd_prtn_chrg", rhs.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(rhs, "gd_prtn_chrg", proton_charge_2)
 
         start_time_3 = "2010-02-01T00:00:00"
+        proton_charge_3 = 20.2
         out = provide_event_ws_with_entries(names[2],start_time_3, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(out, "gd_prtn_chrg", out.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(out, "gd_prtn_chrg", proton_charge_3)
 
         out_ref = CloneWorkspace(InputWorkspace = out)
 
@@ -1324,20 +1327,23 @@ class TestCorrectingCummulativeSampleLogs(unittest.TestCase):
         import time
         time.sleep(10)
         start_time_1 = "2010-01-01T00:00:00"
+        proton_charge_1 = 10.2
         lhs = provide_event_ws_with_entries(names[0],start_time_1, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(lhs, "gd_prtn_chrg", lhs.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(lhs, "gd_prtn_chrg", proton_charge_1)
 
         # The rhs workspace should have an overlap time of about 5s
         start_time_2 = "2010-01-01T00:00:05"
+        proton_charge_2 = 19.2
         rhs = provide_event_ws_with_entries(names[1],start_time_2, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(rhs, "gd_prtn_chrg", rhs.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(rhs, "gd_prtn_chrg", proton_charge_2)
 
         start_time_3 = "2010-02-01T00:00:00"
+        proton_charge_3 = 30.2
         out = provide_event_ws_with_entries(names[2],start_time_3, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(out, "gd_prtn_chrg", out.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(out, "gd_prtn_chrg", proton_charge_3)
 
         out_ref = CloneWorkspace(InputWorkspace = out)
 
@@ -1378,20 +1384,23 @@ class TestCorrectingCummulativeSampleLogs(unittest.TestCase):
         log_names = ['good_uah_log', 'good_frames', 'new_series']
 
         start_time_1 = "2010-01-01T00:00:00"
+        proton_charge_1 = 10.2
         lhs = provide_event_ws_with_entries(names[0],start_time_1, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(lhs, "gd_prtn_chrg", lhs.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(lhs, "gd_prtn_chrg", proton_charge_1)
 
         # The rhs workspace should have an overlap time of about 5s
         start_time_2 = "2010-01-01T00:00:20"
+        proton_charge_2 = 18.2
         rhs = provide_event_ws_with_entries(names[1],start_time_2, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(rhs, "gd_prtn_chrg", rhs.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(rhs, "gd_prtn_chrg", proton_charge_2)
 
         start_time_3 = "2010-02-01T00:00:00"
+        proton_charge_3 = 80.2
         out = provide_event_ws_with_entries(names[2],start_time_3, extra_time_shift = 0.0,
                                             log_names = log_names, make_linear = True)
-        self._add_single_log(out, "gd_prtn_chrg", out.getRun().getProperty("good_uah_log").value[-1])
+        self._add_single_log(out, "gd_prtn_chrg", proton_charge_3)
 
         out_ref = CloneWorkspace(InputWorkspace = out)
 

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -104,7 +104,7 @@ def provide_workspace_with_x_errors(workspace_name,use_xerror = True, nspec = 1,
             ws.setDx(hists, x_error_array)
 
 
-'''
+
 # This test does not pass and was not used before 1/4/2015. SansUtilitytests was disabled.
 class SANSUtilityTest(unittest.TestCase):
 
@@ -1221,7 +1221,7 @@ class TestDetectingValidUserFileExtensions(unittest.TestCase):
         # Act and Assert
         self._do_test(file_name, expected)
 
-'''
+
 class TestCorrectingCummulativeSampleLogs(unittest.TestCase):
     def _clean_up_workspaces(self):
         for name in mtd.getObjectNames():


### PR DESCRIPTION
Fixes #14729 
# For Testing:

You will need the system test data. Make sure that it is in your path.

Please find an installer here: \olympic\Babylon5\Scratch\Anton\Testing\14729_Cummulative_logs

``` python
ws_1 = mtd['SANS2D00022048']  # NAME OF THE FIRST WORKSPACE
ws_2 = mtd['SANS2D00022048']  # NAME OF THE SECOND WORKSPACE
ws_sum = mtd['SANS2D00022048-add']  # NAME OF THE SUMMED WORKSPACE

print " GOOD FRAMES"
good_frames = "good_frames"
# Length should be roughly the sum of two to single workspaces (minus some counts that happened before time 0)
print "Number of entries for ws1 " + str(len(ws_1.getRun().getProperty(good_frames).value))
print "Number of entries for ws2 " + str(len(ws_2.getRun().getProperty(good_frames).value))
print "Number of entries for sum " + str(len(ws_sum.getRun().getProperty(good_frames).value))

print "Last entry for ws1 " + str(ws_1.getRun().getProperty(good_frames).value[-1])
print "Last entry for ws1 " + str(ws_2.getRun().getProperty(good_frames).value[-1])
print "Last entry for sum " + str(ws_sum.getRun().getProperty(good_frames).value[-1])

print 
print 
print " GOOD UAMPH LOG"
good_uamph_log = "good_uah_log"
# Length should be roughly the sum of two to single workspaces (minus some counts that happened before time 0)
print "Number of entries for ws1 " + str(len(ws_1.getRun().getProperty(good_uamph_log).value))
print "Number of entries for ws2 " + str(len(ws_2.getRun().getProperty(good_uamph_log).value))
print "Number of entries for sum " + str(len(ws_sum.getRun().getProperty(good_uamph_log).value))

print "Last entry for ws1 " + str(ws_1.getRun().getProperty(good_uamph_log).value[-1])
print "Last entry for ws1 " + str(ws_2.getRun().getProperty(good_uamph_log).value[-1])
print "Last entry for sum " + str(ws_sum.getRun().getProperty(good_uamph_log).value[-1])

print 
print
print " Good Proton Charge"
proton_charge = "gd_prtn_chrg"
print "Charge for ws1 " + str(ws_1.getRun().getProperty(proton_charge).value)
print "Charge for ws1 " + str(ws_2.getRun().getProperty(proton_charge).value)
print "Charge for sum " + str(ws_sum.getRun().getProperty(proton_charge).value)
```

**Add Event data to itself as Event data** 
1. Run the following script:

``` python
import ISISCommandInterface as i

i.SANS2DTUBES()
i.MaskFile('USER_SANS2D_143ZC_2p4_4m_M4_Knowles_12mm.txt')
i.SetDetectorOffsets('REAR', -16.0, 58.0, 0.0, 0.0, 0.0, 0.0)
i.SetDetectorOffsets('FRONT', -44.0, -20.0, 47.0, 0.0, 1.0, 1.0)
i.Gravity(False)
i.Set1D()

# add files (SAMPLE and CAN) using the ISISCommandInterface
runs_sample = ('22048','22048')

# Note that this will save a file into your output path. It has the ending -add
i.AddRuns(runs_sample, instrument = 'SANS2DTUBES', saveAsEvent=True)
print "Finished"
```
1. You will have a file with -add in your save directory. Load this file and the  SANS2D00022048 file into Mantid.
2. Open the Sample logs for both files and check that `good_frames` looks like it is double in the added file compared to the individual file.
3. Open the Sample logs for both files and check that `good_uamph_log` looks like it is double in the added file compared to the individual file.
4. Open the Sample logs for both fies and check that `gd_prtn_chrg` is twice the value of single workspace. 

**Test add event data as histo data**
1. Run the following script:

``` python
import ISISCommandInterface as i

i.SANS2DTUBES()
i.MaskFile('USER_SANS2D_143ZC_2p4_4m_M4_Knowles_12mm.txt')
i.SetDetectorOffsets('REAR', -16.0, 58.0, 0.0, 0.0, 0.0, 0.0)
i.SetDetectorOffsets('FRONT', -44.0, -20.0, 47.0, 0.0, 1.0, 1.0)
i.Gravity(False)
i.Set1D()

# add files (SAMPLE and CAN) using the ISISCommandInterface
runs_sample = ('22048','22048')

# Note that this will save a file into your output path. It has the ending -add
i.AddRuns(runs_sample, instrument = 'SANS2DTUBES', saveAsEvent=False, binning = "Monitors")

print "Finished"
```
1. You will have a file with -add in your save directory. Load this file and the  SANS2D00022048 file into Mantid.
2. Open the Sample logs for both files and check that `good_frames` looks like it is double in the added file compared to the individual file.
3. Open the Sample logs for both files and check that `good_uamph_log` looks like it is double in the added file compared to the individual file.
4. Open the Sample logs for both fies and check that `gd_prtn_chrg` is twice the value of single workspace. 

**Test add event files as event with differing input workspaces**
1. Run the following script:

`````` python
import ISISCommandInterface as i

i.SANS2DTUBES()
i.MaskFile('USER_SANS2D_143ZC_2p4_4m_M4_Knowles_12mm.txt')
i.SetDetectorOffsets('REAR', -16.0, 58.0, 0.0, 0.0, 0.0, 0.0)
i.SetDetectorOffsets('FRONT', -44.0, -20.0, 47.0, 0.0, 1.0, 1.0)
i.Gravity(False)
i.Set1D()

# add files (SAMPLE and CAN) using the ISISCommandInterface
runs_sample = ('28793','28797')

# Note that this will save a file into your output path. It has the ending -add
i.AddRuns(runs_sample, instrument = 'SANS2DTUBES', saveAsEvent=False, binning = "Monitors")

print "Finished"
```python

2. You will have a file with -add in your save directory. Load this file and the  two input files into Mantid.
3. Open the Sample logs for all three files and check that `good_frames` looks like it is the sum of the individual sample logs. Well it should look like a step.
4. Open the Sample logs for both files and check that `good_uamph_log` looks like  it is the sum of the individual sample logs. It should look like a step.
5. Open the Sample logs for both fies and check that `gd_prtn_chrg` is the sum of the two workspaces
``````

A proper solution to this issue should be available when this [ticket](https://github.com/mantidproject/mantid/issues/14744) is implemented
