### PR TITLE
Colour scale autoscaling in SliceViewer and ColorFill plots

### DIFF
--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -968,6 +968,10 @@ void Graph::enableAutoscaling(bool yes) {
       d_plot->setAxisScaleDiv(i, *d_plot->axisScaleDiv(i));
     }
   }
+  // Propagate this to spectrogram
+  if (spectrogram()) {
+    spectrogram()->setColorMapAutoScale(yes);
+  }
 }
 
 void Graph::setAutoScale() {

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -871,6 +871,9 @@ void MantidUI::showSliceViewer()
       w->getSlicer()->setTransparentZeros(false);
     }
 
+    // Global option for color bar autoscaling
+    w->getSlicer()->setColorBarAutoScale(m_appWindow->autoscale2DPlots);
+
     // Connect the MantidPlot close() event with the the window's close().
     QObject::connect(appWindow(), SIGNAL(destroyed()), w, SLOT(close()));
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3419,6 +3419,14 @@ MultiLayer* MantidUI::drawSingleColorFillPlot(const QString & wsName, Graph::Cur
 
   appWindow()->setSpectrogramTickStyle(plot);
   plot->setAutoScale();
+  /* The 'setAutoScale' above is needed to make sure that the plot initially
+   * encompasses all the data points. However, this has the side-effect
+   * suggested by its name: all the axes become auto-scaling if the data
+   * changes. If, in the plot preferences, autoscaling has been disabled then
+   * the next line re-fixes the axes
+   */
+  if (!appWindow()->autoscale2DPlots)
+    plot->enableAutoscaling(false);
 
   QApplication::restoreOverrideCursor();
   return window;

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -114,8 +114,14 @@ public:
   void setMantidColorMap(const MantidColorMap &map);
   void updateData(Matrix *m);
   void updateData(const Mantid::API::IMDWorkspace_const_sptr & workspace);
-  MantidQt::API::QwtRasterDataMD *dataFromWorkspace(const Mantid::API::IMDWorkspace_const_sptr & workspace);
+  MantidQt::API::QwtRasterDataMD *
+  dataFromWorkspace(const Mantid::API::IMDWorkspace_const_sptr &workspace,
+                    const QwtDoubleInterval *range = nullptr);
   void postDataUpdate();
+  /// Set autoscale on/off for color scale (default: on)
+  void setColorMapAutoScale(bool autoscale = true) {
+    d_color_map_autoscale = autoscale;
+  }
 
   ColorMapPolicy colorMapPolicy()const{return color_map_policy;};
 
@@ -201,6 +207,8 @@ protected:
   QList <PlotMarker *> d_labels_list;
   //! Keeps track of the plot marker on which the user clicked when selecting the labels.
   PlotMarker *d_selected_label;
+  //! Flag for whether we autoscale color bar
+  bool d_color_map_autoscale;
 
   //! Keep track of the coordinates of the point where the user clicked when selecting the labels.
   double d_click_pos_x, d_click_pos_y;

--- a/MantidPlot/src/Spectrogram.h
+++ b/MantidPlot/src/Spectrogram.h
@@ -207,8 +207,6 @@ protected:
   QList <PlotMarker *> d_labels_list;
   //! Keeps track of the plot marker on which the user clicked when selecting the labels.
   PlotMarker *d_selected_label;
-  //! Flag for whether we autoscale color bar
-  bool d_color_map_autoscale;
 
   //! Keep track of the coordinates of the point where the user clicked when selecting the labels.
   double d_click_pos_x, d_click_pos_y;
@@ -228,6 +226,8 @@ protected:
   std::vector<unsigned char> mScaledValues;
   /// boolean flag to indicate intensity changed
   bool m_bIntensityChanged;
+  /// Flag for whether we autoscale color bar
+  bool d_color_map_autoscale;
 };
 
 class SpectrogramData: public QwtRasterData

--- a/MantidQt/Python/mantidqt.sip
+++ b/MantidQt/Python/mantidqt.sip
@@ -1137,6 +1137,16 @@ Mantid::API::MDNormalization SliceViewer::getNormalization()
         the current normalization
 %End
 
+  void setColorBarAutoScale(bool autoscale);
+%Docstring
+void SliceViewer::setColorBarAutoScale(bool autoscale)
+------------------------------------------------------
+    Set autoscaling for the color scale on or off
+	
+	Args:
+	    autoscale :: on/off status for autoscaling
+
+%End
 
   //*WIKI* ==== Dynamic Rebinning ====
   void setRebinThickness(int dim, double thickness)   throw (std::runtime_error);

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.h
@@ -78,6 +78,8 @@ public:
   void setExponent(double);
   double getExponent();
 
