### PR TITLE
Decrease pylint violations for inelastic and system test files

### DIFF
--- a/Testing/SystemTests/tests/analysis/HFIRTestsAPIv2.py
+++ b/Testing/SystemTests/tests/analysis/HFIRTestsAPIv2.py
@@ -1,18 +1,22 @@
-#pylint: disable=invalid-name,no-init
+# pylint: disable=invalid-name,no-init,bad-builtin,attribute-defined-outside-init,protected-access,too-many-arguments
+
 """
     System tests for HFIR SANS reduction.
 
     The following tests were converted from the unittest framework
     that is part of python to the stresstesting framework used in Mantid.
 """
+import types
+
+import traceback
+import math
+import os
+
 import stresstesting
 from mantid.api import *
 from mantid.simpleapi import *
 from reduction_workflow.instruments.sans.hfir_command_interface import *
-import types
-import traceback
-import math
-import os
+
 
 # Set directory containing the test data, relative to the Mantid release directory.
 TEST_DIR = "."
@@ -20,13 +24,17 @@ data_search_dirs = ConfigService.Instance()["datasearch.directories"].split(';')
 for item in data_search_dirs:
     if item.endswith("SANS2D/"):
         TEST_DIR = item
-if len(TEST_DIR)==0:
+if len(TEST_DIR) == 0:
     raise RuntimeError, "Could not locate test data directory: [...]/Data/SANS2D"
 
-def _diff_iq(x,y):
-    return x-y
-def _add(x,y):
-    return x+y
+
+def _diff_iq(x, y):
+    return x - y
+
+
+def _add(x, y):
+    return x + y
+
 
 def _read_IGOR(filepath):
     """
@@ -40,13 +48,15 @@ def _read_IGOR(filepath):
         for line in f:
             toks = line.split()
             try:
-                q    = float(toks[0])
-                iq   = float(toks[1])
-                diq  = float(toks[2])
+                q = float(toks[0])
+                iq = float(toks[1])
+                diq = float(toks[2])
                 data.append([q, iq, diq])
             except:
                 print "_read_IGOR:", sys.exc_value
+                raise
     return data
+
 
 def _check_result(ws, test_file, tolerance=1e-6):
     """
@@ -60,48 +70,52 @@ def _check_result(ws, test_file, tolerance=1e-6):
     x = ws.dataX(0)[:len(ws.dataX(0))]
     y = ws.dataY(0)
     e = ws.dataE(0)
-    data_mantid = zip(x,y,e)
+    data_mantid = zip(x, y, e)
 
     # Read the test data to compare with
     data_igor = _read_IGOR(test_file)
 
     # Check length
-    if not len(data_mantid)==len(data_igor):
+    if not len(data_mantid) == len(data_igor):
         print "Incompatible data lengths"
         return False
 
     # Utility methods for manipulating the lists
-    def _diff_chi2(x,y):
-        return (x[1]-y[1])*(x[1]-y[1])/(x[2]*x[2])
-    def _diff_iq(x,y):
-        return x[1]-y[1]
-    def _diff_err(x,y):
-        return x[2]-y[2]
-    def _add(x,y):
-        return x+y
+    def _diff_chi2(x, y):
+        return (x[1] - y[1]) * (x[1] - y[1]) / (x[2] * x[2])
+
+    def _diff_iq(x, y):
+        return x[1] - y[1]
+
+    def _diff_err(x, y):
+        return x[2] - y[2]
+
+    def _add(x, y):
+        return x + y
 
     # Check that I(q) is the same for both data sets
     deltas = map(_diff_iq, data_mantid, data_igor)
-    delta  = reduce(_add, deltas)/len(deltas)
-    if math.fabs(delta)>tolerance or math.isnan(delta):
+    delta = reduce(_add, deltas) / len(deltas)
+    if math.fabs(delta) > tolerance or math.isnan(delta):
         passed = False
         print "Sum of I(q) deltas is outside tolerance: %g > %g" % (math.fabs(delta), tolerance)
 
     # Then compare the errors
     deltas = map(_diff_err, data_mantid, data_igor)
-    delta_err  = reduce(_add, deltas)/len(deltas)
-    if math.fabs(delta_err)>tolerance or math.isnan(delta):
+    delta_err = reduce(_add, deltas) / len(deltas)
+    if math.fabs(delta_err) > tolerance or math.isnan(delta):
         passed = False
         print "Sum of dI(q) deltas is outside tolerance: %g > %g" % (math.fabs(delta_err), tolerance)
 
     # Compute chi2 of our result relative to IGOR
     deltas = map(_diff_chi2, data_mantid, data_igor)
-    chi2  = reduce(_add, deltas)/len(data_igor)
-    if chi2>10.0*tolerance or math.isnan(delta):
-        passed= False
-        print "Chi2 is outside tolerance: %g > %g" % (chi2, 10.0*tolerance)
+    chi2 = reduce(_add, deltas) / len(data_igor)
+    if chi2 > 10.0 * tolerance or math.isnan(delta):
+        passed = False
+        print "Chi2 is outside tolerance: %g > %g" % (chi2, 10.0 * tolerance)
 
     return passed
