### PR TITLE
Changes suggested by readability-simplify-boolean-expr.

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1419,7 +1419,7 @@ bool Algorithm::isWorkspaceProperty(const Kernel::Property *const prop) const {
   }
   const IWorkspaceProperty *const wsProp =
       dynamic_cast<const IWorkspaceProperty *>(prop);
-  return (wsProp ? true : false);
+  return (wsProp != nullptr);
 }
 
 //=============================================================================================

--- a/Framework/API/src/BoxController.cpp
+++ b/Framework/API/src/BoxController.cpp
@@ -212,10 +212,7 @@ std::string BoxController::getFilename() const {
 /** the function left for compartibility with the previous bc python interface.
 @return true if the workspace is file based and false otherwise */
 bool BoxController::useWriteBuffer() const {
-  if (m_fileIO)
-    return true;
-  else
-    return false;
+  return static_cast<bool>(m_fileIO);
 }
 
 //------------------------------------------------------------------------------------------------------

--- a/Framework/API/src/Expression.cpp
+++ b/Framework/API/src/Expression.cpp
@@ -309,11 +309,7 @@ void Expression::tokenize() {
     }
 
     if (c == '"') {
-      if (!inString) {
-        inString = true;
-      } else {
-        inString = false;
-      }
+      inString = !inString;
     }
 
   } // for i
@@ -401,10 +397,7 @@ void Expression::setFunct(const std::string &name) {
   bool inQuotes = false;
   for (std::string::const_iterator c = name.begin(); c != name.end(); ++c) {
     if (*c == '"') {
-      if (inQuotes)
-        inQuotes = false;
-      else
-        inQuotes = true;
+      inQuotes = !inQuotes;
       continue;
     }
 

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -37,9 +37,7 @@ Mantid::Kernel::Logger g_log("FileFinder");
  * @returns true if extension contains a "*", else false.
  */
 bool containsWildCard(const std::string &ext) {
-  if (std::string::npos != ext.find("*"))
-    return true;
-  return false;
+  return std::string::npos != ext.find("*");
 }
 }
 

--- a/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Framework/API/src/FileLoaderRegistry.cpp
@@ -160,10 +160,7 @@ bool FileLoaderRegistryImpl::canLoad(const std::string &algorithmName,
     loader = searchForLoader<FileDescriptor, IFileLoader<FileDescriptor>>(
         filename, names, m_log);
   }
-  if (loader)
-    return true;
-  else
-    return false;
+  return static_cast<bool>(loader);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/API/src/IPowderDiffPeakFunction.cpp
+++ b/Framework/API/src/IPowderDiffPeakFunction.cpp
@@ -220,10 +220,7 @@ bool IPowderDiffPeakFunction::hasProfileParameter(std::string paramname) {
     return false;
 
   std::string candname = *niter;
-  if (candname.compare(paramname))
-    return false;
-
-  return true;
+  return !static_cast<bool>(candname.compare(paramname));
 }
 
 //-------------------------  External Functions

--- a/Framework/API/src/IPowderDiffPeakFunction.cpp
+++ b/Framework/API/src/IPowderDiffPeakFunction.cpp
@@ -213,14 +213,12 @@ void IPowderDiffPeakFunction::setPeakRadius(const int &r) {
 /** Check whether a parameter is a profile parameter
   */
 bool IPowderDiffPeakFunction::hasProfileParameter(std::string paramname) {
-  std::vector<std::string>::iterator niter;
-  niter = lower_bound(m_sortedProfileParameterNames.begin(),
-                      m_sortedProfileParameterNames.end(), paramname);
-  if (niter == m_sortedProfileParameterNames.end())
+  auto candname = lower_bound(m_sortedProfileParameterNames.begin(),
+                              m_sortedProfileParameterNames.end(), paramname);
+  if (candname == m_sortedProfileParameterNames.end())
     return false;
 
-  std::string candname = *niter;
-  return !static_cast<bool>(candname.compare(paramname));
+  return candname->compare(paramname) != 0;
 }
 
 //-------------------------  External Functions

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -952,7 +952,7 @@ bool &MatrixWorkspace::isDistribution(bool newValue) {
 *  @return whether the workspace contains histogram data
 */
 bool MatrixWorkspace::isHistogramData() const {
-  return (readX(0).size() == blocksize() ? false : true);
+  return (readX(0).size() != blocksize());
 }
 
 /**
@@ -1097,7 +1097,7 @@ bool MatrixWorkspace::hasMaskedBins(const size_t &workspaceIndex) const {
   // against throwing here).
   if (workspaceIndex >= this->getNumberHistograms())
     return false;
-  return (m_masks.find(workspaceIndex) == m_masks.end()) ? false : true;
+  return m_masks.find(workspaceIndex) != m_masks.end();
 }
 
 /** Returns the list of masked bins for a spectrum.

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -29,9 +29,7 @@ Mantid::Kernel::Logger g_log("MultipleFileProperty");
  * a "*" wild card in the file extension string passed to it.
  */
 bool doesNotContainWildCard(const std::string &ext) {
-  if (std::string::npos != ext.find("*"))
-    return false;
-  return true;
+  return std::string::npos == ext.find("*");
 }
 } // anonymous namespace
 
@@ -345,10 +343,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
         // Check for an extension.
         Poco::Path path(*unresolvedFileName);
 
-        if (path.getExtension().empty())
-          useDefaultExt = true;
-        else
-          useDefaultExt = false;
+        useDefaultExt = path.getExtension().empty();
       } catch (Poco::Exception &) {
         // Just shove the problematic filename straight into FileProperty and
         // see

--- a/Framework/API/src/RefAxis.cpp
+++ b/Framework/API/src/RefAxis.cpp
@@ -86,10 +86,7 @@ bool RefAxis::operator==(const Axis &axis2) const {
     return false;
   }
   const RefAxis *ra2 = dynamic_cast<const RefAxis *>(&axis2);
-  if (!ra2) {
-    return false;
-  }
-  return true;
+  return ra2 != nullptr;
 }
 
 /** Check if two numeric axis are equivalent to a given tolerance

--- a/Framework/API/src/Sample.cpp
+++ b/Framework/API/src/Sample.cpp
@@ -193,11 +193,7 @@ void Sample::setCrystalStructure(
 bool Sample::hasCrystalStructure() const {
   // Conversion to bool seems to be a problem in VS2012, so this is a bit more
   // verbose than it should be.
-  if (m_crystalStructure) {
-    return true;
-  }
-
-  return false;
+  return static_cast<bool>(m_crystalStructure);
 }
 
 /// Destroys the internally stored CrystalStructure-object.

--- a/Framework/Algorithms/src/ChangeTimeZero.cpp
+++ b/Framework/Algorithms/src/ChangeTimeZero.cpp
@@ -356,7 +356,7 @@ bool ChangeTimeZero::checkForDateTime(const std::string &val) const {
  * @returns true if the offset has been set
  */
 bool ChangeTimeZero::isRelativeTimeShift(double offset) const {
-  return offset != m_defaultTimeShift ? true : false;
+  return offset != m_defaultTimeShift;
 }
 
 /**
@@ -365,9 +365,7 @@ bool ChangeTimeZero::isRelativeTimeShift(double offset) const {
  * @returns true if the offset has been set
  */
 bool ChangeTimeZero::isAbsoluteTimeShift(const std::string &offset) const {
-  return (offset != m_defaultAbsoluteTimeShift && checkForDateTime(offset))
-             ? true
-             : false;
+  return offset != m_defaultAbsoluteTimeShift && checkForDateTime(offset);
 }
 
 } // namespace Mantid

