### PR TITLE
Added Workspace Groups Tests to MaskAngle Test Suite

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
@@ -18,6 +18,25 @@ class MaskAngleTest(unittest.TestCase):
         DeleteWorkspace(w)
         self.assertTrue(array_equal(masklist,arange(10)+10))
 
+    def testGroupMaskAngle(self):
+        ws1=WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(30,5,False,False)
+        AnalysisDataService.add('ws1',ws1)
+        ws2=WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(30,5,False,False)
+        AnalysisDataService.add('ws2',ws2)
+
+        group = GroupWorkspaces(['ws1', 'ws2'])
+
+        MaskAngle(group, 10, 20)
+
+        for w in group:
+            for i in arange(w.getNumberHistograms())+1:
+                if(i<10) or (i>19):
+                    self.assertTrue(not w.getInstrument().getDetector(int(i)).isMasked())
+                else:
+                    self.assertTrue(w.getInstrument().getDetector(int(i)).isMasked())
+
+        DeleteWorkspace(group)
+
     def testFailNoInstrument(self):
         w1=CreateWorkspace(arange(5),arange(5))
         try:
@@ -27,6 +46,21 @@ class MaskAngleTest(unittest.TestCase):
             pass
         finally:
             DeleteWorkspace(w1)
+
+    def testGroupFailNoInstrument(self):
+        ws1=WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(30,5,False,False)
+        AnalysisDataService.add('ws1',ws1)
+        ws2 = CreateWorkspace(arange(5), arange(5))
+
+        group = GroupWorkspaces(['ws1', 'ws2'])
+
+        try:
+            MaskAngle(group, 10, 20)
+            self.fail("Should not have gotten here. Should throw because no instrument.")
+        except (RuntimeError, ValueError, TypeError):
+            pass
+        finally:
+            DeleteWorkspace(group)
 
     def testFailLimits(self):
         w2=WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(30,5,False,False)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
@@ -25,7 +25,6 @@ class MaskAngleTest(unittest.TestCase):
         AnalysisDataService.add('ws2',ws2)
 
         group = GroupWorkspaces(['ws1', 'ws2'])
-
         MaskAngle(group, 10, 20)
 
         for w in group:


### PR DESCRIPTION
Fixes #14798 
### Changes

Added two tests to the MaskAngle test suite:
- Test to ensure workspace groups are correctly processed in MaskAngle
- Test to ensure workspace groups fail if they do not contain an instrument
### Testing
- Code review
- Run tests and ensure they all pass
