### PR TITLE
PowderDiffraction:: forceRootDirFromScripts default value changed & Doc updated

### DIFF
--- a/docs/source/api/python/techniques/PowderDiffractionISIS-v1.rst
+++ b/docs/source/api/python/techniques/PowderDiffractionISIS-v1.rst
@@ -112,11 +112,12 @@ as shown below, the script shall look for the raw files (with the format of
 .. code-block:: python
 
    #----------------------------------------------------
-   # Calibration Runs Numbers
+   # Runs Numbers
    #----------------------------------------------------
    #
    Vanadium     78338
    V-Empty      78339
+   S-Empty      0
    #
 
 Output

--- a/scripts/PowderISIS/cry_ini.py
+++ b/scripts/PowderISIS/cry_ini.py
@@ -13,7 +13,7 @@ ANALYSIS_DIR = ''
 
 
 class Files:
-    def __init__(self, instr, RawDir="", Analysisdir="", UnitTest=False, debugMode=False, forceRootDirFromScripts=True, inputInstDir=''):
+    def __init__(self, instr, RawDir="", Analysisdir="", UnitTest=False, debugMode=False, forceRootDirFromScripts=False, inputInstDir=''):
         global ANALYSIS_DIR
         self.debugMode = False
         if debugMode:


### PR DESCRIPTION
Fixes #15146

Updates the default value of `forceRootDirFromScripts` to `False` in `cry_ini.Files()`
Documentation updated with compulsory `S-Empty` run number for accurate results 
