### PR TITLE
Set masked data to NaN in MDWorkspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDEventWorkspace.h
@@ -65,9 +65,6 @@ public:
   /// Refresh the cache (integrated signal of each box)
   virtual void refreshCache() = 0;
 
-  /// Return true if there is any mask on the workspace
-  virtual bool hasMask() = 0;
-
   /// Recurse down to a minimum depth
   virtual void setMinRecursionDepth(size_t depth) = 0;
 

--- a/Framework/API/inc/MantidAPI/IMDIterator.h
+++ b/Framework/API/inc/MantidAPI/IMDIterator.h
@@ -76,9 +76,6 @@ public:
   /// Returns the normalized error for this box
   virtual signal_t getNormalizedError() const = 0;
 
-  /// Returns the normalized signal or mask value for this box
-  virtual signal_t getNormalizedSignalWithMask() const = 0;
-
   /// Returns the total signal for this box
   virtual signal_t getSignal() const = 0;
 

--- a/Framework/API/inc/MantidAPI/IMDNode.h
+++ b/Framework/API/inc/MantidAPI/IMDNode.h
@@ -264,13 +264,6 @@ public:
   virtual uint32_t getDepth() const = 0;
   virtual signal_t getSignalNormalized() const = 0;
 
-  virtual signal_t getSignalWithMask() const = 0;
-  virtual signal_t getSignalNormalizedWithMask() const = 0;
-  virtual signal_t getSignalByNEventsWithMask() const {
-    return this->getSignalWithMask() /
-           static_cast<signal_t>(this->getNPoints());
-  }
-
   virtual void calcVolume() = 0;
   virtual void setInverseVolume(const coord_t) = 0;
   virtual void setSignal(const signal_t) = 0;

--- a/Framework/API/inc/MantidAPI/IMDWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDWorkspace.h
@@ -33,7 +33,7 @@ enum MDNormalization {
   NumEventsNormalization = 2
 };
 
-static const signal_t MDMaskValue = 0.0;
+static const signal_t MDMaskValue = std::numeric_limits<double>::quiet_NaN();
 
 /** Basic MD Workspace Abstract Class.
  *

--- a/Framework/API/inc/MantidAPI/MatrixWorkspaceMDIterator.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspaceMDIterator.h
@@ -56,8 +56,6 @@ public:
 
   virtual signal_t getNormalizedError() const;
 
-  virtual signal_t getNormalizedSignalWithMask() const;
-
   virtual signal_t getSignal() const;
 
   virtual signal_t getError() const;

--- a/Framework/API/src/MatrixWorkspaceMDIterator.cpp
+++ b/Framework/API/src/MatrixWorkspaceMDIterator.cpp
@@ -184,11 +184,6 @@ signal_t MatrixWorkspaceMDIterator::getNormalizedError() const {
   return std::numeric_limits<signal_t>::quiet_NaN();
 }
 
-/// Returns the normalized signal for this box
-signal_t MatrixWorkspaceMDIterator::getNormalizedSignalWithMask() const {
-  return this->getNormalizedSignal();
-}
-
 /// Returns the signal for this box, same as innerSignal
 signal_t MatrixWorkspaceMDIterator::getSignal() const { return m_Y[m_xIndex]; }
 

--- a/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
+++ b/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
@@ -127,53 +127,6 @@ public:
     delete it;
   }
 
-  /*
-   * For MatrixWorkspaces, masks are applied by setting the actual data to 0
-   * rather than just returning 0 for masked data with
-   * getNormalizedSignalWithMask, therefore getNormalizedSignal and
-   * getNormalizedSignalWithMask should always return the same value.
-   */
-  void test_getNormalizedSignalWithMask() {
-    boost::shared_ptr<MatrixWorkspace> ws = makeFakeWS();
-
-    // Mask a bin
-    ws->maskBin(0, 4, 1);
-
-    IMDIterator *it = NULL;
-    TS_ASSERT_THROWS_NOTHING(it = ws->createIterator(NULL));
-
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-    it->next();
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-
-    it->setNormalization(NoNormalization);
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-    // Area of each bin is 4.0
-    it->setNormalization(VolumeNormalization);
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-    it->setNormalization(NumEventsNormalization);
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-
-    it->next();
-    it->next();
-    it->next();
-    // This one is masked, the two functions should still return the same
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-    TS_ASSERT_DELTA(it->getNormalizedSignalWithMask(), 0.0, 1e-5);
-    it->next();
-    it->next();
-    // Workspace index 1, x index 1
-    TS_ASSERT_DELTA(it->getNormalizedSignal(),
-                    it->getNormalizedSignalWithMask(), 1e-5);
-
-    delete it;
-  }
 };
 
 #endif /* MANTID_API_MATRIXWORKSPACEMDITERATORTEST_H_ */

