### PR TITLE
ALC interface: fit progress and Plot Guess option

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingPresenter.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingPresenter.h
@@ -60,6 +60,12 @@ namespace CustomInterfaces
     void onFittedPeaksChanged();
     void onDataChanged();
 
+    /// Executed when user clicks "Plot guess"
+    void onPlotGuess();
+
+    // Remove plots from graph
+    void removePlots();
+
   private:
     /// Associated view
     IALCPeakFittingView* const m_view;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.h
@@ -60,6 +60,10 @@ namespace CustomInterfaces
     IPeakFunction_const_sptr peakPicker() const;
     void emitFitRequested();
 
+  public:
+    /// Clear guess when a fit is ready
+    void clearGuess() override;
+
   public slots:
 
     void initialize();
@@ -71,9 +75,9 @@ namespace CustomInterfaces
     void setPeakPicker(const IPeakFunction_const_sptr& peak);
     void displayError(const QString& message);
     void help();
+    void plotGuess() override;
 
     // -- End of IALCPeakFitting interface ---------------------------------------------------------
-
   private:
     /// The widget used
     QWidget* const m_widget;
@@ -89,6 +93,9 @@ namespace CustomInterfaces
 
     /// Peak picker tool - only one on the plot at any given moment
     MantidWidgets::PeakPicker* m_peakPicker;
+
+    /// Whether the guess is currently plotted on the graph
+    bool m_guessPlotted;
   };
 
 

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/ALCPeakFittingView.ui
@@ -36,20 +36,20 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-            <widget class="QPushButton" name="help">
-              <property name="maximumSize">
-                <size>
-                  <width>25</width>
-                  <height>25</height>
-                </size>
-              </property>
-              <property name="text">
-                <string>?</string>
-              </property>
-            </widget>
-          </item>
-          <item>
+         <item>
+          <widget class="QPushButton" name="help">
+           <property name="maximumSize">
+            <size>
+             <width>25</width>
+             <height>25</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>?</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -61,6 +61,16 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="plotGuess">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Plots current guess of the fit function on the graph&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Plot guess</string>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QPushButton" name="fit">
@@ -83,6 +93,7 @@
    <class>QwtPlot</class>
    <extends>QFrame</extends>
    <header>qwt_plot.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::FunctionBrowser</class>

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Muon/IALCPeakFittingView.h
@@ -56,6 +56,9 @@ namespace CustomInterfaces
     /// @return A peak currently represented by the peak picker
     virtual IPeakFunction_const_sptr peakPicker() const = 0;
 
+    /// Clears any guess from the plot
+    virtual void clearGuess() = 0;
+
   public slots:
     /// Performs any necessary initialization
     virtual void initialize() = 0;
@@ -97,6 +100,9 @@ namespace CustomInterfaces
     /// Opens the Mantid Wiki web page
     virtual void help() = 0;
 
+    /// Changes button text and emits signal
+    virtual void plotGuess() = 0;
+
   signals:
     /// Request to perform peak fitting
     void fitRequested();
@@ -108,7 +114,13 @@ namespace CustomInterfaces
     void peakPickerChanged();
 
     /// Parameter value is changed in the Function Browser _either by user or programmatically_
-    void parameterChanged(const QString& funcIndex, const QString& paramName);
+    void parameterChanged(const QString &funcIndex, const QString &paramName);
+
+    /// Request to plot guess
+    void plotGuessRequested();
+
+    /// Request to remove guess from plot
+    void removeGuessRequested();
   };
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCBaselineModellingModel.cpp
@@ -8,6 +8,9 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/TableRow.h"
 
+#include "Poco/ActiveResult.h"
+#include <QApplication>
+
 using namespace Mantid::API;
 
 namespace MantidQt
@@ -38,7 +41,15 @@ namespace CustomInterfaces
     fit->setProperty("Function", funcToFit);
     fit->setProperty("InputWorkspace", dataToFit);
     fit->setProperty("CreateOutput", true);
-    fit->execute();
+
+    // Run async so that progress can be shown
+    Poco::ActiveResult<bool> result(fit->executeAsync());
+    while (!result.available()) {
+      QCoreApplication::processEvents();
+    }
+    if (!result.error().empty()) {
+      throw std::runtime_error(result.error());
+    }
 
     MatrixWorkspace_sptr fitOutput = fit->getProperty("OutputWorkspace");
     m_parameterTable = fit->getProperty("OutputParameters");

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingModel.cpp
@@ -8,6 +8,9 @@
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/CompositeFunction.h"
 
