### PR TITLE
Enable CMake policy CMP0053

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,13 @@ else()
   cmake_minimum_required ( VERSION 2.8.12 )
 endif()
 
+if(POLICY CMP0053)
+  #Simplify variable reference and escape sequence evaluation.
+  #Claims to dramatically improve CMake configure and generate time
+  #requires CMake 3.1 or later
+  cmake_policy(SET CMP0053 NEW)
+endif()
+
 # Define the project name.
 project ( Mantid )
 


### PR DESCRIPTION
This enables CMake policy [CMP0053](https://cmake.org/cmake/help/v3.2/policy/CMP0053.html) when CMake 3.1.0 or later is installed. Kitware claims that this dramatically improved CMake configure and generate time. While it does make the parser less permissive, I encountered no issues building Mantid on OS X.
