### PR TITLE
Surface and contour plots versus log values from workspace groups 

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -186,6 +186,7 @@ set ( MANTID_SRCS  src/Mantid/AlgorithmMonitor.cpp
                    src/Mantid/MantidSampleLogDialog.cpp
                    src/Mantid/MantidSampleMaterialDialog.cpp
 				   src/Mantid/MantidSurfacePlotDialog.cpp
+				   src/Mantid/MantidGroupPlotGenerator.cpp
                    src/Mantid/MantidUI.cpp
                    src/Mantid/MantidTable.cpp
                    src/Mantid/MantidWSIndexDialog.cpp
@@ -426,6 +427,7 @@ set ( MANTID_HDRS  src/Mantid/AlgorithmMonitor.h
                    src/Mantid/MantidSampleLogDialog.h
                    src/Mantid/MantidSampleMaterialDialog.h
 				   src/Mantid/MantidSurfacePlotDialog.h
+				   src/Mantid/MantidGroupPlotGenerator.h
                    src/Mantid/MantidUI.h
                    src/Mantid/MantidWSIndexDialog.h
                    src/Mantid/MantidTable.h

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -185,6 +185,7 @@ set ( MANTID_SRCS  src/Mantid/AlgorithmMonitor.cpp
                    src/Mantid/MantidMatrixDialog.cpp
                    src/Mantid/MantidSampleLogDialog.cpp
                    src/Mantid/MantidSampleMaterialDialog.cpp
+				   src/Mantid/MantidSurfacePlotDialog.cpp
                    src/Mantid/MantidUI.cpp
                    src/Mantid/MantidTable.cpp
                    src/Mantid/MantidWSIndexDialog.cpp
@@ -424,6 +425,7 @@ set ( MANTID_HDRS  src/Mantid/AlgorithmMonitor.h
                    src/Mantid/MantidAlgorithmMetatype.h
                    src/Mantid/MantidSampleLogDialog.h
                    src/Mantid/MantidSampleMaterialDialog.h
+				   src/Mantid/MantidSurfacePlotDialog.h
                    src/Mantid/MantidUI.h
                    src/Mantid/MantidWSIndexDialog.h
                    src/Mantid/MantidTable.h
@@ -699,6 +701,7 @@ set ( MANTID_MOC_FILES src/Mantid/AlgorithmMonitor.h
 		       src/Mantid/MantidMatrixModel.h
                        src/Mantid/MantidSampleLogDialog.h
                        src/Mantid/MantidSampleMaterialDialog.h
+					   src/Mantid/MantidSurfacePlotDialog.h
                        src/Mantid/MantidUI.h
                        src/Mantid/MantidWSIndexDialog.h
                        src/Mantid/MantidTable.h

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -634,16 +634,18 @@ void MantidDockWidget::addPeaksWorkspaceMenuItems(QMenu *menu, const Mantid::API
 * Add the actions that are appropriate for a MatrixWorkspace
 * @param menu :: The menu to store the items
 */
-void MantidDockWidget::addWorkspaceGroupMenuItems(QMenu *menu) const
-{
+void MantidDockWidget::addWorkspaceGroupMenuItems(
+    QMenu *menu, const WorkspaceGroup_const_sptr &groupWS) const {
   m_plotSpec->setEnabled(true);
   menu->addAction(m_plotSpec);
   m_plotSpecErr->setEnabled(true);
   menu->addAction(m_plotSpecErr);
   menu->addAction(m_colorFill);
   m_colorFill->setEnabled(true);
-  menu->addAction(m_plotSurface);
-  m_plotSurface->setEnabled(true);
+  if (groupWS && groupWS->getNumberOfEntries() > 2) {
+    menu->addAction(m_plotSurface);
+    m_plotSurface->setEnabled(true);
+  }
   menu->addSeparator();
   menu->addAction(m_saveNexus);
 }
@@ -1262,13 +1264,11 @@ void MantidDockWidget::popupMenu(const QPoint & pos)
     else if( IPeaksWorkspace_const_sptr peaksWS = boost::dynamic_pointer_cast<const IPeaksWorkspace>(ws) )
     {
       addPeaksWorkspaceMenuItems(menu, peaksWS);
-    }
-    else if( boost::dynamic_pointer_cast<const WorkspaceGroup>(ws) ) 
-    {
-      addWorkspaceGroupMenuItems(menu);
-    }
-    else if( boost::dynamic_pointer_cast<const Mantid::API::ITableWorkspace>(ws) )
-    {
+    } else if (WorkspaceGroup_const_sptr groupWS =
+                   boost::dynamic_pointer_cast<const WorkspaceGroup>(ws)) {
+      addWorkspaceGroupMenuItems(menu, groupWS);
+    } else if (boost::dynamic_pointer_cast<const Mantid::API::ITableWorkspace>(
+                   ws)) {
       addTableWorkspaceMenuItems(menu);
     }
     addClearMenuItems(menu, selectedWsName);

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1753,16 +1753,21 @@ QStringList MantidTreeWidget::getSelectedWorkspaceNames() const
 * single-spectrum workspaces.
 *
 * We also must filter the list of selected workspace names to account for any
-* non-MatrixWorkspaces that may have been selected.  In particular WorkspaceGroups
+* non-MatrixWorkspaces that may have been selected.  In particular
+* WorkspaceGroups
 * (the children of which are to be included if they are MatrixWorkspaces) and
 * TableWorkspaces (which are implicitly excluded).  We only want workspaces we
 * can actually plot!
 *
 * @param showWaterfallOpt If true, show the waterfall option on the dialog
-* @return :: A MantidWSIndexDialog::UserInput structure listing the selected options
+* @param showPlotAll :: [input] If true, show the "Plot All" button on the
+* dialog
+* @return :: A MantidWSIndexDialog::UserInput structure listing the selected
+* options
 */
-MantidWSIndexDialog::UserInput MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt) const
-{
+MantidWSIndexDialog::UserInput
+MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
+                                             bool showPlotAll) const {
   // Check for any selected WorkspaceGroup names and replace with the names of
   // their children.
   QSet<QString> selectedWsNames;
@@ -1826,8 +1831,8 @@ MantidWSIndexDialog::UserInput MantidTreeWidget::chooseSpectrumFromSelected(bool
   }
 
   // Else, one or more workspaces
-  MantidWSIndexDialog *dio = new MantidWSIndexDialog(m_mantidUI, 0, selectedMatrixWsNameList,
-                                                     showWaterfallOpt);
+  MantidWSIndexDialog *dio = new MantidWSIndexDialog(
+      m_mantidUI, 0, selectedMatrixWsNameList, showWaterfallOpt, true);
   dio->exec();
   return dio->getSelections();
 }

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1532,6 +1532,18 @@ void MantidDockWidget::plotSurface() {
         const QString xLabelQ = createWorkspaceForGroupPlot(
             plotWSTitle, wsGroup, options.plotIndex, options.logName);
 
+        // Convert to point data if not already
+        if (auto matrixWS = boost::dynamic_pointer_cast<const MatrixWorkspace>(
+                m_mantidUI->getWorkspace(plotWSTitle))) {
+          if (matrixWS->isHistogramData()) {
+            auto alg = m_mantidUI->createAlgorithm("ConvertToPointData");
+            alg->initialize();
+            alg->setPropertyValue("InputWorkspace", plotWSTitle.toStdString());
+            alg->setProperty("OutputWorkspace", plotWSTitle.toStdString());
+            alg->execute();
+          }
+        }
+
         // Plot the output workspace in 3D
         auto matrixToPlot = m_mantidUI->importMatrixWorkspace(plotWSTitle, -1,
                                                               -1, false, false);

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -651,16 +651,21 @@ void MantidDockWidget::addWorkspaceGroupMenuItems(
   m_colorFill->setEnabled(true);
 
   // If appropriate, add "plot surface" and "plot contour" options
-  // Only add these if there are >2 workspaces in group, and all are
-  // MatrixWorkspaces (otherwise they can't be plotted)
-  if (groupWS && groupWS->getNumberOfEntries() > 2) {
-    if (MantidGroupPlotGenerator::groupIsAllMatrixWorkspaces(groupWS)) {
-      menu->addAction(m_plotSurface);
-      m_plotSurface->setEnabled(true);
-      menu->addAction(m_plotContour);
-      m_plotContour->setEnabled(true);
+  // Only add these if:
+  // - there are >2 workspaces in group
+  // - all are MatrixWorkspaces (otherwise they can't be plotted)
+  // - only one group is selected
+  if (m_tree->selectedItems().size() == 1) {
+    if (groupWS && groupWS->getNumberOfEntries() > 2) {
+      if (MantidGroupPlotGenerator::groupIsAllMatrixWorkspaces(groupWS)) {
+        menu->addAction(m_plotSurface);
+        m_plotSurface->setEnabled(true);
+        menu->addAction(m_plotContour);
+        m_plotContour->setEnabled(true);
+      }
     }
   }
+
   menu->addSeparator();
   menu->addAction(m_saveNexus);
 }

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1525,7 +1525,7 @@ void MantidDockWidget::plotSurface() {
 
       // Each "spectrum" will be the data from one workspace
       int nWorkspaces = wsGroup->getNumberOfEntries();
-      std::string xAxisLabel, dataAxisLabel;
+      std::string xAxisLabel, dataAxisLabel, xAxisUnits;
       alg->setProperty("NSpec", nWorkspaces);
       if (nWorkspaces > 0) {
         // For each workspace in group, add data
@@ -1540,6 +1540,7 @@ void MantidDockWidget::plotSurface() {
             data.insert(data.end(), Y.begin(), Y.end());
             if (i == 0) {
               xAxisLabel = ws->getXDimension()->getName();
+              xAxisUnits = ws->getXDimension()->getUnits();
               dataAxisLabel = ws->YUnitLabel();
             }
           }
@@ -1551,10 +1552,6 @@ void MantidDockWidget::plotSurface() {
       m_mantidUI->executeAlgorithmAsync(alg, true);
 
       // Plot the output workspace in 3D
-      if (auto matrixWS = boost::dynamic_pointer_cast<const MatrixWorkspace>(
-              m_mantidUI->getWorkspace(plotWSTitle))) {
-        matrixWS->getAxis(0)->title() = xAxisLabel;
-      }
       auto matrixToPlot =
           m_mantidUI->importMatrixWorkspace(plotWSTitle, -1, -1, false, false);
       m_mantidUI->deleteWorkspace(plotWSTitle);
@@ -1564,6 +1561,16 @@ void MantidDockWidget::plotSurface() {
       QString title("Surface plot for ");
       title.append(wsGroup->name().c_str());
       plot->setTitle(title);
+
+      // Set the X axis label correctly
+      if (xAxisLabel.empty()) {
+        xAxisLabel = "X";
+      }
+      QString xLabelQ(xAxisLabel.c_str());
+      if (!xAxisUnits.empty()) {
+        xLabelQ.append(" (").append(xAxisUnits.c_str()).append(")");
+      }
+      plot->setXAxisLabel(xLabelQ);
     }
   }
 }

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1562,7 +1562,7 @@ void MantidDockWidget::plotContour() {
     const auto wsGroup = boost::dynamic_pointer_cast<const WorkspaceGroup>(
         m_ads.retrieve(wsName.toStdString()));
     if (wsGroup) {
-      auto options = m_tree->chooseSurfacePlotOptions();
+      auto options = m_tree->chooseContourPlotOptions();
       // If user clicked OK and not Cancel...
       if (options.accepted) {
 
@@ -1942,20 +1942,42 @@ MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
 * Allows users to choose spectra from the selected workspaces by presenting them
 * with a dialog box, and also allows choice of a log to plot against and a name
 * for this axis.
-*
+* @param type :: [input] Type of plot (for dialog title)
 * @returns :: A structure listing the selected options
 */
 MantidSurfacePlotDialog::UserInputSurface
-MantidTreeWidget::chooseSurfacePlotOptions() const {
+MantidTreeWidget::choosePlotOptions(const QString &type) const {
   auto selectedMatrixWsList = getSelectedWorkspaces();
   QList<QString> selectedMatrixWsNameList;
   foreach (const auto matrixWs, selectedMatrixWsList) {
     selectedMatrixWsNameList.append(QString::fromStdString(matrixWs->name()));
   }
-  MantidSurfacePlotDialog *dlg =
-      new MantidSurfacePlotDialog(m_mantidUI, 0, selectedMatrixWsNameList);
+  MantidSurfacePlotDialog *dlg = new MantidSurfacePlotDialog(
+      m_mantidUI, 0, selectedMatrixWsNameList, type);
   dlg->exec();
   return dlg->getSelections();
+}
+
+/**
+* Allows users to choose spectra from the selected workspaces by presenting them
+* with a dialog box, and also allows choice of a log to plot against and a name
+* for this axis.
+* @returns :: A structure listing the selected options
+*/
+MantidSurfacePlotDialog::UserInputSurface
+MantidTreeWidget::chooseSurfacePlotOptions() const {
+  return choosePlotOptions("Surface");
+}
+
+/**
+* Allows users to choose spectra from the selected workspaces by presenting them
+* with a dialog box, and also allows choice of a log to plot against and a name
+* for this axis.
+* @returns :: A structure listing the selected options
+*/
+MantidSurfacePlotDialog::UserInputSurface
+MantidTreeWidget::chooseContourPlotOptions() const {
+  return choosePlotOptions("Contour");
 }
 
 void MantidTreeWidget::setSortScheme(MantidItemSortScheme sortScheme)

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1885,7 +1885,7 @@ void MantidTreeWidget::validatePlotOptions(
   // number of workspaces in the group
   if (options.accepted) {
     if (options.logName == MantidSurfacePlotDialog::CUSTOM) {
-      if (options.customLogValues.size() != nWorkspaces) {
+      if (static_cast<int>(options.customLogValues.size()) != nWorkspaces) {
         QMessageBox errorMessage;
         errorMessage.setText(
             "Number of custom log values must be equal to number "

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1518,18 +1518,9 @@ void MantidDockWidget::plotSurface() {
         m_ads.retrieve(wsName.toStdString()));
     if (wsGroup) {
       // Which spectrum to plot from each workspace
-      // Even if user entered a range, just use the first number
-      int spectrumIndex{0}; // default to 0
-      const auto userInput = m_tree->chooseSpectrumFromSelected(false, false);
-      if (!userInput.plots.empty()) {
-        auto indexList = userInput.plots.values();
-        if (!indexList.empty()) {
-          auto spectrumIndexes = indexList.at(0);
-          if (!spectrumIndexes.empty()) {
-            spectrumIndex = *spectrumIndexes.begin();
-          }
-        }
-      }
+      const int spectrumIndex = getSingleSpectrumIndex();
+      // Name for y-axis of plot
+      QString yLabelQ("Workspace index");
 
       // Set up one new matrix workspace to hold all the data for plotting
       const QString plotWSTitle("__matrixToPlot");
@@ -1577,7 +1568,7 @@ void MantidDockWidget::plotSurface() {
               .arg(wsGroup->name().c_str(), QString::number(spectrumIndex));
       plot->setTitle(title);
 
-      // Set the X axis label correctly
+      // Set the X, Y axis labels correctly
       if (xAxisLabel.empty()) {
         xAxisLabel = "X";
       }
@@ -1586,11 +1577,33 @@ void MantidDockWidget::plotSurface() {
         xLabelQ.append(" (").append(xAxisUnits.c_str()).append(")");
       }
       plot->setXAxisLabel(xLabelQ);
+      plot->setYAxisLabel(yLabelQ);
 
       // Sometimes resolution is auto-set too high and plot appears empty
       plot->setResolution(1);
     }
   }
+}
+
+/**
+ * Ask the user for a choice of which spectrum to plot from each workspace.
+ * Disable waterfall and "Plot all" options.
+ * Even if user enters a range, just use the first number.
+ * @returns Selected spectrum index
+ */
+const int MantidDockWidget::getSingleSpectrumIndex() const {
+  int spectrumIndex{0}; // default to 0
+  const auto userInput = m_tree->chooseSpectrumFromSelected(false, false);
+  if (!userInput.plots.empty()) {
+    const auto indexList = userInput.plots.values();
+    if (!indexList.empty()) {
+      const auto spectrumIndexes = indexList.at(0);
+      if (!spectrumIndexes.empty()) {
+        spectrumIndex = *spectrumIndexes.begin();
+      }
+    }
+  }
+  return spectrumIndex;
 }
 
 //------------ MantidTreeWidget -----------------------//

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1581,10 +1581,18 @@ void MantidDockWidget::plotContour() {
         convertPointsToHisto(plotWSTitle);
 
         // Plot the output workspace as a contour plot
-        auto plot = m_mantidUI->drawSingleColorFillPlot(plotWSTitle,
-                                                        Graph::ColorMapContour);
+        auto matrixToPlot = m_mantidUI->importMatrixWorkspace(plotWSTitle, -1,
+                                                              -1, false, false);
+        m_mantidUI->deleteWorkspace(plotWSTitle);
 
-        // Set X, Y axis titles correctly
+        // Copying the plot in this way ensures that the workspace can be
+        // deleted and the plot will not disappear
+        MultiLayer *plot = m_appParent->multilayerPlot(
+            m_appParent->generateUniqueName(tr("Graph")));
+        plot->removeLayer();
+        plot->copy(matrixToPlot->plotGraph2D(Graph::ColorMapContour));
+
+        // Set the X, Y axis labels correctly
         plot->activeGraph()->setXAxisTitle(xLabelQ);
         plot->activeGraph()->setYAxisTitle(options.axisName);
 
@@ -1593,8 +1601,6 @@ void MantidDockWidget::plotContour() {
                             .arg(wsGroup->name().c_str(),
                                  QString::number(options.plotIndex));
         plot->activeGraph()->setTitle(title);
-        plot->window()->setWindowTitle(
-            m_appParent->generateUniqueName(tr("Graph")));
       }
     }
   }

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -635,8 +635,9 @@ void MantidDockWidget::addPeaksWorkspaceMenuItems(QMenu *menu, const Mantid::API
 }
 
 /**
-* Add the actions that are appropriate for a MatrixWorkspace
+* Add the actions that are appropriate for a WorkspaceGroup
 * @param menu :: The menu to store the items
+* @param groupWS :: [input] Workspace group related to the menu
 */
 void MantidDockWidget::addWorkspaceGroupMenuItems(
     QMenu *menu, const WorkspaceGroup_const_sptr &groupWS) const {
@@ -1721,7 +1722,7 @@ const double MantidDockWidget::getSingleLogValue(
 
   try {
     value = std::stod(logValues.at(wsIndex));
-  } catch (std::exception &e) {
+  } catch (std::exception &) {
     // Either value was not a number, or not enough entries in the vector.
     // Whichever it was, we return zero.
     value = 0;

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1943,7 +1943,7 @@ QStringList MantidTreeWidget::getSelectedWorkspaceNames() const
  * We only want workspaces we can actually plot!
  */
 QList<MatrixWorkspace_const_sptr>
-MantidTreeWidget::getSelectedWorkspaces() const {
+MantidTreeWidget::getSelectedMatrixWorkspaces() const {
   // Check for any selected WorkspaceGroup names and replace with the names of
   // their children.
   QSet<QString> selectedWsNames;
@@ -1952,9 +1952,8 @@ MantidTreeWidget::getSelectedWorkspaces() const {
         m_ads.retrieve(wsName.toStdString()));
     if (groupWs) {
       const auto childWsNames = groupWs->getNames();
-      for (auto childWsName = childWsNames.begin();
-           childWsName != childWsNames.end(); ++childWsName) {
-        selectedWsNames.insert(QString::fromStdString(*childWsName));
+      for (auto childWsName : childWsNames) {
+        selectedWsNames.insert(QString::fromStdString(childWsName));
       }
     } else {
       selectedWsNames.insert(wsName);
@@ -1989,7 +1988,7 @@ MantidTreeWidget::getSelectedWorkspaces() const {
 MantidWSIndexWidget::UserInput
 MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
                                              bool showPlotAll) const {
-  auto selectedMatrixWsList = getSelectedWorkspaces();
+  auto selectedMatrixWsList = getSelectedMatrixWorkspaces();
   QList<QString> selectedMatrixWsNameList;
   foreach (const auto matrixWs, selectedMatrixWsList) {
     selectedMatrixWsNameList.append(QString::fromStdString(matrixWs->name()));
@@ -2040,7 +2039,7 @@ MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
 */
 MantidSurfacePlotDialog::UserInputSurface
 MantidTreeWidget::choosePlotOptions(const QString &type) const {
-  auto selectedMatrixWsList = getSelectedWorkspaces();
+  auto selectedMatrixWsList = getSelectedMatrixWorkspaces();
   QList<QString> selectedMatrixWsNameList;
   foreach (const auto matrixWs, selectedMatrixWsList) {
     selectedMatrixWsNameList.append(QString::fromStdString(matrixWs->name()));

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1680,7 +1680,7 @@ const QString MantidDockWidget::createWorkspaceForGroupPlot(
  * @returns log value as a double, or workspace index
  * @throws invalid_argument if log is wrong type or not present
  */
-const double
+double
 MantidDockWidget::getSingleLogValue(const int wsIndex,
                                     const MatrixWorkspace_const_sptr &matrixWS,
                                     const QString &logName) const {
@@ -1716,7 +1716,7 @@ MantidDockWidget::getSingleLogValue(const int wsIndex,
  * @param logValues :: [input] User-provided vector of log values
  * @returns Numeric log value, or zero
  */
-const double MantidDockWidget::getSingleLogValue(
+double MantidDockWidget::getSingleLogValue(
     const int wsIndex, const std::vector<std::string> &logValues) const {
   double value = 0;
 

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1793,7 +1793,7 @@ QStringList MantidTreeWidget::getSelectedWorkspaceNames() const
 * @return :: A MantidWSIndexDialog::UserInput structure listing the selected
 * options
 */
-MantidWSIndexDialog::UserInput
+MantidWSIndexWidget::UserInput
 MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
                                              bool showPlotAll) const {
   // Check for any selected WorkspaceGroup names and replace with the names of
@@ -1852,7 +1852,7 @@ MantidTreeWidget::chooseSpectrumFromSelected(bool showWaterfallOpt,
         SINGLE_SPECTRUM
         );
     }
-    MantidWSIndexDialog::UserInput selections;
+    MantidWSIndexWidget::UserInput selections;
     selections.plots = spectrumToPlot;
     selections.waterfall = false;
     return selections;

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1581,8 +1581,8 @@ void MantidDockWidget::plotContour() {
         convertPointsToHisto(plotWSTitle);
 
         // Plot the output workspace as a contour plot
-        auto plot =
-            m_mantidUI->drawSingleColorFillPlot(plotWSTitle, Graph::Contour);
+        auto plot = m_mantidUI->drawSingleColorFillPlot(plotWSTitle,
+                                                        Graph::ColorMapContour);
 
         // Set X, Y axis titles correctly
         plot->activeGraph()->setXAxisTitle(xLabelQ);

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1518,7 +1518,7 @@ void MantidDockWidget::plotSurface() {
         m_ads.retrieve(wsName.toStdString()));
     if (wsGroup) {
       // Which spectrum to plot from each workspace
-      const int spectrumIndex = getSingleSpectrumIndex();
+      const int spectrumIndex = 0;
       // Name for y-axis of plot
       QString yLabelQ("Workspace index");
 
@@ -1583,27 +1583,6 @@ void MantidDockWidget::plotSurface() {
       plot->setResolution(1);
     }
   }
-}
-
-/**
- * Ask the user for a choice of which spectrum to plot from each workspace.
- * Disable waterfall and "Plot all" options.
- * Even if user enters a range, just use the first number.
- * @returns Selected spectrum index
- */
-const int MantidDockWidget::getSingleSpectrumIndex() const {
-  int spectrumIndex{0}; // default to 0
-  const auto userInput = m_tree->chooseSpectrumFromSelected(false, false);
-  if (!userInput.plots.empty()) {
-    const auto indexList = userInput.plots.values();
-    if (!indexList.empty()) {
-      const auto spectrumIndexes = indexList.at(0);
-      if (!spectrumIndexes.empty()) {
-        spectrumIndex = *spectrumIndexes.begin();
-      }
-    }
-  }
-  return spectrumIndex;
 }
 
 //------------ MantidTreeWidget -----------------------//

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1845,7 +1845,11 @@ MantidTreeWidget::choosePlotOptions(const QString &type,
       m_mantidUI, 0, selectedMatrixWsNameList, type);
   dlg->exec();
   auto selections = dlg->getSelections();
-  validatePlotOptions(selections, nWorkspaces);
+  std::string errors =
+      MantidGroupPlotGenerator::validatePlotOptions(selections, nWorkspaces);
+  if (!errors.empty()) {
+    MantidSurfacePlotDialog::showPlotOptionsError(errors.c_str());
+  }
   return selections;
 }
 
@@ -1871,31 +1875,6 @@ MantidTreeWidget::chooseSurfacePlotOptions(int nWorkspaces) const {
 MantidSurfacePlotDialog::UserInputSurface
 MantidTreeWidget::chooseContourPlotOptions(int nWorkspaces) const {
   return choosePlotOptions("Contour", nWorkspaces);
-}
-
-/**
- * Performs validation of user's selected options.
- * If errors detected, raises a message box and sets "accepted" to false.
- * @param options :: [input] Selections made from dialog
- * @param nWorkspaces :: [input] Number of workspaces in selected group
- */
-void MantidTreeWidget::validatePlotOptions(
-    MantidSurfacePlotDialog::UserInputSurface &options, int nWorkspaces) const {
-  // If using custom log values, must have the same number of values as the
-  // number of workspaces in the group
-  if (options.accepted) {
-    if (options.logName == MantidSurfacePlotDialog::CUSTOM) {
-      if (static_cast<int>(options.customLogValues.size()) != nWorkspaces) {
-        QMessageBox errorMessage;
-        errorMessage.setText(
-            "Number of custom log values must be equal to number "
-            "of workspaces in group");
-        errorMessage.setIcon(QMessageBox::Critical);
-        errorMessage.exec();
-        options.accepted = false;
-      }
-    }
-  }
 }
 
 void MantidTreeWidget::setSortScheme(MantidItemSortScheme sortScheme)

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1529,7 +1529,7 @@ void MantidDockWidget::plotSurface() {
 
         // Set up one new matrix workspace to hold all the data for plotting
         const QString plotWSTitle("__matrixToPlot");
-        const QString xLabelQ = createWorkspaceForSurfacePlot(
+        const QString xLabelQ = createWorkspaceForGroupPlot(
             plotWSTitle, wsGroup, options.plotIndex, options.logName);
 
         // Plot the output workspace in 3D
@@ -1555,6 +1555,9 @@ void MantidDockWidget::plotSurface() {
   }
 }
 
+/**
+ * Create a contour plot from the selected workspace group
+ */
 void MantidDockWidget::plotContour() {
   const QStringList wsNames = m_tree->getSelectedWorkspaceNames();
   if (!wsNames.empty()) {
@@ -1568,28 +1571,40 @@ void MantidDockWidget::plotContour() {
 
         // Set up one new matrix workspace to hold all the data for plotting
         const QString plotWSTitle("__matrixToPlotContour");
-        const QString xLabelQ = createWorkspaceForSurfacePlot(
+        const QString xLabelQ = createWorkspaceForGroupPlot(
             plotWSTitle, wsGroup, options.plotIndex, options.logName);
 
-        // Plot the output workspace in 3D
+        // Plot the output workspace as a contour plot
         auto plot =
             m_mantidUI->drawSingleColorFillPlot(plotWSTitle, Graph::Contour);
+
+        // Set X, Y axis titles correctly
+        plot->activeGraph()->setXAxisTitle(xLabelQ);
+        plot->activeGraph()->setYAxisTitle(options.axisName);
+
+        // Default title is "__matrixToPlotContour". Change this:
+        QString title = QString("Contour plot for %1, spectrum %2")
+                            .arg(wsGroup->name().c_str(),
+                                 QString::number(options.plotIndex));
+        plot->activeGraph()->setTitle(title);
+        plot->window()->setWindowTitle(
+            m_appParent->generateUniqueName(tr("Graph")));
       }
     }
   }
 }
 
 /**
- * Create a workspace for the surface plot from the given workspace group, and
- * add it to the ADS. Returns title for the X axis.
- * Called by plotSurface().
+ * Create a workspace for the surface/contour plot from the given workspace
+ * group, and add it to the ADS. Returns title for the X axis.
+ * Called by plotSurface() and plotContour().
  * @param wsName :: [input] Name to give the resulting workspace
  * @param wsGroup :: [input] Pointer to workspace group to use as input
  * @param index :: [input] Which spectrum to plot from each workspace
  * @param logName :: [input] Log to read from for axis of XYZ plot
  * @returns Title for the X axis, read from the workspaces in the group
  */
-const QString MantidDockWidget::createWorkspaceForSurfacePlot(
+const QString MantidDockWidget::createWorkspaceForGroupPlot(
     const QString &wsName, WorkspaceGroup_const_sptr wsGroup, const int index,
     const QString &logName) {
   QString xAxisTitle;

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -1571,6 +1571,9 @@ void MantidDockWidget::plotSurface() {
         xLabelQ.append(" (").append(xAxisUnits.c_str()).append(")");
       }
       plot->setXAxisLabel(xLabelQ);
+
+      // Sometimes resolution is auto-set too high and plot appears empty
+      plot->setResolution(1);
     }
   }
 }

--- a/MantidPlot/src/Mantid/MantidDock.cpp
+++ b/MantidPlot/src/Mantid/MantidDock.cpp
@@ -246,6 +246,9 @@ void MantidDockWidget::createWorkspaceMenuActions()
 
   m_plotSurface = new QAction(tr("Plot Surface from Group"), this);
   connect(m_plotSurface, SIGNAL(triggered()), this, SLOT(plotSurface()));
+
+  m_plotContour = new QAction(tr("Plot Contour from Group"), this);
+  connect(m_plotContour, SIGNAL(triggered()), this, SLOT(plotContour()));
 }
 
 /**
@@ -646,6 +649,8 @@ void MantidDockWidget::addWorkspaceGroupMenuItems(
   if (groupWS && groupWS->getNumberOfEntries() > 2) {
     menu->addAction(m_plotSurface);
     m_plotSurface->setEnabled(true);
+    menu->addAction(m_plotContour);
+    m_plotContour->setEnabled(true);
   }
   menu->addSeparator();
   menu->addAction(m_saveNexus);
@@ -1545,6 +1550,30 @@ void MantidDockWidget::plotSurface() {
 
         // Sometimes resolution is auto-set too high and plot appears empty
         plot->setResolution(1);
+      }
+    }
+  }
+}
+
+void MantidDockWidget::plotContour() {
+  const QStringList wsNames = m_tree->getSelectedWorkspaceNames();
+  if (!wsNames.empty()) {
+    const auto wsName = wsNames[0];
+    const auto wsGroup = boost::dynamic_pointer_cast<const WorkspaceGroup>(
+        m_ads.retrieve(wsName.toStdString()));
+    if (wsGroup) {
+      auto options = m_tree->chooseSurfacePlotOptions();
+      // If user clicked OK and not Cancel...
+      if (options.accepted) {
+
+        // Set up one new matrix workspace to hold all the data for plotting
+        const QString plotWSTitle("__matrixToPlotContour");
+        const QString xLabelQ = createWorkspaceForSurfacePlot(
+            plotWSTitle, wsGroup, options.plotIndex, options.logName);
+
+        // Plot the output workspace in 3D
+        auto plot =
+            m_mantidUI->drawSingleColorFillPlot(plotWSTitle, Graph::Contour);
       }
     }
   }

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -167,7 +167,7 @@ public:
   void mouseDoubleClickEvent(QMouseEvent *e);
 
   QStringList getSelectedWorkspaceNames() const;
-  MantidWSIndexDialog::UserInput
+  MantidWSIndexWidget::UserInput
   chooseSpectrumFromSelected(bool showWaterfallOpt = true,
                              bool showPlotAll = true) const;
   void setSortScheme(MantidItemSortScheme);

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -166,7 +166,9 @@ public:
   void mouseDoubleClickEvent(QMouseEvent *e);
 
   QStringList getSelectedWorkspaceNames() const;
-  MantidWSIndexDialog::UserInput chooseSpectrumFromSelected(bool showWaterfallOpt = true) const;
+  MantidWSIndexDialog::UserInput
+  chooseSpectrumFromSelected(bool showWaterfallOpt = true,
+                             bool showPlotAll = true) const;
   void setSortScheme(MantidItemSortScheme);
   void setSortOrder(Qt::SortOrder);
   MantidItemSortScheme getSortScheme() const;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -122,6 +122,8 @@ private:
   getSingleLogValue(const int wsIndex,
                     const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
                     const QString &logName) const;
+  void convertHistoToPoints(const QString &wsName) const;
+  void convertPointsToHisto(const QString &wsName) const;
 
 protected:
   MantidTreeWidget * m_tree;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -7,6 +7,7 @@
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
 
 #include "MantidQtMantidWidgets/AlgorithmSelectorWidget.h"
 
@@ -105,7 +106,8 @@ private:
   void addMDEventWorkspaceMenuItems(QMenu *menu, const Mantid::API::IMDEventWorkspace_const_sptr & mdeventWS) const;
   void addMDHistoWorkspaceMenuItems(QMenu *menu, const Mantid::API::IMDWorkspace_const_sptr & WS) const;
   void addPeaksWorkspaceMenuItems(QMenu *menu, const Mantid::API::IPeaksWorkspace_const_sptr & WS) const;
-  void addWorkspaceGroupMenuItems(QMenu *menu) const;
+  void addWorkspaceGroupMenuItems(
+      QMenu *menu, const Mantid::API::WorkspaceGroup_const_sptr &groupWS) const;
   void addTableWorkspaceMenuItems(QMenu * menu) const;
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -112,7 +112,6 @@ private:
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
-  const int getSingleSpectrumIndex() const;
   
 protected:
   MantidTreeWidget * m_tree;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -195,14 +195,18 @@ public:
   void dropEvent(QDropEvent *de);
   QList<boost::shared_ptr<const Mantid::API::MatrixWorkspace>>
   getSelectedMatrixWorkspaces() const;
-  MantidSurfacePlotDialog::UserInputSurface chooseSurfacePlotOptions() const;
-  MantidSurfacePlotDialog::UserInputSurface chooseContourPlotOptions() const;
+  MantidSurfacePlotDialog::UserInputSurface
+  chooseSurfacePlotOptions(int nWorkspaces) const;
+  MantidSurfacePlotDialog::UserInputSurface
+  chooseContourPlotOptions(int nWorkspaces) const;
 
 protected:
   void dragMoveEvent(QDragMoveEvent *de);
   void dragEnterEvent(QDragEnterEvent *de);
   MantidSurfacePlotDialog::UserInputSurface
-  choosePlotOptions(const QString &type) const;
+  choosePlotOptions(const QString &type, int nWorkspaces) const;
+  void validatePlotOptions(MantidSurfacePlotDialog::UserInputSurface &options,
+                           int nWorkspaces) const;
 
 private:
   QPoint m_dragStartPosition;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -190,10 +190,13 @@ public:
   QList<boost::shared_ptr<const Mantid::API::MatrixWorkspace>>
   getSelectedWorkspaces() const;
   MantidSurfacePlotDialog::UserInputSurface chooseSurfacePlotOptions() const;
+  MantidSurfacePlotDialog::UserInputSurface chooseContourPlotOptions() const;
 
 protected:
   void dragMoveEvent(QDragMoveEvent *de);
   void dragEnterEvent(QDragEnterEvent *de);
+  MantidSurfacePlotDialog::UserInputSurface
+  choosePlotOptions(const QString &type) const;
 
 private:
   QPoint m_dragStartPosition;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -12,6 +12,7 @@
 #include "MantidQtMantidWidgets/AlgorithmSelectorWidget.h"
 
 #include "Mantid/MantidWSIndexDialog.h"
+#include "Mantid/MantidSurfacePlotDialog.h"
 
 #include <QActionGroup>
 #include <QAtomicInt>
@@ -177,6 +178,9 @@ public:
   void disableNodes(bool);
   void sort();
   void dropEvent(QDropEvent *de);
+  QList<boost::shared_ptr<const Mantid::API::MatrixWorkspace>>
+  getSelectedWorkspaces() const;
+  MantidSurfacePlotDialog::UserInputSurface chooseSurfacePlotOptions() const;
 
 protected:
   void dragMoveEvent(QDragMoveEvent *de);

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -191,8 +191,6 @@ protected:
   void dragEnterEvent(QDragEnterEvent *de);
   MantidSurfacePlotDialog::UserInputSurface
   choosePlotOptions(const QString &type, int nWorkspaces) const;
-  void validatePlotOptions(MantidSurfacePlotDialog::UserInputSurface &options,
-                           int nWorkspaces) const;
 
 private:
   QPoint m_dragStartPosition;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -117,6 +117,10 @@ private:
       const QString &wsName,
       boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
       const int index, const QString &logName);
+  const double
+  getSingleLogValue(const int wsIndex,
+                    const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
+                    const QString &logName) const;
 
 protected:
   MantidTreeWidget * m_tree;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -114,7 +114,7 @@ private:
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
-  const QString createWorkspaceForSurfacePlot(
+  const QString createWorkspaceForGroupPlot(
       const QString &wsName,
       boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
       const int index, const QString &logName);

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -113,7 +113,11 @@ private:
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
-  
+  const QString createWorkspaceForSurfacePlot(
+      const QString &wsName,
+      boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
+      const int index, const QString &logName);
+
 protected:
   MantidTreeWidget * m_tree;
   friend class MantidUI;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -118,12 +118,12 @@ private:
       const QString &wsName,
       boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
       const MantidSurfacePlotDialog::UserInputSurface &options);
-  const double
+  double
   getSingleLogValue(const int wsIndex,
                     const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
                     const QString &logName) const;
-  const double getSingleLogValue(const int wsIndex,
-                                 const std::vector<std::string> &values) const;
+  double getSingleLogValue(const int wsIndex,
+                           const std::vector<std::string> &values) const;
   void convertHistoToPoints(const QString &wsName) const;
   void convertPointsToHisto(const QString &wsName) const;
 

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -114,18 +114,18 @@ private:
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
-  const QString createWorkspaceForGroupPlot(
-      const QString &wsName,
+  const Mantid::API::MatrixWorkspace_sptr createWorkspaceForGroupPlot(
       boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
-      const MantidSurfacePlotDialog::UserInputSurface &options);
+      const MantidSurfacePlotDialog::UserInputSurface &options,
+      QString *xAxisTitle);
   double
   getSingleLogValue(const int wsIndex,
                     const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
                     const QString &logName) const;
   double getSingleLogValue(const int wsIndex,
                            const std::vector<std::string> &values) const;
-  void convertHistoToPoints(const QString &wsName) const;
-  void convertPointsToHisto(const QString &wsName) const;
+  void convertHistoToPoints(Mantid::API::MatrixWorkspace_sptr ws) const;
+  void convertPointsToHisto(Mantid::API::MatrixWorkspace_sptr ws) const;
   bool groupIsAllMatrixWorkspaces(
       const Mantid::API::WorkspaceGroup_const_sptr &groupWS) const;
 

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -91,6 +91,7 @@ private slots:
   void clearUB();
   void filterWorkspaceTree(const QString &text);
   void plotSurface();
+  void plotContour();
 
 private:
   void addSaveMenuOption(QString algorithmString, QString menuEntryName = "");
@@ -142,7 +143,7 @@ private:
   QActionGroup *m_sortChoiceGroup;
   QFileDialog *m_saveFolderDialog;
 
-  //Context-menu actions
+  // Context-menu actions
   QAction *m_showData, *m_showInst, *m_plotSpec, *m_plotSpecErr,
       *m_showDetectors, *m_showBoxData, *m_showVatesGui, *m_showSpectrumViewer,
       *m_showSliceViewer, *m_colorFill, *m_showLogs, *m_showSampleMaterial,
@@ -150,7 +151,7 @@ private:
       *m_delete, *m_program, *m_ascendingSortAction, *m_descendingSortAction,
       *m_byNameChoice, *m_byLastModifiedChoice, *m_showTransposed,
       *m_convertToMatrixWorkspace, *m_convertMDHistoToMatrixWorkspace,
-      *m_clearUB, *m_plotSurface;
+      *m_clearUB, *m_plotSurface, *m_plotContour;
 
   ApplicationWindow *m_appParent;
 

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -114,20 +114,6 @@ private:
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
-  const Mantid::API::MatrixWorkspace_sptr createWorkspaceForGroupPlot(
-      boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
-      const MantidSurfacePlotDialog::UserInputSurface &options,
-      QString *xAxisTitle);
-  double
-  getSingleLogValue(const int wsIndex,
-                    const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
-                    const QString &logName) const;
-  double getSingleLogValue(const int wsIndex,
-                           const std::vector<std::string> &values) const;
-  void convertHistoToPoints(Mantid::API::MatrixWorkspace_sptr ws) const;
-  void convertPointsToHisto(Mantid::API::MatrixWorkspace_sptr ws) const;
-  bool groupIsAllMatrixWorkspaces(
-      const Mantid::API::WorkspaceGroup_const_sptr &groupWS) const;
 
 protected:
   MantidTreeWidget * m_tree;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -112,6 +112,7 @@ private:
   void addClearMenuItems(QMenu* menu, const QString& wsName);
 
   void excludeItemFromSort(MantidTreeWidgetItem *item);
+  const int getSingleSpectrumIndex() const;
   
 protected:
   MantidTreeWidget * m_tree;

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -192,7 +192,7 @@ public:
   void sort();
   void dropEvent(QDropEvent *de);
   QList<boost::shared_ptr<const Mantid::API::MatrixWorkspace>>
-  getSelectedWorkspaces() const;
+  getSelectedMatrixWorkspaces() const;
   MantidSurfacePlotDialog::UserInputSurface chooseSurfacePlotOptions() const;
   MantidSurfacePlotDialog::UserInputSurface chooseContourPlotOptions() const;
 

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -117,11 +117,13 @@ private:
   const QString createWorkspaceForGroupPlot(
       const QString &wsName,
       boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
-      const int index, const QString &logName);
+      const MantidSurfacePlotDialog::UserInputSurface &options);
   const double
   getSingleLogValue(const int wsIndex,
                     const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
                     const QString &logName) const;
+  const double getSingleLogValue(const int wsIndex,
+                                 const std::vector<std::string> &values) const;
   void convertHistoToPoints(const QString &wsName) const;
   void convertPointsToHisto(const QString &wsName) const;
 

--- a/MantidPlot/src/Mantid/MantidDock.h
+++ b/MantidPlot/src/Mantid/MantidDock.h
@@ -126,6 +126,8 @@ private:
                            const std::vector<std::string> &values) const;
   void convertHistoToPoints(const QString &wsName) const;
   void convertPointsToHisto(const QString &wsName) const;
+  bool groupIsAllMatrixWorkspaces(
+      const Mantid::API::WorkspaceGroup_const_sptr &groupWS) const;
 
 protected:
   MantidTreeWidget * m_tree;

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
@@ -185,7 +185,7 @@ bool MantidGroupPlotGenerator::groupIsAllMatrixWorkspaces(
  */
 double MantidGroupPlotGenerator::getSingleLogValue(
     int wsIndex, const std::set<double> &logValues) const {
-  double value{0};
+  double value = 0;
   if (wsIndex < logValues.size()) {
     auto it = logValues.begin();
     std::advance(it, wsIndex);

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
@@ -186,7 +186,7 @@ bool MantidGroupPlotGenerator::groupIsAllMatrixWorkspaces(
 double MantidGroupPlotGenerator::getSingleLogValue(
     int wsIndex, const std::set<double> &logValues) const {
   double value = 0;
-  if (wsIndex < logValues.size()) {
+  if (wsIndex < static_cast<int>(logValues.size())) {
     auto it = logValues.begin();
     std::advance(it, wsIndex);
     value = *it;

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
@@ -207,7 +207,7 @@ double MantidGroupPlotGenerator::getSingleLogValue(
  * @throws invalid_argument if log is wrong type or not present
  */
 double MantidGroupPlotGenerator::getSingleLogValue(
-    int wsIndex, const MatrixWorkspace_const_sptr &matrixWS,
+    int wsIndex, const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
     const QString &logName) const {
   if (logName == MantidSurfacePlotDialog::WORKSPACE_INDEX) {
     return wsIndex;

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
@@ -1,0 +1,286 @@
+#include "MantidGroupPlotGenerator.h"
+
+using Mantid::API::WorkspaceGroup_const_sptr;
+using Mantid::API::WorkspaceGroup_sptr;
+using Mantid::API::MatrixWorkspace_const_sptr;
+using Mantid::API::MatrixWorkspace_sptr;
+using Mantid::API::MatrixWorkspace;
+using Mantid::API::ExperimentInfo;
+
+/**
+ * Constructor
+ * @param mantidUI :: [input] Pointer to the Mantid UI
+ */
+MantidGroupPlotGenerator::MantidGroupPlotGenerator(MantidUI *mantidUI)
+    : m_mantidUI(mantidUI) {}
+
+/**
+ * Plots a surface graph from the given workspace group
+ * @param wsGroup :: [input] Workspace group to plot
+ * @param options :: [input] User-selected plot options
+ */
+void MantidGroupPlotGenerator::plotSurface(
+    const WorkspaceGroup_const_sptr &wsGroup,
+    const MantidSurfacePlotDialog::UserInputSurface &options) const {
+  plot(Type::Surface, wsGroup, options);
+}
+
+/**
+ * Plots a contour plot from the given workspace group
+ * @param wsGroup :: [input] Workspace group to plot
+ * @param options :: [input] User-selected plot options
+ */
+void MantidGroupPlotGenerator::plotContour(
+    const WorkspaceGroup_const_sptr &wsGroup,
+    const MantidSurfacePlotDialog::UserInputSurface &options) const {
+  plot(Type::Contour, wsGroup, options);
+}
+
+/**
+ * Plots a graph from the given workspace group
+ * @param graphType :: [input] Type of graph to plot
+ * @param wsGroup :: [input] Workspace group to plot
+ * @param options :: [input] User-selected plot options
+ */
+void MantidGroupPlotGenerator::plot(
+    Type graphType, const WorkspaceGroup_const_sptr &wsGroup,
+    const MantidSurfacePlotDialog::UserInputSurface &options) const {
+  if (wsGroup && options.accepted) {
+    // Set up one new matrix workspace to hold all the data for plotting
+    QString xLabelQ;
+    auto matrixWS = createWorkspaceForGroupPlot(wsGroup, options, &xLabelQ);
+
+    // Convert to correct X axis format
+    convertXData(matrixWS, graphType);
+
+    // Import the data for plotting
+    auto matrixToPlot =
+        m_mantidUI->importMatrixWorkspace(matrixWS, -1, -1, false, false);
+
+    // Change the default plot title
+    QString title =
+        QString("plot for %1, spectrum %2")
+            .arg(wsGroup->name().c_str(), QString::number(options.plotIndex));
+
+    // Plot the correct type of graph
+    if (graphType == Type::Surface) {
+      auto plot = matrixToPlot->plotGraph3D(Qwt3D::PLOTSTYLE::FILLED);
+      plot->setTitle(QString("Surface ").append(title));
+      plot->setXAxisLabel(xLabelQ);
+      plot->setYAxisLabel(options.axisName);
+      plot->setResolution(1); // If auto-set too high, appears empty
+    } else if (graphType == Type::Contour) {
+      MultiLayer *plot = matrixToPlot->plotGraph2D(Graph::ColorMapContour);
+      plot->activeGraph()->setXAxisTitle(xLabelQ);
+      plot->activeGraph()->setYAxisTitle(options.axisName);
+      plot->activeGraph()->setTitle(QString("Contour ").append(title));
+    }
+  }
+}
+
+/**
+ * Create a workspace for the surface/contour plot from the given workspace
+ * group. Returns title for the X axis.
+ *
+ * Note that only MatrixWorkspaces can be plotted, so if the group contains
+ * Table or Peaks workspaces then it cannot be used.
+ *
+ * @param wsGroup :: [input] Pointer to workspace group to use as input
+ * @param options :: [input] User input from dialog
+ * @param xAxisTitle :: [output] Title for the X axis, read from the workspaces
+ * in the group
+ * @returns Pointer to the created workspace
+ */
+const MatrixWorkspace_sptr
+MantidGroupPlotGenerator::createWorkspaceForGroupPlot(
+    WorkspaceGroup_const_sptr wsGroup,
+    const MantidSurfacePlotDialog::UserInputSurface &options,
+    QString *xAxisTitle) const {
+  MatrixWorkspace_sptr matrixWS;     // Workspace to return
+  int index = options.plotIndex;     // which spectrum to plot from each WS
+  QString logName = options.logName; // Log to read from for axis of XYZ plot
+  if (wsGroup && groupIsAllMatrixWorkspaces(wsGroup)) {
+    // Create workspace to hold the data
+    // Each "spectrum" will be the data from one workspace
+    int nWorkspaces = wsGroup->getNumberOfEntries();
+    if (nWorkspaces > 0) {
+      const auto firstWS =
+          boost::dynamic_pointer_cast<const MatrixWorkspace>(wsGroup->getItem(
+              0)); // Already checked group contains only MatrixWorkspaces
+      std::string xAxisLabel, xAxisUnits;
+      matrixWS = Mantid::API::WorkspaceFactory::Instance().create(
+          firstWS, nWorkspaces, firstWS->blocksize(), firstWS->blocksize());
+      matrixWS->setYUnitLabel(firstWS->YUnitLabel());
+      xAxisLabel = firstWS->getXDimension()->getName();
+      xAxisUnits = firstWS->getXDimension()->getUnits();
+
+
+      // For each workspace in group, add data and log values
+      std::vector<double> logValues;
+      for (int i = 0; i < nWorkspaces; i++) {
+        const auto ws = boost::dynamic_pointer_cast<const MatrixWorkspace>(
+            wsGroup->getItem(i));
+        if (ws) {
+          auto X = ws->readX(index);
+          auto Y = ws->readY(index);
+          matrixWS->dataX(i).swap(X);
+          matrixWS->dataY(i).swap(Y);
+          if (logName == MantidSurfacePlotDialog::CUSTOM) {
+            logValues.push_back(getSingleLogValue(i, options.customLogValues));
+          } else {
+            logValues.push_back(getSingleLogValue(i, ws, logName));
+          }
+        }
+      }
+
+      // Set log axis values by replacing the "spectra" axis
+      matrixWS->replaceAxis(1, new Mantid::API::NumericAxis(logValues));
+
+      // Generate title for the X axis
+      *xAxisTitle = xAxisLabel.empty() ? "X" : xAxisLabel.c_str();
+      if (!xAxisUnits.empty()) {
+        xAxisTitle->append(" (").append(xAxisUnits.c_str()).append(")");
+      }
+    }
+  }
+  return matrixWS;
+}
+
+/**
+ * Check if the supplied group contains only MatrixWorkspaces
+ * @param wsGroup :: [input] Pointer to a WorkspaceGroup
+ * @returns True if contains only MatrixWorkspaces, false if contains
+ * other types or is empty
+ */
+bool MantidGroupPlotGenerator::groupIsAllMatrixWorkspaces(
+    const WorkspaceGroup_const_sptr &wsGroup) {
+  bool allMatrixWSes = true;
+  if (wsGroup) {
+    if (wsGroup->isEmpty()) {
+      allMatrixWSes = false;
+    } else {
+      for (int index = 0; index < wsGroup->getNumberOfEntries(); index++) {
+        if (nullptr == boost::dynamic_pointer_cast<MatrixWorkspace>(
+                           wsGroup->getItem(index))) {
+          allMatrixWSes = false;
+          break;
+        }
+      }
+    }
+  } else {
+    allMatrixWSes = false;
+  }
+  return allMatrixWSes;
+}
+
+/**
+ * Gets the custom, user-provided log value of the given index out of the
+ * vector.
+ * Attempts to convert to a numeric value.
+ * If conversion fails, or not enough values in the vector, returns zero.
+ * @param wsIndex :: [input] Index of log value to use
+ * @param logValues :: [input] User-provided vector of log values
+ * @returns Numeric log value, or zero
+ */
+double MantidGroupPlotGenerator::getSingleLogValue(
+    const int wsIndex, const std::vector<std::string> &logValues) const {
+  double value = 0;
+
+  try {
+    value = std::stod(logValues.at(wsIndex));
+  } catch (std::exception &) {
+    // Either value was not a number, or not enough entries in the vector.
+    // Whichever it was, we return zero.
+    value = 0;
+  }
+
+  return value;
+}
+
+/**
+ * Gets the given log value from the given workspace as a double.
+ * Should be a single-valued log!
+ * @param wsIndex :: [input] Index of workspace in group
+ * @param matrixWS :: [input] Workspace to find log from
+ * @param logName :: [input] Name of log
+ * @returns log value as a double, or workspace index
+ * @throws invalid_argument if log is wrong type or not present
+ */
+double MantidGroupPlotGenerator::getSingleLogValue(
+    const int wsIndex, const MatrixWorkspace_const_sptr &matrixWS,
+    const QString &logName) const {
+  if (logName == MantidSurfacePlotDialog::WORKSPACE_INDEX) {
+    return wsIndex;
+  } else {
+    // MatrixWorkspace is an ExperimentInfo
+    if (auto ei = boost::dynamic_pointer_cast<const ExperimentInfo>(matrixWS)) {
+      auto log = ei->run().getLogData(logName.toStdString());
+      if (log) {
+        if (dynamic_cast<Mantid::Kernel::PropertyWithValue<int> *>(log) ||
+            dynamic_cast<Mantid::Kernel::PropertyWithValue<double> *>(log)) {
+          return std::stod(log->value());
+        } else {
+          throw std::invalid_argument(
+              "Log is of wrong type (expected single numeric value");
+        }
+      } else {
+        throw std::invalid_argument("Log not present in workspace");
+      }
+    } else {
+      throw std::invalid_argument("Bad input workspace type");
+    }
+  }
+}
+
+/**
+ * Converts X data to correct (point/histo) format for the graph type.
+ * Contour: convert points to histo, if not already.
+ * Surface: convert histo to points, if not already.
+ * Converts data in place.
+ * @param ws :: [input, output] Workspace to change
+ * @param graphType :: [input] Type of graph to be plotted
+ */
+void MantidGroupPlotGenerator::convertXData(MatrixWorkspace_sptr ws,
+                                            Type graphType) const {
+  if (graphType == Type::Contour) {
+    convertPointsToHisto(ws);
+  } else if (graphType == Type::Surface) {
+    convertHistoToPoints(ws);
+  }
+}
+
+/**
+ * Utility method to convert a histogram workspace to points data
+ * (centred bins) for surface plots.
+ * @param ws :: [input, output] Workspace to convert
+ */
+void MantidGroupPlotGenerator::convertHistoToPoints(
+    MatrixWorkspace_sptr ws) const {
+  if (ws && ws->isHistogramData()) {
+    auto alg = m_mantidUI->createAlgorithm("ConvertToPointData");
+    alg->initialize();
+    alg->setChild(true);
+    alg->setProperty("InputWorkspace", ws);
+    alg->setPropertyValue("OutputWorkspace", "__NotUsed");
+    alg->execute();
+    ws = alg->getProperty("OutputWorkspace");
+  }
+}
+
+/**
+ * Utility method to convert a points workspace to histogram data
+ * for contour plots.
+ * @param ws :: [input, output] Workspace to convert
+ */
+void MantidGroupPlotGenerator::convertPointsToHisto(
+    MatrixWorkspace_sptr ws) const {
+  if (ws && !ws->isHistogramData()) {
+    auto alg = m_mantidUI->createAlgorithm("ConvertToHistogram");
+    alg->initialize();
+    alg->setChild(true);
+    alg->setProperty("InputWorkspace", ws);
+    alg->setPropertyValue("OutputWorkspace", "__NotUsed");
+    alg->execute();
+    ws = alg->getProperty("OutputWorkspace");
+  }
+}

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.cpp
@@ -55,7 +55,7 @@ void MantidGroupPlotGenerator::plot(
 
     // Import the data for plotting
     auto matrixToPlot =
-        m_mantidUI->importMatrixWorkspace(matrixWS, -1, -1, false, false);
+        m_mantidUI->importMatrixWorkspace(matrixWS, -1, -1, false);
 
     // Change the default plot title
     QString title =
@@ -183,7 +183,7 @@ bool MantidGroupPlotGenerator::groupIsAllMatrixWorkspaces(
  * @returns Numeric log value, or zero
  */
 double MantidGroupPlotGenerator::getSingleLogValue(
-    const int wsIndex, const std::vector<std::string> &logValues) const {
+    int wsIndex, const std::vector<std::string> &logValues) const {
   double value = 0;
 
   try {
@@ -207,7 +207,7 @@ double MantidGroupPlotGenerator::getSingleLogValue(
  * @throws invalid_argument if log is wrong type or not present
  */
 double MantidGroupPlotGenerator::getSingleLogValue(
-    const int wsIndex, const MatrixWorkspace_const_sptr &matrixWS,
+    int wsIndex, const MatrixWorkspace_const_sptr &matrixWS,
     const QString &logName) const {
   if (logName == MantidSurfacePlotDialog::WORKSPACE_INDEX) {
     return wsIndex;

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.h
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.h
@@ -46,12 +46,12 @@ private:
 
   /// Returns a single log value from the given workspace
   double
-  getSingleLogValue(const int wsIndex,
+  getSingleLogValue(int wsIndex,
                     const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
                     const QString &logName) const;
 
   /// Returns a single log value from supplied custom log
-  double getSingleLogValue(const int wsIndex,
+  double getSingleLogValue(int wsIndex,
                            const std::vector<std::string> &values) const;
 
   /// Converts histogram to point data, if not already

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.h
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.h
@@ -29,6 +29,11 @@ public:
   static bool groupIsAllMatrixWorkspaces(
       const Mantid::API::WorkspaceGroup_const_sptr &wsGroup);
 
+  /// Validates the given options and returns an error string
+  static std::string
+  validatePlotOptions(MantidSurfacePlotDialog::UserInputSurface &options,
+                      int nWorkspaces);
+
 private:
   /// Type of graph to plot
   enum class Type { Surface, Contour };
@@ -51,8 +56,7 @@ private:
                     const QString &logName) const;
 
   /// Returns a single log value from supplied custom log
-  double getSingleLogValue(int wsIndex,
-                           const std::vector<std::string> &values) const;
+  double getSingleLogValue(int wsIndex, const std::set<double> &values) const;
 
   /// Converts histogram to point data, if not already
   void convertHistoToPoints(Mantid::API::MatrixWorkspace_sptr ws) const;

--- a/MantidPlot/src/Mantid/MantidGroupPlotGenerator.h
+++ b/MantidPlot/src/Mantid/MantidGroupPlotGenerator.h
@@ -1,0 +1,71 @@
+#ifndef MANTIDGROUPPLOTGENERATOR_H_
+#define MANTIDGROUPPLOTGENERATOR_H_
+
+#include "MantidSurfacePlotDialog.h"
+#include "MantidMatrix.h"
+#include "Graph3D.h"
+#include "MantidAPI/NumericAxis.h"
+
+/**
+* This utility class generates a surface or contour plot from a group of
+* workspaces. 
+*/
+class MantidGroupPlotGenerator {
+public:
+  /// Constructor
+  explicit MantidGroupPlotGenerator(MantidUI *mantidUI);
+
+  /// Plots a surface from the given workspace group
+  void
+  plotSurface(const Mantid::API::WorkspaceGroup_const_sptr &wsGroup,
+              const MantidSurfacePlotDialog::UserInputSurface &options) const;
+
+  /// Plots a contour plot from the given workspace group
+  void
+  plotContour(const Mantid::API::WorkspaceGroup_const_sptr &wsGroup,
+              const MantidSurfacePlotDialog::UserInputSurface &options) const;
+
+  /// Tests if WorkspaceGroup contains only MatrixWorkspaces
+  static bool groupIsAllMatrixWorkspaces(
+      const Mantid::API::WorkspaceGroup_const_sptr &wsGroup);
+
+private:
+  /// Type of graph to plot
+  enum class Type { Surface, Contour };
+
+  /// Plots a graph from the given workspace group
+  void plot(Type graphType,
+            const Mantid::API::WorkspaceGroup_const_sptr &wsGroup,
+            const MantidSurfacePlotDialog::UserInputSurface &options) const;
+
+  /// Creates a single workspace to plot from
+  const Mantid::API::MatrixWorkspace_sptr createWorkspaceForGroupPlot(
+      boost::shared_ptr<const Mantid::API::WorkspaceGroup> wsGroup,
+      const MantidSurfacePlotDialog::UserInputSurface &options,
+      QString *xAxisTitle) const;
+
+  /// Returns a single log value from the given workspace
+  double
+  getSingleLogValue(const int wsIndex,
+                    const Mantid::API::MatrixWorkspace_const_sptr &matrixWS,
+                    const QString &logName) const;
+
+  /// Returns a single log value from supplied custom log
+  double getSingleLogValue(const int wsIndex,
+                           const std::vector<std::string> &values) const;
+
+  /// Converts histogram to point data, if not already
+  void convertHistoToPoints(Mantid::API::MatrixWorkspace_sptr ws) const;
+
+  /// Converts point to histogram data, if not already
+  void convertPointsToHisto(Mantid::API::MatrixWorkspace_sptr ws) const;
+
+  /// Converts X data to correct (point/histo) format for the graph type
+  void convertXData(Mantid::API::MatrixWorkspace_sptr ws, Type graphType) const;
+
+  /// Pointer to the Mantid UI
+  MantidUI * const m_mantidUI;
+};
+
+
+#endif

--- a/MantidPlot/src/Mantid/MantidMatrix.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrix.cpp
@@ -700,29 +700,33 @@ Graph3D * MantidMatrix::plotGraph3D(int style)
 
   double zMin =  1e300;
   double zMax = -1e300;
-  for(int i=0;i<numRows();i++)
-    for(int j=0;j<numCols();j++)
-    {
-      if (cell(i,j) < zMin) zMin = cell(i,j);
-      if (cell(i,j) > zMax) zMax = cell(i,j);
+  for (int i = 0; i < numRows(); i++) {
+    for (int j = 0; j < numCols(); j++) {
+      double val = cell(i, j);
+      if (val < zMin)
+        zMin = val;
+      if (val > zMax)
+        zMax = val;
     }
+  }
 
-    // Calculate xStart(), xEnd(), yStart(), yEnd()
-    boundingRect();
+  // Calculate xStart(), xEnd(), yStart(), yEnd()
+  boundingRect();
 
-    MantidMatrixFunction *fun = new MantidMatrixFunction(*this);
-    plot->addFunction(fun, xStart(), xEnd(), yStart(), yEnd(), zMin, zMax, numCols(), numRows() );
+  MantidMatrixFunction *fun = new MantidMatrixFunction(*this);
+  plot->addFunction(fun, xStart(), xEnd(), yStart(), yEnd(), zMin, zMax,
+                    numCols(), numRows());
 
-    using MantidQt::API::PlotAxis;
-    plot->setXAxisLabel(PlotAxis(*m_workspace, 0).title());
-    plot->setYAxisLabel(PlotAxis(*m_workspace, 1).title());
-    plot->setZAxisLabel(PlotAxis(false, *m_workspace).title());
+  using MantidQt::API::PlotAxis;
+  plot->setXAxisLabel(PlotAxis(*m_workspace, 0).title());
+  plot->setYAxisLabel(PlotAxis(*m_workspace, 1).title());
+  plot->setZAxisLabel(PlotAxis(false, *m_workspace).title());
 
-    a->initPlot3D(plot);
-    //plot->confirmClose(false);
-    QApplication::restoreOverrideCursor();
+  a->initPlot3D(plot);
+  // plot->confirmClose(false);
+  QApplication::restoreOverrideCursor();
 
-    return plot;
+  return plot;
 }
 
 void MantidMatrix::attachMultilayer(MultiLayer* ml)

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -1,0 +1,1 @@
+#include "MantidSurfacePlotDialog.h"

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -244,7 +244,7 @@ const std::set<double> MantidSurfacePlotDialog::getCustomLogValues() const {
       if (ok) {
         logValues.insert(number);
       } else {
-        throw std::invalid_argument(value);
+        throw std::invalid_argument(value.toStdString());
       }
     }
   }

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -127,20 +127,30 @@ const QString MantidSurfacePlotDialog::getAxisName() const {
 MantidSurfacePlotDialog::UserInputSurface
 MantidSurfacePlotDialog::getSelections() const {
   UserInputSurface selections;
-  selections.plotOptions.plots = getPlots();
-  selections.plotOptions.waterfall = false; // always false
+  selections.plotIndex = getPlot();
   selections.axisName = getAxisName();
   selections.logName = getLogName();
   return selections;
 }
 
 /**
-* Returns the QMultiMap that contains all the workspaces that are to be
-* plotted, mapped to the set of workspace indices.
-* @returns Workspaces to be plotted
+* Returns the workspace index to be plotted
+* @returns Workspace index to be plotted
 */
-QMultiMap<QString, std::set<int>> MantidSurfacePlotDialog::getPlots() const {
-  return m_widget.getPlots();
+const int MantidSurfacePlotDialog::getPlot() const {
+  int spectrumIndex{0}; // default to 0
+  const auto userInput = m_widget.getPlots();
+
+  if (!userInput.empty()) {
+    const auto indexList = userInput.values();
+    if (!indexList.empty()) {
+      const auto spectrumIndexes = indexList.at(0);
+      if (!spectrumIndexes.empty()) {
+        spectrumIndex = *spectrumIndexes.begin();
+      }
+    }
+  }
+  return spectrumIndex;
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -14,22 +14,27 @@ const QString MantidSurfacePlotDialog::WORKSPACE_INDEX{"Workspace index"};
  * @param mui :: The MantidUI area
  * @param flags :: Window flags that are passed the the QDialog constructor
  * @param wsNames :: the names of the workspaces to be plotted
+ * @param plotType :: Type of plot (for window title)
  */
 MantidSurfacePlotDialog::MantidSurfacePlotDialog(MantidUI *mui,
                                                  Qt::WFlags flags,
-                                                 QList<QString> wsNames)
+                                                 QList<QString> wsNames,
+                                                 const QString &plotType)
     : QDialog(mui->appWindow(), flags), m_mantidUI(mui), m_wsNames(wsNames),
       m_accepted(false), m_widget(this, flags, wsNames, false) {
   // Set up UI.
-  init();
+  init(plotType);
 }
 
 /**
  * Set up layout of dialog
+ * @param plotType :: Type of plot (for window title)
  */
-void MantidSurfacePlotDialog::init() {
+void MantidSurfacePlotDialog::init(const QString &plotType) {
   m_outer = new QVBoxLayout();
-  setWindowTitle(tr("Surface plot versus log value"));
+  QString title(plotType);
+  title.append(tr(" plot versus log value"));
+  setWindowTitle(title);
   m_outer->insertWidget(1, &m_widget);
   initLogs();
   initButtons();

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -27,6 +27,7 @@ MantidSurfacePlotDialog::MantidSurfacePlotDialog(MantidUI *mui,
 void MantidSurfacePlotDialog::init() {
   m_outer = new QVBoxLayout();
   setWindowTitle(tr("Surface plot versus log value"));
+  m_outer->insertWidget(1, &m_widget);
   initLogs();
   initButtons();
   setLayout(m_outer);

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -60,6 +60,7 @@ void MantidSurfacePlotDialog::initLogs() {
   populateLogComboBox();
   m_axisLabel = new QLabel(tr("<br>Label for plot axis:"));
   m_axisNameEdit = new QLineEdit();
+  m_axisNameEdit->setText(m_logSelector->currentText());
   m_customLogLabel = new QLabel(tr("<br>Custom log values:"));
   m_logValues = new QLineEdit();
 
@@ -216,11 +217,13 @@ void MantidSurfacePlotDialog::plot() {
  * Called when log selection changed
  * If "Custom" selected, enable the custom log input box.
  * Otherwise, it is read-only.
+ * Also put the log name into the axis name box as a default choice.
  * @param logName :: [input] Text selected in combo box
  */
 void MantidSurfacePlotDialog::onLogSelected(const QString &logName) {
   m_logValues->setEnabled(logName == CUSTOM);
   m_logValues->clear();
+  m_axisNameEdit->setText(logName);
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -6,6 +6,9 @@ using Mantid::API::IMDWorkspace;
 using Mantid::API::IMDWorkspace_sptr;
 using Mantid::API::ExperimentInfo;
 
+/// The string "Workspace index"
+const QString MantidSurfacePlotDialog::WORKSPACE_INDEX{"Workspace index"};
+
 /**
  * Construct an object of this type
  * @param mui :: The MantidUI area
@@ -76,7 +79,7 @@ void MantidSurfacePlotDialog::initButtons() {
  */
 void MantidSurfacePlotDialog::populateLogComboBox() {
   // First item should be "Workspace index"
-  m_logSelector->addItem(tr("Workspace index"));
+  m_logSelector->addItem(WORKSPACE_INDEX);
 
   // We have been given a list of names of MatrixWorkspaces (m_wsNames)
   // Get the log names out of all of them

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -23,8 +23,8 @@ MantidSurfacePlotDialog::MantidSurfacePlotDialog(MantidUI *mui,
                                                  Qt::WFlags flags,
                                                  QList<QString> wsNames,
                                                  const QString &plotType)
-    : QDialog(mui->appWindow(), flags), m_mantidUI(mui), m_wsNames(wsNames),
-      m_accepted(false), m_widget(this, flags, wsNames, false) {
+    : QDialog(mui->appWindow(), flags), m_widget(this, flags, wsNames, false),
+      m_mantidUI(mui), m_wsNames(wsNames), m_accepted(false) {
   // Set up UI.
   init(plotType);
 }
@@ -165,7 +165,7 @@ MantidSurfacePlotDialog::getSelections() const {
 * Returns the workspace index to be plotted
 * @returns Workspace index to be plotted
 */
-const int MantidSurfacePlotDialog::getPlot() const {
+int MantidSurfacePlotDialog::getPlot() const {
   int spectrumIndex = 0; // default to 0
   const auto userInput = m_widget.getPlots();
 

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -155,6 +155,9 @@ MantidSurfacePlotDialog::getSelections() const {
   selections.plotIndex = getPlot();
   selections.axisName = getAxisName();
   selections.logName = getLogName();
+  if (selections.logName == CUSTOM) {
+    selections.customLogValues = getCustomLogValues();
+  }
   return selections;
 }
 
@@ -202,12 +205,16 @@ void MantidSurfacePlotDialog::onLogSelected(const QString &logName) {
 /**
  * If "Custom" is selected as log, returns the list of values the user has input
  * into the edit box, otherwise returns an empty vector.
- * @returns Vector of numerical log values
+ * @returns Vector of numerical log values (as strings)
  */
-const std::vector<double> MantidSurfacePlotDialog::getCustomLogValues() const {
-  std::vector<double> logValues;
+const std::vector<std::string>
+MantidSurfacePlotDialog::getCustomLogValues() const {
+  std::vector<std::string> logValues;
   if (m_logSelector->currentText() == CUSTOM) {
-    // populate vector here
+    QStringList values = m_logValues->text().split(',');
+    foreach (QString value, values) {
+      logValues.push_back(value.toStdString());
+    }
   }
   return logValues;
 }

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -245,7 +245,6 @@ const std::set<double> MantidSurfacePlotDialog::getCustomLogValues() const {
         logValues.insert(number);
       } else {
         throw std::invalid_argument(value);
-        break;
       }
     }
   }

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -16,7 +16,7 @@ MantidSurfacePlotDialog::MantidSurfacePlotDialog(MantidUI *mui,
                                                  Qt::WFlags flags,
                                                  QList<QString> wsNames)
     : QDialog(mui->appWindow(), flags), m_mantidUI(mui), m_wsNames(wsNames),
-      m_widget(this, flags, wsNames, false) {
+      m_accepted(false), m_widget(this, flags, wsNames, false) {
   // Set up UI.
   init();
 }
@@ -42,7 +42,7 @@ void MantidSurfacePlotDialog::initLogs() {
   m_logLabel = new QLabel(tr("Log value to plot against:"));
   m_logSelector = new QComboBox();
   populateLogComboBox();
-  m_axisLabel = new QLabel(tr("Label for plot axis:"));
+  m_axisLabel = new QLabel(tr("<br>Label for plot axis:"));
   m_axisNameEdit = new QLineEdit();
 
   m_logBox->add(m_logLabel);
@@ -128,6 +128,7 @@ const QString MantidSurfacePlotDialog::getAxisName() const {
 MantidSurfacePlotDialog::UserInputSurface
 MantidSurfacePlotDialog::getSelections() const {
   UserInputSurface selections;
+  selections.accepted = m_accepted;
   selections.plotIndex = getPlot();
   selections.axisName = getAxisName();
   selections.logName = getLogName();
@@ -159,6 +160,7 @@ const int MantidSurfacePlotDialog::getPlot() const {
  */
 void MantidSurfacePlotDialog::plot() {
   if (m_widget.plotRequested()) {
+    m_accepted = true;
     accept();
   }
 }

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -9,6 +9,9 @@ using Mantid::API::ExperimentInfo;
 /// The string "Workspace index"
 const QString MantidSurfacePlotDialog::WORKSPACE_INDEX{"Workspace index"};
 
+/// The string "Custom"
+const QString MantidSurfacePlotDialog::CUSTOM{"Custom"};
+
 /**
  * Construct an object of this type
  * @param mui :: The MantidUI area
@@ -52,12 +55,21 @@ void MantidSurfacePlotDialog::initLogs() {
   populateLogComboBox();
   m_axisLabel = new QLabel(tr("<br>Label for plot axis:"));
   m_axisNameEdit = new QLineEdit();
+  m_customLogLabel = new QLabel(tr("Custom log values:"));
+  m_logValues = new QLineEdit();
 
   m_logBox->add(m_logLabel);
   m_logBox->add(m_logSelector);
+  m_logBox->add(m_customLogLabel);
+  m_logBox->add(m_logValues);
   m_logBox->add(m_axisLabel);
   m_logBox->add(m_axisNameEdit);
   m_outer->addItem(m_logBox);
+
+  m_logValues->setEnabled(false);
+
+  connect(m_logSelector, SIGNAL(currentIndexChanged(const QString &)), this,
+          SLOT(onLogSelected(const QString &)));
 }
 
 /**
@@ -111,6 +123,9 @@ void MantidSurfacePlotDialog::populateLogComboBox() {
   for (std::string name : logNames) {
     m_logSelector->addItem(name.c_str());
   }
+
+  // Add "Custom" at the end of the list
+  m_logSelector->addItem(CUSTOM);
 }
 
 /**
@@ -171,4 +186,28 @@ void MantidSurfacePlotDialog::plot() {
     m_accepted = true;
     accept();
   }
+}
+
+/**
+ * Called when log selection changed
+ * If "Custom" selected, enable the custom log input box.
+ * Otherwise, it is read-only.
+ * @param logName :: [input] Text selected in combo box
+ */
+void MantidSurfacePlotDialog::onLogSelected(const QString &logName) {
+  m_logValues->setEnabled(logName == CUSTOM);
+  m_logValues->clear();
+}
+
+/**
+ * If "Custom" is selected as log, returns the list of values the user has input
+ * into the edit box, otherwise returns an empty vector.
+ * @returns Vector of numerical log values
+ */
+const std::vector<double> MantidSurfacePlotDialog::getCustomLogValues() const {
+  std::vector<double> logValues;
+  if (m_logSelector->currentText() == CUSTOM) {
+    // populate vector here
+  }
+  return logValues;
 }

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -13,6 +13,9 @@ const QString MantidSurfacePlotDialog::WORKSPACE_INDEX = "Workspace index";
 /// The string "Custom"
 const QString MantidSurfacePlotDialog::CUSTOM = "Custom";
 
+/// Minimum width for dialog to fit the title string in
+const int MantidSurfacePlotDialog::MINIMUM_WIDTH = 275;
+
 /**
  * Construct an object of this type
  * @param mui :: The MantidUI area
@@ -43,6 +46,7 @@ void MantidSurfacePlotDialog::init(const QString &plotType) {
   initLogs();
   initButtons();
   setLayout(m_outer);
+  this->setMinimumWidth(MINIMUM_WIDTH);
 }
 
 /**

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -55,7 +55,7 @@ void MantidSurfacePlotDialog::initLogs() {
   populateLogComboBox();
   m_axisLabel = new QLabel(tr("<br>Label for plot axis:"));
   m_axisNameEdit = new QLineEdit();
-  m_customLogLabel = new QLabel(tr("Custom log values:"));
+  m_customLogLabel = new QLabel(tr("<br>Custom log values:"));
   m_logValues = new QLineEdit();
 
   m_logBox->add(m_logLabel);

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -7,10 +7,10 @@ using Mantid::API::IMDWorkspace_sptr;
 using Mantid::API::ExperimentInfo;
 
 /// The string "Workspace index"
-const QString MantidSurfacePlotDialog::WORKSPACE_INDEX{"Workspace index"};
+const QString MantidSurfacePlotDialog::WORKSPACE_INDEX = "Workspace index";
 
 /// The string "Custom"
-const QString MantidSurfacePlotDialog::CUSTOM{"Custom"};
+const QString MantidSurfacePlotDialog::CUSTOM = "Custom";
 
 /**
  * Construct an object of this type
@@ -166,7 +166,7 @@ MantidSurfacePlotDialog::getSelections() const {
 * @returns Workspace index to be plotted
 */
 const int MantidSurfacePlotDialog::getPlot() const {
-  int spectrumIndex{0}; // default to 0
+  int spectrumIndex = 0; // default to 0
   const auto userInput = m_widget.getPlots();
 
   if (!userInput.empty()) {

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.cpp
@@ -1,1 +1,153 @@
 #include "MantidSurfacePlotDialog.h"
+#include "MantidAPI/IMDWorkspace.h"
+#include "MantidAPI/ExperimentInfo.h"
+
+using Mantid::API::IMDWorkspace;
+using Mantid::API::IMDWorkspace_sptr;
+using Mantid::API::ExperimentInfo;
+
+/**
+ * Construct an object of this type
+ * @param mui :: The MantidUI area
+ * @param flags :: Window flags that are passed the the QDialog constructor
+ * @param wsNames :: the names of the workspaces to be plotted
+ */
+MantidSurfacePlotDialog::MantidSurfacePlotDialog(MantidUI *mui,
+                                                 Qt::WFlags flags,
+                                                 QList<QString> wsNames)
+    : QDialog(mui->appWindow(), flags), m_mantidUI(mui), m_wsNames(wsNames),
+      m_widget(this, flags, wsNames, false) {
+  // Set up UI.
+  init();
+}
+
+/**
+ * Set up layout of dialog
+ */
+void MantidSurfacePlotDialog::init() {
+  m_outer = new QVBoxLayout();
+  setWindowTitle(tr("Surface plot versus log value"));
+  initLogs();
+  initButtons();
+  setLayout(m_outer);
+}
+
+/**
+ * Set up UI to choose a log and name of axis
+ */
+void MantidSurfacePlotDialog::initLogs() {
+
+  m_logBox = new QVBoxLayout;
+  m_logLabel = new QLabel(tr("Log value to plot against:"));
+  m_logSelector = new QComboBox();
+  populateLogComboBox();
+  m_axisLabel = new QLabel(tr("Label for plot axis:"));
+  m_axisNameEdit = new QLineEdit();
+
+  m_logBox->add(m_logLabel);
+  m_logBox->add(m_logSelector);
+  m_logBox->add(m_axisLabel);
+  m_logBox->add(m_axisNameEdit);
+  m_outer->addItem(m_logBox);
+}
+
+/**
+ * Set up buttons on UI (OK/Cancel)
+ */
+void MantidSurfacePlotDialog::initButtons() {
+  m_buttonBox = new QHBoxLayout;
+
+  m_okButton = new QPushButton("OK");
+  m_cancelButton = new QPushButton("Cancel");
+
+  m_buttonBox->addWidget(m_okButton);
+  m_buttonBox->addWidget(m_cancelButton);
+
+  m_outer->addItem(m_buttonBox);
+
+  connect(m_okButton, SIGNAL(clicked()), this, SLOT(plot()));
+  connect(m_cancelButton, SIGNAL(clicked()), this, SLOT(close()));
+}
+
+/**
+ * Populate the log combo box with all log names that
+ * have single numeric value per workspace
+ */
+void MantidSurfacePlotDialog::populateLogComboBox() {
+  // First item should be "Workspace index"
+  m_logSelector->addItem(tr("Workspace index"));
+
+  // We have been given a list of names of MatrixWorkspaces (m_wsNames)
+  // Get the log names out of all of them
+  std::set<std::string> logNames;
+  for (auto wsName : m_wsNames) {
+    auto ws = m_mantidUI->getWorkspace(wsName);
+    if (ws) {
+      // It should be MatrixWorkspace, which is an ExperimentInfo
+      auto ei = boost::dynamic_pointer_cast<const ExperimentInfo>(ws);
+      if (ei) {
+        const std::vector<Mantid::Kernel::Property *> &logData =
+            ei->run().getLogData();
+        for (auto log : logData) {
+          // If this is a single-value numeric log, add it to the list
+          if (dynamic_cast<Mantid::Kernel::PropertyWithValue<int> *>(log) ||
+              dynamic_cast<Mantid::Kernel::PropertyWithValue<double> *>(log)) {
+            logNames.insert(log->name());
+          }
+        }
+      }
+    }
+  }
+  // Add the log names to the combo box
+  for (std::string name : logNames) {
+    m_logSelector->addItem(name.c_str());
+  }
+}
+
+/**
+ * Gets the log that user selected to plot against
+ * @returns Name of log, or "Workspace index"
+ */
+const QString MantidSurfacePlotDialog::getLogName() const {
+  return m_logSelector->currentText();
+}
+
+/**
+ * Gets the name that the user gave for the Y axis of the surface plot
+ * @returns Name input by user for axis
+ */
+const QString MantidSurfacePlotDialog::getAxisName() const {
+  return m_axisNameEdit->text();
+}
+
+/**
+ * Returns a structure holding all of the selected options.
+ * @returns Struct holding user input
+ */
+MantidSurfacePlotDialog::UserInputSurface
+MantidSurfacePlotDialog::getSelections() const {
+  UserInputSurface selections;
+  selections.plotOptions.plots = getPlots();
+  selections.plotOptions.waterfall = false; // always false
+  selections.axisName = getAxisName();
+  selections.logName = getLogName();
+  return selections;
+}
+
+/**
+* Returns the QMultiMap that contains all the workspaces that are to be
+* plotted, mapped to the set of workspace indices.
+* @returns Workspaces to be plotted
+*/
+QMultiMap<QString, std::set<int>> MantidSurfacePlotDialog::getPlots() const {
+  return m_widget.getPlots();
+}
+
+/**
+ * Called when OK button pressed
+ */
+void MantidSurfacePlotDialog::plot() {
+  if (m_widget.plotRequested()) {
+    accept();
+  }
+}

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -34,6 +34,9 @@ public:
   UserInputSurface getSelections() const;
   /// Returns the workspace index to be plotted
   const int getPlot() const;
+  /// The string "Workspace index"
+  static const QString WORKSPACE_INDEX;
+
 private slots:
   /// Called when the OK button is pressed.
   void plot();

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -77,6 +77,8 @@ private:
   QComboBox *m_logSelector;
   QLineEdit *m_axisNameEdit, *m_logValues;
   QLabel *m_logLabel, *m_axisLabel, *m_customLogLabel;
+  /// Minimum width for dialog to fit title in
+  static const int MINIMUM_WIDTH;
 };
 
 #endif

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -4,4 +4,65 @@
 #include <QComboBox>
 #include "MantidWSIndexDialog.h"
 
+/**
+ * The MantidSurfacePlotDialog offers the same functionality of choosing a
+ * workspace index/spectrum ID as MantidWSIndexDialog, but adds to it the
+ * ability to choose a log value and the name for an axis.
+ * This is for plotting a surface from a WorkspaceGroup.
+ *
+ * - The user may choose only one spectrum ID, not a range.
+ * - The user is offered the choice of only those logs that have single values
+ * per workspace.
+ */
+class MantidSurfacePlotDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  /// Struct to hold user input
+  struct UserInputSurface {
+    MantidWSIndexWidget::UserInput plotOptions;
+    QString axisName;
+    QString logName;
+  };
+
+  /// Constructor - same parameters as one of the parent constructors, along
+  /// with a list of the names of workspaces to be plotted.
+  MantidSurfacePlotDialog(MantidUI *parent, Qt::WFlags flags,
+                          QList<QString> wsNames);
+  /// Returns a structure holding all of the selected options
+  UserInputSurface getSelections() const;
+  /// Returns the QMultiMap that contains all the workspaces that are to be
+  /// plotted, mapped to the set of workspace indices.
+  QMultiMap<QString, std::set<int>> getPlots() const;
+private slots:
+  /// Called when the OK button is pressed.
+  void plot();
+
+private:
+  MantidWSIndexWidget m_widget;
+  /// Initializes the layout of the dialog
+  void init();
+  /// Initializes the layout of the log options
+  void initLogs();
+  /// Initializes the layout of the buttons
+  void initButtons();
+  /// Populate log combo box with log options
+  void populateLogComboBox();
+  /// Gets input name for log axis
+  const QString getAxisName() const;
+  /// Gets input name for log to use
+  const QString getLogName() const;
+  /// A pointer to the parent MantidUI object
+  MantidUI *m_mantidUI;
+  /// A list of names of workspaces which are to be plotted.
+  QList<QString> m_wsNames;
+  /// Qt objects
+  QPushButton *m_okButton, *m_cancelButton;
+  QHBoxLayout *m_buttonBox;
+  QVBoxLayout *m_logBox, *m_outer;
+  QComboBox *m_logSelector;
+  QLineEdit *m_axisNameEdit;
+  QLabel *m_logLabel, *m_axisLabel;
+};
+
 #endif

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -34,7 +34,7 @@ public:
   /// Returns a structure holding all of the selected options
   UserInputSurface getSelections() const;
   /// Returns the workspace index to be plotted
-  const int getPlot() const;
+  int getPlot() const;
   /// The string "Workspace index"
   static const QString WORKSPACE_INDEX;
   /// The string "Custom"

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -24,6 +24,7 @@ public:
     int plotIndex;
     QString axisName;
     QString logName;
+    std::vector<std::string> customLogValues;
   };
 
   /// Constructor - same parameters as one of the parent constructors, along
@@ -34,8 +35,6 @@ public:
   UserInputSurface getSelections() const;
   /// Returns the workspace index to be plotted
   const int getPlot() const;
-  /// Returns the input custom log values
-  const std::vector<double> getCustomLogValues() const;
   /// The string "Workspace index"
   static const QString WORKSPACE_INDEX;
   /// The string "Custom"
@@ -61,6 +60,8 @@ private:
   const QString getAxisName() const;
   /// Gets input name for log to use
   const QString getLogName() const;
+  /// Returns the input custom log values
+  const std::vector<std::string> getCustomLogValues() const;
   /// A pointer to the parent MantidUI object
   MantidUI *m_mantidUI;
   /// A list of names of workspaces which are to be plotted.

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -20,6 +20,7 @@ class MantidSurfacePlotDialog : public QDialog {
 public:
   /// Struct to hold user input
   struct UserInputSurface {
+    bool accepted;
     int plotIndex;
     QString axisName;
     QString logName;
@@ -55,6 +56,8 @@ private:
   MantidUI *m_mantidUI;
   /// A list of names of workspaces which are to be plotted.
   QList<QString> m_wsNames;
+  /// Set to true when user accepts input
+  bool m_accepted;
   /// Qt objects
   QPushButton *m_okButton, *m_cancelButton;
   QHBoxLayout *m_buttonBox;

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -29,7 +29,7 @@ public:
   /// Constructor - same parameters as one of the parent constructors, along
   /// with a list of the names of workspaces to be plotted.
   MantidSurfacePlotDialog(MantidUI *parent, Qt::WFlags flags,
-                          QList<QString> wsNames);
+                          QList<QString> wsNames, const QString &plotType);
   /// Returns a structure holding all of the selected options
   UserInputSurface getSelections() const;
   /// Returns the workspace index to be plotted
@@ -44,7 +44,7 @@ private slots:
 private:
   MantidWSIndexWidget m_widget;
   /// Initializes the layout of the dialog
-  void init();
+  void init(const QString &plotType);
   /// Initializes the layout of the log options
   void initLogs();
   /// Initializes the layout of the buttons

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -34,12 +34,18 @@ public:
   UserInputSurface getSelections() const;
   /// Returns the workspace index to be plotted
   const int getPlot() const;
+  /// Returns the input custom log values
+  const std::vector<double> getCustomLogValues() const;
   /// The string "Workspace index"
   static const QString WORKSPACE_INDEX;
+  /// The string "Custom"
+  static const QString CUSTOM;
 
 private slots:
   /// Called when the OK button is pressed.
   void plot();
+  /// Called when the log selection is changed.
+  void onLogSelected(const QString &logName);
 
 private:
   MantidWSIndexWidget m_widget;
@@ -66,8 +72,8 @@ private:
   QHBoxLayout *m_buttonBox;
   QVBoxLayout *m_logBox, *m_outer;
   QComboBox *m_logSelector;
-  QLineEdit *m_axisNameEdit;
-  QLabel *m_logLabel, *m_axisLabel;
+  QLineEdit *m_axisNameEdit, *m_logValues;
+  QLabel *m_logLabel, *m_axisLabel, *m_customLogLabel;
 };
 
 #endif

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -24,7 +24,7 @@ public:
     int plotIndex;
     QString axisName;
     QString logName;
-    std::vector<std::string> customLogValues;
+    std::set<double> customLogValues;
   };
 
   /// Constructor - same parameters as one of the parent constructors, along
@@ -35,6 +35,8 @@ public:
   UserInputSurface getSelections() const;
   /// Returns the workspace index to be plotted
   int getPlot() const;
+  /// Display an error message box
+  static void showPlotOptionsError(const QString &message);
   /// The string "Workspace index"
   static const QString WORKSPACE_INDEX;
   /// The string "Custom"
@@ -61,7 +63,7 @@ private:
   /// Gets input name for log to use
   const QString getLogName() const;
   /// Returns the input custom log values
-  const std::vector<std::string> getCustomLogValues() const;
+  const std::set<double> getCustomLogValues() const;
   /// A pointer to the parent MantidUI object
   MantidUI *m_mantidUI;
   /// A list of names of workspaces which are to be plotted.

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -1,0 +1,7 @@
+#ifndef MANTIDSURFACEPLOTDIALOG_H_
+#define MANTIDSURFACEPLOTDIALOG_H_
+
+#include <QComboBox>
+#include "MantidWSIndexDialog.h"
+
+#endif

--- a/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
+++ b/MantidPlot/src/Mantid/MantidSurfacePlotDialog.h
@@ -20,7 +20,7 @@ class MantidSurfacePlotDialog : public QDialog {
 public:
   /// Struct to hold user input
   struct UserInputSurface {
-    MantidWSIndexWidget::UserInput plotOptions;
+    int plotIndex;
     QString axisName;
     QString logName;
   };
@@ -31,9 +31,8 @@ public:
                           QList<QString> wsNames);
   /// Returns a structure holding all of the selected options
   UserInputSurface getSelections() const;
-  /// Returns the QMultiMap that contains all the workspaces that are to be
-  /// plotted, mapped to the set of workspace indices.
-  QMultiMap<QString, std::set<int>> getPlots() const;
+  /// Returns the workspace index to be plotted
+  const int getPlot() const;
 private slots:
   /// Called when the OK button is pressed.
   void plot();

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -475,8 +475,7 @@ MantidMatrix *MantidUI::importMatrixWorkspace(const QString &wsName, int lower,
         wsName.toStdString());
   }
 
-  MantidMatrix *matrix =
-      importMatrixWorkspace(ws, lower, upper, showDlg, makeVisible);
+  MantidMatrix *matrix = importMatrixWorkspace(ws, lower, upper, showDlg);
   if (matrix) {
     appWindow()->addMdiSubWindow(matrix, makeVisible);
   }
@@ -488,12 +487,11 @@ MantidMatrix *MantidUI::importMatrixWorkspace(const QString &wsName, int lower,
 @param lower :: An optional lower boundary
 @param upper :: An optional upper boundary
 @param showDlg :: If true show a dialog box to set some import parameters
-@param makeVisible :: If true show the created MantidMatrix, hide otherwise.
 @return A pointer to the new MantidMatrix.
 */
 MantidMatrix *
 MantidUI::importMatrixWorkspace(const MatrixWorkspace_sptr workspace, int lower,
-                                int upper, bool showDlg, bool makeVisible) {
+                                int upper, bool showDlg) {
   MantidMatrix *matrix = 0;
   if (workspace) {
     const QString wsName(workspace->name().c_str());

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -475,7 +475,12 @@ MantidMatrix *MantidUI::importMatrixWorkspace(const QString &wsName, int lower,
         wsName.toStdString());
   }
 
-  return importMatrixWorkspace(ws, lower, upper, showDlg, makeVisible);
+  MantidMatrix *matrix =
+      importMatrixWorkspace(ws, lower, upper, showDlg, makeVisible);
+  if (matrix) {
+    appWindow()->addMdiSubWindow(matrix, makeVisible);
+  }
+  return matrix;
 }
 
 /**  Import a MatrixWorkspace into a MantidMatrix.
@@ -505,9 +510,6 @@ MantidUI::importMatrixWorkspace(const MatrixWorkspace_sptr workspace, int lower,
     } else {
       matrix = new MantidMatrix(workspace, appWindow(), "Mantid", wsName, lower,
                                 upper);
-    }
-    if (matrix) {
-      appWindow()->addMdiSubWindow(matrix, makeVisible);
     }
   }
   return matrix;

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -372,7 +372,13 @@ signals:
     MantidMatrix *importMatrixWorkspace(const QString& wsName, int lower = -1, int upper = -1,
       bool showDlg = true, bool makeVisible = true);
 
-    // Create a MantidMatrix from workspace wsName
+    // Create a MantidMatrix from workspace
+    MantidMatrix *
+    importMatrixWorkspace(const Mantid::API::MatrixWorkspace_sptr workspace,
+                          int lower = -1, int upper = -1, bool showDlg = true,
+                          bool makeVisible = true);
+
+    // Create a Table from workspace wsName
     Table *importTableWorkspace(const QString& wsName, bool showDlg = true, bool makeVisible = true, bool transpose = false);
 
     void createLoadDAEMantidMatrix(const QString&);

--- a/MantidPlot/src/Mantid/MantidUI.h
+++ b/MantidPlot/src/Mantid/MantidUI.h
@@ -375,8 +375,7 @@ signals:
     // Create a MantidMatrix from workspace
     MantidMatrix *
     importMatrixWorkspace(const Mantid::API::MatrixWorkspace_sptr workspace,
-                          int lower = -1, int upper = -1, bool showDlg = true,
-                          bool makeVisible = true);
+                          int lower = -1, int upper = -1, bool showDlg = true);
 
     // Create a Table from workspace wsName
     Table *importTableWorkspace(const QString& wsName, bool showDlg = true, bool makeVisible = true, bool transpose = false);

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -343,8 +343,8 @@ MantidWSIndexDialog::MantidWSIndexDialog(MantidUI *mui, Qt::WFlags flags,
                                          QList<QString> wsNames,
                                          const bool showWaterfallOption,
                                          const bool showPlotAll)
-    : QDialog(mui->appWindow(), flags), m_mantidUI(mui),
-      m_widget(this, flags, wsNames, showWaterfallOption),
+    : QDialog(mui->appWindow(), flags),
+      m_widget(this, flags, wsNames, showWaterfallOption), m_mantidUI(mui),
       m_plotAll(showPlotAll) {
   // Set up UI.
   init();

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -14,6 +14,321 @@
 #include <QPalette>
 
 //----------------------------------
+// MantidWSIndexWidget methods
+//----------------------------------
+/**
+ * Construct a widget of this type
+ * @param parent :: The owning dialog
+ * @param flags :: Window flags that are passed the the QWidget constructor
+ * @param wsNames :: the names of the workspaces to be plotted
+ * @param showWaterfallOption :: If true the waterfall checkbox is created
+ */
+MantidWSIndexWidget::MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags,
+                                         QList<QString> wsNames,
+                                         const bool showWaterfallOption)
+    : QWidget(parent, flags), m_spectra(false),
+      m_waterfall(showWaterfallOption), m_wsNames(wsNames),
+      m_wsIndexIntervals(), m_spectraIdIntervals(), m_wsIndexChoice(),
+      m_spectraIdChoice() {
+  checkForSpectraAxes();
+  // Generate the intervals allowed to be plotted by the user.
+  generateWsIndexIntervals();
+  if (m_spectra) {
+    generateSpectraIdIntervals();
+  }
+  init();
+}
+
+/**
+ * Returns the user-selected options
+ * @returns Struct containing user options
+ */
+MantidWSIndexWidget::UserInput MantidWSIndexWidget::getSelections() const {
+  UserInput options;
+  options.plots = getPlots();
+  options.waterfall = waterfallPlotRequested();
+  return options;
+}
+
+/**
+ * Returns the user-selected plots 
+ * @returns Plots selected by user
+ */
+QMultiMap<QString, std::set<int>> MantidWSIndexWidget::getPlots() const {
+  // Map of workspace names to set of indices to be plotted.
+  QMultiMap<QString, std::set<int>> plots;
+
+  // If the user typed in the wsField ...
+  if (m_wsIndexChoice.getList().size() > 0) {
+
+    for (int i = 0; i < m_wsNames.size(); i++) {
+      std::set<int> intSet = m_wsIndexChoice.getIntSet();
+      plots.insert(m_wsNames[i], intSet);
+    }
+  }
+  // Else if the user typed in the spectraField ...
+  else if (m_spectraIdChoice.getList().size() > 0) {
+    for (int i = 0; i < m_wsNames.size(); i++) {
+      // Convert the spectra choices of the user into workspace indices for us
+      // to use.
+      Mantid::API::MatrixWorkspace_const_sptr ws =
+          boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
+              Mantid::API::AnalysisDataService::Instance().retrieve(
+                  m_wsNames[i].toStdString()));
+      if (NULL == ws)
+        continue;
+
+      const Mantid::spec2index_map spec2index =
+          ws->getSpectrumToWorkspaceIndexMap();
+
+      std::set<int> origSet = m_spectraIdChoice.getIntSet();
+      std::set<int>::iterator it = origSet.begin();
+      std::set<int> convertedSet;
+
+      for (; it != origSet.end(); ++it) {
+        int origInt = (*it);
+        int convertedInt = static_cast<int>(spec2index.find(origInt)->second);
+        convertedSet.insert(convertedInt);
+      }
+
+      plots.insert(m_wsNames[i], convertedSet);
+    }
+  }
+
+  return plots;
+}
+
+/**
+ * Whether the user checked the "waterfall" box
+ * @returns True if waterfall plot selected
+ */
+bool MantidWSIndexWidget::waterfallPlotRequested() const {
+  return m_waterfallOpt->isChecked();
+}
+
+/**
+ * Called when user edits workspace field
+ */
+void MantidWSIndexWidget::editedWsField() {
+  if (usingSpectraIDs()) {
+    m_spectraField->lineEdit()->clear();
+    m_spectraField->setError("");
+  }
+}
+
+/**
+ * Called when user edits spectra field
+ */
+void MantidWSIndexWidget::editedSpectraField() {
+  m_wsField->lineEdit()->clear();
+  m_wsField->setError("");
+}
+
+/**
+ * Called when dialog requests a plot
+ * @returns True to accept, false to raise error
+ */
+bool MantidWSIndexWidget::plotRequested() {
+  bool acceptable = false;
+  int npos = 0;
+  QString wsText = m_wsField->lineEdit()->text();
+  QString spectraTest = m_spectraField->lineEdit()->text();
+  QValidator::State wsState =
+      m_wsField->lineEdit()->validator()->validate(wsText, npos);
+  QValidator::State spectraState =
+      m_spectraField->lineEdit()->validator()->validate(spectraTest, npos);
+  if (wsState == QValidator::Acceptable) {
+    m_wsIndexChoice.addIntervals(m_wsField->lineEdit()->text());
+    acceptable = true;
+  }
+  // Else if the user typed in the spectraField ...
+  else if (spectraState == QValidator::Acceptable) {
+    m_spectraIdChoice.addIntervals(m_spectraField->lineEdit()->text());
+    acceptable = true;
+  } else {
+    QString error_message("Invalid input. It is not in the range available");
+    if (!wsText.isEmpty())
+      m_wsField->setError(error_message);
+    if (!spectraTest.isEmpty())
+      m_spectraField->setError(error_message);
+  }
+  return acceptable;
+}
+
+/**
+ * Called when dialog requests to plot all
+ */
+void MantidWSIndexWidget::plotAllRequested() {
+  m_wsIndexChoice = m_wsIndexIntervals;
+}
+
+/**
+ * Set up widget UI
+ */
+void MantidWSIndexWidget::init() {
+  m_outer = new QVBoxLayout;
+  initSpectraBox();
+  initWorkspaceBox();
+  initOptionsBoxes();
+  setLayout(m_outer);
+}
+
+/**
+ * Set up Workspace box UI
+ */
+void MantidWSIndexWidget::initWorkspaceBox() {
+  m_wsBox = new QVBoxLayout;
+  m_wsMessage = new QLabel(
+      tr("Enter Workspace Indices: " + m_wsIndexIntervals.toQString()));
+  m_wsField = new QLineEditWithErrorMark();
+
+  m_wsField->lineEdit()->setValidator(
+      new IntervalListValidator(this, m_wsIndexIntervals));
+  m_wsBox->add(m_wsMessage);
+  m_wsBox->add(m_wsField);
+  m_outer->addItem(m_wsBox);
+
+  connect(m_wsField->lineEdit(), SIGNAL(textEdited(const QString &)), this,
+          SLOT(editedWsField()));
+}
+
+/**
+ * Set up Spectra box UI
+ */
+void MantidWSIndexWidget::initSpectraBox() {
+  m_spectraBox = new QVBoxLayout;
+  m_spectraMessage =
+      new QLabel(tr("Enter Spectra IDs: " + m_spectraIdIntervals.toQString()));
+  m_spectraField = new QLineEditWithErrorMark();
+  m_orMessage = new QLabel(tr("<br>Or"));
+
+  m_spectraField->lineEdit()->setValidator(
+      new IntervalListValidator(this, m_spectraIdIntervals));
+  m_spectraBox->add(m_spectraMessage);
+  m_spectraBox->add(m_spectraField);
+  m_spectraBox->add(m_orMessage);
+
+  if (usingSpectraIDs())
+    m_outer->addItem(m_spectraBox);
+
+  connect(m_spectraField->lineEdit(), SIGNAL(textEdited(const QString &)), this,
+          SLOT(editedSpectraField()));
+}
+
+/**
+ * Set up Options boxes UI
+ */
+void MantidWSIndexWidget::initOptionsBoxes() {
+  m_optionsBox = new QHBoxLayout;
+  m_waterfallOpt = new QCheckBox("Waterfall Plot");
+  if (m_waterfall)
+    m_optionsBox->add(m_waterfallOpt);
+  else
+    m_waterfallOpt->setChecked(true);
+
+  m_outer->addItem(m_optionsBox);
+}
+
+/**
+* Check to see if *all* workspaces have a spectrum axis.
+* If even one does not have a spectra axis, then we wont
+* ask the user to enter spectra IDs - only workspace indices.
+*/
+void MantidWSIndexWidget::checkForSpectraAxes() {
+  QList<QString>::const_iterator it = m_wsNames.constBegin();
+  m_spectra = true;
+
+  for (; it != m_wsNames.constEnd(); ++it) {
+    Mantid::API::MatrixWorkspace_const_sptr ws =
+        boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
+            Mantid::API::AnalysisDataService::Instance().retrieve(
+                (*it).toStdString()));
+    if (NULL == ws)
+      continue;
+    bool hasSpectra = false;
+    for (int i = 0; i < ws->axes(); i++) {
+      if (ws->getAxis(i)->isSpectra())
+        hasSpectra = true;
+    }
+    if (hasSpectra == false) {
+      m_spectra = false;
+      break;
+    }
+  }
+}
+
+/**
+ * Get the available interval for each of the workspaces, and then
+ * present the user with interval which is the INTERSECTION of each of
+ * those intervals.
+ */
+void MantidWSIndexWidget::generateWsIndexIntervals() {
+  QList<QString>::const_iterator it = m_wsNames.constBegin();
+
+  // Cycle through the workspaces ...
+  for (; it != m_wsNames.constEnd(); ++it) {
+    Mantid::API::MatrixWorkspace_const_sptr ws =
+        boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
+            Mantid::API::AnalysisDataService::Instance().retrieve(
+                (*it).toStdString()));
+    if (NULL == ws)
+      continue;
+
+    const int endWs = static_cast<int>(ws->getNumberHistograms() -
+                                       1); //= static_cast<int> (end->first);
+
+    Interval interval(0, endWs);
+    // If no interval has been added yet, just add it ...
+    if (it == m_wsNames.constBegin())
+      m_wsIndexIntervals.addInterval(interval);
+    // ... else set the list as the intersection of what's already there
+    // and what has just been added.
+    else
+      m_wsIndexIntervals.setIntervalList(
+          IntervalList::intersect(m_wsIndexIntervals, interval));
+  }
+}
+
+/**
+ * Get available intervals for spectra IDs
+ */
+void MantidWSIndexWidget::generateSpectraIdIntervals() {
+  bool firstWs = true;
+  foreach (const QString wsName, m_wsNames) {
+    Mantid::API::MatrixWorkspace_const_sptr ws =
+        boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(
+            Mantid::API::AnalysisDataService::Instance().retrieve(
+                wsName.toStdString()));
+    if (!ws)
+      continue; // Belt and braces.
+
+    const Mantid::spec2index_map spec2index =
+        ws->getSpectrumToWorkspaceIndexMap();
+
+    IntervalList spectraIntervalList;
+    for (auto pair = spec2index.begin(); pair != spec2index.end(); ++pair) {
+      spectraIntervalList.addInterval(static_cast<int>(pair->first));
+    }
+
+    if (firstWs) {
+      m_spectraIdIntervals = spectraIntervalList;
+      firstWs = false;
+    } else {
+      m_spectraIdIntervals.setIntervalList(
+          IntervalList::intersect(m_spectraIdIntervals, spectraIntervalList));
+    }
+  }
+}
+
+/**
+ * Whether widget is using spectra IDs or workspace indices
+ * @returns True if using spectra IDs
+ */
+bool MantidWSIndexWidget::usingSpectraIDs() const {
+  return m_spectra && m_spectraIdIntervals.getList().size() > 0;
+}
+
+//----------------------------------
 // MantidWSIndexDialog public methods
 //----------------------------------
 /**
@@ -22,133 +337,62 @@
  * @param flags :: Window flags that are passed the the QDialog constructor
  * @param wsNames :: the names of the workspaces to be plotted
  * @param showWaterfallOption :: If true the waterfall checkbox is created
+ * @param showPlotAll :: If true the "Plot all" button is created
  */
 MantidWSIndexDialog::MantidWSIndexDialog(MantidUI *mui, Qt::WFlags flags,
                                          QList<QString> wsNames,
                                          const bool showWaterfallOption,
                                          const bool showPlotAll)
-    : QDialog(mui->appWindow(), flags), m_mantidUI(mui), m_spectra(false),
-      m_waterfall(showWaterfallOption), m_wsNames(wsNames),
-      m_wsIndexIntervals(), m_spectraIdIntervals(), m_wsIndexChoice(),
-      m_spectraIdChoice(), m_plotAll(showPlotAll) {
-  checkForSpectraAxes();
-
-  // Generate the intervals allowed to be plotted by the user.
-  generateWsIndexIntervals();
-  if(m_spectra)
-  {
-    generateSpectraIdIntervals();
-  }
+    : QDialog(mui->appWindow(), flags), m_mantidUI(mui),
+      m_widget(this, flags, wsNames, showWaterfallOption),
+      m_plotAll(showPlotAll) {
   // Set up UI.
   init();
 }
 
-MantidWSIndexDialog::UserInput MantidWSIndexDialog::getSelections() const
-{
-  UserInput options;
-  options.plots = getPlots();
-  options.waterfall = waterfallPlotRequested();
-  return options;
+/**
+ * Returns the user-selected options
+ * @returns Struct containing user options
+ */
+MantidWSIndexWidget::UserInput MantidWSIndexDialog::getSelections() const {
+  return m_widget.getSelections();
 }
 
-QMultiMap<QString,std::set<int> > MantidWSIndexDialog::getPlots() const
-{
-  // Map of workspace names to set of indices to be plotted.
-  QMultiMap<QString,std::set<int> > plots;
+/**
+ * Returns the user-selected plots from the widget
+ * @returns Plots selected by user
+ */
+QMultiMap<QString, std::set<int>> MantidWSIndexDialog::getPlots() const {
 
-  // If the user typed in the wsField ...
-  if(m_wsIndexChoice.getList().size() > 0)
-  {
-    
-    for(int i = 0; i < m_wsNames.size(); i++)
-    {
-      std::set<int> intSet = m_wsIndexChoice.getIntSet();
-      plots.insert(m_wsNames[i],intSet);
-    }
-  }
-  // Else if the user typed in the spectraField ...
-  else if(m_spectraIdChoice.getList().size() > 0)
-  {
-    for(int i = 0; i < m_wsNames.size(); i++)
-    {
-      // Convert the spectra choices of the user into workspace indices for us to use.
-      Mantid::API::MatrixWorkspace_const_sptr ws = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(Mantid::API::AnalysisDataService::Instance().retrieve(m_wsNames[i].toStdString()));
-      if ( NULL == ws ) continue;
-
-      const Mantid::spec2index_map spec2index = ws->getSpectrumToWorkspaceIndexMap();
-
-      std::set<int> origSet = m_spectraIdChoice.getIntSet();
-      std::set<int>::iterator it = origSet.begin();
-      std::set<int> convertedSet;
-
-      for( ; it != origSet.end(); ++it)
-      {
-        int origInt = (*it);
-        int convertedInt = static_cast<int>(spec2index.find(origInt)->second);
-        convertedSet.insert(convertedInt);
-      }
-
-      plots.insert(m_wsNames[i],convertedSet);
-    }
-  }
-
-  return plots;
+  return m_widget.getPlots();
 }
 
-bool MantidWSIndexDialog::waterfallPlotRequested() const
-{
-  return m_waterfallOpt->isChecked();
+/**
+ * Whether the user checked the "waterfall" box
+ * @returns True if waterfall plot selected
+ */
+bool MantidWSIndexDialog::waterfallPlotRequested() const {
+  return m_widget.waterfallPlotRequested();
 }
 
 //----------------------------------
 // MantidWSIndexDialog private slots
 //----------------------------------
-void MantidWSIndexDialog::plot()
-{    
-  int npos = 0;
-  QString wsText = m_wsField->lineEdit()->text();
-  QString spectraTest = m_spectraField->lineEdit()->text();
-  QValidator::State wsState = m_wsField->lineEdit()->validator()->validate(wsText, npos);
-  QValidator::State spectraState = m_spectraField->lineEdit()->validator()->validate(spectraTest, npos);
-  
-  // If the user typed in the wsField ...
-  if(wsState == QValidator::Acceptable)
-  {
-    m_wsIndexChoice.addIntervals(m_wsField->lineEdit()->text());
+/**
+ * Called when OK button pressed
+ */
+void MantidWSIndexDialog::plot() {
+  if (m_widget.plotRequested()) {
     accept();
-  }
-  // Else if the user typed in the spectraField ...
-  else if(spectraState == QValidator::Acceptable)
-  {
-    m_spectraIdChoice.addIntervals(m_spectraField->lineEdit()->text());
-    accept();
-  }else{
-    QString error_message("Invalid input. It is not in the range available"); 
-    if (!wsText.isEmpty())
-      m_wsField->setError(error_message); 
-    if (!spectraTest.isEmpty())
-      m_spectraField->setError(error_message); 
   }
 }
 
-void MantidWSIndexDialog::plotAll()
-{
-  m_wsIndexChoice = m_wsIndexIntervals;
+/**
+ * Called when "Plot all" button pressed
+ */
+void MantidWSIndexDialog::plotAll() {
+  m_widget.plotAllRequested();
   accept();
-}
-
-void MantidWSIndexDialog::editedWsField()
-{
-  if(usingSpectraIDs()) {
-    m_spectraField->lineEdit()->clear();
-    m_spectraField->setError(""); 
-  }
-}
-
-void MantidWSIndexDialog::editedSpectraField()
-{
-  m_wsField->lineEdit()->clear();
-  m_wsField->setError(""); 
 }
 
 //----------------------------------
@@ -159,55 +403,9 @@ void MantidWSIndexDialog::init()
   m_outer = new QVBoxLayout;
 
   setWindowTitle(tr("MantidPlot"));
-  initSpectraBox();
-  initWorkspaceBox();
-  initOptionsBoxes();
+  m_outer->insertWidget(1, &m_widget);
   initButtons();
   setLayout(m_outer);
-}
-
-void MantidWSIndexDialog::initWorkspaceBox()
-{
-  m_wsBox = new QVBoxLayout;
-  m_wsMessage = new QLabel(tr("Enter Workspace Indices: " + m_wsIndexIntervals.toQString()));
-  m_wsField = new QLineEditWithErrorMark();
-
-  m_wsField->lineEdit()->setValidator(new IntervalListValidator(this, m_wsIndexIntervals));
-  m_wsBox->add(m_wsMessage);
-  m_wsBox->add(m_wsField);
-  m_outer->addItem(m_wsBox);
-
-  connect(m_wsField->lineEdit(), SIGNAL(textEdited(const QString &)), this, SLOT(editedWsField()));
-}
-
-void MantidWSIndexDialog::initSpectraBox()
-{
-  m_spectraBox = new QVBoxLayout;
-  m_spectraMessage = new QLabel(tr("Enter Spectra IDs: " + m_spectraIdIntervals.toQString()));
-  m_spectraField = new QLineEditWithErrorMark();
-  m_orMessage = new QLabel(tr("<br>Or"));
-
-  m_spectraField->lineEdit()->setValidator(new IntervalListValidator(this, m_spectraIdIntervals));
-  m_spectraBox->add(m_spectraMessage);
-  m_spectraBox->add(m_spectraField);
-  m_spectraBox->add(m_orMessage);
-  
-  if( usingSpectraIDs() )
-    m_outer->addItem(m_spectraBox);
-
-  connect(m_spectraField->lineEdit(), SIGNAL(textEdited(const QString &)), this, SLOT(editedSpectraField()));
-}
-
-void MantidWSIndexDialog::initOptionsBoxes()
-{
-  m_optionsBox = new QHBoxLayout;
-  m_waterfallOpt = new QCheckBox("Waterfall Plot");
-  if(m_waterfall)
-    m_optionsBox->add(m_waterfallOpt);
-  else
-    m_waterfallOpt->setChecked(true);
-
-  m_outer->addItem(m_optionsBox);
 }
 
 void MantidWSIndexDialog::initButtons()
@@ -229,91 +427,6 @@ void MantidWSIndexDialog::initButtons()
   connect(m_cancelButton, SIGNAL(clicked()), this, SLOT(close()));
   if (m_plotAll)
     connect(m_plotAllButton, SIGNAL(clicked()), this, SLOT(plotAll()));
-}
-
-void MantidWSIndexDialog::checkForSpectraAxes()
-{
-  // Check to see if *all* workspaces have a spectrum axis.
-  // If even one does not have a spectra axis, then we wont
-  // ask the user to enter spectra IDs - only workspace indices.
-  QList<QString>::const_iterator it = m_wsNames.constBegin();
-  m_spectra = true;
-
-  for ( ; it != m_wsNames.constEnd(); ++it )
-  {
-    Mantid::API::MatrixWorkspace_const_sptr ws = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(Mantid::API::AnalysisDataService::Instance().retrieve((*it).toStdString()));
-    if ( NULL == ws ) continue;
-    bool hasSpectra = false;
-    for(int i = 0; i < ws->axes(); i++)
-    {
-      if(ws->getAxis(i)->isSpectra()) 
-        hasSpectra = true;
-    }
-    if(hasSpectra == false)
-    {
-      m_spectra = false;
-      break;
-    }
-  }
-}
-
-void MantidWSIndexDialog::generateWsIndexIntervals()
-{
-  // Get the available interval for each of the workspaces, and then
-  // present the user with interval which is the INTERSECTION of each of
-  // those intervals.
-  QList<QString>::const_iterator it = m_wsNames.constBegin();
-  
-  // Cycle through the workspaces ...
-  for ( ; it != m_wsNames.constEnd(); ++it )
-  {
-    Mantid::API::MatrixWorkspace_const_sptr ws = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(Mantid::API::AnalysisDataService::Instance().retrieve((*it).toStdString()));
-    if ( NULL == ws ) continue;
-    
-    const int endWs = static_cast<int>(ws->getNumberHistograms() - 1);//= static_cast<int> (end->first);
-
-    Interval interval(0,endWs);
-    // If no interval has been added yet, just add it ...
-    if(it == m_wsNames.constBegin())
-      m_wsIndexIntervals.addInterval(interval);
-    // ... else set the list as the intersection of what's already there
-    // and what has just been added.
-    else
-      m_wsIndexIntervals.setIntervalList(IntervalList::intersect(m_wsIndexIntervals,interval));
-  }
-}
-
-void MantidWSIndexDialog::generateSpectraIdIntervals()
-{
-  bool firstWs = true;
-  foreach( const QString wsName, m_wsNames )
-  {
-    Mantid::API::MatrixWorkspace_const_sptr ws = boost::dynamic_pointer_cast<const Mantid::API::MatrixWorkspace>(Mantid::API::AnalysisDataService::Instance().retrieve(wsName.toStdString()));
-    if( !ws ) continue; // Belt and braces.
-
-    const Mantid::spec2index_map spec2index = ws->getSpectrumToWorkspaceIndexMap();
-
-    IntervalList spectraIntervalList;
-    for( auto pair = spec2index.begin(); pair != spec2index.end(); ++pair )
-    {
-      spectraIntervalList.addInterval(static_cast<int>(pair->first));
-    }
-
-    if( firstWs )
-    {
-      m_spectraIdIntervals = spectraIntervalList;
-      firstWs = false;
-    }
-    else
-    {
-      m_spectraIdIntervals.setIntervalList(IntervalList::intersect(m_spectraIdIntervals, spectraIntervalList));
-    }
-  }
-}
-
-bool MantidWSIndexDialog::usingSpectraIDs() const
-{
-  return m_spectra && m_spectraIdIntervals.getList().size() > 0;
 }
 
 //----------------------------------
@@ -778,29 +891,29 @@ QValidator::State IntervalListValidator::validate(QString &input, int &pos) cons
   return QValidator::Invalid;
 }
 
-
-
 //////////////////////////////////////
 // QLineEditWithErrorMark
 //////////////////////////////////////
-MantidWSIndexDialog::QLineEditWithErrorMark::QLineEditWithErrorMark(QWidget * parent): QWidget(parent){
-  QGridLayout * layout = new QGridLayout(); 
-  _lineEdit = new QLineEdit(); 
+MantidWSIndexWidget::QLineEditWithErrorMark::QLineEditWithErrorMark(
+    QWidget *parent)
+    : QWidget(parent) {
+  QGridLayout *layout = new QGridLayout();
+  _lineEdit = new QLineEdit();
   m_validLbl = new QLabel("*"); // make it red
-  QPalette pal = m_validLbl->palette(); 
-  pal.setColor(QPalette::WindowText, Qt::darkRed); 
-  m_validLbl->setPalette(pal); 
-  layout->addWidget(_lineEdit,0,0); 
-  layout->addWidget(m_validLbl,0,1);
+  QPalette pal = m_validLbl->palette();
+  pal.setColor(QPalette::WindowText, Qt::darkRed);
+  m_validLbl->setPalette(pal);
+  layout->addWidget(_lineEdit, 0, 0);
+  layout->addWidget(m_validLbl, 0, 1);
   m_validLbl->setVisible(false);
   setLayout(layout);
 }
 
-void MantidWSIndexDialog::QLineEditWithErrorMark::setError(QString error){
-  if(error.isEmpty()){
-    m_validLbl->setVisible(false); 
-  }else{
-    m_validLbl->setVisible(true); 
-    m_validLbl->setToolTip(error.trimmed()); 
+void MantidWSIndexWidget::QLineEditWithErrorMark::setError(QString error) {
+  if (error.isEmpty()) {
+    m_validLbl->setVisible(false);
+  } else {
+    m_validLbl->setVisible(true);
+    m_validLbl->setToolTip(error.trimmed());
   }
 }

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.cpp
@@ -23,17 +23,14 @@
  * @param wsNames :: the names of the workspaces to be plotted
  * @param showWaterfallOption :: If true the waterfall checkbox is created
  */
-MantidWSIndexDialog::MantidWSIndexDialog(MantidUI* mui, Qt::WFlags flags, QList<QString> wsNames, const bool showWaterfallOption) 
-  : QDialog(mui->appWindow(), flags), 
-  m_mantidUI(mui),
-  m_spectra(false),
-  m_waterfall(showWaterfallOption),
-  m_wsNames(wsNames),
-  m_wsIndexIntervals(),
-  m_spectraIdIntervals(),
-  m_wsIndexChoice(), 
-  m_spectraIdChoice()
-{
+MantidWSIndexDialog::MantidWSIndexDialog(MantidUI *mui, Qt::WFlags flags,
+                                         QList<QString> wsNames,
+                                         const bool showWaterfallOption,
+                                         const bool showPlotAll)
+    : QDialog(mui->appWindow(), flags), m_mantidUI(mui), m_spectra(false),
+      m_waterfall(showWaterfallOption), m_wsNames(wsNames),
+      m_wsIndexIntervals(), m_spectraIdIntervals(), m_wsIndexChoice(),
+      m_spectraIdChoice(), m_plotAll(showPlotAll) {
   checkForSpectraAxes();
 
   // Generate the intervals allowed to be plotted by the user.
@@ -223,13 +220,15 @@ void MantidWSIndexDialog::initButtons()
 
   m_buttonBox->addWidget(m_okButton);
   m_buttonBox->addWidget(m_cancelButton);
-  m_buttonBox->addWidget(m_plotAllButton);
+  if (m_plotAll)
+    m_buttonBox->addWidget(m_plotAllButton);
 
   m_outer->addItem(m_buttonBox);
 
   connect(m_okButton, SIGNAL(clicked()), this, SLOT(plot()));
   connect(m_cancelButton, SIGNAL(clicked()), this, SLOT(close()));
-  connect(m_plotAllButton, SIGNAL(clicked()), this, SLOT(plotAll()));
+  if (m_plotAll)
+    connect(m_plotAllButton, SIGNAL(clicked()), this, SLOT(plotAll()));
 }
 
 void MantidWSIndexDialog::checkForSpectraAxes()

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.h
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.h
@@ -16,10 +16,11 @@
 
 #include <set>
 
+#include "MantidUI.h"
+
 //----------------------------------
 // Forward declarations
 //----------------------------------
-class MantidUI;
 class IntervalList;
 
 /** 

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.h
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.h
@@ -185,58 +185,60 @@ private:
   /// The IntervalList against which to validate.
   IntervalList m_intervalList;
 };
- 
-class MantidWSIndexDialog : public QDialog
-{
+
+class MantidWSIndexWidget : public QWidget {
   Q_OBJECT
 
   /** Auxiliar class to wrap the QLine allowing to have a warn to the user for
- *  invalid inputs. 
+ *  invalid inputs.
 */
-class QLineEditWithErrorMark : public QWidget{
-public:
-  /// constructor that will join togheter the QLineEdit and an 'invisible' * label.
-  explicit QLineEditWithErrorMark(QWidget *parent = 0);
-  /// virtual destructor to allow Qt to deallocate all objects
-  virtual ~QLineEditWithErrorMark(){};
-  /// provide acess to the QLineEdit
-  QLineEdit * lineEdit(){return _lineEdit;}; 
-  /// if Error is not empty, it will make the * label visible and set the tooltip as the error.
-  void setError(QString error); 
-private: 
-  QLineEdit * _lineEdit; 
-  QLabel * m_validLbl;
-};
+  class QLineEditWithErrorMark : public QWidget {
+  public:
+    /// constructor that will join togheter the QLineEdit and an 'invisible' *
+    /// label.
+    explicit QLineEditWithErrorMark(QWidget *parent = 0);
+    /// virtual destructor to allow Qt to deallocate all objects
+    virtual ~QLineEditWithErrorMark(){};
+    /// provide acess to the QLineEdit
+    QLineEdit *lineEdit() { return _lineEdit; };
+    /// if Error is not empty, it will make the * label visible and set the
+    /// tooltip as the error.
+    void setError(QString error);
+
+  private:
+    QLineEdit *_lineEdit;
+    QLabel *m_validLbl;
+  };
 
 public:
   /**
     * POD structure to hold all user-selected input
     */
   struct UserInput {
-    QMultiMap<QString,std::set<int> > plots;
+    QMultiMap<QString, std::set<int>> plots;
     bool waterfall;
   };
 
-/// Constructor - same parameters as one of the parent constructors, along with a 
+  /// Constructor - same parameters as one of the parent constructors, along
+  /// with a
   /// list of the names of workspaces to be plotted.
-  MantidWSIndexDialog(MantidUI *parent, Qt::WFlags flags,
-                      QList<QString> wsNames,
-                      const bool showWaterfallOption = false,
-                      const bool showPlotAll = true);
+  MantidWSIndexWidget(QWidget *parent, Qt::WFlags flags, QList<QString> wsNames,
+                      const bool showWaterfallOption = false);
 
   /// Returns a structure holding all of the selected options
   UserInput getSelections() const;
-  /// Returns the QMultiMap that contains all the workspaces that are to be plotted, 
+  /// Returns the QMultiMap that contains all the workspaces that are to be
+  /// plotted,
   /// mapped to the set of workspace indices.
-  QMultiMap<QString,std::set<int> > getPlots() const;
+  QMultiMap<QString, std::set<int>> getPlots() const;
   /// Returns whether the waterfall option has been selected
   bool waterfallPlotRequested() const;
+  /// Called by dialog when plot requested
+  bool plotRequested();
+  /// Called by dialog when plot all requested
+  void plotAllRequested();
 
 private slots:
-  /// Called when the OK button is pressed.
-  void plot();
-  /// Called when the "Plot All" button is pressed.
-  void plotAll();
   /// Called when the wsField has been edited.
   void editedWsField();
   /// Called when the spectraField has been edited.
@@ -251,23 +253,20 @@ private:
   void initSpectraBox();
   /// Initialize the layout of the options check boxes
   void initOptionsBoxes();
-  /// Initializes the layout of the buttons
-  void initButtons();
 
   /// Check to see if all workspaces have a spectrum axis
   void checkForSpectraAxes();
 
-  /// Generates an IntervalList which defines which workspace indices the user can
+  /// Generates an IntervalList which defines which workspace indices the user
+  /// can
   /// ask to plot.
   void generateWsIndexIntervals();
-  /// Generates an IntervalList which defines which spectra IDs the user can ask to plot.
+  /// Generates an IntervalList which defines which spectra IDs the user can ask
+  /// to plot.
   void generateSpectraIdIntervals();
 
   /// Whether or not there are any common spectra IDs between workspaces.
   bool usingSpectraIDs() const;
-
-  /// A pointer to the parent MantidUI object
-  MantidUI* m_mantidUI;
 
   /// Do we allow the user to ask for a range of spectra IDs or not?
   bool m_spectra;
@@ -275,24 +274,60 @@ private:
   /// Do we allow the display of the waterfall option
   bool m_waterfall;
 
-  /// Do we allow the display of the "Plot all" button
-  bool m_plotAll;
-  
   /// Pointers to the obligatory Qt objects:
   QLabel *m_wsMessage, *m_spectraMessage, *m_orMessage;
   QLineEditWithErrorMark *m_wsField, *m_spectraField;
-  QVBoxLayout *m_outer, *m_wsBox, *m_spectraBox; 
-  QHBoxLayout *m_optionsBox, *m_buttonBox;
+  QVBoxLayout *m_outer, *m_wsBox, *m_spectraBox;
+  QHBoxLayout *m_optionsBox;
   QCheckBox *m_waterfallOpt;
-  QPushButton *m_okButton, *m_cancelButton, *m_plotAllButton;
 
-  
   /// A list of names of workspaces which are to be plotted.
   QList<QString> m_wsNames;
   /// IntervalLists for the range of indices/IDs AVAILABLE to the user.
   IntervalList m_wsIndexIntervals, m_spectraIdIntervals;
   /// IntervalLists for the range of indices/IDs CHOSEN by the user.
   IntervalList m_wsIndexChoice, m_spectraIdChoice;
+};
+
+class MantidWSIndexDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  /// Constructor - same parameters as one of the parent constructors, along
+  /// with a
+  /// list of the names of workspaces to be plotted.
+  MantidWSIndexDialog(MantidUI *parent, Qt::WFlags flags,
+                      QList<QString> wsNames,
+                      const bool showWaterfallOption = false,
+                      const bool showPlotAll = true);
+  /// Returns a structure holding all of the selected options
+  MantidWSIndexWidget::UserInput getSelections() const;
+  /// Returns the QMultiMap that contains all the workspaces that are to be
+  /// plotted,
+  /// mapped to the set of workspace indices.
+  QMultiMap<QString, std::set<int>> getPlots() const;
+  /// Returns whether the waterfall option has been selected
+  bool waterfallPlotRequested() const;
+private slots:
+  /// Called when the OK button is pressed.
+  void plot();
+  /// Called when the "Plot All" button is pressed.
+  void plotAll();
+
+private:
+  MantidWSIndexWidget m_widget;
+  /// Initializes the layout of the dialog
+  void init();
+  /// Initializes the layout of the buttons
+  void initButtons();
+  /// A pointer to the parent MantidUI object
+  MantidUI *m_mantidUI;
+  /// Do we allow the display of the "Plot all" button
+  bool m_plotAll;
+  /// Qt objects
+  QPushButton *m_okButton, *m_cancelButton, *m_plotAllButton;
+  QHBoxLayout *m_buttonBox;
+  QVBoxLayout *m_outer;
 };
 
 #endif //MANTIDWSINDEXDIALOG_H_

--- a/MantidPlot/src/Mantid/MantidWSIndexDialog.h
+++ b/MantidPlot/src/Mantid/MantidWSIndexDialog.h
@@ -219,8 +219,10 @@ public:
 
 /// Constructor - same parameters as one of the parent constructors, along with a 
   /// list of the names of workspaces to be plotted.
-  MantidWSIndexDialog(MantidUI* parent, Qt::WFlags flags, QList<QString> wsNames,
-                      const bool showWaterfallOption = false);
+  MantidWSIndexDialog(MantidUI *parent, Qt::WFlags flags,
+                      QList<QString> wsNames,
+                      const bool showWaterfallOption = false,
+                      const bool showPlotAll = true);
 
   /// Returns a structure holding all of the selected options
   UserInput getSelections() const;
@@ -272,6 +274,9 @@ private:
 
   /// Do we allow the display of the waterfall option
   bool m_waterfall;
+
+  /// Do we allow the display of the "Plot all" button
+  bool m_plotAll;
   
   /// Pointers to the obligatory Qt objects:
   QLabel *m_wsMessage, *m_spectraMessage, *m_orMessage;


### PR DESCRIPTION
Resolves #14739 

On right-clicking on a workspace group, the user is offered the option to plot a 3D surface or contour plot (as long as the group contains more than 2 workspaces). The option is shown as long as the workspace clicked on can be cast to a const WorkspaceGroup and contains >2 workspaces.

A dialog enables the choice of which spectrum to use from each workspace, and also what the Y axis of the plot will be. (X is the x-axis of the workspaces, Z is the data value). The default option is workspace index, and the other options are all the sample logs with single, numeric values per workspace. There is also a "custom" option which allows the user to type their values in as a comma-separated list (as an alternative to using `AddSampleLog`).

The [release notes](http://www.mantidproject.org/ReleaseNotes_3_6_UI_Changes) have been updated.

**Test:**
Use the script below to generate an example WorkspaceGroup of 10 workspaces. 
- Check that right-clicking on the group gives options to plot a surface or contour plot
- Check these options are not shown when clicking on a group of 2 or fewer workspaces, or a group that contains table/peaks workspaces
- Generate plots of each type, using the dialog to choose the Y axis - try the `MyLog` log and also using the custom input box (enter a comma-separated list of 10 values)
- Check layout of dialog is ok
- Code review: check no excessive use of ADS
- Code review: verify not too much bloat has been added to MantidDockWidget and instead the new code is refactored into its own class

**Example data to test:**
The script below creates a minimal data set, and the plots can also be compared to [Pascal Manuel's scripts](https://gist.github.com/tom-perkins/998caf72095c54258571) if you have access to the Dropbox data.

``` python
def create_sample_group(n_items):
    to_group = list()
    for i in range(n_items):
        name = 'ws' + str(i)
        to_group.append(name)
        CreateWorkspace(DataX=range(200, 210, 1), DataY=[i+1]*20, NSpec=2, OutputWorkspace=name)
        AddSampleLog(Workspace=name, LogName="MyLog", LogText=str((i+1)*5), LogType='Number')
    group = GroupWorkspaces(InputWorkspaces=','.join(to_group))
    return group

create_sample_group(n_items=10)
```
