### PR TITLE
Indirect Moments Clear Preview plot on new data entry

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/IndirectMoments.cpp
@@ -107,19 +107,30 @@ namespace CustomInterfaces
     return true;
   }
 
-  void IndirectMoments::handleSampleInputReady(const QString& filename)
-  {
-    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(updateProperties(QtProperty*, double)));
+  /**
+   * Clears previous plot data (in both preview and raw plot) and sets the new
+   * range bars
+   */
+  void IndirectMoments::handleSampleInputReady(const QString &filename) {
+    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+               SLOT(updateProperties(QtProperty *, double)));
 
+    // Clears previous plotted data
     m_uiForm.ppRawPlot->clear();
+    m_uiForm.ppMomentsPreview->clear();
+
+    // Update plot and change data in interface
     m_uiForm.ppRawPlot->addSpectrum("Raw", filename, 0);
     QPair<double, double> range = m_uiForm.ppRawPlot->getCurveRange("Raw");
 
     auto xRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("XRange");
-    setRangeSelector(xRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
-    setPlotPropertyRange(xRangeSelector, m_properties["EMin"], m_properties["EMax"], range);
+    setRangeSelector(xRangeSelector, m_properties["EMin"], m_properties["EMax"],
+                     range);
+    setPlotPropertyRange(xRangeSelector, m_properties["EMin"],
+                         m_properties["EMax"], range);
 
-    connect(m_dblManager, SIGNAL(valueChanged(QtProperty*, double)), this, SLOT(updateProperties(QtProperty*, double)));
+    connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+            SLOT(updateProperties(QtProperty *, double)));
   }
 
   /**


### PR DESCRIPTION
Fixes #14802

The preview plot should now be cleared as well as the raw plot being updated in the Moments interface in Indirect Reduction
- **Files for testing can be found at: `\\olympic\Babylon5\Public\ElliotOram\DataReduction\Moments`**
# To Test
- Change the default instrument in Mantid to be IRIS (View > Preferences > Mantid > Default Instrument)
- Open Moments (Interfaces > Indirect >  Data Reduction > Moments)
- Input the `deltaE_010_sqw.nxs` file and ensure the raw plot (right of the property tree) updates
- Click `Run` and ensure the preview plot updates
- Change the input file to `deltaE_005_sqw.nxs' and ensure the raw plot updates and the preview plot is cleared.
