### PR TITLE
Qt-designer plugin class for MantidWidget::PreviewPlot

### DIFF
--- a/MantidQt/DesignerPlugins/inc/MantidQtDesignerPlugins/PluginCollectionInterface.h
+++ b/MantidQt/DesignerPlugins/inc/MantidQtDesignerPlugins/PluginCollectionInterface.h
@@ -20,6 +20,7 @@
 #include "MantidQtAPI/AlgorithmPropertiesWidget.h"
 #include "MantidQtMantidWidgets/ProcessingAlgoWidget.h"
 #include "MantidQtMantidWidgets/MessageDisplay.h"
+#include "MantidQtMantidWidgets/PreviewPlot.h"
 
 /** 
 The PluginCollectionInterface implements the interface for the plugin library and holds a 
@@ -152,4 +153,9 @@ DECLARE_WIDGET_PLUGIN(MessageDisplayPlugin,
 DECLARE_WIDGET_PLUGIN(DataSelectorPlugin,
     MantidQt::MantidWidgets::DataSelector,
     "Choose a file path or workspace to work with");
+
+DECLARE_WIDGET_PLUGIN(PreviewPlotPlugin,
+    MantidQt::MantidWidgets::PreviewPlot,
+    "Curve plots for workspace spectra");
+
 #endif

--- a/MantidQt/DesignerPlugins/src/PluginCollectionInterface.cpp
+++ b/MantidQt/DesignerPlugins/src/PluginCollectionInterface.cpp
@@ -28,7 +28,7 @@ PluginCollectionInterface::PluginCollectionInterface(QObject *parent) : QObject(
   m_widgets.append(new FitBrowserPlugin(this));
   m_widgets.append(new MuonFitBrowserPlugin(this));
   m_widgets.append(new MessageDisplayPlugin(this));
-
+  m_widgets.append(new PreviewPlotPlugin(this));
 }
 
 /**


### PR DESCRIPTION
Fixes #15091

No release notes

To test, follow these steps:
1. compile to create library of Qt-designer plugins including the MantidWidgets (**make DesignerPlugins** or **ninja DesignerPlugins**).
2. In the terminal, set environment variable **QT_PLUGIN_PATH** to _yourBuildDirectory/bin/_ and then start the Qt-Designer application from the same terminal.
3. In Help -> About Plugins, at the bottom of the pop-up list of plugins you should see the _libMantidWidgetPlugins.so_ library.  The last item of the library should be the PreviewPlot widget
4. In the Widget Box listing all available widgets (usually located on the left side), you should see the MantidWidgets at the bottom of the box. The last item should be the PreviewPlot widget.
5. File --> New, then select _Main Window_, then click on _Create_.
6. Go to the Widget Box and add a PreviewPlot onto the main window you just created. It should look as the typical X and Y cartesian axes. 
