### PR TITLE
Fix system test ImagingIMATTomoScripts for older numpy

### DIFF
--- a/Testing/SystemTests/tests/analysis/ImagingIMATTomoScripts.py
+++ b/Testing/SystemTests/tests/analysis/ImagingIMATTomoScripts.py
@@ -93,7 +93,7 @@ class ImagingIMATTomoTests(unittest.TestCase):
 
         # In the Mantid workspaces we have the usual double/float64 values
         # but reconstruction tools effectively work on float32
-        return data_vol.astype(dtype='float32')
+        return data_vol.astype('float32')
 
     def test_scale_down_errors(self):
         import IMAT.prep as iprep


### PR DESCRIPTION
The system test `ImagingIMATTomoScripts.ImagingIMATScriptsTest` failed last night on osx (machine `ndw-1170`).

This was because `ndarray.astype(dtype='float')` doesn't work with numpy 1.6.x which is what we have on ndw-1170, and seems to requires numpy >= 1.8.x. A simple fix is to give `dtype` as first positional argument rather than as keyword argument.

**To test**:
- the green tick and a quick check of the code change
