### PR TITLE
Fix crash with UpdateInstrumentFromFile for a DetectorGroup

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/UpdateInstrumentFromFile.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/UpdateInstrumentFromFile.h
@@ -112,6 +112,9 @@ private:
 
   /// Parse the header and fill the headerInfo struct
   bool parseAsciiHeader(AsciiFileHeader &headerInfo);
+  /// Set a new detector parameter
+  void setDetectorParameter(const Geometry::IDetector_const_sptr &det,
+                            const std::string &name, double value);
   /// Set the new detector positions
   void setDetectorPositions(const std::vector<int32_t> &detID,
                             const std::vector<float> &l2,

--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ComponentHelper.h"
+#include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidKernel/NexusDescriptor.h"
 #include "LoadRaw/isisraw2.h"
 
@@ -268,8 +269,7 @@ void UpdateInstrumentFromFile::updateFromAscii(const std::string &filename) {
       else if (i == header.phiColIdx)
         phi = value;
       else if (header.detParCols.count(i) == 1) {
-        Geometry::ParameterMap &pmap = m_workspace->instrumentParameters();
-        pmap.addDouble(det->getComponentID(), header.colToName[i], value);
+        setDetectorParameter(det, header.colToName[i], value);
       }
     }
     // Check stream state. stringstream::EOF should have been reached, if not
@@ -349,6 +349,27 @@ bool UpdateInstrumentFromFile::parseAsciiHeader(
 }
 
 /**
+ * Attaches a detector parameter to the given detector
+ * @param det A pointer to the detector object
+ * @param name The name of the parameter
+ * @param value Value of the parameter
+ */
+void UpdateInstrumentFromFile::setDetectorParameter(
+    const Geometry::IDetector_const_sptr &det, const std::string &name,
+    double value) {
+  Geometry::ParameterMap &pmap = m_workspace->instrumentParameters();
+  if (auto group =
+          boost::dynamic_pointer_cast<const Geometry::DetectorGroup>(det)) {
+    auto dets = group->getDetectors();
+    for (const auto &comp : dets) {
+      pmap.addDouble(comp->getComponentID(), name, value);
+    }
+  } else {
+    pmap.addDouble(det->getComponentID(), name, value);
+  }
+}
+
+/**
  * Set the detector positions given the r,theta and phi.
  * @param detID :: A vector of detector IDs
  * @param l2 :: A vector of l2 distances
@@ -397,8 +418,17 @@ void UpdateInstrumentFromFile::setDetectorPosition(
     det->getPos().getSpherical(r, t, p);
     pos.spherical(l2, theta, p);
   }
-  Geometry::ComponentHelper::moveComponent(*det, pmap, pos,
-                                           Geometry::ComponentHelper::Absolute);
+  if (auto group =
+          boost::dynamic_pointer_cast<const Geometry::DetectorGroup>(det)) {
+    auto dets = group->getDetectors();
+    for (const auto &element : dets) {
+      Geometry::ComponentHelper::moveComponent(
+          *element, pmap, pos, Geometry::ComponentHelper::Absolute);
+    }
+  } else {
+    Geometry::ComponentHelper::moveComponent(
+        *det, pmap, pos, Geometry::ComponentHelper::Absolute);
+  }
 }
 
 } // namespace DataHandling


### PR DESCRIPTION
Fixes #14917

**Tester**
Review the code and also run the script that is given in the related issue to check that it no longer crashes.

The release notes have been updated [here](http://www.mantidproject.org/ReleaseNotes_3_6_Framework_Changes#Improved).
