### PR TITLE
Clean up LoadVesuvio

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadEmptyVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadEmptyVesuvio.py
@@ -1,7 +1,6 @@
 #pylint: disable=no-init
 from mantid.kernel import *
 from mantid.api import *
-import mantid.simpleapi as ms
 
 import os
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadEmptyVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadEmptyVesuvio.py
@@ -61,11 +61,13 @@ class LoadEmptyVesuvio(PythonAlgorithm):
         inst_file = os.path.join(inst_dir, "VESUVIO_Definition.xml")
 
         # Load the instrument
-        vesuvio_ws = ms.LoadEmptyInstrument(Filename=inst_file,
-                                            OutputWorkspace=self.getPropertyValue(WKSP_PROP),
-                                            EnableLogging=_LOGGING_)
+        load_empty = self.createChildAlgorithm("LoadEmptyInstrument")
+        load_empty.setLogging(_LOGGING_)
+        load_empty.setProperty("Filename", inst_file)
+        load_empty.setProperty("OutputWorkspace", self.getPropertyValue(WKSP_PROP))
+        load_empty.execute()
 
-        return vesuvio_ws
+        return load_empty.getProperty("OutputWorkspace").value
 
 #----------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -252,7 +252,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         """
 
         if mode == "DoubleDifference":
-            if (not back_scattering):
+            if not back_scattering:
                 raise RuntimeError("Double Difference can only be used for Back scattering spectra")
 
 #----------------------------------------------------------------------------------------
@@ -325,7 +325,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
             Loads an empty VESUVIO instrument and attaches the necessary
             parameters as attributes
         """
-        if(self._load_common_called):
+        if self._load_common_called:
             return
         isis = config.getFacility("ISIS")
         empty_vesuvio_ws = self._load_empty_evs()

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -348,7 +348,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
             return
 
         isis = config.getFacility("ISIS")
-        empty_vesuvio_ws = LoadEmptyVesuvio()
+        empty_vesuvio_ws = self._load_empty_evs()
         empty_vesuvio = empty_vesuvio_ws.getInstrument()
 
         def to_int_list(str_param):
@@ -393,7 +393,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
         self._forw_period_sum1 = to_range_tuple(self.forward_period_sum1)
         self._forw_period_sum2 = to_range_tuple(self.forward_period_sum2)
         self._forw_foil_out_norm = to_range_tuple(self.forward_foil_out_norm)
-        ms.DeleteWorkspace(Workspace="empty_vesuvio_ws")
         self._load_common_called = True
 
 #----------------------------------------------------------------------------------------

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -150,24 +150,35 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
         # Validate SpectrumList
         speclist_str = self.getProperty(SPECTRA_PROP).value
+        # Check ranges
         if "-" in speclist_str:
             lower, upper = speclist_str.split("-")
             lower = int(lower)
             upper = int(upper)
+            # Check format
             if upper < lower:
                 issues[SPECTRA_PROP] = "Range must be in format lower-upper"
+            # Check Min/Max boundaries
             if lower < 3:
                 issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
             if upper > 198:
                 issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
+            # Check forward/backward mixing
             if lower < 135 and upper > 134:
                 issues[SPECTRA_PROP] = "Mixing backward and forward spectra is not permitted"
+        # Check comma separated lists
         if "," in speclist_str:
             spectra_list = speclist_str.split(",")
-            map(int, spectra_list)
+            scattering = int(spectra_list[0]) < 135 # Check scattering of first spectra
             for spec in spectra_list:
+                spec = int(spec)
+                # Check Min/Max boundaries
                 if spec < 3 or spec > 198:
-                    issues[SPECTRA_PROP] = "Invalid Spectra. All Spectra must be between 3 and 198"
+                    issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198"
+                # Check forward/backward mixing
+                spec_scattering = spec < 135
+                if spec_scattering != scattering:
+                    issues[SPECTRA_PROP] = "Mixing backward and forward spectra is not permitted"
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -250,10 +250,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
         SingleDifference - Forward Scattering
         DoubleDifference - Back Scattering
         """
-        if mode == "SingleDifference":
-            if(back_scattering):
-                raise RuntimeError("Single Difference can only be used for Forward scattering spectra")
-        elif mode == "DoubleDifference":
+
+        if mode == "DoubleDifference":
             if (not back_scattering):
                 raise RuntimeError("Double Difference can only be used for Back scattering spectra")
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -165,7 +165,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 # Split ranges
                 spectra_list = spectra_grp.split("-")
                 # Validate format
