### PR TITLE
Indirect Data Analysis ConvFit - Check input validity before use

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1590,7 +1590,10 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         m_properties[fullPropName] = m_dblManager->addProperty(*it);
 
         if (paramName.compare("FWHM") == 0) {
-          double resolution = getInstrumentResolution(m_cfInputWS->getName());
+          double resolution = 0.0;
+          if (m_uiForm.dsResInput->getCurrentDataName().compare("") != 0) {
+            resolution = getInstrumentResolution(m_cfInputWS->getName());
+          }
           if (previouslyOneL && count < 3) {
             m_dblManager->setValue(m_properties[fullPropName], oneLValues[2]);
           } else {
@@ -1634,9 +1637,11 @@ void ConvFit::fitFunctionSelected(const QString &functionName) {
         const QString paramName = QString(*it);
         const QString fullPropName = propName + "." + *it;
         m_properties[fullPropName] = m_dblManager->addProperty(*it);
-
         if (paramName.compare("FWHM") == 0) {
-          double resolution = getInstrumentResolution(m_cfInputWS->getName());
+          double resolution = 0.0;
+          if (m_uiForm.dsResInput->getCurrentDataName().compare("") != 0) {
+            resolution = getInstrumentResolution(m_cfInputWS->getName());
+          }
           m_dblManager->setValue(m_properties[fullPropName], resolution);
         } else if (QString(*it).compare("Amplitude") == 0 ||
                    QString(*it).compare("Intensity") == 0) {


### PR DESCRIPTION
Fixes #15108

**Identified in unscripted testing using Mantid nightly build 20th Jan**

You should now be able to change the fit type in the ConvFit interface before loading in any data
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit)
- Change the fit type from the drop down menu
  - Ensure Mantid does not crash and the function properties update in the property tree
