### PR TITLE
Fix CMP0026 warning with Xcode generator.

### DIFF
--- a/buildconfig/CMake/MantidUtils.cmake
+++ b/buildconfig/CMake/MantidUtils.cmake
@@ -41,14 +41,12 @@ function( SET_TARGET_OUTPUT_DIRECTORY TARGET OUTPUT_DIR )
       # for python to find it.
 
       # Lets get the location of the output for the given target
-      get_target_property(SOURCE_LOCATION ${TARGET} LOCATION)
-
-      # And copy it to where we want it to go
+      # and copy it to where we want it to go
       add_custom_command (TARGET ${TARGET} POST_BUILD 
                           COMMAND ${CMAKE_COMMAND} ARGS -E echo 
                           "Copying \"${SOURCE_LOCATION}\" to \"${OUTPUT_DIR}/\" "
                           COMMAND ${CMAKE_COMMAND} ARGS -E copy
-                          ${SOURCE_LOCATION}
+                          $<TARGET_FILE:${TARGET}>
                           ${OUTPUT_DIR}/
                           )
   else ()

--- a/buildconfig/CMake/MantidUtils.cmake
+++ b/buildconfig/CMake/MantidUtils.cmake
@@ -44,7 +44,7 @@ function( SET_TARGET_OUTPUT_DIRECTORY TARGET OUTPUT_DIR )
       # and copy it to where we want it to go
       add_custom_command (TARGET ${TARGET} POST_BUILD 
                           COMMAND ${CMAKE_COMMAND} ARGS -E echo 
-                          "Copying \"${SOURCE_LOCATION}\" to \"${OUTPUT_DIR}/\" "
+                          "Copying \"$<TARGET_FILE:${TARGET}>\" to \"${OUTPUT_DIR}/\" "
                           COMMAND ${CMAKE_COMMAND} ARGS -E copy
                           $<TARGET_FILE:${TARGET}>
                           ${OUTPUT_DIR}/


### PR DESCRIPTION
This fixes the following warning when generating an Xcode project.

```
CMake Warning (dev) at buildconfig/CMake/MantidUtils.cmake:44 (get_target_property):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target "PythonKernelModule".
  Use the target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.

Call Stack (most recent call first):
  Framework/PythonInterface/mantid/kernel/CMakeLists.txt:166 (set_target_output_directory)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at buildconfig/CMake/MantidUtils.cmake:44 (get_target_property):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target
  "PythonGeometryModule".  Use the target name directly with
  add_custom_command, or use the generator expression $<TARGET_FILE>, as
  appropriate.

Call Stack (most recent call first):
  Framework/PythonInterface/mantid/geometry/CMakeLists.txt:80 (set_target_output_directory)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at buildconfig/CMake/MantidUtils.cmake:44 (get_target_property):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target "PythonAPIModule".
  Use the target name directly with add_custom_command, or use the generator
  expression $<TARGET_FILE>, as appropriate.

Call Stack (most recent call first):
  Framework/PythonInterface/mantid/api/CMakeLists.txt:136 (set_target_output_directory)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at buildconfig/CMake/MantidUtils.cmake:44 (get_target_property):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target
  "PythonDataObjectsModule".  Use the target name directly with
  add_custom_command, or use the generator expression $<TARGET_FILE>, as
  appropriate.

Call Stack (most recent call first):
  Framework/PythonInterface/mantid/dataobjects/CMakeLists.txt:63 (set_target_output_directory)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at buildconfig/CMake/MantidUtils.cmake:44 (get_target_property):
  Policy CMP0026 is not set: Disallow use of the LOCATION target property.
  Run "cmake --help-policy CMP0026" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The LOCATION property should not be read from target
  "PythonWorkspaceCreationHelper".  Use the target name directly with
  add_custom_command, or use the generator expression $<TARGET_FILE>, as
  appropriate.

Call Stack (most recent call first):
  Framework/PythonInterface/test/testhelpers/CMakeLists.txt:33 (set_target_output_directory)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

more information on [CMP0026](https://cmake.org/cmake/help/v3.4/policy/CMP0026.html).

no release notes

code review: Generate an xcode project (`cmake -G Xcode`) and verify the warnings above no longer occur.