+  void setAutoScale(bool autoscale);
+  bool getAutoScale() const;
 
 public slots:
   void changedMinimum();

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>102</width>
-    <height>286</height>
+    <width>184</width>
+    <height>306</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -68,6 +68,13 @@
        </property>
        <property name="accelerated">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="autoScale">
+       <property name="text">
+        <string>Autoscale</string>
        </property>
       </widget>
      </item>

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/SliceViewer.h
@@ -113,6 +113,7 @@ public:
   void toggleLineMode(bool);
   void setNormalization(Mantid::API::MDNormalization norm, bool update=true);
   Mantid::API::MDNormalization getNormalization() const;
+  void setColorBarAutoScale(bool autoscale);
 
   /// Dynamic Rebinning-related Python bindings
   void setRebinThickness(int dim, double thickness);

--- a/MantidQt/SliceViewer/src/ColorBarWidget.cpp
+++ b/MantidQt/SliceViewer/src/ColorBarWidget.cpp
@@ -367,7 +367,20 @@ void ColorBarWidget::updateMinMaxGUI()
   ui.valMax->setValue( m_max );
 }
 
+/**
+ * Sets the state of the "Autoscale" checkbox
+ * @param autoscale :: [input] Autoscale on/off
+ */
+void ColorBarWidget::setAutoScale(bool autoscale) {
+  ui.autoScale->setChecked(autoscale);
+  updateColorMap();
+}
 
+/**
+ * Gets the state of the "Autoscale" checkbox
+ * @returns Whether the box is checked or not
+ */
+bool ColorBarWidget::getAutoScale() const { return ui.autoScale->isChecked(); }
 
 ColorBarWidget::~ColorBarWidget()
 {

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -736,9 +736,13 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   // Build up the widgets
   this->updateDimensionSliceWidgets();
 
-  // Find the full range. And use it
-  findRangeFull();
-  m_colorBar->setViewRange(m_colorRangeFull);
+  // Only autoscale color bar if box is checked
+  if (m_colorBar->getAutoScale()) {
+    // Find the full range. And use it
+    findRangeFull();
+    m_colorBar->setViewRange(m_colorRangeFull);
+    m_colorBar->updateColorMap();
+  }
   // Initial display update
   this->updateDisplay(
       !m_firstWorkspaceOpen /*Force resetting the axes, the first time*/);
@@ -2519,6 +2523,14 @@ void SliceViewer::dropEvent(QDropEvent *e) {
       this->setPeaksWorkspaces(wsNames);
     }
   }
+}
+
+/**
+ * Set autoscaling for the color bar on or off
+ * @param autoscale :: [input] On/off status for autoscaling
+ */
+void SliceViewer::setColorBarAutoScale(bool autoscale) {
+  m_colorBar->setAutoScale(autoscale);
 }
 
 } // namespace


### PR DESCRIPTION
Resolves #14818 

Linked to discussion in #14834 

When the SliceViewer or a Color Fill plot is being used to visualise live data, the user's manually set colour scale should not be reset every time the data is updated. This PR enables the autoscaling of the colour bar to be disabled.

_Color fill plots_
The global option under `View > Preferences > 2D Plots > Autoscale` is used to determine whether or not the colour scale will rescale automatically. 

_SliceViewer_
A checkbox is placed on the UI to control autoscaling. The checkbox takes its default state from the global config option as above.

**Test**
- Start a fake live data listener as [here](http://www.mantidproject.org/MBC_Live_Data_Simple_Examples), e.g. ISIS_Histogram.

**_1. Color fill plot**_
- Launch a colour fill plot from the workspace containing live data
- Change the colour scale and check whether it remains the same when new data arrives
- Repeat with the `View > Preferences > 2D Plots > Autoscale` option toggled. Verify that the behaviour is different.

**_2. SliceViewer**_
- Launch the SliceViewer from the workspace containing live data
- Check that the state of the "Autoscale" checkbox matches the global option
- Change the colour scale with "Autoscale" checked and verify the scale is reset when more data comes in
- Uncheck "Autoscale" and repeat. Verify that the scale is not reset.

**To do:**
- [x] Update release notes
