### PR TITLE
Engg algorithms: Add default values with new list of ceria peaks + other improvements

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -12,30 +12,34 @@ class EnggCalibrate(PythonAlgorithm):
         return "EnggCalibrate"
 
     def summary(self):
-        return "Calibrates a detector bank (or group of detectors) by performing a single peak fitting."
+        return ("Calibrates one or more detector banks (or group(s) of detectors) by performing single peak "
+                "fitting.")
 
     def PyInit(self):
         self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", Direction.Input),\
-                             "Workspace with the calibration run to use.")
+                             doc="Workspace with the calibration run to use.")
 
-        self.declareProperty(FloatArrayProperty("ExpectedPeaks", ""),\
-    		"A list of dSpacing values where peaks are expected.")
+        import EnggUtils
+        self.declareProperty(FloatArrayProperty("ExpectedPeaks",
+                                                values=EnggUtils.CERIA_EXPECTED_PEAKS,
+                                                direction=Direction.Input),
+                             doc="A list of dSpacing values where peaks are expected.")
 
         self.declareProperty(FileProperty(name="ExpectedPeaksFromFile",defaultValue="",
                                           action=FileAction.OptionalLoad,extensions = [".csv"]),
-                             "Load from file a list of dSpacing values to be translated into TOF to "
+                             doc="Load from file a list of dSpacing values to be translated into TOF to "
                              "find expected peaks. This takes precedence over 'ExpectedPeaks' if both "
                              "options are given.")
 
         self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
-                             'Workspace with the Vanadium (correction and calibration) run. '
+                             doc='Workspace with the Vanadium (correction and calibration) run. '
                              'Alternatively, when the Vanadium run has been already processed, '
                              'the properties can be used')
 
         self.declareProperty(ITableWorkspaceProperty("VanIntegrationWorkspace", "",
                                                      Direction.Input, PropertyMode.Optional),
-                             'Results of integrating the spectra of a Vanadium run, with one column '
+                             doc='Results of integrating the spectra of a Vanadium run, with one column '
                              '(integration result) and one row per spectrum. This can be used in '
                              'combination with OutVanadiumCurveFits from a previous execution and '
                              'VanadiumWorkspace to provide pre-calculated values for Vanadium correction.')

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -21,7 +21,7 @@ class EnggCalibrate(PythonAlgorithm):
 
         import EnggUtils
         self.declareProperty(FloatArrayProperty("ExpectedPeaks",
-                                                values=EnggUtils.CERIA_EXPECTED_PEAKS,
+                                                values=EnggUtils.default_ceria_expected_peaks(),
                                                 direction=Direction.Input),
                              doc="A list of dSpacing values where peaks are expected.")
 
@@ -52,7 +52,6 @@ class EnggCalibrate(PythonAlgorithm):
                              'VanadiumWorkspace for testing and performance reasons. If not given, no '
                              'workspace is generated.')
 
-        import EnggUtils
         self.declareProperty("Bank", '', StringListValidator(EnggUtils.ENGINX_BANKS),
                              direction=Direction.Input,
                              doc = "Which bank to calibrate. It can be specified as 1 or 2, or "
@@ -86,8 +85,8 @@ class EnggCalibrate(PythonAlgorithm):
         import EnggUtils
 
         # Get peaks in dSpacing from file
-        expectedPeaksD = EnggUtils.readInExpectedPeaks(self.getPropertyValue("ExpectedPeaksFromFile"),
-                                                       self.getProperty('ExpectedPeaks').value)
+        expectedPeaksD = EnggUtils.read_in_expected_peaks(self.getPropertyValue("ExpectedPeaksFromFile"),
+                                                          self.getProperty('ExpectedPeaks').value)
 
         prog = Progress(self, start=0, end=1, nreports=2)
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -31,6 +31,11 @@ class EnggCalibrate(PythonAlgorithm):
                              "find expected peaks. This takes precedence over 'ExpectedPeaks' if both "
                              "options are given.")
 
+        peaks_grp = 'Peaks to fit'
+        self.setPropertyGroup('ExpectedPeaks', peaks_grp)
+        self.setPropertyGroup('ExpectedPeaksFromFile', peaks_grp)
+
+
         self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
                              doc='Workspace with the Vanadium (correction and calibration) run. '
@@ -52,6 +57,11 @@ class EnggCalibrate(PythonAlgorithm):
                              'VanadiumWorkspace for testing and performance reasons. If not given, no '
                              'workspace is generated.')
 
