### PR TITLE
Cleanup getters, setters and operator>> in FitParameter.

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/FitParameter.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/FitParameter.h
@@ -49,49 +49,59 @@ public:
   /// get paramter value
   double getValue() const;
   /// set parameter value
-  double &setValue() { return m_value; }
+  void setValue(double value) { m_value = value; }
   /// get tie
   std::string getTie() const { return m_tie; }
   /// set tie
-  std::string &setTie() { return m_tie; }
+  void setTie(std::string tie) { m_tie = std::move(tie); }
   /// get constraint
   std::string getConstraint() const;
   /// get penalty factor
-  std::string getConstraintPenaltyFactor() const {
+  const std::string &getConstraintPenaltyFactor() const {
     return m_constraintPenaltyFactor;
   }
   /// set constraint min
-  std::string &setConstraintMin() { return m_constraintMin; }
+  void setConstraintMin(std::string constraintMin) {
+    m_constraintMin = std::move(constraintMin);
+  }
   /// set constraint max
-  std::string &setConstraintMax() { return m_constraintMax; }
+  void setConstraintMax(std::string constraintMax) {
+    m_constraintMax = std::move(constraintMax);
+  }
   /// set the constraint penalty
-  std::string &setConstraintPenaltyFactor() {
-    return m_constraintPenaltyFactor;
+  void setConstraintPenaltyFactor(std::string constraintPenaltyFactor) {
+    m_constraintPenaltyFactor = std::move(constraintPenaltyFactor);
   }
   /// get formula
-  std::string getFormula() const { return m_formula; }
+  const std::string &getFormula() const { return m_formula; }
   /// set formula
-  std::string &setFormula() { return m_formula; }
+  void setFormula(std::string formula) { m_formula = std::move(formula); }
   /// get formula unit, and Empty string is no unit has been specified
-  std::string getFormulaUnit() const { return m_formulaUnit; }
+  const std::string &getFormulaUnit() const { return m_formulaUnit; }
   /// set formula unit
-  std::string &setFormulaUnit() { return m_formulaUnit; }
+  void setFormulaUnit(std::string formulaUnit) {
+    m_formulaUnit = std::move(formulaUnit);
+  }
   /// get result formula unit, and Empty string is no unit has been specified
-  std::string getResultUnit() const { return m_resultUnit; }
+  const std::string &getResultUnit() const { return m_resultUnit; }
   /// set result formula unit
-  std::string &setResultUnit() { return m_resultUnit; }
+  void setResultUnit(std::string resultUnit) {
+    m_resultUnit = std::move(resultUnit);
+  }
   /// get function
-  std::string getFunction() const { return m_function; }
+  const std::string &getFunction() const { return m_function; }
   /// set function
-  std::string &setFunction() { return m_function; }
+  void setFunction(std::string function) { m_function = std::move(function); }
   /// get name
-  std::string getName() const { return m_name; }
+  const std::string &getName() const { return m_name; }
   /// set name
-  std::string &setName() { return m_name; }
+  void setName(std::string name) { m_name = std::move(name); }
   /// get look up table
   const Kernel::Interpolation &getLookUpTable() const { return m_lookUpTable; }
   /// set look up table
-  Kernel::Interpolation &setLookUpTable() { return m_lookUpTable; }
+  void setLookUpTable(Kernel::Interpolation lookupTable) {
+    m_lookUpTable = std::move(lookupTable);
+  }
 
   /// Prints object to stream
   void printSelf(std::ostream &os) const;

--- a/Framework/Geometry/src/Instrument/FitParameter.cpp
+++ b/Framework/Geometry/src/Instrument/FitParameter.cpp
@@ -165,9 +165,10 @@ std::istream &operator>>(std::istream &in, FitParameter &f) {
   typedef Poco::StringTokenizer tokenizer;
   std::string str;
   getline(in, str);
-  tokenizer values(str, ",", tokenizer::TOK_TRIM);
+  tokenizer tokens(str, ",", tokenizer::TOK_TRIM);
+  std::vector<std::string> values(tokens.begin(), tokens.end());
 
-  if (values.count() <= 2) {
+  if (values.size() <= 2) {
     g_log.warning()
         << "Expecting a comma separated list of at each three entries"
         << " (any of which may be empty strings) to set information about a "
@@ -177,9 +178,9 @@ std::istream &operator>>(std::istream &in, FitParameter &f) {
   }
 
   try {
-    f.setValue() = boost::lexical_cast<double>(values[0]);
+    f.setValue(boost::lexical_cast<double>(values[0]));
   } catch (boost::bad_lexical_cast &) {
-    f.setValue() = 0.0;
+    f.setValue(0.0);
 
     if (!values[0].empty()) {
       g_log.warning() << "Could not read " << values[0] << " as double for "
@@ -190,56 +191,27 @@ std::istream &operator>>(std::istream &in, FitParameter &f) {
 
   // read remaining required entries
 
-  f.setFunction() = values[1];
-  f.setName() = values[2];
+  f.setFunction(values[1]);
+  f.setName(values[2]);
 
   // read optional entries
+  values.reserve(10);
+  while (values.size() <= 10)
+    values.emplace_back("");
 
-  try {
-    f.setConstraintMin() = values[3];
-  } catch (...) {
-    f.setConstraintMin() = "";
-  }
+  f.setConstraintMin(values[3]);
+  f.setConstraintMax(values[4]);
+  f.setConstraintPenaltyFactor(values[5]);
+  f.setTie(values[6]);
+  f.setFormula(values[7]);
+  f.setFormulaUnit(values[8]);
+  f.setResultUnit(values[9]);
 
-  try {
-    f.setConstraintMax() = values[4];
-  } catch (...) {
-    f.setConstraintMax() = "";
-  }
-
-  try {
-    f.setConstraintPenaltyFactor() = values[5];
-  } catch (...) {
-    f.setConstraintPenaltyFactor() = "";
-  }
-
-  try {
-    f.setTie() = values[6];
-  } catch (...) {
-    f.setTie() = "";
-  }
-
-  try {
-    f.setFormula() = values[7];
-  } catch (...) {
-    f.setFormula() = "";
-  }
-
-  try {
-    f.setFormulaUnit() = values[8];
-  } catch (...) {
-    f.setFormulaUnit() = "";
-  }
-
-  try {
-    f.setResultUnit() = values[9];
-  } catch (...) {
-    f.setResultUnit() = "";
-  }
-
-  if (values.count() > 10) {
+  if (values.size() > 10) {
     std::stringstream str(values[10]);
-    str >> f.setLookUpTable();
+    Kernel::Interpolation lookupTable;
+    str >> lookupTable;
+    f.setLookUpTable(lookupTable);
   }
 
   return in;

--- a/Framework/Geometry/src/Instrument/FitParameter.cpp
+++ b/Framework/Geometry/src/Instrument/FitParameter.cpp
@@ -196,7 +196,7 @@ std::istream &operator>>(std::istream &in, FitParameter &f) {
 
   // read optional entries
   values.reserve(10);
-  while (values.size() <= 10)
+  while (values.size() < 10)
     values.emplace_back("");
 
   f.setConstraintMin(values[3]);

--- a/Framework/Geometry/test/FitParameterTest.h
+++ b/Framework/Geometry/test/FitParameterTest.h
@@ -16,8 +16,8 @@ public:
   void test1() {
     FitParameter fitP;
 
-    fitP.setValue() = 9.1;
-    fitP.setTie() = "bob";
+    fitP.setValue(9.1);
+    fitP.setTie("bob");
 
     TS_ASSERT_DELTA(fitP.getValue(), 9.1, 0.0001);
     TS_ASSERT(fitP.getTie().compare("bob") == 0);


### PR DESCRIPTION
This cleans up some creative setters and try/catch blocks in the FitParameter class. I replaced them with a cleaner, more standard approach.

No release notes, as this change won't be seen directly by users.

code review: I tried using [pass std::string by value](http://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html), then moving it into place.

testing: build servers should be sufficient.
