### PR TITLE
Instrument Window settings and options automatically saved and read

### DIFF
--- a/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
@@ -198,6 +198,11 @@ QString ColorMapWidget::getMinValue() { return m_minValueBox->text(); }
 QString ColorMapWidget::getMaxValue() { return m_maxValueBox->text(); }
 
 /**
+* returns the mnth powder as QString
+*/
+QString ColorMapWidget::getNth_power() { return m_dspnN->text(); }
+
+/**
  * Update the min value text box.
  * @param value :: Value to be displayed in the text box.
  */

--- a/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.cpp
@@ -188,6 +188,16 @@ void ColorMapWidget::setMaxValue(double value)
 }
 
 /**
+* returns the min value as QString
+*/
+QString ColorMapWidget::getMinValue() { return m_minValueBox->text(); }
+
+/**
+* returns the min value as QString
+*/
+QString ColorMapWidget::getMaxValue() { return m_maxValueBox->text(); }
+
+/**
  * Update the min value text box.
  * @param value :: Value to be displayed in the text box.
  */

--- a/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
+++ b/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
@@ -25,6 +25,8 @@ public:
   void setupColorBarScaling(const MantidColorMap&);
   void setMinValue(double);
   void setMaxValue(double);
+  QString getMinValue();
+  QString getMaxValue();
   void setMinPositiveValue(double);
   int getScaleType()const;
   void setScaleType(int);

--- a/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
+++ b/MantidPlot/src/Mantid/InstrumentWidget/ColorMapWidget.h
@@ -27,6 +27,7 @@ public:
   void setMaxValue(double);
   QString getMinValue();
   QString getMaxValue();
+  QString getNth_power();
   void setMinPositiveValue(double);
   int getScaleType()const;
   void setScaleType(int);

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -1,3 +1,4 @@
+#include "ColorMapWidget.h"
 #include "InstrumentWindow.h"
 #include "InstrumentWindowRenderTab.h"
 #include "InstrumentWindowPickTab.h"
@@ -56,8 +57,11 @@ using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace MantidQt::API;
 
-// Name of the QSettings group to store the InstrumentWindw settings
+// Name of the QSettings group to store the InstrumentWindw &
+// InstrumentWindowRender settings
 const char *InstrumentWindowSettingsGroup = "Mantid/InstrumentWindow";
