### PR TITLE
Changes suggested by clang-tidy: modernize-replace-auto-ptr

### DIFF
--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -150,8 +150,7 @@ public:
     // set up history for the algorithn which is presumably removed from Mantid
     auto ws = API::FrameworkManager::Instance().getWorkspace(wsName);
     API::WorkspaceHistory &history = ws->history();
-    auto pAlg = std::unique_ptr<API::Algorithm>(
-        Mantid::Kernel::make_unique<NonExistingAlgorithm>());
+    auto pAlg = Mantid::Kernel::make_unique<NonExistingAlgorithm>();
     pAlg->initialize();
     history.addHistory(boost::make_shared<AlgorithmHistory>(
         API::AlgorithmHistory(pAlg.get())));

--- a/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
+++ b/Framework/Algorithms/test/GenerateIPythonNotebookTest.h
@@ -13,6 +13,7 @@
 #include "MantidAlgorithms/Power.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidKernel/make_unique.h"
 #include <Poco/File.h>
 
 using namespace Mantid;
@@ -149,7 +150,8 @@ public:
     // set up history for the algorithn which is presumably removed from Mantid
     auto ws = API::FrameworkManager::Instance().getWorkspace(wsName);
     API::WorkspaceHistory &history = ws->history();
-    auto pAlg = std::auto_ptr<API::Algorithm>(new NonExistingAlgorithm());
+    auto pAlg = std::unique_ptr<API::Algorithm>(
+        Mantid::Kernel::make_unique<NonExistingAlgorithm>());
     pAlg->initialize();
     history.addHistory(boost::make_shared<AlgorithmHistory>(
         API::AlgorithmHistory(pAlg.get())));

--- a/Framework/Algorithms/test/GeneratePythonScriptTest.h
+++ b/Framework/Algorithms/test/GeneratePythonScriptTest.h
@@ -148,8 +148,7 @@ public:
     // set up history for the algorithn which is presumably removed from Mantid
     auto ws = API::FrameworkManager::Instance().getWorkspace(wsName);
     API::WorkspaceHistory &history = ws->history();
-    auto pAlg = std::unique_ptr<API::Algorithm>(
-        Mantid::Kernel::make_unique<NonExistingAlgorithm>());
+    auto pAlg = Mantid::Kernel::make_unique<NonExistingAlgorithm>();
     pAlg->initialize();
     history.addHistory(boost::make_shared<AlgorithmHistory>(
         API::AlgorithmHistory(pAlg.get())));

--- a/Framework/Algorithms/test/GeneratePythonScriptTest.h
+++ b/Framework/Algorithms/test/GeneratePythonScriptTest.h
@@ -2,6 +2,7 @@
 #define MANTID_ALGORITHMS_GENERATEPYTHONSCRIPTTEST_H_
 
 #include <cxxtest/TestSuite.h>
+#include "MantidKernel/make_unique.h"
 #include "MantidKernel/Timer.h"
 #include "MantidKernel/System.h"
 #include <fstream>
@@ -147,7 +148,8 @@ public:
     // set up history for the algorithn which is presumably removed from Mantid
     auto ws = API::FrameworkManager::Instance().getWorkspace(wsName);
     API::WorkspaceHistory &history = ws->history();
-    auto pAlg = std::auto_ptr<API::Algorithm>(new NonExistingAlgorithm());
+    auto pAlg = std::unique_ptr<API::Algorithm>(
+        Mantid::Kernel::make_unique<NonExistingAlgorithm>());
     pAlg->initialize();
     history.addHistory(boost::make_shared<AlgorithmHistory>(
         API::AlgorithmHistory(pAlg.get())));

--- a/Framework/Algorithms/test/NormaliseToMonitorTest.h
+++ b/Framework/Algorithms/test/NormaliseToMonitorTest.h
@@ -281,9 +281,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         norm5.setPropertyValue("OutputWorkspace", "normMon5"));
 
