### PR TITLE
Set multiple dissimilar algorithm properties at one time.

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -290,6 +290,50 @@ public:
       const double endProgress = -1., const bool enableLogging = true,
       const int &version = -1);
 
+  template <typename... Args>
+  API::IAlgorithm_sptr execAsChildAlgorithm(const std::string &name,
+                                            Args &&... properties) {
+    API::IAlgorithm_sptr alg = createChildAlgorithm(name);
+    alg->setProperties(std::forward<Args>(properties)...);
+    alg->executeAsChildAlg();
+    return alg;
+  };
+
+  template <typename... Args>
+  API::IAlgorithm_sptr
+  execAsChildAlgorithm(const std::string &name, const double startProgress,
+                       const double endProgress, Args &&... properties) {
+    API::IAlgorithm_sptr alg =
+        createChildAlgorithm(name, startProgress, endProgress);
+    alg->setProperties(std::forward<Args>(properties)...);
+    alg->executeAsChildAlg();
+    return alg;
+  };
+
+  template <typename... Args>
+  API::IAlgorithm_sptr
+  execAsChildAlgorithm(const std::string &name, const double startProgress,
+                       const double endProgress, const bool enableLogging,
+                       Args &&... properties) {
+    API::IAlgorithm_sptr alg =
+        createChildAlgorithm(name, startProgress, endProgress, enableLogging);
+    alg->setProperties(std::forward<Args>(properties)...);
+    alg->executeAsChildAlg();
+    return alg;
+  };
+
+  template <typename... Args>
+  API::IAlgorithm_sptr
+  execAsChildAlgorithm(const std::string &name, const double startProgress,
+                       const double endProgress, const bool enableLogging,
+                       const int &version, Args &&... properties) {
+    API::IAlgorithm_sptr alg = createChildAlgorithm(
+        name, startProgress, endProgress, enableLogging, version);
+    alg->setProperties(std::forward<Args>(properties)...);
+    alg->executeAsChildAlg();
+    return alg;
+  };
+
   /// set whether we wish to track the child algorithm's history and pass it the
   /// parent object to fill.
   void trackAlgorithmHistory(boost::shared_ptr<AlgorithmHistory> parentHist);

--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -297,7 +297,7 @@ public:
     alg->setProperties(std::forward<Args>(properties)...);
     alg->executeAsChildAlg();
     return alg;
-  };
+  }
 
   template <typename... Args>
   API::IAlgorithm_sptr
@@ -308,7 +308,7 @@ public:
     alg->setProperties(std::forward<Args>(properties)...);
     alg->executeAsChildAlg();
     return alg;
-  };
+  }
 
   template <typename... Args>
   API::IAlgorithm_sptr
@@ -320,7 +320,7 @@ public:
     alg->setProperties(std::forward<Args>(properties)...);
     alg->executeAsChildAlg();
     return alg;
-  };
+  }
 
   template <typename... Args>
   API::IAlgorithm_sptr
@@ -332,7 +332,7 @@ public:
     alg->setProperties(std::forward<Args>(properties)...);
     alg->executeAsChildAlg();
     return alg;
-  };
+  }
 
   /// set whether we wish to track the child algorithm's history and pass it the
   /// parent object to fill.

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -143,26 +143,66 @@ public:
     return this;
   }
 
-  /** Templated method to set the value of a PropertyWithValue
-   *  @param name :: The name of the property (case insensitive)
-   *  @param value :: The value to assign to the property
+  /** Variadic method to recursively set the value of a PropertyWithValue.
+   *  specialized for when the name is a std::string.
+   *  @param property :: The name (case insensitive) and value to assign to the
+   * property
+   *  @param others :: Other properties to be set recursively.
    *  @throw Exception::NotFoundError If the named property is unknown
    *  @throw std::invalid_argument If an attempt is made to assign to a property
    * of different type
    */
   template <typename T, typename... Args>