--- a/Framework/Algorithms/src/CorrectToFile.cpp
+++ b/Framework/Algorithms/src/CorrectToFile.cpp
@@ -75,7 +75,7 @@ void CorrectToFile::exec() {
     const MantidVec &Ecor = rkhInput->readE(0);
 
     const bool histogramData = outputWS->isHistogramData();
-    const bool divide = (operation == "Divide") ? true : false;
+    const bool divide = operation == "Divide";
     double Yfactor, correctError;
 
     const int64_t nOutSpec =

--- a/Framework/Algorithms/src/ExponentialCorrection.cpp
+++ b/Framework/Algorithms/src/ExponentialCorrection.cpp
@@ -42,7 +42,7 @@ void ExponentialCorrection::retrieveProperties() {
   m_c0 = getProperty("C0");
   m_c1 = getProperty("C1");
   std::string op = getProperty("Operation");
-  m_divide = (op == "Divide") ? true : false;
+  m_divide = op == "Divide";
 }
 
 void ExponentialCorrection::performUnaryOperation(const double XIn,

--- a/Framework/Algorithms/src/GeneratePeaks.cpp
+++ b/Framework/Algorithms/src/GeneratePeaks.cpp
@@ -697,10 +697,7 @@ bool GeneratePeaks::hasParameter(API::IFunction_sptr function,
   std::vector<std::string> parnames = function->getParameterNames();
   std::vector<std::string>::iterator piter;
   piter = std::find(parnames.begin(), parnames.end(), paramname);
-  if (piter != parnames.end())
-    return true;
-
-  return false;
+  return piter != parnames.end();
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/MaskDetectorsIf.cpp
+++ b/Framework/Algorithms/src/MaskDetectorsIf.cpp
@@ -167,7 +167,7 @@ void MaskDetectorsIf::createNewCalFile(const std::string &oldfile,
     bool selection;
 
     if (it == umap.end())
-      selection = (sel == 0) ? false : true;
+      selection = sel != 0;
     else
       selection = (*it).second;
 

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -64,10 +64,7 @@ bool MonIDPropChanger::isConditionChanged(const IPropertyManager *algo) const {
   //       std::cout << "MonIDPropChanger::isConditionChanged() called  ";
   //       std::cout << monitors_changed << std::endl;
 
-  if (!monitors_changed)
-    return false;
-
-  return true;
+  return monitors_changed;
 }
 // function which modifies the allowed values for the list of monitors.
 void MonIDPropChanger::applyChanges(const IPropertyManager *algo,

--- a/Framework/Algorithms/src/OneMinusExponentialCor.cpp
+++ b/Framework/Algorithms/src/OneMinusExponentialCor.cpp
@@ -39,7 +39,7 @@ void OneMinusExponentialCor::retrieveProperties() {
   m_c = getProperty("C");
   m_c1 = getProperty("C1");
   std::string op = getProperty("Operation");
-  m_divide = (op == "Divide") ? true : false;
+  m_divide = op == "Divide";
 }
 
 void OneMinusExponentialCor::performUnaryOperation(const double XIn,

--- a/Framework/Algorithms/src/PDDetermineCharacterizations.cpp
+++ b/Framework/Algorithms/src/PDDetermineCharacterizations.cpp
@@ -156,10 +156,7 @@ bool closeEnough(const double left, const double right) {
 
   // same within 5%
   const double relativeDiff = diff * 2 / (left + right);
-  if (relativeDiff < .05)
-    return true;
-
-  return false;
+  return relativeDiff < .05;
 }
 
 /// Fill in the property manager from the correct line in the table

--- a/Framework/Algorithms/src/PolynomialCorrection.cpp
+++ b/Framework/Algorithms/src/PolynomialCorrection.cpp
@@ -43,7 +43,7 @@ void PolynomialCorrection::retrieveProperties() {
   m_coeffs = getProperty("Coefficients");
   m_polySize = m_coeffs.size();
   std::string operation = getProperty("Operation");
-  m_isOperationMultiply = operation == "Multiply" ? true : false;
+  m_isOperationMultiply = operation == "Multiply";
 }
 
 void PolynomialCorrection::performUnaryOperation(const double XIn,

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -120,7 +120,7 @@ void Q1D2::exec() {
   // iterations of the loop below
 
   // Flag to decide if Q Resolution is to be used
-  auto useQResolution = qResolution ? true : false;
+  auto useQResolution = static_cast<bool>(qResolution);
 
   // this will become the output workspace from this algorithm
   MatrixWorkspace_sptr outputWS =

--- a/Framework/Algorithms/src/RemoveBins.cpp
+++ b/Framework/Algorithms/src/RemoveBins.cpp
@@ -199,7 +199,7 @@ void RemoveBins::checkProperties() {
   }
 
   const std::string interpolation = getProperty("Interpolation");
-  m_interpolate = (interpolation == "Linear" ? true : false);
+  m_interpolate = (interpolation == "Linear");
 
   return;
 }

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -242,7 +242,7 @@ void SmoothNeighbours::findNeighboursRectangular() {
   int EndY = AdjY;
   int SumX = getProperty("SumPixelsX");
   int SumY = getProperty("SumPixelsY");
-  bool sum = (SumX * SumY > 1) ? true : false;
+  bool sum = SumX * SumY > 1;
   if (sum) {
     StartX = 0;
     StartY = 0;

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -381,11 +381,8 @@ bool CentroidPeaks::edgePixel(std::string bankName, int col, int row,
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
-    if (col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
-        row >= (RDet->ypixels() - Edge))
-      return true;
-    else
-      return false;
+    return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
+           row >= (RDet->ypixels() - Edge);
   } else {
     std::vector<Geometry::IComponent_const_sptr> children;
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
@@ -398,11 +395,8 @@ bool CentroidPeaks::edgePixel(std::string bankName, int col, int row,
     int NROWS = static_cast<int>(grandchildren.size());
     int NCOLS = static_cast<int>(children.size());
     // Wish pixels and tubes start at 1 not 0
-    if (col - 1 < Edge || col - 1 >= (NCOLS - Edge) || row - 1 < Edge ||
-        row - 1 >= (NROWS - Edge))
-      return true;
-    else
-      return false;
+    return col - 1 < Edge || col - 1 >= (NCOLS - Edge) || row - 1 < Edge ||
+           row - 1 >= (NROWS - Edge);
   }
   return false;
 }

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -1762,13 +1762,10 @@ bool DataModeHandler::isEdgePeak(const double *params, int nparams) {
   double Ry =
       lastRCRadius / CellHeight - EdgeY; // span from center  in y direction
 
-  if (Rx * Rx <
-          NStdDevPeakSpan * NStdDevPeakSpan * std::max<double>(Varx, VarxHW) ||
-      Ry * Ry <
-          NStdDevPeakSpan * NStdDevPeakSpan * std::max<double>(Vary, VaryHW))
-    return true;
-
-  return false;
+  return Rx * Rx < NStdDevPeakSpan * NStdDevPeakSpan *
+                       std::max<double>(Varx, VarxHW) ||
+         Ry * Ry <
+             NStdDevPeakSpan * NStdDevPeakSpan * std::max<double>(Vary, VaryHW);
 }
 
 /**

--- a/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
+++ b/Framework/Crystal/src/OptimizeLatticeForCellType.cpp
@@ -262,11 +262,8 @@ bool OptimizeLatticeForCellType::edgePixel(PeaksWorkspace_sptr ws,
     boost::shared_ptr<const RectangularDetector> RDet =
         boost::dynamic_pointer_cast<const RectangularDetector>(parent);
 
-    if (col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
-        row >= (RDet->ypixels() - Edge))
-      return true;
-    else
-      return false;
+    return col < Edge || col >= (RDet->xpixels() - Edge) || row < Edge ||
+           row >= (RDet->ypixels() - Edge);
   } else {
     std::vector<Geometry::IComponent_const_sptr> children;
     boost::shared_ptr<const Geometry::ICompAssembly> asmb =
@@ -288,11 +285,8 @@ bool OptimizeLatticeForCellType::edgePixel(PeaksWorkspace_sptr ws,
     int NROWS = static_cast<int>(grandchildren.size());
     int NCOLS = static_cast<int>(children.size());
     // Wish pixels and tubes start at 1 not 0
-    if (col - startI < Edge || col - startI >= (NCOLS - Edge) ||
-        row - startI < Edge || row - startI >= (NROWS - Edge))
-      return true;
-    else
-      return false;
+    return col - startI < Edge || col - startI >= (NCOLS - Edge) ||
+           row - startI < Edge || row - startI >= (NROWS - Edge);
   }
   return false;
 }

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -1657,10 +1657,7 @@ void LeBailFit::doMarkovChain(const map<string, Parameter> &parammap,
       } else {
         acceptchange = acceptOrDeny(currR, newR);
 
-        if (newR.Rwp < currR.Rwp)
-          prevcyclebetterR = true;
-        else
-          prevcyclebetterR = false;
+        prevcyclebetterR = newR.Rwp < currR.Rwp;
       }
 
       g_log.debug() << "[DBx317] Step " << icycle

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -726,11 +726,7 @@ void RefinePowderInstrumentParameters::doParameterSpaceRandomWalk(
     //      << ".  Acceptance Prob. = " << prob << "; Random = " << randnumber
     //      << endl;
 
-    if (randnumber < prob) {
-      accept = true;
-    } else {
-      accept = false;
-    }
+    accept = randnumber < prob;
 
     // d. Adjust step size
     if (false) {

--- a/Framework/CurveFitting/src/FuncMinimizers/DampingMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/DampingMinimizer.cpp
@@ -110,11 +110,7 @@ bool DampingMinimizer::iterate(size_t) {
   GSLVector p(n);
   m_leastSquares->getParameters(p);
   double dx_norm = gsl_blas_dnrm2(dx.gsl());
-  if (dx_norm < m_relTol) {
-    return false;
-  }
-
-  return true;
+  return dx_norm >= m_relTol;
 }
 
 /// Return current value of the cost function

--- a/Framework/CurveFitting/src/Functions/ChebfunBase.cpp
+++ b/Framework/CurveFitting/src/Functions/ChebfunBase.cpp
@@ -186,10 +186,7 @@ bool ChebfunBase::hasConverged(const std::vector<double> &a, double maxA,
   for (auto i = a.rbegin() + shift; i != a.rend() - 1; ++i) {
     if (*i == 0.0)
       continue;
-    if ((fabs(*i) + fabs(*(i + 1))) / maxA / 2 < tolerance)
-      return true;
-    else
-      return false;
+    return (fabs(*i) + fabs(*(i + 1))) / maxA / 2 < tolerance;
   }
   return false;
 }

--- a/Framework/DataHandling/src/LoadCalFile.cpp
+++ b/Framework/DataHandling/src/LoadCalFile.cpp
@@ -69,10 +69,7 @@ bool LoadCalFile::instrumentIsSpecified(API::Algorithm *alg) {
     return true;
 
   std::string InstrumentFilename = alg->getPropertyValue("InstrumentFilename");
-  if (!InstrumentFilename.empty())
-    return true;
-
-  return false;
+  return !InstrumentFilename.empty();
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1743,10 +1743,7 @@ bool UDlesserExecCount(NXClassInfo elem1, NXClassInfo elem2) {
   is1 >> execNum1;
   is2 >> execNum2;
 
-  if (execNum1 < execNum2)
-    return true;
-  else
-    return false;
+  return execNum1 < execNum2;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -34,10 +34,7 @@ static bool endswith(const std::string &s, const std::string &subs) {
   // get a substring
   std::string tail = s.substr(s.size() - subs.size());
 
-  if (tail.compare(subs) != 0)
-    return false;
-
-  return true;
+  return tail.compare(subs) == 0;
 }
 
 static bool checkIntersection(std::vector<std::string> v1,
@@ -50,10 +47,7 @@ static bool checkIntersection(std::vector<std::string> v1,
   std::vector<std::string> intersectvec(v1.size() + v2.size());
   auto outiter = std::set_intersection(v1.begin(), v1.end(), v2.begin(),
                                        v2.end(), intersectvec.begin());
-  if (static_cast<int>(outiter - intersectvec.begin()) == 0)
-    return false;
-
-  return true;
+  return static_cast<int>(outiter - intersectvec.begin()) != 0;
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/MergeLogs.cpp
+++ b/Framework/DataHandling/src/MergeLogs.cpp
@@ -107,11 +107,7 @@ void Merge2WorkspaceLogs::mergeLogs(std::string ilogname1,
 
     // i. Determine which log to work on
     if (!nocomparison) {
-      if (times1[index1] < times2[index2]) {
-        launch1 = true;
-      } else {
-        launch1 = false;
-      }
+      launch1 = times1[index1] < times2[index2];
     }
 
     // ii. Retrieve data from source log

--- a/Framework/DataHandling/src/SaveRKH.cpp
+++ b/Framework/DataHandling/src/SaveRKH.cpp
@@ -46,10 +46,7 @@ void SaveRKH::exec() {
   // Retrieve the input workspace
   m_workspace = getProperty("InputWorkspace");
 
-  m_2d =
-      (m_workspace->getNumberHistograms() > 1 && m_workspace->blocksize() > 1)
-          ? true
-          : false;
+  m_2d = m_workspace->getNumberHistograms() > 1 && m_workspace->blocksize() > 1;
 
   // If a 2D workspace, check that it has two numeric axes - bail out if not
   if (m_2d && !(m_workspace->getAxis(1)->isNumeric())) {
@@ -134,7 +131,7 @@ void SaveRKH::writeHeader() {
 void SaveRKH::write1D() {
   const size_t noDataPoints = m_workspace->size();
   const size_t nhist = m_workspace->getNumberHistograms();
-  const bool horizontal = (nhist == 1) ? true : false;
+  const bool horizontal = nhist == 1;
   if (horizontal) {
     g_log.notice() << "Values in first column are the X values\n";
     if (m_workspace->getAxis(0)->unit())

--- a/Framework/DataObjects/src/MaskWorkspace.cpp
+++ b/Framework/DataObjects/src/MaskWorkspace.cpp
@@ -281,10 +281,7 @@ bool MaskWorkspace::hasInstrument() const {
   bool hasinst;
   Geometry::Instrument_const_sptr inst = this->getInstrument();
   if (inst) {
-    if (inst->getNumberDetectors() > 0)
-      hasinst = true;
-    else
-      hasinst = false;
+    hasinst = inst->getNumberDetectors() > 0;
   } else
     hasinst = false;
 

--- a/Framework/Geometry/src/Crystal/NiggliCell.cpp
+++ b/Framework/Geometry/src/Crystal/NiggliCell.cpp
@@ -74,7 +74,7 @@ static bool CompareDiffFrom90(const DblMatrix &UB_1, const DblMatrix &UB_2) {
 @param Umatrix :: orientation matrix U. By default this will be identity matrix
 */
 NiggliCell::NiggliCell(const DblMatrix &Umatrix) : UnitCell() {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -99,7 +99,7 @@ NiggliCell::NiggliCell(const NiggliCell &other)
 NiggliCell::NiggliCell(const double _a, const double _b, const double _c,
                        const DblMatrix &Umatrix)
     : UnitCell(_a, _b, _c) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -121,7 +121,7 @@ NiggliCell::NiggliCell(const double _a, const double _b, const double _c,
                        const double _gamma, const DblMatrix &Umatrix,
                        const int angleunit)
     : UnitCell(_a, _b, _c, _alpha, _beta, _gamma, angleunit) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -134,7 +134,7 @@ NiggliCell::NiggliCell(const double _a, const double _b, const double _c,
 */
 NiggliCell::NiggliCell(const UnitCell &uc, const DblMatrix &Umatrix)
     : UnitCell(uc), U(Umatrix) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -143,7 +143,7 @@ NiggliCell::NiggliCell(const UnitCell &uc, const DblMatrix &Umatrix)
 
 NiggliCell::NiggliCell(const UnitCell *uc, const DblMatrix &Umatrix)
     : UnitCell(uc), U(Umatrix) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else

--- a/Framework/Geometry/src/Crystal/OrientedLattice.cpp
+++ b/Framework/Geometry/src/Crystal/OrientedLattice.cpp
@@ -14,7 +14,7 @@ const double TWO_PI = 2. * M_PI;
 @param Umatrix :: orientation matrix U. By default this will be identity matrix
 */
 OrientedLattice::OrientedLattice(const DblMatrix &Umatrix) : UnitCell() {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -39,7 +39,7 @@ OrientedLattice::OrientedLattice(const OrientedLattice &other)
 OrientedLattice::OrientedLattice(const double _a, const double _b,
                                  const double _c, const DblMatrix &Umatrix)
     : UnitCell(_a, _b, _c) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -61,7 +61,7 @@ OrientedLattice::OrientedLattice(const double _a, const double _b,
                                  const double _beta, const double _gamma,
                                  const DblMatrix &Umatrix, const int angleunit)
     : UnitCell(_a, _b, _c, _alpha, _beta, _gamma, angleunit) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -74,7 +74,7 @@ OrientedLattice::OrientedLattice(const double _a, const double _b,
 */
 OrientedLattice::OrientedLattice(const UnitCell &uc, const DblMatrix &Umatrix)
     : UnitCell(uc), U(Umatrix) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else
@@ -83,7 +83,7 @@ OrientedLattice::OrientedLattice(const UnitCell &uc, const DblMatrix &Umatrix)
 
 OrientedLattice::OrientedLattice(const UnitCell *uc, const DblMatrix &Umatrix)
     : UnitCell(uc), U(Umatrix) {
-  if (Umatrix.isRotation() == true) {
+  if (Umatrix.isRotation()) {
     U = Umatrix;
     UB = U * getB();
   } else

--- a/Framework/Geometry/src/Instrument/Goniometer.cpp
+++ b/Framework/Geometry/src/Instrument/Goniometer.cpp
@@ -90,7 +90,7 @@ bool Goniometer::isDefined() const { return initFromR || (!motors.empty()); }
 /// name, direction, sense, angle)
 /// The angle units shown is degrees
 std::string Goniometer::axesInfo() {
-  if (initFromR == true) {
+  if (initFromR) {
     return std::string("Goniometer was initialized from a rotation matrix. No "
                        "information about axis is available.\n");
   } else {
@@ -126,7 +126,7 @@ std::string Goniometer::axesInfo() {
 */
 void Goniometer::pushAxis(std::string name, double axisx, double axisy,
                           double axisz, double angle, int sense, int angUnit) {
-  if (initFromR == true) {
+  if (initFromR) {
     throw std::runtime_error(
         "Initialized from a rotation matrix, so no axes can be pushed.");
   } else {
@@ -155,7 +155,7 @@ void Goniometer::setRotationAngle(std::string name, double value) {
       changed = true;
     }
   }
-  if (changed == false) {
+  if (!changed) {
     throw std::invalid_argument("Motor name " + name + " not found");
   }
   recalculateR();

--- a/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Framework/Geometry/src/Math/Acomp.cpp
@@ -189,7 +189,6 @@ Order (low first)
       return (*ux < *ax);
   }
   return uc != Units.end();
-  // false = everything idential or A.comp bigger:
 }
 
 Acomp &Acomp::operator+=(const Acomp &A)

--- a/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Framework/Geometry/src/Math/Acomp.cpp
@@ -160,15 +160,11 @@ Order (low first)
   const int TS = isSingle(); // is this one component
   const int AS = A.isSingle();
   if (TS != AS)
-    return (TS > AS) ? true : false;
+    return TS > AS;
   // PROCESS Intersection/Union
   if (!TS && Intersect != A.Intersect) {
     // Union==0 therefore this > A
-    if (Intersect > 0) {
-      return true;
-    } else {
-      return false;
-    }
+    return Intersect > 0;
   }
 
   // PROCESS Units. (order : then size)
@@ -192,10 +188,8 @@ Order (low first)
     if (*ax != *ux)
       return (*ux < *ax);
   }
-  if (uc != Units.end())
-    return true;
-  // everything idential or A.comp bigger:
-  return false;
+  return uc != Units.end();
+  // false = everything idential or A.comp bigger:
 }
 
 Acomp &Acomp::operator+=(const Acomp &A)

--- a/Framework/Geometry/src/Objects/BoundingBox.cpp
+++ b/Framework/Geometry/src/Objects/BoundingBox.cpp
@@ -24,16 +24,12 @@ bool BoundingBox::isPointInside(const V3D &point) const {
         "this function has not been modified properly"));
   }
 
-  if (point.X() <= xMax() + Kernel::Tolerance &&
-      point.X() >= xMin() - Kernel::Tolerance &&
-      point.Y() <= yMax() + Kernel::Tolerance &&
-      point.Y() >= yMin() - Kernel::Tolerance &&
-      point.Z() <= zMax() + Kernel::Tolerance &&
-      point.Z() >= zMin() - Kernel::Tolerance) {
-    return true;
-  } else {
-    return false;
-  }
+  return point.X() <= xMax() + Kernel::Tolerance &&
+         point.X() >= xMin() - Kernel::Tolerance &&
+         point.Y() <= yMax() + Kernel::Tolerance &&
+         point.Y() >= yMin() - Kernel::Tolerance &&
+         point.Z() <= zMax() + Kernel::Tolerance &&
+         point.Z() >= zMin() - Kernel::Tolerance;
 }
 
 /**

--- a/Framework/Geometry/src/Objects/RuleItems.cpp
+++ b/Framework/Geometry/src/Objects/RuleItems.cpp
@@ -307,7 +307,7 @@ bool Intersection::isValid(const std::map<int, int> &MX) const
 {
   if (!A || !B)
     return false;
-  return (A->isValid(MX) && B->isValid(MX)) ? true : false;
+  return A->isValid(MX) && B->isValid(MX);
 }
 
 int Intersection::simplify()
@@ -580,7 +580,7 @@ bool Union::isValid(const Kernel::V3D &Vec) const
   @retval 0 :: Vec is outside object.
 */
 {
-  return ((A && A->isValid(Vec)) || (B && B->isValid(Vec))) ? true : false;
+  return (A && A->isValid(Vec)) || (B && B->isValid(Vec));
 }
 
 bool Union::isValid(const std::map<int, int> &MX) const
@@ -592,7 +592,7 @@ bool Union::isValid(const std::map<int, int> &MX) const
   @retval 0 :: Neither side is valid
 */
 {
-  return ((A && A->isValid(MX)) || (B && B->isValid(MX))) ? true : false;
+  return (A && A->isValid(MX)) || (B && B->isValid(MX));
 }
 
 std::string Union::display() const
@@ -819,7 +819,7 @@ bool SurfPoint::isValid(const std::map<int, int> &MX) const
   if (lx == MX.end())
     return false;
   const int rtype = (lx->second) ? 1 : -1;
-  return (rtype * sign) >= 0 ? true : false;
+  return (rtype * sign) >= 0;
 }
 
 std::string SurfPoint::display() const
@@ -1354,7 +1354,7 @@ bool BoolValue::isValid(const Kernel::V3D &pt) const
 */
 {
   (void)pt; // Avoid compiler warning
-  return (status > 0) ? true : false;
+  return status > 0;
 }
 
 bool BoolValue::isValid(const std::map<int, int> &map) const
@@ -1365,7 +1365,7 @@ bool BoolValue::isValid(const std::map<int, int> &map) const
 */
 {
   (void)map; // Avoid compiler warning
-  return (status > 0) ? true : false;
+  return status > 0;
 }
 
 int BoolValue::simplify()
@@ -1575,7 +1575,7 @@ bool CompGrp::isValid(const std::map<int, int> &SMap) const
 {
   // Note:: if isValid is true then return 0:
   if (A)
-    return (A->isValid(SMap)) ? false : true;
+    return !A->isValid(SMap);
   return true;
 }
 

--- a/Framework/Geometry/src/Rendering/OCGeometryHandler.cpp
+++ b/Framework/Geometry/src/Rendering/OCGeometryHandler.cpp
@@ -64,7 +64,7 @@ void OCGeometryHandler::Triangulate() {
 
 void OCGeometryHandler::Render() {
   if (Obj != NULL) {
-    if (boolTriangulated == false)
+    if (!boolTriangulated)
       Triangulate();
     Renderer->Render(Triangulator->getObjectSurface());
   } else if (ObjComp != NULL) {
@@ -74,7 +74,7 @@ void OCGeometryHandler::Render() {
 
 void OCGeometryHandler::Initialize() {
   if (Obj != NULL) {
-    if (boolTriangulated == false)
+    if (!boolTriangulated)
       Triangulate();
     Renderer->Initialize(Triangulator->getObjectSurface());
   } else if (ObjComp != NULL) {
@@ -84,7 +84,7 @@ void OCGeometryHandler::Initialize() {
 
 int OCGeometryHandler::NumberOfTriangles() {
   if (Obj != NULL) {
-    if (boolTriangulated == false)
+    if (!boolTriangulated)
       Triangulate();
     return Triangulator->getNumberOfTriangles();
   } else {
@@ -94,7 +94,7 @@ int OCGeometryHandler::NumberOfTriangles() {
 
 int OCGeometryHandler::NumberOfPoints() {
   if (Obj != NULL) {
-    if (boolTriangulated == false)
+    if (!boolTriangulated)
       Triangulate();
     return Triangulator->getNumberOfPoints();
   } else {
@@ -104,7 +104,7 @@ int OCGeometryHandler::NumberOfPoints() {
 
 double *OCGeometryHandler::getTriangleVertices() {
   if (Obj != NULL) {
-    if (boolTriangulated == false)
+    if (!boolTriangulated)
       Triangulate();
     return Triangulator->getTriangleVertices();
   } else {
@@ -114,7 +114,7 @@ double *OCGeometryHandler::getTriangleVertices() {
 
 int *OCGeometryHandler::getTriangleFaces() {
   if (Obj != NULL) {
-    if (boolTriangulated == false)
+    if (!boolTriangulated)
       Triangulate();
     return Triangulator->getTriangleFaces();
   } else {

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1066,10 +1066,7 @@ bool ConfigServiceImpl::isExecutable(const std::string &target) const {
     Poco::File tempFile = Poco::File(expTarget);
 
     if (tempFile.exists()) {
-      if (tempFile.canExecute())
-        return true;
-      else
-        return false;
+      return tempFile.canExecute();
     } else
       return false;
   } catch (Poco::Exception &) {

--- a/Framework/Kernel/src/MandatoryValidator.cpp
+++ b/Framework/Kernel/src/MandatoryValidator.cpp
@@ -23,10 +23,7 @@ template <> DLLExport bool checkIsEmpty(const std::string &value) {
  * @return True if the value is considered empty, see EmptyValues.h
  */
 template <> DLLExport bool checkIsEmpty(const double &value) {
-  if (std::fabs(value - Mantid::EMPTY_DBL()) < 1e-08)
-    return true;
-  else
-    return false;
+  return std::fabs(value - Mantid::EMPTY_DBL()) < 1e-08;
 }
 /**
  * Specialization of checkIsEmpty for int

--- a/Framework/Kernel/src/Matrix.cpp
+++ b/Framework/Kernel/src/Matrix.cpp
@@ -94,7 +94,7 @@ Matrix<T>::Matrix(const size_t nrow, const size_t ncol, const bool makeIdentity)
   // Note:: nx,ny zeroed so setMem always works
   setMem(nrow, ncol);
   zeroMatrix();
-  if (makeIdentity == true)
+  if (makeIdentity)
     identityMatrix();
 }
 

--- a/Framework/Kernel/src/Quat.cpp
+++ b/Framework/Kernel/src/Quat.cpp
@@ -352,10 +352,8 @@ Quat &Quat::operator*=(const Quat &_q) {
  */
 bool Quat::operator==(const Quat &q) const {
   using namespace std;
-  return (fabs(w - q.w) > Tolerance || fabs(a - q.a) > Tolerance ||
-          fabs(b - q.b) > Tolerance || fabs(c - q.c) > Tolerance)
-             ? false
-             : true;
+  return !(fabs(w - q.w) > Tolerance || fabs(a - q.a) > Tolerance ||
+           fabs(b - q.b) > Tolerance || fabs(c - q.c) > Tolerance);
 
   // return (quat_tol(w,q.w) && quat_tol(a,q.a) && quat_tol(b,q.b) &&
   // quat_tol(c,q.c));

--- a/Framework/Kernel/src/UserStringParser.cpp
+++ b/Framework/Kernel/src/UserStringParser.cpp
@@ -78,7 +78,7 @@ void UserStringParser::parse(const std::string &userString,
   */
 bool UserStringParser::Contains(const std::string &input, char ch) {
   std::string::size_type pos = input.find(ch);
-  return (pos == std::string::npos ? false : true);
+  return (pos != std::string::npos);
 }
 
 /**This method parses a given string of numbers into comma separated tokens.
@@ -191,7 +191,7 @@ bool UserStringParser::isValidStepSeparator(const std::string &input,
       step_separator = input.substr(index - 1, 1);
     }
     // step values must be preceded by colon ':'
-    return (!step_separator.compare(":") ? true : false);
+    return (!step_separator.compare(":"));
   }
   return true;
 }

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -506,7 +506,7 @@ void V3D::rotate(const Kernel::Matrix<double> &A)
 bool V3D::coLinear(const V3D &Bv, const V3D &Cv) const {
   const V3D &Av = *this;
   const V3D Tmp((Bv - Av).cross_prod(Cv - Av));
-  return (Tmp.norm() > Tolerance) ? false : true;
+  return Tmp.norm() <= Tolerance;
 }
 
 bool V3D::nullVector(const double Tol) const

--- a/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
+++ b/Framework/MDAlgorithms/src/ConvertCWSDExpToMomentum.cpp
@@ -570,10 +570,7 @@ ConvertCWSDExpToMomentum::loadSpiceData(const std::string &filename,
     loader->execute();
 
     dataws = loader->getProperty("OutputWorkspace");
-    if (dataws)
-      loaded = true;
-    else
-      loaded = false;
+    loaded = static_cast<bool>(dataws);
   } catch (std::runtime_error &runerror) {
     loaded = false;
     errmsg = runerror.what();

--- a/Framework/MDAlgorithms/src/ConvertToMD.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMD.cpp
@@ -530,11 +530,7 @@ bool ConvertToMD::doWeNeedNewTargetWorkspace(API::IMDEventWorkspace_sptr spws) {
     createNewWs = true;
   } else {
     bool shouldOverwrite = getProperty("OverwriteExisting");
-    if (shouldOverwrite) {
-      createNewWs = true;
-    } else {
-      createNewWs = false;
-    }
+    createNewWs = shouldOverwrite;
   }
   return createNewWs;
 }

--- a/Framework/MDAlgorithms/src/DisplayNormalizationSetter.cpp
+++ b/Framework/MDAlgorithms/src/DisplayNormalizationSetter.cpp
@@ -39,14 +39,10 @@ void DisplayNormalizationSetter::setNormalizationMDEvent(
     Mantid::API::IMDWorkspace_sptr mdWorkspace,
     const Mantid::API::MatrixWorkspace_sptr &underlyingWorkspace, bool isQ,
     const Mantid::Kernel::DeltaEMode::Type &mode) {
-  auto isEventWorkspace = true;
-  if (boost::dynamic_pointer_cast<Mantid::DataObjects::EventWorkspace>(
-          underlyingWorkspace)) {
-    isEventWorkspace = true;
-  } else {
-    isEventWorkspace = false;
-  }
 
+  auto isEventWorkspace = static_cast<bool>(
+      boost::dynamic_pointer_cast<Mantid::DataObjects::EventWorkspace>(
+          underlyingWorkspace));
   Mantid::API::MDNormalization displayNormalization(
       Mantid::API::MDNormalization::VolumeNormalization);
   Mantid::API::MDNormalization displayNormalizationHisto(

--- a/Framework/MDAlgorithms/src/MDTransfNoQ.cpp
+++ b/Framework/MDAlgorithms/src/MDTransfNoQ.cpp
@@ -69,10 +69,7 @@ void MDTransfNoQ::initialize(const MDWSDescription &ConvParams) {
 bool MDTransfNoQ::calcYDepCoordinates(std::vector<coord_t> &Coord, size_t i) {
   if (m_YAxis) {
     Coord[1] = static_cast<coord_t>(m_YAxis->operator()(i));
-    if (Coord[1] < m_DimMin[1] || Coord[1] >= m_DimMax[1])
-      return false;
-    else
-      return true;
+    return !(Coord[1] < m_DimMin[1] || Coord[1] >= m_DimMax[1]);
   }
   return false;
 }

--- a/Framework/MDAlgorithms/src/MDWSDescription.cpp
+++ b/Framework/MDAlgorithms/src/MDWSDescription.cpp
@@ -322,10 +322,8 @@ void MDWSDescription::getMinMax(std::vector<double> &min,
 //******************************************************************************************************************************************
 /** Method checks if the workspace is expected to be processed in powder mode */
 bool MDWSDescription::isPowder() const {
-  if ((this->AlgID == "|Q|") ||
-      (this->AlgID.size() == 0 && !m_InWS->sample().hasOrientedLattice()))
-    return true;
-  return false;
+  return (this->AlgID == "|Q|") ||
+         (this->AlgID.size() == 0 && !m_InWS->sample().hasOrientedLattice());
 }
 
 /** Returns symbolic representation of current Emode */

--- a/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
+++ b/Framework/MDAlgorithms/src/PreprocessDetectorsToMD.cpp
@@ -416,9 +416,7 @@ bool PreprocessDetectorsToMD::isDetInfoLost(
     Mantid::API::MatrixWorkspace_const_sptr inWS2D) const {
   auto pYAxis = dynamic_cast<API::NumericAxis *>(inWS2D->getAxis(1));
   // if this is numeric axis, then the detector's information has been lost:
-  if (pYAxis)
-    return true;
-  return false;
+  return pYAxis != nullptr;
 }
 
 /** Method returns the efixed or Ei value stored in properties of the input

--- a/Framework/MDAlgorithms/src/UnitsConversionHelper.cpp
+++ b/Framework/MDAlgorithms/src/UnitsConversionHelper.cpp
@@ -59,9 +59,7 @@ UnitsConversionHelper::analyzeUnitsConversion(const std::string &UnitsFrom,
 /** Test and check if units conversion really occurs. Return true if unit
  * conversion happens or false if noConversion mode is selected*/
 bool UnitsConversionHelper::isUnitConverted() const {
-  if (m_UnitCnvrsn == CnvrtToMD::ConvertNo)
-    return false;
-  return true;
+  return m_UnitCnvrsn != CnvrtToMD::ConvertNo;
 }
 /** Initialize unit conversion helper
  * This method is interface to internal initialize method, which actually takes
@@ -109,18 +107,12 @@ void UnitsConversionHelper::initialize(const MDWSDescription &targetWSDescr,
 // the helper function which used in the code below to simplify check if the
 // variable is in range
 inline bool inRange(const std::pair<double, double> &range, const double &val) {
-  if (val >= range.first && val <= range.second)
-    return true;
-  else
-    return false;
+  return val >= range.first && val <= range.second;
 }
 // the helper function which used in the code below to simplify check if the
 // variable is in range
 inline bool inRange(const double &xMin, const double &xMax, const double &val) {
-  if (val >= xMin && val <= xMax)
-    return true;
-  else
-    return false;
+  return val >= xMin && val <= xMax;
 }
 
 /** Method verify if the Units transformation is well defined in the range

--- a/Framework/Nexus/src/NexusClasses.cpp
+++ b/Framework/Nexus/src/NexusClasses.cpp
@@ -593,7 +593,7 @@ Kernel::Property *NXLog::createSingleValueProperty() {
   } else if (nxType == NX_UINT8) {
     NXDataSetTyped<unsigned char> value(*this, valAttr);
     value.load();
-    bool state = (value[0] == 0) ? false : true;
+    bool state = value[0] != 0;
     prop = new Kernel::PropertyWithValue<bool>(name(), state);
   } else {
     prop = NULL;

--- a/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
+++ b/Framework/ScriptRepository/src/ScriptRepositoryImpl.cpp
@@ -118,10 +118,7 @@ Test if a file with this filename already exists
 */
 bool fileExists(const std::string &filename) {
   Poco::File test_file(filename);
-  if (test_file.exists()) {
-    return true;
-  }
-  return false;
+  return test_file.exists();
 }
 
 DECLARE_SCRIPTREPOSITORY(ScriptRepositoryImpl)

--- a/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
+++ b/Framework/WorkflowAlgorithms/src/ConvolutionFitSequential.cpp
@@ -367,10 +367,7 @@ void ConvolutionFitSequential::exec() {
 bool ConvolutionFitSequential::checkForTwoLorentz(
     const std::string &subFunction) {
   auto pos = subFunction.rfind("Lorentzian");
-  if (pos != std::string::npos) {
-    return true;
-  }
-  return false;
+  return pos != std::string::npos;
 }
 
 /**

--- a/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSensitivityCorrection.cpp
@@ -93,9 +93,7 @@ bool SANSSensitivityCorrection::fileCheck(const std::string &filePath) {
     return false;
   }
 
-  if (entryName[0] == "mantid_workspace_1")
-    return true;
-  return false;
+  return entryName[0] == "mantid_workspace_1";
 }
 
 void SANSSensitivityCorrection::exec() {


### PR DESCRIPTION
I ran clang-tidy's [readability-simplify-boolean-expr](http://clang.llvm.org/extra/clang-tidy/checks/readability-simplify-boolean-expr.html) check on Mantid Framework, letting it make changes. It found about 100 redundant boolean expressions. 

No release notes

testing: None of these changes should change behavior.

code review: I like that these changes eliminate a branch and therefore reduce cyclomatic complexity. Please flag any changes that make the code much more difficult to read.
