### PR TITLE
Improvements to 1D plots of MDWorkspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IMDHistoWorkspace.h
@@ -91,6 +91,12 @@ public:
   virtual size_t getLinearIndex(size_t index1, size_t index2, size_t index3,
                                 size_t index4) const = 0;
 
+  virtual void getLineData(const Mantid::Kernel::VMD &start,
+                           const Mantid::Kernel::VMD &end,
+                           Mantid::API::MDNormalization normalize,
+                           std::vector<coord_t> &x, std::vector<signal_t> &y,
+                           std::vector<signal_t> &e) const = 0;
+
   virtual double &operator[](const size_t &index) = 0;
 
   virtual void setCoordinateSystem(

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -329,7 +329,8 @@ TMDE(signal_t MDEventWorkspace)::getSignalWithMaskAtCoord(
   }
   // Check if masked
   const API::IMDNode *box = data->getBoxAtCoord(coords);
-  if (!box) return MDMaskValue;
+  if (!box)
+    return MDMaskValue;
   if (box->getIsMasked()) {
     return MDMaskValue;
   }
@@ -379,7 +380,7 @@ TMDE(std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
 TMDE(std::vector<std::string> MDEventWorkspace)::getBoxControllerStats() const {
   std::vector<std::string> out;
   std::ostringstream mess;
- 
+
   size_t mem;
   mem = (this->m_BoxController->getTotalNumMDBoxes() * sizeof(MDBox<MDE, nd>)) /
         1024;
@@ -748,7 +749,7 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
   // TODO: Don't use a fixed number of points later
   size_t numPoints = 500;
 
-  VMD step = (end - start) / double(numPoints);
+  VMD step = (end - start) / double(numPoints - 1);
   double stepLength = step.norm();
 
   // These will be the curve as plotted
@@ -758,22 +759,16 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
   for (size_t i = 0; i < numPoints; i++) {
     // Coordinate along the line
     VMD coord = start + step * double(i);
-    // Record the position along the line
-    x.push_back(static_cast<coord_t>(stepLength * double(i)));
 
     // Look for the box at this coordinate
     // const MDBoxBase<MDE,nd> * box = NULL;
     const IMDNode *box = NULL;
 
-    // TODO: make the logic/reuse in the following nicer.
     if (isInBounds(coord.getBareArray())) {
       box = this->data->getBoxAtCoord(coord.getBareArray());
 
       if (box != NULL) {
-        if (box->getIsMasked()) {
-          y.push_back(MDMaskValue);
-          e.push_back(MDMaskValue);
-        } else {
+        if (!box->getIsMasked()) {
           // What is our normalization factor?
           signal_t normalizer = 1.0;
           switch (normalize) {
@@ -786,23 +781,26 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
             normalizer = 1.0 / double(box->getNPoints());
             break;
           }
-
+          // Record the position along the line
+          x.push_back(static_cast<coord_t>(stepLength * double(i)));
           // And add the normalized signal/error to the list
           y.push_back(box->getSignal() * normalizer);
           e.push_back(box->getError() * normalizer);
         }
       } else {
+        // Record the position along the line
+        x.push_back(static_cast<coord_t>(stepLength * double(i)));
         y.push_back(std::numeric_limits<double>::quiet_NaN());
         e.push_back(std::numeric_limits<double>::quiet_NaN());
       }
     } else {
+      // Record the position along the line
+      x.push_back(static_cast<coord_t>(stepLength * double(i)));
       // Point is outside the workspace. Add NANs
       y.push_back(std::numeric_limits<double>::quiet_NaN());
       e.push_back(std::numeric_limits<double>::quiet_NaN());
     }
   }
-  // And the last point
-  x.push_back((end - start).norm());
 }
 
 /**

--- a/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDEventWorkspace.tcc
@@ -746,7 +746,7 @@ TMDE(void MDEventWorkspace)::getLinePlot(const Mantid::Kernel::VMD &start,
                                          std::vector<signal_t> &y,
                                          std::vector<signal_t> &e) const {
   // TODO: Don't use a fixed number of points later
-  size_t numPoints = 200;
+  size_t numPoints = 500;
 
   VMD step = (end - start) / double(numPoints);
   double stepLength = step.norm();

--- a/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDHistoWorkspace.h
@@ -83,6 +83,12 @@ public:
                            std::vector<coord_t> &x, std::vector<signal_t> &y,
                            std::vector<signal_t> &e) const;
 
+  virtual void getLineData(const Mantid::Kernel::VMD &start,
+                           const Mantid::Kernel::VMD &end,
+                           Mantid::API::MDNormalization normalize,
+                           std::vector<coord_t> &x, std::vector<signal_t> &y,
+                           std::vector<signal_t> &e) const;
+
   void checkWorkspaceSize(const MDHistoWorkspace &other, std::string operation);
 
   // --------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -514,10 +514,10 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
                                    std::vector<signal_t> &y,
                                    std::vector<signal_t> &e) const {
   // TODO: Don't use a fixed number of points later
-  size_t numPoints = 500;
+  const size_t numPoints = 500;
 
-  VMD step = (end - start) / double(numPoints - 1);
-  double stepLength = step.norm();
+  const VMD step = (end - start) / double(numPoints - 1);
+  const auto stepLength = step.norm();
 
   // These will be the curve as plotted
   x.clear();
@@ -528,7 +528,7 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
     VMD coord = start + step * double(i);
 
     // Get index of bin at this coordinate
-    size_t linearIndex = this->getLinearIndexAtCoord(coord.getBareArray());
+    const auto linearIndex = this->getLinearIndexAtCoord(coord.getBareArray());
     if (linearIndex < m_length) {
 
       if (!this->getIsMaskedAt(linearIndex)) {
@@ -550,8 +550,8 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
       // Record the position along the line
       x.push_back(static_cast<coord_t>(stepLength * double(i)));
       // Point is outside the workspace. Add NANs
-      y.push_back(std::numeric_limits<double>::quiet_NaN());
-      e.push_back(std::numeric_limits<double>::quiet_NaN());
+      y.push_back(std::numeric_limits<signal_t>::quiet_NaN());
+      e.push_back(std::numeric_limits<signal_t>::quiet_NaN());
     }
   }
 }
@@ -591,7 +591,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
 
   // Unit-vector of the direction
   VMD dir = end - start;
-  coord_t length = dir.normalize();
+  const auto length = dir.normalize();
 
 // Vector with +1 where direction is positive, -1 where negative
 #define sgn(x) ((x < 0) ? -1.0f : ((x > 0.) ? 1.0f : 0.0f))
@@ -599,7 +599,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
   for (size_t d = 0; d < nd; d++) {
     dirSign[d] = sgn(dir[d]);
   }
-  size_t BADINDEX = size_t(-1);
+  const size_t BADINDEX = size_t(-1);
 
   // Dimensions of the workspace
   boost::scoped_array<size_t> index(new size_t[nd]);
@@ -610,7 +610,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
     numBins[d] = dim->getNBins();
   }
 
-  std::set<coord_t> boundaries =
+  const std::set<coord_t> boundaries =
       getBinBoundariesOnLine(start, end, nd, dir, length);
 
   if (boundaries.empty()) {
@@ -624,7 +624,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
   } else {
     // Get the first point
     std::set<coord_t>::iterator it;
-    it = boundaries.begin();
+    it = boundaries.cbegin();
 
     coord_t lastLinePos = *it;
     VMD lastPos = start + (dir * lastLinePos);
@@ -632,7 +632,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
 
     ++it;
 
-    for (; it != boundaries.end(); ++it) {
+    for (; it != boundaries.cend(); ++it) {
       // This is our current position along the line
       coord_t linePos = *it;
       x.push_back(linePos);
@@ -644,7 +644,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
       VMD middle = (pos + lastPos) * 0.5;
 
       // Find the signal in this bin
-      size_t linearIndex = this->getLinearIndexAtCoord(middle.getBareArray());
+      const auto linearIndex = this->getLinearIndexAtCoord(middle.getBareArray());
       if (linearIndex < m_length) {
 
         // Is the signal here masked?
@@ -652,7 +652,7 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
           y.push_back(MDMaskValue);
           e.push_back(MDMaskValue);
         } else {
-          signal_t normalizer = getNormalizationFactor(normalize, linearIndex);
+          auto normalizer = getNormalizationFactor(normalize, linearIndex);
           // And add the normalized signal/error to the list too
           auto signal = this->getSignalAt(linearIndex) * normalizer;
           if (boost::math::isinf(signal)) {

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -644,7 +644,8 @@ void MDHistoWorkspace::getLineData(const Mantid::Kernel::VMD &start,
       VMD middle = (pos + lastPos) * 0.5;
 
       // Find the signal in this bin
-      const auto linearIndex = this->getLinearIndexAtCoord(middle.getBareArray());
+      const auto linearIndex =
+          this->getLinearIndexAtCoord(middle.getBareArray());
       if (linearIndex < m_length) {
 
         // Is the signal here masked?

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -516,7 +516,7 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
   // TODO: Don't use a fixed number of points later
   size_t numPoints = 500;
 
-  VMD step = (end - start) / double(numPoints);
+  VMD step = (end - start) / double(numPoints - 1);
   double stepLength = step.norm();
 
   // These will be the curve as plotted
@@ -526,17 +526,15 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
   for (size_t i = 0; i < numPoints; i++) {
     // Coordinate along the line
     VMD coord = start + step * double(i);
-    // Record the position along the line
-    x.push_back(static_cast<coord_t>(stepLength * double(i)));
 
     // Get index of bin at this coordinate
     size_t linearIndex = this->getLinearIndexAtCoord(coord.getBareArray());
     if (linearIndex < m_length) {
 
-      if (this->getIsMaskedAt(linearIndex)) {
-        y.push_back(MDMaskValue);
-        e.push_back(MDMaskValue);
-      } else {
+      if (!this->getIsMaskedAt(linearIndex)) {
+        // Record the position along the line
+        x.push_back(static_cast<coord_t>(stepLength * double(i)));
+
         signal_t normalizer = getNormalizationFactor(normalize, linearIndex);
         // And add the normalized signal/error to the list too
         auto signal = this->getSignalAt(linearIndex) * normalizer;
@@ -549,13 +547,13 @@ void MDHistoWorkspace::getLinePlot(const Mantid::Kernel::VMD &start,
       }
 
     } else {
+      // Record the position along the line
+      x.push_back(static_cast<coord_t>(stepLength * double(i)));
       // Point is outside the workspace. Add NANs
       y.push_back(std::numeric_limits<double>::quiet_NaN());
       e.push_back(std::numeric_limits<double>::quiet_NaN());
     }
   }
-  // And the last point
-  x.push_back((end - start).norm());
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/test/MDEventWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDEventWorkspaceTest.h
@@ -554,6 +554,8 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y, e;
     ew->getLinePlot(start, end, NoNormalization, x, y, e);
+    TS_ASSERT_EQUALS(y.size(), 500);
+    TS_ASSERT_EQUALS(x.size(), 500);
     for (size_t i = 0; i < y.size(); i += 10) {
       TS_ASSERT_EQUALS(y[i], signal);
     }
@@ -581,13 +583,15 @@ public:
     ew->refreshCache();
 
     Mantid::Kernel::VMD start(0, 0, 0);
-    Mantid::Kernel::VMD end(2, 0, 0);
+    Mantid::Kernel::VMD end(5, 0, 0);
     std::vector<coord_t> x;
     std::vector<signal_t> y, e;
     ew->getLinePlot(start, end, NoNormalization, x, y, e);
-    TS_ASSERT_EQUALS(y.size(), 200);
-    TS_ASSERT(boost::math::isnan(y[60])); // Masked data is NaN
-    TS_ASSERT_EQUALS(y[180], 3.0);        // Unmasked data
+    // Masked data is omitted from line
+    TS_ASSERT_EQUALS(y.size(), 325);
+    TS_ASSERT_EQUALS(x.size(), 325);
+    // Unmasked data
+    TS_ASSERT_EQUALS(y[300], 3.0);
   }
 
   void test_that_sets_default_normalization_flags_to_volume_normalization() {

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -551,7 +551,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive */
-  void test_getLinePlot_horizontal() {
+  void test_getLineData_horizontal() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
@@ -561,7 +561,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(x.size(), 11);
     TS_ASSERT_DELTA(x[0], 0.0, 1e-5);
     TS_ASSERT_DELTA(x[1], 0.5, 1e-5);
@@ -576,7 +576,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive */
-  void test_getLinePlot_horizontal_withMask() {
+  void test_getLineData_horizontal_withMask() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
@@ -594,7 +594,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
 
     TS_ASSERT_EQUALS(y.size(), 10);
     // Masked value should be zero
@@ -605,7 +605,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive */
-  void test_getLinePlot_3D() {
+  void test_getLineData_3D() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 3, 10);
     for (size_t i = 0; i < 1000; i++)
@@ -615,7 +615,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(x.size(), 11);
     TS_ASSERT_DELTA(x[0], 0.0, 1e-5);
     TS_ASSERT_DELTA(x[1], 0.5, 1e-5);
@@ -630,7 +630,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going negative */
-  void test_getLinePlot_horizontal_backwards() {
+  void test_getLineData_horizontal_backwards() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
@@ -640,7 +640,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(x.size(), 11);
     TS_ASSERT_DELTA(x[0], 0.0, 1e-5);
     TS_ASSERT_DELTA(x[1], 0.5, 1e-5);
@@ -655,7 +655,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Diagonal line at 45 degrees crosses through 3 bins */
-  void test_getLinePlot_diagonal() {
+  void test_getLineData_diagonal() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
@@ -665,7 +665,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
     std::cout << "X\n" << Strings::join(x.begin(), x.end(), ",") << std::endl;
     std::cout << "Y\n" << Strings::join(y.begin(), y.end(), ",") << std::endl;
 
@@ -683,7 +683,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive, starting before and ending after limits */
-  void test_getLinePlot_horizontal_pastEdges() {
+  void test_getLineData_horizontal_pastEdges() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
@@ -693,7 +693,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(x.size(), 11);
     TS_ASSERT_DELTA(x[0], 0.5, 1e-5);
     TS_ASSERT_DELTA(x[1], 1.5, 1e-5);
@@ -708,7 +708,7 @@ public:
 
   //---------------------------------------------------------------------------------------------------
   /** Line that completely misses the workspace */
-  void test_getLinePlot_totallyOutOfBounds() {
+  void test_getLineData_totallyOutOfBounds() {
     MDHistoWorkspace_sptr ws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
     for (size_t i = 0; i < 100; i++)
@@ -718,7 +718,7 @@ public:
     std::vector<coord_t> x;
     std::vector<signal_t> y;
     std::vector<signal_t> e;
-    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    ws->getLineData(start, end, NoNormalization, x, y, e);
     TS_ASSERT_EQUALS(x.size(), 2);
     TS_ASSERT_DELTA(x[0], 0, 1e-5);
     // NAN for Y

--- a/Framework/DataObjects/test/MDHistoWorkspaceTest.h
+++ b/Framework/DataObjects/test/MDHistoWorkspaceTest.h
@@ -549,6 +549,55 @@ public:
         iws->getSignalWithMaskAtVMD(VMD(3.5, 0.5), VolumeNormalization)));
   }
 
+  void test_getLinePlot() {
+    MDHistoWorkspace_sptr ws =
+        MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
+    for (size_t i = 0; i < 100; i++)
+      ws->setSignalAt(i, double(i));
+    VMD start(0.5, 0.5);
+    VMD end(9.5, 0.5);
+    std::vector<coord_t> x;
+    std::vector<signal_t> y;
+    std::vector<signal_t> e;
+    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+    TS_ASSERT_EQUALS(x.size(), 500);
+    TS_ASSERT_DELTA(x[0], 0.0, 1e-5);
+    TS_ASSERT_DELTA(x[50], 0.9018, 1e-5);
+    TS_ASSERT_DELTA(x[100], 1.8036, 1e-5);
+    TS_ASSERT_DELTA(x[499], 9.0, 1e-5);
+
+    TS_ASSERT_EQUALS(y.size(), 500);
+    TS_ASSERT_DELTA(y[0], 0.0, 1e-5);
+    TS_ASSERT_DELTA(y[50], 1.0, 1e-5);
+    TS_ASSERT_DELTA(y[100], 2.0, 1e-5);
+  }
+
+  void test_getLinePlotWithMaskedData() {
+    MDHistoWorkspace_sptr ws =
+        MDEventsTestHelper::makeFakeMDHistoWorkspace(1.0, 2, 10);
+    for (size_t i = 0; i < 100; i++)
+      ws->setSignalAt(i, double(i));
+
+    std::vector<coord_t> min{0, 0};
+    std::vector<coord_t> max{5, 5};
+
+    // Mask part of the workspace
+    MDImplicitFunction *function = new MDBoxImplicitFunction(min, max);
+    ws->setMDMasking(function);
+
+    VMD start(0.5, 0.5);
+    VMD end(9.5, 0.5);
+    std::vector<coord_t> x;
+    std::vector<signal_t> y;
+    std::vector<signal_t> e;
+    ws->getLinePlot(start, end, NoNormalization, x, y, e);
+
+    // Masked points omitted
+    TS_ASSERT_EQUALS(y.size(), 250);
+    // Unmasked value
+    TS_ASSERT_DELTA(y[200], 8.0, 1e-5);
+  }
+
   //---------------------------------------------------------------------------------------------------
   /** Line along X, going positive */
   void test_getLineData_horizontal() {

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -187,7 +187,7 @@ void ConvertMDHistoToMatrixWorkspace::make1DWorkspace() {
   std::vector<Mantid::signal_t> Y;
   std::vector<Mantid::signal_t> E;
 
-  inputWorkspace->getLinePlot(start, end, normalization, X, Y, E);
+  inputWorkspace->getLineData(start, end, normalization, X, Y, E);
 
   MatrixWorkspace_sptr outputWorkspace =
       WorkspaceFactory::Instance().create("Workspace2D", 1, X.size(), Y.size());


### PR DESCRIPTION
Closes #15155 #15082 #14781

`MDHW::getLineData`, which is used by `plotMD`, is now consistent with other workspace types and returns linearly spaced points along the line. The previous implementation, which returns points at bin boundaries, is now `getLineData` and is used by the `ConvertMDHistoToMatrixWorkspace` algorithm.

Masked data was previously returned as NaN and appeared as a high value on the plot, now it is instead omitted from the plot. If masked data falls at one end of the plot then the range of the plot axis is reduced to the range of non-masked data. If masked data falls in the middle of the line then the line joins non-masked points either side (no points or error bars are plotted for masked data).

**To Test:**

.deb is at `smb://olympic/babylon5/Scratch/Matthew%20Jones/15187`

The following script produces MDHisto and MDEvent workspaces which are equivalent, it then calls `plotMD` to display them.
The plots should now look the same.
Note the behaviour of the plot for the masked data (-1 to 1 on the x axis).
You may notice that the masked region is slightly larger than expected for the MDEventWorkspace, this is a separate issue (#14962).

``` python
# MDHistoWorkspace
ws_mdhw = CreateMDWorkspace(Dimensions='1', Extents='-2,2', Names='h',
                       Units='rlu', SplitInto='4')
FakeMDEventData(ws_mdhw, UniformParams='1000', RandomizeSignal='1')
ws_mdhw = BinMD(ws_mdhw,AlignedDim0='h,-2,2,40')
ws_masked_mdhw = CloneMDWorkspace(ws_mdhw)
MaskMD(Workspace=ws_masked_mdhw,Dimensions="h",Extents="-1,1")
plotMD(ws_masked_mdhw, normalization=1, error_bars=True)

# MDEventWorkspace
ws_mdew = CreateMDWorkspace(Dimensions='1', Extents='-2,2', Names='h',
                       Units='rlu', SplitInto='4')
FakeMDEventData(ws_mdew, UniformParams='1000', RandomizeSignal='1')
ws_mdew = SliceMD(ws_mdew,AlignedDim0='h,-2,2,40')
ws_masked_mdew = CloneMDWorkspace(ws_mdew)
MaskMD(Workspace=ws_masked_mdew,Dimensions="h",Extents="-1,1")
plotMD(ws_masked_mdew, normalization=1, error_bars=True)

```
