### PR TITLE
Fix spectra numbering when loading processed file with numeric axis

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1629,11 +1629,20 @@ void LoadNexusProcessed::readInstrumentGroup(
 
   // Now build the spectra list
   int index = 0;
+  bool haveSpectraAxis = local_workspace->getAxis(1)->isSpectra();
 
   for (int i = 1; i <= spectraInfo.nSpectra; ++i) {
     int spectrum(-1);
+    // prefer the spectra number from the instrument section
+    // over anything else. If not there then use a spectra axis
+    // number if we have one, else make one up as nothing was
+    // written to the file. We should always set it so that
+    // CompareWorkspaces gives the expected answer on a Save/Load
+    // round trip.
     if (spectraInfo.hasSpectra) {
       spectrum = spectraInfo.spectraNumbers[i - 1];
+    } else if (haveSpectraAxis && !m_axis1vals.empty()) {
+      spectrum = static_cast<specid_t>(m_axis1vals[i - 1]);
     } else {
       spectrum = i + 1;
     }
@@ -1643,11 +1652,7 @@ void LoadNexusProcessed::readInstrumentGroup(
          find(m_spec_list.begin(), m_spec_list.end(), i) !=
              m_spec_list.end())) {
       ISpectrum *spec = local_workspace->getSpectrum(index);
-      if (m_axis1vals.empty()) {
-        spec->setSpectrumNo(spectrum);
-      } else {
-        spec->setSpectrumNo(static_cast<specid_t>(m_axis1vals[i - 1]));
-      }
+      spec->setSpectrumNo(spectrum);
       ++index;
 
       int start = spectraInfo.detectorIndex[i - 1];

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -21,14 +21,13 @@
 
 #include "SaveNexusProcessedTest.h"
 
-#include <boost/assign/list_of.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include <cxxtest/TestSuite.h>
 
 #include <hdf5.h>
 
 #include <Poco/File.h>
+
+#include <string>
 
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
@@ -130,6 +129,13 @@ public:
 
     // Testing the number of histograms
     TS_ASSERT_EQUALS(matrix_ws->getNumberHistograms(), 3);
+    // Test spectrum numbers are as expected
+    size_t index(0);
+    for (auto spectrum : {3, 4, 5}) {
+      TS_ASSERT_EQUALS(matrix_ws->getSpectrum(index)->getSpectrumNo(),
+                       spectrum);
+      index++;
+    }
     doHistoryTest(matrix_ws);
 
     boost::shared_ptr<const Mantid::Geometry::Instrument> inst =
@@ -163,6 +169,13 @@ public:
 
     // Testing the number of histograms
     TS_ASSERT_EQUALS(matrix_ws->getNumberHistograms(), 4);
+    // Test spectrum numbers
+    size_t index(0);
+    for (auto spectrum : {2, 3, 4, 5}) {
+      TS_ASSERT_EQUALS(matrix_ws->getSpectrum(index)->getSpectrumNo(),
+                       spectrum);
+      index++;
+    }
 
     // Test history
     doHistoryTest(matrix_ws);
@@ -199,6 +212,13 @@ public:
 
     // Testing the number of histograms
     TS_ASSERT_EQUALS(matrix_ws->getNumberHistograms(), 5);
+    // Test spectrum numbers
+    size_t index(0);
+    for (auto spectrum : {2, 3, 4, 5, 6}) {
+      TS_ASSERT_EQUALS(matrix_ws->getSpectrum(index)->getSpectrumNo(),
+                       spectrum);
+      index++;
+    }
 
     // Test history
     doHistoryTest(matrix_ws);
@@ -564,8 +584,7 @@ public:
       TS_ASSERT(ws);
       TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
       TS_ASSERT_EQUALS(ws->blocksize(), 10);
-      TS_ASSERT_EQUALS(ws->name(),
-                       "group_" + boost::lexical_cast<std::string>(i + 1));
+      TS_ASSERT_EQUALS(ws->name(), "group_" + std::to_string(i + 1));
     }
   }
 
@@ -1175,12 +1194,12 @@ private:
     // x errors
 
     // Create histogram workspace with two spectra and 4 points
