### PR TITLE
Modernize rand() => Kernel::MersenneTwister in WorkspaceCreationHelper to "fix" ConvertEventsToMDTest

### DIFF
--- a/Framework/MDAlgorithms/test/ConvertEventsToMDTest.h
+++ b/Framework/MDAlgorithms/test/ConvertEventsToMDTest.h
@@ -46,7 +46,7 @@ public:
 
     pAlg->setRethrows(false);
     pAlg->execute();
-    TSM_ASSERT("Shoud finish succesfully", pAlg->isExecuted());
+    TSM_ASSERT("Should finish succesfully", pAlg->isExecuted());
     Mantid::API::Workspace_sptr spws;
     TS_ASSERT_THROWS_NOTHING(
         spws = AnalysisDataService::Instance().retrieve("testMDEvWorkspace"));
@@ -55,7 +55,7 @@ public:
     boost::shared_ptr<DataObjects::MDEventWorkspace<DataObjects::MDEvent<3>, 3>>
         ws = boost::dynamic_pointer_cast<
             DataObjects::MDEventWorkspace<DataObjects::MDEvent<3>, 3>>(spws);
-    TSM_ASSERT("It shoudl be 3D MD workspace", ws.get());
+    TSM_ASSERT("It should be 3D MD workspace", ws.get());
 
     if (ws.get()) {
       TS_ASSERT_EQUALS(900, ws->getNPoints());

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -68,9 +68,14 @@ Workspace2D_sptr Create1DWorkspaceRand(int size) {
   MantidVecPtr x1, y1, e1;
   x1.access().resize(size, 1);
   y1.access().resize(size);
-  std::generate(y1.access().begin(), y1.access().end(), rand);
+
+  MersenneTwister randomGen(DateAndTime::getCurrentTime().nanoseconds(), 0,
+                            std::numeric_limits<int>::max());
+  auto randFunc = [&randomGen] { return randomGen.nextValue(); };
+
+  std::generate(y1.access().begin(), y1.access().end(), randFunc);
   e1.access().resize(size);
-  std::generate(e1.access().begin(), e1.access().end(), rand);
+  std::generate(e1.access().begin(), e1.access().end(), randFunc);
   Workspace2D_sptr retVal(new Workspace2D);
   retVal->initialize(1, size, size);
   retVal->setX(0, x1);
@@ -760,13 +765,16 @@ EventWorkspace_sptr CreateRandomEventWorkspace(size_t numbins, size_t numpixels,
   }
   pAxis0->setUnit("TOF");
 
+  MersenneTwister randomGen(DateAndTime::getCurrentTime().nanoseconds(), 0,
+                            std::numeric_limits<int>::max());
   // Make up some data for each pixels
   for (size_t i = 0; i < numpixels; i++) {
     // Create one event for each bin
     EventList &events = retVal->getEventList(static_cast<detid_t>(i));
     for (std::size_t ie = 0; ie < numbins; ie++) {
       // Create a list of events, randomize
-      events += TofEvent(std::rand(), std::rand());
+      events += TofEvent(static_cast<double>(randomGen.nextValue()),
+                         static_cast<int64_t>(randomGen.nextValue()));
     }
     events.addDetectorID(detid_t(i));
   }


### PR DESCRIPTION
Fixes #14556.

This simply replaces calls to rand() in the `WorkspaceCreationHelper` file with `Kernel::MersenneTwister`. This seems to be enough to indirectly fix the issue with the test `ConvertEventsToMDTest` (which failed now in last night's clean win7 build!).

Normally it would take 5-30 repetitions on windows to get the failure with rand(). It remains unknown what pattern of tof-pulsetime random values rand() generates in MSVC that makes the test fail. It is not about duplicate pairs nor 0,0 values. 

It also fixes #14925.

A related maintenance issue has been created (#14944) to replace the Mersenne twister implementation of boost  (currently used in `Kernel::MersenneTwister`) with the C++11 one.

**To test**:
- code review
- see that the test `ConvertEventsToMD` and related tests that use the same workspace creation helpers pass.
- see that you like this solution. The Mersenne twister is probably an overkill for this, but it is used as a default which, as per discussions on slack, should be used more generally elsewhere in the code (for further maintenance). So the idea was to modernize `rand()` to C++11 `<random>`, which is done here via the higher level `Kernel::MersenneTwister`. 
