### PR TITLE
Algorithms updated to use std::initializer_list

### DIFF
--- a/Framework/DataHandling/src/NexusTester.cpp
+++ b/Framework/DataHandling/src/NexusTester.cpp
@@ -46,7 +46,7 @@ const std::string NexusTester::category() const {
 /** Initialize the algorithm's properties.
  */
 void NexusTester::init() {
-  std::initializer_list<std::string> exts = { ".nxs" };
+  std::initializer_list<std::string> exts = {".nxs"};
 
   declareProperty(
       new FileProperty("SaveFilename", "", FileProperty::OptionalSave, exts),

--- a/Framework/DataHandling/src/NexusTester.cpp
+++ b/Framework/DataHandling/src/NexusTester.cpp
@@ -46,8 +46,8 @@ const std::string NexusTester::category() const {
 /** Initialize the algorithm's properties.
  */
 void NexusTester::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
+  std::initializer_list<std::string> exts = { ".nxs" };
+
   declareProperty(
       new FileProperty("SaveFilename", "", FileProperty::OptionalSave, exts),
       "The name of the Nexus file to write.");

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -56,9 +56,7 @@ const std::string PDLoadCharacterizations::category() const {
 /** Initialize the algorithm's properties.
  */
 void PDLoadCharacterizations::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".txt");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".txt"}),
                   "Characterizations file");
   declareProperty(
       new FileProperty("ExpIniFilename", "", FileProperty::OptionalLoad, "ini"),

--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -56,8 +56,9 @@ const std::string PDLoadCharacterizations::category() const {
 /** Initialize the algorithm's properties.
  */
 void PDLoadCharacterizations::init() {
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".txt"}),
-                  "Characterizations file");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".txt"}),
+      "Characterizations file");
   declareProperty(
       new FileProperty("ExpIniFilename", "", FileProperty::OptionalLoad, "ini"),
       "(Optional) exp.ini file used at NOMAD");

