### PR TITLE
Indirect Data Analaysis ConvFit - Add validation before Fit Single Spectrum

### DIFF
--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -1133,6 +1133,10 @@ void ConvFit::plotGuess() {
  * Runs the single fit algorithm
  */
 void ConvFit::singleFit() {
+  // Validate tab before running a single fit
+  if (!validate()) {
+	  return;
+  }
   // disconnect signal for single fit
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(singleFit(bool)));


### PR DESCRIPTION
Fixes #15111

**Identified in unscripted testing using Mantid nightly build 20th Jan**

The ConvFit tab is now validated before attempting to `Fit Single Spectrum`

**Data for test can be found in the unit test folder**
# To Test
- Open ConvFit (Interfaces > Indirect > Data Analysis > ConvFit) 
- Before loading any data in, click the Fit Single Spectrum button
  - Ensure that this produces a dialog box informing you of incorrect validation
- Sample = irs26176_graphite002_red.nxs
- Resolution = irs26173_graphite002_res.nxs
- Fit Type = any from list (excluding `Zero Lorentzians`)
- Click `Fit Single Spectrum`
  - Ensure this runs correctly and adds data to the miniplot 
