### PR TITLE
Option for crystallography convention (new branch)

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -120,6 +120,7 @@ public:
   createIterator(Mantid::Geometry::MDImplicitFunction *function = NULL) const;
 
   std::string getConvention() const;
+  void setConvention(std::string m_convention);
   std::string changeQConvention();
 
   signal_t getSignalAtVMD(const Mantid::Kernel::VMD &coords,
@@ -165,7 +166,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
-  std::string convention;
+  std::string m_convention;
   virtual IMDWorkspace *doClone() const = 0;
 };
 

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -162,6 +162,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
+  std::string convention;
   virtual IMDWorkspace *doClone() const = 0;
 };
 

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -120,6 +120,7 @@ public:
   createIterator(Mantid::Geometry::MDImplicitFunction *function = NULL) const;
 
   std::string getConvention() const;
+  std::string changeQConvention();
 
   signal_t getSignalAtVMD(const Mantid::Kernel::VMD &coords,
                           const Mantid::API::MDNormalization &normalization =

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -119,6 +119,8 @@ public:
   IMDIterator *
   createIterator(Mantid::Geometry::MDImplicitFunction *function = NULL) const;
 
+  std::string getConvention() const;
+
   signal_t getSignalAtVMD(const Mantid::Kernel::VMD &coords,
                           const Mantid::API::MDNormalization &normalization =
                               Mantid::API::VolumeNormalization) const;

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -8,6 +8,7 @@
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
+#include "MantidKernel/ConfigService.h"
 #include <boost/optional.hpp>
 
 namespace Mantid {
@@ -48,7 +49,10 @@ class MANTID_API_DLL IPeaksWorkspace : public ITableWorkspace,
                                        public Mantid::API::ExperimentInfo {
 public:
   /// Ctor
-  IPeaksWorkspace() : ITableWorkspace(), ExperimentInfo() {}
+  IPeaksWorkspace() : ITableWorkspace(), ExperimentInfo() {
+    convention =
+        Kernel::ConfigService::Instance().getString("Q.convention");
+}
 
   /// Destructor
   virtual ~IPeaksWorkspace();
@@ -162,6 +166,7 @@ protected:
   virtual const std::string toString() const;
 
 private:
+  std::string convention;
   virtual IPeaksWorkspace *doClone() const = 0;
 };
 }

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -50,9 +50,8 @@ class MANTID_API_DLL IPeaksWorkspace : public ITableWorkspace,
 public:
   /// Ctor
   IPeaksWorkspace() : ITableWorkspace(), ExperimentInfo() {
-    convention =
-        Kernel::ConfigService::Instance().getString("Q.convention");
-}
+    convention = Kernel::ConfigService::Instance().getString("Q.convention");
+  }
 
   /// Destructor
   virtual ~IPeaksWorkspace();

--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -65,6 +65,11 @@ public:
   virtual int getNumberPeaks() const = 0;
 
   //---------------------------------------------------------------------------------------------
+  /** @return the number of peaks
+   */
+  virtual std::string getConvention() const = 0;
+
+  //---------------------------------------------------------------------------------------------
   /** Removes the indicated peak
    * @param peakNum  the peak to remove. peakNum starts at 0
    */
@@ -155,6 +160,8 @@ public:
   peakInfo(Kernel::V3D QFrame, bool labCoords) const = 0;
   virtual int peakInfoNumber(Kernel::V3D qLabFrame, bool labCoords) const = 0;
 
+  std::string convention;
+
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
   IPeaksWorkspace(const IPeaksWorkspace &other)
@@ -165,7 +172,6 @@ protected:
   virtual const std::string toString() const;
 
 private:
-  std::string convention;
   virtual IPeaksWorkspace *doClone() const = 0;
 };
 }

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -19,7 +19,9 @@ IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {
 //-----------------------------------------------------------------------------------------------
 /** Copy constructor */
 IMDWorkspace::IMDWorkspace(const IMDWorkspace &other)
-    : Workspace(other), Mantid::API::MDGeometry(other) {}
+    : Workspace(other), Mantid::API::MDGeometry(other) {
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
+}
 
 /// Destructor
 IMDWorkspace::~IMDWorkspace() {}

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -48,6 +48,15 @@ IMDIterator *IMDWorkspace::createIterator(
  */
 std::string IMDWorkspace::getConvention() const { return convention; }
 
+//---------------------------------------------------------------------------------------------
+/** @return the convention
+ */
+std::string IMDWorkspace::changeQConvention() {
+  if (this->getConvention() == "Crystallography")convention = "Inelastic";
+  else convention = "Crystallography";
+  return convention;
+}
+
 //-------------------------------------------------------------------------------------------
 /** Returns the signal (normalized by volume) at a given coordinates
  *

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -92,9 +92,9 @@ const std::string IMDWorkspace::toString() const {
   }
   os << "\n";
   if (convention == "Crystallography")
-    os << "Crystallography: ki-kf";
+    os << "Crystallography: kf-ki";
   else
-    os << "Inelastic: kf-ki";
+    os << "Inelastic: ki-kf";
   os << "\n";
 
   return os.str();

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -52,8 +52,10 @@ std::string IMDWorkspace::getConvention() const { return convention; }
 /** @return the convention
  */
 std::string IMDWorkspace::changeQConvention() {
-  if (this->getConvention() == "Crystallography")convention = "Inelastic";
-  else convention = "Crystallography";
+  if (this->getConvention() == "Crystallography")
+    convention = "Inelastic";
+  else
+    convention = "Crystallography";
   return convention;
 }
 

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -13,8 +13,7 @@ namespace API {
 //-----------------------------------------------------------------------------------------------
 /** Default constructor */
 IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
 }
 
 //-----------------------------------------------------------------------------------------------

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -12,7 +12,10 @@ namespace Mantid {
 namespace API {
 //-----------------------------------------------------------------------------------------------
 /** Default constructor */
-IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {}
+IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
+}
 
 //-----------------------------------------------------------------------------------------------
 /** Copy constructor */
@@ -89,8 +92,6 @@ const std::string IMDWorkspace::toString() const {
     os << "Binned from '" << getOriginalWorkspace()->getName();
   }
   os << "\n";
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
   if (convention == "Crystallography")
     os << "Crystallography: ki-kf";
   else

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -13,14 +13,14 @@ namespace API {
 //-----------------------------------------------------------------------------------------------
 /** Default constructor */
 IMDWorkspace::IMDWorkspace() : Workspace(), Mantid::API::MDGeometry() {
-  convention = Kernel::ConfigService::Instance().getString("Q.convention");
+  m_convention = Kernel::ConfigService::Instance().getString("Q.convention");
 }
 
 //-----------------------------------------------------------------------------------------------
 /** Copy constructor */
 IMDWorkspace::IMDWorkspace(const IMDWorkspace &other)
     : Workspace(other), Mantid::API::MDGeometry(other) {
-  convention = Kernel::ConfigService::Instance().getString("Q.convention");
+  m_convention = other.getConvention();
 }
 
 /// Destructor
@@ -48,17 +48,24 @@ IMDIterator *IMDWorkspace::createIterator(
 //---------------------------------------------------------------------------------------------
 /** @return the convention
  */
-std::string IMDWorkspace::getConvention() const { return convention; }
+std::string IMDWorkspace::getConvention() const { return m_convention; }
+
+//---------------------------------------------------------------------------------------------
+/** @return the convention
+ */
+void IMDWorkspace::setConvention(std::string convention) {
+  m_convention = convention;
+}
 
 //---------------------------------------------------------------------------------------------
 /** @return the convention
  */
 std::string IMDWorkspace::changeQConvention() {
   if (this->getConvention() == "Crystallography")
-    convention = "Inelastic";
+    m_convention = "Inelastic";
   else
-    convention = "Crystallography";
-  return convention;
+    m_convention = "Crystallography";
+  return m_convention;
 }
 
 //-------------------------------------------------------------------------------------------

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -43,6 +43,11 @@ IMDIterator *IMDWorkspace::createIterator(
   return iterators[0];
 }
 
+//---------------------------------------------------------------------------------------------
+/** @return the convention
+ */
+std::string IMDWorkspace::getConvention() const { return convention; }
+
 //-------------------------------------------------------------------------------------------
 /** Returns the signal (normalized by volume) at a given coordinates
  *
@@ -91,7 +96,7 @@ const std::string IMDWorkspace::toString() const {
     os << "Binned from '" << getOriginalWorkspace()->getName();
   }
   os << "\n";
-  if (convention == "Crystallography")
+  if (this->getConvention() == "Crystallography")
     os << "Crystallography: kf-ki";
   else
     os << "Inelastic: ki-kf";

--- a/Framework/API/src/IMDWorkspace.cpp
+++ b/Framework/API/src/IMDWorkspace.cpp
@@ -1,6 +1,7 @@
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/VMD.h"
 
 #include <sstream>
@@ -88,6 +89,14 @@ const std::string IMDWorkspace::toString() const {
     os << "Binned from '" << getOriginalWorkspace()->getName();
   }
   os << "\n";
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    os << "Crystallography: ki-kf";
+  else
+    os << "Inelastic: kf-ki";
+  os << "\n";
+
   return os.str();
 }
 

--- a/Framework/API/src/IPeaksWorkspace.cpp
+++ b/Framework/API/src/IPeaksWorkspace.cpp
@@ -3,6 +3,7 @@
 //----------------------------------------------------------------------
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidKernel/IPropertyManager.h"
+#include "MantidKernel/ConfigService.h"
 
 namespace Mantid {
 namespace API {
@@ -14,6 +15,11 @@ IPeaksWorkspace::~IPeaksWorkspace() {}
 const std::string IPeaksWorkspace::toString() const {
   std::ostringstream os;
   os << ITableWorkspace::toString() << "\n" << ExperimentInfo::toString();
+  if (convention == "Crystallography")
+    os << "Crystallography: ki-kf";
+  else
+    os << "Inelastic: kf-ki";
+  os << "\n";
 
   return os.str();
 }

--- a/Framework/API/src/IPeaksWorkspace.cpp
+++ b/Framework/API/src/IPeaksWorkspace.cpp
@@ -16,9 +16,9 @@ const std::string IPeaksWorkspace::toString() const {
   std::ostringstream os;
   os << ITableWorkspace::toString() << "\n" << ExperimentInfo::toString();
   if (convention == "Crystallography")
-    os << "Crystallography: ki-kf";
+    os << "Crystallography: kf-ki";
   else
-    os << "Inelastic: kf-ki";
+    os << "Inelastic: ki-kf";
   os << "\n";
 
   return os.str();

--- a/Framework/API/src/MDGeometry.cpp
+++ b/Framework/API/src/MDGeometry.cpp
@@ -379,7 +379,10 @@ void MDGeometry::transformDimensions(std::vector<double> &scaling,
                   static_cast<coord_t>(offset[d]);
     coord_t max = (dim->getMaximum() * static_cast<coord_t>(scaling[d])) +
                   static_cast<coord_t>(offset[d]);
-    dim->setRange(dim->getNBins(), min, max);
+    if (min < max)
+      dim->setRange(dim->getNBins(), min, max);
+    else
+      dim->setRange(dim->getNBins(), max, min);
   }
   // Clear the original workspace
   setOriginalWorkspace(boost::shared_ptr<Workspace>());

--- a/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/LoadIsawPeaks.h
@@ -59,7 +59,7 @@ private:
   /// Read a single peak from peaks file
   DataObjects::Peak readPeak(DataObjects::PeaksWorkspace_sptr outWS,
                              std::string &lastStr, std::ifstream &in,
-                             int &seqNum, std::string bankName);
+                             int &seqNum, std::string bankName, double qSign);
 
   int findPixelID(Geometry::Instrument_const_sptr inst, std::string bankName,
                   int col, int row);

--- a/Framework/Crystal/src/LoadHKL.cpp
+++ b/Framework/Crystal/src/LoadHKL.cpp
@@ -33,9 +33,11 @@ LoadHKL::~LoadHKL() {}
 /** Initialize the algorithm's properties.
  */
 void LoadHKL::init() {
-  declareProperty(
-      new FileProperty("Filename", "", FileProperty::Load, {".hkl"}),
-      "Path to an hkl file to save.");
+  std::vector<std::string> exts;
+  exts.push_back(".hkl");
+
+  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
+                  "Path to an hkl file to save.");
 
   declareProperty(new WorkspaceProperty<PeaksWorkspace>("OutputWorkspace", "",
                                                         Direction::Output),
@@ -58,6 +60,11 @@ void LoadHKL::exec() {
   //    % (H, K, L, FSQ, SIGFSQ, hstnum, WL, TBAR, CURHST, SEQNUM, TRANSMISSION,
   //    DN, TWOTH, DSP))
   // HKL is flipped by -1 due to different q convention in ISAW vs mantid.
+  // Default for kf-ki has -q
+  double qSign = -1.0;
+  std::string convention = ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    qSign = 1.0;
   Instrument_sptr inst(new Geometry::Instrument);
   Detector *detector = new Detector("det1", -1, 0);
   detector->setPos(0.0, 0.0, 0.0);
@@ -105,7 +112,7 @@ void LoadHKL::exec() {
     }
 
     Peak peak(inst, scattering, wl);
-    peak.setHKL(-h, -k, -l);
+    peak.setHKL(qSign * h, qSign * k, qSign * l);
     peak.setIntensity(Inti);
     peak.setSigmaIntensity(SigI);
     peak.setRunNumber(run);

--- a/Framework/Crystal/src/LoadHKL.cpp
+++ b/Framework/Crystal/src/LoadHKL.cpp
@@ -33,11 +33,9 @@ LoadHKL::~LoadHKL() {}
 /** Initialize the algorithm's properties.
  */
 void LoadHKL::init() {
-  std::vector<std::string> exts;
-  exts.push_back(".hkl");
-
-  declareProperty(new FileProperty("Filename", "", FileProperty::Load, exts),
-                  "Path to an hkl file to save.");
+  declareProperty(
+      new FileProperty("Filename", "", FileProperty::Load, {".hkl"}),
+      "Path to an hkl file to save.");
 
   declareProperty(new WorkspaceProperty<PeaksWorkspace>("OutputWorkspace", "",
                                                         Direction::Output),

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -328,12 +328,13 @@ std::string LoadIsawPeaks::readHeader(PeaksWorkspace_sptr outWS,
  * @param in :: input stream
  * @param seqNum [out] :: the sequence number of the peak
  * @param bankName :: the bank number from the ISAW file.
+ * @param qSign :: For inelastic this is 1; for crystallography this is -1
  * @return the Peak the Peak object created
  */
 DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
                                           std::string &lastStr,
                                           std::ifstream &in, int &seqNum,
-                                          std::string bankName) {
+                                          std::string bankName, double qSign) {
   double h;
   double k;
   double l;
@@ -406,8 +407,7 @@ DataObjects::Peak LoadIsawPeaks::readPeak(PeaksWorkspace_sptr outWS,
 
   // Create the peak object
   Peak peak(outWS->getInstrument(), pixelID, wl);
-  // HKL's are flipped by -1 because of the internal Q convention
-  peak.setHKL(-h, -k, -l);
+  peak.setHKL(qSign * h, qSign * k, qSign * l);
   peak.setIntensity(Inti);
   peak.setSigmaIntensity(SigI);
   peak.setBinCount(IPK);
@@ -504,7 +504,12 @@ std::string LoadIsawPeaks::readPeakBlockHeader(std::string lastStr,
  */
 void LoadIsawPeaks::appendFile(PeaksWorkspace_sptr outWS,
                                std::string filename) {
-
+  // HKL's are flipped by -1 because of the internal Q convention
+  // unless Crystallography convention
+  double qSign = -1.0;
+  std::string convention = ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    qSign = 1.0;
   // Open the file
   std::ifstream in(filename.c_str());
 
@@ -564,7 +569,7 @@ void LoadIsawPeaks::appendFile(PeaksWorkspace_sptr outWS,
 
     try {
       // Read the peak
-      Peak peak = readPeak(outWS, s, in, seqNum, bankName);
+      Peak peak = readPeak(outWS, s, in, seqNum, bankName, qSign);
 
       // Get the calculated goniometer matrix
       Matrix<double> gonMat = uniGonio.getR();

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -126,6 +126,12 @@ void SaveHKL::exec() {
   int runSequence = 0;
   int bankold = -1;
   int runold = -1;
+  // HKL is flipped by -1 due to different q convention in ISAW vs mantid.
+  // Default for kf-ki has -q
+  double qSign = -1.0;
+  std::string convention = ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    qSign = 1.0;
 
   std::fstream out;
   bool append = getProperty("AppendFile");
@@ -308,14 +314,14 @@ void SaveHKL::exec() {
     // hklFile.write('%4d%4d%4d%8.2f%8.2f%4d%8.4f%7.4f%7d%7d%7.4f%4d%9.5f%9.4f\n'
     //    % (H, K, L, FSQ, SIGFSQ, hstnum, WL, TBAR, CURHST, SEQNUM,
     //    TRANSMISSION, DN, TWOTH, DSP))
-    // HKL is flipped by -1 due to different q convention in ISAW vs mantid.
     if (p.getH() == 0 && p.getK() == 0 && p.getL() == 0) {
       banned.push_back(wi);
       continue;
     }
     if (decimalHKL == EMPTY_INT())
-      out << std::setw(4) << Utils::round(-p.getH()) << std::setw(4)
-          << Utils::round(-p.getK()) << std::setw(4) << Utils::round(-p.getL());
+      out << std::setw(4) << Utils::round(qSign * p.getH()) << std::setw(4)
+          << Utils::round(qSign * p.getK()) << std::setw(4)
+          << Utils::round(qSign * p.getL());
     else
       out << std::setw(5 + decimalHKL) << std::fixed
           << std::setprecision(decimalHKL) << -p.getH()

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -250,8 +250,7 @@ void SaveIsawPeaks::exec() {
   // HKL's are flipped by -1 because of the internal Q convention
   // unless Crystallography convention
   double qSign = -1.0;
-  std::string convention = ConfigService::Instance().getString("Q.convention");
-  if (convention == "Crystallography")
+  if (ws->getConvention() == "Crystallography")
     qSign = 1.0;
   // ============================== Save all Peaks
   // =========================================

--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -247,7 +247,12 @@ void SaveIsawPeaks::exec() {
       }
     }
   }
-
+  // HKL's are flipped by -1 because of the internal Q convention
+  // unless Crystallography convention
+  double qSign = -1.0;
+  std::string convention = ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    qSign = 1.0;
   // ============================== Save all Peaks
   // =========================================
   // Sequence number
@@ -305,11 +310,11 @@ void SaveIsawPeaks::exec() {
           // Sequence (run) number
           out << "3" << std::setw(7) << seqNum;
 
-          // HKL is flipped by -1 due to different q convention in ISAW vs
-          // mantid.
-          out << std::setw(5) << Utils::round(-p.getH()) << std::setw(5)
-              << Utils::round(-p.getK()) << std::setw(5)
-              << Utils::round(-p.getL());
+          // HKL's are flipped by -1 because of the internal Q convention
+          // unless Crystallography convention
+          out << std::setw(5) << Utils::round(qSign * p.getH()) << std::setw(5)
+              << Utils::round(qSign * p.getK()) << std::setw(5)
+              << Utils::round(qSign * p.getL());
 
           // Row/column
           out << std::setw(8) << std::fixed << std::setprecision(2)

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -111,6 +111,12 @@ void SaveLauenorm::exec() {
 
   // ============================== Save all Peaks
   // =========================================
+  // HKL is flipped by -1 due to different q convention in ISAW vs mantid.
+  // Default for kf-ki has -q
+  double qSign = -1.0;
+  std::string convention = ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    qSign = 1.0;
 
   // Go through each peak at this run / bank
   for (int wi = 0; wi < ws->getNumberPeaks(); wi++) {
@@ -170,10 +176,12 @@ void SaveLauenorm::exec() {
     // h k l lambda theta intensity and  sig(intensity)  in format
     // (3I5,2F10.5,2I10)
     // HKL is flipped by -1 due to different q convention in ISAW vs mantid.
+    // unless Crystallography convention
     if (p.getH() == 0 && p.getK() == 0 && p.getL() == 0)
       continue;
-    out << std::setw(5) << Utils::round(-p.getH()) << std::setw(5)
-        << Utils::round(-p.getK()) << std::setw(5) << Utils::round(-p.getL());
+    out << std::setw(5) << Utils::round(qSign * p.getH()) << std::setw(5)
+        << Utils::round(qSign * p.getK()) << std::setw(5)
+        << Utils::round(qSign * p.getL());
     out << std::setw(10) << std::fixed << std::setprecision(5) << lambda;
     // Assume that want theta not two-theta
     out << std::setw(10) << std::fixed << std::setprecision(5)

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1637,11 +1637,20 @@ void LoadNexusProcessed::readInstrumentGroup(
 
   // Now build the spectra list
   int index = 0;
+  bool haveSpectraAxis = local_workspace->getAxis(1)->isSpectra();
 
   for (int i = 1; i <= spectraInfo.nSpectra; ++i) {
     int spectrum(-1);
+    // prefer the spectra number from the instrument section
+    // over anything else. If not there then use a spectra axis
+    // number if we have one, else make one up as nothing was
+    // written to the file. We should always set it so that
+    // CompareWorkspaces gives the expected answer on a Save/Load
+    // round trip.
     if (spectraInfo.hasSpectra) {
       spectrum = spectraInfo.spectraNumbers[i - 1];
+    } else if (haveSpectraAxis && !m_axis1vals.empty()) {
+      spectrum = static_cast<specid_t>(m_axis1vals[i - 1]);
     } else {
       spectrum = i + 1;
     }
@@ -1651,11 +1660,7 @@ void LoadNexusProcessed::readInstrumentGroup(
          find(m_spec_list.begin(), m_spec_list.end(), i) !=
              m_spec_list.end())) {
       ISpectrum *spec = local_workspace->getSpectrum(index);
-      if (m_axis1vals.empty()) {
-        spec->setSpectrumNo(spectrum);
-      } else {
-        spec->setSpectrumNo(static_cast<specid_t>(m_axis1vals[i - 1]));
-      }
+      spec->setSpectrumNo(spectrum);
       ++index;
 
       int start = spectraInfo.detectorIndex[i - 1];

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1072,22 +1072,24 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
   std::string m_QConvention = "Inelastic";
   try {
     m_cppFile->getAttr("QConvention", m_QConvention);
-  } catch (std::exception &) {}
+  } catch (std::exception &) {
+  }
 
   // peaks_workspace
   m_cppFile->closeGroup();
 
   // Change convention of loaded file to that in Preferen
   double qSign = 1.0;
-  std::string convention =
-      ConfigService::Instance().getString("Q.convention");
+  std::string convention = ConfigService::Instance().getString("Q.convention");
   if (convention != m_QConvention)
     qSign = -1.0;
 
   for (int r = 0; r < numberPeaks; r++) {
     Kernel::V3D v3d;
-    if(convention == "Crystallography") v3d[2] = -1.0;
-    else v3d[2] = 1.0;
+    if (convention == "Crystallography")
+      v3d[2] = -1.0;
+    else
+      v3d[2] = 1.0;
     Geometry::IPeak *p;
     p = peakWS->createPeak(v3d);
     peakWS->addPeak(*p);

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1068,20 +1068,26 @@ API::Workspace_sptr LoadNexusProcessed::loadPeaksEntry(NXEntry &entry) {
       }
     }
   }
+
+  std::string m_QConvention = "Inelastic";
+  try {
+    m_cppFile->getAttr("QConvention", m_QConvention);
+  } catch (std::exception &) {}
+
   // peaks_workspace
   m_cppFile->closeGroup();
 
-  // HKL is flipped by -1 due to different q convention in Crystallography.
-  // Always write out in ki-kf so consistent with old files
+  // Change convention of loaded file to that in Preferen
   double qSign = 1.0;
   std::string convention =
-      ConfigService::Instance().getString("default.convention");
-  if (convention == "Crystallography")
+      ConfigService::Instance().getString("Q.convention");
+  if (convention != m_QConvention)
     qSign = -1.0;
 
   for (int r = 0; r < numberPeaks; r++) {
     Kernel::V3D v3d;
-    v3d[2] = 1.0;
+    if(convention == "Crystallography") v3d[2] = -1.0;
+    else v3d[2] = 1.0;
     Geometry::IPeak *p;
     p = peakWS->createPeak(v3d);
     peakWS->addPeak(*p);

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -690,6 +690,7 @@ TMDE(void MDBox)::centroidSphere(Mantid::API::CoordTransform &radiusTransform,
 TMDE(void MDBox)::transformDimensions(std::vector<double> &scaling,
                                       std::vector<double> &offset) {
   MDBoxBase<MDE, nd>::transformDimensions(scaling, offset);
+  this->calculateCentroid(this->m_centroid);
   std::vector<MDE> &events = this->getEvents();
   typename std::vector<MDE>::iterator it;
   typename std::vector<MDE>::iterator it_end = events.end();

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -16,6 +16,8 @@
 #include "MantidDataObjects/MDFramesToSpecialCoordinateSystem.h"
 #include "MantidDataObjects/MDGridBox.h"
 #include "MantidDataObjects/MDLeanEvent.h"
+#include "MantidKernel/ConfigService.h"
+
 #include <iomanip>
 #include <functional>
 #include <algorithm>
@@ -327,6 +329,7 @@ TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(
   }
   // Check if masked
   const API::IMDNode *box = data->getBoxAtCoord(coords);
+  if (!box) return MDMaskValue;
   if (box->getIsMasked()) {
     return MDMaskValue;
   }
@@ -376,6 +379,7 @@ TMDE(std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
 TMDE(std::vector<std::string> MDEventWorkspace)::getBoxControllerStats() const {
   std::vector<std::string> out;
   std::ostringstream mess;
+ 
   size_t mem;
   mem = (this->m_BoxController->getTotalNumMDBoxes() * sizeof(MDBox<MDE, nd>)) /
         1024;

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -9,6 +9,7 @@
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/System.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
+#include "MantidKernel/ConfigService.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/optional.hpp>
 
@@ -214,6 +215,10 @@ private:
 
   /// Static logger
   static Mantid::Kernel::Logger g_log;
+
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
 };
 
 } // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -217,8 +217,7 @@ private:
   static Mantid::Kernel::Logger g_log;
 
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string convention;
 };
 
 } // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -9,7 +9,6 @@
 #include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/System.h"
 #include "MantidGeometry/Crystal/PeakShape.h"
-#include "MantidKernel/ConfigService.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/optional.hpp>
 

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -102,6 +102,7 @@ public:
   void sort(std::vector<std::pair<std::string, bool>> &criteria);
 
   int getNumberPeaks() const;
+  std::string getConvention() const;
   void removePeak(int peakNum);
   void addPeak(const Geometry::IPeak &ipeak);
   Peak &getPeak(int peakNum);

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -753,7 +753,7 @@ void MDBoxFlatTree::saveWSGenericInfo(::NeXus::File *const file,
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
   std::string m_QConvention =
       Kernel::ConfigService::Instance().getString("Q.convention");
-  file->writeData("QConvention", m_QConvention);
+  file->putAttr("QConvention", m_QConvention);
 
   // Write out the set display normalization
   file->writeData("visual_normalization",

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -752,7 +752,7 @@ void MDBoxFlatTree::saveWSGenericInfo(::NeXus::File *const file,
   // Write out the Qconvention
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
   std::string m_QConvention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+      ws->getConvention();
   file->putAttr("QConvention", m_QConvention);
 
   // Write out the set display normalization

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -749,6 +749,12 @@ void MDBoxFlatTree::saveWSGenericInfo(::NeXus::File *const file,
   file->writeData("coordinate_system",
                   static_cast<uint32_t>(ws->getSpecialCoordinateSystem()));
 
+  // Write out the Qconvention
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string m_QConvention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
+  file->writeData("QConvention", m_QConvention);
+
   // Write out the set display normalization
   file->writeData("visual_normalization",
                   static_cast<uint32_t>(ws->displayNormalization()));
@@ -808,6 +814,8 @@ void MDBoxFlatTree::saveAffineTransformMatricies(
 void MDBoxFlatTree::saveAffineTransformMatrix(
     ::NeXus::File *const file, API::CoordTransform const *transform,
     std::string entry_name) {
+  if (!transform)
+    return;
   Kernel::Matrix<coord_t> matrix = transform->makeAffineMatrix();
   g_log.debug() << "TRFM: " << matrix.str() << std::endl;
   saveMatrix<coord_t>(file, entry_name, matrix, ::NeXus::FLOAT32,

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -751,8 +751,7 @@ void MDBoxFlatTree::saveWSGenericInfo(::NeXus::File *const file,
 
   // Write out the Qconvention
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string m_QConvention =
-      ws->getConvention();
+  std::string m_QConvention = ws->getConvention();
   file->putAttr("QConvention", m_QConvention);
 
   // Write out the set display normalization

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -24,7 +24,8 @@ Peak::Peak()
       m_finalEnergy(0.), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_row(-1), m_col(-1), m_orig_H(0), m_orig_K(0), m_orig_L(0),
-      m_peakShape(new NoShape) {}
+      m_peakShape(new NoShape) {  convention =
+          Kernel::ConfigService::Instance().getString("Q.convention");}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor that uses the Q position of the peak (in the lab frame).
@@ -43,6 +44,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setQLabFrame(QLabFrame, detectorDistance);
 }
@@ -68,6 +71,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
       m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
         "Peak::ctor(): Goniometer matrix must non-singular.");
@@ -89,6 +94,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setDetectorID(m_detectorID);
   this->setWavelength(m_Wavelength);
@@ -109,6 +116,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setDetectorID(m_detectorID);
   this->setWavelength(m_Wavelength);
@@ -131,6 +140,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
         "Peak::ctor(): Goniometer matrix must non-singular.");
@@ -153,6 +164,8 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, double scattering,
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_row(-1), m_col(-1), m_orig_H(0), m_orig_K(0), m_orig_L(0),
       m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setWavelength(m_Wavelength);
   m_detectorID = -1;
@@ -180,7 +193,8 @@ Peak::Peak(const Peak &other)
       m_orig_L(other.m_orig_L), m_detIDs(other.m_detIDs),
       m_peakShape(other.m_peakShape->clone())
 
-{}
+{  convention =
+    Kernel::ConfigService::Instance().getString("Q.convention");}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor making a Peak from IPeak interface
@@ -201,6 +215,8 @@ Peak::Peak(const Geometry::IPeak &ipeak)
       m_monitorCount(ipeak.getMonitorCount()), m_row(ipeak.getRow()),
       m_col(ipeak.getCol()), m_orig_H(0.), m_orig_K(0.), m_orig_L(0.),
       m_peakShape(new NoShape) {
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
         "Peak::ctor(): Goniometer matrix must non-singular.");

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -24,8 +24,9 @@ Peak::Peak()
       m_finalEnergy(0.), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_row(-1), m_col(-1), m_orig_H(0), m_orig_K(0), m_orig_L(0),
-      m_peakShape(new NoShape) {  convention =
-          Kernel::ConfigService::Instance().getString("Q.convention");}
+      m_peakShape(new NoShape) {
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
+}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor that uses the Q position of the peak (in the lab frame).
@@ -44,8 +45,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setQLabFrame(QLabFrame, detectorDistance);
 }
@@ -71,8 +71,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst,
       m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
         "Peak::ctor(): Goniometer matrix must non-singular.");
@@ -94,8 +93,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
       m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setDetectorID(m_detectorID);
   this->setWavelength(m_Wavelength);
@@ -116,8 +114,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(3, 3, true),
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setDetectorID(m_detectorID);
   this->setWavelength(m_Wavelength);
@@ -140,8 +137,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, int m_detectorID,
       m_sigmaIntensity(0), m_binCount(0), m_GoniometerMatrix(goniometer),
       m_InverseGoniometerMatrix(goniometer), m_runNumber(0), m_monitorCount(0),
       m_orig_H(0), m_orig_K(0), m_orig_L(0), m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
         "Peak::ctor(): Goniometer matrix must non-singular.");
@@ -164,8 +160,7 @@ Peak::Peak(Geometry::Instrument_const_sptr m_inst, double scattering,
       m_InverseGoniometerMatrix(3, 3, true), m_runNumber(0), m_monitorCount(0),
       m_row(-1), m_col(-1), m_orig_H(0), m_orig_K(0), m_orig_L(0),
       m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   this->setInstrument(m_inst);
   this->setWavelength(m_Wavelength);
   m_detectorID = -1;
@@ -193,8 +188,9 @@ Peak::Peak(const Peak &other)
       m_orig_L(other.m_orig_L), m_detIDs(other.m_detIDs),
       m_peakShape(other.m_peakShape->clone())
 
-{  convention =
-    Kernel::ConfigService::Instance().getString("Q.convention");}
+{
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
+}
 
 //----------------------------------------------------------------------------------------------
 /** Constructor making a Peak from IPeak interface
@@ -215,8 +211,7 @@ Peak::Peak(const Geometry::IPeak &ipeak)
       m_monitorCount(ipeak.getMonitorCount()), m_row(ipeak.getRow()),
       m_col(ipeak.getCol()), m_orig_H(0.), m_orig_K(0.), m_orig_L(0.),
       m_peakShape(new NoShape) {
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   if (fabs(m_InverseGoniometerMatrix.Invert()) < 1e-8)
     throw std::invalid_argument(
         "Peak::ctor(): Goniometer matrix must non-singular.");

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -452,7 +452,11 @@ Mantid::Kernel::V3D Peak::getQLabFrame() const {
   // Now calculate the wavevector of the scattered neutron
   double wvf = (2.0 * M_PI) / this->getWavelength();
   // And Q in the lab frame
-  return beamDir * wvi - detDir * wvf;
+  // Default for ki-kf is positive
+  double qSign = 1.0;
+  if (convention == "Crystallography")
+    qSign = -1.0;
+  return (beamDir * wvi - detDir * wvf) * qSign;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -528,7 +532,11 @@ void Peak::setQLabFrame(Mantid::Kernel::V3D QLabFrame,
   boost::shared_ptr<const ReferenceFrame> refFrame =
       this->m_inst->getReferenceFrame();
   const V3D refBeamDir = refFrame->vecPointingAlongBeam();
-  const double qBeam = q.scalar_prod(refBeamDir);
+  // Default for ki-kf has -q
+  double qSign = 1.0;
+  if (convention == "Crystallography")
+    qSign = -1.0;
+  const double qBeam = q.scalar_prod(refBeamDir) * qSign;
 
   if (norm_q == 0.0)
     throw std::invalid_argument("Peak::setQLabFrame(): Q cannot be 0,0,0.");
@@ -548,7 +556,12 @@ void Peak::setQLabFrame(Mantid::Kernel::V3D QLabFrame,
   // Save the wavelength
   this->setWavelength(wl);
 
-  V3D detectorDir = q * -1.0;
+  // Default for ki-kf has -q
+  qSign = -1.0;
+  if (convention == "Crystallography")
+    qSign = 1.0;
+
+  V3D detectorDir = q * qSign;
   detectorDir[refFrame->pointingAlongBeam()] = one_over_wl - qBeam;
   detectorDir.normalize();
 

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -3,6 +3,7 @@
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/System.h"
 #include <algorithm>

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -610,20 +610,14 @@ void PeaksWorkspace::saveNexus(::NeXus::File *file) const {
   std::vector<double> goniometerMatrix(9 * np);
   std::vector<std::string> shapes(np);
 
-  // HKL is flipped by -1 due to different q convention in Crystallography.
-  // Always write out in ki-kf so consistent with old files
-  double qSign = 1.0;
-  if (this->getConvention() == "Crystallography")
-    qSign = -1.0;
-
   // Populate column vectors from Peak Workspace
   size_t maxShapeJSONLength = 0;
   for (size_t i = 0; i < np; i++) {
     Peak p = peaks[i];
     detectorID[i] = p.getDetectorID();
-    H[i] = qSign * p.getH();
-    K[i] = qSign * p.getK();
-    L[i] = qSign * p.getL();
+    H[i] = p.getH();
+    K[i] = p.getK();
+    L[i] = p.getL();
     intensity[i] = p.getIntensity();
     sigmaIntensity[i] = p.getSigmaIntensity();
     binCount[i] = p.getBinCount();
@@ -662,6 +656,13 @@ void PeaksWorkspace::saveNexus(::NeXus::File *file) const {
 
   // Coordinate system
   file->writeData("coordinate_system", static_cast<uint32_t>(m_coordSystem));
+
+
+  // Write out the Qconvention
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string m_QConvention = this->getConvention();
+  file->putAttr("QConvention", m_QConvention);
+
 
   // Detectors column
   file->writeData("column_1", detectorID);

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -605,14 +605,21 @@ void PeaksWorkspace::saveNexus(::NeXus::File *file) const {
   std::vector<double> goniometerMatrix(9 * np);
   std::vector<std::string> shapes(np);
 
+  // HKL is flipped by -1 due to different q convention in Crystallography.
+  // Always write out in ki-kf so consistent with old files
+  double qSign = 1.0;
+  std::string convention = ConfigService::Instance().getString("Q.convention");
+  if (convention == "Crystallography")
+    qSign = -1.0;
+
   // Populate column vectors from Peak Workspace
   size_t maxShapeJSONLength = 0;
   for (size_t i = 0; i < np; i++) {
     Peak p = peaks[i];
     detectorID[i] = p.getDetectorID();
-    H[i] = p.getH();
-    K[i] = p.getK();
-    L[i] = p.getL();
+    H[i] = qSign * p.getH();
+    K[i] = qSign * p.getK();
+    L[i] = qSign * p.getL();
     intensity[i] = p.getIntensity();
     sigmaIntensity[i] = p.getSigmaIntensity();
     binCount[i] = p.getBinCount();

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -657,12 +657,10 @@ void PeaksWorkspace::saveNexus(::NeXus::File *file) const {
   // Coordinate system
   file->writeData("coordinate_system", static_cast<uint32_t>(m_coordSystem));
 
-
   // Write out the Qconvention
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
   std::string m_QConvention = this->getConvention();
   file->putAttr("QConvention", m_QConvention);
-
 
   // Detectors column
   file->writeData("column_1", detectorID);

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -128,6 +128,11 @@ void PeaksWorkspace::sort(std::vector<std::pair<std::string, bool>> &criteria) {
 int PeaksWorkspace::getNumberPeaks() const { return int(peaks.size()); }
 
 //---------------------------------------------------------------------------------------------
+/** @return the convention
+ */
+std::string PeaksWorkspace::getConvention() const { return convention; }
+
+//---------------------------------------------------------------------------------------------
 /** Removes the indicated peak
  * @param peakNum  the peak to remove. peakNum starts at 0
  */
@@ -608,8 +613,7 @@ void PeaksWorkspace::saveNexus(::NeXus::File *file) const {
   // HKL is flipped by -1 due to different q convention in Crystallography.
   // Always write out in ki-kf so consistent with old files
   double qSign = 1.0;
-  std::string convention = ConfigService::Instance().getString("Q.convention");
-  if (convention == "Crystallography")
+  if (this->getConvention() == "Crystallography")
     qSign = -1.0;
 
   // Populate column vectors from Peak Workspace

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDDimensionExtents.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDDimensionExtents.h
@@ -58,6 +58,12 @@ public:
     min = static_cast<T>(min * scaling + offset);
     max = static_cast<T>(max * scaling + offset);
     m_size = static_cast<T>(m_size * scaling);
+    if (max < min) {
+      T tmp = max;
+      max = min;
+      min = tmp;
+      m_size = std::fabs(m_size);
+    }
   }
   // it looks like this loses accuracy?
   void expand(MDDimensionExtents &other) {

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -673,10 +673,15 @@ void ConfigServiceImpl::createUserPropertiesFile() const {
     filestr << "## e.g.: ISIS, SNS, ILL" << std::endl;
     filestr << "default.facility=" << std::endl;
     filestr << std::endl;
-    filestr << "## Stes the default instrument" << std::endl;
+    filestr << "## Sets the default instrument" << std::endl;
     filestr << "## e.g. IRIS, HET, NIMROD" << std::endl;
     filestr << "default.instrument=" << std::endl;
     filestr << std::endl;
+    filestr << std::endl;
+    filestr << "## Sets the Q.convention" << std::endl;
+    filestr << "## Set to Crystallography for kf-ki instead of default "
+               "Inelastic which is ki-kf" << std::endl;
+    filestr << "#Q.convention=Crystallography" << std::endl;
     filestr << "##" << std::endl;
     filestr << "## DIRECTORIES" << std::endl;
     filestr << "##" << std::endl;

--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -12,6 +12,7 @@ set ( SRC_FILES
 	src/CalculateCoverageDGS.cpp
 	src/CentroidPeaksMD.cpp
 	src/CentroidPeaksMD2.cpp
+	src/ChangeQConvention.cpp
 	src/CloneMDWorkspace.cpp
 	src/CompactMD.cpp
 	src/CompareMDWorkspaces.cpp
@@ -139,6 +140,7 @@ set ( INC_FILES
 	inc/MantidMDAlgorithms/CalculateCoverageDGS.h
 	inc/MantidMDAlgorithms/CentroidPeaksMD.h
 	inc/MantidMDAlgorithms/CentroidPeaksMD2.h
+	inc/MantidMDAlgorithms/ChangeQConvention.h
 	inc/MantidMDAlgorithms/CloneMDWorkspace.h
 	inc/MantidMDAlgorithms/CompactMD.h
 	inc/MantidMDAlgorithms/CompareMDWorkspaces.h
@@ -264,6 +266,7 @@ set ( TEST_FILES
 	CalculateCoverageDGSTest.h
 	CentroidPeaksMD2Test.h
 	CentroidPeaksMDTest.h
+	ChangeQConventionTest.h
 	CloneMDWorkspaceTest.h
 	CompactMDTest.h
 	CompareMDWorkspacesTest.h

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CalculateCoverageDGS.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CalculateCoverageDGS.h
@@ -47,8 +47,7 @@ private:
   void exec();
 
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string convention;
   /// limits for h,k,l,dE dimensions
   coord_t m_hmin, m_hmax, m_kmin, m_kmax, m_lmin, m_lmax, m_dEmin, m_dEmax;
   /// cached values for incident energy and momentum, final momentum min/max

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CalculateCoverageDGS.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/CalculateCoverageDGS.h
@@ -46,6 +46,9 @@ private:
   void init();
   void exec();
 
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   /// limits for h,k,l,dE dimensions
   coord_t m_hmin, m_hmax, m_kmin, m_kmax, m_lmin, m_lmax, m_dEmin, m_dEmax;
   /// cached values for incident energy and momentum, final momentum min/max

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ChangeQConvention.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ChangeQConvention.h
@@ -56,7 +56,6 @@ private:
   void init();
   /// Run the algorithm
   void exec();
-
 };
 
 } // namespace DataObjects

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ChangeQConvention.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ChangeQConvention.h
@@ -45,7 +45,7 @@ public:
   }
 
   /// Algorithm's version for identification
-  virtual int version() const { return 2; };
+  virtual int version() const { return 1; };
   /// Algorithm's category for identification
   virtual const std::string category() const {
     return "MDAlgorithms\\DataHandling";

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ChangeQConvention.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/ChangeQConvention.h
@@ -1,0 +1,65 @@
+#ifndef MANTID_MDALGORITHMS_ChangeQConvention_H_
+#define MANTID_MDALGORITHMS_ChangeQConvention_H_
+
+#include "MantidKernel/System.h"
+#include "MantidAPI/Algorithm.h"
+#include "MantidDataObjects/MDEventWorkspace.h"
+
+namespace Mantid {
+
+namespace MDAlgorithms {
+
+/** Save a MDEventWorkspace to a .nxs file.
+
+  Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory, NScD Oak Ridge
+  National Laboratory & European Spallation Source
+
+  This file is part of Mantid.
+
+  Mantid is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 3 of the License, or
+  (at your option) any later version.
+
+  Mantid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+  File change history is stored at: <https://github.com/mantidproject/mantid>
+  Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport ChangeQConvention : public API::Algorithm {
+public:
+  ChangeQConvention();
+  ~ChangeQConvention();
+
+  /// Algorithm's name for identification
+  virtual const std::string name() const { return "ChangeQConvention"; };
+  /// Summary of algorithms purpose
+  virtual const std::string summary() const {
+    return "Change the convention of MD workspace.";
+  }
+
+  /// Algorithm's version for identification
+  virtual int version() const { return 2; };
+  /// Algorithm's category for identification
+  virtual const std::string category() const {
+    return "MDAlgorithms\\DataHandling";
+  }
+
+private:
+  /// Initialise the properties
+  void init();
+  /// Run the algorithm
+  void exec();
+
+};
+
+} // namespace DataObjects
+} // namespace Mantid
+
+#endif /* MANTID_MDALGORITHMS_ChangeQConvention_H_ */

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -67,8 +67,7 @@ private:
   void exec();
 
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string convention;
 
   /// Helper method
   template <typename MDE, size_t nd>

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/LoadMD.h
@@ -66,6 +66,10 @@ private:
   /// Run the algorithm
   void exec();
 
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
+
   /// Helper method
   template <typename MDE, size_t nd>
   void doLoad(typename DataObjects::MDEventWorkspace<MDE, nd>::sptr ws);
@@ -83,6 +87,8 @@ private:
   void loadDimensions2();
 
   void loadCoordinateSystem();
+
+  void loadQConvention();
 
   void loadVisualNormalization(
       const std::string &key,
@@ -114,6 +120,8 @@ private:
   std::vector<Mantid::Geometry::IMDDimension_sptr> m_dims;
   /// Coordinate system
   Kernel::SpecialCoordinateSystem m_coordSystem;
+  /// QConvention
+  std::string m_QConvention;
   /// load only the box structure with empty boxes but do not tload boxes events
   bool m_BoxStructureAndMethadata;
 

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -88,6 +88,9 @@ private:
   Kernel::V3D m_samplePos;
   /// Beam direction
   Kernel::V3D m_beamDir;
+  /// ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormDirectSC.h
@@ -89,8 +89,7 @@ private:
   /// Beam direction
   Kernel::V3D m_beamDir;
   /// ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string convention;
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormSCD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormSCD.h
@@ -92,8 +92,7 @@ private:
   /// Beam direction
   Kernel::V3D m_beamDir;
   /// ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string convention;
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormSCD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDNormSCD.h
@@ -91,6 +91,9 @@ private:
   Kernel::V3D m_samplePos;
   /// Beam direction
   Kernel::V3D m_beamDir;
+  /// ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
 };
 
 } // namespace MDAlgorithms

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -100,8 +100,7 @@ protected:
   // and used to calculate Lorentz corrections
   double m_SinThetaSq;
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
-  std::string convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  std::string convention;
   // all other variables are the same as in ModQ
   // hole near origin of Q
   double m_AbsMin;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -4,6 +4,7 @@
 #include "MantidMDAlgorithms/MDTransfInterface.h"
 #include "MantidMDAlgorithms/MDTransfFactory.h"
 #include "MantidMDAlgorithms/MDTransfModQ.h"
+#include "MantidKernel/ConfigService.h"
 //
 namespace Mantid {
 namespace MDAlgorithms {
@@ -98,6 +99,9 @@ protected:
   // current value of Sin(Theta)^2 corresponding to the current detector value
   // and used to calculate Lorentz corrections
   double m_SinThetaSq;
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   // all other variables are the same as in ModQ
   // hole near origin of Q
   double m_AbsMin;

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MDTransfQ3D.h
@@ -4,7 +4,6 @@
 #include "MantidMDAlgorithms/MDTransfInterface.h"
 #include "MantidMDAlgorithms/MDTransfFactory.h"
 #include "MantidMDAlgorithms/MDTransfModQ.h"
-#include "MantidKernel/ConfigService.h"
 //
 namespace Mantid {
 namespace MDAlgorithms {

--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/TransformMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/TransformMD.h
@@ -50,6 +50,7 @@ public:
 private:
   void init();
   void exec();
+  void reverse(signal_t *array, size_t arrayLength);
 
   template <typename MDE, size_t nd>
   void

--- a/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
+++ b/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
@@ -74,28 +74,9 @@ void BinaryOperationMD::exec() {
   m_rhs = getProperty(inputPropName2());
   m_out = getProperty(outputPropName());
   if (m_lhs->getConvention() != m_rhs->getConvention()) {
-    // Convert to the Qconvention from Preferences
-    // ki-kf for Inelastic convention; kf-ki for Crystallography convention
-    std::string pref_QConvention =
-        Kernel::ConfigService::Instance().getString("Q.convention");
-
-    if (pref_QConvention != m_lhs->getConvention()) {
-      g_log.information() << "Transforming Q in lhs" << std::endl;
-      Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
-      transform_alg->setProperty(
-          "InputWorkspace", boost::dynamic_pointer_cast<IMDWorkspace>(m_lhs));
-      transform_alg->setProperty("Scaling", "-1.0");
-      transform_alg->executeAsChildAlg();
-      m_lhs = transform_alg->getProperty("OutputWorkspace");
-    } else {
-      g_log.information() << "Transforming Q in rhs" << std::endl;
-      Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
-      transform_alg->setProperty(
-          "InputWorkspace", boost::dynamic_pointer_cast<IMDWorkspace>(m_rhs));
-      transform_alg->setProperty("Scaling", "-1.0");
-      transform_alg->executeAsChildAlg();
-      m_rhs = transform_alg->getProperty("OutputWorkspace");
-    }
+    throw std::runtime_error(
+        "Workspaces have different conventions for Q. "
+        "Use algorithm ChangeQConvention on one workspace. ");
   }
 
   // Flip LHS and RHS if commutative and :

--- a/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
+++ b/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
@@ -73,6 +73,32 @@ void BinaryOperationMD::exec() {
   m_lhs = getProperty(inputPropName1());
   m_rhs = getProperty(inputPropName2());
   m_out = getProperty(outputPropName());
+  if (m_lhs->getConvention() !=  m_rhs->getConvention())
+  {
+    // Convert to the Qconvention from Preferences
+    // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+    std::string pref_QConvention =
+        Kernel::ConfigService::Instance().getString("Q.convention");
+
+    if (pref_QConvention != m_lhs->getConvention()) {
+      g_log.information() << "Transforming Q in lhs" << std::endl;
+      Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
+      transform_alg->setProperty("InputWorkspace",
+                                 boost::dynamic_pointer_cast<IMDWorkspace>(m_lhs));
+      transform_alg->setProperty("Scaling", "-1.0");
+      transform_alg->executeAsChildAlg();
+      m_lhs = transform_alg->getProperty("OutputWorkspace");
+    }
+    else {
+      g_log.information() << "Transforming Q in rhs" << std::endl;
+      Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
+      transform_alg->setProperty("InputWorkspace",
+                                 boost::dynamic_pointer_cast<IMDWorkspace>(m_rhs));
+      transform_alg->setProperty("Scaling", "-1.0");
+      transform_alg->executeAsChildAlg();
+      m_rhs = transform_alg->getProperty("OutputWorkspace");
+    }
+  }
 
   // Flip LHS and RHS if commutative and :
   //  1. A = B + A -> becomes -> A += B

--- a/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
+++ b/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
@@ -73,11 +73,6 @@ void BinaryOperationMD::exec() {
   m_lhs = getProperty(inputPropName1());
   m_rhs = getProperty(inputPropName2());
   m_out = getProperty(outputPropName());
-  if (m_lhs->getConvention() != m_rhs->getConvention()) {
-    throw std::runtime_error(
-        "Workspaces have different conventions for Q. "
-        "Use algorithm ChangeQConvention on one workspace. ");
-  }
 
   // Flip LHS and RHS if commutative and :
   //  1. A = B + A -> becomes -> A += B
@@ -90,6 +85,16 @@ void BinaryOperationMD::exec() {
     Mantid::API::IMDWorkspace_sptr temp = m_lhs;
     m_lhs = m_rhs;
     m_rhs = temp;
+  }
+
+  // Do not compare conventions if one is single value
+  if (!boost::dynamic_pointer_cast<WorkspaceSingleValue>(m_rhs))
+  {
+    if (m_lhs->getConvention() != m_rhs->getConvention()) {
+      throw std::runtime_error(
+          "Workspaces have different conventions for Q. "
+          "Use algorithm ChangeQConvention on one workspace. ");
+    }
   }
 
   // Can't do A = 1 / B

--- a/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
+++ b/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
@@ -88,8 +88,7 @@ void BinaryOperationMD::exec() {
   }
 
   // Do not compare conventions if one is single value
-  if (!boost::dynamic_pointer_cast<WorkspaceSingleValue>(m_rhs))
-  {
+  if (!boost::dynamic_pointer_cast<WorkspaceSingleValue>(m_rhs)) {
     if (m_lhs->getConvention() != m_rhs->getConvention()) {
       throw std::runtime_error(
           "Workspaces have different conventions for Q. "

--- a/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
+++ b/Framework/MDAlgorithms/src/BinaryOperationMD.cpp
@@ -73,8 +73,7 @@ void BinaryOperationMD::exec() {
   m_lhs = getProperty(inputPropName1());
   m_rhs = getProperty(inputPropName2());
   m_out = getProperty(outputPropName());
-  if (m_lhs->getConvention() !=  m_rhs->getConvention())
-  {
+  if (m_lhs->getConvention() != m_rhs->getConvention()) {
     // Convert to the Qconvention from Preferences
     // ki-kf for Inelastic convention; kf-ki for Crystallography convention
     std::string pref_QConvention =
@@ -83,17 +82,16 @@ void BinaryOperationMD::exec() {
     if (pref_QConvention != m_lhs->getConvention()) {
       g_log.information() << "Transforming Q in lhs" << std::endl;
       Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
-      transform_alg->setProperty("InputWorkspace",
-                                 boost::dynamic_pointer_cast<IMDWorkspace>(m_lhs));
+      transform_alg->setProperty(
+          "InputWorkspace", boost::dynamic_pointer_cast<IMDWorkspace>(m_lhs));
       transform_alg->setProperty("Scaling", "-1.0");
       transform_alg->executeAsChildAlg();
       m_lhs = transform_alg->getProperty("OutputWorkspace");
-    }
-    else {
+    } else {
       g_log.information() << "Transforming Q in rhs" << std::endl;
       Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
-      transform_alg->setProperty("InputWorkspace",
-                                 boost::dynamic_pointer_cast<IMDWorkspace>(m_rhs));
+      transform_alg->setProperty(
+          "InputWorkspace", boost::dynamic_pointer_cast<IMDWorkspace>(m_rhs));
       transform_alg->setProperty("Scaling", "-1.0");
       transform_alg->executeAsChildAlg();
       m_rhs = transform_alg->getProperty("OutputWorkspace");

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -456,8 +456,13 @@ CalculateCoverageDGS::calculateIntersections(const double theta,
                                              const double phi) {
   V3D qout(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta)),
       qin(0., 0., m_ki);
+
   qout = m_rubw * qout;
   qin = m_rubw * qin;
+  if (convention == "Crystallography") {
+    qout *= -1;
+    qin *= -1;
+  }
   double hStart = qin.X() - qout.X() * m_kfmin,
          hEnd = qin.X() - qout.X() * m_kfmax;
   double kStart = qin.Y() - qout.Y() * m_kfmin,

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -433,10 +433,6 @@ void CalculateCoverageDGS::exec() {
       pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
 
       std::vector<coord_t> posNew = affineMat * pos;
-      if (convention == "Crystallography") {
-        for (auto ip = posNew.begin(); ip != posNew.end(); ++ip)
-          *ip = -(*ip);
-      }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))
         continue;
@@ -460,7 +456,6 @@ CalculateCoverageDGS::calculateIntersections(const double theta,
                                              const double phi) {
   V3D qout(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta)),
       qin(0., 0., m_ki);
-
   qout = m_rubw * qout;
   qin = m_rubw * qin;
   if (convention == "Crystallography") {

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -167,6 +167,8 @@ void CalculateCoverageDGS::exec() {
   // get the limits
   Mantid::API::MatrixWorkspace_const_sptr inputWS =
       getProperty("InputWorkspace");
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   // cache two theta and phi
   auto instrument = inputWS->getInstrument();
   std::vector<detid_t> detIDS = instrument->getDetectorIDs(true);

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -433,6 +433,9 @@ void CalculateCoverageDGS::exec() {
       pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
 
       std::vector<coord_t> posNew = affineMat * pos;
+      if (convention == "Crystallography") {
+        for (auto ip = posNew.begin(); ip != posNew.end(); ++ip) *ip = -(*ip);
+      }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))
         continue;

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -434,7 +434,8 @@ void CalculateCoverageDGS::exec() {
 
       std::vector<coord_t> posNew = affineMat * pos;
       if (convention == "Crystallography") {
-        for (auto ip = posNew.begin(); ip != posNew.end(); ++ip) *ip = -(*ip);
+        for (auto ip = posNew.begin(); ip != posNew.end(); ++ip)
+          *ip = -(*ip);
       }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -167,8 +167,7 @@ void CalculateCoverageDGS::exec() {
   // get the limits
   Mantid::API::MatrixWorkspace_const_sptr inputWS =
       getProperty("InputWorkspace");
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   // cache two theta and phi
   auto instrument = inputWS->getInstrument();
   std::vector<detid_t> detIDS = instrument->getDetectorIDs(true);

--- a/Framework/MDAlgorithms/src/ChangeQConvention.cpp
+++ b/Framework/MDAlgorithms/src/ChangeQConvention.cpp
@@ -16,7 +16,6 @@
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 #include "MantidKernel/ConfigService.h"
 
-
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
 using namespace Mantid::DataObjects;
@@ -47,7 +46,6 @@ void ChangeQConvention::init() {
   declareProperty(new WorkspaceProperty<IMDWorkspace>("InputWorkspace", "",
                                                       Direction::InOut),
                   "An input MDEventWorkspace or MDHistoWorkspace.");
-
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/ChangeQConvention.cpp
+++ b/Framework/MDAlgorithms/src/ChangeQConvention.cpp
@@ -1,0 +1,71 @@
+#include "MantidAPI/CoordTransform.h"
+#include "MantidAPI/FileProperty.h"
+#include "MantidAPI/IMDEventWorkspace.h"
+#include "MantidKernel/Matrix.h"
+#include "MantidKernel/System.h"
+#include "MantidDataObjects/MDBoxIterator.h"
+#include "MantidDataObjects/MDEventFactory.h"
+#include "MantidDataObjects/MDEventWorkspace.h"
+#include "MantidMDAlgorithms/ChangeQConvention.h"
+#include "MantidDataObjects/MDBox.h"
+#include "MantidAPI/Progress.h"
+#include "MantidKernel/EnabledWhenProperty.h"
+#include <Poco/File.h>
+#include "MantidDataObjects/MDHistoWorkspace.h"
+#include "MantidDataObjects/MDBoxFlatTree.h"
+#include "MantidDataObjects/BoxControllerNeXusIO.h"
+#include "MantidKernel/ConfigService.h"
+
+
+using namespace Mantid::Kernel;
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::Geometry;
+
+namespace Mantid {
+namespace MDAlgorithms {
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(ChangeQConvention)
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+ChangeQConvention::ChangeQConvention() {}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+ChangeQConvention::~ChangeQConvention() {}
+
+//----------------------------------------------------------------------------------------------
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void ChangeQConvention::init() {
+  declareProperty(new WorkspaceProperty<IMDWorkspace>("InputWorkspace", "",
+                                                      Direction::InOut),
+                  "An input MDEventWorkspace or MDHistoWorkspace.");
+
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void ChangeQConvention::exec() {
+  IMDWorkspace_sptr ws = getProperty("InputWorkspace");
+
+  g_log.information() << "Transforming Q in workspace" << std::endl;
+  Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
+  transform_alg->setProperty("InputWorkspace",
+                             boost::dynamic_pointer_cast<IMDWorkspace>(ws));
+  transform_alg->setProperty("Scaling", "-1.0");
+  transform_alg->executeAsChildAlg();
+  ws = transform_alg->getProperty("OutputWorkspace");
+  ws->changeQConvention();
+  setProperty("InputWorkspace", ws);
+}
+
+} // namespace Mantid
+} // namespace DataObjects

--- a/Framework/MDAlgorithms/src/ChangeQConvention.cpp
+++ b/Framework/MDAlgorithms/src/ChangeQConvention.cpp
@@ -53,15 +53,19 @@ void ChangeQConvention::init() {
  */
 void ChangeQConvention::exec() {
   IMDWorkspace_sptr ws = getProperty("InputWorkspace");
+  std::string convention = ws->getConvention();
 
   g_log.information() << "Transforming Q in workspace" << std::endl;
+
   Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
   transform_alg->setProperty("InputWorkspace",
                              boost::dynamic_pointer_cast<IMDWorkspace>(ws));
   transform_alg->setProperty("Scaling", "-1.0");
   transform_alg->executeAsChildAlg();
   ws = transform_alg->getProperty("OutputWorkspace");
+  ws->setConvention(convention);
   ws->changeQConvention();
+
   setProperty("InputWorkspace", ws);
 }
 

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -19,6 +19,7 @@
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidAPI/MemoryManager.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/ConfigService.h"
 
 using namespace Mantid;
 using namespace Mantid::Kernel;
@@ -215,6 +216,12 @@ void ConvertToDiffractionMDWorkspace::convertEventList(int workspaceIndex,
     //  = input beam direction (normalized to 1) - output beam direction
     //  (normalized to 1)
     V3D Q_dir_lab_frame = beamDir - detDir;
+    double qSign = -1.0;
+    std::string convention =
+        ConfigService::Instance().getString("Q.convention");
+    if (convention == "Crystallography")
+      qSign = 1.0;
+    Q_dir_lab_frame *= qSign;
 
     // Multiply by the rotation matrix to convert to Q in the sample frame (take
     // out goniometer rotation)

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -467,8 +467,8 @@ void LoadMD::loadCoordinateSystem() {
 /** Load the convention for Q  **/
 void LoadMD::loadQConvention() {
   try {
-    m_file->readData("QConvention", m_QConvention);
-  } catch (::NeXus::Exception &) {
+    m_file->getAttr("QConvention", m_QConvention);
+  } catch (std::exception &) {
     m_QConvention = "Inelastic";
   }
 }

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -119,7 +119,8 @@ void LoadMD::init() {
 */
 void LoadMD::exec() {
   m_filename = getPropertyValue("Filename");
-
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   // Start loading
   bool fileBacked = this->getProperty("FileBackEnd");
 

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -119,8 +119,7 @@ void LoadMD::init() {
 */
 void LoadMD::exec() {
   m_filename = getPropertyValue("Filename");
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   // Start loading
   bool fileBacked = this->getProperty("FileBackEnd");
 

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -1,6 +1,7 @@
 #include "MantidAPI/ExperimentInfo.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/IMDEventWorkspace.h"
+#include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/RegisterFileLoader.h"
 #include "MantidGeometry/MDGeometry/IMDDimension.h"
 #include "MantidGeometry/MDGeometry/IMDDimensionFactory.h"
@@ -22,6 +23,7 @@
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 #include "MantidDataObjects/CoordTransformAffine.h"
+#include "MantidKernel/ConfigService.h"
 #include <nexus/NeXusException.hpp>
 #include <boost/algorithm/string.hpp>
 #include <vector>
@@ -186,6 +188,9 @@ void LoadMD::exec() {
   // Coordinate system
   this->loadCoordinateSystem();
 
+  // QConvention (Inelastic or Crystallography)
+  this->loadQConvention();
+
   // Display normalization settting
   if (levelEntries.find(VISUAL_NORMALIZATION_KEY) != levelEntries.end()) {
     this->loadVisualNormalization(VISUAL_NORMALIZATION_KEY,
@@ -225,6 +230,25 @@ void LoadMD::exec() {
     checkForRequiredLegacyFixup(ws);
     if (m_requiresMDFrameCorrection) {
       setMDFrameOnWorkspaceFromLegacyFile(ws);
+    }
+    // Write out the Qconvention
+    // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+    std::string pref_QConvention =
+        Kernel::ConfigService::Instance().getString("Q.convention");
+    g_log.information() << "Convention for Q in Preferences is "
+                        << pref_QConvention
+                        << "; Convention of Q in NeXus file is "
+                        << m_QConvention << std::endl;
+
+    if (pref_QConvention != m_QConvention) {
+      g_log.information() << "Transforming Q" << std::endl;
+      Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
+      transform_alg->setProperty("InputWorkspace",
+                                 boost::dynamic_pointer_cast<IMDWorkspace>(ws));
+      transform_alg->setProperty("Scaling", "-1.0");
+      transform_alg->executeAsChildAlg();
+      IMDWorkspace_sptr tmp = transform_alg->getProperty("OutputWorkspace");
+      ws = boost::dynamic_pointer_cast<IMDEventWorkspace>(tmp);
     }
     // Save to output
     setProperty("OutputWorkspace",
@@ -312,6 +336,26 @@ void LoadMD::loadHisto() {
   checkForRequiredLegacyFixup(ws);
   if (m_requiresMDFrameCorrection) {
     setMDFrameOnWorkspaceFromLegacyFile(ws);
+  }
+
+  // Write out the Qconvention
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string pref_QConvention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
+  g_log.information() << "Convention for Q in Preferences is "
+                      << pref_QConvention
+                      << "; Convention of Q in NeXus file is " << m_QConvention
+                      << std::endl;
+
+  if (pref_QConvention != m_QConvention) {
+    g_log.information() << "Transforming Q" << std::endl;
+    Algorithm_sptr transform_alg = createChildAlgorithm("TransformMD");
+    transform_alg->setProperty("InputWorkspace",
+                               boost::dynamic_pointer_cast<IMDWorkspace>(ws));
+    transform_alg->setProperty("Scaling", "-1.0");
+    transform_alg->executeAsChildAlg();
+    IMDWorkspace_sptr tmp = transform_alg->getProperty("OutputWorkspace");
+    ws = boost::dynamic_pointer_cast<MDHistoWorkspace>(tmp);
   }
 
   // Save to output
@@ -417,6 +461,15 @@ void LoadMD::loadCoordinateSystem() {
     }
     // return to where we started
     m_file->openPath(pathOnEntry);
+  }
+}
+
+/** Load the convention for Q  **/
+void LoadMD::loadQConvention() {
+  try {
+    m_file->readData("QConvention", m_QConvention);
+  } catch (::NeXus::Exception &) {
+    m_QConvention = "Inelastic";
   }
 }
 

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -108,6 +108,8 @@ void MDNormDirectSC::init() {
 void MDNormDirectSC::exec() {
   cacheInputs();
   auto outputWS = binInputWS();
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
   createNormalizationWS(*outputWS);
   setProperty("OutputNormalizationWorkspace", m_normWS);

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -514,6 +514,9 @@ void MDNormDirectSC::calculateNormalization(
       // transform kf to energy transfer
       pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
       std::vector<coord_t> posNew = affineTrans * pos;
+      if (convention == "Crystallography") {
+        for (auto i = posNew.begin(); i != posNew.end(); ++i) *i = -(*i);
+      }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))
         continue;
@@ -610,7 +613,7 @@ MDNormDirectSC::calculateIntersections(const double theta, const double phi) {
 
   qout = m_rubw * qout;
   qin = m_rubw * qin;
-  if (convention != "Crystallography") {
+  if (convention == "Crystallography") {
     qout *= -1;
     qin *= -1;
   }

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -108,8 +108,7 @@ void MDNormDirectSC::init() {
 void MDNormDirectSC::exec() {
   cacheInputs();
   auto outputWS = binInputWS();
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
   createNormalizationWS(*outputWS);
   setProperty("OutputNormalizationWorkspace", m_normWS);

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -514,10 +514,6 @@ void MDNormDirectSC::calculateNormalization(
       // transform kf to energy transfer
       pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
       std::vector<coord_t> posNew = affineTrans * pos;
-      if (convention == "Crystallography") {
-        for (auto i = posNew.begin(); i != posNew.end(); ++i)
-          *i = -(*i);
-      }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))
         continue;

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -8,6 +8,7 @@
 #include "MantidKernel/CompositeValidator.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/VectorHelper.h"
+#include "MantidKernel/ConfigService.h"
 
 namespace Mantid {
 namespace MDAlgorithms {
@@ -606,8 +607,13 @@ std::vector<Kernel::VMD>
 MDNormDirectSC::calculateIntersections(const double theta, const double phi) {
   V3D qout(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta)),
       qin(0., 0., m_ki);
+
   qout = m_rubw * qout;
   qin = m_rubw * qin;
+  if (convention != "Crystallography") {
+    qout *= -1;
+    qin *= -1;
+  }
   double hStart = qin.X() - qout.X() * m_kfmin,
          hEnd = qin.X() - qout.X() * m_kfmax;
   double kStart = qin.Y() - qout.Y() * m_kfmin,

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -515,7 +515,8 @@ void MDNormDirectSC::calculateNormalization(
       pos[3] = static_cast<coord_t>(m_Ei - pos[3] * pos[3] / energyToK);
       std::vector<coord_t> posNew = affineTrans * pos;
       if (convention == "Crystallography") {
-        for (auto i = posNew.begin(); i != posNew.end(); ++i) *i = -(*i);
+        for (auto i = posNew.begin(); i != posNew.end(); ++i)
+          *i = -(*i);
       }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -472,10 +472,6 @@ void MDNormSCD::calculateNormalization(
                      prevIntSec.getBareArray(), pos.begin(),
                      VectorHelper::SimpleAverage<coord_t>());
       std::vector<coord_t> posNew = affineTrans * pos;
-      if (convention == "Crystallography") {
-        for (auto i = posNew.begin(); i != posNew.end(); ++i)
-          *i = -(*i);
-      }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))
         continue;

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -472,6 +472,9 @@ void MDNormSCD::calculateNormalization(
                      prevIntSec.getBareArray(), pos.begin(),
                      VectorHelper::SimpleAverage<coord_t>());
       std::vector<coord_t> posNew = affineTrans * pos;
+      if (convention == "Crystallography") {
+        for (auto i = posNew.begin(); i != posNew.end(); ++i) *i = -(*i);
+      }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))
         continue;
@@ -642,7 +645,7 @@ std::vector<Kernel::VMD> MDNormSCD::calculateIntersections(const double theta,
                                                            const double phi) {
   V3D q(-sin(theta) * cos(phi), -sin(theta) * sin(phi), 1. - cos(theta));
   q = m_rubw * q;
-  if (convention != "Crystallography") {
+  if (convention == "Crystallography") {
     q *= -1;
   }
 

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -473,7 +473,8 @@ void MDNormSCD::calculateNormalization(
                      VectorHelper::SimpleAverage<coord_t>());
       std::vector<coord_t> posNew = affineTrans * pos;
       if (convention == "Crystallography") {
-        for (auto i = posNew.begin(); i != posNew.end(); ++i) *i = -(*i);
+        for (auto i = posNew.begin(); i != posNew.end(); ++i)
+          *i = -(*i);
       }
       size_t linIndex = m_normWS->getLinearIndexAtCoord(posNew.data());
       if (linIndex == size_t(-1))

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -642,6 +642,10 @@ std::vector<Kernel::VMD> MDNormSCD::calculateIntersections(const double theta,
                                                            const double phi) {
   V3D q(-sin(theta) * cos(phi), -sin(theta) * sin(phi), 1. - cos(theta));
   q = m_rubw * q;
+  if (convention != "Crystallography") {
+    q *= -1;
+  }
+
   double hStart = q.X() * m_kiMin, hEnd = q.X() * m_kiMax;
   double kStart = q.Y() * m_kiMin, kEnd = q.Y() * m_kiMax;
   double lStart = q.Z() * m_kiMin, lEnd = q.Z() * m_kiMax;

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -112,6 +112,8 @@ void MDNormSCD::init() {
 void MDNormSCD::exec() {
   cacheInputs();
   auto outputWS = binInputWS();
+  convention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
   setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
   createNormalizationWS(*outputWS);
   setProperty("OutputNormalizationWorkspace", m_normWS);

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -112,8 +112,7 @@ void MDNormSCD::init() {
 void MDNormSCD::exec() {
   cacheInputs();
   auto outputWS = binInputWS();
-  convention =
-      Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   setProperty<Workspace_sptr>("OutputWorkspace", outputWS);
   createNormalizationWS(*outputWS);
   setProperty("OutputNormalizationWorkspace", m_normWS);

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -1,5 +1,6 @@
 #include "MantidMDAlgorithms/MDTransfQ3D.h"
 #include "MantidKernel/RegistrationHelper.h"
+#include "MantidKernel/ConfigService.h"
 
 namespace Mantid {
 namespace MDAlgorithms {

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -205,6 +205,8 @@ bool MDTransfQ3D::calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) {
 /** function initalizes all variables necessary for converting workspace
  * variables into MD variables in ModQ (elastic/inelastic) cases  */
 void MDTransfQ3D::initialize(const MDWSDescription &ConvParams) {
+  convention =
+        Kernel::ConfigService::Instance().getString("Q.convention");
   m_pEfixedArray = NULL;
   m_pDetMasks = NULL;
   //********** Generic part of initialization, common for elastic and inelastic

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -80,6 +80,12 @@ bool MDTransfQ3D::calcMatrixCoord3DInelastic(
   double qy = -m_ey * k_tr;
   double qz = m_Ki - m_ez * k_tr;
 
+  if (convention == "Crystallography") {
+    qx = -qx;
+    qy = -qy;
+    qz = -qz;
+  }
+
   Coord[0] = (coord_t)(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
   if (Coord[0] < m_DimMin[0] || Coord[0] >= m_DimMax[0])
     return false;
@@ -120,6 +126,12 @@ bool MDTransfQ3D::calcMatrixCoord3DElastic(const double &k0,
   double qx = -m_ex * k0;
   double qy = -m_ey * k0;
   double qz = (1 - m_ez) * k0;
+  if (convention == "Crystallography") {
+    qx = -qx;
+    qy = -qy;
+    qz = -qz;
+  }
+
   Coord[0] = (coord_t)(m_RotMat[0] * qx + m_RotMat[1] * qy + m_RotMat[2] * qz);
   if (Coord[0] < m_DimMin[0] || Coord[0] >= m_DimMax[0])
     return false;

--- a/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfQ3D.cpp
@@ -205,8 +205,7 @@ bool MDTransfQ3D::calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) {
 /** function initalizes all variables necessary for converting workspace
  * variables into MD variables in ModQ (elastic/inelastic) cases  */
 void MDTransfQ3D::initialize(const MDWSDescription &ConvParams) {
-  convention =
-        Kernel::ConfigService::Instance().getString("Q.convention");
+  convention = Kernel::ConfigService::Instance().getString("Q.convention");
   m_pEfixedArray = NULL;
   m_pDetMasks = NULL;
   //********** Generic part of initialization, common for elastic and inelastic

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -110,7 +110,7 @@ void SaveMD2::doSaveHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) {
   // ki-kf for Inelastic convention; kf-ki for Crystallography convention
   std::string m_QConvention =
       Kernel::ConfigService::Instance().getString("Q.convention");
-  file->writeData("QConvention", m_QConvention);
+  file->putAttr("QConvention", m_QConvention);
 
   // Write out the visual normalization
   file->writeData("visual_normalization",

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -14,6 +14,7 @@
 #include "MantidDataObjects/MDHistoWorkspace.h"
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
+#include "MantidKernel/ConfigService.h"
 
 // clang-format off
 #if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
@@ -104,6 +105,12 @@ void SaveMD2::doSaveHisto(Mantid::DataObjects::MDHistoWorkspace_sptr ws) {
   // Write out the coordinate system
   file->writeData("coordinate_system",
                   static_cast<uint32_t>(ws->getSpecialCoordinateSystem()));
+
+  // Write out the Qconvention
+  // ki-kf for Inelastic convention; kf-ki for Crystallography convention
+  std::string m_QConvention =
+      Kernel::ConfigService::Instance().getString("Q.convention");
+  file->writeData("QConvention", m_QConvention);
 
   // Write out the visual normalization
   file->writeData("visual_normalization",

--- a/Framework/MDAlgorithms/src/TransformMD.cpp
+++ b/Framework/MDAlgorithms/src/TransformMD.cpp
@@ -94,6 +94,21 @@ void TransformMD::doTransform(
 }
 
 //----------------------------------------------------------------------------------------------
+/** Swap the array elements
+*
+* @param array :: signal array
+*/
+void TransformMD::reverse(signal_t *array, size_t arrayLength)
+{
+  for (size_t i = 0; i < (arrayLength / 2); i++)
+  {
+    signal_t temp = array[i];
+    array[i] = array[(arrayLength - 1) - i];
+    array[(arrayLength - 1) - i] = temp;
+  }
+}
+
+//----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
  */
 void TransformMD::exec() {
@@ -149,6 +164,14 @@ void TransformMD::exec() {
   if (histo) {
     // Recalculate all the values since the dimensions changed.
     histo->cacheValues();
+    if (m_scaling[0] < 0.0){
+      signal_t *signals = histo->getSignalArray();
+      signal_t *errorsSq = histo->getErrorSquaredArray();
+
+      this->reverse(signals, histo->getNPoints());
+      this->reverse(errorsSq, histo->getNPoints());
+    }
+
     this->setProperty("OutputWorkspace", histo);
   } else if (event) {
     // Call the method for this type of MDEventWorkspace.

--- a/Framework/MDAlgorithms/src/TransformMD.cpp
+++ b/Framework/MDAlgorithms/src/TransformMD.cpp
@@ -5,6 +5,7 @@
 #include "MantidAPI/IMDEventWorkspace.h"
 #include "MantidDataObjects/MDEventWorkspace.h"
 #include "MantidDataObjects/MDEventFactory.h"
+#include "MantidGeometry/MDGeometry/IMDDimension.h"
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;
@@ -101,6 +102,7 @@ void TransformMD::exec() {
 
   inWS = getProperty("InputWorkspace");
   outWS = getProperty("OutputWorkspace");
+  std::string outName = getPropertyValue("OutputWorkspace");
 
   if (boost::dynamic_pointer_cast<MatrixWorkspace>(inWS))
     throw std::runtime_error("TransformMD can only transform a "
@@ -147,12 +149,64 @@ void TransformMD::exec() {
   if (histo) {
     // Recalculate all the values since the dimensions changed.
     histo->cacheValues();
+    this->setProperty("OutputWorkspace", histo);
   } else if (event) {
     // Call the method for this type of MDEventWorkspace.
     CALL_MDEVENT_FUNCTION(this->doTransform, outWS);
-  }
+    Progress *prog2 = NULL;
+    ThreadScheduler *ts = new ThreadSchedulerFIFO();
+    ThreadPool tp(ts, 0, prog2);
+    event->splitAllIfNeeded(ts);
+    // prog2->resetNumSteps( ts->size(), 0.4, 0.6);
+    tp.joinAll();
+    event->refreshCache();
+    // Set the special coordinate system.
+    IMDEventWorkspace_sptr inEvent =
+        boost::dynamic_pointer_cast<IMDEventWorkspace>(inWS);
+    event->setCoordinateSystem(inEvent->getSpecialCoordinateSystem());
 
-  this->setProperty("OutputWorkspace", outWS);
+    if (m_scaling[0] < 0) {
+      // Only need these 2 algorithms for transforming with negative number
+      std::vector<double> extents;
+      std::vector<std::string> names, units;
+      for (size_t d = 0; d < nd; d++) {
+        Geometry::IMDDimension_const_sptr dim = event->getDimension(d);
+        // Find the extents
+        extents.push_back(dim->getMinimum());
+        extents.push_back(dim->getMaximum());
+        names.push_back(std::string(dim->getName()));
+        units.push_back(dim->getUnits());
+      }
+      Algorithm_sptr create_alg = createChildAlgorithm("CreateMDWorkspace");
+      create_alg->setProperty("Dimensions", static_cast<int>(nd));
+      create_alg->setProperty("EventType", event->getEventTypeName());
+      create_alg->setProperty("Extents", extents);
+      create_alg->setProperty("Names", names);
+      create_alg->setProperty("Units", units);
+      create_alg->setPropertyValue("OutputWorkspace", "__none");
+      create_alg->executeAsChildAlg();
+      Workspace_sptr none = create_alg->getProperty("OutputWorkspace");
+
+      AnalysisDataService::Instance().addOrReplace(outName, event);
+      AnalysisDataService::Instance().addOrReplace("__none", none);
+      Mantid::API::BoxController_sptr boxController = event->getBoxController();
+      std::vector<int> splits;
+      for (size_t d = 0; d < nd; d++) {
+        splits.push_back(static_cast<int>(boxController->getSplitInto(d)));
+      }
+      Algorithm_sptr merge_alg = createChildAlgorithm("MergeMD");
+      merge_alg->setPropertyValue("InputWorkspaces", outName + ",__none");
+      merge_alg->setProperty("SplitInto", splits);
+      merge_alg->setProperty(
+          "SplitThreshold",
+          static_cast<int>(boxController->getSplitThreshold()));
+      merge_alg->setProperty("MaxRecursionDepth", 13);
+      merge_alg->executeAsChildAlg();
+      event = merge_alg->getProperty("OutputWorkspace");
+      AnalysisDataService::Instance().remove("__none");
+    }
+    this->setProperty("OutputWorkspace", event);
+  }
 }
 
 } // namespace Mantid

--- a/Framework/MDAlgorithms/src/TransformMD.cpp
+++ b/Framework/MDAlgorithms/src/TransformMD.cpp
@@ -97,11 +97,10 @@ void TransformMD::doTransform(
 /** Swap the array elements
 *
 * @param array :: signal array
+* @param arrayLength :: length of signal array
 */
-void TransformMD::reverse(signal_t *array, size_t arrayLength)
-{
-  for (size_t i = 0; i < (arrayLength / 2); i++)
-  {
+void TransformMD::reverse(signal_t *array, size_t arrayLength) {
+  for (size_t i = 0; i < (arrayLength / 2); i++) {
     signal_t temp = array[i];
     array[i] = array[(arrayLength - 1) - i];
     array[(arrayLength - 1) - i] = temp;
@@ -164,7 +163,7 @@ void TransformMD::exec() {
   if (histo) {
     // Recalculate all the values since the dimensions changed.
     histo->cacheValues();
-    if (m_scaling[0] < 0.0){
+    if (m_scaling[0] < 0.0) {
       signal_t *signals = histo->getSignalArray();
       signal_t *errorsSq = histo->getErrorSquaredArray();
 

--- a/Framework/MDAlgorithms/test/ChangeQConventionTest.h
+++ b/Framework/MDAlgorithms/test/ChangeQConventionTest.h
@@ -42,12 +42,10 @@ public:
     // There are this many boxes, so this is the max ID.
     TS_ASSERT_EQUALS(ws->getBoxController()->getMaxId(), 1001);
 
-
     ChangeQConvention alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setPropertyValue("InputWorkspace", wsName));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("InputWorkspace", wsName));
     alg.execute();
     TS_ASSERT(alg.isExecuted());
 
@@ -55,7 +53,5 @@ public:
     TS_ASSERT_EQUALS("Crystallography", ws2->getConvention());
   }
 };
-
-
 
 #endif /* MANTID_MDEVENTS_ChangeQConventionTEST_H_ */

--- a/Framework/MDAlgorithms/test/ChangeQConventionTest.h
+++ b/Framework/MDAlgorithms/test/ChangeQConventionTest.h
@@ -1,0 +1,61 @@
+#ifndef MANTID_MDEVENTS_ChangeQConventionTEST_H_
+#define MANTID_MDEVENTS_ChangeQConventionTEST_H_
+
+#include "MantidAPI/IMDEventWorkspace.h"
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidDataObjects/MDEventFactory.h"
+#include "MantidMDAlgorithms/BinMD.h"
+#include "MantidMDAlgorithms/ChangeQConvention.h"
+#include "MantidTestHelpers/MDEventsTestHelper.h"
+
+#include <cxxtest/TestSuite.h>
+
+#include <Poco/File.h>
+
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace Mantid::MDAlgorithms;
+
+class ChangeQConventionTest : public CxxTest::TestSuite {
+public:
+  void test_Init() {
+    ChangeQConvention alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+
+    Mantid::Kernel::ConfigService::Instance().setString("Q.convention",
+                                                        "Inelastic");
+    std::string wsName = "ChangeQConventionTest_ws";
+    // Make a 3D MDEventWorkspace
+    MDEventWorkspace3Lean::sptr ws =
+        MDEventsTestHelper::makeMDEW<3>(10, 0.0, 10.0, 1);
+    // Make sure it is split
+    ws->splitBox();
+
+    AnalysisDataService::Instance().addOrReplace(wsName, ws);
+
+    ws->refreshCache();
+
+    // There are this many boxes, so this is the max ID.
+    TS_ASSERT_EQUALS(ws->getBoxController()->getMaxId(), 1001);
+
+
+    ChangeQConvention alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("InputWorkspace", wsName));
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+
+    auto ws2 = AnalysisDataService::Instance().retrieveWS<IMDWorkspace>(wsName);
+    TS_ASSERT_EQUALS("Crystallography", ws2->getConvention());
+  }
+};
+
+
+
+#endif /* MANTID_MDEVENTS_ChangeQConventionTEST_H_ */

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -15,6 +15,10 @@ default.facility = ISIS
 # Set a default instrument
 default.instrument =
 
+# This flag controls the convention for converting to Q.  Default is ki-kf
+# Change to Crystallography for kf-ki
+Q.convention = Inelastic
+
 # Set of PyQt interfaces to add to the Interfaces menu, separated by a space.  Interfaces are seperated from their respective categories by a "/".
 mantidqt.python_interfaces = Direct/DGS_Reduction.py Direct/DGSPlanner.py SANS/ORNL_SANS.py Reflectometry/REFL_Reduction.py Reflectometry/REFL_SF_Calculator.py Reflectometry/REFM_Reduction.py Utility/TofConverter.py Reflectometry/ISIS_Reflectometry.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_Powder_Diffraction_Reduction.py Diffraction/HFIR_4Circle_Reduction.py
 

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -690,6 +690,14 @@ void ConfigDialog::initMantidPage()
   ckIgnoreParaView->setChecked(ignoreParaView);
   grid->addWidget(ckIgnoreParaView, 3, 0);
 
+  //Change to Crystallography Convention
+  ckQconvention = new QCheckBox("Crystallography Convention");
+  ckQconvention->setToolTip("Change from default ki-kf to kf-ki.");
+  const std::string QconventionProperty = "Q.convention";
+  bool Qconvention =  cfgSvc.hasProperty(QconventionProperty) && bool(cfgSvc.getString(QconventionProperty) == "Crystallography");
+  ckQconvention->setChecked(Qconvention);
+  grid->addWidget(ckQconvention, 4, 0);
+
   // Populate boxes
   auto faclist =  cfgSvc.getFacilityNames();
   for ( auto it = faclist.begin(); it != faclist.end(); ++it )
@@ -2464,6 +2472,10 @@ void ConfigDialog::apply()
    cfgSvc.setString("default.facility", facility->currentText().toStdString());
    cfgSvc.setString("default.instrument", defInstr->currentText().toStdString());
    cfgSvc.setString("paraview.ignore", QString::number(ckIgnoreParaView->isChecked()).toStdString());
+   if (ckQconvention->isChecked())
+     cfgSvc.setString("Q.convention", "Crystallography");
+   else
+     cfgSvc.setString("Q.convention", "Inelastic");
 
 
   updateDirSearchSettings();

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -188,6 +188,7 @@ private:
   QComboBox *facility;
   MantidQt::MantidWidgets::InstrumentSelector  *defInstr;
   QCheckBox* ckIgnoreParaView;
+  QCheckBox* ckQconvention;
 
   /// Mantid tab for setting directories
   QWidget *directoriesPage;

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -701,6 +701,12 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
     // MDEWs)
     coord_t min = m_ws->getDimension(d)->getMinimum();
     coord_t max = m_ws->getDimension(d)->getMaximum();
+    if (max < min)
+    {
+      coord_t tmp = max;
+      max = min;
+      min = tmp;
+    }
     if (boost::math::isnan(min) || boost::math::isinf(min) ||
         boost::math::isnan(max) || boost::math::isinf(max)) {
       mess << "Dimension " << m_ws->getDimension(d)->getName()

--- a/docs/source/algorithms/ChangeQConvention-v1.rst
+++ b/docs/source/algorithms/ChangeQConvention-v1.rst
@@ -9,6 +9,9 @@
 Description
 -----------
 This algorithm changes the sign of Q and the label of the workspace convention.
+This should only be used on MD workspaces that contain only Q or HKL dimensions.  If there are other dimensions,
+user should still run this algorithm (so that the convention flag is changed), but then run TransformMD with -1 
+for the non-Q dimensions.
 
 
 Usage

--- a/docs/source/algorithms/ChangeQConvention-v1.rst
+++ b/docs/source/algorithms/ChangeQConvention-v1.rst
@@ -1,0 +1,16 @@
+.. algorithm::
+
+.. summary::
+
+.. alias::
+
+.. properties::
+
+Description
+-----------
+
+This algorithm changes the sign of Q and the label of the workspace convention.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/ChangeQConvention-v1.rst
+++ b/docs/source/algorithms/ChangeQConvention-v1.rst
@@ -8,8 +8,31 @@
 
 Description
 -----------
-
 This algorithm changes the sign of Q and the label of the workspace convention.
+
+
+Usage
+-----
+
+**Example - an example of running ChangeQConvention with PointGroup option.**
+
+.. testcode:: ExChangeQConventionOption
+
+    mdws = LoadMD('MAPS_MDEW.nxs')
+    dim = mdws.getXDimension()
+    print "X range of Q ",dim.getX(0),dim.getX(1)
+    ChangeQConvention(mdws)
+    mdws = mtd['mdws']
+    dim = mdws.getXDimension()
+    print "X range of Q after ChangeQConvention ",dim.getX(0),dim.getX(1)
+
+Output:
+
+.. testoutput:: ExChangeQConventionOption
+
+    X range of Q  0.0 10.0
+    X range of Q after ChangeQConvention  -10.0 0.0
+
 
 .. categories::
 

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -43,19 +43,23 @@ General properties
 Facility and instrument properties
 **********************************
 
-+------------------------------+---------------------------------------------------+-------------+
-|Property                      |Description                                        |Example value|
-+==============================+===================================================+=============+
-|default.facility              |The name of the default facility. The facility must| ISIS        |
-|                              |be defined within the facilites.xml file to be     |             |
-|                              |considered valid. The file is described here.      |             |
-|                              |:ref:`here <Facilities file>`.                     |             |
-+------------------------------+---------------------------------------------------+-------------+
-|default.instrument            |The name of the default instrument. The instrument | WISH        |
-|                              |must be defined within the facilities.xml file to  |             |
-|                              |be valid. The file is described                    |             |
-|                              |:ref:`here <Facilities file>`.                     |             |
-+------------------------------+---------------------------------------------------+-------------+
++------------------------------+---------------------------------------------------+-----------------+
+|Property                      |Description                                        |Example value    |
++==============================+===================================================+=================+
+|default.facility              |The name of the default facility. The facility must| ISIS            |
+|                              |be defined within the facilites.xml file to be     |                 |
+|                              |considered valid. The file is described here.      |                 |
+|                              |:ref:`here <Facilities file>`.                     |                 |
++------------------------------+---------------------------------------------------+-----------------+
+|default.instrument            |The name of the default instrument. The instrument | WISH            |
+|                              |must be defined within the facilities.xml file to  |                 |
+|                              |be valid. The file is described                    |                 |
+|                              |:ref:`here <Facilities file>`.                     |                 |
++------------------------------+---------------------------------------------------+-----------------+
+|Q.convention                  |The convention for converting to Q. For inelastic  | Crystallography |
+|                              |the convention is ki-kf.  For Crystallography the  |                 |
+|                              |convention is kf-ki.                               |                 |
++------------------------------+---------------------------------------------------+-----------------+
 
 Directory Properties
 ********************

--- a/tools/DefaultConfigFiles/Mantid.user.properties
+++ b/tools/DefaultConfigFiles/Mantid.user.properties
@@ -31,6 +31,10 @@ default.facility=
 ## e.g. IRIS, HET, NIMROD
 default.instrument=
 
+# This flag controls the convention for converting to Q.  Default is ki-kf
+# Change to Crystallography for kf-ki
+Q.convention = Inelastic
+
 ##
 ## DIRECTORIES
 ##


### PR DESCRIPTION
Fixes #12863

To test run crystallography algorithms before and after setting Crystallography convention in the preferences and make sure the sign of Q3D and HKL changes. Added to release notes.
