### PR TITLE
Indirect Data Reduction ISIS Energy Transfer - Add validation to plot time spinners

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -328,9 +328,10 @@ void ISISEnergyTransfer::setInstrumentDefault() {
     return;
   }
 
-  int specMin = instDetails["spectra-min"].toInt();
-  int specMax = instDetails["spectra-max"].toInt();
-
+  // Set spectra min/max for spinners in UI
+  const int specMin = instDetails["spectra-min"].toInt();
+  const int specMax = instDetails["spectra-max"].toInt();
+  // Spectra spinners
   m_uiForm.spSpectraMin->setMinimum(specMin);
   m_uiForm.spSpectraMin->setMaximum(specMax);
   m_uiForm.spSpectraMin->setValue(specMin);
@@ -338,6 +339,15 @@ void ISISEnergyTransfer::setInstrumentDefault() {
   m_uiForm.spSpectraMax->setMinimum(specMin);
   m_uiForm.spSpectraMax->setMaximum(specMax);
   m_uiForm.spSpectraMax->setValue(specMax);
+
+  // Plot time spectra spinners
+  m_uiForm.spPlotTimeSpecMin->setMinimum(1);		// 1 to allow for monitors
+  m_uiForm.spPlotTimeSpecMin->setMaximum(specMax);
+  m_uiForm.spPlotTimeSpecMin->setValue(1);
+
+  m_uiForm.spPlotTimeSpecMax->setMinimum(1);
+  m_uiForm.spPlotTimeSpecMax->setMaximum(specMax);
+  m_uiForm.spPlotTimeSpecMax->setValue(1);
 
   if (!instDetails["Efixed"].isEmpty())
     m_uiForm.spEfixed->setValue(instDetails["Efixed"].toDouble());


### PR DESCRIPTION
Fixes #15059

**Identified in unscripted testing using Mantid nightly build 20th Jan**

ISIS Energy Transfer Plot Time spinners are now set to have a maximum of spectraMax for the selected instrument
# To Test
- Change your default instrument to IRIS (ISIS Facility)
- Open ISISEnergyTransfer (Interfaces > Indirect > Data Reduction > ISISEnergyTransfer)
- Enter the run number 26176
- In the plot time spectra spinners (near the bottom of the interface) ensure that the spinners are defaulting to 1 and  remain within the min/max boundaries (for IRIS this is 1-53)
- Change instrument to OSIRIS (using the instrument interface at the top of the tab)
- Enter run number 111500
- In the plot time spectra spinners (near the bottom of the interface) ensure that the spinners are defaulting to 1 and remain within the min/max boundaries (for OSIRIS this is 1-1004)
