### PR TITLE
Fix SpaceGroupFactoryTest for rhel6 

### DIFF
--- a/Testing/SystemTests/tests/analysis/SpaceGroupFactoryTest.py
+++ b/Testing/SystemTests/tests/analysis/SpaceGroupFactoryTest.py
@@ -23,7 +23,8 @@ class SpaceGroupFactoryTest(stresstesting.MantidStressTest):
 
         # There are some space groups which have new names in the latest tables, they will be included in the
         # test when aliases are available.
-        self.assertLess(len(self.notChecked), 25,
+        # Note: avoiding assertLess() for now, not available in Python < 2.7 (rhel6)
+        self.assertTrue(len(self.notChecked) < 25,
                         'Some space groups were not checked: ' + str(self.notChecked))
 
     def checkSpaceGroup(self, symbol):


### PR DESCRIPTION
This simply replaces `assertLess()` with `assertTrue()`.
`assertLess()` was introduced in Python 2.7 and so it is too "modern" for rhel6: https://docs.python.org/2/library/unittest.html#classes-and-functions

This is just the usual problem with rhel6, not a real issue, but setting it as "High Priority" as it blocks the master rhel6 build pipeline: http://builds.mantidproject.org/job/master_systemtests-rhel6/98/testReport/

@MichaelWedel : could you have a quick look at this? 
