### PR TITLE
Algorithms updated to use std::initializer_list

### DIFF
--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -48,8 +48,7 @@ SaveToSNSHistogramNexus::SaveToSNSHistogramNexus()
 void SaveToSNSHistogramNexus::init() {
   // Declare required parameters, filename with ext {.nx,.nx5,xml} and input
   // workspac
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
+  std::initializer_list<std::string> exts = { ".nxs" };
 
   declareProperty(
       new FileProperty("InputFilename", "", FileProperty::Load, exts),

--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -48,7 +48,7 @@ SaveToSNSHistogramNexus::SaveToSNSHistogramNexus()
 void SaveToSNSHistogramNexus::init() {
   // Declare required parameters, filename with ext {.nx,.nx5,xml} and input
   // workspac
-  std::initializer_list<std::string> exts = { ".nxs" };
+  std::initializer_list<std::string> exts = {".nxs"};
 
   declareProperty(
       new FileProperty("InputFilename", "", FileProperty::Load, exts),

--- a/Framework/DataHandling/src/SetScalingPSD.cpp
+++ b/Framework/DataHandling/src/SetScalingPSD.cpp
@@ -31,11 +31,8 @@ SetScalingPSD::SetScalingPSD() : Algorithm(), m_scalingOption(0) {}
  */
 void SetScalingPSD::init() {
   // Declare required input parameters for algorithm
-  std::vector<std::string> exts;
-  exts.push_back(".sca");
-  exts.push_back(".raw");
   declareProperty(
-      new FileProperty("ScalingFilename", "", FileProperty::Load, exts),
+	  new FileProperty("ScalingFilename", "", FileProperty::Load, {".sca", ".raw"}),
       "The name of the scaling calibrations file to read, including its\n"
       "full or relative path. The file extension must be either .sca or\n"
       ".raw (filenames are case sensitive on linux)");

--- a/Framework/DataHandling/src/SetScalingPSD.cpp
+++ b/Framework/DataHandling/src/SetScalingPSD.cpp
@@ -32,7 +32,8 @@ SetScalingPSD::SetScalingPSD() : Algorithm(), m_scalingOption(0) {}
 void SetScalingPSD::init() {
   // Declare required input parameters for algorithm
   declareProperty(
-	  new FileProperty("ScalingFilename", "", FileProperty::Load, {".sca", ".raw"}),
+      new FileProperty("ScalingFilename", "", FileProperty::Load,
+                       {".sca", ".raw"}),
       "The name of the scaling calibrations file to read, including its\n"
       "full or relative path. The file extension must be either .sca or\n"
       ".raw (filenames are case sensitive on linux)");

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -44,7 +44,8 @@ void UpdateInstrumentFromFile::init() {
       new WorkspaceProperty<MatrixWorkspace>("Workspace", "Anonymous",
                                              Direction::InOut),
       "The name of the workspace in which to store the imported instrument");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".raw", ".nxs", ".s*"}),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load,
+                                   {".raw", ".nxs", ".s*"}),
                   "The filename of the input file.\n"
                   "Currently supports RAW, ISIS NeXus, DAT & multi-column (at "
                   "least 2) ascii files");

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -44,12 +44,7 @@ void UpdateInstrumentFromFile::init() {
       new WorkspaceProperty<MatrixWorkspace>("Workspace", "Anonymous",
                                              Direction::InOut),
       "The name of the workspace in which to store the imported instrument");
-
-  std::vector<std::string> exts;
-  exts.push_back(".raw");
-  exts.push_back(".nxs");
-  exts.push_back(".s*");
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".raw", ".nxs", ".s*"}),
                   "The filename of the input file.\n"
                   "Currently supports RAW, ISIS NeXus, DAT & multi-column (at "
                   "least 2) ascii files");

--- a/Framework/MDAlgorithms/src/CreateMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/CreateMDWorkspace.cpp
@@ -86,7 +86,7 @@ void CreateMDWorkspace::init() {
                                                    Direction::Output),
                   "Name of the output MDEventWorkspace.");
   declareProperty(
-	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
+      new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
       "Optional: to use a file as the back end, give the path to the file to "
       "save.");
 

--- a/Framework/MDAlgorithms/src/CreateMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/CreateMDWorkspace.cpp
@@ -85,11 +85,8 @@ void CreateMDWorkspace::init() {
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output),
                   "Name of the output MDEventWorkspace.");
