### PR TITLE
Declare output properites

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -491,7 +491,12 @@ class SNSPowderReduction(DataProcessorAlgorithm):
         results = api.PDLoadCharacterizations(Filename=charFilename,
                                               ExpIniFilename=expIniFilename,
                                               OutputWorkspace="characterizations")
+        # export the characterizations table
         self._charTable = results[0]
+        self.declareProperty(ITableWorkspaceProperty("CharacterizationsTable", "characterizations", Direction.Output))
+        self.setProperty("CharacterizationsTable", self._charTable)
+
+        # get the focus positions from the properties
         self.iparmFile = results[1]
         self._focusPos['PrimaryFlightPath'] = results[2]
         self._focusPos['SpectrumIDs'] = results[3]
@@ -864,6 +869,10 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             except Exception, e:
                 self.log().warning(str(e))
 
+            propertyName = "OutputWorkspace%s" % str(wksplist[itemp])
+            self.log().warning(propertyName)
+            self.declareProperty(WorkspaceProperty(propertyName, str(wksplist[itemp]), Direction.Output))
+            self.setProperty(propertyName, wksplist[itemp])
             self._save(wksplist[itemp], self._info, False, True)
             self.log().information("Done focussing data of %d." % (itemp))
 
@@ -906,6 +915,7 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             prefix = self._outPrefix
         filename = os.path.join(self._outDir, prefix)
         if pdfgetn:
+            self.log().notice("Saving 'pdfgetn' is deprecated. Use PDtoPDFgetN instead.")
             if "pdfgetn" in self._outTypes:
                 pdfwksp = str(wksp)+"_norm"
                 pdfwksp = api.SetUncertainties(InputWorkspace=wksp, OutputWorkspace=pdfwksp, SetError="sqrt")
@@ -926,7 +936,8 @@ class SNSPowderReduction(DataProcessorAlgorithm):
             #api.Rebin(InputWorkspace=wksp, OutputWorkspace=wksp, Params=self._binning) # crop edges
             api.SaveNexus(InputWorkspace=wksp, Filename=filename+".nxs")
 
-        # always save python script
+        # always save python script - this is broken because the history isn't
+        # attached until the algorithm is finished
         api.GeneratePythonScript(InputWorkspace=wksp, Filename=filename+".py")
 
         return

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -77,12 +77,12 @@ void AlignAndFocusPowder::init() {
       "The name of the CalFile with offset, masking, and grouping data");
   declareProperty(
       new WorkspaceProperty<GroupingWorkspace>(
-          "GroupingWorkspace", "", Direction::Input, PropertyMode::Optional),
+          "GroupingWorkspace", "", Direction::InOut, PropertyMode::Optional),
       "Optional: A GroupingWorkspace giving the grouping info.");
 
   declareProperty(
       new WorkspaceProperty<ITableWorkspace>(
-          "CalibrationWorkspace", "", Direction::Input, PropertyMode::Optional),
+          "CalibrationWorkspace", "", Direction::InOut, PropertyMode::Optional),
       "Optional: A Workspace containing the calibration information. Either "
       "this or CalibrationFile needs to be specified.");
   declareProperty(
@@ -90,7 +90,7 @@ void AlignAndFocusPowder::init() {
           "OffsetsWorkspace", "", Direction::Input, PropertyMode::Optional),
       "Optional: An OffsetsWorkspace giving the detector calibration values.");
   declareProperty(new WorkspaceProperty<MaskWorkspace>("MaskWorkspace", "",
-                                                       Direction::Input,
+                                                       Direction::InOut,
                                                        PropertyMode::Optional),
                   "Optional: A workspace giving which detectors are masked.");
   declareProperty(new WorkspaceProperty<TableWorkspace>("MaskBinTable", "",
@@ -940,18 +940,24 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFileName) {
   // replace workspaces as appropriate
   if (loadGrouping) {
     m_groupWS = alg->getProperty("OutputGroupingWorkspace");
-    AnalysisDataService::Instance().addOrReplace(m_instName + "_group",
-                                                 m_groupWS);
+
+    const std::string name = m_instName + "_group";
+    AnalysisDataService::Instance().addOrReplace(name, m_groupWS);
+    this->setPropertyValue("GroupingWorkspace", name);
   }
   if (loadCalibration) {
     m_calibrationWS = alg->getProperty("OutputCalWorkspace");
-    AnalysisDataService::Instance().addOrReplace(m_instName + "_cal",
-                                                 m_calibrationWS);
+
+    const std::string name = m_instName + "_cal";
+    AnalysisDataService::Instance().addOrReplace(name, m_calibrationWS);
+    this->setPropertyValue("CalibrationWorkspace", name);
   }
   if (loadMask) {
     m_maskWS = alg->getProperty("OutputMaskWorkspace");
-    AnalysisDataService::Instance().addOrReplace(m_instName + "_mask",
-                                                 m_maskWS);
+
+    const std::string name = m_instName + "_mask";
+    AnalysisDataService::Instance().addOrReplace(name, m_maskWS);
+    this->setPropertyValue("MaskWorkspace", name);
   }
 
   return;


### PR DESCRIPTION
**To test:** run the algorithm(s) and see that more workspaces have histories. For `AlignAndFocusPowder` it will be all of them. For `SNSPowderReduction` it is most.

This does not need to be in the release notes.
