### PR TITLE
Fix error bars in MuonAnalysis plots

### DIFF
--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -1920,8 +1920,9 @@ void MuonAnalysis::plotSpectrum(const QString& wsName, bool logScale)
       s << "pw = newGraph(altName, 0)";
     }
 
-    s << "w = plotSpectrum(ws.name(), 0, %ERRORS%, %CONNECT%, window = pw, "
-      "clearWindow = True)";
+    s << "w = plotSpectrum(ws.name(), 0, error_bars = %ERRORS%, type = "
+         "%CONNECT%, window = pw, "
+         "clearWindow = True)";
     s << "w.setName(altName)";
     s << "w.setObjectName(ws.name())";
     s << "w.show()";


### PR DESCRIPTION
Resolves #15025 

Small issue found during unscripted testing. Fixed the Python plotting string in MuonAnalysis by passing the option to plot errors or not correctly - previously the argument was in the wrong place, resulting in errors never being plotted.

**Test:**
- Launch MuonAnalysis interface, go to Settings tab and ensure the checkbox "Show error bars" is ticked.
- Go back to the home tab and load a muon data file (example: MUSR00015190.nxs from the system test data, but any will do)
- Check that errors are shown. (For a picture of what it should look like with the file above, see [here](http://www.mantidproject.org/Unscripted_Manual_Testing_MuonAnalysis))
- Go back to the settings tab and uncheck the checkbox. Errors should no longer be shown.