-  IPropertyManager *setProperties(std::pair<std::string, T> prop,
+  IPropertyManager *setProperties(const std::tuple<std::string, T> &&property,
                                   Args &&... others) {
-    setTypedProperty(prop.first, prop.second,
-                     boost::is_convertible<T, boost::shared_ptr<DataItem>>());
-    this->afterPropertySet(prop.first);
+    setProperties(std::forward<const std::tuple<std::string, T>>(property));
     setProperties(std::forward<Args>(others)...);
     return this;
   }
 
+  /** Variadic method to recursively set the value of a PropertyWithValue.
+   *  specialized for when the name is a string literal.
+   *  @param property :: The name (case insensitive) and value to assign to the
+   * property
+   *  @param others :: Other properties to be set recursively.
+   *  @throw Exception::NotFoundError If the named property is unknown
+   *  @throw std::invalid_argument If an attempt is made to assign to a property
+   * of different type
+   */
+  template <typename T, typename... Args>
+  IPropertyManager *setProperties(const std::tuple<const char *, T> &&property,
+                                  Args &&... others) {
+    setProperties(std::forward<const std::tuple<const char *, T>>(property));
+    setProperties(std::forward<Args>(others)...);
+    return this;
+  }
+
+  /** Templated method to set the value of a PropertyWithValue
+   *  specialized for when the name is a std::string.
+   *  @param property :: The name (case insensitive) and value to assign to the
+   * property
+   *  @throw Exception::NotFoundError If the named property is unknown
+   *  @throw std::invalid_argument If an attempt is made to assign to a property
+   * of different type
+   */
   template <typename T>
-  IPropertyManager *setProperties(const std::pair<std::string, T> &prop) {
-    setProperty(prop.first, prop.second);
+  IPropertyManager *setProperties(const std::tuple<std::string, T> &&property) {
+    setProperty(std::get<0>(property), std::get<1>(property));
+    return this;
+  }
+
+  /** Templated method to set the value of a PropertyWithValue
+   *  specialized for when the name is a string literal.
+   *  @param property :: The name (case insensitive) and value to assign to the
+   * property
+   *  @throw Exception::NotFoundError If the named property is unknown
+   *  @throw std::invalid_argument If an attempt is made to assign to a property
+   * of different type
+   */
+  template <typename T>
+  IPropertyManager *
+  setProperties(const std::tuple<const char *, T> &&property) {
+    setProperty(std::string(std::get<0>(property)), std::get<1>(property));
     return this;
   }
 

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -143,6 +143,29 @@ public:
     return this;
   }
 
+  /** Templated method to set the value of a PropertyWithValue
+   *  @param name :: The name of the property (case insensitive)
+   *  @param value :: The value to assign to the property
+   *  @throw Exception::NotFoundError If the named property is unknown
+   *  @throw std::invalid_argument If an attempt is made to assign to a property
+   * of different type
+   */
+  template <typename T, typename... Args>
+  IPropertyManager *setProperties(std::pair<std::string, T> prop,
+                                  Args &&... others) {
+    setTypedProperty(prop.first, prop.second,
+                     boost::is_convertible<T, boost::shared_ptr<DataItem>>());
+    this->afterPropertySet(prop.first);
+    setProperties(std::forward<Args>(others)...);
+    return this;
+  }
+
+  template <typename T>
+  IPropertyManager *setProperties(const std::pair<std::string, T> &prop) {
+    setProperty(prop.first, prop.second);
+    return this;
+  }
+
   /** Specialised version of setProperty template method to handle const char *
   *  @param name :: The name of the property (case insensitive)
   *  @param value :: The value to assign to the property

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -367,11 +367,10 @@ void AlignAndFocusPowder::exec() {
       g_log.information() << "running CompressEvents(Tolerance=" << tolerance
                           << ")\n";
       API::IAlgorithm_sptr compressAlg = createChildAlgorithm("CompressEvents");
-      compressAlg->setProperties(
-          std::make_pair(std::string("InputWorkspace"), m_outputEW),
-          std::make_pair(std::string("OutputWorkspace"), m_outputEW),
-          std::make_pair(std::string("OutputWorkspace"), m_outputEW),
-          std::make_pair(std::string("Tolerance"), tolerance));
+      compressAlg->setProperties(std::make_tuple("InputWorkspace", m_outputEW),
+                                 std::make_tuple("OutputWorkspace", m_outputEW),
+                                 std::make_tuple("OutputWorkspace", m_outputEW),
+                                 std::make_tuple("Tolerance", tolerance));
       compressAlg->executeAsChildAlg();
       m_outputEW = compressAlg->getProperty("OutputWorkspace");
       m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -366,12 +366,10 @@ void AlignAndFocusPowder::exec() {
     if (tolerance > 0.) {
       g_log.information() << "running CompressEvents(Tolerance=" << tolerance
                           << ")\n";
-      API::IAlgorithm_sptr compressAlg = createChildAlgorithm("CompressEvents");
-      compressAlg->setProperties(std::make_tuple("InputWorkspace", m_outputEW),
-                                 std::make_tuple("OutputWorkspace", m_outputEW),
-                                 std::make_tuple("OutputWorkspace", m_outputEW),
-                                 std::make_tuple("Tolerance", tolerance));
-      compressAlg->executeAsChildAlg();
+      API::IAlgorithm_sptr compressAlg = execAsChildAlgorithm(
+          "CompressEvents", std::make_tuple("InputWorkspace", m_outputEW),
+          std::make_tuple("OutputWorkspace", m_outputEW),
+          std::make_tuple("Tolerance", tolerance));
       m_outputEW = compressAlg->getProperty("OutputWorkspace");
       m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);
     } else {

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -367,10 +367,11 @@ void AlignAndFocusPowder::exec() {
       g_log.information() << "running CompressEvents(Tolerance=" << tolerance
                           << ")\n";
       API::IAlgorithm_sptr compressAlg = createChildAlgorithm("CompressEvents");
-      compressAlg->setProperty("InputWorkspace", m_outputEW);
-      compressAlg->setProperty("OutputWorkspace", m_outputEW);
-      compressAlg->setProperty("OutputWorkspace", m_outputEW);
-      compressAlg->setProperty("Tolerance", tolerance);
+      compressAlg->setProperties(
+          std::make_pair(std::string("InputWorkspace"), m_outputEW),
+          std::make_pair(std::string("OutputWorkspace"), m_outputEW),
+          std::make_pair(std::string("OutputWorkspace"), m_outputEW),
+          std::make_pair(std::string("Tolerance"), tolerance));
       compressAlg->executeAsChildAlg();
       m_outputEW = compressAlg->getProperty("OutputWorkspace");
       m_outputW = boost::dynamic_pointer_cast<MatrixWorkspace>(m_outputEW);


### PR DESCRIPTION
DO NOT MERGE THIS INTO MASTER!

This is a potential implementation of option 2 in [this design document](https://github.com/mantidproject/documents/pull/8). Currently, I want to get feedback from others and check that this builds on all platforms.

I used `std::make_tuple` to construct each property. So far I've been unable to get uniform initialization of a std::tuple. [This](http://stackoverflow.com/questions/16703838/is-it-possible-to-infer-template-parameters-of-tuple-from-brace-type-initializat) post seems to suggest  doing so is impossible.

I tried to forward parameters to the appropriate function. We'll want to verify that this is both actually working and beneficial before merging.
