### PR TITLE
Fix cppcheck memleak in LoadLog.cpp

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -3,6 +3,7 @@
 
 #include "MantidAPI/DllConfig.h"
 #include "MantidKernel/Cache.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/Statistics.h"
 #include "MantidKernel/TimeSplitter.h"
@@ -82,7 +83,13 @@ public:
   virtual size_t getMemorySize() const;
 
   /// Add data to the object in the form of a property
-  void addProperty(Kernel::Property *prop, bool overwrite = false);
+  /// @deprecated new code should use smart pointers
+  void addProperty(Kernel::Property *prop, bool overwrite = false) {
+    addProperty(std::unique_ptr<Kernel::Property>(prop), overwrite);
+  };
+  /// Add data to the object in the form of a property
+  void addProperty(std::unique_ptr<Kernel::Property> prop,
+                   bool overwrite = false);
   /// Add a property of given type
   template <class TYPE>
   void addProperty(const std::string &name, const TYPE &value,
@@ -122,8 +129,18 @@ public:
   /**
    * Add a log entry
    * @param p :: A pointer to the property containing the log entry
+   * @deprecated new code should use smart pointers
    */
-  void addLogData(Kernel::Property *p) { addProperty(p); }
+  void addLogData(Kernel::Property *p) {
+    addLogData(std::unique_ptr<Kernel::Property>(p));
+  }
+  /**
+   * Add a log entry
+   * @param p :: A pointer to the property containing the log entry
+   */
+  void addLogData(std::unique_ptr<Kernel::Property> p) {
+    addProperty(std::move(p));
+  }
   /**
    * Access a single log entry
    * @param name :: The name of the log entry to retrieve
@@ -202,7 +219,9 @@ typedef boost::shared_ptr<const LogManager> LogManager_const_sptr;
 template <class TYPE>
 void LogManager::addProperty(const std::string &name, const TYPE &value,
                              bool overwrite) {
-  addProperty(new Kernel::PropertyWithValue<TYPE>(name, value), overwrite);
+  addProperty(
+      Mantid::Kernel::make_unique<Kernel::PropertyWithValue<TYPE>>(name, value),
+      overwrite);
 }
 
 /**
@@ -217,9 +236,10 @@ void LogManager::addProperty(const std::string &name, const TYPE &value,
 template <class TYPE>
 void LogManager::addProperty(const std::string &name, const TYPE &value,
                              const std::string &units, bool overwrite) {
-  Kernel::Property *newProp = new Kernel::PropertyWithValue<TYPE>(name, value);
+  auto newProp =
+      Mantid::Kernel::make_unique<Kernel::PropertyWithValue<TYPE>>(name, value);
   newProp->setUnits(units);
-  addProperty(newProp, overwrite);
+  addProperty(std::move(newProp), overwrite);
 }
 }
 }

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -183,12 +183,15 @@ void LogManager::filterByLog(const Kernel::TimeSeriesProperty<bool> &filter) {
 
 //-----------------------------------------------------------------------------------------------
 /**
- * Add data to the object in the form of a property
- * @param prop :: A pointer to a property whose ownership is transferred to this
- * object
- * @param overwrite :: If true, a current value is overwritten. (Default: False)
- */
-void LogManager::addProperty(Kernel::Property *prop, bool overwrite) {
+  * Add data to the object in the form of a property
+  * @param prop :: A pointer to a property whose ownership is transferred to
+ * this
+  * object
+  * @param overwrite :: If true, a current value is overwritten. (Default:
+ * False)
+  */
+void LogManager::addProperty(std::unique_ptr<Kernel::Property> prop,
+                             bool overwrite) {
   // Make an exception for the proton charge
   // and overwrite it's value as we don't want to store the proton charge in two
   // separate locations
@@ -199,7 +202,7 @@ void LogManager::addProperty(Kernel::Property *prop, bool overwrite) {
        prop->name() == "run_title")) {
     removeProperty(name);
   }
-  m_manager.declareProperty(prop, "");
+  m_manager.declareProperty(prop.release(), "");
 }
 
 //-----------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -8,6 +8,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Glob.h"
 #include "MantidKernel/LogParser.h"
+#include "MantidKernel/make_unique.h"
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/TimeSeriesProperty.h"
@@ -195,11 +196,10 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
                                      std::string logFileName, API::Run &run) {
   std::string str;
   std::string propname;
-  std::map<std::string, Kernel::TimeSeriesProperty<double> *> dMap;
-  std::map<std::string, Kernel::TimeSeriesProperty<std::string> *> sMap;
-  typedef std::pair<std::string, Kernel::TimeSeriesProperty<double> *> dpair;
-  typedef std::pair<std::string, Kernel::TimeSeriesProperty<std::string> *>
-      spair;
+  std::map<std::string, std::unique_ptr<Kernel::TimeSeriesProperty<double>>>
+      dMap;
+  std::map<std::string,
+           std::unique_ptr<Kernel::TimeSeriesProperty<std::string>>> sMap;
   kind l_kind(LoadLog::empty);
   bool isNumeric(false);
 
@@ -254,38 +254,33 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
     if (isNumeric) {
       auto ditr = dMap.find(propname);
       if (ditr != dMap.end()) {
-        Kernel::TimeSeriesProperty<double> *prop = ditr->second;
+        auto prop = ditr->second.get();
         if (prop)
           prop->addValue(timecolumn, dvalue);
       } else {
         auto logd = Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<double>>(propname);
         logd->addValue(timecolumn, dvalue);
-        dMap.insert(dpair(propname, logd.release()));
+        dMap.emplace(std::make_pair(propname, std::move(logd)));
       }
     } else {
       auto sitr = sMap.find(propname);
       if (sitr != sMap.end()) {
-        Kernel::TimeSeriesProperty<std::string> *prop = sitr->second;
+        auto prop = sitr->second.get();
         if (prop)
           prop->addValue(timecolumn, valuecolumn);
       } else {
         auto logs = Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<std::string>>(propname);
         logs->addValue(timecolumn, valuecolumn);
-        sMap.insert(spair(propname, logs.release()));
+        sMap.emplace(std::make_pair(propname, std::move(logs)));
       }
     }
   }
   try {
-    std::map<std::string, Kernel::TimeSeriesProperty<double> *>::const_iterator
-        itr = dMap.begin();
-    for (; itr != dMap.end(); ++itr) {
-      run.addLogData(itr->second);
+    for (auto itr = dMap.begin(); itr != dMap.end(); ++itr) {
+      run.addLogData(itr->second.release());
     }
-    std::map<std::string,
-             Kernel::TimeSeriesProperty<std::string> *>::const_iterator sitr =
-        sMap.begin();
-    for (; sitr != sMap.end(); ++sitr) {
-      run.addLogData(sitr->second);
+    for (auto sitr = sMap.begin(); sitr != sMap.end(); ++sitr) {
+      run.addLogData(sitr->second.release());
     }
   } catch (std::invalid_argument &e) {
     g_log.warning() << e.what();

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -195,8 +195,6 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
                                      std::string logFileName, API::Run &run) {
   std::string str;
   std::string propname;
-  Mantid::Kernel::TimeSeriesProperty<double> *logd = 0;
-  Mantid::Kernel::TimeSeriesProperty<std::string> *logs = 0;
   std::map<std::string, Kernel::TimeSeriesProperty<double> *> dMap;
   std::map<std::string, Kernel::TimeSeriesProperty<std::string> *> sMap;
   typedef std::pair<std::string, Kernel::TimeSeriesProperty<double> *> dpair;
@@ -260,9 +258,9 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
         if (prop)
           prop->addValue(timecolumn, dvalue);
       } else {
-        logd = new Kernel::TimeSeriesProperty<double>(propname);
+        auto logd = Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<double>>(propname);
         logd->addValue(timecolumn, dvalue);
-        dMap.insert(dpair(propname, logd));
+        dMap.insert(dpair(propname, logd.release()));
       }
     } else {
       auto sitr = sMap.find(propname);
@@ -271,9 +269,9 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
         if (prop)
           prop->addValue(timecolumn, valuecolumn);
       } else {
-        logs = new Kernel::TimeSeriesProperty<std::string>(propname);
+        auto logs = Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<std::string>>(propname);
         logs->addValue(timecolumn, valuecolumn);
-        sMap.insert(spair(propname, logs));
+        sMap.insert(spair(propname, logs.release()));
       }
     }
   }

