### PR TITLE
Algorithms updated to use std::initializer_list in FileProperties

### DIFF
--- a/Framework/Algorithms/src/AlignDetectors.cpp
+++ b/Framework/Algorithms/src/AlignDetectors.cpp
@@ -416,8 +416,8 @@ void AlignDetectors::execEvent() {
   if (outputWS->getTofMin() < 0.) {
     std::stringstream msg;
     msg << "Something wrong with the calibration. Negative minimum d-spacing "
-           "created. d_min = "
-        << outputWS->getTofMin() << " d_max " << outputWS->getTofMax();
+           "created. d_min = " << outputWS->getTofMin() << " d_max "
+        << outputWS->getTofMax();
     g_log.warning(msg.str());
   }
   outputWS->clearMRU();

--- a/Framework/Algorithms/src/AlignDetectors.cpp
+++ b/Framework/Algorithms/src/AlignDetectors.cpp
@@ -177,13 +177,9 @@ void AlignDetectors::init() {
                       "OutputWorkspace", "", Direction::Output),
                   "The name to use for the output workspace");
 
-  std::vector<std::string> exts;
-  exts.push_back(".h5");
-  exts.push_back(".hd5");
-  exts.push_back(".hdf");
-  exts.push_back(".cal");
   declareProperty(
-      new FileProperty("CalibrationFile", "", FileProperty::OptionalLoad, exts),
+      new FileProperty("CalibrationFile", "", FileProperty::OptionalLoad,
+                       {".h5", ".hd5", ".hdf", ".cal"}),
       "Optional: The .cal file containing the position correction factors. "
       "Either this or OffsetsWorkspace needs to be specified.");
 
@@ -420,8 +416,8 @@ void AlignDetectors::execEvent() {
   if (outputWS->getTofMin() < 0.) {
     std::stringstream msg;
     msg << "Something wrong with the calibration. Negative minimum d-spacing "
-           "created. d_min = " << outputWS->getTofMin() << " d_max "
-        << outputWS->getTofMax();
+           "created. d_min = "
+        << outputWS->getTofMin() << " d_max " << outputWS->getTofMax();
     g_log.warning(msg.str());
   }
   outputWS->clearMRU();

--- a/Framework/Algorithms/src/FixGSASInstrumentFile.cpp
+++ b/Framework/Algorithms/src/FixGSASInstrumentFile.cpp
@@ -40,10 +40,10 @@ FixGSASInstrumentFile::~FixGSASInstrumentFile() {}
 /** Implement abstract Algorithm methods
  */
 void FixGSASInstrumentFile::init() {
+
+  std::initializer_list<std::string> exts = {".prm", ".iparm"};
+
   // Input file
-  vector<std::string> exts;
-  exts.push_back(".prm");
-  exts.push_back(".iparm");
   declareProperty(
       new FileProperty("InputFilename", "", FileProperty::Load, exts),
       "Name of the GSAS instrument parameter file to get fixed for format. ");

--- a/Framework/Algorithms/src/ReadGroupsFromFile.cpp
+++ b/Framework/Algorithms/src/ReadGroupsFromFile.cpp
@@ -52,11 +52,9 @@ void ReadGroupsFromFile::init() {
                   "workspace.");
 
   // The calibration file that contains the grouping information
-  std::vector<std::string> exts;
-  exts.push_back(".cal");
-  exts.push_back(".xml");
   declareProperty(
-      new FileProperty("GroupingFileName", "", FileProperty::Load, exts),
+      new FileProperty("GroupingFileName", "", FileProperty::Load,
+                       {".cal", ".xml"}),
       "Either as a XML grouping file (see [[GroupDetectors]]) or as a "
       "[[CalFile]] (.cal extension).");
   // Flag to consider unselected detectors in the cal file

--- a/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
+++ b/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp
@@ -73,12 +73,9 @@ void VesuvioL1ThetaResolution::init() {
   auto positiveDouble = boost::make_shared<Kernel::BoundedValidator<double>>();
   positiveDouble->setLower(DBL_EPSILON);
 
-  std::vector<std::string> exts;
-  exts.push_back(".par");
-  exts.push_back(".dat");
   declareProperty(new FileProperty("PARFile", "",
-                                   FileProperty::FileAction::OptionalLoad, exts,
-                                   Direction::Input),
+                                   FileProperty::FileAction::OptionalLoad,
+                                   {".par", ".dat"}, Direction::Input),
                   "PAR file containing calibrated detector positions.");
 
   declareProperty("SampleWidth", 3.0, positiveDouble, "With of sample in cm.");

--- a/Framework/Crystal/src/LoadHKL.cpp
+++ b/Framework/Crystal/src/LoadHKL.cpp
@@ -33,11 +33,9 @@ LoadHKL::~LoadHKL() {}
 /** Initialize the algorithm's properties.
  */
 void LoadHKL::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".hkl");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "Path to an hkl file to save.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".hkl"}),
+      "Path to an hkl file to save.");
 
   declareProperty(new WorkspaceProperty<PeaksWorkspace>("OutputWorkspace", "",
                                                         Direction::Output),

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -88,11 +88,9 @@ int LoadIsawPeaks::confidence(Kernel::FileDescriptor &descriptor) const {
 /** Initialize the algorithm's properties.
  */
 void LoadIsawPeaks::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".peaks");
-  exts.push_back(".integrate");
 
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".peaks", ".integrate"}),
                   "Path to an ISAW-style .peaks filename.");
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output),

