### PR TITLE
Fix bug with mask boundary for MDEventWorkspaces

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -502,7 +502,7 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
       for (size_t p = 0; p < numPlanes; p++) {
         // Save whether this vertex is contained by this plane
         vertexContained[p * numVertices + linearVertexIndex] =
-            function->getPlane(p).isPointBounded(vertexCoord);
+            function->getPlane(p).isPointInside(vertexCoord);
       }
     }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -499,10 +499,13 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
                          coord_t(double(vertexIndex[d]) * m_SubBoxSize[d]);
 
       // Now check each plane to see if the vertex is bounded by it
+      // Don't include vertices on the plane to exclude case that box touches
+      // but does not intersect with the plane, as in this case no volume of the
+      // box is in the masked volume
       for (size_t p = 0; p < numPlanes; p++) {
         // Save whether this vertex is contained by this plane
         vertexContained[p * numVertices + linearVertexIndex] =
-            function->getPlane(p).isPointBounded(vertexCoord);
+            function->getPlane(p).isPointInside(vertexCoord);
       }
     }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -499,13 +499,10 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
                          coord_t(double(vertexIndex[d]) * m_SubBoxSize[d]);
 
       // Now check each plane to see if the vertex is bounded by it
-      // Don't include vertices on the plane to exclude case that box touches
-      // but does not intersect with the plane, as in this case no volume of the
-      // box is in the masked volume
       for (size_t p = 0; p < numPlanes; p++) {
         // Save whether this vertex is contained by this plane
         vertexContained[p * numVertices + linearVertexIndex] =
-            function->getPlane(p).isPointInside(vertexCoord);
+            function->getPlane(p).isPointBounded(vertexCoord);
       }
     }
 

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
@@ -88,7 +88,7 @@ public:
    */
   inline bool isPointBounded(const coord_t *coords) const {
     coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
+    for (size_t d = 0; d < m_nd; ++d) {
       total += m_normal[d] * coords[d];
     }
     return (total >= m_inequality);
@@ -103,7 +103,7 @@ public:
    */
   inline bool isPointBounded(const Mantid::Kernel::VMD &coords) const {
     coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
+    for (size_t d = 0; d < m_nd; ++d) {
       total += m_normal[d] * static_cast<coord_t>(coords[d]);
     }
     return (total >= m_inequality);
@@ -118,7 +118,7 @@ public:
    */
   inline bool isPointBounded(const std::vector<coord_t> &coords) const {
     coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
+    for (size_t d = 0; d < m_nd; ++d) {
       total += m_normal[d] * coords[d];
     }
     return (total >= m_inequality);
@@ -136,7 +136,7 @@ public:
    */
   inline bool isPointInside(const coord_t *coords) const {
     coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
+    for (size_t d = 0; d < m_nd; ++d) {
       total += m_normal[d] * coords[d];
     }
     return (total > m_inequality);
@@ -154,7 +154,7 @@ public:
    */
   inline bool isPointInside(const std::vector<coord_t> &coords) const {
     coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
+    for (size_t d = 0; d < m_nd; ++d) {
       total += m_normal[d] * coords[d];
     }
     return (total > m_inequality);
@@ -189,7 +189,7 @@ private:
   void construct(IterableType normal, IterableType point) {
     m_normal = new coord_t[m_nd];
     m_inequality = 0;
-    for (size_t d = 0; d < m_nd; d++) {
+    for (size_t d = 0; d < m_nd; ++d) {
       m_normal[d] = static_cast<coord_t>(normal[d]);
       m_inequality += static_cast<coord_t>(point[d]) * m_normal[d];
     }

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
@@ -125,6 +125,42 @@ public:
   }
 
   //----------------------------------------------------------------------------------------------
+  /** Is a point in MDimensions bounded by this hyperplane, that is,
+   * is (a1*x1 + a2*x2 + ... > b)?
+   * False for points that lie on the hyperplane, this is used to detect
+   * when two volumes (for example an MDBox and a mask) touch but do
+   * not share a finite volume
+   *
+   * @param coords :: nd-sized array of coordinates
+   * @return true if it is bounded by the plane
+   */
+  inline bool isPointInside(const coord_t *coords) const {
+    coord_t total = 0;
+    for (size_t d = 0; d < m_nd; d++) {
+      total += m_normal[d] * coords[d];
+    }
+    return (total > m_inequality);
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Is a point in MDimensions bounded by this hyperplane, that is,
+   * is (a1*x1 + a2*x2 + ... > b)?
+   * False for points that lie on the hyperplane, this is used to detect
+   * when two volumes (for example an MDBox and a mask) touch but do
+   * not share a finite volume
+   *
+   * @param coords :: nd-sized vector of coordinates. No size check is made!
+   * @return true if it is bounded by the plane
+   */
+  inline bool isPointInside(const std::vector<coord_t> &coords) const {
+    coord_t total = 0;
+    for (size_t d = 0; d < m_nd; d++) {
+      total += m_normal[d] * coords[d];
+    }
+    return (total > m_inequality);
+  }
+
+  //----------------------------------------------------------------------------------------------
   /** Given two points defining the start and end point of a line,
    * is there an intersection between the hyperplane and the line
    * defined by the points?

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
@@ -125,37 +125,6 @@ public:
   }
 
   //----------------------------------------------------------------------------------------------
-  /** Is a point in MDimensions inside the region bounded by this hyperplane,
-  * that is,
-  * is (a1*x1 + a2*x2 + ... > b)?
-  *
-  * @param coords :: nd-sized array of coordinates
-  * @return true if it is bounded by the plane
-  */
-  inline bool isPointInside(const coord_t *coords) const {
-    coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
-      total += m_normal[d] * coords[d];
-    }
-    return (total > m_inequality);
-  }
-
-  //----------------------------------------------------------------------------------------------
-  /** Is a point in MDimensions inside the region bounded by this hyperplane,
-   * that is, is (a1*x1 + a2*x2 + ... > b)?
-   *
-   * @param coords :: nd-sized vector of coordinates. No size check is made!
-   * @return true if it is bounded by the plane
-   */
-  inline bool isPointInside(const std::vector<coord_t> &coords) const {
-    coord_t total = 0;
-    for (size_t d = 0; d < m_nd; d++) {
-      total += m_normal[d] * coords[d];
-    }
-    return (total > m_inequality);
-  }
-
-  //----------------------------------------------------------------------------------------------
   /** Given two points defining the start and end point of a line,
    * is there an intersection between the hyperplane and the line
    * defined by the points?

--- a/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
+++ b/Framework/Geometry/inc/MantidGeometry/MDGeometry/MDPlane.h
@@ -125,6 +125,37 @@ public:
   }
 
   //----------------------------------------------------------------------------------------------
+  /** Is a point in MDimensions inside the region bounded by this hyperplane,
+  * that is,
+  * is (a1*x1 + a2*x2 + ... > b)?
+  *
+  * @param coords :: nd-sized array of coordinates
+  * @return true if it is bounded by the plane
+  */
+  inline bool isPointInside(const coord_t *coords) const {
+    coord_t total = 0;
+    for (size_t d = 0; d < m_nd; d++) {
+      total += m_normal[d] * coords[d];
+    }
+    return (total > m_inequality);
+  }
+
+  //----------------------------------------------------------------------------------------------
+  /** Is a point in MDimensions inside the region bounded by this hyperplane,
+   * that is, is (a1*x1 + a2*x2 + ... > b)?
+   *
+   * @param coords :: nd-sized vector of coordinates. No size check is made!
+   * @return true if it is bounded by the plane
+   */
+  inline bool isPointInside(const std::vector<coord_t> &coords) const {
+    coord_t total = 0;
+    for (size_t d = 0; d < m_nd; d++) {
+      total += m_normal[d] * coords[d];
+    }
+    return (total > m_inequality);
+  }
+
+  //----------------------------------------------------------------------------------------------
   /** Given two points defining the start and end point of a line,
    * is there an intersection between the hyperplane and the line
    * defined by the points?

--- a/Framework/Geometry/test/MDPlaneTest.h
+++ b/Framework/Geometry/test/MDPlaneTest.h
@@ -214,6 +214,23 @@ public:
     point.push_back(-5.0);
     TS_ASSERT(!p1.isPointBounded(point));
   }
+
+  void test_isPointInside_vectorversion() {
+    // Plane where x < 5
+    coord_t normal1[2] = {-1., 0};
+    coord_t point1[2] = {5., 0};
+    MDPlane p1(2, normal1, point1);
+    std::vector<coord_t> point;
+    point.clear();
+    point.push_back(4.0);
+    point.push_back(12.0);
+    TS_ASSERT(p1.isPointInside(point));
+
+    point.clear();
+    point.push_back(6.0);
+    point.push_back(-5.0);
+    TS_ASSERT(!p1.isPointInside(point));
+  }
 };
 
 //=========================================================================================

--- a/Framework/Geometry/test/MDPlaneTest.h
+++ b/Framework/Geometry/test/MDPlaneTest.h
@@ -210,6 +210,13 @@ public:
     TS_ASSERT(p1.isPointBounded(point));
 
     point.clear();
+    point.push_back(5.0);
+    point.push_back(-5.0);
+    TSM_ASSERT("Point should be found to be bounded by "
+               "plane, it lies exactly on the plane",
+               p1.isPointBounded(point));
+
+    point.clear();
     point.push_back(6.0);
     point.push_back(-5.0);
     TS_ASSERT(!p1.isPointBounded(point));
@@ -224,12 +231,16 @@ public:
     point.clear();
     point.push_back(4.0);
     point.push_back(12.0);
-    TS_ASSERT(p1.isPointInside(point));
+    TSM_ASSERT("Point should be found to be inside region bounded by plane",
+               p1.isPointInside(point));
 
+    // Point lies on the plane, not inside it
     point.clear();
-    point.push_back(6.0);
+    point.push_back(5.0);
     point.push_back(-5.0);
-    TS_ASSERT(!p1.isPointInside(point));
+    TSM_ASSERT("Point should not be found to be inside region bounded by "
+               "plane, it lies exactly on the plane",
+               !p1.isPointInside(point));
   }
 };
 

--- a/Framework/Geometry/test/MDPlaneTest.h
+++ b/Framework/Geometry/test/MDPlaneTest.h
@@ -242,6 +242,22 @@ public:
                "plane, it lies exactly on the plane",
                !p1.isPointInside(point));
   }
+
+  void test_isPointInside_arrayversion() {
+    // Plane where x < 5
+    coord_t normal1[2] = {-1.0, 0.0};
+    coord_t point1[2] = {5.0, 0.0};
+    MDPlane plane1(2, normal1, point1);
+    coord_t test_point1[2] = {4.5, 0.0};
+    TSM_ASSERT("Point should be found to be inside region bounded by plane",
+               plane1.isPointInside(test_point1));
+
+    // Point lies on the plane, not inside it
+    coord_t test_point2[2] = {5.0, 0.0};
+    TSM_ASSERT("Point should not be found to be inside region bounded by "
+               "plane, it lies exactly on the plane",
+               !plane1.isPointInside(test_point2));
+  }
 };
 
 //=========================================================================================

--- a/Framework/Geometry/test/MDPlaneTest.h
+++ b/Framework/Geometry/test/MDPlaneTest.h
@@ -214,23 +214,6 @@ public:
     point.push_back(-5.0);
     TS_ASSERT(!p1.isPointBounded(point));
   }
-
-  void test_isPointInside_vectorversion() {
-    // Plane where x < 5
-    coord_t normal1[2] = {-1., 0};
-    coord_t point1[2] = {5., 0};
-    MDPlane p1(2, normal1, point1);
-    std::vector<coord_t> point;
-    point.clear();
-    point.push_back(4.0);
-    point.push_back(12.0);
-    TS_ASSERT(p1.isPointInside(point));
-
-    point.clear();
-    point.push_back(6.0);
-    point.push_back(-5.0);
-    TS_ASSERT(!p1.isPointInside(point));
-  }
 };
 
 //=========================================================================================


### PR DESCRIPTION
Fixes #14962

**To Test:**

.deb is at `smb://olympic/babylon5/Scratch/Matthew%20Jones/15209`

Use the script below to make a masked and unmasked 3D workspace. The masked workspace should have one octant masked.
View the workspaces in Slice Viewer or VSI, it should be clear that exactly one octant is masked. Previously the masked region appeared too large by one in bin in each dimension.

``` python
ws_mdew = CreateMDWorkspace(Dimensions='3', Extents='-2,2,-2,2,-2,2', Names='h,k,l',
                       Units='rlu,rlu,rlu', SplitInto='12')
FakeMDEventData(ws_mdew, UniformParams='1000', RandomizeSignal='1')
ws_mdew = SliceMD(ws_mdew,AlignedDim0='h,-2,2,12',AlignedDim1='k,-2,2,12',AlignedDim2='l,-2,2,12')
ws_masked_mdew = CloneMDWorkspace(ws_mdew)
MaskMD(Workspace=ws_masked_mdew,Dimensions="h,k,l",Extents="-2,0,-2,0,-2,0")
```
