### PR TITLE
Vates: fix crashes seen in VSI 

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Chainable.h
+++ b/Framework/Kernel/inc/MantidKernel/Chainable.h
@@ -48,15 +48,19 @@ protected:
   /// Successor factory
   /// boost::optional<std::unique_ptr<ChainableType>> m_successor;
   std::unique_ptr<ChainableType> m_successor;
+  /// Provide option for derived classes to check successor and throw if bad
+  virtual void checkSuccessor() const {};
 
 public:
   /// Set the successor
   Chainable &setSuccessor(std::unique_ptr<ChainableType> &successor) {
     m_successor = std::move(successor);
+    checkSuccessor();
     return *m_successor;
   }
   Chainable &setSuccessor(std::unique_ptr<ChainableType> &&successor) {
     m_successor = std::move(successor);
+    checkSuccessor();
     return *m_successor;
   }
   bool hasSuccessor() const { return m_successor.get() != NULL; }

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
@@ -131,8 +131,8 @@ int vtkMDEWNexusReader::RequestData(vtkInformation * vtkNotUsed(request), vtkInf
   auto lineFactory = Mantid::Kernel::make_unique<vtkMDLineFactory>(
       thresholdRange, m_normalization);
 
-  hexahedronFactory->SetSuccessor(std::move(quadFactory));
   quadFactory->SetSuccessor(std::move(lineFactory));
+  hexahedronFactory->SetSuccessor(std::move(quadFactory));
   hexahedronFactory->setTime(m_time);
   vtkDataSet *product = m_presenter->execute(
       hexahedronFactory.get(), loadingProgressAction, drawingProgressAction);

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDEWNexusReader/vtkMDEWNexusReader.cxx
@@ -126,13 +126,12 @@ int vtkMDEWNexusReader::RequestData(vtkInformation * vtkNotUsed(request), vtkInf
       boost::make_shared<IgnoreZerosThresholdRange>();
   auto hexahedronFactory = Mantid::Kernel::make_unique<vtkMDHexFactory>(
       thresholdRange, m_normalization);
-  auto quadFactory = Mantid::Kernel::make_unique<vtkMDQuadFactory>(
-      thresholdRange, m_normalization);
-  auto lineFactory = Mantid::Kernel::make_unique<vtkMDLineFactory>(
-      thresholdRange, m_normalization);
 
-  quadFactory->SetSuccessor(std::move(lineFactory));
-  hexahedronFactory->SetSuccessor(std::move(quadFactory));
+  hexahedronFactory->setSuccessor(Mantid::Kernel::make_unique<vtkMDQuadFactory>(
+                                      thresholdRange, m_normalization))
+      .setSuccessor(Mantid::Kernel::make_unique<vtkMDLineFactory>(
+          thresholdRange, m_normalization));
+
   hexahedronFactory->setTime(m_time);
   vtkDataSet *product = m_presenter->execute(
       hexahedronFactory.get(), loadingProgressAction, drawingProgressAction);

--- a/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
+++ b/Vates/ParaviewPlugins/ParaViewReaders/MDHWNexusReader/vtkMDHWNexusReader.cxx
@@ -120,12 +120,11 @@ int vtkMDHWNexusReader::RequestData(vtkInformation * vtkNotUsed(request), vtkInf
 
   // Will attempt to handle drawing in 4D case and then in 3D case
   // if that fails.
-  auto successor = Mantid::Kernel::make_unique<vtkMDHistoHexFactory>(
-      thresholdRange, m_normalizationOption);
   auto factory =
       Mantid::Kernel::make_unique<vtkMDHistoHex4DFactory<TimeToTimeStep>>(
           thresholdRange, m_normalizationOption, m_time);
-  factory->SetSuccessor(std::move(successor));
+  factory->setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoHexFactory>(
+      thresholdRange, m_normalizationOption));
 
   auto product = m_presenter->execute(factory.get(), loadingProgressAction,
                                       drawingProgressAction);

--- a/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDEWSource/vtkMDEWSource.cxx
@@ -176,17 +176,15 @@ int vtkMDEWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
 
     ThresholdRange_scptr thresholdRange =
         boost::make_shared<IgnoreZerosThresholdRange>();
-    auto zeroDFactory = Mantid::Kernel::make_unique<vtkMD0DFactory>();
     auto hexahedronFactory = Mantid::Kernel::make_unique<vtkMDHexFactory>(
         thresholdRange, m_normalization);
-    auto quadFactory = Mantid::Kernel::make_unique<vtkMDQuadFactory>(
-        thresholdRange, m_normalization);
-    auto lineFactory = Mantid::Kernel::make_unique<vtkMDLineFactory>(
-        thresholdRange, m_normalization);
 
-    lineFactory->SetSuccessor(std::move(zeroDFactory));
-    quadFactory->SetSuccessor(std::move(lineFactory));
-    hexahedronFactory->SetSuccessor(std::move(quadFactory));
+    hexahedronFactory->setSuccessor(
+                         Mantid::Kernel::make_unique<vtkMDQuadFactory>(
+                             thresholdRange, m_normalization))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMDLineFactory>(
+            thresholdRange, m_normalization))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMD0DFactory>());
 
     hexahedronFactory->setTime(m_time);
     vtkSmartPointer<vtkDataSet> product;

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -172,10 +172,10 @@ int vtkMDHWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
         Mantid::Kernel::make_unique<vtkMDHistoHex4DFactory<TimeToTimeStep>>(
             thresholdRange, m_normalizationOption, m_time);
 
