### PR TITLE
Indirect Data Reduction ISIS Energy Transfer - Disable LoadLogFiles for PlotTime

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ISISEnergyTransfer.cpp
@@ -525,6 +525,7 @@ void ISISEnergyTransfer::plotRaw() {
   loadAlg->initialize();
   loadAlg->setProperty("Filename", rawFile.toStdString());
   loadAlg->setProperty("OutputWorkspace", name);
+  loadAlg->setProperty("LoadLogFiles", false);
   if (extension.compare(".nxs") == 0) {
     int64_t detectorMin =
         static_cast<int64_t>(m_uiForm.spPlotTimeSpecMin->value());


### PR DESCRIPTION
Fixes #15049

**This issue was discovered by a beta tester**

PlotTime should no longer attempt to Load the Log files for the run number provided
# To Test
- Create a directory only containing a single OSIRIS `.raw` file (can be found at `\\isis\inst$\NDXOSIRIS\Instrument\data`)
- Open MantidPlot and set the only directory path to be to the directory you have just made (Ensure you are not using the data archive either)
- Change your default instrument in MantidPlot to `OSIRIS`
- Open ISIS Energy Transfer (Interfaces > Indirect > Data Reduction > Energy Transfer)
- Type the run number of the file you chose into the run number input field.
- Click the `Plot Time` button further down the interface
- Ensure that a plot is produced within from data within the spectra limits
