### PR TITLE
EnggCalibrate: add output with the fitted (peak) parameters

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -118,9 +118,9 @@ class EnggCalibrate(PythonAlgorithm):
 
         prog.report('Focusing the input workspace')
         focussed_ws = self._focus_run(self.getProperty('InputWorkspace').value,
-                                     self.getProperty("VanadiumWorkspace").value,
-                                     self.getProperty('Bank').value,
-                                     self.getProperty(self.INDICES_PROP_NAME).value)
+                                      self.getProperty("VanadiumWorkspace").value,
+                                      self.getProperty('Bank').value,
+                                      self.getProperty(self.INDICES_PROP_NAME).value)
 
         if len(expectedPeaksD) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -128,6 +128,12 @@ class EnggCalibrate(PythonAlgorithm):
         prog.report('Fitting parameters for the focused run')
         difc, zero, fitted_peaks = self._fit_params(focussed_ws, expectedPeaksD)
 
+        self.log().information("Fitted {0} peaks. Resulting difc: {1}, tzero: {2}".
+                               format(fitted_peaks.rowCount(), difc, zero))
+        self.log().information("Peaks fitted: {0}, centers in ToF: {1}".
+                               format(fitted_peaks.column("dSpacing"),
+                                      fitted_peaks.column("X0")))
+
         self._produce_outputs(difc, zero, fitted_peaks)
 
     def _fit_params(self, focused_ws, expected_peaks_d):

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -78,9 +78,10 @@ class EnggCalibrate(PythonAlgorithm):
         self.setPropertyGroup('Bank', banks_grp)
         self.setPropertyGroup(self.INDICES_PROP_NAME, banks_grp)
 
