### PR TITLE
Fix crash in InstrumentView when adding Peak

### DIFF
--- a/MantidPlot/src/Mantid/InstrumentWidget/PeakOverlay.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/PeakOverlay.cpp
@@ -103,6 +103,9 @@ QString PeakHKL::formatNumber(double h, int prec) {
 /// Extract minimum and maximum intensity from peaks workspace for scaling.
 void AbstractIntensityScale::setPeaksWorkspace(
     const boost::shared_ptr<Mantid::API::IPeaksWorkspace> &pws) {
+  m_maxIntensity = 0.0;
+  m_minIntensity = 0.0;
+
   if (pws) {
     int peakCount = pws->getNumberPeaks();
 
@@ -116,11 +119,10 @@ void AbstractIntensityScale::setPeaksWorkspace(
     auto minMaxIntensity =
         std::minmax_element(intensities.begin(), intensities.end());
 
-    m_maxIntensity = *minMaxIntensity.second;
-    m_minIntensity = *minMaxIntensity.first;
-  } else {
-    m_maxIntensity = 0.0;
-    m_minIntensity = 0.0;
+    if (peakCount > 0) {
+      m_maxIntensity = *minMaxIntensity.second;
+      m_minIntensity = *minMaxIntensity.first;
+    }
   }
 }
 


### PR DESCRIPTION
This fixes #15129.

**Testing information**
Load the file `SXD23767.raw` from the SystemTestData, open the InstrumentView. Zoom in to one of the peaks, switch to the "Pick"-tab and select the tool "Add single crystal peak". Click on the peak in the view on the right hand side, then zoom in to one of the peaks in the TOF-plot in the lower left corner and click the peak position with the left mouse button. Make sure that Mantid does not crash and that PeaksWorkspace is created with one peak in it. This should work with the "Indicate relative intensity"-option on the "Render" tab on or off.