-    factory->SetSuccessor(std::move(hexFactory));
-    hexFactory->SetSuccessor(std::move(quadFactory));
-    quadFactory->SetSuccessor(std::move(lineFactory));
     lineFactory->SetSuccessor(std::move(zeroDFactory));
+    quadFactory->SetSuccessor(std::move(lineFactory));
+    hexFactory->SetSuccessor(std::move(quadFactory));
+    factory->SetSuccessor(std::move(hexFactory));
 
     auto product = m_presenter->execute(factory.get(), loadingProgressUpdate,
                                         drawingProgressUpdate);

--- a/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
+++ b/Vates/ParaviewPlugins/ParaViewSources/MDHWSource/vtkMDHWSource.cxx
@@ -161,21 +161,17 @@ int vtkMDHWSource::RequestData(vtkInformation *, vtkInformationVector **, vtkInf
     /*
     Will attempt to handle drawing in 4D case and then in 3D case if that fails, and so on down to 1D
     */
-    auto zeroDFactory = Mantid::Kernel::make_unique<vtkMD0DFactory>();
-    auto lineFactory = Mantid::Kernel::make_unique<vtkMDHistoLineFactory>(
-        thresholdRange, m_normalizationOption);
-    auto quadFactory = Mantid::Kernel::make_unique<vtkMDHistoQuadFactory>(
-        thresholdRange, m_normalizationOption);
-    auto hexFactory = Mantid::Kernel::make_unique<vtkMDHistoHexFactory>(
-        thresholdRange, m_normalizationOption);
     auto factory =
         Mantid::Kernel::make_unique<vtkMDHistoHex4DFactory<TimeToTimeStep>>(
             thresholdRange, m_normalizationOption, m_time);
 
-    lineFactory->SetSuccessor(std::move(zeroDFactory));
-    quadFactory->SetSuccessor(std::move(lineFactory));
-    hexFactory->SetSuccessor(std::move(quadFactory));
-    factory->SetSuccessor(std::move(hexFactory));
+    factory->setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoHexFactory>(
+                              thresholdRange, m_normalizationOption))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoQuadFactory>(
+            thresholdRange, m_normalizationOption))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoLineFactory>(
+            thresholdRange, m_normalizationOption))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMD0DFactory>());
 
     auto product = m_presenter->execute(factory.get(), loadingProgressUpdate,
                                         drawingProgressUpdate);

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
@@ -210,6 +210,9 @@ protected:
   /// Template Method pattern to validate the factory before use.
   virtual void validate() const = 0;
 
+  /// Checks successor when set and throws if bad
+  virtual void checkSuccessor() const override;
+
   /// Flag indicating whether a transformation should be used.
   bool m_useTransform;
 

--- a/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
+++ b/Vates/VatesAPI/inc/MantidVatesAPI/vtkDataSetFactory.h
@@ -5,6 +5,7 @@
 
 #include "MantidAPI/IMDWorkspace.h"
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidKernel/Chainable.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/make_unique.h"
 #include "vtkDataSet.h"
