### PR TITLE
Indirect Bayes Quasi Add validation on EMin/EMax

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -102,7 +102,7 @@ bool Quasi::validate() {
   const auto eMin = m_dblManager->value(m_properties["EMin"]);
   const auto eMax = m_dblManager->value(m_properties["EMax"]);
   if (eMin > eMax)
-	  errors.append("EMin must be more than EMax.\n");
+	  errors.append("EMin must be less than EMax.\n");
   if (eMin == eMax)
 	  errors.append("EMin can not be equal to EMax.\n");
 

--- a/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -84,6 +84,7 @@ void Quasi::setup() {}
  */
 bool Quasi::validate() {
   UserInputValidator uiv;
+  QString errors("");
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
@@ -97,12 +98,23 @@ bool Quasi::validate() {
     uiv.checkMWRunFilesIsValid("Width", m_uiForm.mwFixWidthDat);
   }
 
-  QString errors = uiv.generateErrorMessage();
+  // check eMin and eMax values
+  const auto eMin = m_dblManager->value(m_properties["EMin"]);
+  const auto eMax = m_dblManager->value(m_properties["EMax"]);
+  if (eMin > eMax)
+	  errors.append("EMin must be more than EMax.\n");
+  if (eMin == eMax)
+	  errors.append("EMin can not be equal to EMax.\n");
+
+  // Create and show error messages
+  errors.append(uiv.generateErrorMessage());
+  auto test = errors.toStdString();
   if (!errors.isEmpty()) {
     emit showMessageBox(errors);
     return false;
   }
 
+  //Validate program
   QString program = m_uiForm.cbProgram->currentText();
   if (program == "Stretched Exponential") {
     QString resName = m_uiForm.dsResolution->getCurrentDataName();

--- a/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/Quasi.cpp
@@ -101,10 +101,8 @@ bool Quasi::validate() {
   // check eMin and eMax values
   const auto eMin = m_dblManager->value(m_properties["EMin"]);
   const auto eMax = m_dblManager->value(m_properties["EMax"]);
-  if (eMin > eMax)
-	  errors.append("EMin must be less than EMax.\n");
-  if (eMin == eMax)
-	  errors.append("EMin can not be equal to EMax.\n");
+  if (eMin >= eMax)
+	  errors.append("EMin must be strictly less than EMax.\n");
 
   // Create and show error messages
   errors.append(uiv.generateErrorMessage());


### PR DESCRIPTION
Fixes #15063

**Identified in unscripted testing using Mantid nightly build 20th Jan**

EMin/EMax should now no longer be able to be equal or EMin be more than EMax (and vis versa)
# To Test
- Open Quasi (Interfaces > Indirect > Bayes > Quasi)
- Input = `irs26176_graphite002_red.nxs`
- Resolution = `irs26173_graphitee002_res.nxs`
- Other default settings are fine
- Change EMin and EMax to be equal
- Click `Run`
  - Ensure an error is raised about them being equal
- Change EMax to be less than EMin - this must be done by altering the numbers in the property tree (can not be done by sliding the range bars as the numbers will swap) 
- Click `Run` and ensure an error is raised about EMin > EMax 
