### PR TITLE
Replace macro with std::enable_if and SFINAE.

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -194,31 +194,21 @@ template <typename T> T extractToValueVector(const std::string &strvalue) {
   return valueVec;
 }
 
-/// Macro for the vector<int> specializations
-#define PROPERTYWITHVALUE_TOVALUE(type)                                        \
-  template <>                                                                  \
-  inline void toValue<type>(const std::string &strvalue,                       \
-                            std::vector<type> &value) {                        \
-    typedef Poco::StringTokenizer tokenizer;                                   \
-    tokenizer values(strvalue, ",",                                            \
-                     tokenizer::TOK_IGNORE_EMPTY | tokenizer::TOK_TRIM);       \
-    value.clear();                                                             \
-    value.reserve(values.count());                                             \
-    for (tokenizer::Iterator it = values.begin(); it != values.end(); ++it) {  \
-      appendValue(*it, value);                                                 \
-    }                                                                          \
+/// vector<int> specializations
+template <typename T>
+inline void
+toValue(const std::string &strvalue,
+        std::vector<typename std::enable_if<std::is_integral<T>::value>::type>
+            &value) {
+  typedef Poco::StringTokenizer tokenizer;
+  tokenizer values(strvalue, ",",
+                   tokenizer::TOK_IGNORE_EMPTY | tokenizer::TOK_TRIM);
+  value.clear();
+  value.reserve(values.count());
+  for (tokenizer::Iterator it = values.begin(); it != values.end(); ++it) {
+    appendValue(*it, value);
   }
-
-PROPERTYWITHVALUE_TOVALUE(int)
-PROPERTYWITHVALUE_TOVALUE(long)
-PROPERTYWITHVALUE_TOVALUE(uint32_t)
-PROPERTYWITHVALUE_TOVALUE(uint64_t)
-#if defined(__APPLE__)
-PROPERTYWITHVALUE_TOVALUE(unsigned long);
-#endif
-
-// Clear up the namespace
-#undef PROPERTYWITHVALUE_TOVALUE
+}
 
 //------------------------------------------------------------------------------------------------
 // Templated += operator functions for specific types

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -198,8 +198,8 @@ template <typename T> T extractToValueVector(const std::string &strvalue) {
 template <typename T>
 inline void
 toValue(const std::string &strvalue,
-        std::vector<typename std::enable_if<std::is_integral<T>::value>::type>
-            &value) {
+        std::vector<typename std::enable_if<std::is_integral<T>::value>::type> &
+            value) {
   typedef Poco::StringTokenizer tokenizer;
   tokenizer values(strvalue, ",",
                    tokenizer::TOK_IGNORE_EMPTY | tokenizer::TOK_TRIM);


### PR DESCRIPTION
This replaces a function-like macro with a check that the template argument is integral. This shouldn't change behavior, but will make it easier to step through this function inside a debugger.

No release notes.

If the tests pass, code review should be sufficient.