-                issues = self._validate_range_formatting(spectra_list[0], spectra_list[0], SPECTRA_PROP, issues)
+                issues = self._validate_range_formatting(spectra_list[0], spectra_list[1], SPECTRA_PROP, issues)
             elif "," in spectra_grp:
                 # Split comma separated lists
                 spectra_list = spectra_grp.split(",")
@@ -199,7 +199,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         # Only validate boundaries if in difference Mode
         if "Difference" in self.getProperty(MODE_PROP).value:
             specMin = self._backward_spectra_list[0]
-            specMax = self._forward_spectra_list[len(self._forward_spectra_list) - 1]
+            specMax = self._forward_spectra_list[-1]
             if spectra < specMin:
                 issues[SPECTRA_PROP] = ("Lower limit for spectra is %d in difference mode" % specMin)
             if spectra > specMax:

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -163,22 +163,14 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
             if upper > 198:
                 issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
-            # Check forward/backward mixing
-            if lower < 135 and upper > 134:
-                issues[SPECTRA_PROP] = "Mixing backward and forward spectra is not permitted"
         # Check comma separated lists
         if "," in speclist_str:
             spectra_list = speclist_str.split(",")
-            scattering = int(spectra_list[0]) < 135 # Check scattering of first spectra
             for spec in spectra_list:
                 spec = int(spec)
                 # Check Min/Max boundaries
                 if spec < 3 or spec > 198:
                     issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198"
-                # Check forward/backward mixing
-                spec_scattering = spec < 135
-                if spec_scattering != scattering:
-                    issues[SPECTRA_PROP] = "Mixing backward and forward spectra is not permitted"
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -912,9 +912,15 @@ class LoadVesuvio(LoadEmptyVesuvio):
 class SpectraToFoilPeriodMap(object):
     """Defines the mapping between a spectrum number
     & the period index into a WorkspaceGroup for a foil state.
-    2 period only runs in forward scattering - odd_even & even_odd
-    3 period only runs in back scattering - one_to_one
-    6 period runs in both backward and forward scattering
+    2 period :: forward scattering
+    3 period :: back scattering
+    6 period :: back & forward scattering
+
+    one_to_one          :: Only used in back scattering where there is a single
+                           static foil
+    odd_even/even_odd   :: Only used in forward scatter models when the foil
+                           is/isn't infront of each detector. First bank 135-142
+                           is odd_even, second (143-150) is even_odd and so on.
     """
 
     def __init__(self, nperiods=6):

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -39,6 +39,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
     foil_map = None
     _inst_prefix = None
     _back_scattering = None
+    _load_common_called = False
     _mon_spectra = None
     _mon_index = None
     _backward_spectra_list = None
@@ -140,6 +141,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
 #----------------------------------------------------------------------------------------
 
     def validateInputs(self):
+        self._load_common_inst_parameters()
         issues = {}
 
         # Validate run number ranges
@@ -152,7 +154,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
         # Validate SpectrumList
         speclists_str = self.getProperty(SPECTRA_PROP).value
-
+        specMin = self._backward_spectra_list[0]
+        specMax = self._forward_spectra_list[len(self._forward_spectra_list) - 1]
         if ";" in speclists_str:
             # Split if in 2-3;6-7 format
             speclists_str = speclists_str.split(";")
@@ -169,9 +172,9 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 if upper < lower:
                     issues[SPECTRA_PROP] = "Range must be in format lower-upper"
                 # Check Min/Max boundaries
-                if lower < 3:
+                if lower < specMin:
                     issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
-                if upper > 198:
+                if upper > specMax:
                     issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
             # Check comma separated lists
             if "," in speclist_str:
@@ -179,12 +182,11 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 for spec in spectra_list:
                     spec = int(spec)
                     # Check Min/Max boundaries
-                    if spec < 3 or spec > 198:
+                    if spec < specMin or spec > specMax:
                         issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198"
 
         return issues
 
-#----------------------------------------------------------------------------------------
 
 #----------------------------------------------------------------------------------------
 
