### PR TITLE
 Fix the crash when cutting along boundary in vsi

### DIFF
--- a/Vates/VatesSimpleGui/ViewWidgets/src/AutoScaleRangeGenerator.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/AutoScaleRangeGenerator.cpp
@@ -244,14 +244,19 @@ namespace SimpleGui
     }
 
     // Otherwise get the data range of the representation for the active view
-    pqPipelineRepresentation* pipelineRepresentation = qobject_cast<pqPipelineRepresentation*>(source->getRepresentation(pqActiveObjects::instance().activeView()));
+    pqPipelineRepresentation *pipelineRepresentation =
+        qobject_cast<pqPipelineRepresentation *>(source->getRepresentation(
+            pqActiveObjects::instance().activeView()));
 
-    if (pipelineRepresentation)
-    {
-      QPair<double, double> range = pipelineRepresentation->getLookupTable()->getScalarRange();
-
-      minValue = range.first;
-      maxValue = range.second;
+    if (pipelineRepresentation) {
+      // The existence of the lookuptable needs to be checked at this point.
+      // ParaView seems to sometimes return NULL for the lookuptable, eg when
+      // a cut is performed along a box boundary
+      if (auto lookuptable = pipelineRepresentation->getLookupTable()) {
+        auto range = lookuptable->getScalarRange();
+        minValue = range.first;
+        maxValue = range.second;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes  #14938
# For testing

Use the script below for sample data

``` python
ws_mdew = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='12')
FakeMDEventData(ws_mdew, UniformParams='1000', RandomizeSignal='1')
ws_mdew = SliceMD(ws_mdew,AlignedDim0='h,-2,2,12',AlignedDim1='k,-2,2,12',AlignedDim2='l,-2,2,12')
ws_masked_mdew = CloneMDWorkspace(ws_mdew)
MaskMD(Workspace=ws_masked_mdew,Dimensions="h,k,l",Extents="-1,1,-1,1,-1,1")
```

**Perform cut on test data**
1. Load the test data into the VSI
2. Click on the "Cut" button
3. Use the default settings and click on "Apply"
   - Confirm Mantid does not crash
4. Close the VSI
   - Confirm that Mantid does not crash