+
 
 def do_cleanup():
     Files = ["GPSANS_reduction.log",
@@ -123,8 +137,8 @@ def do_cleanup():
             os.remove(absfile)
     return True
 
-class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
+class HFIRTestsAPIv2(stresstesting.MantidStressTest):
     def cleanup(self):
         do_cleanup()
         return True
@@ -167,6 +181,7 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
                     return self._test_method()
                 except:
                     print traceback.format_exc()
+                    raise
                 return False
 
         self.all_passed = True
@@ -175,12 +190,12 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         self.failed_tests = []
         for current_item in dir(self):
             m = getattr(self, current_item)
-            if current_item.startswith("test_") and type(m)==types.MethodType:
+            if current_item.startswith("test_") and type(m) == types.MethodType:
                 self.n_tests += 1
                 t = TestStub(m)
                 result = t.run_test()
                 self._cleanup()
-                if result is None or result==True:
+                if result is None or result == True:
                     self.n_passed += 1
                 else:
                     self.failed_tests.append(current_item)
@@ -188,7 +203,7 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
     def test_data_path(self):
         self.assertEqual(ReductionSingleton()._data_path, '.')
-        #any path that definitely exists on a computer with Mantid installed
+        # any path that definitely exists on a computer with Mantid installed
         test_path = os.path.normcase(ConfigService.Instance()['instrumentDefinition.directory'])
         DataPath(test_path)
         self.assertEqual(ReductionSingleton()._data_path, test_path)
@@ -298,7 +313,7 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         self.assertEqual(sdd, 6000.0)
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
-        self.assertTrue(_check_result(ws, TEST_DIR+"reduced_center_calculated.txt", tolerance=1e-4))
+        self.assertTrue(_check_result(ws, TEST_DIR + "reduced_center_calculated.txt", tolerance=1e-4))
 
     def test_reduction_1(self):
         GPSANS()
@@ -311,20 +326,25 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        check = [0.19472,0.204269,0.215354,0.230114,0.238961,0.237201,0.247843,0.248424,0.253676,0.254327,
-                 0.254366,0.252931,0.258339,0.259297,0.257155,0.254059,0.252383,0.252826,0.256604,0.256754,
-                 0.255592,0.256813,0.248569,0.25331,0.251032,0.246424,0.249477,0.250939,0.251959,0.24925,0.250372,
-                 0.246148,0.250478,0.244621,0.247428,0.246431,0.245041,0.241647,0.24307,0.240096,0.242797,0.238182,
-                 0.237548,0.239789,0.241477,0.23456,0.237372,0.233715,0.233789,0.232262,0.231589,0.230986,0.231646,
-                 0.231331,0.230484,0.2277,0.226819,0.224341,0.227239,0.223228,0.221232,0.222011,0.224747,0.219533,
-                 0.216973,0.218734,0.21668,0.218366,0.214926,0.213985,0.214469,0.210473,0.209867,0.209066,
-                 0.208965,0.207498,0.204505,0.205786,0.202186,0.200442,0.200485,0.200554,0.200499,0.198152,0.193945,
-                 0.192082,0.193783,0.193787,0.190557,0.190471,0.186827,0.190088,0.188204,0.187547,0.182206,
-                 0.181384,0.180358,0.182663,0.178844,0.176556]
+        check = [0.19472, 0.204269, 0.215354, 0.230114, 0.238961, 0.237201, 0.247843, 0.248424, 0.253676, 0.254327,
+                 0.254366, 0.252931, 0.258339, 0.259297, 0.257155, 0.254059, 0.252383, 0.252826, 0.256604, 0.256754,
+                 0.255592, 0.256813, 0.248569, 0.25331, 0.251032, 0.246424, 0.249477, 0.250939, 0.251959, 0.24925,
+                 0.250372,
+                 0.246148, 0.250478, 0.244621, 0.247428, 0.246431, 0.245041, 0.241647, 0.24307, 0.240096, 0.242797,
+                 0.238182,
+                 0.237548, 0.239789, 0.241477, 0.23456, 0.237372, 0.233715, 0.233789, 0.232262, 0.231589, 0.230986,
+                 0.231646,
+                 0.231331, 0.230484, 0.2277, 0.226819, 0.224341, 0.227239, 0.223228, 0.221232, 0.222011, 0.224747,
+                 0.219533,
+                 0.216973, 0.218734, 0.21668, 0.218366, 0.214926, 0.213985, 0.214469, 0.210473, 0.209867, 0.209066,
+                 0.208965, 0.207498, 0.204505, 0.205786, 0.202186, 0.200442, 0.200485, 0.200554, 0.200499, 0.198152,
+                 0.193945,
+                 0.192082, 0.193783, 0.193787, 0.190557, 0.190471, 0.186827, 0.190088, 0.188204, 0.187547, 0.182206,
+                 0.181384, 0.180358, 0.182663, 0.178844, 0.176556]
 
         deltas = map(_diff_iq, data, check)
-        delta  = reduce(_add, deltas)/len(deltas)
-        self.assertTrue(math.fabs(delta)<0.00001)
+        delta = reduce(_add, deltas) / len(deltas)
+        self.assertTrue(math.fabs(delta) < 0.00001)
 
     def test_no_solid_angle(self):
         GPSANS()
@@ -353,31 +373,31 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        check = [0.268942,0.272052,0.269806,0.27129,0.273852,
-                 0.271301,0.271732,0.271103,0.270996,0.269677,
-                 0.27098,0.266802,0.26789,0.268222,0.266125,
-                 0.262736,0.262752,0.263827,0.26315,0.262775,
-                 0.261541,0.260818,0.258955,0.257675,0.255908,
-                 0.254088,0.256778,0.256883,0.253568,0.25636,
-                 0.252323,0.251833,0.251914,0.252298,0.249375,
-                 0.247718,0.247768,0.244636,0.245604,0.243996,
-                 0.244332,0.244363,0.242985,0.242234,0.241118,
-                 0.241411,0.24084,0.239293,0.2392,0.236565,
-                 0.234557,0.233974,0.232905,0.231898,0.231085,
-                 0.229586,0.22862,0.227001,0.226783,0.225837,
-                 0.224835,0.223807,0.222296,0.221557,0.220464,
-                 0.219139,0.217611,0.217049,0.21606,0.215739,
-                 0.216233,0.213467,0.213141,0.213275,0.219695,
-                 0.216121,0.215502,0.21792,0.209364,0.209368,
-                 0.2064,0.205844,0.20431,0.203443,0.202442,
-                 0.200195,0.199408,0.19853,0.195654,
-                 0.195514,0.193086,0.193388,0.19137,
-                 0.190122,0.189119,0.18864,0.185473,
-                 0.184958,0.183981,0.182581]
+        check = [0.268942, 0.272052, 0.269806, 0.27129, 0.273852,
+                 0.271301, 0.271732, 0.271103, 0.270996, 0.269677,
+                 0.27098, 0.266802, 0.26789, 0.268222, 0.266125,
+                 0.262736, 0.262752, 0.263827, 0.26315, 0.262775,
+                 0.261541, 0.260818, 0.258955, 0.257675, 0.255908,
+                 0.254088, 0.256778, 0.256883, 0.253568, 0.25636,
+                 0.252323, 0.251833, 0.251914, 0.252298, 0.249375,
+                 0.247718, 0.247768, 0.244636, 0.245604, 0.243996,
+                 0.244332, 0.244363, 0.242985, 0.242234, 0.241118,
+                 0.241411, 0.24084, 0.239293, 0.2392, 0.236565,
+                 0.234557, 0.233974, 0.232905, 0.231898, 0.231085,
+                 0.229586, 0.22862, 0.227001, 0.226783, 0.225837,
+                 0.224835, 0.223807, 0.222296, 0.221557, 0.220464,
+                 0.219139, 0.217611, 0.217049, 0.21606, 0.215739,
+                 0.216233, 0.213467, 0.213141, 0.213275, 0.219695,
+                 0.216121, 0.215502, 0.21792, 0.209364, 0.209368,
+                 0.2064, 0.205844, 0.20431, 0.203443, 0.202442,
+                 0.200195, 0.199408, 0.19853, 0.195654,
+                 0.195514, 0.193086, 0.193388, 0.19137,
+                 0.190122, 0.189119, 0.18864, 0.185473,
+                 0.184958, 0.183981, 0.182581]
 
         deltas = map(_diff_iq, data, check)
-        delta  = reduce(_add, deltas)/len(deltas)
-        self.assertTrue(math.fabs(delta)<0.00001)
+        delta = reduce(_add, deltas) / len(deltas)
+        self.assertTrue(math.fabs(delta) < 0.00001)
 
     def test_straight_Q1D(self):
         GPSANS()
@@ -389,27 +409,27 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        check = [0.269037,0.272176,0.269917,0.271416,0.273988,0.271432,
-                 0.271857,0.271232,0.271118,0.269797,0.271095,0.266912,
-                 0.268015,0.268356,0.266256,0.26287,0.262888,0.263964,
-                 0.263281,0.262905,0.261669,0.26094,0.259081,0.257802,
-                 0.256029,0.254228,0.256913,0.257021,0.253692,0.256491,
-                 0.252454,0.251969,0.25204,0.252423,0.249516,0.247844,
-                 0.247895,0.24476,0.245734,0.244125,0.244474,0.244491,
-                 0.243126,0.242359,0.241239,0.24154,0.240976,0.239421,
-                 0.23933,0.236688,0.234685,0.234105,0.233034,0.232036,
-                 0.231208,0.229714,0.228749,0.227122,0.226918,0.225969,
-                 0.22497,0.223933,0.222426,0.221684,0.2206,0.219277,
-                 0.217739,0.217173,0.216193,0.215869,0.216354,0.213597,
-                 0.213271,0.213407,0.219829,0.216259,0.215635,0.218058,
-                 0.209499,0.209503,0.206529,0.205981,0.20445,0.203577,
-                 0.202577,0.200334,0.199544,0.198663,0.195786,
-                 0.195653,0.19322,0.193537,0.191503,0.190253,
-                 0.189253,0.188771,0.1856,0.185099,0.184111,0.182717]
+        check = [0.269037, 0.272176, 0.269917, 0.271416, 0.273988, 0.271432,
+                 0.271857, 0.271232, 0.271118, 0.269797, 0.271095, 0.266912,
+                 0.268015, 0.268356, 0.266256, 0.26287, 0.262888, 0.263964,
+                 0.263281, 0.262905, 0.261669, 0.26094, 0.259081, 0.257802,
+                 0.256029, 0.254228, 0.256913, 0.257021, 0.253692, 0.256491,
+                 0.252454, 0.251969, 0.25204, 0.252423, 0.249516, 0.247844,
+                 0.247895, 0.24476, 0.245734, 0.244125, 0.244474, 0.244491,
+                 0.243126, 0.242359, 0.241239, 0.24154, 0.240976, 0.239421,
+                 0.23933, 0.236688, 0.234685, 0.234105, 0.233034, 0.232036,
+                 0.231208, 0.229714, 0.228749, 0.227122, 0.226918, 0.225969,
+                 0.22497, 0.223933, 0.222426, 0.221684, 0.2206, 0.219277,
+                 0.217739, 0.217173, 0.216193, 0.215869, 0.216354, 0.213597,
+                 0.213271, 0.213407, 0.219829, 0.216259, 0.215635, 0.218058,
+                 0.209499, 0.209503, 0.206529, 0.205981, 0.20445, 0.203577,
+                 0.202577, 0.200334, 0.199544, 0.198663, 0.195786,
+                 0.195653, 0.19322, 0.193537, 0.191503, 0.190253,
+                 0.189253, 0.188771, 0.1856, 0.185099, 0.184111, 0.182717]
 
         deltas = map(_diff_iq, data, check)
-        delta  = reduce(_add, deltas)/len(deltas)
-        self.assertTrue(math.fabs(delta)<0.00001)
+        delta = reduce(_add, deltas) / len(deltas)
+        self.assertTrue(math.fabs(delta) < 0.00001)
 
     def test_transmission(self):
         GPSANS()
@@ -424,27 +444,27 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        check = [0.514758,0.520759,0.516451,0.51932,0.524206,0.519275,
-                 0.520125,0.518997,0.518729,0.516198,0.518718,0.51072,
-                 0.512816,0.513449,0.509453,0.502968,0.503003,0.505098,
-                 0.503835,0.503088,0.500716,0.499304,0.495777,0.49332,
-                 0.489926,0.486497,0.491656,0.491858,0.48546,0.490808,
-                 0.483111,0.482176,0.482359,0.483098,0.477528,0.474279,
-                 0.474485,0.468472,0.470305,0.467228,0.467934,0.467971,
-                 0.465358,0.463885,0.461762,0.462352,0.461285,0.458322,
-                 0.458118,0.453064,0.44927,0.448151,0.446129,0.444207,
-                 0.442629,0.439792,0.437958,0.434826,0.434443,0.432655,
-                 0.430731,0.428771,0.425893,0.424477,0.422421,0.419886,
-                 0.416942,0.415876,0.414037,0.41339,0.414353,0.409062,
-                 0.408431,0.408712,0.419282,0.412833,0.41062,0.414427,
-                 0.400056,0.400141,0.394724,0.393821,0.390721,0.38932,
-                 0.387497,0.383062,0.381603,0.380016,0.374635,0.374214,
-                 0.369733,0.370353,0.366464,0.364109,0.362184,0.361299,
-                 0.355246,0.354339,0.352412,0.349748]
+        check = [0.514758, 0.520759, 0.516451, 0.51932, 0.524206, 0.519275,
+                 0.520125, 0.518997, 0.518729, 0.516198, 0.518718, 0.51072,
+                 0.512816, 0.513449, 0.509453, 0.502968, 0.503003, 0.505098,
+                 0.503835, 0.503088, 0.500716, 0.499304, 0.495777, 0.49332,
+                 0.489926, 0.486497, 0.491656, 0.491858, 0.48546, 0.490808,
+                 0.483111, 0.482176, 0.482359, 0.483098, 0.477528, 0.474279,
+                 0.474485, 0.468472, 0.470305, 0.467228, 0.467934, 0.467971,
+                 0.465358, 0.463885, 0.461762, 0.462352, 0.461285, 0.458322,
+                 0.458118, 0.453064, 0.44927, 0.448151, 0.446129, 0.444207,
+                 0.442629, 0.439792, 0.437958, 0.434826, 0.434443, 0.432655,
+                 0.430731, 0.428771, 0.425893, 0.424477, 0.422421, 0.419886,
+                 0.416942, 0.415876, 0.414037, 0.41339, 0.414353, 0.409062,
+                 0.408431, 0.408712, 0.419282, 0.412833, 0.41062, 0.414427,
+                 0.400056, 0.400141, 0.394724, 0.393821, 0.390721, 0.38932,
+                 0.387497, 0.383062, 0.381603, 0.380016, 0.374635, 0.374214,
+                 0.369733, 0.370353, 0.366464, 0.364109, 0.362184, 0.361299,
+                 0.355246, 0.354339, 0.352412, 0.349748]
 
         deltas = map(_diff_iq, data, check)
-        delta  = reduce(_add, deltas)/len(deltas)
-        self.assertTrue(math.fabs(delta)<0.001)
+        delta = reduce(_add, deltas) / len(deltas)
+        self.assertTrue(math.fabs(delta) < 0.001)
 
     def test_spreader_transmission(self):
         GPSANS()
@@ -475,10 +495,10 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         Reduce1D()
 
         property_manager = PropertyManagerDataService.retrieve(ReductionSingleton().get_reduction_table_name())
-        p=property_manager.getProperty("TransmissionAlgorithm")
+        _p = property_manager.getProperty("TransmissionAlgorithm")
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
-        self.assertTrue(_check_result(ws, TEST_DIR+"reduced_transmission.txt", 0.0001))
+        self.assertTrue(_check_result(ws, TEST_DIR + "reduced_transmission.txt", 0.0001))
 
     def test_center_by_hand(self):
         GPSANS()
@@ -491,7 +511,7 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         Reduce1D()
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
-        self.assertTrue(_check_result(ws, TEST_DIR+"reduced_center_by_hand.txt", 0.0001))
+        self.assertTrue(_check_result(ws, TEST_DIR + "reduced_center_by_hand.txt", 0.0001))
 
     def test_background(self):
         GPSANS()
@@ -506,9 +526,9 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        self.assertAlmostEqual(data[0], 0.0,10)
-        self.assertAlmostEqual(data[10], 0.0,10)
-        self.assertAlmostEqual(data[20], 0.0,10)
+        self.assertAlmostEqual(data[0], 0.0, 10)
+        self.assertAlmostEqual(data[10], 0.0, 10)
+        self.assertAlmostEqual(data[20], 0.0, 10)
 
     def test_background_multiple_files(self):
         """
@@ -528,9 +548,9 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        self.assertAlmostEqual(data[0], 0.0,10)
-        self.assertAlmostEqual(data[10], 0.0,10)
-        self.assertAlmostEqual(data[20], 0.0,10)
+        self.assertAlmostEqual(data[0], 0.0, 10)
+        self.assertAlmostEqual(data[10], 0.0, 10)
+        self.assertAlmostEqual(data[20], 0.0, 10)
 
     def test_bck_w_transmission(self):
         GPSANS()
@@ -540,16 +560,16 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         SensitivityCorrection("BioSANS_flood_data.xml", dark_current="BioSANS_dark_current.xml")
         DarkCurrent("BioSANS_dark_current.xml")
         Background("BioSANS_test_data.xml")
-        SetTransmission(0.6,0.1)
-        SetBckTransmission(0.6,0.1)
+        SetTransmission(0.6, 0.1)
+        SetBckTransmission(0.6, 0.1)
         AzimuthalAverage(binning="0.01,0.001,0.11", error_weighting=True)
         Reduce1D()
 
         ws = AnalysisDataService.retrieve("test_data_Iq")
         data = ws.dataY(0)
-        self.assertAlmostEqual(data[0], 0.0,10)
-        self.assertAlmostEqual(data[10], 0.0,10)
-        self.assertAlmostEqual(data[20], 0.0,10)
+        self.assertAlmostEqual(data[0], 0.0, 10)
+        self.assertAlmostEqual(data[10], 0.0, 10)
+        self.assertAlmostEqual(data[20], 0.0, 10)
 
     def test_transmission_by_hand_w_sensitivity(self):
         GPSANS()
@@ -563,33 +583,33 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
         ws = AnalysisDataService.retrieve("BioSANS_test_data_Iq")
         data = ws.dataY(0)
-        check = [0.374914,0.393394,0.414756,0.443152,0.460175,0.456802,
-                 0.477264,0.478456,0.488523,0.489758,0.489871,0.487127,
-                 0.497585,0.499346,0.49526,0.489273,0.486082,0.486923,
-                 0.494208,0.494531,0.492264,0.494608,0.478766,0.487872,
-                 0.48357,0.474654,0.48052,0.483367,0.485269,0.480079,
-                 0.482254,0.47413,0.48245,0.471207,0.476589,0.474701,
-                 0.472014,0.465479,0.468236,0.462524,0.46773,0.458851,
-                 0.457653,0.461929,0.465216,0.451887,0.45733,0.450281,
-                 0.45045,0.447508,0.446209,0.445063,0.446328,0.445735,
-                 0.444096,0.438758,0.43707,0.432302,0.437903,0.430176,
-                 0.426317,0.427858,0.433131,0.423087,0.418146,0.421584,
-                 0.417606,0.420891,0.414255,0.412448,0.413393,0.405706,
-                 0.404541,0.403016,0.402806,0.400023,0.394248,0.396725,
-                 0.389808,0.386475,0.386525,0.386674,0.386575,0.382081,
-                 0.373986,0.370391,0.37367,0.373686,0.367479,0.36732,
-                 0.36031,0.366588,0.362994,0.361712,0.351433,0.349867,
-                 0.3479,0.352355,0.344987,0.340605]
+        check = [0.374914, 0.393394, 0.414756, 0.443152, 0.460175, 0.456802,
+                 0.477264, 0.478456, 0.488523, 0.489758, 0.489871, 0.487127,
+                 0.497585, 0.499346, 0.49526, 0.489273, 0.486082, 0.486923,
+                 0.494208, 0.494531, 0.492264, 0.494608, 0.478766, 0.487872,
+                 0.48357, 0.474654, 0.48052, 0.483367, 0.485269, 0.480079,
+                 0.482254, 0.47413, 0.48245, 0.471207, 0.476589, 0.474701,
+                 0.472014, 0.465479, 0.468236, 0.462524, 0.46773, 0.458851,
+                 0.457653, 0.461929, 0.465216, 0.451887, 0.45733, 0.450281,
+                 0.45045, 0.447508, 0.446209, 0.445063, 0.446328, 0.445735,
+                 0.444096, 0.438758, 0.43707, 0.432302, 0.437903, 0.430176,
+                 0.426317, 0.427858, 0.433131, 0.423087, 0.418146, 0.421584,
+                 0.417606, 0.420891, 0.414255, 0.412448, 0.413393, 0.405706,
+                 0.404541, 0.403016, 0.402806, 0.400023, 0.394248, 0.396725,
+                 0.389808, 0.386475, 0.386525, 0.386674, 0.386575, 0.382081,
+                 0.373986, 0.370391, 0.37367, 0.373686, 0.367479, 0.36732,
+                 0.36031, 0.366588, 0.362994, 0.361712, 0.351433, 0.349867,
+                 0.3479, 0.352355, 0.344987, 0.340605]
 
         # Check that I(q) is the same for both data sets
         deltas = map(_diff_iq, data, check)
-        delta  = reduce(_add, deltas)/len(deltas)
-        self.assertTrue(math.fabs(delta)<0.00001)
+        delta = reduce(_add, deltas) / len(deltas)
+        self.assertTrue(math.fabs(delta) < 0.00001)
 
     def test_SampleGeometry_functions(self):
         print "SKIPPING test_SampleGeometry_functions()"
         return
-        #pylint: disable=unreachable
+        # pylint: disable=unreachable
         GPSANS()
         DataPath(TEST_DIR)
         AppendDataFile("BioSANS_test_data.xml")
@@ -606,38 +626,38 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         ws = AnalysisDataService.retrieve("BioSANS_test_data")
         data = [ws.dataY(0)[0], ws.dataY(1)[0], ws.dataY(2)[0], ws.dataY(3)[0], ws.dataY(4)[0], ws.dataY(5)[0]]
 
-        check = [500091.0,60.0,40.8333,13.6333, 13.4667,13.6667]
-                # Check that I(q) is the same for both data sets
+        check = [500091.0, 60.0, 40.8333, 13.6333, 13.4667, 13.6667]
+        # Check that I(q) is the same for both data sets
         deltas = map(_diff_iq, data, check)
-        delta  = reduce(_add, deltas)/len(deltas)
-        self.assertTrue(math.fabs(delta)<0.1)
+        delta = reduce(_add, deltas) / len(deltas)
+        self.assertTrue(math.fabs(delta) < 0.1)
 
     def test_noDC_eff_with_DC(self):
-        ref = [28.06525, 136.94662, -16.20412,   0.00000, 147.79915, 146.42713, 302.00869,
-               0.00000,   0.00000,-1869.20724,-2190.89681,-1892.14939,-2140.79608,-1980.60037,
-               -2096.75974,-2221.30118,-2263.51541,-2264.89989,-2364.83528,
-               -2420.58152,-2444.51906,-2418.28886,-2606.16991,-2556.93660,
-               -2623.71380,-2547.79671,-2670.60962,-2714.35237,-2717.01692,
-               -2730.84974,-2768.92925,-2753.96396,-2732.66316,-2795.89687,
-               -2780.37320,-2755.38910,-2814.88120,-2830.74081,-2803.42030,
-               -2815.33244,-2754.70444,-2718.55136,-2740.03811,-2754.60415,
-               -2815.96387,-2754.62039,-2781.54596,-2765.26282,-2676.04665,
-               -2762.33751,-2722.94832,-2707.74990,-2730.50371,-2721.71272,
-               -2682.02439,-2703.36446,-2679.47677,-2658.57573,-2669.41871,
-               -2618.90655,-2638.41601,-2614.69128,-2583.29713,-2589.39730,
-               -2567.19209,-2535.09328,-2539.43296,-2489.60117,-2500.76844,
-               -2456.22248,-2444.13734,-2392.68589,-2410.98591,-2348.68064,
-               -2334.84651,-2310.41426,-2250.24085,-2220.02192,-2184.65990,
-               -2154.19638,-2099.56797,-2058.51585,-2004.05601,-1966.52356,
-               -1910.47283,-1876.72098,-1817.69045,-1768.62167,-1721.56444,
-               -1666.47199,-1608.86707,-1544.26178,-1492.78389,-1438.69256,
-               -1358.60437,-1299.34476,-1221.57010,-1080.69421,-609.77891, -77.72765]
+        ref = [28.06525, 136.94662, -16.20412, 0.00000, 147.79915, 146.42713, 302.00869,
+               0.00000, 0.00000, -1869.20724, -2190.89681, -1892.14939, -2140.79608, -1980.60037,
+               -2096.75974, -2221.30118, -2263.51541, -2264.89989, -2364.83528,
+               -2420.58152, -2444.51906, -2418.28886, -2606.16991, -2556.93660,
+               -2623.71380, -2547.79671, -2670.60962, -2714.35237, -2717.01692,
+               -2730.84974, -2768.92925, -2753.96396, -2732.66316, -2795.89687,
+               -2780.37320, -2755.38910, -2814.88120, -2830.74081, -2803.42030,
+               -2815.33244, -2754.70444, -2718.55136, -2740.03811, -2754.60415,
+               -2815.96387, -2754.62039, -2781.54596, -2765.26282, -2676.04665,
+               -2762.33751, -2722.94832, -2707.74990, -2730.50371, -2721.71272,
+               -2682.02439, -2703.36446, -2679.47677, -2658.57573, -2669.41871,
+               -2618.90655, -2638.41601, -2614.69128, -2583.29713, -2589.39730,
+               -2567.19209, -2535.09328, -2539.43296, -2489.60117, -2500.76844,
+               -2456.22248, -2444.13734, -2392.68589, -2410.98591, -2348.68064,
+               -2334.84651, -2310.41426, -2250.24085, -2220.02192, -2184.65990,
+               -2154.19638, -2099.56797, -2058.51585, -2004.05601, -1966.52356,
+               -1910.47283, -1876.72098, -1817.69045, -1768.62167, -1721.56444,
+               -1666.47199, -1608.86707, -1544.26178, -1492.78389, -1438.69256,
+               -1358.60437, -1299.34476, -1221.57010, -1080.69421, -609.77891, -77.72765]
         BIOSANS()
         SetSampleDetectorOffset(837.9)
-        #SolidAngle() # name clash with SolidAngle algorithm
+        # SolidAngle() # name clash with SolidAngle algorithm
         MonitorNormalization()
         AzimuthalAverage(n_bins=100, n_subpix=1, log_binning=True)
-        #IQxQy(nbins=100)
+        # IQxQy(nbins=100)
         DirectBeamCenter("BioSANS_empty_cell.xml")
         SensitivityCorrection('BioSANS_flood_data.xml', min_sensitivity=0.5, max_sensitivity=1.5,
                               dark_current='BioSANS_empty_trans.xml', use_sample_dc=False)
@@ -659,29 +679,29 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
                                     msg="result point %d: %g, found %g" % (i, ref[i], res[i]))
 
     def test_DC_eff_with_DC(self):
-        ref = [28.0476,136.906,-16.3079,0,147.757,146.403,301.982,
-               0,0,-1869.21,-2190.93,-1892.16,-2140.81,-1980.62,-2096.79,
-               -2221.34,-2263.55,-2264.93,-2364.87,-2420.61,-2444.56,
-               -2418.32,-2606.21,-2556.98,-2623.75,-2547.84,-2670.66,
-               -2714.39,-2717.06,-2730.89,-2768.96,-2754.01,-2732.7,
-               -2795.93,-2780.41,-2755.42,-2814.92,-2830.79,-2803.46,
-               -2815.38,-2754.75,-2718.6,-2740.08,-2754.65,-2816.01,
-               -2754.66,-2781.59,-2765.3,-2676.09,-2762.38,-2722.99,
-               -2707.8,-2730.55,-2721.76,-2682.07,-2703.41,-2679.52,
-               -2658.62,-2669.46,-2618.95,-2638.46,-2614.74,-2583.34,
-               -2589.44,-2567.23,-2535.14,-2539.48,-2489.64,-2500.81,
-               -2456.26,-2444.18,-2392.73,-2411.03,-2348.73,-2334.89,
-               -2310.46,-2250.28,-2220.07,-2184.7,-2154.24,-2099.61,
-               -2058.56,-2004.1,-1966.57,-1910.52,-1876.76,-1817.73,
-               -1768.67,-1721.61,-1666.51,-1608.91,-1544.31,
-               -1492.83,-1438.74,-1358.65,-1299.39,-1221.61,-1080.73,-609.821,-77.7712]
+        ref = [28.0476, 136.906, -16.3079, 0, 147.757, 146.403, 301.982,
+               0, 0, -1869.21, -2190.93, -1892.16, -2140.81, -1980.62, -2096.79,
+               -2221.34, -2263.55, -2264.93, -2364.87, -2420.61, -2444.56,
+               -2418.32, -2606.21, -2556.98, -2623.75, -2547.84, -2670.66,
+               -2714.39, -2717.06, -2730.89, -2768.96, -2754.01, -2732.7,
+               -2795.93, -2780.41, -2755.42, -2814.92, -2830.79, -2803.46,
+               -2815.38, -2754.75, -2718.6, -2740.08, -2754.65, -2816.01,
+               -2754.66, -2781.59, -2765.3, -2676.09, -2762.38, -2722.99,
+               -2707.8, -2730.55, -2721.76, -2682.07, -2703.41, -2679.52,
+               -2658.62, -2669.46, -2618.95, -2638.46, -2614.74, -2583.34,
+               -2589.44, -2567.23, -2535.14, -2539.48, -2489.64, -2500.81,
+               -2456.26, -2444.18, -2392.73, -2411.03, -2348.73, -2334.89,
+               -2310.46, -2250.28, -2220.07, -2184.7, -2154.24, -2099.61,
+               -2058.56, -2004.1, -1966.57, -1910.52, -1876.76, -1817.73,
+               -1768.67, -1721.61, -1666.51, -1608.91, -1544.31,
+               -1492.83, -1438.74, -1358.65, -1299.39, -1221.61, -1080.73, -609.821, -77.7712]
         BIOSANS()
         SetSampleDetectorOffset(837.9)
-        #SolidAngle()
+        # SolidAngle()
         DarkCurrent("BioSANS_dark_current.xml")
         MonitorNormalization()
         AzimuthalAverage(n_bins=100, n_subpix=1, log_binning=True)
-        #IQxQy(nbins=100)
+        # IQxQy(nbins=100)
         DirectBeamCenter("BioSANS_empty_cell.xml")
         SensitivityCorrection('BioSANS_flood_data.xml', min_sensitivity=0.5,
                               max_sensitivity=1.5, dark_current='BioSANS_empty_trans.xml', use_sample_dc=False)
@@ -703,27 +723,27 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
                                     msg="result point %d: %g, found %g" % (i, ref[i], res[i]))
 
     def test_DC_eff_noDC(self):
-        ref = [10.4139,124.814,25.0443,0,38.3413,133.417,0,0,-1733.56,-1627.57,
-               -1811.38,-1851.58,-1888.38,-1957.07,-2056.47,-2117.52,
-               -2139.32,-2176.94,-2239.91,-2350.65,-2417.75,-2406.99,-2525.48,
-               -2551.45,-2566.83,-2499.38,-2632.35,-2662.17,-2653.14,-2718.65,
-               -2740.78,-2758.94,-2712,-2771.35,-2761.38,-2724.05,-2809.97,
-               -2815.92,-2801.25,-2824.54,-2726.76,-2716.63,-2737.83,-2752.06,
-               -2798.95,-2757.7,-2787.58,-2753.12,-2691.47,-2759.93,-2703.94,
-               -2705.55,-2722.64,-2714.75,-2685.28,-2693.49,-2685.75,-2655.65,
-               -2662.42,-2614.47,-2633.12,-2602.29,-2579.4,-2591.17,-2565.28,
-               -2529.61,-2533.85,-2491.87,-2496.78,-2458.25,-2437.25,
-               -2398.16,-2407.29,-2350.32,-2340.43,-2301.5,-2254.37,-2224.97,
-               -2186.64,-2146.73,-2096.71,-2058.12,-2006.2,-1968.6,-1914.93,
-               -1874.31,-1819.05,-1767.14,-1722.35,-1670.38,-1606.61,
-               -1544.51,-1496.24,-1438.21,-1360.12,-1299.68,-1221.61,-1080.91,-610.638,-71.9557]
+        ref = [10.4139, 124.814, 25.0443, 0, 38.3413, 133.417, 0, 0, -1733.56, -1627.57,
+               -1811.38, -1851.58, -1888.38, -1957.07, -2056.47, -2117.52,
+               -2139.32, -2176.94, -2239.91, -2350.65, -2417.75, -2406.99, -2525.48,
+               -2551.45, -2566.83, -2499.38, -2632.35, -2662.17, -2653.14, -2718.65,
+               -2740.78, -2758.94, -2712, -2771.35, -2761.38, -2724.05, -2809.97,
+               -2815.92, -2801.25, -2824.54, -2726.76, -2716.63, -2737.83, -2752.06,
+               -2798.95, -2757.7, -2787.58, -2753.12, -2691.47, -2759.93, -2703.94,
+               -2705.55, -2722.64, -2714.75, -2685.28, -2693.49, -2685.75, -2655.65,
+               -2662.42, -2614.47, -2633.12, -2602.29, -2579.4, -2591.17, -2565.28,
+               -2529.61, -2533.85, -2491.87, -2496.78, -2458.25, -2437.25,
+               -2398.16, -2407.29, -2350.32, -2340.43, -2301.5, -2254.37, -2224.97,
+               -2186.64, -2146.73, -2096.71, -2058.12, -2006.2, -1968.6, -1914.93,
+               -1874.31, -1819.05, -1767.14, -1722.35, -1670.38, -1606.61,
+               -1544.51, -1496.24, -1438.21, -1360.12, -1299.68, -1221.61, -1080.91, -610.638, -71.9557]
         BIOSANS()
         SetSampleDetectorOffset(837.9)
-        #SolidAngle()
+        # SolidAngle()
         DarkCurrent("BioSANS_dark_current.xml")
         MonitorNormalization()
         AzimuthalAverage(n_bins=100, n_subpix=1, log_binning=True)
-        #IQxQy(nbins=100)
+        # IQxQy(nbins=100)
         DirectBeamCenter("BioSANS_empty_cell.xml")
         SensitivityCorrection('BioSANS_flood_data.xml', min_sensitivity=0.5, max_sensitivity=1.5, use_sample_dc=False)
         DivideByThickness(1)
@@ -753,7 +773,7 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         DirectBeamTransmission(sample_file="BioSANS_sample_trans.xml",
                                empty_file="BioSANS_empty_trans.xml",
                                beam_radius=10.0)
-        SetTransmissionBeamCenter(100,15)
+        SetTransmissionBeamCenter(100, 15)
         AzimuthalAverage(binning="0.01,0.001,0.11", error_weighting=True)
         Reduce1D()
 
@@ -770,8 +790,9 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         AppendDataFile("BioSANS_test_data.xml", "test_data")
         DarkCurrent("BioSANS_dark_current.xml")
         Background("BioSANS_test_data.xml")
-        SetTransmission(0.6,0.1)
-        BckDirectBeamTransmission(sample_file="BioSANS_sample_trans.xml", empty_file="BioSANS_empty_trans.xml", beam_radius=10.0)
+        SetTransmission(0.6, 0.1)
+        BckDirectBeamTransmission(sample_file="BioSANS_sample_trans.xml", empty_file="BioSANS_empty_trans.xml",
+                                  beam_radius=10.0)
         AzimuthalAverage(binning="0.01,0.001,0.11", error_weighting=True)
         Reduce1D()
 
@@ -788,9 +809,10 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
         AppendDataFile("BioSANS_test_data.xml", "test_data")
         DarkCurrent("BioSANS_dark_current.xml")
         Background("BioSANS_test_data.xml")
-        SetTransmission(0.6,0.1)
-        BckDirectBeamTransmission(sample_file="BioSANS_sample_trans.xml", empty_file="BioSANS_empty_trans.xml", beam_radius=10.0)
-        SetBckTransmissionBeamCenter(100,15)
+        SetTransmission(0.6, 0.1)
+        BckDirectBeamTransmission(sample_file="BioSANS_sample_trans.xml", empty_file="BioSANS_empty_trans.xml",
+                                  beam_radius=10.0)
+        SetBckTransmissionBeamCenter(100, 15)
         AzimuthalAverage(binning="0.01,0.001,0.11", error_weighting=True)
         Reduce1D()
 
@@ -802,13 +824,14 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
     def test_bck_transmission_direct_beam_center(self):
         GPSANS()
         DataPath(TEST_DIR)
-        #DirectBeamCenter("BioSANS_empty_cell.xml")
-        SetBeamCenter(100,15)
+        # DirectBeamCenter("BioSANS_empty_cell.xml")
+        SetBeamCenter(100, 15)
         AppendDataFile("BioSANS_test_data.xml", "test_data")
         DarkCurrent("BioSANS_dark_current.xml")
         Background("BioSANS_test_data.xml")
-        SetTransmission(0.6,0.1)
-        BckDirectBeamTransmission(sample_file="BioSANS_sample_trans.xml", empty_file="BioSANS_empty_trans.xml", beam_radius=10.0)
+        SetTransmission(0.6, 0.1)
+        BckDirectBeamTransmission(sample_file="BioSANS_sample_trans.xml", empty_file="BioSANS_empty_trans.xml",
+                                  beam_radius=10.0)
         BckTransmissionDirectBeamCenter("BioSANS_empty_cell.xml")
         AzimuthalAverage(binning="0.01,0.001,0.11", error_weighting=True)
         Reduce1D()
@@ -820,12 +843,12 @@ class HFIRTestsAPIv2(stresstesting.MantidStressTest):
 
     def validate(self):
         print "HFIRTests: %d / %d tests passed" % (self.n_passed, self.n_tests)
-        for item in self.failed_tests:
-            print item
+        for items in self.failed_tests:
+            print items
         return self.all_passed
 
-#pylint: disable=too-many-arguments,unused-argument
-def assertAlmostEqual(first, second, places=None, msg=None, delta=None, rel_delta=None):
+
+def assertAlmostEqual(first, second, places=None, _msg=None, delta=None, rel_delta=None):
     """
         Simple test to compare two numbers
         @return: True of the two numbers agree within tolerance
@@ -840,10 +863,10 @@ def assertAlmostEqual(first, second, places=None, msg=None, delta=None, rel_delt
     if delta is not None:
         if abs(first - second) <= delta:
             return True
-        elif abs(first - second)/abs(second)<rel_delta:
+        elif abs(first - second) / abs(second) < rel_delta:
             print '\n-----> %s != %s but within %s percent' % (str(first),
                                                                str(second),
-                                                               str(rel_delta*100.0))
+                                                               str(rel_delta * 100.0))
             return True
 
         standardMsg = '%s != %s within %s delta' % (str(first),
@@ -853,7 +876,7 @@ def assertAlmostEqual(first, second, places=None, msg=None, delta=None, rel_delt
         if places is None:
             places = 7
 
-        if round(abs(second-first), places) == 0:
+        if round(abs(second - first), places) == 0:
             return True
 
         standardMsg = '%s != %s within %r places' % (str(first),
@@ -861,4 +884,3 @@ def assertAlmostEqual(first, second, places=None, msg=None, delta=None, rel_delt
                                                      places)
     print standardMsg
     return False
-

--- a/Testing/SystemTests/tests/analysis/Peak2ConvCell_Test.py
+++ b/Testing/SystemTests/tests/analysis/Peak2ConvCell_Test.py
@@ -1,931 +1,925 @@
-#pylint: disable=invalid-name,no-init,too-many-arguments,too-many-branches
-#This script creates numerous PeaksWorkspaces for different Crystal Types and Centerings. Random errors
-#are also introduced into the peak's.  Each PeaksWorkspace is sent through the algorithm's FindPeaksMD,
-#FindUBUsingFFT, and SelectByForm to determine the corresponding Primitive and Conventional cells. These
-#results are tested against the theoretical results that should have been gotten
+# pylint: disable=invalid-name,no-init,too-many-arguments,too-many-branches, unused-variable,too-many-return-statements
+# This script creates numerous PeaksWorkspaces for different Crystal Types and Centerings. Random errors
+# are also introduced into the peak's.  Each PeaksWorkspace is sent through the algorithm's FindPeaksMD,
+# FindUBUsingFFT, and SelectByForm to determine the corresponding Primitive and Conventional cells. These
+# results are tested against the theoretical results that should have been gotten
 
-#NOTE; THIS TEST TAKES AN EXTREMELY LONG TIME. DELETE "XXX" IN requiredFiles method to get it to run.
-#!!!!!!!!!  REPLACE THE "XXX" OR else !!!!!!!!!!
+# NOTE; THIS TEST TAKES AN EXTREMELY LONG TIME. DELETE "XXX" IN requiredFiles method to get it to run.
+# !!!!!!!!!  REPLACE THE "XXX" OR else !!!!!!!!!!
 
 
-#import stresstesting
+# import stresstesting
 import numpy
 from numpy import matrix
 import math
 import random
 import mantid
 from mantid.simpleapi import *
-#from mantid.simpleapi import *
-#TODO premultiply cases, fix up.. Maybe not needed Cause Conv cell was "Nigglied"
-#TODO: SWitch cases, if use approx inequality, may get error cause low level code  [does Not](does) premult but when it [should](should not)
-class Peak2ConvCell_Test(object):#(stresstesting.MantidStressTest):
-    conventionalUB=numpy.zeros(shape=(3,3))
-    Cubic=[1,3,5]
-    Tetr=[6,7,11,15,18,21]
-    Orth=[8,13,16,19,23,26,32,36,38,40,42]
-    Hex = [2,4,9,12,22,24]
-    Tricl=[31,44]
-    Mon=[28,29,30,33,34,35,43]
-    MonI=[17,27]
-    MonC=[10,14,20,25,37,39,41]
-    CentP=[3,11,12,21,22,31,32,33,34,35,44]
-    CentF=[1,16,26]
-    CentI=[2,4,5,6,7,8,9,10,14,15,17,18,19,20,24,25,27,37,39,41,42,43]
-    CentC=[10,13,14,17,20,23,25,27,28,29,30,36,37,38,39,40,41]
 
 
-    def CalcConventionalUB(self,a,b,c,alpha,beta,gamma,celltype):
-        Res= matrix([[0.,0.,0.],[0.,0.,0.],[0.,0.,0.]])
+# from mantid.simpleapi import *
+# TODO premultiply cases, fix up.. Maybe not needed Cause Conv cell was "Nigglied"
+# TODO: SWitch cases, if use approx inequality, may get error cause low level code
+# [does Not](does) premult but when it [should](should not)
+class Peak2ConvCell_Test(object):  # (stresstesting.MantidStressTest):
+    conventionalUB = numpy.zeros(shape=(3, 3))
+    Cubic = [1, 3, 5]
+    Tetr = [6, 7, 11, 15, 18, 21]
+    Orth = [8, 13, 16, 19, 23, 26, 32, 36, 38, 40, 42]
+    Hex = [2, 4, 9, 12, 22, 24]
+    Tricl = [31, 44]
+    Mon = [28, 29, 30, 33, 34, 35, 43]
+    MonI = [17, 27]
+    MonC = [10, 14, 20, 25, 37, 39, 41]
+    CentP = [3, 11, 12, 21, 22, 31, 32, 33, 34, 35, 44]
+    CentF = [1, 16, 26]
+    CentI = [2, 4, 5, 6, 7, 8, 9, 10, 14, 15, 17, 18, 19, 20, 24, 25, 27, 37, 39, 41, 42, 43]
+    CentC = [10, 13, 14, 17, 20, 23, 25, 27, 28, 29, 30, 36, 37, 38, 39, 40, 41]
 
-        if celltype=='O':
+    def CalcConventionalUB(self, a, b, c, alpha, _beta, _gamma, celltype):
+        Res = matrix([[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]])
 
-            Res[0,0]=1./a
-            Res[1,1]=1./b
-            Res[2,2]=1./c
+        if celltype == 'O':
 
-        elif celltype=='H':
-            Res[0,0]= a*1.0
-            Res[1,0]= -a/2.
-            Res[1,1]= a*.866
-            Res[2,2]=c*1.0
-            Res=Res.I
+            Res[0, 0] = 1. / a
+            Res[1, 1] = 1. / b
+            Res[2, 2] = 1. / c
+
+        elif celltype == 'H':
+            Res[0, 0] = a * 1.0
+            Res[1, 0] = -a / 2.
+            Res[1, 1] = a * .866
+            Res[2, 2] = c * 1.0
+            Res = Res.I
         else:
-            if alpha <=90:
+            if alpha <= 90:
                 self.conventionalUB = None
                 return None
-            Res[0,0] = a*1.0
-            Res[1,1] = b*1.0
-            Alpha = (alpha*math.pi/180)
-            Res[2,0] = c*math.cos( Alpha)
-            Res[2,2] = c*math.sin(Alpha)
-         # Now Nigglify the matrix( get 3 smallest sides)
+            Res[0, 0] = a * 1.0
+            Res[1, 1] = b * 1.0
+            Alpha = (alpha * math.pi / 180)
+            Res[2, 0] = c * math.cos(Alpha)
+            Res[2, 2] = c * math.sin(Alpha)
+            # Now Nigglify the matrix( get 3 smallest sides)
 
-            n =0
-            YY=0
-            if  a <=c:
-                n = (int)(-Res[2,0]/a)
-                YY= Res[2,0] +n*a
+            n = 0
+            YY = 0
+            if a <= c:
+                n = (int)(-Res[2, 0] / a)
+                YY = Res[2, 0] + n * a
 
             else:
 
-                n= (int)(-a*Res[2,0]/(c*c)-.5)
-                YY=n*Res[2,0]+a
+                n = (int)(-a * Res[2, 0] / (c * c) - .5)
+                YY = n * Res[2, 0] + a
 
-         #print ["A",YY,n]
-            sgn=1
-            if  a <= c:
+                # print ["A",YY,n]
+            sgn = 1
+            if a <= c:
 
-                if  math.fabs( YY + a ) < math.fabs( YY ) and a <= c :
-
+                if math.fabs(YY + a) < math.fabs(YY) and a <= c:
                     YY += a
                     sgn = -1
-                    n=n+1
+                    n += 1
 
+            elif (YY + Res[2, 0]) * (YY + Res[2, 0]) + (n + 1) * (n + 1) * Res[2, 2] * Res[2, 2] < a * a:
 
-            elif( (YY+Res[2,0])*(YY+Res[2,0])+(n+1)*(n+1)*Res[2,2]*Res[2,2] < a*a):
-
-                YY+=Res[2,0]
-                n=n+1
+                YY += Res[2, 0]
+                n += 1
                 sgn = -1
 
-         #print ["B",YY,sgn,n]
+                # print ["B",YY,sgn,n]
 
-            if  n>0 :
-                if  a <= c:
+            if n > 0:
+                if a <= c:
 
-                    Res[2,0]= sgn*YY
-                    Res[2,2] *=sgn
+                    Res[2, 0] = sgn * YY
+                    Res[2, 2] *= sgn
 
                 else:
 
-                    if( YY*Res[2,0]+n*Res[2,2]*Res[2,2] > 0):
-                        sgn =-1
+                    if YY * Res[2, 0] + n * Res[2, 2] * Res[2, 2] > 0:
+                        sgn = -1
 
                     else:
                         sgn = 1
-                    Res[0,0]= sgn*YY
-                    Res[0,2] =sgn*n*Res[2,2]
+                    Res[0, 0] = sgn * YY
+                    Res[0, 2] = sgn * n * Res[2, 2]
 
-
-            Res=Res.I
-
+            Res = Res.I
 
         self.conventionalUB = Res
 
         return Res
 
-
-    def Niggli( self, Res):
-        RUB= Res.I
-        X=RUB*RUB.T
+    def Niggli(self, Res):
+        RUB = Res.I
+        X = RUB * RUB.T
         done = False
 
         while not done:
             done = True
             for i in range(2):
-                if X[i,i]>X[i+1,i+1]:
+                if X[i, i] > X[i + 1, i + 1]:
                     done = False
                     for j in range(3):
-                        sav= RUB[i,j]
-                        RUB[i,j]=RUB[i+1,j]
-                        RUB[i+1,j]=sav
-                    X=RUB*RUB.T
+                        sav = RUB[i, j]
+                        RUB[i, j] = RUB[i + 1, j]
+                        RUB[i + 1, j] = sav
+                    X = RUB * RUB.T
 
             if not done:
                 continue
-         #do bc,ac,then ab
+                # do bc,ac,then ab
             for kk in range(3):
-                jj=2
-                if kk>1:
-                    jj=1
-                    i=0
+                jj = 2
+                if kk > 1:
+                    jj = 1
+                    i = 0
                 else:
-                    i=jj-kk-1
-                if X[i,i]<2*math.fabs(X[i,jj]):
-                    sgn=1
-                    if X[i,jj] >0:
-                        sgn=-1
+                    i = jj - kk - 1
+                if X[i, i] < 2 * math.fabs(X[i, jj]):
+                    sgn = 1
+                    if X[i, jj] > 0:
+                        sgn = -1
                     for j in range(3):
-                        RUB[jj,j]=RUB[jj,j]+sgn*RUB[i,j]
-                    done=False
-                    X=RUB*RUB.T
+                        RUB[jj, j] += sgn * RUB[i, j]
+
+                    done = False
+                    X = RUB * RUB.T
 
                     break
 
-
-        if  numpy.linalg.det( RUB )< 0:
-            for  cc in range(3):
-                RUB[0,cc] *=-1
-
+        if numpy.linalg.det(RUB) < 0:
+            for cc in range(3):
+                RUB[0, cc] *= -1
 
         return RUB.I
 
-    def CalcNiggliUB( self,a, b,c,alpha, beta, gamma,celltype, Center):
+    def CalcNiggliUB(self, a, b, c, alpha, beta, gamma, celltype, Center):
 
-        if  Center=='P':
-            X = self.CalcConventionalUB( a,b,c,alpha,beta,gamma,celltype)
+        if Center == 'P':
+            X = self.CalcConventionalUB(a, b, c, alpha, beta, gamma, celltype)
             return X
 
-        Res= matrix([[0.,0.,0.],[0.,0.,0.],[0.,0.,0.]])
-        ConvUB = self.CalcConventionalUB(a,b,c,alpha,beta,gamma,celltype)
-        if  ConvUB== None:
+        Res = matrix([[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]])
+        ConvUB = self.CalcConventionalUB(a, b, c, alpha, beta, gamma, celltype)
+        if ConvUB == None:
             return None
 
-        ResP =  numpy.matrix.copy(ConvUB)
-        ResP =ResP.I
+        ResP = numpy.matrix.copy(ConvUB)
+        ResP = ResP.I
 
-        if  celltype=='H' and Center =='I':
-            Center ='R'
+        if celltype == 'H' and Center == 'I':
+            Center = 'R'
 
-        if  Center == 'I':
+        if Center == 'I':
 
-            s1=1
-            s2=1
-            for  r in range(0,3):
+            s1 = 1
+            s2 = 1
+            for r in range(0, 3):
                 for cc in range(3):
 
+                    if cc == 0:
+                        if r > 0:
+                            s1 = (-1) ** r
+                            s2 = -s1
 
-                    if  cc==0:
-                        if  r>0:
+                    Res[r, cc] = ResP[0, cc] / 2 + s1 * ResP[1, cc] / 2 + s2 * ResP[2, cc] / 2
 
-                            s1 = (-1)**r
-                            s2 =-s1
+            Res = Res.I
 
-                    Res[r,cc] =ResP[0,cc]/2+s1*ResP[1,cc]/2+s2*ResP[2,cc]/2
+        elif Center == 'F':
 
-
-            Res=Res.I
-
-        elif  Center =='F':
-
-            if  celltype =='H'  or  celltype=='M':
+            if celltype == 'H' or celltype == 'M':
                 return None
 
-            ss = [0,0,0]
+            ss = [0, 0, 0]
 
-            for  r in range(3):
+            for r in range(3):
                 for cc in range(3):
+                    ss = [1, 1, 1]
+                    ss[r] = 0
 
-                    ss=[1,1,1]
-                    ss[r]=0
+                    Res[r, cc] = ss[0] * ResP[0, cc] / 2 + ss[1] * ResP[1, cc] / 2 + ss[2] * ResP[2, cc] / 2
 
-                    Res[r,cc]=ss[0]*ResP[0,cc]/2+ss[1]*ResP[1,cc]/2+ss[2]*ResP[2,cc]/2
+            Res = Res.I
 
+        elif Center == 'A' or Center == 'B' or Center == 'C':
 
-
-            Res=Res.I
-
-        elif  Center =='A' or Center=='B'or Center=='C':
-
-            if  celltype =='H' :
+            if celltype == 'H':
                 return None
-            if  celltype =='M'  and  Center== 'B':
+            if celltype == 'M' and Center == 'B':
                 return None
 
-            r=2
-            if  Center =='A' :
+            r = 2
+            if Center == 'A':
 
-                r=0
-                if  b==c  and  celltype=='O':# result would be orthorhombic primitive
+                r = 0
+                if b == c and celltype == 'O':  # result would be orthorhombic primitive
                     return None
 
-            elif  Center =='B':
+            elif Center == 'B':
 
-                r=1
-                if  a==c and  celltype=='O':
+                r = 1
+                if a == c and celltype == 'O':
                     return None
 
-            elif  a==b  and  celltype=='O':
+            elif a == b and celltype == 'O':
                 return None
 
-            k=0
+            k = 0
 
-            Res[r,0]= ResP[r,0]
-            Res[r,1]= ResP[r,1]
-            Res[r,2]= ResP[r,2]
-            for i in range(1,3):
+            Res[r, 0] = ResP[r, 0]
+            Res[r, 1] = ResP[r, 1]
+            Res[r, 2] = ResP[r, 2]
+            for i in range(1, 3):
 
-                if  k==r:
-                    k=k+1
-                for  cc in range(3) :
+                if k == r:
+                    k += 1
+                for cc in range(3):
+                    R = (r + 1) % 3
+                    s = (-1) ** i
 
-                    R = (r+1)%3
-                    s =   (-1)**i
+                    Res[k, cc] = ResP[(R) % 3, cc] / 2 + s * ResP[(R + 1) % 3, cc] / 2
 
-                    Res[k,cc]= ResP[(R)%3,cc]/2+s*ResP[(R+1)%3,cc]/2
+                k += 1
 
-                k=k+1
-
-            Res=Res.I
-
+            Res = Res.I
 
 
-        elif  Center =='R':
 
-            if  celltype != 'H' or alpha >120:#alpha =120 planar, >120 no go or c under a-b plane.
+        elif Center == 'R':
 
-                self.conventionalUB=NiggliUB = None
+            if celltype != 'H' or alpha > 120:  # alpha =120 planar, >120 no go or c under a-b plane.
+
+                self.conventionalUB = NiggliUB = None
                 return None
 
-         #Did not work with 0 error. FindUBUsingFFT failed
-         #Alpha = alpha*math.pi/180
+                # Did not work with 0 error. FindUBUsingFFT failed
+                # Alpha = alpha*math.pi/180
 
-         #Res[0,0] = a
-         #Res[1,0] =(a*math.cos( Alpha ))
-         #Res[1,1] = (a*math.sin( Alpha ))
-         #Res[2,0] =(a*math.cos( Alpha ))
-         #Res[2,1] =(a*Res[1,0] -Res[2,0]*Res[1,0])/Res[1,1]
-         #Res[2,2] =math.sqrt( a*a- Res[2,1]*Res[2,1]-Res[2,0]*Res[2,0])
-            Res[0,0]=.5*a
-            Res[0,1]=math.sqrt(3)*a/2
-            Res[0,2]=.5*b
-            Res[1,0]=-a
-            Res[1,1]=0
-            Res[1,2]=.5*b
-            Res[2,0]=.5*a
-            Res[2,1]=-math.sqrt(3)*a/2
-            Res[2,2]=.5*b
+                # Res[0,0] = a
+                # Res[1,0] =(a*math.cos( Alpha ))
+                # Res[1,1] = (a*math.sin( Alpha ))
+                # Res[2,0] =(a*math.cos( Alpha ))
+                # Res[2,1] =(a*Res[1,0] -Res[2,0]*Res[1,0])/Res[1,1]
+                # Res[2,2] =math.sqrt( a*a- Res[2,1]*Res[2,1]-Res[2,0]*Res[2,0])
+            Res[0, 0] = .5 * a
+            Res[0, 1] = math.sqrt(3) * a / 2
+            Res[0, 2] = .5 * b
+            Res[1, 0] = -a
+            Res[1, 1] = 0
+            Res[1, 2] = .5 * b
+            Res[2, 0] = .5 * a
+            Res[2, 1] = -math.sqrt(3) * a / 2
+            Res[2, 2] = .5 * b
 
+            Rhomb2Hex = matrix([[1., -1., 0.], [-1., 0., 1.], [-1., -1., -1.]])
 
-            Rhomb2Hex= matrix([[1. ,-1., 0.],[-1. ,0., 1.],[-1. ,-1., -1.]])
+            self.conventionalUB = Rhomb2Hex * Res
+            Res = Res.I
 
-            self.conventionalUB=Rhomb2Hex*Res
-            Res=Res.I
-
-            self.conventionalUB=self.Niggli(self.conventionalUB.I)
+            self.conventionalUB = self.Niggli(self.conventionalUB.I)
 
         Res = self.Niggli(Res)
-        if  numpy.linalg.det( Res )< 0:
-            for  cc in range(3):
-                Res[cc,0] *=-1
-
-
+        if numpy.linalg.det(Res) < 0:
+            for cc in range(3):
+                Res[cc, 0] *= -1
 
         return Res
 
-    def Perturb( self,val, error):
-        return val+random.random()*error-error/2
+    def Perturb(self, val, error):
+        return val + random.random() * error - error / 2
 
-    def Next( self, hkl1):
-      #print "Next"
-        hkl=matrix([[hkl1[0,0]],[hkl1[1,0]],[hkl1[2,0]]])
-        S =(math.fabs( hkl[0,0])+math.fabs( hkl[1,0])+math.fabs( hkl[2,0]))
-      #print ["S=",S]
-      #The sum of abs hkl's = S until not possible. Increasing lexicographically
-        if( hkl[2,0] < 0):
-         #print "Nexta"
-            hkl[2,0] = -hkl[2,0]
-         #print hkl
+    def Next(self, hkl1):
+        # print "Next"
+        hkl = matrix([[hkl1[0, 0]], [hkl1[1, 0]], [hkl1[2, 0]]])
+        S = (math.fabs(hkl[0, 0]) + math.fabs(hkl[1, 0]) + math.fabs(hkl[2, 0]))
+        # print ["S=",S]
+        # The sum of abs hkl's = S until not possible. Increasing lexicographically
+        if (hkl[2, 0] < 0):
+            # print "Nexta"
+            hkl[2, 0] = -hkl[2, 0]
+            # print hkl
             return hkl
 
-        if  math.fabs( hkl[0,0])+ math.fabs( hkl[1,0]+1 ) <= S:
+        if math.fabs(hkl[0, 0]) + math.fabs(hkl[1, 0] + 1) <= S:
 
-         #print "Nextb"
-            hkl[1,0] +=1
-            hkl[2,0] = -(S -math.fabs( hkl[0,0])- math.fabs( hkl[1,0] ))
-        elif  math.fabs( hkl[0,0]+1 ) <= S:
+            # print "Nextb"
+            hkl[1, 0] += 1
+            hkl[2, 0] = -(S - math.fabs(hkl[0, 0]) - math.fabs(hkl[1, 0]))
+        elif math.fabs(hkl[0, 0] + 1) <= S:
 
-         #print "Nextc"
-            hkl[0,0]=  hkl[0,0]+1.0
-            hkl[1,0] = -(S - math.fabs( hkl[0,0]))
-            hkl[2,0] = 0
+            # print "Nextc"
+            hkl[0, 0] = hkl[0, 0] + 1.0
+            hkl[1, 0] = -(S - math.fabs(hkl[0, 0]))
+            hkl[2, 0] = 0
         else:
 
-         #print "Nextd"
-            hkl[1,0]=0
-            hkl[2,0]=0
-            hkl[0,0] = -S-1
-      #print hkl
+            # print "Nextd"
+            hkl[1, 0] = 0
+            hkl[2, 0] = 0
+            hkl[0, 0] = -S - 1
+            # print hkl
         return hkl
 
-    def FixLatParams( self,List):
-        npos=0
-        nneg=0
-        if len(List)<6:
+    def FixLatParams(self, List):
+        npos = 0
+        nneg = 0
+        if len(List) < 6:
             return List
-        has90=False
-        for i in range(3,6):
-            if math.fabs(List[i]-90)<.05:
-                nneg  =nneg+1
-                has90=True
-            elif List[i] <90:
-                npos=npos+1
+        has90 = False
+        for i in range(3, 6):
+            if math.fabs(List[i] - 90) < .05:
+                nneg += 1
+                has90 = True
+            elif List[i] < 90:
+                npos += 1
             else:
-                nneg=nneg+1
-        over90=False
-        if nneg ==3  or has90 or nneg==1:
-            over90= True
+                nneg += 1
+        over90 = False
+        if nneg == 3 or has90 or nneg == 1:
+            over90 = True
 
-        for i in range(3,6):
-            if  List[i]>90 and not over90:
-                List[i]=180-List[i]
-            elif List[i]<90 and over90:
-                List[i]=180-List[i]
+        for i in range(3, 6):
+            if List[i] > 90 and not over90:
+                List[i] = 180 - List[i]
+            elif List[i] < 90 and over90:
+                List[i] = 180 - List[i]
 
-        bdotc = math.cos(List[3]/180.*math.pi)*List[1]*List[2]
-        adotc= math.cos(List[4]/180.*math.pi)*List[0]*List[2]
-        adotb= math.cos(List[5]/180.*math.pi)*List[1]*List[0]
-        if List[0] > List[1] or (List[0] == List[1] and math.fabs(bdotc)>math.fabs(adotc)):
-            List = self.XchangeSides( List,0,1)
-        bdotc = math.cos(List[3]/180.*math.pi)*List[1]*List[2]
-        adotc= math.cos(List[4]/180.*math.pi)*List[0]*List[2]
-        adotb= math.cos(List[5]/180.*math.pi)*List[1]*List[0]
-        if List[1] > List[2] or (List[1] == List[2] and math.fabs(adotc)>math.fabs(adotb)):
-            List = self.XchangeSides(List,1,2)
-        bdotc = math.cos(List[3]/180.*math.pi)*List[1]*List[2]
-        adotc= math.cos(List[4]/180.*math.pi)*List[0]*List[2]
-        adotb= math.cos(List[5]/180.*math.pi)*List[1]*List[0]
+        bdotc = math.cos(List[3] / 180. * math.pi) * List[1] * List[2]
+        adotc = math.cos(List[4] / 180. * math.pi) * List[0] * List[2]
+        adotb = math.cos(List[5] / 180. * math.pi) * List[1] * List[0]
+        if List[0] > List[1] or (List[0] == List[1] and math.fabs(bdotc) > math.fabs(adotc)):
+            List = self.XchangeSides(List, 0, 1)
+        bdotc = math.cos(List[3] / 180. * math.pi) * List[1] * List[2]
+        adotc = math.cos(List[4] / 180. * math.pi) * List[0] * List[2]
+        adotb = math.cos(List[5] / 180. * math.pi) * List[1] * List[0]
+        if List[1] > List[2] or (List[1] == List[2] and math.fabs(adotc) > math.fabs(adotb)):
+            List = self.XchangeSides(List, 1, 2)
+        bdotc = math.cos(List[3] / 180. * math.pi) * List[1] * List[2]
+        adotc = math.cos(List[4] / 180. * math.pi) * List[0] * List[2]
+        adotb = math.cos(List[5] / 180. * math.pi) * List[1] * List[0]
 
-        if List[0] > List[1] or (List[0] == List[1] and math.fabs(bdotc)>math.fabs(adotc)):
-            List = self.XchangeSides( List,0,1)
+        if List[0] > List[1] or (List[0] == List[1] and math.fabs(bdotc) > math.fabs(adotc)):
+            List = self.XchangeSides(List, 0, 1)
 
         return List
 
-    def FixUpPlusMinus( self, UB):#TODO make increasing lengthed sides too
-        M= matrix([[1.0,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,1.0]])
-        M1= matrix([[1.0,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,1.0]])
-        G= UB.T*UB
+    def FixUpPlusMinus(self, UB):  # TODO make increasing lengthed sides too
+        M = matrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        M1 = matrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        G = UB.T * UB
         G.I
 
-        if G[0,1]>0:
-            if G[0,2]>0:
-                if G[1,2]>0:
+        if G[0, 1] > 0:
+            if G[0, 2] > 0:
+                if G[1, 2] > 0:
                     return UB
                 else:
-                    M[1,1]=M[2,2]=-1
-            elif G[1,2]>0:
-                M[0,0]=M[2,2]=-1
+                    M[1, 1] = M[2, 2] = -1
+            elif G[1, 2] > 0:
+                M[0, 0] = M[2, 2] = -1
             else:
-                M[1,1]=M[0,0]=-1
+                M[1, 1] = M[0, 0] = -1
         else:
-            if G[0,2]>0:
-                if G[1,2]>0:
-                    M[1,1]=M[0,0]=-1
+            if G[0, 2] > 0:
+                if G[1, 2] > 0:
+                    M[1, 1] = M[0, 0] = -1
                 else:
-                    M[0,0]=M[2,2]=-1
-            elif G[1,2]>0:
-                M[2,2]=M[1,1]=-1
+                    M[0, 0] = M[2, 2] = -1
+            elif G[1, 2] > 0:
+                M[2, 2] = M[1, 1] = -1
             else:
                 return UB
 
+        return UB * M
+        # is closeness to 90 deg( cos of ), and equal sides
 
-        return UB*M
-   # is closeness to 90 deg( cos of ), and equal sides
-    def FixUB(self,UB, tolerance):
+    def FixUB(self, UB, tolerance):
         done = 1
         print "A"
-        while done==1:
-            done=0
-            X = UB.T*UB
+        while done == 1:
+            done = 0
+            X = UB.T * UB
             X.I
 
-            print "B1",X
-            if X[0,0]> X[1,1] or (math.fabs(X[0,0]-X[1,1])<tolerance/10 and math.fabs(X[1,2])>math.fabs(X[0,2])+tolerance/10):
+            print "B1", X
+            if X[0, 0] > X[1, 1] or (math.fabs(X[0, 0] - X[1, 1]) < tolerance / 10 and math.fabs(X[1, 2]) > math.fabs(
+                    X[0, 2]) + tolerance / 10):
                 done = 1
-                for i in range(0,3):
-                    sav= UB[i,0]
-                    UB[i,0]=UB[i,1]
-                    UB[i,1]=sav
+                for i in range(0, 3):
+                    sav = UB[i, 0]
+                    UB[i, 0] = UB[i, 1]
+                    UB[i, 1] = sav
                 print "B"
                 continue
 
             print "B2"
-            if X[1,1]>X[2,2] or (math.fabs(X[1,1]-X[2,2])<tolerance and math.fabs(X[1,0])< math.fabs(X[2,0])-tolerance/10):
+            if X[1, 1] > X[2, 2] or (math.fabs(X[1, 1] - X[2, 2]) < tolerance and math.fabs(X[1, 0]) < math.fabs(
+                    X[2, 0]) - tolerance / 10):
                 done = 1
-                for i in range(0,3):
-                    sav= UB[i,1]
-                    UB[i,1]=UB[i,2]
-                    UB[i,2]=sav
+                for i in range(0, 3):
+                    sav = UB[i, 1]
+                    UB[i, 1] = UB[i, 2]
+                    UB[i, 2] = sav
 
                 print "C"
                 continue
 
             print "B3"
             if numpy.linalg.det(UB) < 0:
-                for i in range(0,3):
-                    UB[i,0]=-1*UB[i,0]
+                for i in range(0, 3):
+                    UB[i, 0] = -1 * UB[i, 0]
 
                 print "D"
-                done=1
+                done = 1
                 continue
             print "E"
-            L= [X[0,1],X[0,2],X[1,2]]
+            L = [X[0, 1], X[0, 2], X[1, 2]]
 
-            nneg=0
-            is90=False
-            odd=-1
-            for i in range(0,3):
+            nneg = 0
+            is90 = False
+            odd = -1
+            for i in range(0, 3):
 
-                if math.fabs(L[i])<tolerance:
-                    is90=True
-                    odd=i
-                    nneg=nneg+1
-                elif L[i]<0:
-                    nneg=nneg+1
+                if math.fabs(L[i]) < tolerance:
+                    is90 = True
+                    odd = i
+                    nneg = nneg + 1
+                elif L[i] < 0:
+                    nneg = nneg + 1
 
-            if nneg==3 or nneg==0:
+            if nneg == 3 or nneg == 0:
                 continue
 
-            for i in range(0,3):
-                if is90 :
-                    if nneg ==1:
-                        odd=i
+            for i in range(0, 3):
+                if is90:
+                    if nneg == 1:
+                        odd = i
                         break
-                    if nneg==2 and odd !=i and L[i]>0:
-                        odd=i
+                    if nneg == 2 and odd != i and L[i] > 0:
+                        odd = i
                         break
 
 
-                elif nneg==1 and L[i]<0:
-                    odd=i
-                elif nneg==2 and L[i]>0:
+                elif nneg == 1 and L[i] < 0:
                     odd = i
-            odd= 2-odd
-            i1=(odd+1)%3
-            i2=(odd+2)%3
-            print ["L=",L, odd,i1,i2, is90,tolerance]
+                elif nneg == 2 and L[i] > 0:
+                    odd = i
+            odd = 2 - odd
+            i1 = (odd + 1) % 3
+            i2 = (odd + 2) % 3
+            print ["L=", L, odd, i1, i2, is90, tolerance]
             print UB
-            for i in range(0,3):
-                UB[i,i1]=-1*UB[i,i1]
-                UB[i,i2]=-1*UB[i,i2]
+            for i in range(0, 3):
+                UB[i, i1] = -1 * UB[i, i1]
+                UB[i, i2] = -1 * UB[i, i2]
             print UB
             done = 1
         return UB
 
+    def getPeaks(self, _Inst, UB, error, Npeaks):
 
-
-
-
-
-
-    def getPeaks( self,Inst,UB, error,Npeaks):
-
-        CreatePeaksWorkspace(InstrumentWorkspace="Sws",NumberOfPeaks=0,OutputWorkspace="Peaks")
-        Peaks=mtd["Peaks"]
-
+        CreatePeaksWorkspace(InstrumentWorkspace="Sws", NumberOfPeaks=0, OutputWorkspace="Peaks")
+        Peaks = mtd["Peaks"]
 
         MinAbsQ = 100000000
-        UBi= matrix([[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,0.0,0.0]])
+        UBi = matrix([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 
         for ii in range(3):
-            for jj in range(ii,3):
+            for jj in range(ii, 3):
 
-                UBi = UB[ii,jj]
-                if  math.fabs( UBi ) < MinAbsQ  and  UBi !=0:
-                    MinAbsQ =  math.fabs(UBi )
+                UBi = UB[ii, jj]
+                if math.fabs(UBi) < MinAbsQ and UBi != 0:
+                    MinAbsQ = math.fabs(UBi)
 
-        hkl=matrix([[0.0],[0.0],[0.0]])
+        hkl = matrix([[0.0], [0.0], [0.0]])
 
-        Error = error*MinAbsQ
-        npeaks=0
+        Error = error * MinAbsQ
+        npeaks = 0
 
-
-        a1= hkl[0,0]
-        a2=hkl[1,0]
-        a3=hkl[2,0]
+        a1 = hkl[0, 0]
+        a2 = hkl[1, 0]
+        a3 = hkl[2, 0]
         done = False
         while not done:
 
-
-            Qs = (UB*hkl)
-            Qs=Qs*(2*math.pi)
+            Qs = (UB * hkl)
+            Qs *= 2 * math.pi
 
             for qs in range(3):
-                Qs[qs,0] = self.Perturb(Qs[qs,0],Error)
+                Qs[qs, 0] = self.Perturb(Qs[qs, 0], Error)
 
-
-
-            if( Qs is not None  and  Qs[2,0] > 0):
-	       #QQ= numpy.array([Qs[0,0],Qs[1,0],Qs[2,0]])
-                QQ = mantid.kernel.V3D(Qs[0,0],Qs[1,0],Qs[2,0])
+            if Qs is not None and Qs[2, 0] > 0:
+                # QQ= numpy.array([Qs[0,0],Qs[1,0],Qs[2,0]])
+                QQ = mantid.kernel.V3D(Qs[0, 0], Qs[1, 0], Qs[2, 0])
                 norm = QQ.norm()
 
+                if .3 < norm < 30:
+                    peak = Peaks.createPeak(QQ, 1.0)
 
-                if norm>.3 and   norm < 30:
-                    peak =Peaks.createPeak(  QQ, 1.0)
-
-                    peak.setQLabFrame(mantid.kernel.V3D(Qs[0,0],Qs[1,0],Qs[2,0]),1.0)
+                    peak.setQLabFrame(mantid.kernel.V3D(Qs[0, 0], Qs[1, 0], Qs[2, 0]), 1.0)
 
                     Peaks.addPeak(peak)
-                    npeaks = npeaks+1
+                    npeaks += 1
 
-
-            hkl = self.Next( hkl)
-            if npeaks>= Npeaks:
-                done =True
-            if math.fabs(hkl[0,0])>15:
+            hkl = self.Next(hkl)
+            if npeaks >= Npeaks:
                 done = True
-            if  math.fabs(hkl[1,0])>15:
+            if math.fabs(hkl[0, 0]) > 15:
                 done = True
-            if math.fabs(hkl[2,0])>15:
+            if math.fabs(hkl[1, 0]) > 15:
                 done = True
-
-
+            if math.fabs(hkl[2, 0]) > 15:
+                done = True
 
         return Peaks
 
-
-    def newSetting( self, side1,side2,Xtal,Center,ang, i1,i2a):
-        C=Center
-        if Center =='A' or Center =='B' or Center=='C':
-            C='C'
-        if  Xtal=='O':
-            if   ang>20 or i1>0 or i2a >1:
+    def newSetting(self, side1, side2, Xtal, Center, ang, i1, i2a):
+        C = Center
+        if Center == 'A' or Center == 'B' or Center == 'C':
+            C = 'C'
+        if Xtal == 'O':
+            if ang > 20 or i1 > 0 or i2a > 1:
                 return False
-            elif (side1==0 and side2 !=0) and (C=='F' or C=='C'):#No Tetragonal "F" or C Center
+            elif (side1 == 0 and side2 != 0) and (C == 'F' or C == 'C'):  # No Tetragonal "F" or C Center
                 return False
-            elif (C=='F'or C=='C') and ( side1==side2 and side1 !=0):
-                return False
-            else:
-                return True
-
-        if Xtal=='H':
-            if ang > 20 or i2a>1 or not(C=='P' or C=='I'):
-                return False
-            elif side2>side1:
+            elif (C == 'F' or C == 'C') and (side1 == side2 and side1 != 0):
                 return False
             else:
                 return True
 
-        if  Xtal!='M':
+        if Xtal == 'H':
+            if ang > 20 or i2a > 1 or not (C == 'P' or C == 'I'):
+                return False
+            elif side2 > side1:
+                return False
+            else:
+                return True
+
+        if Xtal != 'M':
             return False
         return True
 
-    def MonoClinicRearrange(self, Sides,Xtal,Center, i1,i2a):
-        i1q =i1
-        i2q = (i1+i2a)%3
-        i3q=(i2q+1)%3
-        if  i1q==i3q:
-            i3q = (i3q+1)%3
+    def MonoClinicRearrange(self, Sides, _Xtal, _Center, i1, i2a):
+        i1q = i1
+        i2q = (i1 + i2a) % 3
+        i3q = (i2q + 1) % 3
+        if i1q == i3q:
+            i3q = (i3q + 1) % 3
         a = Sides[i1q]
-        b= Sides[ i2q]
+        b = Sides[i2q]
         c = Sides[i3q]
 
-        return [a,b,c]
+        return [a, b, c]
 
-    def getMatrixAxis( self,v, Xtal):
-        ident= matrix([[1.0,0.0,0.0],[0.0,1.0,0.0],[0.0,0.0,1.0]])
-        if Xtal !='H' or v>=2:
+    def getMatrixAxis(self, v, Xtal):
+        ident = matrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+        if Xtal != 'H' or v >= 2:
             return ident
-        ident[v,v] =0
-        ident[2,2] =0
-        v1= 2
-        ident[v,v1] =1
-        ident[v1,v] =1
+        ident[v, v] = 0
+        ident[2, 2] = 0
+        v1 = 2
+        ident[v, v1] = 1
+        ident[v1, v] = 1
         return ident
 
-    def getLat( self, UB):
-        G=UB.T*UB
-        G1=G.I
-        Res=[math.sqrt(G1[0,0]),math.sqrt(G1[1,1]),math.sqrt(G1[2,2])]
-        Res.append(math.acos( G1[1,2]/Res[1]/Res[2])*180.0/math.pi)
-        Res.append(math.acos( G1[0,2]/Res[0]/Res[2])*180.0/math.pi)
-        Res.append(math.acos( G1[0,1]/Res[0]/Res[1])*180.0/math.pi)
+    def getLat(self, UB):
+        G = UB.T * UB
+        G1 = G.I
+        Res = [math.sqrt(G1[0, 0]), math.sqrt(G1[1, 1]), math.sqrt(G1[2, 2]),
+               math.acos(G1[1, 2] / Res[1] / Res[2]) * 180.0 / math.pi,
+               math.acos(G1[0, 2] / Res[0] / Res[2]) * 180.0 / math.pi,
+               math.acos(G1[0, 1] / Res[0] / Res[1]) * 180.0 / math.pi]
         return Res
 
-
-    def AppendForms( self, condition, Center,CenterTarg, FormNums, List2Append):
-        L= List2Append
+    def AppendForms(self, condition, Center, CenterTarg, FormNums, List2Append):
+        L = List2Append
         if condition and Center != CenterTarg:
             for i in range(len(FormNums)):
                 L.append(FormNums[i])
-        elif Center ==CenterTarg:
+        elif Center == CenterTarg:
             for i in range(len(FormNums)):
                 L.append(FormNums[i])
         return L
 
-    def Xlate(self,Xtal,Center,sides,LatNiggle): #sides are sides of conventional cell
-        if Xtal=='O':
-            C=Center
+    def Xlate(self, Xtal, Center, sides, LatNiggle):  # sides are sides of conventional cell
+        if Xtal == 'O':
+            C = Center
             if sides[0] == sides[1]:
-                if sides[1]==sides[2]:
-                    X="Cubic"
-                    Z1=list(self.Cubic)
+                if sides[1] == sides[2]:
+                    X = "Cubic"
+                    Z1 = list(self.Cubic)
                 else:
-                    X="Tetragonal"
-                    Z1=list(self.Tetr)
-            elif sides[0]==sides[2]:
-                X="Tetragonal"
-                Z1=list(self.Tetr)
-            elif  sides[1]==sides[2]:
-                X="Tetragonal"
-                Z1=list(self.Tetr)
+                    X = "Tetragonal"
+                    Z1 = list(self.Tetr)
+            elif sides[0] == sides[2]:
+                X = "Tetragonal"
+                Z1 = list(self.Tetr)
+            elif sides[1] == sides[2]:
+                X = "Tetragonal"
+                Z1 = list(self.Tetr)
             else:
-                X="Orthorhombic"
-                Z1=list(self.Orth)
+                X = "Orthorhombic"
+                Z1 = list(self.Orth)
 
-            if C=='A' or C =='B':
-                C ='C'
+            if C == 'A' or C == 'B':
+                C = 'C'
 
-        elif Xtal=='H':
-            if Center =='I':
-                C ='R'
-                X='Rhombohedral'
-                Z1=list(self.Hex)
+        elif Xtal == 'H':
+            if Center == 'I':
+                C = 'R'
+                X = 'Rhombohedral'
+                Z1 = list(self.Hex)
             else:
-                C='P'
-                X="Hexagonal"
-                Z1=list(self.Hex)
-        else:#Monoclinic
-            X="Monoclinic"
-            Z1=list(self.Mon)
-            C=Center
-            LL=[math.cos(LatNiggle[5]/180*math.pi)*LatNiggle[0]*LatNiggle[1], math.cos(LatNiggle[4]/180*math.pi)*LatNiggle[0]*LatNiggle[2],math.cos(LatNiggle[3]/180*math.pi)*LatNiggle[2]*LatNiggle[1]]
+                C = 'P'
+                X = "Hexagonal"
+                Z1 = list(self.Hex)
+        else:  # Monoclinic
+            X = "Monoclinic"
+            Z1 = list(self.Mon)
+            C = Center
+            LL = [math.cos(LatNiggle[5] / 180 * math.pi) * LatNiggle[0] * LatNiggle[1],
+                  math.cos(LatNiggle[4] / 180 * math.pi) * LatNiggle[0] * LatNiggle[2],
+                  math.cos(LatNiggle[3] / 180 * math.pi) * LatNiggle[2] * LatNiggle[1]]
 
-            if C=='A' or C =='B':
-                C ='C'
+            if C == 'A' or C == 'B':
+                C = 'C'
 
-            if C=='C' or C=='I':#'I':
+            if C == 'C' or C == 'I':  # 'I':
 
-                Z1=self.AppendForms( LatNiggle[2]*LatNiggle[2]<4*math.fabs(LL[2])+.001, 'C',C,[10,14,39], Z1)
-                Z1=self.AppendForms( LatNiggle[0]*LatNiggle[0]<4*math.fabs(LL[1])+.001, 'C',C,[20,25,41], Z1)
+                Z1 = self.AppendForms(LatNiggle[2] * LatNiggle[2] < 4 * math.fabs(LL[2]) + .001, 'C', C, [10, 14, 39],
+                                      Z1)
+                Z1 = self.AppendForms(LatNiggle[0] * LatNiggle[0] < 4 * math.fabs(LL[1]) + .001, 'C', C, [20, 25, 41],
+                                      Z1)
 
-                Z1=self.AppendForms( LatNiggle[1]*LatNiggle[1]<4*math.fabs(LL[2]+.001), 'C',C,[37], Z1)
+                Z1 = self.AppendForms(LatNiggle[1] * LatNiggle[1] < 4 * math.fabs(LL[2] + .001), 'C', C, [37], Z1)
 
-                Z1=self.AppendForms( 3*LatNiggle[0]*LatNiggle[0] < LatNiggle[2]*LatNiggle[2]+2*math.fabs(LL[1])+.001, 'I',C,[17], Z1)
-                Z1=self.AppendForms( 3*LatNiggle[1]*LatNiggle[1]<  LatNiggle[2]*LatNiggle[2]+2*math.fabs(LL[2]+.001), 'I',C,[27], Z1)
+                Z1 = self.AppendForms(
+                    3 * LatNiggle[0] * LatNiggle[0] < LatNiggle[2] * LatNiggle[2] + 2 * math.fabs(LL[1]) + .001, 'I', C,
+                    [17], Z1)
+                Z1 = self.AppendForms(
+                    3 * LatNiggle[1] * LatNiggle[1] < LatNiggle[2] * LatNiggle[2] + 2 * math.fabs(LL[2] + .001), 'I', C,
+                    [27], Z1)
 
-        if  C=='P':
-            Z2=self.CentP
-        elif C=='F':
-            Z2=self.CentF
-        elif C=='I' or C=='R':
-            Z2=self.CentI
-        elif C=='C':
-            Z2=self.CentC
-        Z1=sorted(Z1)
-        return [X,C, Z1, Z2]
+        if C == 'P':
+            Z2 = self.CentP
+        elif C == 'F':
+            Z2 = self.CentF
+        elif C == 'I' or C == 'R':
+            Z2 = self.CentI
+        elif C == 'C':
+            Z2 = self.CentC
+        Z1 = sorted(Z1)
+        return [X, C, Z1, Z2]
 
+    def MatchXtlparams(self, List1a, List2, tolerance, message):
+        List1 = List1a
 
+        self.assertEqual(len(List1a), 6, "Not the correct number of Xtal parameters." + message)
+        self.assertEqual(len(List2), 6, "Not the correct number of Xtal parameters." + message)
+        Var = ["a", "b", "c", "alpha", "beta", "gamma"]
+        self.assertDelta(List1[0], List2[0], tolerance, message + "for " + Var[0])
+        self.assertDelta(List1[1], List2[1], tolerance, message + "for " + Var[1])
+        self.assertDelta(List1[2], List2[2], tolerance, message + "for " + Var[2])
+        angtolerance = tolerance * 180 / math.pi
+        if List1[3] < 90 and List2[3] >= 90:
+            List1[3] = 180 - List1[3]
+            List1[4] = 180 - List1[4]
+            List1[5] = 180 - List1[5]
 
-    def MatchXtlparams( self, List1a, List2, tolerance, message):
-        List1=List1a
-
-
-        self.assertEqual(len(List1a),6,"Not the correct number of Xtal parameters."+message)
-        self.assertEqual(len(List2),6,"Not the correct number of Xtal parameters."+message)
-        Var=["a","b","c","alpha","beta","gamma"]
-        self.assertDelta( List1[0],List2[0],tolerance, message +"for "+Var[0])
-        self.assertDelta( List1[1],List2[1],tolerance, message +"for "+Var[1])
-        self.assertDelta( List1[2],List2[2],tolerance, message +"for "+Var[2])
-        angtolerance = tolerance*180/math.pi
-        if List1[3]<90 and List2[3]>=90:
-            List1[3]= 180-List1[3]
-            List1[4]= 180-List1[4]
-            List1[5]= 180-List1[5]
-
-
-        if List1[0] >List1[1]-tolerance:
-            if List1[1]>List1[2]-tolerance:   # 3 equal sides
+        if List1[0] > List1[1] - tolerance:
+            if List1[1] > List1[2] - tolerance:  # 3 equal sides
                 match = False
 
-                i=0
-
-                for i in range(0,3):
-                    match= math.fabs(List1[3]-List2[3])<angtolerance and  math.fabs(List1[4]-List2[4])<angtolerance and  math.fabs(List1[5]-List2[5])<angtolerance
+                _i = 0
+                for _i in range(0, 3):
+                    match = math.fabs(List1[3] - List2[3]) < angtolerance and math.fabs(
+                        List1[4] - List2[4]) < angtolerance and math.fabs(List1[5] - List2[5]) < angtolerance
 
                     if match:
                         break
-                    List1=self.XchangeSides( List1,1,0)
+                    List1 = self.XchangeSides(List1, 1, 0)
 
-                    match= math.fabs(List1[3]-List2[3])<angtolerance and  math.fabs(List1[4]-List2[4])<angtolerance and  math.fabs(List1[5]-List2[5])<angtolerance
+                    match = math.fabs(List1[3] - List2[3]) < angtolerance and math.fabs(
+                        List1[4] - List2[4]) < angtolerance and math.fabs(List1[5] - List2[5]) < angtolerance
                     if match:
                         break
 
-                    List1=self.XchangeSides( List1,1,2)
+                    List1 = self.XchangeSides(List1, 1, 2)
 
-                match= math.fabs(List1[3]-List2[3])<angtolerance and  math.fabs(List1[4]-List2[4])<angtolerance and  math.fabs(List1[5]-List2[5])<angtolerance
-                self.assertTrue( match,"Angles do not match in any order")
+                match = math.fabs(List1[3] - List2[3]) < angtolerance and math.fabs(
+                    List1[4] - List2[4]) < angtolerance and math.fabs(List1[5] - List2[5]) < angtolerance
+                self.assertTrue(match, "Angles do not match in any order")
             else:
-                self.assertDelta( List1[5],List2[5],angtolerance,"Error in "+Var[5])
-                if math.fabs(List1[3]-List2[3])>angtolerance:
-                    List1 = self.XchangeSides( List1,0,1)
-                self.assertDelta( List1[3],List2[3],angtolerance,"Error in "+Var[3])
-                self.assertDelta( List1[4],List2[4],angtolerance,"Error in "+Var[4])
-        elif List1[1]> List1[2]-tolerance:
-            self.assertDelta(List1[3],List2[3],angtolerance,"Error in "+Var[3])
-            if math.fabs(List1[4]-List2[4])>angtolerance:
-                List1= self.XchangeSides(List1,1,2)
+                self.assertDelta(List1[5], List2[5], angtolerance, "Error in " + Var[5])
+                if math.fabs(List1[3] - List2[3]) > angtolerance:
+                    List1 = self.XchangeSides(List1, 0, 1)
+                self.assertDelta(List1[3], List2[3], angtolerance, "Error in " + Var[3])
+                self.assertDelta(List1[4], List2[4], angtolerance, "Error in " + Var[4])
+        elif List1[1] > List1[2] - tolerance:
+            self.assertDelta(List1[3], List2[3], angtolerance, "Error in " + Var[3])
+            if math.fabs(List1[4] - List2[4]) > angtolerance:
+                List1 = self.XchangeSides(List1, 1, 2)
 
-            self.assertDelta(List1[4],List2[4],angtolerance,"Error in "+Var[5])
+            self.assertDelta(List1[4], List2[4], angtolerance, "Error in " + Var[5])
 
-            self.assertDelta(List1[5],List2[5],angtolerance,"Error in "+Var[5])
+            self.assertDelta(List1[5], List2[5], angtolerance, "Error in " + Var[5])
         else:
-            self.assertDelta(List1[3],List2[3],angtolerance,"Error in "+Var[3])
+            self.assertDelta(List1[3], List2[3], angtolerance, "Error in " + Var[3])
 
-            self.assertDelta(List1[4],List2[4],angtolerance,"Error in "+Var[5])
+            self.assertDelta(List1[4], List2[4], angtolerance, "Error in " + Var[5])
 
-            self.assertDelta(List1[5],List2[5],angtolerance,"Error in "+Var[5])
+            self.assertDelta(List1[5], List2[5], angtolerance, "Error in " + Var[5])
 
-
-    def XchangeSides( self, Lat1, s1,s2):
-        Lat=list(Lat1)
-        if s1<0 or s2<0 or s1>=3 or s2>2 or s1==s2:
+    def XchangeSides(self, Lat1, s1, s2):
+        Lat = list(Lat1)
+        if s1 < 0 or s2 < 0 or s1 >= 3 or s2 > 2 or s1 == s2:
             return Lat
-        sav=Lat[s1]
-        Lat[s1]=Lat[s2]
-        Lat[s2]=sav
-        sav=Lat[s1+3]
-        Lat[s1+3]=Lat[s2+3]
-        Lat[s2+3]=sav
+        sav = Lat[s1]
+        Lat[s1] = Lat[s2]
+        Lat[s2] = sav
+        sav = Lat[s1 + 3]
+        Lat[s1 + 3] = Lat[s2 + 3]
+        Lat[s2 + 3] = sav
 
         return Lat
 
-    def GetConvCell( self,Peaks,XtalCenter1,wsName, nOrigIndexed,tolerance,matchLat):
+    def GetConvCell(self, Peaks, XtalCenter1, wsName, nOrigIndexed, tolerance, matchLat):
 
-        CopySample(Peaks,wsName,CopyMaterial="0",CopyEnvironment="0",CopyName="0",CopyShape="0",CopyLattice="1")
-        OrLat= mtd[wsName].sample().getOrientedLattice()
-        Lat1= [OrLat.a(),OrLat.b(),OrLat.c(),OrLat.alpha(),OrLat.beta(),OrLat.gamma()]
-        FormXtal=XtalCenter1[2]
-        FormCenter= XtalCenter1[3]
-        i1=0
-        i2=0
-        Lat0= self.FixLatParams( matchLat)
-        Lat1= self.FixLatParams( Lat1)
-       # print "--------------------- Getting the Conventional Cell for--------------------------------"
-       # print Lat1
-       # print Lat0
-       # print [FormXtal,FormCenter]
-        angTolerance = tolerance*180/math.pi
-        while i1< len(FormXtal) and i2 < len(FormCenter):
-            if FormXtal[i1]<FormCenter[i2]:
-                i1=i1+1
-            elif FormXtal[i1]>FormCenter[i2]:
-                i2=i2+1
+        CopySample(Peaks, wsName, CopyMaterial="0", CopyEnvironment="0", CopyName="0", CopyShape="0", CopyLattice="1")
+        OrLat = mtd[wsName].sample().getOrientedLattice()
+        Lat1 = [OrLat.a(), OrLat.b(), OrLat.c(), OrLat.alpha(), OrLat.beta(), OrLat.gamma()]
+        FormXtal = XtalCenter1[2]
+        FormCenter = XtalCenter1[3]
+        i1 = 0
+        i2 = 0
+        Lat0 = self.FixLatParams(matchLat)
+        Lat1 = self.FixLatParams(Lat1)
+        # print "--------------------- Getting the Conventional Cell for--------------------------------"
+        # print Lat1
+        # print Lat0
+        # print [FormXtal,FormCenter]
+        angTolerance = tolerance * 180 / math.pi
+        while i1 < len(FormXtal) and i2 < len(FormCenter):
+            if FormXtal[i1] < FormCenter[i2]:
+                i1 = i1 + 1
+            elif FormXtal[i1] > FormCenter[i2]:
+                i2 = i2 + 1
             else:
-                Res=SelectCellWithForm(Peaks, FormXtal[i1],True)
+                Res = SelectCellWithForm(Peaks, FormXtal[i1], True)
 
-                if Res[0] > .85* nOrigIndexed:
-                    CopySample(Peaks,"Temp",CopyMaterial="0",CopyEnvironment="0",CopyName="0",CopyShape="0",CopyLattice="1")
-                    OrLat= mtd["Temp"].sample().getOrientedLattice()
-                    Lat1= [OrLat.a(),OrLat.b(),OrLat.c(),OrLat.alpha(),OrLat.beta(),OrLat.gamma()]
+                if Res[0] > .85 * nOrigIndexed:
+                    CopySample(Peaks, "Temp", CopyMaterial="0", CopyEnvironment="0", CopyName="0", CopyShape="0",
+                               CopyLattice="1")
+                    OrLat = mtd["Temp"].sample().getOrientedLattice()
+                    Lat1 = [OrLat.a(), OrLat.b(), OrLat.c(), OrLat.alpha(), OrLat.beta(), OrLat.gamma()]
                     Lat1 = self.FixLatParams(Lat1)
-                    print ["Formnum,Lat1,Lat0",FormXtal[i1],Lat1,Lat0]
-                    if  math.fabs(Lat0[0]-Lat1[0])<tolerance and math.fabs(Lat0[1]-Lat1[1])<tolerance and math.fabs(Lat0[2]-Lat1[2])<tolerance:
+                    print ["Formnum,Lat1,Lat0", FormXtal[i1], Lat1, Lat0]
+                    if math.fabs(Lat0[0] - Lat1[0]) < tolerance and math.fabs(Lat0[1] - Lat1[1]) < tolerance \
+                            and math.fabs(Lat0[2] - Lat1[2]) < tolerance:
 
                         for dummy_i in range(3):
-                            if math.fabs(Lat0[3]-Lat1[3])<angTolerance and math.fabs(Lat0[4]-Lat1[4])<angTolerance and math.fabs(Lat0[5]-Lat1[5])<angTolerance:
+                            if math.fabs(Lat0[3] - Lat1[3]) < angTolerance and\
+                                            math.fabs(Lat0[4] - Lat1[4]) < angTolerance and\
+                                            math.fabs(Lat0[5] - Lat1[5]) < angTolerance:
                                 break
-                            if Lat1[0]>Lat1[1]-tolerance:
-                                Lat1=self.XchangeSides( Lat1,0,1)
+                            if Lat1[0] > Lat1[1] - tolerance:
+                                Lat1 = self.XchangeSides(Lat1, 0, 1)
 
-                            if math.fabs(Lat0[3]-Lat1[3])<angTolerance and math.fabs(Lat0[4]-Lat1[4])<angTolerance and math.fabs(Lat0[5]-Lat1[5])<angTolerance:
+                            if math.fabs(Lat0[3] - Lat1[3]) < angTolerance and\
+                                            math.fabs(Lat0[4] - Lat1[4]) < angTolerance and\
+                                math.fabs(Lat0[5] - Lat1[5]) < angTolerance:
                                 break
-                            if Lat1[1]>Lat1[2]- tolerance:
-                                Lat1=self.XchangeSides( Lat1,1,2)
+                            if Lat1[1] > Lat1[2] - tolerance:
+                                Lat1 = self.XchangeSides(Lat1, 1, 2)
 
-                            if math.fabs(Lat0[3]-Lat1[3])<angTolerance and math.fabs(Lat0[4]-Lat1[4])<angTolerance and math.fabs(Lat0[5]-Lat1[5])<angTolerance:
+                            if math.fabs(Lat0[3] - Lat1[3]) < angTolerance and\
+                                            math.fabs(Lat0[4] - Lat1[4]) < angTolerance and\
+                                            math.fabs(Lat0[5] - Lat1[5]) < angTolerance:
                                 break
 
-                        if math.fabs(Lat0[3]-Lat1[3])<angTolerance and math.fabs(Lat0[4]-Lat1[4])<angTolerance and math.fabs(Lat0[5]-Lat1[5])<angTolerance:
+                        if math.fabs(Lat0[3] - Lat1[3]) < angTolerance and\
+                                        math.fabs(Lat0[4] - Lat1[4]) < angTolerance and\
+                                        math.fabs(Lat0[5] - Lat1[5]) < angTolerance:
                             return Lat1
-                    i1=i1+1
-                    i2=i2+1
-                    CopySample(wsName, Peaks,CopyMaterial="0",CopyEnvironment="0",CopyName="0",CopyShape="0",CopyLattice="1")
+                    i1 = i1 + 1
+                    i2 = i2 + 1
+                    CopySample(wsName, Peaks, CopyMaterial="0", CopyEnvironment="0", CopyName="0", CopyShape="0",
+                               CopyLattice="1")
         return []
-
-
 
     def runTest(self):
 
-        CreateSingleValuedWorkspace(OutputWorkspace="Sws",DataValue="3")
+        CreateSingleValuedWorkspace(OutputWorkspace="Sws", DataValue="3")
 
-        CreateSingleValuedWorkspace(OutputWorkspace="Temp",DataValue="3")
-        LoadInstrument(Workspace="Sws",InstrumentName="TOPAZ", RewriteSpectraMap=True)
-        Inst= mtd["Sws"].getInstrument()
+        CreateSingleValuedWorkspace(OutputWorkspace="Temp", DataValue="3")
+        LoadInstrument(Workspace="Sws", InstrumentName="TOPAZ", RewriteSpectraMap=True)
+        Inst = mtd["Sws"].getInstrument()
         startA = 2
-        side1Ratios =[1.0, 1.2,  3.0,  8.0]
-        alphas =[20,50,80,110,140]
-        xtal=['O','M','H']#['O','M','H']
-        centerings = ['P','I','F','A', 'B',  'C']
-      #['P','I','F','A', 'B',  'C']
-        error=[0.0] #[ 0, .05,  0.1, 0, 0.15]
-        Npeaks=150
+        side1Ratios = [1.0, 1.2, 3.0, 8.0]
+        alphas = [20, 50, 80, 110, 140]
+        xtal = ['O', 'M', 'H']  # ['O','M','H']
+        centerings = ['P', 'I', 'F', 'A', 'B', 'C']
+        # ['P','I','F','A', 'B',  'C']
+        error = [0.0]  # [ 0, .05,  0.1, 0, 0.15]
+        Npeaks = 150
         for Error in error:
-            for side1 in range(0,4):#make (0,4)
-                for side2 in range(side1,4):#make side1,4
+            for side1 in range(0, 4):  # make (0,4)
+                for side2 in range(side1, 4):  # make side1,4
                     for Xtal in xtal:
                         for Center in centerings:
                             for ang in alphas:
                                 for i1 in range(3):
-                                    for i2a in range(1,3):
-                                        if self.newSetting( side1,side2,Xtal,Center,ang, i1,i2a):
+                                    for i2a in range(1, 3):
+                                        if self.newSetting(side1, side2, Xtal, Center, ang, i1, i2a):
                                             print "============================================================="
-                                            Sides=[startA, startA*side1Ratios[side1],startA*side1Ratios[side2]]
-                                            Sides= self.MonoClinicRearrange( Sides,Xtal,Center,i1,i2a)
-                                            print [Sides,Error,Xtal,Center,ang,i1,i2a]
+                                            Sides = [startA, startA * side1Ratios[side1], startA * side1Ratios[side2]]
+                                            Sides = self.MonoClinicRearrange(Sides, Xtal, Center, i1, i2a)
+                                            print [Sides, Error, Xtal, Center, ang, i1, i2a]
 
-                                            UBconv= self.CalcConventionalUB(Sides[0],Sides[1],Sides[2],ang,ang,ang,Xtal)
+                                            UBconv = self.CalcConventionalUB(Sides[0], Sides[1], Sides[2], ang, ang,
+                                                                             ang, Xtal)
 
-                                            UBnig= self.CalcNiggliUB(Sides[0],Sides[1],Sides[2],ang,ang,ang,Xtal,Center)
+                                            UBnig = self.CalcNiggliUB(Sides[0], Sides[1], Sides[2], ang, ang, ang, Xtal,
+                                                                      Center)
 
                                             UBconv = self.conventionalUB
-                                            V =self.getMatrixAxis( i1,Xtal)
-                                            if  UBconv == None:
+                                            V = self.getMatrixAxis(i1, Xtal)
+                                            if UBconv == None:
                                                 continue
-                                            if UBnig==None:
+                                            if UBnig == None:
                                                 continue
-                                            UBnig= V*UBnig
-                                            UBconv = V*UBconv
-                  #UBnig1= self.FixUB(UBnig,.05)
+                                            UBnig = V * UBnig
+                                            UBconv = V * UBconv
+                                            # UBnig1= self.FixUB(UBnig,.05)
                                             UBnig = self.FixUpPlusMinus(UBnig)
-                                            UBconv= self.FixUpPlusMinus(UBconv)
-                                            Lat0= self.getLat(UBnig)
+                                            UBconv = self.FixUpPlusMinus(UBconv)
+                                            Lat0 = self.getLat(UBnig)
 
+                                            Lat0 = self.FixLatParams(Lat0)
+                                            print ["UBnig", UBnig, Lat0]
 
+                                            Peaks = self.getPeaks(Inst, UBnig, Error, Npeaks + Error * 300)
 
-                                            Lat0=self.FixLatParams(Lat0)
-                                            print ["UBnig",UBnig,Lat0]
+                                            # -------Failed tests because of FindUBUsingFFT -------------------
 
-                                            Peaks=self.getPeaks(Inst,UBnig, Error,Npeaks +Error*300)
-
-                  #------------------------Failed tests because of FindUBUsingFFT ------------------------------------
-
-                                            if side1==1 and side2==2 and Error==0.0 and Xtal=='M' and Center=='C' and i1==0 and i2a==1 and ang==140:
+                                            if side1 == 1 and side2 == 2 and Error == 0.0 and Xtal == 'M' and \
+                                                            Center == 'C' and i1 == 0 and i2a == 1 and ang == 140:
                                                 continue
 
-                                            if side1==2 and side2==2 and Error==0.0 and Xtal=='M' and Center=='P' and i1==1 and i2a==1 and ang==110:
-                                                continue # one side doubled
+                                            if side1 == 2 and side2 == 2 and Error == 0.0 and Xtal == 'M' and\
+                                                            Center == 'P' and i1 == 1 and i2a == 1 and ang == 110:
+                                                continue  # one side doubled
 
-                                            if side1==3 and side2==3 and Error==0.0 and Xtal=='M' and Center=='I' and i1 == 1 and i2a==2 :
+                                            if side1 == 3 and side2 == 3 and Error == 0.0 and Xtal == 'M' and\
+                                                            Center == 'I' and i1 == 1 and i2a == 2:
                                                 continue
 
-                                            if side1==3 and side2==3 and Error==0.0 and Xtal=='M' and Center=='I' and i1 == 2 and i2a==1 :
+                                            if side1 == 3 and side2 == 3 and Error == 0.0 and Xtal == 'M' and\
+                                                            Center == 'I' and i1 == 2 and i2a == 1:
                                                 continue
 
-                                            if side1==3 and side2==3 and Error==0.0 and Xtal=='H' and Center=='I' and i1 == 2 and i2a==1  and ang==20:
+                                            if side1 == 3 and side2 == 3 and Error == 0.0 and Xtal == 'H' and\
+                                                            Center == 'I' and i1 == 2 and i2a == 1 and ang == 20:
                                                 continue
-                  #------------------------------ end Failed FindUB test----------------------------
-                                            FindUBUsingFFT(Peaks,Lat0[0]*.5,Lat0[2]*2.0,.15)
-                                            InPks=IndexPeaks(Peaks,.10)
+                                                # ------------------------------ end Failed FindUB test------------
+                                            FindUBUsingFFT(Peaks, Lat0[0] * .5, Lat0[2] * 2.0, .15)
+                                            InPks = IndexPeaks(Peaks, .10)
 
+                                            CopySample(Peaks, "Sws", CopyMaterial="0",
+                                                       CopyEnvironment="0", CopyName="0", CopyShape="0",
+                                                       CopyLattice="1")
+                                            OrLat = mtd["Sws"].sample().getOrientedLattice()
 
-                                            CopySample(Peaks,"Sws",CopyMaterial="0",
-                                                       CopyEnvironment="0",CopyName="0",CopyShape="0",CopyLattice="1")
-                                            OrLat= mtd["Sws"].sample().getOrientedLattice()
+                                            Lat1 = [OrLat.a(), OrLat.b(), OrLat.c(), OrLat.alpha(), OrLat.beta(),
+                                                    OrLat.gamma()]
 
-                                            Lat1= [OrLat.a(),OrLat.b(),OrLat.c(),OrLat.alpha(),OrLat.beta(),OrLat.gamma()]
+                                            Lat1 = self.FixLatParams(Lat1)
 
-                                            Lat1=self.FixLatParams(Lat1)
-
-                                            MatchXtalTol= .03*(1+4*Error)*(side1Ratios[side2])
+                                            MatchXtalTol = .03 * (1 + 4 * Error) * (side1Ratios[side2])
                                             print Lat0
                                             print Lat1
-                                            self.MatchXtlparams( Lat1, Lat0, MatchXtalTol, "Niggli values do not match")
+                                            self.MatchXtlparams(Lat1, Lat0, MatchXtalTol, "Niggli values do not match")
 
 
-                  #Now see if the conventional cell is in list
-                                            XtalCenter1= self.Xlate(Xtal,Center,Sides,Lat0) #get proper strings for SelectCellOfType
+                                            # Now see if the conventional cell is in list
+                                            XtalCenter1 = self.Xlate(Xtal, Center, Sides,
+                                                                     Lat0)  # get proper strings for SelectCellOfType
 
-                                            Lat0= self.getLat(UBconv)
-                                            Lat0=self.FixLatParams(Lat0)
-                                            Lat1 = self.GetConvCell( Peaks,XtalCenter1,"Sws",InPks[0],MatchXtalTol,Lat0)
+                                            Lat0 = self.getLat(UBconv)
+                                            Lat0 = self.FixLatParams(Lat0)
+                                            Lat1 = self.GetConvCell(Peaks, XtalCenter1, "Sws", InPks[0], MatchXtalTol,
+                                                                    Lat0)
 
+                                            Lat1 = self.FixLatParams(Lat1)
 
-                                            Lat1=self.FixLatParams(Lat1)
+                                            self.MatchXtlparams(Lat1, Lat0, MatchXtalTol,
+                                                                "Conventional lattice parameter do not match")
+                                            self.assertTrue(len(Lat1) > 4, "Conventional values do not match")
+                                            # "XYXYZS"
 
-                                            self.MatchXtlparams( Lat1, Lat0, MatchXtalTol, "Conventional lattice parameter do not match")
-                                            self.assertTrue( len(Lat1)>4,"Conventional values do not match")
-     #"XYXYZS"
     def requiredFiles(self):
         return []

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -1,5 +1,5 @@
-﻿#!/usr/bin/python
-
+﻿
+#!/usr/bin/python
 import os
 import sys
 import platform
@@ -31,14 +31,14 @@ class UserProperties(object):
         self._cycle_IDs = {}
         self._start_dates = {}
         self._rb_exist = {}
-        #
+
         self._user_id = None
         self._recent_dateID = None
         if args[0] is None:
             return
         if len(args) == 1:
-            _input = str(args[0])
-            param = _input.split()
+            input_ = str(args[0])
+            param = input_.split()
             self._user_id = param[0]
             if len(param) == 5:
                 self.set_user_properties(param[1], param[2], param[3], param[4])
@@ -694,8 +694,8 @@ class MantidConfigDirectInelastic(object):
             raise RuntimeError("SERVER ERROR: no correct home path defined at {0}".format(self._home_path))
         if not os.path.exists(self._script_repo):
             raise RuntimeError(("SERVER ERROR: no correct user script repository defined at {0}\n"
-                                "Check out Mantid script repository from account, "
-                                "which have admin rights").format(self._script_repo))
+                                "Check out Mantid script repository from account,"
+                                " which have admin rights").format(self._script_repo))
         if not os.path.exists(self._map_mask_folder):
             raise RuntimeError(("SERVER ERROR: no correct map/mask folder defined at {0}\n"
                                 "Check out Mantid map/mask files from svn at "
@@ -847,56 +847,55 @@ class MantidConfigDirectInelastic(object):
         file_time = time.mktime(start_date.timetuple())
         os.utime(config_file_name, (file_time, file_time))
 
-
+# pylint: disable = invalid-name
 if __name__ == "__main__":
 
     if len(sys.argv) != 6:
         print "usage: Config.py userID instrument RBNumber cycleID start_date"
         exit()
 
-    ARGI = sys.argv[1:]
-    USER = UserProperties(*ARGI)
+    argi = sys.argv[1:]
+    user = UserProperties(*argi)
 
     if platform.system() == 'Windows':
         sys.path.insert(0, 'c:/Mantid/scripts/Inelastic/Direct')
 
-        BASE = 'd:/Data/Mantid_Testing/config_script_test_folder'
-        ANALYSIS_DIR = BASE
+        base = 'd:/Data/Mantid_Testing/config_script_test_folder'
+        analysisDir = base
 
-        MANTID_DIR = r"c:\Mantid\_builds\br_master\bin\Release"
-        USER_SCRIPT_REPO_DIR = os.path.join(ANALYSIS_DIR, "UserScripts")
-        MAP_MASK_DIR = os.path.join(ANALYSIS_DIR, "InstrumentFiles")
+        MantidDir = r"c:\Mantid\_builds\br_master\bin\Release"
+        UserScriptRepoDir = os.path.join(analysisDir, "UserScripts")
+        MapMaskDir = os.path.join(analysisDir, "InstrumentFiles")
 
-        ROOT_DIR = os.path.join(BASE, 'users')
+        rootDir = os.path.join(base, 'users')
     else:
         sys.path.insert(0, '/opt/Mantid/scripts/Inelastic/Direct/')
         # sys.path.insert(0,'/opt/mantidnightly/scripts/Inelastic/Direct/')
 
 
-        MANTID_DIR = '/opt/Mantid'
-        MAP_MASK_DIR = '/usr/local/mprogs/InstrumentFiles/'
-        USER_SCRIPT_REPO_DIR = '/opt/UserScripts'
+        MantidDir = '/opt/Mantid'
+        MapMaskDir = '/usr/local/mprogs/InstrumentFiles/'
+        UserScriptRepoDir = '/opt/UserScripts'
         home = '/home'
         #
-        ROOT_DIR = "/home/"
-        ANALYSIS_DIR = "/instrument/"
+        rootDir = "/home/"
+        analysisDir = "/instrument/"
 
     # initialize Mantid configuration
 
     from ISISDirecInelasticConfig import MantidConfigDirectInelastic, UserProperties
 
-    MCF = MantidConfigDirectInelastic(MANTID_DIR, ROOT_DIR, USER_SCRIPT_REPO_DIR, MAP_MASK_DIR)
+    mcf = MantidConfigDirectInelastic(MantidDir, rootDir, UserScriptRepoDir, MapMaskDir)
     print "Successfully initialized ISIS Inelastic Configuration script generator"
 
-    RB_USER_FOLDER = os.path.join(MCF._home_path, USER.userID)
-    USER.rb_dir = RB_USER_FOLDER
-    if not USER.rb_dir_exist:
-
-        print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(USER.rb_dir,
-                                                                                                        USER.userID)
+    rb_user_folder = os.path.join(mcf._home_path, user.userID)
+    user.rb_dir = rb_user_folder
+    if not user.rb_dir_exist:
+        print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(user.rb_dir,
+                                                                                                        user.userID)
         exit()
     # Configure user
-    MCF.init_user(USER.userID, USER)
-    MCF.generate_config()
+    mcf.init_user(user.userID, user)
+    mcf.generate_config()
     print "Successfully Configured user: {0} for instrument {1} and RBNum: {2}" \
-        .format(USER.userID, USER.instrument, USER.rb_folder)
+        .format(user.userID, user.instrument, user.rb_folder)

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -1,5 +1,4 @@
-﻿
-#!/usr/bin/python
+﻿#!/usr/bin/python
 import os
 import sys
 import platform
@@ -37,8 +36,8 @@ class UserProperties(object):
         if args[0] is None:
             return
         if len(args) == 1:
-            input_ = str(args[0])
-            param = input_.split()
+            input = str(args[0])
+            param = input.split()
             self._user_id = param[0]
             if len(param) == 5:
                 self.set_user_properties(param[1], param[2], param[3], param[4])
@@ -106,7 +105,6 @@ class UserProperties(object):
                 ind = str_parts.index(prop)
             except Exception:
                 ind = None
-                raise
             if not ind is None:
                 str_parts[ind] = str(getattr(self, prop))
         data_string = "".join(str_parts)
@@ -590,7 +588,7 @@ class MantidConfigDirectInelastic(object):
         # user files description is not there
         try:
             domObj = minidom.parse(job_description_file)
-        except (StandardError, Warning):
+        except Exception:
             input_file, output_file = self._fullpath_to_copy()
             filenames_to_copy.append((input_file, output_file, None))
             return filenames_to_copy
@@ -694,12 +692,12 @@ class MantidConfigDirectInelastic(object):
             raise RuntimeError("SERVER ERROR: no correct home path defined at {0}".format(self._home_path))
         if not os.path.exists(self._script_repo):
             raise RuntimeError(("SERVER ERROR: no correct user script repository defined at {0}\n"
-                                "Check out Mantid script repository from account,"
-                                " which have admin rights").format(self._script_repo))
+                                "Check out Mantid script repository from account, "
+                                "which have admin rights").format(self._script_repo))
         if not os.path.exists(self._map_mask_folder):
             raise RuntimeError(("SERVER ERROR: no correct map/mask folder defined at {0}\n"
-                                "Check out Mantid map/mask files from svn at "
-                                "https://svn.isis.rl.ac.uk/InstrumentFiles/trunk").format(self._map_mask_folder))
+                                "Check out Mantid map/mask files from svn at"
+                                " https://svn.isis.rl.ac.uk/InstrumentFiles/trunk").format(self._map_mask_folder))
 
     def _init_config(self):
         """Execute Mantid properties setup methods"""
@@ -848,6 +846,7 @@ class MantidConfigDirectInelastic(object):
         os.utime(config_file_name, (file_time, file_time))
 
 # pylint: disable = invalid-name
+
 if __name__ == "__main__":
 
     if len(sys.argv) != 6:

--- a/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
+++ b/scripts/Inelastic/Direct/ISISDirecInelasticConfig.py
@@ -1,4 +1,5 @@
 ﻿#!/usr/bin/python
+
 import os
 import sys
 import platform
@@ -10,55 +11,58 @@ import time
 from xml.dom import minidom
 
 # the list of instruments this configuration is applicable to
-INELASTIC_INSTRUMENTS = ['MAPS','LET','MERLIN','MARI','HET']
+INELASTIC_INSTRUMENTS = ['MAPS', 'LET', 'MERLIN', 'MARI', 'HET']
 # the list of the parameters, which can be replaced if found in user files
-USER_PROPERTIES=['instrument','userID', 'cycleID', 'start_date', 'rb_folder']
+USER_PROPERTIES = ['instrument', 'userID', 'cycleID', 'start_date', 'rb_folder']
+
 
 class UserProperties(object):
     """Helper class to define & retrieve user properties
        as retrieved from file provided by user office
     """
-    def __init__(self,*args):
+
+    def __init__(self, *args):
         """ Build user properties from space separated string in the form:
             "userId instr_name rb_num cycle_mu start_date"
             or list of five elements with the same meaning
         """
-        self._instrument={}
+        self._instrument = {}
         self._rb_dirs = {}
-        self._cycle_IDs={}
+        self._cycle_IDs = {}
         self._start_dates = {}
-        self._rb_exist={}
-        # 
+        self._rb_exist = {}
+        #
         self._user_id = None
-        self._recent_dateID=None
+        self._recent_dateID = None
         if args[0] is None:
             return
         if len(args) == 1:
-            input = str(args[0])
-            param = input.split()
+            _input = str(args[0])
+            param = _input.split()
             self._user_id = param[0]
             if len(param) == 5:
-                self.set_user_properties(param[1],param[2],param[3],param[4])
-            else: # only userID was provided, nothing else is defined
+                self.set_user_properties(param[1], param[2], param[3], param[4])
+            else:  # only userID was provided, nothing else is defined
                 return
         elif len(args) == 5:
             self._user_id = str(args[0])
-            self.set_user_properties(args[1],args[2],args[3],args[4])
+            self.set_user_properties(args[1], args[2], args[3], args[4])
         else:
-            raise RuntimeError("User has to be defined by the list of 5 components in the form:\n{0}".\
-                format("[userId,instr_name,rb_num,cycle_mu,start_date]"))
+            raise RuntimeError("User has to be defined by the list of 5 components in the form:\n{0}". \
+                               format("[userId,instr_name,rb_num,cycle_mu,start_date]"))
 
     def __str__(self):
         """Convert class to string. Only last cycle settings are returned"""
         if self._user_id:
-            return "{0} {1} {2} {3} {4}".format(self._user_id,self.instrument,\
-                    self.rb_folder,self.cycleID,str(self.start_date))
+            return "{0} {1} {2} {3} {4}".format(self._user_id, self.instrument, \
+                                                self.rb_folder, self.cycleID, str(self.start_date))
         else:
             return "None"
 
-       
-#
-    def set_user_properties(self,instrument,rb_folder_or_id,cycle,start_date):
+
+            #
+
+    def set_user_properties(self, instrument, rb_folder_or_id, cycle, start_date):
         """Define the information, user office provides about user.
 
            The info has the form:
@@ -69,28 +73,29 @@ class UserProperties(object):
            rb_folder  -- string containing the full path to working folder available
                         for all users and IS participating in the experiment.
         """
-        instrument,start_date,cycle,rb_folder_or_id,rb_exist =self.check_input(instrument,start_date,cycle,rb_folder_or_id)
-        #when user starts
-        recent_date = date(int(start_date[0:4]),int(start_date[4:6]),int(start_date[6:8]))
+        instrument, start_date, cycle, rb_folder_or_id, rb_exist = self.check_input(instrument, start_date, cycle,
+                                                                                    rb_folder_or_id)
+        # when user starts
+        recent_date = date(int(start_date[0:4]), int(start_date[4:6]), int(start_date[6:8]))
         recent_date_id = str(recent_date)
-        self._start_dates[recent_date_id]=recent_date
-        self._rb_exist[recent_date_id]  = rb_exist
+        self._start_dates[recent_date_id] = recent_date
+        self._rb_exist[recent_date_id] = rb_exist
 
 
         # a data which define the cycle ID e.g 2014_3 or something
-        self._cycle_IDs[recent_date_id]  = (str(cycle[5:9]),str(cycle[9:10]))
+        self._cycle_IDs[recent_date_id] = (str(cycle[5:9]), str(cycle[9:10]))
         self._instrument[recent_date_id] = str(instrument).upper()
-        self._rb_dirs[recent_date_id]    = rb_folder_or_id
+        self._rb_dirs[recent_date_id] = rb_folder_or_id
         if self._recent_dateID:
             max_date = self._start_dates[self._recent_dateID]
-            for date_key,a_date in self._start_dates.iteritems():
-                if a_date>max_date:
+            for date_key, a_date in self._start_dates.iteritems():
+                if a_date > max_date:
                     self._recent_dateID = date_key
                     max_date = a_date
         else:
             self._recent_dateID = recent_date_id
 
-    def replace_variables(self,data_string):
+    def replace_variables(self, data_string):
         """Replace variables defined in USER_PROPERTIES
             and enclosed in $ sign with their values
             defined for a user
@@ -101,11 +106,13 @@ class UserProperties(object):
                 ind = str_parts.index(prop)
             except Exception:
                 ind = None
+                raise
             if not ind is None:
-                str_parts[ind] = str(getattr(self,prop))
+                str_parts[ind] = str(getattr(self, prop))
         data_string = "".join(str_parts)
         return data_string
-#
+
+    #
     @property
     def GID(self):
         """Returns user's group ID which coincide with
@@ -116,7 +123,8 @@ class UserProperties(object):
             return RBfolder[2:]
         else:
             return None
-#
+            #
+
     @property
     def rb_folder(self):
         """Returns short name of user's RB folder
@@ -128,6 +136,7 @@ class UserProperties(object):
             return RBfolder
         else:
             return None
+
     @property
     def rb_id(self):
         """the same as rb_folder:
@@ -136,84 +145,91 @@ class UserProperties(object):
         """
         return self.rb_folder
 
-
-#
+    #
     @property
     def start_date(self):
         """Last start date"""
         if self._recent_dateID:
-            return  self._start_dates[self._recent_dateID]
+            return self._start_dates[self._recent_dateID]
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
- #
+            #
+
     @property
     def instrument(self):
         """return instrument used in last actual experiment"""
         if self._recent_dateID:
-            return  self._instrument[self._recent_dateID]
+            return self._instrument[self._recent_dateID]
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
-#
+            #
+
     @property
     def rb_dir(self):
         """return rb folder used in last actual instrument"""
         if self._recent_dateID:
-            return  self._rb_dirs[self._recent_dateID]
+            return self._rb_dirs[self._recent_dateID]
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
+
     @rb_dir.setter
-    def rb_dir(self,user_home_path):
+    def rb_dir(self, user_home_path):
         """Set user's rb-folder path"""
         rb_path = self.rb_folder
-        full_path = os.path.join(user_home_path,rb_path)
+        full_path = os.path.join(user_home_path, rb_path)
         if os.path.exists(full_path) and os.path.isdir(full_path):
             self._rb_dirs[self._recent_dateID] = full_path
             self._rb_exist[self._recent_dateID] = True
         else:
             pass
+
     #
     @property
     def rb_dir_exist(self):
         """return true if user's rb dir exist and false otherwise"""
         if self._recent_dateID:
-            return  self._rb_exist[self._recent_dateID]
+            return self._rb_exist[self._recent_dateID]
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
 
-#
+            #
+
     @property
     def cycleID(self):
         """return last cycleID the user is participating"""
         if self._recent_dateID:
-            year,num =self._cycle_IDs[self._recent_dateID]
-            return  "{0}_{1}".format(year,num)
+            year, num = self._cycle_IDs[self._recent_dateID]
+            return "{0}_{1}".format(year, num)
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
+
     @property
     def cycle(self):
         """return last cycle the user is participating"""
         if self._recent_dateID:
-            return  self._cycle_IDs[self._recent_dateID]
+            return self._cycle_IDs[self._recent_dateID]
         else:
             raise RuntimeError("User's experiment date is not defined. User undefined")
-#
+            #
+
     @property
     def userID(self):
         return self._user_id
+
     @userID.setter
-    def userID(self,val):
+    def userID(self, val):
         self._user_id = str(val)
 
-#
-    def check_input(self,instrument,start_date,cycle,rb_folder_or_id):
+    #
+    def check_input(self, instrument, start_date, cycle, rb_folder_or_id):
         """Verify that input is correct"""
         if not instrument in INELASTIC_INSTRUMENTS:
-            raise RuntimeError("Instrument {0} has to be one of "\
-                  "ISIS inelastic instruments".format(instrument))
-        if isinstance(start_date,str):
-            start_date = start_date.replace('-','')
+            raise RuntimeError("Instrument {0} has to be one of " \
+                               "ISIS inelastic instruments".format(instrument))
+        if isinstance(start_date, str):
+            start_date = start_date.replace('-', '')
             if len(start_date) != 8:
-                start_date = '20'+start_date
+                start_date = '20' + start_date
             if len(start_date) == 8:
                 error = False
             else:
@@ -221,54 +237,57 @@ class UserProperties(object):
         else:
             error = True
         if error:
-            raise RuntimeError("Experiment start date should be defined as"\
-            " a sting in the form YYYYMMDD or YYMMDD but it is: {0}".format(start_date))
+            raise RuntimeError("Experiment start date should be defined as" \
+                               " a sting in the form YYYYMMDD or YYMMDD but it is: {0}".format(start_date))
         #
         def convert_cycle_int(cycle_int):
-            if cycle_int > 999: # Full cycle format 20151
-               cycle = "CYCLE{0:05}".format(cycle_int)
+            if cycle_int > 999:  # Full cycle format 20151
+                cycle = "CYCLE{0:05}".format(cycle_int)
             else:
-               cycle = "CYCLE20{0:03}".format(cycle_int)
+                cycle = "CYCLE20{0:03}".format(cycle_int)
             return cycle
 
-        if isinstance(cycle,int):
+        if isinstance(cycle, int):
             cycle = convert_cycle_int(cycle)
-        if isinstance(cycle,str):
-            if not(len(cycle) == 10):
-                cycle = cycle.replace('_','')
+        if isinstance(cycle, str):
+            if len(cycle) != 10:
+                cycle = cycle.replace('_', '')
                 try:
                     cycle = int(cycle)
                 except ValueError:
-                    raise RuntimeError("Cycle should be a string in the form CYCLEYYYYN "\
-                    "N-- the cycle's number in a year or integer in the form: YYYYN or YYN "\
-                    "but it is {0}".format(cycle))
+                    raise RuntimeError("Cycle should be a string in the form CYCLEYYYYN " \
+                                       "N-- the cycle's number in a year or integer in the form: YYYYN or YYN " \
+                                       "but it is {0}".format(cycle))
                 cycle = convert_cycle_int(cycle)
-                if not(len(cycle) == 10 and re.match('^CYCLE',cycle)):
-                    raise RuntimeError("Cycle should be a string in form CYCLEYYYYN "\
-                    "N-- the cycle's number in a year or integer in the form: YYYYN or YYN "\
-                    "but it is {0}".format(cycle))
-        if isinstance(rb_folder_or_id,int):
-           rb_folder_or_id = "RB{0:07}".format(rb_folder_or_id)
-        if not isinstance(rb_folder_or_id,str):
+                if not (len(cycle) == 10 and re.match('^CYCLE', cycle)):
+                    raise RuntimeError("Cycle should be a string in form CYCLEYYYYN " \
+                                       "N-- the cycle's number in a year or integer in the form: YYYYN or YYN " \
+                                       "but it is {0}".format(cycle))
+        if isinstance(rb_folder_or_id, int):
+            rb_folder_or_id = "RB{0:07}".format(rb_folder_or_id)
+        if not isinstance(rb_folder_or_id, str):
             raise RuntimeError("RB Folder {0} should be a string".format(rb_folder_or_id))
         else:
-            base,rbf = os.path.split(rb_folder_or_id)
-            if(len(rbf) != 9):
+            base, rbf = os.path.split(rb_folder_or_id)
+            if len(rbf) != 9:
                 try:
                     rbf = int(rbf)
                     rbf = "RB{0:07}".format(rbf)
-                    rb_folder_or_id = os.path.join(base,rbf)
+                    rb_folder_or_id = os.path.join(base, rbf)
                 except ValueError:
-                    raise RuntimeError("RB Folder {0} should be a string containing RB number at the end".format(rb_folder_or_id))
-        #end
+                    raise RuntimeError(
+                        "RB Folder {0} should be a string containing RB number at the end".format(rb_folder_or_id))
+        # end
         if os.path.exists(rb_folder_or_id) and os.path.isdir(rb_folder_or_id):
             rb_exist = True
         else:
             rb_exist = False
 
-        return instrument,start_date,cycle,rb_folder_or_id,rb_exist
+        return instrument, start_date, cycle, rb_folder_or_id, rb_exist
+
+
 #
-#--------------------------------------------------------------------#
+# --------------------------------------------------------------------#
 #
 class MantidConfigDirectInelastic(object):
     """Class describes Mantid server specific user's configuration,
@@ -295,29 +314,29 @@ class MantidConfigDirectInelastic(object):
     """
     # pylint: disable=too-many-instance-attributes
     # It has as many as parameters describing ISIS configuration.
-    def __init__(self,mantid='/opt/Mantid/',home='/home/',\
-                 script_repo='/opt/UserScripts/',\
+    def __init__(self, mantid='/opt/Mantid/', home='/home/', \
+                 script_repo='/opt/UserScripts/', \
                  map_mask_folder='/usr/local/mprogs/InstrumentFiles/'):
         """Initialize generic config variables and variables specific to a server"""
 
         self._mantid_path = str(mantid)
-        self._home_path  = str(home)
+        self._home_path = str(home)
         self._script_repo = str(script_repo)
         self._map_mask_folder = str(map_mask_folder)
         # check if all necessary server folders specified as class parameters are present
         self._check_server_folders_present()
         #
         # Static Parts of dynamic contents of Mantid configuration file
-        self._root_data_folder='/archive' # root folder for all experimental results -- particular one will depend on
-                                          # instrument and cycle number.
+        self._root_data_folder = '/archive'  # root folder for all experimental results -- particular one will depend on
+        # instrument and cycle number.
         # the common part of all strings, generated dynamically as function of input class parameters.
         self._dynamic_options_base = ['default.facility=ISIS']
         # Path to python scripts, defined and used by mantid wrt to Mantid Root (this path may be version specific)
-        self._python_mantid_path = ['scripts/Calibration/','scripts/Examples/','scripts/Interface/','scripts/Vates/']
+        self._python_mantid_path = ['scripts/Calibration/', 'scripts/Examples/', 'scripts/Interface/', 'scripts/Vates/']
         # Static paths to user scripts, defined wrt script repository root
         self._python_user_scripts = set(['direct_inelastic/ISIS/qtiGenie/'])
         # Relative to a particular user path to place links, important to user
-        self._user_specific_link_path='Desktop'
+        self._user_specific_link_path = 'Desktop'
         # Relative to a particular user name of folders with link to instrument files
         self._map_mask_link_name = 'instrument_files'
         # the name of the file, which describes python files to copy to user. The file has to be placed in
@@ -327,10 +346,10 @@ class MantidConfigDirectInelastic(object):
         # fall back files defined to use if USER_Files_description is for some reason not available or wrong
         # pylint: disable=W0108
         # it will not work without lambda as intended
-        self._sample_reduction_file = lambda InstrName : '{0}Reduction_Sample.py'.format(InstrName)
+        self._sample_reduction_file = lambda InstrName: '{0}Reduction_Sample.py'.format(InstrName)
         # File name, used as target for copying to user folder for user to deploy as the base for his reduction script
         # it will not work without lambda as intended
-        self._target_reduction_file = lambda InstrName,cycleID : '{0}Reduction_{1}.py'.format(InstrName,cycleID)
+        self._target_reduction_file = lambda InstrName, cycleID: '{0}Reduction_{1}.py'.format(InstrName, cycleID)
 
 
         # Static contents of the Mantid Config file
@@ -372,11 +391,12 @@ class MantidConfigDirectInelastic(object):
 
         # Methods, which build & verify various parts of Mantid configuration
         self._dynamic_options = [self._set_default_inst,
-                                 self._set_script_repo, # necessary to have on an Instrument scientist account, disabled on generic setup
+                                 self._set_script_repo,
+                                 # necessary to have on an Instrument scientist account, disabled on generic setup
                                  self._def_python_search_path,
-                                 self._set_datasearch_directory,self._set_rb_directory]
+                                 self._set_datasearch_directory, self._set_rb_directory]
         self._user = None
-        self._cycle_data_folder=set()
+        self._cycle_data_folder = set()
         # this is the list, containing configuration strings
         # generated by the class. No configuration is present initially.
         # Its contents is generated by _init_config method from server and user specific
@@ -386,8 +406,9 @@ class MantidConfigDirectInelastic(object):
         self._force_change_config = False
         # Unconditionally rewrite copy of sample reduction script
         self._force_change_script = False
-#
-    def config_need_replacing(self,config_file_name):
+
+    #
+    def config_need_replacing(self, config_file_name):
         """Method specifies conditions when existing configuration file should be replaced"""
         if self._force_change_config:
             return True
@@ -397,26 +418,28 @@ class MantidConfigDirectInelastic(object):
 
         start_date = self._user.start_date
         unmodified_creation_time = time.mktime(start_date.timetuple())
-        targ_config_time  = os.path.getmtime(config_file_name)
+        targ_config_time = os.path.getmtime(config_file_name)
 
         # Only rewrite configuration if nobody have touched it
-        if unmodified_creation_time  == targ_config_time:
+        if unmodified_creation_time == targ_config_time:
             return True
         else:
             return False
-#
+            #
+
     @property
     def user_file_description(self):
         """defines full file name (with path) for an xml file which describes
            files, which should be copied to a user
         """
         if self._user:
-            return os.path.join(self._script_repo,'direct_inelastic',self._user.instrument,
+            return os.path.join(self._script_repo, 'direct_inelastic', self._user.instrument,
                                 self._user_files_descr)
         else:
-            return  self._user_files_descr
-#
-    def script_need_replacing(self,target_script_name):
+            return self._user_files_descr
+            #
+
+    def script_need_replacing(self, target_script_name):
         """Method specifies conditions when existing reduction file should be replaced
            by a sample file.
         """
@@ -425,17 +448,18 @@ class MantidConfigDirectInelastic(object):
         # non-existing file should always be replaced
         if not os.path.isfile(target_script_name):
             return True
-        #Always replace sample file if it has not been touched
+        # Always replace sample file if it has not been touched
         start_date = self._user.start_date
         # this time is set up to the file, copied from the repository
         unmodified_file_time = time.mktime(start_date.timetuple())
-        targ_file_time  = os.path.getmtime(target_script_name)
-        if unmodified_file_time ==  targ_file_time:
+        targ_file_time = os.path.getmtime(target_script_name)
+        if unmodified_file_time == targ_file_time:
             return True
-        else: # somebody have modified the target file. Leave it alone
+        else:  # somebody have modified the target file. Leave it alone
             return False
-#
-    def _fullpath_to_copy(self,short_source_file=None,short_target_file=None):
+            #
+
+    def _fullpath_to_copy(self, short_source_file=None, short_target_file=None):
         """Append full path to source and target files """
 
         InstrName = self._user.instrument
@@ -444,15 +468,15 @@ class MantidConfigDirectInelastic(object):
             short_source_file = self._sample_reduction_file(InstrName)
         if short_target_file is None:
             CycleID = self._user.cycleID
-            short_target_file = self._target_reduction_file(InstrName,CycleID)
+            short_target_file = self._target_reduction_file(InstrName, CycleID)
 
+        source_path = os.path.join(self._script_repo, 'direct_inelastic', InstrName.upper())
+        full_source = os.path.join(source_path, short_source_file)
 
-        source_path = os.path.join(self._script_repo,'direct_inelastic',InstrName.upper())
-        full_source = os.path.join(source_path,short_source_file)
+        full_target = os.path.join(rb_folder, short_target_file)
+        return full_source, full_target
 
-        full_target = os.path.join(rb_folder,short_target_file)
-        return full_source,full_target
-#
+    #
     def copy_reduction_sample(self, users_file_description=None):
         """copy sample reduction scripts from Mantid script repository
            to user folder.
@@ -461,15 +485,14 @@ class MantidConfigDirectInelastic(object):
             users_file_description = self._user_files_descr
         info_to_copy = self._parse_user_files_description(users_file_description)
         for info in info_to_copy:
-            self._copy_user_file_job(info[0],info[1],info[2])
+            self._copy_user_file_job(info[0], info[1], info[2])
 
-
-    def _copy_and_parse_user_file(self,input_file,output_file,replacemets_list):
+    def _copy_and_parse_user_file(self, input_file, output_file, replacemets_list):
         """Method processes file provided for user and replaces list of keywords, describing user
            and experiment (See comments in User_files_description.xml) with their values
         """
-        fh_targ    = open(output_file,'w')
-        if not fh_targ :
+        fh_targ = open(output_file, 'w')
+        if not fh_targ:
             return
         var_to_replace = replacemets_list.keys()
         with open(input_file) as fh_source:
@@ -480,8 +503,9 @@ class MantidConfigDirectInelastic(object):
                         rez = rez.replace(var, replacemets_list[var])
                 fh_targ.write(rez)
         fh_targ.close()
-#
-    def _copy_user_file_job(self,input_file,output_file,replacement_list=None):
+
+    #
+    def _copy_user_file_job(self, input_file, output_file, replacement_list=None):
         """Method copies file provided into the requested destination
            and replaces keys specified in replacement list dictionary with their
            values if replacement_list is provided.
@@ -495,24 +519,24 @@ class MantidConfigDirectInelastic(object):
         if os.path.isfile(output_file):
             os.remove(output_file)
         if replacement_list is None:
-            shutil.copyfile(input_file,output_file)
+            shutil.copyfile(input_file, output_file)
         else:
-            self._copy_and_parse_user_file(input_file,output_file,replacement_list)
-        os.chmod(output_file,0777)
+            self._copy_and_parse_user_file(input_file, output_file, replacement_list)
+        os.chmod(output_file, 0777)
 
         if platform.system() != 'Windows':
-            os.system("chown {0}:{1} {2}".format(self._user.userID,self._user.rb_id,output_file))
+            os.system("chown {0}:{1} {2}".format(self._user.userID, self._user.rb_id, output_file))
         # Set up the file creation and modification dates to the users start date
         start_date = self._user.start_date
         file_time = time.mktime(start_date.timetuple())
-        os.utime(output_file,(file_time,file_time))
+        os.utime(output_file, (file_time, file_time))
 
-    def _get_file_attributes(self,file_node):
+    def _get_file_attributes(self, file_node):
         """processes xml file_node to retrieve file attributes to copy """
 
         source_file = file_node.getAttribute("file_name")
         if source_file is None:
-            return (None,None)
+            return (None, None)
         target_file = file_node.getAttribute("copy_as")
 
         if target_file is None:
@@ -520,11 +544,12 @@ class MantidConfigDirectInelastic(object):
         else:
             if "$" in target_file:
                 target_file = self._user.replace_variables(target_file)
-        full_source,full_target  = self._fullpath_to_copy(source_file,target_file)
+        full_source, full_target = self._fullpath_to_copy(source_file, target_file)
 
-        return (full_source,full_target)
-#
-    def _parse_replacement_info(self,repl_info):
+        return (full_source, full_target)
+
+    #
+    def _parse_replacement_info(self, repl_info):
         """process dom element 'replacement' and
            returns the  variables with its correspondent value
            to replace variable by their value.
@@ -535,26 +560,28 @@ class MantidConfigDirectInelastic(object):
            and their values are taken from current self._user class
         """
         # what should be replaced in the file
-        source  = repl_info.getAttribute("var")
+        source = repl_info.getAttribute("var")
         if len(source) == 0:
-            raise InvalidArgument('"replace" field of {0} file for instrument {1} has to contain attribute "var" and its value'\
-                                   .format(self._user_files_descr,self._user.instrument))
+            raise InvalidArgument(
+                '"replace" field of {0} file for instrument {1} has to contain attribute "var" and its value' \
+                    .format(self._user_files_descr, self._user.instrument))
         # what should be placed instead of the replacement
-        dest    = repl_info.getAttribute("by_var")
+        dest = repl_info.getAttribute("by_var")
         if len(dest) == 0:
-            raise InvalidArgument('"replace" field of {0} file for instrument {1} has to contain attribute "by_var" and its value'\
-                                   .format(self._user_files_descr,self._user.instrument))
+            raise InvalidArgument(
+                '"replace" field of {0} file for instrument {1} has to contain attribute "by_var" and its value' \
+                    .format(self._user_files_descr, self._user.instrument))
 
         # replace use-specific variables by their values
         if '$' in dest:
             dest = self._user.replace_variables(dest)
-        return (source,dest)
+        return (source, dest)
 
-    def _parse_user_files_description(self,job_description_file):
+    def _parse_user_files_description(self, job_description_file):
         """ Method parses xml file used to describe files to provide to user"""
 
         # mainly for debugging purposes
-        filenames_to_copy=[]
+        filenames_to_copy = []
 
         # does not work if user is not defined
         if self._user is None:
@@ -562,18 +589,18 @@ class MantidConfigDirectInelastic(object):
         # parse job description file, fail down on default behavior if
         # user files description is not there
         try:
-            domObj=minidom.parse(job_description_file)
-        except Exception:
-            input_file,output_file = self._fullpath_to_copy()
-            filenames_to_copy.append((input_file,output_file,None))
+            domObj = minidom.parse(job_description_file)
+        except (StandardError, Warning):
+            input_file, output_file = self._fullpath_to_copy()
+            filenames_to_copy.append((input_file, output_file, None))
             return filenames_to_copy
 
         files_to_copy = domObj.getElementsByTagName("file_to_copy")
 
         # go through all files in the description and define file copying operations
-        for file_node in files_to_copy :
+        for file_node in files_to_copy:
             # retrieve file attributes or its default values if the attributes are missing
-            input_file,output_file =self._get_file_attributes(file_node)
+            input_file, output_file = self._get_file_attributes(file_node)
             if input_file is None:
                 continue
 
@@ -584,32 +611,34 @@ class MantidConfigDirectInelastic(object):
             else:
                 replacement_list = {}
                 for replacement in replacements_info:
-                    source,dest = self._parse_replacement_info(replacement)
-                    replacement_list[source]=dest
-            filenames_to_copy.append((input_file,output_file,replacement_list))
+                    source, dest = self._parse_replacement_info(replacement)
+                    replacement_list[source] = dest
+            filenames_to_copy.append((input_file, output_file, replacement_list))
 
         return filenames_to_copy
-#
-    def get_data_folder_name(self,instr,cycle_ID):
+
+    #
+    def get_data_folder_name(self, instr, cycle_ID):
         """Method to generate a data folder from instrument name and the cycle start date
            (cycle ID)
            The agreement on the naming as currently in ISIS:
            e.g: /archive/NDXMERLIN/Instrument/data/cycle_08_1
         """
         # cycle folder have short form without leading numbers
-        cycle_fold_n =int(cycle_ID[0])-2000
-        folder = os.path.join(self._root_data_folder,'NDX'+instr.upper(),\
-                              "Instrument/data/cycle_{0:02}_{1}".format(cycle_fold_n,str(cycle_ID[1])))
+        cycle_fold_n = int(cycle_ID[0]) - 2000
+        folder = os.path.join(self._root_data_folder, 'NDX' + instr.upper(), \
+                              "Instrument/data/cycle_{0:02}_{1}".format(cycle_fold_n, str(cycle_ID[1])))
         return folder
 
-    def is_inelastic(self,instr_name):
+    def is_inelastic(self, instr_name):
         """Check if the instrument is inelastic"""
         if instr_name in INELASTIC_INSTRUMENTS:
             return True
         else:
             return False
+
     #
-    def init_user(self,fedIDorUser,theUser=None):
+    def init_user(self, fedIDorUser, theUser=None):
         """Define settings, specific to a user
            Supports two interfaces -- old and the new one
            where
@@ -620,7 +649,7 @@ class MantidConfigDirectInelastic(object):
            theUser -- class defining all user's properties including fedID
         """
         if not theUser:
-            if isinstance(fedIDorUser,UserProperties):
+            if isinstance(fedIDorUser, UserProperties):
                 theUser = fedIDorUser
             else:
                 raise RuntimeError("self.init_user(val) has to have val of UserProperty type only and got")
@@ -632,30 +661,32 @@ class MantidConfigDirectInelastic(object):
         for instr in theUser._instrument.values():
             if not self.is_inelastic(instr):
                 raise RuntimeError('Instrument {0} is not among acceptable instruments'.format(instrument))
-        self._user=theUser
+        self._user = theUser
 
         # pylint: disable=W0201
         # its init method so the change is reasonable
-        self._fedid =  theUser.userID
-        user_folder = os.path.join(self._home_path,self._fedid)
+        self._fedid = theUser.userID
+        user_folder = os.path.join(self._home_path, self._fedid)
         if not os.path.exists(user_folder):
             raise RuntimeError("User with fedID {0} does not exist. Create such user folder first".format(self._fedid))
         # pylint: disable=W0212
         # bad practice but I need all rb_dires, not the current one
         for rb_folder in theUser._rb_dirs.values():
             if not os.path.exists(str(rb_folder)):
-                raise RuntimeError("Experiment folder with {0} does not exist. Create such folder first".format(rb_folder))
+                raise RuntimeError(
+                    "Experiment folder with {0} does not exist. Create such folder first".format(rb_folder))
         #
         # how to check cycle folders, they may not be available
-        self._cycle_data_folder=set()
+        self._cycle_data_folder = set()
         # pylint: disable=W0212
-        for date_key,folder_id in theUser._cycle_IDs.items():
-            self._cycle_data_folder.add(self.get_data_folder_name(theUser._instrument[date_key],folder_id))
+        for date_key, folder_id in theUser._cycle_IDs.items():
+            self._cycle_data_folder.add(self.get_data_folder_name(theUser._instrument[date_key], folder_id))
         # Initialize configuration settings
         self._dynamic_configuration = copy.deepcopy(self._dynamic_options_base)
         self._init_config()
+
     #
-    def  _check_server_folders_present(self):
+    def _check_server_folders_present(self):
         """Routine checks all necessary server folder are present"""
         if not os.path.exists(self._mantid_path):
             raise RuntimeError("SERVER ERROR: no correct Mantid path defined at {0}".format(self._mantid_path))
@@ -663,16 +694,18 @@ class MantidConfigDirectInelastic(object):
             raise RuntimeError("SERVER ERROR: no correct home path defined at {0}".format(self._home_path))
         if not os.path.exists(self._script_repo):
             raise RuntimeError(("SERVER ERROR: no correct user script repository defined at {0}\n"
-                                "Check out Mantid script repository from account, which have admin rights").format(self._script_repo))
+                                "Check out Mantid script repository from account, "
+                                "which have admin rights").format(self._script_repo))
         if not os.path.exists(self._map_mask_folder):
             raise RuntimeError(("SERVER ERROR: no correct map/mask folder defined at {0}\n"
-                                "Check out Mantid map/mask files from svn at https://svn.isis.rl.ac.uk/InstrumentFiles/trunk")\
-                                .format(self._map_mask_folder))
+                                "Check out Mantid map/mask files from svn at "
+                                "https://svn.isis.rl.ac.uk/InstrumentFiles/trunk").format(self._map_mask_folder))
 
     def _init_config(self):
         """Execute Mantid properties setup methods"""
         for fun in self._dynamic_options:
             fun()