+        vana_grp = 'Vanadium (open beam) properties'
+        self.setPropertyGroup('VanadiumWorkspace', vana_grp)
+        self.setPropertyGroup('VanIntegrationWorkspace', vana_grp)
+        self.setPropertyGroup('VanCurvesWorkspace', vana_grp)
+
         self.declareProperty("Bank", '', StringListValidator(EnggUtils.ENGINX_BANKS),
                              direction=Direction.Input,
                              doc = "Which bank to calibrate. It can be specified as 1 or 2, or "
@@ -63,6 +73,10 @@ class EnggCalibrate(PythonAlgorithm):
                              'that should be considered in the calibration (all others will be '
                              'ignored). This option cannot be used together with Bank, as they overlap. '
                              'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
+
+        banks_grp = 'Banks / spectra'
+        self.setPropertyGroup('Bank', banks_grp)
+        self.setPropertyGroup(self.INDICES_PROP_NAME, banks_grp)
 
         self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "",\
                 Direction.Input, PropertyMode.Optional),\
@@ -79,6 +93,12 @@ class EnggCalibrate(PythonAlgorithm):
 
         self.declareProperty("Zero", 0.0, direction = Direction.Output,
                              doc = "Calibrated Zero value for the bank or range of pixels/detectors given")
+
+        out_grp = 'Outputs'
+        self.setPropertyGroup('DetectorPositions', out_grp)
+        self.setPropertyGroup('OutputParametersTableName', out_grp)
+        self.setPropertyGroup('Difc', out_grp)
+        self.setPropertyGroup('Zero', out_grp)
 
     def PyExec(self):
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -64,7 +64,7 @@ class EnggCalibrateFull(PythonAlgorithm):
                              "(OutDetPosTable).")
 
         self.declareProperty(FloatArrayProperty("ExpectedPeaks",
-                                                values=EnggUtils.CERIA_EXPECTED_PEAKS,
+                                                values=EnggUtils.default_ceria_expected_peaks(),
                                                 direction=Direction.Input),
                              doc="A list of dSpacing values where peaks are expected.")
 
@@ -77,8 +77,8 @@ class EnggCalibrateFull(PythonAlgorithm):
     def PyExec(self):
 
         # Get peaks in dSpacing from file, and check we have what we need, before doing anything
-        expectedPeaksD = EnggUtils.readInExpectedPeaks(self.getPropertyValue("ExpectedPeaksFromFile"),
-                                                       self.getProperty('ExpectedPeaks').value)
+        expectedPeaksD = EnggUtils.read_in_expected_peaks(self.getPropertyValue("ExpectedPeaksFromFile"),
+                                                          self.getProperty('ExpectedPeaks').value)
 
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -20,6 +20,7 @@ class EnggCalibrateFull(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty("Workspace", "", Direction.InOut),
                              "Workspace with the calibration run to use. The calibration will be applied on it.")
 
+
         self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
                              "Workspace with the Vanadium (correction and calibration) run.")
@@ -38,6 +39,11 @@ class EnggCalibrateFull(PythonAlgorithm):
                              'by the algorithm Fit. This is meant to be used as an alternative input '
                              'VanadiumWorkspace for testing and performance reasons. If not given, no '
                              'workspace is generated.')
