### PR TITLE
Reflectometry GUI should close after saving of .TBL file

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -172,7 +172,10 @@ class ReflGui(QtGui.QMainWindow, ui_refl_window.Ui_windowRefl):
             ret, saved = self._save_check()
             if ret == QtGui.QMessageBox.AcceptRole:
                 if saved:
-                    event.accept()
+                    self.mod_flag = False
+                event.accept()
+            elif ret == QtGui.QMessageBox.RejectRole:
+                event.ignore()
             elif ret == QtGui.QMessageBox.NoRole:
                 self.mod_flag = False
                 event.accept()


### PR DESCRIPTION
**_This issue was found during unscripted tested of the Reflectometry Interfaces**_

**To Test:**
- Open the Reflectometry interface (`Interfaces > Reflectometry > Reflectometry ISIS`)
- Edit some cells in the processing table
- Close the interface, confirm that you want to save the changes, supply a file name and save.
- Ensure the interface closes after save has completed
- Ensure that the file did save out to where you set it to.

**Release Notes:** // todo

Fixes #13655
