### PR TITLE
Algorithms updated to use std::initializer_list

### DIFF
--- a/Framework/DataHandling/src/LoadGSS.cpp
+++ b/Framework/DataHandling/src/LoadGSS.cpp
@@ -60,14 +60,9 @@ int LoadGSS::confidence(Kernel::FileDescriptor &descriptor) const {
 /** Initialise the algorithm
   */
 void LoadGSS::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".gsa");
-  exts.push_back(".gss");
-  exts.push_back(".gda");
-  exts.push_back(".txt");
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Load, exts),
-      "The input filename of the stored data");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Load,
+                                        {".gsa", ".gss", ".gda", ".txt"}),
+                  "The input filename of the stored data");
 
   declareProperty(new API::WorkspaceProperty<>("OutputWorkspace", "",
                                                Kernel::Direction::Output),

--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -39,11 +39,8 @@ void LoadIDFFromNexus::init() {
                                              Direction::InOut),
       "The name of the workspace in which to attach the imported instrument");
 
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".nxs.h5");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".nxs.h5"}),
       "The name (including its full or relative path) of the Nexus file to "
       "attempt to load the instrument from.");
 
@@ -297,7 +294,8 @@ void LoadIDFFromNexus::LoadParameters(
     }
   } else { // We do have parameters from the Nexus file
     g_log.notice() << "Found Instrument parameter map entry in Nexus file, "
-                      "which is loaded.\n" << std::endl;
+                      "which is loaded.\n"
+                   << std::endl;
     // process parameterString into parameters in workspace
     localWorkspace->readParameterMap(parameterString);
   }

--- a/Framework/DataHandling/src/LoadIDFFromNexus.cpp
+++ b/Framework/DataHandling/src/LoadIDFFromNexus.cpp
@@ -294,8 +294,7 @@ void LoadIDFFromNexus::LoadParameters(
     }
   } else { // We do have parameters from the Nexus file
     g_log.notice() << "Found Instrument parameter map entry in Nexus file, "
-                      "which is loaded.\n"
-                   << std::endl;
+                      "which is loaded.\n" << std::endl;
     // process parameterString into parameters in workspace
     localWorkspace->readParameterMap(parameterString);
   }

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -72,10 +72,7 @@ int LoadISISNexus2::confidence(Kernel::NexusDescriptor &descriptor) const {
 
 /// Initialization method.
 void LoadISISNexus2::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".n*");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".n*"}),
                   "The name of the Nexus file to load");
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output));

--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -72,8 +72,9 @@ int LoadISISNexus2::confidence(Kernel::NexusDescriptor &descriptor) const {
 
 /// Initialization method.
 void LoadISISNexus2::init() {
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".n*"}),
-                  "The name of the Nexus file to load");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".n*"}),
+      "The name of the Nexus file to load");
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output));
 

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -34,11 +34,8 @@ void LoadInstrumentFromRaw::init() {
                                              Direction::InOut),
       "The name of the workspace in which to store the imported instrument.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".raw");
-  exts.push_back(".s*");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+      new FileProperty("Filename", "", FileProperty::Load, {".raw", ".s*"}),
       "The filename (including its full or relative path) of an ISIS RAW file. "
       "The file extension must either be .raw or .s??");
   declareProperty(new ArrayProperty<int>("MonitorList", Direction::Output),
@@ -159,7 +156,8 @@ void LoadInstrumentFromRaw::exec() {
       << "Source component added with position set to (0,0,-" << l1
       << "). In standard configuration, with \n"
       << "the beam along z-axis pointing from source to sample, this implies "
-         "the source is " << l1 << "m in front \n"
+         "the source is "
+      << l1 << "m in front \n"
       << "of the sample. This value can be changed via the 'instrument.l1' "
          "configuration property.\n";
 

--- a/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadInstrumentFromRaw.cpp
@@ -156,8 +156,7 @@ void LoadInstrumentFromRaw::exec() {
       << "Source component added with position set to (0,0,-" << l1
       << "). In standard configuration, with \n"
       << "the beam along z-axis pointing from source to sample, this implies "
-         "the source is "
-      << l1 << "m in front \n"
+         "the source is " << l1 << "m in front \n"
       << "of the sample. This value can be changed via the 'instrument.l1' "
          "configuration property.\n";
 

--- a/Framework/DataHandling/src/LoadLLB.cpp
+++ b/Framework/DataHandling/src/LoadLLB.cpp
@@ -68,11 +68,9 @@ int LoadLLB::confidence(Kernel::NexusDescriptor &descriptor) const {
 /** Initialize the algorithm's properties.
  */
 void LoadLLB::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".hdf");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the Nexus file to load");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".hdf"}),
+      "The name of the Nexus file to load");
   declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
       "The name to use for the output workspace");

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -47,17 +47,15 @@ void LoadLog::init() {
                                              Direction::InOut),
       "The name of the workspace to which the log data will be added.");
 