+
+        vana_grp = 'Vanadium (open beam) properties'
+        self.setPropertyGroup('VanadiumWorkspace', vana_grp)
+        self.setPropertyGroup('VanIntegrationWorkspace', vana_grp)
+        self.setPropertyGroup('VanCurvesWorkspace', vana_grp)
 
         self.declareProperty(ITableWorkspaceProperty("OutDetPosTable", "", Direction.Output),\
                              doc="A table with the detector IDs and calibrated detector positions and "
@@ -58,10 +64,17 @@ class EnggCalibrateFull(PythonAlgorithm):
                              'ignored). This option cannot be used together with Bank, as they overlap. '
                              'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
 
+        banks_grp = 'Banks / spectra'
+        self.setPropertyGroup('Bank', banks_grp)
+        self.setPropertyGroup(self.INDICES_PROP_NAME, banks_grp)
+
         self.declareProperty(FileProperty("OutDetPosFilename", "", FileAction.OptionalSave, [".csv"]),
                              doc="Name of the file to save the pre-/post-calibrated detector positions - this "
                              "saves the same information that is provided in the output table workspace "
                              "(OutDetPosTable).")
+
+        opt_outs_grp = 'Optional outputs'
+        self.setPropertyGroup('OutDetPosFilename', opt_outs_grp)
 
         self.declareProperty(FloatArrayProperty("ExpectedPeaks",
                                                 values=EnggUtils.default_ceria_expected_peaks(),
@@ -73,6 +86,11 @@ class EnggCalibrateFull(PythonAlgorithm):
                              doc="Load from file a list of dSpacing values to be translated into TOF to "
                              "find expected peaks. This takes precedence over 'ExpectedPeaks' if both "
                              "options are given.")
+
+        peaks_grp = 'Peaks to fit'
+        self.setPropertyGroup('ExpectedPeaks', peaks_grp)
+        self.setPropertyGroup('ExpectedPeaksFromFile', peaks_grp)
+
 
     def PyExec(self):
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -40,10 +40,11 @@ class EnggCalibrateFull(PythonAlgorithm):
                              'workspace is generated.')
 
         self.declareProperty(ITableWorkspaceProperty("OutDetPosTable", "", Direction.Output),\
-                             "A table with the detector IDs and calibrated detector positions and additional "
-                             "calibration information. The table includes: the old positions in V3D format "
-                             "(3D vector with x, y, z values), the new positions in V3D, the new positions "
-                             "in spherical coordinates, the change in L2, and the DIFC and ZERO parameters.")
+                             doc="A table with the detector IDs and calibrated detector positions and "
+                             "additional calibration information. The table includes: the old positions "
+                             "in V3D format (3D vector with x, y, z values), the new positions in V3D, the "
+                             "new positions in spherical coordinates, the change in L2, and the DIFC and "
+                             "ZERO parameters.")
 
         self.declareProperty("Bank", '', StringListValidator(EnggUtils.ENGINX_BANKS),
                              direction=Direction.Input,
@@ -58,16 +59,18 @@ class EnggCalibrateFull(PythonAlgorithm):
                              'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
 
         self.declareProperty(FileProperty("OutDetPosFilename", "", FileAction.OptionalSave, [".csv"]),
-                             "Name of the file to save the pre-/post-calibrated detector positions - this "
+                             doc="Name of the file to save the pre-/post-calibrated detector positions - this "
                              "saves the same information that is provided in the output table workspace "
                              "(OutDetPosTable).")
 
-        self.declareProperty(FloatArrayProperty("ExpectedPeaks", ""),\
-    		"A list of dSpacing values where peaks are expected.")
+        self.declareProperty(FloatArrayProperty("ExpectedPeaks",
+                                                values=EnggUtils.CERIA_EXPECTED_PEAKS,
+                                                direction=Direction.Input),
+                             doc="A list of dSpacing values where peaks are expected.")
 
         self.declareProperty(FileProperty(name="ExpectedPeaksFromFile",defaultValue="",
                                           action=FileAction.OptionalLoad,extensions = [".csv"]),
-                             "Load from file a list of dSpacing values to be translated into TOF to "
+                             doc="Load from file a list of dSpacing values to be translated into TOF to "
                              "find expected peaks. This takes precedence over 'ExpectedPeaks' if both "
                              "options are given.")
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -34,6 +34,10 @@ class EnggFitPeaks(PythonAlgorithm):
                              "find expected peaks. This takes precedence over 'ExpectedPeaks' if both "
                              "options are given.")
 