@@ -325,6 +327,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
             Loads an empty VESUVIO instrument and attaches the necessary
             parameters as attributes
         """
+        if(self._load_common_called):
+            return
         isis = config.getFacility("ISIS")
         empty_vesuvio_ws = self._load_empty_evs()
         empty_vesuvio = empty_vesuvio_ws.getInstrument()
@@ -371,6 +375,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         self._forw_period_sum1 = to_range_tuple(self.forward_period_sum1)
         self._forw_period_sum2 = to_range_tuple(self.forward_period_sum2)
         self._forw_foil_out_norm = to_range_tuple(self.forward_foil_out_norm)
+        self._load_common_called = True
 
 #----------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -908,13 +908,10 @@ class SpectraToFoilPeriodMap(object):
     def __init__(self, nperiods=6):
         """Constructor. For nperiods seet up the mappings"""
         if nperiods == 2:
-            self._one_to_one = {1:1, 2:2}
             self._odd_even =  {1:1, 2:3}
             self._even_odd =  {1:2, 2:4}
         elif nperiods == 3:
             self._one_to_one = {1:1, 2:2, 3:3}
-            self._odd_even =   {1:1, 2:3, 3:5}
-            self._even_odd =   {1:2, 2:4, 3:6}
         elif nperiods == 6:
             self._one_to_one = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6}
             self._odd_even =   {1:1, 2:3, 3:5, 4:2, 5:4, 6:6}

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -154,6 +154,16 @@ class LoadVesuvio(LoadEmptyVesuvio):
             lower, upper = speclist_str.split("-")
             if upper < lower:
                 issues[SPECTRA_PROP] = "Range must be in format lower-upper"
+            if lower < 3:
+                issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
+            if upper > 198:
+                issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
+        elif "," in speclist_str:
+            spectra_list = speclist_str.split(",")
+            logger.information("spectra_list = " + str(spectra_list))
+            for spec in spectra_list:
+                if int(spec) < 3 or int(spec) > 198:
+                    issues[SPECTRA_PROP] = "Invalid Spectra. All Spectra must be between 3 and 198"
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -151,28 +151,36 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
 
         # Validate SpectrumList
-        speclist_str = self.getProperty(SPECTRA_PROP).value
-        # Check ranges
-        if "-" in speclist_str:
-            lower, upper = speclist_str.split("-")
-            lower = int(lower)
-            upper = int(upper)
-            # Check format
-            if upper < lower:
-                issues[SPECTRA_PROP] = "Range must be in format lower-upper"
-            # Check Min/Max boundaries
-            if lower < 3:
-                issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
-            if upper > 198:
-                issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
-        # Check comma separated lists
-        if "," in speclist_str:
-            spectra_list = speclist_str.split(",")
-            for spec in spectra_list:
-                spec = int(spec)
+        speclists_str = self.getProperty(SPECTRA_PROP).value
+
+        if ";" in speclists_str:
+            # Split if in 2-3;6-7 format
+            speclists_str = speclists_str.split(";")
+        else:
+            # Treat spec as a list
+            speclists_str = [speclists_str]
+
+        for speclist_str in speclists_str:
+            if "-" in speclist_str:
+                lower, upper = speclist_str.split("-")
+                lower = int(lower)
+                upper = int(upper)
+                # Check format
+                if upper < lower:
+                    issues[SPECTRA_PROP] = "Range must be in format lower-upper"
                 # Check Min/Max boundaries
-                if spec < 3 or spec > 198:
-                    issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198"
+                if lower < 3:
+                    issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
+                if upper > 198:
+                    issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
+            # Check comma separated lists
+            if "," in speclist_str:
+                spectra_list = speclist_str.split(",")
+                for spec in spectra_list:
+                    spec = int(spec)
+                    # Check Min/Max boundaries
+                    if spec < 3 or spec > 198:
+                        issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198"
 
         return issues
 
@@ -223,6 +231,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         Assumes that the spectra is sorted sorted
         """
         if len(spectra) == 1:
+            self._back_scattering = self._is_back_scattering(spectra[0])
             return
         all_back = self._is_back_scattering(spectra[0])
         for spec_no in spectra[1:]:

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -60,7 +60,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
     _raw_grp = None
     _raw_monitors = None
     _nperiods = None