--- a/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
+++ b/Framework/API/test/MatrixWorkspaceMDIteratorTest.h
@@ -126,7 +126,6 @@ public:
     }
     delete it;
   }
-
 };
 
 #endif /* MANTID_API_MATRIXWORKSPACEMDITERATORTEST_H_ */

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -704,7 +704,11 @@ TMDE(void MDBox)::transformDimensions(std::vector<double> &scaling,
 }
 
 /// Setter for masking the box
-TMDE(void MDBox)::mask() { m_bIsMasked = true; }
+TMDE(void MDBox)::mask() {
+  this->setSignal(MDMaskValue);
+  this->setErrorSquared(MDMaskValue);
+  m_bIsMasked = true;
+}
 
 /// Setter for unmasking the box
 TMDE(void MDBox)::unmask() { m_bIsMasked = false; }

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.h
@@ -255,16 +255,6 @@ public:
   virtual signal_t getError() const { return sqrt(m_errorSquared); }
 
   //-----------------------------------------------------------------------------------------------
-  /** Returns the integrated signal from all points within or mask value.
-   */
-  virtual signal_t getSignalWithMask() const {
-    if (this->getIsMasked()) {
-      return Mantid::API::MDMaskValue;
-    }
-    return m_signal;
-  }
-
-  //-----------------------------------------------------------------------------------------------
   /** Returns the integrated error squared from all points within.
    */
   virtual signal_t getErrorSquared() const { return m_errorSquared; }
@@ -311,17 +301,6 @@ public:
    */
   virtual signal_t getErrorSquaredNormalized() const {
     return m_errorSquared * m_inverseVolume;
-  }
-
-  //-----------------------------------------------------------------------------------------------
-  /** Returns the integrated signal from all points within, normalized for the
-   * cell volume
-   */
-  virtual signal_t getSignalNormalizedWithMask() const {
-    if (this->getIsMasked()) {
-      return Mantid::API::MDMaskValue;
-    }
-    return m_signal * m_inverseVolume;
   }
 
   //-----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.h
@@ -50,8 +50,6 @@ public:
 
   signal_t getNormalizedError() const;
 
-  signal_t getNormalizedSignalWithMask() const;
-
   signal_t getSignal() const;
 
   signal_t getError() const;

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
@@ -253,23 +253,6 @@ TMDE(signal_t MDBoxIterator)::getNormalizedError() const {
   return std::numeric_limits<signal_t>::quiet_NaN();
 }
 
