### PR TITLE
Fix sequential fits in Muon Analysis interface

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -3100,7 +3100,6 @@ Workspace_sptr MuonAnalysis::loadDeadTimes(const std::string& filename) const
 ITableWorkspace_sptr MuonAnalysis::getDeadTimeCorrection(
     boost::shared_ptr<LoadResult> loadResult) const {
   // Dead time table which will be used
-  ITableWorkspace_sptr deadTimesTable;
   Workspace_sptr deadTimes;
 
   if (m_uiForm.deadTimeType->currentText() != "None") {
@@ -3150,6 +3149,9 @@ Algorithm_sptr MuonAnalysis::createLoadAlgorithm()
   loadAlg->setProperty("Mode", "Combined");
 
   // -- Dead Time Correction --------------------------------------------------
+  // If ApplyDeadTimeCorrection is set, the algorithm must have DeadTimeTable
+  // set too. If it can't be set here (from disk file), the sequential fit
+  // must load the dead times from each file.
 
   if (m_uiForm.deadTimeType->currentIndex() != 0)
   {

--- a/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
+++ b/MantidQt/MantidWidgets/src/MuonSequentialFitDialog.cpp
@@ -3,6 +3,8 @@
 
 #include "MantidAPI/AnalysisDataService.h" 
 #include "MantidAPI/AlgorithmProxy.h"
+#include "MantidAPI/WorkspaceProperty.h"
+#include "MantidAPI/ITableWorkspace.h"
 
 namespace MantidQt
 {
@@ -369,6 +371,20 @@ namespace MantidWidgets
       MatrixWorkspace_sptr ws;
 
       try {
+        // If ApplyDeadTimeCorrection is set but no dead time table is set,
+        // we need to load one from the file.
+        bool loadDeadTimesFromFile = false;
+        bool applyDTC = m_loadAlg->getProperty("ApplyDeadTimeCorrection");
+        if (applyDTC) {
+          if (auto deadTimes =
+                  m_loadAlg->getPointerToProperty("DeadTimeTable")) {
+            if (deadTimes->value() == "") {
+              // No workspace set for dead time table - we need to load one
+              loadDeadTimesFromFile = true;
+            }
+          }
+        }
+
         // Use LoadMuonNexus to load the file
         auto loadAlg = AlgorithmManager::Instance().create("LoadMuonNexus");
         loadAlg->initialize();
@@ -376,6 +392,9 @@ namespace MantidWidgets
         loadAlg->setRethrows(true);
         loadAlg->setPropertyValue("Filename", fileIt->toStdString());
         loadAlg->setPropertyValue("OutputWorkspace", "__NotUsed");
+        if (loadDeadTimesFromFile) {
+          loadAlg->setPropertyValue("DeadTimeTable", "__DeadTimes");
+        }
         loadAlg->execute();
         Workspace_sptr loadedWS = loadAlg->getProperty("OutputWorkspace");
         double loadedTimeZero = loadAlg->getProperty("TimeZero");
@@ -391,10 +410,30 @@ namespace MantidWidgets
         process->setPropertyValue("OutputWorkspace", "__YouDontSeeMeIAmNinja");
         if (m_fitPropBrowser->rawData()) // TODO: or vice verca?
           process->setPropertyValue("RebinParams", "");
+        if (loadDeadTimesFromFile) {
+          Workspace_sptr deadTimes = loadAlg->getProperty("DeadTimeTable");
+          ITableWorkspace_sptr deadTimesTable;
+          if (auto table =
+                  boost::dynamic_pointer_cast<ITableWorkspace>(deadTimes)) {
+            deadTimesTable = table;
+          } else if (auto group = boost::dynamic_pointer_cast<WorkspaceGroup>(
+                         deadTimes)) {
+            deadTimesTable =
+                boost::dynamic_pointer_cast<ITableWorkspace>(group->getItem(0));
+          }
+          process->setProperty("DeadTimeTable", deadTimesTable);
+        }
 
         process->execute();
 
-        ws = process->getProperty("OutputWorkspace");
+        Workspace_sptr outputWS = process->getProperty("OutputWorkspace");
+        ws = boost::dynamic_pointer_cast<MatrixWorkspace>(outputWS);
+      } catch (const std::exception &ex) {
+        g_log.error(ex.what());
+        QMessageBox::critical(
+            this, "Loading failed",
+            "Unable to load one of the files.\n\nCheck log for details");
+
       } catch (...) {
         QMessageBox::critical(
             this, "Loading failed",


### PR DESCRIPTION
Resolves #14800 

Sequential fits in the Muon Analysis interface were failing. The sequential fit dialog is passed a MuonProcess algorithm with some properties set, and loads each file and passes it through this algorithm.

If the algorithm passed in has the property "ApplyDeadTimeCorrection" set true, it will expect there to be a dead time table. If this is not the case then the processing fails. This PR checks this property and, if no dead time table is set, loads the dead times from the file.

Other changes:
- The output workspace type has been corrected.
- Log error message from exceptions

**To test**
- Download the data files from `\\olympic\babylon5\Public\TomPerkins` (`emu00059683-5.nxs`) and put them in a directory where Mantid can find them
- Start MantidPlot and select Interfaces -> Muon -> Muon Analysis
- Load one of the files
- Go to the "Data Analysis" tab. Add a fit function (e.g. ExpDecayMuon).
- Select Fit->Sequential fit.
- Enter `59683-59685` in the Runs box and start the fit.
- Verify the fit runs ok with no errors.