-        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "",\
-                Direction.Input, PropertyMode.Optional),\
-    		"Calibrated detector positions. If not specified, default ones are used.")
+        self.declareProperty(ITableWorkspaceProperty("DetectorPositions", "",
+                                                     Direction.Input, PropertyMode.Optional),
+                             "Calibrated detector positions. If not specified, default ones (from the "
+                             "current instrument definition) are used.")
 
         self.declareProperty('OutputParametersTableName', '', direction=Direction.Input,
                              doc = 'Name for a table workspace with the calibration parameters calculated '
@@ -94,11 +95,16 @@ class EnggCalibrate(PythonAlgorithm):
         self.declareProperty("Zero", 0.0, direction = Direction.Output,
                              doc = "Calibrated Zero value for the bank or range of pixels/detectors given")
 
+        self.declareProperty(ITableWorkspaceProperty("FittedPeaks", "", Direction.Output),
+                             doc = "Information on fitted peaks as produced by the (child) algorithm "
+                             "EnggFitPeaks.")
+
         out_grp = 'Outputs'
         self.setPropertyGroup('DetectorPositions', out_grp)
         self.setPropertyGroup('OutputParametersTableName', out_grp)
         self.setPropertyGroup('Difc', out_grp)
         self.setPropertyGroup('Zero', out_grp)
+        self.setPropertyGroup('FittedPeaks', out_grp)
 
     def PyExec(self):
 
@@ -111,7 +117,7 @@ class EnggCalibrate(PythonAlgorithm):
         prog = Progress(self, start=0, end=1, nreports=2)
 
         prog.report('Focusing the input workspace')
-        focussed_ws = self._focusRun(self.getProperty('InputWorkspace').value,
+        focussed_ws = self._focus_run(self.getProperty('InputWorkspace').value,
                                      self.getProperty("VanadiumWorkspace").value,
                                      self.getProperty('Bank').value,
                                      self.getProperty(self.INDICES_PROP_NAME).value)
@@ -120,34 +126,38 @@ class EnggCalibrate(PythonAlgorithm):
             raise ValueError("Cannot run this algorithm without any input expected peaks")
 
         prog.report('Fitting parameters for the focused run')
-        difc, zero = self._fitParams(focussed_ws, expectedPeaksD)
+        difc, zero, fitted_peaks = self._fit_params(focussed_ws, expectedPeaksD)
 
-        self._produceOutputs(difc, zero)
+        self._produce_outputs(difc, zero)
 
-    def _fitParams(self, focusedWS, expectedPeaksD):
+    def _fit_params(self, focused_ws, expected_peaks_d):
         """
-        Fit the GSAS parameters that this algorithm produces: difc and zero
+        Fit the GSAS parameters that this algorithm produces: difc and zero. Fits a
+        number of peaks starting from the expected peak positions. Then it fits a line
+        on the peak positions to produce the DIFC and TZERO as used in GSAS.
 
-        @param focusedWS :: focused workspace to do the fitting on
-        @param expectedPeaksD :: expected peaks for the fitting, in d-spacing units
+        @param focused_ws :: focused workspace to do the fitting on
+        @param expected_peaks_d :: expected peaks, used as intial peak positions for the
+        fitting, in d-spacing units
 
-        @returns a pair of parameters: difc and zero
+        @returns a tuple of parameters: difc, zero, and a list of peak centers as fitted
         """
 
-        fitPeaksAlg = self.createChildAlgorithm('EnggFitPeaks')
-        fitPeaksAlg.setProperty('InputWorkspace', focusedWS)
-        fitPeaksAlg.setProperty('WorkspaceIndex', 0) # There should be only one index anyway
-        fitPeaksAlg.setProperty('ExpectedPeaks', expectedPeaksD)
+        fit_alg = self.createChildAlgorithm('EnggFitPeaks')
+        fit_alg.setProperty('InputWorkspace', focused_ws)
+        fit_alg.setProperty('WorkspaceIndex', 0) # There should be only one index anyway
+        fit_alg.setProperty('ExpectedPeaks', expected_peaks_d)
         # we could also pass raw 'ExpectedPeaks' and 'ExpectedPeaksFromFile' to
         # EnggFitPaks, but better to check inputs early, before this
-        fitPeaksAlg.execute()
+        fit_alg.execute()
 
-        difc = fitPeaksAlg.getProperty('Difc').value
-        zero = fitPeaksAlg.getProperty('Zero').value
+        difc = fit_alg.getProperty('Difc').value
+        zero = fit_alg.getProperty('Zero').value
+        fitted_peaks = fit_alg.getProperty('FittedPeaks').value
 
-        return difc, zero
+        return difc, zero, fitted_peaks
 
-    def _focusRun(self, ws, vanWS, bank, indices):
+    def _focus_run(self, ws, vanWS, bank, indices):
         """
         Focuses the input workspace by running EnggFocus as a child algorithm, which will produce a
         single spectrum workspace.
@@ -185,7 +195,7 @@ class EnggCalibrate(PythonAlgorithm):
 
         return alg.getProperty('OutputWorkspace').value
 
-    def _produceOutputs(self, difc, zero):
+    def _produce_outputs(self, difc, zero):
         """
         Just fills in the output properties as requested
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrate.py
@@ -128,7 +128,7 @@ class EnggCalibrate(PythonAlgorithm):
         prog.report('Fitting parameters for the focused run')
         difc, zero, fitted_peaks = self._fit_params(focussed_ws, expectedPeaksD)
 
-        self._produce_outputs(difc, zero)
+        self._produce_outputs(difc, zero, fitted_peaks)
 
     def _fit_params(self, focused_ws, expected_peaks_d):
         """
@@ -195,18 +195,20 @@ class EnggCalibrate(PythonAlgorithm):
 
         return alg.getProperty('OutputWorkspace').value
 
-    def _produce_outputs(self, difc, zero):
+    def _produce_outputs(self, difc, zero, fitted_peaks):
         """
         Just fills in the output properties as requested
 
         @param difc :: the difc GSAS parameter as fitted here
         @param zero :: the zero GSAS parameter as fitted here
+        @param fitted_peaks :: table workspace with peak parameters (one peak per row)
         """
 
         import EnggUtils
 
         self.setProperty('Difc', difc)
         self.setProperty('Zero', zero)
+        self.setProperty('FittedPeaks', fitted_peaks)
 
         # make output table if requested
         tblName = self.getPropertyValue("OutputParametersTableName")

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -128,7 +128,7 @@ class EnggFitPeaks(PythonAlgorithm):
             self.log().information("Output parameters added into a table workspace: %s" % tbl_name)
 
 
-    def _estimate_start_end_fitting_range(self, centre, width):
+    def _estimate_start_end_fitting_range(self, center, width):
         """
         Try to predict a fit window for the peak (using magic numbers). The heuristic
         +-COEF_LEFT/RIGHT sometimes produces ranges that are too narrow and contain too few
@@ -141,8 +141,8 @@ class EnggFitPeaks(PythonAlgorithm):
         COEF_RIGHT = 3
         MIN_RANGE_WIDTH = 175
 
-        startx = centre - (width * COEF_LEFT)
-        endx = centre + (width * COEF_RIGHT)
+        startx = center - (width * COEF_LEFT)
+        endx = center + (width * COEF_RIGHT)
         # force startx-endx > 175, etc
         x_diff = endx-startx
         min_width = MIN_RANGE_WIDTH
@@ -193,7 +193,7 @@ class EnggFitPeaks(PythonAlgorithm):
             width = initial_params[2]
             if width <= 0.:
                 detailTxt = ("Cannot fit a peak with these initial parameters from FindPeaks, center: %s "
-                             ", width: %s, height: %s"%(centre, width, height))
+                             ", width: %s, height: %s"%(initial_params[0], width, initial_params[1]))
                 self.log().notice('For workspace index ' + str(wks_index) + ', a peak that is in the list of '
                                   'expected peaks and was found by FindPeaks has not been fitted correctly. '
                                   'It will be ignored. Details: ' + detailTxt)

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -65,34 +65,34 @@ class EnggFitPeaks(PythonAlgorithm):
         import EnggUtils
 
         # Get peaks in dSpacing from file
-        expectedPeaksD = EnggUtils.read_in_expected_peaks(self.getPropertyValue("ExpectedPeaksFromFile"),
+        expected_peaks_dsp = EnggUtils.read_in_expected_peaks(self.getPropertyValue("ExpectedPeaksFromFile"),
                                                           self.getProperty('ExpectedPeaks').value)
 
-        if len(expectedPeaksD) < 1:
+        if len(expected_peaks_dsp) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")
 
         # Get expected peaks in TOF for the detector
-        inWS = self.getProperty("InputWorkspace").value
-        dimType = inWS.getXDimension().getName()
+        in_wks = self.getProperty("InputWorkspace").value
+        dimType = in_wks.getXDimension().getName()
         if self.EXPECTED_DIM_TYPE != dimType:
             raise ValueError("This algorithm expects a workspace with %s X dimension, but "
                              "the X dimension of the input workspace is: '%s'" % (self.EXPECTED_DIM_TYPE, dimType))
 
-        wsIndex = self.getProperty("WorkspaceIndex").value
+        wks_index = self.getProperty("WorkspaceIndex").value
 
         # FindPeaks will return a list of peaks sorted by the centre found. Sort the peaks as well,
         # so we can match them with fitted centres later.
-        expectedPeaksToF = sorted(self._expectedPeaksInTOF(expectedPeaksD, inWS, wsIndex))
+        expected_peaks_ToF = sorted(self._expected_peaks_in_ToF(expected_peaks_dsp, in_wks, wks_index))
 
-        foundPeaks = self._peaksFromFindPeaks(inWS, expectedPeaksToF, wsIndex)
-        if foundPeaks.rowCount() < len(expectedPeaksToF):
-            txt = "Peaks effectively found: " + str(foundPeaks)[1:-1]
+        found_peaks = self._peaks_from_find_peaks(in_wks, expected_peaks_ToF, wks_index)
+        if found_peaks.rowCount() < len(expected_peaks_ToF):
+            txt = "Peaks effectively found: " + str(found_peaks)[1:-1]
             self.log().warning("Some peaks from the list of expected peaks were not found by the algorithm "
                                "FindPeaks which this algorithm uses to check that the data has the the "
                                "expected peaks. " + txt)
 
-        peaksTableName = self.getPropertyValue("OutFittedPeaksTable")
-        difc, zero, fitted_peaks = self._fit_all_peaks(inWS, wsIndex, (foundPeaks, expectedPeaksD), peaksTableName)
+        peaks_table_name = self.getPropertyValue("OutFittedPeaksTable")
+        difc, zero, fitted_peaks = self._fit_all_peaks(in_wks, wks_index, (found_peaks, expected_peaks_dsp), peaks_table_name)
         self._produce_outputs(difc, zero, fitted_peaks)
 
     def _get_default_peaks(self):
@@ -122,10 +122,10 @@ class EnggFitPeaks(PythonAlgorithm):
         self.setProperty('FittedPeaks', fitted_peaks)
 
         # optional outputs
-        tblName = self.getPropertyValue("OutParametersTable")
-        if '' != tblName:
-            EnggUtils.generateOutputParTable(tblName, difc, zero)
-            self.log().information("Output parameters added into a table workspace: %s" % tblName)
+        tbl_name = self.getPropertyValue("OutParametersTable")
+        if '' != tbl_name:
+            EnggUtils.generateOutputParTable(tbl_name, difc, zero)
+            self.log().information("Output parameters added into a table workspace: %s" % tbl_name)
 
 
     def _estimate_start_end_fitting_range(self, centre, width):
@@ -153,7 +153,7 @@ class EnggFitPeaks(PythonAlgorithm):
 
         return (startx, endx)
 
-    def _fit_all_peaks(self, inWS, wsIndex, peaks, peaksTableName):
+    def _fit_all_peaks(self, in_wks, wks_index, peaks, peaks_table_name):
         """
         This method is the core of EnggFitPeaks. It tries to fit as many peaks as there are in the list of
         expected peaks passed to the algorithm. This is a single peak fitting, in the sense that peaks
@@ -162,12 +162,12 @@ class EnggFitPeaks(PythonAlgorithm):
         The parameters from the (Gaussian) peaks fitted by FindPeaks elsewhere (before calling this method)
         are used as initial guesses.
 
-        @param inWS :: input workspace with spectra for fitting
-        @param wsIndex :: workspace index of the spectrum where the given peaks should be fitted
-        @param peaks :: tuple made of two lists: foundPeaks (peaks found by FindPeaks or similar
-                        algorithm), and expectedPeaksD (expected peaks given as input to this algorithm
+        @param in_wks :: input workspace with spectra for fitting
+        @param wks_index :: workspace index of the spectrum where the given peaks should be fitted
+        @param peaks :: tuple made of two lists: found_peaks (peaks found by FindPeaks or similar
+                        algorithm), and expected_peaks_dsp (expected peaks given as input to this algorithm
                         (in dSpacing units)
-        @param peaksTableName :: name of an (output) table with peaks parameters. If empty, the table is anonymous
+        @param peaks_table_name :: name of an (output) table with peaks parameters. If empty, the table is anonymous
 
         @returns difc and zero parameters and a table with parameters for every fitted peak. The difc and zero
         parameters are obtained from fitting a linear background (in _fit_dSpacing_to_ToF) to the peaks fitted
@@ -177,67 +177,41 @@ class EnggFitPeaks(PythonAlgorithm):
         if 2 != len(peaks):
             raise RuntimeError("Unexpected inconsistency found. This method requires a tuple with the list "
                                "of found peaks and the list of expected peaks.")
-        foundPeaks = peaks[0]
-        fittedPeaks = self._createFittedPeaksTable(peaksTableName)
+        found_peaks = peaks[0]
+        fitted_peaks = self._create_fitted_peaks_table(peaks_table_name)
 
-        prog = Progress(self, start=0, end=1, nreports=foundPeaks.rowCount())
+        prog = Progress(self, start=0, end=1, nreports=found_peaks.rowCount())
 
-        for i in range(foundPeaks.rowCount()):
+        for i in range(found_peaks.rowCount()):
             prog.report('Fitting peak number ' + str(i+1))
 
-            row = foundPeaks.row(i)
+            row = found_peaks.row(i)
             # Peak parameters estimated by FindPeaks
-            centre = row['centre']
-            width = row['width']
-            height = row['height']
+            initial_params = (row['centre'], row['width'], row['height'])
             # Oh oh, this actually happens sometimes for some spectra of the system test dataset
             # and it should be clarified when the role of FindPeaks etc. is fixed (trac ticket #10907)
+            width = initial_params[2]
             if width <= 0.:
                 detailTxt = ("Cannot fit a peak with these initial parameters from FindPeaks, center: %s "
                              ", width: %s, height: %s"%(centre, width, height))
-                self.log().notice('For workspace index ' + str(wsIndex) + ', a peak that is in the list of '
+                self.log().notice('For workspace index ' + str(wks_index) + ', a peak that is in the list of '
                                   'expected peaks and was found by FindPeaks has not been fitted correctly. '
                                   'It will be ignored. Details: ' + detailTxt)
                 continue
 
-            # Sigma value of the peak, assuming Gaussian shape
-            sigma = width / (2 * math.sqrt(2 * math.log(2)))
 
-            # Approximate peak intensity, assuming Gaussian shape
-            intensity = height * sigma * math.sqrt(2 * math.pi)
+            param_table, chi_over_dof = self._fit_single_peak(peaks[1][i], initial_params, in_wks, wks_index)
 
-            peak = FunctionFactory.createFunction(self.PEAK_TYPE)
-            peak.setParameter('X0', centre)
-            peak.setParameter('S', sigma)
-            peak.setParameter('I', intensity)
+            fitted_params = {}
+            fitted_params['dSpacing'] = peaks[1][i]
+            fitted_params['Chi'] = chi_over_dof
+            self._add_parameters_to_map(fitted_params, param_table)
 
-            # Fit using predicted window and a proper function with approximated initital values
-            fitAlg = self.createChildAlgorithm('Fit')
-            fit_function = 'name=LinearBackground;{0}'.format(peak)
-            fitAlg.setProperty('Function', fit_function)
-            fitAlg.setProperty('InputWorkspace', inWS)
-            fitAlg.setProperty('WorkspaceIndex', wsIndex)
-            fitAlg.setProperty('CreateOutput', True)
-
-            (startx, endx) = self._estimate_start_end_fitting_range(centre, width)
-            fitAlg.setProperty('StartX', startx)
-            fitAlg.setProperty('EndX', endx)
-            self.log().debug("Fitting for peak expectd in (d-spacing): {0}, Fitting peak function: "
-                             "{1}, with startx: {2}, endx: {3}".
-                             format(peaks[1][i], fit_function, startx, endx))
-            fitAlg.execute()
-            paramTable = fitAlg.getProperty('OutputParameters').value
-
-            fittedParams = {}
-            fittedParams['dSpacing'] = peaks[1][i]
-            fittedParams['Chi'] = fitAlg.getProperty('OutputChi2overDoF').value
-            self._addParametersToMap(fittedParams, paramTable)
-
-            fittedPeaks.addRow(fittedParams)
+            fitted_peaks.addRow(fitted_params)
 
         # Check if we were able to really fit any peak
-        if 0 == fittedPeaks.rowCount():
-            detailTxt = ("Could find " + str(len(foundPeaks)) + " peaks using the algorithm FindPeaks but " +
+        if 0 == fitted_peaks.rowCount():
+            detailTxt = ("Could find " + str(len(found_peaks)) + " peaks using the algorithm FindPeaks but " +
                          "then it was not possible to fit any peak starting from these peaks found and using '" +
                          self.PEAK_TYPE + "' as peak function.")
             self.log().warning('Could not fit any peak. Please check the list of expected peaks, as it does not '
@@ -245,77 +219,123 @@ class EnggFitPeaks(PythonAlgorithm):
                                detailTxt)
 
             raise RuntimeError('Could not fit any peak.  Failed to fit peaks with peak type ' +
-                               self.PEAK_TYPE + ' even though FindPeaks found ' + str(foundPeaks.rowCount()) +
+                               self.PEAK_TYPE + ' even though FindPeaks found ' + str(found_peaks.rowCount()) +
                                ' peaks in principle. See the logs for further details.')
         # Better than failing to fit the linear function
-        if 1 == fittedPeaks.rowCount():
+        if 1 == fitted_peaks.rowCount():
             raise RuntimeError('Could find only one peak. This is not enough to fit the output parameters '
                                'difc and zero. Please check the list of expected peaks given and if it is '
                                'appropriate for the workspace')
 
-        difc, zero = self._fit_dSpacing_to_ToF(fittedPeaks)
+        difc, zero = self._fit_dSpacing_to_ToF(fitted_peaks)
 
-        return (difc, zero, fittedPeaks)
+        return (difc, zero, fitted_peaks)
 
-    def _peaksFromFindPeaks(self, inWS, expectedPeaksToF, wsIndex):
+    def _fit_single_peak(self, expected_center, initial_params, wks, wks_index):
+        """
+        Fits one peak, given an initial guess of parameters (center, width, height).
+
+        @param expected_center :: expected peak position
+        @param initial_params :: tuple with initial guess of the peak center, width and height
+        @param wks :: workspace with data (spectra) to fit
+        @param wks_index :: index of the spectrum to fit
+
+        @return parameters from Fit, and the goodness of fit estimation from Fit (as Chi^2/DoF)
+        """
+
+        center, width, height = initial_params
+        # Sigma value of the peak, assuming Gaussian shape
+        sigma = width / (2 * math.sqrt(2 * math.log(2)))
+
+        # Approximate peak intensity, assuming Gaussian shape
+        intensity = height * sigma * math.sqrt(2 * math.pi)
+
+        peak = FunctionFactory.createFunction(self.PEAK_TYPE)
+        peak.setParameter('X0', center)
+        peak.setParameter('S', sigma)
+        peak.setParameter('I', intensity)
+
+        # Fit using predicted window and a proper function with approximated initital values
+        fit_alg = self.createChildAlgorithm('Fit')
+        fit_function = 'name=LinearBackground;{0}'.format(peak)
+        fit_alg.setProperty('Function', fit_function)
+        fit_alg.setProperty('InputWorkspace', wks)
+        fit_alg.setProperty('WorkspaceIndex', wks_index)
+        fit_alg.setProperty('CreateOutput', True)
+
+        (startx, endx) = self._estimate_start_end_fitting_range(center, width)
+        fit_alg.setProperty('StartX', startx)
+        fit_alg.setProperty('EndX', endx)
+        self.log().debug("Fitting for peak expectd in (d-spacing): {0}, Fitting peak function: "
+                         "{1}, with startx: {2}, endx: {3}".
+                         format(expected_center, fit_function, startx, endx))
+        fit_alg.execute()
+        param_table = fit_alg.getProperty('OutputParameters').value
+        chi_over_dof = fit_alg.getProperty('OutputChi2overDoF').value
+
+        return (param_table, chi_over_dof)
+
+    def _peaks_from_find_peaks(self, in_wks, expected_peaks_ToF, wks_index):
         """
         Use the algorithm FindPeaks to check that the expected peaks are there.
 
-        @param inWS data workspace
-        @param expectedPeaksToF vector/list of expected peak values
-        @param wsIndex workspace index
+        @param in_wks data workspace
+        @param expected_peaks_ToF vector/list of expected peak values
+        @param wks_index workspace index
 
         @return list of peaks found by FindPeaks. If there are no issues, the length
         of this list should be the same as the number of expected peaks received.
         """
-        # Find approximate peak positions, asumming Gaussian shapes
-        findPeaksAlg = self.createChildAlgorithm('FindPeaks')
-        findPeaksAlg.setProperty('InputWorkspace', inWS)
-        findPeaksAlg.setProperty('PeakPositions', expectedPeaksToF)
-        findPeaksAlg.setProperty('PeakFunction', 'Gaussian')
-        findPeaksAlg.setProperty('WorkspaceIndex', wsIndex)
-        findPeaksAlg.execute()
-        foundPeaks = findPeaksAlg.getProperty('PeaksList').value
-        return foundPeaks
 
-    def _fit_dSpacing_to_ToF(self, fittedPeaksTable):
+        # Find approximate peak positions, asumming Gaussian shapes
+        find_peaks_alg = self.createChildAlgorithm('FindPeaks')
+        find_peaks_alg.setProperty('InputWorkspace', in_wks)
+        find_peaks_alg.setProperty('PeakPositions', expected_peaks_ToF)
+        find_peaks_alg.setProperty('PeakFunction', 'Gaussian')
+        find_peaks_alg.setProperty('WorkspaceIndex', wks_index)
+        find_peaks_alg.execute()
+        found_peaks = find_peaks_alg.getProperty('PeaksList').value
+        return found_peaks
+
+    def _fit_dSpacing_to_ToF(self, fitted_peaksTable):
         """
         Fits a linear background to the dSpacing <-> TOF relationship and returns fitted difc
         and zero values. If the table passed has less than 2 peaks this raises an exception, as it
         is not possible to fit the difc, zero parameters.
 
-        @param fittedPeaksTable :: table with one row per fitted peak, expecting column 'dSpacing'
+        @param fitted_peaksTable :: table with one row per fitted peak, expecting column 'dSpacing'
         as x values and column 'X0' as y values.
 
         @return the pair of difc and zero values fitted to the peaks.
     	"""
-        numPeaks = fittedPeaksTable.rowCount()
-        if numPeaks < 2:
-            raise ValueError('Cannot fit a linear function with less than two peaks. Got a table of ' +
-                             'peaks with ' + str(numPeaks) + ' peaks')
 
-        convertTableAlg = self.createChildAlgorithm('ConvertTableToMatrixWorkspace')
-        convertTableAlg.setProperty('InputWorkspace', fittedPeaksTable)
-        convertTableAlg.setProperty('ColumnX', 'dSpacing')
-        convertTableAlg.setProperty('ColumnY', 'X0')
-        convertTableAlg.execute()
-        dSpacingVsTof = convertTableAlg.getProperty('OutputWorkspace').value
+        num_peaks = fitted_peaksTable.rowCount()
+        if num_peaks < 2:
+            raise ValueError('Cannot fit a linear function with less than two peaks. Got a table of ' +
+                             'peaks with ' + str(num_peaks) + ' peaks')
+
+        convert_tbl_alg = self.createChildAlgorithm('ConvertTableToMatrixWorkspace')
+        convert_tbl_alg.setProperty('InputWorkspace', fitted_peaksTable)
+        convert_tbl_alg.setProperty('ColumnX', 'dSpacing')
+        convert_tbl_alg.setProperty('ColumnY', 'X0')
+        convert_tbl_alg.execute()
+        dSpacingVsTof = convert_tbl_alg.getProperty('OutputWorkspace').value
 
     	# Fit the curve to get linear coefficients of TOF <-> dSpacing relationship for the detector
-        fitAlg = self.createChildAlgorithm('Fit')
-        fitAlg.setProperty('Function', 'name=LinearBackground')
-        fitAlg.setProperty('InputWorkspace', dSpacingVsTof)
-        fitAlg.setProperty('WorkspaceIndex', 0)
-        fitAlg.setProperty('CreateOutput', True)
-        fitAlg.execute()
-        paramTable = fitAlg.getProperty('OutputParameters').value
+        fit_alg = self.createChildAlgorithm('Fit')
+        fit_alg.setProperty('Function', 'name=LinearBackground')
+        fit_alg.setProperty('InputWorkspace', dSpacingVsTof)
+        fit_alg.setProperty('WorkspaceIndex', 0)
+        fit_alg.setProperty('CreateOutput', True)
+        fit_alg.execute()
+        param_table = fit_alg.getProperty('OutputParameters').value
 
-        zero = paramTable.cell('Value', 0) # A0
-        difc = paramTable.cell('Value', 1) # A1
+        zero = param_table.cell('Value', 0) # A0
+        difc = param_table.cell('Value', 1) # A1
 
         return (difc, zero)
 
-    def _expectedPeaksInTOF(self, expectedPeaks, inWS, wsIndex):
+    def _expected_peaks_in_ToF(self, expectedPeaks, in_wks, wks_index):
         """
         Converts expected peak dSpacing values to TOF values for the
         detector. Implemented by using the Mantid algorithm ConvertUnits. A
@@ -325,16 +345,16 @@ class EnggFitPeaks(PythonAlgorithm):
         import mantid.simpleapi as sapi
 
         yVals = [1] * (len(expectedPeaks) - 1)
-        wsFrom = sapi.CreateWorkspace(UnitX='dSpacing', DataX=expectedPeaks, DataY=yVals,
-                                      ParentWorkspace=inWS)
-        targetUnits = 'TOF'
-        wsTo = sapi.ConvertUnits(InputWorkspace=wsFrom, Target=targetUnits)
-        peaksToF = wsTo.dataX(0)
-        values = [peaksToF[i] for i in range(0,len(peaksToF))]
+        ws_from = sapi.CreateWorkspace(UnitX='dSpacing', DataX=expectedPeaks, DataY=yVals,
+                                      ParentWorkspace=in_wks)
+        target_units = 'TOF'
+        wsTo = sapi.ConvertUnits(InputWorkspace=ws_from, Target=target_units)
+        peaks_ToF = wsTo.dataX(0)
+        values = [peaks_ToF[i] for i in range(0,len(peaks_ToF))]
 
         @param expectedPeaks :: vector of expected peaks, in dSpacing units
-        @param inWS :: input workspace with the relevant instrument/geometry
-        @param wsIndex spectrum index
+        @param in_wks :: input workspace with the relevant instrument/geometry
+        @param wks_index spectrum index
 
         Returns:
             a vector of ToF values converted from the input (dSpacing) vector.
@@ -348,8 +368,8 @@ class EnggFitPeaks(PythonAlgorithm):
         # The present behavior of 'ConvertUnits' is to show an information log:
         # "Unable to calculate sample-detector distance for 1 spectra. Masking spectrum"
         # and silently produce a wrong output workspace. That might need revisiting.
-        if 1 == inWS.getNumberHistograms():
-            return self._doApproxHardCodedConvertUnitsToToF(expectedPeaks, inWS, wsIndex)
+        if 1 == in_wks.getNumberHistograms():
+            return self._do_approx_hard_coded_convert_units_to_ToF(expectedPeaks, in_wks, wks_index)
 
         # Create workspace just to convert dSpacing -> ToF, yVals are irrelevant
         # this used to be calculated with:
@@ -358,59 +378,59 @@ class EnggFitPeaks(PythonAlgorithm):
         # remember the -1, we must produce a histogram data workspace, which is what
         # for example EnggCalibrate expects
         yVals = [1] * (len(expectedPeaks) - 1)
-        # Do like: wsFrom = sapi.CreateWorkspace(UnitX='dSpacing', DataX=expectedPeaks, DataY=yVals,
+        # Do like: ws_from = sapi.CreateWorkspace(UnitX='dSpacing', DataX=expectedPeaks, DataY=yVals,
         #                                        ParentWorkspace=self.getProperty("InputWorkspace").value)
-        createAlg = self.createChildAlgorithm("CreateWorkspace")
-        createAlg.setProperty("UnitX", 'dSpacing')
-        createAlg.setProperty("DataX", expectedPeaks)
-        createAlg.setProperty("DataY", yVals)
-        createAlg.setProperty("ParentWorkspace", inWS)
-        createAlg.execute()
+        create_alg = self.createChildAlgorithm("CreateWorkspace")
+        create_alg.setProperty("UnitX", 'dSpacing')
+        create_alg.setProperty("DataX", expectedPeaks)
+        create_alg.setProperty("DataY", yVals)
+        create_alg.setProperty("ParentWorkspace", in_wks)
+        create_alg.execute()
 
-        wsFrom = createAlg.getProperty("OutputWorkspace").value
+        ws_from = create_alg.getProperty("OutputWorkspace").value
 
-        # finally convert units, like: sapi.ConvertUnits(InputWorkspace=wsFrom, Target=targetUnits)
-        convAlg = self.createChildAlgorithm("ConvertUnits")
-        convAlg.setProperty("InputWorkspace", wsFrom)
-        targetUnits = 'TOF'
-        convAlg.setProperty("Target", targetUnits)
+        # finally convert units, like: sapi.ConvertUnits(InputWorkspace=ws_from, Target=target_units)
+        conv_alg = self.createChildAlgorithm("ConvertUnits")
+        conv_alg.setProperty("InputWorkspace", ws_from)
+        target_units = 'TOF'
+        conv_alg.setProperty("Target", target_units)
         # note: this implicitly uses default property "EMode" value 'Elastic'
-        goodExec = convAlg.execute()
+        goodExec = conv_alg.execute()
 
         if not goodExec:
             raise RuntimeError("Conversion of units went wrong. Failed to run ConvertUnits for %d peaks: %s"
                                % (len(expectedPeaks), expectedPeaks))
 
-        wsTo = convAlg.getProperty('OutputWorkspace').value
-        peaksToF = wsTo.readX(0)
-        if len(peaksToF) != len(expectedPeaks):
+        wsTo = conv_alg.getProperty('OutputWorkspace').value
+        peaks_ToF = wsTo.readX(0)
+        if len(peaks_ToF) != len(expectedPeaks):
             raise RuntimeError("Conversion of units went wrong. Converted %d peaks from the original "
                                "list of %d peaks. The instrument definition might be incomplete for the "
-                               "original workspace / file."% (len(peaksToF), len(expectedPeaks)))
+                               "original workspace / file."% (len(peaks_ToF), len(expectedPeaks)))
 
-        ToFvalues = [peaksToF[i] for i in range(0,len(peaksToF))]
+        tof_values = [peaks_ToF[i] for i in range(0,len(peaks_ToF))]
         # catch potential failures because of geometry issues, etc.
-        if ToFvalues == expectedPeaks:
-            vals = self._doApproxHardCodedConvertUnitsToToF(expectedPeaks, inWS, wsIndex)
+        if tof_values == expectedPeaks:
+            vals = self._do_approx_hard_coded_convert_units_to_ToF(expectedPeaks, in_wks, wks_index)
             return vals
 
-        return ToFvalues
+        return tof_values
 
-    def _doApproxHardCodedConvertUnitsToToF(self, dspValues, ws, wsIndex):
+    def _do_approx_hard_coded_convert_units_to_ToF(self, dsp_values, ws, wks_index):
         """
         Converts from dSpacing to Time-of-flight, for one spectrum/detector. This method
         is here for exceptional cases that presently need clarification / further work,
         here and elsewhere in Mantid, and should ideally be removed in favor of the more
         general method that uses the algorithm ConvertUnits.
 
-        @param dspValues to convert from dSpacing
+        @param dsp_values to convert from dSpacing
         @param ws workspace with the appropriate instrument / geometry definition
-        @param wsIndex index of the spectrum
+        @param wks_index index of the spectrum
 
         Return:
         input values converted from dSpacing to ToF
         """
-        det = ws.getDetector(wsIndex)
+        det = ws.getDetector(wks_index)
 
         # Current detector parameters
         detL2 = det.getDistance(ws.getInstrument().getSample())
@@ -420,23 +440,23 @@ class EnggFitPeaks(PythonAlgorithm):
         dSpacingToTof = lambda d: 252.816 * 2 * (50 + detL2) * math.sin(detTwoTheta / 2.0) * d
 
         # Values (in principle, expected peak positions) in TOF for the detector
-        ToFvalues = [dSpacingToTof(ep) for ep in dspValues]
-        return ToFvalues
+        tof_values = [dSpacingToTof(ep) for ep in dsp_values]
+        return tof_values
 
-    def _createFittedPeaksTable(self, tblName):
+    def _create_fitted_peaks_table(self, tbl_name):
         """
         Creates a table where to put peak fitting results to
 
-        @param tblName :: name of the table workspace (can be empty)
+        @param tbl_name :: name of the table workspace (can be empty)
     	"""
         table = None
-        if not tblName:
+        if not tbl_name:
             alg = self.createChildAlgorithm('CreateEmptyTableWorkspace')
             alg.execute()
             table = alg.getProperty('OutputWorkspace').value
         else:
             import mantid.simpleapi as sapi
-            table = sapi.CreateEmptyTableWorkspace(OutputWorkspace=tblName)
+            table = sapi.CreateEmptyTableWorkspace(OutputWorkspace=tbl_name)
 
         table.addColumn('double', 'dSpacing')
 
@@ -448,22 +468,22 @@ class EnggFitPeaks(PythonAlgorithm):
 
         return table
 
-    def _addParametersToMap(self, paramMap, paramTable):
+    def _add_parameters_to_map(self, param_map, param_table):
         """
         Takes parameters from a table that contains output parameters from a Fit run, and adds
         them as name:value and name_Err:error_value pairs to the map.
 
-        @param paramMap :: map where to add the fitting parameters
-        @param paramTable :: table with parameters from a Fit algorithm run
+        @param param_map :: map where to add the fitting parameters
+        @param param_table :: table with parameters from a Fit algorithm run
         """
-        for i in range(paramTable.rowCount() - 1): # Skip the last (fit goodness) row
-            row = paramTable.row(i)
+        for i in range(param_table.rowCount() - 1): # Skip the last (fit goodness) row
+            row = param_table.row(i)
 
             # Get local func. param name. E.g., not f1.A0, but just A0
             name = (row['Name'].rpartition('.'))[2]
 
-            paramMap[name] = row['Value']
-            paramMap[name + '_Err'] = row['Error']
+            param_map[name] = row['Value']
+            param_map[name + '_Err'] = row['Error']
 
 
 AlgorithmFactory.subscribe(EnggFitPeaks)

--- a/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggFitPeaks.py
@@ -66,7 +66,7 @@ class EnggFitPeaks(PythonAlgorithm):
 
         # Get peaks in dSpacing from file
         expected_peaks_dsp = EnggUtils.read_in_expected_peaks(self.getPropertyValue("ExpectedPeaksFromFile"),
-                                                          self.getProperty('ExpectedPeaks').value)
+                                                              self.getProperty('ExpectedPeaks').value)
 
         if len(expected_peaks_dsp) < 1:
             raise ValueError("Cannot run this algorithm without any input expected peaks")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggCalibrateTest.py
