### PR TITLE
Indirect Corrections ContainerSubtraction multi workspace

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -220,13 +220,13 @@ bool ContainerSubtraction::validate() {
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             m_uiForm.dsContainer->getCurrentDataName().toStdString());
 
-    // Check Sample is of same type as container
+    // Check Sample is of same type as container (e.g. _red/_sqw)
     QString sample = m_uiForm.dsSample->getCurrentDataName();
     QString sampleType =
         sample.right(sample.length() - sample.lastIndexOf("_"));
     QString container = m_uiForm.dsContainer->getCurrentDataName();
     QString containerType =
-        container.right(sample.length() - container.lastIndexOf("_"));
+        container.right(container.length() - container.lastIndexOf("_"));
 
     g_log.debug() << "Sample type is: " << sampleType.toStdString()
                   << std::endl;

--- a/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ContainerSubtraction.cpp
@@ -212,21 +212,13 @@ bool ContainerSubtraction::validate() {
       uiv.checkDataSelectorIsValid("Container", m_uiForm.dsContainer);
 
   if (samValid && canValid) {
-    // Get Workspaces
-    MatrixWorkspace_sptr sampleWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            m_uiForm.dsSample->getCurrentDataName().toStdString());
-    MatrixWorkspace_sptr containerWs =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            m_uiForm.dsContainer->getCurrentDataName().toStdString());
-
     // Check Sample is of same type as container (e.g. _red/_sqw)
-    QString sample = m_uiForm.dsSample->getCurrentDataName();
-    QString sampleType =
-        sample.right(sample.length() - sample.lastIndexOf("_"));
-    QString container = m_uiForm.dsContainer->getCurrentDataName();
-    QString containerType =
-        container.right(container.length() - container.lastIndexOf("_"));
+    const QString sampleName = m_uiForm.dsSample->getCurrentDataName();
+    const QString sampleType =
+        sampleName.right(sampleName.length() - sampleName.lastIndexOf("_"));
+    const QString containerName = m_uiForm.dsContainer->getCurrentDataName();
+    const QString containerType = containerName.right(
+        containerName.length() - containerName.lastIndexOf("_"));
 
     g_log.debug() << "Sample type is: " << sampleType.toStdString()
                   << std::endl;
@@ -236,6 +228,14 @@ bool ContainerSubtraction::validate() {
     if (containerType != sampleType)
       uiv.addErrorMessage(
           "Sample and can workspaces must contain the same type of data.");
+
+    // Get Workspaces for histogram checking
+    MatrixWorkspace_sptr sampleWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            sampleName.toStdString());
+    MatrixWorkspace_sptr containerWs =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            containerName.toStdString());
 
     // Check sample has the same number of Histograms as the contianer
     const size_t sampleHist = sampleWs->getNumberHistograms();


### PR DESCRIPTION
Fixes #14858

It should now be possible to use multi workspaces as well as normal workspaces
- **Files for testing can be found at:`\\olympic\babylon5\Public\ElliotOram\Corrections\ContainerSubtraction\iris_hist17`**
# To Test
- Open ContainerSubtraction (Interfaces > Indirect > Corrections > ContainerSubtraction)
- Sample = `iris26176_multi_graphite002_red.nxs`
- Container = `iris26174_graphite002_red.nxs`
- Click `Run`
  - Ensure that the algorithm completes and produces the following preview plot:
    ![image](https://cloud.githubusercontent.com/assets/13132128/12086554/3be4c35a-b2c3-11e5-8969-a784ca322b1f.png)