-    _goodframes = None
     pt_times = None
     delta_t = None
     mon_pt_times = None
@@ -380,7 +379,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
         first_ws = self._raw_grp[0]
         self._nperiods = nperiods
-        self._goodframes = first_ws.getRun().getLogData("goodfrm").value
 
         # Cache delta_t values
         raw_t = first_ws.readX(0)
@@ -626,10 +624,6 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 foil_out_periods = (4,5,6)
                 foil_thin_periods = (1,2,3)
                 foil_thick_periods = (1,2)
-        elif self._nperiods == 9:
-            foil_out_periods = (7,8,9)
-            foil_thin_periods = (4,5,6)
-            foil_thick_periods = (1,2,3)
         else:
             pass
 
@@ -882,13 +876,9 @@ class SpectraToFoilPeriodMap(object):
             self._one_to_one = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6}
             self._odd_even =   {1:1, 2:3, 3:5, 4:2, 5:4, 6:6}
             self._even_odd =   {1:2, 2:4, 3:6, 4:1, 5:3, 6:5}
-        elif nperiods == 9:
-            self._one_to_one = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8, 9:9}
-            self._odd_even =   {1:1, 2:3, 3:5, 4:2, 5:4, 6:6, 7:7, 8:8, 9:9}
-            self._even_odd =   {1:2, 2:4, 3:6, 4:1, 5:3, 6:5, 7:7, 8:8, 9:9}
         else:
             raise RuntimeError("Unsupported number of periods given: " + str(nperiods) +
-                               ". Supported number of periods=2,3,6,9")
+                               ". Supported number of periods=2,3,6")
 
 #----------------------------------------------------------------------------------------
 
@@ -958,7 +948,7 @@ class SpectraToFoilPeriodMap(object):
         Returns a tuple of indices that can be used to access the Workspace within
         a WorkspaceGroup that corresponds to the foil state numbers given
         @param spectrum_no :: A spectrum number (1->nspectra)
-        @param foil_state_no :: A number between 1 & 9(inclusive) that defines which foil
+        @param foil_state_no :: A number between 1 & 6(inclusive) that defines which foil
                                 state is required
         @returns A tuple of indices in a WorkspaceGroup that gives the associated Workspace
         """
@@ -973,7 +963,7 @@ class SpectraToFoilPeriodMap(object):
         """Returns an index that can be used to access the Workspace within
         a WorkspaceGroup that corresponds to the foil state given
             @param spectrum_no :: A spectrum number (1->nspectra)
