### PR TITLE
Make importing TBL file into Reflectometry (Polref) more user friendly

### DIFF
--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -324,7 +324,6 @@ void QtReflMainView::tableUpdated(const QModelIndex &topLeft,
   Q_UNUSED(topLeft);
   Q_UNUSED(bottomRight);
   m_presenter->notify(IReflPresenter::TableUpdatedFlag);
-
 }
 
 /**

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -462,7 +462,10 @@ void QtReflMainView::showImportDialog() {
   // otherwise this should be an empty string.
   QString outputWorkspaceName =
       runPythonCode(QString::fromStdString(pythonSrc.str()), false);
-  m_toOpen = outputWorkspaceName.trimmed();
+  m_toOpen = outputWorkspaceName.trimmed().toStdString();
+  // notifying the presenter that a new table should be opened
+  // The presenter will ask about any unsaved changes etc
+  // before opening the new table
   m_presenter->notify(ReflMainViewPresenter::OpenTableFlag);
 }
 

--- a/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
+++ b/MantidQt/CustomInterfaces/src/Reflectometry/QtReflMainView.cpp
@@ -97,6 +97,10 @@ void QtReflMainView::showTable(QReflTableModel_sptr model) {
           SLOT(tableUpdated(const QModelIndex &, const QModelIndex &)));
   ui.viewTable->setModel(m_model.get());
   ui.viewTable->resizeColumnsToContents();
+  std::string windowTitle = "ISIS Reflectometry (Polref) - " + m_toOpen;
+  auto mainWindowWidget = this->topLevelWidget();
+  mainWindowWidget->setWindowTitle(QString::fromStdString(windowTitle + "[*]"));
+  this->setWindowModified(false);
 }
 
 /**
@@ -320,6 +324,7 @@ void QtReflMainView::tableUpdated(const QModelIndex &topLeft,
   Q_UNUSED(topLeft);
   Q_UNUSED(bottomRight);
   m_presenter->notify(IReflPresenter::TableUpdatedFlag);
+
 }
 
 /**
@@ -458,7 +463,8 @@ void QtReflMainView::showImportDialog() {
   // otherwise this should be an empty string.
   QString outputWorkspaceName =
       runPythonCode(QString::fromStdString(pythonSrc.str()), false);
-  this->setModel(outputWorkspaceName.trimmed());
+  m_toOpen = outputWorkspaceName.trimmed();
+  m_presenter->notify(ReflMainViewPresenter::OpenTableFlag);
 }
 
 /**


### PR DESCRIPTION
The changes made to the importing of TBL files into the GUI are:
- Display name of the table in the main window title i.e 'ISIS Reflectometry (Polref) - _table name here_ '
- When importing another table, if there are unsaved changes to the current table, the user is warned via a dialog box

**To test:**

Before testing make sure you have the data from `SampleData-ISIS` which can be downloaded from [here](http://sourceforge.net/projects/mantid/files/Sample%20Data/SampleData-ISIS.zip/download)
- Manage your data directories to point to the location of `INTER_NR.tbl` found inside `SampleData-ISIS`
- Go to Interfaces -> Reflectometry -> ISIS Reflectometry (Polref)
- Click `Reflectometry` on the menu bar of the interface
- Click `Import .TBL`
- Load the `INTER_NR.tbl` file from `SampleData-ISIS` and give it a workspace name
- Make sure the table is loaded straight into the processing table (right hand side table)
- Ensure the workspace name you gave it is now present in the window title
- Change some of the values that are in the table (just so they are different)
- Repeat the loading step but give the workspace a different name 
- Ensure a pop-up dialog appears asking you whether you are sure you want to load the table and discard any unsaved changes
- Click `No` and make sure the dialog does not reappear
- Try to load the table again (go to Open table option on the Reflectometry menu), but click `Yes` on the dialog this time
- Make sure table has been loaded and the name of that table has replaced the previous name in the window title bar.

**Release notes** http://www.mantidproject.org/Release_Notes_3_6_Reflectometry

Fixes #14758 