--- a/Framework/DataHandling/src/RawFileInfo.cpp
+++ b/Framework/DataHandling/src/RawFileInfo.cpp
@@ -83,9 +83,10 @@ const std::string RawFileInfo::runHeader(const ISISRAW &isisRaw) {
 
 /// Create properties
 void RawFileInfo::init() {
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".raw", ".s*"}),
-                  "The name of the [[RAW_File | RAW]] file from which to "
-                  "extract the parameters");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".raw", ".s*"}),
+      "The name of the [[RAW_File | RAW]] file from which to "
+      "extract the parameters");
   declareProperty("GetRunParameters", false,
                   "If this is true, the parameters from the RPB struct are "
                   "placed into a TableWorkspace called Raw_RPB",

--- a/Framework/DataHandling/src/RawFileInfo.cpp
+++ b/Framework/DataHandling/src/RawFileInfo.cpp
@@ -83,10 +83,7 @@ const std::string RawFileInfo::runHeader(const ISISRAW &isisRaw) {
 
 /// Create properties
 void RawFileInfo::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".raw");
-  exts.push_back(".s*");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".raw", ".s*"}),
                   "The name of the [[RAW_File | RAW]] file from which to "
                   "extract the parameters");
   declareProperty("GetRunParameters", false,

--- a/Framework/DataHandling/src/SaveAscii.cpp
+++ b/Framework/DataHandling/src/SaveAscii.cpp
@@ -30,12 +30,8 @@ void SaveAscii::init() {
       new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
       "The name of the workspace containing the data you want to save to a "
       "Ascii file.");
-
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
-  exts.push_back(".csv");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save,
+                                   {".dat", ".txt", ".csv"}),
                   "The filename of the output Ascii file.");
 
   auto mustBeNonNegative = boost::make_shared<BoundedValidator<int>>();

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -33,11 +33,8 @@ void SaveAscii2::init() {
       "The name of the workspace containing the data you want to save to a "
       "Ascii file.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".dat");
-  exts.push_back(".txt");
-  exts.push_back(".csv");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save,
+                                   {".dat", ".txt", ".csv"}),
                   "The filename of the output Ascii file.");
 
   auto mustBePositive = boost::make_shared<BoundedValidator<int>>();

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -33,7 +33,7 @@ void SaveDaveGrp::init() {
       new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
       "An input workspace.");
   this->declareProperty(
-	  new FileProperty("Filename", "", FileProperty::Save, { ".grp" }),
+      new FileProperty("Filename", "", FileProperty::Save, {".grp"}),
       "A DAVE grouped data format file that will be created");
   this->declareProperty(new Kernel::PropertyWithValue<bool>(
                             "ToMicroEV", false, Kernel::Direction::Input),

--- a/Framework/DataHandling/src/SaveDaveGrp.cpp
+++ b/Framework/DataHandling/src/SaveDaveGrp.cpp
@@ -32,10 +32,8 @@ void SaveDaveGrp::init() {
   this->declareProperty(
       new WorkspaceProperty<>("InputWorkspace", "", Direction::Input),
       "An input workspace.");
-  std::vector<std::string> exts;
-  exts.push_back(".grp");
   this->declareProperty(
-      new FileProperty("Filename", "", FileProperty::Save, exts),
+	  new FileProperty("Filename", "", FileProperty::Save, { ".grp" }),
       "A DAVE grouped data format file that will be created");
   this->declareProperty(new Kernel::PropertyWithValue<bool>(
                             "ToMicroEV", false, Kernel::Direction::Input),

--- a/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
+++ b/Framework/DataHandling/src/SaveGSASInstrumentFile.cpp
@@ -304,11 +304,8 @@ void SaveGSASInstrumentFile::init() {
   declareProperty(infileprop,
                   "Name of the input Fullprof resolution file (.irf).");
 
-  vector<string> exts;
-  exts.push_back(".iparam");
-  exts.push_back(".prm");
-  auto fileprop =
-      new FileProperty("OutputFileName", "", FileProperty::Save, exts);
+  auto fileprop = new FileProperty("OutputFileName", "", FileProperty::Save,
+                                   {".iparam", ".prm"});
   declareProperty(fileprop, "Name of the output GSAS instrument file.");
 
   declareProperty(

--- a/Framework/DataHandling/src/SaveISISNexus.cpp
+++ b/Framework/DataHandling/src/SaveISISNexus.cpp
@@ -54,17 +54,10 @@ void SaveISISNexus::init() {
 
   // Declare required parameters, filename with ext {.nx,.nx5,xml} and input
   // workspac
-  std::vector<std::string> nxs_exts;
-  nxs_exts.push_back(".nxs");
-  nxs_exts.push_back(".nx5");
-  nxs_exts.push_back(".xml");
-  declareProperty(
-      new FileProperty("OutputFilename", "", FileProperty::Save, nxs_exts),
-      "The name of the Nexus file to write, as a full or relative\n"
-      "path");
-  // declareProperty(new WorkspaceProperty<MatrixWorkspace> ("InputWorkspace",
-  // "", Direction::Input),
-  //    "Name of the workspace to be saved");
+  declareProperty(new FileProperty("OutputFilename", "", FileProperty::Save,
+                                   {".nxs", ".nx5", ".xml"}),
+                  "The name of the Nexus file to write, as a full or relative\n"
+                  "path");
 }
 
 /**

--- a/Framework/DataHandling/src/SaveISISNexus.cpp
+++ b/Framework/DataHandling/src/SaveISISNexus.cpp
@@ -46,12 +46,9 @@ SaveISISNexus::SaveISISNexus()
  *
  */
 void SaveISISNexus::init() {
-  std::vector<std::string> raw_exts;
-  raw_exts.push_back(".raw");
-  raw_exts.push_back(".s*");
-  raw_exts.push_back(".add");
   declareProperty(
-      new FileProperty("InputFilename", "", FileProperty::Load, raw_exts),
+      new FileProperty("InputFilename", "", FileProperty::Load,
+                       {".raw", ".s*", ".add"}),
       "The name of the RAW file to read, including its full or relative\n"
       "path. (N.B. case sensitive if running on Linux).");
 

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -41,10 +41,7 @@ void SaveIsawDetCal::init() {
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input),
       "An input workspace.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".DetCal");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save, {".DetCal"}),
                   "Path to an ISAW-style .detcal file to save.");
 
   declareProperty("TimeOffset", 0.0, "Offsets to be applied to times");

--- a/Framework/DataHandling/src/SaveIsawDetCal.cpp
+++ b/Framework/DataHandling/src/SaveIsawDetCal.cpp
@@ -41,8 +41,9 @@ void SaveIsawDetCal::init() {
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input),
       "An input workspace.");
 
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, {".DetCal"}),
-                  "Path to an ISAW-style .detcal file to save.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Save, {".DetCal"}),
+      "Path to an ISAW-style .detcal file to save.");
 
   declareProperty("TimeOffset", 0.0, "Offsets to be applied to times");
   declareProperty(new ArrayProperty<string>("BankNames", Direction::Input),

--- a/Framework/DataHandling/src/SaveNexus.cpp
+++ b/Framework/DataHandling/src/SaveNexus.cpp
@@ -36,11 +36,9 @@ void SaveNexus::init() {
   declareProperty(
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input),
       "Name of the workspace to be saved");
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".nx5");
-  exts.push_back(".xml");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save,
+                                   {".nxs", ".nx5", ".xml"}),
                   "The name of the Nexus file to write, as a full or relative\n"
                   "path");
   //

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -45,12 +45,8 @@ void SaveNexusProcessed::init() {
       new WorkspaceProperty<Workspace>("InputWorkspace", "", Direction::Input),
       "Name of the workspace to be saved");
   // Declare required input parameters for algorithm
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
-  exts.push_back(".nx5");
-  exts.push_back(".xml");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save,
+                                   {".nxs", ".nx5", ".xml"}),
                   "The name of the Nexus file to write, as a full or relative\n"
                   "path");
 

