### PR TITLE
Fix slice viewer crash

### DIFF
--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -73,8 +82,11 @@
      </item>
      <item>
       <widget class="QCheckBox" name="autoScale">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this flag is disabled, auto scaling on loading&lt;/p&gt;&lt;p&gt;a workspace will be disabled, except for when&lt;/p&gt;&lt;p&gt;the SliceViewer is initially created. This is mainly&lt;/p&gt;&lt;p&gt;relevant for live data workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
-        <string>Autoscale</string>
+        <string>Autoscale on Load</string>
        </property>
       </widget>
      </item>

--- a/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
+++ b/MantidQt/SliceViewer/inc/MantidQtSliceViewer/ColorBarWidget.ui
@@ -83,7 +83,7 @@
      <item>
       <widget class="QCheckBox" name="autoScale">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If this flag is disabled, auto scaling on loading&lt;/p&gt;&lt;p&gt;a workspace will be disabled, except for when&lt;/p&gt;&lt;p&gt;the SliceViewer is initially created. This is mainly&lt;/p&gt;&lt;p&gt;relevant for live data workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This flag signals that the color scale range should be set automatically to the current slice range when a workspace is loaded. Note that auto scaling will be applied when a workspace is loaded for the very first time. This option is mainly relevant for live data workspaces, which are continuously being updated and reloaded.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Autoscale on Load</string>

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -71,8 +71,8 @@ Checks if the rebinning is in a consistent state, ie if rebin mode is selected a
 is a rebin workspace or there is no rebin workspace and no rebin mode selected.
 The state is inconsistent if rebin mode is selected and there is no workspace.
 */
-  bool isRebinInConsistentState(Mantid::API::IMDWorkspace_sptr rebinnedWS, bool useRebinMode) {
-    return rebinnedWS && useRebinMode;
+  bool isRebinInConsistentState(Mantid::API::IMDWorkspace* rebinnedWS, bool useRebinMode) {
+    return (rebinnedWS != nullptr) && useRebinMode;
   }
 }
 
@@ -755,7 +755,7 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   this->updateDimensionSliceWidgets();
 
   // Only autoscale color bar if box is checked