+        peaks_grp = 'Peaks to fit'
+        self.setPropertyGroup('ExpectedPeaks', peaks_grp)
+        self.setPropertyGroup('ExpectedPeaksFromFile', peaks_grp)
+
         self.declareProperty('OutParametersTable', '', direction=Direction.Input,
                              doc = 'Name for a table workspace with the fitted values calculated by '
                              'this algorithm (Difc and Zero parameters) for GSAS. '

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -55,8 +55,8 @@ class EnggFitPeaks(PythonAlgorithm):
         import EnggUtils
 
         # Get peaks in dSpacing from file
-        expectedPeaksD = EnggUtils.readInExpectedPeaks(self.getPropertyValue("ExpectedPeaksFromFile"),
-                                                       self.getProperty('ExpectedPeaks').value)
+        expectedPeaksD = EnggUtils.read_in_expected_peaks(self.getPropertyValue("ExpectedPeaksFromFile"),
+                                                          self.getProperty('ExpectedPeaks').value)
 
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")
@@ -87,11 +87,10 @@ class EnggFitPeaks(PythonAlgorithm):
 
     def _getDefaultPeaks(self):
         """ Gets default peaks for Engg algorithm. Values from CeO2 """
-        defaultPeaks = [3.1243, 2.7057, 1.9132, 1.6316, 1.5621, 1.3529, 1.2415,
-                        1.2100, 1.1046, 1.0414, 0.9566, 0.9147, 0.9019, 0.8556,
-                        0.8252, 0.8158, 0.7811]
 
-        return defaultPeaks
+        import EnggUtils
+
+        return EnggUtils.default_ceria_expected_peaks()
 
     def _produceOutputs(self, difc, zero):
         """
@@ -113,9 +112,34 @@ class EnggFitPeaks(PythonAlgorithm):
             EnggUtils.generateOutputParTable(tblName, difc, zero)
             self.log().information("Output parameters added into a table workspace: %s" % tblName)
 
+    def _estimate_start_end_fitting_range(self, centre, width):
+        """
+        Try to predict a fit window for the peak (using magic numbers). The heuristic
+        +-COEF_LEFT/RIGHT sometimes produces ranges that are too narrow and contain too few
+        samples (one or a handful) for the fitting to run correctly. A minimum is enforced.
+
+        @Returns :: a tuple with the range (start and end values) for fitting a peak.
+        """
+        # Magic numbers, approx. represanting the shape/proportions of a B2BExponential peak
+        COEF_LEFT = 2
+        COEF_RIGHT = 3
+        MIN_RANGE_WIDTH = 175
+
+        startx = centre - (width * COEF_LEFT)
+        endx = centre + (width * COEF_RIGHT)
+        # force startx-endx > 175, etc
+        x_diff = endx-startx
+        min_width = MIN_RANGE_WIDTH
+        if x_diff < min_width:
+            inc = (min_width-x_diff)/2
+            endx = endx + inc
+            startx = startx - inc
+
+        return (startx, endx)
+
     def _fitAllPeaks(self, inWS, wsIndex, peaks, peaksTableName):
         """
-        This method is the core of EnggFitPeaks. Ittries to fit as many peaks as there are in the list of
+        This method is the core of EnggFitPeaks. It tries to fit as many peaks as there are in the list of
         expected peaks passed to the algorithm.
 
         The parameters from the (Gaussian) peaks fitted by FindPeaks elsewhere (before calling this method)
@@ -170,19 +194,20 @@ class EnggFitPeaks(PythonAlgorithm):
             peak.setParameter('S', sigma)
             peak.setParameter('I', intensity)
 
-            # Magic numbers
-            COEF_LEFT = 2
-            COEF_RIGHT = 3
-
             # Fit using predicted window and a proper function with approximated initital values
             fitAlg = self.createChildAlgorithm('Fit')
-            fitAlg.setProperty('Function', 'name=LinearBackground;' + str(peak))
+            fit_function = 'name=LinearBackground;{0}'.format(peak)
+            fitAlg.setProperty('Function', fit_function)
             fitAlg.setProperty('InputWorkspace', inWS)
             fitAlg.setProperty('WorkspaceIndex', wsIndex)
             fitAlg.setProperty('CreateOutput', True)
-            # Try to predict a fit window for the peak (using magic numbers)
-            fitAlg.setProperty('StartX', centre - (width * COEF_LEFT))
-            fitAlg.setProperty('EndX', centre + (width * COEF_RIGHT))
+
+            (startx, endx) = self._estimate_start_end_fitting_range(centre, width)
+            fitAlg.setProperty('StartX', startx)
+            fitAlg.setProperty('EndX', endx)
+            self.log().debug("Fitting for peak expectd in (d-spacing): {0}, Fitting peak function: "
+                             "{1}, with startx: {2}, endx: {3}".
+                             format(peaks[1][i], fit_function, startx, endx))
             fitAlg.execute()
             paramTable = fitAlg.getProperty('OutputParameters').value
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggFocus.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFocus.py
@@ -23,6 +23,11 @@ class EnggFocus(PythonAlgorithm):
         self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", Direction.Output),
                              "A workspace with focussed data")
 
