### PR TITLE
Replaced incorrect OFFSPEC Definition

### DIFF
--- a/instrument/OFFSPEC_Definition.xml
+++ b/instrument/OFFSPEC_Definition.xml
@@ -109,7 +109,7 @@
      <location  z=" 3.52 " />
    </component>
    <component type="WLSFDetector">
-     <location  z=" 3.63 " />
+     <location  z=" 3.46 " />
    </component>
   </type>
 
@@ -690,7 +690,7 @@
 -->
   <type name="WLSFDetector">
  <component type="wlsfpixel">
-   <locations y="-0.19775" y-end="0.18225" n-elements="768" />
+   <locations y="-0.1975" y-end="0.1865" n-elements="768" />
  </component>
  </type>
  


### PR DESCRIPTION
There were some issues with the positions of detectors in the OFFSPEC definition. Since these measurments were incorrect it seemed fruitless to keep them in the instrument folder. The OFFSPEC IDF has now been replaced by a new IDF given to us by Jos Cooper.

**To Test**:
- Load OFFSPEC workspace
- see that it's instrument definition is called `OFFSPEC_Definition`

**Release Notes:** This can be added to the release notes once the test has been completed.

Fixes #15157
