### PR TITLE
Algorithms updated to use std::initializer_list

### DIFF
--- a/Framework/DataHandling/src/LoadQKK.cpp
+++ b/Framework/DataHandling/src/LoadQKK.cpp
@@ -48,14 +48,11 @@ int LoadQKK::confidence(Kernel::NexusDescriptor &descriptor) const {
  * read from after the execution (output).
  */
 void LoadQKK::init() {
-  // Specify file extensions which can be associated with a QKK file.
-  std::vector<std::string> exts;
-  exts.push_back(".nx.hdf");
   // Declare the Filename algorithm property. Mandatory. Sets the path to the
   // file to load.
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Load, exts),
-      "The input filename of the stored data");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Load,
+                                        {".nx.hdf"}),
+                  "The input filename of the stored data");
   // Declare the OutputWorkspace property. This sets the name of the workspace
   // to be filled with the data
   // from the file.

--- a/Framework/DataHandling/src/LoadRKH.cpp
+++ b/Framework/DataHandling/src/LoadRKH.cpp
@@ -131,13 +131,9 @@ int LoadRKH::confidence(Kernel::FileDescriptor &descriptor) const {
  * Initialise the algorithm
  */
 void LoadRKH::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".txt");
-  exts.push_back(".q");
-  exts.push_back(".dat");
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Load, exts),
-      "Name of the RKH file to load");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Load,
+                                        {".txt", ".q", ".dat"}),
+                  "Name of the RKH file to load");
   declareProperty(new API::WorkspaceProperty<>("OutputWorkspace", "",
                                                Kernel::Direction::Output),
                   "The name to use for the output workspace");

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -847,8 +847,7 @@ void LoadRawHelper::loadRunParameters(API::MatrixWorkspace_sptr localWorkspace,
       DateAndTime(isisDate.substr(7, 4) + "-" +
                   convertMonthLabelToIntStr(isisDate.substr(3, 3)) + "-" +
                   isisDate.substr(0, 2) + "T" +
-                  std::string(localISISRaw->hdr.hd_time, 8))
-          .toISO8601String());
+                  std::string(localISISRaw->hdr.hd_time, 8)).toISO8601String());
 }
 
 /// To help transforming date stored in ISIS raw file into iso 8601

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -47,11 +47,8 @@ LoadRawHelper::~LoadRawHelper() {}
 
 /// Initialisation method.
 void LoadRawHelper::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".raw");
-  exts.push_back(".s*");
-  exts.push_back(".add");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".raw", ".s*", ".add"}),
                   "The name of the RAW file to read, including its full or "
                   "relative path. The file extension must be .raw or .RAW "
                   "(N.B. case sensitive if running on Linux).");
@@ -850,7 +847,8 @@ void LoadRawHelper::loadRunParameters(API::MatrixWorkspace_sptr localWorkspace,
       DateAndTime(isisDate.substr(7, 4) + "-" +
                   convertMonthLabelToIntStr(isisDate.substr(3, 3)) + "-" +
                   isisDate.substr(0, 2) + "T" +
-                  std::string(localISISRaw->hdr.hd_time, 8)).toISO8601String());
+                  std::string(localISISRaw->hdr.hd_time, 8))
+          .toISO8601String());
 }
 
 /// To help transforming date stored in ISIS raw file into iso 8601

--- a/Framework/DataHandling/src/LoadReflTBL.cpp
+++ b/Framework/DataHandling/src/LoadReflTBL.cpp
@@ -224,12 +224,10 @@ size_t LoadReflTBL::getCells(std::string line,
 //--------------------------------------------------------------------------
 /// Initialisation method.
 void LoadReflTBL::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".tbl");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the table file to read, including its full or "
-                  "relative path. The file extension must be .tbl");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".tbl"}),
+      "The name of the table file to read, including its full or "
+      "relative path. The file extension must be .tbl");
   declareProperty(new WorkspaceProperty<ITableWorkspace>("OutputWorkspace", "",
                                                          Direction::Output),
                   "The name of the workspace that will be created.");

--- a/Framework/DataHandling/src/LoadSINQFocus.cpp
+++ b/Framework/DataHandling/src/LoadSINQFocus.cpp
@@ -70,11 +70,9 @@ int LoadSINQFocus::confidence(Kernel::NexusDescriptor &descriptor) const {
 /** Initialize the algorithm's properties.
  */
 void LoadSINQFocus::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".hdf");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the Nexus file to load");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs", ".hdf"}),
+      "The name of the Nexus file to load");
   declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
       "The name to use for the output workspace");

