### PR TITLE
Python fit function attributes cannot be set from fit browser

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
@@ -59,7 +59,8 @@ public:
   void setAttribute(const std::string &attName,
                     const API::IFunction::Attribute &attr);
   /// Store the attribute's value in the default IFunction's cache
-  void storeAttributePythonValue(const std::string &name, const boost::python::object &value);
+  void storeAttributePythonValue(const std::string &name,
+                                 const boost::python::object &value);
 
   // Each overload of declareParameter requires a different name as we
   // can't use a function pointer with a virtual base class

--- a/Framework/PythonInterface/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
@@ -58,6 +58,8 @@ public:
   /// Called by the framework when an attribute has been set
   void setAttribute(const std::string &attName,
                     const API::IFunction::Attribute &attr);
+  /// Store the attribute's value in the default IFunction's cache
+  void storeAttributePythonValue(const std::string &name, const boost::python::object &value);
 
   // Each overload of declareParameter requires a different name as we
   // can't use a function pointer with a virtual base class

--- a/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -94,6 +94,9 @@ void export_FunctionFactory() {
       .def("createFunction", &FunctionFactoryImpl::createFunction,
            (arg("self"), arg("type")),
            "Return a pointer to the requested function")
+      .def("createInitialized", &FunctionFactoryImpl::createInitialized,
+           (arg("self"), arg("init_expr")),
+           "Return a pointer to the requested function")
       .def("subscribe", &subscribe, (arg("self"), arg("object")),
            "Register a Python class derived from IFunction into the factory")
       .def("unsubscribe", &FunctionFactoryImpl::unsubscribe,

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -119,6 +119,10 @@ void export_IFunction() {
            (arg("self"), arg("name")),
            "Return the value of the named attribute")
 
+      .def("storeAttributeValue", &IFunctionAdapter::storeAttributePythonValue,
+           (arg("self"), arg("name"), arg("value")),
+           "Store an attribute value in the default cache")
+
       .def("declareParameter", &IFunctionAdapter::declareFitParameter,
            (arg("self"), arg("name"), arg("init_value"), arg("description")),
            "Declare a fitting parameter settings its default value & "

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -14,10 +14,12 @@ namespace {
 
 /**
  * Create an Attribute from a python value.
- * @param value :: A value python object. Allowed python types: float,int,str,bool.
+ * @param value :: A value python object. Allowed python types:
+ * float,int,str,bool.
  * @return :: The created attribute.
  */
-Mantid::API::IFunction::Attribute createAttributeFromPythonValue(const object &value) {
+Mantid::API::IFunction::Attribute
+createAttributeFromPythonValue(const object &value) {
   PyObject *rawptr = value.ptr();
   Mantid::API::IFunction::Attribute attr;
 
@@ -135,7 +137,7 @@ void IFunctionAdapter::setAttribute(const std::string &attName,
  * @param value :: The value to store
  */
 void IFunctionAdapter::storeAttributePythonValue(const std::string &name,
-                                           const object &value) {
+                                                 const object &value) {
   auto attr = createAttributeFromPythonValue(value);
   storeAttributeValue(name, attr);
 }

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -73,6 +73,10 @@ void IFunctionAdapter::declareAttribute(const std::string &name,
                                         const object &defaultValue) {
   auto attr = createAttributeFromPythonValue(defaultValue);
   IFunction::declareAttribute(name, attr);
+  if (PyObject_HasAttrString(getSelf(), "setAttributeValue")) {
+    CallMethod2<void, std::string, object>::dispatchWithException(
+        getSelf(), "setAttributeValue", name, defaultValue);
+  }
 }
 
 /**

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -10,6 +10,34 @@ using Mantid::PythonInterface::Environment::CallMethod1;
 using Mantid::PythonInterface::Environment::CallMethod2;
 using namespace boost::python;
 
+namespace {
+
+/**
+ * Create an Attribute from a python value.
+ * @param value :: A value python object. Allowed python types: float,int,str,bool.
+ * @return :: The created attribute.
+ */
+Mantid::API::IFunction::Attribute createAttributeFromPythonValue(const object &value) {
+  PyObject *rawptr = value.ptr();
+  Mantid::API::IFunction::Attribute attr;
+
+  if (PyBool_Check(rawptr) == 1)
+    attr = Mantid::API::IFunction::Attribute(extract<bool>(rawptr)());
+  else if (PyInt_Check(rawptr) == 1)
+    attr = Mantid::API::IFunction::Attribute(extract<int>(rawptr)());
+  else if (PyFloat_Check(rawptr) == 1)
+    attr = Mantid::API::IFunction::Attribute(extract<double>(rawptr)());
+  else if (PyString_Check(rawptr) == 1)
+    attr = Mantid::API::IFunction::Attribute(extract<std::string>(rawptr)());
+  else
+    throw std::invalid_argument(
+        "Invalid attribute type. Allowed types=float,int,str,bool");
+
+  return attr;
+}
+
+} // namespace
+
 /**
  * Construct the wrapper and stores the reference to the PyObject
  * @param self A reference to the calling Python object
@@ -43,21 +71,7 @@ void IFunctionAdapter::init() {
  */
 void IFunctionAdapter::declareAttribute(const std::string &name,
                                         const object &defaultValue) {
-  PyObject *rawptr = defaultValue.ptr();
-  IFunction::Attribute attr;
-
-  if (PyBool_Check(rawptr) == 1)
-    attr = IFunction::Attribute(extract<bool>(rawptr)());
-  else if (PyInt_Check(rawptr) == 1)
-    attr = IFunction::Attribute(extract<int>(rawptr)());
-  else if (PyFloat_Check(rawptr) == 1)
-    attr = IFunction::Attribute(extract<double>(rawptr)());
-  else if (PyString_Check(rawptr) == 1)
-    attr = IFunction::Attribute(extract<std::string>(rawptr)());
-  else
-    throw std::invalid_argument(
-        "Invalid attribute type. Allowed types=float,int,str,bool");
-
+  auto attr = createAttributeFromPythonValue(defaultValue);
   IFunction::declareAttribute(name, attr);
 }
 
@@ -102,13 +116,24 @@ IFunctionAdapter::getAttributeValue(const API::IFunction::Attribute &attr) {
  */
 void IFunctionAdapter::setAttribute(const std::string &attName,
                                     const Attribute &attr) {
-  object value = object(handle<>(getAttributeValue(attr)));
-  try {
+  if (PyObject_HasAttrString(getSelf(), "setAttributeValue")) {
+    object value = object(handle<>(getAttributeValue(attr)));
     CallMethod2<void, std::string, object>::dispatchWithException(
         getSelf(), "setAttributeValue", attName, value);
-  } catch (std::runtime_error &) {
+  } else {
     IFunction::setAttribute(attName, attr);
   }
+}
+
+/**
+ * Store the attribute's value in the default IFunction's cache
+ * @param name :: The name of the attribute
+ * @param value :: The value to store
+ */
+void IFunctionAdapter::storeAttributePythonValue(const std::string &name,
+                                           const object &value) {
+  auto attr = createAttributeFromPythonValue(value);
+  storeAttributeValue(name, attr);
 }
 
 /**

--- a/Framework/PythonInterface/test/python/plugins/functions/AttributeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/AttributeTest.py
@@ -1,0 +1,58 @@
+import unittest
+from mantid.kernel import *
+from mantid.api import *
+from mantid.simpleapi import Fit
+import testhelpers
+import numpy
+
+class AttributeExample(IFunction1D):
+    
+        def init(self):
+            self.declareParameter("Amplitude",0.2)
+            self.declareParameter("Baseline",0.1)
+            self.declareAttribute("Frequency",0.26)
+            self.declareAttribute("Sine",False)
+
+        def setAttributeValue(self,name,value):
+            if name == "Frequency":
+                    self._freq = value
+            if name == "Sine":
+                    self._sine = value
+            self.storeAttributeValue(name, value)
+
+        def function1D(self,xvals):
+            ampl=self.getParameterValue("Amplitude")
+            base=self.getParameterValue("Baseline")
+
+            if(self._sine):
+                    ybins=numpy.sin(xvals*self._freq*2.0*numpy.pi)*ampl+base
+            else:
+                    ybins=numpy.cos(xvals*self._freq*2.0*numpy.pi)*ampl+base
+            return ybins
+
+FunctionFactory.subscribe(AttributeExample)
+
+class AttributeTest(unittest.TestCase):
+
+    def test_setAttributeValue_called_on_declaration(self):
+        fun = FunctionFactory.createFunction("AttributeExample")
+        res = fun.function1D(numpy.array([0, 1,2,3]))
+        # If function1D doesn't throw an exception then _freq and _sine
+        # member variables are defined.
+        # res[0] == 0.3 means that _sin is False
+        self.assertAlmostEqual(res[0],  0.3, 10)
+        self.assertAlmostEqual(res[1],  0.0874419, 7)
+        self.assertAlmostEqual(res[2], -0.09842294, 7)
+        self.assertAlmostEqual(res[3],  0.13747626, 7)
+
+    def test_setAttributeValue_called(self):
+        fun = FunctionFactory.createInitialized("name=AttributeExample,Sine=true")
+        res = fun.function1D(numpy.array([0, 1,2,3]))
+        # res[0] == 0.1 means that _sin is True
+        self.assertAlmostEqual(res[0],  0.1, 10)
+        self.assertAlmostEqual(res[1],  0.29960535, 7)
+        self.assertAlmostEqual(res[2],  0.07493335, 7)
+        self.assertAlmostEqual(res[3], -0.09645745, 7)
+        
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/functions/CMakeLists.txt
@@ -7,6 +7,7 @@ set ( TEST_PY_FILES
   Example1DFunctionTest.py
   ExamplePeakFunctionTest.py
   StretchedExpFTTest.py
+  AttributeTest.py
 )
 
 check_tests_valid ( ${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES} )


### PR DESCRIPTION
Fixes #8586. 

To test use this function definition:

```
class AttributeExample(IFunction1D):

        def init(self):
            self.declareParameter("Amplitude",0.2)
            self.declareParameter("Baseline",0.1)
            self.declareAttribute("Frequency",0.26)
            self.declareAttribute("Sine",False)

        def setAttributeValue(self,name,value):
            if name == "Frequency":
                    self._freq = value
            if name == "Sine":
                    self._sine = value
            self.storeAttributeValue(name, value)

        def function1D(self,xvals):
            ampl=self.getParameterValue("Amplitude")
            base=self.getParameterValue("Baseline")

            if(self._sine):
                    ybins=numpy.sin(xvals*self._freq*2.0*numpy.pi)*ampl+base
            else:
                    ybins=numpy.cos(xvals*self._freq*2.0*numpy.pi)*ampl+base
            return ybins

FunctionFactory.subscribe(AttributeExample)
```