--- a/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
+++ b/Framework/DataHandling/src/SaveOpenGenieAscii.cpp
@@ -41,14 +41,10 @@ void SaveOpenGenieAscii::init() {
       "The name of the workspace containing the data you wish to save");
 
   // Declare required parameters, filename with ext {.his} and input
-  // workspac
-  std::vector<std::string> his_exts;
-  his_exts.push_back(".his");
-  his_exts.push_back(".txt");
-  his_exts.push_back("");
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Save, his_exts),
-      "The filename to use for the saved data");
+  // workspace
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Save,
+                                        {".his", ".txt", ""}),
+                  "The filename to use for the saved data");
   declareProperty("IncludeHeader", true,
                   "Whether to include the header lines (default: true)");
   std::vector<std::string> header(2);

--- a/Framework/DataHandling/src/SaveParameterFile.cpp
+++ b/Framework/DataHandling/src/SaveParameterFile.cpp
@@ -60,7 +60,7 @@ void SaveParameterFile::init() {
       "Workspace to save the instrument parameters from.");
 
   declareProperty(
-	  new API::FileProperty("Filename", "", API::FileProperty::Save, { ".xml" }),
+      new API::FileProperty("Filename", "", API::FileProperty::Save, {".xml"}),
       "The name of the file into which the instrument parameters will be "
       "saved.");
 

--- a/Framework/DataHandling/src/SaveParameterFile.cpp
+++ b/Framework/DataHandling/src/SaveParameterFile.cpp
@@ -59,11 +59,8 @@ void SaveParameterFile::init() {
                               boost::make_shared<InstrumentValidator>()),
       "Workspace to save the instrument parameters from.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".xml");
-
   declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Save, exts),
+	  new API::FileProperty("Filename", "", API::FileProperty::Save, { ".xml" }),
       "The name of the file into which the instrument parameters will be "
       "saved.");
 

--- a/Framework/DataHandling/src/SaveRKH.cpp
+++ b/Framework/DataHandling/src/SaveRKH.cpp
@@ -31,13 +31,9 @@ void SaveRKH::init() {
   declareProperty(new API::WorkspaceProperty<>("InputWorkspace", "",
                                                Kernel::Direction::Input),
                   "The name of the workspace to save");
-  std::vector<std::string> exts;
-  exts.push_back(".txt");
-  exts.push_back(".Q");
-  exts.push_back(".dat");
-  declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Save, exts),
-      "The name to use when saving the file");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Save,
+                                        {".txt", ".Q", ".dat"}),
+                  "The name to use when saving the file");
   declareProperty(
       "Append", true,
       "If true and Filename already exists, append, else overwrite");

--- a/Framework/DataHandling/src/SaveReflTBL.cpp
+++ b/Framework/DataHandling/src/SaveReflTBL.cpp
@@ -23,8 +23,9 @@ SaveReflTBL::SaveReflTBL() : m_sep(','), m_stichgroups(), m_nogroup() {}
 
 /// Initialisation method.
 void SaveReflTBL::init() {
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, { ".tbl" }),
-                  "The filename of the output TBL file.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Save, {".tbl"}),
+      "The filename of the output TBL file.");
 
   declareProperty(new WorkspaceProperty<ITableWorkspace>("InputWorkspace", "",
                                                          Direction::Input),

--- a/Framework/DataHandling/src/SaveReflTBL.cpp
+++ b/Framework/DataHandling/src/SaveReflTBL.cpp
@@ -23,10 +23,7 @@ SaveReflTBL::SaveReflTBL() : m_sep(','), m_stichgroups(), m_nogroup() {}
 
 /// Initialisation method.
 void SaveReflTBL::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".tbl");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Save, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Save, { ".tbl" }),
                   "The filename of the output TBL file.");
 
   declareProperty(new WorkspaceProperty<ITableWorkspace>("InputWorkspace", "",


### PR DESCRIPTION
Resolved #14771 
## Changes

The following algorithms have been updated to use std::initializer_list

```
NexusTester
PDLoadCharacterizations
RawFileInfo
SaveAscii
SaveDaveGrp
SaveGSASInstrumentFile
SaveIsawDetCal
SaveISISNexus
SaveNexus
SaveNexusProcessed
SaveOpenGenieAscii
SaveParameterFile
SaveRKH
SaveReflTBL
```
## Testing

Code Review and maybe run usage examples on algorithms to ensure all still works correctly.
http://docs.mantidproject.org/nightly/algorithms/index.html