-/// Returns the normalized signal for this box
-TMDE(signal_t MDBoxIterator)::getNormalizedSignalWithMask() const {
-  if (this->getIsMasked()) {
-    return MDMaskValue;
-  }
-  // What is our normalization factor?
-  switch (m_normalization) {
-  case NoNormalization:
-    return m_current->getSignal();
-  case VolumeNormalization:
-    return m_current->getSignal() * m_current->getInverseVolume();
-  case NumEventsNormalization:
-    return m_current->getSignal() / double(m_current->getNPoints());
-  }
-  return std::numeric_limits<signal_t>::quiet_NaN();
-}
-
 /// Returns the signal for this box
 TMDE(signal_t MDBoxIterator)::getSignal() const {
   return m_current->getSignal();

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.h
@@ -172,9 +172,6 @@ public:
   /// Clear masking
   void clearMDMasking();
 
-  /// Return true if there is any mask on the workspace
-  bool hasMask();
-
   /// Get the coordinate system.
   Kernel::SpecialCoordinateSystem getSpecialCoordinateSystem() const;
   /// Set the coordinate system.

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -833,13 +833,6 @@ TMDE(void MDEventWorkspace)::clearMDMasking() {
 }
 
 /**
-Return true if there is any mask on the workspace
-*/
-TMDE(bool MDEventWorkspace)::hasMask() {
-  return false;
-}
-
-/**
 Get the coordinate system (if any) to use.
 @return An enumeration specifying the coordinate system if any.
 */

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -836,15 +836,6 @@ TMDE(void MDEventWorkspace)::clearMDMasking() {
 Return true if there is any mask on the workspace
 */
 TMDE(bool MDEventWorkspace)::hasMask() {
-  auto *it = this->createIterator();
-  size_t counter = 0;
-  for (; counter < it->getDataSize(); ++counter) {
-    if (it->getIsMasked()) {
-      delete it;
-      return true;
-    }
-  }
-  delete it;
   return false;
 }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspaceIterator.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspaceIterator.h
@@ -91,8 +91,6 @@ public:
 
   virtual signal_t getNormalizedError() const;
 
-  virtual signal_t getNormalizedSignalWithMask() const;
-
   virtual signal_t getSignal() const;
 
   virtual signal_t getError() const;

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -1219,7 +1219,7 @@ void MDHistoWorkspace::setMDMasking(
       // If the function masks the point, then mask it, otherwise leave it as it
       // is.
       if (maskingRegion->isPointContained(this->getCenter(i))) {
-        m_masks[i] = true;
+        this->setMDMaskAt(i, true);
       }
     }
     delete maskingRegion;
@@ -1233,9 +1233,18 @@ void MDHistoWorkspace::setMDMasking(
  */
 void MDHistoWorkspace::setMDMaskAt(const size_t &index, bool mask) {
   m_masks[index] = mask;
+  if (mask) {
+    // Set signal and error of masked points to the value of MDMaskValue
+    this->setSignalAt(index, MDMaskValue);
+    this->setErrorSquaredAt(index, MDMaskValue);
+  }
 }
 
-/// Clear any existing masking.
+/**
+ * Clear any existing masking.
+ * Note that this clears the mask flag but does not restore the data
+ * which was set to NaN when it was masked.
+ */
 void MDHistoWorkspace::clearMDMasking() {
   for (size_t i = 0; i < this->getNPoints(); ++i) {
     m_masks[i] = false;

--- a/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspaceIterator.cpp
@@ -372,25 +372,6 @@ signal_t MDHistoWorkspaceIterator::getNormalizedError() const {
 }
 
 //----------------------------------------------------------------------------------------------
-/// Returns the normalized signal for this box
-signal_t MDHistoWorkspaceIterator::getNormalizedSignalWithMask() const {
-  if (this->getIsMasked()) {
-    return MDMaskValue;
-  }
-  // What is our normalization factor?
-  switch (m_normalization) {
-  case NoNormalization:
-    return m_ws->getSignalAt(m_pos);
-  case VolumeNormalization:
-    return m_ws->getSignalAt(m_pos) * m_ws->getInverseVolume();
-  case NumEventsNormalization:
-    return m_ws->getSignalAt(m_pos) / m_ws->getNumEventsAt(m_pos);
-  }
-  // Should not reach here
-  return std::numeric_limits<signal_t>::quiet_NaN();
-}
-
-//----------------------------------------------------------------------------------------------
 /// Returns the signal for this box, same as innerSignal
 signal_t MDHistoWorkspaceIterator::getSignal() const {
   return m_ws->getSignalAt(m_pos);

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -632,7 +632,7 @@ public:
     // Mask box 0, unmask box 1 and mask box 2.
     // For masked boxes, getNormalizedSignalWithMask() should return 0.
     it->getBox()->mask();
-    TS_ASSERT_DELTA(it->getNormalizedSignalWithMask(), 0.0, 1e-5);
+    TS_ASSERT(boost::math::isnan(it->getNormalizedSignalWithMask()));
     TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
     it->next();
     it->getBox()->unmask();
@@ -640,7 +640,7 @@ public:
     TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
     it->next();
     it->getBox()->mask();
-    TS_ASSERT_DELTA(it->getNormalizedSignalWithMask(), 0.0, 1e-5);
+    TS_ASSERT(boost::math::isnan(it->getNormalizedSignalWithMask()));
     TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
 
     delete it;

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -622,7 +622,7 @@ public:
                testing::Mock::VerifyAndClearExpectations(mockPolicy));
   }
 
-  void test_getNormalizedSignalWithMask_returns_zero_for_masked() {
+  void test_getNormalizedSignal_with_mask() {
     // Make a MDBox with 10 events
     ibox_t *A = MDEventsTestHelper::makeMDBox1();
     MDEventsTestHelper::feedMDBox<1>(A, 1, 10, 0.5, 1.0);
@@ -630,18 +630,15 @@ public:
         new MDBoxIterator<MDLeanEvent<1>, 1>(A, 20, true);
 
     // Mask box 0, unmask box 1 and mask box 2.
-    // For masked boxes, getNormalizedSignalWithMask() should return 0.
+    // For masked boxes, getNormalizedSignal() should return NaN.
     it->getBox()->mask();
-    TS_ASSERT(boost::math::isnan(it->getNormalizedSignalWithMask()));
-    TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
+    TS_ASSERT(boost::math::isnan(it->getNormalizedSignal()));
     it->next();
     it->getBox()->unmask();
-    TS_ASSERT_DELTA(it->getNormalizedSignalWithMask(), 1.0, 1e-5);
     TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
     it->next();
     it->getBox()->mask();
-    TS_ASSERT(boost::math::isnan(it->getNormalizedSignalWithMask()));
-    TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
+    TS_ASSERT(boost::math::isnan(it->getNormalizedSignal()));
 
     delete it;
   }

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -13,6 +13,7 @@
 #include "MantidTestHelpers/MDEventsTestHelper.h"
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;

--- a/Framework/DataObjects/test/MDBoxIteratorTest.h
+++ b/Framework/DataObjects/test/MDBoxIteratorTest.h
@@ -629,15 +629,14 @@ public:
     MDBoxIterator<MDLeanEvent<1>, 1> *it =
         new MDBoxIterator<MDLeanEvent<1>, 1>(A, 20, true);
 
-    // Mask box 0, unmask box 1 and mask box 2.
-    // For masked boxes, getNormalizedSignal() should return NaN.
-    it->getBox()->mask();
-    TS_ASSERT(boost::math::isnan(it->getNormalizedSignal()));
-    it->next();
-    it->getBox()->unmask();
+    // Initially the box is unmasked
     TS_ASSERT_DELTA(it->getNormalizedSignal(), 1.0, 1e-5);
+
     it->next();
+
+    // Now mask the box
     it->getBox()->mask();
+    // For masked boxes, getNormalizedSignal() should return NaN.
     TS_ASSERT(boost::math::isnan(it->getNormalizedSignal()));
 
     delete it;

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -586,8 +586,8 @@ public:
     std::vector<signal_t> y, e;
     ew->getLinePlot(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(y.size(), 200);
-    TS_ASSERT(boost::math::isnan(y[60]));  // Masked data is NaN
-    TS_ASSERT_EQUALS(y[180], 3.0); // Unmasked data
+    TS_ASSERT(boost::math::isnan(y[60])); // Masked data is NaN
+    TS_ASSERT_EQUALS(y[180], 3.0);        // Unmasked data
   }
 
   void test_that_sets_default_normalization_flags_to_volume_normalization() {

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -321,10 +321,9 @@ public:
     TSM_ASSERT_DELTA(
         "Value ignoring mask is 1.0",
         ew->getSignalAtCoord(coords1, Mantid::API::NoNormalization), 1.0, 1e-5);
-    TSM_ASSERT_DELTA(
-        "Masked returns 0",
-        ew->getSignalWithMaskAtCoord(coords1, Mantid::API::NoNormalization),
-        0.0, 1e-5);
+    TSM_ASSERT("Masked returns NaN",
+               boost::math::isnan(ew->getSignalWithMaskAtCoord(
+                   coords1, Mantid::API::NoNormalization)));
   }
 
   //-------------------------------------------------------------------------------------
@@ -606,7 +605,7 @@ public:
     std::vector<signal_t> y, e;
     ew->getLinePlot(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(y.size(), 200);
-    TS_ASSERT_EQUALS(y[60], 0.0);  // Masked data is zero
+    TS_ASSERT(boost::math::isnan(y[60]));  // Masked data is NaN
     TS_ASSERT_EQUALS(y[180], 3.0); // Unmasked data
   }
 

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -327,25 +327,6 @@ public:
   }
 
   //-------------------------------------------------------------------------------------
-  /** hasMask should return true when the workspace has a mask */
-  void test_hasMask() {
-    MDEventWorkspace3Lean::sptr ew =
-        MDEventsTestHelper::makeMDEW<3>(4, 0.0, 4.0, 1);
-
-    TSM_ASSERT("Should return false as the workspace does not have a mask",
-               !ew->hasMask());
-
-    std::vector<coord_t> min{0, 0, 0};
-    std::vector<coord_t> max{1.5, 1.5, 1.5};
-
-    // Create a function to mask some of the workspace.
-    MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
-    ew->setMDMasking(function);
-
-    TSM_ASSERT("Should return true as the workspace has a mask", ew->hasMask());
-  }
-
-  //-------------------------------------------------------------------------------------
   void test_estimateResolution() {
     MDEventWorkspace2Lean::sptr b =
         MDEventsTestHelper::makeMDEW<2>(10, 0.0, 10.0);

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -159,11 +159,11 @@ public:
     ws->setSignalAt(3, 3.0);
     ws->setSignalAt(4, 3.0);
 
-    ws->setMaskValueAt(0, false); // Unmasked
-    ws->setMaskValueAt(1, false); // Unmasked
-    ws->setMaskValueAt(2, true);  // Masked
-    ws->setMaskValueAt(3, false); // Unmasked
-    ws->setMaskValueAt(4, true);  // Masked
+    ws->setMDMaskAt(0, false); // Unmasked
+    ws->setMDMaskAt(1, false); // Unmasked
+    ws->setMDMaskAt(2, true);  // Masked
+    ws->setMDMaskAt(3, false); // Unmasked
+    ws->setMDMaskAt(4, true);  // Masked
 
     Mantid::DataObjects::MDHistoWorkspace_sptr ws_sptr(ws);
 

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -140,7 +140,7 @@ public:
     delete histoIt;
   }
 
-  void test_getNormalizedSignalWIthMask() {
+  void test_getNormalizedSignal_with_mask() {
     // std::vector<coord_t> normal_vector{1.};
     // std::vector<coord_t> bound_vector{3.};
 
@@ -172,14 +172,14 @@ public:
 
     TSM_ASSERT_EQUALS("Should get the signal value here as data at the iterator"
                       " are unmasked",
-                      3.0, histoIt->getNormalizedSignalWithMask());
+                      3.0, histoIt->getNormalizedSignal());
     histoIt->jumpTo(2);
     TSM_ASSERT("Should return NaN here as data at the iterator are masked",
-               boost::math::isnan(histoIt->getNormalizedSignalWithMask()));
+               boost::math::isnan(histoIt->getNormalizedSignal()));
     histoIt->jumpTo(3);
     TSM_ASSERT_EQUALS("Should get the signal value here as data at the iterator"
                       " are unmasked",
-                      3.0, histoIt->getNormalizedSignalWithMask());
+                      3.0, histoIt->getNormalizedSignal());
 
     delete histoIt;
   }

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -15,6 +15,7 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 
 using namespace Mantid;
 using namespace Mantid::DataObjects;

--- a/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceIteratorTest.h
@@ -174,8 +174,8 @@ public:
                       " are unmasked",
                       3.0, histoIt->getNormalizedSignalWithMask());
     histoIt->jumpTo(2);
-    TSM_ASSERT_EQUALS("Should return 0 here as data at the iterator are masked",
-                      0.0, histoIt->getNormalizedSignalWithMask());
+    TSM_ASSERT("Should return NaN here as data at the iterator are masked",
+               boost::math::isnan(histoIt->getNormalizedSignalWithMask()));
     histoIt->jumpTo(3);
     TSM_ASSERT_EQUALS("Should get the signal value here as data at the iterator"
                       " are unmasked",

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -535,14 +535,18 @@ public:
     ws->setMDMasking(function);
 
     IMDWorkspace_sptr iws(ws);
-    TS_ASSERT_DELTA(iws->getSignalAtVMD(VMD(0.5, 0.5)), 0.0, 1e-6);
-    TS_ASSERT_DELTA(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5)), 0.0, 1e-6);
 