-            @param foil_state_no :: A number between 1 & 9(inclusive) that defines which
+            @param foil_state_no :: A number between 1 & 6(inclusive) that defines which
                                         foil state is required
             @returns The index in a WorkspaceGroup that gives the associated Workspace
         """
@@ -999,9 +989,9 @@ class SpectraToFoilPeriodMap(object):
 #----------------------------------------------------------------------------------------
 
     def _validate_foil_number(self, foil_number):
-        if foil_number < 1 or foil_number > 9:
+        if foil_number < 1 or foil_number > 6:
             raise ValueError("Invalid foil state given, expected a number between "
-                             "1 and 9. number=%d" % foil_number)
+                             "1 and 6. number=%d" % foil_number)
 
 #----------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -148,7 +148,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         run_str = self.getProperty(RUN_PROP).value
         if "-" in run_str:
             lower, upper = run_str.split("-")
-            issues = self._validate_range_formatting(upper, lower, RUN_PROP, issues)
+            issues = self._validate_range_formatting(lower, upper, RUN_PROP, issues)
 
         # Validate SpectrumList
         grp_spectra_list = self.getProperty(SPECTRA_PROP).value
@@ -182,10 +182,12 @@ class LoadVesuvio(LoadEmptyVesuvio):
 
 #----------------------------------------------------------------------------------------
 
-    def _validate_range_formatting(self, upper, lower, property_name, issues):
+    def _validate_range_formatting(self, lower, upper, property_name, issues):
         """
         Validates is a range style input is in the correct form of lower-upper
         """
+        upper = int(upper)
+        lower = int(lower)
         if upper < lower:
             issues[property_name] = "Range must be in format lower-upper"
         return issues

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -172,18 +172,20 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 if upper < lower:
                     issues[SPECTRA_PROP] = "Range must be in format lower-upper"
                 # Check Min/Max boundaries
-                if lower < specMin:
-                    issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
-                if upper > specMax:
-                    issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
+                if "Difference" in self.getProperty(MODE_PROP).value:
+                    if lower < specMin:
+                        issues[SPECTRA_PROP] = "Lower limit for spectra is 3 in difference mode"
+                    if upper > specMax:
+                        issues[SPECTRA_PROP] = "Upper limit for spectra is 198 in difference mode"
             # Check comma separated lists
             if "," in speclist_str:
-                spectra_list = speclist_str.split(",")
-                for spec in spectra_list:
-                    spec = int(spec)
-                    # Check Min/Max boundaries
-                    if spec < specMin or spec > specMax:
-                        issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198"
+                if "Difference" in self.getProperty(MODE_PROP).value:
+                    spectra_list = speclist_str.split(",")
+                    for spec in spectra_list:
+                        spec = int(spec)
+                        # Check Min/Max boundaries
+                        if spec < specMin or spec > specMax:
+                            issues[SPECTRA_PROP] = "All Spectra must be between 3 and 198 in difference mode"
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -156,7 +156,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
             # Split on ';' if in form of 2-3;6-7
             grp_spectra_list = grp_spectra_list.split(";")
         else:
-            # Treat input as a list
+            # Treat input as a list (for use in loop)
             grp_spectra_list = [grp_spectra_list]
 
         for spectra_grp in grp_spectra_list:
@@ -170,8 +170,8 @@ class LoadVesuvio(LoadEmptyVesuvio):
                 # Split comma separated lists
                 spectra_list = spectra_grp.split(",")
             else:
-                # Single spectra
-                spectra_list = spectra_grp
+                # Single spectra (put into list for use in loop)
+                spectra_list = [spectra_grp]
 
             # Validate boundaries
             for spec in spectra_list:

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -141,12 +141,19 @@ class LoadVesuvio(LoadEmptyVesuvio):
     def validateInputs(self):
         issues = {}
 
-        # Validtae run number ranges
+        # Validate run number ranges
         run_str = self.getProperty(RUN_PROP).value
         if "-" in run_str:
             lower, upper = run_str.split("-")
             if upper < lower:
                 issues[RUN_PROP] = "Range must be in format lower-upper"
+
+        # Validate SpectrumList
+        speclist_str = self.getProperty(SPECTRA_PROP).value
+        if "-" in speclist_str:
+            lower, upper = speclist_str.split("-")
+            if upper < lower:
+                issues[SPECTRA_PROP] = "Range must be in format lower-upper"
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -329,8 +329,9 @@ class LoadVesuvio(LoadEmptyVesuvio):
         """
         if self._load_common_called:
             return
+
         isis = config.getFacility("ISIS")
-        empty_vesuvio_ws = self._load_empty_evs()
+        empty_vesuvio_ws = LoadEmptyVesuvio()
         empty_vesuvio = empty_vesuvio_ws.getInstrument()
 
         def to_int_list(str_param):
@@ -375,6 +376,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         self._forw_period_sum1 = to_range_tuple(self.forward_period_sum1)
         self._forw_period_sum2 = to_range_tuple(self.forward_period_sum2)
         self._forw_foil_out_norm = to_range_tuple(self.forward_foil_out_norm)
+        ms.DeleteWorkspace(Workspace="empty_vesuvio_ws")
         self._load_common_called = True
 
 #----------------------------------------------------------------------------------------

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -152,17 +152,21 @@ class LoadVesuvio(LoadEmptyVesuvio):
         speclist_str = self.getProperty(SPECTRA_PROP).value
         if "-" in speclist_str:
             lower, upper = speclist_str.split("-")
+            lower = int(lower)
+            upper = int(upper)
             if upper < lower:
                 issues[SPECTRA_PROP] = "Range must be in format lower-upper"
             if lower < 3:
                 issues[SPECTRA_PROP] = "Lower limit for spectra is 3"
             if upper > 198:
                 issues[SPECTRA_PROP] = "Upper limit for spectra is 198"
-        elif "," in speclist_str:
+            if lower < 135 and upper > 134:
+                issues[SPECTRA_PROP] = "Mixing backward and forward spectra is not permitted"
+        if "," in speclist_str:
             spectra_list = speclist_str.split(",")