+
     #
     def _set_default_inst(self):
         """Set up last instrument, deployed by user"""
@@ -681,10 +714,12 @@ class MantidConfigDirectInelastic(object):
             self._dynamic_configuration.append('default.instrument={0}'.format(InstrName))
         else:
             self._dynamic_configuration.append('default.instrument={0}'.format('MARI'))
+
     #
     def _set_script_repo(self):
         """ defines script repository location. By default its option is commented"""
         self._dynamic_configuration.append('#ScriptLocalRepository={0}'.format(self._script_repo))
+
     #
     def _def_python_search_path(self):
         """Define path for Mantid Inelastic python scripts"""
@@ -693,19 +728,20 @@ class MantidConfigDirectInelastic(object):
             raise RuntimeError("Can not define python search path without defined user")
 
         # define main Mantid scripts search path
-        path = os.path.join(self._mantid_path,'scripts/')
+        path = os.path.join(self._mantid_path, 'scripts/')
         for part in self._python_mantid_path:
-            path +=';'+os.path.join(self._mantid_path,part)
+            path += ';' + os.path.join(self._mantid_path, part)
 
         # define and append user scripts search path
         user_path_part = copy.deepcopy(self._python_user_scripts)
         # pylint: disable=W0212
         for instr in self._user._instrument.values():