+
+        self.declareProperty(ITableWorkspaceProperty('DetectorPositions', '', Direction.Input,
+                                                     PropertyMode.Optional),
+                             "Calibrated detector positions. If not specified, default ones are used.")
+
         self.declareProperty(MatrixWorkspaceProperty("VanadiumWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
                              doc = 'Workspace with the Vanadium (correction and calibration) run. '
@@ -44,6 +49,11 @@ class EnggFocus(PythonAlgorithm):
                              'VanadiumWorkspace for testing and performance reasons. If not given, no '
                              'workspace is generated.')
 
+        vana_grp = 'Vanadium (open beam) properties'
+        self.setPropertyGroup('VanadiumWorkspace', vana_grp)
+        self.setPropertyGroup('VanIntegrationWorkspace', vana_grp)
+        self.setPropertyGroup('VanCurvesWorkspace', vana_grp)
+
         self.declareProperty("Bank", '', StringListValidator(EnggUtils.ENGINX_BANKS),
                              direction=Direction.Input,
                              doc = "Which bank to focus: It can be specified as 1 or 2, or "
@@ -56,10 +66,9 @@ class EnggFocus(PythonAlgorithm):
                              'ignored). This option cannot be used together with Bank, as they overlap. '
                              'You can give multiple ranges, for example: "0-99", or "0-9, 50-59, 100-109".')
 
-        self.declareProperty(ITableWorkspaceProperty('DetectorPositions', '', Direction.Input,
-                                                     PropertyMode.Optional),
-                             "Calibrated detector positions. If not specified, default ones are used.")
-
+        banks_grp = 'Banks / spectra'
+        self.setPropertyGroup('Bank', banks_grp)
+        self.setPropertyGroup(self.INDICES_PROP_NAME, banks_grp)
 
     def PyExec(self):
         # Get the run workspace

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -40,6 +40,10 @@ class EnggVanadiumCorrections(PythonAlgorithm):
                                                      PropertyMode.Optional),
                              'Output curves workspace produced when given an input Vanadium workspace')
 
