### PR TITLE
Plot Normalization controlled from python.

### DIFF
--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -398,7 +398,7 @@ def fitBrowser():
 
 
 # -----------------------------------------------------------------------------
-def plotBin(source, indices, error_bars=False, type=-1, window=None, clearWindow=False,
+def plotBin(source, indices, distribution=mantidqtpython.MantidQt.DistributionDefault, error_bars=False, type=-1, window=None, clearWindow=False,
             waterfall=False):
     """Create a 1D Plot of bin count vs spectrum in a workspace.
 
@@ -440,7 +440,7 @@ def plotBin(source, indices, error_bars=False, type=-1, window=None, clearWindow
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
-                                          workspace_names, index_list, False, 0, error_bars,
+                                          workspace_names, index_list, False, distribution, error_bars,
                                           type, window, clearWindow, waterfall))
     if graph._getHeldObject() == None:
         raise RuntimeError("Cannot create graph, see log for details.")

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 MantidPlot module to gain access to plotting functions etc.
 Requires that the main script be run from within MantidPlot
 """
@@ -16,6 +16,7 @@ from PyQt4.QtCore import Qt
 import os
 import time
 import mantid.api
+import mantidqtpython
 
 # Import into the global namespace qti classes that:
 #   (a) don't need a proxy & (b) can be constructed from python or (c) have enumerations within them
@@ -217,7 +218,7 @@ def newTiledWindow(name=None, sources = None, ncols = None):
 
 
 # ----------------------------------------------------------------------------------------------------
-def plotSpectrum(source, indices, error_bars=False, type=-1, window=None,
+def plotSpectrum(source, indices, distribution = mantidqtpython.MantidQt.DistributionDefault, error_bars=False, type=-1, window=None,
                  clearWindow=False, waterfall=False):
     """Open a 1D Plot of a spectrum in a workspace.
 
@@ -256,7 +257,7 @@ def plotSpectrum(source, indices, error_bars=False, type=-1, window=None,
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
-                                          workspace_names, index_list, True, error_bars,
+                                          workspace_names, index_list, True, distribution, error_bars,
                                           type, window, clearWindow, waterfall))
     if graph._getHeldObject() == None:
         raise RuntimeError("Cannot create graph, see log for details.")
@@ -439,7 +440,7 @@ def plotBin(source, indices, error_bars=False, type=-1, window=None, clearWindow
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
-                                          workspace_names, index_list, False, error_bars,
+                                          workspace_names, index_list, False, 0, error_bars,
                                           type, window, clearWindow, waterfall))
     if graph._getHeldObject() == None:
         raise RuntimeError("Cannot create graph, see log for details.")
@@ -856,6 +857,10 @@ Layer.Right = _qti.GraphOptions.Right
 Layer.Bottom = _qti.GraphOptions.Bottom
 Layer.Top = _qti.GraphOptions.Top
 
+DistributionFlag = mantidqtpython.MantidQt
+DistributionFlag.DistributionDefault = mantidqtpython.MantidQt.DistributionDefault
+DistributionFlag.DistributionTrue = mantidqtpython.MantidQt.DistributionTrue
+DistributionFlag.DistributionFalse = mantidqtpython.MantidQt.DistributionFalse
 
 # -----------------------------------------------------------------------------
 # --------------------------- "Private" functions -----------------------------

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -857,10 +857,10 @@ Layer.Right = _qti.GraphOptions.Right
 Layer.Bottom = _qti.GraphOptions.Bottom
 Layer.Top = _qti.GraphOptions.Top
 
-DistributionFlag = mantidqtpython.MantidQt
-DistributionFlag.DistributionDefault = mantidqtpython.MantidQt.DistributionDefault
-DistributionFlag.DistributionTrue = mantidqtpython.MantidQt.DistributionTrue
-DistributionFlag.DistributionFalse = mantidqtpython.MantidQt.DistributionFalse
+DistrFlag = mantidqtpython.MantidQt
+DistrFlag.DistrDefault = mantidqtpython.MantidQt.DistributionDefault
+DistrFlag.DistrTrue = mantidqtpython.MantidQt.DistributionTrue
+DistrFlag.DistrFalse = mantidqtpython.MantidQt.DistributionFalse
 
 # -----------------------------------------------------------------------------
 # --------------------------- "Private" functions -----------------------------

--- a/MantidPlot/pymantidplot/__init__.py
+++ b/MantidPlot/pymantidplot/__init__.py
@@ -398,7 +398,7 @@ def fitBrowser():
 
 
 # -----------------------------------------------------------------------------
-def plotBin(source, indices, distribution=mantidqtpython.MantidQt.DistributionDefault, error_bars=False, type=-1, window=None, clearWindow=False,
+def plotBin(source, indices, error_bars=False, type=-1, window=None, clearWindow=False,
             waterfall=False):
     """Create a 1D Plot of bin count vs spectrum in a workspace.
 
@@ -440,7 +440,7 @@ def plotBin(source, indices, distribution=mantidqtpython.MantidQt.DistributionDe
         window = window._getHeldObject()
 
     graph = proxies.Graph(threadsafe_call(_qti.app.mantidUI.plot1D,
-                                          workspace_names, index_list, False, distribution, error_bars,
+                                          workspace_names, index_list, False, mantidqtpython.MantidQt.DistributionDefault, error_bars,
                                           type, window, clearWindow, waterfall))
     if graph._getHeldObject() == None:
         raise RuntimeError("Cannot create graph, see log for details.")

--- a/MantidPlot/pymantidplot/pyplot.py
+++ b/MantidPlot/pymantidplot/pyplot.py
@@ -1344,14 +1344,13 @@ def plot_bin(workspaces, indices, *args, **kwargs):
     # Find optional params to plotBin
     bars_val = __translate_error_bars_kwarg(**kwargs)
     window_val, clearWindow_val = __translate_hold_kwarg(**kwargs)
-    dist_val = __translate_distribution_kwarg(**kwargs)
 
     # to change properties on the new lines being added
     first_line = 0
     if None != window_val:
         first_line = window_val.activeLayer().numCurves()
 
-    graph = mantidplot.plotBin(workspaces, indices, dist_val, error_bars=bars_val, type=-1, window=window_val, clearWindow=clearWindow_val)
+    graph = mantidplot.plotBin(workspaces, indices, error_bars=bars_val, type=-1, window=window_val, clearWindow=clearWindow_val)
 
     __apply_plot_args(graph, first_line, *args)
     __apply_plot_kwargs(graph, first_line, **kwargs)

--- a/MantidPlot/pymantidplot/pyplot.py
+++ b/MantidPlot/pymantidplot/pyplot.py
@@ -1227,7 +1227,7 @@ def __translate_distribution_kwarg(**kwargs):
     # distribution param
     distr_val = False
     distr_name = 'distribution'
-    missing_off = mantidqtpython.DistributionDefault
+    missing_off = mantidqtpython.ManidQt.DistributionDefault
     str_val = kwargs.get(distr_name, missing_off)
     if str_val != missing_off and str_val == 'DistributionTrue':
         distr_val = mantidqtpython.DistributionTrue
@@ -1344,14 +1344,14 @@ def plot_bin(workspaces, indices, *args, **kwargs):
     # Find optional params to plotBin
     bars_val = __translate_error_bars_kwarg(**kwargs)
     window_val, clearWindow_val = __translate_hold_kwarg(**kwargs)
-    #dist_val = __translate_distribution_kwarg(**kwargs)
+    dist_val = __translate_distribution_kwarg(**kwargs)
 
     # to change properties on the new lines being added
     first_line = 0
     if None != window_val:
         first_line = window_val.activeLayer().numCurves()
 
-    graph = mantidplot.plotBin(workspaces, indices, error_bars=bars_val, type=-1, window=window_val, clearWindow=clearWindow_val)
+    graph = mantidplot.plotBin(workspaces, indices, dist_val, error_bars=bars_val, type=-1, window=window_val, clearWindow=clearWindow_val)
 
     __apply_plot_args(graph, first_line, *args)
     __apply_plot_kwargs(graph, first_line, **kwargs)

--- a/MantidPlot/pymantidplot/pyplot.py
+++ b/MantidPlot/pymantidplot/pyplot.py
@@ -1227,7 +1227,7 @@ def __translate_distribution_kwarg(**kwargs):
     # distribution param
     distr_val = False
     distr_name = 'distribution'
-    missing_off = mantidqtpython.ManidQt.DistributionDefault
+    missing_off = mantidqtpython.MantidQt.DistributionDefault
     str_val = kwargs.get(distr_name, missing_off)
     if str_val != missing_off and str_val == 'DistributionTrue':
         distr_val = mantidqtpython.DistributionTrue

--- a/MantidPlot/pymantidplot/pyplot.py
+++ b/MantidPlot/pymantidplot/pyplot.py
@@ -1,4 +1,4 @@
-"""============================================================================
+﻿"""============================================================================
 New Python command line interface for plotting in Mantid (a la matplotlib)
 ============================================================================
 
@@ -460,6 +460,7 @@ from mantid.api import mtd
 #    return __is_workspace(arg) or (mantid.api.mtd.doesExist(arg) and isinstance(mantid.api.mtd[arg], mantid.api.IMDWorkspace))
 from mantid.simpleapi import CreateWorkspace as CreateWorkspace
 import mantidplot  
+import mantidqtpython
 
 class Line2D():
     """
@@ -1213,6 +1214,28 @@ def __translate_error_bars_kwarg(**kwargs):
 
     return bars_val
 
+def __translate_distribution_kwarg(**kwargs):
+    """
+    Helper function to translate from distribution=DistributionDefault/DistributionTrue/DistributionFalse kwarg to a
+    mantidplot distribution argument
+
+    @param kwargs :: keyword arguments passed to a plot function. This function only cares about 'distribution'.
+
+    Returns :: DistributionDefault/DistributionTrue/DistributionFalse value for distribution, to be used with plotSpectrum, plotBin, etc.
+
+    """
+    # distribution param
+    distr_val = False
+    distr_name = 'distribution'
+    missing_off = mantidqtpython.DistributionDefault
+    str_val = kwargs.get(distr_name, missing_off)
+    if str_val != missing_off and str_val == 'DistributionTrue':
+        distr_val = mantidqtpython.DistributionTrue
+    elif str_val != missing_off and str_val == 'DistributionFalse':
+        distr_val = mantidqtpython.DistributionFalse
+
+    return distr_val
+
 def __plot_as_workspace(*args, **kwargs):
     """
         plot spectrum via qti plotting framework to plot a workspace.
@@ -1321,6 +1344,7 @@ def plot_bin(workspaces, indices, *args, **kwargs):
     # Find optional params to plotBin
     bars_val = __translate_error_bars_kwarg(**kwargs)
     window_val, clearWindow_val = __translate_hold_kwarg(**kwargs)
+    #dist_val = __translate_distribution_kwarg(**kwargs)
 
     # to change properties on the new lines being added
     first_line = 0
@@ -1374,6 +1398,7 @@ def plot_spectrum(workspaces, indices, *args, **kwargs):
     """
     # Find optional params to plotSpectrum
     bars_val = __translate_error_bars_kwarg(**kwargs)
+    distr_val = __translate_distribution_kwarg(**kwargs)
     window_val, clearWindow_val = __translate_hold_kwarg(**kwargs)
 
     # to change properties on the new lines being added

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3006,32 +3006,35 @@ Plots the spectra from the given workspaces
 @param clearWindow :: Whether to clear specified plotWindow before plotting. Ignored if plotWindow == NULL
 @param waterfallPlot :: If true create a waterfall type plot
 */
-MultiLayer* MantidUI::plot1D(const QStringList& ws_names, const QList<int>& indexList, bool spectrumPlot, bool errs,
-                             Graph::CurveType style, MultiLayer* plotWindow, bool clearWindow, bool waterfallPlot)
+MultiLayer *MantidUI::plot1D(const QStringList &ws_names, const QList<int> &indexList,
+					bool spectrumPlot, MantidQt::DistributionFlag distr,
+					bool errs, Graph::CurveType style, MultiLayer *plotWindow, 
+					bool clearWindow, bool waterfallPlot)
 {
-  // Convert the list into a map (with the same workspace as key in each case)
-  QMultiMap<QString,int> pairs;
-  QListIterator<QString> ws_itr(ws_names);
-  ws_itr.toBack();
-  QListIterator<int> spec_itr(indexList);
-  spec_itr.toBack();
+	// Convert the list into a map (with the same workspace as key in each case)
+	QMultiMap<QString, int> pairs;
+	QListIterator<QString> ws_itr(ws_names);
+	ws_itr.toBack();
+	QListIterator<int> spec_itr(indexList);
+	spec_itr.toBack();
 
-  // Need to iterate through the set in reverse order to get the curves in the correct order on the plot
-  while( ws_itr.hasPrevious() )
-  {
-    QString workspace_name = ws_itr.previous();
-    while( spec_itr.hasPrevious() )
-    {
-      pairs.insert(workspace_name, spec_itr.previous());
-    }
-    //Reset spectrum index pointer
-    spec_itr.toBack();
-  }
+	// Need to iterate through the set in reverse order to get the curves in the correct order on the plot
+	while (ws_itr.hasPrevious())
+	{
+		QString workspace_name = ws_itr.previous();
+		while (spec_itr.hasPrevious())
+		{
+			pairs.insert(workspace_name, spec_itr.previous());
+		}
+		//Reset spectrum index pointer
+		spec_itr.toBack();
+	}
 
-  // Pass over to the overloaded method
-  return plot1D(pairs,spectrumPlot,MantidQt::DistributionDefault, errs,style,plotWindow, clearWindow,
-                waterfallPlot);
+	// Pass over to the overloaded method
+	return plot1D(pairs, spectrumPlot, distr, errs, style, plotWindow, clearWindow,
+		waterfallPlot);
 }
+
 /** Create a 1D graph from the specified list of workspaces/spectra.
 @param toPlot :: Map of form ws -> [spectra_list]
 @param spectrumPlot :: True if indices should be interpreted as row indices

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3000,6 +3000,7 @@ Plots the spectra from the given workspaces
 @param ws_names :: List of ws names to plot
 @param indexList :: List of indices to plot for each workspace
 @param spectrumPlot :: True if indices should be interpreted as row indices
+@param distr :: if true, workspace plot as y data/bin width
 @param errs :: If true include the errors on the graph
 @param style :: Curve style for plot
 @param plotWindow :: Window to plot to. If NULL a new one will be created

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -210,9 +210,11 @@ public:
 
   public slots:
     // Create a 1d graph form specified MatrixWorkspace and index
-  MultiLayer* plot1D(const QStringList& wsnames, const QList<int>& indexList, bool spectrumPlot,
-                     bool errs=true, Graph::CurveType style = Graph::Unspecified,
-                     MultiLayer* plotWindow = NULL, bool clearWindow = false, bool waterfallPlot = false);
+  MultiLayer *plot1D(const QStringList &wsnames, const QList<int> &indexList, bool spectrumPlot,
+					 MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
+					 bool errs = true, Graph::CurveType style = Graph::Unspecified,
+					 MultiLayer *plotWindow = NULL, bool clearWindow = false,
+					 bool waterfallPlot = false);
 
   MultiLayer* plot1D(const QString& wsName, const std::set<int>& indexList, bool spectrumPlot,
                      MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -1688,9 +1688,11 @@ sipClass=sipFindClass(sipCpp->className());
 
 public:
   // Plotting methods
-  MultiLayer* plot1D(const QList<QString>& wsnames, const QList<int>&, bool spectrumPlot, bool errs=false,
-    Graph::CurveType style = Graph::Unspecified, MultiLayer* window = NULL,
-                     bool clearWindow = false, bool waterfallPlot = false);
+  MultiLayer *plot1D(const QList<QString> &wsnames, const QList<int> &, bool spectrumPlot,
+					 MantidQt::DistributionFlag distr = MantidQt::DistributionDefault,
+					 bool errs = true, Graph::CurveType style = Graph::Unspecified,
+					 MultiLayer *plotWindow = NULL, bool clearWindow = false,
+					 bool waterfallPlot = false);
 
   MultiLayer* drawSingleColorFillPlot(const QString & name, Graph::CurveType style = Graph::ColorMap,
                                       MultiLayer* window = NULL);

--- a/MantidPlot/src/qti.sip
+++ b/MantidPlot/src/qti.sip
@@ -694,6 +694,15 @@ namespace GraphOptions
   enum Axis{Left, Right, Bottom, Top};
 };
 
+namespace MantidQt 
+{
+%TypeHeaderCode 
+#include "MantidQtAPI/DistributionOptions.h"
+%End
+
+	enum DistributionFlag {DistributionDefault, DistributionTrue, DistributionFalse};  
+};
+
 class Graph : QWidget /PyName=Layer/
 {
 %TypeHeaderCode

--- a/MantidQt/API/CMakeLists.txt
+++ b/MantidQt/API/CMakeLists.txt
@@ -82,6 +82,7 @@ set ( INC_FILES
 	inc/MantidQtAPI/DllOption.h
 	inc/MantidQtAPI/FileDialogHandler.h
 	inc/MantidQtAPI/GraphOptions.h
+    inc/MantidQtAPI/DistributionOptions.h
 	inc/MantidQtAPI/HelpWindow.h
 	inc/MantidQtAPI/InterfaceFactory.h
 	inc/MantidQtAPI/InterfaceManager.h

--- a/MantidQt/API/inc/MantidQtAPI/DistributionOptions.h
+++ b/MantidQt/API/inc/MantidQtAPI/DistributionOptions.h
@@ -1,0 +1,18 @@
+#ifndef DISTRIBUTIONOPTIONS_H_
+#define DISTRIBUTIONOPTIONS_H_
+
+/**
+* This file contains declarations of options which control 
+* normalization of mantid curves.
+*/
+namespace MantidQt {
+
+	// Enumerate how to handle distributions
+	enum DistributionFlag {
+		DistributionDefault = 0, // Use preferences value
+		DistributionTrue,        // Force distribution plotting
+		DistributionFalse        // Disable distribution plotting
+	};
+}
+
+#endif //DISTRIBUTIONOPTIONS_H_

--- a/MantidQt/API/inc/MantidQtAPI/QwtWorkspaceSpectrumData.h
+++ b/MantidQt/API/inc/MantidQtAPI/QwtWorkspaceSpectrumData.h
@@ -2,22 +2,13 @@
 #define MANTIDQTAPI_QWTWORKSPACESPECTRUMDATA_H
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "DistributionOptions.h"
 #include "MantidKernel/cow_ptr.h"
 #include "MantidQtAPI/MantidQwtWorkspaceData.h"
 #include "DllOption.h"
 
 #include <boost/shared_ptr.hpp>
 #include <QString>
-
-namespace MantidQt {
-
-// Enumerate how to handle distributions
-enum DistributionFlag {
-  DistributionDefault = 0, // Use preferences value
-  DistributionTrue,        // Force distribution plotting
-  DistributionFalse        // Disable distribution plotting
-};
-}
 
 //=================================================================================================
 //=================================================================================================

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -70,7 +70,7 @@
 namespace MantidQt 
 {
 %TypeHeaderCode 
-#include "MantidQtAPI/QwtWorkspaceSpectrumData.h"
+#include "MantidQtAPI/DistributionOptions.h"
 %End
 
 	enum DistributionFlag {DistributionDefault, DistributionTrue, DistributionFalse};  

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -66,17 +66,6 @@
 %End
 };
 
-
-namespace MantidQt 
-{
-%TypeHeaderCode 
-#include "MantidQtAPI/DistributionOptions.h"
-%End
-
-	enum DistributionFlag {DistributionDefault, DistributionTrue, DistributionFalse};  
-};
-
-
 namespace Mantid
 {
 namespace API

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -67,11 +67,20 @@
 };
 
 
+namespace MantidQt 
+{
+%TypeHeaderCode 
+#include "MantidQtAPI/QwtWorkspaceSpectrumData.h"
+%End
+
+	enum DistributionFlag {DistributionDefault, DistributionTrue, DistributionFalse};  
+};
+
+
 namespace Mantid
 {
 namespace API
 {
-
 
 enum MDNormalization
 {


### PR DESCRIPTION
Resolves #13751 
- [x] The [release notes](http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Python) have been updated.
  ## Changes

Added the ability control plot normalization from python. A distribution keyword argument has been added to the python plotSpectrum function and the function exposed to qti.sip has been modified to reflect this change.
## Testing

Code Review and run the following script (compare with doing this by hand):

``` python
ws = Load(Filename="MUSR00022725.nxs")
plotSpectrum(source="ws", indices= 0, distribution=DistrFlag.DistrTrue)
plotSpectrum(source="ws", indices= 0, distribution=DistrFlag.DistrFalse)
```