-            logger.information("spectra_list = " + str(spectra_list))
+            map(int, spectra_list)
             for spec in spectra_list:
-                if int(spec) < 3 or int(spec) > 198:
+                if spec < 3 or spec > 198:
                     issues[SPECTRA_PROP] = "Invalid Spectra. All Spectra must be between 3 and 198"
 
         return issues

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -38,6 +38,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
     _spectrum_no = None
     foil_map = None
     _inst_prefix = None
+    _back_scattering = None
     _mon_spectra = None
     _mon_index = None
     _backward_spectra_list = None
@@ -148,6 +149,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
             if upper < lower:
                 issues[RUN_PROP] = "Range must be in format lower-upper"
 
+
         # Validate SpectrumList
         speclist_str = self.getProperty(SPECTRA_PROP).value
         # Check ranges
@@ -185,6 +187,7 @@ class LoadVesuvio(LoadEmptyVesuvio):
         try:
             all_spectra = [item for sublist in self._spectra for item in sublist]
             self._raise_error_if_mix_fwd_back(all_spectra)
+            self._raise_error_if_non_valid_mode(self._diff_opt, self._back_scattering)
             self._set_spectra_type(all_spectra[0])
             self._setup_raw(all_spectra)
             self._create_foil_workspaces()
@@ -226,6 +229,22 @@ class LoadVesuvio(LoadEmptyVesuvio):
             if all_back and self._is_fwd_scattering(spec_no):
                 raise RuntimeError("Mixing backward and forward spectra is not permitted."
                                    "Please correct the SpectrumList property.")
+        self._back_scattering = all_back
+
+#----------------------------------------------------------------------------------------
+
+    def _raise_error_if_non_valid_mode(self, mode, back_scattering):
+        """
+        Checks that the input are valid for the Mode of operation selected
+        SingleDifference - Forward Scattering
+        DoubleDifference - Back Scattering
+        """
+        if mode == "SingleDifference":
+            if(back_scattering):
+                raise RuntimeError("Single Difference can only be used for Forward scattering spectra")
+        elif mode == "DoubleDifference":
+            if (not back_scattering):
+                raise RuntimeError("Double Difference can only be used for Back scattering spectra")
 
 #----------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadVesuvio.py
@@ -912,6 +912,9 @@ class LoadVesuvio(LoadEmptyVesuvio):
 class SpectraToFoilPeriodMap(object):
     """Defines the mapping between a spectrum number
     & the period index into a WorkspaceGroup for a foil state.
+    2 period only runs in forward scattering - odd_even & even_odd
+    3 period only runs in back scattering - one_to_one
+    6 period runs in both backward and forward scattering
     """
 
     def __init__(self, nperiods=6):

--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -300,6 +300,16 @@ class VesuvioTests(unittest.TestCase):
         self.assertRaises(ValueError, ms.LoadVesuvio, Filename="14188",
                           OutputWorkspace=self.ws_name, Mode="",SpectrumList="3-134")
 
+    def test_back_scattering_spectra_with_single_difference_mode_raises_error(self):
+        self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188",
+                          Mode="SingleDifference",
+                          OutputWorkspace=self.ws_name, SpectrumList="10-20")
+
+    def test_forward_scattering_spectra_with_double_difference_mode_raises_error(self):
+        self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188",
+                          Mode="DoubleDifference",
+                          OutputWorkspace=self.ws_name, SpectrumList="140-150")
+
     def test_raising_error_removes_temporary_raw_workspaces(self):
         self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188,14199", # Second run is invalid
                           OutputWorkspace=self.ws_name, Mode="SingleDifference",SpectrumList="3-134")

--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -32,6 +32,20 @@ class VesuvioTests(unittest.TestCase):
         self._verify_correct_parameters_loaded(evs_raw, forward_scatter=False,
                                                diff_mode=diff_mode)
 