+        out_vana_grp = 'Output parameters (for when calculating corrections)'
+        self.setPropertyGroup('OutIntegrationWorkspace', out_vana_grp)
+        self.setPropertyGroup('OutCurvesWorkspace', out_vana_grp)
+
         self.declareProperty(ITableWorkspaceProperty("IntegrationWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
                              "Workspace with the integrated values for every spectra of the reference "
@@ -51,6 +55,10 @@ class EnggVanadiumCorrections(PythonAlgorithm):
                              'data, one per bank. This workspace has three spectra per bank, as produced '
                              'by the algorithm Fit. This is meant to be used as an alternative input '
                              'VanadiumWorkspace')
+
+        in_vana_grp = 'Input parameters (for when applying pre-calculated corrections)'
+        self.setPropertyGroup('IntegrationWorkspace', in_vana_grp)
+        self.setPropertyGroup('CurvesWorkspace', in_vana_grp)
 
     def PyExec(self):
         """

--- a/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggVanadiumCorrections.py
@@ -40,9 +40,16 @@ class EnggVanadiumCorrections(PythonAlgorithm):
                                                      PropertyMode.Optional),
                              'Output curves workspace produced when given an input Vanadium workspace')
 
+        # ~10 break points is still poor, there is no point in using less than that
+        self.declareProperty("SplineBreakPoints", defaultValue=50,
+                             validator=IntBoundedValidator(10),
+                             doc="Number of break points used when fitting the bank profiles with a spline "
+                             "function.")
+
         out_vana_grp = 'Output parameters (for when calculating corrections)'
         self.setPropertyGroup('OutIntegrationWorkspace', out_vana_grp)
         self.setPropertyGroup('OutCurvesWorkspace', out_vana_grp)
+        self.setPropertyGroup('SplineBreakPoints', out_vana_grp)
 
         self.declareProperty(ITableWorkspaceProperty("IntegrationWorkspace", "", Direction.Input,
                                                      PropertyMode.Optional),
@@ -79,6 +86,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         vanWS = self.getProperty('VanadiumWorkspace').value
         integWS = self.getProperty('IntegrationWorkspace').value
         curvesWS = self.getProperty('CurvesWorkspace').value
+        spline_breaks = self.getProperty('SplineBreakPoints').value
 
         preports = 1
         if ws:
@@ -90,7 +98,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         if vanWS:
             self.log().information("A workspace with reference Vanadium data was passed. Calculating "
                                    "corrections")
-            integWS, curvesWS = self._calcVanadiumCorrection(vanWS)
+            integWS, curvesWS = self._calcVanadiumCorrection(vanWS, spline_breaks)
             self.setProperty('OutIntegrationWorkspace', integWS)
             self.setProperty('OutCurvesWorkspace', curvesWS)
 
@@ -151,12 +159,13 @@ class EnggVanadiumCorrections(PythonAlgorithm):
 
         self._divideByCurves(ws, curvesDict)
 
-    def _calcVanadiumCorrection(self, vanWS):
+    def _calcVanadiumCorrection(self, vanWS, spline_breaks):
         """
         Calculates the features that are required to perform vanadium corrections: integration
         of the vanadium data spectra, and per-bank curves fitted to the summed spectra
 
         @param vanWS :: workspace with data from a Vanadium run
+        @param spline_breaks :: number of break points when fitting spline functions
 
         @returns two workspaces: the integration and the curves. The integration workspace is a
         matrix workspace as produced by the algotithm 'Integration'. The curves workspace is a
@@ -166,7 +175,7 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         integWS = self._calcIntegrationSpectra(vanWS)
 
         # Have to calculate curves. get one curve per bank, in d-spacing
-        curvesWS = self._fitCurvesPerBank(vanWS, self._ENGINX_BANKS_FOR_PIXBYPIX_CORR)
+        curvesWS = self._fitCurvesPerBank(vanWS, self._ENGINX_BANKS_FOR_PIXBYPIX_CORR, spline_breaks)
 
         return integWS, curvesWS
 
@@ -201,13 +210,14 @@ class EnggVanadiumCorrections(PythonAlgorithm):
 
         return integTbl
 
-    def _fitCurvesPerBank(self, vanWS, banks):
+    def _fitCurvesPerBank(self, vanWS, banks, spline_breaks):
         """
         Fits one curve to every bank (where for every bank the data fitted is the result of
         summing up all the spectra of the bank). The fitting is done in d-spacing.
 
         @param vanWS :: Vanadium run workspace to fit, expected in TOF units as they are archived
         @param banks :: list of banks to consider which is normally all the banks of the instrument
+        @param spline_breaks :: number of break points when fitting spline functions
 
         @returns a workspace with fitting results for all banks (3 spectra per bank). The spectra
         are in dSpacing units.
@@ -224,19 +234,20 @@ class EnggVanadiumCorrections(PythonAlgorithm):
             wsToFit = EnggUtils.convertToDSpacing(self, wsToFit)
             wsToFit = EnggUtils.sumSpectra(self, wsToFit)
 
-            fitWS = self._fitBankCurve(wsToFit, b)
+            fitWS = self._fitBankCurve(wsToFit, b, spline_breaks)
             curves.update({b: fitWS})
 
         curvesWS = self._prepareCurvesWS(curves)
 
         return curvesWS
 
-    def _fitBankCurve(self, vanWS, bank):
+    def _fitBankCurve(self, vanWS, bank, spline_breaks):
         """
         Fits a spline to a single-spectrum workspace (in d-spacing)
 
         @param vanWS :: Vanadium workspace to fit (normally this contains spectra for a single bank)
         @param bank :: instrument bank this is fitting is done for
+        @param spline_breaks :: number of break points when fitting spline functions
 
         @returns fit workspace (MatrixWorkspace), with the same number of bins as the input
         workspace, and the Y values simulated from the fitted curve
@@ -254,7 +265,8 @@ class EnggVanadiumCorrections(PythonAlgorithm):
         xvec = vanWS.readX(0)
         startX = min(xvec)
         endX = max(xvec)
-        functionDesc = 'name=BSpline, Order=3, StartX=' + str(startX) +', EndX=' + str(endX) + ', NBreak=12'
+        functionDesc = ('name=BSpline, Order=3, StartX={0}, EndX={1}, NBreak={2}'.
+                        format(startX, endX, spline_breaks))
         fitAlg = self.createChildAlgorithm('Fit')
         fitAlg.setProperty('Function', functionDesc)
         fitAlg.setProperty('InputWorkspace', vanWS)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -109,7 +109,7 @@ class EnggFitPeaksTest(unittest.TestCase):
         EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[90], PrimaryFlightPath=50)
         self.assertRaises(RuntimeError,
                           EnggFitPeaks,
-                          sws, 0, [1, 3])
+                          sws, 0, [1.1, 3])
 
         # this should fail because of nan/infinity issues
         peak_def = "name=BackToBackExponential, I=12000, A=1, B=1.5, X0=10000, S=350"
@@ -119,7 +119,7 @@ class EnggFitPeaksTest(unittest.TestCase):
         EditInstrumentGeometry(Workspace=sws, L2=[1.0], Polar=[35], PrimaryFlightPath=35)
         self.assertRaises(RuntimeError,
                           EnggFitPeaks,
-                          sws, 0, [1, 2, 3])
+                          sws, 0, [1, 2.3, 3])
 
         # this should fail because FindPeaks doesn't initialize/converge well
         peak_def = "name=BackToBackExponential, I=90000, A=0.1, B=0.5, X0=5000, S=400"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggVanadiumCorrectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggVanadiumCorrectionsTest.py
