### PR TITLE
Add Tile plot functionality to I(Q, t) interface

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.h
@@ -32,6 +32,8 @@ namespace IDA
     void calculateBinning();
 
   private:
+    QString makePyPlotSource(const int &index);
+
     Ui::Iqt m_uiForm;
     QtTreePropertyBrowser* m_furTree;
     bool m_furyResFileType;

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
@@ -142,6 +142,13 @@
        </widget>
       </item>
       <item>
+        <widget class="QCheckBox" name="ckTile">
+          <property name="text">
+            <string>TilePlot</string>
+          </property>
+        </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_1">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -125,13 +125,34 @@ namespace IDA
    *
    * @param error If the algorithm failed
    */
-  void Iqt::algorithmComplete(bool error)
-  {
-    if(error)
+  void Iqt::algorithmComplete(bool error) {
+    if (error)
       return;
 
-    if(m_uiForm.ckPlot->isChecked())
+	// Regular Plot
+    if (m_uiForm.ckPlot->isChecked())
       plotSpectrum(QString::fromStdString(m_pythonExportWsName));
+
+	// Tile plot
+    if (m_uiForm.ckTile->isChecked()) {
+      MatrixWorkspace_const_sptr outWs =
+          AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+              m_pythonExportWsName);
+      const size_t nPlots = outWs->getNumberHistograms();
+      if (nPlots <= 0)
+        return;
+      QString pyInput = "from mantidplot import newTiledWindow\n";
+      pyInput += "newTiledWindow(sources=[";
+      for (int index = 0; index < nPlots; ++index) {
+        if (index > 0) {
+          pyInput += ",";
+        }
+		const std::string pyInStr = "(['" + m_pythonExportWsName + "'], " + std::to_string(index) + ")";
+        pyInput += QString::fromStdString(pyInStr);
+      }
+	  pyInput += "])\n";
+      runPythonCode(pyInput);
+    }
   }
 
   /**

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -143,7 +143,7 @@ namespace IDA
         return;
       QString pyInput = "from mantidplot import newTiledWindow\n";
       pyInput += "newTiledWindow(sources=[";
-      for (int index = 0; index < nPlots; ++index) {
+      for (size_t index = 0; index < nPlots; ++index) {
         if (index > 0) {
           pyInput += ",";
         }

--- a/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Iqt.cpp
@@ -139,7 +139,7 @@ namespace IDA
           AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
               m_pythonExportWsName);
       const size_t nPlots = outWs->getNumberHistograms();
-      if (nPlots <= 0)
+      if (nPlots == 0)
         return;
       QString pyInput = "from mantidplot import newTiledWindow\n";
       pyInput += "newTiledWindow(sources=[";


### PR DESCRIPTION
Fixes #14663

Added a Tile plot option to the `I(Q,t)` interface.
- **Data for test can be found in `\ExternalData\Testing\Data\UnitTest` directory**
# To Test
- Open `I(Q, t)` (Interfaces > Indirect > Data Analysis > `I(Q,t)`
- Sample = `irs26176_graphite002_red.nxs`
- Resolution = `irs26173_graphite002_res.nxs`
- Check the `TilePlot` option in the `Output` section
- Click `Run`
  - Ensure that the algorithm runs without issue and a TilePlot is produced containing the same number of spectra as `irs26176_graphite002_iqt`