-            user_path_part.add(os.path.join('direct_inelastic',instr.upper()))
+            user_path_part.add(os.path.join('direct_inelastic', instr.upper()))
         for part in user_path_part:
-            path +=';'+os.path.join(self._script_repo,part)+'/'
+            path += ';' + os.path.join(self._script_repo, part) + '/'
 
         self._dynamic_configuration.append('pythonscripts.directories=' + path)
+
     #
     def _set_rb_directory(self):
         """Set up default save directory, the one where data are saved by default"""
@@ -715,6 +751,7 @@ class MantidConfigDirectInelastic(object):
             self._dynamic_configuration.append('defaultsave.directory={0}'.format(rb_folder))
         else:
             raise RuntimeError("Can not define RB folder without user being defined")
+
     #
     def _set_datasearch_directory(self):
         """Note, map/mask instrument folder is lower case as if loaded from SVN.
@@ -723,75 +760,77 @@ class MantidConfigDirectInelastic(object):
             raise RuntimeError("Can not define Data search path without user being defined")
 
         instr_name = self._user.instrument
-        map_mask_dir  = os.path.abspath(os.path.join('{0}'.format(self._map_mask_folder),\
-                                                     '{0}'.format(str.lower(instr_name))))
+        map_mask_dir = os.path.abspath(os.path.join('{0}'.format(self._map_mask_folder), \
+                                                    '{0}'.format(str.lower(instr_name))))
         # set up all data folders
-        all_data_folders=list(self._cycle_data_folder)
+        all_data_folders = list(self._cycle_data_folder)
         data_dir = os.path.abspath('{0}'.format(all_data_folders[0]))
         for folder in all_data_folders[1:]:
-            data_dir +=';'+os.path.abspath('{0}'.format(folder))
+            data_dir += ';' + os.path.abspath('{0}'.format(folder))
 
         # pylint: disable=W0212
         all_rb_folders = self._user._rb_dirs
         for folder in all_rb_folders.values():
-            data_dir+=';'+os.path.abspath('{0}'.format(folder))
+            data_dir += ';' + os.path.abspath('{0}'.format(folder))
 
-        self._dynamic_configuration.append('datasearch.directories='+map_mask_dir+';'+data_dir)
+        self._dynamic_configuration.append('datasearch.directories=' + map_mask_dir + ';' + data_dir)
+
     #
     def generate_config(self):
         """Save generated Mantid configuration file into user's home folder
            and copy other files, necessary for Mantid to work properly
         """
-        user_path = os.path.join(self._home_path,self._fedid)
-        config_path = os.path.join(user_path,'.mantid')
+        user_path = os.path.join(self._home_path, self._fedid)
+        config_path = os.path.join(user_path, '.mantid')
         if not os.path.exists(config_path):
             err = os.makedirs(config_path)
             if err:
                 raise RuntimeError('can not find or create Mantid configuration path {0}'.format(config_path))
 
-        config_file = os.path.join(config_path,'Mantid.user.properties')
+        config_file = os.path.join(config_path, 'Mantid.user.properties')
         if self.config_need_replacing(config_file):
             self._write_user_config_file(config_file)
         else:
             pass
         if platform.system() != 'Windows':
-            os.system('chown -R {0}:{0} {1}'.format(self._fedid,config_path))
+            os.system('chown -R {0}:{0} {1}'.format(self._fedid, config_path))
 
         self.copy_reduction_sample(self.user_file_description)
         #
         self.make_map_mask_links(user_path)
+
     #
-    def make_map_mask_links(self,user_path):
+    def make_map_mask_links(self, user_path):
         """The method generates references to map files and places these references
            to the user's desktop.
         """
         # the path where to set up links, important to user
-        links_path = os.path.join(user_path,self._user_specific_link_path)
+        links_path = os.path.join(user_path, self._user_specific_link_path)
         if not os.path.exists(links_path):
             os.makedirs(links_path)
             # the path have to belong to user
             if platform.system() != 'Windows':
-                os.system('chown -R {0}:{0} {1}'.format(self._fedid,links_path))
+                os.system('chown -R {0}:{0} {1}'.format(self._fedid, links_path))
 
-        map_mask_folder_link = os.path.join(links_path,self._map_mask_link_name)
+        map_mask_folder_link = os.path.join(links_path, self._map_mask_link_name)
         if os.path.exists(map_mask_folder_link):
             return
         # create link to map mask folder
         if platform.system() == 'Windows':
             # the script is not intended to run on Windows, so this is just for testing
-            mmfl = map_mask_folder_link.replace('/','\\')
-            mmf  = self._map_mask_folder.replace('/','\\')
-            os.system("mklink /J {0} {1}".format(mmfl,mmf))
+            mmfl = map_mask_folder_link.replace('/', '\\')
+            mmf = self._map_mask_folder.replace('/', '\\')
+            os.system("mklink /J {0} {1}".format(mmfl, mmf))
         else:
-            os.system('ln -s {0} {1}'.format(self._map_mask_folder,map_mask_folder_link))
+            os.system('ln -s {0} {1}'.format(self._map_mask_folder, map_mask_folder_link))
 
-    def _write_user_config_file(self,config_file_name):
+    def _write_user_config_file(self, config_file_name):
         """Write existing dynamic configuration from memory to
            user defined configuration file
         """
         # pylint: disable=C0103
         # What is wrong with fp variable name here?
-        fp = open(config_file_name,'w')
+        fp = open(config_file_name, 'w')
         fp.write(self._header)
         fp.write('## -----   Generated user properties ------------ \n')
         fp.write('##\n')
@@ -801,12 +840,12 @@ class MantidConfigDirectInelastic(object):
         fp.write(self._footer)
         fp.close()
         if platform.system() != 'Windows':
-            os.system('chown -R {0}:{0} {1}'.format(self._fedid,config_file_name))
-        # Set up configuration for the specific time, which should change only if user 
+            os.system('chown -R {0}:{0} {1}'.format(self._fedid, config_file_name))
+        # Set up configuration for the specific time, which should change only if user
         # modified this configuration
         start_date = self._user.start_date
         file_time = time.mktime(start_date.timetuple())
-        os.utime(config_file_name,(file_time,file_time))
+        os.utime(config_file_name, (file_time, file_time))
 
 
 if __name__ == "__main__":
@@ -815,51 +854,49 @@ if __name__ == "__main__":
         print "usage: Config.py userID instrument RBNumber cycleID start_date"
         exit()
 
-    argi  = sys.argv[1:]
-    user = UserProperties(*argi)
-
+    ARGI = sys.argv[1:]
+    USER = UserProperties(*ARGI)
 
     if platform.system() == 'Windows':
-        sys.path.insert(0,'c:/Mantid/scripts/Inelastic/Direct')
+        sys.path.insert(0, 'c:/Mantid/scripts/Inelastic/Direct')
 
-        base = 'd:/Data/Mantid_Testing/config_script_test_folder'
-        analysisDir= base
+        BASE = 'd:/Data/Mantid_Testing/config_script_test_folder'
+        ANALYSIS_DIR = BASE
 
-        MantidDir = r"c:\Mantid\_builds\br_master\bin\Release"
-        UserScriptRepoDir = os.path.join(analysisDir,"UserScripts")
-        MapMaskDir =  os.path.join(analysisDir,"InstrumentFiles")
+        MANTID_DIR = r"c:\Mantid\_builds\br_master\bin\Release"
+        USER_SCRIPT_REPO_DIR = os.path.join(ANALYSIS_DIR, "UserScripts")
+        MAP_MASK_DIR = os.path.join(ANALYSIS_DIR, "InstrumentFiles")
 
-        rootDir = os.path.join(base,'users')
+        ROOT_DIR = os.path.join(BASE, 'users')
     else:
-        sys.path.insert(0,'/opt/Mantid/scripts/Inelastic/Direct/')
-        #sys.path.insert(0,'/opt/mantidnightly/scripts/Inelastic/Direct/')
+        sys.path.insert(0, '/opt/Mantid/scripts/Inelastic/Direct/')
+        # sys.path.insert(0,'/opt/mantidnightly/scripts/Inelastic/Direct/')
 
 
-        MantidDir = '/opt/Mantid'
-        MapMaskDir = '/usr/local/mprogs/InstrumentFiles/'
-        UserScriptRepoDir = '/opt/UserScripts'
+        MANTID_DIR = '/opt/Mantid'
+        MAP_MASK_DIR = '/usr/local/mprogs/InstrumentFiles/'
+        USER_SCRIPT_REPO_DIR = '/opt/UserScripts'
         home = '/home'
         #
-        rootDir = "/home/"
-        analysisDir = "/instrument/"
+        ROOT_DIR = "/home/"
+        ANALYSIS_DIR = "/instrument/"
 
     # initialize Mantid configuration
 
-    from ISISDirecInelasticConfig import MantidConfigDirectInelastic,UserProperties
+    from ISISDirecInelasticConfig import MantidConfigDirectInelastic, UserProperties
 
-    mcf = MantidConfigDirectInelastic(MantidDir,rootDir,UserScriptRepoDir,MapMaskDir)
+    MCF = MantidConfigDirectInelastic(MANTID_DIR, ROOT_DIR, USER_SCRIPT_REPO_DIR, MAP_MASK_DIR)
     print "Successfully initialized ISIS Inelastic Configuration script generator"
 
+    RB_USER_FOLDER = os.path.join(MCF._home_path, USER.userID)
+    USER.rb_dir = RB_USER_FOLDER
+    if not USER.rb_dir_exist:
 
-
-    rb_user_folder = os.path.join(mcf._home_path,user.userID)
-    user.rb_dir = rb_user_folder
-    if not user.rb_dir_exist:
-        print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(user.rb_dir,user.userID)
+        print "RB folder {0} for user {1} should exist and be accessible to configure this user".format(USER.rb_dir,
+                                                                                                        USER.userID)
         exit()
     # Configure user
-    mcf.init_user(user.userID,user)
-    mcf.generate_config()
-    print "Successfully Configured user: {0} for instrument {1} and RBNum: {2}"\
-           .format(user.userID,user.instrument,user.rb_folder)
-
+    MCF.init_user(USER.userID, USER)
+    MCF.generate_config()
+    print "Successfully Configured user: {0} for instrument {1} and RBNum: {2}" \
+        .format(USER.userID, USER.instrument, USER.rb_folder)

--- a/scripts/Inelastic/IndirectNeutron.py
+++ b/scripts/Inelastic/IndirectNeutron.py
@@ -1,4 +1,4 @@
-#pylint: disable=invalid-name,too-many-arguments
+# pylint: disable=invalid-name,too-many-arguments, redefined-builtin, too-many-locals
 
 """
 Force for ILL backscattering raw