-
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::OptionalSave, exts),
+	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
       "Optional: to use a file as the back end, give the path to the file to "
       "save.");
 

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -81,11 +81,8 @@ int LoadMD::confidence(Kernel::NexusDescriptor &descriptor) const {
 /** Initialize the algorithm's properties.
 */
 void LoadMD::init() {
-
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, exts),
+	  new FileProperty("Filename", "", FileProperty::Load, {".nxs"}),
       "The name of the Nexus file to load, as a full or relative path");
 
   declareProperty(new Kernel::PropertyWithValue<bool>("MetadataOnly", false),

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -82,7 +82,7 @@ int LoadMD::confidence(Kernel::NexusDescriptor &descriptor) const {
 */
 void LoadMD::init() {
   declareProperty(
-	  new FileProperty("Filename", "", FileProperty::Load, {".nxs"}),
+      new FileProperty("Filename", "", FileProperty::Load, {".nxs"}),
       "The name of the Nexus file to load, as a full or relative path");
 
   declareProperty(new Kernel::PropertyWithValue<bool>("MetadataOnly", false),

--- a/Framework/MDAlgorithms/src/SaveIsawQvector.cpp
+++ b/Framework/MDAlgorithms/src/SaveIsawQvector.cpp
@@ -65,12 +65,8 @@ void SaveIsawQvector::init() {
                       "InputWorkspace", "", Direction::Input, ws_valid),
                   "An input EventWorkspace with units along X-axis and defined "
                   "instrument with defined sample");
-
-  std::vector<std::string> exts;
-  exts.push_back(".bin");
-
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::OptionalSave, exts),
+	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".bin"}),
       "Optional path to an hkl file to save.  Vectors returned if no file "
       "requested.");
   declareProperty("RightHanded", true, "Save the Q-vector as k_f - k_i");

--- a/Framework/MDAlgorithms/src/SaveIsawQvector.cpp
+++ b/Framework/MDAlgorithms/src/SaveIsawQvector.cpp
@@ -66,7 +66,7 @@ void SaveIsawQvector::init() {
                   "An input EventWorkspace with units along X-axis and defined "
                   "instrument with defined sample");
   declareProperty(
-	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".bin"}),
+      new FileProperty("Filename", "", FileProperty::OptionalSave, {".bin"}),
       "Optional path to an hkl file to save.  Vectors returned if no file "
       "requested.");
   declareProperty("RightHanded", true, "Save the Q-vector as k_f - k_i");

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -54,7 +54,7 @@ void SaveMD::init() {
                   "An input MDEventWorkspace or MDHistoWorkspace.");
 
   declareProperty(
-	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
+      new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
       "The name of the Nexus file to write, as a full or relative path.\n"
       "Optional if UpdateFileBackEnd is checked.");
   // Filename is NOT used if UpdateFileBackEnd

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -53,10 +53,8 @@ void SaveMD::init() {
                                                       Direction::Input),
                   "An input MDEventWorkspace or MDHistoWorkspace.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::OptionalSave, exts),
+	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
       "The name of the Nexus file to write, as a full or relative path.\n"
       "Optional if UpdateFileBackEnd is checked.");
   // Filename is NOT used if UpdateFileBackEnd

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -54,10 +54,8 @@ void SaveMD2::init() {
                                                       Direction::Input),
                   "An input MDEventWorkspace or MDHistoWorkspace.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::OptionalSave, exts),
+	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
       "The name of the Nexus file to write, as a full or relative path.\n"
       "Optional if UpdateFileBackEnd is checked.");
   // Filename is NOT used if UpdateFileBackEnd

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -55,7 +55,7 @@ void SaveMD2::init() {
                   "An input MDEventWorkspace or MDHistoWorkspace.");
 
   declareProperty(
-	  new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
+      new FileProperty("Filename", "", FileProperty::OptionalSave, {".nxs"}),
       "The name of the Nexus file to write, as a full or relative path.\n"
       "Optional if UpdateFileBackEnd is checked.");
   // Filename is NOT used if UpdateFileBackEnd

--- a/Framework/MDAlgorithms/src/SaveZODS.cpp
+++ b/Framework/MDAlgorithms/src/SaveZODS.cpp
@@ -48,10 +48,8 @@ void SaveZODS::init() {
                                                            Direction::Input),
                   "An input MDHistoWorkspace in HKL space.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".h5");
   declareProperty(
-      new FileProperty("Filename", "", FileProperty::Save, exts),
+	  new FileProperty("Filename", "", FileProperty::Save, {".h5"}),
       "The name of the HDF5 file to write, as a full or relative path.");
 }
 

