### PR TITLE
Colour scale in SliceViewer and ColorFill plots should not update on live data changes

### DIFF
--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -6193,7 +6193,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
         * spectrogram.
         */
         Spectrogram *s =
-            new Spectrogram(QString::fromUtf8(wsName.c_str()), wsPtr);
+            new Spectrogram(QString::fromUtf8(wsName.c_str()), wsPtr, false);
         plotSpectrogram(s, Graph::ColorMap);
         s->loadFromProject(*it);
         curveID++;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3410,7 +3410,18 @@ MultiLayer* MantidUI::drawSingleColorFillPlot(const QString & wsName, Graph::Cur
 
   plot->setTitle(wsName);
 
-  Spectrogram *spgrm = new Spectrogram(wsName, workspace);
+  // Find out if this is live data
+  bool isLiveData(false);
+  auto liveAlgorithms =
+      AlgorithmManager::Instance().runningInstancesOf("MonitorLiveData");
+  for (auto liveAlg : liveAlgorithms) {
+    if (liveAlg->getPropertyValue("OutputWorkspace") == workspace->name()) {
+      isLiveData = true;
+      break;
+    }
+  }
+  Spectrogram *spgrm = new Spectrogram(wsName, workspace, isLiveData);
+
   plot->plotSpectrogram(spgrm, curveType);
   connect(spgrm, SIGNAL(removeMe(Spectrogram*)),
           plot, SLOT(removeSpectrogram(Spectrogram*)));

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -236,11 +236,9 @@ MantidQt::API::QwtRasterDataMD *Spectrogram::dataFromWorkspace(const Mantid::API
   wsData->setZerosAsNan(false);
 
   // colour range
-  if (!m_liveData) {
-    QwtDoubleInterval fullRange =
-        MantidQt::API::SignalRange(*workspace).interval();
-    wsData->setRange(fullRange);
-  }
+  QwtDoubleInterval fullRange =
+      MantidQt::API::SignalRange(*workspace).interval();
+  wsData->setRange(fullRange);
 
   auto dim0 = workspace->getDimension(0);
   auto dim1 = workspace->getDimension(1);

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -187,8 +187,6 @@ protected:
 
   //! Axis used to display the color scale
   int color_axis;
-  /// Flag to indicate live data. If live, don't update colour scale
-  bool m_liveData;
 
   //! Flags
   ColorMapPolicy color_map_policy;
@@ -224,6 +222,8 @@ protected:
   std::vector<unsigned char> mScaledValues;
   /// boolean flag to indicate intensity changed
   bool m_bIntensityChanged;
+  /// Flag to indicate live data. If live, don't update colour scale
+  bool m_liveData;
 };
 
 class SpectrogramData: public QwtRasterData

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -68,7 +68,9 @@ class Spectrogram: public QObject, public QwtPlotSpectrogram, public MantidQt::A
 public:
   Spectrogram();
   explicit Spectrogram(Matrix *m);
-  Spectrogram(const QString &wsName, const Mantid::API::IMDWorkspace_const_sptr & workspace);
+  Spectrogram(const QString &wsName,
+              const Mantid::API::IMDWorkspace_const_sptr &workspace,
+              const bool isLiveData);
   Spectrogram(Function2D *f,int nrows, int ncols,double left, double top, double width, double height,double minz,double maxz);//Mantid
   Spectrogram(Function2D *f,int nrows, int ncols,QwtDoubleRect bRect,double minz,double maxz);//Mantid
   ~Spectrogram();
@@ -185,6 +187,8 @@ protected:
 
   //! Axis used to display the color scale
   int color_axis;
+  /// Flag to indicate live data. If live, don't update colour scale
+  bool m_liveData;
 
   //! Flags
   ColorMapPolicy color_map_policy;

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -358,6 +358,9 @@ private:
   /// Logger
   Mantid::Kernel::Logger m_logger;
 
+  /// Names of the workspaces (if any) being used for live data
+  std::vector<std::string> m_liveDataWSNames;
+
   // -------------------------- Controllers ------------------------
   boost::shared_ptr<CompositePeaksPresenter>  m_peaksPresenter;
 


### PR DESCRIPTION
Resolves #14818 

When the SliceViewer or a ColorFill plot is being used to visualise live data, the user's carefully set colour scale should not be reset every time the data is updated. This PR disables the scale reset if the data is live.

The SliceViewer checks if the workspace updated contains live data by looking for currently running instances of the `MonitorLiveData` algorithm, and comparing their output workspace names with the current workspace name. The code creating the color fill plot works in a similar way, passing the 'is live' flag to the constructor of Spectrogram that takes a workspace. In both cases, the colour scale is not reset on each update if the data is live.

**Test:**
- Start a fake live data listener as [here](http://www.mantidproject.org/MBC_Live_Data_Simple_Examples), e.g. ISIS_Histogram.
- Launch the SliceViewer from the workspace containing live data
- Change the colour scale and make sure it doesn't change back when new data comes in
- Launch a colour fill plot from the workspace containing live data
- Change the colour scale and check it remains the same when new data arrives
- Check that this still works when more than one live data listener is running
