### PR TITLE
Visual Studio: move CompileUI targets inside a folder

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -19,6 +19,16 @@ add_custom_target(CompilePyUI DEPENDS
   CompileUIHFIR_4Circle_Reduction
 )
 
+# Put them into the 'CompileUI' folder or group in VS and the like, for convenience
+set_property ( TARGET CompilePyUI PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIFilterEvents PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIHFIRPowderReduction PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIPyChop PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUITofConverter PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIUI PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUILib1To2 PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIHFIR_4Circle_Reduction PROPERTY FOLDER "CompilePyUI" )
+
 set ( TEST_PY_FILES
       test/ConvertToWavelengthTest.py
       test/DirectReductionHelpersTest.py

--- a/scripts/Interface/ui/CMakeLists.txt
+++ b/scripts/Interface/ui/CMakeLists.txt
@@ -25,3 +25,10 @@ add_custom_target(CompileUIUI DEPENDS
   CompileUIReflectometer
   CompileUISANS
 )
+
+# Put all ui targets inside the 'CompilePyUI' folder or group in VS and the like, for convenience
+set_property ( TARGET CompileUIUIBase PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIDiffraction PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIInElastic PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUIReflectometer PROPERTY FOLDER "CompilePyUI" )
+set_property ( TARGET CompileUISANS PROPERTY FOLDER "CompilePyUI" )


### PR DESCRIPTION
Fixes #14466.

**To test**:
- Re-generate/configure with cmake.
- Open Visual Studio with the "visual-studio" batch file that is generated on the target build directory (or opening the solution produced by cmake).
- Verify that all the "CompileUI..." targets are now conveniently included in a VS "folder" as described in the issue (named CompilePyUI), and that the solution still builds correctly on windows and elsewhere.