--- a/Framework/DataHandling/src/LoadSNSspec.cpp
+++ b/Framework/DataHandling/src/LoadSNSspec.cpp
@@ -79,13 +79,10 @@ LoadSNSspec::LoadSNSspec() {}
 
 /// Initialisation method.
 void LoadSNSspec::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the text file to read, including its full or "
-                  "relative path. The file extension must be .txt or .dat.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".dat", ".txt"}),
+      "The name of the text file to read, including its full or "
+      "relative path. The file extension must be .txt or .dat.");
   declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
       "The name of the workspace that will be created, filled with the read-in "

--- a/Framework/DataHandling/src/LoadSampleDetailsFromRaw.cpp
+++ b/Framework/DataHandling/src/LoadSampleDetailsFromRaw.cpp
@@ -27,11 +27,9 @@ void LoadSampleDetailsFromRaw::init() {
       new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
       "The sample details are attached to this workspace.");
 
-  std::vector<std::string> exts;
-  exts.push_back("raw");
-  exts.push_back(".s*");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The raw file containing the sample geometry information.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {"raw", ".s*"}),
+      "The raw file containing the sample geometry information.");
 }
 
 /**

--- a/Framework/DataHandling/src/LoadSassena.cpp
+++ b/Framework/DataHandling/src/LoadSassena.cpp
@@ -325,16 +325,11 @@ void LoadSassena::loadFQT(const hid_t &h5file, API::WorkspaceGroup_sptr gws,
  * read from after the execution (output).
  */
 void LoadSassena::init() {
-  std::vector<std::string> exts; // Specify file extensions which can be
-                                 // associated with an output Sassena file
-  exts.push_back(".h5");
-  exts.push_back(".hd5");
-
   // Declare the Filename algorithm property. Mandatory. Sets the path to the
   // file to load.
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Load, exts),
-      "A Sassena file");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Load,
+                                        {".h5", ".hd5"}),
+                  "A Sassena file");
   // Declare the OutputWorkspace property
   declareProperty(new API::WorkspaceProperty<API::Workspace>(
                       "OutputWorkspace", "", Kernel::Direction::Output),

--- a/Framework/DataHandling/src/LoadSavuTomoConfig.cpp
+++ b/Framework/DataHandling/src/LoadSavuTomoConfig.cpp
@@ -62,8 +62,7 @@ void LoadSavuTomoConfig::exec() {
     }
   } catch (std::exception &e) {
     g_log.error() << "Failed to load savu tomography reconstruction "
-                     "parameterization file: "
-                  << e.what() << std::endl;
+                     "parameterization file: " << e.what() << std::endl;
     return;
   }
 
@@ -166,8 +165,8 @@ ITableWorkspace_sptr LoadSavuTomoConfig::loadFile(std::string &fname,
       // detailed NeXus error message and throw...
       g_log.error() << "Failed to load plugin '" << j
                     << "' from"
-                       "NeXus file. Error description: "
-                    << e.what() << std::endl;
+                       "NeXus file. Error description: " << e.what()
+                    << std::endl;
       throw std::runtime_error(
           "Could not load one or more plugin "
           "entries from the tomographic reconstruction parameterization "
@@ -195,8 +194,7 @@ ITableWorkspace_sptr LoadSavuTomoConfig::loadFile(std::string &fname,
       g_log.warning()
           << "Failed to read some fields in tomographic "
              "reconstruction plugin line. The file seems to be wrong. Error "
-             "description: "
-          << e.what() << std::endl;
+             "description: " << e.what() << std::endl;
     }
 
     table << id << params << name << cite;

--- a/Framework/DataHandling/src/LoadSavuTomoConfig.cpp
+++ b/Framework/DataHandling/src/LoadSavuTomoConfig.cpp
@@ -25,13 +25,9 @@ LoadSavuTomoConfig::~LoadSavuTomoConfig() {}
  */
 void LoadSavuTomoConfig::init() {
   // Required input properties
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".nx5");
-  exts.push_back(".xml");
-
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+      new FileProperty("Filename", "", FileProperty::Load,
+                       {".nxs", ".nx5", ".xml"}),
       "The name of the Nexus parameterization file to read, as a full "
       "or relative path.");
 
@@ -66,7 +62,8 @@ void LoadSavuTomoConfig::exec() {
     }
   } catch (std::exception &e) {
     g_log.error() << "Failed to load savu tomography reconstruction "
-                     "parameterization file: " << e.what() << std::endl;
+                     "parameterization file: "
+                  << e.what() << std::endl;
     return;
   }
 
