### PR TITLE
Workflow Diagram for FuryFitMultiple

### DIFF
--- a/docs/source/algorithms/FuryFitMultiple-v1.rst
+++ b/docs/source/algorithms/FuryFitMultiple-v1.rst
@@ -17,6 +17,12 @@ an exponential and stretched exponential.
 
 This routine was originally part of the MODES package.
 
+Workflow
+--------
+
+.. diagram:: FuryFitMultiple-v1_wkflw.dot
+
+
 Usage
 -----
 

--- a/docs/source/diagrams/FuryFitMultiple-v1_wkflw.dot
+++ b/docs/source/diagrams/FuryFitMultiple-v1_wkflw.dot
@@ -16,8 +16,10 @@ digraph FuryFitMultiple {
     ParameterTable
     ParameterNames
     FitGroup
+    FitGroup2                [label="FitGroup"]
     SampleLogs
-    OutputWorkspaces
+    ResultWorkspace
+    ResultWorkspace2        [label="ResultWorkspace"]
   }
 
   subgraph algorithms {
@@ -26,7 +28,9 @@ digraph FuryFitMultiple {
     Fit
     ConvertToHistogram
     AddSampleLogMultiple
+    AddSampleLogMultiple2   [label="AddSampleLogMultiple"]
     CopyLogs
+    CopyLogs2           [label="Copy logs"]
   }
   
   subgraph decisions {
@@ -52,15 +56,19 @@ digraph FuryFitMultiple {
   Minimizer                     -> Fit
   MaxIterations                 -> Fit
   Fit                           -> ParameterTable
-  Fit                           -> FitGroup
+  Fit                           -> FitGroup                     [label="GroupWorkspace containing fitting results from each spectra"]
   ParameterTable                -> TransposeFitParametersTable  [label="Makes output consistent with PlotPeakByLogValue"]
   TransposeFitParametersTable   -> ConvertParametersToWorkspace
-  ParameterNames                -> ConvertParametersToWorkspace [label="Convert parameter table to a MatrixWorkspace containing paramNames"]
-  InputWorkspace2               -> CopyLogs
-  ConvertParametersToWorkspace  -> CopyLogs
-  FitGroup                      -> CopyLogs
-  CopyLogs                      -> AddSampleLogMultiple
-  SampleLogs                    -> AddSampleLogMultiple
-  FitGroup                      -> AddSampleLogMultiple
-  AddSampleLogMultiple          -> OutputWorkspaces
+  ParameterNames                -> ConvertParametersToWorkspace [label="Convert parameter of interest into MatrixWorkspace containing paramNames"]
+  ConvertParametersToWorkspace  -> ResultWorkspace              [label="Outputs Matrixworkspace containing Tau, Intensity, A0 and Beta"]
+  InputWorkspace2               -> CopyLogs                     [label="Copy SampleLogs from InputWorkspace to OutputWorkspaces"]
+  ResultWorkspace               -> CopyLogs
+  InputWorkspace2               -> CopyLogs2
+  FitGroup                      -> CopyLogs2
+  CopyLogs                      -> AddSampleLogMultiple         
+  CopyLogs2                     -> AddSampleLogMultiple2
+  SampleLogs                    -> AddSampleLogMultiple2
+  SampleLogs                    -> AddSampleLogMultiple         [label="Additional SampleLogs based on Fit data"]
+  AddSampleLogMultiple          -> ResultWorkspace2             [label="Outputworkspace"]
+  AddSampleLogMultiple2         -> FitGroup2                    [label="OutputWorkspace"]
 }

--- a/docs/source/diagrams/FuryFitMultiple-v1_wkflw.dot
+++ b/docs/source/diagrams/FuryFitMultiple-v1_wkflw.dot
@@ -1,0 +1,66 @@
+digraph FuryFitMultiple {
+  label="FuryFitMultiple Flowchart"
+  $global_style
+  
+  subgraph params {
+    $param_style
+    InputWorkspace
+    InputWorkspace2     [label="InputWorkspace"]
+    Function
+    StartX
+    EndX
+    SpecMin
+    SpecMax
+    Minimizer
+    MaxIterations
+    ParameterTable
+    ParameterNames
+    FitGroup
+    SampleLogs
+    OutputWorkspaces
+  }
+
+  subgraph algorithms {
+    $algorithm_style
+    CropWorkspace
+    Fit
+    ConvertToHistogram
+    AddSampleLogMultiple
+    CopyLogs
+  }
+  
+  subgraph decisions {
+    $decision_style
+  }
+  
+  subgraph process  {
+    $process_style
+    ConvertToElasticQ
+    TransposeFitParametersTable
+    ConvertParametersToWorkspace
+  }
+  
+  InputWorkspace                -> CropWorkspace
+  StartX                        -> CropWorkspace
+  EndX                          -> CropWorkspace
+  SpecMin                       -> CropWorkspace
+  SpecMax                       -> CropWorkspace
+  CropWorkspace                 -> ConvertToHistogram
+  ConvertToHistogram            -> ConvertToElasticQ        [label="Convert spectrum axis to ElaticQ"]
+  ConvertToElasticQ             -> Fit
+  Function                      -> Fit
+  Minimizer                     -> Fit
+  MaxIterations                 -> Fit
+  Fit                           -> ParameterTable
+  Fit                           -> FitGroup
+  ParameterTable                -> TransposeFitParametersTable  [label="Makes output consistent with PlotPeakByLogValue"]
+  TransposeFitParametersTable   -> ConvertParametersToWorkspace
+  ParameterNames                -> ConvertParametersToWorkspace [label="Convert parameter table to a MatrixWorkspace containing paramNames"]
+  InputWorkspace2                -> CopyLogs
+  ConvertParametersToWorkspace  -> CopyLogs
+  FitGroup                      -> CopyLogs
+  CopyLogs                      -> AddSampleLogMultiple
+  SampleLogs                    -> AddSampleLogMultiple
+  FitGroup                      -> AddSampleLogMultiple
+  AddSampleLogMultiple          -> OutputWorkspaces
+}

--- a/docs/source/diagrams/FuryFitMultiple-v1_wkflw.dot
+++ b/docs/source/diagrams/FuryFitMultiple-v1_wkflw.dot
@@ -56,7 +56,7 @@ digraph FuryFitMultiple {
   ParameterTable                -> TransposeFitParametersTable  [label="Makes output consistent with PlotPeakByLogValue"]
   TransposeFitParametersTable   -> ConvertParametersToWorkspace
   ParameterNames                -> ConvertParametersToWorkspace [label="Convert parameter table to a MatrixWorkspace containing paramNames"]
-  InputWorkspace2                -> CopyLogs
+  InputWorkspace2               -> CopyLogs
   ConvertParametersToWorkspace  -> CopyLogs
   FitGroup                      -> CopyLogs
   CopyLogs                      -> AddSampleLogMultiple


### PR DESCRIPTION
Fixes #15009 

Adds a workflow diagram for `FuryFitMultiple` to the documentation page.
# To Test
- Ensure that the diagram is representative of the workflow of the algorithm