-  std::vector<std::string> exts(2, "");
-  exts[0] = ".txt";
-  exts[1] = ".log";
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The filename (including its full or relative path) of a SNS "
-                  "text log file (not cvinfo), "
-                  "an ISIS log file, or an ISIS raw file. "
-                  "If a raw file is specified all log files associated with "
-                  "that raw file are loaded into the specified workspace. The "
-                  "file extension must "
-                  "either be .raw or .s when specifying a raw file");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".txt", ".log"}),
+      "The filename (including its full or relative path) of a SNS "
+      "text log file (not cvinfo), "
+      "an ISIS log file, or an ISIS raw file. "
+      "If a raw file is specified all log files associated with "
+      "that raw file are loaded into the specified workspace. The "
+      "file extension must "
+      "either be .raw or .s when specifying a raw file");
 
   declareProperty(
       new ArrayProperty<std::string>("Names"),

--- a/Framework/DataHandling/src/LoadMLZ.cpp
+++ b/Framework/DataHandling/src/LoadMLZ.cpp
@@ -67,12 +67,8 @@ const std::string LoadMLZ::category() const { return "DataHandling\\Nexus"; }
 /** Initialize the algorithm's properties.
  */
 void LoadMLZ::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".hdf");
-  exts.push_back(".hd5");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".nxs", ".hdf", ".hd5"}),
                   "File path of the Data file to load");
 
   declareProperty(

--- a/Framework/DataHandling/src/LoadMask.cpp
+++ b/Framework/DataHandling/src/LoadMask.cpp
@@ -71,12 +71,10 @@ void LoadMask::init() {
   declareProperty("Instrument", "",
                   boost::make_shared<MandatoryValidator<std::string>>(),
                   "The name of the instrument to apply the mask.");
-  std::vector<std::string> exts;
-  exts.push_back(".xml");
-  exts.push_back(".msk");
-  declareProperty(new FileProperty("InputFile", "", FileProperty::Load, exts),
-                  "Masking file for masking. Supported file format is XML and "
-                  "ISIS ASCII. ");
+  declareProperty(
+      new FileProperty("InputFile", "", FileProperty::Load, {".xml", ".msk"}),
+      "Masking file for masking. Supported file format is XML and "
+      "ISIS ASCII. ");
   declareProperty(new WorkspaceProperty<DataObjects::MaskWorkspace>(
                       "OutputWorkspace", "Masking", Direction::Output),
                   "Output Masking Workspace");

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -274,8 +274,7 @@ void LoadMcStas::readEventData(
     ::NeXus::Info id_info = nxFile.getInfo();
     if (id_info.dims.size() != 2) {
       g_log.error() << "Event data in McStas nexus file not loaded. Expected "
-                       "event data block to be two dimensional"
-                    << std::endl;
+                       "event data block to be two dimensional" << std::endl;
       return;
     }
     int64_t nNeutrons = id_info.dims[0];

--- a/Framework/DataHandling/src/LoadMcStas.cpp
+++ b/Framework/DataHandling/src/LoadMcStas.cpp
@@ -52,11 +52,9 @@ const std::string LoadMcStas::category() const { return "DataHandling\\Nexus"; }
 /** Initialize the algorithm's properties.
  */
 void LoadMcStas::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".h5");
-  exts.push_back(".nxs");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the Nexus file to load");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".h5", ".nxs"}),
+      "The name of the Nexus file to load");
 
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output),
@@ -276,7 +274,8 @@ void LoadMcStas::readEventData(
     ::NeXus::Info id_info = nxFile.getInfo();
     if (id_info.dims.size() != 2) {
       g_log.error() << "Event data in McStas nexus file not loaded. Expected "
-                       "event data block to be two dimensional" << std::endl;
+                       "event data block to be two dimensional"
+                    << std::endl;
       return;
     }
     int64_t nNeutrons = id_info.dims[0];

--- a/Framework/DataHandling/src/LoadMcStasNexus.cpp
+++ b/Framework/DataHandling/src/LoadMcStasNexus.cpp
@@ -58,11 +58,9 @@ int LoadMcStasNexus::confidence(Kernel::NexusDescriptor &descriptor) const {
 /** Initialize the algorithm's properties.
  */
 void LoadMcStasNexus::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".h5");
-  exts.push_back(".nxs");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the Nexus file to load");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".h5", ".nxs"}),
+      "The name of the Nexus file to load");
 
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output),

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -89,11 +89,9 @@ int LoadNXSPE::confidence(Kernel::NexusDescriptor &descriptor) const {
 /** Initialize the algorithm's properties.
  */
 void LoadNXSPE::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxspe");
-  exts.push_back("");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "An NXSPE file");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".nxspe", ""}),
+      "An NXSPE file");
   declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
       "The name of the workspace that will be created.");