--- a/Framework/MDAlgorithms/src/SaveZODS.cpp
+++ b/Framework/MDAlgorithms/src/SaveZODS.cpp
@@ -49,7 +49,7 @@ void SaveZODS::init() {
                   "An input MDHistoWorkspace in HKL space.");
 
   declareProperty(
-	  new FileProperty("Filename", "", FileProperty::Save, {".h5"}),
+      new FileProperty("Filename", "", FileProperty::Save, {".h5"}),
       "The name of the HDF5 file to write, as a full or relative path.");
 }
 

--- a/Framework/MDAlgorithms/src/SliceMD.cpp
+++ b/Framework/MDAlgorithms/src/SliceMD.cpp
@@ -49,7 +49,8 @@ void SliceMD::init() {
                   "Name of the output MDEventWorkspace.");
 
   declareProperty(
-	  new FileProperty("OutputFilename", "", FileProperty::OptionalSave, {".nxs"}),
+      new FileProperty("OutputFilename", "", FileProperty::OptionalSave,
+                       {".nxs"}),
       "Optional: Specify a NeXus file to write if you want the output "
       "workspace to be file-backed.");
 

--- a/Framework/MDAlgorithms/src/SliceMD.cpp
+++ b/Framework/MDAlgorithms/src/SliceMD.cpp
@@ -48,10 +48,8 @@ void SliceMD::init() {
                                                    Direction::Output),
                   "Name of the output MDEventWorkspace.");
 
-  std::vector<std::string> exts;
-  exts.push_back(".nxs");
   declareProperty(
-      new FileProperty("OutputFilename", "", FileProperty::OptionalSave, exts),
+	  new FileProperty("OutputFilename", "", FileProperty::OptionalSave, {".nxs"}),
       "Optional: Specify a NeXus file to write if you want the output "
       "workspace to be file-backed.");
 

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -24,9 +24,11 @@ using namespace ::NeXus;
 
 void LoadFlexiNexus::init() {
 
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".hdf", ".h5", ""}),
-                  "A NeXus file");
-  declareProperty(new FileProperty("Dictionary", "", FileProperty::Load, {".txt", ".dic", ""}),
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".hdf", ".h5", ""}),
+      "A NeXus file");
+  declareProperty(new FileProperty("Dictionary", "", FileProperty::Load,
+                                   {".txt", ".dic", ""}),
                   "A Dictionary for controlling NeXus loading");
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output));

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -24,18 +24,9 @@ using namespace ::NeXus;
 
 void LoadFlexiNexus::init() {
 
-  std::vector<std::string> exts;
-  exts.push_back(".hdf");
-  exts.push_back(".h5");
-  exts.push_back("");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load, {".hdf", ".h5", ""}),
                   "A NeXus file");