+#include <Poco/ActiveResult.h>
+#include <QApplication>
+
 namespace MantidQt
 {
 namespace CustomInterfaces
@@ -56,7 +59,15 @@ namespace CustomInterfaces
     fit->setProperty("InputWorkspace", boost::const_pointer_cast<MatrixWorkspace>(m_data));
     fit->setProperty("CreateOutput", true);
     fit->setProperty("OutputCompositeMembers", true);
-    fit->execute();
+
+    // Execute async so we can show progress bar
+    Poco::ActiveResult<bool> result(fit->executeAsync());
+    while (!result.available()) {
+      QCoreApplication::processEvents();
+    }
+    if (!result.error().empty()) {
+      throw std::runtime_error(result.error());
+    }
 
     m_data = fit->getProperty("OutputWorkspace");
     m_parameterTable = fit->getProperty("OutputParameters");

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingPresenter.cpp
@@ -27,12 +27,15 @@ namespace CustomInterfaces
 
     connect(m_model, SIGNAL(fittedPeaksChanged()), SLOT(onFittedPeaksChanged()));
     connect(m_model, SIGNAL(dataChanged()), SLOT(onDataChanged()));
+    connect(m_view, SIGNAL(plotGuessRequested()), SLOT(onPlotGuess()));
+    connect(m_view, SIGNAL(removeGuessRequested()), SLOT(removePlots()));
   }
 
   void ALCPeakFittingPresenter::fit()
   {
     IFunction_const_sptr func = m_view->function("");
     if ( func ) {
+      m_view->clearGuess();
       m_model->fitPeaks(func);
     } else {
        m_view->displayError("Couldn't fit an empty function");
@@ -112,5 +115,25 @@ namespace CustomInterfaces
                          ALCHelper::curveErrorsFromWs(m_model->data(), 0));
   }
 
-} // namespace CustomInterfaces
-} // namespace MantidQt
+  /**
+   * Called when user clicks "Plot guess" on the view.
+   * Plots the current guess fit on the graph.
+   */
+  void ALCPeakFittingPresenter::onPlotGuess() {
+    if (auto func = m_view->function("")) {
+      auto xdata = m_model->data()->readX(0);
+      m_view->setFittedCurve(*(ALCHelper::curveDataFromFunction(func, xdata)));
+    } else {
+      removePlots();
+    }
+  }
+
+  /**
+   * Removes any fit function from the graph.
+   */
+  void ALCPeakFittingPresenter::removePlots() {
+    m_view->setFittedCurve(*(ALCHelper::emptyCurveData()));
+  }
+
+  } // namespace CustomInterfaces
+  } // namespace MantidQt

--- a/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/ALCPeakFittingView.cpp
@@ -12,10 +12,10 @@ namespace MantidQt
 namespace CustomInterfaces
 {
 
-ALCPeakFittingView::ALCPeakFittingView(QWidget* widget)
-  : m_widget(widget), m_ui(), m_dataCurve(new QwtPlotCurve()), m_fittedCurve(new QwtPlotCurve()),
-    m_dataErrorCurve(NULL), m_peakPicker(NULL)
-{}
+ALCPeakFittingView::ALCPeakFittingView(QWidget *widget)
+    : m_widget(widget), m_ui(), m_dataCurve(new QwtPlotCurve()),
+      m_fittedCurve(new QwtPlotCurve()), m_dataErrorCurve(NULL),
+      m_peakPicker(NULL), m_guessPlotted(false) {}
 
 ALCPeakFittingView::~ALCPeakFittingView()
 {
@@ -71,6 +71,7 @@ void ALCPeakFittingView::initialize()
           SIGNAL(parameterChanged(QString,QString)));
 
   connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
+  connect(m_ui.plotGuess, SIGNAL(clicked()), this, SLOT(plotGuess()));
 }
 
 void ALCPeakFittingView::setDataCurve(const QwtData &data,
@@ -148,7 +149,39 @@ void ALCPeakFittingView::displayError(const QString& message)
 }
 
 void ALCPeakFittingView::emitFitRequested() {
+  // Fit requested: reset "plot guess"
+  clearGuess();
   emit fitRequested();
+}
+
+/**
+ * Clears fit guess and changes button text
+ */
+void ALCPeakFittingView::clearGuess() {
+  m_guessPlotted = false;
+  m_ui.plotGuess->setText("Plot guess");
+}
+
+/**
+ * Changes the text on the "Plot guess" button and emits a signal
+ * to plot the guess on the graph
+ */
+void ALCPeakFittingView::plotGuess() {
+  QString buttonText("Plot guess");
+
+  if (m_guessPlotted) {
+    // Remove the plotted guess
+    emit removeGuessRequested();
+    m_guessPlotted = false;
+  } else {
+    // Plot the guess function, if there is one
+    if (function("") != nullptr) {
+      buttonText = "Remove guess";
+      emit plotGuessRequested();
+      m_guessPlotted = true;
+    }
+  }
+  m_ui.plotGuess->setText(buttonText);
 }
 
 } // namespace CustomInterfaces

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -38,6 +38,8 @@ public:
   {
     emit parameterChanged(funcIndex, paramName);
   }
