### PR TITLE
Indirect Data Reduction ISISEnergyTransfer - Ensure that scale factor works correctly in the algorithm 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -243,7 +243,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
                 # Scale
                 if self._scale_factor != 1.0:
-                    Scale(InputWorkspaces=ws_name,
+                    Scale(InputWorkspace=ws_name,
                           OutputWorkspace=ws_name,
                           Factor=self._scale_factor,
                           Operation='Multiply')

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ISISIndirectEnergyTransferTest.py
@@ -329,5 +329,21 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         self.assertTrue(CheckWorkspacesMatch(ref, wks), 'Success!')
 
 
+    def test_reduction_with_can_scale(self):
+        """
+        Sanity check tio ensure a reduction with can scale value completes.
+        """
+
+        wks = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'],
+                                         Instrument='IRIS',
+                                         Analyser='graphite',
+                                         Reflection='002',
+                                         SpectraRange=[3, 53],
+                                         ScaleFactor=0.5)
+
+        red_ws = wks.getItem(0)
+        self.assertEqual(red_ws.getNumberHistograms(), 51)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #15050

**Identified in unscripted testing using Mantid nightly build 20th Jan**

ISISIndirectEnergyTransfer was not working properly with container scaling due to a typo in the algorithm. This has now been fixed and a unit test case has been added to ensure that it works.
# To Test
- Ensure the unit tests all pass 
- Ensure the following script runs correctly and produces a WorkspaceGroup containing a single MatrixWorkspace. Ensure the peak in the MatrixWorkspace is about 1.1meV in spectrum number 3:

```
wks = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'],
                                         Instrument='IRIS',
                                         Analyser='graphite',
                                         Reflection='002',
                                         SpectraRange=[3, 53],
                                         ScaleFactor=0.5)
```