-    std::auto_ptr<MonIDPropChanger> pID =
-        std::auto_ptr<MonIDPropChanger>(new MonIDPropChanger(
-            "InputWorkspace", "MonitorSpectrum", "MonitorWorkspace"));
+    auto pID = Mantid::Kernel::make_unique<MonIDPropChanger>(
+        "InputWorkspace", "MonitorSpectrum", "MonitorWorkspace");
 
     // property is enabled but the conditions have not changed;
     TS_ASSERT(pID->isEnabled(&norm5));
@@ -322,9 +321,8 @@ public:
         norm6.setPropertyValue("InputWorkspace", "normMon"));
     TS_ASSERT_THROWS_NOTHING(
         norm6.setPropertyValue("OutputWorkspace", "normMon6"));
-    std::auto_ptr<MonIDPropChanger> pID =
-        std::auto_ptr<MonIDPropChanger>(new MonIDPropChanger(
-            "InputWorkspace", "MonitorSpectrum", "MonitorWorkspace"));
+    auto pID = Mantid::Kernel::make_unique<MonIDPropChanger>(
+        "InputWorkspace", "MonitorSpectrum", "MonitorWorkspace");
     // first time in a row the condition has changed as it shluld read the
     // monitors from the workspace
     TS_ASSERT(pID->isConditionChanged(&norm6));

--- a/Framework/DataHandling/test/FindDetectorsParTest.h
+++ b/Framework/DataHandling/test/FindDetectorsParTest.h
@@ -536,7 +536,7 @@ private:
     std::string polw_pattern("0.804071,0.804258,0.804442,");
     std::string azw_pattern("5.72472,5.72472,5.72472,");
 
-    std::array<std::stringstream, 5> bufs{};
+    std::array<std::stringstream, 5> bufs;
     for (int j = 0; j < 5; j++) {
       for (int i = 0; i < 3; i++) {
         bufs[j] << spResult->cell<double>(i, j) << ",";

--- a/Framework/DataHandling/test/FindDetectorsParTest.h
+++ b/Framework/DataHandling/test/FindDetectorsParTest.h
@@ -541,18 +541,17 @@ private:
     std::string polw_pattern("0.804071,0.804258,0.804442,");
     std::string azw_pattern("5.72472,5.72472,5.72472,");
 
-    std::auto_ptr<std::stringstream> bufs[5];
+    std::vector<std::stringstream> bufs(5);
     for (int j = 0; j < 5; j++) {
-      bufs[j] = std::auto_ptr<std::stringstream>(new std::stringstream);
       for (int i = 0; i < 3; i++) {
-        *(bufs[j]) << spResult->cell<double>(i, j) << ",";
+        bufs[j] << spResult->cell<double>(i, j) << ",";
       }
     }
-    TSM_ASSERT_EQUALS("azimut wrong", pol_pattern, bufs[0]->str());
-    TSM_ASSERT_EQUALS("polar wrong ", azim_pattern, bufs[1]->str());
-    TSM_ASSERT_EQUALS("flight path wrong ", sfp_pattern, bufs[2]->str());
-    TSM_ASSERT_EQUALS("polar width wrong ", polw_pattern, bufs[3]->str());
-    TSM_ASSERT_EQUALS("azimuthal width wrong ", azw_pattern, bufs[4]->str());
+    TSM_ASSERT_EQUALS("azimut wrong", pol_pattern, bufs[0].str());
+    TSM_ASSERT_EQUALS("polar wrong ", azim_pattern, bufs[1].str());
+    TSM_ASSERT_EQUALS("flight path wrong ", sfp_pattern, bufs[2].str());
+    TSM_ASSERT_EQUALS("polar width wrong ", polw_pattern, bufs[3].str());
+    TSM_ASSERT_EQUALS("azimuthal width wrong ", azw_pattern, bufs[4].str());
   }
 };
 #endif

--- a/Framework/DataHandling/test/FindDetectorsParTest.h
+++ b/Framework/DataHandling/test/FindDetectorsParTest.h
@@ -536,7 +536,7 @@ private:
     std::string polw_pattern("0.804071,0.804258,0.804442,");
     std::string azw_pattern("5.72472,5.72472,5.72472,");
 