+  void plotGuess() { emit plotGuessRequested(); }
+  void clearGuess() { emit removeGuessRequested(); }
 
   MOCK_CONST_METHOD1(function, IFunction_const_sptr(QString));
   MOCK_CONST_METHOD0(currentFunctionIndex, boost::optional<QString>());

--- a/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
+++ b/MantidQt/CustomInterfaces/test/ALCPeakFittingPresenterTest.h
@@ -285,7 +285,38 @@ public:
     EXPECT_CALL(*m_view, help()).Times(1);
     m_view->help();
   }
-};
 
+  /**
+   * Test that clearing the guess from the view removes the fitted curve
+   */
+  void test_clearGuess() {
+    EXPECT_CALL(*m_view, setFittedCurve(Property(&QwtData::size, 0)));
+    m_view->clearGuess();
+  }
+
+  /**
+   * Test that clicking "Plot guess" with no function set plots nothing
+   */
+  void test_plotGuess_noFunction() {
+    auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 3);
+    ON_CALL(*m_model, data()).WillByDefault(Return(ws));
+    ON_CALL(*m_view, function(QString("")))
+        .WillByDefault(Return(IFunction_const_sptr()));
+    EXPECT_CALL(*m_view, setFittedCurve(Property(&QwtData::size, 0)));
+    m_view->plotGuess();
+  }
+
+  /**
+   * Test that "Plot guess" with a function set plots a function
+   */
+  void test_plotGuess() {
+    auto ws = WorkspaceCreationHelper::Create2DWorkspace123(1, 3);
+    ON_CALL(*m_model, data()).WillByDefault(Return(ws));
+    IFunction_sptr peaks = createGaussian(1, 2, 3);
+    ON_CALL(*m_view, function(QString(""))).WillByDefault(Return(peaks));
+    EXPECT_CALL(*m_view, setFittedCurve(_));
+    m_view->plotGuess();
+  }
+};
 
 #endif /* MANTIDQT_CUSTOMINTERFACES_ALCPEAKFITTINGTEST_H_ */


### PR DESCRIPTION
Resolves #14840 
- [x] Changed the fit algorithms in the baseline modelling and peak fitting stages to run asynchronously. This means that their progress will be shown in the MantidPlot UI.
- [x] Added a "Plot guess" button to the peak fitting UI, which works like "Plot guess" elsewhere. The alternative would be to replace the pane here with a FitPropertyBrowser as in Muon Analysis.
- [x] Updated the [release notes](http://www.mantidproject.org/Release_Notes_3_6_MuonAnalysis)
- [x] Added unit tests

**To test:**
- Start the ALC interface (Interfaces/Muon/ALC) and load start/end data files. A minimal data set is MUSR00015189-15193 (in the doctest data), or a more extensive example with peaks to fit is HIFI00051636-51786 (`\\hifi\data\cycle_13_1`).
- Go to the next screen and fit a baseline to the data. It's hard to see the progress bar appear here as it is so fast, but try clicking "Fit" several times and see if you can see it appear.
- Go to the peak fitting screen and add one or more peaks. Check that the "Plot guess" button plots a guess fit, and that it works as it should with the fit.
- Run the fit and check that the progress is shown in MantidPlot. (The progress bar may only appear fleetingly if the fit is fast). If the fit is lengthy enough, check that the UI doesn't freeze while it is ongoing.
