### PR TITLE
Ensure ipython notebook filename ends with .ipynb

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -5,6 +5,7 @@
 #include "MantidQtMantidWidgets/HintingLineEditFactory.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidQtAPI/HelpWindow.h"
+#include "MantidQtAPI/FileDialogHandler.h"
 #include "MantidKernel/ConfigService.h"
 #include <qinputdialog.h>
 #include <qmessagebox.h>
@@ -464,14 +465,18 @@ void QtReflMainView::showImportDialog() {
 Show the user file dialog to choose save location of notebook
 */
 std::string QtReflMainView::requestNotebookPath() {
-  QString qfilename = QFileDialog::getSaveFileName(
+
+  // We won't use QFileDialog directly here as using the NativeDialog option
+  // causes problems on MacOS.
+  QString qfilename = API::FileDialogHandler::getSaveFileName(
       this, "Save notebook file", QDir::currentPath(),
       "IPython Notebook files (*.ipynb);;All files (*.*)",
       new QString("IPython Notebook files (*.ipynb)"));
 
-  // Sadly there is a Qt bug (QTBUG-27186) which means the filename returned
+  // There is a Qt bug (QTBUG-27186) which means the filename returned
   // from the dialog doesn't always the file extension appended.
   // So we'll have to ensure this ourselves.
+  // Important, notebooks can't be loaded without this extension.
   std::string filename = qfilename.toStdString();
   if (filename.size() > 6) {
     if (filename.substr(filename.size() - 6) != ".ipynb") {

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -465,7 +465,7 @@ Show the user file dialog to choose save location of notebook
 */
 std::string QtReflMainView::requestNotebookPath() {
   QString qfilename = QFileDialog::getSaveFileName(
-      0, "Save notebook file", QDir::currentPath(),
+      this, "Save notebook file", QDir::currentPath(),
       "IPython Notebook files (*.ipynb);;All files (*.*)",
       new QString("IPython Notebook files (*.ipynb)"));
 

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -468,7 +468,20 @@ std::string QtReflMainView::requestNotebookPath() {
       0, "Save notebook file", QDir::currentPath(),
       "IPython Notebook files (*.ipynb);;All files (*.*)",
       new QString("IPython Notebook files (*.ipynb)"));
-  return qfilename.toStdString();
+
+  // Sadly there is a Qt bug (QTBUG-27186) which means the filename returned
+  // from the dialog doesn't always the file extension appended.
+  // So we'll have to ensure this ourselves.
+  std::string filename = qfilename.toStdString();
+  if (filename.size() > 6) {
+    if (filename.substr(filename.size() - 6) != ".ipynb") {
+      filename.append(".ipynb");
+    }
+  } else {
+    filename.append(".ipynb");
+  }
+
+  return filename;
 }
 
 /**


### PR DESCRIPTION
Fixes #14751 

**Note, must be tested in Linux**

Due to [this Qt bug](https://bugreports.qt.io/browse/QTBUG-27186) the save file dialog for generated notebooks from the Reflectometry (Polref) interface was not returning a filename with the .ipynb extension when running MantidPlot in Linux. The file extension is important as the ipython notebook interface does not load notebooks correctly unless they have this extension.

I've fixed the problem by manually appending the expected extension to the filename in the case where it does not already end with ".ipynb".

**To Test:**
- Generate an ipython notebook from the Reflectometry (Polref) Interface by following the example workflow in the [interface's documentation](http://docs.mantidproject.org/nightly/interfaces/ISIS_Reflectometry.html?highlight=reflectometry%20interface) and ticking the "Output Notebook" checkbox before "Process".
- Save the notebook with a filename that does not end in ".ipynb" and check that the resulting saved notebook does end in "ipynb".
- The file dialogue should grab focus (appear on top of other windows) when processing is complete.