@@ -169,8 +166,8 @@ ITableWorkspace_sptr LoadSavuTomoConfig::loadFile(std::string &fname,
       // detailed NeXus error message and throw...
       g_log.error() << "Failed to load plugin '" << j
                     << "' from"
-                       "NeXus file. Error description: " << e.what()
-                    << std::endl;
+                       "NeXus file. Error description: "
+                    << e.what() << std::endl;
       throw std::runtime_error(
           "Could not load one or more plugin "
           "entries from the tomographic reconstruction parameterization "
@@ -198,7 +195,8 @@ ITableWorkspace_sptr LoadSavuTomoConfig::loadFile(std::string &fname,
       g_log.warning()
           << "Failed to read some fields in tomographic "
              "reconstruction plugin line. The file seems to be wrong. Error "
-             "description: " << e.what() << std::endl;
+             "description: "
+          << e.what() << std::endl;
     }
 
     table << id << params << name << cite;

--- a/Framework/DataHandling/src/LoadSpec.cpp
+++ b/Framework/DataHandling/src/LoadSpec.cpp
@@ -23,13 +23,10 @@ LoadSpec::LoadSpec() {}
 
 /// Initialisation method.
 void LoadSpec::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the text file to read, including its full or "
-                  "relative path. The file extension must be .txt or .dat.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".dat", ".txt"}),
+      "The name of the text file to read, including its full or "
+      "relative path. The file extension must be .txt or .dat.");
   declareProperty(
       new WorkspaceProperty<>("OutputWorkspace", "", Direction::Output),
       "The name of the workspace that will be created, filled with the read-in "

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -99,7 +99,7 @@ const std::string LoadSpiceAscii::summary() const {
  */
 void LoadSpiceAscii::init() {
   declareProperty(
-	  new FileProperty("Filename", "", API::FileProperty::Load, {".dat"}),
+      new FileProperty("Filename", "", API::FileProperty::Load, {".dat"}),
       "Name of SPICE data file.");
 
   // Logs to be float type sample log

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -98,11 +98,8 @@ const std::string LoadSpiceAscii::summary() const {
 /** Declaration of properties
  */
 void LoadSpiceAscii::init() {
-  // Input files
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
   declareProperty(
-      new FileProperty("Filename", "", API::FileProperty::Load, exts),
+	  new FileProperty("Filename", "", API::FileProperty::Load, {".dat"}),
       "Name of SPICE data file.");
 
   // Logs to be float type sample log

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -27,11 +27,9 @@ LoadTOFRawNexus::LoadTOFRawNexus()
 //-------------------------------------------------------------------------------------------------
 /// Initialisation method.
 void LoadTOFRawNexus::init() {
-
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "The name of the NeXus file to load");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs"}),
+      "The name of the NeXus file to load");
   declareProperty(new WorkspaceProperty<MatrixWorkspace>("OutputWorkspace", "",
                                                          Direction::Output),
                   "The name of the Workspace2D to create.");

--- a/Framework/DataHandling/src/ModifyDetectorDotDatFile.cpp
+++ b/Framework/DataHandling/src/ModifyDetectorDotDatFile.cpp
@@ -39,9 +39,7 @@ void ModifyDetectorDotDatFile::init() {
       "Workspace with detectors in the positions to be put into the detector "
       "dot dat file");
 
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
+  std::initializer_list<std::string> exts = {".dat", ".txt"};
 
   declareProperty(
       new FileProperty("InputFilename", "", FileProperty::Load, exts),

--- a/Framework/DataHandling/src/NexusTester.cpp
+++ b/Framework/DataHandling/src/NexusTester.cpp
@@ -46,8 +46,8 @@ const std::string NexusTester::category() const {
 /** Initialize the algorithm's properties.
  */
 void NexusTester::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
+  std::initializer_list<std::string> exts = {".nxs"};
+
   declareProperty(
       new FileProperty("SaveFilename", "", FileProperty::OptionalSave, exts),
       "The name of the Nexus file to write.");


### PR DESCRIPTION
Resolves #14769 
## Changes

The following algorithms have been updated to use std::initializer_list

```
LoadQKK
LoadRKH
LoadRawHelper
LoadReflTBL
LoadSINQFocus
LoadSampleDetailsFromRaw
LoadSassena
LoadSavuTomoConfig
LoadSNSspec
LoadSpec
LoadSpiceAscii
LoadTOFRawNexus
ModifyDetectorDotDatFile
NexusTester
```
## Testing

Code Review and maybe run usage examples on algorithms to ensure all still works correctly.
http://docs.mantidproject.org/nightly/algorithms/index.html
