### PR TITLE
Removed use of ADS retrieval in ReflectometryReductionOneAuto

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -510,8 +510,7 @@ bool ReflectometryReductionOneAuto::checkGroups() {
   std::string wsName = getPropertyValue("InputWorkspace");
 
   try {
-    auto ws =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(wsName);
+    WorkspaceGroup_sptr ws = getProperty("InputWorkspace");
     if (ws)
       return true;
   } catch (...) {
@@ -567,8 +566,7 @@ bool ReflectometryReductionOneAuto::processGroups() {
       this->getPropertyValue("PolarizationAnalysis") !=
       noPolarizationCorrectionMode();
   // Get our input workspace group
-  auto group = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-      getPropertyValue("InputWorkspace"));
+  WorkspaceGroup_sptr group = getProperty("InputWorkspace");
   // Get name of IvsQ workspace
   const std::string outputIvsQ = this->getPropertyValue("OutputWorkspace");
   // Get name of IvsLam workspace
@@ -595,8 +593,7 @@ bool ReflectometryReductionOneAuto::processGroups() {
   const std::string firstTrans = this->getPropertyValue("FirstTransmissionRun");
   WorkspaceGroup_sptr firstTransG;
   if (!firstTrans.empty()) {
-    auto firstTransWS =
-        AnalysisDataService::Instance().retrieveWS<Workspace>(firstTrans);
+    Workspace_sptr firstTransWS = getProperty("FirstTransmissionRun");
     firstTransG = boost::dynamic_pointer_cast<WorkspaceGroup>(firstTransWS);
 
     if (!firstTransG) {
@@ -616,8 +613,7 @@ bool ReflectometryReductionOneAuto::processGroups() {
       this->getPropertyValue("SecondTransmissionRun");
   WorkspaceGroup_sptr secondTransG;
   if (!secondTrans.empty()) {
-    auto secondTransWS =
-        AnalysisDataService::Instance().retrieveWS<Workspace>(secondTrans);
+    Workspace_sptr secondTransWS = getProperty("SecondTransmissionRun");
     secondTransG = boost::dynamic_pointer_cast<WorkspaceGroup>(secondTransWS);
 
     if (!secondTransG)

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto.cpp
@@ -507,8 +507,6 @@ double ReflectometryReductionOneAuto::checkForDefault(
 }
 
 bool ReflectometryReductionOneAuto::checkGroups() {
-  std::string wsName = getPropertyValue("InputWorkspace");
-
   try {
     WorkspaceGroup_sptr ws = getProperty("InputWorkspace");
     if (ws)


### PR DESCRIPTION
The use of the ADS in ReflectometryReductionOneAuto was not necessary in some cases so these have been replaced with retrieving the workspace straight from the algorithm properties.

**To Test:**
Make sure unit tests pass and code review

**Release Notes:**
This is an internal maintenance task and therefore release notes should not be updated.

Fixes #14099
