### PR TITLE
Move the source back to its original position

### DIFF
--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -686,8 +686,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne::transmissonCorrection(
           stitchingDelta.is_initialized()) {
         const std::vector<double> params =
             boost::assign::list_of(stitchingStart.get())(stitchingDelta.get())(
-                stitchingEnd.get())
-                .convert_to_container<std::vector<double>>();
+                stitchingEnd.get()).convert_to_container<std::vector<double>>();
         alg->setProperty("Params", params);
       } else if (stitchingDelta.is_initialized()) {
         alg->setProperty("Params",

--- a/Framework/Algorithms/src/ReflectometryReductionOne.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne.cpp
@@ -394,10 +394,15 @@ Mantid::API::MatrixWorkspace_sptr ReflectometryReductionOne::toIvsQ(
 
   // Rotate the source back to its original position
   if (rotationTheta != 0.0) {
+    // for IvsLam Workspace
     auto rotateSource = this->createChildAlgorithm("RotateSource");
     rotateSource->setChild(true);
     rotateSource->initialize();
     rotateSource->setProperty("Workspace", toConvert);
+    rotateSource->setProperty("Angle", -rotationTheta);
+    rotateSource->execute();
+    // for IvsQ Workspace
+    rotateSource->setProperty("Workspace", inQ);
     rotateSource->setProperty("Angle", -rotationTheta);
     rotateSource->execute();
   }

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -208,7 +208,7 @@ public:
     TS_ASSERT_EQUALS(m_tinyReflWS->getInstrument()->getSource()->getPos(),
                      outLam->getInstrument()->getSource()->getPos());
     TS_ASSERT_EQUALS(outLam->getInstrument()->getSource()->getPos(),
-                      outQ->getInstrument()->getSource()->getPos());
+                     outQ->getInstrument()->getSource()->getPos());
   }
 
   void test_Qrange() {
@@ -271,7 +271,7 @@ public:
 
     TS_ASSERT_DELTA(45.0, outTheta, 0.00001);
     TS_ASSERT_EQUALS(source->getPos(),
-        inQ->getInstrument()->getSource()->getPos());
+                     inQ->getInstrument()->getSource()->getPos());
     // convert from degrees to radians for sin() function
     double outThetaInRadians = outTheta * M_PI / 180;
 

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -206,9 +206,9 @@ public:
     MatrixWorkspace_sptr outQ = alg->getProperty("OutputWorkspace");
 
     TS_ASSERT_EQUALS(m_tinyReflWS->getInstrument()->getSource()->getPos(),
-                      outLam->getInstrument()->getSource()->getPos());
+                     outLam->getInstrument()->getSource()->getPos());
     TS_ASSERT_DIFFERS(outLam->getInstrument()->getSource()->getPos(),
-                     outQ->getInstrument()->getSource()->getPos());
+                      outQ->getInstrument()->getSource()->getPos());
   }
 
   void test_Qrange() {

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -205,9 +205,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg->execute());
     MatrixWorkspace_sptr outQ = alg->getProperty("OutputWorkspace");
 
-    TS_ASSERT_DIFFERS(m_tinyReflWS->getInstrument()->getSource()->getPos(),
+    TS_ASSERT_EQUALS(m_tinyReflWS->getInstrument()->getSource()->getPos(),
                       outLam->getInstrument()->getSource()->getPos());
-    TS_ASSERT_EQUALS(outLam->getInstrument()->getSource()->getPos(),
+    TS_ASSERT_DIFFERS(outLam->getInstrument()->getSource()->getPos(),
                      outQ->getInstrument()->getSource()->getPos());
   }
 

--- a/Framework/Algorithms/test/ReflectometryReductionOneTest.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneTest.h
@@ -207,7 +207,7 @@ public:
 
     TS_ASSERT_EQUALS(m_tinyReflWS->getInstrument()->getSource()->getPos(),
                      outLam->getInstrument()->getSource()->getPos());
-    TS_ASSERT_DIFFERS(outLam->getInstrument()->getSource()->getPos(),
+    TS_ASSERT_EQUALS(outLam->getInstrument()->getSource()->getPos(),
                       outQ->getInstrument()->getSource()->getPos());
   }
 
@@ -270,8 +270,8 @@ public:
     double outTheta = alg->getProperty("ThetaOut");
 
     TS_ASSERT_DELTA(45.0, outTheta, 0.00001);
-    TS_ASSERT_DIFFERS(source->getPos(),
-                      inQ->getInstrument()->getSource()->getPos())
+    TS_ASSERT_EQUALS(source->getPos(),
+        inQ->getInstrument()->getSource()->getPos());
     // convert from degrees to radians for sin() function
     double outThetaInRadians = outTheta * M_PI / 180;
 

--- a/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAuto.py
+++ b/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAuto.py
@@ -1,4 +1,4 @@
-﻿#pylint: disable=no-init,invalid-name
+﻿# pylint: disable=no-init,invalid-name,attribute-defined-outside-init
 """
 This system test verifies that OFFSPEC data is processed correctly by
 ReflectometryReductionOneAuto

--- a/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAuto.py
+++ b/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAuto.py
@@ -33,6 +33,11 @@ class OFFSPECReflRedOneAuto(stresstesting.MantidStressTest):
         return True
 
     def validate(self):
+        '''
+        we only wish to check the Q-range in this system test. It is not necessary
+        to check the Instrument definition or Instrument Parameters
+        '''
+        self.disableChecking = ["Instrument"]
         return ("ivq_75_76_78","OFFSPECReflRedOneAuto_good_v2.nxs")
 
     def requiredFiles(self):

--- a/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAutoPolarizationCorrection.py
+++ b/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAutoPolarizationCorrection.py
@@ -35,6 +35,11 @@ class OFFSPECReflRedOneAutoPolarizationCorrection(stresstesting.MantidStressTest
         return True
 
     def validate(self):
+        '''
+        we only wish to check the data from PolarizationCorrection in this system test.
+        It is not necessary to check the Instrument definition or Instrument Parameters
+        '''
+        self.disableChecking = ["Instrument"]
         return ("_IvsLam_polCorr", "OFFSPECReflRedOneAutoPolarizationCorrection_good_v2.nxs")
 
     def requiredFiles(self):

--- a/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAutoPolarizationCorrection.py
+++ b/Testing/SystemTests/tests/analysis/OFFSPECReflRedOneAutoPolarizationCorrection.py
@@ -1,4 +1,4 @@
-#pylint: disable=no-init,invalid-name,line-too-long
+# pylint: disable=no-init, invalid-name, line-too-long, attribute-defined-outside-init
 
 """
 This system test verifies that OFFSPEC data is processed correctly


### PR DESCRIPTION
Fixes #15136 

Tester: 

See #15136 for a description of the problem and run the example script. With this fix, you should get the following `QxQz` map

![qxqz23dec](https://cloud.githubusercontent.com/assets/8956985/12716526/29ae4d74-c8d9-11e5-89cc-7622661f99a1.png)

I still don't understand why we need to have the source in the "correct" position (i.e. at `(0, y, -z)`) for `ConvertUnits`, but we have to have it at `(0, 0, -z)` for `ConvertSpectrumAxis`.
