### PR TITLE
Indirect Data Analysis ConvFit - Default values for certain properties

### DIFF
--- a/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
+++ b/MantidQt/CustomInterfaces/inc/MantidQtCustomInterfaces/Indirect/ConvFit.h
@@ -73,11 +73,16 @@ private:
   bool m_confitResFileType;
   Mantid::API::IAlgorithm_sptr m_singleFitAlg;
   QString m_singleFitOutputName;
-  QStringList m_fitStrings;
   QString m_previousFit;
   QString m_baseName;
   int m_runMin;
   int m_runMax;
+
+  // ShortHand Naming for fit functions
+  QStringList m_fitStrings;
+
+  // Used in auto generating defaults for parameters
+  QStringList m_defaultParams;
 
 };
 } // namespace IDA

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -48,6 +48,15 @@ void ConvFit::setup() {
                                << "EDS"
                                << "EDC"
                                << "SFT";
+  // All Parameters in tree that should be defaulting to 1
+  m_defaultParams = QStringList() << "Amplitude"
+                                  << "Beta"
+                                  << "Decay"
+                                  << "Diffusion"
+                                  << "Height"
+                                  << "Intensity"
+                                  << "Radius"
+                                  << "Tau";
 
   // Create TreeProperty Widget
   m_cfTree = new QtTreePropertyBrowser();
@@ -1576,37 +1585,42 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         if (count == 3) {
           propName = "Lorentzian 2";
         }
-        QString name = propName + "." + *it;
-        m_properties[name] = m_dblManager->addProperty(*it);
+		const QString paramName = QString(*it);
+        const QString fullPropName = propName + "." + *it;
+        m_properties[fullPropName] = m_dblManager->addProperty(*it);
 
-        if (QString(*it).compare("FWHM") == 0) {
+        if (paramName.compare("FWHM") == 0) {
           double resolution = getInstrumentResolution(m_cfInputWS->getName());
           if (previouslyOneL && count < 3) {
-            m_dblManager->setValue(m_properties[name], oneLValues[2]);
+            m_dblManager->setValue(m_properties[fullPropName], oneLValues[2]);
           } else {
-            m_dblManager->setValue(m_properties[name], resolution);
+            m_dblManager->setValue(m_properties[fullPropName], resolution);
           }
-        } else if (QString(*it).compare("Amplitude") == 0) {
+        } else if (paramName.compare("Amplitude") == 0) {
           if (previouslyOneL && count < 3) {
-            m_dblManager->setValue(m_properties[name], oneLValues[0]);
+            m_dblManager->setValue(m_properties[fullPropName], oneLValues[0]);
           } else {
-            m_dblManager->setValue(m_properties[name], 1.0);
+            m_dblManager->setValue(m_properties[fullPropName], 1.0);
           }
-        } else if (QString(*it).compare("PeakCentre") == 0) {
+        } else if (paramName.compare("PeakCentre") == 0) {
           if (previouslyOneL && count < 3) {
-            m_dblManager->setValue(m_properties[name], oneLValues[1]);
+            m_dblManager->setValue(m_properties[fullPropName], oneLValues[1]);
           } else {
-            m_dblManager->setValue(m_properties[name], 0.0);
+            m_dblManager->setValue(m_properties[fullPropName], 0.0);
           }
         } else {
-          m_dblManager->setValue(m_properties[name], 0.0);
+          if (m_defaultParams.contains(paramName, Qt::CaseInsensitive)) {
+            m_dblManager->setValue(m_properties[fullPropName], 1.0);
+          } else {
+            m_dblManager->setValue(m_properties[fullPropName], 0.0);
+          }
         }
 
-        m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
+        m_dblManager->setDecimals(m_properties[fullPropName], NUM_DECIMALS);
         if (count < 3) {
-          m_properties["FitFunction1"]->addSubProperty(m_properties[name]);
+          m_properties["FitFunction1"]->addSubProperty(m_properties[fullPropName]);
         } else {
-          m_properties["FitFunction2"]->addSubProperty(m_properties[name]);
+          m_properties["FitFunction2"]->addSubProperty(m_properties[fullPropName]);
         }
         count++;
       }
@@ -1617,21 +1631,26 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         propName = functionName;
       }
       for (auto it = parameters.begin(); it != parameters.end(); ++it) {
-        QString name = propName + "." + *it;
-        m_properties[name] = m_dblManager->addProperty(*it);
+        const QString paramName = QString(*it);
+        const QString fullPropName = propName + "." + *it;
+        m_properties[fullPropName] = m_dblManager->addProperty(*it);
 
-        if (QString(*it).compare("FWHM") == 0) {
+        if (paramName.compare("FWHM") == 0) {
           double resolution = getInstrumentResolution(m_cfInputWS->getName());
-          m_dblManager->setValue(m_properties[name], resolution);
+          m_dblManager->setValue(m_properties[fullPropName], resolution);
         } else if (QString(*it).compare("Amplitude") == 0 ||
                    QString(*it).compare("Intensity") == 0) {
-          m_dblManager->setValue(m_properties[name], 1.0);
+          m_dblManager->setValue(m_properties[fullPropName], 1.0);
         } else {
-          m_dblManager->setValue(m_properties[name], 0.0);
+          if (m_defaultParams.contains(paramName, Qt::CaseInsensitive)) {
+            m_dblManager->setValue(m_properties[fullPropName], 1.0);
+          } else {
+            m_dblManager->setValue(m_properties[fullPropName], 0.0);
+          }
         }
 
-        m_dblManager->setDecimals(m_properties[name], NUM_DECIMALS);
-        m_properties["FitFunction1"]->addSubProperty(m_properties[name]);
+        m_dblManager->setDecimals(m_properties[fullPropName], NUM_DECIMALS);
+        m_properties["FitFunction1"]->addSubProperty(m_properties[fullPropName]);
       }
     }
   }


### PR DESCRIPTION
Fixes #15054

**This issue was discovered by a beta tester**

default values have been updated in the interface
# To Test
- Open ConvFit(Interfaces > Indirect > Data Analysis > ConvFit)
- Sample = irs26176_graphite002_red.nxs
- Resolution = irs26173_graphite002_res.nxs
- Ensure that the following properties should be default value of one in the property tree:
  - Amplitude
  - Height
  - Intensity
  - Beta
  - Tau
  - Radius
  - Diffusion
  - Decay

**_FWHM=0.0175 by default**_

All other properties in the function section of the property tree should be 0 
