### PR TITLE
Fix clang v3.7.1 warnings.

### DIFF
--- a/Framework/CurveFitting/src/Functions/ComptonProfile.cpp
+++ b/Framework/CurveFitting/src/Functions/ComptonProfile.cpp
@@ -17,8 +17,6 @@ namespace {
 ///@cond
 // const char * WSINDEX_NAME = "WorkspaceIndex";
 const char *MASS_NAME = "Mass";
-
-const double STDDEV_TO_HWHM = std::sqrt(std::log(4.0));
 ///@endcond
 }
 

--- a/Framework/PythonInterface/inc/MantidPythonInterface/api/PythonAlgorithm/DataProcessorAdapter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/api/PythonAlgorithm/DataProcessorAdapter.h
@@ -83,19 +83,12 @@ public:
       const std::string &propertyManager = std::string()) {
     return this->getProcessProperties(propertyManager);
   }
-  void setPropManagerPropName(const std::string &propName) {
-    this->setPropManagerPropName(propName);
-  }
-
-  void mapPropertyName(const std::string &nameInProp,
-                       const std::string &nameInPropManager) {
-    this->mapPropertyName(nameInProp, nameInPropManager);
-  }
 
   API::Workspace_sptr assembleProxy(const std::string &partialWSName,
                                     const std::string &outputWSName) {
     return this->assemble(partialWSName, outputWSName);
   }
+
   void saveNexusProxy(const std::string &outputWSName,
                       const std::string &outputFile) {
     this->saveNexus(outputWSName, outputFile);


### PR DESCRIPTION
This fixes #14927.

I removed the two member functions that currently cause an infinite recursion and don't appears to be exposed to python. I also removed an unused variable.

no release notes.

testing: code review.