+    def test_load_with_back_scattering_spectra_produces_correct_workspace_using_single_difference(self):
+        diff_mode = "SingleDifference"
+        self._run_load("14188", "3-134", diff_mode)
+
+        # Check some data
+        evs_raw = mtd[self.ws_name]
+        self.assertAlmostEqual(0.10197619851290973, evs_raw.readY(0)[1], places=DIFF_PLACES)
+        self.assertAlmostEqual(0.13636377723938517, evs_raw.readE(0)[1], places=DIFF_PLACES)
+        self.assertAlmostEqual(0.053028031396861852, evs_raw.readY(131)[1188], places=DIFF_PLACES)
+        self.assertAlmostEqual(0.070808659911133845, evs_raw.readE(131)[1188], places=DIFF_PLACES)
+
+        self._verify_correct_parameters_loaded(evs_raw, forward_scatter=False,
+                                               diff_mode=diff_mode)
+
     def test_load_with_forward_scattering_spectra_produces_correct_workspace(self):
         diff_mode = "SingleDifference"
         self._run_load("14188", "135-198", diff_mode)
@@ -299,11 +313,6 @@ class VesuvioTests(unittest.TestCase):
     def test_load_with_difference_option_not_applicable_to_current_spectra_raises_error(self):
         self.assertRaises(ValueError, ms.LoadVesuvio, Filename="14188",
                           OutputWorkspace=self.ws_name, Mode="",SpectrumList="3-134")
-
-    def test_back_scattering_spectra_with_single_difference_mode_raises_error(self):
-        self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188",
-                          Mode="SingleDifference",
-                          OutputWorkspace=self.ws_name, SpectrumList="10-20")
 
     def test_forward_scattering_spectra_with_double_difference_mode_raises_error(self):
         self.assertRaises(RuntimeError, ms.LoadVesuvio, Filename="14188",

--- a/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
+++ b/Testing/SystemTests/tests/analysis/LoadVesuvioTest.py
@@ -32,20 +32,6 @@ class VesuvioTests(unittest.TestCase):
         self._verify_correct_parameters_loaded(evs_raw, forward_scatter=False,
                                                diff_mode=diff_mode)
 
-    def test_load_with_back_scattering_spectra_produces_correct_workspace_using_single_difference(self):
-        diff_mode = "SingleDifference"
-        self._run_load("14188", "3-134", diff_mode)
-
-        # Check some data
-        evs_raw = mtd[self.ws_name]
-        self.assertAlmostEqual(0.10197619851290973, evs_raw.readY(0)[1], places=DIFF_PLACES)
-        self.assertAlmostEqual(0.13636377723938517, evs_raw.readE(0)[1], places=DIFF_PLACES)
-        self.assertAlmostEqual(0.053028031396861852, evs_raw.readY(131)[1188], places=DIFF_PLACES)
-        self.assertAlmostEqual(0.070808659911133845, evs_raw.readE(131)[1188], places=DIFF_PLACES)
-
-        self._verify_correct_parameters_loaded(evs_raw, forward_scatter=False,
-                                               diff_mode=diff_mode)
-
     def test_load_with_forward_scattering_spectra_produces_correct_workspace(self):
         diff_mode = "SingleDifference"
         self._run_load("14188", "135-198", diff_mode)
@@ -113,16 +99,6 @@ class VesuvioTests(unittest.TestCase):
         evs_raw = mtd[self.ws_name]
         self.assertAlmostEqual(37594.0, evs_raw.readY(0)[1], places=DIFF_PLACES)
         self.assertAlmostEqual(193.89172236070317, evs_raw.readE(0)[1], places=DIFF_PLACES)
-
-    def test_using_ip_file_adjusts_instrument_and_attaches_parameters_difference_mode(self):
-        self._run_load("14188", "3", "SingleDifference", "IP0005.dat")
-
-        # Check some data
-        evs_raw = mtd[self.ws_name]
-        det0 = evs_raw.getDetector(0)
-        param = det0.getNumberParameter("t0")
-        self.assertEqual(1, len(param))
-        self.assertAlmostEqual(-0.4157, param[0], places=4)
 
     def test_using_ip_file_adjusts_instrument_and_attaches_parameters_foil_mode(self):
         self._run_load("14188", "3", "FoilOut", "IP0005.dat")


### PR DESCRIPTION
Fixes #14910

This issue has included:
- Removing 9 period case
- Improving validation
- Removing unused map options for 2 and 3 period cases
- Improving commenting
- Remove invalid tests and Adding new failure cases
# To Test
- Ensure tests pass and the changes to the tests look sensible
- Try to run `LoadVesuvio` with invalid values including incorrect scattering vs. modes of operation. Ensure that for these cases LoadVesuvio does not run