@@ -66,6 +66,32 @@ class EnggVanadiumCorrectionsTest(unittest.TestCase):
                           IntegWorkspace=self.__class__._van_integ_tbl,
                           CurvesWorkspace=self.__class__._van_curves_ws)
 
+        # mispelled SplineBreakPoints
+        self.assertRaises(RuntimeError,
+                          sapi.EnggVanadiumCorrections,
+                          BreakPoints=self.__class__._van_integ_tbl,
+                          IntegrationWorkspace=self.__class__._van_integ_tbl,
+                          CurvesWorkspace=self.__class__._van_curves_ws)
+
+        # validation of SplineBreakPoints value bounds fails
+        self.assertRaises(ValueError,
+                          sapi.EnggVanadiumCorrections,
+                          SplineBreakPoints=-1,
+                          IntegrationWorkspace=self.__class__._van_integ_tbl,
+                          CurvesWorkspace=self.__class__._van_curves_ws)
+
+        self.assertRaises(ValueError,
+                          sapi.EnggVanadiumCorrections,
+                          SplineBreakPoints=0,
+                          IntegrationWorkspace=self.__class__._van_integ_tbl,
+                          CurvesWorkspace=self.__class__._van_curves_ws)
+
+        self.assertRaises(ValueError,
+                          sapi.EnggVanadiumCorrections,
+                          SplineBreakPoints=3,
+                          IntegrationWorkspace=self.__class__._van_integ_tbl,
+                          CurvesWorkspace=self.__class__._van_curves_ws)
+
     def _check_corrected_ws(self, ws):
         self.assertEqual(ws.getAxis(0).getUnit().unitID(), 'TOF')
         self.assertEqual(ws.getAxis(1).getUnit().unitID(), 'Label')

--- a/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
+++ b/Testing/SystemTests/tests/analysis/EnggCalibrationTest.py
@@ -48,8 +48,9 @@ class EnginXFocusWithVanadiumCorrection(stresstesting.MantidStressTest):
         van_ws = Load(Filename = 'ENGINX00236516.nxs')
 
         # note: not giving calibrated detector positions
-
+        # Using just 12 break points which is enough for this test. The normal/default value would be 50
         EnggVanadiumCorrections(VanadiumWorkspace = van_ws,
+                                SplineBreakPoints = 12,
                                 OutIntegrationWorkspace = self.van_integ_name,
                                 OutCurvesWorkspace = self.van_bank_curves_name)
 

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -4,6 +4,16 @@
 from mantid.api import *
 import mantid.simpleapi as sapi
 
+CERIA_EXPECTED_PEAKS = [3.124277511, 2.705702376, 1.913220892, 1.631600313,
+                        1.562138267, 1.352851554, 1.241461538, 1.210027059,
+                        1.104598643, 1.04142562, 1.04142562, 0.956610446,
+                        0.914694494, 0.901900955, 0.855618487, 0.825231622,
+                        0.815800156, 0.781069134, 0.757748432, 0.750426918,
+                        0.723129589, 0.704504971, 0.676425777, 0.66110842,
+                        0.656229382, 0.637740216, 0.624855346, 0.620730846,
+                        0.605013529
+                       ]
+
 ENGINX_BANKS = ['', 'North', 'South', '1', '2']
 
 def readInExpectedPeaks(filename, expectedGiven):
@@ -22,7 +32,7 @@ def readInExpectedPeaks(filename, expectedGiven):
 
     expectedPeaksD = None
 
-    if filename != "":
+    if filename:
         exPeakArray = []
         readInArray = []
         try:
@@ -47,7 +57,7 @@ def readInExpectedPeaks(filename, expectedGiven):
             expectedPeaksD = sorted(exPeakArray)
 
     else:
-        if [] == expectedGiven:
+        if not expectedGiven:
             raise ValueError("No expected peaks were given in the property 'ExpectedPeaks', "
                              "could not get default expected peaks, and 'ExpectedPeaksFromFile' "
                              "was not given either. Cannot continout without a list of expected peaks.")

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -4,7 +4,7 @@
 from mantid.api import *
 import mantid.simpleapi as sapi
 
