### PR TITLE
Coverity found mismatched iterator comparison

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/ReflSearchModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/ReflSearchModel.cpp
@@ -87,23 +87,21 @@ QVariant ReflSearchModel::data(const QModelIndex &index, int role) const {
   if (role != Qt::DisplayRole) {
     if (role == Qt::ToolTipRole) {
       // setting the tool tips for any unsuccessful transfers
-      for (auto errorIt = m_errors.begin(); errorIt != m_errors.end();
-           ++errorIt) {
-        auto &errorRow = *errorIt;
-        if (errorRow.find(run) != errorIt->end()) {
+      for (auto errorRow = m_errors.begin(); errorRow != m_errors.end();
+           ++errorRow) {
+        if (errorRow->find(run) != errorRow->end()) {
           // get the error message from the unsuccessful transfer
           std::string errorMessage =
-              "Invalid transfer: " + errorRow.find(run)->second;
+              "Invalid transfer: " + errorRow->find(run)->second;
           // set the message as the tooltip
           return QString::fromStdString(errorMessage);
         }
       }
     } else if (role == Qt::BackgroundRole) {
       // setting the background colour for any unsuccessful transfers
-      for (auto errorIt = m_errors.begin(); errorIt != m_errors.end();
-           ++errorIt) {
-        auto &errorRow = *errorIt;
-        if (errorRow.find(run) != errorIt->end()) {
+      for (auto errorRow = m_errors.begin(); errorRow != m_errors.end();
+           ++errorRow) {
+        if (errorRow->find(run) != errorRow->end()) {
           // return the colour yellow for any successful runs
           return QColor("#FF8040");
         }


### PR DESCRIPTION
In the ReflSearchModel we iterate through the invalid rows, setting their tooltip to explain their invalidity and also set their cell colour to Orange. The way that this was not efficient and involved storing a reference to the iterator in another variable, which was then used for comparison against the original iterator. Coverity didn't like it (and rightly so) so the fix involves just using the original iterator for comparisons and removing the reassignment.

**To Test**

A code comparison between old and new versions of the `data` method would be good.

Unfortunately, Coverity will only run on merged code so if this is not the correct fix then I will have to re-open the issue. However, if all builds pass then it should be fine to merge. 

Fixes #14822