--- a/Framework/DataHandling/src/LoadLog.cpp
+++ b/Framework/DataHandling/src/LoadLog.cpp
@@ -258,7 +258,9 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
         if (prop)
           prop->addValue(timecolumn, dvalue);
       } else {
-        auto logd = Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<double>>(propname);
+        auto logd =
+            Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<double>>(
+                propname);
         logd->addValue(timecolumn, dvalue);
         dMap.emplace(std::make_pair(propname, std::move(logd)));
       }
@@ -269,7 +271,8 @@ void LoadLog::loadThreeColumnLogFile(std::ifstream &logFileStream,
         if (prop)
           prop->addValue(timecolumn, valuecolumn);
       } else {
-        auto logs = Mantid::Kernel::make_unique<Kernel::TimeSeriesProperty<std::string>>(propname);
+        auto logs = Mantid::Kernel::make_unique<
+            Kernel::TimeSeriesProperty<std::string>>(propname);
         logs->addValue(timecolumn, valuecolumn);
         sMap.emplace(std::make_pair(propname, std::move(logs)));
       }


### PR DESCRIPTION
This fixes two memory leaks reported by [cppcheck 1.72](http://builds.mantidproject.org/view/Static%20Analysis/job/cppcheck-1.72/). I also changed some sinks to look more like solution 3c in [GotW #91](http://herbsutter.com/2013/06/05/gotw-91-solution-smart-pointer-parameters/). 

no release notes

testing: code review, especially checking that the second commit doesn't change behavior.