-ENGINX_BANKS = ['', 'North', 'South', '1', '2']
+ENGINX_BANKS = ['', 'North', 'South', 'Both: North, South', '1', '2']
 
 def default_ceria_expected_peaks():
     """
@@ -92,7 +92,7 @@ def getWsIndicesFromInProperties(ws, bank, detIndices):
                          "'DetectorIndices', as they overlap. Please use either of them. Got Bank: '%s', "
                          "and DetectorIndices: '%s'"%(bank, detIndices))
     elif bank:
-        bankAliases = {'North': '1', 'South': '2'}
+        bankAliases = {'North': '1', 'South': '2', 'Both: North, South': '-1'}
         bank = bankAliases.get(bank, bank)
         indices = getWsIndicesForBank(ws, bank)
         if not indices:
@@ -138,7 +138,7 @@ def getWsIndicesForBank(ws, bank):
     Finds the workspace indices of all the pixels/detectors/spectra corresponding to a bank.
 
     ws :: workspace with instrument definition
-    bank :: bank number as it appears in the instrument definition
+    bank :: bank number as it appears in the instrument definition.  A <0 value implies all banks.
 
     @returns :: list of workspace indices for the bank
     """
@@ -158,7 +158,7 @@ def getDetIDsForBank(bank):
     Find the detector IDs for an instrument bank. Note this is at this point specific to
     the ENGINX instrument.
 
-    @param bank :: name/number as a string
+    @param bank :: name/number as a string.
 
     @returns list of detector IDs corresponding to the specified Engg bank number
     """
@@ -184,8 +184,9 @@ def getDetIDsForBank(bank):
 
     detIDs = set()
 
+    bank_int = int(bank)
     for i in range(grouping.getNumberHistograms()):
-        if grouping.readY(i)[0] == int(bank):
+        if bank_int < 0 or grouping.readY(i)[0] == bank_int:
             detIDs.add(grouping.getDetector(i).getID())
 
     sapi.DeleteWorkspace(grouping)

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -4,19 +4,28 @@
 from mantid.api import *
 import mantid.simpleapi as sapi
 
-CERIA_EXPECTED_PEAKS = [3.124277511, 2.705702376, 1.913220892, 1.631600313,
-                        1.562138267, 1.352851554, 1.241461538, 1.210027059,
-                        1.104598643, 1.04142562, 1.04142562, 0.956610446,
-                        0.914694494, 0.901900955, 0.855618487, 0.825231622,
-                        0.815800156, 0.781069134, 0.757748432, 0.750426918,
-                        0.723129589, 0.704504971, 0.676425777, 0.66110842,
-                        0.656229382, 0.637740216, 0.624855346, 0.620730846,
-                        0.605013529
-                       ]
-
 ENGINX_BANKS = ['', 'North', 'South', '1', '2']
 
-def readInExpectedPeaks(filename, expectedGiven):
+def default_ceria_expected_peaks():
+    """
+    Get the list of expected Ceria peaks, which can be a good default for the expected peaks
+    properties of algorithms like EnggCalibrate and EnggCalibrateFull
+
+    @Returns :: a list of peaks in d-spacing as a float list
+    """
+    _CERIA_EXPECTED_PEAKS = [3.124277511, 2.705702376, 1.913220892, 1.631600313,
+                             1.562138267, 1.352851554, 1.241461538, 1.210027059,
+                             1.104598643, 1.04142562, 1.04142562, 0.956610446,
+                             0.914694494, 0.901900955, 0.855618487, 0.825231622,
+                             0.815800156, 0.781069134, 0.757748432, 0.750426918,
+                             0.723129589, 0.704504971, 0.676425777, 0.66110842,
+                             0.656229382, 0.637740216, 0.624855346, 0.620730846,
+                             0.605013529
+                            ]
+
+    return _CERIA_EXPECTED_PEAKS
+
+def read_in_expected_peaks(filename, expectedGiven):
     """
     Reads in expected peaks from the .csv file if requested. Otherwise fall back to the list of
     peaks given (and check that it is not empty).
@@ -57,7 +66,7 @@ def readInExpectedPeaks(filename, expectedGiven):
             expectedPeaksD = sorted(exPeakArray)
 
     else:
-        if not expectedGiven:
+        if [] == expectedGiven:
             raise ValueError("No expected peaks were given in the property 'ExpectedPeaks', "
                              "could not get default expected peaks, and 'ExpectedPeaksFromFile' "
                              "was not given either. Cannot continout without a list of expected peaks.")


### PR DESCRIPTION
Fixes #14600.

Adds new default values for the calibration algorithms + a few more improvements listed in the issue.

**To test**:
- Check code and If all tests pass, including new ones.
- See that the properties of the following algorithms are grouped, in their algorithm dialogs: `EnggVanadiumCorrection`, `EnggCalibrate`, `EnggCalibrateFull`, `EnggFocus`, `EnggFitPeaks`. This should make it easier to understand what the algorithms do and how to use them(with the help of their documentation).