@@ -61,16 +62,13 @@ namespace VATES
  Code Documentation is available at: <http://doxygen.mantidproject.org>
  */
 
-class DLLExport vtkDataSetFactory
+class DLLExport vtkDataSetFactory : public Mantid::Kernel::Chainable<vtkDataSetFactory>
 {
 
 public:
 
   /// Constructor
   vtkDataSetFactory();
-
-  /// Destructor
-  virtual ~vtkDataSetFactory()=0;
 
   /// Factory Method. Should also handle delegation to successors.
   virtual vtkSmartPointer<vtkDataSet> create(ProgressAction &) const = 0;
@@ -81,12 +79,6 @@ public:
   /// Create the product in one step.
   virtual vtkSmartPointer<vtkDataSet> oneStepCreate(Mantid::API::Workspace_sptr,
                                                     ProgressAction &);
-
-  /// Add a chain-of-responsibility successor to this factory. Handle case where the factory cannot render the MDWorkspace owing to its dimensionality.
-  virtual void SetSuccessor(std::unique_ptr<vtkDataSetFactory> pSuccessor);
-
-  /// Determine whether a successor factory has been provided.
-  virtual bool hasSuccessor() const;
 
   /// Get the name of the type.
   virtual std::string getFactoryTypeName() const =0;
@@ -214,11 +206,6 @@ protected:
     }
     return nullptr;
   }
-
-  /// Typedef for internal unique pointer for successor types.
-  typedef std::unique_ptr<vtkDataSetFactory> SuccessorType;
-
-  vtkDataSetFactory::SuccessorType m_successor;
 
   /// Template Method pattern to validate the factory before use.
   virtual void validate() const = 0;

--- a/Vates/VatesAPI/src/vtkDataSetFactory.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetFactory.cpp
@@ -11,6 +11,23 @@ vtkDataSetFactory::vtkDataSetFactory() : m_useTransform(false), m_bCheckDimensio
 {
 }
 