@@ -9,26 +9,28 @@ from mantid.simpleapi import *
 from mantid import config, logger, mtd, FileFinder
 import sys, math, os.path, numpy as np
 from IndirectCommon import StartTime, EndTime, ExtractFloat, ExtractInt, getEfixed
+
 MTD_PLOT = import_mantidplot()
+
 
 #  Routines for Ascii file of raw data
 
-def Iblock(a,first):                                 #read Ascii block of Integers
+def Iblock(a, first):  # read Ascii block of Integers
     line1 = a[first]
-    line2 = a[first+1]
+    line2 = a[first + 1]
     val = ExtractInt(line2)
     numb = val[0]
-    lines=numb/10
-    last = numb-10*lines
+    lines = numb / 10
+    last = numb - 10 * lines
     if line1.startswith('I'):
         error = ''
     else:
-        error = 'NOT an I block starting at line ' +str(first)
+        error = 'NOT an I block starting at line ' + str(first)
         logger.information('ERROR *** ' + error)
         sys.exit(error)
     ival = []
     for m in range(0, lines):
-        mm = first+2+m
+        mm = first + 2 + m
         val = ExtractInt(a[mm])
         for n in range(0, 10):
             ival.append(val[n])
@@ -37,24 +39,25 @@ def Iblock(a,first):                                 #read Ascii block of Intege
     for n in range(0, last):
         ival.append(val[n])
     mm += 1
