### PR TITLE
I(Q,t) Data Cropping to improve TiledPlot

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -287,12 +287,17 @@ class TransformToIqt(PythonAlgorithm):
         DeleteWorkspace('__sam')
 
         # Crop nonsense values off workspace
-        binning = int(math.ceil(mtd[self._output_workspace].blocksize() / 2.0))
-        bin_v = mtd[self._output_workspace].dataX(0)[binning]
-        trans_prog.report('Cropping output')
-        CropWorkspace(InputWorkspace=self._output_workspace,
+        y_data = mtd[self._output_workspace].dataY(0)
+        max_index = 0
+        for index in range(len(y_data)):
+            if y_data[index] > 1.0:
+                max_index = index - 1
+                break
+        x_data = mtd[self._output_workspace].dataX(0)
+        crop_value = x_data[max_index]
+        CropWorkspace(Inputworkspace =self._output_workspace,
                       OutputWorkspace=self._output_workspace,
-                      XMax=bin_v)
+                      XMax = crop_value)
 
         # Set Y axis unit and label
         mtd[self._output_workspace].setYUnit('')
@@ -304,7 +309,6 @@ class TransformToIqt(PythonAlgorithm):
         DeleteWorkspace('__res_int')
         DeleteWorkspace('__res_fft')
         DeleteWorkspace('__res')
-
 
 # Register algorithm with Mantid
 AlgorithmFactory.subscribe(TransformToIqt)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -3,7 +3,6 @@ from mantid.simpleapi import *
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, PropertyMode, Progress
 from mantid.kernel import Direction, logger
 from mantid import config
-import math
 import os
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -288,7 +288,7 @@ class TransformToIqt(PythonAlgorithm):
 
         # Crop nonsense values off workspace
         y_data = mtd[self._output_workspace].dataY(0)
-        max_index = 0
+        max_index = len(y_data) - 1 # Defaults to final value in spectra
         for index in range(len(y_data)):
             if y_data[index] > 1.0:
                 max_index = index - 1

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TransformToIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TransformToIqtTest.py
@@ -56,7 +56,7 @@ class TransformToIqtTest(unittest.TestCase):
         self.assertEqual(CheckWorkspacesMatch(params, self._param_table), "Success!")
 
 
-    def test_for_unwanted_data(self):
+    def test_cropping_of_data(self):
         """
         Test to see if data is more than 1 in y axis for the first spectra. Any data like this should be cropped
         """
@@ -71,6 +71,24 @@ class TransformToIqtTest(unittest.TestCase):
         iqt_y_data = iqt.dataY(0)
         for bin_index in range(len(iqt_y_data)):
             self.assertLessEqual(iqt_y_data[bin_index], 1)
+
+
+    def test_output_size(self):
+        """
+        Test to ensure the workspace has not been over-cropped
+        """
+
+        sample = Load('irs26176_graphite002_red.nxs')
+        resolution = Load('irs26173_graphite002_res.nxs')
+
+        params, iqt = TransformToIqt(SampleWorkspace=sample,
+                                     ResolutionWorkspace=resolution,
+                                     EnergyMin=-0.5,
+                                     EnergyMax=0.5,
+                                     BinReductionFactor=10)
+
+        expected_bins = 78 # Expected bin number after cropping for this data set
+        self.assertEquals(iqt.blocksize(), expected_bins)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TransformToIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TransformToIqtTest.py
@@ -70,7 +70,7 @@ class TransformToIqtTest(unittest.TestCase):
 
         iqt_y_data = iqt.dataY(0)
         for bin_index in range(len(iqt_y_data)):
-            self.assertLessEqual(iqt_y_data[bin_index], 1)
+            self.assertTrue(iqt_y_data[bin_index] < 1)
 
 
     def test_output_size(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TransformToIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TransformToIqtTest.py
@@ -56,5 +56,21 @@ class TransformToIqtTest(unittest.TestCase):
         self.assertEqual(CheckWorkspacesMatch(params, self._param_table), "Success!")
 
 
+    def test_for_unwanted_data(self):
+        """
+        Test to see if data is more than 1 in y axis for the first spectra. Any data like this should be cropped
+        """
+
+        sample = Load('irs26176_graphite002_red')
+        resolution = Load('irs26173_graphite002_res')
+
+        params, iqt = TransformToIqt(SampleWorkspace=sample,
+                                     ResolutionWorkspace=resolution,
+                                     BinReductionFactor=10)
+
+        iqt_y_data = iqt.dataY(0)
+        for bin_index in range(len(iqt_y_data)):
+            self.assertLessEqual(iqt_y_data[bin_index], 1)
+
 if __name__ == '__main__':
     unittest.main()

--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/Iqt.ui
@@ -144,7 +144,7 @@
       <item>
         <widget class="QCheckBox" name="ckTile">
           <property name="text">
-            <string>TilePlot</string>
+            <string>TiledPlot</string>
           </property>
         </widget>
       </item>


### PR DESCRIPTION
Fixes #15010

Data is now cropped to where the 0th spectra goes above 1. After this point the data is meaningless.
# To Test
- Run the following script:

```
sample = Load('irs26176_graphite002_red.nxs')
resolution = Load('irs26173_graphite002_res.nxs')

params, iqt = TransformToIqt(SampleWorkspace=sample,
                             ResolutionWorkspace=resolution,
                             EnergyMin=-0.5,
                             EnergyMax=0.5,
                             BinReductionFactor=10)
```
- Ensure 4 workspaces are added to the ADS
- Ensure that Intensity is always less than or equal to 1 for the 0th spectra in 
- Ensure that the `iqt` workspace has 78 bins and the 0th bin has a y value of 1 for all spectra
