### PR TITLE
Fixed 'Cancel' button behaviour in "Open Table" messageBox for Reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -282,7 +282,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         #first check if the table has been changed before clearing it
         if self.mod_flag:
             ret, _saved = self._save_check()
-            if ret == QtGui.QMessageBox.Cancel:
+            if ret == QtGui.QMessageBox.RejectRole:
                 return
         self.current_table = None
 

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -138,7 +138,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
         msgBox = QtGui.QMessageBox()
         msgBox.setText("The table has been modified. Do you want to save your changes?")
 
-        accept_btn = QtGui.QPushButton('Accept')
+        accept_btn = QtGui.QPushButton('Save')
         cancel_btn = QtGui.QPushButton('Cancel')
         discard_btn = QtGui.QPushButton('Discard')
 

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -1146,7 +1146,7 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
                 #before loading make sure you give them a chance to save
                 if self.mod_flag:
                     ret, _saved = self._save_check()
-                    if ret == QtGui.QMessageBox.Cancel:
+                    if ret == QtGui.QMessageBox.RejectRole:
                         #if they hit cancel abort the load
                         self.loading = False
                         return


### PR DESCRIPTION
**_This was found during unscripted testing for Reflectometry**_

**To Test:**
- Download `SampleData-ISIS` so that `INTER_NR_test.tbl` is in your managed data directories 
- Open up the Reflectometry Interface `Interfaces > Reflectometry > ISIS Reflectometry`
- Open the .tbl file (File > Open Table..)
- Edit some values in the table
- Open another .tbl file (File > Open Table..)
- Make sure a dialog pops up asking you about discarding your files
- Click `Cancel` 
- Make sure the values you entered previously are still present and the table hasn't been reset.

**Release Notes**:
http://www.mantidproject.org/Release_Notes_3_6_Reflectometry#ISIS_Reflectometry_.28Polref.29

Fixes #15046