@@ -79,10 +79,10 @@ class EnggCalibrateTest(unittest.TestCase):
         Checks normal operation.
         """
 
-        difc, zero = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
-                                        VanIntegrationWorkspace=self.__class__._van_integ_tbl,
-                                        VanCurvesWorkspace=self.__class__._van_curves_ws,
-                                        ExpectedPeaks=[1.6, 1.1, 1.8], Bank='2')
+        difc, zero, peaks = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
+                                               VanIntegrationWorkspace=self.__class__._van_integ_tbl,
+                                               VanCurvesWorkspace=self.__class__._van_curves_ws,
+                                               ExpectedPeaks=[1.6, 1.1, 1.8], Bank='2')
 
         self.check_3peaks_values(difc, zero)
 
@@ -93,12 +93,12 @@ class EnggCalibrateTest(unittest.TestCase):
         """
         # This file has: 1.6, 1.1, 1.8 (as the test above)
         filename = 'EnginX_3_expected_peaks_unittest.csv'
-        difc, zero = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
-                                        VanIntegrationWorkspace=self.__class__._van_integ_tbl,
-                                        VanCurvesWorkspace=self.__class__._van_curves_ws,
-                                        ExpectedPeaks=[-4, 40, 323], # nonsense, but FromFile should prevail
-                                        ExpectedPeaksFromFile=filename,
-                                        Bank='2')
+        difc, zero, peaks = sapi.EnggCalibrate(InputWorkspace=self.__class__._data_ws,
+                                               VanIntegrationWorkspace=self.__class__._van_integ_tbl,
+                                               VanCurvesWorkspace=self.__class__._van_curves_ws,
+                                               ExpectedPeaks=[-4, 40, 323], # nonsense, but FromFile should prevail
+                                               ExpectedPeaksFromFile=filename,
+                                               Bank='2')
 
         self.check_3peaks_values(difc, zero)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFitPeaksTest.py
