### PR TITLE
Fix HistoryView (invalidated iterator caught by VS2015 debug mode)

### DIFF
--- a/Framework/API/src/HistoryView.cpp
+++ b/Framework/API/src/HistoryView.cpp
@@ -181,7 +181,7 @@ void HistoryView::roll(std::vector<HistoryItem>::iterator &it) {
     this->rollChildren(it);
     // Then just remove the children from the list
     ++it;
-    m_historyItems.erase(it, it + numChildren);
+    it = m_historyItems.erase(it, it + numChildren);
   } else
     ++it;
 }


### PR DESCRIPTION
Fixes #15077.

The issue in the test turn out to be that HistoryView was using an invalid iterator (after erase) which doesn't seem to create any visible issues with release code. The debug VS2015 catches the invalid iterator via an assert.

**To test**:
- check code change, and that tets pass.
- It was not obvious how to add a regression test on this, as it seems that all std implementations will just shift the elements after the erased block in the vector, and be happy with the supposedly invalid iterator. If there's any ideas for how to regression-test this, please suggest.

No release notes (bug fix not visible to users).