--- a/Framework/Crystal/src/LoadIsawUB.cpp
+++ b/Framework/Crystal/src/LoadIsawUB.cpp
@@ -38,12 +38,8 @@ void LoadIsawUB::init() {
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::InOut),
       "An input workspace to which to add the lattice information.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".mat");
-  exts.push_back(".ub");
-  exts.push_back(".txt");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".mat", ".ub", ".txt"}),
                   "Path to an ISAW-style UB matrix text file.");
 
   declareProperty("CheckUMatrix", true, "If True (default) then a check is "

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -625,7 +625,8 @@ void SCDCalibratePanels::exec() {
     }
     if (!GoodStart(peaksWs, a, b, c, alpha, beta, gamma, tolerance)) {
       g_log.warning() << "**** Indexing is NOT compatible with given lattice "
-                         "parameters******" << std::endl;
+                         "parameters******"
+                      << std::endl;
       g_log.warning() << "        Index with conventional orientation matrix???"
                       << std::endl;
     }
@@ -1056,7 +1057,8 @@ void SCDCalibratePanels::exec() {
   outfile << std::setw(13) << std::setprecision(3) << stats.mean << std::endl;
   outfile << "4 DETNUM  NROWS  NCOLS   WIDTH   HEIGHT   DEPTH   DETD   CenterX "
              "  CenterY   CenterZ    BaseX    BaseY    BaseZ      UpX      UpY "
-             "     UpZ" << std::endl;
+             "     UpZ"
+          << std::endl;
   for (vector<std::string>::const_iterator itdet = detcal.begin();
        itdet != detcal.end(); ++itdet)
     outfile << *itdet << "\n";
@@ -1408,17 +1410,14 @@ void SCDCalibratePanels::init() {
   setPropertyGroup("InitialTimeOffset", PREPROC);
 
   // ---------- outputs
-  vector<string> exts;
-  exts.push_back(".DetCal");
-  exts.push_back(".Det_Cal");
-  declareProperty(
-      new FileProperty("DetCalFilename", "", FileProperty::OptionalSave, exts),
-      "Path to an ISAW-style .detcal file to save.");
+  declareProperty(new FileProperty("DetCalFilename", "",
+                                   FileProperty::OptionalSave,
+                                   {".DetCal", ".Det_Cal"}),
+                  "Path to an ISAW-style .detcal file to save.");
 
   vector<string> exts1;
-  exts1.push_back(".xml");
   declareProperty(
-      new FileProperty("XmlFilename", "", FileProperty::OptionalSave, exts1),
+      new FileProperty("XmlFilename", "", FileProperty::OptionalSave, {".xml"}),
       "Path to an Mantid .xml description(for LoadParameterFile) file to "
       "save.");
 
@@ -1532,9 +1531,9 @@ void SCDCalibratePanels::CreateFxnGetValues(
   fit->setAttribute("NGroups", IFunction::Attribute(NGroups));
   fit->setAttribute("BankNames", IFunction::Attribute(BankNameString));
 
-  string fieldBase[8] = {"detWidthScale", "detHeightScale", "Xoffset",
-                         "Yoffset",       "Zoffset",        "Xrot",
-                         "Yrot",          "Zrot"};
+  string fieldBase[8] = {
+      "detWidthScale", "detHeightScale", "Xoffset", "Yoffset",
+      "Zoffset",       "Xrot",           "Yrot",    "Zrot"};
   set<string> FieldB(fieldBase, fieldBase + 8);
 
   for (int g = 0; g < NGroups; ++g) {

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -625,8 +625,7 @@ void SCDCalibratePanels::exec() {
     }
     if (!GoodStart(peaksWs, a, b, c, alpha, beta, gamma, tolerance)) {
       g_log.warning() << "**** Indexing is NOT compatible with given lattice "
-                         "parameters******"
-                      << std::endl;
+                         "parameters******" << std::endl;
       g_log.warning() << "        Index with conventional orientation matrix???"
                       << std::endl;
     }
@@ -1057,8 +1056,7 @@ void SCDCalibratePanels::exec() {
   outfile << std::setw(13) << std::setprecision(3) << stats.mean << std::endl;
   outfile << "4 DETNUM  NROWS  NCOLS   WIDTH   HEIGHT   DEPTH   DETD   CenterX "
              "  CenterY   CenterZ    BaseX    BaseY    BaseZ      UpX      UpY "
-             "     UpZ"
-          << std::endl;
+             "     UpZ" << std::endl;
   for (vector<std::string>::const_iterator itdet = detcal.begin();
        itdet != detcal.end(); ++itdet)
     outfile << *itdet << "\n";
@@ -1415,7 +1413,6 @@ void SCDCalibratePanels::init() {
                                    {".DetCal", ".Det_Cal"}),
                   "Path to an ISAW-style .detcal file to save.");
 
-  vector<string> exts1;
   declareProperty(
       new FileProperty("XmlFilename", "", FileProperty::OptionalSave, {".xml"}),
       "Path to an Mantid .xml description(for LoadParameterFile) file to "
@@ -1531,9 +1528,9 @@ void SCDCalibratePanels::CreateFxnGetValues(
   fit->setAttribute("NGroups", IFunction::Attribute(NGroups));
   fit->setAttribute("BankNames", IFunction::Attribute(BankNameString));
 
-  string fieldBase[8] = {
-      "detWidthScale", "detHeightScale", "Xoffset", "Yoffset",
-      "Zoffset",       "Xrot",           "Yrot",    "Zrot"};
+  string fieldBase[8] = {"detWidthScale", "detHeightScale", "Xoffset",
+                         "Yoffset",       "Zoffset",        "Xrot",
+                         "Yrot",          "Zrot"};
   set<string> FieldB(fieldBase, fieldBase + 8);
 
   for (int g = 0; g < NGroups; ++g) {

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -75,10 +75,7 @@ void SaveHKL::init() {
                                    API::FileProperty::OptionalLoad, ".dat"),
                   " Spectrum data read from a spectrum file.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".hkl");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save, { ".hkl" }),
                   "Path to an hkl file to save.");
 
   std::vector<std::string> histoTypes;

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -75,8 +75,9 @@ void SaveHKL::init() {
                                    API::FileProperty::OptionalLoad, ".dat"),
                   " Spectrum data read from a spectrum file.");
 
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, { ".hkl" }),
-                  "Path to an hkl file to save.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Save, {".hkl"}),
+      "Path to an hkl file to save.");
 
   std::vector<std::string> histoTypes;
   histoTypes.push_back("Bank");

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -167,8 +167,7 @@ void SaveIsawPeaks::exec() {
     if (true) {
       out << "4 DETNUM  NROWS  NCOLS   WIDTH   HEIGHT   DEPTH   DETD   CenterX "
              "  CenterY   CenterZ    BaseX    BaseY    BaseZ      UpX      UpY "
-             "     UpZ"
-          << std::endl;
+             "     UpZ" << std::endl;
       // Here would save each detector...
       std::set<int>::iterator it;
       for (it = uniqueBanks.begin(); it != uniqueBanks.end(); ++it) {

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -48,7 +48,8 @@ void SaveIsawPeaks::init() {
   exts.push_back(".peaks");
   exts.push_back(".integrate");
 
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save,
+                                   {".peaks", ".integrate"}),
                   "Path to an ISAW-style peaks or integrate file to save.");
 
   declareProperty(
@@ -166,7 +167,8 @@ void SaveIsawPeaks::exec() {
     if (true) {
       out << "4 DETNUM  NROWS  NCOLS   WIDTH   HEIGHT   DEPTH   DETD   CenterX "
              "  CenterY   CenterZ    BaseX    BaseY    BaseZ      UpX      UpY "
-             "     UpZ" << std::endl;
+             "     UpZ"
+          << std::endl;
       // Here would save each detector...
       std::set<int>::iterator it;
       for (it = uniqueBanks.begin(); it != uniqueBanks.end(); ++it) {

--- a/Framework/Crystal/src/SaveIsawUB.cpp
+++ b/Framework/Crystal/src/SaveIsawUB.cpp
@@ -37,12 +37,8 @@ void SaveIsawUB::init() {
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input),
       "An input workspace containing the orientation matrix.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".mat");
-  exts.push_back(".ub");
-  exts.push_back(".txt");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save,
+                                   {".mat", ".ub", ".txt"}),
                   "Path to an ISAW-style UB matrix text file.");
 }
 
@@ -146,8 +142,7 @@ void SaveIsawUB::exec() {
         << lattice.errorgamma() << setw(12) << setprecision(4) << ErrorVolume
         << " " << endl;
 
-    out << endl
-        << endl;
+    out << endl << endl;
 
     out << "The above matrix is the Transpose of the UB Matrix. ";
     out << "The UB matrix maps the column" << endl;

--- a/Framework/Crystal/src/SaveIsawUB.cpp
+++ b/Framework/Crystal/src/SaveIsawUB.cpp
@@ -142,7 +142,8 @@ void SaveIsawUB::exec() {
         << lattice.errorgamma() << setw(12) << setprecision(4) << ErrorVolume
         << " " << endl;
 
-    out << endl << endl;
+    out << endl
+        << endl;
 
     out << "The above matrix is the Transpose of the UB Matrix. ";
     out << "The UB matrix maps the column" << endl;

--- a/Framework/Crystal/src/SavePeaksFile.cpp
+++ b/Framework/Crystal/src/SavePeaksFile.cpp
@@ -31,11 +31,10 @@ void SavePeaksFile::init() {
   declareProperty(
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input),
       "An input PeaksWorkspace.");
-  std::vector<std::string> exts;
-  exts.push_back(".peaks");
 
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
-                  "Path to an ISAW-style .peaks filename.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Save, {".peaks"}),
+      "Path to an ISAW-style .peaks filename.");
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/AsciiPointBase.cpp
+++ b/Framework/DataHandling/src/AsciiPointBase.cpp
@@ -25,9 +25,7 @@ void AsciiPointBase::init() {
       new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
       "The name of the workspace containing the data you want to save.");
 
-  std::vector<std::string> exts;
-  exts.push_back(ext());
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save, {ext()}),
                   "The filename of the output file.");
   extraProps();
 }

--- a/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
+++ b/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
@@ -82,12 +82,9 @@ void CreateChunkingFromInstrument::init() {
   // instrument selection
   string grp1Name("Specify the Instrument");
 
-  std::vector<std::string> exts;
-  exts.push_back("_event.nxs");
-  exts.push_back(".nxs.h5");
-  exts.push_back(".nxs");
   this->declareProperty(
-      new FileProperty(PARAM_IN_FILE, "", FileProperty::OptionalLoad, exts),
+      new FileProperty(PARAM_IN_FILE, "", FileProperty::OptionalLoad,
+                       {"_event.nxs", ".nxs.h5", ".nxs"}),
       "The name of the event nexus file to read, including its full or "
       "relative path.");
 

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -357,8 +357,7 @@ void GroupDetectors2::getGroups(API::MatrixWorkspace_const_sptr workspace,
       if (*it > maxIn) {
         g_log.error() << "Spectra index " << *it
                       << " doesn't exist in the input workspace, the highest "
-                         "possible index is "
-                      << maxIn << std::endl;
+                         "possible index is " << maxIn << std::endl;
         throw std::out_of_range("One of the spectra requested to group does "
                                 "not exist in the input workspace");
       }

--- a/Framework/DataHandling/src/GroupDetectors2.cpp
+++ b/Framework/DataHandling/src/GroupDetectors2.cpp
@@ -46,11 +46,9 @@ void GroupDetectors2::init() {
                                                          Direction::Output),
                   "The name of the output workspace");
 
-  std::vector<std::string> fileExts(2);
-  fileExts[0] = ".map";
-  fileExts[1] = ".xml";
   declareProperty(
-      new FileProperty("MapFile", "", FileProperty::OptionalLoad, fileExts),
+      new FileProperty("MapFile", "", FileProperty::OptionalLoad,
+                       {".map", ".xml"}),
       "A file that consists of lists of spectra numbers to group. See the "
       "help\n"
       "for the file format");
@@ -359,7 +357,8 @@ void GroupDetectors2::getGroups(API::MatrixWorkspace_const_sptr workspace,
       if (*it > maxIn) {
         g_log.error() << "Spectra index " << *it
                       << " doesn't exist in the input workspace, the highest "
-                         "possible index is " << maxIn << std::endl;
+                         "possible index is "
+                      << maxIn << std::endl;
         throw std::out_of_range("One of the spectra requested to group does "
                                 "not exist in the input workspace");
       }

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -313,9 +313,12 @@ void LoadAscii::init() {
                   "the read-in data and stored in the [[Analysis Data "
                   "Service]].");
 
-  std::string spacers[6][6] = {{"Automatic", ",\t:; "}, {"CSV", ","},
-                               {"Tab", "\t"},           {"Space", " "},
-                               {"Colon", ":"},          {"SemiColon", ";"}};
+  std::string spacers[6][6] = {{"Automatic", ",\t:; "},
+                               {"CSV", ","},
+                               {"Tab", "\t"},
+                               {"Space", " "},
+                               {"Colon", ":"},
+                               {"SemiColon", ";"}};
   // For the ListValidator
   std::vector<std::string> sepOptions;
   for (size_t i = 0; i < 5; ++i) {

--- a/Framework/DataHandling/src/LoadAscii.cpp
+++ b/Framework/DataHandling/src/LoadAscii.cpp
@@ -302,13 +302,8 @@ void LoadAscii::fillInputValues(std::vector<double> &values,
 //--------------------------------------------------------------------------
 /// Initialisation method.
 void LoadAscii::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
-  exts.push_back(".csv");
-  exts.push_back("");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".dat", ".txt", ".csv", ""}),
                   "The name of the text file to read, including its full or "
                   "relative path. The file extension must be .tst, .dat, or "
                   ".csv");
@@ -318,12 +313,9 @@ void LoadAscii::init() {
                   "the read-in data and stored in the [[Analysis Data "
                   "Service]].");
 
-  std::string spacers[6][6] = {{"Automatic", ",\t:; "},
-                               {"CSV", ","},
-                               {"Tab", "\t"},
-                               {"Space", " "},
-                               {"Colon", ":"},
-                               {"SemiColon", ";"}};
+  std::string spacers[6][6] = {{"Automatic", ",\t:; "}, {"CSV", ","},
+                               {"Tab", "\t"},           {"Space", " "},
+                               {"Colon", ":"},          {"SemiColon", ";"}};
   // For the ListValidator
   std::vector<std::string> sepOptions;
   for (size_t i = 0; i < 5; ++i) {

--- a/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Framework/DataHandling/src/LoadAscii2.cpp
@@ -673,8 +673,7 @@ void LoadAscii2::exec() {
   if (sep.empty()) {
     g_log.notice() << "\"UserDefined\" has been selected, but no custom "
                       "separator has been entered."
-                      " Using default instead."
-                   << std::endl;
+                      " Using default instead." << std::endl;
     sep = ",";
   }
   m_columnSep = sep;

--- a/Framework/DataHandling/src/LoadAscii2.cpp
+++ b/Framework/DataHandling/src/LoadAscii2.cpp
@@ -579,13 +579,8 @@ void LoadAscii2::fillInputValues(std::vector<double> &values,
 //--------------------------------------------------------------------------
 /// Initialisation method.
 void LoadAscii2::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
-  exts.push_back(".csv");
-  exts.push_back("");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".dat", ".txt", ".csv", ""}),
                   "The name of the text file to read, including its full or "
                   "relative path. The file extension must be .txt, .dat, or "
                   ".csv");
@@ -678,7 +673,8 @@ void LoadAscii2::exec() {
   if (sep.empty()) {
     g_log.notice() << "\"UserDefined\" has been selected, but no custom "
                       "separator has been entered."
-                      " Using default instead." << std::endl;
+                      " Using default instead."
+                   << std::endl;
     sep = ",";
   }
   m_columnSep = sep;

--- a/Framework/DataHandling/src/LoadDetectorInfo.cpp
+++ b/Framework/DataHandling/src/LoadDetectorInfo.cpp
@@ -39,14 +39,10 @@ void LoadDetectorInfo::init() {
   declareProperty(new WorkspaceProperty<>("Workspace", "", Direction::InOut),
                   "The name of the workspace to that the detector information "
                   "will be loaded into.");
-  std::vector<std::string> exts;
-  // each of these allowed extensions must be dealt with in exec() below
-  exts.push_back(".dat");
-  exts.push_back(".raw");
-  exts.push_back(".sca");
-  exts.push_back(".nxs");
+
   declareProperty(
-      new FileProperty("DataFilename", "", FileProperty::Load, exts),
+      new FileProperty("DataFilename", "", FileProperty::Load,
+                       {".dat", ".raw", ".sca", ".nxs"}),
       "A **raw, dat, nxs** or **sca** file that contains information about the "
       "detectors in the "
       "workspace. The description of **dat** and **nxs** file format is "

--- a/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
+++ b/Framework/DataHandling/src/LoadDetectorsGroupingFile.cpp
@@ -45,12 +45,8 @@ LoadDetectorsGroupingFile::~LoadDetectorsGroupingFile() {}
 void LoadDetectorsGroupingFile::init() {
   /// Initialise the properties
 
-  std::vector<std::string> fileExts(2);
-  fileExts[0] = ".xml";
-  fileExts[1] = ".map";
-
   declareProperty(
-      new FileProperty("InputFile", "", FileProperty::Load, fileExts),
+      new FileProperty("InputFile", "", FileProperty::Load, {".xml", ".map"}),
       "The XML or Map file with full path.");
 
   declareProperty(new WorkspaceProperty<DataObjects::GroupingWorkspace>(

--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -69,12 +69,8 @@ void LoadDiffCal::init() {
   // 3 properties for getting the right instrument
   LoadCalFile::getInstrument3WaysInit(this);
 
-  std::vector<std::string> exts;
-  exts.push_back(".h5");
-  exts.push_back(".hd5");
-  exts.push_back(".hdf");
-  exts.push_back(".cal");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".h5", ".hd5", ".hdf", ".cal"}),
                   "Path to the .h5 file.");
 
   declareProperty(new PropertyWithValue<bool>("MakeGroupingWorkspace", true,

--- a/Framework/DataHandling/src/LoadDspacemap.cpp
+++ b/Framework/DataHandling/src/LoadDspacemap.cpp
@@ -41,12 +41,9 @@ void LoadDspacemap::init() {
   // 3 properties for getting the right instrument
   LoadCalFile::getInstrument3WaysInit(this);
 
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".bin");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The DspacemapFile containing the d-space mapping.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".dat", ".bin"}),
+      "The DspacemapFile containing the d-space mapping.");
 
   std::vector<std::string> propOptions;
   propOptions.push_back("POWGEN");

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1054,12 +1054,9 @@ int LoadEventNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
 /** Initialisation method.
 */
 void LoadEventNexus::init() {
-  std::vector<std::string> exts;
-  exts.push_back("_event.nxs");
-  exts.push_back(".nxs.h5");
-  exts.push_back(".nxs");
   this->declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+      new FileProperty("Filename", "", FileProperty::Load,
+                       {"_event.nxs", ".nxs.h5", ".nxs"}),
       "The name of the Event NeXus file to read, including its full or "
       "relative path. "
       "The file name is typically of the form INST_####_event.nxs (N.B. case "
@@ -1975,11 +1972,13 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
 
   if (shortest_tof < 0)
     g_log.warning() << "The shortest TOF was negative! At least 1 event has an "
-                       "invalid time-of-flight." << std::endl;
+                       "invalid time-of-flight."
+                    << std::endl;
   if (bad_tofs > 0)
     g_log.warning() << "Found " << bad_tofs << " events with TOF > 2e8. This "
                                                "may indicate errors in the raw "
-                                               "TOF data." << std::endl;
+                                               "TOF data."
+                    << std::endl;
 
   // Use T0 offset from TOPAZ Parameter file if it exists
   if (m_ws->getInstrument()->hasParameter("T0")) {
@@ -2308,7 +2307,8 @@ void LoadEventNexus::runLoadMonitorsAsEvents(API::Progress *const prog) {
     if (m_instrument_loaded_correctly) {
       m_ws->setInstrument(dataWS->getInstrument());
       g_log.information() << "Instrument data copied into monitors workspace "
-                             " from the data workspace." << std::endl;
+                             " from the data workspace."
+                          << std::endl;
     }
 
     // Perform the load (only events from monitor)
@@ -2330,7 +2330,8 @@ void LoadEventNexus::runLoadMonitorsAsEvents(API::Progress *const prog) {
         g_log.error()
             << "Could not copy log data into monitors workspace. Some "
                " logs may be wrong and/or missing in the output "
-               "monitors workspace." << std::endl;
+               "monitors workspace."
+            << std::endl;
       }
     }
 

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1972,13 +1972,11 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
 
   if (shortest_tof < 0)
     g_log.warning() << "The shortest TOF was negative! At least 1 event has an "
-                       "invalid time-of-flight."
-                    << std::endl;
+                       "invalid time-of-flight." << std::endl;
   if (bad_tofs > 0)
     g_log.warning() << "Found " << bad_tofs << " events with TOF > 2e8. This "
                                                "may indicate errors in the raw "
-                                               "TOF data."
-                    << std::endl;
+                                               "TOF data." << std::endl;
 
   // Use T0 offset from TOPAZ Parameter file if it exists
   if (m_ws->getInstrument()->hasParameter("T0")) {
@@ -2307,8 +2305,7 @@ void LoadEventNexus::runLoadMonitorsAsEvents(API::Progress *const prog) {
     if (m_instrument_loaded_correctly) {
       m_ws->setInstrument(dataWS->getInstrument());
       g_log.information() << "Instrument data copied into monitors workspace "
-                             " from the data workspace."
-                          << std::endl;
+                             " from the data workspace." << std::endl;
     }
 
     // Perform the load (only events from monitor)
@@ -2330,8 +2327,7 @@ void LoadEventNexus::runLoadMonitorsAsEvents(API::Progress *const prog) {
         g_log.error()
             << "Could not copy log data into monitors workspace. Some "
                " logs may be wrong and/or missing in the output "
-               "monitors workspace."
-            << std::endl;
+               "monitors workspace." << std::endl;
       }
     }
 

--- a/Framework/DataHandling/src/LoadFullprofResolution.cpp
+++ b/Framework/DataHandling/src/LoadFullprofResolution.cpp
@@ -53,10 +53,9 @@ LoadFullprofResolution::~LoadFullprofResolution() {}
  */
 void LoadFullprofResolution::init() {
   // Input file name
-  vector<std::string> exts;
-  exts.push_back(".irf");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "Path to an Fullprof .irf file to load.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".irf"}),
+      "Path to an Fullprof .irf file to load.");
 
   // Output table workspace
   auto wsprop = new WorkspaceProperty<API::ITableWorkspace>(

--- a/Framework/DataHandling/src/LoadGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/LoadGSASInstrumentFile.cpp
@@ -53,10 +53,9 @@ LoadGSASInstrumentFile::~LoadGSASInstrumentFile() {}
  */
 void LoadGSASInstrumentFile::init() {
   // Input file name
-  vector<std::string> exts;
-  exts.push_back(".prm");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "Path to an GSAS file to load.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".prm"}),
+      "Path to an GSAS file to load.");
 
   // Output table workspace
   auto wsprop = new WorkspaceProperty<API::ITableWorkspace>(


### PR DESCRIPTION
Resolves #14725 

Release notes have not been updated.
## Changes

The following algorithms now use std::initializer_list

```
AlignDetectors 
FixGSASInstrumentFile 
ReadGroupsFromFile 
VesuvioL1ThetaResolution 
LoadHKL 
LoadIsawPeaks 
LoadIsawUB 
SaveHKL 
SaveIsawPeaks 
SCDCalibratePanels 
SaveIsawUB 
SavePeaksFile
AsciiPointBase 
CreateChunkingFromInstrument 
GroupDetectors2
LoadAscii/2 
LoadDetectorInfo
LoadDetectorGroupingFile
LoadDiffCal
LoadDspacemap
LoadEventNexus
LoadFullprofResolution
LoadGSASInstrumentFile
```
## Testing

Code Review and maybe run usage examples on algorithms to ensure all still works correctly.
http://docs.mantidproject.org/nightly/algorithms/index.html