-  std::vector<std::string> exts2;
-  exts2.push_back(".txt");
-  exts2.push_back(".dic");
-  exts2.push_back("");
-  declareProperty(new FileProperty("Dictionary", "", FileProperty::Load, exts2),
+  declareProperty(new FileProperty("Dictionary", "", FileProperty::Load, {".txt", ".dic", ""}),
                   "A Dictionary for controlling NeXus loading");
   declareProperty(new WorkspaceProperty<Workspace>("OutputWorkspace", "",
                                                    Direction::Output));

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -71,13 +71,8 @@ void AlignAndFocusPowder::init() {
   //   Direction::Output, PropertyMode::Optional),
   //   "The name of the workspace containing the filtered low resolution TOF
   //   data.");
-  std::vector<std::string> exts;
-  exts.push_back(".h5");
-  exts.push_back(".hd5");
-  exts.push_back(".hdf");
-  exts.push_back(".cal");
   declareProperty(
-      new FileProperty("CalFileName", "", FileProperty::OptionalLoad, exts),
+	  new FileProperty("CalFileName", "", FileProperty::OptionalLoad, {".h5", ".hd5", ".hdf", ".cal"}),
       "The name of the CalFile with offset, masking, and grouping data");
   declareProperty(
       new WorkspaceProperty<GroupingWorkspace>(

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -72,7 +72,8 @@ void AlignAndFocusPowder::init() {
   //   "The name of the workspace containing the filtered low resolution TOF
   //   data.");
   declareProperty(
-	  new FileProperty("CalFileName", "", FileProperty::OptionalLoad, {".h5", ".hd5", ".hdf", ".cal"}),
+      new FileProperty("CalFileName", "", FileProperty::OptionalLoad,
+                       {".h5", ".hd5", ".hdf", ".cal"}),
       "The name of the CalFile with offset, masking, and grouping data");
   declareProperty(
       new WorkspaceProperty<GroupingWorkspace>(

--- a/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
@@ -25,9 +25,9 @@ using namespace Geometry;
 using namespace DataObjects;
 
 void SANSBeamFinder::init() {
-  declareProperty(
-	  new API::FileProperty("Filename", "", API::FileProperty::Load, {"_event.nxs", ".xml"}),
-      "Data filed used to find beam center");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Load,
+                                        {"_event.nxs", ".xml"}),
+                  "Data filed used to find beam center");
 
   declareProperty("BeamCenterX", EMPTY_DBL(),
                   "Beam position in X pixel coordinates");

--- a/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
@@ -25,11 +25,8 @@ using namespace Geometry;
 using namespace DataObjects;
 
 void SANSBeamFinder::init() {
-  std::vector<std::string> exts;
-  exts.push_back("_event.nxs");
-  exts.push_back(".xml");
   declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Load, exts),
+	  new API::FileProperty("Filename", "", API::FileProperty::Load, {"_event.nxs", ".xml"}),
       "Data filed used to find beam center");
 
   declareProperty("BeamCenterX", EMPTY_DBL(),

--- a/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
@@ -33,15 +33,15 @@ using namespace DataObjects;
 void SANSSensitivityCorrection::init() {
   declareProperty(new WorkspaceProperty<>(
       "InputWorkspace", "", Direction::Input, PropertyMode::Optional));
-  declareProperty(
-	  new API::FileProperty("Filename", "", API::FileProperty::Load, {"_event.nxs", ".xml"}),
-      "Flood field or sensitivity file.");
+  declareProperty(new API::FileProperty("Filename", "", API::FileProperty::Load,
+                                        {"_event.nxs", ".xml"}),
+                  "Flood field or sensitivity file.");
   declareProperty("UseSampleDC", true, "If true, the dark current subtracted "
                                        "from the sample data will also be "
                                        "subtracted from the flood field.");
   declareProperty(new API::FileProperty("DarkCurrentFile", "",
                                         API::FileProperty::OptionalLoad,
-										{"_event.nxs", ".xml"}),
+                                        {"_event.nxs", ".xml"}),
                   "The name of the input file to load as dark current.");
 
   auto positiveDouble = boost::make_shared<BoundedValidator<double>>();

--- a/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
@@ -33,22 +33,15 @@ using namespace DataObjects;
 void SANSSensitivityCorrection::init() {
   declareProperty(new WorkspaceProperty<>(
       "InputWorkspace", "", Direction::Input, PropertyMode::Optional));
-
-  std::vector<std::string> exts;
-  exts.push_back("_event.nxs");
-  exts.push_back(".xml");
   declareProperty(
-      new API::FileProperty("Filename", "", API::FileProperty::Load, exts),
+	  new API::FileProperty("Filename", "", API::FileProperty::Load, {"_event.nxs", ".xml"}),
       "Flood field or sensitivity file.");
   declareProperty("UseSampleDC", true, "If true, the dark current subtracted "
                                        "from the sample data will also be "
                                        "subtracted from the flood field.");
-  std::vector<std::string> dc_exts;
-  dc_exts.push_back("_event.nxs");
-  dc_exts.push_back(".xml");
   declareProperty(new API::FileProperty("DarkCurrentFile", "",
                                         API::FileProperty::OptionalLoad,
-                                        dc_exts),
+										{"_event.nxs", ".xml"}),
                   "The name of the input file to load as dark current.");
 
   auto positiveDouble = boost::make_shared<BoundedValidator<double>>();


### PR DESCRIPTION
Resolves #14773 #14760 
## Changes

The following algorithms have been updated to use std::initializer_list

```
SaveToSNSHistogramNexus
SetScalingPSD
UpdateInstrumentFromFile
CreateMDWorkspace
LoadMD 
SaveIsawQvector 
SaveMD
SaveZODS
SliceMD
LoadFlexiNexus
AlignAndFocusPowder
SANSBeamFinder 
SANSSensitivityCorrection
```
## Testing

Code Review and maybe run usage examples on algorithms to ensure all still works correctly.
http://docs.mantidproject.org/nightly/algorithms/index.html
