### PR TITLE
EnggDiffractionGUI::Disables and Enables the group box for Focus Cropped and Texture

### DIFF
--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -534,14 +534,16 @@ void EnggDiffractionViewQtGUI::enableCalibrateAndFocusActions(bool enable) {
 
   // focus
   m_uiTabFocus.lineEdit_run_num->setEnabled(enable);
+
+  m_uiTabFocus.groupBox_cropped->setEnabled(enable);
+  m_uiTabFocus.groupBox_texture->setEnabled(enable);
+
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
   m_uiTabFocus.checkBox_FocusedWS->setEnabled(enable);
   m_uiTabFocus.checkBox_SaveOutputFiles->setEnabled(enable);
   m_uiTabFocus.comboBox_Multi_Runs->setEnabled(enable);
 
   m_uiTabFocus.pushButton_focus->setEnabled(enable);
-  m_uiTabFocus.pushButton_focus_cropped->setEnabled(enable);
-  m_uiTabFocus.pushButton_focus_texture->setEnabled(enable);
   m_uiTabFocus.pushButton_stopFocus->setDisabled(enable);
 
   // pre-processing
@@ -557,8 +559,9 @@ void EnggDiffractionViewQtGUI::enableTabs(bool enable) {
 }
 
 std::vector<std::string> EnggDiffractionViewQtGUI::currentPreprocRunNo() const {
-	return qListToVector(m_uiTabPreproc.MWRunFiles_preproc_run_num->getFilenames(),
-		m_uiTabPreproc.MWRunFiles_preproc_run_num->isValid());
+  return qListToVector(
+      m_uiTabPreproc.MWRunFiles_preproc_run_num->getFilenames(),
+      m_uiTabPreproc.MWRunFiles_preproc_run_num->isValid());
 }
 
 double EnggDiffractionViewQtGUI::rebinningTimeBin() const {


### PR DESCRIPTION
Fixes #15067

All the features which are included inside Focus Cropped and Focus Texture group-box are now disabled when Calibration, Focus or Rebin process is being carried out on the interface.