-    std::array<std::stringstream, 5> bufs;
+    std::array<std::stringstream, 5> bufs{};
     for (int j = 0; j < 5; j++) {
       for (int i = 0; i < 3; i++) {
         bufs[j] << spResult->cell<double>(i, j) << ",";

--- a/Framework/DataHandling/test/FindDetectorsParTest.h
+++ b/Framework/DataHandling/test/FindDetectorsParTest.h
@@ -10,6 +10,7 @@
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidAPI/TableRow.h"
 #include "MantidAPI/FrameworkManager.h"
+#include <array>
 
 using namespace Mantid;
 using namespace Mantid::API;
@@ -386,13 +387,7 @@ public:
 #else
 //   TS_ASSERT_EQUALS(char(0x0A),descr.line_end);
 #endif
-    std::vector<double> pattern(6, 0);
-    pattern[0] = 10;
-    pattern[1] = 0;
-    pattern[2] = 5;
-    pattern[3] = 6;
-    pattern[4] = 7;
-    pattern[5] = 8;
+    std::vector<double> pattern{10, 0, 5, 6, 7, 8};
     for (size_t j = 0; j < descr.nData_records; j++) {
       for (size_t i = 0; i < 6; i++) {
         TS_ASSERT_DELTA(pattern[i], result[i + j * 6], FLT_EPSILON)
@@ -541,7 +536,7 @@ private:
     std::string polw_pattern("0.804071,0.804258,0.804442,");
     std::string azw_pattern("5.72472,5.72472,5.72472,");
 
-    std::vector<std::stringstream> bufs(5);
+    std::array<std::stringstream, 5> bufs;
     for (int j = 0; j < 5; j++) {
       for (int i = 0; i < 3; i++) {
         bufs[j] << spResult->cell<double>(i, j) << ",";

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -5,13 +5,7 @@
 #include "MantidDataObjects/MDEventFactory.h"
 #include <Poco/File.h>
 
-// clang-format off
-#if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr< ::NeXus::File> file_holder_type;
-#else
-typedef std::auto_ptr< ::NeXus::File> file_holder_type;
-#endif
-// clang-format on
 
 namespace Mantid {
 namespace DataObjects {

--- a/Framework/DataObjects/src/MDBoxFlatTree.cpp
+++ b/Framework/DataObjects/src/MDBoxFlatTree.cpp
@@ -5,7 +5,7 @@
 #include "MantidDataObjects/MDEventFactory.h"
 #include <Poco/File.h>
 
-typedef std::unique_ptr< ::NeXus::File> file_holder_type;
+typedef std::unique_ptr<::NeXus::File> file_holder_type;
 
 namespace Mantid {
 namespace DataObjects {

--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -26,11 +26,7 @@
 #include <boost/algorithm/string.hpp>
 #include <vector>
 
-#if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr<Mantid::API::IBoxControllerIO> file_holder_type;
-#else
-typedef std::auto_ptr<Mantid::API::IBoxControllerIO> file_holder_type;
-#endif
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -15,13 +15,7 @@
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 
-// clang-format off
-#if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr< ::NeXus::File> file_holder_type;
-#else
-typedef std::auto_ptr< ::NeXus::File> file_holder_type;
-#endif
-// clang-format on
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -15,7 +15,7 @@
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 
-typedef std::unique_ptr< ::NeXus::File> file_holder_type;
+typedef std::unique_ptr<::NeXus::File> file_holder_type;
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -15,13 +15,7 @@
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 
-// clang-format off
-#if defined(__GLIBCXX__) && __GLIBCXX__ >= 20100121 // libstdc++-4.4.3
 typedef std::unique_ptr< ::NeXus::File> file_holder_type;
-#else
-typedef std::auto_ptr< ::NeXus::File> file_holder_type;
-#endif
-// clang-format on
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -15,7 +15,7 @@
 #include "MantidDataObjects/MDBoxFlatTree.h"
 #include "MantidDataObjects/BoxControllerNeXusIO.h"
 
-typedef std::unique_ptr< ::NeXus::File> file_holder_type;
+typedef std::unique_ptr<::NeXus::File> file_holder_type;
 
 using namespace Mantid::Kernel;
 using namespace Mantid::API;

--- a/Framework/MDAlgorithms/test/ConvertEventsToMDTest.h
+++ b/Framework/MDAlgorithms/test/ConvertEventsToMDTest.h
@@ -22,7 +22,7 @@ public:
 
 //
 class ConvertEventsToMDTest : public CxxTest::TestSuite {
-  std::auto_ptr<ConvertEvents2MDEvTestHelper> pAlg;
+  std::unique_ptr<ConvertEvents2MDEvTestHelper> pAlg;
 
 public:
   static ConvertEventsToMDTest *createSuite() {
@@ -68,8 +68,7 @@ public:
   ConvertEventsToMDTest() {
     FrameworkManager::Instance();
 
-    pAlg = std::auto_ptr<ConvertEvents2MDEvTestHelper>(
-        new ConvertEvents2MDEvTestHelper());
+    pAlg = Mantid::Kernel::make_unique<ConvertEvents2MDEvTestHelper>();
     pAlg->initialize();
 
     int numHist = 10;

--- a/Framework/MDAlgorithms/test/ConvertToMDComponentsTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDComponentsTest.h
@@ -64,7 +64,7 @@ public:
 
 //
 class ConvertToMDComponentsTest : public CxxTest::TestSuite {
-  std::auto_ptr<Convert2MDComponentsTestHelper> pAlg;
+  std::unique_ptr<Convert2MDComponentsTestHelper> pAlg;
   Mantid::API::MatrixWorkspace_sptr ws2D;
 
 public:
@@ -299,8 +299,7 @@ public:
   }
 
   ConvertToMDComponentsTest() {
-    pAlg = std::auto_ptr<Convert2MDComponentsTestHelper>(
-        new Convert2MDComponentsTestHelper());
+    pAlg = Mantid::Kernel::make_unique<Convert2MDComponentsTestHelper>();
     ws2D = WorkspaceCreationHelper::
         createProcessedWorkspaceWithCylComplexInstrument(4, 10, true);
     // rotate the crystal by twenty degrees back;

--- a/Framework/MDAlgorithms/test/ConvertToMDTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDTest.h
@@ -44,7 +44,7 @@ std::vector<std::string> dim_availible() {
 }
 //
 class ConvertToMDTest : public CxxTest::TestSuite {
-  std::auto_ptr<Convert2AnyTestHelper> pAlg;
+  std::unique_ptr<Convert2AnyTestHelper> pAlg;
 
 public:
   static ConvertToMDTest *createSuite() { return new ConvertToMDTest(); }
@@ -405,7 +405,7 @@ public:
   }
 
   ConvertToMDTest() {
-    pAlg = std::auto_ptr<Convert2AnyTestHelper>(new Convert2AnyTestHelper());
+    pAlg = Mantid::Kernel::make_unique<Convert2AnyTestHelper>();
     Mantid::API::MatrixWorkspace_sptr ws2D = WorkspaceCreationHelper::
         createProcessedWorkspaceWithCylComplexInstrument(4, 10, true);
     // rotate the crystal by twenty degrees back;
@@ -461,7 +461,7 @@ class ConvertToMDTestPerformance : public CxxTest::TestSuite {
   DataObjects::TableWorkspace_sptr pDetLoc_events;
   DataObjects::TableWorkspace_sptr pDetLoc_histo;
   // pointer to mock algorithm to work with progress bar
-  std::auto_ptr<WorkspaceCreationHelper::MockAlgorithm> pMockAlgorithm;
+  std::unique_ptr<WorkspaceCreationHelper::MockAlgorithm> pMockAlgorithm;
 
   boost::shared_ptr<MDEventWSWrapper> pTargWS;
 
@@ -641,8 +641,7 @@ public:
     inWs2D->mutableRun().addProperty("Ei", 12., "meV", true);
     API::AnalysisDataService::Instance().addOrReplace("TestMatrixWS", inWs2D);
 
-    auto pAlg =
-        std::auto_ptr<PreprocessDetectorsToMD>(new PreprocessDetectorsToMD());
+    auto pAlg = Mantid::Kernel::make_unique<PreprocessDetectorsToMD>();
     pAlg->initialize();
 
     pAlg->setPropertyValue("InputWorkspace", "TestMatrixWS");
@@ -679,8 +678,8 @@ public:
     Rot.toRotation();
 
     // this will be used to display progress
-    pMockAlgorithm = std::auto_ptr<WorkspaceCreationHelper::MockAlgorithm>(
-        new WorkspaceCreationHelper::MockAlgorithm());
+    pMockAlgorithm =
+        Mantid::Kernel::make_unique<WorkspaceCreationHelper::MockAlgorithm>();
   }
 };
 

--- a/Framework/MDAlgorithms/test/ConvertToQ3DdETest.h
+++ b/Framework/MDAlgorithms/test/ConvertToQ3DdETest.h
@@ -4,6 +4,7 @@
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidMDAlgorithms/ConvertToMD.h"
 #include "MantidMDAlgorithms/MDWSDescription.h"
 #include "MantidTestHelpers/ComponentCreationHelper.h"
@@ -27,7 +28,7 @@ public:
 // Test is transformed from ConvetToQ3DdE but actually tests some aspects of
 // ConvertToMD algorithm.
 class ConvertToQ3DdETest : public CxxTest::TestSuite {
-  std::auto_ptr<ConvertTo3DdETestHelper> pAlg;
+  std::unique_ptr<ConvertTo3DdETestHelper> pAlg;
 
 public:
   static ConvertToQ3DdETest *createSuite() { return new ConvertToQ3DdETest(); }
@@ -489,8 +490,7 @@ public:
   }
 
   ConvertToQ3DdETest() {
-    pAlg =
-        std::auto_ptr<ConvertTo3DdETestHelper>(new ConvertTo3DdETestHelper());
+    pAlg = Mantid::Kernel::make_unique<ConvertTo3DdETestHelper>();
     pAlg->initialize();
     // initialize (load)Matid algorithm framework -- needed to run this test
     // separately

--- a/Framework/MDAlgorithms/test/MDEventWSWrapperTest.h
+++ b/Framework/MDAlgorithms/test/MDEventWSWrapperTest.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidGeometry/MDGeometry/MDTypes.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidMDAlgorithms/MDEventWSWrapper.h"
 
 #include <cxxtest/TestSuite.h>
@@ -12,7 +13,7 @@ using namespace Mantid::Kernel;
 using namespace Mantid::MDAlgorithms;
 
 class MDEventWSWrapperTest : public CxxTest::TestSuite {
-  std::auto_ptr<MDEventWSWrapper> pWSWrap;
+  std::unique_ptr<MDEventWSWrapper> pWSWrap;
 
 public:
   // This pair of boilerplate methods prevent the suite being created statically
@@ -24,7 +25,7 @@ public:
 
   void test_construct() {
     TS_ASSERT_THROWS_NOTHING(
-        pWSWrap = std::auto_ptr<MDEventWSWrapper>(new MDEventWSWrapper()));
+        pWSWrap = Mantid::Kernel::make_unique<MDEventWSWrapper>());
   }
   void test_buildNewWS() {
     IMDEventWorkspace_sptr pws;

--- a/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
+++ b/Framework/MDAlgorithms/test/PreprocessDetectorsToMDTest.h
@@ -32,7 +32,7 @@ public:
 // Test is transformed from ConvetToQ3DdE but actually tests some aspects of
 // ConvertToMD algorithm.
 class PreprocessDetectorsToMDTest : public CxxTest::TestSuite {
-  std::auto_ptr<PrepcocessDetectorsToMDTestHelper> pAlg;
+  std::unique_ptr<PrepcocessDetectorsToMDTestHelper> pAlg;
   API::MatrixWorkspace_sptr ws2D;
   boost::shared_ptr<DataObjects::TableWorkspace> tws;
 
@@ -134,8 +134,8 @@ public:
   }
 
   void testTheAlg() {
-    auto pAlg = std::auto_ptr<PrepcocessDetectorsToMDTestHelper>(
-        new PrepcocessDetectorsToMDTestHelper());
+    auto pAlg =
+        Mantid::Kernel::make_unique<PrepcocessDetectorsToMDTestHelper>();
 
     TS_ASSERT_THROWS_NOTHING(
         pAlg->setPropertyValue("InputWorkspace", "testMatrWS"));
@@ -177,8 +177,8 @@ public:
   }
 
   void testCreateWSWithEfixed() {
-    auto pAlg = std::auto_ptr<PrepcocessDetectorsToMDTestHelper>(
-        new PrepcocessDetectorsToMDTestHelper());
+    auto pAlg =
+        Mantid::Kernel::make_unique<PrepcocessDetectorsToMDTestHelper>();
 
     TS_ASSERT_THROWS_NOTHING(
         pAlg->setPropertyValue("InputWorkspace", "testMatrWS"));
@@ -204,8 +204,8 @@ public:
   }
 
   void testUpdateMasks() {
-    auto pAlg = std::auto_ptr<PrepcocessDetectorsToMDTestHelper>(
-        new PrepcocessDetectorsToMDTestHelper());
+    auto pAlg =
+        Mantid::Kernel::make_unique<PrepcocessDetectorsToMDTestHelper>();
     // do first run which generates first masks
     TS_ASSERT_THROWS_NOTHING(
         pAlg->setPropertyValue("InputWorkspace", "testMatrWS"));
@@ -292,8 +292,8 @@ public:
     API::AnalysisDataService::Instance().remove("PreprocDetectorsWSMasks");
   }
   void testNoMasksColumnTrhows() {
-    auto pAlg = std::auto_ptr<PrepcocessDetectorsToMDTestHelper>(
-        new PrepcocessDetectorsToMDTestHelper());
+    auto pAlg =
+        Mantid::Kernel::make_unique<PrepcocessDetectorsToMDTestHelper>();
     // do first run which generates first masks
     TS_ASSERT_THROWS_NOTHING(
         pAlg->setPropertyValue("InputWorkspace", "testMatrWS"));
@@ -321,8 +321,7 @@ public:
   }
 
   PreprocessDetectorsToMDTest() {
-    pAlg = std::auto_ptr<PrepcocessDetectorsToMDTestHelper>(
-        new PrepcocessDetectorsToMDTestHelper());
+    pAlg = Mantid::Kernel::make_unique<PrepcocessDetectorsToMDTestHelper>();
 
     ws2D = WorkspaceCreationHelper::
         createProcessedWorkspaceWithCylComplexInstrument(4, 10, true);

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -24,6 +24,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "MantidGeometry/Instrument/Detector.h"
+#include "MantidKernel/make_unique.h"
 
 namespace Mantid {
 namespace DataObjects {
@@ -65,15 +66,15 @@ public:
 
   Mantid::API::Progress *getProgress() { return m_Progress.get(); }
   void resetProgress(size_t nSteps) {
-    m_Progress = std::auto_ptr<Mantid::API::Progress>(
-        new Mantid::API::Progress(this, 0, 1, nSteps));
+    m_Progress =
+        Mantid::Kernel::make_unique<Mantid::API::Progress>(this, 0, 1, nSteps);
   }
 
 private:
   void init(){};
   void exec(){};
 
-  std::auto_ptr<Mantid::API::Progress> m_Progress;
+  std::unique_ptr<Mantid::API::Progress> m_Progress;
   /// logger -> to provide logging,
   static Mantid::Kernel::Logger &g_log;
 };

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -45,8 +45,7 @@ using Mantid::MantidVec;
 using Mantid::MantidVecPtr;
 
 MockAlgorithm::MockAlgorithm(size_t nSteps) {
-  m_Progress =
-      std::auto_ptr<API::Progress>(new API::Progress(this, 0, 1, nSteps));
+  m_Progress = Mantid::Kernel::make_unique<API::Progress>(this, 0, 1, nSteps);
 }
 
 /**


### PR DESCRIPTION
I made the changes suggested by modernize-replace-auto-ptr as well as removed most other occurences of `std::auto_ptr` I could find and replace with `std::unique_ptr`.

No release notes

testing: code review. 
