### PR TITLE
Fix windows paths in LoadCIF

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -232,14 +232,21 @@ class LoadCIF(PythonAlgorithm):
                              doc='Load UB-matrix from CIF file if available.')
 
     def PyExec(self):
+        try:
+            self._loadFromCif()
+        except ImportError:
+            raise RuntimeError('This algorithm requires an additional Python package: PyCifRW' \
+                               ' (https://pypi.python.org/pypi/PyCifRW/4.1)')
+
+    def _loadFromCif(self):
         cifFileName = self.getProperty('InputFile').value
         workspace = self.getProperty('Workspace').value
 
         # Try to parse cif file using PyCifRW
+        from CifFile import ReadCif
+
         parsedCifFile = ReadCif(cifFileName)
-
         self._setCrystalStructureFromCifFile(workspace, parsedCifFile)
-
         ubOption = self.getProperty('LoadUBMatrix').value
         if ubOption:
             self._setUBMatrixFromCifFile(workspace, parsedCifFile)
@@ -277,10 +284,4 @@ class LoadCIF(PythonAlgorithm):
         return builder.getUBMatrix()
 
 
-try:
-    from CifFile import ReadCif
-
-    AlgorithmFactory.subscribe(LoadCIF)
-except ImportError:
-    logger.debug('Failed to subscribe algorithm LoadCIF; Python package PyCifRW' \
-                 'may be missing (https://pypi.python.org/pypi/PyCifRW/4.1)')
+AlgorithmFactory.subscribe(LoadCIF)

--- a/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadCIF.py
@@ -239,17 +239,27 @@ class LoadCIF(PythonAlgorithm):
                                ' (https://pypi.python.org/pypi/PyCifRW/4.1)')
 
     def _loadFromCif(self):
-        cifFileName = self.getProperty('InputFile').value
+        from CifFile import ReadCif
+
+        cifFileUrl = self._getFileUrl()
         workspace = self.getProperty('Workspace').value
 
         # Try to parse cif file using PyCifRW
-        from CifFile import ReadCif
+        parsedCifFile = ReadCif(cifFileUrl)
 
-        parsedCifFile = ReadCif(cifFileName)
         self._setCrystalStructureFromCifFile(workspace, parsedCifFile)
+
         ubOption = self.getProperty('LoadUBMatrix').value
         if ubOption:
             self._setUBMatrixFromCifFile(workspace, parsedCifFile)
+
+    def _getFileUrl(self):
+        # ReadCif requires a URL, windows path specs seem to confuse urllib,
+        # so the pathname is converted to a URL before passing it to ReadCif.
+        from urllib import pathname2url
+
+        cifFileName = self.getProperty('InputFile').value
+        return pathname2url(cifFileName)
 
     def _setCrystalStructureFromCifFile(self, workspace, cifFile):
         crystalStructure = self._getCrystalStructureFromCifFile(cifFile)


### PR DESCRIPTION
This addresses #15117.

In addition, I found a better way to handle the optional dependency on `PyCifRW`, the algorithm is now registered in any case, but an exception is raised when it's executed and the dependency is not met. This way the documentation can be generated and the user has a way of actually knowing that the algorithm exists.

**Testing information**
Make sure that the documentation is also generated when `PyCifRW` is not installed. Try loading a CIF-file on Windows (see example in documentation), but make sure that the path has a `c:` or `d:` (or any other drive letter) in the beginning.

I could not test this on Linux, please let me know if there are problems on Windows.