-    return mm,ival                                       #values as list
+    return mm, ival  # values as list
 
-def Fblock(a,first):                                 #read Ascii block of Floats
+
+def Fblock(a, first):  # read Ascii block of Floats
     line1 = a[first]
-    line2 = a[first+1]
+    line2 = a[first + 1]
     val = ExtractInt(line2)
     numb = val[0]
-    lines=numb/5
-    last = numb-5*lines
+    lines = numb / 5
+    last = numb - 5 * lines
     if line1.startswith('F'):
-        error= ''
+        error = ''
     else:
-        error = 'NOT an F block starting at line ' +str(first)
+        error = 'NOT an F block starting at line ' + str(first)
         logger.information('ERROR *** ' + error)
         sys.exit(error)
     fval = []
     for m in range(0, lines):
-        mm = first+2+m
+        mm = first + 2 + m
         val = ExtractFloat(a[mm])
         for n in range(0, 5):
             fval.append(val[n])
@@ -63,46 +66,48 @@ def Fblock(a,first):                                 #read Ascii block of Floats
     for n in range(0, last):
         fval.append(val[n])
     mm += 1
-    return mm,fval                                       #values as list
+    return mm, fval  # values as list
 
-def ReadIbackGroup(a,first):                           #read Ascii block of spectrum values
+
+def ReadIbackGroup(a, first):  # read Ascii block of spectrum values
     x = []
     y = []
     e = []
     next = first
     line1 = a[next]
     next += 1
