### PR TITLE
Refactor parsing of dimension names in MaskMD

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/MaskMD.h
@@ -9,16 +9,7 @@ namespace Mantid {
 namespace MDAlgorithms {
 
 std::vector<std::string> MANTID_MDALGORITHMS_DLL
-splitByCommas(const std::string &names_string);
-
-std::vector<std::string> MANTID_MDALGORITHMS_DLL
-findNamesInBrackets(const std::string &names_string);
-
-std::vector<std::string> MANTID_MDALGORITHMS_DLL
 parseDimensionNames(const std::string &names_string);
-
-std::vector<std::string> MANTID_MDALGORITHMS_DLL
-removeBracketedNames(const std::string &names_string);
 
 /** MaskMD : Mask an MDWorkspace. Can provide complex masking shapes over an
   exisitng MDWorkspace. Operates on a MDWorkspace in-situ.

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -23,6 +23,11 @@ namespace MDAlgorithms {
  */
 std::vector<std::string> parseDimensionNames(const std::string &names_string) {
 
+  // This regex has two parts which are separated by the "|" (or)
+  // The first part matches anything which is bounded by square brackets
+  // unless they contain square brackets (so that it only matches inner pairs)
+  // The second part matches anything that doesn't contain a comma
+  // NB, the order of the two parts matters
   regex expression("\\[([^\\[]*)\\]|[^,]+");
 
   boost::sregex_token_iterator iter(names_string.begin(), names_string.end(),

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -15,59 +15,6 @@ using boost::regex;
 namespace Mantid {
 namespace MDAlgorithms {
 
-static const std::string REGEX_STR = "\\[[^\\[\\]]*\\]";
-
-/*
- * Split the input string on commas and trim leading and trailing whitespace
- * from the results
- */
-std::vector<std::string> splitByCommas(const std::string &names_string) {
-  std::vector<std::string> names_split_by_commas;
-  boost::split(names_split_by_commas, names_string, boost::is_any_of(","));
-
-  // Remove leading/trailing whitespace from potential dimension name
-  for (auto &name : names_split_by_commas) {
-    boost::trim(name);
-  }
-  return names_split_by_commas;
-}
-
-/*
- * Return a vector of only those names from the input string which are within
- * brackets
- */
-std::vector<std::string> findNamesInBrackets(const std::string &names_string) {
-  std::vector<std::string> names_result;
-
-  regex re(REGEX_STR);
-  boost::sregex_token_iterator iter(names_string.begin(), names_string.end(),
-                                    re, 0);
-  boost::sregex_token_iterator end;
-  std::ostringstream ss;
-  for (; iter != end; ++iter) {
-    ss.str(std::string());
-    ss << *iter;
-    names_result.push_back(ss.str());
-  }
-
-  return names_result;
-}
-
-/*
- * Return a vector of names from the string, but with names in brackets reduced
- * to '[]'
- */
-std::vector<std::string> removeBracketedNames(const std::string &names_string) {
-  regex re(REGEX_STR);
-  const std::string names_string_reduced =
-      regex_replace(names_string, re, "[]");
-
-  std::vector<std::string> remainder_split =
-      splitByCommas(names_string_reduced);
-
-  return remainder_split;
-}
-
 /*
  * The list of dimension names often looks like "[H,0,0],[0,K,0]" with "[H,0,0]"
  * being the first dimension but getProperty returns a vector of
@@ -76,31 +23,14 @@ std::vector<std::string> removeBracketedNames(const std::string &names_string) {
  */
 std::vector<std::string> parseDimensionNames(const std::string &names_string) {
 
-  // If there are no brackets then simply split the string on commas
-  if (!boost::contains(names_string, "[")) {
-    // Split input string by commas
-    return splitByCommas(names_string);
-  }
+  regex expression("\\[([^\\[]*)\\]|[^,]+");
 
-  std::vector<std::string> names_result = findNamesInBrackets(names_string);
-  std::vector<std::string> remainder_split = removeBracketedNames(names_string);
+  boost::sregex_token_iterator iter(names_string.begin(), names_string.end(),
+                                    expression, 0);
+  boost::sregex_token_iterator end;
 
-  // Insert these into results vector if they are not "[]"
-  // if they are "[]" then skip a position in the vector instead
-  // This preserves the original order of the names,
-  // it is also inefficient, but the name list is expected to be short
-  size_t names_position = 0;
-  auto begin_it = names_result.begin();
-  for (std::string name : remainder_split) {
-    if (name != "[]") {
-      if (names_position == names_result.size()) {
-        names_result.push_back(name);
-      } else {
-        names_result.insert(begin_it + names_position, name);
-      }
-    }
-    ++names_position;
-  }
+  std::vector<std::string> names_result(iter, end);
+
   return names_result;
 }
 

--- a/Framework/MDAlgorithms/test/MaskMDTest.h
+++ b/Framework/MDAlgorithms/test/MaskMDTest.h
@@ -60,28 +60,6 @@ public:
   static MaskMDTest *createSuite() { return new MaskMDTest(); }
   static void destroySuite(MaskMDTest *suite) { delete suite; }
 
-  void test_split_by_commas() {
-    std::string test_string = "a, b,c ,d,e ";
-    std::vector<std::string> split_test_string = splitByCommas(test_string);
-
-    // String should be split on commas and whitespace trimmed off to result in:
-    TS_ASSERT_EQUALS(split_test_string[0], "a");
-    TS_ASSERT_EQUALS(split_test_string[1], "b");
-    TS_ASSERT_EQUALS(split_test_string[2], "c");
-    TS_ASSERT_EQUALS(split_test_string[3], "d");
-    TS_ASSERT_EQUALS(split_test_string[4], "e");
-  }
-
-  void test_find_names_in_brackets() {
-    std::string test_string = "[a,b,c], [d,e], f, g";
-    std::vector<std::string> names_in_brackets =
-        findNamesInBrackets(test_string);
-
-    TS_ASSERT_EQUALS(names_in_brackets[0], "[a,b,c]");
-    TS_ASSERT_EQUALS(names_in_brackets[1], "[d,e]");
-    TS_ASSERT_EQUALS(names_in_brackets.size(), 2);
-  }
-
   void test_parse_dimension_names() {
     // These are default dimension names from CreateMD
     std::string test_string = "[H,0,0],[0,K,0],[0,0,L],DeltaE";
@@ -91,16 +69,6 @@ public:
     TS_ASSERT_EQUALS(names_result[1], "[0,K,0]");
     TS_ASSERT_EQUALS(names_result[2], "[0,0,L]");
     TS_ASSERT_EQUALS(names_result[3], "DeltaE");
-  }
-
-  void test_remove_bracketed_names() {
-    std::string test_string = "[a,b] , c, [d,e], f";
-    std::vector<std::string> names_result = removeBracketedNames(test_string);
-
-    TS_ASSERT_EQUALS(names_result[0], "[]");
-    TS_ASSERT_EQUALS(names_result[1], "c");
-    TS_ASSERT_EQUALS(names_result[2], "[]");
-    TS_ASSERT_EQUALS(names_result[3], "f");
   }
 
   void test_parse_dimension_names_retains_order() {


### PR DESCRIPTION
Parsing of dimension names was greatly simplified in MaskMD by using a single regex to identify names rather than the existing splitting method.

**To Test:**
.deb is at `smb://olympic/babylon5/Scratch/Matthew%20Jones/15194`

Please read the code and check that the explanation of the regex is clear (line 26 of MaskMD.cpp).
Get the data to test with from //olympic/babylon5/Scratch/Matthew Jones/Fe_data.
In the script below, replace the path with the correct path to the data.
It should run with no errors.

``` python
import numpy as np

# Create arrays of run numbers and corresponding values of psi
run_numbers = range(15052, 15062)
psi_array = np.arange(0.0, 20.0, 2)

input_runs = ['/path/to/Fe_data/map' + str(run_number) + '_ei400.nxspe' for run_number in run_numbers]

md_ws = CreateMD(input_runs, Emode='Direct', Alatt=[2.87, 2.87, 2.87], Angdeg=[90, 90, 90], u=[1, 0, 0, ],
                 v=[0, 1, 0], Psi=psi_array, EFix=400.0)

MaskMD(Workspace=md_ws,Dimensions="[H,0,0],[0,K,0],[0,0,L],DeltaE",Extents="-4,4,-4,4,-4,4,-4,360")
```