-  if (m_colorBar->getAutoScale()) {
+  if (!m_firstWorkspaceOpen || m_colorBar->getAutoScale()) {
     // Find the full range. And use it
     findRangeFull();
     m_colorBar->setViewRange(m_colorRangeFull);
@@ -1392,7 +1392,7 @@ void SliceViewer::findRangeSlice() {
   if (m_rebinMode) {
     // If the rebinned state is inconsistent, then we turn off
     // the rebin selection and continue to use the original WS
-    if (!isRebinInConsistentState(m_overlayWS, m_rebinMode)) {
+    if (!isRebinInConsistentState(m_overlayWS.get(), m_rebinMode)) {
       setRebinMode(false);
     } else {
       workspace_used = this->m_overlayWS;

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -74,6 +74,15 @@ The state is inconsistent if rebin mode is selected and there is no workspace.
   bool isRebinInConsistentState(Mantid::API::IMDWorkspace* rebinnedWS, bool useRebinMode) {
     return (rebinnedWS != nullptr) && useRebinMode;
   }
+
+/**
+ * Checks if the colors scale range should be automatically set. We should provide auto scaling
+ * on load if the workspaces is either loaded the first time or if it is explictly selected.
+ */
+  bool shouldAutoScaleForNewlySetWorkspace(bool isFirstWorkspaceOpen, bool isAutoScalingOnLoad) {
+    return !isFirstWorkspaceOpen || isAutoScalingOnLoad;
+  }
+
 }
 
 
@@ -754,9 +763,11 @@ void SliceViewer::setWorkspace(Mantid::API::IMDWorkspace_sptr ws) {
   // Build up the widgets
   this->updateDimensionSliceWidgets();
 
-  // Only autoscale color bar if box is checked
-  if (!m_firstWorkspaceOpen || m_colorBar->getAutoScale()) {
-    // Find the full range. And use it
+  // This will auto scale the color bar to the current slice when the workspace is
+  // loaded. This always happens when a workspace is loaded for the first time.
+  // For live event data workspaces subsequent updates might not lead to an auto
+  // scaling of the color scale range (if this is explicitly turned off).
+  if (shouldAutoScaleForNewlySetWorkspace(m_firstWorkspaceOpen, m_colorBar->getAutoScale())) {
     findRangeFull();
     m_colorBar->setViewRange(m_colorRangeFull);
     m_colorBar->updateColorMap();

--- a/MantidQt/SliceViewer/src/SliceViewer.cpp
+++ b/MantidQt/SliceViewer/src/SliceViewer.cpp
@@ -65,6 +65,18 @@ using Poco::XML::NodeIterator;
 using Poco::XML::NodeFilter;
 using MantidQt::API::AlgorithmRunner;
 
+namespace {
+/*
+Checks if the rebinning is in a consistent state, ie if rebin mode is selected and there
+is a rebin workspace or there is no rebin workspace and no rebin mode selected.
+The state is inconsistent if rebin mode is selected and there is no workspace.
+*/
+  bool isRebinInConsistentState(Mantid::API::IMDWorkspace_sptr rebinnedWS, bool useRebinMode) {
+    return rebinnedWS && useRebinMode;
+  }
+}
+
+
 namespace MantidQt {
 namespace SliceViewer {
 
@@ -1378,7 +1390,13 @@ part of the workspace */
 void SliceViewer::findRangeSlice() {
   IMDWorkspace_sptr workspace_used = m_ws;
   if (m_rebinMode) {
-    workspace_used = this->m_overlayWS;
+    // If the rebinned state is inconsistent, then we turn off
+    // the rebin selection and continue to use the original WS
+    if (!isRebinInConsistentState(m_overlayWS, m_rebinMode)) {
+      setRebinMode(false);
+    } else {
+      workspace_used = this->m_overlayWS;
+    }
   }
 
   if (!workspace_used)


### PR DESCRIPTION
Fixes #15161 

**Issue:**
The slice viewer crashed when using rebin mode with very fine rebinning. The memory maxes out and the underlying vectors of the rebinned workspace cannot be allocated. This leads to an inconsistent rebin state in the slice viewer. 

When the user presses the zoom button, the color range and subsequently the data range are updated in the colorScaleAutoSlice method(https://github.com/mantidproject/mantid/blob/master/MantidQt/SliceViewer/src/SliceViewer.cpp#L849:L853). The issue starts in the `findRangeSlice` method as we are in a state where the rebinMode is `true` yet the overlay workspace `m_overlayWS` is `nullptr`(rebinning failed, hence we never got a rebinned workspace). The current logic does not evaluate the color range in this case. This means that the last value of `m_colorRangeSlice` will be used. If this the first time that this variable is being used, then we end up with the default setting of this variable. It turns out that the default is a `QwtDoubleInterval` with min= 0 and max = -1 which is an invalid interval range. Further down the line this color scale range is written into the data range of the `QwtRasterDataMD` data set which is used for plotting. This eventually will cause problems in Qt and Qwt (I did not assess this during the debug session though).

**Solution:**
In the `findRangeSlice` method we check if the Slive Viewer is in an inconsitent state, ie if `m_overlay` == nullptr and the rebin mode is set to true (or `m_overlay` exists but the rebin mode is false). If the state is consistent, the logic does not change. If the state is inconsistent, then we turn off the rebin mode and use the underlying workspace to extract the color scale range.
# For Testing
1. Load the NaCl event mode data set
2. Open the workspace in the Slice Viewer ( make sure that you dont press the zoom button)
3. Select the rebin mode 
4. Set rebinning to 9500 for both axes
   - Note that there will be warnings regarding `execution terminated`: This is ok
   - Increase the rebinning until you see an error saying `Bad Alloc`: This is to be expected
5. Once you see the `Bad Alloc` error in the Mantid console, click on the zoom button
   - Confirm that there is no exception

Please perform more free testing.