-    val = ExtractInt(a[next])
+    _val = ExtractInt(a[next])
     if line1.startswith('S'):
         error = ''
     else:
-        error = 'NOT an S block starting at line ' +str(first)
+        error = 'NOT an S block starting at line ' + str(first)
         logger.information('ERROR *** ' + error)
         sys.exit(error)
     next += 1
-    next,Ival = Iblock(a,next)
+    next, Ival = Iblock(a, next)
     for m in range(0, len(Ival)):
         x.append(float(m))
         yy = float(Ival[m])
         y.append(yy)
         ee = math.sqrt(yy)
         e.append(ee)
-    return next,x,y,e                                #values of x,y,e as lists
+    return next, x, y, e  # values of x,y,e as lists
+
 
 # Get the path to the file
 # checks if we already know the path, else
 # returns searches of the file based on run number and instrument
-def getFilePath(run,ext,instr):
+def getFilePath(run, ext, instr):
     path = None
     fname = None
     if os.path.isfile(run):
-        #using full file path
+        # using full file path
         path = run
-        #base name less extension
+        # base name less extension
         base = os.path.basename(path)
         fname = os.path.splitext(base)[0]
     else:
-        #using run number
+        # using run number
         path = FileFinder.getFullPath(instr + "_" + run + ext)
         fname = instr + "_" + run
 
@@ -111,6 +116,7 @@ def getFilePath(run,ext,instr):
     else:
         error = 'ERROR *** Could not find ' + ext + ' file: ' + fname
         sys.exit(error)
+
 
 # Load an ascii/inx file
 def loadFile(path):
@@ -127,158 +133,161 @@ def loadFile(path):
         error = 'ERROR *** Could not load ' + path
         sys.exit(error)
 
-def IbackStart(instr,run,ana,refl,rejectZ,useM,mapPath,Plot,Save):      #Ascii start routine
+
+def IbackStart(instr, run, ana, refl, rejectZ, useM, mapPath, Plot, Save):  # Ascii start routine
     StartTime('Iback')
     workdir = config['defaultsave.directory']
 
-    path, fname = getFilePath(run,'.asc',instr)
+    path, fname = getFilePath(run, '.asc', instr)
 
     logger.information('Reading file : ' + path)
 
     asc = loadFile(path)
-    lasc = len(asc)
+    _lasc = len(asc)
 
-# raw head
+    # raw head
     text = asc[1]
     run = text[:8]
     first = 5
-    next,Ival = Iblock(asc,first)
+    next, _Ival = Iblock(asc, first)
     next += 2
-    title = asc[next]    # title line
+    title = asc[next]  # title line
     next += 1
-    text = asc[next]   # user line
-    user = text[20:32]
-    time = text[40:50]
-    next += 6           # 5 lines of text
-# back head1
-    next,Fval = Fblock(asc,next)
+    text = asc[next]  # user line
+    _user = text[20:32]
+    _time = text[40:50]
+    next += 6  # 5 lines of text
+    # back head1
+    next, Fval = Fblock(asc, next)
     if instr == 'IN10':
         freq = Fval[89]
     if instr == 'IN16':
         freq = Fval[2]
         amp = Fval[3]
         wave = Fval[69]
-        Ef = 81.787/(4.0*wave*wave)
+        _Ef = 81.787 / (4.0 * wave * wave)
         npt = int(Fval[6])
         nsp = int(Fval[7])
-# back head2
-    next,Fval = Fblock(asc,next)
-    k0 = 4.0*math.pi/wave
-    d2r = math.pi/180.0
+    # back head2
+    next, Fval = Fblock(asc, next)
+    _k0 = 4.0 * math.pi / wave
+    _d2r = math.pi / 180.0
     theta = []
-    Q = []
+    _Q = []
     for m in range(0, nsp):
         theta.append(Fval[m])
-# raw spectra
-    val = ExtractInt(asc[next+3])
+    # raw spectra
+    val = ExtractInt(asc[next + 3])
     npt = val[0]
-    lgrp=5+npt/10
-    val = ExtractInt(asc[next+1])
+    lgrp = 5 + npt / 10
+    val = ExtractInt(asc[next + 1])
     if instr == 'IN10':
         nsp = int(val[2])
     logger.information('Number of spectra : ' + str(nsp))
-# read monitor
-    nmon = next+nsp*lgrp
-    nm,xm,ym,em = ReadIbackGroup(asc,nmon)
-# monitor calcs
+    # read monitor
+    nmon = next + nsp * lgrp
+    _nm, _xm, ym, em = ReadIbackGroup(asc, nmon)
+    # monitor calcs
     imin = 0
     ymax = 0
     for m in range(0, 20):
         if ym[m] > ymax:
-            imin=m
-            ymax=ym[m]
+            imin = m
+            ymax = ym[m]
     npt = len(ym)
     imax = npt
     ymax = 0
-    for m in range(npt-1, npt-20, -1):
+    for m in range(npt - 1, npt - 20, -1):
         if ym[m] > ymax:
-            imax=m
-            ymax=ym[m]
-    new=imax-imin
-    imid=new/2+1
+            imax = m
+            ymax = ym[m]
+    new = imax - imin
+    imid = new / 2 + 1
     if instr == 'IN10':
-        DRV=18.706                            # fast drive
-        vmax=freq*DRV
+        DRV = 18.706  # fast drive
+        vmax = freq * DRV
     if instr == 'IN16':
-        vmax=1.2992581918414711e-4*freq*amp*2.0/wave     #max energy
-    dele=2.0*vmax/new
+        vmax = 1.2992581918414711e-4 * freq * amp * 2.0 / wave  # max energy
+    dele = 2.0 * vmax / new
     xMon = []
     yOut = []
     eOut = []
-    for m in range(0, new+1):
-        xe = (m-imid)*dele
-        mm = m+imin
+    for m in range(0, new + 1):
+        xe = (m - imid) * dele
+        mm = m + imin
         xMon.append(xe)
-        yOut.append(ym[mm]/100.0)
-        eOut.append(em[mm]/10.0)
-    xMon.append(2*xMon[new-1]-xMon[new-2])
+        yOut.append(ym[mm] / 100.0)
+        eOut.append(em[mm] / 10.0)
+    xMon.append(2 * xMon[new - 1] - xMon[new - 2])
     monWS = '__Mon'
-    CreateWorkspace(OutputWorkspace=monWS, DataX=xMon, DataY=yOut, DataE=eOut,\
-        Nspec=1, UnitX='DeltaE')
-#
-    Qaxis = ''
+    CreateWorkspace(OutputWorkspace=monWS, DataX=xMon, DataY=yOut, DataE=eOut, \
+                    Nspec=1, UnitX='DeltaE')
+    #
+    _Qaxis = ''
     xDat = []
     yDat = []
     eDat = []
     tot = []
     for n in range(0, nsp):
-        next,xd,yd,ed = ReadIbackGroup(asc,next)
+        next, _xd, yd, ed = ReadIbackGroup(asc, next)
         tot.append(sum(yd))
-        logger.information('Spectrum ' + str(n+1) +' at angle '+ str(theta[n])+\
-                      ' ; Total counts = '+str(sum(yd)))
-        for m in range(0, new+1):
-            mm = m+imin
+        logger.information('Spectrum ' + str(n + 1) + ' at angle ' + str(theta[n]) + \
+                           ' ; Total counts = ' + str(sum(yd)))
+        for m in range(0, new + 1):
+            mm = m + imin
             xDat.append(xMon[m])
             yDat.append(yd[mm])
             eDat.append(ed[mm])
         if n != 0:
