### PR TITLE
Indirect Data Reduction Add default value to scale in Moments interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/IndirectMoments.ui
@@ -75,6 +75,9 @@
           <property name="singleStep">
            <double>0.100000000000000</double>
           </property>
+          <property name="value">
+            <double>1.000000000000000</double>
+          </property>
          </widget>
         </item>
         <item>


### PR DESCRIPTION
Fixes #14734

Default scale value in IndirectMoments is now 1.0000 
# To Test
- Open Moments (Interfaces > Indirect > Data Reduction > Moments)
- In the Input section ensure that the default value for `Scale By:` is `1.00000`