@@ -32,6 +32,12 @@ class EnggFitPeaksTest(unittest.TestCase):
                           InputWorkspace=ws_name, BankPixelFoo=33,
                           WorkspaceIndex=0, ExpectedPeaks='0.51, 0.72')
 
+        # missing FittedPeaks output property
+        self.assertRaises(RuntimeError,
+                          EnggFitPeaks,
+                          InputWorkspace=ws_name,
+                          WorkspaceIndex=0, ExpectedPeaks='0.51, 0.72')
+
         # Wrong ExpectedPeaks value
         self.assertRaises(ValueError,
                           EnggFitPeaks,
@@ -164,9 +170,12 @@ class EnggFitPeaksTest(unittest.TestCase):
         ep1 = 0.4
         ep2 = 1.09
         paramsTblName = 'test_difc_zero_table'
-        difc, zero = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
-                                    OutFittedPeaksTable=peaksTblName,
-                                    OutParametersTable=paramsTblName)
+        difc, zero, test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2],
+                                                        OutFittedPeaksTable=peaksTblName,
+                                                        OutParametersTable=paramsTblName)
+
+        self.assertEquals(test_fit_peaks_table.rowCount(), 2)
+
         pTable = mtd[paramsTblName]
         self.assertEquals(pTable.rowCount(), 1)
         self.assertEquals(pTable.columnCount(), 2)