-    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> dx1 = boost::assign::list_of(3)(2)(1);
-    std::vector<double> y1 = boost::assign::list_of(1)(2);
-    std::vector<double> x2 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> dx2 = boost::assign::list_of(3)(2)(1);
-    std::vector<double> y2 = boost::assign::list_of(1)(2);
+    std::vector<double> x1{1, 2, 3};
+    std::vector<double> dx1{3, 2, 1};
+    std::vector<double> y1{1, 2};
+    std::vector<double> x2{1, 2, 3};
+    std::vector<double> dx2{3, 2, 1};
+    std::vector<double> y2{1, 2};
     MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
         "Workspace2D", 2, x1.size(), y1.size());
     inputWs->dataX(0) = x1;
@@ -1216,6 +1235,8 @@ private:
     // Check spectra in loaded workspace
     MatrixWorkspace_sptr outputWs =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("output");
+    TS_ASSERT_EQUALS(1, inputWs->getSpectrum(0)->getSpectrumNo());
+    TS_ASSERT_EQUALS(2, inputWs->getSpectrum(1)->getSpectrumNo());
     TS_ASSERT_EQUALS(inputWs->readX(0), outputWs->readX(0));
     TS_ASSERT_EQUALS(inputWs->readX(1), outputWs->readX(1));
     TS_ASSERT_EQUALS(inputWs->readY(0), outputWs->readY(0));
@@ -1237,12 +1258,12 @@ private:
     // Test SaveNexusProcessed/LoadNexusProcessed on a point-like workspace
 
     // Create histogram workspace with two spectra and 4 points
-    std::vector<double> x1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> dx1 = boost::assign::list_of(3)(2)(1);
-    std::vector<double> y1 = boost::assign::list_of(1)(2)(3);
-    std::vector<double> x2 = boost::assign::list_of(10)(20)(30);
-    std::vector<double> dx2 = boost::assign::list_of(30)(22)(10);
-    std::vector<double> y2 = boost::assign::list_of(10)(20)(30);
+    std::vector<double> x1{1, 2, 3};
+    std::vector<double> dx1{3, 2, 1};
+    std::vector<double> y1{1, 2, 3};
+    std::vector<double> x2{10, 20, 30};
+    std::vector<double> dx2{30, 22, 10};
+    std::vector<double> y2{10, 20, 30};
     MatrixWorkspace_sptr inputWs = WorkspaceFactory::Instance().create(
         "Workspace2D", 2, x1.size(), y1.size());
     inputWs->dataX(0) = x1;


### PR DESCRIPTION
Fixes #14838 

**Tester**
Start with the following script, it should pass now:

``` python
import numpy

# create a 2D workspace with a user Y axis
height=20
width=20
scale=0.1
image=numpy.random.normal(loc=0.0,scale=1.0,size=[width,height])
ws=WorkspaceFactory.create("Workspace2D",NVectors=height,XLength=width+1,YLength=width)
ws.setDistribution(True) # always polarisation or similar normalised value, not raw or simulated counts
xaxdat=numpy.linspace(0.0,width*scale,width+1)
yaxdat=numpy.linspace(0.0,(height-1)*scale,height)
for i in range(height):
    ws.dataX(i)[:]=xaxdat
    ws.dataY(i)[:]=image[:,height-1-i]
    spec = ws.getSpectrum(i)
    print spec.getSpectrumNo()

na = NumericAxis.create(height)
for i in range(height):
        na.setValue(i,yaxdat[i])
lbl=na.setUnit("Label")
lbl.setLabel("height","cm")
ws.replaceAxis(1,na)
lbl=ws.getAxis(0).setUnit("Label")
lbl.setLabel("width","cm")
ws.setYUnitLabel("brightness")

AnalysisDataService.addOrReplace("ws",ws)

# test it
# this works
CloneWorkspace(InputWorkspace="ws",OutputWorkspace="ClonedWS")
print CheckWorkspacesMatch(Workspace1="ws",Workspace2="ClonedWS")

# but this doesn't. Why?
ff="foo.nxs" # somewhere writable
SaveNexus(InputWorkspace="ws",Filename=ff)
LoadNexus(Filename=ff,OutputWorkspace="CopyOfWS")
print CheckWorkspacesMatch(Workspace1="ws",Workspace2="CopyOfWS")
```

[Release notes](http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Improved) have been updated.
