### PR TITLE
SpecularReflectionCalculateTheta now output TwoTheta 

### DIFF
--- a/Framework/Algorithms/src/SpecularReflectionCalculateTheta.cpp
+++ b/Framework/Algorithms/src/SpecularReflectionCalculateTheta.cpp
@@ -85,7 +85,7 @@ void SpecularReflectionCalculateTheta::exec() {
   const double beamoffset =
       refFrame->vecPointingAlongBeam().scalar_prod(detSample);
 
-  const double twoTheta = std::atan(upoffset / beamoffset) * 180 / M_PI;
+  const double twoTheta = 2 * std::atan(upoffset / beamoffset) * 180 / M_PI;
 
   std::stringstream strstream;
   strstream << "Recalculated two theta as: " << twoTheta;

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -144,7 +144,7 @@ public:
 
     const double outTheta = alg->getProperty("ThetaOut");
 
-    TS_ASSERT_DELTA(45.0 / 2, outTheta, 0.00001);
+    TS_ASSERT_DELTA(45.0, outTheta, 0.00001);
   }
 };
 

--- a/Framework/Algorithms/test/SpecularReflectionCalculateThetaTest.h
+++ b/Framework/Algorithms/test/SpecularReflectionCalculateThetaTest.h
@@ -14,8 +14,8 @@ using namespace Mantid::API;
 // clang-format off
 class SpecularReflectionCalculateThetaTest: public CxxTest::TestSuite,
     public SpecularReflectionAlgorithmTest
-      // clang-format on
-      {
+// clang-format on
+{
 
 private:
   Mantid::API::IAlgorithm_sptr makeAlgorithm() const {
@@ -100,7 +100,7 @@ public:
 
     // Based on the current positions, calculate the current incident theta.
     const double currentTwoThetaInRad =
-        std::atan(sampleToDetectorVerticalOffset / sampleToDetectorBeamOffset);
+        2 * std::atan(sampleToDetectorVerticalOffset / sampleToDetectorBeamOffset);
     const double currentTwoThetaInDeg = currentTwoThetaInRad * (180.0 / M_PI);
 
     IAlgorithm_sptr alg = this->makeAlgorithm();

--- a/Framework/Algorithms/test/SpecularReflectionCalculateThetaTest.h
+++ b/Framework/Algorithms/test/SpecularReflectionCalculateThetaTest.h
@@ -14,8 +14,8 @@ using namespace Mantid::API;
 // clang-format off
 class SpecularReflectionCalculateThetaTest: public CxxTest::TestSuite,
     public SpecularReflectionAlgorithmTest
-// clang-format on
-{
+      // clang-format on
+      {
 
 private:
   Mantid::API::IAlgorithm_sptr makeAlgorithm() const {
@@ -100,7 +100,8 @@ public:
 
     // Based on the current positions, calculate the current incident theta.
     const double currentTwoThetaInRad =
-        2 * std::atan(sampleToDetectorVerticalOffset / sampleToDetectorBeamOffset);
+        2 *
+        std::atan(sampleToDetectorVerticalOffset / sampleToDetectorBeamOffset);
     const double currentTwoThetaInDeg = currentTwoThetaInRad * (180.0 / M_PI);
 
     IAlgorithm_sptr alg = this->makeAlgorithm();

--- a/docs/source/algorithms/SpecularReflectionCalculateTheta-v1.rst
+++ b/docs/source/algorithms/SpecularReflectionCalculateTheta-v1.rst
@@ -46,7 +46,7 @@ Output:
 
 .. testoutput:: SpecularReflectionCalculateThetaPointDetectorExample 
  
-   45.0
+   90.0
   
 .. categories::
 


### PR DESCRIPTION
Changes involved multiplying the output of SpecularReflectionCalculateTheta by a factor of 2 before it is set as the output property.

**To Test**:
This might be difficult to test, as we can't add detectors into an instrument using python and I don't think there are any instruments that have the setup displayed in the issue description.
- Code Review to make sure this change makes sense
- Make sure that the reflectometry algorithms that use this calculation still function properly
  and display the right results.

**Release Notes**: //todo

Fixes #14757