+const std::string InstrumentWindow::m_windowRendSettingsGroup =
+    "Mantid/InstrumentWindowRender";
 
 namespace {
 /**
@@ -238,6 +242,9 @@ void InstrumentWindow::init(bool resetGeometry, bool autoscaling,
     surface->resetInstrumentActor(m_instrumentActor);
     updateInfoText();
   }
+  readSettings();
+  updateInfoText();
+  update();
 }
 
 /**
@@ -702,6 +709,56 @@ void InstrumentWindow::saveSettings() {
     foreach (InstrumentWindowTab *tab, m_tabs) { tab->saveSettings(settings); }
   }
   settings.endGroup();
+
+  QSettings qs;
+  qs.beginGroup(QString::fromStdString(m_windowRendSettingsGroup));
+
+  // sets the combo to the particular value but does
+  // not update the setSurface? combo value
+  qs.setValue("user_params_Full3d", m_renderTab->m_full3D->isChecked());
+  qs.setValue("user_params_m_cylindricalX",
+	  m_renderTab->m_cylindricalX->isChecked());
+  qs.setValue("user_params_m_cylindricalY",
+	  m_renderTab->m_cylindricalY->isChecked());
+  qs.setValue("user_params_m_cylindricalZ",
+	  m_renderTab->m_cylindricalZ->isChecked());
+  qs.setValue("user_params_m_sphericalX",
+	  m_renderTab->m_sphericalX->isChecked());
+  qs.setValue("user_params_m_sphericalY",
+	  m_renderTab->m_sphericalY->isChecked());
+  qs.setValue("user_params_m_sphericalZ",
+	  m_renderTab->m_sphericalZ->isChecked());
+  qs.setValue("user_params_m_sideBySide",
+	  m_renderTab->m_sideBySide->isChecked());
+  qs.endGroup();
+}
+
+/**
+* Reads properties of the render window
+*/
+void InstrumentWindow::readSettings() {
+	QSettings qs;
+	qs.beginGroup(QString::fromStdString(m_windowRendSettingsGroup));
+
+	// sets the combo to the particular value but does
+	// not update the combo value
+	m_renderTab->m_full3D->setChecked(
+		qs.value("user_params_Full3d", false).toBool());
+	m_renderTab->m_cylindricalX->setChecked(
+		qs.value("user_params_m_cylindricalX", false).toBool());
+	m_renderTab->m_cylindricalY->setChecked(
+		qs.value("user_params_m_cylindricalY", true).toBool());
+	m_renderTab->m_cylindricalZ->setChecked(
+		qs.value("user_params_m_cylindricalZ", false).toBool());
+	m_renderTab->m_sphericalX->setChecked(
+		qs.value("user_params_m_sphericalX", false).toBool());
+	m_renderTab->m_sphericalY->setChecked(
+		qs.value("user_params_m_sphericalX", false).toBool());
+	m_renderTab->m_sphericalZ->setChecked(
+		qs.value("user_params_m_sphericalZ", false).toBool());
+	m_renderTab->m_sideBySide->setChecked(
+		qs.value("user_params_m_sideBySide", false).toBool());
+	qs.endGroup();
 }
 
 /**

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -769,6 +769,27 @@ void InstrumentWindow::readSettings() {
   m_renderTab->m_sideBySide->setChecked(
       qs.value("user_params_m_sideBySide", false).toBool());
 
+  // QString surfaceType;
+  int surfaceType;
+  if ((qs.value("user_params_Full3d").toBool())) {
+    surfaceType = 0;
+  } else if ((qs.value("user_params_m_cylindricalX").toBool())) {
+    surfaceType = 1;
+  } else if ((qs.value("user_params_m_cylindricalY").toBool())) {
+    surfaceType = 2;
+  } else if ((qs.value("user_params_m_cylindricalZ").toBool())) {
+    surfaceType = 3;
+  } else if ((qs.value("user_params_m_sphericalX").toBool())) {
+    surfaceType = 4;
+  } else if ((qs.value("user_params_m_sphericalY").toBool())) {
+    surfaceType = 5;
+  } else if ((qs.value("user_params_m_sphericalZ").toBool())) {
+    surfaceType = 6;
+  } else {
+    surfaceType = 7;
+  }
+  setSurfaceType(surfaceType);
+
   m_renderTab->m_flipCheckBox->setChecked(
       qs.value("user_params_flipCheckBox", false).toBool());
 

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -730,15 +730,20 @@ void InstrumentWindow::saveSettings() {
   qs.setValue("user_params_m_sideBySide",
               m_renderTab->m_sideBySide->isChecked());
 
+  qs.setValue("user_param_mAxisCombo", m_renderTab->mAxisCombo->currentText());
   qs.setValue("user_params_flipCheckBox",
               m_renderTab->m_flipCheckBox->isChecked());
 
-  qs.setValue("user_params_autoscaling",
-              m_renderTab->m_autoscaling->isChecked());
   qs.setValue("user_param_minVal",
               m_renderTab->m_colorMapWidget->getMinValue());
   qs.setValue("user_param_maxVal",
               m_renderTab->m_colorMapWidget->getMaxValue());
+  qs.setValue("user_params_autoscaling",
+              m_renderTab->m_autoscaling->isChecked());
+
+  // saving the bin range entered
+  qs.setValue("user_params_minBinRange", m_instrumentActor->minBinValue());
+  qs.setValue("user_params_maxBinRange", m_instrumentActor->maxBinValue());
 
   qs.endGroup();
 }
@@ -769,8 +774,8 @@ void InstrumentWindow::readSettings() {
   m_renderTab->m_sideBySide->setChecked(
       qs.value("user_params_m_sideBySide", false).toBool());
 
-  // QString surfaceType;
-  int surfaceType;
+  // if true assign surfaceType int
+  int surfaceType = 2;
   if ((qs.value("user_params_Full3d").toBool())) {
     surfaceType = 0;
   } else if ((qs.value("user_params_m_cylindricalX").toBool())) {
@@ -785,11 +790,13 @@ void InstrumentWindow::readSettings() {
     surfaceType = 5;
   } else if ((qs.value("user_params_m_sphericalZ").toBool())) {
     surfaceType = 6;
-  } else {
+  } else if ((qs.value("user_params_m_sideBySide").toBool())) {
     surfaceType = 7;
   }
   setSurfaceType(surfaceType);
 
+  // setAxis can only be initailised after setSurfaceType has been called
+  m_renderTab->setAxis(qs.value("user_param_mAxisCombo").toString());
   m_renderTab->m_flipCheckBox->setChecked(
       qs.value("user_params_flipCheckBox", false).toBool());
 
@@ -800,9 +807,13 @@ void InstrumentWindow::readSettings() {
   m_renderTab->m_autoscaling->setChecked(
       qs.value("user_params_autoscaling", true).toBool());
 
+  // setting the bin range which is not from InstrumentWindowRenderTab
+  setBinRange(qs.value("user_params_minBinRange").toDouble(),
+              qs.value("user_params_maxBinRange").toDouble());
+
   qs.endGroup();
 
-  // update according to read settings
+  // update according to settings
   updateInfoText();
   update();
 }

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -803,8 +803,9 @@ void InstrumentWindow::readSettings() {
 
   colorMapRangeChanged(qs.value("user_param_minVal").toDouble(),
                        qs.value("user_param_maxVal").toDouble());
-  m_renderTab->m_colorMapWidget->setNthPower(
-      qs.value("user_param_nthTerm").toDouble());
+  m_renderTab->nthPowerChanged(qs.value("user_param_nthTerm").toDouble());
+  changeNthPower(qs.value("user_param_nthTerm").toDouble());
+
   // auto scale after max and min value required as it will
   // read the above above and uncheck the box
   m_renderTab->m_autoscaling->setChecked(

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -243,8 +243,7 @@ void InstrumentWindow::init(bool resetGeometry, bool autoscaling,
     updateInfoText();
   }
   readSettings();
-  updateInfoText();
-  update();
+
 }
 
 /**
@@ -717,19 +716,30 @@ void InstrumentWindow::saveSettings() {
   // not update the setSurface? combo value
   qs.setValue("user_params_Full3d", m_renderTab->m_full3D->isChecked());
   qs.setValue("user_params_m_cylindricalX",
-	  m_renderTab->m_cylindricalX->isChecked());
+              m_renderTab->m_cylindricalX->isChecked());
   qs.setValue("user_params_m_cylindricalY",
-	  m_renderTab->m_cylindricalY->isChecked());
+              m_renderTab->m_cylindricalY->isChecked());
   qs.setValue("user_params_m_cylindricalZ",
-	  m_renderTab->m_cylindricalZ->isChecked());
+              m_renderTab->m_cylindricalZ->isChecked());
   qs.setValue("user_params_m_sphericalX",
-	  m_renderTab->m_sphericalX->isChecked());
+              m_renderTab->m_sphericalX->isChecked());
   qs.setValue("user_params_m_sphericalY",
-	  m_renderTab->m_sphericalY->isChecked());
+              m_renderTab->m_sphericalY->isChecked());
   qs.setValue("user_params_m_sphericalZ",
-	  m_renderTab->m_sphericalZ->isChecked());
+              m_renderTab->m_sphericalZ->isChecked());
   qs.setValue("user_params_m_sideBySide",
-	  m_renderTab->m_sideBySide->isChecked());
+              m_renderTab->m_sideBySide->isChecked());
+
+  qs.setValue("user_params_flipCheckBox",
+              m_renderTab->m_flipCheckBox->isChecked());
+
+  qs.setValue("user_params_autoscaling",
+              m_renderTab->m_autoscaling->isChecked());
+  qs.setValue("user_param_minVal",
+              m_renderTab->m_colorMapWidget->getMinValue());
+  qs.setValue("user_param_maxVal",
+              m_renderTab->m_colorMapWidget->getMaxValue());
+
   qs.endGroup();
 }
 
@@ -737,28 +747,43 @@ void InstrumentWindow::saveSettings() {
 * Reads properties of the render window
 */
 void InstrumentWindow::readSettings() {
-	QSettings qs;
-	qs.beginGroup(QString::fromStdString(m_windowRendSettingsGroup));
+  QSettings qs;
+  qs.beginGroup(QString::fromStdString(m_windowRendSettingsGroup));
 
-	// sets the combo to the particular value but does
-	// not update the combo value
-	m_renderTab->m_full3D->setChecked(
-		qs.value("user_params_Full3d", false).toBool());
-	m_renderTab->m_cylindricalX->setChecked(
-		qs.value("user_params_m_cylindricalX", false).toBool());
-	m_renderTab->m_cylindricalY->setChecked(
-		qs.value("user_params_m_cylindricalY", true).toBool());
-	m_renderTab->m_cylindricalZ->setChecked(
-		qs.value("user_params_m_cylindricalZ", false).toBool());
-	m_renderTab->m_sphericalX->setChecked(
-		qs.value("user_params_m_sphericalX", false).toBool());
-	m_renderTab->m_sphericalY->setChecked(
-		qs.value("user_params_m_sphericalX", false).toBool());
-	m_renderTab->m_sphericalZ->setChecked(
-		qs.value("user_params_m_sphericalZ", false).toBool());
-	m_renderTab->m_sideBySide->setChecked(
-		qs.value("user_params_m_sideBySide", false).toBool());
-	qs.endGroup();
+  // sets the combo to the particular value but does
+  // not update the combo value
+  m_renderTab->m_full3D->setChecked(
+      qs.value("user_params_Full3d", false).toBool());
+  m_renderTab->m_cylindricalX->setChecked(
+      qs.value("user_params_m_cylindricalX", false).toBool());
+  m_renderTab->m_cylindricalY->setChecked(
+      qs.value("user_params_m_cylindricalY", true).toBool());
+  m_renderTab->m_cylindricalZ->setChecked(
+      qs.value("user_params_m_cylindricalZ", false).toBool());
+  m_renderTab->m_sphericalX->setChecked(
+      qs.value("user_params_m_sphericalX", false).toBool());
+  m_renderTab->m_sphericalY->setChecked(
+      qs.value("user_params_m_sphericalY", false).toBool());
+  m_renderTab->m_sphericalZ->setChecked(
+      qs.value("user_params_m_sphericalZ", false).toBool());
+  m_renderTab->m_sideBySide->setChecked(
+      qs.value("user_params_m_sideBySide", false).toBool());
+
+  m_renderTab->m_flipCheckBox->setChecked(
+      qs.value("user_params_flipCheckBox", false).toBool());
+
+  colorMapRangeChanged(qs.value("user_param_minVal").toDouble(),
+                       qs.value("user_param_maxVal").toDouble());
+  // auto scale after max and min value required as it will
+  // read the above above and uncheck the box
+  m_renderTab->m_autoscaling->setChecked(
+      qs.value("user_params_autoscaling", true).toBool());
+
+  qs.endGroup();
+
+  // update according to read settings
+  updateInfoText();
+  update();
 }
 
 /**

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.cpp
@@ -243,7 +243,6 @@ void InstrumentWindow::init(bool resetGeometry, bool autoscaling,
     updateInfoText();
   }
   readSettings();
-
 }
 
 /**
@@ -729,15 +728,17 @@ void InstrumentWindow::saveSettings() {
               m_renderTab->m_sphericalZ->isChecked());
   qs.setValue("user_params_m_sideBySide",
               m_renderTab->m_sideBySide->isChecked());
-
   qs.setValue("user_param_mAxisCombo", m_renderTab->mAxisCombo->currentText());
   qs.setValue("user_params_flipCheckBox",
               m_renderTab->m_flipCheckBox->isChecked());
 
+  // saving the settings for the graph and color map
   qs.setValue("user_param_minVal",
               m_renderTab->m_colorMapWidget->getMinValue());
   qs.setValue("user_param_maxVal",
               m_renderTab->m_colorMapWidget->getMaxValue());
+  qs.setValue("user_param_nthTerm",
+              m_renderTab->m_colorMapWidget->getNth_power());
   qs.setValue("user_params_autoscaling",
               m_renderTab->m_autoscaling->isChecked());
 
@@ -749,7 +750,7 @@ void InstrumentWindow::saveSettings() {
 }
 
 /**
-* Reads properties of the render window
+* Reads properties of the instrument render window and the bin range
 */
 void InstrumentWindow::readSettings() {
   QSettings qs;
@@ -802,12 +803,15 @@ void InstrumentWindow::readSettings() {
 
   colorMapRangeChanged(qs.value("user_param_minVal").toDouble(),
                        qs.value("user_param_maxVal").toDouble());
+  m_renderTab->m_colorMapWidget->setNthPower(
+      qs.value("user_param_nthTerm").toDouble());
   // auto scale after max and min value required as it will
   // read the above above and uncheck the box
   m_renderTab->m_autoscaling->setChecked(
       qs.value("user_params_autoscaling", true).toBool());
 
-  // setting the bin range which is not from InstrumentWindowRenderTab
+  // setting the bin range which is not accessed from InstrumentWindowRenderTab
+  // trouble setting the slider according to bin range?
   setBinRange(qs.value("user_params_minBinRange").toDouble(),
               qs.value("user_params_maxBinRange").toDouble());
 

--- a/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
+++ b/MantidPlot/src/Mantid/InstrumentWidget/InstrumentWindow.h
@@ -183,6 +183,7 @@ private:
   QWidget * createInstrumentTreeTab(QTabWidget* ControlsTab);
   void createTabs(QSettings& settings);
   void saveSettings();
+  void readSettings();
 
   QString asString(const std::vector<int>& numbers) const;
   QString confirmDetectorOperation(const QString & opName, const QString & inputWS, int ndets);
@@ -244,6 +245,7 @@ private:
   bool m_blocked;     
   QList<int> m_selectedDetectors;
   bool m_instrumentDisplayContextMenuOn;
+  const static std::string m_windowRendSettingsGroup;
 
 private:
   /// ADS notification handlers


### PR DESCRIPTION
fixes #1890 

Following options and settings select in `InstrumentWindow` will automatically be saved upon closure  of the window, these settings will be read the next time `InstrumentWindow` has been opened.
- Surface Type
  - For `Full 3D`, `Axis` that have been selected
- Flip View
- Colour Map
- Colour Min & Max
- Scale
  - Scale Type
  - nth Term
- auto-scaling check box 
- Min and Max bin range

Make sure all the options and interface have been updated correctly, the instrument view plots the correct surface type and axis (under `Full 3D` surface type).

There seems to be a bug with the slide bar when the bin range is set, however a separate issue has been created for this #15134. However for now reset button can be used to fix the slide bar.
