### PR TITLE
Script Window now allows soft wrapping of text

### DIFF
--- a/MantidPlot/src/MultiTabScriptInterpreter.h
+++ b/MantidPlot/src/MultiTabScriptInterpreter.h
@@ -179,6 +179,8 @@ public slots:
   void toggleProgressReporting(bool on);
   /// Toggle code folding
   void toggleCodeFolding(bool on);
+  /// Toggle line wrapping
+  void toggleLineWrapping(bool on);
   /// Toggle the whitespace reporting arrow
   void toggleWhitespace(bool state);
   /// Show configuration dialogue for tab whitespace
@@ -251,6 +253,8 @@ private:
   QString m_fontFamily;
   // Save the code folding preference
   bool m_codeFolding;
+  // Save the line wrapping preference
+  bool m_LineWrapping;
 };
 
 #endif

--- a/MantidPlot/src/ScriptFileInterpreter.cpp
+++ b/MantidPlot/src/ScriptFileInterpreter.cpp
@@ -20,59 +20,51 @@
  * Construct a widget
  * @param parent :: The parent widget
  */
-ScriptFileInterpreter::ScriptFileInterpreter(QWidget *parent, const QString & settingsGroup)
-  : QWidget(parent), m_splitter(new QSplitter(Qt::Vertical,this)),
-    m_editor(new ScriptEditor(this, NULL,settingsGroup)),
-    m_messages(new ScriptOutputDisplay), m_status(new QStatusBar),
-    m_runner()
-{
+ScriptFileInterpreter::ScriptFileInterpreter(QWidget *parent,
+                                             const QString &settingsGroup)
+    : QWidget(parent), m_splitter(new QSplitter(Qt::Vertical, this)),
+      m_editor(new ScriptEditor(this, NULL, settingsGroup)),
+      m_messages(new ScriptOutputDisplay), m_status(new QStatusBar),
+      m_runner() {
+
+  // Initialise line wrapping to include additional indent and visual arrow flag
+  m_editor->setWrapIndentMode(QsciScintilla::WrapIndentIndented);
+  m_editor->setWrapVisualFlags(QsciScintilla::WrapFlagByText);
+
   setupChildWidgets();
 
   setContextMenuPolicy(Qt::CustomContextMenu);
-  connect(this, SIGNAL(customContextMenuRequested(const QPoint &)),
-          this, SLOT(showContextMenu(const QPoint&)));
+  connect(this, SIGNAL(customContextMenuRequested(const QPoint &)), this,
+          SLOT(showContextMenu(const QPoint &)));
 
-  connect(m_editor, SIGNAL(textZoomedIn()), m_messages,
-          SLOT(zoomUp()));
-  connect(m_editor, SIGNAL(textZoomedOut()), m_messages,
-          SLOT(zoomDown()));
-  connect(m_messages, SIGNAL(textZoomedIn()), m_editor,
-          SLOT(zoomIn()));
-  connect(m_messages, SIGNAL(textZoomedOut()), m_editor,
-          SLOT(zoomOut()));
-  connect(m_editor, SIGNAL(textZoomedIn()), this,
-          SLOT(emitZoomIn()));
-  connect(m_editor, SIGNAL(textZoomedOut()), this,
-          SLOT(emitZoomOut()));
-  connect(m_messages, SIGNAL(textZoomedIn()), this,
-          SLOT(emitZoomIn()));
-  connect(m_messages, SIGNAL(textZoomedOut()), this,
-          SLOT(emitZoomOut()));
-
+  connect(m_editor, SIGNAL(textZoomedIn()), m_messages, SLOT(zoomUp()));
+  connect(m_editor, SIGNAL(textZoomedOut()), m_messages, SLOT(zoomDown()));
+  connect(m_messages, SIGNAL(textZoomedIn()), m_editor, SLOT(zoomIn()));
+  connect(m_messages, SIGNAL(textZoomedOut()), m_editor, SLOT(zoomOut()));
+  connect(m_editor, SIGNAL(textZoomedIn()), this, SLOT(emitZoomIn()));
+  connect(m_editor, SIGNAL(textZoomedOut()), this, SLOT(emitZoomOut()));
+  connect(m_messages, SIGNAL(textZoomedIn()), this, SLOT(emitZoomIn()));
+  connect(m_messages, SIGNAL(textZoomedOut()), this, SLOT(emitZoomOut()));
 }
 
 /// Destroy the object
-ScriptFileInterpreter::~ScriptFileInterpreter()
-{
-}
+ScriptFileInterpreter::~ScriptFileInterpreter() {}
 
 /**
  * Check if the interpreter is running and the script is saved
  * @return True if the interpreter should be closed
  */
-bool ScriptFileInterpreter::shouldClose()
-{
+bool ScriptFileInterpreter::shouldClose() {
   ScriptCloseDialog dialog(*this, this);
   return dialog.shouldScriptClose();
 }
 
 /// Convert tabs in selection to spaces
-void ScriptFileInterpreter::tabsToSpaces()
-{
+void ScriptFileInterpreter::tabsToSpaces() {
   int selFromLine, selFromInd, selToLine, selToInd;
 
   m_editor->getSelection(&selFromLine, &selFromInd, &selToLine, &selToInd);
-  if(selFromLine == -1)
+  if (selFromLine == -1)
     m_editor->selectAll();
 
   QString text = m_editor->selectedText();
@@ -80,7 +72,7 @@ void ScriptFileInterpreter::tabsToSpaces()
   // Use the tab space count for each converted character
   QString spaces = "";
 
-  for(int i=0;i<m_editor->tabWidth();++i)
+  for (int i = 0; i < m_editor->tabWidth(); ++i)
     spaces = spaces + " ";
 
   text = text.replace("\t", spaces, Qt::CaseInsensitive);
@@ -88,12 +80,11 @@ void ScriptFileInterpreter::tabsToSpaces()
 }
 
 /// Convert spaces in selection to tabs
-void ScriptFileInterpreter::spacesToTabs()
-{
+void ScriptFileInterpreter::spacesToTabs() {
   int selFromLine, selFromInd, selToLine, selToInd;
 
   m_editor->getSelection(&selFromLine, &selFromInd, &selToLine, &selToInd);
-  if(selFromLine == -1)
+  if (selFromLine == -1)
     m_editor->selectAll();
 
   QString text = m_editor->selectedText();
@@ -101,7 +92,7 @@ void ScriptFileInterpreter::spacesToTabs()
   // Use the tab space count for each converted characters
   QString spaces = "";
 
-  for(int i=0;i<m_editor->tabWidth();++i)
+  for (int i = 0; i < m_editor->tabWidth(); ++i)
     spaces = spaces + " ";
 
   text = text.replace(spaces, "\t", Qt::CaseInsensitive);
@@ -109,80 +100,71 @@ void ScriptFileInterpreter::spacesToTabs()
 }
 
 /// Set a font
-void ScriptFileInterpreter::setFont(const QString &fontFamily)
-{
+void ScriptFileInterpreter::setFont(const QString &fontFamily) {
   // This needs to check if the font exists and use default if not
   QFontDatabase database;
 
   // Select saved choice. If not available, use current font
   QString fontToUse = m_editor->lexer()->defaultFont().family();
 
-  if(database.families().contains(fontFamily))
+  if (database.families().contains(fontFamily))
     fontToUse = fontFamily;
 
   QFont defaultFont = m_editor->lexer()->defaultFont();
   defaultFont.setFamily(fontToUse);
   m_editor->lexer()->setDefaultFont(defaultFont);
 
-  // Check through all styles until it starts creating new ones (they match the default style)
+  // Check through all styles until it starts creating new ones (they match the
+  // default style)
   // On each, copy the font and change only the family
   int count = 0;
-  while(m_editor->lexer()->font(count) != m_editor->lexer()->defaultFont())
-  {
+  while (m_editor->lexer()->font(count) != m_editor->lexer()->defaultFont()) {
     QFont font = m_editor->lexer()->font(count);
     font.setFamily(fontToUse);
-    m_editor->lexer()->setFont(font,count);
+    m_editor->lexer()->setFont(font, count);
 
     count++;
   }
 }
 
 /// Toggle replacing tabs with whitespace
-void ScriptFileInterpreter::toggleReplaceTabs(bool state)
-{
+void ScriptFileInterpreter::toggleReplaceTabs(bool state) {
   m_editor->setIndentationsUseTabs(!state);
 }
 
 /// Number of spaces to insert for a tab
-void ScriptFileInterpreter::setTabWhitespaceCount(int count)
-{
+void ScriptFileInterpreter::setTabWhitespaceCount(int count) {
   m_editor->setTabWidth(count);
 }
 
 /// Toggles the whitespace on/off
-void ScriptFileInterpreter::toggleWhitespace(bool state)
-{
+void ScriptFileInterpreter::toggleWhitespace(bool state) {
   m_editor->setEolVisibility(state);
 
-  if(state)
-      m_editor->setWhitespaceVisibility(QsciScintilla::WhitespaceVisibility::WsVisible);
+  if (state)
+    m_editor->setWhitespaceVisibility(
+        QsciScintilla::WhitespaceVisibility::WsVisible);
   else
-    m_editor->setWhitespaceVisibility(QsciScintilla::WhitespaceVisibility::WsInvisible);
+    m_editor->setWhitespaceVisibility(
+        QsciScintilla::WhitespaceVisibility::WsInvisible);
 }
 
 /// Comment a block of code
-void ScriptFileInterpreter::comment()
-{
-  toggleComment(true);
-}
+void ScriptFileInterpreter::comment() { toggleComment(true); }
 
 /// Uncomment a block of code
-void ScriptFileInterpreter::uncomment()
-{
-  toggleComment(false);
-}
+void ScriptFileInterpreter::uncomment() { toggleComment(false); }
 
-void ScriptFileInterpreter::toggleComment(bool addComment)
-{
+void ScriptFileInterpreter::toggleComment(bool addComment) {
   // Get selected text
-  std::string whitespaces (" \t\f\r");
+  std::string whitespaces(" \t\f\r");
   int selFromLine, selFromInd, selToLine, selToInd;
 
   m_editor->getSelection(&selFromLine, &selFromInd, &selToLine, &selToInd);
 
-  // Expand selection to first character on start line to the end char on second line.
-  if(selFromLine == -1)
-  {
+  // Expand selection to first character on start line to the end char on second
+  // line.
+  if (selFromLine == -1) {
     m_editor->getCursorPosition(&selFromLine, &selFromInd);
     selToLine = selFromLine;
   }
@@ -190,40 +172,36 @@ void ScriptFileInterpreter::toggleComment(bool addComment)
   // For each line, select it, copy the line into a new string minus the comment
   QString replacementText = "";
 
-  // If it's adding comment, check all lines to find the lowest index for a non space character
+  // If it's adding comment, check all lines to find the lowest index for a non
+  // space character
   int minInd = -1;
-  if(addComment)
-  {
-    for(int i=selFromLine;i<=selToLine;++i)
-    {
+  if (addComment) {
+    for (int i = selFromLine; i <= selToLine; ++i) {
       std::string thisLine = m_editor->text(i).toUtf8().constData();
-      int lineFirstChar = static_cast<int>(thisLine.find_first_not_of(whitespaces + "\n"));
+      int lineFirstChar =
+          static_cast<int>(thisLine.find_first_not_of(whitespaces + "\n"));
 
-      if(minInd == -1 || (lineFirstChar != -1 && lineFirstChar < minInd))
-      {
-          minInd = lineFirstChar;
+      if (minInd == -1 || (lineFirstChar != -1 && lineFirstChar < minInd)) {
+        minInd = lineFirstChar;
       }
     }
   }
 
-  for(int i=selFromLine;i<=selToLine;++i)
-  {
+  for (int i = selFromLine; i <= selToLine; ++i) {
     std::string thisLine = m_editor->text(i).toUtf8().constData();
 
-    int lineFirstChar = static_cast<int>(thisLine.find_first_not_of(whitespaces + "\n"));
+    int lineFirstChar =
+        static_cast<int>(thisLine.find_first_not_of(whitespaces + "\n"));
 
-    if(lineFirstChar != -1)
-    {
-      if(addComment)
-      {
-        thisLine.insert(minInd,"#");
-      }
-      else
-      {
+    if (lineFirstChar != -1) {
+      if (addComment) {
+        thisLine.insert(minInd, "#");
+      } else {
         // Check that the first character is a #
-        if(thisLine[lineFirstChar] == '#') // Remove the comment, or ignore to add as is
+        if (thisLine[lineFirstChar] ==
+            '#') // Remove the comment, or ignore to add as is
         {
-          thisLine = thisLine.erase(lineFirstChar,1);
+          thisLine = thisLine.erase(lineFirstChar, 1);
         }
       }
     }
@@ -231,26 +209,31 @@ void ScriptFileInterpreter::toggleComment(bool addComment)
     replacementText = replacementText + QString::fromStdString(thisLine);
   }
 
-  m_editor->setSelection(selFromLine,0,selToLine, m_editor->lineLength(selToLine));
+  m_editor->setSelection(selFromLine, 0, selToLine,
+                         m_editor->lineLength(selToLine));
   replaceSelectedText(m_editor, replacementText);
-  m_editor->setCursorPosition(selFromLine,selFromInd);
+  m_editor->setCursorPosition(selFromLine, selFromInd);
 }
 
 // Replaces the currently selected text in the editor
-// Reimplementation of .replaceSelectedText from QScintilla. Added as osx + rhel builds are
-// using an older version(2.4.6) of the library missing the method, and too close to code freeze to update.
-inline void ScriptFileInterpreter::replaceSelectedText(const ScriptEditor *editor, const QString &text)
-{
+// Reimplementation of .replaceSelectedText from QScintilla. Added as osx + rhel
+// builds are
+// using an older version(2.4.6) of the library missing the method, and too
+// close to code freeze to update.
+inline void
+ScriptFileInterpreter::replaceSelectedText(const ScriptEditor *editor,
+                                           const QString &text) {
   int UTF8_CodePage = 65001;
-  const char *b = (( editor->SCI_GETCODEPAGE == UTF8_CodePage) ? text.utf8().constData() : text.latin1());
-  editor->SendScintilla( editor->SCI_REPLACESEL, b );
+  const char *b =
+      ((editor->SCI_GETCODEPAGE == UTF8_CodePage) ? text.utf8().constData()
+                                                  : text.latin1());
+  editor->SendScintilla(editor->SCI_REPLACESEL, b);
 }
 
 /**
  * Show custom context menu event
  */
-void ScriptFileInterpreter::showContextMenu(const QPoint & clickPoint)
-{
+void ScriptFileInterpreter::showContextMenu(const QPoint &clickPoint) {
   QMenu context(this);
   context.addAction("&Save", m_editor, SLOT(saveToCurrentFile()));
 
@@ -269,8 +252,7 @@ void ScriptFileInterpreter::showContextMenu(const QPoint & clickPoint)
 /**
  * Set the status bar when the script is executing
  */
-void ScriptFileInterpreter::setExecutingStatus()
-{
+void ScriptFileInterpreter::setExecutingStatus() {
   m_status->showMessage("Status: Executing...");
   m_editor->setReadOnly(true);
 }
@@ -278,72 +260,59 @@ void ScriptFileInterpreter::setExecutingStatus()
 /**
  * Set the status bar when the script is stopped
  */
-void ScriptFileInterpreter::setStoppedStatus()
-{
+void ScriptFileInterpreter::setStoppedStatus() {
   m_status->showMessage("Status: Stopped");
   m_editor->setReadOnly(false);
 }
 
-void ScriptFileInterpreter::emitZoomIn()
-{
-  emit textZoomedIn();
-}
-void ScriptFileInterpreter::emitZoomOut()
-{
-  emit textZoomedOut();
-}
+void ScriptFileInterpreter::emitZoomIn() { emit textZoomedIn(); }
+void ScriptFileInterpreter::emitZoomOut() { emit textZoomedOut(); }
 
 /**
  * Set up the widget from a given scripting envment
  * @param env :: A pointer to the current scripting envment
- * @param identifier :: A string identifier, used mainly in error messages to identify the
+ * @param identifier :: A string identifier, used mainly in error messages to
+ * identify the
  * current script
  */
-void ScriptFileInterpreter::setup(const ScriptingEnv & env, const QString & identifier)
-{
+void ScriptFileInterpreter::setup(const ScriptingEnv &env,
+                                  const QString &identifier) {
   setupEditor(env, identifier);
   setupScriptRunner(env, identifier);
-  connect(m_runner.data(), SIGNAL(autoCompleteListGenerated(const QStringList &)),
-          m_editor, SLOT(updateCompletionAPI(const QStringList &)));
+  connect(m_runner.data(),
+          SIGNAL(autoCompleteListGenerated(const QStringList &)), m_editor,
+          SLOT(updateCompletionAPI(const QStringList &)));
   m_runner->generateAutoCompleteList();
-  connect(m_runner.data(), SIGNAL(currentLineChanged(int,bool)),
-          m_editor, SLOT(updateProgressMarker(int,bool)));
+  connect(m_runner.data(), SIGNAL(currentLineChanged(int, bool)), m_editor,
+          SLOT(updateProgressMarker(int, bool)));
 }
-
 
 /**
  * @return The string containing the filename of the script
  */
-QString ScriptFileInterpreter::filename() const
-{
-  return m_editor->fileName();
-}
+QString ScriptFileInterpreter::filename() const { return m_editor->fileName(); }
 
 /**
  * Has the script been modified
  * @return True if the script has been modified
  */
-bool ScriptFileInterpreter::isScriptModified() const
-{
+bool ScriptFileInterpreter::isScriptModified() const {
   return m_editor->isModified();
 }
 
 /// Is the script running
-bool ScriptFileInterpreter::isExecuting() const
-{
+bool ScriptFileInterpreter::isExecuting() const {
   return m_runner->isExecuting();
 }
 
 /// Save to the currently stored name
-void ScriptFileInterpreter::saveToCurrentFile()
-{
+void ScriptFileInterpreter::saveToCurrentFile() {
   m_editor->saveToCurrentFile();
   m_runner->setIdentifier(m_editor->fileName());
 }
 
 /// Save to a different name
-void ScriptFileInterpreter::saveAs()
-{
+void ScriptFileInterpreter::saveAs() {
   m_editor->saveAs();
   m_runner->setIdentifier(m_editor->fileName());
 }
@@ -352,8 +321,7 @@ void ScriptFileInterpreter::saveAs()
  * Save the current script in the editor to a file
  * @param filename :: The filename to save the script in
  */
-void ScriptFileInterpreter::saveScript(const QString & filename)
-{
+void ScriptFileInterpreter::saveScript(const QString &filename) {
   m_editor->saveScript(filename);
   m_runner->setIdentifier(m_editor->fileName());
 }
@@ -363,55 +331,32 @@ void ScriptFileInterpreter::saveScript(const QString & filename)
  * @param filename :: The filename to save the script in
  */
 
-void ScriptFileInterpreter::saveOutput(const QString & filename)
-{
+void ScriptFileInterpreter::saveOutput(const QString &filename) {
   m_messages->saveToFile(filename);
 }
 
 /**
  * Print script
  */
-void ScriptFileInterpreter::printScript()
-{
-  m_editor->print();
-}
+void ScriptFileInterpreter::printScript() { m_editor->print(); }
 
 /// Print the output
-void ScriptFileInterpreter::printOutput()
-{
-  m_messages->print();
-}
+void ScriptFileInterpreter::printOutput() { m_messages->print(); }
 
 /// Undo
-void ScriptFileInterpreter::undo()
-{
-  m_editor->undo();
-}
+void ScriptFileInterpreter::undo() { m_editor->undo(); }
 /// Redo
-void ScriptFileInterpreter::redo()
-{
-  m_editor->redo();
-}
+void ScriptFileInterpreter::redo() { m_editor->redo(); }
 
 /// Copy from the editor
-void ScriptFileInterpreter::copy()
-{
-  m_editor->copy();
-}
+void ScriptFileInterpreter::copy() { m_editor->copy(); }
 
 /// Cut from the editor
-void ScriptFileInterpreter::cut()
-{
-  m_editor->cut();
-}
+void ScriptFileInterpreter::cut() { m_editor->cut(); }
 /// Paste into the editor
-void ScriptFileInterpreter::paste()
-{
-  m_editor->paste();
-}
+void ScriptFileInterpreter::paste() { m_editor->paste(); }
 /// Find in editor
-void ScriptFileInterpreter::showFindReplaceDialog()
-{
+void ScriptFileInterpreter::showFindReplaceDialog() {
   m_editor->showFindReplaceDialog();
 }
 
@@ -419,8 +364,7 @@ void ScriptFileInterpreter::showFindReplaceDialog()
  * Execute the whole script in the editor. Always clears the contents of the
  * local variable dictionary first.
  */
-void ScriptFileInterpreter::executeAll(const Script::ExecutionMode mode)
-{
+void ScriptFileInterpreter::executeAll(const Script::ExecutionMode mode) {
   m_runner->clearLocals();
   executeCode(ScriptCode(m_editor->text()), mode);
 }
@@ -428,16 +372,12 @@ void ScriptFileInterpreter::executeAll(const Script::ExecutionMode mode)
 /**
  * Execute the current selection from the editor.
  */
-void ScriptFileInterpreter::executeSelection(const Script::ExecutionMode mode)
-{
-  if((m_editor->hasSelectedText() && (!m_editor->selectedText().isEmpty())))
-  {
+void ScriptFileInterpreter::executeSelection(const Script::ExecutionMode mode) {
+  if ((m_editor->hasSelectedText() && (!m_editor->selectedText().isEmpty()))) {
     int firstLineOffset(0), unused(0);
     m_editor->getSelection(&firstLineOffset, &unused, &unused, &unused);
     executeCode(ScriptCode(m_editor->selectedText(), firstLineOffset), mode);
-  }
-  else
-  {
+  } else {
     executeAll(mode);
   }
 }
@@ -445,38 +385,37 @@ void ScriptFileInterpreter::executeSelection(const Script::ExecutionMode mode)
 /**
  * The envment has to support this behaviour or is does nothing
  */
-void ScriptFileInterpreter::abort() {
-  m_runner->abort();
-}
+void ScriptFileInterpreter::abort() { m_runner->abort(); }
 
 /**
  */
-void ScriptFileInterpreter::clearVariables()
-{
-  m_runner->clearLocals();
-}
+void ScriptFileInterpreter::clearVariables() { m_runner->clearLocals(); }
 
 /// Toggles the progress reports on/off
-void ScriptFileInterpreter::toggleProgressReporting(bool state)
-{
-  if(state) m_runner->enableProgressReporting();
-  else
-  {
+void ScriptFileInterpreter::toggleProgressReporting(bool state) {
+  if (state)
+    m_runner->enableProgressReporting();
+  else {
     m_editor->setMarkerState(false);
     m_runner->disableProgressReporting();
   }
 }
 
 /// Toggles the code folding on/off
-void ScriptFileInterpreter::toggleCodeFolding(bool state)
-{
-  if(state)
-  {
+void ScriptFileInterpreter::toggleCodeFolding(bool state) {
+  if (state) {
     m_editor->setFolding(QsciScintilla::BoxedTreeFoldStyle);
-  }
-  else
-  {
+  } else {
     m_editor->setFolding(QsciScintilla::NoFoldStyle);
+  }
+}
+
+/// Toggles soft wrapping of text on/off;
+void ScriptFileInterpreter::toggleLineWrapping(bool state) {
+  if (state) {
+    m_editor->setWrapMode(QsciScintilla::WrapWord);
+  } else {
+    m_editor->setWrapMode(QsciScintilla::WrapNone);
   }
 }
 
@@ -486,12 +425,11 @@ void ScriptFileInterpreter::toggleCodeFolding(bool state)
 /**
  * Create the splitter and layout for the child widgets
  */
-void ScriptFileInterpreter::setupChildWidgets()
-{
+void ScriptFileInterpreter::setupChildWidgets() {
   m_splitter->addWidget(m_editor);
   m_splitter->addWidget(m_messages);
   QVBoxLayout *mainLayout = new QVBoxLayout;
-  mainLayout->setContentsMargins(0,0,0,0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
   mainLayout->addWidget(m_splitter);
   mainLayout->addWidget(m_status);
   setLayout(mainLayout);
@@ -502,13 +440,13 @@ void ScriptFileInterpreter::setupChildWidgets()
 
 /**
  * @param env :: A pointer to the current scripting envment
- * @param identifier :: A string identifier, used mainly in error messages to identify the
+ * @param identifier :: A string identifier, used mainly in error messages to
+ * identify the
  * current script
  */
-void ScriptFileInterpreter::setupEditor(const ScriptingEnv & env, const QString & identifier)
-{
-  if(QFileInfo(identifier).exists())
-  {
+void ScriptFileInterpreter::setupEditor(const ScriptingEnv &env,
+                                        const QString &identifier) {
+  if (QFileInfo(identifier).exists()) {
     readFileIntoEditor(identifier);
   }
   m_editor->setLexer(env.createCodeLexer());
@@ -516,37 +454,51 @@ void ScriptFileInterpreter::setupEditor(const ScriptingEnv & env, const QString 
   m_editor->padMargin();
   m_editor->setAutoMarginResize();
   m_editor->enableAutoCompletion();
-  m_editor->setCursorPosition(0,0);
+  m_editor->setCursorPosition(0, 0);
 
   connect(m_editor, SIGNAL(textChanged()), this, SIGNAL(textChanged()));
-  connect(m_editor, SIGNAL(modificationChanged(bool)), this, SIGNAL(editorModificationChanged(bool)));
-  connect(m_editor, SIGNAL(undoAvailable(bool)), this, SIGNAL(editorUndoAvailable(bool)));
-  connect(m_editor, SIGNAL(redoAvailable(bool)), this, SIGNAL(editorRedoAvailable(bool)));
+  connect(m_editor, SIGNAL(modificationChanged(bool)), this,
+          SIGNAL(editorModificationChanged(bool)));
+  connect(m_editor, SIGNAL(undoAvailable(bool)), this,
+          SIGNAL(editorUndoAvailable(bool)));
+  connect(m_editor, SIGNAL(redoAvailable(bool)), this,
+          SIGNAL(editorRedoAvailable(bool)));
 }
 
 /**
  * @param env :: A pointer to the current scripting envment
- * @param identifier :: A string identifier, used mainly in error messages to identify the
+ * @param identifier :: A string identifier, used mainly in error messages to
+ * identify the
  * current script
  */
-void ScriptFileInterpreter::setupScriptRunner(const ScriptingEnv & env, const QString & identifier)
-{
-  m_runner = QSharedPointer<Script>(env.newScript(identifier,this, Script::Interactive));
+void ScriptFileInterpreter::setupScriptRunner(const ScriptingEnv &env,
+                                              const QString &identifier) {
+  m_runner = QSharedPointer<Script>(
+      env.newScript(identifier, this, Script::Interactive));
 
-  connect(m_runner.data(), SIGNAL(started(const QString &)), this, SLOT(setExecutingStatus()));
-  connect(m_runner.data(), SIGNAL(started(const QString &)), m_messages, SLOT(displayMessageWithTimestamp(const QString &)));
-  connect(m_runner.data(), SIGNAL(started(const QString &)), this, SIGNAL(executionStarted()));
+  connect(m_runner.data(), SIGNAL(started(const QString &)), this,
+          SLOT(setExecutingStatus()));
+  connect(m_runner.data(), SIGNAL(started(const QString &)), m_messages,
+          SLOT(displayMessageWithTimestamp(const QString &)));
+  connect(m_runner.data(), SIGNAL(started(const QString &)), this,
+          SIGNAL(executionStarted()));
 
-  connect(m_runner.data(), SIGNAL(finished(const QString &)), m_messages, SLOT(displayMessageWithTimestamp(const QString &)));
-  connect(m_runner.data(), SIGNAL(finished(const QString &)), this, SLOT(setStoppedStatus()));
-  connect(m_runner.data(), SIGNAL(finished(const QString &)), this, SIGNAL(executionStopped()));
+  connect(m_runner.data(), SIGNAL(finished(const QString &)), m_messages,
+          SLOT(displayMessageWithTimestamp(const QString &)));
+  connect(m_runner.data(), SIGNAL(finished(const QString &)), this,
+          SLOT(setStoppedStatus()));
+  connect(m_runner.data(), SIGNAL(finished(const QString &)), this,
+          SIGNAL(executionStopped()));
 
-  connect(m_runner.data(), SIGNAL(print(const QString &)), m_messages, SLOT(displayMessage(const QString &)));
+  connect(m_runner.data(), SIGNAL(print(const QString &)), m_messages,
+          SLOT(displayMessage(const QString &)));
 
-  connect(m_runner.data(), SIGNAL(error(const QString &,const QString &, int)), m_messages, SLOT(displayError(const QString &)));
-  connect(m_runner.data(), SIGNAL(error(const QString &,const QString &, int)), this, SLOT(setStoppedStatus()));
-  connect(m_runner.data(), SIGNAL(error(const QString &,const QString &, int)), this, SIGNAL(executionStopped()));
-
+  connect(m_runner.data(), SIGNAL(error(const QString &, const QString &, int)),
+          m_messages, SLOT(displayError(const QString &)));
+  connect(m_runner.data(), SIGNAL(error(const QString &, const QString &, int)),
+          this, SLOT(setStoppedStatus()));
+  connect(m_runner.data(), SIGNAL(error(const QString &, const QString &, int)),
+          this, SIGNAL(executionStopped()));
 }
 
 /**
@@ -554,13 +506,12 @@ void ScriptFileInterpreter::setupScriptRunner(const ScriptingEnv & env, const QS
  * @param filename
  * @return True if the read succeeded, false otherwise
  */
-bool ScriptFileInterpreter::readFileIntoEditor(const QString & filename)
-{
+bool ScriptFileInterpreter::readFileIntoEditor(const QString &filename) {
   m_editor->setFileName(filename);
   QFile scriptFile(filename);
-  if(!scriptFile.open(QIODevice::ReadOnly|QIODevice::Text))
-  {
-    QMessageBox::critical(this, tr("MantidPlot - File error"),
+  if (!scriptFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    QMessageBox::critical(
+        this, tr("MantidPlot - File error"),
         tr("Could not open file \"%1\" for reading.").arg(filename));
     return false;
   }
@@ -574,26 +525,19 @@ bool ScriptFileInterpreter::readFileIntoEditor(const QString & filename)
  * Use the current Script object to execute the code asynchronously
  * @param code :: The code string to run
  */
-void ScriptFileInterpreter::executeCode(const ScriptCode & code, const Script::ExecutionMode mode)
-{
-  if(code.isEmpty()) return;
-  if(mode == Script::Asynchronous)
-  {
-    try
-    {
+void ScriptFileInterpreter::executeCode(const ScriptCode &code,
+                                        const Script::ExecutionMode mode) {
+  if (code.isEmpty())
+    return;
+  if (mode == Script::Asynchronous) {
+    try {
       m_runner->executeAsync(code);
-    }
-    catch(std::runtime_error& exc)
-    {
+    } catch (std::runtime_error &exc) {
       QMessageBox::critical(this, "MantidPlot", exc.what());
     }
-  }
-  else if(mode == Script::Serialised)
-  {
+  } else if (mode == Script::Serialised) {
     m_runner->execute(code);
-  }
-  else
-  {
+  } else {
     QMessageBox::warning(this, "MantidPlot", "Unknown script execution mode");
   }
 }
@@ -603,7 +547,8 @@ void ScriptFileInterpreter::executeCode(const ScriptCode & code, const Script::E
 //-----------------------------------------------------------------------------
 ScriptCloseDialog::ScriptCloseDialog(ScriptFileInterpreter &interpreter,
                                      QWidget *parent)
-  : QWidget(parent), m_msgBox(new QMessageBox(this)), m_interpreter(interpreter) {
+    : QWidget(parent), m_msgBox(new QMessageBox(this)),
+      m_interpreter(interpreter) {
   QVBoxLayout *layout = new QVBoxLayout;
   layout->addWidget(m_msgBox);
   setLayout(layout);
@@ -616,9 +561,10 @@ ScriptCloseDialog::ScriptCloseDialog(ScriptFileInterpreter &interpreter,
  */
 bool ScriptCloseDialog::shouldScriptClose() {
   const bool executing(m_interpreter.isExecuting()),
-    modified(m_interpreter.isScriptModified());
+      modified(m_interpreter.isScriptModified());
   // Is the dialog even necessary?
-  if(!modified && !executing) return true;
+  if (!modified && !executing)
+    return true;
 
   m_msgBox->setModal(true);
   m_msgBox->setWindowTitle("MantidPlot");
@@ -626,25 +572,25 @@ bool ScriptCloseDialog::shouldScriptClose() {
 
   QString filename = m_interpreter.filename();
   bool close(true);
-  if(modified) {
+  if (modified) {
     m_msgBox->addButton(QMessageBox::Save);
     m_msgBox->addButton(QMessageBox::Cancel);
     m_msgBox->addButton(QMessageBox::Discard);
     m_msgBox->setDefaultButton(QMessageBox::Save);
-    if(filename.isEmpty()) {
+    if (filename.isEmpty()) {
       m_msgBox->setText(QString("Save changes before closing?"));
       m_msgBox->button(QMessageBox::Save)->setText("Save As");
     } else {
-      m_msgBox->setText(QString("Save changes to '%1' before closing?").arg(filename));
+      m_msgBox->setText(
+          QString("Save changes to '%1' before closing?").arg(filename));
     }
-    if(executing) {
+    if (executing) {
       m_msgBox->setInformativeText(tr("The script will be aborted."));
     }
     // show dialog
     int ret = m_msgBox->exec();
     try {
-      switch(ret)
-      {
+      switch (ret) {
       case QMessageBox::Save:
         m_interpreter.saveToCurrentFile();
         close = true;
@@ -656,29 +602,28 @@ bool ScriptCloseDialog::shouldScriptClose() {
         close = false;
         break;
       }
-    }
-    catch(ScriptEditor::SaveCancelledException &) {
+    } catch (ScriptEditor::SaveCancelledException &) {
       close = false;
     }
-  }
-  else if(executing) {
-    if(filename.isEmpty()) {
+  } else if (executing) {
+    if (filename.isEmpty()) {
       m_msgBox->setText(tr("Abort and close?"));
     } else {
-      m_msgBox->setText(tr("Abort '%1' and close?").arg(m_interpreter.filename()));
+      m_msgBox->setText(
+          tr("Abort '%1' and close?").arg(m_interpreter.filename()));
     }
     m_msgBox->addButton(QMessageBox::Abort);
     m_msgBox->addButton(QMessageBox::Cancel);
     m_msgBox->setDefaultButton(QMessageBox::Abort);
     int ret = m_msgBox->exec();
-    switch(ret) {
-      case QMessageBox::Abort:
-        m_interpreter.m_runner->abort();
-        close = true;
-        break;
-      default:
-        close = false;
-        break;
+    switch (ret) {
+    case QMessageBox::Abort:
+      m_interpreter.m_runner->abort();
+      close = true;
+      break;
+    default:
+      close = false;
+      break;
     }
   }
   return close;

--- a/MantidPlot/src/ScriptFileInterpreter.cpp
+++ b/MantidPlot/src/ScriptFileInterpreter.cpp
@@ -27,8 +27,7 @@ ScriptFileInterpreter::ScriptFileInterpreter(QWidget *parent,
       m_messages(new ScriptOutputDisplay), m_status(new QStatusBar),
       m_runner() {
 
-  // Initialise line wrapping to include additional indent and visual arrow flag
-  m_editor->setWrapIndentMode(QsciScintilla::WrapIndentIndented);
+  // Initialise line wrapping to include visual arrow indicator
   m_editor->setWrapVisualFlags(QsciScintilla::WrapFlagByText);
 
   setupChildWidgets();

--- a/MantidPlot/src/ScriptFileInterpreter.h
+++ b/MantidPlot/src/ScriptFileInterpreter.h
@@ -26,19 +26,19 @@ class ScriptOutputDisplay;
  * edit, execute and display script code
  *
  */
-class ScriptFileInterpreter : public QWidget
-{
+class ScriptFileInterpreter : public QWidget {
   Q_OBJECT
 
 public:
   /// Construct the object
-  ScriptFileInterpreter(QWidget *parent = NULL, const QString & settingsGroup = "");
+  ScriptFileInterpreter(QWidget *parent = NULL,
+                        const QString &settingsGroup = "");
   /// Destroy the object
   ~ScriptFileInterpreter();
   /// Determine if the script is ready to be closed
   virtual bool shouldClose();
   /// Setup from a script envment
-  virtual void setup(const ScriptingEnv & env, const QString & identifier);
+  virtual void setup(const ScriptingEnv &env, const QString &identifier);
 
   /// Return the filename of the script in the editor
   virtual QString filename() const;
@@ -57,9 +57,9 @@ public slots:
   /// Save to a different name
   virtual void saveAs();
   /// Save to the given filename
-  virtual void saveScript(const QString & filename);
+  virtual void saveScript(const QString &filename);
   /// Save the current output
-  virtual void saveOutput(const QString & filename);
+  virtual void saveOutput(const QString &filename);
   /// Print the script
   virtual void printScript();
   /// Print the script
@@ -87,9 +87,11 @@ public slots:
   virtual void spacesToTabs();
 
   /// Execute the whole script.
-  virtual void executeAll(const Script::ExecutionMode mode = Script::Asynchronous);
+  virtual void
+  executeAll(const Script::ExecutionMode mode = Script::Asynchronous);
   /// Execute the current selection
-  virtual void executeSelection(const Script::ExecutionMode mode = Script::Asynchronous);
+  virtual void
+  executeSelection(const Script::ExecutionMode mode = Script::Asynchronous);
   /// Request that the script execution be aborted
   virtual void abort();
   /// Clear the script variable cache
@@ -99,6 +101,8 @@ public slots:
   virtual void toggleProgressReporting(bool state);
   /// Toggles the code folding on/off
   virtual void toggleCodeFolding(bool state);
+  /// Toggles soft wrapping of text on/off;
+  virtual void toggleLineWrapping(bool state);
   /// Toggles the whitespace visibility
   virtual void toggleWhitespace(bool state);
   /// Toggle replacing tabs with whitespace
@@ -128,16 +132,15 @@ signals:
 
 private slots:
   /// Popup a context menu
-  void showContextMenu(const QPoint & clickPoint);
+  void showContextMenu(const QPoint &clickPoint);
   /// Update the status bar while the script is executing
   void setExecutingStatus();
   /// Update the status bar when the script has stopped
   void setStoppedStatus();
-  //capture zoom in signals from either widget an emit our own
+  // capture zoom in signals from either widget an emit our own
   void emitZoomIn();
-  //capture zoom out signals from either widget an emit our own
+  // capture zoom out signals from either widget an emit our own
   void emitZoomOut();
-
 
 private:
   friend class ScriptCloseDialog;
@@ -145,17 +148,16 @@ private:
   Q_DISABLE_COPY(ScriptFileInterpreter)
   void setupChildWidgets();
 
-  void setupEditor(const ScriptingEnv & env, const QString & identifier);
-  void setupScriptRunner(const ScriptingEnv & env, const QString & identifier);
+  void setupEditor(const ScriptingEnv &env, const QString &identifier);
+  void setupScriptRunner(const ScriptingEnv &env, const QString &identifier);
 
-  bool readFileIntoEditor(const QString & filename);
-  void executeCode(const ScriptCode & code, const Script::ExecutionMode mode);
+  bool readFileIntoEditor(const QString &filename);
+  void executeCode(const ScriptCode &code, const Script::ExecutionMode mode);
 
   void toggleComment(bool addComment);
   // Replaces the currently selected text in the editor
-  inline void replaceSelectedText(const ScriptEditor *editor, const QString &text);
-
-
+  inline void replaceSelectedText(const ScriptEditor *editor,
+                                  const QString &text);
 
   QSplitter *m_splitter;
   ScriptEditor *m_editor;
@@ -169,14 +171,12 @@ private:
  * implements the Null object pattern to return a object of
  * this type that does nothing
  */
-class NullScriptFileInterpreter : public ScriptFileInterpreter
-{
+class NullScriptFileInterpreter : public ScriptFileInterpreter {
   Q_OBJECT
 
 public:
   /// Constructor
-  NullScriptFileInterpreter() :
-    ScriptFileInterpreter(NULL) {}
+  NullScriptFileInterpreter() : ScriptFileInterpreter(NULL) {}
 
   /// Does nothing
   bool shouldClose() { return false; }
@@ -237,13 +237,11 @@ private slots:
 //-----------------------------------------------------------------------------
 // ScriptCloseDialog - Specific message for closing the widget
 //-----------------------------------------------------------------------------
-class ScriptCloseDialog : public QWidget
-{
+class ScriptCloseDialog : public QWidget {
   Q_OBJECT
 
 public:
-  ScriptCloseDialog(ScriptFileInterpreter &interpreter,
-                    QWidget *parent = NULL);
+  ScriptCloseDialog(ScriptFileInterpreter &interpreter, QWidget *parent = NULL);
 
   bool shouldScriptClose();
 

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -93,6 +93,7 @@ void ScriptingWindow::saveSettings() {
   settings.setValue("/TabWhitespaceCount", m_manager->m_tabWhitespaceCount);
   settings.setValue("/ScriptFontFamily", m_manager->m_fontFamily);
   settings.setValue("/CodeFolding", m_toggleFolding->isChecked());
+  settings.setValue("/LineWrapping", m_toggleWrapping->isChecked());
   settings.setValue("/PreviousFiles", m_manager->fileNamesToQStringList());
   settings.endGroup();
 }
@@ -116,6 +117,7 @@ void ScriptingWindow::readSettings() {
   m_manager->setRecentScripts(settings.value("/RecentScripts").toStringList());
   m_manager->m_globalZoomLevel = settings.value("ZoomLevel", 0).toInt();
   m_toggleFolding->setChecked(settings.value("CodeFolding", false).toBool());
+  m_toggleWrapping->setChecked(settings.value("LineWrapping", false).toBool());
   m_toggleWhitespace->setChecked(
       settings.value("ShowWhitespace", false).toBool());
 
@@ -275,6 +277,7 @@ void ScriptingWindow::populateWindowMenu() {
     m_windowMenu->insertSeparator();
     m_windowMenu->addAction(m_toggleProgress);
     m_windowMenu->addAction(m_toggleFolding);
+    m_windowMenu->addAction(m_toggleWrapping);
     m_windowMenu->addAction(m_toggleWhitespace);
 
     m_windowMenu->insertSeparator();
@@ -725,6 +728,11 @@ void ScriptingWindow::initWindowMenuActions() {
   m_toggleFolding->setCheckable(true);
   connect(m_toggleFolding, SIGNAL(toggled(bool)), m_manager,
           SLOT(toggleCodeFolding(bool)));
+
+  m_toggleWrapping = new QAction(tr("Line &Wrapping"), this);
+  m_toggleWrapping->setCheckable(true);
+  connect(m_toggleWrapping, SIGNAL(toggled(bool)), m_manager,
+          SLOT(toggleLineWrapping(bool)));
 
   // Toggle the whitespace arrow
   m_toggleWhitespace = new QAction(tr("&Show Whitespace"), this);

--- a/MantidPlot/src/ScriptingWindow.h
+++ b/MantidPlot/src/ScriptingWindow.h
@@ -172,7 +172,7 @@ private:
   QMenu *m_windowMenu;
   /// Window actions
   QAction *m_alwaysOnTop, *m_hide, *m_zoomIn, *m_zoomOut, *m_resetZoom,
-      *m_toggleProgress, *m_toggleFolding, *m_toggleWhitespace,
+      *m_toggleProgress, *m_toggleFolding, *m_toggleWrapping, *m_toggleWhitespace,
       *m_openConfigTabs, *m_selectFont;
   /// Help menu
   QMenu *m_helpMenu;


### PR DESCRIPTION
Resolves #13946 
- [x] [Release Notes](http://www.mantidproject.org/ReleaseNotes_3_6_UI_Changes#Scripting_Window) updated
## Changes

The Script Window **_Window**_ menu now has an extra option which allows users to toggle line wrapping on/off.
## Testing

When MantidPlot is launched open the script editor and enter a line of text which exceeds the size of the script window. Enable Line Wrapping by enabling to **_Window->Line Wrapping**_ in the script window. Resize the window to see the text wrapping to fit the window size.
