### PR TITLE
Indirect Bayes ResNorm - Add validation for EMin/EMax

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ResNorm.cpp
@@ -53,6 +53,7 @@ void ResNorm::setup() {}
  */
 bool ResNorm::validate() {
   UserInputValidator uiv;
+  QString errors("");
 
   const bool vanValid = uiv.checkDataSelectorIsValid("Vanadium", m_uiForm.dsVanadium);
   const bool resValid = uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
@@ -88,7 +89,14 @@ bool ResNorm::validate() {
     }
   }
 
-  QString errors = uiv.generateErrorMessage();
+  // check eMin and eMax values
+  const auto eMin = m_dblManager->value(m_properties["EMin"]);
+  const auto eMax = m_dblManager->value(m_properties["EMax"]);
+  if (eMin >= eMax)
+    errors.append("EMin must be strictly less than EMax.\n");
+
+  // Create and show error messages
+  errors.append(uiv.generateErrorMessage());
   if (!errors.isEmpty()) {
     emit showMessageBox(errors);
     return false;


### PR DESCRIPTION
Fixes #15061

**Identified in unscripted testing using Mantid nightly build 20th Jan**

EMin/EMax should now no longer be able to be equal or EMin be more than EMax (and vis versa)
# To Test
- Open ResNorm (Interfaces > Indirect > Bayes > ResNorm)
- Input = `irs26173_graphite002_`**`red`**`.nxs`
- Resolution = `irs26173_graphite002_`**`res`**`.nxs`
- Other default settings are fine
- Change EMin and EMax to be equal
- Click `Run`
  - Ensure an error is raised about them being equal
- Change EMax to be less than EMin - this must be done by altering the numbers in the property tree (can not be done by sliding the range bars as the numbers will swap) 
- Click `Run` and ensure an error is raised about EMin > EMax 
