### PR TITLE
Python boolean attributes correctly interpreted in mantidplot

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -47,7 +47,7 @@ void IFunctionAdapter::declareAttribute(const std::string &name,
   IFunction::Attribute attr;
 
   if (PyBool_Check(rawptr) == 1)
-	  attr = IFunction::Attribute(extract<bool>(rawptr)());
+    attr = IFunction::Attribute(extract<bool>(rawptr)());
   else if (PyInt_Check(rawptr) == 1)
     attr = IFunction::Attribute(extract<int>(rawptr)());
   else if (PyFloat_Check(rawptr) == 1)

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -45,14 +45,15 @@ void IFunctionAdapter::declareAttribute(const std::string &name,
                                         const object &defaultValue) {
   PyObject *rawptr = defaultValue.ptr();
   IFunction::Attribute attr;
-  if (PyInt_Check(rawptr) == 1)
+
+  if (PyBool_Check(rawptr) == 1)
+	  attr = IFunction::Attribute(extract<bool>(rawptr)());
+  else if (PyInt_Check(rawptr) == 1)
     attr = IFunction::Attribute(extract<int>(rawptr)());
   else if (PyFloat_Check(rawptr) == 1)
     attr = IFunction::Attribute(extract<double>(rawptr)());
   else if (PyString_Check(rawptr) == 1)
     attr = IFunction::Attribute(extract<std::string>(rawptr)());
-  else if (PyBool_Check(rawptr) == 1)
-    attr = IFunction::Attribute(extract<bool>(rawptr)());
   else
     throw std::invalid_argument(
         "Invalid attribute type. Allowed types=float,int,str,bool");


### PR DESCRIPTION
Fixes #14786 

Release notes not updated
### Changes

Declaring `python Boolean` attributes in python fit functions now produces a checkbox in the mantidplot gui. Before this resulted in an integer due to incorrect placement of a validator in the python interface.
### Test

Code review and compare the following script with another version of mantidplot:

``` python
import numpy
import math
from mantid.api import *
from mantid.kernel import *
from mantid.simpleapi import *
numpy.set_printoptions(linewidth=100)

class AttributeExample(IFunction1D):
    # model "resonance wiggles"
    # integrated linear background function
    def init(self):
        self.declareParameter("Amplitude",0.2)
        self.declareParameter("Baseline",0.1)
        self.declareAttribute("Frequency",0.26)
        self.declareAttribute("Sine", False)

# not used any more?
    def setAttributeValue(self,name,value):
        if name == "Frequency":
            self._freq = value
        if name == "Sine":
            self._sine = value
        super(AttributeExample, self).setAttributeValue(name, value)

    def function1D(self,xvals):
        ampl=self.getParameterValue("Amplitude")
        base=self.getParameterValue("Baseline")

        #self._nspec=self.getAttributeValue("Nspec")
        #self._y0=self.getAttributeValue("Y0")
        #self._dY=self.getAttributeValue("dY")

        if(self._sine):
            ybins=numpy.sin(xvals*self._freq*2.0*math.pi)*ampl+base
        else:
            ybins=numpy.cos(xvals*self._freq*2.0*math.pi)*ampl+base
        return ybins

FunctionFactory.subscribe(AttributeExample)
```