+/**
+ * Checks the successor and throws if invalid.
+ * @throw std::runtime_error if types are the same
+ * @throw std::invalid_argument if successor is nullptr
+ */
+void vtkDataSetFactory::checkSuccessor() const {
+  if (m_successor) {
+    if (m_successor->getFactoryTypeName() == this->getFactoryTypeName()) {
+      throw std::runtime_error("Cannot assign a successor to vtkDataSetFactory "
+                               "with the same type as the present "
+                               "vtkDataSetFactory type.");
+    }
+  } else {
+    throw std::invalid_argument("Null pointer passed as successor");
+  }
+}
+
 /*
 Set a flag indicating whether dimensionality should be checked
 @param flag : TRUE to check dimensionality otherwise FALSE.

--- a/Vates/VatesAPI/src/vtkDataSetFactory.cpp
+++ b/Vates/VatesAPI/src/vtkDataSetFactory.cpp
@@ -11,41 +11,6 @@ vtkDataSetFactory::vtkDataSetFactory() : m_useTransform(false), m_bCheckDimensio
 {
 }
 
-vtkDataSetFactory::~vtkDataSetFactory()
-{
-}
-
-/**
- Set the successor factory for the chain-of-responsibility.
- @param pSuccessor :: pointer to the successor. Note RAII is used.
- @throw std::runtime_error if types are the same
- @throw std::invalid_argument if successor is nullptr
- */
-void vtkDataSetFactory::SetSuccessor(vtkDataSetFactory_uptr pSuccessor) {
-  if (pSuccessor) {
-    // Assignment peformed first (RAII) to guarantee no side effects.
-    m_successor = std::move(pSuccessor);
-    // Unless overriden, successors should not be the same type as the present
-    // instance.
-    if (m_successor->getFactoryTypeName() == this->getFactoryTypeName()) {
-      throw std::runtime_error("Cannot assign a successor to vtkDataSetFactory "
-                               "with the same type as the present "
-                               "vtkDataSetFactory type.");
-    }
-  } else {
-    throw std::invalid_argument("Null pointer passed as successor");
-  }
-}
-
-/**
- Determine when a successor is available.
- @return true if a successor is available.
- */
-bool vtkDataSetFactory::hasSuccessor() const
-{
-  return NULL != m_successor.get();
-}
-
 /*
 Set a flag indicating whether dimensionality should be checked
 @param flag : TRUE to check dimensionality otherwise FALSE.

--- a/Vates/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
+++ b/Vates/VatesAPI/test/MDHWNexusLoadingPresenterTest.h
@@ -161,20 +161,16 @@ public:
     auto normalizationOption = Mantid::VATES::VisualNormalization::AutoSelect;
     MDHWNexusLoadingPresenter presenter(std::move(view), filename);
     const double time = 0.0;
-    auto zeroDFactory = Mantid::Kernel::make_unique<vtkMD0DFactory>();
-    auto lineFactory = Mantid::Kernel::make_unique<vtkMDHistoLineFactory>(
-        thresholdRange, normalizationOption);
-    auto quadFactory = Mantid::Kernel::make_unique<vtkMDHistoQuadFactory>(
-        thresholdRange, normalizationOption);
-    auto hexFactory = Mantid::Kernel::make_unique<vtkMDHistoHexFactory>(
-        thresholdRange, normalizationOption);
     auto factory = boost::make_shared<vtkMDHistoHex4DFactory<TimeToTimeStep>>(
         thresholdRange, normalizationOption, time);
 
-    lineFactory->SetSuccessor(std::move(zeroDFactory));
-    quadFactory->SetSuccessor(std::move(lineFactory));
-    hexFactory->SetSuccessor(std::move(quadFactory));
-    factory->SetSuccessor(std::move(hexFactory));
+    factory->setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoHexFactory>(
+                              thresholdRange, normalizationOption))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoQuadFactory>(
+            thresholdRange, normalizationOption))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMDHistoLineFactory>(
+            thresholdRange, normalizationOption))
+        .setSuccessor(Mantid::Kernel::make_unique<vtkMD0DFactory>());
 
     presenter.executeLoadMetadata();
     auto product = presenter.execute(factory.get(), mockLoadingProgressAction,

--- a/Vates/VatesAPI/test/vtkDataSetFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkDataSetFactoryTest.h
@@ -36,8 +36,8 @@ private:
     MOCK_CONST_METHOD0(validate,
       void());
     MOCK_CONST_METHOD0(getFactoryTypeName, std::string());
-    void SetSuccessorConcrete(std::unique_ptr<vtkDataSetFactory> pSuccessor) {
-      vtkDataSetFactory::SetSuccessor(std::move(pSuccessor));
+    void setSuccessorConcrete(std::unique_ptr<vtkDataSetFactory> pSuccessor) {
+      vtkDataSetFactory::setSuccessor(pSuccessor);
     }
     bool hasSuccessorConcrete() const {
       return vtkDataSetFactory::hasSuccessor();
@@ -55,33 +55,35 @@ private:
 public:
   void testSetSuccessor() {
     MockvtkDataSetFactory factory;
-    auto successor = Mantid::Kernel::make_unique<MockvtkDataSetFactory>();
+    auto successor = new MockvtkDataSetFactory();
+    auto uniqueSuccessor = std::unique_ptr<MockvtkDataSetFactory>(successor);
 
     EXPECT_CALL(factory, getFactoryTypeName())
         .WillOnce(testing::Return("TypeA"));
     EXPECT_CALL(*successor, getFactoryTypeName())
         .WillOnce(testing::Return("TypeB")); // Different type name, so setting
                                              // the successor should work.
-    factory.SetSuccessor(std::move(successor));
+    factory.setSuccessor(std::move(uniqueSuccessor));
 
     TSM_ASSERT("Successor should have been set", factory.hasSuccessor());
     TS_ASSERT(testing::Mock::VerifyAndClearExpectations(&factory));
-    TS_ASSERT(testing::Mock::VerifyAndClearExpectations(successor.get()));
+    TS_ASSERT(testing::Mock::VerifyAndClearExpectations(successor));
   }
 
   void testSetSuccessorThrows() {
     MockvtkDataSetFactory factory;
-    auto successor = Mantid::Kernel::make_unique<MockvtkDataSetFactory>();
+    auto successor = new MockvtkDataSetFactory();
+    auto uniqueSuccessor = std::unique_ptr<MockvtkDataSetFactory>(successor);
     EXPECT_CALL(factory, getFactoryTypeName())
         .WillOnce(testing::Return("TypeA"));
     EXPECT_CALL(*successor, getFactoryTypeName())
         .WillOnce(testing::Return("TypeA")); // Same type name. should NOT work.
     TSM_ASSERT_THROWS("By default, should throw when successor type is the "
                       "same as the container.",
-                      factory.SetSuccessor(std::move(successor)),
+                      factory.setSuccessor(std::move(uniqueSuccessor)),
                       std::runtime_error);
     TS_ASSERT(testing::Mock::VerifyAndClearExpectations(&factory));
-    TS_ASSERT(testing::Mock::VerifyAndClearExpectations(successor.get()));
+    TS_ASSERT(testing::Mock::VerifyAndClearExpectations(successor));
   }
 
   void testEnumValues()

--- a/Vates/VatesAPI/test/vtkMDLineFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkMDLineFactoryTest.h
@@ -34,27 +34,31 @@ public:
 
   void testInitializeDelegatesToSuccessor()
   {
-    auto mockSuccessor = Mantid::Kernel::make_unique<MockvtkDataSetFactory>();
+    auto mockSuccessor = new MockvtkDataSetFactory();
+    auto uniqueSuccessor =
+        std::unique_ptr<MockvtkDataSetFactory>(mockSuccessor);
     EXPECT_CALL(*mockSuccessor, initialize(_)).Times(1);
     EXPECT_CALL(*mockSuccessor, getFactoryTypeName()).Times(1);
 
     vtkMDLineFactory factory(boost::make_shared<NoThresholdRange>(),
                              Mantid::VATES::VolumeNormalization);
-    factory.SetSuccessor(std::move(mockSuccessor));
+    factory.setSuccessor(std::move(uniqueSuccessor));
 
     ITableWorkspace_sptr ws =
         boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     TS_ASSERT_THROWS_NOTHING(factory.initialize(ws));
 
     TSM_ASSERT("Successor has not been used properly.",
-               Mock::VerifyAndClearExpectations(mockSuccessor.get()));
+               Mock::VerifyAndClearExpectations(mockSuccessor));
   }
 
   void testCreateDelegatesToSuccessor()
   {
     FakeProgressAction progressUpdate;
 
-    auto mockSuccessor = Mantid::Kernel::make_unique<MockvtkDataSetFactory>();
+    auto mockSuccessor = new MockvtkDataSetFactory();
+    auto uniqueSuccessor =
+        std::unique_ptr<MockvtkDataSetFactory>(mockSuccessor);
     EXPECT_CALL(*mockSuccessor, initialize(_)).Times(1);
     EXPECT_CALL(*mockSuccessor, create(Ref(progressUpdate)))
         .Times(1)
@@ -63,14 +67,14 @@ public:
 
     vtkMDLineFactory factory(boost::make_shared<NoThresholdRange>(),
                              Mantid::VATES::VolumeNormalization);
-    factory.SetSuccessor(std::move(mockSuccessor));
+    factory.setSuccessor(std::move(uniqueSuccessor));
 
     ITableWorkspace_sptr ws(new Mantid::DataObjects::TableWorkspace);
     TS_ASSERT_THROWS_NOTHING(factory.initialize(ws));
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
 
     TSM_ASSERT("Successor has not been used properly.",
-               Mock::VerifyAndClearExpectations(mockSuccessor.get()));
+               Mock::VerifyAndClearExpectations(mockSuccessor));
   }
 
   void testOnInitaliseCannotDelegateToSuccessor()

--- a/Vates/VatesAPI/test/vtkMDQuadFactoryTest.h
+++ b/Vates/VatesAPI/test/vtkMDQuadFactoryTest.h
@@ -35,27 +35,31 @@ public:
 
   void testInitializeDelegatesToSuccessor()
   {
-    auto mockSuccessor = Mantid::Kernel::make_unique<MockvtkDataSetFactory>();
+    auto mockSuccessor = new MockvtkDataSetFactory();
+    auto uniqueSuccessor =
+        std::unique_ptr<MockvtkDataSetFactory>(mockSuccessor);
     EXPECT_CALL(*mockSuccessor, initialize(_)).Times(1);
     EXPECT_CALL(*mockSuccessor, getFactoryTypeName()).Times(1);
 
     vtkMDQuadFactory factory(boost::make_shared<NoThresholdRange>(),
                              Mantid::VATES::VolumeNormalization);
-    factory.SetSuccessor(std::move(mockSuccessor));
+    factory.setSuccessor(std::move(uniqueSuccessor));
 
     ITableWorkspace_sptr ws =
         boost::make_shared<Mantid::DataObjects::TableWorkspace>();
     TS_ASSERT_THROWS_NOTHING(factory.initialize(ws));
 
     TSM_ASSERT("Successor has not been used properly.",
-               Mock::VerifyAndClearExpectations(mockSuccessor.get()));
+               Mock::VerifyAndClearExpectations(mockSuccessor));
   }
 
   void testCreateDelegatesToSuccessor()
   {
     FakeProgressAction progressUpdate;
 
-    auto mockSuccessor = Mantid::Kernel::make_unique<MockvtkDataSetFactory>();
+    auto mockSuccessor = new MockvtkDataSetFactory();
+    auto uniqueSuccessor =
+        std::unique_ptr<MockvtkDataSetFactory>(mockSuccessor);
     EXPECT_CALL(*mockSuccessor, initialize(_)).Times(1);
     EXPECT_CALL(*mockSuccessor, create(Ref(progressUpdate)))
         .Times(1)
@@ -64,7 +68,7 @@ public:
 
     vtkMDQuadFactory factory(boost::make_shared<NoThresholdRange>(),
                              Mantid::VATES::VolumeNormalization);
-    factory.SetSuccessor(std::move(mockSuccessor));
+    factory.setSuccessor(std::move(uniqueSuccessor));
 
     ITableWorkspace_sptr ws =
         boost::make_shared<Mantid::DataObjects::TableWorkspace>();
@@ -72,7 +76,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(factory.create(progressUpdate));
 
     TSM_ASSERT("Successor has not been used properly.",
-               Mock::VerifyAndClearExpectations(mockSuccessor.get()));
+               Mock::VerifyAndClearExpectations(mockSuccessor));
   }
 
   void testOnInitaliseCannotDelegateToSuccessor()

--- a/Vates/VatesSimpleGui/ViewWidgets/src/ColorUpdater.cpp
+++ b/Vates/VatesSimpleGui/ViewWidgets/src/ColorUpdater.cpp
@@ -191,15 +191,18 @@ void ColorUpdater::logScale(int state)
       for (QList<pqDataRepresentation *>::iterator rep = reps.begin();
            rep != reps.end(); ++rep) {
         // Set the logarithmic (linear) scale
-        pqSMAdaptor::setElementProperty(
-            (*rep)->getLookupTable()->getProxy()->GetProperty("UseLogScale"),
-            this->m_logScaleState);
-        if (m_logScaleState)
-          vtkSMTransferFunctionProxy::MapControlPointsToLogSpace(
-              (*rep)->getLookupTable()->getProxy());
-        else
-          vtkSMTransferFunctionProxy::MapControlPointsToLinearSpace(
-              (*rep)->getLookupTable()->getProxy());
+        auto lut = (*rep)->getLookupTable();
+        if (lut) {
+          pqSMAdaptor::setElementProperty(
+              (*rep)->getLookupTable()->getProxy()->GetProperty("UseLogScale"),
+              this->m_logScaleState);
+          if (m_logScaleState)
+            vtkSMTransferFunctionProxy::MapControlPointsToLogSpace(
+                (*rep)->getLookupTable()->getProxy());
+          else
+            vtkSMTransferFunctionProxy::MapControlPointsToLinearSpace(
+                (*rep)->getLookupTable()->getProxy());
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves #15006 
- Reorder factory set successor lines (crash observed in issue)
- Fix crash seen on deleting `clipper` by replacing `vtkNew` (subsequent crash)
- Test lookup table for null pointer (observed when switching to log scale)

Can now run the [usage examples](http://www.mantidproject.org/MBC_MDVisualisation#Examples), loading an MD workspace and using the VSI, and all succeeds without crashing. 

**Test**
Load an MD workspace into the VSI and try out its features - no crash should be seen. For example, see http://www.mantidproject.org/MBC_MDVisualisation#Examples