@@ -205,8 +214,10 @@ class EnggFitPeaksTest(unittest.TestCase):
         ep1 = 0.4
         ep2 = 0.83
         ep3 = 1.09
-        difc, zero = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2, ep3],
-                                    OutFittedPeaksTable=peaksTblName)
+        difc, zero, test_fit_peaks_table = EnggFitPeaks(sws, WorkspaceIndex=0, ExpectedPeaks=[ep1, ep2, ep3],
+                                                        OutFittedPeaksTable=peaksTblName)
+
+        self.assertEquals(test_fit_peaks_table.rowCount(), 3)
 
         expected_difc = 17335.67250113934
         # assertLess would be nices, but only available in unittest >= 2.7

--- a/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/MantidQt/CustomInterfaces/src/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -68,8 +68,7 @@ void EnggDiffractionPresenter::cleanup() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A calibration process is currently running, shutting "
-                        "it down immediately..."
-                     << std::endl;
+                        "it down immediately..." << std::endl;
       m_workerThread->wait(10);
     }
     delete m_workerThread;
@@ -178,8 +177,7 @@ void EnggDiffractionPresenter::processCalcCalib() {
     return;
   }
   g_log.notice() << "EnggDiffraction GUI: starting new calibration. This may "
-                    "take a few seconds... "
-                 << std::endl;
+                    "take a few seconds... " << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -212,8 +210,7 @@ void EnggDiffractionPresenter::ProcessCropCalib() {
 
   g_log.notice()
       << "EnggDiffraction GUI: starting cropped calibration. This may "
-         "take a few seconds... "
-      << std::endl;
+         "take a few seconds... " << std::endl;
 
   const std::string outFilename = outputCalibFilename(vanNo, ceriaNo);
 
@@ -411,8 +408,7 @@ void EnggDiffractionPresenter::processRebinTime() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) with a TOF bin into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -438,8 +434,7 @@ void EnggDiffractionPresenter::processRebinMultiperiod() {
   g_log.notice() << "EnggDiffraction GUI: starting new pre-processing "
                     "(re-binning) by pulse times into workspace '" +
                         outWSName + "'. This "
-                                    "may take some seconds... "
-                 << std::endl;
+                                    "may take some seconds... " << std::endl;
 
   m_view->enableCalibrateAndFocusActions(false);
   // GUI-blocking alternative:
@@ -475,8 +470,7 @@ void EnggDiffractionPresenter::processStopFocus() {
   if (m_workerThread) {
     if (m_workerThread->isRunning()) {
       g_log.notice() << "A focus process is currently running, shutting "
-                        "it down as soon as possible..."
-                     << std::endl;
+                        "it down as soon as possible..." << std::endl;
 
       g_abortThread = true;
       g_log.warning() << "Focus Stop has been clicked, please wait until "
@@ -814,13 +808,11 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   } catch (std::runtime_error &) {
     g_log.error() << "The calibration calculations failed. One of the "
                      "algorithms did not execute correctly. See log messages "
-                     "for details. "
-                  << std::endl;
+                     "for details. " << std::endl;
   } catch (std::invalid_argument &) {
     g_log.error()
         << "The calibration calculations failed. Some input properties "
-           "were not valid. See log messages for details. "
-        << std::endl;
+           "were not valid. See log messages for details. " << std::endl;
   }
   // restore normal data search paths
   conf.setDataSearchDirs(tmpDirs);
@@ -967,9 +959,10 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
           "3.1243, 2.7057, 1.9132, 1.6316, 1.5621, "
           "1.3529, 1.2415, 1.2100, 1.1046, 1.0414, 0.9566, 0.9147, 0.9019, "
           "0.8556, 0.8252, 0.8158, 0.7811");
-      alg->setPropertyValue("OutputParametersTableName",
-                            "engggui_calibration_bank_" +
-                                boost::lexical_cast<std::string>(i + 1));
+      const std::string outFitParamsTblName =
+          "engggui_calibration_bank_" + boost::lexical_cast<std::string>(i + 1);
+      alg->setPropertyValue("FittedPeaks", outFitParamsTblName);
+      alg->setPropertyValue("OutputParametersTableName", outFitParamsTblName);
       alg->execute();
     } catch (std::runtime_error &re) {
       g_log.error() << "Error in calibration. ",
@@ -1238,8 +1231,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
     g_lastValidRun = runNo;
 
     g_log.notice() << "Generating new focusing workspace(s) and file(s) into "
-                      "this directory: "
-                   << dir << std::endl;
+                      "this directory: " << dir << std::endl;
 
     // TODO: this is almost 100% common with doNewCalibrate() - refactor
     EnggDiffCalibSettings cs = m_view->currentCalibSettings();
@@ -1282,8 +1274,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
           loadDetectorGroupingCSV(dgFile, bankIDs, specs);
         } catch (std::runtime_error &re) {
           g_log.error() << "Error loading detector grouping file: " + dgFile +
-                               ". Detailed error: " + re.what()
-                        << std::endl;
+                               ". Detailed error: " + re.what() << std::endl;
           bankIDs.clear();
           specs.clear();
         }
@@ -1299,8 +1290,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
           fpath.append(effectiveFilenames[idx]).toString();
       g_log.notice() << "Generating new focused file (bank " +
                             boost::lexical_cast<std::string>(bankIDs[idx]) +
-                            ") for run " + runNo + " into: "
-                     << effectiveFilenames[idx] << std::endl;
+                            ") for run " + runNo +
+                            " into: " << effectiveFilenames[idx] << std::endl;
       try {
         m_focusFinishedOK = false;
         doFocusing(cs, fullFilename, runNo, bankIDs[idx], specs[idx], dgFile);
@@ -1313,8 +1304,8 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &dir,
       } catch (std::invalid_argument &ia) {
         g_log.error() << "The focusing failed. Some input properties "
                          "were not valid. "
-                         "See log messages for details. Error: "
-                      << ia.what() << std::endl;
+                         "See log messages for details. Error: " << ia.what()
+                      << std::endl;
       }
     }
 