-            Qaxis += ','
-        xDat.append(2*xDat[new-1]-xDat[new-2])
-        Qaxis += str(theta[n])
-    ascWS = fname +'_' +ana+refl +'_asc'
-    outWS = fname +'_' +ana+refl +'_red'
-    CreateWorkspace(OutputWorkspace=ascWS, DataX=xDat, DataY=yDat, DataE=eDat,\
-        Nspec=nsp, UnitX='DeltaE')
-    Divide(LHSWorkspace=ascWS, RHSWorkspace=monWS, OutputWorkspace=ascWS,\
-        AllowDifferentNumberSpectra=True)
-    DeleteWorkspace(monWS)                                # delete monitor WS
-    InstrParas(ascWS,instr,ana,refl)
-    efixed = RunParas(ascWS,instr,run,title)
-    ChangeAngles(ascWS,instr,theta)
+            _Qaxis += ','
+        xDat.append(2 * xDat[new - 1] - xDat[new - 2])
+        _Qaxis += str(theta[n])
+    ascWS = fname + '_' + ana + refl + '_asc'
+    outWS = fname + '_' + ana + refl + '_red'
+    CreateWorkspace(OutputWorkspace=ascWS, DataX=xDat, DataY=yDat, DataE=eDat, \
+                    Nspec=nsp, UnitX='DeltaE')
+    Divide(LHSWorkspace=ascWS, RHSWorkspace=monWS, OutputWorkspace=ascWS, \
+           AllowDifferentNumberSpectra=True)
+    DeleteWorkspace(monWS)  # delete monitor WS
+    InstrParas(ascWS, instr, ana, refl)
+    _efixed = RunParas(ascWS, instr, run, title)
+    ChangeAngles(ascWS, instr, theta)
     if useM:
         map = ReadMap(mapPath)
-        UseMap(ascWS,map)
+        UseMap(ascWS, map)
     if rejectZ:
-        RejectZero(ascWS,tot)
+        RejectZero(ascWS, tot)
     if useM == False and rejectZ == False:
         CloneWorkspace(InputWorkspace=ascWS, OutputWorkspace=outWS)
     if Save:
-        opath = os.path.join(workdir,outWS+'.nxs')
+        opath = os.path.join(workdir, outWS + '.nxs')
         SaveNexusProcessed(InputWorkspace=outWS, Filename=opath)
         logger.information('Output file : ' + opath)
     if Plot:
-        plotForce(outWS,Plot)
+        plotForce(outWS, Plot)
     EndTime('Iback')
+
 
 # Routines for Inx ascii file
 
-def ReadInxGroup(asc,n,lgrp):                  # read ascii x,y,e
+def ReadInxGroup(asc, n, lgrp):  # read ascii x,y,e
     x = []
     y = []
     e = []
-    first = n*lgrp
-    last = (n+1)*lgrp
-    val = ExtractFloat(asc[first+2])
+    first = n * lgrp
+    last = (n + 1) * lgrp
+    val = ExtractFloat(asc[first + 2])
     Q = val[0]
-    for m in range(first+4, last):
+    for m in range(first + 4, last):
         val = ExtractFloat(asc[m])
-        x.append(val[0]/1000.0)
+        x.append(val[0] / 1000.0)
         y.append(val[1])
         e.append(val[2])
     npt = len(x)
-    return Q,npt,x,y,e                                 #values of x,y,e as lists
+    return Q, npt, x, y, e  # values of x,y,e as lists
 
-def InxStart(instr,run,ana,refl,rejectZ,useM,mapPath,Plot,Save):
+
+def InxStart(instr, run, ana, refl, rejectZ, useM, mapPath, Plot, Save):
     StartTime('Inx')
     workdir = config['defaultsave.directory']
 
@@ -292,76 +301,77 @@ def InxStart(instr,run,ana,refl,rejectZ,useM,mapPath,Plot,Save):
     val = ExtractInt(asc[0])
     lgrp = int(val[0])
     ngrp = int(val[2])
-    npt = int(val[7])
+    _npt = int(val[7])
     title = asc[1]
-    ltot = ngrp*lgrp
+    ltot = ngrp * lgrp
     logger.information('Number of spectra : ' + str(ngrp))
     if ltot == lasc:
         error = ''
     else:
-        error = 'file ' +filext+ ' should be ' +str(ltot)+ ' lines'
+        error = 'file ' + filext + ' should be ' + str(ltot) + ' lines'
         logger.information('ERROR *** ' + error)
         sys.exit(error)
-    Qaxis = ''
+    _Qaxis = ''
     xDat = []
     yDat = []
     eDat = []
     ns = 0
     Q = []
     tot = []
-    for m in range(0,ngrp):
-        Qq,nd,xd,yd,ed = ReadInxGroup(asc,m,lgrp)
+    for m in range(0, ngrp):
+        Qq, nd, xd, yd, ed = ReadInxGroup(asc, m, lgrp)
         tot.append(sum(yd))
-        logger.information('Spectrum ' + str(m+1) +' at Q= '+ str(Qq)+' ; Total counts = '+str(tot))
+        logger.information('Spectrum ' + str(m + 1) + ' at Q= ' + str(Qq) + ' ; Total counts = ' + str(tot))
         if ns != 0:
-            Qaxis += ','
-        Qaxis += str(Qq)
+            _Qaxis += ','
+        _Qaxis += str(Qq)
         Q.append(Qq)
-        for n in range(0,nd):
+        for n in range(0, nd):
             xDat.append(xd[n])
             yDat.append(yd[n])
             eDat.append(ed[n])
-        xDat.append(2*xd[nd-1]-xd[nd-2])
+        xDat.append(2 * xd[nd - 1] - xd[nd - 2])
         ns += 1
-    ascWS = fname +'_' +ana+refl +'_inx'
-    outWS = fname +'_' +ana+refl +'_red'
-    CreateWorkspace(OutputWorkspace=ascWS, DataX=xDat, DataY=yDat, DataE=eDat,\
-        Nspec=ns, UnitX='DeltaE')
-    InstrParas(ascWS,instr,ana,refl)
-    efixed = RunParas(ascWS,instr,0,title)
-    pi4 = 4.0*math.pi
-    wave=1.8*math.sqrt(25.2429/efixed)
+    ascWS = fname + '_' + ana + refl + '_inx'
+    outWS = fname + '_' + ana + refl + '_red'
+    CreateWorkspace(OutputWorkspace=ascWS, DataX=xDat, DataY=yDat, DataE=eDat, \
+                    Nspec=ns, UnitX='DeltaE')
+    InstrParas(ascWS, instr, ana, refl)
+    efixed = RunParas(ascWS, instr, 0, title)
+    pi4 = 4.0 * math.pi
+    wave = 1.8 * math.sqrt(25.2429 / efixed)
     theta = []
-    for n in range(0,ngrp):
-        qw = wave*Q[n]/pi4
-        ang = 2.0*math.degrees(math.asin(qw))
+    for n in range(0, ngrp):
+        qw = wave * Q[n] / pi4
+        ang = 2.0 * math.degrees(math.asin(qw))
         theta.append(ang)
-    ChangeAngles(ascWS,instr,theta)
+    ChangeAngles(ascWS, instr, theta)
     if useM:
         map = ReadMap(mapPath)
-        UseMap(ascWS,map)
+        UseMap(ascWS, map)
     if rejectZ:
-        RejectZero(ascWS,tot)
+        RejectZero(ascWS, tot)
     if useM == False and rejectZ == False:
         CloneWorkspace(InputWorkspace=ascWS, OutputWorkspace=outWS)
     if Save:
-        opath = os.path.join(workdir,outWS+'.nxs')
+        opath = os.path.join(workdir, outWS + '.nxs')
         SaveNexusProcessed(InputWorkspace=outWS, Filename=opath)
         logger.information('Output file : ' + opath)
     if Plot:
-        plotForce(outWS,Plot)
+        plotForce(outWS, Plot)
     EndTime('Inx')
+
 
 # General routines
 
-def RejectZero(inWS,tot):
-    nin = mtd[inWS].getNumberHistograms()                      # no. of hist/groups in sam
+def RejectZero(inWS, tot):
+    nin = mtd[inWS].getNumberHistograms()  # no. of hist/groups in sam
     nout = 0
-    outWS = inWS[:-3]+'red'
+    outWS = inWS[:-3] + 'red'
     for n in range(0, nin):
         if tot[n] > 0:
-            ExtractSingleSpectrum(InputWorkspace=inWS, OutputWorkspace='__tmp',\
-                WorkspaceIndex=n)
+            ExtractSingleSpectrum(InputWorkspace=inWS, OutputWorkspace='__tmp', \
+                                  WorkspaceIndex=n)
             if nout == 0:
                 RenameWorkspace(InputWorkspace='__tmp', OutputWorkspace=outWS)
             else:
@@ -369,80 +379,86 @@ def RejectZero(inWS,tot):
                                   CheckOverlapping=False)
             nout += 1
         else:
-            logger.information('** spectrum '+str(n+1)+' rejected')
+            logger.information('** spectrum ' + str(n + 1) + ' rejected')
+
 
 def ReadMap(path):
-    workdir = config['defaultsave.directory']
+    _workdir = config['defaultsave.directory']
 
     asc = loadFile(path)
 
     lasc = len(asc)
-    logger.information('Map file : ' + path +' ; spectra = ' +str(lasc-1))
+    logger.information('Map file : ' + path + ' ; spectra = ' + str(lasc - 1))
     val = ExtractInt(asc[0])
     numb = val[0]
-    if numb != (lasc-1):
+    if numb != (lasc - 1):
         error = 'Number of lines  not equal to number of spectra'
         logger.error(error)
         sys.exit(error)
     map = []
-    for n in range(1,lasc):
+    for n in range(1, lasc):
         val = ExtractInt(asc[n])
         map.append(val[1])
     return map
 
+
 def UseMap(inWS, map):
-    nin = mtd[inWS].getNumberHistograms()                      # no. of hist/groups in sam
+    nin = mtd[inWS].getNumberHistograms()  # no. of hist/groups in sam
     nout = 0
-    outWS = inWS[:-3]+'red'
+    outWS = inWS[:-3] + 'red'
     for n in range(0, nin):
         if map[n] == 1:
-            ExtractSingleSpectrum(InputWorkspace=inWS, OutputWorkspace='__tmp',\
-                WorkspaceIndex=n)
+            ExtractSingleSpectrum(InputWorkspace=inWS, OutputWorkspace='__tmp', \
+                                  WorkspaceIndex=n)
             if nout == 0:
                 RenameWorkspace(InputWorkspace='__tmp', OutputWorkspace=outWS)
             else:
                 ConjoinWorkspaces(InputWorkspace1=outWS, InputWorkspace2='__tmp',
                                   CheckOverlapping=False)
             nout += 1
-            logger.information('** spectrum '+str(n+1)+' mapped')
+            logger.information('** spectrum ' + str(n + 1) + ' mapped')
         else:
-            logger.information('** spectrum '+str(n+1)+' skipped')
+            logger.information('** spectrum ' + str(n + 1) + ' skipped')
 
-def plotForce(inWS,Plot):
+
+def plotForce(inWS, Plot):
     if Plot == 'Spectrum' or Plot == 'Both':
         nHist = mtd[inWS].getNumberHistograms()
-        if nHist > 10 :
+        if nHist > 10:
             nHist = 10
         plot_list = []
         for i in range(0, nHist):
             plot_list.append(i)
-        MTD_PLOT.plotSpectrum(inWS,plot_list)
+        MTD_PLOT.plotSpectrum(inWS, plot_list)
     if Plot == 'Contour' or Plot == 'Both':
         MTD_PLOT.importMatrixWorkspace(inWS).plotGraph2D()
 
-def ChangeAngles(inWS,instr,theta):
+
+def ChangeAngles(inWS, instr, theta):
     workdir = config['defaultsave.directory']
-    filename = instr+'_angles.txt'
+    filename = instr + '_angles.txt'
     path = os.path.join(workdir, filename)
     logger.information('Creating angles file : ' + path)
     handle = open(path, 'w')
     head = 'spectrum,theta'
-    handle.write(head +" \n" )
-    for n in range(0,len(theta)):
-        handle.write(str(n+1) +'   '+ str(theta[n]) +"\n" )
-        logger.information('Spectrum ' +str(n+1)+ ' = '+str(theta[n]))
+    handle.write(head + " \n")
+    for n in range(0, len(theta)):
+        handle.write(str(n + 1) + '   ' + str(theta[n]) + "\n")
+        logger.information('Spectrum ' + str(n + 1) + ' = ' + str(theta[n]))
     handle.close()
-    UpdateInstrumentFromFile(Workspace=inWS, Filename=path, MoveMonitors=False, IgnorePhi=False,\
-        AsciiHeader=head)
+    UpdateInstrumentFromFile(Workspace=inWS, Filename=path, MoveMonitors=False, IgnorePhi=False, \
+                             AsciiHeader=head)
 
-def InstrParas(ws,instr,ana,refl):
+
+def InstrParas(ws, instr, ana, refl):
     idf_dir = config['instrumentDefinition.directory']
     idf = idf_dir + instr + '_Definition.xml'
     LoadInstrument(Workspace=ws, Filename=idf, RewriteSpectraMap=False)
     ipf = idf_dir + instr + '_' + ana + '_' + refl + '_Parameters.xml'
     LoadParameterFile(Workspace=ws, Filename=ipf)
 
-def RunParas(ascWS,instr,run,title):
+
+def RunParas(ascWS, _instr, run, title):
     ws = mtd[ascWS]
     inst = ws.getInstrument()
     AddSampleLog(Workspace=ascWS, LogName="facility", LogType="String", LogText="ILL")
@@ -451,122 +467,124 @@ def RunParas(ascWS,instr,run,title):
     efixed = getEfixed(ascWS)
 
     facility = ws.getRun().getLogData('facility').value
-    logger.information('Facility is ' +facility)
+    logger.information('Facility is ' + facility)
     runNo = ws.getRun()['run_number'].value
     runTitle = ws.getRun()['run_title'].value.strip()
     logger.information('Run : ' + str(runNo) + ' ; Title : ' + runTitle)
     an = inst.getStringParameter('analyser')[0]
     ref = inst.getStringParameter('reflection')[0]
-    logger.information('Analyser : ' +an+ref +' with energy = ' + str(efixed))
+    logger.information('Analyser : ' + an + ref + ' with energy = ' + str(efixed))
 
     return efixed
+
 
 # IN13 routines
 # These routines are specific to loading data for the ILL IN13 instrument
 
-def IN13Start(instr,run,ana,refl,rejectZ,useM,mapPath,Plot,Save):      #Ascii start routine
+def IN13Start(instr, run, ana, refl, _rejectZ, _useM, _mapPath, Plot, Save):  # Ascii start routine
     StartTime('IN13')
-    samWS = IN13Read(instr,run,ana,refl,Plot,Save)
+    _samWS = IN13Read(instr, run, ana, refl, Plot, Save)
     EndTime('IN13')
 
-def IN13Read(instr,run,ana,refl,Plot,Save):      #Ascii start routine
+
+def IN13Read(instr, run, ana, refl, Plot, Save):  # Ascii start routine
     workdir = config['defaultsave.directory']
 
-    path, fname = getFilePath(run,'.asc', instr)
+    path, fname = getFilePath(run, '.asc', instr)
 
     logger.information('Reading file : ' + path)
 
     asc = loadFile(path)
-    lasc = len(asc)
+    _lasc = len(asc)
 
-# header block
+    # header block
     text = asc[1]
     run = text[:8]
-    text = asc[4]    # run line
+    text = asc[4]  # run line
     instr = text[:4]
-    time = text[14:33]   # user line
-    next,Ival = Iblock(asc,5)
+    _time = text[14:33]  # user line
+    next, Ival = Iblock(asc, 5)
     nsubsp = Ival[0]
-    nspec = Ival[153]-2
-# text block
+    nspec = Ival[153] - 2
+    # text block
     text = asc[25]
     title = text[:20]
-# para1 block
-    next,Fval = Fblock(asc,32)
+    # para1 block
+    next, Fval = Fblock(asc, 32)
     ntemp = int(Fval[6])
-    f1 = ntemp/10
+    f1 = ntemp / 10
     ltemp = int(f1)
-    f2 = f1 -10*ltemp
+    f2 = f1 - 10 * ltemp
     if f2 >= 0.:
-        ltemp = ltemp +1
-    wave = 2.0*Fval[81]
+        ltemp = ltemp + 1
+    wave = 2.0 * Fval[81]
 
     logger.information('No. sub-spectra : ' + str(nsubsp))
     logger.information('No. spectra : ' + str(nspec))
-    logger.information('Scan type : ' + str(int(Fval[8]))+\
-        ' ; Average energy : ' + str(Fval[9]))
-    logger.information('CaF2 lattice : ' + str(Fval[81])+\
-        ' ; Graphite lattice : ' + str(Fval[82]))
+    logger.information('Scan type : ' + str(int(Fval[8])) + \
+                       ' ; Average energy : ' + str(Fval[9]))
+    logger.information('CaF2 lattice : ' + str(Fval[81]) + \
+                       ' ; Graphite lattice : ' + str(Fval[82]))
     logger.information('Wavelength : ' + str(wave))
     logger.information('No. temperatures : ' + str(ntemp))
     logger.information('No. temperature lines : ' + str(ltemp))
 
-# para2 block
-    next,Fval = Fblock(asc,next)
+    # para2 block
+    next, Fval = Fblock(asc, next)
     angles = Fval[:nspec]
     logger.information('Angles : ' + str(angles))
-    lspec = 4 +ltemp
-# monitors
-    psd = next + (nspec+2048)*lspec
+    lspec = 4 + ltemp
+    # monitors
+    psd = next + (nspec + 2048) * lspec
     l1m1 = psd + 1
-    txt = asc[l1m1]
-    l2m1 = l1m1 +3
+    _txt = asc[l1m1]
+    l2m1 = l1m1 + 3
     mon1 = ExtractFloat(asc[l2m1])
-    logger.information('Mon1 : Line '+str(l2m1)+' : ' + asc[l2m1])
-# raw spectra
+    logger.information('Mon1 : Line ' + str(l2m1) + ' : ' + asc[l2m1])
+    # raw spectra
     first = next
     xDat = angles
     y2D = []
     e2D = []
-    for n in range(0,nspec):
+    for n in range(0, nspec):
         ylist = []
         elist = []
-        l1 = first + lspec*n + 1
-        logger.information('Line '+str(l1)+' : ' + asc[l1])
-        for l in range(0,ltemp):
+        l1 = first + lspec * n + 1
+        logger.information('Line ' + str(l1) + ' : ' + asc[l1])
+        for l in range(0, ltemp):
             l2 = l1 + 3 + l
             val = ExtractFloat(asc[l2])
             nval = len(val)
-            for m in range(0,nval):
-                ylist.append(val[m]/mon1[m])
-                elist.append(math.sqrt(val[m])/mon1[m])
+            for m in range(0, nval):
+                ylist.append(val[m] / mon1[m])
+                elist.append(math.sqrt(val[m]) / mon1[m])
         y2D.append(ylist)
         e2D.append(elist)
-# create WS
+    # create WS
     npt = len(xDat)
-    xDat.append(2*xDat[npt-1]-xDat[npt-2])
+    xDat.append(2 * xDat[npt - 1] - xDat[npt - 2])
     ascWS = fname + '_' + ana + refl + '_ang'
     outWS = fname + '_' + ana + refl + '_q'
     xD = np.array(xDat)
-    k0 = 4*math.pi/wave
+    k0 = 4 * math.pi / wave
     Q = []
-    for n in range(0,nspec):
+    for n in range(0, nspec):
         if angles[n] >= 180.0:
             angles[n] = 360.0 - angles[n]
-        theta = math.radians(angles[n]/2.)
-        qq = k0*math.sin(theta)
+        theta = math.radians(angles[n] / 2.)
+        qq = k0 * math.sin(theta)
         Q.append(qq)
     Qa = np.array(Q)
-    sorted_indices=Qa.argsort()
-    sorted_Q=Qa[sorted_indices]
+    sorted_indices = Qa.argsort()
+    sorted_Q = Qa[sorted_indices]
     lxdq = len(sorted_Q)
-    xlast = 2*sorted_Q[lxdq-1]-sorted_Q[lxdq-2]
-    sorted_Q = np.append(sorted_Q,xlast)
+    xlast = 2 * sorted_Q[lxdq - 1] - sorted_Q[lxdq - 2]
+    sorted_Q = np.append(sorted_Q, xlast)
     xDq = sorted_Q
-    for m in range(0,nval):
+    for m in range(0, nval):
         ylist = []
         elist = []
-        for n in range(0,nspec):
+        for n in range(0, nspec):
             ylist.append(y2D[n][m])
             elist.append(e2D[n][m])
         y1D = np.array(ylist)
@@ -581,35 +599,36 @@ def IN13Read(instr,run,ana,refl,Plot,Save):      #Ascii start routine
             yDq = y1Dq
             eDq = e1Dq
         else:
-            xData = np.append(xData,xD)
-            yData = np.append(yData,y1D)
-            eData = np.append(eData,e1D)
-            xDq = np.append(xDq,sorted_Q)
-            yDq = np.append(yDq,y1Dq)
-            eDq = np.append(eDq,e1Dq)
-    CreateWorkspace(OutputWorkspace=ascWS, DataX=xData, DataY=yData, DataE=eData,\
-        Nspec=3, UnitX='MomentumTransfer')
-    IN13Paras(ascWS,run,title,wave)
-    CreateWorkspace(OutputWorkspace=outWS, DataX=xDq, DataY=yDq, DataE=eDq,\
-        Nspec=3, UnitX='MomentumTransfer')
-    IN13Paras(outWS,run,title,wave)
+            xData = np.append(xData, xD)
+            yData = np.append(yData, y1D)
+            eData = np.append(eData, e1D)
+            xDq = np.append(xDq, sorted_Q)
+            yDq = np.append(yDq, y1Dq)
+            eDq = np.append(eDq, e1Dq)
+    CreateWorkspace(OutputWorkspace=ascWS, DataX=xData, DataY=yData, DataE=eData, \
+                    Nspec=3, UnitX='MomentumTransfer')
+    IN13Paras(ascWS, run, title, wave)
+    CreateWorkspace(OutputWorkspace=outWS, DataX=xDq, DataY=yDq, DataE=eDq, \
+                    Nspec=3, UnitX='MomentumTransfer')
+    IN13Paras(outWS, run, title, wave)
     if Save:
-        opath = os.path.join(workdir,outWS+'.nxs')
+        opath = os.path.join(workdir, outWS + '.nxs')
         SaveNexusProcessed(InputWorkspace=outWS, Filename=opath)
         logger.information('Output file : ' + opath)
     if Plot != 'None':
-        plotForce(outWS,Plot)
+        plotForce(outWS, Plot)
     return outWS
 
-def IN13Paras(ascWS,run,title,wave):
+
+def IN13Paras(ascWS, run, title, wave):
     ws = mtd[ascWS]
     AddSampleLog(Workspace=ascWS, LogName="facility", LogType="String", LogText="ILL")
     ws.getRun()['run_number'] = run
     ws.getRun()['run_title'] = title
 
     facility = ws.getRun().getLogData('facility').value
-    logger.information('Facility is ' +facility)
+    logger.information('Facility is ' + facility)
     runNo = ws.getRun()['run_number'].value
     runTitle = ws.getRun()['run_title'].value.strip()
-    logger.information('Run : ' +runNo + ' ; Title : ' + runTitle)
+    logger.information('Run : ' + runNo + ' ; Title : ' + runTitle)
     logger.information('Wavelength : ' + str(wave))

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -56,7 +56,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         self.rbdir = os.path.join(targetDir,self.userID,self.rbnumber)
         self.UserScriptRepoDir = os.path.join(targetDir,'UserScripts')
-        self.MapMaskDir        = os.path.join(targetDir,'MapMaskDir')
+        self.MapMaskDir = os.path.join(targetDir,'MapMaskDir')
         self.userRootDir = os.path.join(targetDir,self.userID)
         if not os.path.exists(self.rbdir):
             os.makedirs(self.rbdir)

--- a/scripts/test/ISISDirecInelasticConfigTest.py
+++ b/scripts/test/ISISDirecInelasticConfigTest.py
@@ -56,7 +56,7 @@ class ISISDirectInelasticConfigTest(unittest.TestCase):
 
         self.rbdir = os.path.join(targetDir,self.userID,self.rbnumber)
         self.UserScriptRepoDir = os.path.join(targetDir,'UserScripts')
-        self.MapMaskDir = os.path.join(targetDir,'MapMaskDir')
+        self.MapMaskDir        = os.path.join(targetDir,'MapMaskDir')
         self.userRootDir = os.path.join(targetDir,self.userID)
         if not os.path.exists(self.rbdir):
             os.makedirs(self.rbdir)


### PR DESCRIPTION
Fixes #15171

Reduces the number of violations in the following files significantly:
- [x] `scripts/Inelastic/IndirectNeutron.py`
- [x]  `scripts/Inelastic/Direct/ISISDirecInelasticConfig.py`
- [x]  `SystemTests/tests/analysis/HFIRTestsAPIv2.py`
- [x]  `SystemTests/tests/analysis/Peak2ConvCell_Test.py`

**To Check**
- The functionalities of the files has not been affected so all the related tests should pass
- Code within the files have been cleaned up and reformatted according to `PEP-8`/`Pylint`
- Reduces **107** `pylint` violations 

Once merged, reset the jenkins pylint violations threshold
