### PR TITLE
Indirect Data Analysis ConvFit plot guess crash 

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -25,10 +25,10 @@ private slots:
   void typeSelection(int index);
   void bgTypeSelection(int index);
   void newDataLoaded(const QString wsName);
+  void extendResolutionWorkspace();
   void updatePlot();
   void plotGuess();
-  void singleFitExtension();
-  void singleFit(const bool &error);
+  void singleFit();
   void specMinChanged(int value);
   void specMaxChanged(int value);
   void minChanged(double);
@@ -44,7 +44,6 @@ private slots:
   void showTieCheckbox(QString);
   void singleFitComplete(bool error);
   void fitFunctionSelected(const QString &);
-  void extensionComplete(bool error);
   void algorithmComplete(bool error);
 
 
@@ -65,7 +64,6 @@ private:
   void updatePlotOptions();
   QString convertFuncToShort(const QString &);
   QString convertBackToShort(const std::string &original);
-  void extendResolutionWorkspace(const bool &run);
   Ui::ConvFit m_uiForm;
   QtStringPropertyManager *m_stringManager;
   QtTreePropertyBrowser *m_cfTree;

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1126,8 +1126,7 @@ void ConvFit::plotGuess() {
 
 
 /**
- * Runs the single fit algorithm after the workspace has been extended
- * @param error :: if the resolution extension algorithm was successful
+ * Runs the single fit algorithm
  */
 void ConvFit::singleFit() {
   // disconnect signal for single fit

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -187,6 +187,11 @@ void ConvFit::setup() {
   connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
           SLOT(newDataLoaded(const QString &)));
 
+  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
+	  SLOT(extendResolutionWorkspace()));
+  connect(m_uiForm.dsResInput, SIGNAL(dataReady(const QString &)), this,
+	  SLOT(extendResolutionWorkspace()));
+
   connect(m_uiForm.spSpectraMin, SIGNAL(valueChanged(int)), this,
           SLOT(specMinChanged(int)));
   connect(m_uiForm.spSpectraMax, SIGNAL(valueChanged(int)), this,
@@ -196,8 +201,7 @@ void ConvFit::setup() {
           SLOT(typeSelection(int)));
   connect(m_uiForm.cbBackground, SIGNAL(currentIndexChanged(int)), this,
           SLOT(bgTypeSelection(int)));
-  connect(m_uiForm.pbSingleFit, SIGNAL(clicked()), this,
-          SLOT(singleFitExtension()));
+  connect(m_uiForm.pbSingleFit, SIGNAL(clicked()), this, SLOT(singleFit()));
 
   // Context menu
   m_cfTree->setContextMenuPolicy(Qt::CustomContextMenu);
@@ -219,131 +223,80 @@ void ConvFit::setup() {
 * algorithm
 */
 void ConvFit::run() {
+	if (m_cfInputWS == NULL) {
+		g_log.error("No workspace loaded");
+		return;
+	}
 
-  if (m_cfInputWS == NULL) {
-    g_log.error("No workspace loaded");
-    return;
-  }
-  extendResolutionWorkspace(true);
+	QString fitType = fitTypeString();
+	QString bgType = backgroundString();
+
+	if (fitType == "") {
+		g_log.error("No fit type defined");
+	}
+
+	bool useTies = m_uiForm.ckTieCentres->isChecked();
+	QString ties = (useTies ? "True" : "False");
+
+	CompositeFunction_sptr func = createFunction(useTies);
+	std::string function = std::string(func->asString());
+	std::string stX = m_properties["StartX"]->valueText().toStdString();
+	std::string enX = m_properties["EndX"]->valueText().toStdString();
+	m_runMin = m_uiForm.spSpectraMin->value();
+	m_runMax = m_uiForm.spSpectraMax->value();
+	std::string specMin = m_uiForm.spSpectraMin->text().toStdString();
+	std::string specMax = m_uiForm.spSpectraMax->text().toStdString();
+	int maxIterations =
+		static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
+
+	// Construct expected name
+	m_baseName = QString::fromStdString(m_cfInputWS->getName());
+	int pos = m_baseName.lastIndexOf("_");
+	if (pos != -1) {
+		m_baseName = m_baseName.left(pos + 1);
+	}
+	m_baseName += "conv_";
+	if (m_blnManager->value(m_properties["UseDeltaFunc"])) {
+		m_baseName += "Delta";
+	}
+	int fitIndex = m_uiForm.cbFitType->currentIndex();
+	if (fitIndex < 3 && fitIndex != 0) {
+		m_baseName += QString::number(fitIndex);
+		m_baseName += "L";
+	}
+	else {
+		m_baseName += convertFuncToShort(m_uiForm.cbFitType->currentText());
+	}
+	m_baseName +=
+		convertBackToShort(m_uiForm.cbBackground->currentText().toStdString()) +
+		"_s";
+	m_baseName += QString::fromStdString(specMin);
+	m_baseName += "_to_";
+	m_baseName += QString::fromStdString(specMax);
+
+	// Run ConvolutionFitSequential Algorithm
+	IAlgorithm_sptr cfs =
+		AlgorithmManager::Instance().create("ConvolutionFitSequential");
+	cfs->initialize();
+
+	cfs->setProperty("InputWorkspace", m_cfInputWS->getName());
+	cfs->setProperty("Function", function);
+	cfs->setProperty("BackgroundType",
+		m_uiForm.cbBackground->currentText().toStdString());
+	cfs->setProperty("StartX", stX);
+	cfs->setProperty("EndX", enX);
+	cfs->setProperty("SpecMin", specMin);
+	cfs->setProperty("SpecMax", specMax);
+	cfs->setProperty("Convolve", true);
+	cfs->setProperty("Minimizer",
+		minimizerString("$outputname_$wsindex").toStdString());
+	cfs->setProperty("MaxIterations", maxIterations);
+	m_batchAlgoRunner->addAlgorithm(cfs);
+	connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
+		SLOT(algorithmComplete(bool)));
+	m_batchAlgoRunner->executeBatchAsync();
 }
 
-/**
-* Create a resolution workspace with the same number of histograms as in the
-* sample.
-*
-* Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as
-* they need
-* to have the WorkspaceIndex attribute set.
-* @param run :: if the call is from running the algorithm or single fit (true =
-* algorithm)
-*/
-void ConvFit::extendResolutionWorkspace(const bool &run) {
-  if (m_cfInputWS && m_uiForm.dsResInput->isValid()) {
-    const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
-    API::BatchAlgorithmRunner::AlgorithmRuntimeProps appendProps;
-    appendProps["InputWorkspace1"] = "__ConvFit_Resolution";
-
-    size_t numHist = m_cfInputWS->getNumberHistograms();
-    for (size_t i = 0; i < numHist; i++) {
-      IAlgorithm_sptr appendAlg =
-          AlgorithmManager::Instance().create("AppendSpectra");
-      appendAlg->initialize();
-      appendAlg->setProperty("InputWorkspace2", resWsName.toStdString());
-      appendAlg->setProperty("OutputWorkspace", "__ConvFit_Resolution");
-
-      if (i == 0) {
-        appendAlg->setProperty("InputWorkspace1", resWsName.toStdString());
-        m_batchAlgoRunner->addAlgorithm(appendAlg);
-      } else {
-        m_batchAlgoRunner->addAlgorithm(appendAlg, appendProps);
-      }
-    }
-    if (run) {
-      connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-              SLOT(extensionComplete(bool)));
-    } else {
-      connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-              SLOT(singleFit(bool)));
-    }
-    m_batchAlgoRunner->executeBatchAsync();
-  }
-}
-
-void ConvFit::extensionComplete(bool error) {
-  disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-             SLOT(extensionComplete(bool)));
-
-  if (error)
-    return;
-
-  // Run Convolution Fit Sequetial algorithm
-  QString fitType = fitTypeString();
-  QString bgType = backgroundString();
-
-  if (fitType == "") {
-    g_log.error("No fit type defined");
-  }
-
-  bool useTies = m_uiForm.ckTieCentres->isChecked();
-  QString ties = (useTies ? "True" : "False");
-
-  CompositeFunction_sptr func = createFunction(useTies);
-  std::string function = std::string(func->asString());
-  std::string stX = m_properties["StartX"]->valueText().toStdString();
-  std::string enX = m_properties["EndX"]->valueText().toStdString();
-  m_runMin = m_uiForm.spSpectraMin->value();
-  m_runMax = m_uiForm.spSpectraMax->value();
-  std::string specMin = m_uiForm.spSpectraMin->text().toStdString();
-  std::string specMax = m_uiForm.spSpectraMax->text().toStdString();
-  int maxIterations =
-      static_cast<int>(m_dblManager->value(m_properties["MaxIterations"]));
-
-  // Construct expected name
-  m_baseName = QString::fromStdString(m_cfInputWS->getName());
-  int pos = m_baseName.lastIndexOf("_");
-  if (pos != -1) {
-    m_baseName = m_baseName.left(pos + 1);
-  }
-  m_baseName += "conv_";
-  if (m_blnManager->value(m_properties["UseDeltaFunc"])) {
-    m_baseName += "Delta";
-  }
-  int fitIndex = m_uiForm.cbFitType->currentIndex();
-  if (fitIndex < 3 && fitIndex != 0) {
-    m_baseName += QString::number(fitIndex);
-    m_baseName += "L";
-  } else {
-    m_baseName += convertFuncToShort(m_uiForm.cbFitType->currentText());
-  }
-  m_baseName +=
-      convertBackToShort(m_uiForm.cbBackground->currentText().toStdString()) +
-      "_s";
-  m_baseName += QString::fromStdString(specMin);
-  m_baseName += "_to_";
-  m_baseName += QString::fromStdString(specMax);
-
-  // Run ConvolutionFitSequential Algorithm
-  IAlgorithm_sptr cfs =
-      AlgorithmManager::Instance().create("ConvolutionFitSequential");
-  cfs->initialize();
-
-  cfs->setProperty("InputWorkspace", m_cfInputWS->getName());
-  cfs->setProperty("Function", function);
-  cfs->setProperty("BackgroundType",
-                   m_uiForm.cbBackground->currentText().toStdString());
-  cfs->setProperty("StartX", stX);
-  cfs->setProperty("EndX", enX);
-  cfs->setProperty("SpecMin", specMin);
-  cfs->setProperty("SpecMax", specMax);
-  cfs->setProperty("Convolve", true);
-  cfs->setProperty("Minimizer",
-                   minimizerString("$outputname_$wsindex").toStdString());
-  cfs->setProperty("MaxIterations", maxIterations);
-  m_batchAlgoRunner->addAlgorithm(cfs);
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
-          SLOT(algorithmComplete(bool)));
-  m_batchAlgoRunner->executeBatchAsync();
-}
 
 /**
 * Handles completion of the ConvolutionFitSequential algorithm.
@@ -531,6 +484,43 @@ void ConvFit::newDataLoaded(const QString wsName) {
 
   updatePlot();
 }
+
+
+/**
+* Create a resolution workspace with the same number of histograms as in the
+* sample.
+*
+* Needed to allow DiffSphere and DiffRotDiscreteCircle fit functions to work as
+* they need
+* to have the WorkspaceIndex attribute set.
+*/
+void ConvFit::extendResolutionWorkspace() {
+	if (m_cfInputWS && m_uiForm.dsResInput->isValid()) {
+		const QString resWsName = m_uiForm.dsResInput->getCurrentDataName();
+		API::BatchAlgorithmRunner::AlgorithmRuntimeProps appendProps;
+		appendProps["InputWorkspace1"] = "__ConvFit_Resolution";
+
+		size_t numHist = m_cfInputWS->getNumberHistograms();
+		for (size_t i = 0; i < numHist; i++) {
+			IAlgorithm_sptr appendAlg =
+				AlgorithmManager::Instance().create("AppendSpectra");
+			appendAlg->initialize();
+			appendAlg->setProperty("InputWorkspace2", resWsName.toStdString());
+			appendAlg->setProperty("OutputWorkspace", "__ConvFit_Resolution");
+
+			if (i == 0) {
+				appendAlg->setProperty("InputWorkspace1", resWsName.toStdString());
+				m_batchAlgoRunner->addAlgorithm(appendAlg);
+			}
+			else {
+				m_batchAlgoRunner->addAlgorithm(appendAlg, appendProps);
+			}
+		}
+
+		m_batchAlgoRunner->executeBatchAsync();
+	}
+}
+
 
 namespace {
 ////////////////////////////
@@ -1134,32 +1124,16 @@ void ConvFit::plotGuess() {
   m_uiForm.ppPlot->addSpectrum("Guess", guessWs, 0, Qt::green);
 }
 
-/**
-* Runs the extension of the resolution workspace before the singlefit takes
-* place
-*/
-void ConvFit::singleFitExtension() {
-  if (!validate())
-    return;
-
-  updatePlot();
-
-  extendResolutionWorkspace(false);
-}
 
 /**
  * Runs the single fit algorithm after the workspace has been extended
  * @param error :: if the resolution extension algorithm was successful
  */
-void ConvFit::singleFit(const bool &error) {
+void ConvFit::singleFit() {
   // disconnect signal for single fit
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(singleFit(bool)));
   // ensure algorithm was successful
-  if (error) {
-    showMessageBox("Workspace extension failed.");
-    return;
-  }
   m_uiForm.ckPlotGuess->setChecked(false);
 
   CompositeFunction_sptr function =


### PR DESCRIPTION
Fixes #14801

This bug was introduced with the new method of resolution extension. After further analysis it has been decided that, for the time being, the old method of resolution extension (extending upon data entry) was better and more efficient. 
This PR reverts to the older style of resolution extension.
- **Files for testing can be found at: `\\olympic\babylon5\Public\ElliotOram\DataAnalysis\ConvFit\IRIS`**
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Sample = `iris26176_graphite002_red.nxs`
- Resolution = `irs26173_graphite002_res.nxs`
  - Ensure that when the Resolution workspace is loaded the append algorithm is run automatically (this is a sign that the resolution workspace is being 'extended')
- Fit type = "One Lorentzian"
- Check the `PlotGuess` check box 
  - Ensure this does not cause error and produces a green plot guess curve on the mini plot
- Click `Fit Single Spectrum` button
  -  Ensure this does not cause error and produces fit curve on the mini plot
- Click `Run`
  -  Ensure this does not cause error and produces a fit curve and diff curve in the mini plot 