@@ -1410,8 +1401,7 @@ void EnggDiffractionPresenter::focusingFinished() {
     if (lastRun != lastValid) {
       g_log.warning()
           << "Focussing process has been stopped, last successful "
-             "run number: "
-          << g_lastValidRun
+             "run number: " << g_lastValidRun
           << " , total number of focus run that could not be processed: "
           << (lastRun - lastValid) << std::endl;
     }
@@ -1490,8 +1480,7 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
 
     if (multi_RunNo.size() == 1) {
       g_log.notice() << "Only single file has been listed, the Sum Of Files"
-                        "cannot not be processed"
-                     << std::endl;
+                        "cannot not be processed" << std::endl;
     } else {
       g_log.notice()
           << "Load alogirthm has successfully merged the files provided"
@@ -1657,8 +1646,7 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "This is possibly because some of the settings are not "
                        "consistent. Please check the log messages for "
                        "details. Details: " +
-                           std::string(ia.what())
-                    << std::endl;
+                           std::string(ia.what()) << std::endl;
       throw;
     } catch (std::runtime_error &re) {
       g_log.error() << "Failed to calculate Vanadium corrections. "
@@ -1667,15 +1655,14 @@ void EnggDiffractionPresenter::loadOrCalcVanadiumWorkspaces(
                        "There was no obvious error in the input properties "
                        "but the algorithm failed. Please check the log "
                        "messages for details." +
-                           std::string(re.what())
-                    << std::endl;
+                           std::string(re.what()) << std::endl;
       throw;
     }
   } else {
     g_log.notice() << "Found precalculated Vanadium correction features for "
-                      "Vanadium run "
-                   << vanNo << ". Re-using these files: " << preIntegFilename
-                   << ", and " << preCurvesFilename << std::endl;
+                      "Vanadium run " << vanNo
+                   << ". Re-using these files: " << preIntegFilename << ", and "
+                   << preCurvesFilename << std::endl;
     try {
       loadVanadiumPrecalcWorkspaces(preIntegFilename, preCurvesFilename,
                                     vanIntegWS, vanCurvesWS, vanNo);
@@ -1858,13 +1845,12 @@ EnggDiffractionPresenter::loadToPreproc(const std::string runNo) {
     auto load =
         Mantid::API::AlgorithmManager::Instance().createUnmanaged("Load");
     load->initialize();
-	if (Poco::File(runNoDir).exists()) {
-		load->setPropertyValue("Filename", runNoDir);
-	}
-	else {
-		load->setPropertyValue("Filename", instStr + runNo);
-	}
-	const std::string inWSName = "engggui_preproc_input_ws";
+    if (Poco::File(runNoDir).exists()) {
+      load->setPropertyValue("Filename", runNoDir);
+    } else {
+      load->setPropertyValue("Filename", instStr + runNo);
+    }
+    const std::string inWSName = "engggui_preproc_input_ws";
     load->setPropertyValue("OutputWorkspace", inWSName);
 
     load->execute();
@@ -1910,15 +1896,14 @@ void EnggDiffractionPresenter::doRebinningTime(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() + "."
-                  << std::endl;
+                         rebinName + ". Error description: " + ia.what() +
+                         "." << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning with a regular bin width in time. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "."
-                  << std::endl;
+                         re.what() + "." << std::endl;
     return;
   }
 
@@ -2014,15 +1999,14 @@ void EnggDiffractionPresenter::doRebinningPulses(const std::string &runNo,
   } catch (std::invalid_argument &ia) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "There was an error in the inputs to the algorithm " +
-                         rebinName + ". Error description: " + ia.what() + "."
-                  << std::endl;
+                         rebinName + ". Error description: " + ia.what() +
+                         "." << std::endl;
     return;
   } catch (std::runtime_error &re) {
     g_log.error() << "Error when rebinning by pulse times. "
                      "Coult not run the algorithm " +
                          rebinName + " successfully. Error description: " +
-                         re.what() + "."
-                  << std::endl;
+                         re.what() + "." << std::endl;
     return;
   }
 
@@ -2076,8 +2060,7 @@ void EnggDiffractionPresenter::rebinningFinished() {
         << std::endl;
   } else {
     g_log.notice() << "Pre-processing (re-binning) finished - the output "
-                      "workspace is ready."
-                   << std::endl;
+                      "workspace is ready." << std::endl;
   }
   if (m_workerThread) {
     delete m_workerThread;

--- a/docs/source/algorithms/EnggCalibrate-v1.rst
+++ b/docs/source/algorithms/EnggCalibrate-v1.rst
@@ -67,16 +67,16 @@ Usage
    van_integ_ws = Load('ENGINX_precalculated_vanadium_run000236516_integration.nxs')
    van_curves_ws = Load('ENGINX_precalculated_vanadium_run000236516_bank_curves.nxs')
 
-   Difc1, Zero1 = EnggCalibrate(InputWorkspace=ws_name,
-                                VanIntegrationWorkspace=van_integ_ws,
-                                VanCurvesWorkspace=van_curves_ws,
-                                ExpectedPeaks=[1.097, 2.1], Bank='1',
-                                OutputParametersTableName=out_tbl_name)
+   Difc1, Zero1, peaks1 = EnggCalibrate(InputWorkspace=ws_name,
+                                        VanIntegrationWorkspace=van_integ_ws,
+                                        VanCurvesWorkspace=van_curves_ws,
+                                        ExpectedPeaks=[1.097, 2.1], Bank='1',
+                                        OutputParametersTableName=out_tbl_name)
 
-   Difc2, Zero2 = EnggCalibrate(InputWorkspace=ws_name,
-                                VanIntegrationWorkspace=van_integ_ws,
-                                VanCurvesWorkspace=van_curves_ws,
-                                ExpectedPeaks=[1.097, 2.1], Bank='2')
+   Difc2, Zero2, peaks2 = EnggCalibrate(InputWorkspace=ws_name,
+                                        VanIntegrationWorkspace=van_integ_ws,
+                                        VanCurvesWorkspace=van_curves_ws,
+                                        ExpectedPeaks=[1.097, 2.1], Bank='2')
 
    # You can produce an instrument parameters (iparam) file for GSAS.
    # Note that this is very specific to ENGIN-X

--- a/docs/source/algorithms/EnggFitPeaks-v1.rst
+++ b/docs/source/algorithms/EnggFitPeaks-v1.rst
@@ -68,8 +68,8 @@ Usage
    # Run the algorithm. Defaults are shown below. Files entered must be in .csv format and if both ExpectedPeaks and ExpectedPeaksFromFile are entered, the latter will be used.
    # difc, zero = EnggXFitPeaks(InputWorkspace = No default, WorkspaceIndex = None, ExpectedPeaks=[0.6, 1.9], ExpectedPeaksFromFile=None)
 
-   out_tbl_name = 'out_params'
-   difc, zero = EnggFitPeaks(ws, 0, [0.65, 1.9], OutParametersTable=out_tbl_name)
+   out_tbl_name = 'peaks'
+   difc, zero, peaks_tbl = EnggFitPeaks(ws, 0, [0.65, 1.9], OutParametersTable=out_tbl_name)
 
 
    # Print the results
@@ -78,6 +78,9 @@ Usage
    tbl = mtd[out_tbl_name]
    print "The output table has %d row(s)" % tbl.rowCount()
    print "Parameters from the table, Difc: %.1f, Zero: %.1f" % (tbl.cell(0,0), tbl.cell(0,1))
+   print "Number of peaks fitted: {0}".format(peaks_tbl.rowCount())
+   print "First peak expected: {0}".format(peaks_tbl.column('dSpacing')[0])
+   print "First fitted peak center: {0:.1f}".format(peaks_tbl.column('X0')[0])
 
 Output:
 
@@ -91,6 +94,9 @@ Output:
    Zero: 46.0
    The output table has 1 row(s)
    Parameters from the table, Difc: 18400.0, Zero: 46.0
+   Number of peaks fitted: 2
+   First peak expected: 0.65
+   First fitted peak center: 12006.0
 
 .. categories::
 


### PR DESCRIPTION
Fixes  #15180.
- Code review. This PR also includes a bit of refactoring of `EnggFitPeaks`
- Unit, doc, and system tests have been updated and extended. They should pass.
- The new output is described in the documentation (table of properties), and some examples are given.
- Make sure that this makes it possible to implement the second point of #13377. That would require plots of the 'dSpacing' column against the 'X0' column of the `EnggCalibrate` output parameters table, for banks 1, 2, etc.
- For an example of how to retrieve the peak parameters, see the `EnggFitPeak` and `EnggCalibrate` documentation examples.

Release note: http://www.mantidproject.org/ReleaseNotes_3_7_Framework_Changes#Improved
