### PR TITLE
Fix API::Bool from returning a double

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -209,7 +209,7 @@ struct MANTID_API_DLL Boolean {
   /// equal to operator
   bool operator==(const Boolean &b) const { return (this->value == b.value); }
   //
-  operator double(void) const { return double(this->value); }
+  operator bool() const { return this->value; }
   bool value; ///< boolean value
 };
 

--- a/Framework/Algorithms/src/AsymmetryCalc.cpp
+++ b/Framework/Algorithms/src/AsymmetryCalc.cpp
@@ -145,7 +145,7 @@ void AsymmetryCalc::exec() {
         (tmpWS->dataY(forward)[j] + alpha * tmpWS->dataY(backward)[j]);
 
     // cal F-aB / F+aB
-    if (denominator) {
+    if (denominator != 0.0) {
       outputWS->dataY(0)[j] = numerator / denominator;
     } else {
       outputWS->dataY(0)[j] = 0.;
@@ -153,7 +153,7 @@ void AsymmetryCalc::exec() {
 
     // Work out the error (as in 1st attachment of ticket #4188)
     double error = 1.0;
-    if (denominator) {
+    if (denominator != 0.0) {
       // cal F + a2B
       double q1 =
           tmpWS->dataY(forward)[j] + alpha * alpha * tmpWS->dataY(backward)[j];

--- a/Framework/Algorithms/src/MaxEnt.cpp
+++ b/Framework/Algorithms/src/MaxEnt.cpp
@@ -481,7 +481,7 @@ SearchDirections MaxEnt::calculateSearchDirections(
       dirs.s2[k][l] = 0.;
       dirs.c2[k][l] = 0.;
       for (size_t i = 0; i < npoints; i++) {
-        if (error[i])
+        if (error[i] != 0.0)
           dirs.c2[k][l] +=
               dirs.xDat[k][i] * dirs.xDat[l][i] / error[i] / error[i];
         dirs.s2[k][l] -= dirs.xIm[k][i] * dirs.xIm[l][i] / fabs(image[i]);
@@ -522,7 +522,7 @@ double MaxEnt::getChiSq(const std::vector<double> &data,
   // ChiSq = sum_i [ data_i - dataCalc_i ]^2 / [ error_i ]^2
   double chiSq = 0;
   for (size_t i = 0; i < npoints; i++) {
-    if (errors[i]) {
+    if (errors[i] != 0.0) {
       double term = (data[i] - dataCalc[i]) / errors[i];
       chiSq += term * term;
     }
@@ -550,7 +550,7 @@ std::vector<double> MaxEnt::getCGrad(const std::vector<double> &data,
   // CGrad_i = -2 * [ data_i - dataCalc_i ] / [ error_i ]^2
   std::vector<double> cgrad(npoints, 0.);
   for (size_t i = 0; i < npoints; i++) {
-    if (errors[i])
+    if (errors[i] != 0.0)
       cgrad[i] = -2. * (data[i] - dataCalc[i]) / errors[i] / errors[i];
   }
 

--- a/Framework/Algorithms/src/PhaseQuadMuon.cpp
+++ b/Framework/Algorithms/src/PhaseQuadMuon.cpp
@@ -178,7 +178,7 @@ PhaseQuadMuon::squash(const API::MatrixWorkspace_sptr &ws,
       maxAsym = phase->Double(h, 1);
     }
   }
-  if (!maxAsym) {
+  if (maxAsym == 0.0) {
     throw std::invalid_argument("Invalid detector asymmetries");
   }
 

--- a/Framework/Algorithms/src/PoissonErrors.cpp
+++ b/Framework/Algorithms/src/PoissonErrors.cpp
@@ -43,8 +43,10 @@ void PoissonErrors::performBinaryOperation(const MantidVec &lhsX,
   // Now make the fractional error the same as it was on the rhs
   const int bins = static_cast<int>(lhsE.size());
   for (int j = 0; j < bins; ++j) {
-    const double fractional = rhsY[j] ? rhsE[j] / rhsY[j] : 0.0;
-    EOut[j] = fractional * lhsY[j];
+    if (rhsY[j] != 0.0)
+      EOut[j] = rhsE[j] / rhsY[j] * lhsY[j];
+    else
+      EOut[j] = 0.0;
   }
 }
 
@@ -60,8 +62,10 @@ void PoissonErrors::performBinaryOperation(const MantidVec &lhsX,
   // If we get here we've got two single column workspaces so it's easy.
   YOut[0] = lhsY[0];
 
-  const double fractional = rhsY ? rhsE / rhsY : 0.0;
-  EOut[0] = fractional * lhsY[0];
+  if (rhsY != 0.0)
+    EOut[0] = rhsE / rhsY * lhsY[0];
+  else
+    EOut[0] = 0.0;
 }
 }
 }

--- a/Framework/Algorithms/src/RemoveExpDecay.cpp
+++ b/Framework/Algorithms/src/RemoveExpDecay.cpp
@@ -164,13 +164,12 @@ void MuonRemoveExpDecay::removeDecayError(const MantidVec &inX,
                                           MantidVec &outY) {
   // Do the removal
   for (size_t i = 0; i < inY.size(); ++i) {
-    if (inY[i])
+    if (inY[i] != 0.0)
       outY[i] =
           inY[i] *
           exp(inX[i] / (Mantid::PhysicalConstants::MuonLifetime * 1000000.0));
     else
       outY[i] =
-          1.0 *
           exp(inX[i] / (Mantid::PhysicalConstants::MuonLifetime * 1000000.0));
   }
 }
@@ -188,7 +187,7 @@ void MuonRemoveExpDecay::removeDecayData(const MantidVec &inX,
                                          MantidVec &outY) {
   // Do the removal
   for (size_t i = 0; i < inY.size(); ++i) {
-    if (inY[i])
+    if (inY[i] != 0.0)
       outY[i] =
           inY[i] *
           exp(inX[i] / (Mantid::PhysicalConstants::MuonLifetime * 1000000.0));

--- a/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
+++ b/Framework/CurveFitting/src/Functions/ProcessBackground.cpp
@@ -257,7 +257,7 @@ void ProcessBackground::exec() {
   if (intemp < 0)
     throw std::invalid_argument(
         "WorkspaceIndex is not allowed to be less than 0. ");
-  m_wsIndex = size_t(intemp);
+  m_wsIndex = intemp;
   if (m_wsIndex >= static_cast<int>(m_dataWS->getNumberHistograms()))
     throw runtime_error("Workspace index is out of boundary.");
 

--- a/Framework/DataHandling/src/DetermineChunking.cpp
+++ b/Framework/DataHandling/src/DetermineChunking.cpp
@@ -242,7 +242,7 @@ void DetermineChunking::exec() {
   }
 
   int numChunks = 0;
-  if (maxChunk) // protect from divide by zero
+  if (maxChunk != 0.0) // protect from divide by zero
   {
     numChunks = static_cast<int>(filesize / maxChunk);
   }

--- a/Framework/DataHandling/src/FindDetectorsPar.cpp
+++ b/Framework/DataHandling/src/FindDetectorsPar.cpp
@@ -252,7 +252,7 @@ void AvrgDetector::addDetInfo(const Geometry::IDetector_const_sptr &spDet,
 
   Kernel::V3D er(0, 1, 0), e_th,
       ez(0, 0, 1); // ez along beamline, which is always oz;
-  if (dist2Det)
+  if (dist2Det != 0.0)
     er = toDet / dist2Det; // direction to the detector
   Kernel::V3D e_tg =
       er.cross_prod(ez); // tangential to the ring and anticloakwise;

--- a/Framework/DataHandling/src/LoadFITS.cpp
+++ b/Framework/DataHandling/src/LoadFITS.cpp
@@ -981,9 +981,9 @@ void LoadFITS::doFilterNoise(double thresh, MantidImage &imageY,
 
   for (size_t j = 1; j < (imageY.size() - 1); ++j) {
     for (size_t i = 1; i < (imageY[0].size() - 1); ++i) {
-      if (!goodY[j][i]) {
-        if (goodY[j - 1][i] || goodY[j + 1][i] || goodY[j][i - 1] ||
-            goodY[j][i + 1]) {
+      if (goodY[j][i] == 0.0) {
+        if (goodY[j - 1][i] != 0.0 || goodY[j + 1][i] != 0.0 ||
+            goodY[j][i - 1] != 0.0 || goodY[j][i + 1] != 0.0) {
           imageY[j][i] = goodY[j - 1][i] * imageY[j - 1][i] +
                          goodY[j + 1][i] * imageY[j + 1][i] +
                          goodY[j][i - 1] * imageY[j][i - 1] +
@@ -991,9 +991,9 @@ void LoadFITS::doFilterNoise(double thresh, MantidImage &imageY,
         }
       }
 
-      if (!goodE[j][i]) {
-        if (goodE[j - 1][i] || goodE[j + 1][i] || goodE[j][i - 1] ||
-            goodE[j][i + 1]) {
+      if (goodE[j][i] == 0.0) {
+        if (goodE[j - 1][i] != 0.0 || goodE[j + 1][i] != 0.0 ||
+            goodE[j][i - 1] != 0.0 || goodE[j][i + 1] != 0.0) {
           imageE[j][i] = goodE[j - 1][i] * imageE[j - 1][i] +
                          goodE[j + 1][i] * imageE[j + 1][i] +
                          goodE[j][i - 1] * imageE[j][i - 1] +

--- a/Framework/MDAlgorithms/test/MDWSDescriptionTest.h
+++ b/Framework/MDAlgorithms/test/MDWSDescriptionTest.h
@@ -148,7 +148,7 @@ public:
     // add workspace energy
     ws2D->mutableRun().addProperty("Ei", 13., "meV", true);
     // ADD time series property
-    ws2D->mutableRun().addProperty("H", 10., "Gs");
+    ws2D->mutableRun().addProperty(std::string("H"), 10., std::string("Gs"));
   }
 };
 

--- a/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
+++ b/Framework/RemoteAlgorithms/test/SimpleJSONTest.h
@@ -32,11 +32,11 @@ public:
     TS_ASSERT_EQUALS(false, vBool.getValue(getBool));
     TS_ASSERT_EQUALS(true, getBool);
 
-    TS_ASSERT_THROWS_NOTHING(JSONValue str1(""));
-    TS_ASSERT_THROWS_NOTHING(JSONValue str2("str"));
+    TS_ASSERT_THROWS_NOTHING(JSONValue str1(std::string("")));
+    TS_ASSERT_THROWS_NOTHING(JSONValue str2(std::string("str")));
 
-    JSONValue str1("s1");
-    JSONValue str2("s2");
+    JSONValue str1(std::string("s1"));
+    JSONValue str2(std::string("s2"));
     TS_ASSERT_THROWS_NOTHING(str1 = str2);
 
     JSONValue vs;

--- a/MantidPlot/src/Mantid/MantidCurve.cpp
+++ b/MantidPlot/src/Mantid/MantidCurve.cpp
@@ -193,19 +193,22 @@ void MantidCurve::doDraw(QPainter *p,
       {
         // This call can crash MantidPlot if the error is zero,
         //   so protect against this (line of zero length anyway)
-        if (E) p->drawLine(xi,ei1,xi,ylh);
+        if (E != 0.0)
+          p->drawLine(xi, ei1, xi, ylh);
         p->drawLine(xi-dx,ei1,xi+dx,ei1);
       }
       if ( m_errorSettings->plusSide() )
       {
         // This call can crash MantidPlot if the error is zero,
         //   so protect against this (line of zero length anyway)
-        if (E) p->drawLine(xi,yhl,xi,ei2);
+        if (E != 0.0)
+          p->drawLine(xi, yhl, xi, ei2);
         p->drawLine(xi-dx,ei2,xi+dx,ei2);
       }
       if ( m_errorSettings->throughSymbol() )
       {
-        if (E) p->drawLine(xi,yhl,xi,ylh);
+        if (E != 0.0)
+          p->drawLine(xi, yhl, xi, ylh);
       }
       
       xi0 = xi;

--- a/MantidPlot/src/nrutil.cpp
+++ b/MantidPlot/src/nrutil.cpp
@@ -249,10 +249,10 @@ for (i=1;i<=n;i++)
 	if (ii)
 		for (j=ii;j<=i-1;j++)
 			sum -= a[i][j]*b[j];
-	else if (sum)
-		ii=i;
+        else if (sum != 0.0)
+          ii = i;
 
-	b[i]=sum;
+        b[i]=sum;
 	}
 for (i=n;i>=1;i--)
 	{

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -335,7 +335,7 @@ void EnggDiffractionViewQtGUI::readSettings() {
           .toString()
           .toStdString();
   m_calibSettings.m_forceRecalcOverwrite =
-      qs.value("rebin-calib", g_defaultRebinWidth).toFloat();
+      qs.value("rebin-calib", g_defaultRebinWidth).toBool();
 
   // 'focusing' block
   m_focusDir = qs.value("focus-dir").toString().toStdString();

--- a/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
+++ b/MantidQt/CustomInterfaces/src/Indirect/ConvFit.cpp
@@ -877,7 +877,7 @@ void ConvFit::populateFunction(IFunction_sptr func, IFunction_sptr comp,
     } else {
       std::string propName = props[i]->propertyName().toStdString();
       double propValue = props[i]->valueText().toDouble();
-      if (propValue) {
+      if (propValue != 0.0) {
         if (func->hasAttribute(propName))
           func->setAttributeValue(propName, propValue);
         else

--- a/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
+++ b/MantidQt/CustomInterfaces/src/Muon/MuonAnalysis.cpp
@@ -2620,8 +2620,7 @@ void MuonAnalysis::changeTab(int newTabIndex)
 
     // setFitPropertyBrowser() above changes the fitting range, so we have to
     // either initialise it to the correct values:
-    if ( !xmin && !xmax )
-    {
+    if (xmin == 0.0 && xmax == 0.0) {
       // A previous fitting range of [0,0] means this is the first time the users goes to "Data Analysis" tab
       // We have to initialise the fitting range
       m_uiForm.fitBrowser->setStartX(m_uiForm.timeAxisStartAtInput->text().toDouble());

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -63,7 +63,7 @@ endif ()
 # Force 64-bit compiler as that's all we support
 ###########################################################################
 
-set ( CLANG_WARNINGS "-Wall -Wextra -pedantic -Wconversion -Wno-sign-conversion -Winit-self -Wpointer-arith -Wcast-qual -fno-common  -Wno-deprecated-register -Wno-deprecated-declarations")
+set ( CLANG_WARNINGS "-Wall -Wextra -pedantic -Wconversion -Wno-sign-conversion -Winit-self -Wpointer-arith -Wcast-qual -fno-common -Wno-deprecated-declarations")
 
 set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 ${CLANG_WARNINGS}" )
 if(${CMAKE_VERSION} VERSION_GREATER 3.1.0 OR ${CMAKE_VERSION} VERSION_EQUAL 3.1.0)

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -63,7 +63,7 @@ endif ()
 # Force 64-bit compiler as that's all we support
 ###########################################################################
 
-set ( CLANG_WARNINGS "-Wall -Wextra -pedantic -Winit-self -Wpointer-arith -Wcast-qual -fno-common  -Wno-deprecated-register -Wno-deprecated-declarations")
+set ( CLANG_WARNINGS "-Wall -Wextra -pedantic -Wconversion -Wno-sign-conversion -Winit-self -Wpointer-arith -Wcast-qual -fno-common  -Wno-deprecated-register -Wno-deprecated-declarations")
 
 set ( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -m64 ${CLANG_WARNINGS}" )
 if(${CMAKE_VERSION} VERSION_GREATER 3.1.0 OR ${CMAKE_VERSION} VERSION_EQUAL 3.1.0)


### PR DESCRIPTION
This adds the `-Wfloat-conversion` flag and fixes all related warnings. This is gets us closer to having the same warning flags on both Clang and GCC.

I would like to get this PR in release 3.6 because it fixes a significant issue with our Boolean implementation.

Testing:  I'm most concerned about [this](https://github.com/mantidproject/mantid/blob/705f56707943cffa78d97a94662480db5f080d04/Framework/API/inc/MantidAPI/Column.h#L212) change to `API::Boolean`, hence the core tag.

No release notes
