### PR TITLE
Pass MaxIteration from fit browser to sequential dialog.

### DIFF
--- a/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FitPropertyBrowser.h
+++ b/MantidQt/MantidWidgets/inc/MantidQtMantidWidgets/FitPropertyBrowser.h
@@ -145,6 +145,8 @@ public:
   bool convolveMembers()const;
   /// Set if the data must be normalised before fitting
   void normaliseData(bool on) {m_shouldBeNormalised = on;}
+  /// Get the max number of iterations
+  int maxIterations() const;
 
   /// Get the start X
   double startX()const;

--- a/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
+++ b/MantidQt/MantidWidgets/src/FitPropertyBrowser.cpp
@@ -1185,6 +1185,12 @@ bool FitPropertyBrowser::convolveMembers() const
     return m_boolManager->value(m_convolveMembers);
 }
 
+/// Get the max number of iterations
+int FitPropertyBrowser::maxIterations() const
+{
+  return m_intManager->value(m_maxIterations);
+}
+
 /// Get the registered function names
 void FitPropertyBrowser::populateFunctionNames()
 {

--- a/MantidQt/MantidWidgets/src/SequentialFitDialog.cpp
+++ b/MantidQt/MantidWidgets/src/SequentialFitDialog.cpp
@@ -357,6 +357,7 @@ void SequentialFitDialog::accept()
   }
   alg->setPropertyValue("Minimizer",m_fitBrowser->minimizer());
   alg->setPropertyValue("CostFunction",m_fitBrowser->costFunction());
+  alg->setProperty("MaxIterations",m_fitBrowser->maxIterations());
   if (ui.rbIndividual->isChecked())
   {
     alg->setPropertyValue("FitType","Individual");


### PR DESCRIPTION
Fixes #14953.

**To test**

Run sequential fit form the docked fit browser. Vary `Max Iterations` property and check history of the output that it gets passed to PlotPeakByLogValue algorithm.