--- a/Framework/DataHandling/src/LoadNexus.cpp
+++ b/Framework/DataHandling/src/LoadNexus.cpp
@@ -36,13 +36,9 @@ LoadNexus::LoadNexus() : Algorithm(), m_filename() {}
  */
 void LoadNexus::init() {
   // Declare required input parameters for all Child Algorithms
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".nx5");
-  exts.push_back(".xml");
-  exts.push_back(".n*");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+      new FileProperty("Filename", "", FileProperty::Load,
+                       {".nxs", ".nx5", ".xml", ".n*"}),
       "The name of the Nexus file to read, as a full or relative path.");
 
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -83,12 +83,10 @@ void LoadNexusLogs::init() {
       new WorkspaceProperty<MatrixWorkspace>("Workspace", "Anonymous",
                                              Direction::InOut),
       "The name of the workspace that will be filled with the logs.");
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".n*");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "Path to the .nxs file to load. Can be an EventNeXus or a "
-                  "histogrammed NeXus.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".n*"}),
+      "Path to the .nxs file to load. Can be an EventNeXus or a "
+      "histogrammed NeXus.");
   declareProperty(
       new PropertyWithValue<bool>("OverwriteLogs", true, Direction::Input),
       "If true then existing logs will be overwritten, if false they will "

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -216,12 +216,9 @@ int LoadNexusProcessed::confidence(Kernel::NexusDescriptor &descriptor) const {
  */
 void LoadNexusProcessed::init() {
   // Declare required input parameters for algorithm
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".nx5");
-  exts.push_back(".xml");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+      new FileProperty("Filename", "", FileProperty::Load,
+                       {".nxs", ".nx5", ".xml"}),
       "The name of the Nexus file to read, as a full or relative path.");
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output),
@@ -302,7 +299,8 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(
     std::stringstream buffer;
     buffer << "Group entry " << p - 1 << " has fractional area present. Try "
                                          "reloading with FastMultiPeriod set "
-                                         "off." << std::endl;
+                                         "off."
+           << std::endl;
     throw std::runtime_error(buffer.str());
   }
 

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -299,8 +299,7 @@ Workspace_sptr LoadNexusProcessed::doAccelleratedMultiPeriodLoading(
     std::stringstream buffer;
     buffer << "Group entry " << p - 1 << " has fractional area present. Try "
                                          "reloading with FastMultiPeriod set "
-                                         "off."
-           << std::endl;
+                                         "off." << std::endl;
     throw std::runtime_error(buffer.str());
   }
 

--- a/Framework/DataHandling/src/LoadPDFgetNFile.cpp
+++ b/Framework/DataHandling/src/LoadPDFgetNFile.cpp
@@ -75,17 +75,10 @@ int LoadPDFgetNFile::confidence(Kernel::FileDescriptor &descriptor) const {
 /** Define input
   */
 void LoadPDFgetNFile::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".sq");
-  exts.push_back(".sqa");
-  exts.push_back(".sqb");
-  exts.push_back(".gr");
-  exts.push_back(".ain");
-  exts.push_back(".braw");
-  exts.push_back(".bsmo");
-
-  auto fileproperty = new FileProperty("Filename", "", FileProperty::Load, exts,
-                                       Kernel::Direction::Input);
+  auto fileproperty =
+      new FileProperty("Filename", "", FileProperty::Load,
+                       {".sq", ".sqa", ".sqb", ".gr", ".ain", ".braw", ".bsmo"},
+                       Kernel::Direction::Input);
   this->declareProperty(fileproperty, "The input filename of the stored data");
 
   // auto wsproperty = new WorkspaceProperty<Workspace2D>("OutputWorkspace",


### PR DESCRIPTION
Resolves #14761
## Changes

The following algorithms have been updated to use std::initializer_list

```
LoadGSS
LoadIDFFromNexus
LoadISISNexus
LoadInstrumentFromRaw
LoadLLB 
LoadLog 
LoadMask
LoadMcStas
LoadMLZ
LoadMcStasNexus
LoadNXSPE
LoadNexus
LoadNexusLogs
LoadNexusProcessed
LoadPDFgetNFile
```
## Testing

Code Review and maybe run usage examples on algorithms to ensure all still works correctly.
http://docs.mantidproject.org/nightly/algorithms/index.html
