### PR TITLE
Export of EventList to Python.

### DIFF
--- a/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -22,8 +22,8 @@ set ( EXPORT_FILES
   src/Exports/FileProperty.cpp
   src/Exports/MultipleFileProperty.cpp
   src/Exports/FrameworkManager.cpp
-  src/Exports/IEventList.cpp
   src/Exports/ISpectrum.cpp
+  src/Exports/IEventList.cpp
   src/Exports/WorkspaceHistory.cpp
   src/Exports/ExperimentInfo.cpp
   src/Exports/MultipleExperimentInfos.cpp

--- a/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
@@ -27,7 +27,8 @@ void export_IEventList() {
       .value("WEIGHTED_NOTIME", WEIGHTED_NOTIME)
       .export_values();
 
-  class_<IEventList, boost::noncopyable>("IEventList", no_init)
+  class_<IEventList, bases<Mantid::API::ISpectrum>, boost::noncopyable>(
+      "IEventList", no_init)
       .def("getEventType", &IEventList::getEventType, args("self"),
            "Return the type of events stored.")
       .def("switchTo", &IEventList::switchTo, args("self", "newType"),

--- a/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt
@@ -8,6 +8,7 @@ set ( MODULE_TEMPLATE src/dataobjects.cpp.in )
 # -- Do NOT sort this list. The order defines the order in which the export
 #    definitions occur and some depend on their base classes being exported first --
 set ( EXPORT_FILES
+  src/Exports/EventList.cpp
   src/Exports/EventWorkspace.cpp
   src/Exports/Workspace2D.cpp
   src/Exports/RebinnedOutput.cpp

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/EventList.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/EventList.cpp
@@ -1,0 +1,23 @@
+#include "MantidDataObjects/EventList.h"
+#include <boost/python/class.hpp>
+#include <boost/python/register_ptr_to_python.hpp>
+
+using namespace boost::python;
+using namespace Mantid::DataObjects;
+
+namespace {
+void addEventToEventList(EventList &self, double tof,
+                         Mantid::Kernel::DateAndTime pulsetime) {
+  self.addEventQuickly(Mantid::DataObjects::TofEvent(tof, pulsetime));
+}
+}
+
+void export_EventList() {
+  register_ptr_to_python<EventList *>();
+
+  class_<EventList, bases<Mantid::API::IEventList>, boost::noncopyable>(
+      "EventList")
+      .def("addEventQuickly", &addEventToEventList,
+           args("self", "tof", "pulsetime"),
+           "Create TofEvent and add to EventList.");
+}

--- a/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/CMakeLists.txt
@@ -4,6 +4,7 @@
 add_subdirectory( kernel )
 add_subdirectory( geometry )
 add_subdirectory( api )
+add_subdirectory( dataobjects )
 
 set ( TEST_PY_FILES
   ImportModuleTest.py

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/CMakeLists.txt
@@ -1,0 +1,11 @@
+##
+## mantid.dataobjects tests
+##
+set ( TEST_PY_FILES
+  EventListTest.py
+)
+
+check_tests_valid ( ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES} )
+
+# Prefix for test=PythonInterfaceDataObjects
+pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR} PythonInterfaceDataObjects ${TEST_PY_FILES} )

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name, too-many-public-methods
 import unittest
 
 from mantid.kernel import DateAndTime

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
@@ -1,0 +1,24 @@
+import unittest
+
+from mantid.kernel import DateAndTime
+from mantid.api import EventType
+from mantid.dataobjects import EventList
+
+class EventListTest(unittest.TestCase):
+
+    def test_event_list_constructor(self):
+        el = EventList()
+        self.assertEquals(el.getNumberEvents(), 0)
+        self.assertEquals(el.getEventType(), EventType.TOF)
+
+    def test_event_list_addEventQuickly(self):
+        el = EventList()
+        el.addEventQuickly(float(0.123), DateAndTime(42))
+        self.assertEquals(el.getNumberEvents(), 1)
+        self.assertEquals(el.getEventType(), EventType.TOF)
+        self.assertEquals(el.getTofs()[0], float(0.123))
+        self.assertEquals(el.getPulseTimes()[0], DateAndTime(42))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #14826.

To keep this small, I included only the single method I needed, but now that it is there and the tests in dataobjects are set up it should be simple to add more, when necessary.

Testing:
Code review.