-    TS_ASSERT_DELTA(iws->getSignalAtVMD(VMD(3.5, 0.5), VolumeNormalization),
-                    0.25, 1e-6);
-    TS_ASSERT_DELTA(
-        iws->getSignalWithMaskAtVMD(VMD(3.5, 0.5), VolumeNormalization), 0.0,
-        1e-6);
+    // Testing with isnan() as following commented line doesn't work
+    // when MDMaskValue is NaN.
+    // TS_ASSERT_DELTA(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5)), MDMaskValue,
+    // 1e-6);
+    TS_ASSERT(boost::math::isnan(iws->getSignalAtVMD(VMD(0.5, 0.5))));
+    TS_ASSERT(boost::math::isnan(iws->getSignalWithMaskAtVMD(VMD(0.5, 0.5))));
+
+    TS_ASSERT(boost::math::isnan(
+        iws->getSignalAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
+    TS_ASSERT(boost::math::isnan(
+        iws->getSignalWithMaskAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
   }
 
   //---------------------------------------------------------------------------------------------------
@@ -594,7 +598,7 @@ public:
 
     TS_ASSERT_EQUALS(y.size(), 10);
     // Masked value should be zero
-    TS_ASSERT_DELTA(y[2], 0.0, 1e-5);
+    TS_ASSERT(boost::math::isnan(y[2]));
     // Unmasked value
     TS_ASSERT_DELTA(y[9], 9.0, 1e-5);
   }

--- a/Framework/MDAlgorithms/test/FitMDTest.h
+++ b/Framework/MDAlgorithms/test/FitMDTest.h
@@ -31,7 +31,6 @@ public:
   virtual void jumpTo(size_t index);
   virtual bool next();
   virtual bool next(size_t) { return false; }
-  virtual signal_t getNormalizedSignalWithMask() const;
   virtual signal_t getNormalizedSignal() const;
   virtual signal_t getNormalizedError() const;
   virtual signal_t getSignal() const { return 0; }
@@ -91,10 +90,6 @@ bool IMDWorkspaceTesterIterator::next() {
     ++ix;
   }
   return true;
-}
-
-signal_t IMDWorkspaceTesterIterator::getNormalizedSignalWithMask() const {
-  return signal_t(m_ws->readY(iy)[ix]);
 }
 
 signal_t IMDWorkspaceTesterIterator::getNormalizedSignal() const {

--- a/Framework/MDAlgorithms/test/ReplicateMDTest.h
+++ b/Framework/MDAlgorithms/test/ReplicateMDTest.h
@@ -253,11 +253,11 @@ public:
     // increasing
 
     TSM_ASSERT_EQUALS(
-        "Neighours vertical. Should be the same.", outWS->getSignalAt(0),
-        outWS->getSignalAt(shapeShape[0] /*one row verically down*/));
-    TSM_ASSERT_DIFFERS("Neighours horizontal. Should be different.",
+        "Neighbours vertical. Should be the same.", outWS->getSignalAt(0),
+        outWS->getSignalAt(shapeShape[0] /*one row vertically down*/));
+    TSM_ASSERT_DIFFERS("Neighbours horizontal. Should be different.",
                        outWS->getSignalAt(0), outWS->getSignalAt(1));
-    TSM_ASSERT_EQUALS("Horzontal points should be same in data and output",
+    TSM_ASSERT_EQUALS("Horizontal points should be same in data and output",
                       dataWS->getSignalAt(1), outWS->getSignalAt(1));
   }
 

--- a/Vates/VatesAPI/inc/MantidVatesAPI/Normalization.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/Normalization.h
@@ -42,10 +42,9 @@ typedef Mantid::signal_t (Mantid::API::IMDNode::*NormFuncIMDNodePtr)() const;
 /**
 Determine which normalization function will be called on an IMDNode
 */
-NormFuncIMDNodePtr
-makeMDEventNormalizationFunction(VisualNormalization normalizationOption,
-                                 Mantid::API::IMDEventWorkspace const *const ws,
-                                 const bool hasMask);
+NormFuncIMDNodePtr makeMDEventNormalizationFunction(
+    VisualNormalization normalizationOption,
+    Mantid::API::IMDEventWorkspace const *const ws);
 
 /**
 Determine which normalization function will be called on an IMDIterator of an

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkMDHWSignalArray.h
@@ -247,7 +247,7 @@ template <class Scalar> void vtkMDHWSignalArray<Scalar>::ClearLookup() {
 template <class Scalar>
 double *vtkMDHWSignalArray<Scalar>::GetTuple(vtkIdType i) {
   m_iterator->jumpTo(m_offset + i);
-  m_temporaryTuple[0] = m_iterator->getNormalizedSignalWithMask();
+  m_temporaryTuple[0] = m_iterator->getNormalizedSignal();
   return &m_temporaryTuple[0];
 }
 
@@ -255,7 +255,7 @@ double *vtkMDHWSignalArray<Scalar>::GetTuple(vtkIdType i) {
 template <class Scalar>
 void vtkMDHWSignalArray<Scalar>::GetTuple(vtkIdType i, double *tuple) {
   m_iterator->jumpTo(m_offset + i);
-  tuple[0] = m_iterator->getNormalizedSignalWithMask();
+  tuple[0] = m_iterator->getNormalizedSignal();
 }
 
 //------------------------------------------------------------------------------
@@ -293,13 +293,13 @@ vtkIdType vtkMDHWSignalArray<Scalar>::Lookup(const Scalar &val,
 template <class Scalar>
 Scalar vtkMDHWSignalArray<Scalar>::GetValue(vtkIdType idx) {
   m_iterator->jumpTo(m_offset + idx);
-  return m_iterator->getNormalizedSignalWithMask();
+  return m_iterator->getNormalizedSignal();
 }
 //------------------------------------------------------------------------------
 template <class Scalar>
 Scalar &vtkMDHWSignalArray<Scalar>::GetValueReference(vtkIdType idx) {
   m_iterator->jumpTo(m_offset + idx);
-  m_temporaryTuple[0] = m_iterator->getNormalizedSignalWithMask();
+  m_temporaryTuple[0] = m_iterator->getNormalizedSignal();
   return m_temporaryTuple[0];
 }
 
@@ -308,7 +308,7 @@ template <class Scalar>
 void vtkMDHWSignalArray<Scalar>::GetTupleValue(vtkIdType tupleId,
                                                Scalar *tuple) {
   m_iterator->jumpTo(m_offset + tupleId);
-  tuple[0] = m_iterator->getNormalizedSignalWithMask();
+  tuple[0] = m_iterator->getNormalizedSignal();
 }
 
 //------------------------------------------------------------------------------

--- a/Vates/VatesAPI/src/Normalization.cpp
+++ b/Vates/VatesAPI/src/Normalization.cpp
@@ -12,13 +12,11 @@ requested normalisation.
 This is used for visualisation of IMDEventWorkspaces.
 @param normalizationOption : Visual Normalization option desired
 @param ws : workspace to fetch defaults from if needed
-@param hasMask : true if the workspace has a mask
 @return member function to use on IMDNodes
 */
-NormFuncIMDNodePtr
-makeMDEventNormalizationFunction(VisualNormalization normalizationOption,
-                                 Mantid::API::IMDEventWorkspace const *const ws,
-                                 const bool hasMask) {
+NormFuncIMDNodePtr makeMDEventNormalizationFunction(
+    VisualNormalization normalizationOption,
+    Mantid::API::IMDEventWorkspace const *const ws) {
 
   using namespace Mantid::API;
 
@@ -31,24 +29,12 @@ makeMDEventNormalizationFunction(VisualNormalization normalizationOption,
 
   NormFuncIMDNodePtr normalizationFunction;
 
-  // Avoid checking every box for a mask if there is no mask in the workspace
-  // by using different functions
-  if (hasMask) {
-    if (normalizationOption == Mantid::VATES::NumEventsNormalization) {
-      normalizationFunction = &IMDNode::getSignalByNEventsWithMask;
-    } else if (normalizationOption == Mantid::VATES::NoNormalization) {
-      normalizationFunction = &IMDNode::getSignalWithMask;
-    } else {
-      normalizationFunction = &IMDNode::getSignalNormalizedWithMask;
-    }
+  if (normalizationOption == Mantid::VATES::NumEventsNormalization) {
+    normalizationFunction = &IMDNode::getSignalByNEvents;
+  } else if (normalizationOption == Mantid::VATES::NoNormalization) {
+    normalizationFunction = &IMDNode::getSignal;
   } else {
-    if (normalizationOption == Mantid::VATES::NumEventsNormalization) {
-      normalizationFunction = &IMDNode::getSignalByNEvents;
-    } else if (normalizationOption == Mantid::VATES::NoNormalization) {
-      normalizationFunction = &IMDNode::getSignal;
-    } else {
-      normalizationFunction = &IMDNode::getSignalNormalized;
-    }
+    normalizationFunction = &IMDNode::getSignalNormalized;
   }
 
   return normalizationFunction;

--- a/Vates/VatesAPI/src/vtkMDHexFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDHexFactory.cpp
@@ -103,7 +103,7 @@ void vtkMDHexFactory::doCreate(
   hexPointList->SetNumberOfIds(8);
 
   NormFuncIMDNodePtr normFunction = makeMDEventNormalizationFunction(
-      m_normalizationOption, ws.get(), ws.get()->hasMask());
+      m_normalizationOption, ws.get());
 
   // This can be parallelized
   // cppcheck-suppress syntaxError

--- a/Vates/VatesAPI/src/vtkMDLineFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDLineFactory.cpp
@@ -109,7 +109,7 @@ vtkDataSet *vtkMDLineFactory::create(ProgressAction &progressUpdating) const {
     do {
       progressUpdating.eventRaised(double(iBox) * progressFactor);
 
-      Mantid::signal_t signal_normalized = it->getNormalizedSignalWithMask();
+      Mantid::signal_t signal_normalized = it->getNormalizedSignal();
       if (!isSpecial(signal_normalized) &&
           m_thresholdRange->inRange(signal_normalized)) {
         useBox[iBox] = true;

--- a/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
+++ b/Vates/VatesAPI/src/vtkMDQuadFactory.cpp
@@ -106,7 +106,7 @@ vtkDataSet *vtkMDQuadFactory::create(ProgressAction &progressUpdating) const {
     do {
       progressUpdating.eventRaised(progressFactor * double(iBox));
 
-      Mantid::signal_t signal = it->getNormalizedSignalWithMask();
+      Mantid::signal_t signal = it->getNormalizedSignal();
       if (!isSpecial(signal) && m_thresholdRange->inRange(signal)) {
         useBox[iBox] = true;
         signals->InsertNextValue(static_cast<float>(signal));

--- a/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
+++ b/Vates/VatesAPI/src/vtkSplatterPlotFactory.cpp
@@ -77,13 +77,7 @@ void vtkSplatterPlotFactory::doCreate(
   // from algos modifying ws)
   ReadLock lock(*ws);
 
-  // Avoid checking if each box is masked if there is no mask on the workspace
-  SigFuncIMDNodePtr getSignalFunction;
-  if (ws->hasMask()) {
-    getSignalFunction = &IMDNode::getSignalNormalizedWithMask;
-  } else {
-    getSignalFunction = &IMDNode::getSignalNormalized;
-  }
+  SigFuncIMDNodePtr getSignalFunction = &IMDNode::getSignalNormalized;
 
   // Find out how many events to plot, and the percentage of the largest
   // boxes to use.

--- a/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
+++ b/Vates/VatesAPI/test/vtkMDHWSignalArrayTest.h
@@ -125,10 +125,6 @@ public:
 
     vtkNew<vtkIdList> idList1, idList2;
 
-    signal->LookupValue(0.0, idList1.GetPointer());
-    TSM_ASSERT_EQUALS("IDs for the 3 masked points should have been found",
-                      idList1->GetNumberOfIds(), 3);
-
     signal->LookupTypedValue(1.0, idList2.GetPointer());
     TSM_ASSERT_EQUALS("IDs for the 61 unmasked points should have been found",
                       idList2->GetNumberOfIds(), 61);


### PR DESCRIPTION
Closes #14782 

In the case of MDEventWorkspaces this means setting the signal and error to NaN for masked boxes, the actual events are not removed. This change should mean that displaying masked MDWorkspaces in the VSI and Slice Viewer. Masked regions should be invisible in the VSI and match out-of-bounds of the workspace in the Slice Viewer (white).

NaN displays as a high number in 1D plots, which is undesirable for masked data, but this will be addressed in #14781.

**To Test**

You can create a masked MDEventWorkspace and MDHistoWorkspace with the following script. One octant of each workspace is masked, this should be clear when viewing them in VSI and the Slice Viewer.
The workspaces with "masked" in the name are masked, the others are unmasked and there for comparison if you wish.

```
ws_mdhw = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='12')
FakeMDEventData(ws_mdhw, UniformParams='1000', RandomizeSignal='1')
ws_mdhw = BinMD(ws_mdhw,AlignedDim0='h,-2,2,12',AlignedDim1='k,-2,2,12',AlignedDim2='l,-2,2,12')
ws_masked_mdhw = CloneMDWorkspace(ws_mdhw)
MaskMD(Workspace=ws_masked_mdhw,Dimensions="h,k,l",Extents="-2,0,-2,0,-2,0")

ws_mdew = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='12')
FakeMDEventData(ws_mdew, UniformParams='1000', RandomizeSignal='1')
ws_mdew = SliceMD(ws_mdew,AlignedDim0='h,-2,2,12',AlignedDim1='k,-2,2,12',AlignedDim2='l,-2,2,12')
ws_masked_mdew = CloneMDWorkspace(ws_mdew)
MaskMD(Workspace=ws_masked_mdew,Dimensions="h,k,l",Extents="-2,0,-2,0,-2,0")
```
