### PR TITLE
Fix building docs-qthelp with newer sphinx.

### DIFF
--- a/docs/source/api/python/techniques/PowderDiffractionISIS-v1.rst
+++ b/docs/source/api/python/techniques/PowderDiffractionISIS-v1.rst
@@ -248,4 +248,4 @@ Usage
 .. toctree::
    :maxdepth: 1
 
-   /../../api/python/index
+   api/python/index


### PR DESCRIPTION
Building `docs-qthelp` currently fails with [OSX](http://builds.mantidproject.org/job/master_clean-osx/106/console) and [Arch](http://builds.mantidproject.org/view/All/job/master_clean-archlinux/191/) after changes from #15110. I believe because of the newer version of sphinx, `1.3.5` on Arch.

**To test**:
- Code Review
- Check that the `qtdocs` build correctly on OSX ( I did a CLEAN OSX rebuild.)
