### PR TITLE
Fix cpp-check warning: condition always true.

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -747,8 +747,7 @@ void SCDCalibratePanels::exec() {
 
     //---------- setup ties ----------------------------------
     tie(iFunc, !use_PanelWidth, "f0_detWidthScale", detWidthScale0);
-    tie(iFunc, !use_PanelHeight, "f0_detHeightScale",
-        detHeightScale0);
+    tie(iFunc, !use_PanelHeight, "f0_detHeightScale", detHeightScale0);
     tie(iFunc, !use_PanelPosition, "f0_Xoffset", Xoffset0);
     tie(iFunc, !use_PanelPosition, "f0_Yoffset", Yoffset0);
     tie(iFunc, !use_PanelPosition, "f0_Zoffset", Zoffset0);
@@ -760,11 +759,9 @@ void SCDCalibratePanels::exec() {
     constrain(iFunc, "l0", (MIN_DET_HW_SCALE * L0), (MAX_DET_HW_SCALE * L0));
     constrain(iFunc, "t0", -5., 5.);
 
-    constrain(iFunc, "f0_detWidthScale",
-              MIN_DET_HW_SCALE * detWidthScale0,
+    constrain(iFunc, "f0_detWidthScale", MIN_DET_HW_SCALE * detWidthScale0,
               MAX_DET_HW_SCALE * detWidthScale0);
-    constrain(iFunc, "f0_detHeightScale",
-              MIN_DET_HW_SCALE * detHeightScale0,
+    constrain(iFunc, "f0_detHeightScale", MIN_DET_HW_SCALE * detHeightScale0,
               MAX_DET_HW_SCALE * detHeightScale0);
     constrain(iFunc, "f0_Xoffset", -1. * maxXYOffset + Xoffset0,
               maxXYOffset + Xoffset0);
@@ -928,13 +925,11 @@ void SCDCalibratePanels::exec() {
       Quat newRelRot = Quat(rotx, V3D(1, 0, 0)) * Quat(roty, V3D(0, 1, 0)) *
                        Quat(rotz, V3D(0, 0, 1)); //*RelRot;
 
-      FixUpBankParameterMap((banksVec), NewInstrument,
-                            V3D(result["f0_Xoffset"],
-                                result["f0_Yoffset"],
-                                result["f0_Zoffset"]),
-                            newRelRot, result["f0_detWidthScale"],
-                            result["f0_detHeightScale"], pmapOld,
-                            getProperty("RotateCenters"));
+      FixUpBankParameterMap(
+          (banksVec), NewInstrument,
+          V3D(result["f0_Xoffset"], result["f0_Yoffset"], result["f0_Zoffset"]),
+          newRelRot, result["f0_detWidthScale"], result["f0_detHeightScale"],
+          pmapOld, getProperty("RotateCenters"));
 
       //} // For @ group
 

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -706,9 +706,6 @@ void SCDCalibratePanels::exec() {
     iFunc->setParameter("t0", T0);
 
     double maxXYOffset = getProperty("MaxPositionChange_meters");
-    int i = -1; // position in ParamResults Array.
-    // for (auto group = Groups.begin(); group != Groups.end(); ++group) {
-    i++;
 
     boost::shared_ptr<const RectangularDetector> bank_rect;
     string paramPrefix = "f" + boost::lexical_cast<string>(i) + "_";
@@ -761,10 +758,8 @@ void SCDCalibratePanels::exec() {
     tie(iFunc, !use_PanelOrientation, paramPrefix + "Zrot", Zrot0);
 
     //--------------- setup constraints ------------------------------
-    if (i == 0) {
-      constrain(iFunc, "l0", (MIN_DET_HW_SCALE * L0), (MAX_DET_HW_SCALE * L0));
-      constrain(iFunc, "t0", -5., 5.);
-    }
+    constrain(iFunc, "l0", (MIN_DET_HW_SCALE * L0), (MAX_DET_HW_SCALE * L0));
+    constrain(iFunc, "t0", -5., 5.);
 
     constrain(iFunc, paramPrefix + "detWidthScale",
               MIN_DET_HW_SCALE * detWidthScale0,

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -708,7 +708,6 @@ void SCDCalibratePanels::exec() {
     double maxXYOffset = getProperty("MaxPositionChange_meters");
 
     boost::shared_ptr<const RectangularDetector> bank_rect;
-    string paramPrefix = "f" + boost::lexical_cast<string>(i) + "_";
 
     string name = group->front();
     boost::shared_ptr<const IComponent> bank_cmp =
@@ -729,14 +728,14 @@ void SCDCalibratePanels::exec() {
                    Zrot0);
 
     // --- set Function property ----------------------
-    iFunc->setParameter(paramPrefix + "detWidthScale", detWidthScale0);
-    iFunc->setParameter(paramPrefix + "detHeightScale", detHeightScale0);
-    iFunc->setParameter(paramPrefix + "Xoffset", Xoffset0);
-    iFunc->setParameter(paramPrefix + "Yoffset", Yoffset0);
-    iFunc->setParameter(paramPrefix + "Zoffset", Zoffset0);
-    iFunc->setParameter(paramPrefix + "Xrot", Xrot0);
-    iFunc->setParameter(paramPrefix + "Yrot", Yrot0);
-    iFunc->setParameter(paramPrefix + "Zrot", Zrot0);
+    iFunc->setParameter("f0_detWidthScale", detWidthScale0);
+    iFunc->setParameter("f0_detHeightScale", detHeightScale0);
+    iFunc->setParameter("f0_Xoffset", Xoffset0);
+    iFunc->setParameter("f0_Yoffset", Yoffset0);
+    iFunc->setParameter("f0_Zoffset", Zoffset0);
+    iFunc->setParameter("f0_Xrot", Xrot0);
+    iFunc->setParameter("f0_Yrot", Yrot0);
+    iFunc->setParameter("f0_Zrot", Zrot0);
 
     int startX = bounds[0];
     int endXp1 = bounds[group->size()];
@@ -747,37 +746,37 @@ void SCDCalibratePanels::exec() {
     }
 
     //---------- setup ties ----------------------------------
-    tie(iFunc, !use_PanelWidth, paramPrefix + "detWidthScale", detWidthScale0);
-    tie(iFunc, !use_PanelHeight, paramPrefix + "detHeightScale",
+    tie(iFunc, !use_PanelWidth, "f0_detWidthScale", detWidthScale0);
+    tie(iFunc, !use_PanelHeight, "f0_detHeightScale",
         detHeightScale0);
-    tie(iFunc, !use_PanelPosition, paramPrefix + "Xoffset", Xoffset0);
-    tie(iFunc, !use_PanelPosition, paramPrefix + "Yoffset", Yoffset0);
-    tie(iFunc, !use_PanelPosition, paramPrefix + "Zoffset", Zoffset0);
-    tie(iFunc, !use_PanelOrientation, paramPrefix + "Xrot", Xrot0);
-    tie(iFunc, !use_PanelOrientation, paramPrefix + "Yrot", Yrot0);
-    tie(iFunc, !use_PanelOrientation, paramPrefix + "Zrot", Zrot0);
+    tie(iFunc, !use_PanelPosition, "f0_Xoffset", Xoffset0);
+    tie(iFunc, !use_PanelPosition, "f0_Yoffset", Yoffset0);
+    tie(iFunc, !use_PanelPosition, "f0_Zoffset", Zoffset0);
+    tie(iFunc, !use_PanelOrientation, "f0_Xrot", Xrot0);
+    tie(iFunc, !use_PanelOrientation, "f0_Yrot", Yrot0);
+    tie(iFunc, !use_PanelOrientation, "f0_Zrot", Zrot0);
 
     //--------------- setup constraints ------------------------------
     constrain(iFunc, "l0", (MIN_DET_HW_SCALE * L0), (MAX_DET_HW_SCALE * L0));
     constrain(iFunc, "t0", -5., 5.);
 
-    constrain(iFunc, paramPrefix + "detWidthScale",
+    constrain(iFunc, "f0_detWidthScale",
               MIN_DET_HW_SCALE * detWidthScale0,
               MAX_DET_HW_SCALE * detWidthScale0);
-    constrain(iFunc, paramPrefix + "detHeightScale",
+    constrain(iFunc, "f0_detHeightScale",
               MIN_DET_HW_SCALE * detHeightScale0,
               MAX_DET_HW_SCALE * detHeightScale0);
-    constrain(iFunc, paramPrefix + "Xoffset", -1. * maxXYOffset + Xoffset0,
+    constrain(iFunc, "f0_Xoffset", -1. * maxXYOffset + Xoffset0,
               maxXYOffset + Xoffset0);
-    constrain(iFunc, paramPrefix + "Yoffset", -1. * maxXYOffset + Yoffset0,
+    constrain(iFunc, "f0_Yoffset", -1. * maxXYOffset + Yoffset0,
               maxXYOffset + Yoffset0);
-    constrain(iFunc, paramPrefix + "Zoffset", -1. * maxXYOffset + Zoffset0,
+    constrain(iFunc, "f0_Zoffset", -1. * maxXYOffset + Zoffset0,
               maxXYOffset + Zoffset0);
 
     double MaxRotOffset = getProperty("MaxRotationChangeDegrees");
-    constrain(iFunc, paramPrefix + "Xrot", -1. * MaxRotOffset, MaxRotOffset);
-    constrain(iFunc, paramPrefix + "Yrot", -1. * MaxRotOffset, MaxRotOffset);
-    constrain(iFunc, paramPrefix + "Zrot", -1. * MaxRotOffset, MaxRotOffset);
+    constrain(iFunc, "f0_Xrot", -1. * MaxRotOffset, MaxRotOffset);
+    constrain(iFunc, "f0_Yrot", -1. * MaxRotOffset, MaxRotOffset);
+    constrain(iFunc, "f0_Zrot", -1. * MaxRotOffset, MaxRotOffset);
     //} // for vector< string > in Groups
 
     // Function supports setting the sample position even when it isn't be
@@ -919,30 +918,22 @@ void SCDCalibratePanels::exec() {
       boost::shared_ptr<const Instrument> NewInstrument(
           new Instrument(instrument->baseInstrument(), pmap));
 
-      i = -1;
-
-      /*for (vector<vector<string>>::iterator itv = Groups.begin();
-           itv != Groups.end(); ++itv) {*/
-      i++;
-
       boost::shared_ptr<const RectangularDetector> bank_rect;
       double rotx, roty, rotz;
 
-      string prefix = "f" + boost::lexical_cast<string>(i) + "_";
-
-      rotx = result[prefix + "Xrot"];
-      roty = result[prefix + "Yrot"];
-      rotz = result[prefix + "Zrot"];
+      rotx = result["f0_Xrot"];
+      roty = result["f0_Yrot"];
+      rotz = result["f0_Zrot"];
 
       Quat newRelRot = Quat(rotx, V3D(1, 0, 0)) * Quat(roty, V3D(0, 1, 0)) *
                        Quat(rotz, V3D(0, 0, 1)); //*RelRot;
 
       FixUpBankParameterMap((banksVec), NewInstrument,
-                            V3D(result[prefix + "Xoffset"],
-                                result[prefix + "Yoffset"],
-                                result[prefix + "Zoffset"]),
-                            newRelRot, result[prefix + "detWidthScale"],
-                            result[prefix + "detHeightScale"], pmapOld,
+                            V3D(result["f0_Xoffset"],
+                                result["f0_Yoffset"],
+                                result["f0_Zoffset"]),
+                            newRelRot, result["f0_detWidthScale"],
+                            result["f0_detHeightScale"], pmapOld,
                             getProperty("RotateCenters"));
 
       //} // For @ group


### PR DESCRIPTION
This fixes a recently introduced [cpp-check warning](http://builds.mantidproject.org/view/Static%20Analysis/job/cppcheck-1.71/862/cppcheckResult/source.8/#754) that `if( i==0 )` is always true. 

no release notes

testing: Check that the unit tests still pass.
