### PR TITLE
Fixes W matrix in CalculateCoverageDGS

### DIFF
--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -292,9 +292,9 @@ void CalculateCoverageDGS::exec() {
   std::vector<double> Q1Basis = getProperty("Q1Basis");
   std::vector<double> Q2Basis = getProperty("Q2Basis");
   std::vector<double> Q3Basis = getProperty("Q3Basis");
-  W.setRow(0, Q1Basis);
-  W.setRow(1, Q2Basis);
-  W.setRow(2, Q3Basis);
+  W.setColumn(0, Q1Basis);
+  W.setColumn(1, Q2Basis);
+  W.setColumn(2, Q3Basis);
 
   m_rubw = gon * UB * W * (2.0 * M_PI);
 


### PR DESCRIPTION
Fixes #15182. 
To test, follow the steps in the original issue. Check that the coverage calculated using projection u (1,1,0), projection v (1,-1,0) is the same as projection u (1,-1,0), projection v (1,1,0) when plotted HH0 axis along x, and H-H0 axis along y, and that they match the output from ConvertToMD
Code review: look at lines 219-227 in MDWSTransform.cpp for comparison
Release notes: http://www.mantidproject.org/index.php?title=Release_Notes_3_6_Direct_Inelastic&diff=26223&oldid=26108
