### PR TITLE
Disable updates for nightly and unstable.

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -575,10 +575,20 @@ else ()
   set ( MANTID_ROOT .. )
 endif ()
 
+# Whether or not to check for updates is tied to a patch version being defined
+# nighly/unstable is basically ISO8601 so it will be longer than 8 char.
+# This affects Mantid.properties.install only.
+string( LENGTH "VERSION_PATCH ${VERSION_PATCH}" VERSION_PATCH_LENGTH)
+set (ENABLE_WEB_UPDATES 0)
+if (${VERSION_PATCH_LENGTH} LESS 8)
+  set (ENABLE_WEB_UPDATES 1)
+endif()
+message( STATUS "For Mantid.properties.install: ENABLE_WEB_UPDATES=${ENABLE_WEB_UPDATES}")
+
 set ( PLUGINS ${MANTID_ROOT}/plugins )
 set ( PYTHONPLUGIN_DIRS "${PLUGINS}/python" )
-set ( UPDATE_INSTRUMENT_DEFINTITIONS "1" )
-set ( CHECK_FOR_NEW_MANTID_VERSION "1" )
+set ( UPDATE_INSTRUMENT_DEFINTITIONS "${ENABLE_WEB_UPDATES}" )
+set ( CHECK_FOR_NEW_MANTID_VERSION "${ENABLE_WEB_UPDATES}" )
 set ( ENABLE_USAGE_REPORTS "1" )
 set ( DATADIRS "" )
 set ( MANTIDPUBLISHER "http://upload.mantidproject.org/scriptrepository" )


### PR DESCRIPTION
If you are unstable or nightly, you should have the newest of
everything anyhow.

This does not need to be in the release notes because versioned releases will not change.
