### PR TITLE
Workflow diagram added for SANSStitch Algorithm

### DIFF
--- a/docs/source/algorithms/SANSStitch-v1.rst
+++ b/docs/source/algorithms/SANSStitch-v1.rst
@@ -43,6 +43,11 @@ Merging of front and rear banks for the can is achieved using a different form f
 
 where *C* denotes counts, *N* denotes normalization and *f* and *r* relate to forward (high-angle) and rear (low-angle) respectively. The can workspace is subtracted from the merged sample workspace to generate the output.
 
+Workflow
+########
+
+.. diagram:: SANSStitch-v1_wkflw.dot
+
 Usage
 -----
 

--- a/docs/source/diagrams/SANSStitch-v1_wkflw.dot
+++ b/docs/source/diagrams/SANSStitch-v1_wkflw.dot
@@ -81,13 +81,13 @@ digraph SansStitch {
     hABNormSample -> divideHABSample;
     lABCountsSample -> divideLABSample;
     lABNormSample -> divideLABSample;
-    divideLABSample -> valQLAB;
-    divideHABSample -> valQHAB;
+    divideLABSample -> valQLAB  [label="If can is not processed."];
+    divideHABSample -> valQHAB  [label="If can is not processed."];
     processCan -> checkProcessCan;
     divideHABSample -> subtractCanHAB;
     divideLABSample -> subtractCanLAB;
-    subtractCanHAB -> valQHAB;
-    subtractCanLAB -> valQLAB;
+    subtractCanHAB -> valQHAB  [label="If can is processed."];
+    subtractCanLAB -> valQLAB  [label="If can is processed."];
     checkProcessCan -> readCanInputs  [label="yes"];
     mode -> checkModeForFit;
     checkModeForFit -> sansFitShiftScale  [label="yes"];
@@ -111,8 +111,8 @@ digraph SansStitch {
     lABCountsSample -> calculateMergedQ;
     lABNormSample -> calculateMergedQ;
     calculateMergedQ -> subtractMerged;
-    calculateMergedQ -> mergedQ
-    subtractMerged -> mergedQ;
+    calculateMergedQ -> mergedQ  [label="If can is processed."];
+    subtractMerged -> mergedQ  [label="If can is not processed."];
     mergedQ -> errorCorrection;
     errorCorrection -> outputWorkspace;
 }

--- a/docs/source/diagrams/SANSStitch-v1_wkflw.dot
+++ b/docs/source/diagrams/SANSStitch-v1_wkflw.dot
@@ -1,8 +1,9 @@
 digraph SansStitch {
     label="SANSStitch Flowchart";
+    $global_style
+
     subgraph params {
-        $global_style
-        
+        $param_style
         hABCountsSample [label="HABCountsSample"];
         lABCountsSample [label="LABCountsSample"];
         hABNormSample [label="HABNormSample"];
@@ -22,19 +23,12 @@ digraph SansStitch {
 
     subgraph decisions {
         $decision_style
-        
-        node [shape=diamond, 
-              fillcolor=limegreen];
         checkProcessCan [label="Process the can?"];
         checkModeForFit [label="Mode Requires Fitting"];
     }
 
     subgraph algorithms {
         $algorithm_style
-    
-        node [shape=rectangle, 
-              style="rounded,filled", 
-              fillcolor=lightskyblue];
         divideHABSample [label="Divide\nHAB sample\ncounts/normalization"];
         divideLABSample [label="Divide\nLAB sample\ncounts/normalization"];
         divideHABCan [label="Divide\nHAB can\ncounts/normalization"];
@@ -46,9 +40,6 @@ digraph SansStitch {
 
     subgraph processes {
         $process_style
-       
-        node [shape=rectangle, 
-              fillcolor=lightseagreen];
         errorCorrection [label="Error Correction Merged Workspace"];
         calculateMergedQ [label="Calculate Merged Q"];
         readCanInputs [label="Read Can Inputs"];

--- a/docs/source/diagrams/SANSStitch-v1_wkflw.dot
+++ b/docs/source/diagrams/SANSStitch-v1_wkflw.dot
@@ -1,0 +1,115 @@
+digraph SansStitch {
+    label="SANSStitch Flowchart";
+    subgraph params {
+        $global_style
+        
+        hABCountsSample [label="HABCountsSample"];
+        lABCountsSample [label="LABCountsSample"];
+        hABNormSample [label="HABNormSample"];
+        lABNormSample [label="LABNormSample"];
+        hABCountsCan [label="HABCountsCan"];
+        lABCountsCan [label="LABCountsCan"];
+        hABNormCan [label="HABNormCan"];
+        lABNormCan [label="LABNormCan"];
+        processCan [label="ProcessCan"];
+        scaleFactor [label="ScaleFactor"];
+        shiftFactor [label="ShiftFactor"];
+        outputWorkspace [label="OutputWorkspace"];
+        outScaleFactor [label="OutScaleFactor"];
+        outShiftFactor [label="OutShiftFactor"];
+        mode [label="Mode"];
+    }
+
+    subgraph decisions {
+        $decision_style
+        
+        node [shape=diamond, 
+              fillcolor=limegreen];
+        checkProcessCan [label="Process the can?"];
+        checkModeForFit [label="Mode Requires Fitting"];
+    }
+
+    subgraph algorithms {
+        $algorithm_style
+    
+        node [shape=rectangle, 
+              style="rounded,filled", 
+              fillcolor=lightskyblue];
+        divideHABSample [label="Divide\nHAB sample\ncounts/normalization"];
+        divideLABSample [label="Divide\nLAB sample\ncounts/normalization"];
+        divideHABCan [label="Divide\nHAB can\ncounts/normalization"];
+        divideLABCan [label="Divide\nLAB can\ncounts/normalization"];
+        subtractCanHAB [label="Subtract"];
+        subtractCanLAB [label="Subtract"];
+        sansFitShiftScale [label="SANSFitShiftScale"];
+    }
+
+    subgraph processes {
+        $process_style
+       
+        node [shape=rectangle, 
+              fillcolor=lightseagreen];
+        errorCorrection [label="Error Correction Merged Workspace"];
+        calculateMergedQ [label="Calculate Merged Q"];
+        readCanInputs [label="Read Can Inputs"];
+        copyShiftFactor [label="Copy Shift Factor"];
+        copyScaleFactor [label="Copy Scale Factor"];
+    }
+
+    subgraph cluster {
+        color=blue;
+        label="Can Processing";
+        node [style=filled];
+        readCanInputs -> hABCountsCan;
+        readCanInputs -> lABCountsCan;
+        readCanInputs -> hABNormCan;
+        readCanInputs -> lABNormCan;
+        hABCountsCan -> divideHABCan;
+        hABNormCan -> divideHABCan;
+        lABCountsCan -> divideLABCan;
+        lABNormCan -> divideLABCan;
+        divideHABCan -> subtractCanHAB;
+        divideLABCan -> subtractCanLAB;
+    }
+
+    subgraph values {
+        $value_style
+        valQLAB [label="LAB Normalized"];
+        valQHAB [label="HAB Normalized"];
+    }
+
+    hABCountsSample -> divideHABSample;
+    hABNormSample -> divideHABSample;
+    lABCountsSample -> divideLABSample;
+    lABNormSample -> divideLABSample;
+    divideLABSample -> valQLAB;
+    divideHABSample -> valQHAB;
+    processCan -> checkProcessCan;
+    divideHABSample -> subtractCanHAB;
+    divideLABSample -> subtractCanLAB;
+    subtractCanHAB -> valQHAB;
+    subtractCanLAB -> valQLAB;
+    checkProcessCan -> readCanInputs  [label="yes"];
+    mode -> checkModeForFit;
+    checkModeForFit -> sansFitShiftScale  [label="yes"];
+    valQHAB -> sansFitShiftScale;
+    valQLAB -> sansFitShiftScale;
+    scaleFactor -> sansFitShiftScale;
+    shiftFactor -> sansFitShiftScale;
+    sansFitShiftScale -> outShiftFactor;
+    sansFitShiftScale -> outScaleFactor;
+    checkModeForFit -> copyScaleFactor  [label="no"];
+    checkModeForFit -> copyShiftFactor  [label="no"];
+    scaleFactor -> copyScaleFactor;
+    shiftFactor -> copyShiftFactor;
+    copyScaleFactor -> outScaleFactor;
+    copyShiftFactor -> outShiftFactor;
+    outScaleFactor -> calculateMergedQ;
+    outShiftFactor -> calculateMergedQ;
+    hABCountsSample -> calculateMergedQ;
+    hABNormSample -> calculateMergedQ;
+    lABCountsSample -> calculateMergedQ;
+    lABNormSample -> calculateMergedQ;
+    calculateMergedQ -> errorCorrection;
+    errorCorrection -> outputWorkspace;
+}

--- a/docs/source/diagrams/SANSStitch-v1_wkflw.dot
+++ b/docs/source/diagrams/SANSStitch-v1_wkflw.dot
@@ -36,12 +36,14 @@ digraph SansStitch {
         subtractCanHAB [label="Subtract"];
         subtractCanLAB [label="Subtract"];
         sansFitShiftScale [label="SANSFitShiftScale"];
+        subtractMerged [label="Subtract"];
     }
 
     subgraph processes {
         $process_style
         errorCorrection [label="Error Correction Merged Workspace"];
         calculateMergedQ [label="Calculate Merged Q"];
+        calculateMergedQCan [label="Calculate Merged Q Can"];
         readCanInputs [label="Read Can Inputs"];
         copyShiftFactor [label="Copy Shift Factor"];
         copyScaleFactor [label="Copy Scale Factor"];
@@ -61,12 +63,18 @@ digraph SansStitch {
         lABNormCan -> divideLABCan;
         divideHABCan -> subtractCanHAB;
         divideLABCan -> subtractCanLAB;
+        hABCountsCan -> calculateMergedQCan;
+        hABNormCan -> calculateMergedQCan;
+        lABCountsCan -> calculateMergedQCan;
+        lABNormCan -> calculateMergedQCan;
+        calculateMergedQCan -> subtractMerged;
     }
 
     subgraph values {
         $value_style
         valQLAB [label="LAB Normalized"];
         valQHAB [label="HAB Normalized"];
+        mergedQ [label="Merged"];
     }
 
     hABCountsSample -> divideHABSample;
@@ -97,10 +105,14 @@ digraph SansStitch {
     copyShiftFactor -> outShiftFactor;
     outScaleFactor -> calculateMergedQ;
     outShiftFactor -> calculateMergedQ;
+    outScaleFactor -> calculateMergedQCan;
     hABCountsSample -> calculateMergedQ;
     hABNormSample -> calculateMergedQ;
     lABCountsSample -> calculateMergedQ;
     lABNormSample -> calculateMergedQ;
-    calculateMergedQ -> errorCorrection;
+    calculateMergedQ -> subtractMerged;
+    calculateMergedQ -> mergedQ
+    subtractMerged -> mergedQ;
+    mergedQ -> errorCorrection;
     errorCorrection -> outputWorkspace;
 }


### PR DESCRIPTION
Fixes #14870

Previously no workflow diagram for this DataProcessor algorithm.

**Tester** a.k.a Anton: Check the generated workflow diagram.
